### PR TITLE
ci(deploy-suite): restore Playwright browsers from ci.yml's cache

### DIFF
--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -68,6 +68,38 @@ jobs:
           ref: ${{ inputs.next-ref || 'v16.2.6' }}
           path: next.js
 
+      # Resolve the Playwright version from Next.js's lockfile so the cache
+      # key tracks the browser revision installed by `pnpm install` below.
+      # Mirrors ci.yml's pattern and key format — vinext's CI keeps the
+      # `playwright-chromium-Linux-vX.Y.Z` cache hot on every run, so when
+      # the two projects agree on a Playwright version (currently 1.58.2)
+      # this restore is a hit and the prepare script's playwright install
+      # becomes a no-op. Falls through to the hang otherwise; if Next.js
+      # bumps Playwright before vinext does, we'll need to seed the cache
+      # by running vinext's CI once on the new version first.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: next.js
+        run: |
+          set -euo pipefail
+          version=$(grep -E "^\s+playwright:\s+[0-9]" pnpm-lock.yaml | head -n1 | awk '{print $2}' || true)
+          if [ -z "$version" ]; then
+            version="unknown-${{ hashFiles('next.js/pnpm-lock.yaml') }}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved Playwright version: $version"
+
+      # Restore-only — vinext's ci.yml owns saving this cache. Sidesteps
+      # the upstream Playwright extraction hang that started 2026-05-22
+      # (runs 26265986264, 26279790373, 26281061094, 26281758803) by
+      # avoiding the download+extract path entirely on cache hit.
+      - name: Restore Playwright browsers
+        id: playwright-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-v${{ steps.playwright-version.outputs.version }}
+
       - name: Build vinext
         run: vp run vinext#build
 


### PR DESCRIPTION
## Summary

Follow-up to [#1428](https://github.com/cloudflare/vinext/pull/1428) and [#1430](https://github.com/cloudflare/vinext/pull/1430). Those PRs added log markers and skipped the wedged transitive postinstall, but the underlying problem remained: the explicit \`pnpm playwright install chromium chromium-headless-shell\` in the prepare script hits the **same upstream extraction hang** — download to 100%, then no progress until step timeout ([run 26281758803](https://github.com/cloudflare/vinext/actions/runs/26281758803)).

## What's actually different between green and hanging runs

**Nothing on our side.** Verified across runs:

| Variable | May 19-21 (extract: 2.7s) | May 22 (extract: never) |
|---|---|---|
| Chrome version | 145.0.7632.6 (chromium v1208) | 145.0.7632.6 (chromium v1208) |
| Playwright | 1.58.2 | 1.58.2 |
| Node | 24.16.0 | 24.16.0 |
| Runner image | 20260513.135.3 / 20260518.149.1 | same |
| Azure region | mix (eastus / eastus2 / northcentralus) | same mix |
| pnpm | 11.1.1 | 11.1.1 |

Some upstream change — bad bytes from \`cdn.playwright.dev\`, an Azure storage hiccup affecting fsync during extraction, a Playwright installer interaction we can't see from here — is wedging the extraction step. We can't fix it from this repo.

## What we can do: stop downloading

vinext's own [ci.yml](.github/workflows/ci.yml) already keeps a \`playwright-chromium-Linux-v1.58.2\` cache hot. Verified via \`gh api\`:

\`\`\`
key:               playwright-chromium-Linux-v1.58.2
size_in_bytes:     261228479 (261 MB)
last_accessed_at:  minutes ago, every CI E2E run today
\`\`\`

The deploy-suite has never used this. Its only cache (line 188-190's \`Save build artifacts\`) is keyed per-run (\`${{ github.sha }}-${{ github.run_id }}\`), so every nightly starts with an empty \`~/.cache/ms-playwright\` and re-runs the install that's now hanging.

This PR adds a restore step before the Prepare step that uses ci.yml's exact key format. On hit, \`pnpm playwright install\` sees the browsers already present at \`~/.cache/ms-playwright/chromium-1208\` and is a fast no-op. Combined with \`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1\` from #1430 (which quiets the transitive postinstall), prepare should drop from "hangs forever" back to ~2-3 minutes.

**Restore-only** — ci.yml owns the save side, no key conflict.

**Fallback:** if Next.js bumps Playwright before vinext catches up, the cache key won't match and we fall through to the existing (currently broken) install path. By then either upstream is fixed, or we seed the cache by running vinext's ci.yml once on the new Playwright version first.

## Test plan

- [ ] \`gh workflow run nextjs-deploy-suite.yml --ref ci/cache-playwright-from-ci-key\`
- [ ] In the build job log, confirm \"Restore Playwright browsers\" reports \`Cache restored from key: playwright-chromium-Linux-v1.58.2\`
- [ ] Confirm the \`>>> ... pnpm playwright install\` marker completes in seconds (browsers already cached), and \`>>> ... prepare done\` prints — currently they never appear
- [ ] Confirm the 16 test shards still find Chrome (the build-job's cached \`~/.cache/ms-playwright\` is included in their cache restore on line 226 of the workflow)