### PR TITLE
ci(deploy-suite): skip wedged playwright-chromium postinstall

### DIFF
--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -79,6 +79,16 @@ jobs:
           VINEXT_BUILD: "0"
           NEXTJS_PREPARE: "1"
           NEXTJS_PREPARE_ONLY: "1"
+          # The Next.js workspace pulls `playwright-chromium` as a transitive
+          # dep, whose postinstall downloads Chrome via the Playwright CDN.
+          # Since 2026-05-22 that postinstall has wedged on this runner after
+          # the 167 MiB Chrome zip downloads but before extraction completes,
+          # silently consuming the whole job timeout (runs 26265986264,
+          # 26279790373, 26281061094). The explicit `pnpm playwright install
+          # chromium chromium-headless-shell` later in the prepare script is
+          # what actually provisions the browsers we use at test time, so
+          # skipping the transitive postinstall is safe.
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
       - name: Generate deploy manifest
         env:


### PR DESCRIPTION
## Summary

Follow-up to [#1428](https://github.com/cloudflare/vinext/pull/1428). That PR added log markers to the prepare step, which gave us the actual diagnosis on the latest hang ([run 26281061094](https://github.com/cloudflare/vinext/actions/runs/26281061094)):

```
>>> 2026-05-22T09:55:43+00:00 pnpm install
...
.../node_modules/playwright-chromium install: |■■...| 100% of 167.3 MiB
.../node_modules/cpu-features install: Done
[hang — step timeout fires at 15m, no `>>> pnpm build` marker]
```

`playwright-chromium`'s postinstall (`node install.js`, pulled transitively by the Next.js workspace) downloads Chrome 145.0.7632.6 from `cdn.playwright.dev`, hits **100%**, and then **never prints "Done"** — extraction/verification silently wedges. Every other postinstall in the same install (cpu-features, sharp, esbuild, msw, etc.) finishes cleanly. The hang is *inside the first `pnpm install`*, not in `pnpm build` or the explicit `playwright install` later — so #1428's cleanup didn't address the actual cause.

Confirmed identical fingerprint on three runs:
- [26265986264](https://github.com/cloudflare/vinext/actions/runs/26265986264) (nightly, 2026-05-22)
- [26279790373](https://github.com/cloudflare/vinext/actions/runs/26279790373) (manual retry)
- [26281061094](https://github.com/cloudflare/vinext/actions/runs/26281061094) (post-#1428 retry)

Identical lockfiles built fine the three nights before. Best guess is a Playwright CDN / Chrome-for-Testing-zip change on/around 2026-05-22 that wedges extraction; not something we can fix upstream from here.

## Fix

Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` on the Prepare step. This makes the transitive `playwright-chromium` postinstall skip the download entirely — it's documented exactly for this scenario.

The explicit `pnpm playwright install chromium chromium-headless-shell` that runs later in the prepare script (via the `playwright` CLI, not the auto-postinstall) provisions the actual browsers we use at test time. Those go to `~/.cache/ms-playwright`, which is cached and restored by the 16 test shards. So skipping the transitive postinstall costs us nothing functionally.

## Test plan

- [ ] `gh workflow run nextjs-deploy-suite.yml --ref ci/skip-playwright-postinstall` (or merge + manual dispatch)
- [ ] Confirm Prepare step finishes in ~2 min with all four `>>>` markers visible (the `>>> pnpm build` and `>>> prepare done` lines never appeared on the hung runs)
- [ ] Confirm the test shards still resolve Chrome correctly (cache restore + their own `playwright install`)