### PR TITLE
chore: add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize line endings on commit; check out as LF on every platform.
+# Prevents Windows clones (with core.autocrlf=true) from converting LF→CRLF
+# and breaking oxfmt, which only accepts LF.
+* text=auto eol=lf


### PR DESCRIPTION
### Summary

Add `.gitattributes` with `* text=auto eol=lf` so text files are stored and checked out as LF on every platform. `text=auto` lets Git auto-detect binary files and leave them untouched.

### Motivation

A fresh Windows clone (where Git's default is `core.autocrlf=true`) silently rewrites every text file's LF to CRLF on checkout. oxfmt only accepts LF, so `pnpm run check` immediately reports ~1400 files as needing formatting and the local toolchain is unusable until the contributor reconfigures Git globally. CI runs on Ubuntu and never sees this, so the issue stays invisible until a Windows contributor hits it.

Pinning `eol=lf` in `.gitattributes` overrides `core.autocrlf` per-repo and makes the working tree match what CI expects, regardless of the contributor's global Git config.