### PR TITLE
fix: private use-cache request data

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -33,6 +33,7 @@ import {
   cacheLifeProfiles,
   _setRequestScopedCacheLife,
   _registerCacheContextAccessor,
+  type CachedFetchValue,
   type CacheControlMetadata,
   type CacheLifeConfig,
 } from "./cache.js";
@@ -406,12 +407,11 @@ export function clearPrivateCache(): void {
  * @param variant - Cache variant: "" (default/shared), "remote", "private"
  * @returns A wrapper function that checks cache before calling the original
  */
-// oxlint-disable-next-line typescript/no-explicit-any
-export function registerCachedFunction<T extends (...args: any[]) => Promise<any>>(
-  fn: T,
+export function registerCachedFunction<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
   id: string,
   variant?: string,
-): T {
+): (...args: TArgs) => Promise<TResult> {
   const cacheVariant = variant ?? "";
 
   // In dev mode, skip the shared cache so code changes are immediately
@@ -422,8 +422,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
   // it's scoped to a single request and doesn't persist across HMR.
   const isDev = typeof process !== "undefined" && process.env.NODE_ENV === "development";
 
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  const cachedFn = async (...args: any[]): Promise<any> => {
+  const cachedFn = async (...args: TArgs): Promise<TResult> => {
     const rsc = await getRscModule();
     const keySeed = getUseCacheKeySeed();
 
@@ -444,7 +443,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
         // values (e.g., section:"sports" vs section:"electronics") produce
         // identical cache keys. We must extract the plain data so the actual
         // values are included in the cache key.
-        const processedArgs = unwrapThenableObjects(args) as unknown[];
+        const processedArgs = unwrapThenableObjectArray(args);
         const encoded = await rsc.encodeReply(processedArgs, {
           temporaryReferences: tempRefs,
         });
@@ -460,6 +459,11 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
 
     // "use cache: private" uses per-request in-memory cache
     if (cacheVariant === "private") {
+      const parentCtx = cacheContextStorage.getStore();
+      if (parentCtx && parentCtx.variant !== "private") {
+        throwPrivateUseCacheInsidePublicUseCacheError();
+      }
+
       if (typeof process !== "undefined" && process.env.VINEXT_PRERENDER === "1") {
         // Next.js treats "use cache: private" as dynamic during prerendering:
         // it is excluded from the static artifact and resolved per request.
@@ -470,7 +474,9 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
       const privateCache = _getPrivateState()._privateCache!;
       const privateHit = privateCache.get(cacheKey);
       if (privateHit !== undefined) {
-        return privateHit;
+        // The private cache is heterogeneous across cached functions; the key
+        // includes this function's stable id, so a hit belongs to this TResult.
+        return privateHit as TResult;
       }
 
       const result = await executeWithContext(fn, args, cacheVariant);
@@ -495,7 +501,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
           // RSC-serialized entry: base64 → bytes → stream → deserialize
           const bytes = base64ToUint8(existing.value.data.body);
           const stream = uint8ToStream(bytes);
-          const result = await rsc.createFromReadableStream(stream);
+          const result = await rsc.createFromReadableStream<TResult>(stream);
           recordRequestScopedCacheControl(existing.cacheControl);
           return result;
         }
@@ -540,7 +546,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
       }
 
       const cacheValue = {
-        kind: "FETCH" as const,
+        kind: "FETCH",
         data: {
           headers,
           body,
@@ -548,7 +554,7 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
         },
         tags: ctx.tags,
         revalidate: revalidateSeconds,
-      };
+      } satisfies CachedFetchValue;
 
       await handler.set(cacheKey, cacheValue, {
         fetchCache: true,
@@ -565,7 +571,16 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
     return result;
   };
 
-  return cachedFn as T;
+  return cachedFn;
+}
+
+function throwPrivateUseCacheInsidePublicUseCacheError(): never {
+  const error = new Error(
+    '"use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".',
+  );
+  const ctx = getRequestContext();
+  if (ctx) ctx.invalidDynamicUsageError = error;
+  throw error;
 }
 
 function recordRequestScopedCacheControl(cacheControl: CacheControlMetadata | undefined): void {
@@ -618,9 +633,9 @@ async function executeWithContext<T extends (...args: any[]) => Promise<any>>(
  *   propagates lifeConfigs/dynamicNestedCacheError up to the parent.
  * - Private variant (`"use cache: private"`): always reaches here via
  *   `executeWithContext`. The variant is excluded from being a *parent* that
- *   throws (see the `parentCtx.variant !== "private"` guard below), but can
- *   still propagate its resolved life *up* to a public parent — matching
- *   Next.js's `propagateCacheEntryMetadata` for `private` kind.
+ *   throws (see the `parentCtx.variant !== "private"` guard below). Entry into
+ *   a private cache from a public parent is rejected earlier to prevent request
+ *   data from flowing into a shared cache entry.
  * - Dev mode (`registerCachedFunction`, NODE_ENV=development): skips the
  *   shared cache and always reaches here via `executeWithContext`.
  *
@@ -863,6 +878,10 @@ function unwrapThenableObjects(value: unknown): unknown {
     result[key] = unwrapThenableObjects((value as any)[key]);
   }
   return result;
+}
+
+function unwrapThenableObjectArray(values: readonly unknown[]): unknown[] {
+  return values.map(unwrapThenableObjects);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -43,6 +43,7 @@ import {
   getRequestContext,
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
+import { markDynamicUsage } from "./headers.js";
 
 // ---------------------------------------------------------------------------
 // Constants for nested-dynamic cache life detection
@@ -459,6 +460,13 @@ export function registerCachedFunction<T extends (...args: any[]) => Promise<any
 
     // "use cache: private" uses per-request in-memory cache
     if (cacheVariant === "private") {
+      if (typeof process !== "undefined" && process.env.VINEXT_PRERENDER === "1") {
+        // Next.js treats "use cache: private" as dynamic during prerendering:
+        // it is excluded from the static artifact and resolved per request.
+        // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts
+        markDynamicUsage();
+      }
+
       const privateCache = _getPrivateState()._privateCache!;
       const privateHit = privateCache.get(cacheKey);
       if (privateHit !== undefined) {

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -8,7 +8,6 @@
  * We support both the sync (legacy) and async patterns.
  */
 
-import type { AsyncLocalStorage } from "node:async_hooks";
 import { MIDDLEWARE_SET_COOKIE_HEADER } from "../server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
@@ -206,15 +205,29 @@ export function consumeRenderRequestApiUsage(): RenderRequestApiKind[] {
 const _USE_CACHE_ALS_KEY = Symbol.for("vinext.cacheRuntime.contextAls");
 /** Symbol used by cache.ts to store the unstable_cache ALS on globalThis */
 const _UNSTABLE_CACHE_ALS_KEY = Symbol.for("vinext.unstableCache.als");
-const _gHeaders = globalThis as unknown as Record<PropertyKey, unknown>;
 
 type UseCacheGuardContext = {
   variant?: unknown;
 };
 
+type CacheScopeStorage = {
+  getStore: () => unknown;
+};
+
+function _getGlobalCacheScopeStorage(key: symbol): CacheScopeStorage | null {
+  const value = Reflect.get(globalThis, key);
+  if (!value || typeof value !== "object") return null;
+
+  const getStore = Reflect.get(value, "getStore");
+  if (typeof getStore !== "function") return null;
+
+  return {
+    getStore: () => getStore.call(value),
+  };
+}
+
 function _getUseCacheGuardContext(): UseCacheGuardContext | null {
-  const als = _gHeaders[_USE_CACHE_ALS_KEY] as AsyncLocalStorage<unknown> | undefined;
-  const store = als?.getStore();
+  const store = _getGlobalCacheScopeStorage(_USE_CACHE_ALS_KEY)?.getStore();
   if (!store || typeof store !== "object") return null;
   return store;
 }
@@ -229,8 +242,7 @@ function _isInsidePublicUseCache(): boolean {
 }
 
 function _isInsideUnstableCache(): boolean {
-  const als = _gHeaders[_UNSTABLE_CACHE_ALS_KEY] as AsyncLocalStorage<unknown> | undefined;
-  return als?.getStore() === true;
+  return _getGlobalCacheScopeStorage(_UNSTABLE_CACHE_ALS_KEY)?.getStore() === true;
 }
 
 /**

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -208,9 +208,24 @@ const _USE_CACHE_ALS_KEY = Symbol.for("vinext.cacheRuntime.contextAls");
 const _UNSTABLE_CACHE_ALS_KEY = Symbol.for("vinext.unstableCache.als");
 const _gHeaders = globalThis as unknown as Record<PropertyKey, unknown>;
 
-function _isInsideUseCache(): boolean {
+type UseCacheGuardContext = {
+  variant?: unknown;
+};
+
+function _getUseCacheGuardContext(): UseCacheGuardContext | null {
   const als = _gHeaders[_USE_CACHE_ALS_KEY] as AsyncLocalStorage<unknown> | undefined;
-  return als?.getStore() != null;
+  const store = als?.getStore();
+  if (!store || typeof store !== "object") return null;
+  return store;
+}
+
+function _isInsidePublicUseCache(): boolean {
+  const ctx = _getUseCacheGuardContext();
+  // Next.js models "use cache: private" as a private-cache work unit that
+  // carries request headers and cookies. Only public "use cache" scopes freeze
+  // request APIs into persisted cache entries and must reject these reads.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+  return ctx !== null && ctx.variant !== "private";
 }
 
 function _isInsideUnstableCache(): boolean {
@@ -226,7 +241,7 @@ function _isInsideUnstableCache(): boolean {
  * @param apiName - The name of the API being called (e.g. "connection()")
  */
 export function throwIfInsideCacheScope(apiName: string): void {
-  if (_isInsideUseCache()) {
+  if (_isInsidePublicUseCache()) {
     const error = new Error(
       `\`${apiName}\` cannot be called inside "use cache". ` +
         `If you need this data inside a cached function, call \`${apiName}\` ` +

--- a/tests/e2e/app-router/use-cache.spec.ts
+++ b/tests/e2e/app-router/use-cache.spec.ts
@@ -98,3 +98,33 @@ test.describe('"use cache" function-level directive', () => {
     expect(Number(dataValue2)).toBeGreaterThan(Number(dataValue1));
   });
 });
+
+test.describe('"use cache: private"', () => {
+  test("allows reading cookies inside private caches", async ({ request }) => {
+    // Ported from Next.js: test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+    const emptyResponse = await request.get(`${BASE}/use-cache-private-cookies`);
+    expect(emptyResponse.status()).toBe(200);
+    await expect(emptyResponse.text()).resolves.toContain(
+      'data-testid="test-cookie">&lt;empty&gt;</span>',
+    );
+
+    const cookieResponse = await request.get(`${BASE}/use-cache-private-cookies`, {
+      headers: { cookie: "test-cookie=foo" },
+    });
+    expect(cookieResponse.status()).toBe(200);
+    await expect(cookieResponse.text()).resolves.toContain('data-testid="test-cookie">foo</span>');
+  });
+
+  test("allows reading search params inside private cached pages", async ({ page }) => {
+    // Ported from Next.js: test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+    await page.goto(`${BASE}/use-cache-private-search?q=foo`);
+    await expect(page.getByTestId("search-param")).toBeVisible();
+    await expect(page.getByTestId("search-param")).toHaveText("foo");
+
+    await page.goto(`${BASE}/use-cache-private-search?q=bar`);
+    await expect(page.getByTestId("search-param")).toBeVisible();
+    await expect(page.getByTestId("search-param")).toHaveText("bar");
+  });
+});

--- a/tests/fixtures/app-basic/app/use-cache-private-cookies/page.tsx
+++ b/tests/fixtures/app-basic/app/use-cache-private-cookies/page.tsx
@@ -1,0 +1,19 @@
+import { cacheLife } from "next/cache";
+import { cookies } from "next/headers";
+
+async function PrivateCookie() {
+  "use cache: private";
+
+  cacheLife({ stale: 420 });
+  const cookie = (await cookies()).get("test-cookie");
+
+  return <span data-testid="test-cookie">{cookie?.value ?? "<empty>"}</span>;
+}
+
+export default function Page() {
+  return (
+    <p>
+      test-cookie: <PrivateCookie />
+    </p>
+  );
+}

--- a/tests/fixtures/app-basic/app/use-cache-private-search/loading.tsx
+++ b/tests/fixtures/app-basic/app/use-cache-private-search/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading...</p>;
+}

--- a/tests/fixtures/app-basic/app/use-cache-private-search/page.tsx
+++ b/tests/fixtures/app-basic/app/use-cache-private-search/page.tsx
@@ -1,0 +1,15 @@
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  "use cache: private";
+
+  const { q } = await searchParams;
+
+  return (
+    <p>
+      Query: <span data-testid="search-param">{q}</span>
+    </p>
+  );
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4047,6 +4047,38 @@ describe('"use cache" runtime', () => {
     expect(r3).toEqual({ count: 2 });
   });
 
+  it("private variant marks prerender output dynamic", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { consumeDynamicUsage } = await import("../packages/vinext/src/shims/headers.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    // Ported from Next.js: "use cache: private" is dynamic in prerendering contexts.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+    process.env.VINEXT_PRERENDER = "1";
+
+    try {
+      await runWithRequestContext(createRequestContext(), async () => {
+        const cached = registerCachedFunction(
+          async () => "private",
+          "test:private-prerender",
+          "private",
+        );
+        await cached();
+
+        expect(consumeDynamicUsage()).toBe(true);
+      });
+    } finally {
+      if (previousPrerender === undefined) {
+        delete process.env.VINEXT_PRERENDER;
+      } else {
+        process.env.VINEXT_PRERENDER = previousPrerender;
+      }
+    }
+  });
+
   it("cacheLife minimum-wins rule applies", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");
@@ -15506,6 +15538,69 @@ describe("cache scope guards for dynamic APIs", () => {
     );
 
     setHeadersContext(null);
+  });
+
+  it('headers() is allowed inside "use cache: private" scope', async () => {
+    const { cacheContextStorage } = await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { headers, setHeadersContext } = await import("../packages/vinext/src/shims/headers.js");
+
+    // Next.js private-cache stores carry request headers.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+    try {
+      setHeadersContext({
+        headers: new Headers({ "x-private": "allowed" }),
+        cookies: new Map(),
+      });
+
+      await cacheContextStorage.run(
+        {
+          tags: [],
+          lifeConfigs: [],
+          variant: "private",
+          hasExplicitRevalidate: false,
+          hasExplicitExpire: false,
+          dynamicNestedCacheError: undefined,
+        },
+        async () => {
+          expect((await headers()).get("x-private")).toBe("allowed");
+        },
+      );
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
+  it('cookies() is allowed inside "use cache: private" scope', async () => {
+    const { cacheContextStorage } = await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { cookies, setHeadersContext } = await import("../packages/vinext/src/shims/headers.js");
+
+    // Ported from Next.js: test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+    try {
+      setHeadersContext({
+        headers: new Headers({ cookie: "test-cookie=allowed" }),
+        cookies: new Map([["test-cookie", "allowed"]]),
+      });
+
+      await cacheContextStorage.run(
+        {
+          tags: [],
+          lifeConfigs: [],
+          variant: "private",
+          hasExplicitRevalidate: false,
+          hasExplicitExpire: false,
+          dynamicNestedCacheError: undefined,
+        },
+        async () => {
+          await expect(cookies()).resolves.toMatchObject({
+            get: expect.any(Function),
+          });
+          expect((await cookies()).get("test-cookie")?.value).toBe("allowed");
+        },
+      );
+    } finally {
+      setHeadersContext(null);
+    }
   });
 
   it('cookies() sync access throws the "use cache" error instead of a TypeError', async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4079,6 +4079,38 @@ describe('"use cache" runtime', () => {
     }
   });
 
+  it('rejects "use cache: private" nested inside public "use cache"', async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { cookies, setHeadersContext } = await import("../packages/vinext/src/shims/headers.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    // Ported from Next.js: "use cache: private" must not run inside public "use cache".
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts
+    await runWithRequestContext(createRequestContext(), async () => {
+      try {
+        setHeadersContext({
+          headers: new Headers({ cookie: "test-cookie=leaked" }),
+          cookies: new Map([["test-cookie", "leaked"]]),
+        });
+
+        const inner = registerCachedFunction(
+          async () => (await cookies()).get("test-cookie")?.value,
+          "test:private-nested-inner",
+          "private",
+        );
+        const outer = registerCachedFunction(async () => inner(), "test:private-nested-outer", "");
+
+        await expect(outer()).rejects.toThrow(
+          /"use cache: private" must not be used within "use cache"/,
+        );
+      } finally {
+        setHeadersContext(null);
+      }
+    });
+  });
+
   it("cacheLife minimum-wins rule applies", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");


### PR DESCRIPTION
## Summary

Fixes two private `use cache` parity gaps exposed by the upstream Next.js deploy-suite:

- allow `headers()` and `cookies()` inside `"use cache: private"` scopes while preserving the public `"use cache"` guard
- mark private cache execution as dynamic during vinext prerendering so page-level private caches are excluded from static artifacts and resolved per request
- port focused regression coverage for cookies, search params, and the prerender dynamic signal

## Next.js references

- Upstream failing/passing test: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
- Private cache work-unit shape carrying request data: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/work-unit-async-storage.external.ts
- Private cache prerender semantics in `use-cache-wrapper`: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts

## Validation

- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/use-cache-private/use-cache-private.test.ts`
- `vp test run tests/shims.test.ts -t "private variant|cache scope guards for dynamic APIs"`
- `CI=1 PLAYWRIGHT_PROJECT=app-router pnpm exec playwright test tests/e2e/app-router/use-cache.spec.ts`
- `vp check`
