### PR TITLE
fix(middleware): warn when legacy middleware filename is detected

### DIFF
--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -97,13 +97,20 @@ export function findMiddlewareFile(root: string, fileMatcher: ValidFileMatcher):
   // Fall back to middleware.ts (deprecated in Next.js 16).
   // This is a warning, not an error: middleware.ts is still fully supported
   // by both Next.js 16 and vinext. Do not change to `throw` or `process.exit`.
+  //
+  // Warning text matches Next.js canonical wording from
+  // packages/next/src/build/index.ts (search for "file convention is
+  // deprecated") so Next.js's own deprecation-warnings and app-middleware
+  // e2e suites pass when run against vinext.
   for (const dir of MIDDLEWARE_LOCATIONS) {
     for (const ext of fileMatcher.dottedExtensions) {
       const fullPath = path.join(root, dir, `middleware${ext}`);
       if (fs.existsSync(fullPath)) {
         console.warn(
-          "[vinext] middleware.ts is deprecated in Next.js 16. " +
-            "Rename to proxy.ts and export a default or named proxy function.",
+          `The "middleware" file convention is deprecated. Please use "proxy" instead.\n\n` +
+            `  To migrate automatically, run:\n` +
+            `  npx @next/codemod@canary middleware-to-proxy .\n\n` +
+            `  Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`,
         );
         return fullPath;
       }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4635,8 +4635,17 @@ describe("middleware runner", () => {
     try {
       findMiddlewareFile(FIXTURE_DIR, createValidFileMatcher());
       expect(warnSpy).toHaveBeenCalledOnce();
+      // Match Next.js canonical wording: deprecation-warnings and
+      // app-middleware e2e suites assert on this exact phrase via toContain.
+      // See .nextjs-ref/packages/next/src/build/index.ts (the Log.warnOnce call
+      // adjacent to MIDDLEWARE_FILENAME / PROXY_FILENAME).
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("middleware.ts is deprecated in Next.js 16"),
+        expect.stringContaining(
+          'The "middleware" file convention is deprecated. Please use "proxy" instead.',
+        ),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("https://nextjs.org/docs/messages/middleware-to-proxy"),
       );
     } finally {
       warnSpy.mockRestore();


### PR DESCRIPTION
Closes #1455

## Summary
- Emit deprecation warning when `middleware.{js,ts}` file convention is used (renamed to `proxy.{js,ts}` in Next.js 16+).
- Match the canonical Next.js wording from `packages/next/src/build/index.ts` so the Next.js `deprecation-warnings` and `app-middleware` e2e suites pass against vinext:
  `The "middleware" file convention is deprecated. Please use "proxy" instead.` (plus the codemod hint and docs link).
- `proxy.{js,ts}` discovery already exists (and is preferred over `middleware.{js,ts}`); no behavior change there.

## Test plan
- [x] `tests/shims.test.ts > findMiddlewareFile emits a deprecation warning...` tightened to assert the canonical phrase and the docs URL.
- [x] `pnpm test tests/shims.test.ts -t 'middleware runner'` passes.
- [x] `pnpm run check` passes.