### PR TITLE
fix: match Next metadata image route behavior

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -177,7 +177,7 @@ function resolveOptionalDependency(projectRoot: string, specifier: string): stri
 function resolveShimModulePath(shimsDir: string, moduleName: string): string {
   // Source checkouts only ship TypeScript shims, while built packages only ship
   // JavaScript. Check .ts first to avoid an extra stat in development.
-  const candidates = [".ts", ".js"];
+  const candidates = [".ts", ".tsx", ".js"];
   for (const ext of candidates) {
     const candidate = path.join(shimsDir, `${moduleName}${ext}`);
     if (fs.existsSync(candidate)) {
@@ -185,6 +185,21 @@ function resolveShimModulePath(shimsDir: string, moduleName: string): string {
     }
   }
   return path.join(shimsDir, `${moduleName}.js`);
+}
+
+function isVercelOgImport(id: string): boolean {
+  return id === "@vercel/og" || id === "@vercel/og.js";
+}
+
+function isVinextOgShimImporter(importer: string | undefined): boolean {
+  if (!importer) return false;
+  const cleanImporter = (importer.startsWith("\0") ? importer.slice(1) : importer).split("?")[0];
+  const normalizedImporter = cleanImporter.replace(/\\/g, "/");
+  return (
+    normalizedImporter.endsWith("/shims/og.tsx") ||
+    normalizedImporter.endsWith("/shims/og.js") ||
+    normalizedImporter.endsWith("/dist/shims/og.js")
+  );
 }
 
 function toRelativeFileEntry(root: string, absPath: string): string {
@@ -2060,18 +2075,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       resolveId: {
-        // Hook filter: only invoke JS for next/* imports and virtual:vinext-* modules.
+        // Hook filter: only invoke JS for handled Next/Vinext compatibility modules.
         // Matches "next/navigation", "next/router.js", "virtual:vinext-rsc-entry",
-        // and \0-prefixed re-imports from @vitejs/plugin-rsc.
+        // direct @vercel/og imports in metadata routes, and \0-prefixed
+        // re-imports from @vitejs/plugin-rsc.
         filter: {
-          id: /(?:next\/|virtual:vinext-)/,
+          id: /(?:next\/|virtual:vinext-|^@vercel\/og(?:\.js)?$)/,
         },
-        handler(id) {
+        handler(id, importer) {
           // Strip \0 prefix if present — @vitejs/plugin-rsc's generated
           // browser entry imports our virtual module using the already-resolved
           // ID (with \0 prefix). We need to re-resolve it so the client
           // environment's import-analysis can find it.
           const cleanId = id.startsWith("\0") ? id.slice(1) : id;
+
+          if (isVercelOgImport(cleanId) && !isVinextOgShimImporter(importer)) {
+            return resolveShimModulePath(_shimsDir, "og");
+          }
 
           // Pages Router virtual modules
           if (cleanId === VIRTUAL_SERVER_ENTRY) return RESOLVED_SERVER_ENTRY;

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -1018,7 +1018,7 @@ export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
         ? metadata.icons.shortcut
         : [metadata.icons.shortcut];
       for (const s of shortcuts) {
-        elements.push(<link key={key++} rel="shortcut icon" href={resolveUrl(s)} />);
+        elements.push(<link key={key++} rel="shortcut icon" href={stringifyUrl(s)} />);
       }
     }
     // Icon
@@ -1028,7 +1028,7 @@ export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
           <link
             key={key++}
             rel="icon"
-            href={resolveUrl(i.url)}
+            href={stringifyUrl(i.url)}
             {...(i.sizes ? { sizes: i.sizes } : {})}
             {...(i.type ? { type: i.type } : {})}
             {...(i.media ? { media: i.media } : {})}
@@ -1046,7 +1046,7 @@ export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
           <link
             key={key++}
             rel="apple-touch-icon"
-            href={resolveUrl(a.url)}
+            href={stringifyUrl(a.url)}
             {...(a.sizes ? { sizes: a.sizes } : {})}
             {...(a.type ? { type: a.type } : {})}
           />,
@@ -1060,7 +1060,7 @@ export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
           <link
             key={key++}
             rel={o.rel}
-            href={resolveUrl(o.url)}
+            href={stringifyUrl(o.url)}
             {...(o.sizes ? { sizes: o.sizes } : {})}
           />,
         );

--- a/packages/vinext/src/shims/og.tsx
+++ b/packages/vinext/src/shims/og.tsx
@@ -1,19 +1,60 @@
+import { ImageResponse as VercelImageResponse } from "@vercel/og";
+import type { ImageResponseOptions } from "@vercel/og";
+import type { ReactElement } from "react";
+
+const CACHE_HEADERS = {
+  noCache: "no-cache, no-store",
+  revalidate: "public, max-age=0, must-revalidate",
+} as const;
+
 /**
- * next/og shim
+ * next/og shim.
  *
- * Re-exports ImageResponse from @vercel/og which provides OG image generation
- * using Satori (SVG) + Resvg WASM (PNG).
- *
- * The vinext:og-inline-fetch-assets Vite plugin (in packages/vinext/src/index.ts)
- * patches @vercel/og/dist/index.edge.js at transform time: any
- * `fetch(new URL("./asset", import.meta.url)).then(res => res.arrayBuffer())`
- * expression is replaced with an inline base64 IIFE so no runtime fetch is needed.
- * This is required for Cloudflare Workers where import.meta.url is "worker" (not
- * a real URL) and new URL(..., import.meta.url) would throw at module load time.
- *
- * Usage:
- *   import { ImageResponse } from "next/og";
- *   return new ImageResponse(<div>Hello</div>, { width: 1200, height: 630 });
+ * The vinext:og-inline-fetch-assets Vite plugin patches @vercel/og's runtime
+ * asset fetches so this wrapper can delegate image generation while preserving
+ * Next.js's public ImageResponse headers and option merging semantics.
  */
-export { ImageResponse } from "@vercel/og";
+export class ImageResponse extends Response {
+  static displayName = "ImageResponse";
+
+  constructor(element: ReactElement, options?: ImageResponseOptions) {
+    const readable = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const imageResponse = new VercelImageResponse(element, options);
+        if (!imageResponse.body) {
+          controller.close();
+          return;
+        }
+
+        const reader = imageResponse.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(value);
+        }
+      },
+    });
+
+    const headers = new Headers({
+      "content-type": "image/png",
+      "cache-control":
+        process.env.NODE_ENV === "development" ? CACHE_HEADERS.noCache : CACHE_HEADERS.revalidate,
+    });
+    if (options?.headers) {
+      new Headers(options.headers).forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
+
+    super(readable, {
+      headers,
+      status: options?.status,
+      statusText: options?.statusText,
+    });
+  }
+}
+
 export type { ImageResponseOptions } from "@vercel/og";

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2692,6 +2692,26 @@ describe("MetadataHead rendering", () => {
     expect(html).toContain('href="/manual-icon.png"');
   });
 
+  it("keeps icon metadata hrefs relative when metadataBase is configured", () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+    const html = renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          metadataBase: new URL("https://mydomain.com"),
+          icons: {
+            icon: [{ url: "/dynamic/big/icon-ahg52g/small", sizes: "48x48", type: "image/png" }],
+            apple: [{ url: "/dynamic/big/apple-icon-ahg52g/0", sizes: "48x48", type: "image/png" }],
+          },
+        },
+      }),
+    );
+
+    expect(html).toContain('href="/dynamic/big/icon-ahg52g/small"');
+    expect(html).toContain('href="/dynamic/big/apple-icon-ahg52g/0"');
+    expect(html).not.toContain("https://mydomain.com/dynamic/big");
+  });
+
   it("renders alternate hreflang links", () => {
     const html = renderToStaticMarkup(
       React.createElement(MetadataHead, {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9821,6 +9821,22 @@ describe("next/og shim", () => {
     expect(bytes[3]).toBe(0x47); // G
   });
 
+  it("sets Next.js metadata image cache headers by default", async () => {
+    const React = await import("react");
+    const og = await import("../packages/vinext/src/shims/og.js");
+
+    const element = React.createElement("div", {
+      style: { display: "flex", width: "100%", height: "100%", backgroundColor: "blue" },
+    });
+
+    const response = new og.ImageResponse(element, {
+      width: 50,
+      height: 50,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+  });
+
   it("respects custom status and headers", async () => {
     const React = await import("react");
     const og = await import("../packages/vinext/src/shims/og.js");
@@ -15835,6 +15851,51 @@ describe("shim alias map .js variants", () => {
 
     const missing = topLevel.filter((key) => !(key + ".js" in aliases!));
     expect(missing, `Missing .js aliases for: ${missing.join(", ")}`).toEqual([]);
+  });
+});
+
+describe("@vercel/og compatibility resolution", () => {
+  type ResolveIdHook = {
+    filter: { id: RegExp };
+    handler: (
+      this: { environment?: { name?: string } },
+      id: string,
+      importer?: string,
+    ) => string | undefined;
+  };
+
+  function getResolveIdHook(): ResolveIdHook {
+    const plugins = vinext() as Plugin[];
+    const configPlugin = plugins.find((p) => p.name === "vinext:config");
+    if (!configPlugin?.resolveId || typeof configPlugin.resolveId === "function") {
+      throw new Error("vinext:config resolveId hook not found");
+    }
+    return configPlugin.resolveId as ResolveIdHook;
+  }
+
+  it("routes direct @vercel/og app imports through the Next-compatible ImageResponse shim", () => {
+    const hook = getResolveIdHook();
+    const expectedShim = path.resolve(import.meta.dirname, "../packages/vinext/src/shims/og.tsx");
+
+    expect(hook.filter.id.test("@vercel/og")).toBe(true);
+    expect(hook.filter.id.test("@vercel/og.js")).toBe(true);
+    expect(
+      hook.handler.call({}, "@vercel/og", path.join(FIXTURE_DIR, "app/opengraph-image.tsx")),
+    ).toBe(expectedShim);
+    expect(
+      hook.handler.call({}, "@vercel/og.js", path.join(FIXTURE_DIR, "app/twitter-image.tsx")),
+    ).toBe(expectedShim);
+  });
+
+  it("lets the ImageResponse shim delegate to the real @vercel/og package", () => {
+    const hook = getResolveIdHook();
+
+    expect(
+      hook.handler.call({}, "@vercel/og", "/repo/packages/vinext/src/shims/og.tsx"),
+    ).toBeUndefined();
+    expect(
+      hook.handler.call({}, "@vercel/og", "/repo/node_modules/vinext/dist/shims/og.js"),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Wrap `next/og` `ImageResponse` so vinext keeps delegating image generation to `@vercel/og` while matching Next.js's public wrapper semantics: `displayName`, default metadata-image `Cache-Control`, status, and custom header merging.
- Resolve direct userland `@vercel/og` imports to vinext's Next-compatible wrapper, with an importer guard so the wrapper itself still delegates to the real package.
- Render icon metadata hrefs from the stored URL value instead of resolving them through `metadataBase`, while leaving social image URL resolution behavior unchanged.

## Next.js References

- Upstream coverage for the failing cases: [`metadata-dynamic-routes/index.test.ts`](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts#L213-L356)
- Upstream fixture that expects direct `@vercel/og` imports to match `next/og`'s `ImageResponse`: [`app/twitter-image.tsx`](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/metadata-dynamic-routes/app/twitter-image.tsx#L1-L8)
- Next.js `ImageResponse` wrapper default headers and `displayName`: [`packages/next/src/server/og/image-response.ts`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/og/image-response.ts#L19-L58)
- Next.js metadata route cache header constants: [`next-metadata-route-loader.ts`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts#L42-L85)
- Next.js icon metadata rendering uses `url.toString()` for icon hrefs: [`metadata.tsx`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/lib/metadata/metadata.tsx#L1911-L1969)

## Verification

- `vp test run tests/shims.test.ts -t "@vercel/og compatibility resolution|next/og shim|shim alias map"`
- `vp test run tests/shims.test.ts tests/features.test.ts tests/metadata-route-response.test.ts`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/metadata-dynamic-routes/index.test.ts`
