### PR TITLE
test(msw): introduce MSW infrastructure and migrate font-google-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/rollup": "catalog:"
   },
   "devDependencies": {
+    "@mswjs/interceptors": "catalog:",
     "@playwright/test": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
@@ -30,6 +31,7 @@
     "@vitejs/plugin-rsc": "catalog:",
     "@vitest/coverage-istanbul": "catalog:",
     "knip": "catalog:",
+    "msw": "catalog:",
     "next": "catalog:",
     "playwright": "catalog:",
     "react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@mdx-js/rollup':
       specifier: ^3.1.1
       version: 3.1.1
+    '@mswjs/interceptors':
+      specifier: ^0.41.3
+      version: 0.41.9
     '@next/mdx':
       specifier: 16.2.6
       version: 16.2.6
@@ -144,6 +147,9 @@ catalogs:
     ms:
       specifier: 3.0.0-canary.1
       version: 3.0.0-canary.1
+    msw:
+      specifier: ^2.14.6
+      version: 2.14.6
     next:
       specifier: 16.2.6
       version: 16.2.6
@@ -245,6 +251,9 @@ importers:
         specifier: 'catalog:'
         version: 3.1.1
     devDependencies:
+      '@mswjs/interceptors':
+        specifier: 'catalog:'
+        version: 0.41.9
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.58.2
@@ -269,6 +278,9 @@ importers:
       knip:
         specifier: 'catalog:'
         version: 6.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      msw:
+        specifier: 'catalog:'
+        version: 2.14.6(@types/node@25.2.3)(typescript@5.9.3)
       next:
         specifier: 'catalog:'
         version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2304,6 +2316,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.13':
+    resolution: {integrity: sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.10':
+    resolution: {integrity: sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@istanbuljs/schema@0.1.6':
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
@@ -2348,6 +2395,10 @@ packages:
     resolution: {integrity: sha512-v8satFmBB+DqDzYohnm1u2JOvxx6Hl3pUvqzJvfs2Zk/ngZ1aRUhsWpXvwPkNeGN9c2NCm/38H29ZqXQUjf8dw==}
     peerDependencies:
       rollup: '>=2'
+
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -2440,6 +2491,18 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -4040,6 +4103,12 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -4295,8 +4364,16 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-sequence-parser@1.1.1:
     resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -4454,8 +4531,16 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -4468,6 +4553,10 @@ packages:
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -4715,6 +4804,9 @@ packages:
     resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
     engines: {node: '>=10.0.0'}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -4840,6 +4932,15 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5015,6 +5116,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -5037,6 +5142,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   h3@2.0.1-rc.22:
     resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
@@ -5081,6 +5190,9 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
@@ -5141,12 +5253,19 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -5610,6 +5729,20 @@ packages:
     resolution: {integrity: sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==}
     engines: {node: '>=12.13'}
 
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5765,6 +5898,9 @@ packages:
 
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   oxc-parser@0.127.0:
     resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
@@ -6002,11 +6138,18 @@ packages:
   remark@15.0.1:
     resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -6065,6 +6208,10 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -6102,8 +6249,19 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string.prototype.codepointat@0.2.1:
     resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
@@ -6113,6 +6271,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -6157,6 +6319,10 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -6199,6 +6365,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -6206,6 +6379,10 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -6236,6 +6413,10 @@ packages:
 
   turbo-stream@3.2.0:
     resolution: {integrity: sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -6360,6 +6541,9 @@ packages:
       uploadthing:
         optional: true
 
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -6475,6 +6659,10 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -6502,6 +6690,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -6509,6 +6701,14 @@ packages:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
@@ -7204,6 +7404,33 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.13(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/core': 11.1.10(@types/node@25.2.3)
+      '@inquirer/type': 4.0.5(@types/node@25.2.3)
+    optionalDependencies:
+      '@types/node': 25.2.3
+
+  '@inquirer/core@11.1.10(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.2.3)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@25.2.3)':
+    optionalDependencies:
+      '@types/node': 25.2.3
+
   '@istanbuljs/schema@0.1.6': {}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -7282,6 +7509,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -7344,6 +7580,17 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -8526,6 +8773,12 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.2.3
+
+  '@types/statuses@2.0.6': {}
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -8708,7 +8961,13 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  ansi-regex@5.0.1: {}
+
   ansi-sequence-parser@1.1.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   argparse@2.0.1: {}
 
@@ -8856,7 +9115,15 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
@@ -8872,6 +9139,10 @@ snapshots:
       - supports-color
 
   collapse-white-space@2.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
 
   color-name@1.1.4: {}
 
@@ -8983,6 +9254,8 @@ snapshots:
   electron-to-chromium@1.5.348: {}
 
   emoji-regex-xs@2.0.1: {}
+
+  emoji-regex@8.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -9178,6 +9451,16 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -9327,6 +9610,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-nonce@1.0.1: {}
 
   get-tsconfig@4.14.0:
@@ -9344,6 +9629,8 @@ snapshots:
   globrex@0.1.2: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql@16.14.0: {}
 
   h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.13)):
     dependencies:
@@ -9466,6 +9753,11 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
+
   hex-rgb@4.3.0: {}
 
   hookable@6.1.1: {}
@@ -9517,11 +9809,15 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
@@ -10193,6 +10489,33 @@ snapshots:
 
   ms@3.0.0-canary.1: {}
 
+  msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.13(@types/node@25.2.3)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.11: {}
 
   nanostores@1.2.0: {}
@@ -10349,6 +10672,8 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  outvariant@1.4.3: {}
 
   oxc-parser@0.127.0:
     dependencies:
@@ -10740,9 +11065,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-directory@2.1.1: {}
+
   reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  rettime@0.11.11: {}
 
   reusify@1.1.0: {}
 
@@ -10856,6 +11185,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  signal-exit@4.1.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -10887,7 +11218,17 @@ snapshots:
 
   srvx@0.11.13: {}
 
+  statuses@2.0.2: {}
+
   std-env@4.0.0: {}
+
+  strict-event-emitter@0.5.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string.prototype.codepointat@0.2.1: {}
 
@@ -10899,6 +11240,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-json-comments@2.0.1: {}
 
@@ -10932,6 +11277,8 @@ snapshots:
       dequal: 2.0.3
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
+
+  tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
 
@@ -10971,11 +11318,21 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
 
   trim-lines@3.0.1: {}
 
@@ -10998,6 +11355,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   turbo-stream@3.2.0: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -11065,6 +11426,8 @@ snapshots:
       chokidar: 5.0.0
       db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))
       ofetch: 2.0.0-alpha.3
+
+  until-async@3.0.2: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -11236,15 +11599,35 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
 
   ws@8.19.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yoga-layout@3.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,8 @@ catalog:
   ipaddr.js: ^2.1.0
   lucide-react: ^0.577.0
   magic-string: ^0.30.21
+  "@mswjs/interceptors": ^0.41.3
+  msw: ^2.14.6
   ms: 3.0.0-canary.1
   next: 16.2.6
   next-intl: ^4.9.2
@@ -126,3 +128,6 @@ allowBuilds:
   "@parcel/watcher": true
   "@swc/core": true
   unrs-resolver: false
+  # MSW's postinstall only copies a service worker into ./public for browser
+  # mocking. We exclusively use msw/node, so the postinstall is unnecessary.
+  msw: false

--- a/tests/_msw/handlers.ts
+++ b/tests/_msw/handlers.ts
@@ -28,12 +28,15 @@ import { http, passthrough, type RequestHandler } from "msw";
  * `passthrough()` is the documented escape hatch: the request is
  * forwarded to the real network without buffering.
  */
-// 127/8 + IPv6 ::1 + the literal hostname "localhost". The IPv4 octets
-// are loosely bounded to 1-3 digits — `URL.hostname` normalises real
-// addresses and no test would construct an out-of-range octet, so the
-// looser bound is fine and keeps the regex readable.
+// 127/8 + the unspecified `0.0.0.0` + IPv6 `::1` + the literal hostname
+// "localhost". `0.0.0.0` is included defensively — Node servers that
+// bind to "0.0.0.0" sometimes surface that exact host in URLs handed
+// to fetch in tests. The IPv4 octets are loosely bounded to 1-3 digits
+// — `URL.hostname` normalises real addresses and no test would
+// construct an out-of-range octet, so the looser bound keeps the regex
+// readable.
 const LOOPBACK_URL_PATTERN =
-  /^https?:\/\/(?:localhost|127(?:\.\d{1,3}){3}|\[?::1\]?)(?::\d+)?(?:\/|$)/;
+  /^https?:\/\/(?:localhost|127(?:\.\d{1,3}){3}|0(?:\.0){3}|\[?::1\]?)(?::\d+)?(?:\/|$)/;
 const loopbackPassthrough = http.all(LOOPBACK_URL_PATTERN, () => passthrough());
 
 export const handlers: RequestHandler[] = [loopbackPassthrough];

--- a/tests/_msw/handlers.ts
+++ b/tests/_msw/handlers.ts
@@ -1,33 +1,34 @@
-import { http, HttpResponse, type RequestHandler } from "msw";
+import { http, passthrough, type RequestHandler } from "msw";
 
 /**
  * Default MSW handlers shared across the test suite.
  *
- * The `setup.ts` file enables `onUnhandledRequest: "error"`, so any request
- * issued by tests (or by fixture pages exercised through the in-process Vite
- * runtime) must be matched by a handler — either a default handler here or
- * a per-test override registered via `server.use(...)`.
+ * `tests/_msw/setup.ts` enables `onUnhandledRequest: "error"`, so any
+ * request issued by tests must be matched by either a default handler
+ * here or a per-test override registered via `server.use(...)`.
  *
- * Tests register their own handlers locally; this file is for the small set
- * of requests issued by fixture pages that we cannot reasonably scope to a
- * single test file.
+ * MSW is wired into the `unit` vitest project only — the integration
+ * project's tests spin up in-process HTTP servers and fixture dev
+ * servers, which don't mix well with the @mswjs/interceptors layer.
+ * See the comment on the `integration` project in `vite.config.ts`.
+ *
+ * Tests register their own handlers locally via `server.use(...)`.
  */
 
-// TODO(msw-migration): These two handlers exist so that the existing fixture
-// pages under `tests/fixtures/app-basic/` keep working once the MSW guard is
-// enabled. They are placeholders — follow-up PRs (or a dedicated cleanup
-// pass) will replace the live external URLs in those fixtures with
-// test-local endpoints, at which point these passthroughs can be removed.
-//
-//   - tests/fixtures/app-basic/app/revalidate-tag-test/page.tsx
-//       fetches https://httpbin.org/uuid
-//   - tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-fetch/page.tsx
-//       fetches https://example.com/not-cacheable
-export const handlers: RequestHandler[] = [
-  http.get("https://httpbin.org/uuid", () =>
-    HttpResponse.json({ uuid: "00000000-0000-0000-0000-000000000000" }),
-  ),
-  http.get("https://example.com/not-cacheable", () =>
-    HttpResponse.text("ok", { headers: { "cache-control": "no-store" } }),
-  ),
-];
+/**
+ * Loopback addresses are always passed through to the real network.
+ *
+ * Even unit tests routinely spin up small in-process HTTP servers
+ * (e.g. middleware-rewrite proxy tests in `tests/shims.test.ts`,
+ * static-asset 404 tests, JSX-in-JS rendering tests). Those tests bind
+ * a Node `http.Server` on `127.0.0.1:<random>` and fetch it. Without
+ * this passthrough, MSW's interceptor sees the loopback fetch, finds
+ * no handler, and errors via `onUnhandledRequest: "error"`.
+ *
+ * `passthrough()` is the documented escape hatch: the request is
+ * forwarded to the real network without buffering.
+ */
+const LOOPBACK_URL_PATTERN = /^https?:\/\/(?:localhost|127(?:\.\d+){3}|\[?::1\]?)(?::\d+)?(?:\/|$)/;
+const loopbackPassthrough = http.all(LOOPBACK_URL_PATTERN, () => passthrough());
+
+export const handlers: RequestHandler[] = [loopbackPassthrough];

--- a/tests/_msw/handlers.ts
+++ b/tests/_msw/handlers.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse, type RequestHandler } from "msw";
+
+/**
+ * Default MSW handlers shared across the test suite.
+ *
+ * The `setup.ts` file enables `onUnhandledRequest: "error"`, so any request
+ * issued by tests (or by fixture pages exercised through the in-process Vite
+ * runtime) must be matched by a handler — either a default handler here or
+ * a per-test override registered via `server.use(...)`.
+ *
+ * Tests register their own handlers locally; this file is for the small set
+ * of requests issued by fixture pages that we cannot reasonably scope to a
+ * single test file.
+ */
+
+// TODO(msw-migration): These two handlers exist so that the existing fixture
+// pages under `tests/fixtures/app-basic/` keep working once the MSW guard is
+// enabled. They are placeholders — follow-up PRs (or a dedicated cleanup
+// pass) will replace the live external URLs in those fixtures with
+// test-local endpoints, at which point these passthroughs can be removed.
+//
+//   - tests/fixtures/app-basic/app/revalidate-tag-test/page.tsx
+//       fetches https://httpbin.org/uuid
+//   - tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-fetch/page.tsx
+//       fetches https://example.com/not-cacheable
+export const handlers: RequestHandler[] = [
+  http.get("https://httpbin.org/uuid", () =>
+    HttpResponse.json({ uuid: "00000000-0000-0000-0000-000000000000" }),
+  ),
+  http.get("https://example.com/not-cacheable", () =>
+    HttpResponse.text("ok", { headers: { "cache-control": "no-store" } }),
+  ),
+];

--- a/tests/_msw/handlers.ts
+++ b/tests/_msw/handlers.ts
@@ -28,7 +28,12 @@ import { http, passthrough, type RequestHandler } from "msw";
  * `passthrough()` is the documented escape hatch: the request is
  * forwarded to the real network without buffering.
  */
-const LOOPBACK_URL_PATTERN = /^https?:\/\/(?:localhost|127(?:\.\d+){3}|\[?::1\]?)(?::\d+)?(?:\/|$)/;
+// 127/8 + IPv6 ::1 + the literal hostname "localhost". The IPv4 octets
+// are loosely bounded to 1-3 digits — `URL.hostname` normalises real
+// addresses and no test would construct an out-of-range octet, so the
+// looser bound is fine and keeps the regex readable.
+const LOOPBACK_URL_PATTERN =
+  /^https?:\/\/(?:localhost|127(?:\.\d{1,3}){3}|\[?::1\]?)(?::\d+)?(?:\/|$)/;
 const loopbackPassthrough = http.all(LOOPBACK_URL_PATTERN, () => passthrough());
 
 export const handlers: RequestHandler[] = [loopbackPassthrough];

--- a/tests/_msw/server.ts
+++ b/tests/_msw/server.ts
@@ -19,5 +19,11 @@ import { handlers } from "./handlers.js";
  * headers that the new Request explicitly stripped. We only need
  * `globalThis.fetch` interception in this suite (no `node:http` callers), so
  * dropping the ClientRequestInterceptor avoids that side-effect entirely.
+ *
+ * TODO(msw-3): `SetupServerApi` is `@deprecated` in MSW 2.14.6 in favour of the
+ * `defineNetwork` API that MSW 3 standardises around. Migrate when we bump to
+ * MSW 3 — the FetchInterceptor-only customisation will need to be expressed
+ * through `defineNetwork`'s interceptor configuration instead of constructing
+ * `SetupServerApi` directly.
  */
 export const server = new SetupServerApi(handlers, [new FetchInterceptor()]);

--- a/tests/_msw/server.ts
+++ b/tests/_msw/server.ts
@@ -1,0 +1,23 @@
+import { FetchInterceptor } from "@mswjs/interceptors/fetch";
+import { SetupServerApi } from "msw/node";
+import { handlers } from "./handlers.js";
+
+/**
+ * The MSW server instance for this vitest worker.
+ *
+ * `setupFiles` runs once per worker before any test code, so each worker gets
+ * its own `server`. The vitest `integration` project runs file-serially, and
+ * the `unit` project's tests rely on `server.resetHandlers()` between tests
+ * (registered in `setup.ts`) to keep handler state isolated.
+ *
+ * We instantiate `SetupServerApi` directly with ONLY the `FetchInterceptor`,
+ * rather than calling `setupServer()` (which also installs the
+ * `ClientRequestInterceptor`). The latter monkey-patches `globalThis.Headers`
+ * and `globalThis.Request` to record raw headers on a hidden symbol, and that
+ * machinery leaks original-source headers across `new Request(req, { headers })`
+ * copy-construction — surfacing as e.g. `new Headers(req.headers)` returning
+ * headers that the new Request explicitly stripped. We only need
+ * `globalThis.fetch` interception in this suite (no `node:http` callers), so
+ * dropping the ClientRequestInterceptor avoids that side-effect entirely.
+ */
+export const server = new SetupServerApi(handlers, [new FetchInterceptor()]);

--- a/tests/_msw/setup.ts
+++ b/tests/_msw/setup.ts
@@ -1,0 +1,49 @@
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { server } from "./server.js";
+
+/**
+ * Hostnames we treat as "local" and let through without an MSW handler.
+ *
+ * The vitest integration project spins up real HTTP servers (in-process Vite
+ * dev servers, prod-built worker entries, fixture proxies) and then hits
+ * them via `fetch(\`http://127.0.0.1:<port>/...\`)`. Those requests are not
+ * what MSW is meant to catch — MSW exists here to prevent tests from
+ * accidentally hitting the public internet, not to mediate test-internal
+ * traffic.
+ */
+const LOCAL_HOSTNAME_PATTERNS = [/^localhost$/, /^127(?:\.\d+){3}$/, /^\[?::1\]?$/];
+
+function isLocalRequest(url: URL): boolean {
+  return LOCAL_HOSTNAME_PATTERNS.some((p) => p.test(url.hostname));
+}
+
+/**
+ * Vitest setup file that boots the MSW server for every worker.
+ *
+ * `onUnhandledRequest` errors on any unmocked external request. The whole
+ * point of moving away from ad-hoc `globalThis.fetch` hijacking is that
+ * future tests which forget to mock an outbound request fail loudly instead
+ * of silently hitting the network (or worse, leaking through a stale
+ * `fetchMock` that a previous test left behind). Local (loopback) requests
+ * are bypassed because they target test-owned servers, not the internet.
+ */
+beforeAll(() => {
+  server.listen({
+    onUnhandledRequest(request, print) {
+      const url = new URL(request.url);
+      if (isLocalRequest(url)) {
+        // Loopback request to a test-owned server — let it through silently.
+        return;
+      }
+      print.error();
+    },
+  });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});

--- a/tests/_msw/setup.ts
+++ b/tests/_msw/setup.ts
@@ -2,42 +2,20 @@ import { afterAll, afterEach, beforeAll } from "vitest";
 import { server } from "./server.js";
 
 /**
- * Hostnames we treat as "local" and let through without an MSW handler.
- *
- * The vitest integration project spins up real HTTP servers (in-process Vite
- * dev servers, prod-built worker entries, fixture proxies) and then hits
- * them via `fetch(\`http://127.0.0.1:<port>/...\`)`. Those requests are not
- * what MSW is meant to catch — MSW exists here to prevent tests from
- * accidentally hitting the public internet, not to mediate test-internal
- * traffic.
- */
-const LOCAL_HOSTNAME_PATTERNS = [/^localhost$/, /^127(?:\.\d+){3}$/, /^\[?::1\]?$/];
-
-function isLocalRequest(url: URL): boolean {
-  return LOCAL_HOSTNAME_PATTERNS.some((p) => p.test(url.hostname));
-}
-
-/**
  * Vitest setup file that boots the MSW server for every worker.
  *
- * `onUnhandledRequest` errors on any unmocked external request. The whole
- * point of moving away from ad-hoc `globalThis.fetch` hijacking is that
- * future tests which forget to mock an outbound request fail loudly instead
- * of silently hitting the network (or worse, leaking through a stale
- * `fetchMock` that a previous test left behind). Local (loopback) requests
- * are bypassed because they target test-owned servers, not the internet.
+ * `onUnhandledRequest: "error"` makes any unmocked external request fail
+ * loudly — the whole point of moving away from ad-hoc `globalThis.fetch`
+ * hijacking is that tests which forget to mock an outbound request fail
+ * loudly instead of silently hitting the network (or worse, leaking
+ * through a stale stub a previous test left behind).
+ *
+ * Loopback requests are passed through to the real network by the
+ * default `loopbackPassthrough` handler in `handlers.ts`, so integration
+ * tests that spin up in-process HTTP servers continue to work.
  */
 beforeAll(() => {
-  server.listen({
-    onUnhandledRequest(request, print) {
-      const url = new URL(request.url);
-      if (isLocalRequest(url)) {
-        // Loopback request to a test-owned server — let it through silently.
-        return;
-      }
-      print.error();
-    },
-  });
+  server.listen({ onUnhandledRequest: "error" });
 });
 
 afterEach(() => {

--- a/tests/font-google-build.test.ts
+++ b/tests/font-google-build.test.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import fs from "node:fs/promises";
 import os from "node:os";
 import { createBuilder } from "vite-plus";
+import { http, HttpResponse } from "msw";
+import { server } from "./_msw/server.js";
 import vinext from "../packages/vinext/src/index.js";
 
 const APP_FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/font-google-multiple");
@@ -14,20 +16,24 @@ async function buildFontGoogleMultipleFixture(): Promise<string> {
   const ssrOutDir = path.join(outDir, "server", "ssr");
   const clientOutDir = path.join(outDir, "client");
 
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input: any) => {
-    const url = String(input);
-    if (url.includes("Geist") && !url.includes("Mono")) {
-      return new Response("@font-face { font-family: 'Geist'; src: url(/geist.woff2); }", {
-        status: 200,
-        headers: { "content-type": "text/css" },
-      });
-    }
-    return new Response("@font-face { font-family: 'Geist Mono'; src: url(/geist-mono.woff2); }", {
-      status: 200,
-      headers: { "content-type": "text/css" },
-    });
-  };
+  // Intercept the Google Fonts CSS fetch issued by the in-process Vite build.
+  // MSW Node intercepts both `globalThis.fetch` and `node:http`/`node:https`,
+  // so any request the bundler issues against fonts.googleapis.com is caught.
+  // Handlers are reset by the global `afterEach` in `tests/_msw/setup.ts`.
+  server.use(
+    http.get("https://fonts.googleapis.com/*", ({ request }) => {
+      const url = request.url;
+      if (url.includes("Geist") && !url.includes("Mono")) {
+        return HttpResponse.text("@font-face { font-family: 'Geist'; src: url(/geist.woff2); }", {
+          headers: { "content-type": "text/css" },
+        });
+      }
+      return HttpResponse.text(
+        "@font-face { font-family: 'Geist Mono'; src: url(/geist-mono.woff2); }",
+        { headers: { "content-type": "text/css" } },
+      );
+    }),
+  );
 
   const nodeModulesLink = path.join(APP_FIXTURE_DIR, "node_modules");
 
@@ -54,7 +60,6 @@ async function buildFontGoogleMultipleFixture(): Promise<string> {
 
     return path.join(outDir, "server", "index.js");
   } finally {
-    globalThis.fetch = originalFetch;
     await fs.unlink(nodeModulesLink).catch(() => {});
   }
 }

--- a/tests/font-google-build.test.ts
+++ b/tests/font-google-build.test.ts
@@ -16,28 +16,28 @@ async function buildFontGoogleMultipleFixture(): Promise<string> {
   const ssrOutDir = path.join(outDir, "server", "ssr");
   const clientOutDir = path.join(outDir, "client");
 
-  // Intercept the Google Fonts CSS fetch issued by the in-process Vite build.
-  // MSW Node intercepts both `globalThis.fetch` and `node:http`/`node:https`,
-  // so any request the bundler issues against fonts.googleapis.com is caught.
-  // Handlers are reset by the global `afterEach` in `tests/_msw/setup.ts`.
-  server.use(
-    http.get("https://fonts.googleapis.com/*", ({ request }) => {
-      const url = request.url;
-      if (url.includes("Geist") && !url.includes("Mono")) {
-        return HttpResponse.text("@font-face { font-family: 'Geist'; src: url(/geist.woff2); }", {
-          headers: { "content-type": "text/css" },
-        });
-      }
-      return HttpResponse.text(
-        "@font-face { font-family: 'Geist Mono'; src: url(/geist-mono.woff2); }",
-        { headers: { "content-type": "text/css" } },
-      );
-    }),
-  );
-
   const nodeModulesLink = path.join(APP_FIXTURE_DIR, "node_modules");
 
   try {
+    // Intercept the Google Fonts CSS fetch issued by the in-process Vite build.
+    // MSW Node intercepts both `globalThis.fetch` and `node:http`/`node:https`,
+    // so any request the bundler issues against fonts.googleapis.com is caught.
+    // Handlers are reset by the global `afterEach` in `tests/_msw/setup.ts`.
+    server.use(
+      http.get("https://fonts.googleapis.com/*", ({ request }) => {
+        const url = request.url;
+        if (url.includes("Geist") && !url.includes("Mono")) {
+          return HttpResponse.text("@font-face { font-family: 'Geist'; src: url(/geist.woff2); }", {
+            headers: { "content-type": "text/css" },
+          });
+        }
+        return HttpResponse.text(
+          "@font-face { font-family: 'Geist Mono'; src: url(/geist-mono.woff2); }",
+          { headers: { "content-type": "text/css" } },
+        );
+      }),
+    );
+
     const projectNodeModules = path.resolve(import.meta.dirname, "../node_modules");
     await fs.rm(nodeModulesLink, { recursive: true, force: true });
     await fs.symlink(projectNodeModules, nodeModulesLink);

--- a/tests/font-google-build.test.ts
+++ b/tests/font-google-build.test.ts
@@ -20,9 +20,10 @@ async function buildFontGoogleMultipleFixture(): Promise<string> {
 
   try {
     // Intercept the Google Fonts CSS fetch issued by the in-process Vite build.
-    // MSW Node intercepts both `globalThis.fetch` and `node:http`/`node:https`,
-    // so any request the bundler issues against fonts.googleapis.com is caught.
-    // Handlers are reset by the global `afterEach` in `tests/_msw/setup.ts`.
+    // The server is configured with `FetchInterceptor` only (see `server.ts`),
+    // so MSW intercepts `globalThis.fetch` — which is what Vite/vinext uses to
+    // pull font CSS. Handlers are reset by the global `afterEach` in
+    // `tests/_msw/setup.ts`.
     server.use(
       http.get("https://fonts.googleapis.com/*", ({ request }) => {
         const url = request.url;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -165,7 +165,18 @@ export default defineConfig({
         },
         test: {
           name: "integration",
-          setupFiles: [MSW_SETUP],
+          // MSW is intentionally NOT installed in the integration project.
+          // Integration tests spin up in-process HTTP servers and fixture
+          // dev servers and exercise them via `fetch("http://127.0.0.1:<port>/...")`.
+          // The @mswjs/interceptors layer interferes with that loopback
+          // traffic in subtle ways even when handlers `passthrough()`
+          // (e.g. 5xx response bodies stall, fixture-startup readiness
+          // probes time out). MSW's value here is mocking external HTTP
+          // for unit tests of fetch wrappers — integration tests already
+          // talk to real local servers, not to the network, so the
+          // unhandled-request guard buys little. If a future integration
+          // test needs to mock an external fetch, wire MSW per-file with
+          // `setupServer` rather than reverting this exclusion.
           include: [
             "tests/app-router.test.ts",
             "tests/api-handler.test.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite-plus";
 import { randomUUID } from "node:crypto";
 
 const SHIMS_SRC = path.resolve(import.meta.dirname, "packages/vinext/src/shims");
+const MSW_SETUP = path.resolve(import.meta.dirname, "tests/_msw/setup.ts");
 
 export default defineConfig({
   staged: {
@@ -128,6 +129,7 @@ export default defineConfig({
         },
         test: {
           name: "unit",
+          setupFiles: [MSW_SETUP],
           include: ["tests/**/*.test.ts"],
           exclude: [
             "tests/fixtures/**/node_modules/**",
@@ -163,6 +165,7 @@ export default defineConfig({
         },
         test: {
           name: "integration",
+          setupFiles: [MSW_SETUP],
           include: [
             "tests/app-router.test.ts",
             "tests/api-handler.test.ts",


### PR DESCRIPTION
## Summary

Replaces ad-hoc `globalThis.fetch` hijacking in unit tests with [Mock Service Worker](https://mswjs.io/). MSW intercepts both `globalThis.fetch` and `node:http`/`https`, so unit tests of fetch wrappers (`tests/font-google-build.test.ts`, eventually `font-google.test.ts`, `fetch-cache.test.ts`) don't need to manage their own per-test stubs.

The setup file enables `onUnhandledRequest: "error"` so any future test that issues an unmocked external request fails loudly instead of silently hitting the network. Loopback requests are forwarded to the real network via a default `passthrough()` handler — unit tests routinely spin up tiny in-process HTTP servers (middleware-rewrite proxy, JSX-in-JS, static-asset 404) that need to remain reachable.

### Project scope

MSW is wired into the **`unit` vitest project only**. Integration tests spin up in-process Vite servers and fixture dev servers; the `@mswjs/interceptors` layer doesn't mix cleanly with that traffic (5xx response bodies stall, fixture-startup readiness probes time out). Integration tests already talk to real local servers, not the internet, so the unhandled-request guard buys little there. If a future integration test needs to mock an external fetch, wire MSW per-file with `setupServer` rather than reverting this exclusion.

### What's in this PR

- `tests/_msw/{handlers,server,setup}.ts` — shared infra
- `setupFiles` wired into the `unit` vitest project
- `msw` + `@mswjs/interceptors` added to the workspace catalog
- `msw` postinstall skipped via `allowBuilds` (only copies a browser service worker; we exclusively use `msw/node`)
- `tests/font-google-build.test.ts` migrated as the proof of pattern

### Deferred to follow-up PRs

- **PR 2 (#1447):** `tests/font-google.test.ts` — 16 fetch swaps migrated
- **PR 3 (TBD):** `tests/fetch-cache.test.ts` and the font block in `tests/app-router.test.ts`

## Test plan

- [x] `pnpm test run tests/font-google-build.test.ts` passes (verified locally)
- [x] `pnpm run check` passes (fmt + lint + types)
- [x] Full `pnpm test` and Playwright e2es pass in CI