### PR TITLE
fix(pages-router): rename data-vinext-head to data-next-head

### DIFF
--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -246,7 +246,7 @@ function headChildToHTML(tag: string, props: Record<string, unknown>): string {
   const attrStr = attrs.length ? " " + attrs.join(" ") : "";
 
   if (SELF_CLOSING_HEAD_TAGS.has(tag)) {
-    return `<${tag}${attrStr} data-vinext-head="true" />`;
+    return `<${tag}${attrStr} data-next-head="" />`;
   }
 
   // For raw-content tags (script, style), escape closing-tag sequences so the
@@ -255,7 +255,7 @@ function headChildToHTML(tag: string, props: Record<string, unknown>): string {
     innerHTML = escapeInlineContent(innerHTML, tag);
   }
 
-  return `<${tag}${attrStr} data-vinext-head="true">${innerHTML}</${tag}>`;
+  return `<${tag}${attrStr} data-next-head="">${innerHTML}</${tag}>`;
 }
 
 function escapeHTML(s: string): string {
@@ -325,7 +325,7 @@ export function _applyHeadPropsToElement(
 }
 
 function syncClientHead(): void {
-  document.querySelectorAll("[data-vinext-head]").forEach((el) => el.remove());
+  document.querySelectorAll("[data-next-head]").forEach((el) => el.remove());
 
   for (const child of reduceHeadChildren([..._clientHeadChildren.values()])) {
     if (typeof child.type !== "string") continue;
@@ -334,7 +334,7 @@ function syncClientHead(): void {
     const props = child.props as Record<string, unknown>;
     _applyHeadPropsToElement(domEl, props);
 
-    domEl.setAttribute("data-vinext-head", "true");
+    domEl.setAttribute("data-next-head", "");
     document.head.appendChild(domEl);
   }
 }

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -61,7 +61,7 @@ describe("Head SSR collection", () => {
     expect(headHtml).toContain("<title");
     expect(headHtml).toContain("My Page Title");
     expect(headHtml).toContain("</title>");
-    expect(headHtml).toContain('data-vinext-head="true"');
+    expect(headHtml).toContain('data-next-head=""');
   });
 
   it("collects meta elements as self-closing", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15431,7 +15431,7 @@ describe("next/head SSR security", () => {
       const html = await collectHeadHTML([el]);
 
       expect(html).toContain(`<${tag}`);
-      expect(html).toContain('data-vinext-head="true"');
+      expect(html).toContain('data-next-head=""');
     }
   });
 });


### PR DESCRIPTION
Refs #1475 — attribute rename only. Follow-up issue: #1569.

## Summary
- Pages Router `<Head>` now emits the canonical `data-next-head` attribute (empty value) instead of `data-vinext-head="true"`.

## Out of scope (tracked in #1569)
- charset/viewport ordering parity
- `_document.getInitialProps()` head-tag merge order

Do **not** close #1475 when this PR merges — close it when #1569 also lands.

## Test plan
- [x] Tests assert canonical attribute
- [x] `vp check` passes