### PR TITLE
fix(router): preserve default locale for unprefixed root links

### DIFF
--- a/packages/vinext/src/shims/client-locale.ts
+++ b/packages/vinext/src/shims/client-locale.ts
@@ -1,0 +1,30 @@
+import { stripBasePath } from "../utils/base-path.js";
+import {
+  detectDomainLocale,
+  getLocalePathPrefix,
+  type DomainLocale,
+} from "../utils/domain-locale.js";
+
+export function getCurrentBrowserLocale({
+  basePath,
+  domainLocales,
+  hostname,
+}: {
+  basePath: string;
+  domainLocales: readonly DomainLocale[] | undefined;
+  hostname: string | null | undefined;
+}): string | undefined {
+  if (typeof window === "undefined") return undefined;
+
+  const pathnameLocale = getLocalePathPrefix(
+    stripBasePath(window.location.pathname, basePath),
+    window.__VINEXT_LOCALES__,
+  );
+  if (pathnameLocale) return pathnameLocale;
+
+  return (
+    detectDomainLocale(domainLocales, hostname ?? undefined)?.defaultLocale ??
+    window.__VINEXT_DEFAULT_LOCALE__ ??
+    window.__VINEXT_LOCALE__
+  );
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -59,7 +59,13 @@ import {
   withBasePath,
 } from "./url-utils.js";
 import { appendSearchParamsToUrl, type UrlQuery, urlQueryToSearchParams } from "../utils/query.js";
-import { addLocalePrefix, getDomainLocaleUrl, type DomainLocale } from "../utils/domain-locale.js";
+import {
+  addLocalePrefix,
+  detectDomainLocale,
+  getDomainLocaleUrl,
+  getLocalePathPrefix,
+  type DomainLocale,
+} from "../utils/domain-locale.js";
 import { getI18nContext } from "./i18n-context.js";
 import type { VinextLinkPrefetchRoute, VinextNextData } from "../client/vinext-next-data.js";
 import { navigatePagesRouterLink } from "../client/pages-router-link-navigation.js";
@@ -424,7 +430,17 @@ function getDefaultLocale(): string | undefined {
 
 function getCurrentLocale(): string | undefined {
   if (typeof window !== "undefined") {
-    return window.__VINEXT_LOCALE__;
+    const pathnameLocale = getLocalePathPrefix(
+      stripBasePath(window.location.pathname, __basePath),
+      window.__VINEXT_LOCALES__,
+    );
+    if (pathnameLocale) return pathnameLocale;
+
+    return (
+      detectDomainLocale(getDomainLocales(), getCurrentHostname())?.defaultLocale ??
+      window.__VINEXT_DEFAULT_LOCALE__ ??
+      window.__VINEXT_LOCALE__
+    );
   }
   return getI18nContext()?.locale;
 }
@@ -449,6 +465,25 @@ function getDomainLocaleHref(href: string, locale: string): string | undefined {
     currentHostname: getCurrentHostname(),
     domainItems: getDomainLocales(),
   });
+}
+
+function addLocalePrefixForRoot(href: string, locale: string): string | undefined {
+  if (href !== "/" && !href.startsWith("/?") && !href.startsWith("/#")) {
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(href, "http://vinext.local");
+  } catch {
+    return undefined;
+  }
+
+  if (parsed.origin !== "http://vinext.local" || parsed.pathname !== "/") {
+    return undefined;
+  }
+
+  return `/${locale}${parsed.search}${parsed.hash}`;
 }
 
 /**
@@ -479,7 +514,13 @@ function applyLocaleToHref(href: string, locale: string | false | undefined): st
     return domainLocaleHref;
   }
 
-  return addLocalePrefix(href, resolvedLocale, getDefaultLocale() ?? "");
+  const defaultLocale = getDefaultLocale() ?? "";
+  if (resolvedLocale.toLowerCase() === defaultLocale.toLowerCase()) {
+    const localeRootHref = addLocalePrefixForRoot(href, resolvedLocale);
+    if (localeRootHref) return localeRootHref;
+  }
+
+  return addLocalePrefix(href, resolvedLocale, defaultLocale);
 }
 
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -59,18 +59,13 @@ import {
   withBasePath,
 } from "./url-utils.js";
 import { appendSearchParamsToUrl, type UrlQuery, urlQueryToSearchParams } from "../utils/query.js";
-import {
-  addLocalePrefix,
-  detectDomainLocale,
-  getDomainLocaleUrl,
-  getLocalePathPrefix,
-  type DomainLocale,
-} from "../utils/domain-locale.js";
+import { addLocalePrefix, getDomainLocaleUrl, type DomainLocale } from "../utils/domain-locale.js";
 import { getI18nContext } from "./i18n-context.js";
 import type { VinextLinkPrefetchRoute, VinextNextData } from "../client/vinext-next-data.js";
 import { navigatePagesRouterLink } from "../client/pages-router-link-navigation.js";
 import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
 import { stripBasePath } from "../utils/base-path.js";
+import { getCurrentBrowserLocale } from "./client-locale.js";
 
 type NavigateEvent = {
   url: URL;
@@ -430,17 +425,11 @@ function getDefaultLocale(): string | undefined {
 
 function getCurrentLocale(): string | undefined {
   if (typeof window !== "undefined") {
-    const pathnameLocale = getLocalePathPrefix(
-      stripBasePath(window.location.pathname, __basePath),
-      window.__VINEXT_LOCALES__,
-    );
-    if (pathnameLocale) return pathnameLocale;
-
-    return (
-      detectDomainLocale(getDomainLocales(), getCurrentHostname())?.defaultLocale ??
-      window.__VINEXT_DEFAULT_LOCALE__ ??
-      window.__VINEXT_LOCALE__
-    );
+    return getCurrentBrowserLocale({
+      basePath: __basePath,
+      domainLocales: getDomainLocales(),
+      hostname: getCurrentHostname(),
+    });
   }
   return getI18nContext()?.locale;
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -34,6 +34,7 @@ import {
 import { stripBasePath } from "../utils/base-path.js";
 import {
   addLocalePrefix,
+  detectDomainLocale,
   getDomainLocaleUrl,
   getLocalePathPrefix,
   type DomainLocale,
@@ -164,10 +165,24 @@ function resolveNavigationTarget(
   return applyNavigationLocale(as ?? resolveUrl(url), locale);
 }
 
+function getCurrentUrlLocale(): string | undefined {
+  const pathnameLocale = getLocalePathPrefix(
+    stripBasePath(window.location.pathname, __basePath),
+    window.__VINEXT_LOCALES__,
+  );
+  if (pathnameLocale) return pathnameLocale;
+
+  return (
+    detectDomainLocale(getDomainLocales(), getCurrentHostname())?.defaultLocale ??
+    window.__VINEXT_DEFAULT_LOCALE__ ??
+    window.__VINEXT_LOCALE__
+  );
+}
+
 function resolveTransitionLocale(locale: TransitionOptions["locale"]): string | undefined {
   if (typeof window === "undefined") return undefined;
   if (locale === false) return window.__VINEXT_DEFAULT_LOCALE__;
-  return locale ?? window.__VINEXT_LOCALE__;
+  return locale ?? getCurrentUrlLocale();
 }
 
 function getDomainLocales(): readonly DomainLocale[] | undefined {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -34,7 +34,6 @@ import {
 import { stripBasePath } from "../utils/base-path.js";
 import {
   addLocalePrefix,
-  detectDomainLocale,
   getDomainLocaleUrl,
   getLocalePathPrefix,
   type DomainLocale,
@@ -49,6 +48,7 @@ import { matchRoutePattern, routePatternParts } from "../routing/route-pattern.j
 import { scrollToHashTarget } from "./hash-scroll.js";
 import { setPagesRouterPopStateHandler } from "./pages-router-runtime.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
+import { getCurrentBrowserLocale } from "./client-locale.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
@@ -166,17 +166,11 @@ function resolveNavigationTarget(
 }
 
 function getCurrentUrlLocale(): string | undefined {
-  const pathnameLocale = getLocalePathPrefix(
-    stripBasePath(window.location.pathname, __basePath),
-    window.__VINEXT_LOCALES__,
-  );
-  if (pathnameLocale) return pathnameLocale;
-
-  return (
-    detectDomainLocale(getDomainLocales(), getCurrentHostname())?.defaultLocale ??
-    window.__VINEXT_DEFAULT_LOCALE__ ??
-    window.__VINEXT_LOCALE__
-  );
+  return getCurrentBrowserLocale({
+    basePath: __basePath,
+    domainLocales: getDomainLocales(),
+    hostname: getCurrentHostname(),
+  });
 }
 
 function resolveTransitionLocale(locale: TransitionOptions["locale"]): string | undefined {

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -408,6 +408,21 @@ describe("Link locale handling", () => {
     expect(html).toContain('href="/id"');
   });
 
+  it("locale=undefined renders a default-locale root fallback during SSR", async () => {
+    delete (globalThis as any).window;
+
+    const html = await runWithI18nState(async () => {
+      setI18nContext({
+        locale: "en",
+        locales: ["en", "id"],
+        defaultLocale: "en",
+      });
+      return ReactDOMServer.renderToString(React.createElement(Link, { href: "/" }, "x"));
+    });
+
+    expect(html).toContain('href="/en"');
+  });
+
   it("locale=undefined treats a non-locale-prefixed browser path as the default locale", () => {
     // Ported from Next.js:
     // test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -408,6 +408,46 @@ describe("Link locale handling", () => {
     expect(html).toContain('href="/id"');
   });
 
+  it("locale=undefined treats a non-locale-prefixed browser path as the default locale", () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    (globalThis as any).window = {
+      location: {
+        pathname: "/new",
+        hostname: "localhost",
+      },
+      __VINEXT_LOCALE__: "id",
+      __VINEXT_LOCALES__: ["en", "id"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+      __NEXT_DATA__: {},
+    };
+
+    const html = ReactDOMServer.renderToString(React.createElement(Link, { href: "/" }, "x"));
+
+    expect(html).toContain('href="/en"');
+  });
+
+  it("locale=undefined keeps the current locale for locale-prefixed browser paths", () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    (globalThis as any).window = {
+      location: {
+        pathname: "/id/new",
+        hostname: "localhost",
+      },
+      __VINEXT_LOCALE__: "id",
+      __VINEXT_LOCALES__: ["en", "id"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+      __NEXT_DATA__: {},
+    };
+
+    const html = ReactDOMServer.renderToString(React.createElement(Link, { href: "/" }, "x"));
+
+    expect(html).toContain('href="/id"');
+  });
+
   it("locale string prepends locale prefix", () => {
     // When locale is a non-default locale string, it prepends /{locale}
     // Note: default locale check uses __VINEXT_DEFAULT_LOCALE__ which is undefined in tests

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11862,6 +11862,124 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("treats a non-locale-prefixed current path as the default locale for root Link navigations", async () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    win.location.pathname = "/new";
+    win.location.href = "http://localhost/new";
+    Object.assign(win, {
+      // Simulate a stale/preferred locale signal that must not override the
+      // URL-derived Pages Router locale for an unprefixed path.
+      __VINEXT_LOCALE__: "id",
+      __VINEXT_LOCALES__: ["en", "id"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+    });
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(
+      async () =>
+        new Response(
+          buildNavHtml(
+            "/",
+            pageModuleUrl,
+            {},
+            {
+              locale: "en",
+              locales: ["en", "id"],
+              defaultLocale: "en",
+            },
+          ),
+          { status: 200 },
+        ),
+    );
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/");
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith("/en", expect.any(Object));
+      expect(win.history.pushState).toHaveBeenCalledWith({}, "", "/");
+      expect(win.location.href).toBe("http://localhost/");
+      expect(win.__VINEXT_LOCALE__).toBe("en");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps a locale-prefixed current path locale for root Link navigations", async () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    win.location.pathname = "/id/new";
+    win.location.href = "http://localhost/id/new";
+    Object.assign(win, {
+      __VINEXT_LOCALE__: "id",
+      __VINEXT_LOCALES__: ["en", "id"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+    });
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(
+      async () =>
+        new Response(
+          buildNavHtml(
+            "/",
+            pageModuleUrl,
+            {},
+            {
+              locale: "id",
+              locales: ["en", "id"],
+              defaultLocale: "en",
+            },
+          ),
+          { status: 200 },
+        ),
+    );
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/");
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith("/id", expect.any(Object));
+      expect(win.history.pushState).toHaveBeenCalledWith({}, "", "/id");
+      expect(win.location.href).toBe("http://localhost/id");
+      expect(win.__VINEXT_LOCALE__).toBe("id");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("popstate fetches default-locale root through a locale-qualified URL", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js i18n preferred-locale behavior when a client link navigates from an unprefixed Pages Router path back to `/`. |
| Core change | Infer implicit client navigation locale from the current URL first, then domain/default locale state, instead of trusting stale preferred-locale globals. |
| Main boundary | Unprefixed Pages Router URLs represent the default locale even when direct root access would redirect to the browser's preferred non-default locale. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `packages/vinext/src/shims/router.ts`, `tests/link.test.ts`, `tests/shims.test.ts` |
| Expected impact | `/new` with preferred locale `id` links back to default-locale index content, while `/id/new` still links back to `id` index content. |

## Why

The client router has to distinguish preferred-locale detection from the locale represented by the current URL. Next.js only applies preferred-locale root redirect semantics to direct root requests; once the user is on an unprefixed Pages Router path, the active locale is the default locale.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Pages Router navigation | The current URL is the strongest signal for implicit locale. | `Router.push("/")` now resolves the transition locale from the pathname prefix, then domain default, then configured default locale. |
| Link rendering | A non-intercepted root link must not accidentally re-enter preferred-locale detection. | Default-locale root links render a locale-qualified fallback href while intercepted navigation still presents the canonical visible URL. |
| i18n parity | Direct root access and client link-to-root are different observable cases. | Ported the relevant upstream Next.js preferred-locale regression at the Link and router boundaries. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Browser is on `/new`, preferred locale is `id`, link goes to `/` | Navigation/fallback could request `/id`, returning `id` content. | Navigation requests default-locale index content and the visible URL stays `/`. |
| Browser is on `/id/new`, link goes to `/` | Navigation stays on `id`. | Navigation still stays on `id`. |
| Direct root request with preferred locale `id` | Redirects to `/id`. | Unchanged. |

<details>
<summary>Maintainer review path</summary>

1. `tests/shims.test.ts` verifies the Pages Router transition request URL and visible URL for unprefixed and locale-prefixed paths.
2. `tests/link.test.ts` verifies the rendered fallback href for the same boundary.
3. `packages/vinext/src/shims/router.ts` shows the URL-first implicit locale lookup for client transitions.
4. `packages/vinext/src/shims/link.tsx` mirrors that lookup for rendered links and scopes the default-locale root fallback to `/`, `/?...`, and `/#...`.

</details>

<details>
<summary>Validation</summary>

Added regression coverage:

- `tests/shims.test.ts`: non-locale-prefixed `/new` to `/` requests default-locale content.
- `tests/shims.test.ts`: locale-prefixed `/id/new` to `/` requests `id` content.
- `tests/link.test.ts`: rendered root link fallback href follows the same current-URL locale rule.

Commands run:

```sh
vp test run tests/link.test.ts tests/shims.test.ts
vp check
vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
```

The upstream deploy-suite file now passes all three cases. The initial run reproduced the named failure. One intermediate upstream run exposed that the router fix also needed the rendered Link fallback boundary covered, so the final implementation fixes both boundaries.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no API shape changes.
- Runtime: scoped to client-side i18n locale inference for Pages Router links and transitions.
- Compatibility: follows Next.js semantics for deriving implicit Link locale from the router/current URL. The locale-qualified default root fallback href is vinext-specific because vinext can otherwise fall through to a full root request and trigger preferred-locale detection before client interception.
- Existing-app risk: limited to i18n-enabled apps with default-locale root links. Non-root paths and explicit `locale` props keep existing behavior.

</details>

<details>
<summary>Non-goals</summary>

- This does not change server-side direct root preferred-locale redirects.
- This does not change config headers, redirects, rewrites, or middleware ordering.
- This does not alter domain-locale URL generation beyond using domain defaults as the fallback locale source.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream regression test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts) | Defines the three observable preferred-locale cases this PR ports and verifies. |
| [Next.js Link locale rendering](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/link.tsx) | Shows `locale={undefined}` resolves from the current router locale. |
| [Next.js addLocale helper](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/utils/add-locale.ts) | Shows default locale is normally omitted from generated app paths. |
| [Next.js preferred locale redirect](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/i18n/get-locale-redirect.ts) | Shows preferred-locale detection is root-request behavior. |
