### PR TITLE
ci: avoid killing deploy-suite test runners during cleanup

### DIFF
--- a/scripts/e2e-cleanup.sh
+++ b/scripts/e2e-cleanup.sh
@@ -29,18 +29,19 @@ fi
 PID="$(cat "${PID_FILE}")"
 rm -f "${PID_FILE}"
 
-# Kill the process group if possible (handles vp exec → node → vinext chains).
-# On macOS/Linux, -PID sends the signal to the entire process group.
-kill -TERM "-${PID}" >/dev/null 2>&1 || kill -TERM "${PID}" >/dev/null 2>&1 || true
+# Kill the recorded process first. A follow-up listener sweep below handles
+# child processes that outlive the package-manager wrapper without risking the
+# Jest/run-tests process group.
+kill -TERM "${PID}" >/dev/null 2>&1 || true
 sleep 1
-kill -KILL "-${PID}" >/dev/null 2>&1 || kill -KILL "${PID}" >/dev/null 2>&1 || true
+kill -KILL "${PID}" >/dev/null 2>&1 || true
 
 # If a port file exists, also kill any process still listening on that port.
 # This catches orphaned child processes that escaped process group signaling.
 PORT_FILE=".vinext-deploy-server.port"
 if [ -f "${PORT_FILE}" ]; then
   PORT="$(cat "${PORT_FILE}")"
-  LISTENER_PID="$(lsof -ti "tcp:${PORT}" 2>/dev/null || true)"
+  LISTENER_PID="$(lsof -ti "tcp:${PORT}" -sTCP:LISTEN 2>/dev/null || true)"
   if [ -n "${LISTENER_PID}" ]; then
     kill -TERM ${LISTENER_PID} >/dev/null 2>&1 || true
     sleep 1

--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -207,9 +207,9 @@ cleanup_on_error() {
   if [ -f "${PID_FILE}" ]; then
     local pid
     pid="$(cat "${PID_FILE}")"
-    kill -TERM "-${pid}" >/dev/null 2>&1 || kill -TERM "${pid}" >/dev/null 2>&1 || true
+    kill -TERM "${pid}" >/dev/null 2>&1 || true
     sleep 1
-    kill -KILL "-${pid}" >/dev/null 2>&1 || kill -KILL "${pid}" >/dev/null 2>&1 || true
+    kill -KILL "${pid}" >/dev/null 2>&1 || true
   fi
 
   # Kill any process still listening on the allocated port (handles orphaned children).
@@ -219,7 +219,7 @@ cleanup_on_error() {
     local cleanup_port
     cleanup_port="$(cat "${PORT_FILE}")"
     local listener_pid
-    listener_pid="$(lsof -ti "tcp:${cleanup_port}" 2>/dev/null || true)"
+    listener_pid="$(lsof -ti "tcp:${cleanup_port}" -sTCP:LISTEN 2>/dev/null || true)"
     if [ -n "${listener_pid}" ]; then
       kill -TERM ${listener_pid} >/dev/null 2>&1 || true
       sleep 1


### PR DESCRIPTION
Fixes #1422.

## Summary

- Stop signaling the recorded deploy server PID as a process group during deploy-suite cleanup.
- Restrict fallback port cleanup to sockets in `LISTEN` state so client test-runner connections are not killed.

## Validation

- `bash -n scripts/e2e-cleanup.sh scripts/e2e-deploy.sh`
- Commit hook `vp check` passed.