### PR TITLE
ci(deploy-suite): unstick Next.js prepare step

### DIFF
--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -72,6 +72,7 @@ jobs:
         run: vp run vinext#build
 
       - name: Prepare Next.js checkout
+        timeout-minutes: 15
         run: bash scripts/run-nextjs-deploy-suite.sh "$GITHUB_WORKSPACE/next.js"
         env:
           CI: true

--- a/scripts/run-nextjs-deploy-suite.sh
+++ b/scripts/run-nextjs-deploy-suite.sh
@@ -60,14 +60,13 @@ fi
 if [ "${NEXTJS_PREPARE:-0}" = "1" ]; then
   (
     cd "${NEXTJS_DIR}"
+    echo ">>> $(date -Iseconds) pnpm install"
     run_pnpm install
+    echo ">>> $(date -Iseconds) pnpm build"
     run_pnpm build
-    run_pnpm install
-    if [ "${CI:-0}" = "1" ] || [ "${CI:-}" = "true" ]; then
-      run_pnpm playwright install --with-deps chromium chromium-headless-shell
-    else
-      run_pnpm playwright install chromium chromium-headless-shell
-    fi
+    echo ">>> $(date -Iseconds) pnpm playwright install"
+    run_pnpm playwright install chromium chromium-headless-shell
+    echo ">>> $(date -Iseconds) prepare done"
   )
 fi
 


### PR DESCRIPTION
## Summary

The nightly Next.js deploy suite hung for 29m+ in the **"Prepare Next.js checkout"** step on two consecutive runs ([26265986264](https://github.com/cloudflare/vinext/actions/runs/26265986264), [26279790373](https://github.com/cloudflare/vinext/actions/runs/26279790373)), eating the 30m job timeout. The same `v16.2.6` SHA (`ee6e79b1`) built fine the three previous nights, so it's environmental, not source drift.

The first `pnpm install` completes around 30s in, then logs go silent until cancellation — with no per-command markers we couldn't tell which command actually hangs.

This PR:

- **Drops `--with-deps`** from the build-job playwright install. `--with-deps` runs `apt-get install` for browser system libraries, the most plausible silent-hang culprit (stuck `dpkg` lock, slow apt repo). The 16 test-shard runners each spin up a fresh `ubuntu-latest` and run `playwright install` without `--with-deps` — so the apt state from the build runner never transferred anyway. Doing it on the build runner is wasted work even when it doesn't hang.
- **Removes the redundant second `pnpm install`.** Workspace symlinks survive the build; nothing between build and re-install adds new packages.
- **Adds timestamped `>>>` markers** around each prepare command so the next hang is diagnosable from the logs.
- **Adds `timeout-minutes: 15`** on the Prepare step so a future hang fails fast (well under the 30m job cap) instead of starving the whole job.

`pnpm build` stays for now — `run-tests.js` and some fixtures resolve `next` against the workspace and need the compiled output. Worth investigating separately whether deploy mode can skip it (each fixture runs its own install via `e2e-deploy.sh` and injects `vinext` as a `file:` dep, so the workspace `next` may not actually be on the resolution path for deploy tests).

## Test plan

- [ ] Trigger the workflow manually (`gh workflow run nextjs-deploy-suite.yml`) and confirm the Prepare step finishes in ~2 min (matching pre-hang nightlies) with the new `>>>` markers in the log
- [ ] Confirm the test shards still pass (cache restore + per-shard `playwright install` should be unaffected)
- [ ] If it still hangs, the markers will tell us which command is stuck so we can iterate