### PR TITLE
ci(deps): add dependabot config with 1-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 1
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 1


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for the `npm` and `github-actions` ecosystems
- Sets `cooldown.default-days: 1` to match the existing `minimumReleaseAge: 1440` (24h) in `pnpm-workspace.yaml`, so Dependabot won't open PRs for versions younger than the window pnpm already enforces locally

## Test plan
- [ ] Confirm Dependabot picks up the new config on the next run and respects the cooldown