### PR TITLE
ci: extract Playwright cache plumbing into a composite action

### DIFF
--- a/.github/actions/playwright-cache/action.yml
+++ b/.github/actions/playwright-cache/action.yml
@@ -1,0 +1,77 @@
+name: Playwright cache
+description: >-
+  Resolve the Playwright version from a pnpm lockfile and restore (and
+  optionally save) the browsers cache under ~/.cache/ms-playwright. Keeps the
+  cache key format consistent across workflows so they share entries.
+
+inputs:
+  browser:
+    description: Browser variant — used as a cache-key segment (chromium, webkit, ...).
+    required: false
+    default: chromium
+  lockfile:
+    description: Path to the pnpm-lock.yaml that pins `playwright`, relative to $GITHUB_WORKSPACE.
+    required: false
+    default: pnpm-lock.yaml
+  mode:
+    description: >-
+      'cache' for restore + save (default — the workflow owns the cache).
+      'restore' for read-only restore (another workflow owns saving; pairs well
+      with a workflow that runs less often than the owner).
+    required: false
+    default: cache
+  restore-keys:
+    description: Optional restore-keys for partial cache fallback.
+    required: false
+    default: ""
+
+outputs:
+  cache-hit:
+    description: Set to 'true' when the cache was restored from an exact-key match.
+    value: ${{ steps.restore.outputs.cache-hit || steps.cache.outputs.cache-hit }}
+  version:
+    description: The Playwright version parsed from the lockfile.
+    value: ${{ steps.version.outputs.version }}
+  key:
+    description: The full cache key used (useful for diagnostics).
+    value: playwright-${{ inputs.browser }}-${{ runner.os }}-v${{ steps.version.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Playwright version
+      id: version
+      shell: bash
+      env:
+        LOCKFILE: ${{ inputs.lockfile }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "$LOCKFILE" ]; then
+          echo "Lockfile not found: $LOCKFILE" >&2
+          exit 1
+        fi
+        version=$(grep -E "^\s+playwright:\s+[0-9]" "$LOCKFILE" | head -n1 | awk '{print $2}' || true)
+        if [ -z "$version" ]; then
+          version="unknown-$(sha256sum "$LOCKFILE" | cut -c1-12)"
+          echo "Warning: could not parse playwright version from $LOCKFILE; using lockfile hash fallback ($version)" >&2
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "Resolved Playwright version: $version (from $LOCKFILE)"
+
+    - name: Restore Playwright browsers (restore-only)
+      if: inputs.mode == 'restore'
+      id: restore
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ inputs.browser }}-${{ runner.os }}-v${{ steps.version.outputs.version }}
+        restore-keys: ${{ inputs.restore-keys }}
+
+    - name: Cache Playwright browsers
+      if: inputs.mode == 'cache'
+      id: cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ inputs.browser }}-${{ runner.os }}-v${{ steps.version.outputs.version }}
+        restore-keys: ${{ inputs.restore-keys }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,26 +227,15 @@ jobs:
       - name: Build plugin
         run: vp run build
 
-      # Resolve the exact Playwright version from the lockfile so the cache key
-      # only changes when Playwright itself is bumped, not on unrelated lockfile
-      # churn. Falls back to a hash of pnpm-lock.yaml if parsing fails.
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: |
-          set -euo pipefail
-          version=$(grep -E "^\s+playwright:\s+[0-9]" pnpm-lock.yaml | head -n1 | awk '{print $2}' || true)
-          if [ -z "$version" ]; then
-            version="unknown-${{ hashFiles('pnpm-lock.yaml') }}"
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Resolved Playwright version: $version"
-
+      # ci.yml owns the playwright browsers cache; nextjs-deploy-suite.yml
+      # restores it read-only via the same composite action so both workflows
+      # share a single warm cache entry per Playwright version + browser + OS.
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v5
+        uses: ./.github/actions/playwright-cache
         with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ matrix.project == 'app-router-webkit-browser-specific' && 'webkit' || 'chromium' }}-${{ runner.os }}-v${{ steps.playwright-version.outputs.version }}
+          browser: ${{ matrix.project == 'app-router-webkit-browser-specific' && 'webkit' || 'chromium' }}
+          mode: cache
           restore-keys: |
             playwright-${{ matrix.project == 'app-router-webkit-browser-specific' && 'webkit' || 'chromium' }}-${{ runner.os }}-
 
@@ -259,7 +248,7 @@ jobs:
         with:
           path: |
             ~/.cache/apt-archives
-          key: apt-webkit-${{ runner.os }}-v${{ steps.playwright-version.outputs.version }}
+          key: apt-webkit-${{ runner.os }}-v${{ steps.playwright-cache.outputs.version }}
           restore-keys: |
             apt-webkit-${{ runner.os }}-
 

--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -68,37 +68,22 @@ jobs:
           ref: ${{ inputs.next-ref || 'v16.2.6' }}
           path: next.js
 
-      # Resolve the Playwright version from Next.js's lockfile so the cache
-      # key tracks the browser revision installed by `pnpm install` below.
-      # Mirrors ci.yml's pattern and key format — vinext's CI keeps the
-      # `playwright-chromium-Linux-vX.Y.Z` cache hot on every run, so when
-      # the two projects agree on a Playwright version (currently 1.58.2)
-      # this restore is a hit and the prepare script's playwright install
-      # becomes a no-op. Falls through to the hang otherwise; if Next.js
-      # bumps Playwright before vinext does, we'll need to seed the cache
-      # by running vinext's CI once on the new version first.
-      - name: Resolve Playwright version
-        id: playwright-version
-        working-directory: next.js
-        run: |
-          set -euo pipefail
-          version=$(grep -E "^\s+playwright:\s+[0-9]" pnpm-lock.yaml | head -n1 | awk '{print $2}' || true)
-          if [ -z "$version" ]; then
-            version="unknown-${{ hashFiles('next.js/pnpm-lock.yaml') }}"
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Resolved Playwright version: $version"
-
-      # Restore-only — vinext's ci.yml owns saving this cache. Sidesteps
-      # the upstream Playwright extraction hang that started 2026-05-22
-      # (runs 26265986264, 26279790373, 26281061094, 26281758803) by
-      # avoiding the download+extract path entirely on cache hit.
+      # Share the playwright-chromium cache with ci.yml, which keeps it hot
+      # on every run. Restore-only — ci.yml owns saving. Sidesteps the
+      # upstream Playwright extraction hang that started 2026-05-22 (runs
+      # 26265986264, 26279790373, 26281061094, 26281758803) by avoiding
+      # the download+extract path entirely on cache hit. The lockfile lives
+      # under next.js/ because that's where the prepare-step install pulls
+      # `playwright` from; if Next.js bumps Playwright before vinext does,
+      # the cache key won't match ci.yml's and we'd need to seed by running
+      # vinext's CI once on the new version first.
       - name: Restore Playwright browsers
         id: playwright-cache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/playwright-cache
         with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-v${{ steps.playwright-version.outputs.version }}
+          browser: chromium
+          lockfile: next.js/pnpm-lock.yaml
+          mode: restore
 
       - name: Build vinext
         run: vp run vinext#build


### PR DESCRIPTION
## Summary

Two workflows now share identical Playwright-version + cache-restore plumbing:
- [`ci.yml`](.github/workflows/ci.yml) — owns the cache, used by E2E jobs
- [`nextjs-deploy-suite.yml`](.github/workflows/nextjs-deploy-suite.yml) — restores it read-only, added in [#1435](https://github.com/cloudflare/vinext/pull/1435)

Pull the duplication into `.github/actions/playwright-cache` so the cache key format can't drift between the two callers. If it ever did, the deploy-suite would stop hitting ci.yml's cache, and the upstream Playwright extraction hang from 2026-05-22 ([#1428](https://github.com/cloudflare/vinext/pull/1428) / [#1430](https://github.com/cloudflare/vinext/pull/1430) / [#1435](https://github.com/cloudflare/vinext/pull/1435) context) would reappear.

## The composite action

`.github/actions/playwright-cache/action.yml`:

- **Lockfile input** — `lockfile` (defaults to `pnpm-lock.yaml`). Set to `next.js/pnpm-lock.yaml` from the deploy-suite, since that's the workspace whose install determines the browser revision.
- **Mode input** — `cache` (restore + save, default; for the workflow that owns the cache) or `restore` (read-only; for downstream consumers).
- **Browser input** — `chromium`/`webkit`/etc., used as a cache-key segment.
- **Outputs** — `cache-hit`, `version`, and `key` (the latter useful for diagnostics).

Cache key format unchanged: `playwright-${browser}-${runner.os}-v${version}`.

## What each caller looks like now

`ci.yml` (10 lines → was 23):

\`\`\`yaml
- name: Cache Playwright browsers
  id: playwright-cache
  uses: ./.github/actions/playwright-cache
  with:
    browser: \${{ matrix.project == 'app-router-webkit-browser-specific' && 'webkit' || 'chromium' }}
    mode: cache
    restore-keys: |
      playwright-\${{ matrix.project == 'app-router-webkit-browser-specific' && 'webkit' || 'chromium' }}-\${{ runner.os }}-
\`\`\`

`nextjs-deploy-suite.yml` (5 lines → was 22):

\`\`\`yaml
- name: Restore Playwright browsers
  id: playwright-cache
  uses: ./.github/actions/playwright-cache
  with:
    browser: chromium
    lockfile: next.js/pnpm-lock.yaml
    mode: restore
\`\`\`

## No behavioural change

- Same cache keys (verified by reading the action's key template)
- Same restore-keys (passed through)
- Same `~/.cache/ms-playwright` path
- Same `cache-hit` output → `ci.yml`'s `Install Playwright Chromium` step still gates on `steps.playwright-cache.outputs.cache-hit != 'true'`
- ci.yml's apt-archives cache key now reads `steps.playwright-cache.outputs.version` (the new composite output) instead of the removed `playwright-version` step

## Test plan

- [ ] Trigger ci.yml on this branch (a push or PR), confirm E2E jobs still hit the existing `playwright-chromium-Linux-v1.58.2` cache and skip the install step
- [ ] Trigger `nextjs-deploy-suite.yml` via `workflow_dispatch --ref ci/playwright-cache-composite-action`, confirm Prepare step still completes in ~2 min with the cache hit