### PR TITLE
fix: resolve relative server action redirects

### DIFF
--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -70,6 +70,36 @@ export function parseServerActionRevalidationHeader(
   }
 }
 
+type ServerActionRedirectLocation = {
+  href: string;
+  internal: boolean;
+};
+
+/**
+ * Resolve a server-action redirect target against the URL that initiated the
+ * action. Dot-relative redirects intentionally resolve as if the current route
+ * pathname were a directory, matching Next.js' `assignLocation()` behavior:
+ * `./subpage` from `/subdir` lands on `/subdir/subpage`, not `/subpage`.
+ */
+export function resolveServerActionRedirectLocation(options: {
+  currentHref: string;
+  location: string;
+  origin: string;
+}): ServerActionRedirectLocation {
+  const currentUrl = new URL(options.currentHref, options.origin);
+  const redirectUrl = options.location.startsWith(".")
+    ? new URL(
+        options.location,
+        `${currentUrl.origin}${currentUrl.pathname.endsWith("/") ? currentUrl.pathname : `${currentUrl.pathname}/`}`,
+      )
+    : new URL(options.location, currentUrl.href);
+
+  return {
+    href: redirectUrl.href,
+    internal: redirectUrl.origin === currentUrl.origin,
+  };
+}
+
 export function shouldScheduleRefreshForDiscardedServerAction(
   revalidation: ServerActionRevalidationKind,
 ): boolean {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -21,6 +21,7 @@ import {
   getClientNavigationRenderContext,
   getPrefetchCache,
   invalidatePrefetchCache,
+  navigateClientSide,
   pushHistoryStateWithoutNotify,
   replaceClientParamsWithoutNotify,
   replaceHistoryStateWithoutNotify,
@@ -60,6 +61,7 @@ import {
   createServerActionInitiationSnapshot,
   isServerActionResult,
   parseServerActionRevalidationHeader,
+  resolveServerActionRedirectLocation,
   shouldClearClientNavigationCachesForServerActionResult,
   type ServerActionRevalidationKind,
   type AppBrowserServerActionResult,
@@ -1178,28 +1180,26 @@ function registerServerActionCallback(): void {
         return undefined;
       }
 
-      // Check for external URLs that need a hard redirect.
+      const redirectType = fetchResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER) ?? "push";
+      const historyUpdateMode = redirectType === "push" ? "push" : "replace";
+      const hardNavigationMode = historyUpdateMode === "push" ? "assign" : "replace";
+      let redirectLocation: ReturnType<typeof resolveServerActionRedirectLocation>;
       try {
-        const redirectUrl = new URL(actionRedirect, window.location.origin);
-        if (redirectUrl.origin !== window.location.origin) {
-          browserNavigationController.performHardNavigation(actionRedirect);
-          return undefined;
-        }
+        redirectLocation = resolveServerActionRedirectLocation({
+          currentHref: actionInitiation.href,
+          location: actionRedirect,
+          origin: window.location.origin,
+        });
       } catch {
-        // Fall through to hard redirect below if URL parsing fails.
+        clearClientNavigationCaches();
+        browserNavigationController.performHardNavigation(actionRedirect, hardNavigationMode);
+        return undefined;
       }
 
-      // Use hard redirect for all action redirects because vinext's server
-      // currently returns an empty body for redirect responses. RSC navigation
-      // requires a valid RSC payload. This is a known parity gap with Next.js,
-      // which pre-renders the redirect target's RSC payload.
       clearClientNavigationCaches();
-      const redirectType = fetchResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER) ?? "replace";
-      if (redirectType === "push") {
-        browserNavigationController.performHardNavigation(actionRedirect, "assign");
-      } else {
-        browserNavigationController.performHardNavigation(actionRedirect, "replace");
-      }
+      startTransition(() => {
+        void navigateClientSide(redirectLocation.href, historyUpdateMode, true, true);
+      });
       return undefined;
     }
 
@@ -1713,16 +1713,19 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           void cacheBufferPromise.catch(() => {});
           return;
         }
-        const cacheBuffer = await cacheBufferPromise;
-        storeVisitedResponseSnapshot(
-          rscUrl,
-          resolveVisitedResponseInterceptionContext(
-            requestInterceptionContext,
-            metadata.interceptionContext,
-          ),
-          createCachedRscResponseSnapshot(navResponse, cacheBuffer, navResponseUrl),
-          navParams,
-        );
+        void cacheBufferPromise
+          .then((cacheBuffer) => {
+            storeVisitedResponseSnapshot(
+              rscUrl,
+              resolveVisitedResponseInterceptionContext(
+                requestInterceptionContext,
+                metadata.interceptionContext,
+              ),
+              createCachedRscResponseSnapshot(navResponse, cacheBuffer, navResponseUrl),
+              navParams,
+            );
+          })
+          .catch(() => {});
         return;
       }
     } catch (error) {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -5,6 +5,7 @@ import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
   parseServerActionRevalidationHeader,
+  resolveServerActionRedirectLocation,
   shouldClearClientNavigationCachesForServerActionResult,
   shouldScheduleRefreshForDiscardedServerAction,
 } from "../packages/vinext/src/server/app-browser-action-result.js";
@@ -660,6 +661,65 @@ describe("app browser entry navigation scheduling", () => {
     expect(snapshot.navigationId).toBe(42);
     expect(snapshot.path).toBe("/a?tab=1");
     expect(snapshot.routerState).toBe(routerState);
+  });
+
+  it("resolves server action dot-relative redirects against the initiating route", () => {
+    expect(
+      resolveServerActionRedirectLocation({
+        currentHref: "https://example.com/subdir?tab=1#section",
+        location: "./subpage",
+        origin: "https://example.com",
+      }),
+    ).toEqual({
+      href: "https://example.com/subdir/subpage",
+      internal: true,
+    });
+
+    expect(
+      resolveServerActionRedirectLocation({
+        currentHref: "https://example.com/subdir?tab=1#section",
+        location: "../subpage",
+        origin: "https://example.com",
+      }),
+    ).toEqual({
+      href: "https://example.com/subpage",
+      internal: true,
+    });
+  });
+
+  it("classifies absolute server action redirects after URL resolution", () => {
+    expect(
+      resolveServerActionRedirectLocation({
+        currentHref: "https://example.com/subdir",
+        location: "/subpage",
+        origin: "https://example.com",
+      }),
+    ).toEqual({
+      href: "https://example.com/subpage",
+      internal: true,
+    });
+
+    expect(
+      resolveServerActionRedirectLocation({
+        currentHref: "https://example.com/subdir",
+        location: "https://other.example/subpage",
+        origin: "https://example.com",
+      }),
+    ).toEqual({
+      href: "https://other.example/subpage",
+      internal: false,
+    });
+
+    expect(
+      resolveServerActionRedirectLocation({
+        currentHref: "https://preview.example/subdir",
+        location: "/subpage",
+        origin: "https://fallback.example",
+      }),
+    ).toEqual({
+      href: "https://preview.example/subpage",
+      internal: true,
+    });
   });
 
   it("keeps client navigation caches for no-root server action results", () => {

--- a/tests/e2e/app-router/nextjs-compat/server-actions-relative-redirect.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/server-actions-relative-redirect.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+const ROUTE = "/nextjs-compat/server-actions-relative-redirect";
+
+test.describe("Next.js compat: server-actions-relative-redirect", () => {
+  // Ported from Next.js: test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  test("should work with relative redirect", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#relative-redirect").click();
+
+    await expect(page.locator("#page-loaded")).toHaveText("hello nested page");
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/subpage`);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  test("should work with absolute redirect", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#absolute-redirect").click();
+
+    await expect(page.locator("#page-loaded")).toHaveText("hello nested page");
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/subpage`);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  test("should work with relative redirect from subdir", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/subdir`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#relative-subdir-redirect").click();
+
+    await expect(page.locator("#page-loaded")).toHaveText("hello subdir nested page");
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/subdir/subpage`);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  test("should work with absolute redirect from subdir", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/subdir`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#absolute-subdir-redirect").click();
+
+    await expect(page.locator("#page-loaded")).toHaveText("hello nested page");
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/subpage`);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+  test("should work with multi-level relative redirect from subdir without a document reload", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}${ROUTE}/subdir`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => {
+      Reflect.set(window, "notReloaded", true);
+    });
+
+    await page.locator("#multi-relative-subdir-redirect").click();
+
+    await expect(page.locator("#page-loaded")).toHaveText("hello nested page");
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/subpage`);
+    await expect.poll(() => page.evaluate(() => Reflect.get(window, "notReloaded"))).toBe(true);
+  });
+
+  test("default push redirects scroll to top and restore previous scroll on back", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}${ROUTE}/scroll`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#page-loaded")).toHaveText("checkout page");
+    await page.evaluate(() => window.scrollTo(0, 900));
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(800);
+
+    await page.click("#default-push-redirect");
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/receipt`);
+    await expect(page.locator("#page-loaded")).toHaveText("receipt page");
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/scroll`);
+    await expect(page.locator("#page-loaded")).toHaveText("checkout page");
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(800);
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export async function relativeRedirect() {
+  redirect("./subpage");
+}
+
+export async function multiRelativeRedirect() {
+  redirect("../subpage");
+}
+
+export async function absoluteRedirect() {
+  redirect("/nextjs-compat/server-actions-relative-redirect/subpage");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { startTransition } from "react";
+import { absoluteRedirect, relativeRedirect } from "./actions";
+
+export default function Page() {
+  return (
+    <>
+      <p>hello root page</p>
+      <button
+        onClick={() => {
+          startTransition(async () => {
+            await relativeRedirect();
+          });
+        }}
+        id="relative-redirect"
+      >
+        relative redirect
+      </button>
+      <button
+        onClick={() => {
+          startTransition(async () => {
+            await absoluteRedirect();
+          });
+        }}
+        id="absolute-redirect"
+      >
+        absolute redirect
+      </button>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/receipt/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/receipt/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main style={{ minHeight: "2200px", padding: "24px" }}>
+      <p id="page-loaded">receipt page</p>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/scroll/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/scroll/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export async function redirectToReceipt() {
+  redirect("../receipt");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/scroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/scroll/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { startTransition } from "react";
+import { redirectToReceipt } from "./actions";
+
+export default function Page() {
+  return (
+    <main style={{ minHeight: "2200px", padding: "24px" }}>
+      <p id="page-loaded">checkout page</p>
+      <div style={{ height: "1200px" }} />
+      <button
+        id="default-push-redirect"
+        onClick={() => startTransition(() => void redirectToReceipt())}
+        style={{ bottom: "24px", position: "fixed", right: "24px" }}
+      >
+        complete checkout
+      </button>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subdir/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subdir/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { startTransition } from "react";
+import { absoluteRedirect, multiRelativeRedirect, relativeRedirect } from "../actions";
+
+export default function Page() {
+  return (
+    <>
+      <p>hello subdir page</p>
+      <button
+        onClick={() => {
+          startTransition(async () => {
+            await relativeRedirect();
+          });
+        }}
+        id="relative-subdir-redirect"
+      >
+        relative redirect
+      </button>
+      <button
+        onClick={() => {
+          startTransition(async () => {
+            await multiRelativeRedirect();
+          });
+        }}
+        id="multi-relative-subdir-redirect"
+      >
+        multi-level relative redirect
+      </button>
+      <button
+        onClick={() => {
+          startTransition(async () => {
+            await absoluteRedirect();
+          });
+        }}
+        id="absolute-subdir-redirect"
+      >
+        absolute redirect
+      </button>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subdir/subpage/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subdir/subpage/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page-loaded">hello subdir nested page</p>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subpage/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subpage/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page-loaded">hello nested page</p>;
+}


### PR DESCRIPTION
## Overview

| Item | Details |
| --- | --- |
| Goal | Match Next.js server action redirect semantics for dot-relative redirects. |
| Core change | Resolve action redirect locations against the action initiation pathname and keep same-origin redirects on the App Router navigation path. |
| Boundary | Browser-visible App Router behavior, with focused helper coverage for URL resolution. |
| Primary files | `packages/vinext/src/server/app-browser-action-result.ts`, `packages/vinext/src/server/app-browser-entry.ts`, `tests/e2e/app-router/nextjs-compat/server-actions-relative-redirect.spec.ts` |
| Impact | Nested server actions that call `redirect("./...")` or `redirect("../...")` land on the same routes as Next.js and do not force a document reload for same-origin App Router navigation. |

## Why

Server action redirect locations are relative to the route that initiated the action, not to an arbitrary later browser document URL, and same-origin action redirects should remain in the App Router client navigation lifecycle. The previous path treated the raw `x-action-redirect` value as a hard navigation target, which could resolve nested `./subpage` redirects incorrectly and drop client state.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| URL resolution | Dot-relative action redirects resolve with Next.js directory-style semantics from the action route. | Adds a typed resolver for server action redirect locations. |
| Client navigation | Same-origin App Router action redirects should not require a document reload. | Routes internal redirects through the app navigation runtime when available. |
| Compatibility tests | Regression coverage should prove the user-visible contract. | Ports the upstream browser scenario into the app-router compat fixture. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `redirect("./subpage")` from a nested route | Could land on the parent route's subpage or reload the document. | Lands on the nested subpage, matching Next.js. |
| `redirect("../subpage")` from a nested route | Hard navigation could lose client state. | Uses App Router navigation and preserves the in-page marker. |
| External action redirect | Hard navigation. | Still hard navigation. |

<details>
<summary>Validation</summary>

- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/nextjs-compat/server-actions-relative-redirect.spec.ts`
- `vp test run tests/app-browser-entry.test.ts -t "server action"`
- `vp fmt --check packages/vinext/src/server/app-browser-action-result.ts packages/vinext/src/server/app-browser-entry.ts tests/app-browser-entry.test.ts tests/e2e/app-router/nextjs-compat/server-actions-relative-redirect.spec.ts tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/actions.ts tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/page.tsx tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subdir/page.tsx tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subdir/subpage/page.tsx tests/fixtures/app-basic/app/nextjs-compat/server-actions-relative-redirect/subpage/page.tsx`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts`
- `vp check`
- commit hook: format, lint/typecheck, `knip --no-progress`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public API.
- Runtime: same-origin action redirects now use the App Router navigation runtime when present, which matches existing client navigation behavior.
- External redirects: remain hard navigations.
- Fallback behavior: parse fallback remains a hard navigation after the existing dangerous-scheme guard.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts) | Defines the browser-visible compatibility scenario ported here. |
| [Next.js action handler](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts) | Shows action redirects resolving relative locations from the current pathname before rendering the redirect result. |
| [Next.js assignLocation](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/assign-location.ts) | Shows client-side handling of dot-relative navigation locations using a directory-style base URL. |

Closes #1482