### PR TITLE
fix(build): clean stale vinext build output before rebuilds

### DIFF
--- a/packages/vinext/src/build/clean-output.ts
+++ b/packages/vinext/src/build/clean-output.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type CleanBuildOutputOptions = {
+  root: string;
+  outDir?: string;
+  emptyOutDir?: boolean;
+};
+
+type CleanBuildOutputResult = {
+  cleaned: boolean;
+  outDir: string;
+};
+
+function resolveOutDir(root: string, outDir: string | undefined): string {
+  const resolvedRoot = path.resolve(root);
+  if (!outDir) return path.join(resolvedRoot, "dist");
+  return path.isAbsolute(outDir) ? outDir : path.resolve(resolvedRoot, outDir);
+}
+
+function isPathInsideOrEqual(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function shouldCleanBuildOutput(options: CleanBuildOutputOptions): boolean {
+  if (options.emptyOutDir === false) return false;
+  if (options.emptyOutDir === true) return true;
+
+  return isPathInsideOrEqual(
+    path.resolve(options.root),
+    resolveOutDir(options.root, options.outDir),
+  );
+}
+
+export function cleanBuildOutput(options: CleanBuildOutputOptions): CleanBuildOutputResult {
+  const outDir = resolveOutDir(options.root, options.outDir);
+  if (!shouldCleanBuildOutput(options)) return { cleaned: false, outDir };
+
+  fs.rmSync(outDir, { recursive: true, force: true });
+  return { cleaned: true, outDir };
+}

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -139,7 +139,8 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   process.env.VINEXT_PRERENDER = "1";
 
   // The manifest lands in dist/server/ alongside the server bundle so it's
-  // cleaned by Vite's emptyOutDir on rebuild and co-located with server artifacts.
+  // cleaned with the rest of vinext's build output on rebuild and co-located
+  // with server artifacts.
   const manifestDir = path.join(root, "dist", "server");
 
   const loadedConfig = await resolveNextConfig(await loadNextConfig(root), root);

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -28,6 +28,7 @@ import { init as runInit, getReactUpgradeDeps } from "./init.js";
 import { loadDotenv } from "./config/dotenv.js";
 import { loadNextConfig, resolveNextConfig, PHASE_PRODUCTION_BUILD } from "./config/next-config.js";
 import { emitStandaloneOutput } from "./build/standalone.js";
+import { cleanBuildOutput } from "./build/clean-output.js";
 import { resolveVinextPackageRoot } from "./utils/vinext-root.js";
 import { parseArgs } from "./cli-args.js";
 import {
@@ -210,12 +211,26 @@ function hasPagesDir(): boolean {
   );
 }
 
-function hasViteConfig(): boolean {
+function hasViteConfig(root = process.cwd()): boolean {
   return (
-    fs.existsSync(path.join(process.cwd(), "vite.config.ts")) ||
-    fs.existsSync(path.join(process.cwd(), "vite.config.js")) ||
-    fs.existsSync(path.join(process.cwd(), "vite.config.mjs"))
+    fs.existsSync(path.join(root, "vite.config.ts")) ||
+    fs.existsSync(path.join(root, "vite.config.js")) ||
+    fs.existsSync(path.join(root, "vite.config.mjs"))
   );
+}
+
+async function loadBuildEmptyOutDir(vite: ViteModule, root: string): Promise<boolean | undefined> {
+  if (!hasViteConfig(root)) return undefined;
+
+  // Read the raw user config before the multi-environment build so
+  // `build.emptyOutDir: false` remains an escape hatch for vinext's upfront clean.
+  const loaded = await vite.loadConfigFromFile(
+    { command: "build", mode: "production" },
+    undefined,
+    root,
+  );
+  const emptyOutDir = loaded?.config.build?.emptyOutDir;
+  return typeof emptyOutDir === "boolean" ? emptyOutDir : undefined;
 }
 
 /**
@@ -433,13 +448,14 @@ async function buildApp() {
 
   console.log(`\n  vinext build  (Vite ${getViteVersion()})\n`);
 
+  const root = process.cwd();
   const isApp = hasAppDir();
   const resolvedNextConfig = await resolveNextConfig(
-    await loadNextConfig(process.cwd(), PHASE_PRODUCTION_BUILD),
-    process.cwd(),
+    await loadNextConfig(root, PHASE_PRODUCTION_BUILD),
+    root,
   );
   const outputMode = resolvedNextConfig.output;
-  const distDir = path.resolve(process.cwd(), "dist");
+  const distDir = path.resolve(root, "dist");
 
   // Pre-flight check: verify vinext's own dist/ exists before starting the build.
   // Without this, a missing dist/ (e.g. from a broken install) only surfaces after
@@ -475,6 +491,12 @@ async function buildApp() {
       });
     }
   }
+
+  cleanBuildOutput({
+    root,
+    outDir: distDir,
+    emptyOutDir: await loadBuildEmptyOutDir(vite, root),
+  });
 
   // All paths (App Router, Pages Router + Cloudflare, Pages Router plain Node)
   // use createBuilder + buildApp(). vinext() defines the appropriate environments

--- a/tests/clean-build-output.test.ts
+++ b/tests/clean-build-output.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { cleanBuildOutput } from "../packages/vinext/src/build/clean-output.js";
+
+let tmpDir: string;
+
+function writeFile(root: string, relativePath: string, content: string): string {
+  const target = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content, "utf-8");
+  return target;
+}
+
+describe("cleanBuildOutput", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-clean-output-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("removes stale server modules from the build output by default", () => {
+    const staleModule = writeFile(
+      tmpDir,
+      "dist/server/ssr/_next/static/stale-dead-module.js",
+      "export default 1;\n",
+    );
+
+    const result = cleanBuildOutput({ root: tmpDir });
+
+    expect(result.cleaned).toBe(true);
+    expect(result.outDir).toBe(path.join(tmpDir, "dist"));
+    expect(fs.existsSync(staleModule)).toBe(false);
+  });
+
+  it("preserves the build output when emptyOutDir is explicitly disabled", () => {
+    const staleModule = writeFile(
+      tmpDir,
+      "dist/server/ssr/_next/static/stale-dead-module.js",
+      "export default 1;\n",
+    );
+
+    const result = cleanBuildOutput({ root: tmpDir, emptyOutDir: false });
+
+    expect(result.cleaned).toBe(false);
+    expect(fs.existsSync(staleModule)).toBe(true);
+  });
+
+  it("does not remove an output directory outside the project root by default", () => {
+    const externalOutDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-external-output-"));
+    try {
+      const staleModule = writeFile(externalOutDir, "stale-dead-module.js", "export default 1;\n");
+
+      const result = cleanBuildOutput({ root: tmpDir, outDir: externalOutDir });
+
+      expect(result.cleaned).toBe(false);
+      expect(fs.existsSync(staleModule)).toBe(true);
+    } finally {
+      fs.rmSync(externalOutDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Overview

| Item | Details |
| --- | --- |
| Goal | Stop `vinext build` from retaining stale hashed server chunks across rebuilds |
| Core change | Clean `dist/` once before the production Vite build starts, with `build.emptyOutDir: false` preserved as the opt-out |
| Main boundary | Build output ownership belongs to the CLI before the multi-environment builder and hybrid Pages pass write into sibling output dirs |
| Primary files | `packages/vinext/src/cli.ts`, `packages/vinext/src/build/clean-output.ts`, `tests/clean-build-output.test.ts` |
| Expected impact | Worker deploys no longer upload historical JS/MJS modules matched by Wrangler `no_bundle` rules |

Fixes #1584.

## Why

Production build output should represent the current build, not a historical superset of every hashed chunk ever emitted. This matters more for Cloudflare Workers because vinext's generated Wrangler config uses `no_bundle: true` plus ES module globs, so stale JS/MJS files still count toward upload size even when the current manifest no longer references them.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Build output | A production build owns its output directory unless the user explicitly opts out | `vinext build` removes `dist/` before starting the Vite builder |
| Vite compatibility | `build.emptyOutDir: false` should remain an escape hatch | The CLI reads the raw Vite config and skips the upfront clean when that flag is explicitly false |
| Workers deploys | Wrangler uploads every module matched by `rules.globs` in `no_bundle` mode | Historical hashed modules are removed before Wrangler can see them |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Default repeated `vinext build` | Stale `dist/server/**/{*.js,*.mjs}` files could remain forever | `dist/` is cleaned once immediately before the build writes current artifacts |
| Hybrid App+Pages build | The extra Pages Router server build still needs `emptyOutDir: false` to preserve RSC artifacts | That pass stays unchanged because the one clean happens before all build phases |
| User sets `build.emptyOutDir: false` | No explicit vinext behaviour | The existing output is preserved |
| Out dir outside project root | Risky to delete by default | The helper follows Vite's default shape and skips outside-root output unless explicitly enabled |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/build/clean-output.ts` for the cleanup decision and filesystem mutation boundary.
2. `packages/vinext/src/cli.ts` for where the clean runs relative to standalone preflight, React upgrade, and `createBuilder().buildApp()`.
3. `tests/clean-build-output.test.ts` for default cleanup, explicit preservation, and outside-root safety.
4. `packages/vinext/src/build/run-prerender.ts` for the updated comment describing the new cleanup owner.

</details>

<details>
<summary>Validation</summary>

- `vp test run --project unit tests/clean-build-output.test.ts`
- `vp check`
- `pnpm exec knip --no-progress`
- `vp run vinext#build`
- Temp hybrid App+Pages Cloudflare runtime probe:
  - default rebuild removed `dist/server/ssr/_next/static/stale-dead-module.js`
  - changing a client component left `counter_chunks_before=1` and `counter_chunks_after=1`
  - `build.emptyOutDir: false` preserved `dist/server/ssr/_next/static/preserved-by-empty-out-dir-false.js`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no public API change.
- Config: preserves Vite's `build.emptyOutDir: false` opt-out.
- Build output: removes stale `dist/` contents by default, matching the expected clean build model.
- Workers: reduces accidental upload size when Wrangler deploys `no_bundle` module outputs.
- Existing-app risk: apps relying on arbitrary persistent files under `dist/` need to opt out with `build.emptyOutDir: false`.

</details>

<details>
<summary>Non-goals</summary>

- Does not change the hybrid Pages Router server build's internal `emptyOutDir: false`, since that still preserves RSC artifacts from the same build.
- Does not introduce a new vinext CLI flag for preserving build output.
- Does not change Wrangler's generated `no_bundle` module rules.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Issue #1584](https://github.com/cloudflare/vinext/issues/1584) | Reports stale hashed chunks accumulating and being uploaded by Wrangler |
| [Next.js clean distDir test](https://github.com/vercel/next.js/blob/canary/test/production/clean-distdir/index.test.ts) | Confirms Next.js expects the production build directory to be cleaned by default |
| [Next.js build cleanup implementation](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/index.ts) | Shows `cleanDistDir` cleanup before build work proceeds |
| [Vite `build.emptyOutDir` docs](https://github.com/vitejs/vite/blob/v8.0.10/docs/config/build-options.md#buildemptyoutdir) | Defines the default cleanup behaviour and explicit opt-out |
