### PR TITLE
fix: normalize static file cache paths on Windows

### DIFF
--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -330,7 +330,7 @@ async function* walkFilesWithStats(
     const stats = await Promise.all(batch.map((f) => fsp.stat(f)));
     for (let j = 0; j < batch.length; j++) {
       yield {
-        relativePath: path.relative(base, batch[j]),
+        relativePath: path.relative(base, batch[j]).replaceAll(path.sep, "/"),
         fullPath: batch[j],
         stat: { size: stats[j].size, mtimeMs: stats[j].mtimeMs },
       };


### PR DESCRIPTION

## Summary

Fixes static asset serving in `vinext start` on Windows by normalizing `StaticFileCache` lookup keys to URL-style forward slashes.

On Windows, `path.relative(base, file)` returns paths with `\` separators. `StaticFileCache` currently stores those paths directly as lookup keys, producing entries such as:

```txt
/_next\static\index-C5wrhk-x.css
/images\logo.svg
```

Browsers request URL paths with `/` separators:

```txt
/_next/static/index-C5wrhk-x.css
/images/logo.svg
```

Because the cache key and request pathname do not match, valid files that exist under `dist/client` are returned as `404` by `vinext start`.

This patch converts scanned relative file paths to URL path separators before inserting them into the static cache.

## Reproduction

On Windows:

1. Build an App Router project with static assets:

```bash
pnpm run build
pnpm exec vinext start
```

2. Open a built route in the browser.
3. Observe 404s for valid assets such as:

```txt
/_next/static/*.js
/_next/static/*.css
/images/logo.svg
```

The files exist on disk under `dist/client`, but the production server cannot serve them because the in-memory static cache uses backslash-separated keys.

## Fix

Normalize the relative path generated during static file scanning:

```ts
path.relative(base, file).replaceAll(path.sep, "/")
```

This keeps behavior unchanged on POSIX platforms and makes Windows cache keys match URL pathnames.

## Verification

Verified in a Windows project using `vinext@0.0.52`:

- `pnpm run build` succeeds.
- `vinext start` serves the app route successfully.
- Actual HTML-referenced assets under `/_next/static/*` return `200`.
- Public assets such as `/images/logo.svg` return `200`.
- Browser console no longer reports static asset 404s.

## Related

Related to #1337 in that both involve `_next/static` 404 handling, but this PR fixes a different root cause: valid static assets on Windows are cached under backslash-separated keys.

Similar class of Windows path normalization issue as #825.
