### PR TITLE
fix(app-router): emit vary marker on edge RSC route response

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -269,6 +269,7 @@ import {
   resolveAppPageGenerateStaticParamsSources as __resolveAppPageGenerateStaticParamsSources,
 } from ${JSON.stringify(appPageRequestPath)};
 import {
+  isEdgeRuntime as __isEdgeRuntime,
   resolveAppPageFetchCacheMode as __resolveAppPageFetchCacheMode,
   resolveAppPageSegmentConfig as __resolveAppPageSegmentConfig,
 } from ${JSON.stringify(appSegmentConfigPath)};
@@ -565,6 +566,7 @@ export default __createAppRscHandler({
       dynamicConfig: __segmentConfig.dynamicConfig,
       dynamicParamsConfig: __segmentConfig.dynamicParamsConfig,
       fetchCache: __segmentConfig.fetchCache ?? null,
+      isEdgeRuntime: __isEdgeRuntime(__segmentConfig.runtime),
       findIntercept(pathname) {
         return findIntercept(pathname, interceptionContext);
       },

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -174,6 +174,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   hasPageModule: boolean;
   handlerStart: number;
   interceptionContext: string | null;
+  isEdgeRuntime?: boolean;
   isProgressiveActionRender?: boolean;
   isProduction: boolean;
   isRscRequest: boolean;
@@ -660,6 +661,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     isDraftMode,
     isForceDynamic,
     isForceStatic,
+    isEdgeRuntime: options.isEdgeRuntime === true,
     isPrerender: process.env.VINEXT_PRERENDER === "1",
     isProduction: options.isProduction,
     isRscRequest: options.isRscRequest,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -90,6 +90,7 @@ type RenderAppPageLifecycleOptions = {
   hasLoadingBoundary: boolean;
   isDynamicError: boolean;
   isDraftMode: boolean;
+  isEdgeRuntime?: boolean;
   isForceDynamic: boolean;
   isForceStatic: boolean;
   isProgressiveActionRender?: boolean;
@@ -415,6 +416,7 @@ export async function renderAppPageLifecycle(
       revalidateSeconds,
     });
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
+      isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
       params: options.params,
@@ -625,6 +627,7 @@ export async function renderAppPageLifecycle(
     const isrResponse = buildAppPageHtmlResponse(safeHtmlStream, {
       draftCookie,
       fontLinkHeader,
+      isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       policy: htmlResponsePolicy,
       timing: htmlResponseTiming,
@@ -688,6 +691,7 @@ export async function renderAppPageLifecycle(
   return buildAppPageHtmlResponse(safeHtmlStream, {
     draftCookie,
     fontLinkHeader,
+    isEdgeRuntime: options.isEdgeRuntime,
     middlewareContext: options.middlewareContext,
     policy: htmlResponsePolicy,
     timing: htmlResponseTiming,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -223,6 +223,11 @@ export function buildAppPageRscResponse(
   const headers = new Headers({
     "Content-Type": VINEXT_RSC_CONTENT_TYPE,
     Vary: VINEXT_RSC_VARY_HEADER,
+    // Mirror Next.js' edge runtime marker. vinext serves every App Router
+    // response from a Worker (edge-equivalent runtime), so the test that
+    // asserts `x-edge-runtime: '1'` on RSC responses must see this header.
+    // See edge-ssr-app.ts in the Next.js source for the canonical emission.
+    "x-edge-runtime": "1",
   });
 
   if (options.params && Object.keys(options.params).length > 0) {
@@ -257,6 +262,11 @@ export function buildAppPageHtmlResponse(
   const headers = new Headers({
     "Content-Type": "text/html; charset=utf-8",
     Vary: VINEXT_RSC_VARY_HEADER,
+    // Mirror Next.js' edge runtime marker. vinext serves every App Router
+    // response from a Worker (edge-equivalent runtime), so the test that
+    // asserts `x-edge-runtime: '1'` on HTML responses must see this header.
+    // See edge-ssr-app.ts in the Next.js source for the canonical emission.
+    "x-edge-runtime": "1",
   });
 
   if (options.policy.cacheControl) {

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -58,6 +58,7 @@ type AppPageHtmlResponsePolicy = {
 } & AppPageResponsePolicy;
 
 type BuildAppPageRscResponseOptions = {
+  isEdgeRuntime?: boolean;
   middlewareContext: AppPageMiddlewareContext;
   mountedSlotsHeader?: string | null;
   params?: Record<string, unknown>;
@@ -68,6 +69,7 @@ type BuildAppPageRscResponseOptions = {
 type BuildAppPageHtmlResponseOptions = {
   draftCookie?: string | null;
   fontLinkHeader?: string;
+  isEdgeRuntime?: boolean;
   middlewareContext: AppPageMiddlewareContext;
   policy: AppPageResponsePolicy;
   timing?: AppPageResponseTiming;
@@ -223,12 +225,15 @@ export function buildAppPageRscResponse(
   const headers = new Headers({
     "Content-Type": VINEXT_RSC_CONTENT_TYPE,
     Vary: VINEXT_RSC_VARY_HEADER,
-    // Mirror Next.js' edge runtime marker. vinext serves every App Router
-    // response from a Worker (edge-equivalent runtime), so the test that
-    // asserts `x-edge-runtime: '1'` on RSC responses must see this header.
-    // See edge-ssr-app.ts in the Next.js source for the canonical emission.
-    "x-edge-runtime": "1",
   });
+
+  // Mirror Next.js' edge-runtime marker (set in edge-ssr-app.ts). Only routes
+  // whose resolved segment config is `runtime = "edge"` should advertise it —
+  // nodejs-runtime routes must not, otherwise downstream consumers can't tell
+  // the configured runtime from the response.
+  if (options.isEdgeRuntime) {
+    headers.set("x-edge-runtime", "1");
+  }
 
   if (options.params && Object.keys(options.params).length > 0) {
     // encodeURIComponent so non-ASCII params (e.g. Korean slugs) survive the
@@ -262,12 +267,15 @@ export function buildAppPageHtmlResponse(
   const headers = new Headers({
     "Content-Type": "text/html; charset=utf-8",
     Vary: VINEXT_RSC_VARY_HEADER,
-    // Mirror Next.js' edge runtime marker. vinext serves every App Router
-    // response from a Worker (edge-equivalent runtime), so the test that
-    // asserts `x-edge-runtime: '1'` on HTML responses must see this header.
-    // See edge-ssr-app.ts in the Next.js source for the canonical emission.
-    "x-edge-runtime": "1",
   });
+
+  // Mirror Next.js' edge-runtime marker (set in edge-ssr-app.ts). Only routes
+  // whose resolved segment config is `runtime = "edge"` should advertise it —
+  // nodejs-runtime routes must not, otherwise downstream consumers can't tell
+  // the configured runtime from the response.
+  if (options.isEdgeRuntime) {
+    headers.set("x-edge-runtime", "1");
+  }
 
   if (options.policy.cacheControl) {
     headers.set("Cache-Control", options.policy.cacheControl);

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -1,4 +1,5 @@
 import type { FetchCacheMode } from "vinext/shims/fetch-cache";
+import { isEdgeApiRuntime } from "./edge-api-runtime.js";
 
 type AppRouteSegmentDynamic = "auto" | "error" | "force-dynamic" | "force-static";
 
@@ -7,6 +8,7 @@ type AppRouteSegmentConfigModule = {
   dynamicParams?: unknown;
   fetchCache?: unknown;
   revalidate?: unknown;
+  runtime?: unknown;
 };
 
 type EffectiveAppPageSegmentConfig = {
@@ -14,6 +16,7 @@ type EffectiveAppPageSegmentConfig = {
   dynamicParamsConfig?: boolean;
   fetchCache?: FetchCacheMode;
   revalidateSeconds: number | null;
+  runtime?: string;
 };
 
 type ResolveAppPageSegmentConfigOptions = {
@@ -147,6 +150,10 @@ export function resolveAppPageSegmentConfig(
       config.revalidateSeconds,
       segment.revalidate,
     );
+
+    if (typeof segment.runtime === "string") {
+      config.runtime = segment.runtime;
+    }
   }
 
   if (config.dynamicConfig === "force-dynamic") {
@@ -177,4 +184,8 @@ export function resolveAppPageFetchCacheMode(
   options: ResolveAppPageSegmentConfigOptions,
 ): FetchCacheMode | null {
   return resolveAppPageSegmentConfig(options).fetchCache ?? null;
+}
+
+export function isEdgeRuntime(runtime: string | undefined): boolean {
+  return isEdgeApiRuntime(runtime);
 }

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -388,6 +388,18 @@ describe("app page response helpers", () => {
     await expect(response.text()).resolves.toBe("flight");
   });
 
+  it("emits the `x-edge-runtime: 1` marker on RSC responses (issue #1531)", () => {
+    // Next.js sets `x-edge-runtime: 1` on edge-runtime app responses (see
+    // edge-ssr-app.ts in the Next.js source). vinext serves every App Router
+    // response from a Worker, so the marker must always be present.
+    const response = buildAppPageRscResponse(createBody("flight"), {
+      middlewareContext: { headers: null, status: null },
+      policy: {},
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBe("1");
+  });
+
   it("builds RSC responses with the current compatibility ID header", () => {
     const response = withEnvVar("__VINEXT_RSC_COMPATIBILITY_ID", "compat-a", () =>
       buildAppPageRscResponse(createBody("flight"), {
@@ -477,6 +489,18 @@ describe("app page response helpers", () => {
     expect(setCookies).toContain("__prerender_bypass=token; Path=/");
     expect(setCookies).toContain("mw=1; Path=/");
     await expect(response.text()).resolves.toBe("<h1>page</h1>");
+  });
+
+  it("emits the `x-edge-runtime: 1` marker on HTML responses (issue #1531)", () => {
+    // Next.js sets `x-edge-runtime: 1` on edge-runtime app responses (see
+    // edge-ssr-app.ts in the Next.js source). vinext serves every App Router
+    // response from a Worker, so the marker must always be present.
+    const response = buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
+      middlewareContext: { headers: null, status: null },
+      policy: {},
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBe("1");
   });
 });
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -388,16 +388,26 @@ describe("app page response helpers", () => {
     await expect(response.text()).resolves.toBe("flight");
   });
 
-  it("emits the `x-edge-runtime: 1` marker on RSC responses (issue #1531)", () => {
+  it("emits the `x-edge-runtime: 1` marker on RSC responses when the route opts into the edge runtime (issue #1531)", () => {
     // Next.js sets `x-edge-runtime: 1` on edge-runtime app responses (see
-    // edge-ssr-app.ts in the Next.js source). vinext serves every App Router
-    // response from a Worker, so the marker must always be present.
+    // edge-ssr-app.ts in the Next.js source). Mirror that only for routes
+    // whose resolved segment config is `runtime = "edge"`.
     const response = buildAppPageRscResponse(createBody("flight"), {
+      isEdgeRuntime: true,
       middlewareContext: { headers: null, status: null },
       policy: {},
     });
 
     expect(response.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("omits the `x-edge-runtime` marker on RSC responses for nodejs-runtime routes", () => {
+    const response = buildAppPageRscResponse(createBody("flight"), {
+      middlewareContext: { headers: null, status: null },
+      policy: {},
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBeNull();
   });
 
   it("builds RSC responses with the current compatibility ID header", () => {
@@ -491,16 +501,26 @@ describe("app page response helpers", () => {
     await expect(response.text()).resolves.toBe("<h1>page</h1>");
   });
 
-  it("emits the `x-edge-runtime: 1` marker on HTML responses (issue #1531)", () => {
+  it("emits the `x-edge-runtime: 1` marker on HTML responses when the route opts into the edge runtime (issue #1531)", () => {
     // Next.js sets `x-edge-runtime: 1` on edge-runtime app responses (see
-    // edge-ssr-app.ts in the Next.js source). vinext serves every App Router
-    // response from a Worker, so the marker must always be present.
+    // edge-ssr-app.ts in the Next.js source). Mirror that only for routes
+    // whose resolved segment config is `runtime = "edge"`.
     const response = buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
+      isEdgeRuntime: true,
       middlewareContext: { headers: null, status: null },
       policy: {},
     });
 
     expect(response.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("omits the `x-edge-runtime` marker on HTML responses for nodejs-runtime routes", () => {
+    const response = buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
+      middlewareContext: { headers: null, status: null },
+      policy: {},
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBeNull();
   });
 });
 

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isEdgeRuntime,
   resolveAppPageFetchCacheMode,
   resolveAppPageSegmentConfig,
 } from "../packages/vinext/src/server/app-segment-config.js";
@@ -214,5 +215,32 @@ describe("resolveAppPageSegmentConfig", () => {
         page: {},
       }),
     ).toBeNull();
+  });
+
+  it("captures the runtime export and lets child segments override parents", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ runtime: "nodejs" }],
+        page: { runtime: "edge" },
+      }).runtime,
+    ).toBe("edge");
+
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ runtime: "edge" }],
+        page: {},
+      }).runtime,
+    ).toBe("edge");
+
+    expect(resolveAppPageSegmentConfig({ page: {} }).runtime).toBeUndefined();
+  });
+});
+
+describe("isEdgeRuntime", () => {
+  it("matches Next.js' edge-runtime values", () => {
+    expect(isEdgeRuntime("edge")).toBe(true);
+    expect(isEdgeRuntime("experimental-edge")).toBe(true);
+    expect(isEdgeRuntime("nodejs")).toBe(false);
+    expect(isEdgeRuntime(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #1531

## Summary
- Add the expected `x-edge-runtime: 1` marker header on edge runtime App Router responses (both RSC and HTML response builders) to match Next.js, which sets this header in `edge-ssr-app.ts`.
- Without this header the upstream `test/e2e/app-dir/app/index.test.ts` "should return the `vary` header from edge runtime" assertion fails — it saw `null` instead of `'1'`.

## Test plan
- [x] New unit tests in `tests/app-page-response.test.ts` assert the header is present on both RSC and HTML responses.
- [x] `pnpm run check` passes (lint, format, types).
- [x] Existing `app-page-response`, `app-page-render`, and `app-router` suites stay green.