### PR TITLE
ci: address zizmor security audit findings

### DIFF
--- a/.github/actions/playwright-cache/action.yml
+++ b/.github/actions/playwright-cache/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Restore Playwright browsers (restore-only)
       if: inputs.mode == 'restore'
       id: restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ inputs.browser }}-${{ runner.os }}-v${{ steps.version.outputs.version }}
@@ -70,7 +70,7 @@ runs:
     - name: Cache Playwright browsers
       if: inputs.mode == 'cache'
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ inputs.browser }}-${{ runner.os }}-v${{ steps.version.outputs.version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 1
+      default-days: 1 # zizmor: ignore[dependabot-cooldown] — fast cooldown is intentional
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 1
+      default-days: 1 # zizmor: ignore[dependabot-cooldown] — fast cooldown is intentional

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,8 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0 # Need full history for commit info
 
       - uses: ./.github/actions/setup
@@ -56,7 +57,7 @@ jobs:
 
       # Upload results as artifact (backup)
       - name: Upload results artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results-${{ github.sha }}
           path: benchmarks/results/bench-*.json
@@ -67,9 +68,9 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           BENCHMARK_UPLOAD_TOKEN: ${{ secrets.BENCHMARK_UPLOAD_TOKEN }}
+          RESULTS_FILE: ${{ steps.results.outputs.file }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          RESULTS_FILE="${{ steps.results.outputs.file }}"
-          COMMIT_SHA="${{ github.sha }}"
           COMMIT_SHORT="${COMMIT_SHA:0:7}"
           COMMIT_MSG=$(git log -1 --format='%s' "$COMMIT_SHA")
           COMMIT_DATE=$(git log -1 --format='%aI' "$COMMIT_SHA")

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -29,14 +29,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 30 # 30 is a balance in providing enough context for the agent vs. pulling down the entire repo history. It is not a scientific number. 27 or 31 or 36 would likely work as well.
 
       - uses: ./.github/actions/setup
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        uses: ask-bonk/ask-bonk/github@8c7a8314f4f4865e2e41e5718dfabc4ab7a2274b # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -29,14 +29,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 30 # 30 is a balance in providing enough context for the agent vs. pulling down the entire repo history. It is not a scientific number. 27 or 31 or 36 would likely work as well.
 
       - uses: ./.github/actions/setup
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        uses: ask-bonk/ask-bonk/github@8c7a8314f4f4865e2e41e5718dfabc4ab7a2274b # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Build plugin (needed for benchmark workspace type resolution)
         run: vp run build
@@ -35,7 +37,9 @@ jobs:
     name: Vitest (unit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - run: vp test run --project unit
 
@@ -48,7 +52,9 @@ jobs:
         shardIndex: [1, 2, 3]
         shardTotal: [3]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Build plugin (needed by ecosystem and nextjs-compat fixtures)
         run: vp run build
@@ -57,7 +63,7 @@ jobs:
       - run: vp test run --project integration ${{ github.event_name == 'push' && '--coverage' || '' }} --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           CI: true
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: blob-report-${{ matrix.shardIndex }}
@@ -71,9 +77,11 @@ jobs:
     needs: [test-integration]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: .vitest-reports
           pattern: blob-report-*
@@ -87,7 +95,7 @@ jobs:
       - name: Publish coverage matrix to job summary
         if: ${{ !cancelled() && hashFiles('coverage/coverage-summary.json') != '' }}
         run: node scripts/coverage-summary.mjs >> "$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() && hashFiles('coverage/index.html') != '' }}
         with:
           name: coverage-html
@@ -102,7 +110,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Build plugin
         run: vp run build
@@ -222,7 +232,9 @@ jobs:
           - app-with-src
           - standalone-output
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Build plugin
         run: vp run build
@@ -244,7 +256,7 @@ jobs:
       # the package archives cached we skip the (slow) download step on hits.
       - name: Cache apt archives (WebKit deps)
         if: ${{ matrix.project == 'app-router-webkit-browser-specific' }}
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/apt-archives
@@ -293,7 +305,7 @@ jobs:
           CI: true
           PLAYWRIGHT_PROJECT: ${{ matrix.project }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: playwright-report-${{ matrix.project }}

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -10,6 +10,8 @@ concurrency:
   group: deploy-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   deploy:
     # Skip entirely for fork PRs — they don't have access to deploy secrets.
@@ -56,7 +58,9 @@ jobs:
             working_directory: apps/web
             wrangler_config: dist/server/wrangler.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
 
       - name: Build vinext plugin
@@ -68,7 +72,7 @@ jobs:
 
       - name: Apply D1 migrations (benchmarks only)
         if: matrix.example.name == 'benchmarks' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -77,7 +81,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers (Production)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -86,7 +90,7 @@ jobs:
 
       - name: Deploy Preview Version
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -97,8 +101,12 @@ jobs:
     name: Smoke Test Deployments
     runs-on: ubuntu-latest
     needs: deploy
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Smoke test (production)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -117,7 +125,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment PR with preview URLs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prNumber = context.issue.number;

--- a/.github/workflows/ecosystem-run.yml
+++ b/.github/workflows/ecosystem-run.yml
@@ -23,7 +23,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout vinext
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -19,7 +19,9 @@ jobs:
     outputs:
       repos: ${{ steps.read.outputs.repos }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - id: read
         run: echo "repos=$(jq -c . .github/repos.json)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -50,8 +50,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout vinext
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.vinext-ref || github.ref }}
 
       - uses: ./.github/actions/setup
@@ -62,8 +63,9 @@ jobs:
         run: corepack enable pnpm
 
       - name: Checkout Next.js
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           repository: vercel/next.js
           ref: ${{ inputs.next-ref || 'v16.2.6' }}
           path: next.js
@@ -195,7 +197,7 @@ jobs:
       # be re-submitted manually (e.g. if the live POST hiccupped) or
       # inspected when debugging misclassifications.
       - name: Upload suite router classification
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextjs-suite-routers
           path: |
@@ -205,7 +207,7 @@ jobs:
           retention-days: 14
 
       - name: Save build artifacts
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # The test job needs: vinext built dist + workspace metadata (for
           # e2e-deploy.sh dependency injection), the scripts, the prepared
@@ -247,7 +249,7 @@ jobs:
 
     steps:
       - name: Restore build artifacts
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .
@@ -288,11 +290,13 @@ jobs:
           NEXT_TEST_DEPLOY_SCRIPT_PATH: ${{ github.workspace }}/scripts/e2e-deploy.sh
           NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH: ${{ github.workspace }}/scripts/e2e-logs.sh
           NEXT_TEST_CLEANUP_SCRIPT_PATH: ${{ github.workspace }}/scripts/e2e-cleanup.sh
-        run: node run-tests.js --timings --retries 0 -g ${{ matrix.group }} -c ${{ inputs.test-concurrency || '2' }} --type e2e
+          GROUP: ${{ matrix.group }}
+          CONCURRENCY: ${{ inputs.test-concurrency || '2' }}
+        run: node run-tests.js --timings --retries 0 -g "$GROUP" -c "$CONCURRENCY" --type e2e
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results-${{ strategy.job-index }}
           path: next.js/test/**/*.results.json
@@ -301,7 +305,7 @@ jobs:
 
       - name: Upload deploy debug logs
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deploy-debug-${{ strategy.job-index }}
           path: reports/nextjs-deploy-debug/
@@ -316,7 +320,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download all test results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: test-results-*
           path: results
@@ -324,7 +328,7 @@ jobs:
 
       - name: Generate report
         id: report
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           # Resolve the GitHub Actions expressions to env vars once, instead
           # of splicing `${{ ... }}` into JS string literals further down.
@@ -517,7 +521,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deploy-suite-report
           # Include both files: the human-readable report and the

--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -30,7 +30,9 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
 
@@ -121,7 +123,7 @@ jobs:
 
       - name: Run Next.js Tracker
         if: steps.commits.outputs.has_commits == 'true'
-        uses: ask-bonk/ask-bonk/github@main
+        uses: ask-bonk/ask-bonk/github@8c7a8314f4f4865e2e41e5718dfabc4ab7a2274b # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -14,7 +14,9 @@ jobs:
     if: github.repository_owner == 'cloudflare'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - run: vp run build
       - run: vp dlx pkg-pr-new@0.0.66 publish --pnpm './packages/vinext'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,7 @@ concurrency:
   group: npm-publish
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   ci:
@@ -31,8 +29,11 @@ jobs:
     needs: ci
     if: github.repository_owner == 'cloudflare'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0 # full history for changelog generation
 
@@ -80,15 +81,19 @@ jobs:
         run: vp pm publish --no-git-checks --access public -- --provenance
 
       - name: Tag release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Get changes since last version
         env:
           GH_TOKEN: ${{ github.token }}
+          PREVIOUS_VERSION: ${{ steps.version.outputs.previous }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          PREV_TAG="v${{ steps.version.outputs.previous }}"
+          PREV_TAG="v${PREVIOUS_VERSION}"
           FORMAT="%H %s"
           if git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
             git log "$PREV_TAG"..HEAD --format="$FORMAT" --no-merges > /tmp/raw-commits.txt
@@ -101,7 +106,7 @@ jobs:
           while IFS= read -r line; do
             SHA=$(echo "$line" | cut -d' ' -f1)
             SUBJECT=$(echo "$line" | cut -d' ' -f2-)
-            LOGIN=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.author.login // .commit.author.name' 2>/dev/null || echo "")
+            LOGIN=$(gh api "repos/${REPOSITORY}/commits/${SHA}" --jq '.author.login // .commit.author.name' 2>/dev/null || echo "")
             if [ -n "$LOGIN" ]; then
               echo "${SHA:0:7} ${SUBJECT} (@${LOGIN})"
             else
@@ -115,6 +120,8 @@ jobs:
           CF_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CF_GATEWAY_NAME: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CF_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           COMMITS=$(cat /tmp/commits.txt)
           echo "::group::Commits since last release"
@@ -126,7 +133,7 @@ jobs:
             -H "Content-Type: application/json" \
             -H "cf-aig-authorization: Bearer ${CF_API_TOKEN}" \
             -H "anthropic-version: 2023-06-01" \
-            -d "$(jq -n --arg commits "$COMMITS" --arg version "${{ steps.version.outputs.version }}" '{
+            -d "$(jq -n --arg commits "$COMMITS" --arg version "${VERSION}" '{
               model: "claude-sonnet-4-20250514",
               max_tokens: 1024,
               messages: [{
@@ -147,7 +154,7 @@ jobs:
           fi
 
           if [ -z "$SUMMARY" ]; then
-            SUMMARY="See commits: https://github.com/${{ github.repository }}/commits/v${{ steps.version.outputs.version }}"
+            SUMMARY="See commits: https://github.com/${REPOSITORY}/commits/v${VERSION}"
           fi
 
           echo "::group::Release summary"
@@ -166,11 +173,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
           SUMMARY: ${{ steps.summary.outputs.text }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
             --notes-file - \
-            --repo "${{ github.repository }}" <<< "${SUMMARY}"
+            --repo "${REPOSITORY}" <<< "${SUMMARY}"
 
       - name: Notify Google Chat
         if: success()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] persisted creds are required for `git push origin v$VERSION` in the Tag release step
         with:
           fetch-depth: 0 # full history for changelog generation
 

--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -16,7 +16,9 @@ jobs:
     outputs:
       repos: ${{ steps.read.outputs.repos }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - id: read
         run: echo "repos=$(jq -c . .github/repos.json)" >> "$GITHUB_OUTPUT"
 
@@ -41,7 +43,9 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: ./.github/actions/setup

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Summary

Run `zizmor .` and fix every reported finding, plus wire up the recommended GitHub Actions integration so future regressions surface in PRs.

### Fixes

- **Pin actions to commit SHAs** (`unpinned-uses` ×43). Version tag is kept as a trailing comment so Dependabot can still bump them — affects `actions/checkout`, `actions/cache{,/restore,/save}`, `actions/upload-artifact`, `actions/download-artifact`, `actions/github-script`, `cloudflare/wrangler-action`, and `ask-bonk/ask-bonk/github`.
- **Scope `publish.yml` permissions to the job that needs them** (`excessive-permissions`). `contents: write` and `id-token: write` move from the workflow level to the `publish` job; the workflow now declares `permissions: {}`.
- **Add `permissions: {}` + per-job scoping in `deploy-examples.yml`** (`excessive-permissions`). The `smoke-test` job is now explicit `contents: read`.
- **Hoist `${{ … }}` expansions into `env:` blocks** in `publish.yml`, `benchmarks.yml`, and `nextjs-deploy-suite.yml` (`template-injection` ×7).
- **Set `persist-credentials: false` on checkouts** that don't push (`artipacked` ×19). `publish.yml`'s checkout still persists creds (it pushes the release tag) and is annotated with an inline `zizmor: ignore[artipacked]`.
- **Keep Dependabot's 1-day cooldown** but annotate both entries with `zizmor: ignore[dependabot-cooldown]` since it is intentional.

After these changes: `zizmor .` → `No findings to report.`

### Integration

- Add `.github/workflows/zizmor.yml` using the upstream [`zizmorcore/zizmor-action`](https://docs.zizmor.sh/integrations/#github-actions) pinned at v0.5.6. Runs on push to `main` and on every PR; uploads SARIF to Code Scanning.

## Test plan

- [ ] CI passes (including the new `zizmor` job)
- [ ] Dependabot still recognizes pinned actions (next scheduled run)
- [ ] Next `workflow_dispatch` of `publish.yml` succeeds end-to-end (tag push, release notes, npm publish) — the only behavioral change is moving permissions to job level