### PR TITLE
fix: preserve Next.js cache headers for prerendered app pages

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -69,6 +69,7 @@ export default {
         "src/server/app-post-middleware-context.ts",
         "src/server/app-request-context.ts",
         "src/server/app-rsc-error-handler.ts",
+        "src/server/isr-cache.ts",
         "src/server/rsc-stream-hints.ts",
         // #726-CACHE-01/04 defines the disabled proof boundary before runtime
         // observation recording or cache reuse is wired in later slices.

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -43,6 +43,7 @@ import { navigationRuntimeRscBootstrapExpression } from "../server/app-ssr-strea
 import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
+import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
 export { readPrerenderSecret } from "./server-manifest.js";
 
 function getErrorMessageWithStack(err: Error): string {
@@ -365,17 +366,6 @@ function buildUrlFromParams(
   }
 
   return "/" + result.join("/");
-}
-
-/**
- * Determine the HTML output file path for a URL.
- * Respects trailingSlash config.
- */
-export function getOutputPath(urlPath: string, trailingSlash: boolean): string {
-  if (urlPath === "/") return "index.html";
-  const clean = urlPath.replace(/^\//, "");
-  if (trailingSlash) return `${clean}/index.html`;
-  return `${clean}.html`;
 }
 
 /** Map of route patterns to generateStaticParams functions (or null/undefined). */
@@ -1370,16 +1360,6 @@ export async function prerenderApp({
       await new Promise<void>((resolve) => ownedProdServerHandle!.server.close(() => resolve()));
     }
   }
-}
-
-/**
- * Determine the RSC output file path for a URL.
- * "/blog/hello-world" → "blog/hello-world.rsc"
- * "/"                 → "index.rsc"
- */
-export function getRscOutputPath(urlPath: string): string {
-  if (urlPath === "/") return "index.rsc";
-  return urlPath.replace(/^\//, "") + ".rsc";
 }
 
 function resolveRenderedCacheControl(

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -79,6 +79,7 @@ const appPrerenderStaticParamsPath = resolveEntryPath(
   "../server/app-prerender-static-params.js",
   import.meta.url,
 );
+const seedCachePath = resolveEntryPath("../server/seed-cache.js", import.meta.url);
 const appHookWarningSuppressionPath = resolveEntryPath(
   "../server/app-hook-warning-suppression.js",
   import.meta.url,
@@ -274,6 +275,7 @@ import {
   appIsrRouteKey as __isrRouteKey,
   isrGet as __isrGet,
   isrSet as __isrSet,
+  isrSetPrerenderedAppPage as __isrSetPrerenderedAppPage,
   triggerBackgroundRegeneration as __triggerBackgroundRegeneration,
 } from ${JSON.stringify(isrCachePath)};
 // Import server-only state module to register ALS-backed accessors.
@@ -292,6 +294,7 @@ ${hasPagesDir ? `// Pages Router routes are loaded lazily from the SSR environme
 import { suppressHookWarningAls } from ${JSON.stringify(appHookWarningSuppressionPath)};
 import { clearAppRequestContext as __clearRequestContext, setAppNavigationContext as setNavigationContext } from ${JSON.stringify(appRequestContextPath)};
 import { createAppPrerenderStaticParamsResolver as __createAppPrerenderStaticParamsResolver } from ${JSON.stringify(appPrerenderStaticParamsPath)};
+import { seedMemoryCacheFromPrerender as __seedMemoryCacheFromPrerender } from ${JSON.stringify(seedCachePath)};
 
 // Note: cache entries are written with \`headers: undefined\`. Next.js stores
 // response headers (e.g. set-cookie from cookies().set() during render) in the
@@ -457,6 +460,20 @@ const __expireTime = ${JSON.stringify(expireTime)};
 // mirrors the embedded \`__basePath\` pattern (and Pages Router's
 // \`vinextConfig\` export). Empty string when unset.
 export const __assetPrefix = ${JSON.stringify(assetPrefix)};
+
+export function seedMemoryCacheFromPrerender(serverDir) {
+  return __seedMemoryCacheFromPrerender(serverDir, {
+    buildAppPageHtmlKey(pathname) {
+      return __isrHtmlKey(pathname);
+    },
+    buildAppPageRscKey(pathname) {
+      return __isrRscKey(pathname);
+    },
+    writeAppPageEntry(key, data, metadata) {
+      return __isrSetPrerenderedAppPage(key, data, metadata);
+    },
+  });
+}
 
 ${generateDevOriginCheckCode(config?.allowedDevOrigins)}
 

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -5,7 +5,8 @@ import {
   applyRscCompatibilityIdHeader,
 } from "./app-rsc-cache-busting.js";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
-import { VINEXT_CACHE_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
+import { VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
+import { setCacheStateHeaders } from "./cache-headers.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { readStreamAsText } from "../utils/text-stream.js";
@@ -202,8 +203,8 @@ function buildAppPageCachedHeaders(options: {
     "Cache-Control": options.cacheControl,
     "Content-Type": options.contentType,
     Vary: VINEXT_RSC_VARY_HEADER,
-    [VINEXT_CACHE_HEADER]: options.cacheState,
   });
+  setCacheStateHeaders(headers, options.cacheState);
 
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
@@ -487,7 +488,7 @@ export function finalizeAppPageHtmlCacheResponse(
     // consumed. Until that late dynamic check finishes, downstream shared caches
     // must not cache a response whose ISR policy was known before streaming.
     clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
-    clientHeaders.set(VINEXT_CACHE_HEADER, "MISS");
+    setCacheStateHeaders(clientHeaders, "MISS");
   }
 
   const cachePromise = (async () => {
@@ -586,7 +587,7 @@ export function finalizeAppPageRscCacheResponse(
   // late request API was used, the client-facing MISS response must not enter a
   // shared cache when the ISR policy was known before streaming.
   clientHeaders.set("Cache-Control", NO_STORE_CACHE_CONTROL);
-  clientHeaders.set(VINEXT_CACHE_HEADER, "MISS");
+  setCacheStateHeaders(clientHeaders, "MISS");
 
   return new Response(response.body, {
     status: response.status,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -4,11 +4,11 @@ import {
   STATIC_CACHE_CONTROL,
 } from "./cache-control.js";
 import {
-  VINEXT_CACHE_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_TIMING_HEADER,
 } from "./headers.js";
+import { setCacheStateHeaders } from "./cache-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import {
   VINEXT_RSC_CONTENT_TYPE,
@@ -237,7 +237,7 @@ export function buildAppPageRscResponse(
     headers.set("Cache-Control", options.policy.cacheControl);
   }
   if (options.policy.cacheState) {
-    headers.set(VINEXT_CACHE_HEADER, options.policy.cacheState);
+    setCacheStateHeaders(headers, options.policy.cacheState);
   }
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
   applyRscCompatibilityIdHeader(headers);
@@ -263,7 +263,7 @@ export function buildAppPageHtmlResponse(
     headers.set("Cache-Control", options.policy.cacheControl);
   }
   if (options.policy.cacheState) {
-    headers.set(VINEXT_CACHE_HEADER, options.policy.cacheState);
+    setCacheStateHeaders(headers, options.policy.cacheState);
   }
   if (options.draftCookie) {
     headers.append("Set-Cookie", options.draftCookie);

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -8,8 +8,10 @@ import {
   MIDDLEWARE_HEADER_PREFIX,
   MIDDLEWARE_NEXT_HEADER,
   MIDDLEWARE_REWRITE_HEADER,
+  NEXTJS_CACHE_HEADER,
   VINEXT_CACHE_HEADER,
 } from "./headers.js";
+import { setCacheStateHeaders } from "./cache-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 
@@ -110,7 +112,7 @@ export function buildRouteHandlerCachedResponse(
       headers.set(key, value);
     }
   }
-  headers.set(VINEXT_CACHE_HEADER, options.cacheState);
+  setCacheStateHeaders(headers, options.cacheState);
   const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
   const expireSeconds =
     options.cacheControl === undefined
@@ -139,7 +141,7 @@ export function applyRouteHandlerRevalidateHeader(
 }
 
 export function markRouteHandlerCacheMiss(response: Response): void {
-  response.headers.set(VINEXT_CACHE_HEADER, "MISS");
+  setCacheStateHeaders(response.headers, "MISS");
 }
 
 function getSetCookieName(cookie: string): string | null {
@@ -198,6 +200,7 @@ export async function buildAppRouteCacheValue(response: Response): Promise<Cache
     if (
       key === "set-cookie" ||
       key === VINEXT_CACHE_HEADER.toLowerCase() ||
+      key === NEXTJS_CACHE_HEADER.toLowerCase() ||
       key === "cache-control" ||
       key.startsWith(MIDDLEWARE_HEADER_PREFIX)
     ) {

--- a/packages/vinext/src/server/cache-headers.ts
+++ b/packages/vinext/src/server/cache-headers.ts
@@ -1,0 +1,20 @@
+import { NEXTJS_CACHE_HEADER, VINEXT_CACHE_HEADER } from "./headers.js";
+
+type VinextCacheState = "HIT" | "MISS" | "STALE" | "STATIC";
+type NextJsCacheState = "HIT" | "MISS" | "STALE";
+
+function toNextJsCacheState(cacheState: VinextCacheState): NextJsCacheState {
+  return cacheState === "STATIC" ? "HIT" : cacheState;
+}
+
+export function setCacheStateHeaders(headers: Headers, cacheState: VinextCacheState): void {
+  headers.set(VINEXT_CACHE_HEADER, cacheState);
+  headers.set(NEXTJS_CACHE_HEADER, toNextJsCacheState(cacheState));
+}
+
+export function buildCacheStateHeaders(cacheState: VinextCacheState): Record<string, string> {
+  return {
+    [VINEXT_CACHE_HEADER]: cacheState,
+    [NEXTJS_CACHE_HEADER]: toNextJsCacheState(cacheState),
+  };
+}

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -6,7 +6,7 @@ import { normalizeStaticPathname, type StaticPathsEntry } from "../routing/route
 import type { ModuleImporter } from "./instrumentation.js";
 import { importModule, reportRequestError } from "./instrumentation.js";
 import type { NextI18nConfig } from "../config/next-config.js";
-import { VINEXT_CACHE_HEADER } from "./headers.js";
+import { buildCacheStateHeaders } from "./cache-headers.js";
 import {
   isrGet,
   isrSet,
@@ -634,7 +634,7 @@ export function createSSRHandler(
             const revalidateSecs = getRevalidateDuration(cacheKey) ?? 60;
             const hitHeaders: Record<string, string> = {
               "Content-Type": "text/html",
-              [VINEXT_CACHE_HEADER]: "HIT",
+              ...buildCacheStateHeaders("HIT"),
               "Cache-Control": `s-maxage=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) hitHeaders["Link"] = earlyFontLinkHeader;
@@ -787,7 +787,7 @@ export function createSSRHandler(
             const revalidateSecs = getRevalidateDuration(cacheKey) ?? 60;
             const staleHeaders: Record<string, string> = {
               "Content-Type": "text/html",
-              [VINEXT_CACHE_HEADER]: "STALE",
+              ...buildCacheStateHeaders("STALE"),
               "Cache-Control": `s-maxage=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) staleHeaders["Link"] = earlyFontLinkHeader;
@@ -1059,7 +1059,7 @@ hydrate();
           } else {
             extraHeaders["Cache-Control"] =
               `s-maxage=${isrRevalidateSeconds}, stale-while-revalidate`;
-            extraHeaders[VINEXT_CACHE_HEADER] = "MISS";
+            Object.assign(extraHeaders, buildCacheStateHeaders("MISS"));
           }
         }
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -16,6 +16,9 @@
 /** ISR / page cache state indicator: "HIT" | "MISS" | "STALE" | "STATIC". */
 export const VINEXT_CACHE_HEADER = "X-Vinext-Cache";
 
+/** Next.js public ISR / page cache state indicator. */
+export const NEXTJS_CACHE_HEADER = "x-nextjs-cache";
+
 /** Static file signal — value is URL-encoded pathname. */
 export const VINEXT_STATIC_FILE_HEADER = "x-vinext-static-file";
 

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -81,6 +81,34 @@ export async function isrSet(
   });
 }
 
+export async function isrSetPrerenderedAppPage(
+  key: string,
+  data: CachedAppPageValue,
+  metadata: { expireSeconds?: number; revalidateSeconds?: number },
+): Promise<void> {
+  const handler = getCacheHandler();
+  const revalidateSeconds = metadata.revalidateSeconds;
+  if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
+    console.debug("[vinext] ISR: seed", key);
+  }
+  await handler.set(
+    key,
+    data,
+    revalidateSeconds === undefined
+      ? {}
+      : metadata.expireSeconds === undefined
+        ? { cacheControl: { revalidate: revalidateSeconds }, revalidate: revalidateSeconds }
+        : {
+            cacheControl: { revalidate: revalidateSeconds, expire: metadata.expireSeconds },
+            revalidate: revalidateSeconds,
+          },
+  );
+
+  if (revalidateSeconds !== undefined) {
+    setRevalidateDuration(key, revalidateSeconds);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Background regeneration dedup — one in-flight regeneration per cache key.
 // Uses Symbol.for() on globalThis so the map is shared across Vite's

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -3,7 +3,7 @@ import type { Route } from "../routing/pages-router.js";
 import { normalizeStaticPathname } from "../routing/route-pattern.js";
 import type { CachedPagesValue, CacheControlMetadata } from "vinext/shims/cache";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
-import { VINEXT_CACHE_HEADER } from "./headers.js";
+import { buildCacheStateHeaders } from "./cache-headers.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import {
   buildPagesNextDataScript,
@@ -235,7 +235,7 @@ function buildPagesCacheResponse(
     cacheControl === undefined ? undefined : (cacheControl.expire ?? expireSeconds);
   const headers: Record<string, string> = {
     "Content-Type": "text/html",
-    [VINEXT_CACHE_HEADER]: cacheState,
+    ...buildCacheStateHeaders(cacheState),
     "Cache-Control": buildCachedRevalidateCacheControl(
       cacheState,
       effectiveRevalidateSeconds,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -4,7 +4,7 @@ import type { CachedPagesValue } from "vinext/shims/cache";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { buildRevalidateCacheControl } from "./cache-control.js";
-import { VINEXT_CACHE_HEADER } from "./headers.js";
+import { setCacheStateHeaders } from "./cache-headers.js";
 import { createInlineScriptTag, createNonceAttribute, escapeHtmlAttr } from "./html.js";
 import { reportRequestError } from "./instrumentation.js";
 import { readStreamAsText } from "../utils/text-stream.js";
@@ -383,7 +383,7 @@ export async function renderPagesPageResponse(
       "Cache-Control",
       buildRevalidateCacheControl(options.isrRevalidateSeconds, options.expireSeconds),
     );
-    responseHeaders.set(VINEXT_CACHE_HEADER, "MISS");
+    setCacheStateHeaders(responseHeaders, "MISS");
   }
   if (options.fontLinkHeader) {
     responseHeaders.set("Link", options.fontLinkHeader);

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -940,17 +940,22 @@ function resolveAppRouterHandler(entry: unknown): (request: Request) => Promise<
 }
 
 type AppRouterPrerenderSeeder = (serverDir: string) => Promise<number>;
+type AppRouterPrerenderSeederExport = (serverDir: string) => unknown;
+
+function isAppRouterPrerenderSeederExport(value: unknown): value is AppRouterPrerenderSeederExport {
+  return typeof value === "function";
+}
 
 export function resolveAppRouterPrerenderSeeder(entryModule: unknown): AppRouterPrerenderSeeder {
   if (typeof entryModule !== "object" || entryModule === null) {
     return seedMemoryCacheFromPrerenderFallback;
   }
 
-  const seedExport = Object.getOwnPropertyDescriptor(
+  const seedExport: unknown = Object.getOwnPropertyDescriptor(
     entryModule,
     "seedMemoryCacheFromPrerender",
   )?.value;
-  if (typeof seedExport !== "function") {
+  if (!isAppRouterPrerenderSeederExport(seedExport)) {
     if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
       console.debug("[vinext] ISR: using fallback prerender cache seeder");
     }
@@ -962,9 +967,7 @@ export function resolveAppRouterPrerenderSeeder(entryModule: unknown): AppRouter
   }
 
   return async (serverDir) => {
-    const result: unknown = await Promise.resolve(
-      Reflect.apply(seedExport, undefined, [serverDir]),
-    );
+    const result = await Promise.resolve(seedExport(serverDir));
     return typeof result === "number" ? result : 0;
   };
 }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -70,7 +70,7 @@ import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import type { ExecutionContextLike } from "vinext/shims/request-context";
 import { readPrerenderSecret } from "../build/server-manifest.js";
 import { VINEXT_PRERENDER_SECRET_HEADER, VINEXT_STATIC_FILE_HEADER } from "./headers.js";
-import { seedMemoryCacheFromPrerender } from "./seed-cache.js";
+import { seedMemoryCacheFromPrerender as seedMemoryCacheFromPrerenderFallback } from "./seed-cache.js";
 import { installSocketErrorBackstop } from "./socket-error-backstop.js";
 import { stripI18nLocaleForApiRoute } from "./pages-i18n.js";
 
@@ -939,6 +939,36 @@ function resolveAppRouterHandler(entry: unknown): (request: Request) => Promise<
   process.exit(1);
 }
 
+type AppRouterPrerenderSeeder = (serverDir: string) => Promise<number>;
+
+export function resolveAppRouterPrerenderSeeder(entryModule: unknown): AppRouterPrerenderSeeder {
+  if (typeof entryModule !== "object" || entryModule === null) {
+    return seedMemoryCacheFromPrerenderFallback;
+  }
+
+  const seedExport = Object.getOwnPropertyDescriptor(
+    entryModule,
+    "seedMemoryCacheFromPrerender",
+  )?.value;
+  if (typeof seedExport !== "function") {
+    if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
+      console.debug("[vinext] ISR: using fallback prerender cache seeder");
+    }
+    return seedMemoryCacheFromPrerenderFallback;
+  }
+
+  if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
+    console.debug("[vinext] ISR: using App Router entry prerender cache seeder");
+  }
+
+  return async (serverDir) => {
+    const result: unknown = await Promise.resolve(
+      Reflect.apply(seedExport, undefined, [serverDir]),
+    );
+    return typeof result === "number" ? result : 0;
+  };
+}
+
 /**
  * Resolve a request pathname to a static-asset lookup path inside `clientDir`.
  *
@@ -1055,7 +1085,8 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
 
   // Seed the memory cache with pre-rendered routes so the first request to
   // any pre-rendered page is a cache HIT instead of a full re-render.
-  const seededRoutes = await seedMemoryCacheFromPrerender(path.dirname(rscEntryPath));
+  const seedPrerenderedRoutes = resolveAppRouterPrerenderSeeder(rscModule);
+  const seededRoutes = await seedPrerenderedRoutes(path.dirname(rscEntryPath));
   if (seededRoutes > 0) {
     console.log(
       `[vinext] Seeded ${seededRoutes} pre-rendered route${seededRoutes !== 1 ? "s" : ""} into memory cache`,

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -33,7 +33,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { getCacheHandler, type CachedAppPageValue } from "vinext/shims/cache";
 import { isrCacheKey, setRevalidateDuration } from "./isr-cache.js";
-import { getOutputPath, getRscOutputPath } from "../build/prerender.js";
+import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
 
 // ─── Manifest types ───────────────────────────────────────────────────────────
 
@@ -52,6 +52,21 @@ type PrerenderManifestRoute = {
   router?: "app" | "pages";
 };
 
+type PrerenderCacheSeedMetadata = {
+  expireSeconds?: number;
+  revalidateSeconds?: number;
+};
+
+type PrerenderCacheSeedOptions = {
+  buildAppPageHtmlKey?: (pathname: string) => string;
+  buildAppPageRscKey?: (pathname: string) => string;
+  writeAppPageEntry?: (
+    key: string,
+    data: CachedAppPageValue,
+    metadata: PrerenderCacheSeedMetadata,
+  ) => Promise<void>;
+};
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
@@ -63,7 +78,10 @@ type PrerenderManifestRoute = {
  * @param serverDir - Path to `dist/server/` (where vinext-prerender.json lives)
  * @returns The number of routes seeded (0 if no manifest or no renderable routes).
  */
-export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<number> {
+export async function seedMemoryCacheFromPrerender(
+  serverDir: string,
+  options?: PrerenderCacheSeedOptions,
+): Promise<number> {
   const manifestPath = path.join(serverDir, "vinext-prerender.json");
   if (!fs.existsSync(manifestPath)) return 0;
 
@@ -80,7 +98,7 @@ export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<n
 
   const trailingSlash = manifest.trailingSlash ?? false;
   const prerenderDir = path.join(serverDir, "prerendered-routes");
-  const handler = getCacheHandler();
+  const writeAppPageEntry = options?.writeAppPageEntry ?? createDefaultAppPageEntryWriter();
   let seeded = 0;
 
   for (const route of routes) {
@@ -89,21 +107,30 @@ export async function seedMemoryCacheFromPrerender(serverDir: string): Promise<n
 
     const pathname = route.path ?? route.route;
     const baseKey = isrCacheKey("app", pathname, buildId);
+    const htmlKey = options?.buildAppPageHtmlKey?.(pathname) ?? baseKey + ":html";
+    const rscKey = options?.buildAppPageRscKey?.(pathname) ?? baseKey + ":rsc";
     const revalidateSeconds = typeof route.revalidate === "number" ? route.revalidate : undefined;
     const expireSeconds = typeof route.expire === "number" ? route.expire : undefined;
 
     if (
       await seedHtml(
-        handler,
+        writeAppPageEntry,
         prerenderDir,
-        baseKey,
+        htmlKey,
         pathname,
         trailingSlash,
         revalidateSeconds,
         expireSeconds,
       )
     ) {
-      await seedRsc(handler, prerenderDir, baseKey, pathname, revalidateSeconds, expireSeconds);
+      await seedRsc(
+        writeAppPageEntry,
+        prerenderDir,
+        rscKey,
+        pathname,
+        revalidateSeconds,
+        expireSeconds,
+      );
       seeded++;
     }
   }
@@ -130,14 +157,27 @@ function revalidateCtx(
       };
 }
 
+function createDefaultAppPageEntryWriter(): NonNullable<
+  PrerenderCacheSeedOptions["writeAppPageEntry"]
+> {
+  const handler = getCacheHandler();
+  return async (key, data, metadata) => {
+    await handler.set(key, data, revalidateCtx(metadata.revalidateSeconds, metadata.expireSeconds));
+
+    if (metadata.revalidateSeconds !== undefined) {
+      setRevalidateDuration(key, metadata.revalidateSeconds);
+    }
+  };
+}
+
 /**
  * Seed the HTML cache entry for a single route.
  * Returns true if the file existed and was seeded.
  */
 async function seedHtml(
-  handler: ReturnType<typeof getCacheHandler>,
+  writeAppPageEntry: NonNullable<PrerenderCacheSeedOptions["writeAppPageEntry"]>,
   prerenderDir: string,
-  baseKey: string,
+  key: string,
   pathname: string,
   trailingSlash: boolean,
   revalidateSeconds: number | undefined,
@@ -156,12 +196,7 @@ async function seedHtml(
     status: undefined,
   };
 
-  const key = baseKey + ":html";
-  await handler.set(key, htmlValue, revalidateCtx(revalidateSeconds, expireSeconds));
-
-  if (revalidateSeconds !== undefined) {
-    setRevalidateDuration(key, revalidateSeconds);
-  }
+  await writeAppPageEntry(key, htmlValue, { expireSeconds, revalidateSeconds });
 
   return true;
 }
@@ -171,9 +206,9 @@ async function seedHtml(
  * No-op if the .rsc file doesn't exist on disk.
  */
 async function seedRsc(
-  handler: ReturnType<typeof getCacheHandler>,
+  writeAppPageEntry: NonNullable<PrerenderCacheSeedOptions["writeAppPageEntry"]>,
   prerenderDir: string,
-  baseKey: string,
+  key: string,
   pathname: string,
   revalidateSeconds: number | undefined,
   expireSeconds: number | undefined,
@@ -195,10 +230,5 @@ async function seedRsc(
     status: undefined,
   };
 
-  const key = baseKey + ":rsc";
-  await handler.set(key, rscValue, revalidateCtx(revalidateSeconds, expireSeconds));
-
-  if (revalidateSeconds !== undefined) {
-    setRevalidateDuration(key, revalidateSeconds);
-  }
+  await writeAppPageEntry(key, rscValue, { expireSeconds, revalidateSeconds });
 }

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -31,8 +31,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { getCacheHandler, type CachedAppPageValue } from "vinext/shims/cache";
-import { isrCacheKey, setRevalidateDuration } from "./isr-cache.js";
+import type { CachedAppPageValue } from "vinext/shims/cache";
+import { isrCacheKey, isrSetPrerenderedAppPage } from "./isr-cache.js";
 import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
 
 // ─── Manifest types ───────────────────────────────────────────────────────────
@@ -106,6 +106,9 @@ export async function seedMemoryCacheFromPrerender(
     if (route.router !== "app") continue;
 
     const pathname = route.path ?? route.route;
+    // Fallback keys support older generated entries that do not export their
+    // runtime key builders. Current App Router entries inject buildAppPage*Key
+    // so seeded keys match process.env.__VINEXT_BUILD_ID exactly.
     const baseKey = isrCacheKey("app", pathname, buildId);
     const htmlKey = options?.buildAppPageHtmlKey?.(pathname) ?? baseKey + ":html";
     const rscKey = options?.buildAppPageRscKey?.(pathname) ?? baseKey + ":rsc";
@@ -140,34 +143,10 @@ export async function seedMemoryCacheFromPrerender(
 
 // ─── Internals ────────────────────────────────────────────────────────────────
 
-/**
- * Build the CacheHandler context object from a revalidate value.
- * `revalidate: undefined` (static routes) → empty context → no expiry.
- */
-function revalidateCtx(
-  revalidateSeconds: number | undefined,
-  expireSeconds: number | undefined,
-): Record<string, unknown> {
-  if (revalidateSeconds === undefined) return {};
-  return expireSeconds === undefined
-    ? { cacheControl: { revalidate: revalidateSeconds }, revalidate: revalidateSeconds }
-    : {
-        cacheControl: { revalidate: revalidateSeconds, expire: expireSeconds },
-        revalidate: revalidateSeconds,
-      };
-}
-
 function createDefaultAppPageEntryWriter(): NonNullable<
   PrerenderCacheSeedOptions["writeAppPageEntry"]
 > {
-  const handler = getCacheHandler();
-  return async (key, data, metadata) => {
-    await handler.set(key, data, revalidateCtx(metadata.revalidateSeconds, metadata.expireSeconds));
-
-    if (metadata.revalidateSeconds !== undefined) {
-      setRevalidateDuration(key, metadata.revalidateSeconds);
-    }
-  };
+  return (key, data, metadata) => isrSetPrerenderedAppPage(key, data, metadata);
 }
 
 /**

--- a/packages/vinext/src/utils/prerender-output-paths.ts
+++ b/packages/vinext/src/utils/prerender-output-paths.ts
@@ -1,0 +1,20 @@
+/**
+ * Determine the HTML output file path for a prerendered URL.
+ * Respects trailingSlash config.
+ */
+export function getOutputPath(urlPath: string, trailingSlash: boolean): string {
+  if (urlPath === "/") return "index.html";
+  const clean = urlPath.replace(/^\//, "");
+  if (trailingSlash) return `${clean}/index.html`;
+  return `${clean}.html`;
+}
+
+/**
+ * Determine the RSC output file path for a prerendered URL.
+ * "/blog/hello-world" -> "blog/hello-world.rsc"
+ * "/"                 -> "index.rsc"
+ */
+export function getRscOutputPath(urlPath: string): string {
+  if (urlPath === "/") return "index.rsc";
+  return urlPath.replace(/^\//, "") + ".rsc";
+}

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -73,6 +73,9 @@ describe("app page cache helpers", () => {
     expect(htmlResponse?.headers.get("content-type")).toBe("text/html; charset=utf-8");
     expect(htmlResponse?.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
     expect(htmlResponse?.headers.get("x-vinext-cache")).toBe("HIT");
+    // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+    expect(htmlResponse?.headers.get("x-nextjs-cache")).toBe("HIT");
     await expect(htmlResponse?.text()).resolves.toBe("<h1>cached</h1>");
 
     const rscResponse = withEnvVar("__VINEXT_RSC_COMPATIBILITY_ID", "compat-a", () =>
@@ -86,6 +89,7 @@ describe("app page cache helpers", () => {
     expect(rscResponse?.headers.get("content-type")).toBe("text/x-component");
     expect(rscResponse?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
     expect(rscResponse?.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
+    expect(rscResponse?.headers.get("x-nextjs-cache")).toBe("STALE");
     expect(await rscResponse?.arrayBuffer()).toEqual(rscData);
   });
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -382,6 +382,7 @@ describe("app page response helpers", () => {
     expect(response.headers.get("x-vinext-params")).toBe(encodeURIComponent('{"slug":"test"}'));
     expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(response.headers.get("x-nextjs-cache")).toBe("MISS");
     expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
     expect(response.headers.get("x-vinext-timing")).toBe("10,5,-1");
     await expect(response.text()).resolves.toBe("flight");
@@ -464,6 +465,7 @@ describe("app page response helpers", () => {
     expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
     expect(response.headers.get("cache-control")).toBe("private, max-age=5");
     expect(response.headers.get("x-vinext-cache")).toBe("STATIC");
+    expect(response.headers.get("x-nextjs-cache")).toBe("HIT");
     expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
     expect(response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -101,6 +101,7 @@ describe("app route handler response helpers", () => {
       revalidateSeconds: 60,
     });
     expect(hit.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(hit.headers.get("x-nextjs-cache")).toBe("HIT");
     expect(hit.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
     await expect(hit.text()).resolves.toBe("from-cache");
 
@@ -111,6 +112,7 @@ describe("app route handler response helpers", () => {
       revalidateSeconds: 60,
     });
     expect(staleHead.headers.get("x-vinext-cache")).toBe("STALE");
+    expect(staleHead.headers.get("x-nextjs-cache")).toBe("STALE");
     expect(staleHead.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
     await expect(staleHead.text()).resolves.toBe("");
   });
@@ -153,6 +155,7 @@ describe("app route handler response helpers", () => {
         "content-type": "text/plain",
         "cache-control": "s-maxage=60, stale-while-revalidate",
         "x-vinext-cache": "MISS",
+        "x-nextjs-cache": "MISS",
         "x-middleware-set-cookie": "internal=1; Path=/",
         "x-extra": "kept",
       },

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -5120,6 +5120,20 @@ describe("generateRscEntry ISR code generation", () => {
     expect(code).toContain('["locale"]');
   });
 
+  it("generated code exposes prerender cache seeding from the RSC module graph", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes);
+
+    expect(code).toContain("seedMemoryCacheFromPrerender as __seedMemoryCacheFromPrerender");
+    expect(code).toContain("isrSetPrerenderedAppPage as __isrSetPrerenderedAppPage");
+    expect(code).toContain("export function seedMemoryCacheFromPrerender(serverDir)");
+    expect(code).toContain("buildAppPageHtmlKey(pathname)");
+    expect(code).toContain("return __isrHtmlKey(pathname)");
+    expect(code).toContain("buildAppPageRscKey(pathname)");
+    expect(code).toContain("return __isrRscKey(pathname)");
+    expect(code).toContain("writeAppPageEntry(key, data, metadata)");
+    expect(code).toContain("return __isrSetPrerenderedAppPage(key, data, metadata)");
+  });
+
   it("generated code delegates server-action header handling to the typed handler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("handleServerActionRequest({");

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -271,6 +271,7 @@ describe("pages page data", () => {
       throw new Error("expected response result");
     }
     expect(result.response.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(result.response.headers.get("x-nextjs-cache")).toBe("HIT");
     expect(result.response.headers.get("cache-control")).toBe(
       "s-maxage=15, stale-while-revalidate=285",
     );

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -177,6 +177,7 @@ describe("pages page response", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(response.headers.get("x-nextjs-cache")).toBe("MISS");
     await expect(response.text()).resolves.toContain("<div>live-body</div>");
     await settleMicrotasks();
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -383,8 +383,15 @@ describe("Pages Router integration", () => {
     const first = await fetch(`${baseUrl}/isr-test`);
     expect(first.status).toBe(200);
     expect(first.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(first.headers.get("x-nextjs-cache")).toBe("MISS");
     const firstHtml = await first.text();
     expect(firstHtml).not.toContain("nonce=");
+
+    const cached = await fetch(`${baseUrl}/isr-test`);
+    expect(cached.status).toBe(200);
+    expect(cached.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(cached.headers.get("x-nextjs-cache")).toBe("HIT");
+    await cached.text();
 
     const second = await fetch(`${baseUrl}/isr-test?mw-csp-nonce=pages-isr`);
     expect(second.status).toBe(200);
@@ -4979,6 +4986,7 @@ describe("Pages Router dev ISR regeneration", () => {
         200,
         expect.objectContaining({
           "X-Vinext-Cache": "STALE",
+          "x-nextjs-cache": "STALE",
         }),
       );
 

--- a/tests/prod-server-prerender-seeder.test.ts
+++ b/tests/prod-server-prerender-seeder.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { resolveAppRouterPrerenderSeeder } from "../packages/vinext/src/server/prod-server.js";
+
+describe("resolveAppRouterPrerenderSeeder", () => {
+  it("uses the seeder exported by the RSC entry module", async () => {
+    const calls: string[] = [];
+    const seedPrerenderedRoutes = resolveAppRouterPrerenderSeeder({
+      seedMemoryCacheFromPrerender(serverDir: string): number {
+        calls.push(serverDir);
+        return 7;
+      },
+    });
+
+    await expect(seedPrerenderedRoutes("/app/dist/server")).resolves.toBe(7);
+    expect(calls).toEqual(["/app/dist/server"]);
+  });
+
+  it("falls back to the startup seeder for older app entries", async () => {
+    const serverDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prerender-seeder-"));
+    try {
+      const seedPrerenderedRoutes = resolveAppRouterPrerenderSeeder({});
+
+      await expect(seedPrerenderedRoutes(serverDir)).resolves.toBe(0);
+    } finally {
+      fs.rmSync(serverDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -255,6 +255,76 @@ describe("seedMemoryCacheFromPrerender", () => {
     ]);
   });
 
+  it("can write through an injected app page cache writer", async () => {
+    const writes: {
+      key: string;
+      metadata: { expireSeconds?: number; revalidateSeconds?: number };
+      valueKind: string;
+    }[] = [];
+
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId: "seed-injected-writer-test",
+        routes: [{ route: "/isr", status: "rendered", revalidate: 60, expire: 300, router: "app" }],
+      },
+      {
+        "isr.html": "<html>ISR</html>",
+        "isr.rsc": "RSC isr",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir, {
+      async writeAppPageEntry(key, data, metadata): Promise<void> {
+        writes.push({ key, metadata, valueKind: data.kind });
+      },
+    });
+
+    const baseKey = isrCacheKey("app", "/isr", "seed-injected-writer-test");
+    expect(writes).toEqual([
+      {
+        key: baseKey + ":html",
+        metadata: { expireSeconds: 300, revalidateSeconds: 60 },
+        valueKind: "APP_PAGE",
+      },
+      {
+        key: baseKey + ":rsc",
+        metadata: { expireSeconds: 300, revalidateSeconds: 60 },
+        valueKind: "APP_PAGE",
+      },
+    ]);
+  });
+
+  it("can use injected runtime app page cache key builders", async () => {
+    const keys: string[] = [];
+
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId: "manifest-build-id",
+        routes: [{ route: "/isr", status: "rendered", revalidate: 60, router: "app" }],
+      },
+      {
+        "isr.html": "<html>ISR</html>",
+        "isr.rsc": "RSC isr",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir, {
+      buildAppPageHtmlKey(pathname) {
+        return `runtime-build:${pathname}:html`;
+      },
+      buildAppPageRscKey(pathname) {
+        return `runtime-build:${pathname}:rsc`;
+      },
+      async writeAppPageEntry(key): Promise<void> {
+        keys.push(key);
+      },
+    });
+
+    expect(keys).toEqual(["runtime-build:/isr:html", "runtime-build:/isr:rsc"]);
+  });
+
   it("does not set revalidate duration for static routes", async () => {
     const buildId = "static-duration-test";
     setupPrerenderFixture(


### PR DESCRIPTION
## Summary

Fixes App Router prerender/cache response-header parity with Next.js by emitting `x-nextjs-cache` anywhere vinext already reports page/route cache state, and by seeding prerendered App Router cache entries with the runtime cache keys exported by the generated RSC entry.

## Root Cause

The upstream deploy-suite case [`app-root-params-getters/generate-static-params.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts) expects a statically prerendered route to expose a cache header via `getCacheHeader(response)`. That helper reads [`x-nextjs-cache` or `x-vercel-cache`](https://github.com/vercel/next.js/blob/canary/test/lib/next-test-utils.ts).

vinext returned the correct 200/body but only emitted `X-Vinext-Cache`, so `getCacheHeader(response)` was null. While triaging, the first `x-nextjs-cache` alias exposed a second issue: startup prerender seeding used the manifest build ID while runtime App Router cache lookups use `process.env.__VINEXT_BUILD_ID`, so prerendered App Router entries could be seeded under keys that the request path never reads.

Next.js sets `x-nextjs-cache` from App Page cache state in [`packages/next/src/build/templates/app-page.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/templates/app-page.ts).

## Changes

- Add a shared cache-header helper that writes both `X-Vinext-Cache` and `x-nextjs-cache`.
- Preserve Next.js header values for App Page, App Route, and Pages Router cache responses.
- Export a generated App Router prerender seeder from the RSC module graph so startup seeding uses the same runtime App Page cache-key builders as request handling.
- Keep a fallback seeder for older generated entries.
- Move prerender output-path helpers out of the build module so runtime cache seeding does not import build-only code.
- Add focused regression coverage for cache headers, generated seeder wiring, fallback resolution, and injected runtime key builders.

## Validation

- `vp test run tests/seed-cache.test.ts tests/prod-server-prerender-seeder.test.ts tests/app-page-cache.test.ts tests/app-page-response.test.ts tests/app-route-handler-response.test.ts tests/pages-page-response.test.ts tests/pages-page-data.test.ts tests/app-router.test.ts -t "generated code exposes prerender cache seeding|seedMemoryCacheFromPrerender|resolveAppRouterPrerenderSeeder|x-nextjs-cache|cache"`
- `vp check`
- `vp run knip`
- `NEXT_EXTERNAL_TESTS_FILTERS=/Users/nathan/Projects/vinext/.refs/nextjs-deploy-test-manifest.local.json vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug`
