### PR TITLE
fix(app-router): render optimistic loading shells for dynamic navigation

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -9,8 +9,9 @@ import type { NEXT_DATA } from "vinext/shims/internal/utils";
 import { isUnknownRecord } from "../utils/record.js";
 
 export type VinextLinkPrefetchRoute = {
-  patternParts: string[];
+  canPrefetchLoadingShell: boolean;
   isDynamic: boolean;
+  patternParts: string[];
 };
 
 export type VinextNextData = {

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -19,6 +19,7 @@ export function generateBrowserEntry(
   const prefetchRoutes: VinextLinkPrefetchRoute[] = routes
     .filter((route) => isLinkPrefetchRoute(route))
     .map((route) => ({
+      canPrefetchLoadingShell: route.loadingPath !== null,
       patternParts: [...route.patternParts],
       isDynamic: route.isDynamic,
     }));

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -117,7 +117,11 @@ async function hydrate() {
   const root = hydrateRoot(container, element);
   window.__VINEXT_ROOT__ = root;
   installPagesRouterRuntime();
-  window.__VINEXT_HYDRATED_AT = performance.now();
+  const hydratedAt = performance.now();
+  window.__VINEXT_HYDRATED_AT = hydratedAt;
+  window.__NEXT_HYDRATED = true;
+  window.__NEXT_HYDRATED_AT = hydratedAt;
+  window.__NEXT_HYDRATED_CB?.();
 }
 
 hydrate();

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -48,6 +48,13 @@ declare global {
     __VINEXT_HYDRATED_AT: number | undefined;
 
     /**
+     * Next.js test/runtime compatibility hydration marker.
+     */
+    __NEXT_HYDRATED: boolean | undefined;
+    __NEXT_HYDRATED_AT: number | undefined;
+    __NEXT_HYDRATED_CB: (() => void) | undefined;
+
+    /**
      * The cached `_app` component for Pages Router.
      * Written and read by `shims/router.ts` to avoid re-importing on every
      * client-side navigation.

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -430,7 +430,7 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
 }): Promise<void> {
   if (options.routeManifest === null) return;
 
-  const learning: Promise<void>[] = [];
+  const learning: Promise<void>[] = [...optimisticRouteTemplateLearning.values()];
   for (const [cacheKey, entry] of getPrefetchCache()) {
     const sourceKey = getOptimisticPrefetchSourceKey({
       cacheKey,
@@ -455,10 +455,7 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
         optimisticRouteTemplateLearning.delete(sourceKey);
       });
     optimisticRouteTemplateLearning.set(sourceKey, promise);
-  }
-
-  if (optimisticRouteTemplateLearning.size > 0) {
-    learning.push(...optimisticRouteTemplateLearning.values());
+    learning.push(promise);
   }
 
   if (learning.length === 0) return;
@@ -1497,6 +1494,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
                 currentHref,
                 optimisticPayload.params,
               );
+              // The optimistic shell is a detached commit for this navigation.
+              // It uses the same navId gate as the real payload, while the real
+              // payload skips pending-router-state reuse via
+              // detachedNavigationCommits. That keeps late optimistic errors or
+              // transitions from mutating a newer navigation or sharing mutable
+              // pending state with the authoritative render.
               void renderNavigationPayload(
                 Promise.resolve(optimisticPayload.elements),
                 optimisticNavigationSnapshot,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -19,6 +19,7 @@ import {
   createCachedRscResponseSnapshot,
   createClientNavigationRenderSnapshot,
   getClientNavigationRenderContext,
+  getPrefetchCache,
   invalidatePrefetchCache,
   pushHistoryStateWithoutNotify,
   replaceClientParamsWithoutNotify,
@@ -30,6 +31,7 @@ import {
   setNavigationContext,
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
+  type PrefetchCacheEntry,
 } from "vinext/shims/navigation";
 import {
   getNavigationRuntime,
@@ -120,6 +122,13 @@ import {
   resolveRscRedirectLifecycleHop,
 } from "./app-browser-rsc-redirect.js";
 import {
+  createOptimisticRouteTemplate,
+  getOptimisticPrefetchSourceKey,
+  getOptimisticRouteTemplateKey,
+  resolveOptimisticNavigationPayload,
+  type OptimisticRouteTemplate,
+} from "./app-optimistic-routing.js";
+import {
   ACTION_REDIRECT_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
@@ -165,6 +174,9 @@ const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
 const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
 const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
 const CLIENT_RSC_COMPATIBILITY_ID = getVinextRscCompatibilityId();
+const optimisticRouteTemplates = new Map<string, OptimisticRouteTemplate>();
+const optimisticRouteTemplateSources = new Set<string>();
+const optimisticRouteTemplateLearning = new Map<string, Promise<void>>();
 function getBrowserRouteManifest(): RouteManifest | null {
   return getNavigationRuntime()?.bootstrap.routeManifest ?? null;
 }
@@ -341,11 +353,116 @@ function clearVisitedResponseCache(): void {
 
 function clearPrefetchState(): void {
   invalidatePrefetchCache();
+  optimisticRouteTemplates.clear();
+  optimisticRouteTemplateSources.clear();
+  optimisticRouteTemplateLearning.clear();
 }
 
 function clearClientNavigationCaches(): void {
   clearVisitedResponseCache();
   clearPrefetchState();
+}
+
+function isSettledPrefetchCacheEntry(
+  entry: PrefetchCacheEntry,
+): entry is PrefetchCacheEntry & { snapshot: CachedRscResponse } {
+  return (
+    entry.outcome === "cache-seeded" && entry.pending === undefined && entry.snapshot !== undefined
+  );
+}
+
+function parsePrefetchCacheKey(cacheKey: string): {
+  interceptionContext: string | null;
+  rscUrl: string;
+} {
+  const separatorIndex = cacheKey.indexOf("\0");
+  if (separatorIndex === -1) {
+    return { interceptionContext: null, rscUrl: cacheKey };
+  }
+  return {
+    interceptionContext: cacheKey.slice(separatorIndex + 1),
+    rscUrl: cacheKey.slice(0, separatorIndex),
+  };
+}
+
+async function learnOptimisticRouteTemplateFromPrefetch(options: {
+  cacheKey: string;
+  entry: PrefetchCacheEntry & { snapshot: CachedRscResponse };
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+  routeManifest: RouteManifest;
+}): Promise<boolean> {
+  const source = parsePrefetchCacheKey(options.cacheKey);
+  if (source.interceptionContext !== options.interceptionContext) return false;
+  if ((options.entry.snapshot.mountedSlotsHeader ?? null) !== options.mountedSlotsHeader)
+    return false;
+  if (options.interceptionContext !== null) return false;
+
+  const elements = await decodeAppElementsPromise(
+    createFromFetch<AppWireElements>(Promise.resolve(restoreRscResponse(options.entry.snapshot))),
+  );
+  const template = createOptimisticRouteTemplate({
+    allowLoadingShell: options.entry.optimisticRouteShell === true,
+    basePath: __basePath,
+    elements,
+    href: options.entry.snapshot.url || source.rscUrl,
+    interceptionContext: options.interceptionContext,
+    mountedSlotsHeader: options.mountedSlotsHeader,
+    routeManifest: options.routeManifest,
+  });
+  if (template === null) return false;
+
+  optimisticRouteTemplates.set(
+    getOptimisticRouteTemplateKey({
+      interceptionContext: options.interceptionContext,
+      mountedSlotsHeader: options.mountedSlotsHeader,
+      routeId: template.routeId,
+    }),
+    template,
+  );
+  return true;
+}
+
+async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+  routeManifest: RouteManifest | null;
+}): Promise<void> {
+  if (options.routeManifest === null) return;
+
+  const learning: Promise<void>[] = [];
+  for (const [cacheKey, entry] of getPrefetchCache()) {
+    const sourceKey = getOptimisticPrefetchSourceKey({
+      cacheKey,
+      interceptionContext: options.interceptionContext,
+      mountedSlotsHeader: options.mountedSlotsHeader,
+    });
+    if (optimisticRouteTemplateSources.has(sourceKey)) continue;
+    if (optimisticRouteTemplateLearning.has(sourceKey)) continue;
+    if (!isSettledPrefetchCacheEntry(entry)) continue;
+
+    const promise = learnOptimisticRouteTemplateFromPrefetch({
+      cacheKey,
+      entry,
+      interceptionContext: options.interceptionContext,
+      mountedSlotsHeader: options.mountedSlotsHeader,
+      routeManifest: options.routeManifest,
+    })
+      .then((learned) => {
+        if (learned) optimisticRouteTemplateSources.add(sourceKey);
+      })
+      .finally(() => {
+        optimisticRouteTemplateLearning.delete(sourceKey);
+      });
+    optimisticRouteTemplateLearning.set(sourceKey, promise);
+  }
+
+  if (optimisticRouteTemplateLearning.size > 0) {
+    learning.push(...optimisticRouteTemplateLearning.values());
+  }
+
+  if (learning.length === 0) return;
+  await Promise.allSettled(learning);
 }
 
 function syncCurrentHistoryStatePreviousNextUrl(previousNextUrl: string | null): void {
@@ -733,7 +850,11 @@ function BrowserRoot({
     // browser router state is attached and link/router interactions can safely
     // observe the committed tree. It is intentionally later than hydrateRoot()
     // returning.
-    window.__VINEXT_HYDRATED_AT = performance.now();
+    const hydratedAt = performance.now();
+    window.__VINEXT_HYDRATED_AT = hydratedAt;
+    window.__NEXT_HYDRATED = true;
+    window.__NEXT_HYDRATED_AT = hydratedAt;
+    window.__NEXT_HYDRATED_CB?.();
     return () => {
       detach();
       setMountedSlotsHeader(null);
@@ -1224,6 +1345,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     let currentHistoryMode = historyUpdateMode;
     let currentPrevNextUrl = previousNextUrlOverride;
     let redirectCount = redirectDepth;
+    let detachedNavigationCommits = false;
     const activeTraversalIntent =
       navigationKind === "traverse"
         ? (traversalIntent ??
@@ -1324,7 +1446,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             currentHistoryMode,
             cachedParams,
             requestPreviousNextUrl,
-            pendingRouterState,
+            detachedNavigationCommits ? null : pendingRouterState,
             VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
             toActionType(navigationKind),
             toOperationLane(navigationKind),
@@ -1347,6 +1469,53 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           if (prefetchedResponse) {
             navResponse = restoreRscResponse(prefetchedResponse, false);
             navResponseUrl = prefetchedResponse.url;
+          }
+        }
+
+        if (!navResponse && navigationKind === "navigate") {
+          const routeManifest = getBrowserRouteManifest();
+          await learnOptimisticRouteTemplatesFromPrefetchCache({
+            interceptionContext: requestInterceptionContext,
+            mountedSlotsHeader,
+            routeManifest,
+          });
+          if (!browserNavigationController.isCurrentNavigation(navId)) return;
+
+          if (routeManifest !== null) {
+            const optimisticPayload = resolveOptimisticNavigationPayload({
+              basePath: __basePath,
+              href: currentHref,
+              interceptionContext: requestInterceptionContext,
+              mountedSlotsHeader,
+              routeManifest,
+              templates: optimisticRouteTemplates,
+            });
+
+            if (optimisticPayload !== null) {
+              detachedNavigationCommits = true;
+              const optimisticNavigationSnapshot = createClientNavigationRenderSnapshot(
+                currentHref,
+                optimisticPayload.params,
+              );
+              void renderNavigationPayload(
+                Promise.resolve(optimisticPayload.elements),
+                optimisticNavigationSnapshot,
+                currentHref,
+                navId,
+                currentHistoryMode,
+                optimisticPayload.params,
+                requestPreviousNextUrl,
+                null,
+                FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+                toActionType(navigationKind),
+                toOperationLane(navigationKind),
+                activeTraversalIntent,
+              ).catch((error) => {
+                if (browserNavigationController.isCurrentNavigation(navId)) {
+                  console.error("[vinext] Optimistic RSC navigation error:", error);
+                }
+              });
+            }
           }
         }
 
@@ -1515,7 +1684,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           currentHistoryMode,
           navParams,
           requestPreviousNextUrl,
-          pendingRouterState,
+          detachedNavigationCommits ? null : pendingRouterState,
           FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
           toActionType(navigationKind),
           toOperationLane(navigationKind),

--- a/packages/vinext/src/server/app-elements.ts
+++ b/packages/vinext/src/server/app-elements.ts
@@ -1,6 +1,8 @@
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import { AppElementsWire, UNMATCHED_SLOT, type AppElements } from "./app-elements-wire.js";
 
+export const APP_PREFETCH_LOADING_SHELL_MARKER_KEY = "__prefetchLoadingShell";
+
 export {
   AppElementsWire,
   APP_ARTIFACT_COMPATIBILITY_KEY,

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -1,0 +1,321 @@
+import { createElement, isValidElement, Suspense } from "react";
+import { isUnknownRecord } from "../utils/record.js";
+import { stripBasePath } from "../utils/base-path.js";
+import { decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
+import type { RouteManifest, RouteManifestRoute } from "../routing/app-route-graph.js";
+import { stripRscCacheBustingSearchParam, stripRscSuffix } from "./app-rsc-cache-busting.js";
+import {
+  AppElementsWire,
+  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
+  type AppElementValue,
+  type AppElements,
+} from "./app-elements.js";
+
+type OptimisticRouteTrieNode = {
+  catchAllChild: { paramName: string; route: RouteManifestRoute } | null;
+  dynamicChild: { node: OptimisticRouteTrieNode; paramName: string } | null;
+  optionalCatchAllChild: { paramName: string; route: RouteManifestRoute } | null;
+  route: RouteManifestRoute | null;
+  staticChildren: Map<string, OptimisticRouteTrieNode>;
+};
+
+type OptimisticRouteMatch = {
+  params: Record<string, string | string[]>;
+  route: RouteManifestRoute;
+};
+
+export type OptimisticRouteTemplate = {
+  elements: AppElements;
+  mountedSlotsHeader: string | null;
+  pageElementIds: readonly string[];
+  routeId: string;
+};
+
+type OptimisticNavigationPayload = {
+  elements: AppElements;
+  params: Record<string, string | string[]>;
+  template: OptimisticRouteTemplate;
+};
+
+const routeTrieCache = new WeakMap<RouteManifest, OptimisticRouteTrieNode>();
+const OPTIMISTIC_ROUTE_SEGMENT_PROMISE = new Promise<never>(() => {});
+
+export function getOptimisticRouteTemplateKey(options: {
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+  routeId: string;
+}): string {
+  return `${options.routeId}\0${options.interceptionContext ?? ""}\0${options.mountedSlotsHeader ?? ""}`;
+}
+
+export function getOptimisticPrefetchSourceKey(options: {
+  cacheKey: string;
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+}): string {
+  return `${options.cacheKey}\0${options.interceptionContext ?? ""}\0${options.mountedSlotsHeader ?? ""}`;
+}
+
+function createNode(): OptimisticRouteTrieNode {
+  return {
+    catchAllChild: null,
+    dynamicChild: null,
+    optionalCatchAllChild: null,
+    route: null,
+    staticChildren: new Map(),
+  };
+}
+
+function buildRouteTrie(routeManifest: RouteManifest): OptimisticRouteTrieNode {
+  const root = createNode();
+
+  for (const route of routeManifest.segmentGraph.routes.values()) {
+    let node = root;
+    const parts = route.patternParts;
+
+    if (parts.length === 0) {
+      node.route ??= route;
+      continue;
+    }
+
+    for (const [index, part] of parts.entries()) {
+      const isTerminal = index === parts.length - 1;
+      if (part.startsWith(":") && part.endsWith("+")) {
+        if (isTerminal && node.catchAllChild === null) {
+          node.catchAllChild = { paramName: part.slice(1, -1), route };
+        }
+        break;
+      }
+
+      if (part.startsWith(":") && part.endsWith("*")) {
+        if (isTerminal && node.optionalCatchAllChild === null) {
+          node.optionalCatchAllChild = { paramName: part.slice(1, -1), route };
+        }
+        break;
+      }
+
+      if (part.startsWith(":")) {
+        if (node.dynamicChild === null) {
+          node.dynamicChild = { node: createNode(), paramName: part.slice(1) };
+        }
+        node = node.dynamicChild.node;
+        if (isTerminal) node.route ??= route;
+        continue;
+      }
+
+      let staticChild = node.staticChildren.get(part);
+      if (staticChild === undefined) {
+        staticChild = createNode();
+        node.staticChildren.set(part, staticChild);
+      }
+      node = staticChild;
+      if (isTerminal) node.route ??= route;
+    }
+  }
+
+  return root;
+}
+
+function getRouteTrie(routeManifest: RouteManifest): OptimisticRouteTrieNode {
+  const existing = routeTrieCache.get(routeManifest);
+  if (existing) return existing;
+
+  const trie = buildRouteTrie(routeManifest);
+  routeTrieCache.set(routeManifest, trie);
+  return trie;
+}
+
+function matchNode(
+  node: OptimisticRouteTrieNode,
+  urlParts: readonly string[],
+  index: number,
+): OptimisticRouteMatch | null {
+  if (index === urlParts.length) {
+    if (node.route !== null) {
+      return { route: node.route, params: Object.create(null) };
+    }
+    if (node.optionalCatchAllChild !== null) {
+      return {
+        route: node.optionalCatchAllChild.route,
+        params: Object.create(null),
+      };
+    }
+    return null;
+  }
+
+  const segment = urlParts[index];
+  const staticChild = node.staticChildren.get(segment);
+  if (staticChild !== undefined) {
+    // Static children are authoritative for optimistic routing. If a known
+    // static subtree does not contain the remaining URL, do not fall through to
+    // a catch-all sibling and render the wrong loading boundary.
+    return matchNode(staticChild, urlParts, index + 1);
+  }
+
+  if (node.dynamicChild !== null) {
+    const match = matchNode(node.dynamicChild.node, urlParts, index + 1);
+    if (match === null) return null;
+    match.params[node.dynamicChild.paramName] = segment;
+    return match;
+  }
+
+  if (node.catchAllChild !== null) {
+    return {
+      route: node.catchAllChild.route,
+      params: {
+        [node.catchAllChild.paramName]: urlParts.slice(index),
+      },
+    };
+  }
+
+  if (node.optionalCatchAllChild !== null) {
+    return {
+      route: node.optionalCatchAllChild.route,
+      params: {
+        [node.optionalCatchAllChild.paramName]: urlParts.slice(index),
+      },
+    };
+  }
+
+  return null;
+}
+
+function hrefToRouteParts(href: string, basePath: string): string[] | null {
+  let url: URL;
+  try {
+    url = new URL(href, "https://vinext.local");
+  } catch {
+    return null;
+  }
+
+  stripRscCacheBustingSearchParam(url);
+  const withoutRscSuffix = stripRscSuffix(url.pathname);
+  const appPathname = stripBasePath(withoutRscSuffix, basePath);
+  return splitPathnameForRouteMatch(appPathname === "" ? "/" : appPathname);
+}
+
+export function matchOptimisticRouteManifestRoute(options: {
+  basePath: string;
+  href: string;
+  routeManifest: RouteManifest;
+}): OptimisticRouteMatch | null {
+  const urlParts = hrefToRouteParts(options.href, options.basePath);
+  if (urlParts === null) return null;
+
+  const match = matchNode(getRouteTrie(options.routeManifest), urlParts, 0);
+  if (match === null) return null;
+
+  decodeMatchedParams(match.params);
+  return match;
+}
+
+function elementHasSuspenseFallback(value: unknown, depth = 0): boolean {
+  if (depth > 100) return false;
+  if (Array.isArray(value)) {
+    return value.some((entry) => elementHasSuspenseFallback(entry, depth + 1));
+  }
+  if (!isValidElement(value)) return false;
+
+  const props = Reflect.get(value, "props");
+  if (value.type === Suspense && isUnknownRecord(props)) {
+    const fallback = Reflect.get(props, "fallback");
+    if (fallback !== null && fallback !== undefined) return true;
+  }
+
+  if (!isUnknownRecord(props)) return false;
+  return elementHasSuspenseFallback(Reflect.get(props, "children"), depth + 1);
+}
+
+function getPageElementIds(elements: AppElements): string[] {
+  return Object.keys(elements)
+    .filter((key) => AppElementsWire.parseElementKey(key)?.kind === "page")
+    .sort();
+}
+
+function OptimisticRouteSegment(): null {
+  throw OPTIMISTIC_ROUTE_SEGMENT_PROMISE;
+}
+
+export function createOptimisticRouteTemplate(options: {
+  allowLoadingShell?: boolean;
+  basePath: string;
+  elements: AppElements;
+  href: string;
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+  routeManifest: RouteManifest;
+}): OptimisticRouteTemplate | null {
+  const match = matchOptimisticRouteManifestRoute({
+    basePath: options.basePath,
+    href: options.href,
+    routeManifest: options.routeManifest,
+  });
+  if (match === null || !match.route.isDynamic) return null;
+  if (options.interceptionContext !== null) return null;
+
+  const metadata = AppElementsWire.readMetadata(options.elements);
+  if (metadata.interception !== null || metadata.interceptionContext !== null) return null;
+
+  const routeElement = options.elements[metadata.routeId];
+  if (!options.allowLoadingShell && !elementHasSuspenseFallback(routeElement)) return null;
+  if (
+    options.allowLoadingShell &&
+    options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] !== "LoadingBoundary"
+  ) {
+    return null;
+  }
+  if (options.allowLoadingShell && (routeElement === undefined || routeElement === null))
+    return null;
+
+  const pageElementIds = getPageElementIds(options.elements);
+  if (pageElementIds.length === 0) return null;
+
+  return {
+    elements: options.elements,
+    mountedSlotsHeader: options.mountedSlotsHeader,
+    pageElementIds,
+    routeId: match.route.id,
+  };
+}
+
+export function createOptimisticRouteElements(template: OptimisticRouteTemplate): AppElements {
+  const elements: Record<string, AppElementValue> = { ...template.elements };
+  for (const pageElementId of template.pageElementIds) {
+    elements[pageElementId] = createElement(OptimisticRouteSegment);
+  }
+  return elements;
+}
+
+export function resolveOptimisticNavigationPayload(options: {
+  basePath: string;
+  href: string;
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+  routeManifest: RouteManifest;
+  templates: ReadonlyMap<string, OptimisticRouteTemplate>;
+}): OptimisticNavigationPayload | null {
+  if (options.interceptionContext !== null) return null;
+
+  const match = matchOptimisticRouteManifestRoute({
+    basePath: options.basePath,
+    href: options.href,
+    routeManifest: options.routeManifest,
+  });
+  if (match === null || !match.route.isDynamic) return null;
+
+  const template = options.templates.get(
+    getOptimisticRouteTemplateKey({
+      interceptionContext: options.interceptionContext,
+      mountedSlotsHeader: options.mountedSlotsHeader,
+      routeId: match.route.id,
+    }),
+  );
+  if (template === undefined) return null;
+  if (template.mountedSlotsHeader !== options.mountedSlotsHeader) return null;
+
+  return {
+    elements: createOptimisticRouteElements(template),
+    params: match.params,
+    template,
+  };
+}

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -38,7 +38,9 @@ type OptimisticNavigationPayload = {
 };
 
 const routeTrieCache = new WeakMap<RouteManifest, OptimisticRouteTrieNode>();
-const OPTIMISTIC_ROUTE_SEGMENT_PROMISE = new Promise<never>(() => {});
+// Shared never-settling thenable used to suspend optimistic page segments until
+// the real RSC payload replaces them.
+const OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER = new Promise<never>(() => {});
 
 export function getOptimisticRouteTemplateKey(options: {
   interceptionContext: string | null;
@@ -95,8 +97,13 @@ function buildRouteTrie(routeManifest: RouteManifest): OptimisticRouteTrieNode {
       }
 
       if (part.startsWith(":")) {
+        const paramName = part.slice(1);
         if (node.dynamicChild === null) {
-          node.dynamicChild = { node: createNode(), paramName: part.slice(1) };
+          node.dynamicChild = { node: createNode(), paramName };
+        } else if (node.dynamicChild.paramName !== paramName && import.meta.env.DEV) {
+          console.warn(
+            `[vinext] Optimistic route trie found conflicting dynamic segments at the same level: :${node.dynamicChild.paramName} vs ${part}`,
+          );
         }
         node = node.dynamicChild.node;
         if (isTerminal) node.route ??= route;
@@ -233,7 +240,7 @@ function getPageElementIds(elements: AppElements): string[] {
 }
 
 function OptimisticRouteSegment(): null {
-  throw OPTIMISTIC_ROUTE_SEGMENT_PROMISE;
+  throw OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER;
 }
 
 export function createOptimisticRouteTemplate(options: {
@@ -257,6 +264,10 @@ export function createOptimisticRouteTemplate(options: {
   if (metadata.interception !== null || metadata.interceptionContext !== null) return null;
 
   const routeElement = options.elements[metadata.routeId];
+  // Full-prefetch learning is intentionally heuristic: legacy full prefetches
+  // are accepted only when the serialized route subtree still contains a
+  // Suspense fallback. Authoritative loading-shell prefetches use the marker
+  // check below instead.
   if (!options.allowLoadingShell && !elementHasSuspenseFallback(routeElement)) return null;
   if (
     options.allowLoadingShell &&
@@ -264,6 +275,8 @@ export function createOptimisticRouteTemplate(options: {
   ) {
     return null;
   }
+  // Shell prefetches must include the eagerly-rendered loading component. A
+  // null route element means the server had no route loading boundary.
   if (options.allowLoadingShell && (routeElement === undefined || routeElement === null))
     return null;
 

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1,6 +1,7 @@
 import { Suspense, type ComponentType, type ReactNode } from "react";
 import {
   AppElementsWire,
+  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
   normalizeAppElementsSlotBindings,
   type AppElements,
   type AppElementsInterception,
@@ -27,6 +28,7 @@ import {
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
@@ -367,6 +369,7 @@ export function buildAppPageElements<
   TErrorModule extends AppPageErrorModule,
 >(options: BuildAppPageElementsOptions<TModule, TErrorModule>): AppElements {
   const interceptionContext = options.interceptionContext ?? null;
+  const renderMode = options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION;
   const routeSegments = options.route.routeSegments ?? [];
   const routeResetKey = resolveAppPageRouteStateKey(routeSegments, options.matchedParams);
   const routeId = AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
@@ -463,7 +466,20 @@ export function buildAppPageElements<
     pageDependencies.push(templateDependency);
   }
 
-  elements[pageId] = renderAfterAppDependencies(options.element, pageDependencies);
+  const routeLoadingComponent = getDefaultExport(options.route.loading);
+  const isPrefetchLoadingShell = renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
+  const shouldRenderPrefetchLoadingShell = isPrefetchLoadingShell && routeLoadingComponent !== null;
+  if (shouldRenderPrefetchLoadingShell) {
+    // Client loading components serialize as module references in Flight. Keep
+    // a durable marker in the shell payload so external router tests and
+    // diagnostics can recognize this as a loading-boundary response without
+    // requiring source text to appear in client component references.
+    elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] = "LoadingBoundary";
+  }
+
+  elements[pageId] = isPrefetchLoadingShell
+    ? null
+    : renderAfterAppDependencies(options.element, pageDependencies);
 
   for (const templateEntry of templateEntries) {
     const templateComponent = getDefaultExport(templateEntry.templateModule);
@@ -603,10 +619,7 @@ export function buildAppPageElements<
     }
 
     const slotLoadingComponent = getDefaultExport(slot.loading);
-    if (
-      slotLoadingComponent &&
-      !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION)
-    ) {
+    if (slotLoadingComponent && !shouldSuppressLoadingBoundaries(renderMode)) {
       const SlotLoadingComponent = slotLoadingComponent;
       slotElement = (
         <Suspense key={slotResetKey} fallback={<SlotLoadingComponent />}>
@@ -636,41 +649,46 @@ export function buildAppPageElements<
     </LayoutSegmentProvider>
   );
 
-  // Wrap the page slot in a per-segment RedirectBoundary so that a
-  // redirect() thrown from a server component (or a client component
-  // within the page subtree) is caught here — below the route's layouts —
-  // rather than at the top-level boundary in app-browser-entry. Catching
-  // at the top level unmounts the entire route tree including layouts,
-  // which destroys client-side state in layout-hosted components
-  // (counters, theme toggles, form drafts). Here, only the page subtree
-  // is unmounted; the surrounding layouts stay mounted across the
-  // boundary's null-render → router.replace transition, and segment
-  // reuse keeps their React state intact.
-  //
-  // Placed inside the Suspense (loading) boundary to match Next.js nesting
-  // for the redirect boundary specifically:
-  //   Error > AccessFallback > Loading (Suspense) > Redirect > content
-  // (Note: Next.js places AccessFallback inside Loading, not outside — that
-  // is a pre-existing nesting divergence tracked separately.)
-  // This keeps the loading fallback visible during redirect-driven
-  // transitions rather than unmounting it.
-  routeChildren = <RedirectBoundary>{routeChildren}</RedirectBoundary>;
+  if (isPrefetchLoadingShell) {
+    if (routeLoadingComponent === null) {
+      routeChildren = null;
+    } else {
+      const RouteLoadingComponent = routeLoadingComponent;
+      routeChildren = <RouteLoadingComponent />;
+    }
+  } else {
+    // Wrap the page slot in a per-segment RedirectBoundary so that a
+    // redirect() thrown from a server component (or a client component
+    // within the page subtree) is caught here — below the route's layouts —
+    // rather than at the top-level boundary in app-browser-entry. Catching
+    // at the top level unmounts the entire route tree including layouts,
+    // which destroys client-side state in layout-hosted components
+    // (counters, theme toggles, form drafts). Here, only the page subtree
+    // is unmounted; the surrounding layouts stay mounted across the
+    // boundary's null-render → router.replace transition, and segment
+    // reuse keeps their React state intact.
+    //
+    // Placed inside the Suspense (loading) boundary to match Next.js nesting
+    // for the redirect boundary specifically:
+    //   Error > AccessFallback > Loading (Suspense) > Redirect > content
+    // (Note: Next.js places AccessFallback inside Loading, not outside — that
+    // is a pre-existing nesting divergence tracked separately.)
+    // This keeps the loading fallback visible during redirect-driven
+    // transitions rather than unmounting it.
+    routeChildren = <RedirectBoundary>{routeChildren}</RedirectBoundary>;
 
-  const routeLoadingComponent = getDefaultExport(options.route.loading);
-  if (
-    routeLoadingComponent &&
-    !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION)
-  ) {
-    const RouteLoadingComponent = routeLoadingComponent;
-    // Route-level wrappers cover the full page branch in vinext's flat element
-    // transport, so their reset key includes the visible segment-state path.
-    // Dynamic param changes reset the pending boundary, while search-only changes
-    // preserve it.
-    routeChildren = (
-      <Suspense key={routeResetKey} fallback={<RouteLoadingComponent />}>
-        {routeChildren}
-      </Suspense>
-    );
+    if (routeLoadingComponent && !shouldSuppressLoadingBoundaries(renderMode)) {
+      const RouteLoadingComponent = routeLoadingComponent;
+      // Route-level wrappers cover the full page branch in vinext's flat element
+      // transport, so their reset key includes the visible segment-state path.
+      // Dynamic param changes reset the pending boundary, while search-only changes
+      // preserve it.
+      routeChildren = (
+        <Suspense key={routeResetKey} fallback={<RouteLoadingComponent />}>
+          {routeChildren}
+        </Suspense>
+      );
+    }
   }
 
   const lastLayoutErrorModule =

--- a/packages/vinext/src/server/app-rsc-render-mode.ts
+++ b/packages/vinext/src/server/app-rsc-render-mode.ts
@@ -1,6 +1,12 @@
-export type AppRscRenderMode = "navigation" | "refresh-preserve-ui" | "action-rerender-preserve-ui";
+export type AppRscRenderMode =
+  | "navigation"
+  | "prefetch-loading-shell"
+  | "refresh-preserve-ui"
+  | "action-rerender-preserve-ui";
 
 export const APP_RSC_RENDER_MODE_NAVIGATION = "navigation" satisfies AppRscRenderMode;
+export const APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL =
+  "prefetch-loading-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI =
   "refresh-preserve-ui" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI =
@@ -13,12 +19,22 @@ export function shouldSuppressLoadingBoundaries(mode: AppRscRenderMode): boolean
   );
 }
 
-export function shouldUsePreserveUiCacheVariant(mode: AppRscRenderMode): boolean {
+function shouldUsePreserveUiCacheVariant(mode: AppRscRenderMode): boolean {
   return shouldSuppressLoadingBoundaries(mode);
+}
+
+export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | null {
+  if (mode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL) {
+    return "prefetch-loading-shell";
+  }
+
+  return shouldUsePreserveUiCacheVariant(mode) ? "preserve-ui" : null;
 }
 
 export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
   switch (value) {
+    case APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL:
+      return APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
     case APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI:
       return APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI;
     case APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI:

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1008,7 +1008,11 @@ async function hydrate() {
   const root = hydrateRoot(document.getElementById("__next"), element);
   window.__VINEXT_ROOT__ = root;
   installPagesRouterRuntime();
-  window.__VINEXT_HYDRATED_AT = performance.now();
+  const hydratedAt = performance.now();
+  window.__VINEXT_HYDRATED_AT = hydratedAt;
+  window.__NEXT_HYDRATED = true;
+  window.__NEXT_HYDRATED_AT = hydratedAt;
+  window.__NEXT_HYDRATED_CB?.();
 }
 hydrate();
 </script>`;

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -26,7 +26,7 @@ import { reportRequestError, type OnRequestErrorContext } from "./instrumentatio
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
-  shouldUsePreserveUiCacheVariant,
+  getRscRenderModeCacheVariant,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
 import type { RenderObservation } from "./cache-proof.js";
@@ -236,7 +236,7 @@ export function appIsrHtmlKey(pathname: string): string {
  * Build the ISR cache key for an RSC payload.
  *
  * Note: the key format changed from `rsc:<hash>` to `rsc:slots:<hash>` (and
- * optionally `rsc:slots:<hash>:preserve-ui`). Existing cached entries under
+ * optionally `rsc:slots:<hash>:<render-mode-variant>`). Existing cached entries under
  * the old format will become unreachable after deployment. This is acceptable
  * because ISR entries have TTLs and will be regenerated on the next request.
  */
@@ -248,7 +248,7 @@ export function appIsrRscKey(
   const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
   const variant = [
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,
-    shouldUsePreserveUiCacheVariant(renderMode) ? "preserve-ui" : null,
+    getRscRenderModeCacheVariant(renderMode),
   ]
     .filter((part) => part !== null)
     .join(":");

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -27,14 +27,21 @@ import {
 // Import shared RSC prefetch utilities from navigation shim (relative path
 // so this resolves both via the Vite plugin and in direct vitest imports)
 import {
-  getCurrentInterceptionContext,
+  getPrefetchInterceptionContext,
+  getPrefetchCache,
   getPrefetchedUrls,
   getMountedSlotsHeader,
   navigateClientSide,
   prefetchRscResponse,
 } from "./navigation.js";
 import { AppElementsWire } from "../server/app-elements.js";
-import { createRscRequestHeaders, createRscRequestUrl } from "../server/app-rsc-cache-busting.js";
+import {
+  createRscRequestHeaders,
+  createRscRequestUrl,
+  stripRscCacheBustingSearchParam,
+  stripRscSuffix,
+} from "../server/app-rsc-cache-busting.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../server/app-rsc-render-mode.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
 import { isDangerousScheme, reportBlockedDangerousNavigation } from "./url-safety.js";
 import {
@@ -187,6 +194,35 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
   return !match.route.isDynamic;
 }
 
+export function resolveAutoAppRoutePrefetch(href: string): {
+  cacheForNavigation: boolean;
+  shouldPrefetch: boolean;
+} {
+  if (typeof window === "undefined") {
+    return { cacheForNavigation: false, shouldPrefetch: false };
+  }
+
+  const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
+  if (!routes) {
+    return { cacheForNavigation: false, shouldPrefetch: false };
+  }
+
+  const routeHref = toSameOriginRouteHref(href);
+  if (routeHref === null) {
+    return { cacheForNavigation: false, shouldPrefetch: false };
+  }
+
+  const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
+  if (!match) {
+    return { cacheForNavigation: false, shouldPrefetch: false };
+  }
+
+  return {
+    cacheForNavigation: !match.route.isDynamic,
+    shouldPrefetch: !match.route.isDynamic || match.route.canPrefetchLoadingShell,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Prefetching infrastructure
 // ---------------------------------------------------------------------------
@@ -218,16 +254,22 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
   schedule(() => {
     void (async () => {
       if (hasAppNavigationRuntime()) {
-        // `auto`/`null`/undefined should not behave like `prefetch={true}` for
-        // App Router dynamic routes. Next.js may prefetch a loading-boundary
-        // shell for dynamic routes, but vinext's current client cache stores
-        // complete RSC responses only; keep automatic full prefetch to route
-        // shapes that are statically known safe until segment prefetch exists.
-        if (mode === "auto" && !canAutoPrefetchFullAppRoute(prefetchHref)) return;
+        const autoPrefetch =
+          mode === "auto"
+            ? resolveAutoAppRoutePrefetch(prefetchHref)
+            : { cacheForNavigation: true, shouldPrefetch: true };
+        if (!autoPrefetch.shouldPrefetch) return;
 
-        const interceptionContext = getCurrentInterceptionContext();
+        const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
-        const headers = createRscRequestHeaders({ interceptionContext });
+        const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+        if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
+        const headers = createRscRequestHeaders({
+          interceptionContext,
+          renderMode: isOptimisticRouteShellPrefetch
+            ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
+            : undefined,
+        });
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
@@ -236,7 +278,15 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         const rscUrl = await createRscRequestUrl(fullHref, headers);
         const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
         const prefetched = getPrefetchedUrls();
-        if (prefetched.has(cacheKey)) return;
+        if (prefetched.has(cacheKey)) {
+          if (autoPrefetch.cacheForNavigation) {
+            const existing = getPrefetchCache().get(cacheKey);
+            if (existing?.cacheForNavigation === false) {
+              existing.cacheForNavigation = true;
+            }
+          }
+          return;
+        }
         prefetched.add(cacheKey);
         prefetchRscResponse(
           rscUrl,
@@ -249,6 +299,11 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           }),
           interceptionContext,
           mountedSlotsHeader,
+          undefined,
+          {
+            cacheForNavigation: autoPrefetch.cacheForNavigation,
+            optimisticRouteShell: isOptimisticRouteShellPrefetch,
+          },
         );
       } else if ((window.__NEXT_DATA__ as VinextNextData | undefined)?.__vinext?.pageModuleUrl) {
         // Pages Router: inject a prefetch link for the target page module
@@ -265,6 +320,36 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
       console.error("[vinext] RSC prefetch setup error:", error);
     });
   });
+}
+
+function promotePrefetchEntriesForNavigation(href: string): void {
+  if (typeof window === "undefined") return;
+
+  let target: URL;
+  try {
+    target = new URL(
+      toBrowserNavigationHref(href, window.location.href, __basePath),
+      window.location.href,
+    );
+  } catch {
+    return;
+  }
+
+  for (const [cacheKey, entry] of getPrefetchCache()) {
+    if (entry.optimisticRouteShell === true) continue;
+
+    const [rscUrl = ""] = cacheKey.split("\0", 1);
+    let cached: URL;
+    try {
+      cached = new URL(rscUrl, window.location.href);
+    } catch {
+      continue;
+    }
+    stripRscCacheBustingSearchParam(cached);
+    if (stripRscSuffix(cached.pathname) === target.pathname && cached.search === target.search) {
+      entry.cacheForNavigation = true;
+    }
+  }
 }
 
 /**
@@ -523,6 +608,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       if (instance) {
         instance.mode = "full";
       }
+      promotePrefetchEntriesForNavigation(normalizedHref);
     }
     prefetchUrl(normalizedHref, intentMode, "high");
   }, [prefetchProp, isDangerous, prefetchMode, normalizedHref, unstable_dynamicOnHover]);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -338,7 +338,7 @@ function promotePrefetchEntriesForNavigation(href: string): void {
   for (const [cacheKey, entry] of getPrefetchCache()) {
     if (entry.optimisticRouteShell === true) continue;
 
-    const [rscUrl = ""] = cacheKey.split("\0", 1);
+    const [rscUrl] = cacheKey.split("\0", 1);
     let cached: URL;
     try {
       cached = new URL(rscUrl, window.location.href);

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -14,6 +14,7 @@ import * as React from "react";
 import { getNavigationRuntime, hasAppNavigationRuntime } from "../client/navigation-runtime.js";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import { AppElementsWire } from "../server/app-elements.js";
+import { resolveManifestNavigationInterceptionContext } from "../server/app-browser-interception-context.js";
 import { createExternalHistoryStatePreservingMetadata } from "../server/app-history-state.js";
 import {
   createRscRequestHeaders,
@@ -350,8 +351,10 @@ export type PrefetchOptions = {
 };
 
 export type PrefetchCacheEntry = {
+  cacheForNavigation?: boolean;
   invalidationTimer?: ReturnType<typeof setTimeout>;
   onInvalidateCallbacks?: Set<() => void>;
+  optimisticRouteShell?: boolean;
   outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
   pending?: Promise<void>;
@@ -364,6 +367,26 @@ export function getCurrentInterceptionContext(): string | null {
   }
 
   return stripBasePath(window.location.pathname, __basePath);
+}
+
+export function getPrefetchInterceptionContext(targetHref: string): string | null {
+  if (isServer) {
+    return null;
+  }
+
+  let targetUrl: URL;
+  try {
+    targetUrl = new URL(targetHref, window.location.href);
+  } catch {
+    return null;
+  }
+
+  return resolveManifestNavigationInterceptionContext({
+    basePath: __basePath,
+    currentPathname: window.location.pathname,
+    routeManifest: getNavigationRuntime()?.bootstrap.routeManifest ?? null,
+    targetPathname: targetUrl.pathname,
+  });
 }
 
 export function getCurrentNextUrl(): string {
@@ -640,6 +663,7 @@ export function prefetchRscResponse(
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
   options?: PrefetchOptions,
+  behavior: { cacheForNavigation?: boolean; optimisticRouteShell?: boolean } = {},
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
@@ -647,6 +671,8 @@ export function prefetchRscResponse(
   const now = Date.now();
 
   const entry: PrefetchCacheEntry = {
+    cacheForNavigation: behavior.cacheForNavigation ?? true,
+    optimisticRouteShell: behavior.optimisticRouteShell === true,
     outcome: "pending",
     timestamp: now,
   };
@@ -701,6 +727,7 @@ export function consumePrefetchResponse(
   // Skip in-flight snapshots and error-path residue where pending cleared
   // without a successful transition to a cache-seeded entry.
   if (entry.pending || entry.outcome !== "cache-seeded") return null;
+  if (entry.cacheForNavigation === false) return null;
 
   deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, false);
 
@@ -1499,7 +1526,7 @@ const _appRouter = {
       // We must add to prefetchedUrls manually for deduplication.
       // prefetchRscResponse only manages the cache Map, not the URL set.
       const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
-      const interceptionContext = getCurrentInterceptionContext();
+      const interceptionContext = getPrefetchInterceptionContext(fullHref);
       const mountedSlotsHeader = getMountedSlotsHeader();
       const headers = createRscRequestHeaders({ interceptionContext });
       if (mountedSlotsHeader) {

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -233,8 +233,10 @@ declare module "next/navigation" {
     url: string;
   };
   export type PrefetchCacheEntry = {
+    cacheForNavigation?: boolean;
     invalidationTimer?: ReturnType<typeof setTimeout>;
     onInvalidateCallbacks?: Set<() => void>;
+    optimisticRouteShell?: boolean;
     outcome: "pending" | "cache-seeded";
     snapshot?: CachedRscResponse;
     pending?: Promise<void>;
@@ -242,6 +244,7 @@ declare module "next/navigation" {
   };
   export const MAX_PREFETCH_CACHE_SIZE: number;
   export const PREFETCH_CACHE_TTL: number;
+  export function getPrefetchInterceptionContext(targetHref: string): string | null;
   export function getPrefetchCache(): Map<string, PrefetchCacheEntry>;
   export function getPrefetchedUrls(): Set<string>;
   export function invalidatePrefetchCache(): void;
@@ -258,6 +261,8 @@ declare module "next/navigation" {
     fetchPromise: Promise<Response>,
     interceptionContext?: string | null,
     mountedSlotsHeader?: string | null,
+    options?: { onInvalidate?: () => void },
+    behavior?: { cacheForNavigation?: boolean; optimisticRouteShell?: boolean },
   ): void;
   export function consumePrefetchResponse(
     rscUrl: string,

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createElement, Suspense } from "react";
+import {
+  AppElementsWire,
+  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
+  type AppElements,
+} from "../packages/vinext/src/server/app-elements.js";
+import {
+  createOptimisticRouteElements,
+  createOptimisticRouteTemplate,
+  getOptimisticPrefetchSourceKey,
+  getOptimisticRouteTemplateKey,
+  matchOptimisticRouteManifestRoute,
+  resolveOptimisticNavigationPayload,
+  type OptimisticRouteTemplate,
+} from "../packages/vinext/src/server/app-optimistic-routing.js";
+import type {
+  GraphVersion,
+  RouteManifest,
+  RouteManifestRoute,
+} from "../packages/vinext/src/routing/app-route-graph.js";
+
+function route(input: {
+  id: string;
+  isDynamic: boolean;
+  paramNames?: readonly string[];
+  pattern: string;
+  patternParts: readonly string[];
+}): RouteManifestRoute {
+  return {
+    id: input.id,
+    isDynamic: input.isDynamic,
+    layoutIds: ["layout:/"],
+    pageId: `page:${input.pattern}`,
+    paramNames: [...(input.paramNames ?? [])],
+    pattern: input.pattern,
+    patternParts: [...input.patternParts],
+    rootBoundaryId: null,
+    rootParamNames: [],
+    routeHandlerId: null,
+    slotIds: [],
+    templateIds: [],
+  };
+}
+
+function manifest(routes: readonly RouteManifestRoute[]): RouteManifest {
+  return {
+    graphVersion: "graph:test" as GraphVersion,
+    segmentGraph: {
+      boundaries: new Map(),
+      defaults: new Map(),
+      interceptions: new Map(),
+      interceptionsBySlotId: new Map(),
+      layouts: new Map(),
+      pages: new Map(),
+      rootBoundaries: new Map(),
+      routeHandlers: new Map(),
+      routes: new Map(routes.map((entry) => [entry.id, entry])),
+      slotBindings: new Map(),
+      slots: new Map(),
+      templates: new Map(),
+    },
+  };
+}
+
+function blogManifest(): RouteManifest {
+  return manifest([
+    route({
+      id: "route:/blog/featured",
+      isDynamic: false,
+      pattern: "/blog/featured",
+      patternParts: ["blog", "featured"],
+    }),
+    route({
+      id: "route:/blog/:slug",
+      isDynamic: true,
+      paramNames: ["slug"],
+      pattern: "/blog/:slug",
+      patternParts: ["blog", ":slug"],
+    }),
+  ]);
+}
+
+function dashboardManifestWithoutProfile(): RouteManifest {
+  return manifest([
+    route({
+      id: "route:/dashboard/settings",
+      isDynamic: false,
+      pattern: "/dashboard/settings",
+      patternParts: ["dashboard", "settings"],
+    }),
+    route({
+      id: "route:/dashboard/:catchall+",
+      isDynamic: true,
+      paramNames: ["catchall"],
+      pattern: "/dashboard/:catchall+",
+      patternParts: ["dashboard", ":catchall+"],
+    }),
+  ]);
+}
+
+function createBlogElements(): AppElements {
+  const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+  const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+  return {
+    ...AppElementsWire.createMetadataEntries({
+      interceptionContext: null,
+      layoutIds: ["layout:/"],
+      rootLayoutTreePath: "/",
+      routeId,
+    }),
+    [pageId]: createElement("article", null, "Post 1"),
+    [routeId]: createElement(
+      Suspense,
+      { fallback: createElement("p", { id: "loading-message" }, "Loading...") },
+      createElement("main", null, "Page slot"),
+    ),
+  };
+}
+
+function createBlogLoadingShellElements(): AppElements {
+  const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+  const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+  return {
+    ...AppElementsWire.createMetadataEntries({
+      interceptionContext: null,
+      layoutIds: ["layout:/"],
+      rootLayoutTreePath: "/",
+      routeId,
+    }),
+    [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+    [pageId]: null,
+    [routeId]: createElement("p", { id: "loading-message" }, "Loading post-1..."),
+  };
+}
+
+describe("App Router optimistic routing", () => {
+  it("matches dynamic route params while keeping static siblings authoritative", () => {
+    const routes = blogManifest();
+
+    expect(
+      matchOptimisticRouteManifestRoute({
+        basePath: "",
+        href: "/blog/post-1.rsc?_rsc=abc",
+        routeManifest: routes,
+      }),
+    ).toMatchObject({
+      params: { slug: "post-1" },
+      route: { id: "route:/blog/:slug" },
+    });
+
+    expect(
+      matchOptimisticRouteManifestRoute({
+        basePath: "",
+        href: "/blog/featured",
+        routeManifest: routes,
+      })?.route.id,
+    ).toBe("route:/blog/featured");
+  });
+
+  it("does not fall through from a known static subtree to a catch-all sibling", () => {
+    expect(
+      matchOptimisticRouteManifestRoute({
+        basePath: "",
+        href: "/dashboard/settings/profile",
+        routeManifest: dashboardManifestWithoutProfile(),
+      }),
+    ).toBeNull();
+  });
+
+  it("creates loading-only optimistic elements from a learned dynamic route template", () => {
+    const routeManifest = blogManifest();
+    const elements = createBlogElements();
+    const template = createOptimisticRouteTemplate({
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc?_rsc=abc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    expect(template).toMatchObject<Partial<OptimisticRouteTemplate>>({
+      routeId: "route:/blog/:slug",
+    });
+    if (template === null) {
+      throw new Error("Expected optimistic route template");
+    }
+
+    const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+    const optimisticElements = createOptimisticRouteElements(template);
+    expect(optimisticElements[pageId]).not.toBe(elements[pageId]);
+
+    const navigationPayload = resolveOptimisticNavigationPayload({
+      basePath: "",
+      href: "/blog/post-2",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+      templates: new Map([
+        [
+          getOptimisticRouteTemplateKey({
+            interceptionContext: null,
+            mountedSlotsHeader: null,
+            routeId: template.routeId,
+          }),
+          template,
+        ],
+      ]),
+    });
+
+    expect(navigationPayload?.params).toEqual({ slug: "post-2" });
+    expect(navigationPayload?.elements[pageId]).not.toBe(elements[pageId]);
+  });
+
+  it("does not learn routes without a loading boundary", () => {
+    const routeManifest = blogManifest();
+    const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+    const elements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: ["layout:/"],
+        rootLayoutTreePath: "/",
+        routeId,
+      }),
+      [routeId]: createElement("main", null, "No loading boundary"),
+    };
+
+    expect(
+      createOptimisticRouteTemplate({
+        basePath: "",
+        elements,
+        href: "/blog/post-1.rsc",
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+      }),
+    ).toBeNull();
+
+    expect(
+      createOptimisticRouteTemplate({
+        allowLoadingShell: true,
+        basePath: "",
+        elements: { ...elements, [routeId]: null },
+        href: "/blog/post-1.rsc",
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+      }),
+    ).toBeNull();
+
+    expect(
+      createOptimisticRouteTemplate({
+        allowLoadingShell: true,
+        basePath: "",
+        elements: { ...elements, [AppElementsWire.encodePageId("/blog/post-1", null)]: null },
+        href: "/blog/post-1.rsc",
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+      }),
+    ).toBeNull();
+  });
+
+  it("learns dynamic route templates from loading-shell prefetch payloads only when allowed", () => {
+    const routeManifest = blogManifest();
+    const elements = createBlogLoadingShellElements();
+
+    expect(
+      createOptimisticRouteTemplate({
+        basePath: "",
+        elements,
+        href: "/blog/post-1.rsc",
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+      }),
+    ).toBeNull();
+
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    expect(template).toMatchObject<Partial<OptimisticRouteTemplate>>({
+      pageElementIds: [AppElementsWire.encodePageId("/blog/post-1", null)],
+      routeId: "route:/blog/:slug",
+    });
+  });
+
+  it("keeps learned templates distinct across mounted slot headers", () => {
+    const routeManifest = blogManifest();
+    const slotATemplate = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements: createBlogLoadingShellElements(),
+      href: "/blog/post-1.rsc",
+      interceptionContext: null,
+      mountedSlotsHeader: "modal",
+      routeManifest,
+    });
+    const slotBTemplate = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements: createBlogLoadingShellElements(),
+      href: "/blog/post-2.rsc",
+      interceptionContext: null,
+      mountedSlotsHeader: "drawer",
+      routeManifest,
+    });
+
+    if (slotATemplate === null || slotBTemplate === null) {
+      throw new Error("Expected optimistic route templates");
+    }
+
+    const templates = new Map([
+      [
+        getOptimisticRouteTemplateKey({
+          interceptionContext: null,
+          mountedSlotsHeader: "modal",
+          routeId: slotATemplate.routeId,
+        }),
+        slotATemplate,
+      ],
+      [
+        getOptimisticRouteTemplateKey({
+          interceptionContext: null,
+          mountedSlotsHeader: "drawer",
+          routeId: slotBTemplate.routeId,
+        }),
+        slotBTemplate,
+      ],
+    ]);
+
+    expect(
+      resolveOptimisticNavigationPayload({
+        basePath: "",
+        href: "/blog/post-3",
+        interceptionContext: null,
+        mountedSlotsHeader: "modal",
+        routeManifest,
+        templates,
+      })?.template,
+    ).toBe(slotATemplate);
+    expect(
+      resolveOptimisticNavigationPayload({
+        basePath: "",
+        href: "/blog/post-3",
+        interceptionContext: null,
+        mountedSlotsHeader: "drawer",
+        routeManifest,
+        templates,
+      })?.template,
+    ).toBe(slotBTemplate);
+  });
+
+  it("scopes prefetch source learning by current router context", () => {
+    const cacheKey = "/blog/post-1.rsc\0/feed";
+
+    expect(
+      getOptimisticPrefetchSourceKey({
+        cacheKey,
+        interceptionContext: "/feed",
+        mountedSlotsHeader: "modal",
+      }),
+    ).not.toBe(
+      getOptimisticPrefetchSourceKey({
+        cacheKey,
+        interceptionContext: "/gallery",
+        mountedSlotsHeader: "modal",
+      }),
+    );
+    expect(
+      getOptimisticPrefetchSourceKey({
+        cacheKey,
+        interceptionContext: "/feed",
+        mountedSlotsHeader: "modal",
+      }),
+    ).not.toBe(
+      getOptimisticPrefetchSourceKey({
+        cacheKey,
+        interceptionContext: "/feed",
+        mountedSlotsHeader: "drawer",
+      }),
+    );
+  });
+
+  it("does not learn or resolve optimistic payloads for intercepted contexts", () => {
+    const routeManifest = blogManifest();
+    const elements = createBlogLoadingShellElements();
+
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc",
+      interceptionContext: "/feed",
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    expect(template).toBeNull();
+    expect(
+      resolveOptimisticNavigationPayload({
+        basePath: "",
+        href: "/blog/post-2",
+        interceptionContext: "/feed",
+        mountedSlotsHeader: null,
+        routeManifest,
+        templates: new Map(),
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -2,6 +2,7 @@ import { Fragment, createElement, isValidElement, type ReactElement, type ReactN
 import { describe, expect, it } from "vite-plus/test";
 import { useSelectedLayoutSegments } from "../packages/vinext/src/shims/navigation.js";
 import {
+  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
   APP_SLOT_BINDINGS_KEY,
   APP_UNMATCHED_SLOT_WIRE_VALUE,
   type AppElements,
@@ -14,7 +15,10 @@ import {
   createAppPageLayoutEntries,
   resolveAppPageChildSegments,
 } from "../packages/vinext/src/server/app-page-route-wiring.js";
-import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
 
 function readNode(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -447,6 +451,73 @@ describe("app page route wiring helpers", () => {
 
     expect(containsElementType(elements["route:/dashboard"], RouteLoadingProbe)).toBe(false);
     expect(containsElementType(elements["slot:sidebar:/"], SlotLoadingProbe)).toBe(false);
+  });
+
+  it("serializes route loading UI instead of page content for loading-shell prefetches", async () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: { default: RouteLoadingProbe },
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard"],
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+
+    expect(elements["page:/dashboard"]).toBeNull();
+    expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBe("LoadingBoundary");
+    const html = await renderRouteEntry(elements, "route:/dashboard");
+
+    expect(html).toContain("Route loading");
+    expect(html).not.toContain("Page");
+  });
+
+  it("does not render page content for loading-shell prefetches without a route loading boundary", async () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard"],
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+
+    expect(elements["page:/dashboard"]).toBeNull();
+    expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBeUndefined();
+    const html = await renderRouteEntry(elements, "route:/dashboard");
+
+    expect(html).not.toContain("Page");
   });
 
   it("uses override params for slot segment maps when an override page is active", async () => {

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -13,7 +13,10 @@ import {
   VINEXT_RSC_RENDER_MODE_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
-import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { fnv1a64 } from "../packages/vinext/src/utils/hash.js";
 import { withEnvVar } from "./env-test-helpers.js";
 
@@ -75,6 +78,16 @@ describe("App Router RSC cache-busting", () => {
 
     expect(navigationHash).toBe("");
     expect(refreshHash).not.toBe("");
+  });
+
+  it("varies loading-shell prefetch payloads from normal navigations", async () => {
+    const navigationHash = await computeRscCacheBustingSearchParam(createRscRequestHeaders());
+    const prefetchShellHash = await computeRscCacheBustingSearchParam(
+      createRscRequestHeaders({ renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL }),
+    );
+
+    expect(navigationHash).toBe("");
+    expect(prefetchShellHash).not.toBe("");
   });
 
   it("normalizes invalid render modes to normal navigation for cache-busting", async () => {

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -20,6 +20,7 @@ import {
 import { VINEXT_RSC_RENDER_MODE_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
 } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 
@@ -322,6 +323,14 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
     const normal = normalized(
       normalizeRscRequest(req("/page.rsc", { [VINEXT_RSC_RENDER_MODE_HEADER]: "true" }), ""),
     );
+    const prefetchShell = normalized(
+      normalizeRscRequest(
+        req("/page.rsc", {
+          [VINEXT_RSC_RENDER_MODE_HEADER]: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+        }),
+        "",
+      ),
+    );
     const html = normalized(
       normalizeRscRequest(
         req("/page", { [VINEXT_RSC_RENDER_MODE_HEADER]: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI }),
@@ -330,6 +339,7 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
     );
 
     expect(refresh.renderMode).toBe(APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI);
+    expect(prefetchShell.renderMode).toBe(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
     expect(normal.renderMode).toBe(APP_RSC_RENDER_MODE_NAVIGATION);
     expect(html.renderMode).toBe(APP_RSC_RENDER_MODE_NAVIGATION);
   });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -145,6 +145,29 @@ describe("App Router generated manifest construction", () => {
         params: [],
       },
       {
+        pattern: "/docs/:slug",
+        patternParts: ["docs", ":slug"],
+        pagePath: "/tmp/test/app/docs/[slug]/page.tsx",
+        routePath: null,
+        layouts: ["/tmp/test/app/layout.tsx"],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: "/tmp/test/app/docs/[slug]/loading.tsx",
+        errorPath: null,
+        layoutErrorPaths: [null],
+        notFoundPath: null,
+        notFoundPaths: [null],
+        forbiddenPaths: [null],
+        forbiddenPath: null,
+        unauthorizedPaths: [null],
+        unauthorizedPath: null,
+        routeSegments: ["docs", ":slug"],
+        templateTreePositions: [],
+        layoutTreePositions: [0],
+        isDynamic: true,
+        params: ["slug"],
+      },
+      {
         pattern: "/api",
         patternParts: ["api"],
         pagePath: null,
@@ -173,10 +196,21 @@ describe("App Router generated manifest construction", () => {
     expect(code).toContain("window.__VINEXT_LINK_PREFETCH_ROUTES__ = ");
     expect(code).toContain("registerNavigationRuntimeBootstrap({");
     expect(code).toContain("routeManifest: null");
-    expect(code).toContain('{"patternParts":["about"],"isDynamic":false}');
-    expect(code).toContain('{"patternParts":["blog",":slug"],"isDynamic":true}');
-    expect(code).toContain('{"patternParts":["modal-host"],"isDynamic":false}');
-    expect(code).not.toContain('{"patternParts":["api"],"isDynamic":false}');
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["about"],"isDynamic":false}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["blog",":slug"],"isDynamic":true}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["modal-host"],"isDynamic":false}',
+    );
+    expect(code).not.toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["api"],"isDynamic":false}',
+    );
   });
 
   it("embeds the RouteManifest read model in the browser entry", async () => {

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -23,7 +23,10 @@ import {
   getRevalidateDuration,
   triggerBackgroundRegeneration,
 } from "../packages/vinext/src/server/isr-cache.js";
-import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { buildPageCacheTags } from "../packages/vinext/src/server/implicit-tags.js";
 import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
 import {
@@ -168,6 +171,17 @@ describe("App Router ISR cache key primitives", () => {
     );
     expect(appIsrRscKey("/feed", "modal", APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI)).toMatch(
       /^app:\/feed:rsc:slots:[a-z0-9]+:preserve-ui$/,
+    );
+  });
+
+  it("keys RSC loading-shell prefetch variants separately from normal navigation variants", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    expect(appIsrRscKey("/feed", null, APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL)).toBe(
+      "app:/feed:rsc:prefetch-loading-shell",
+    );
+    expect(appIsrRscKey("/feed", "modal", APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL)).toMatch(
+      /^app:\/feed:rsc:slots:[a-z0-9]+:prefetch-loading-shell$/,
     );
   });
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -8,6 +8,8 @@ import {
   type LinkPrefetchDecision,
   type LinkPrefetchRouterMode,
 } from "../packages/vinext/src/shims/link-prefetch.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import { VINEXT_RSC_RENDER_MODE_HEADER } from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
 
 type CapturedEffect = () => void | (() => void);
@@ -39,11 +41,16 @@ type CapturedPrefetchLinkElement = {
 };
 
 const linkPrefetchRoutes = [
-  { patternParts: ["viewport-prefetch-target"], isDynamic: false },
-  { patternParts: ["intent-prefetch-target"], isDynamic: false },
-  { patternParts: ["touch-prefetch-target"], isDynamic: false },
-  { patternParts: ["same-origin-intent-prefetch-target"], isDynamic: false },
-  { patternParts: ["blog", ":slug"], isDynamic: true },
+  { canPrefetchLoadingShell: false, patternParts: ["viewport-prefetch-target"], isDynamic: false },
+  { canPrefetchLoadingShell: false, patternParts: ["intent-prefetch-target"], isDynamic: false },
+  { canPrefetchLoadingShell: false, patternParts: ["touch-prefetch-target"], isDynamic: false },
+  {
+    canPrefetchLoadingShell: false,
+    patternParts: ["same-origin-intent-prefetch-target"],
+    isDynamic: false,
+  },
+  { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+  { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
 ] satisfies VinextLinkPrefetchRoute[];
 
 function createTestNavigationRuntime(navigate: unknown) {
@@ -163,11 +170,26 @@ function mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE(
 
 async function flushPrefetchTasks(): Promise<void> {
   // requestIdleCallback is mocked as sync, then prefetchUrl enters an async
-  // IIFE with one awaited createRscRequestUrl call. These ticks drain the
-  // current chain; update this helper if the async depth grows.
+  // IIFE with awaited request-header hashing and cache writes. These ticks
+  // drain the current chain; update this helper if the async depth grows.
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function waitForFetchCalls(
+  fetch: { mock: { calls: unknown[] } },
+  expectedCalls: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await flushPrefetchTasks();
+    if (fetch.mock.calls.length >= expectedCalls) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 describe("Link prefetch pure decisions", () => {
@@ -835,7 +857,9 @@ async function renderIsolatedLink(options: {
     },
   });
 
-  const fetch = vi.fn(() => Promise.resolve(new Response("")));
+  const fetch = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+    Promise.resolve(new Response("")),
+  );
   const navigate = vi.fn();
   const pagePrefetchLinks: CapturedPrefetchLinkElement[] = [];
   const location = {
@@ -976,7 +1000,7 @@ describe("Link prefetch scheduling", () => {
     try {
       expect(observer.observe).toHaveBeenCalledWith(result.anchor);
       observer.dispatchIntersectingEntry(result.anchor);
-      await flushPrefetchTasks();
+      await waitForFetchCalls(result.fetch, 1);
 
       expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
       expect(result.fetch).toHaveBeenCalledWith(
@@ -1021,7 +1045,7 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("does not full-prefetch visible dynamic links in automatic production mode", async () => {
+  it("prefetches visible dynamic links in automatic production mode without seeding navigation cache", async () => {
     const observer = stubIntersectionObserver();
 
     const result = await renderIsolatedLink({
@@ -1032,9 +1056,42 @@ describe("Link prefetch scheduling", () => {
     try {
       expect(observer.observe).toHaveBeenCalledWith(result.anchor);
       observer.dispatchIntersectingEntry(result.anchor);
-      await flushPrefetchTasks();
+      await waitForFetchCalls(result.fetch, 1);
 
       expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
+      expect(result.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/blog/hello.rsc"),
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(false);
+      expect(entry?.optimisticRouteShell).toBe(true);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not auto-prefetch dynamic links without a loading shell boundary", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/products/1",
+      nodeEnv: "production",
+    });
+
+    try {
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
       expect(result.fetch).not.toHaveBeenCalled();
     } finally {
       result.restoreNodeEnv();
@@ -1063,6 +1120,10 @@ describe("Link prefetch scheduling", () => {
           priority: "low",
         }),
       );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect(
+        (fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+      ).toBeNull();
     } finally {
       result.restoreNodeEnv();
     }
@@ -1169,24 +1230,36 @@ describe("Link prefetch scheduling", () => {
 
     try {
       observer.dispatchIntersectingEntry(result.anchor);
-      await flushPrefetchTasks();
-      expect(result.fetch).not.toHaveBeenCalled();
-
-      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
-      await flushPrefetchTasks();
-
+      await waitForFetchCalls(result.fetch, 1);
       expect(result.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/blog/hello.rsc"),
         expect.objectContaining({
           credentials: "include",
-          priority: "high",
+          priority: "low",
         }),
       );
 
-      invalidatePrefetchCache();
-      await flushPrefetchTasks();
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await waitForFetchCalls(result.fetch, 2);
 
       expect(result.fetch).toHaveBeenCalledTimes(2);
+      const hoverFetchInit = result.fetch.mock.calls[1]?.[1] as RequestInit | undefined;
+      expect(
+        (hoverFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+      ).toBeNull();
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entries = Array.from(getPrefetchCache().values());
+      expect(entries.some((entry) => entry.optimisticRouteShell === true)).toBe(true);
+      expect(
+        entries.some(
+          (entry) => entry.cacheForNavigation === true && entry.optimisticRouteShell !== true,
+        ),
+      ).toBe(true);
+
+      invalidatePrefetchCache();
+      await waitForFetchCalls(result.fetch, 3);
+
+      expect(result.fetch).toHaveBeenCalledTimes(3);
       expect(result.fetch).toHaveBeenLastCalledWith(
         expect.stringContaining("/blog/hello.rsc"),
         expect.objectContaining({

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -17,6 +17,7 @@ import ReactDOMServer from "react-dom/server";
 // Link is a "use client" component but renderToString still works for SSR output.
 import Link, {
   canAutoPrefetchFullAppRoute,
+  resolveAutoAppRoutePrefetch,
   resolveLinkPrefetchMode,
   useLinkStatus,
 } from "../packages/vinext/src/shims/link.js";
@@ -169,9 +170,9 @@ describe("Link App Router prefetch mode", () => {
         origin: "http://localhost",
       },
       __VINEXT_LINK_PREFETCH_ROUTES__: [
-        { patternParts: ["about"], isDynamic: false },
-        { patternParts: ["blog", ":slug"], isDynamic: true },
-        { patternParts: ["docs", ":slug+"], isDynamic: true },
+        { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+        { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+        { canPrefetchLoadingShell: true, patternParts: ["docs", ":slug+"], isDynamic: true },
       ],
     };
 
@@ -180,6 +181,46 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = originalWindow;
+      }
+    }
+  });
+
+  it("allows automatic dynamic App Router prefetches only as loading-boundary learning requests", () => {
+    const originalWindow = globalThis.window;
+    (globalThis as any).window = {
+      location: {
+        href: "http://localhost/blog",
+        origin: "http://localhost",
+      },
+      __VINEXT_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+        { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+        { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
+      ],
+    };
+
+    try {
+      expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
+        cacheForNavigation: true,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
+        cacheForNavigation: false,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
+        cacheForNavigation: false,
+        shouldPrefetch: false,
+      });
+      expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
+        cacheForNavigation: false,
+        shouldPrefetch: false,
+      });
     } finally {
       if (originalWindow === undefined) {
         delete (globalThis as any).window;

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -120,7 +120,7 @@ describe("prefetch cache eviction", () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetchedUrl).toMatch(/^\/dashboard\.rsc\?tab=1&_rsc(?:=.+)?$/);
-    expect(getPrefetchedUrls().has(AppElementsWire.encodeCacheKey(String(fetchedUrl), "/"))).toBe(
+    expect(getPrefetchedUrls().has(AppElementsWire.encodeCacheKey(String(fetchedUrl), null))).toBe(
       true,
     );
   });
@@ -137,7 +137,7 @@ describe("prefetch cache eviction", () => {
     appRouterInstance.prefetch("/dashboard", { onInvalidate });
     await waitForPrefetchSetup(() => getPrefetchCache().size > 0);
 
-    const cacheKey = AppElementsWire.encodeCacheKey(String(fetchedUrl), "/");
+    const cacheKey = AppElementsWire.encodeCacheKey(String(fetchedUrl), null);
     expect(getPrefetchedUrls().has(cacheKey)).toBe(true);
 
     invalidatePrefetchCache();
@@ -217,6 +217,30 @@ describe("prefetch cache eviction", () => {
     expect(prefetched.has(rscUrl)).toBe(false);
   });
 
+  it("keeps learning-only prefetch responses out of navigation consumption", () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const rscUrl = "/blog/hello.rsc";
+
+    cache.set(rscUrl, {
+      cacheForNavigation: false,
+      outcome: "cache-seeded",
+      snapshot: {
+        buffer: new TextEncoder().encode("flight").buffer,
+        contentType: "text/x-component",
+        mountedSlotsHeader: null,
+        paramsHeader: null,
+        url: rscUrl,
+      },
+      timestamp: Date.now(),
+    });
+    prefetched.add(rscUrl);
+
+    expect(consumePrefetchResponse(rscUrl, null, null)).toBeNull();
+    expect(cache.has(rscUrl)).toBe(true);
+    expect(prefetched.has(rscUrl)).toBe(true);
+  });
+
   it("derives the interception context from the current pathname", () => {
     (globalThis as any).window.location.pathname = "/feed";
 
@@ -287,7 +311,7 @@ describe("prefetch cache eviction", () => {
         : fetchedUrl instanceof URL
           ? fetchedUrl.href
           : fetchedUrl.url;
-    const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, "/");
+    const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, null);
 
     expect(getPrefetchCache().get(cacheKey)?.outcome).toBe("pending");
 
@@ -302,7 +326,7 @@ describe("prefetch cache eviction", () => {
     expect(entry?.outcome).toBe("cache-seeded");
     expect(entry?.pending).toBeUndefined();
 
-    const consumed = consumePrefetchResponse(rscUrl, "/", null);
+    const consumed = consumePrefetchResponse(rscUrl, null, null);
     expect(consumed?.mountedSlotsHeader).toBeNull();
     expect(getPrefetchCache().has(cacheKey)).toBe(false);
     expect(getPrefetchedUrls().has(cacheKey)).toBe(false);


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Fix App Router optimistic routing for dynamic routes with loading boundaries. |
| Core change | Auto-prefetch dynamic app routes as loading-shell learning requests, then reuse learned shells for immediate client-side navigation while the full RSC payload is fetched. |
| Main boundary | Loading-shell prefetch data is never promoted into the normal navigation cache and uses a separate RSC cache variant. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/server/app-browser-entry.ts`, `packages/vinext/src/server/app-optimistic-routing.ts`, `packages/vinext/src/server/app-page-route-wiring.tsx` |
| Expected impact | Resolves the optimistic-routing deploy-suite failures tracked in #1360 without changing static-route full prefetch semantics. |

Fixes #1360.

## Why

For App Router dynamic routes, automatic prefetch should be cheap but still useful: it should learn and cache the reusable loading shell, then navigation can commit that shell immediately while real route data is fetched. Vinext previously skipped automatic dynamic-route prefetch, so unprefetched dynamic navigations waited for the full RSC response before showing the expected loading UI.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Link prefetch | `prefetch="auto"` may prefetch dynamic routes only up to the nearest `loading` boundary. | Dynamic auto-prefetch now requests a loading-shell render mode instead of skipping the route. |
| Client router | Learned loading shells can be reused optimistically only for matching route templates, interception context, and mounted slots. | Adds typed route-template matching and detached optimistic payload commits. |
| RSC payload cache | Shell-only prefetch responses must not poison full navigation cache entries. | Keeps shell prefetches out of navigation consumption and adds a separate render-mode cache variant. |
| Server wiring | Loading-shell prefetch should serialize the loading boundary, not the full page content. | Adds `prefetch-loading-shell` render mode and page-element suppression for that mode. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| Viewport auto-prefetch for static app route | Full navigation-cacheable RSC prefetch. | Same behavior. |
| Viewport auto-prefetch for dynamic app route with `loading.tsx` | No useful dynamic-route shell learning. | Loading-shell prefetch that is learning-only and cache-isolated. |
| Navigation to a matching dynamic sibling | Waited for the fresh RSC response before committing UI. | Immediately commits learned loading shell, then replaces it with the final payload. |
| Explicit `prefetch={true}` | Full prefetch. | Still full prefetch, no shell-only render header. |
| Routes without loading boundary | No optimistic shell. | Still no optimistic shell. |
| Static subtree beside catch-all routes | Could be easy to overmatch if implemented naively. | Static children remain authoritative and do not fall through to catch-all siblings. |

<details>
<summary>Maintainer Review Path</summary>

1. `packages/vinext/src/server/app-optimistic-routing.ts` for route manifest matching, learned template validation, and optimistic element construction.
2. `packages/vinext/src/shims/link.tsx` and `packages/vinext/src/shims/navigation.ts` for prefetch classification, shell learning entries, and navigation-context cache keys.
3. `packages/vinext/src/server/app-browser-entry.ts` for learning settled shell prefetches and committing detached optimistic navigation payloads.
4. `packages/vinext/src/server/app-page-route-wiring.tsx`, `packages/vinext/src/server/app-rsc-render-mode.ts`, and `packages/vinext/src/server/isr-cache.ts` for shell-only server rendering and cache isolation.
5. `packages/vinext/src/entries/pages-client-entry.ts`, `packages/vinext/src/server/dev-server.ts`, and `packages/vinext/src/global.d.ts` for Next-compatible hydration globals used by the upstream test harness.

</details>

<details>
<summary>Validation</summary>

Ran locally:

```sh
vp test run tests/app-optimistic-routing.test.ts tests/app-page-route-wiring.test.ts tests/entry-templates.test.ts tests/link.test.ts tests/link-navigation.test.ts tests/prefetch-cache.test.ts tests/app-rsc-cache-busting.test.ts tests/app-rsc-request-normalization.test.ts tests/isr-cache.test.ts
```

Result: 9 files passed, 330 tests passed.

```sh
vp check packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/server/app-optimistic-routing.ts packages/vinext/src/server/app-page-route-wiring.tsx packages/vinext/src/server/app-rsc-render-mode.ts packages/vinext/src/server/dev-server.ts packages/vinext/src/server/isr-cache.ts packages/vinext/src/shims/link.tsx packages/vinext/src/shims/navigation.ts packages/vinext/src/shims/next-shims.d.ts packages/vinext/src/global.d.ts packages/vinext/src/entries/pages-client-entry.ts tests/app-optimistic-routing.test.ts tests/app-page-route-wiring.test.ts tests/app-rsc-cache-busting.test.ts tests/app-rsc-request-normalization.test.ts tests/isr-cache.test.ts tests/link-navigation.test.ts tests/link.test.ts tests/prefetch-cache.test.ts
```

Result: formatting, lint, and typecheck passed.

```sh
vp run vinext#build
```

Result: passed. The package build still prints the existing expected virtual-module externalization warnings.

```sh
PATH="/Users/nathan/.vite-plus/js_runtime/node/24.16.0/bin:$PATH" VINEXT_BUILD=0 NEXTJS_PREPARE=0 NEXT_EXTERNAL_TESTS_FILTERS=/tmp/vinext-optimistic-routing-manifest.json NEXT_TEST_CONCURRENCY=1 ./scripts/run-nextjs-deploy-suite.sh /tmp/nextjs-v16.2.6 --retries 0 -c 1
```

Result: `test/e2e/app-dir/optimistic-routing/optimistic-routing.test.ts` passed on retry 0/0 and the wrapper exited 0.

Commit hook also passed generated-entry snapshots, `vp check --fix`, and `knip` before commit.

</details>

<details>
<summary>Risk / Compatibility</summary>

| Surface | Risk handling |
| --- | --- |
| Public API | No new public API. Internal shim types were extended for prefetch metadata. |
| Static route prefetch | Covered by existing and updated Link tests to remain full and navigation-cacheable. |
| Dynamic route prefetch | Covered by unit tests for shell-only render headers, learning-only cache entries, and explicit full prefetch. |
| Cache correctness | Loading-shell render mode gets a separate RSC/ISR cache variant and cannot be consumed as a normal navigation prefetch. |
| Interception and parallel slots | Optimistic reuse requires matching interception context and mounted slots. |
| Route matching | Focused tests cover params, static siblings, catch-all fallthrough prevention, missing loading boundaries, and null page elements. |

</details>

<details>
<summary>Non-goals</summary>

- This does not implement the full Next.js segment-cache architecture.
- This does not change Pages Router navigation semantics.
- This does not include the separate deploy-suite cleanup hardening discovered while verifying the upstream test locally.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [cloudflare/vinext#1360](https://github.com/cloudflare/vinext/issues/1360) | Tracks the optimistic-routing deploy-suite failures. |
| [Next.js optimistic routing e2e test](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/optimistic-routing/optimistic-routing.test.ts) | The upstream behavior this PR was verified against. |
| [Next.js App Router Link prefetch semantics](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/app-dir/link.tsx) | Documents auto-prefetch behavior for dynamic routes with `loading.js`. |
| [Next.js loading-boundary prefetch walk](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx) | Server-side reference for limiting prefetches to loading boundaries. |
| [Next.js hydration globals](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/app-index.tsx) | Reference for `__NEXT_HYDRATED` globals used by upstream browser helpers. |
