### PR TITLE
fix(next-request): throw canonical relative URL error

### DIFF
--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -102,16 +102,10 @@ export class NextRequest extends Request {
     // fallback URL parsing kicks in. Next.js calls `validateURL(url)` at the
     // top of its NextRequest constructor; we mirror that here so middleware
     // tests asserting on the error message text get the documented string.
+    // Reuse the local `validateURL` helper so the message format stays in lockstep
+    // with NextResponse, and so `javascript:` / `data:` URIs are blocked too.
     const rawUrl = typeof input !== "string" && "url" in input ? input.url : String(input);
-    try {
-      // eslint-disable-next-line no-new
-      new URL(rawUrl);
-    } catch (error) {
-      throw new Error(
-        `URL is malformed "${rawUrl}". Please use only absolute URLs - https://nextjs.org/docs/messages/middleware-relative-urls`,
-        { cause: error },
-      );
-    }
+    validateURL(rawUrl);
     // Strip nextConfig before passing to super() — it's vinext-internal,
     // not a valid RequestInit property.
     const { nextConfig: _nextConfig, ...requestInit } = init ?? {};

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -98,6 +98,20 @@ export class NextRequest extends Request {
       };
     },
   ) {
+    // Match Next.js: reject relative URLs with the canonical error before any
+    // fallback URL parsing kicks in. Next.js calls `validateURL(url)` at the
+    // top of its NextRequest constructor; we mirror that here so middleware
+    // tests asserting on the error message text get the documented string.
+    const rawUrl = typeof input !== "string" && "url" in input ? input.url : String(input);
+    try {
+      // eslint-disable-next-line no-new
+      new URL(rawUrl);
+    } catch (error) {
+      throw new Error(
+        `URL is malformed "${rawUrl}". Please use only absolute URLs - https://nextjs.org/docs/messages/middleware-relative-urls`,
+        { cause: error },
+      );
+    }
     // Strip nextConfig before passing to super() — it's vinext-internal,
     // not a valid RequestInit property.
     const { nextConfig: _nextConfig, ...requestInit } = init ?? {};

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6808,6 +6808,16 @@ describe("cookie name validation", () => {
 // NextRequest API tests
 
 describe("NextRequest API", () => {
+  it("throws canonical 'Please use only absolute URLs' error for relative URL input", async () => {
+    const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+    // Matches Next.js's documented behaviour — middleware tests assert on this
+    // exact message via the middleware-relative-urls docs link.
+    expect(() => new NextRequest("/foo")).toThrow(/Please use only absolute URLs/);
+    expect(() => new NextRequest("/urls-b")).toThrow(
+      /URL is malformed "\/urls-b"\. Please use only absolute URLs/,
+    );
+  });
+
   it("cookies reads request cookies", async () => {
     const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
     const req = new NextRequest("http://localhost/test", {


### PR DESCRIPTION
Closes #1521

## Summary
- `new NextRequest(relativeUrl)` now throws `Please use only absolute URLs` to match Next.js.

## Test plan
- [x] Test asserts canonical error message
- [x] `vp check` passes