### PR TITLE
fix(app-router): guard deployment fallback hard navigations

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1182,7 +1182,7 @@ function registerServerActionCallback(): void {
       try {
         const redirectUrl = new URL(actionRedirect, window.location.origin);
         if (redirectUrl.origin !== window.location.origin) {
-          window.location.href = actionRedirect;
+          browserNavigationController.performHardNavigation(actionRedirect);
           return undefined;
         }
       } catch {
@@ -1196,9 +1196,9 @@ function registerServerActionCallback(): void {
       clearClientNavigationCaches();
       const redirectType = fetchResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER) ?? "replace";
       if (redirectType === "push") {
-        window.location.assign(actionRedirect);
+        browserNavigationController.performHardNavigation(actionRedirect, "assign");
       } else {
-        window.location.replace(actionRedirect);
+        browserNavigationController.performHardNavigation(actionRedirect, "replace");
       }
       return undefined;
     }
@@ -1212,7 +1212,7 @@ function registerServerActionCallback(): void {
         responseUrl: fetchResponse.url,
       }).kind === "hard-navigate"
     ) {
-      window.location.reload();
+      browserNavigationController.performHardNavigation(actionInitiation.href);
       return undefined;
     }
 
@@ -1409,7 +1409,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             responseUrl: cachedRoute.response.url,
           });
           if (compatibilityDecision.kind === "hard-navigate") {
-            window.location.href = compatibilityDecision.hardNavigationTarget;
+            browserNavigationController.performHardNavigation(
+              compatibilityDecision.hardNavigationTarget,
+            );
             return;
           }
           // Check stale-navigation before and after createFromFetch. The pre-check
@@ -1554,10 +1556,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const isRscResponse = navContentType.startsWith("text/x-component");
         if (!navResponse.ok || !isRscResponse || !navResponse.body) {
           const responseUrl = navResponseUrl ?? navResponse.url;
-          window.location.href = resolveHardNavigationTargetFromRscResponse(
-            responseUrl,
-            currentHref,
-            window.location.origin,
+          browserNavigationController.performHardNavigation(
+            resolveHardNavigationTargetFromRscResponse(
+              responseUrl,
+              currentHref,
+              window.location.origin,
+            ),
           );
           return;
         }
@@ -1570,7 +1574,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           responseUrl: navResponseUrl ?? navResponse.url,
         });
         if (compatibilityDecision.kind === "hard-navigate") {
-          window.location.href = compatibilityDecision.hardNavigationTarget;
+          browserNavigationController.performHardNavigation(
+            compatibilityDecision.hardNavigationTarget,
+          );
           return;
         }
 
@@ -1589,7 +1595,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
               "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
             );
           }
-          window.location.href = redirectDecision.href;
+          browserNavigationController.performHardNavigation(redirectDecision.href);
           return;
         }
 
@@ -1624,14 +1630,14 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           void navResponse.body?.cancel().catch(() => {});
           const resolvedTarget = new URL(flightRedirectTarget, window.location.origin);
           if (resolvedTarget.origin !== window.location.origin) {
-            window.location.href = resolvedTarget.href;
+            browserNavigationController.performHardNavigation(resolvedTarget.href);
             return;
           }
           if (redirectCount >= MAX_RSC_REDIRECT_DEPTH) {
             console.error(
               "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
             );
-            window.location.href = resolvedTarget.href;
+            browserNavigationController.performHardNavigation(resolvedTarget.href);
             return;
           }
           currentHref = `${resolvedTarget.pathname}${resolvedTarget.search}${resolvedTarget.hash}`;
@@ -1730,7 +1736,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       if (!isPageUnloading) {
         console.error("[vinext] RSC navigation error:", error);
       }
-      window.location.href = currentHref;
+      browserNavigationController.performHardNavigation(currentHref);
     } finally {
       // Single settlement site: covers normal return, early returns on stale-id
       // checks, and error paths. The finally runs even when the catch returns.

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -69,6 +69,7 @@ type BrowserNavigationController = {
   hasBrowserRouterState(): boolean;
   getBrowserRouterState(): AppRouterState;
   isCurrentNavigation(navId: number): boolean;
+  performHardNavigation(href: string, mode?: HardNavigationMode): boolean;
   waitForBrowserRouterStateReady(): Promise<void>;
   attachBrowserRouterState(
     setter: Dispatch<AppRouterState | Promise<AppRouterState>>,
@@ -690,6 +691,7 @@ export function createAppBrowserNavigationController(
     hasBrowserRouterState,
     getBrowserRouterState,
     isCurrentNavigation,
+    performHardNavigation,
     waitForBrowserRouterStateReady,
     attachBrowserRouterState,
     beginPendingBrowserRouterState,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -3309,6 +3309,18 @@ describe("app browser root-layout hard navigation", () => {
     }
   });
 
+  it("blocks a repeated same-target hard-navigation fallback outside visible commits", () => {
+    const controller = createAppBrowserNavigationController();
+    const { assign } = stubWindow("https://example.com/dashboard");
+
+    expect(controller.performHardNavigation("https://example.com/dashboard")).toBe(true);
+    expect(assign).toHaveBeenCalledTimes(1);
+
+    assign.mockClear();
+    expect(controller.performHardNavigation("https://example.com/dashboard")).toBe(false);
+    expect(assign).not.toHaveBeenCalled();
+  });
+
   it("allows cross-page hard navigation when the stored guard target is not the current URL", async () => {
     const { controller, detach } = createControllerHarness(
       createState({ rootLayoutTreePath: "/(marketing)" }),

--- a/tests/skip-cache-proof.test.ts
+++ b/tests/skip-cache-proof.test.ts
@@ -125,6 +125,7 @@ function createVerifiedFixture(
   const payloadHash = createClientReusePayloadHash("dashboard-layout-payload");
   const decision = createReuseDecision({
     candidateArtifactCompatibility: artifactCompatibility,
+    currentArtifactCompatibility: artifactCompatibility,
   });
   expectReuseDecision(decision);
 
@@ -269,6 +270,74 @@ describe("skip/cache proof cross-checks", () => {
           compatibilityFallback: "renderFresh",
           reason: "graphVersionUnknown",
         },
+      },
+    });
+  });
+
+  it("verifies canary and rollback skip hints when deployments share a compatibility set", () => {
+    const rollbackCompatibility = createCompatibility({
+      deploymentVersion: "deploy-rollback",
+    });
+    const fixture = createVerifiedFixture({ artifactCompatibility: rollbackCompatibility });
+
+    const result = crossCheckClientReuseManifestEntryWithCache({
+      artifact: fixture.artifact,
+      cacheDecision: fixture.decision,
+      compatibilityMap: {
+        deploymentVersions: [["deploy-stable", "deploy-canary", "deploy-rollback"]],
+      },
+      entry: {
+        ...fixture.entry,
+        artifactCompatibility: createCompatibility({
+          deploymentVersion: "deploy-canary",
+        }),
+      },
+    });
+
+    expect(result).toMatchObject({
+      code: "SKIP_CACHE_CROSS_CHECK_PASSED",
+      entryId: "layout:/dashboard",
+      kind: "verified",
+      skipDisposition: {
+        enabled: false,
+        mode: "renderAndSend",
+      },
+    });
+  });
+
+  it("rejects canary and rollback skip hints when the compatibility map is stale", () => {
+    const rollbackCompatibility = createCompatibility({
+      deploymentVersion: "deploy-rollback",
+    });
+    const fixture = createVerifiedFixture({ artifactCompatibility: rollbackCompatibility });
+
+    const result = crossCheckClientReuseManifestEntryWithCache({
+      artifact: fixture.artifact,
+      cacheDecision: fixture.decision,
+      compatibilityMap: {
+        deploymentVersions: [["deploy-stable", "deploy-canary"]],
+      },
+      entry: {
+        ...fixture.entry,
+        artifactCompatibility: createCompatibility({
+          deploymentVersion: "deploy-canary",
+        }),
+      },
+    });
+
+    expect(result).toMatchObject({
+      kind: "rejected",
+      rejection: {
+        code: "SKIP_CACHE_ARTIFACT_COMPATIBILITY_INCOMPATIBLE",
+        entryId: "layout:/dashboard",
+        fields: {
+          compatibilityFallback: "renderFresh",
+          reason: "deploymentVersionNotDeclaredCompatible",
+        },
+      },
+      skipDisposition: {
+        enabled: false,
+        mode: "renderAndSend",
       },
     });
   });


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Complete `#726-COMPAT-09: Prevent reload loops across canary/rollback`. |
| Core change | Route App Router deployment-skew and RSC fallback hard navigations through the existing controller loop guard. |
| Boundary | The navigation controller remains the lifecycle owner for hard-navigation loop prevention. Skip/cache compatibility remains proof-based and disabled for transport. |
| Primary files | `app-browser-navigation-controller.ts`, `app-browser-entry.ts`, `app-browser-entry.test.ts`, `skip-cache-proof.test.ts` |
| Expected impact | A canary/rollback mismatch may still force one hard navigation, but a repeated same-target fallback is blocked instead of reloading indefinitely. |

Bonk: please read issue #726 for the architectural big picture before reviewing this `#726-COMPAT-09` slice.

## Why

Deployment compatibility is an outcome protocol, not strict equality everywhere. A mismatch can legitimately require a hard navigation, but issue #726 requires that hard-navigation fallback to have loop prevention so rolling deploys, canaries, and rollbacks do not trap users in repeated reloads.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| App Router fallback navigation | Hard-navigation loop prevention has one owner. | Exposes the controller's guarded hard-navigation executor and uses it from RSC/server-action fallback paths. |
| Skip/cache proof | Unknown or stale compatibility never authorizes skip/reuse. | Adds canary/rollback skip coverage for declared compatibility and stale compatibility maps. |
| Visible commit lifecycle | Fallback hard navigation must not publish visible state. | Existing fallback call sites still return without committing after invoking the guarded executor. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Cached or fetched RSC payload has stale/missing compatibility ID | Browser entry wrote `window.location` directly. | Browser entry asks the navigation controller to perform the hard navigation through the loop guard. |
| Server action response indicates deployment mismatch | Client called `window.location.reload()`. | Client asks the controller to hard navigate to the action initiation URL through the loop guard. |
| Canary/rollback skip hint with declared compatibility | Not covered at skip/cache cross-check boundary. | Verified as compatible, while skip transport still remains disabled. |
| Canary/rollback skip hint with stale map | Not covered at skip/cache cross-check boundary. | Rejected with `renderFresh` fallback and render-and-send disposition. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-browser-navigation-controller.ts`  
   Check that `performHardNavigation` is now part of the controller contract and still delegates to the existing same-target sessionStorage guard.

2. `packages/vinext/src/server/app-browser-entry.ts`  
   Review the replaced direct `window.location` fallback writers for RSC compatibility, server-action compatibility, invalid RSC responses, redirect terminal fallbacks, and RSC navigation errors.

3. `tests/app-browser-entry.test.ts`  
   Check the new controller-level fallback regression test alongside the existing root-boundary loop-prevention test.

4. `tests/skip-cache-proof.test.ts`  
   Check declared canary/rollback compatibility versus stale-map rejection at the skip/cache proof boundary.

</details>

<details>
<summary>Validation</summary>

- Red check before implementation: `vp test run tests/skip-cache-proof.test.ts tests/app-browser-entry.test.ts -t "canary and rollback|hard-navigation fallback outside visible commits"`
- Targeted unit files after implementation and rebase: `vp test run tests/skip-cache-proof.test.ts tests/client-reuse-manifest.test.ts tests/app-rsc-request-normalization.test.ts tests/app-browser-entry.test.ts`
  - 4 files passed, 196 tests passed.
- `vp check`
  - Formatting passed.
  - Lint and type checks passed.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no user-facing API change.
- Runtime behavior: hard-navigation fallbacks still navigate by default, but repeated same-target fallback is now blocked by the existing guard.
- Cache/skip: skip transport remains disabled. These tests only assert proof compatibility and safe fallback semantics.
- Existing-app risk: low. The changed paths are fallback paths where the alternative was already a hard navigation or reload.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| #726-COMPAT-09 | Tracks this specific roadmap task. |
| Related to #726 | Architectural source for deployment compatibility, skip proof, and hard-navigation loop prevention. |
| Next.js `handleHardNavigation` / deployment mismatch handling | Confirms the compatibility oracle: deployment mismatch can force hard navigation, but same-target hard navigation must not loop. |