### PR TITLE
fix(router): route hybrid pages api fallbacks through pages entry

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -35,6 +35,10 @@ const appRouteHandlerDispatchPath = resolveEntryPath(
   "../server/app-route-handler-dispatch.js",
   import.meta.url,
 );
+const appRouteHandlerResponsePath = resolveEntryPath(
+  "../server/app-route-handler-response.js",
+  import.meta.url,
+);
 const appServerActionExecutionPath = resolveEntryPath(
   "../server/app-server-action-execution.js",
   import.meta.url,
@@ -227,6 +231,9 @@ import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromM
 import {
   dispatchAppRouteHandler as __dispatchAppRouteHandler,
 } from ${JSON.stringify(appRouteHandlerDispatchPath)};
+import {
+  applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext,
+} from ${JSON.stringify(appRouteHandlerResponsePath)};
 import {
   handleProgressiveServerActionRequest as __handleProgressiveServerActionRequest,
   handleServerActionRscRequest as __handleServerActionRscRequest,
@@ -826,17 +833,35 @@ export default __createAppRscHandler({
     if (isRscRequest) return null;
 
     const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-    if (typeof __pagesEntry.renderPage !== "function") return null;
 
     const __pagesRequestHeaders = middlewareContext.requestHeaders
       ? __buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareContext.requestHeaders)
       : null;
-    const __pagesRequest = __pagesRequestHeaders
-      ? new Request(request.url, { method: request.method, headers: __pagesRequestHeaders })
-      : request;
+    let __pagesRequest = request;
+    if (__pagesRequestHeaders) {
+      const __pagesRequestInit = {
+        method: request.method,
+        headers: __pagesRequestHeaders,
+      };
+      if (request.method !== "GET" && request.method !== "HEAD") {
+        __pagesRequestInit.body = request.body;
+        __pagesRequestInit.duplex = "half";
+      }
+      __pagesRequest = new Request(request.url, __pagesRequestInit);
+    }
+
+    const __pagesUrl = __decodePathParams(url.pathname) + (url.search || "");
+    const __pagesPathname = url.pathname;
+    if (__pagesPathname.startsWith("/api/") || __pagesPathname === "/api") {
+      if (typeof __pagesEntry.handleApiRoute !== "function") return null;
+      const __pagesApiResponse = await __pagesEntry.handleApiRoute(__pagesRequest, __pagesUrl);
+      return __applyRouteHandlerMiddlewareContext(__pagesApiResponse, middlewareContext);
+    }
+
+    if (typeof __pagesEntry.renderPage !== "function") return null;
     const __pagesRes = await __pagesEntry.renderPage(
       __pagesRequest,
-      __decodePathParams(url.pathname) + (url.search || ""),
+      __pagesUrl,
       {},
       undefined,
       middlewareContext.requestHeaders,

--- a/packages/vinext/src/entries/app-ssr-entry.ts
+++ b/packages/vinext/src/entries/app-ssr-entry.ts
@@ -7,9 +7,9 @@ import { resolveRuntimeEntryModule } from "./runtime-entry-module.js";
  * deserializes it to a React tree, and renders to HTML.
  *
  * When `hasPagesDir` is true (hybrid App + Pages Router project), the SSR
- * entry also re-exports `pageRoutes` from `virtual:vinext-server-entry` so
- * that the Cloudflare Workers RSC bundle can access Pages Router route
- * metadata (including `getStaticPaths`) via `import("./ssr/index.js")`.
+ * entry also re-exports selected Pages server entry hooks from
+ * `virtual:vinext-server-entry` so the RSC bundle can access Pages Router
+ * route metadata and fallback dispatchers via `import("./ssr/index.js")`.
  */
 export function generateSsrEntry(hasPagesDir = false): string {
   const entryPath = resolveRuntimeEntryModule("app-ssr-entry");
@@ -20,7 +20,7 @@ export { default } from ${JSON.stringify(entryPath)};
 ${
   hasPagesDir
     ? `
-export { pageRoutes, renderPage } from "virtual:vinext-server-entry";
+export { handleApiRoute, pageRoutes, renderPage } from "virtual:vinext-server-entry";
 `
     : ""
 }`;

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -6,6 +6,7 @@ import zlib from "node:zlib";
 import { createBuilder, createServer, type ViteDevServer } from "vite";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { generateRscEntry } from "../packages/vinext/src/entries/app-rsc-entry.js";
+import { generateSsrEntry } from "../packages/vinext/src/entries/app-ssr-entry.js";
 import type { AppRoute } from "../packages/vinext/src/routing/app-router.js";
 import vinext from "../packages/vinext/src/index.js";
 import {
@@ -2388,6 +2389,17 @@ describe("App Router Production server (startProdServer)", () => {
     expect(html).toContain('"cookie":null');
   });
 
+  it("serves Pages Router edge API ImageResponse routes in hybrid production", async () => {
+    // Ported from Next.js: test/e2e/og-api/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/index.test.ts
+    const res = await fetch(`${baseUrl}/api/pages-og`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
+    expect(res.headers.get("x-mw-ran")).toBe("true");
+    expect((await res.blob()).size).toBeGreaterThan(0);
+  });
+
   it("serves dynamic routes", async () => {
     const res = await fetch(`${baseUrl}/blog/test-post`);
     expect(res.status).toBe(200);
@@ -4056,6 +4068,42 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("configHeaders: __configHeaders");
     expect(code).toContain("X-Custom-Header");
     expect(code).toContain("vinext");
+  });
+
+  it("routes hybrid Pages API misses through the Pages server entry", () => {
+    // Ported from Next.js: test/e2e/og-api/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/index.test.ts
+    //
+    // In a mixed app/ + pages/ project, a Pages Router API route such as
+    // pages/api/og.js remains a real route even though the production server
+    // enters through the App Router handler.
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
+      hasPagesDir: true,
+    });
+
+    expect(code).toContain("const __pagesPathname = url.pathname;");
+    expect(code).toContain(
+      'if (__pagesPathname.startsWith("/api/") || __pagesPathname === "/api")',
+    );
+    expect(code).toContain('typeof __pagesEntry.handleApiRoute !== "function"');
+    expect(code).toContain("__pagesEntry.handleApiRoute(");
+    expect(code).toContain(
+      "__applyRouteHandlerMiddlewareContext(__pagesApiResponse, middlewareContext)",
+    );
+  });
+
+  it("re-exports Pages API handling from the hybrid SSR entry", () => {
+    // Ported from Next.js: test/e2e/og-api/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/index.test.ts
+    //
+    // The production App Router entry loads the SSR environment's "index"
+    // module for Pages fallbacks. That bridge must expose the Pages API
+    // dispatcher as well as page rendering.
+    const code = generateSsrEntry(true);
+
+    expect(code).toContain(
+      'export { handleApiRoute, pageRoutes, renderPage } from "virtual:vinext-server-entry";',
+    );
   });
 
   it("embeds basePath and trailingSlash alongside config", () => {

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -310,6 +310,7 @@ export const config = {
     "/headers/override-from-middleware",
     "/header-override-delete",
     "/api/header-override-delete",
+    "/api/pages-og",
     "/header-override-after-prior-access",
     "/pages-header-override-delete",
     "/revalidate-test",

--- a/tests/fixtures/app-basic/pages/api/pages-og.tsx
+++ b/tests/fixtures/app-basic/pages/api/pages-og.tsx
@@ -1,0 +1,23 @@
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+export default function handler() {
+  return new ImageResponse(
+    <div
+      style={{
+        alignItems: "center",
+        background: "lavender",
+        display: "flex",
+        fontSize: 96,
+        height: "100%",
+        justifyContent: "center",
+        width: "100%",
+      }}
+    >
+      Hello!
+    </div>,
+  );
+}


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Restore Next.js-compatible `pages/api` routing in hybrid App Router plus Pages Router production builds. |
| Core change | The generated App Router RSC fallback now dispatches `/api` misses to the Pages server entry's `handleApiRoute`. |
| Boundary | Mixed `app/` and `pages/` production requests where `vinext start` enters through the App Router handler. |
| Primary files | `packages/vinext/src/entries/app-rsc-entry.ts`, `packages/vinext/src/entries/app-ssr-entry.ts`, `tests/app-router.test.ts` |
| Expected impact | `/api/*` routes from `pages/api` return their Pages API response instead of the App Router 404 in hybrid builds. |

## Why

A hybrid build must preserve both routing surfaces even when the production server enters through the App Router bundle. Next.js treats `pages/api/*` as Pages API routes independent of the App Router, and the `og-api` deploy test confirms that an edge Pages API route returning `ImageResponse` must respond with `200 image/png`.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Hybrid route misses | App Router misses should delegate to the matching Pages surface before rendering not-found. | Adds an `/api` branch in the generated Pages fallback that calls `handleApiRoute`. |
| SSR bridge | The RSC environment can only call Pages fallback hooks that the SSR entry re-exports. | Re-exports `handleApiRoute` from the hybrid SSR entry alongside `pageRoutes` and `renderPage`. |
| Middleware effects | A fallback response should still receive middleware response headers/status. | Applies `applyRouteHandlerMiddlewareContext` to Pages API fallback responses. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Hybrid `app/` plus `pages/api/og` production request | App Router missed the route, delegated only to `renderPage`, then returned 404. | App Router fallback detects `/api`, calls the Pages API dispatcher, and returns the ImageResponse. |
| Middleware-matched Pages API fallback | API response skipped middleware response header/status application. | API response is wrapped with the same middleware response helper used for App route handlers. |
| Generated hybrid SSR entry | Exposed `pageRoutes` and `renderPage` only. | Exposes `handleApiRoute`, `pageRoutes`, and `renderPage`. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/entries/app-rsc-entry.ts`: review the generated `renderPagesFallback` branch. The important path is `/api` detection before `renderPage`, request-header override preservation, and middleware response application.
2. `packages/vinext/src/entries/app-ssr-entry.ts`: verify the SSR bridge exports the Pages API dispatcher for the RSC environment import.
3. `tests/app-router.test.ts`: review the production regression and generated-entry assertions.
4. `tests/fixtures/app-basic/pages/api/pages-og.tsx` and `tests/fixtures/app-basic/middleware.ts`: review the focused hybrid fixture coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-router.test.ts`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/og-api/index.test.ts`

The upstream deploy-suite file now passes all 5 `og-api` cases, including `should work in pages/api`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no public API shape changes.
- Runtime: affects hybrid App plus Pages production fallback only.
- Middleware: preserves middleware response effects for the newly routed Pages API fallback path.
- Compatibility: intentionally follows Next.js behavior for `pages/api` route ownership in mixed apps.

</details>

<details>
<summary>Non-goals</summary>

- Does not change standalone Pages Router production routing.
- Does not change App Router route handler dispatch.
- Does not address unrelated known config-header ordering parity gaps.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `og-api` e2e test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/og-api/index.test.ts) | Defines the failing deploy-suite behavior, including `should work in pages/api`. |
| [Next.js `pages/api/og.js` fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/og-api/app/pages/api/og.js) | Shows the Pages API edge route returning `ImageResponse`. |
| [Next.js dev Pages API route matcher](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts) | Confirms files under `pages/api` are treated as Pages API route matchers. |
| [Next.js Pages API route matcher tests](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/route-matcher-providers/pages-api-route-matcher-provider.test.ts) | Confirms manifest-backed Pages API route matching behavior. |
| [Next.js API resolver](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/api-utils/node/api-resolver.ts) | Confirms the Pages API runtime boundary, including Response handling differences in non-edge Node Pages API routes. |