### PR TITLE
feat(app-router): support useRouter bfcacheId semantics

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import { createHash } from "node:crypto";
-import { compareRoutes, decodeRouteSegment } from "./utils.js";
+import { compareRoutes, decodeRouteSegment, isInvisibleSegment } from "./utils.js";
 import { scanWithExtensions, type ValidFileMatcher } from "./file-matcher.js";
 import { validateRoutePatterns } from "./route-validation.js";
 
@@ -2152,18 +2152,10 @@ function computeInterceptSourceMatchPattern(interceptParentDir: string, appDir: 
   return "/" + urlSegments.join("/");
 }
 
-/**
- * Check whether a path segment is invisible in the URL (route groups, parallel slots, ".").
- *
- * Used by computeInterceptTarget, convertSegmentsToRouteParts, and
- * hasRemainingVisibleSegments — keep this the single source of truth.
- */
-export function isInvisibleSegment(segment: string): boolean {
-  if (segment === ".") return true;
-  if (segment.startsWith("(") && segment.endsWith(")")) return true;
-  if (segment.startsWith("@")) return true;
-  return false;
-}
+// `isInvisibleSegment` (route groups, parallel slots, ".") is defined in the
+// browser-safe ./utils module and re-exported here so existing import sites
+// keep working without pulling node:path/node:fs into client bundles.
+export { isInvisibleSegment };
 
 /**
  * Compute the target URL pattern for an intercepting route.

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -181,3 +181,16 @@ export function decodeMatchedParams(params: Record<string, string | string[]>): 
     }
   }
 }
+
+/**
+ * Check whether a path segment is invisible in the URL (route groups, parallel
+ * slots, "."). Single source of truth shared by the route graph (Node) and
+ * browser-side bfcache identity logic. Lives in this browser-safe utils module
+ * so importing it does not drag node:path/node:fs into the client bundle.
+ */
+export function isInvisibleSegment(segment: string): boolean {
+  if (segment === ".") return true;
+  if (segment.startsWith("(") && segment.endsWith(")")) return true;
+  if (segment.startsWith("@")) return true;
+  return false;
+}

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -206,7 +206,7 @@ export function splitPathSegments(pathname: string): string[] {
  * bracket conventions live in one place. The length guard rejects empty names
  * (`[...]`).
  */
-export function isCatchAllSegment(segment: string): boolean {
+function isCatchAllSegment(segment: string): boolean {
   return segment.startsWith("[...") && segment.endsWith("]") && segment.length > 5;
 }
 
@@ -214,7 +214,7 @@ export function isCatchAllSegment(segment: string): boolean {
  * Optional-catch-all filesystem segment, e.g. `[[...slug]]`. Unlike a catch-all,
  * this matches zero or more URL segments.
  */
-export function isOptionalCatchAllSegment(segment: string): boolean {
+function isOptionalCatchAllSegment(segment: string): boolean {
   return segment.startsWith("[[...") && segment.endsWith("]]") && segment.length > 7;
 }
 

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -194,3 +194,64 @@ export function isInvisibleSegment(segment: string): boolean {
   if (segment.startsWith("@")) return true;
   return false;
 }
+
+/** Split a pathname into its non-empty segments without decoding. */
+export function splitPathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+/**
+ * Catch-all filesystem segment, e.g. `[...slug]`. Browser-safe predicate shared
+ * with the route graph's segment parsing (dynamicParamNameFromSegment) so the
+ * bracket conventions live in one place. The length guard rejects empty names
+ * (`[...]`).
+ */
+export function isCatchAllSegment(segment: string): boolean {
+  return segment.startsWith("[...") && segment.endsWith("]") && segment.length > 5;
+}
+
+/**
+ * Optional-catch-all filesystem segment, e.g. `[[...slug]]`. Unlike a catch-all,
+ * this matches zero or more URL segments.
+ */
+export function isOptionalCatchAllSegment(segment: string): boolean {
+  return segment.startsWith("[[...") && segment.endsWith("]]") && segment.length > 7;
+}
+
+/**
+ * Count how many pathname segments a tree path's *visible* segments consume,
+ * given the total number of pathname segments available.
+ *
+ * This is the minimal pure slice of the canonical filesystem-segment →
+ * URL-segment mapping in `app-route-graph.ts` (`convertSegmentsToRouteParts`),
+ * extracted here so browser-side bfcache identity logic can share it without
+ * importing the Node-bound route graph module. `convertSegmentsToRouteParts`
+ * remains the source of truth for how each segment kind maps to a URL part.
+ *
+ * Each ordinary visible segment (static or `[x]`) consumes exactly one pathname
+ * segment. A catch-all (`[...x]`) is terminal and consumes every remaining
+ * pathname segment. An optional-catch-all (`[[...x]]`) is also terminal but may
+ * match zero segments, so it consumes only the remaining pathname segments
+ * (which is zero once preceding segments have already consumed the pathname) —
+ * never more than are actually present.
+ *
+ * @param visibleTreePathSegments URL-visible tree-path segments (callers must
+ *   pre-filter invisible segments via `isInvisibleSegment`).
+ * @param pathnameSegmentCount Total number of pathname segments available.
+ */
+export function countConsumedPathnameSegments(
+  visibleTreePathSegments: readonly string[],
+  pathnameSegmentCount: number,
+): number {
+  let consumed = 0;
+  for (const segment of visibleTreePathSegments) {
+    if (isCatchAllSegment(segment) || isOptionalCatchAllSegment(segment)) {
+      // Terminal: a (possibly optional) catch-all swallows whatever pathname
+      // segments remain. Clamping to the available count keeps an optional
+      // catch-all that matches zero URL segments from over-counting.
+      return Math.max(consumed, pathnameSegmentCount);
+    }
+    consumed += 1;
+  }
+  return consumed;
+}

--- a/packages/vinext/src/server/app-bfcache-id.ts
+++ b/packages/vinext/src/server/app-bfcache-id.ts
@@ -1,0 +1,4 @@
+// Internal zero cache-node sentinel. The public hook formats this as "_b_0_"
+// so user keys see the same opaque shape as freshly-minted ids.
+export const INITIAL_BFCACHE_ID = "0";
+export const PUBLIC_INITIAL_BFCACHE_ID = "_b_0_";

--- a/packages/vinext/src/server/app-bfcache-id.ts
+++ b/packages/vinext/src/server/app-bfcache-id.ts
@@ -1,4 +1,6 @@
-// Internal zero cache-node sentinel. The public hook formats this as "_b_0_"
-// so user keys see the same opaque shape as freshly-minted ids.
+// Internal zero cache-node sentinel. BfcacheIdMap intentionally stores this
+// raw sentinel for hydration entries while freshly-minted ids use the public
+// "_b_N_" shape. The public hook formats "0" as "_b_0_" so user keys always
+// see the same opaque format.
 export const INITIAL_BFCACHE_ID = "0";
 export const PUBLIC_INITIAL_BFCACHE_ID = "_b_0_";

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -633,6 +633,8 @@ function createNavigationCommitEffect(options: {
     }
 
     if (!wroteHistoryState) {
+      // Traversal and refresh commits may keep the URL unchanged, but still
+      // persist the latest bfcache id map for future history restoration.
       syncCurrentHistoryStatePreviousNextUrl(previousNextUrl, bfcacheIds);
       stageClientParams(params);
       if (targetHistoryIndex !== undefined) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -103,7 +103,7 @@ import {
 import {
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
-  createInitialBfcacheIdMap,
+  createHydratedBfcacheIdMap,
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
   readHistoryStateBfcacheIds,
@@ -1018,9 +1018,12 @@ function BrowserRoot({
   const initialMetadata = AppElementsWire.readMetadata(resolvedElements);
   const [treeStateValue, setTreeStateValue] = useState<
     AppRouterState | Promise<AppRouterState> | MpaNavigationState
-  >({
+  >(() => ({
     activeOperation: null,
-    bfcacheIds: createInitialBfcacheIdMap(resolvedElements),
+    bfcacheIds: createHydratedBfcacheIdMap(
+      resolvedElements,
+      readHistoryStateBfcacheIds(window.history.state),
+    ),
     elements: resolvedElements,
     interception: initialMetadata.interception,
     interceptionContext: initialMetadata.interceptionContext,
@@ -1033,7 +1036,7 @@ function BrowserRoot({
     routeId: initialMetadata.routeId,
     slotBindings: initialMetadata.slotBindings,
     visibleCommitVersion: 0,
-  });
+  }));
   if (isMpaNavigationState(treeStateValue)) {
     performMpaNavigation(treeStateValue.href, treeStateValue.historyUpdateMode);
     throw unresolvedMpaNavigation;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -551,6 +551,8 @@ function areBfcacheIdMapsEqual(
   const aEntries = Object.entries(a);
   const bEntries = Object.entries(b);
   if (aEntries.length !== bEntries.length) return false;
+  // Equal lengths make this bidirectional: if every a entry exists in b with
+  // the same value, b cannot contain an extra distinct key.
   return aEntries.every(([key, value]) => b[key] === value);
 }
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1047,6 +1047,10 @@ function BrowserRoot({
     AppRouterState | Promise<AppRouterState> | MpaNavigationState
   >(() => ({
     activeOperation: null,
+    // A hard reload starts a new browser document without Next.js's
+    // in-memory CacheNode/Activity tree. Hydrate the new document on the
+    // zero sentinel and rely on the document-scoped bfcache version gate to
+    // reject stale ids persisted by previous documents.
     bfcacheIds: createInitialBfcacheIdMap(resolvedElements),
     elements: resolvedElements,
     interception: initialMetadata.interception,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1714,6 +1714,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       consumeAppRouterScrollIntent(scrollIntent ?? null);
       return browserNavigationController.performHardNavigation(targetHref);
     };
+    // Traversal restores history-state ids before identity matching. Any
+    // redirect hop that changes currentHref must null this before commit so
+    // stale ids from the pre-redirect history entry cannot win.
     let restoredBfcacheIds =
       navigationKind === "traverse"
         ? readCurrentBfcacheVersionHistoryIds(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1679,7 +1679,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       consumeAppRouterScrollIntent(scrollIntent ?? null);
       return browserNavigationController.performHardNavigation(targetHref);
     };
-    const restoredBfcacheIds =
+    let restoredBfcacheIds =
       navigationKind === "traverse" ? readHistoryStateBfcacheIds(window.history.state) : null;
 
     try {
@@ -1744,6 +1744,33 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           if (compatibilityDecision.kind === "hard-navigate") {
             performHardNavigationForScrollIntent(compatibilityDecision.hardNavigationTarget);
             return;
+          }
+          const cachedRedirectDecision = resolveRscRedirectLifecycleHop({
+            currentHref,
+            historyUpdateMode: currentHistoryMode ?? "replace",
+            origin: window.location.origin,
+            redirectDepth: redirectCount,
+            requestPreviousNextUrl,
+            responseUrl: cachedRoute.response.url,
+          });
+          if (cachedRedirectDecision.kind === "terminal-hard-navigation") {
+            if (cachedRedirectDecision.reason === "maxRedirectsExceeded") {
+              console.error(
+                "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
+              );
+            }
+            performHardNavigationForScrollIntent(cachedRedirectDecision.href);
+            return;
+          }
+          if (cachedRedirectDecision.kind === "follow") {
+            if (navigationKind === "traverse") {
+              restoredBfcacheIds = null;
+            }
+            currentHref = cachedRedirectDecision.href;
+            currentHistoryMode = cachedRedirectDecision.historyUpdateMode;
+            currentPrevNextUrl = cachedRedirectDecision.previousNextUrl;
+            redirectCount = cachedRedirectDecision.redirectDepth;
+            continue;
           }
           // Check stale-navigation before and after createFromFetch. The pre-check
           // avoids wasted parse work; the post-check catches supersessions that
@@ -1941,6 +1968,13 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           // and defer URL/history mutation to the eventual approved commit.
           // This keeps isPending true across all hops and avoids publishing a
           // destination URL before its RSC payload is lifecycle-approved.
+          // Traverse restored ids belong to the history entry being traversed
+          // to. Once a server redirect changes the target href, those ids no
+          // longer describe the redirected payload and must not win over fresh
+          // segment identities.
+          if (navigationKind === "traverse") {
+            restoredBfcacheIds = null;
+          }
           currentHref = redirectDecision.href;
           currentHistoryMode = redirectDecision.historyUpdateMode;
           currentPrevNextUrl = redirectDecision.previousNextUrl;
@@ -1977,7 +2011,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             performHardNavigationForScrollIntent(resolvedTarget.href);
             return;
           }
+          if (navigationKind === "traverse") {
+            restoredBfcacheIds = null;
+          }
           currentHref = `${resolvedTarget.pathname}${resolvedTarget.search}${resolvedTarget.hash}`;
+          currentHistoryMode = currentHistoryMode ?? "replace";
+          currentPrevNextUrl = requestPreviousNextUrl;
           redirectCount += 1;
           continue;
         }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -27,6 +27,7 @@ import {
   createCachedRscResponseSnapshot,
   createClientNavigationRenderSnapshot,
   getClientNavigationRenderContext,
+  getBfcacheIdMapContext,
   getPrefetchCache,
   invalidatePrefetchCache,
   decodeRedirectError,
@@ -102,8 +103,10 @@ import {
 import {
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
+  createInitialBfcacheIdMap,
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
+  readHistoryStateBfcacheIds,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   isCacheRestorableAppPayloadMetadata,
@@ -245,6 +248,7 @@ function syncServerActionHttpFallbackHead(status: number | null): void {
   robots.setAttribute(ACTION_HTTP_FALLBACK_ROBOTS_META_ATTR, "robots");
   document.head.appendChild(robots);
 }
+const BfcacheIdMapContext = getBfcacheIdMapContext();
 
 // Parses a URI-encoded JSON value carried in a response header (e.g.
 // `X-Vinext-Params`). Returns `null` on missing or malformed input so callers
@@ -319,9 +323,13 @@ function commitHashOnlyNavigation(
   const previousNextUrl = hasBrowserRouterState()
     ? getBrowserRouterState().previousNextUrl
     : readHistoryStatePreviousNextUrl(window.history.state);
+  const bfcacheIds = hasBrowserRouterState()
+    ? getBrowserRouterState().bfcacheIds
+    : readHistoryStateBfcacheIds(window.history.state);
   const historyState = createHistoryStateWithNavigationMetadata(
     createHashOnlyNavigationBaseHistoryState(historyUpdateMode, scroll),
     {
+      bfcacheIds,
       previousNextUrl,
       traversalIndex: navigationHistoryIndex,
     },
@@ -510,14 +518,34 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
   await Promise.allSettled(learning);
 }
 
-function syncCurrentHistoryStatePreviousNextUrl(previousNextUrl: string | null): void {
-  if (readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl) {
+function areBfcacheIdMapsEqual(
+  a: Readonly<Record<string, string>> | null,
+  b: Readonly<Record<string, string>> | null,
+): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  const aEntries = Object.entries(a);
+  const bEntries = Object.entries(b);
+  if (aEntries.length !== bEntries.length) return false;
+  return aEntries.every(([key, value]) => b[key] === value);
+}
+
+function syncCurrentHistoryStatePreviousNextUrl(
+  previousNextUrl: string | null,
+  bfcacheIds?: Readonly<Record<string, string>> | null,
+): void {
+  if (
+    readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl &&
+    (bfcacheIds === undefined ||
+      areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds))
+  ) {
     return;
   }
 
   const nextHistoryState = createHistoryStateWithPreviousNextUrl(
     window.history.state,
     previousNextUrl,
+    bfcacheIds,
   );
   // First attempt: use replaceHistoryStateWithoutNotify which fires no popstate
   // or hashchange events. If the browser accepted the state update (checked via
@@ -526,7 +554,11 @@ function syncCurrentHistoryStatePreviousNextUrl(previousNextUrl: string | null):
   // replaceState calls when called in rapid succession (e.g. back-to-back
   // navigation commits). The fallback fires only when the state didn't stick.
   replaceHistoryStateWithoutNotify(nextHistoryState, "", window.location.href);
-  if (readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl) {
+  if (
+    readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl &&
+    (bfcacheIds === undefined ||
+      areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds))
+  ) {
     return;
   }
   window.history.replaceState(nextHistoryState, "", window.location.href);
@@ -544,6 +576,7 @@ function createActionInitiationSnapshot() {
 type ActionInitiationSnapshot = ReturnType<typeof createActionInitiationSnapshot>;
 
 function createNavigationCommitEffect(options: {
+  bfcacheIds: Readonly<Record<string, string>>;
   href: string;
   historyUpdateMode: HistoryUpdateMode | undefined;
   navId: number;
@@ -551,7 +584,15 @@ function createNavigationCommitEffect(options: {
   previousNextUrl: string | null;
   targetHistoryIndex?: number | null;
 }): () => void {
-  const { href, historyUpdateMode, navId, params, previousNextUrl, targetHistoryIndex } = options;
+  const {
+    bfcacheIds,
+    href,
+    historyUpdateMode,
+    navId,
+    params,
+    previousNextUrl,
+    targetHistoryIndex,
+  } = options;
 
   return () => {
     // Only update URL if this is still the active navigation.
@@ -572,6 +613,7 @@ function createNavigationCommitEffect(options: {
     const historyState = createHistoryStateWithNavigationMetadata(
       preserveExistingState ? window.history.state : null,
       {
+        bfcacheIds,
         previousNextUrl,
         traversalIndex: navigationHistoryIndex,
       },
@@ -591,7 +633,7 @@ function createNavigationCommitEffect(options: {
     }
 
     if (!wroteHistoryState) {
-      syncCurrentHistoryStatePreviousNextUrl(previousNextUrl);
+      syncCurrentHistoryStatePreviousNextUrl(previousNextUrl, bfcacheIds);
       stageClientParams(params);
       if (targetHistoryIndex !== undefined) {
         commitHistoryTraversalIndex(targetHistoryIndex);
@@ -618,6 +660,7 @@ async function renderNavigationPayload(
   operationLane: OperationLane = "navigation",
   traversalIntent: HistoryTraversalIntent | null = null,
   scrollIntent: AppRouterScrollIntent | null | undefined = null,
+  restoredBfcacheIds: Readonly<Record<string, string>> | null = null,
 ): Promise<NavigationPayloadOutcome> {
   syncServerActionHttpFallbackHead(null);
   try {
@@ -636,6 +679,7 @@ async function renderNavigationPayload(
       pendingRouterState,
       previousNextUrl,
       scrollIntent,
+      restoredBfcacheIds,
       targetHistoryIndex: traversalIntent === null ? undefined : traversalIntent.targetHistoryIndex,
       targetHref,
       navId,
@@ -974,6 +1018,7 @@ function BrowserRoot({
     AppRouterState | Promise<AppRouterState> | MpaNavigationState
   >({
     activeOperation: null,
+    bfcacheIds: createInitialBfcacheIdMap(resolvedElements),
     elements: resolvedElements,
     interception: initialMetadata.interception,
     interceptionContext: initialMetadata.interceptionContext,
@@ -1055,13 +1100,14 @@ function BrowserRoot({
 
     replaceHistoryStateWithoutNotify(
       createHistoryStateWithNavigationMetadata(window.history.state, {
+        bfcacheIds: treeState.bfcacheIds,
         previousNextUrl: treeState.previousNextUrl,
         traversalIndex: currentHistoryTraversalIndex,
       }),
       "",
       window.location.href,
     );
-  }, [treeState.previousNextUrl, treeState.renderId]);
+  }, [treeState.bfcacheIds, treeState.previousNextUrl, treeState.renderId]);
 
   const routeTree = createElement(
     RedirectBoundary,
@@ -1076,13 +1122,13 @@ function BrowserRoot({
       ),
     ),
   );
-  const innerTree = AppRouterContext
-    ? createElement(
-        AppRouterContext.Provider,
-        { value: appRouterInstance },
-        createElement(AppRouterRedirectBridge, null, routeTree),
-      )
+  const bfcacheTree = BfcacheIdMapContext
+    ? createElement(BfcacheIdMapContext.Provider, { value: treeState.bfcacheIds }, routeTree)
     : routeTree;
+  const redirectedTree = createElement(AppRouterRedirectBridge, null, bfcacheTree);
+  const innerTree = AppRouterContext
+    ? createElement(AppRouterContext.Provider, { value: appRouterInstance }, redirectedTree)
+    : bfcacheTree;
 
   // In dev, wrap the route tree in a top-level recovery boundary. A render
   // error (e.g. a slot's RSC reference rejects) is caught here instead of
@@ -1354,7 +1400,10 @@ function registerServerActionCallback(): void {
     const actionInitiation = createActionInitiationSnapshot();
     // Keep history aligned with the captured snapshot. Action POST headers
     // read from actionInitiation, not from history, after this point.
-    syncCurrentHistoryStatePreviousNextUrl(actionInitiation.routerState.previousNextUrl);
+    syncCurrentHistoryStatePreviousNextUrl(
+      actionInitiation.routerState.previousNextUrl,
+      actionInitiation.routerState.bfcacheIds,
+    );
     const body = await encodeReply(args, { temporaryReferences });
     const { headers } = resolveServerActionRequestState({
       actionId: id,
@@ -1625,6 +1674,8 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       consumeAppRouterScrollIntent(scrollIntent ?? null);
       return browserNavigationController.performHardNavigation(targetHref);
     };
+    const restoredBfcacheIds =
+      navigationKind === "traverse" ? readHistoryStateBfcacheIds(window.history.state) : null;
 
     try {
       const shouldUsePendingRouterState = programmaticTransition;
@@ -1650,7 +1701,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const requestInterceptionContext = requestState.interceptionContext;
         const requestPreviousNextUrl = requestState.previousNextUrl;
         if (navigationKind === "refresh") {
-          syncCurrentHistoryStatePreviousNextUrl(requestPreviousNextUrl);
+          syncCurrentHistoryStatePreviousNextUrl(
+            requestPreviousNextUrl,
+            getBrowserRouterState().bfcacheIds,
+          );
         }
 
         // Set this navigation as the pending pathname, overwriting any previous.
@@ -1723,6 +1777,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             toOperationLane(navigationKind),
             activeTraversalIntent,
             scrollIntent,
+            restoredBfcacheIds,
           );
           return;
         }
@@ -1793,6 +1848,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
                 toOperationLane(navigationKind),
                 activeTraversalIntent,
                 scrollIntent,
+                restoredBfcacheIds,
               ).catch((error) => {
                 if (browserNavigationController.isCurrentNavigation(navId)) {
                   console.error("[vinext] Optimistic RSC navigation error:", error);
@@ -1975,6 +2031,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           toOperationLane(navigationKind),
           activeTraversalIntent,
           scrollIntent,
+          restoredBfcacheIds,
         );
         if (renderOutcome !== "committed") return;
         // Don't cache the response if this navigation was superseded during

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -556,16 +556,24 @@ function areBfcacheIdMapsEqual(
   return aEntries.every(([key, value]) => b[key] === value);
 }
 
+function isHistoryStateNavigationMetadataInSync(
+  state: unknown,
+  previousNextUrl: string | null,
+  bfcacheIds?: Readonly<Record<string, string>> | null,
+): boolean {
+  return (
+    readHistoryStatePreviousNextUrl(state) === previousNextUrl &&
+    (bfcacheIds === undefined ||
+      (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(state), bfcacheIds) &&
+        isCurrentBfcacheVersion(state)))
+  );
+}
+
 function syncCurrentHistoryStatePreviousNextUrl(
   previousNextUrl: string | null,
   bfcacheIds?: Readonly<Record<string, string>> | null,
 ): void {
-  if (
-    readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl &&
-    (bfcacheIds === undefined ||
-      (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds) &&
-        isCurrentBfcacheVersion(window.history.state)))
-  ) {
+  if (isHistoryStateNavigationMetadataInSync(window.history.state, previousNextUrl, bfcacheIds)) {
     return;
   }
 
@@ -581,12 +589,7 @@ function syncCurrentHistoryStatePreviousNextUrl(
   // replaceState calls when called in rapid succession (e.g. back-to-back
   // navigation commits). The fallback fires only when the state didn't stick.
   replaceHistoryStateWithoutNotify(nextHistoryState, "", window.location.href);
-  if (
-    readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl &&
-    (bfcacheIds === undefined ||
-      (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds) &&
-        isCurrentBfcacheVersion(window.history.state)))
-  ) {
+  if (isHistoryStateNavigationMetadataInSync(window.history.state, previousNextUrl, bfcacheIds)) {
     return;
   }
   window.history.replaceState(nextHistoryState, "", window.location.href);

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -103,10 +103,10 @@ import {
 import {
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
-  createHydratedBfcacheIdMap,
   createHistoryStateWithNavigationMetadata,
-  createHistoryStateWithPreviousNextUrl,
+  createInitialBfcacheIdMap,
   readHistoryStateBfcacheIds,
+  readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   isCacheRestorableAppPayloadMetadata,
@@ -283,9 +283,31 @@ let browserRouterStateHasEverCommitted = false;
 let pendingNavigationRecoveryHref: string | null = null;
 const mpaNavigationScheduler = new AppBrowserMpaNavigationScheduler();
 const unresolvedMpaNavigation = new Promise<never>(() => {});
+const initialHistoryBfcacheVersion = readHistoryStateBfcacheVersion(window.history.state);
+// A new browser document does not retain Next's in-memory BFCache entries.
+// Treat bfcache ids persisted by an older document as stale so a hard reload
+// cannot restore/collide with pre-reload route identities.
+let currentBfcacheVersion =
+  initialHistoryBfcacheVersion === null ? 0 : initialHistoryBfcacheVersion + 1;
 let currentHistoryTraversalIndex: number | null =
   readHistoryStateTraversalIndex(window.history.state) ?? 0;
 let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
+
+function isCurrentBfcacheVersion(state: unknown): boolean {
+  return (readHistoryStateBfcacheVersion(state) ?? 0) === currentBfcacheVersion;
+}
+
+function readCurrentBfcacheVersionHistoryIds(
+  state: unknown,
+): Readonly<Record<string, string>> | null {
+  const ids = readHistoryStateBfcacheIds(state);
+  if (ids === null) return null;
+  return isCurrentBfcacheVersion(state) ? ids : null;
+}
+
+function invalidateRestorableBfcacheIds(): void {
+  currentBfcacheVersion += 1;
+}
 
 function allocateNavigationHistoryTraversalIndex(
   historyUpdateMode: HistoryUpdateMode | undefined,
@@ -325,11 +347,12 @@ function commitHashOnlyNavigation(
     : readHistoryStatePreviousNextUrl(window.history.state);
   const bfcacheIds = hasBrowserRouterState()
     ? getBrowserRouterState().bfcacheIds
-    : readHistoryStateBfcacheIds(window.history.state);
+    : readCurrentBfcacheVersionHistoryIds(window.history.state);
   const historyState = createHistoryStateWithNavigationMetadata(
     createHashOnlyNavigationBaseHistoryState(historyUpdateMode, scroll),
     {
       bfcacheIds,
+      bfcacheVersion: bfcacheIds === null ? undefined : currentBfcacheVersion,
       previousNextUrl,
       traversalIndex: navigationHistoryIndex,
     },
@@ -417,6 +440,7 @@ function clearPrefetchState(): void {
 function clearClientNavigationCaches(): void {
   clearVisitedResponseCache();
   clearPrefetchState();
+  invalidateRestorableBfcacheIds();
 }
 
 function isSettledPrefetchCacheEntry(
@@ -537,16 +561,17 @@ function syncCurrentHistoryStatePreviousNextUrl(
   if (
     readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl &&
     (bfcacheIds === undefined ||
-      areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds))
+      (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds) &&
+        isCurrentBfcacheVersion(window.history.state)))
   ) {
     return;
   }
 
-  const nextHistoryState = createHistoryStateWithPreviousNextUrl(
-    window.history.state,
-    previousNextUrl,
+  const nextHistoryState = createHistoryStateWithNavigationMetadata(window.history.state, {
     bfcacheIds,
-  );
+    bfcacheVersion: bfcacheIds === undefined ? undefined : currentBfcacheVersion,
+    previousNextUrl,
+  });
   // First attempt: use replaceHistoryStateWithoutNotify which fires no popstate
   // or hashchange events. If the browser accepted the state update (checked via
   // readHistoryStatePreviousNextUrl), we're done. The double-read is needed
@@ -557,7 +582,8 @@ function syncCurrentHistoryStatePreviousNextUrl(
   if (
     readHistoryStatePreviousNextUrl(window.history.state) === previousNextUrl &&
     (bfcacheIds === undefined ||
-      areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds))
+      (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(window.history.state), bfcacheIds) &&
+        isCurrentBfcacheVersion(window.history.state)))
   ) {
     return;
   }
@@ -614,6 +640,7 @@ function createNavigationCommitEffect(options: {
       preserveExistingState ? window.history.state : null,
       {
         bfcacheIds,
+        bfcacheVersion: currentBfcacheVersion,
         previousNextUrl,
         traversalIndex: navigationHistoryIndex,
       },
@@ -1020,10 +1047,7 @@ function BrowserRoot({
     AppRouterState | Promise<AppRouterState> | MpaNavigationState
   >(() => ({
     activeOperation: null,
-    bfcacheIds: createHydratedBfcacheIdMap(
-      resolvedElements,
-      readHistoryStateBfcacheIds(window.history.state),
-    ),
+    bfcacheIds: createInitialBfcacheIdMap(resolvedElements),
     elements: resolvedElements,
     interception: initialMetadata.interception,
     interceptionContext: initialMetadata.interceptionContext,
@@ -1106,6 +1130,7 @@ function BrowserRoot({
     replaceHistoryStateWithoutNotify(
       createHistoryStateWithNavigationMetadata(window.history.state, {
         bfcacheIds: treeState.bfcacheIds,
+        bfcacheVersion: currentBfcacheVersion,
         previousNextUrl: treeState.previousNextUrl,
         traversalIndex: currentHistoryTraversalIndex,
       }),
@@ -1680,7 +1705,11 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       return browserNavigationController.performHardNavigation(targetHref);
     };
     let restoredBfcacheIds =
-      navigationKind === "traverse" ? readHistoryStateBfcacheIds(window.history.state) : null;
+      navigationKind === "traverse"
+        ? readCurrentBfcacheVersionHistoryIds(
+            activeTraversalIntent?.historyState ?? window.history.state,
+          )
+        : null;
 
     try {
       const shouldUsePendingRouterState = programmaticTransition;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1047,10 +1047,11 @@ function BrowserRoot({
     AppRouterState | Promise<AppRouterState> | MpaNavigationState
   >(() => ({
     activeOperation: null,
-    // A hard reload starts a new browser document without Next.js's
-    // in-memory CacheNode/Activity tree. Hydrate the new document on the
-    // zero sentinel and rely on the document-scoped bfcache version gate to
-    // reject stale ids persisted by previous documents.
+    // Intentional Next.js parity: a hard reload starts a new browser
+    // document without the prior in-memory CacheNode/Activity tree. Hydrate
+    // the new document on the zero sentinel and rely on the document-scoped
+    // bfcache version gate to reject stale ids persisted by previous
+    // documents.
     bfcacheIds: createInitialBfcacheIdMap(resolvedElements),
     elements: resolvedElements,
     interception: initialMetadata.interception,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -105,6 +105,7 @@ import {
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createHistoryStateWithNavigationMetadata,
   createInitialBfcacheIdMap,
+  isHistoryStateBfcacheVersionCurrent,
   readHistoryStateBfcacheIds,
   readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,
@@ -294,14 +295,7 @@ let currentHistoryTraversalIndex: number | null =
 let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
 
 function isCurrentBfcacheVersion(state: unknown): boolean {
-  // A missing/invalid stored version must NEVER be treated as matching the
-  // current version. Coercing null to 0 would let un-versioned entries (older
-  // builds / external pushState) pass the gate on a fresh document where
-  // currentBfcacheVersion is 0, defeating the document-scoped stale-id
-  // rejection. App-written entries always carry an explicit version, so the
-  // legitimate first-document path (version 0 === 0) still matches.
-  const version = readHistoryStateBfcacheVersion(state);
-  return version !== null && version === currentBfcacheVersion;
+  return isHistoryStateBfcacheVersionCurrent(state, currentBfcacheVersion);
 }
 
 function readCurrentBfcacheVersionHistoryIds(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -294,7 +294,14 @@ let currentHistoryTraversalIndex: number | null =
 let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
 
 function isCurrentBfcacheVersion(state: unknown): boolean {
-  return (readHistoryStateBfcacheVersion(state) ?? 0) === currentBfcacheVersion;
+  // A missing/invalid stored version must NEVER be treated as matching the
+  // current version. Coercing null to 0 would let un-versioned entries (older
+  // builds / external pushState) pass the gate on a fresh document where
+  // currentBfcacheVersion is 0, defeating the document-scoped stale-id
+  // rejection. App-written entries always carry an explicit version, so the
+  // legitimate first-document path (version 0 === 0) still matches.
+  const version = readHistoryStateBfcacheVersion(state);
+  return version !== null && version === currentBfcacheVersion;
 }
 
 function readCurrentBfcacheVersionHistoryIds(

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -42,6 +42,7 @@ export type NavigationPayloadOutcome = "committed" | "no-commit" | "hard-navigat
 type HardNavigationMode = "assign" | "replace";
 
 type BrowserNavigationCommitEffectFactory = (options: {
+  bfcacheIds: Readonly<Record<string, string>>;
   href: string;
   historyUpdateMode: HistoryUpdateMode | undefined;
   navId: number;
@@ -65,7 +66,10 @@ type BrowserNavigationControllerDeps = {
   commitClientNavigationState?: typeof commitClientNavigationState;
   performHardNavigation?: (href: string, mode?: HardNavigationMode) => boolean;
   getRouteManifest?: () => RouteManifest | null;
-  syncHistoryStatePreviousNextUrl?: (previousNextUrl: string | null) => void;
+  syncHistoryStatePreviousNextUrl?: (
+    previousNextUrl: string | null,
+    bfcacheIds?: Readonly<Record<string, string>> | null,
+  ) => void;
 };
 
 type BrowserNavigationController = {
@@ -94,6 +98,7 @@ type BrowserNavigationController = {
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
     scrollIntent?: AppRouterScrollIntent | null;
+    restoredBfcacheIds?: Readonly<Record<string, string>> | null;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -508,6 +513,7 @@ export function createAppBrowserNavigationController(
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
     scrollIntent?: AppRouterScrollIntent | null;
+    restoredBfcacheIds?: Readonly<Record<string, string>> | null;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -530,6 +536,7 @@ export function createAppBrowserNavigationController(
         payloadOrigin: options.payloadOrigin,
         previousNextUrl: options.previousNextUrl,
         renderId,
+        restoredBfcacheIds: options.restoredBfcacheIds,
         type: options.actionType,
       });
 
@@ -565,6 +572,7 @@ export function createAppBrowserNavigationController(
       queuePrePaintNavigationEffect(
         renderId,
         options.createNavigationCommitEffect({
+          bfcacheIds: approvedCommit.action.bfcacheIds,
           href: options.targetHref,
           historyUpdateMode: options.historyUpdateMode,
           navId: options.navId,
@@ -654,7 +662,10 @@ export function createAppBrowserNavigationController(
 
       if (latestApproval.approvedCommit) {
         dispatchSynchronousVisibleCommit(latestApproval.approvedCommit);
-        syncHistoryStatePreviousNextUrl(latestApproval.approvedCommit.previousNextUrl);
+        syncHistoryStatePreviousNextUrl(
+          latestApproval.approvedCommit.previousNextUrl,
+          latestApproval.approvedCommit.action.bfcacheIds,
+        );
       } else {
         notifyDiscardedServerActionRevalidation(lifecycleOptions);
       }

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -178,9 +178,27 @@ function getVisibleTreePathSegments(treePath: string): string[] {
     .filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")));
 }
 
-function getPathPrefix(pathname: string, segmentCount: number): string {
-  if (segmentCount === 0) return "/";
-  const segments = getPathSegments(pathname).slice(0, segmentCount);
+function isCatchAllTreePathSegment(segment: string): boolean {
+  return (
+    (segment.startsWith("[...") && segment.endsWith("]") && segment.length > 5) ||
+    (segment.startsWith("[[...") && segment.endsWith("]]") && segment.length > 7)
+  );
+}
+
+function getTreePathIdentityPrefix(pathname: string, treePath: string): string {
+  const pathnameSegments = getPathSegments(pathname);
+  let consumedPathnameSegments = 0;
+
+  for (const segment of getVisibleTreePathSegments(treePath)) {
+    if (isCatchAllTreePathSegment(segment)) {
+      consumedPathnameSegments = pathnameSegments.length;
+      break;
+    }
+    consumedPathnameSegments += 1;
+  }
+
+  if (consumedPathnameSegments === 0) return "/";
+  const segments = pathnameSegments.slice(0, consumedPathnameSegments);
   return `/${segments.join("/")}`;
 }
 
@@ -193,8 +211,7 @@ function createBfcacheSegmentIdentity(id: string, pathname: string): string | nu
   }
 
   if (parsed.kind === "layout" || parsed.kind === "slot" || parsed.kind === "template") {
-    const segmentCount = getVisibleTreePathSegments(parsed.treePath).length;
-    return `${id}@${getPathPrefix(pathname, segmentCount)}`;
+    return `${id}@${getTreePathIdentityPrefix(pathname, parsed.treePath)}`;
   }
 
   return null;

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -35,12 +35,13 @@ import {
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
-import type { BfcacheIdMap } from "./app-history-state.js";
+import { isBfcacheSegmentId, type BfcacheIdMap } from "./app-history-state.js";
 
 export {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
   readHistoryStateBfcacheIds,
+  readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   resolveHistoryTraversalIntent,
@@ -157,16 +158,6 @@ function mintBfcacheId(): string {
   return `_b_${nextBfcacheId}_`;
 }
 
-function isBfcacheSegmentId(id: string): boolean {
-  const parsed = AppElementsWire.parseElementKey(id);
-  return (
-    parsed?.kind === "layout" ||
-    parsed?.kind === "page" ||
-    parsed?.kind === "slot" ||
-    parsed?.kind === "template"
-  );
-}
-
 function getPathSegments(pathname: string): string[] {
   return pathname.split("/").filter(Boolean);
 }
@@ -273,31 +264,6 @@ export function createInitialBfcacheIdMap(elements: AppElements): BfcacheIdMap {
     ids[id] = INITIAL_BFCACHE_ID;
   }
   return ids;
-}
-
-export function createHydratedBfcacheIdMap(
-  elements: AppElements,
-  restored: BfcacheIdMap | null,
-): BfcacheIdMap {
-  if (restored === null) {
-    return createInitialBfcacheIdMap(elements);
-  }
-
-  const ids: Record<string, string> = {};
-  let hasRestoredId = false;
-  for (const id of collectBfcacheSegmentIds(elements)) {
-    const restoredValue = restored[id];
-    if (restoredValue !== undefined) {
-      ids[id] = restoredValue;
-      hasRestoredId = true;
-      // Keep future fresh ids ahead of values restored from session history.
-      rememberBfcacheId(restoredValue);
-    } else {
-      ids[id] = INITIAL_BFCACHE_ID;
-    }
-  }
-
-  return hasRestoredId ? ids : createInitialBfcacheIdMap(elements);
 }
 
 export function createNextBfcacheIdMap(options: {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -151,6 +151,8 @@ type PendingNavigationCommitDispositionDecision =
 let nextBfcacheId = 0;
 
 function rememberBfcacheId(value: string): void {
+  // The hydration sentinel is the raw "0" value and intentionally does not
+  // advance the counter; fresh ids start at "_b_1_".
   const match = /^_b_(\d+)_$/.exec(value);
   if (!match) return;
   nextBfcacheId = Math.max(nextBfcacheId, Number(match[1]));
@@ -302,6 +304,8 @@ export function createNextBfcacheIdMap(options: {
     // Restored ids intentionally win over identity-matching: the target entry's
     // ids were authoritative when that entry was created, and traversal must
     // faithfully restore them even if the segment's identity has since changed.
+    // Callers must clear restored ids before this point when traversal redirects
+    // change the target href, because stale history ids otherwise win here.
     const value = options.restored?.[id] ?? currentValue ?? mintBfcacheId();
     ids[id] = value;
     rememberBfcacheId(value);

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -243,6 +243,31 @@ export function createInitialBfcacheIdMap(elements: AppElements): BfcacheIdMap {
   return ids;
 }
 
+export function createHydratedBfcacheIdMap(
+  elements: AppElements,
+  restored: BfcacheIdMap | null,
+): BfcacheIdMap {
+  if (restored === null) {
+    return createInitialBfcacheIdMap(elements);
+  }
+
+  const ids: Record<string, string> = {};
+  let hasRestoredId = false;
+  for (const id of collectBfcacheSegmentIds(elements)) {
+    const restoredValue = restored[id];
+    if (restoredValue !== undefined) {
+      ids[id] = restoredValue;
+      hasRestoredId = true;
+      // Keep future fresh ids ahead of values restored from session history.
+      rememberBfcacheId(restoredValue);
+    } else {
+      ids[id] = INITIAL_BFCACHE_ID;
+    }
+  }
+
+  return hasRestoredId ? ids : createInitialBfcacheIdMap(elements);
+}
+
 export function createNextBfcacheIdMap(options: {
   current: BfcacheIdMap;
   currentPathname: string;

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -35,6 +35,7 @@ import {
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
+import { INITIAL_BFCACHE_ID } from "./app-bfcache-id.js";
 import { isBfcacheSegmentId, type BfcacheIdMap } from "./app-history-state.js";
 
 export {
@@ -144,7 +145,6 @@ type PendingNavigationCommitDispositionDecision =
   | DispatchPendingNavigationCommitDispositionDecision
   | NonDispatchPendingNavigationCommitDispositionDecision;
 
-const INITIAL_BFCACHE_ID = "0";
 // Monotonic within a single browser document. Full reloads reset the counter,
 // while the browser entry's document-scoped version gate prevents old history
 // ids from being restored into the new document and colliding with fresh mints.

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -202,6 +202,11 @@ function getTreePathIdentityPrefix(pathname: string, treePath: string): string {
   return `/${segments.join("/")}`;
 }
 
+/**
+ * Legacy bridge for deriving a bfcache segment identity from AppElements wire
+ * keys. Keep wire-key parsing contained here until Vinext has a route-manifest
+ * semantic authority equivalent to Next.js CacheNode/segment-cache state.
+ */
 function createBfcacheSegmentIdentity(id: string, pathname: string): string | null {
   const parsed = AppElementsWire.parseElementKey(id);
   if (!parsed) return null;

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -35,12 +35,16 @@ import {
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
+import type { BfcacheIdMap } from "./app-history-state.js";
+
 export {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
+  readHistoryStateBfcacheIds,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   resolveHistoryTraversalIntent,
+  type BfcacheIdMap,
   type HistoryTraversalIntent,
 } from "./app-history-state.js";
 
@@ -65,6 +69,7 @@ export type OperationRecord = PendingOperationRecord | CommittedOperationRecord;
 
 export type AppRouterState = {
   activeOperation: OperationRecord | null;
+  bfcacheIds: BfcacheIdMap;
   elements: AppElements;
   interception: AppElementsInterception | null;
   interceptionContext: string | null;
@@ -80,6 +85,7 @@ export type AppRouterState = {
 };
 
 export type AppRouterAction = {
+  bfcacheIds: BfcacheIdMap;
   cacheEntryReuseProof?: CacheEntryReuseProof;
   elements: AppElements;
   interception: AppElementsInterception | null;
@@ -136,6 +142,137 @@ type NonDispatchPendingNavigationCommitDispositionDecision = {
 type PendingNavigationCommitDispositionDecision =
   | DispatchPendingNavigationCommitDispositionDecision
   | NonDispatchPendingNavigationCommitDispositionDecision;
+
+let nextBfcacheId = 0;
+const INITIAL_BFCACHE_ID = "0";
+
+function rememberBfcacheId(value: string): void {
+  const match = /^_b_(\d+)_$/.exec(value);
+  if (!match) return;
+  nextBfcacheId = Math.max(nextBfcacheId, Number(match[1]));
+}
+
+function mintBfcacheId(): string {
+  nextBfcacheId += 1;
+  return `_b_${nextBfcacheId}_`;
+}
+
+function isBfcacheSegmentId(id: string): boolean {
+  const parsed = AppElementsWire.parseElementKey(id);
+  return (
+    parsed?.kind === "layout" ||
+    parsed?.kind === "page" ||
+    parsed?.kind === "slot" ||
+    parsed?.kind === "template"
+  );
+}
+
+function getPathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+function getVisibleTreePathSegments(treePath: string): string[] {
+  return treePath
+    .split("/")
+    .filter(Boolean)
+    .filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")));
+}
+
+function getPathPrefix(pathname: string, segmentCount: number): string {
+  if (segmentCount === 0) return "/";
+  const segments = getPathSegments(pathname).slice(0, segmentCount);
+  return `/${segments.join("/")}`;
+}
+
+function createBfcacheSegmentIdentity(id: string, pathname: string): string | null {
+  const parsed = AppElementsWire.parseElementKey(id);
+  if (!parsed) return null;
+
+  if (parsed.kind === "page") {
+    return `${id}@${pathname}`;
+  }
+
+  if (parsed.kind === "layout" || parsed.kind === "slot" || parsed.kind === "template") {
+    const segmentCount = getVisibleTreePathSegments(parsed.treePath).length;
+    return `${id}@${getPathPrefix(pathname, segmentCount)}`;
+  }
+
+  return null;
+}
+
+function collectBfcacheSegmentIds(elements: AppElements): string[] {
+  const ids = new Set(Object.keys(elements));
+  try {
+    for (const layoutId of AppElementsWire.readMetadata(elements).layoutIds) {
+      ids.add(layoutId);
+    }
+  } catch {
+    // Some low-level tests pass partial element maps without metadata.
+  }
+
+  return Array.from(ids).filter(isBfcacheSegmentId);
+}
+
+export function createInitialBfcacheIdMap(elements: AppElements): BfcacheIdMap {
+  const ids: Record<string, string> = {};
+  for (const id of collectBfcacheSegmentIds(elements)) {
+    ids[id] = INITIAL_BFCACHE_ID;
+  }
+  return ids;
+}
+
+export function createNextBfcacheIdMap(options: {
+  current: BfcacheIdMap;
+  currentPathname: string;
+  elements: AppElements;
+  nextPathname: string;
+  restored?: BfcacheIdMap | null;
+}): BfcacheIdMap {
+  for (const value of Object.values(options.current)) {
+    rememberBfcacheId(value);
+  }
+  for (const value of Object.values(options.restored ?? {})) {
+    rememberBfcacheId(value);
+  }
+
+  const ids: Record<string, string> = {};
+  for (const id of collectBfcacheSegmentIds(options.elements)) {
+    const currentIdentity = createBfcacheSegmentIdentity(id, options.currentPathname);
+    const nextIdentity = createBfcacheSegmentIdentity(id, options.nextPathname);
+    const currentValue = currentIdentity === nextIdentity ? options.current[id] : undefined;
+    // History traversals restore persisted ids first, matching segments keep
+    // their current id, and newly-created segments mint a fresh opaque id.
+    const value = options.restored?.[id] ?? currentValue ?? mintBfcacheId();
+    ids[id] = value;
+    rememberBfcacheId(value);
+  }
+  return ids;
+}
+
+export function preserveBfcacheIdsForMergedElements(options: {
+  elements: AppElements;
+  next: BfcacheIdMap;
+  previous: BfcacheIdMap;
+}): BfcacheIdMap {
+  const ids: Record<string, string> = {};
+  for (const id of collectBfcacheSegmentIds(options.elements)) {
+    const nextValue = options.next[id];
+    if (nextValue !== undefined) {
+      ids[id] = nextValue;
+      continue;
+    }
+
+    const previousValue = options.previous[id];
+    if (previousValue !== undefined) {
+      ids[id] = previousValue;
+      // Keep the module-level opaque-id counter ahead of restored ids so future
+      // mints cannot reuse a value after reducer-level preservation.
+      rememberBfcacheId(previousValue);
+    }
+  }
+  return ids;
+}
+
 function createOperationRecord(options: {
   id: number;
   lane: OperationLane;
@@ -463,6 +600,7 @@ export async function createPendingNavigationCommit(options: {
   // current visible previousNextUrl.
   previousNextUrl?: string | null;
   renderId: number;
+  restoredBfcacheIds?: BfcacheIdMap | null;
   type: "navigate" | "replace" | "traverse";
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
@@ -480,6 +618,13 @@ export async function createPendingNavigationCommit(options: {
 
   return {
     action: {
+      bfcacheIds: createNextBfcacheIdMap({
+        current: options.currentState.bfcacheIds,
+        currentPathname: options.currentState.navigationSnapshot.pathname,
+        elements,
+        nextPathname: options.navigationSnapshot.pathname,
+        restored: options.restoredBfcacheIds,
+      }),
       ...(cacheEntryReuseProof ? { cacheEntryReuseProof } : {}),
       elements,
       interception: metadata.interception,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -144,8 +144,11 @@ type PendingNavigationCommitDispositionDecision =
   | DispatchPendingNavigationCommitDispositionDecision
   | NonDispatchPendingNavigationCommitDispositionDecision;
 
-let nextBfcacheId = 0;
 const INITIAL_BFCACHE_ID = "0";
+// Monotonic within a single browser document. Full reloads reset the counter,
+// while the browser entry's document-scoped version gate prevents old history
+// ids from being restored into the new document and colliding with fresh mints.
+let nextBfcacheId = 0;
 
 function rememberBfcacheId(value: string): void {
   const match = /^_b_(\d+)_$/.exec(value);
@@ -205,7 +208,7 @@ function readAppElementsMetadata(elements: AppElements): AppElementsMetadata | n
 
 function createActiveSlotIdentity(id: string, metadata: AppElementsMetadata | null): string | null {
   const activeSlotBinding = metadata?.slotBindings.find((binding) => binding.slotId === id);
-  if (activeSlotBinding?.activeRouteId) {
+  if (activeSlotBinding?.activeRouteId != null && activeSlotBinding.activeRouteId !== "") {
     return `${id}@${activeSlotBinding.activeRouteId}`;
   }
 
@@ -296,6 +299,9 @@ export function createNextBfcacheIdMap(options: {
     const currentValue = currentIdentity === nextIdentity ? options.current[id] : undefined;
     // History traversals restore persisted ids first, matching segments keep
     // their current id, and newly-created segments mint a fresh opaque id.
+    // Restored ids intentionally win over identity-matching: the target entry's
+    // ids were authoritative when that entry was created, and traversal must
+    // faithfully restore them even if the segment's identity has since changed.
     const value = options.restored?.[id] ?? currentValue ?? mintBfcacheId();
     ids[id] = value;
     rememberBfcacheId(value);

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -208,7 +208,7 @@ function readAppElementsMetadata(elements: AppElements): AppElementsMetadata | n
 
 function createActiveSlotIdentity(id: string, metadata: AppElementsMetadata | null): string | null {
   const activeSlotBinding = metadata?.slotBindings.find((binding) => binding.slotId === id);
-  if (activeSlotBinding?.activeRouteId != null && activeSlotBinding.activeRouteId !== "") {
+  if (activeSlotBinding?.activeRouteId != null) {
     return `${id}@${activeSlotBinding.activeRouteId}`;
   }
 

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -202,21 +202,53 @@ function getTreePathIdentityPrefix(pathname: string, treePath: string): string {
   return `/${segments.join("/")}`;
 }
 
+type AppElementsMetadata = ReturnType<typeof AppElementsWire.readMetadata>;
+
+function readAppElementsMetadata(elements: AppElements): AppElementsMetadata | null {
+  try {
+    return AppElementsWire.readMetadata(elements);
+  } catch {
+    return null;
+  }
+}
+
+function createActiveSlotIdentity(id: string, metadata: AppElementsMetadata | null): string | null {
+  const activeSlotBinding = metadata?.slotBindings.find((binding) => binding.slotId === id);
+  if (activeSlotBinding?.activeRouteId) {
+    return `${id}@${activeSlotBinding.activeRouteId}`;
+  }
+
+  const interception = metadata?.interception;
+  if (interception?.slotId !== id) return null;
+
+  return `${id}@${interception.targetRouteId}`;
+}
+
 /**
  * Legacy bridge for deriving a bfcache segment identity from AppElements wire
  * keys. Keep wire-key parsing contained here until Vinext has a route-manifest
  * semantic authority equivalent to Next.js CacheNode/segment-cache state.
  */
-function createBfcacheSegmentIdentity(id: string, pathname: string): string | null {
+function createBfcacheSegmentIdentity(
+  id: string,
+  options: { metadata: AppElementsMetadata | null; pathname: string },
+): string | null {
   const parsed = AppElementsWire.parseElementKey(id);
   if (!parsed) return null;
 
   if (parsed.kind === "page") {
-    return `${id}@${pathname}`;
+    return `${id}@${options.pathname}`;
   }
 
-  if (parsed.kind === "layout" || parsed.kind === "slot" || parsed.kind === "template") {
-    return `${id}@${getTreePathIdentityPrefix(pathname, parsed.treePath)}`;
+  if (parsed.kind === "slot") {
+    const activeSlotIdentity = createActiveSlotIdentity(id, options.metadata);
+    if (activeSlotIdentity !== null) return activeSlotIdentity;
+
+    return `${id}@${getTreePathIdentityPrefix(options.pathname, parsed.treePath)}`;
+  }
+
+  if (parsed.kind === "layout" || parsed.kind === "template") {
+    return `${id}@${getTreePathIdentityPrefix(options.pathname, parsed.treePath)}`;
   }
 
   return null;
@@ -270,6 +302,7 @@ export function createHydratedBfcacheIdMap(
 
 export function createNextBfcacheIdMap(options: {
   current: BfcacheIdMap;
+  currentElements: AppElements;
   currentPathname: string;
   elements: AppElements;
   nextPathname: string;
@@ -282,10 +315,18 @@ export function createNextBfcacheIdMap(options: {
     rememberBfcacheId(value);
   }
 
+  const currentMetadata = readAppElementsMetadata(options.currentElements);
+  const nextMetadata = readAppElementsMetadata(options.elements);
   const ids: Record<string, string> = {};
   for (const id of collectBfcacheSegmentIds(options.elements)) {
-    const currentIdentity = createBfcacheSegmentIdentity(id, options.currentPathname);
-    const nextIdentity = createBfcacheSegmentIdentity(id, options.nextPathname);
+    const currentIdentity = createBfcacheSegmentIdentity(id, {
+      metadata: currentMetadata,
+      pathname: options.currentPathname,
+    });
+    const nextIdentity = createBfcacheSegmentIdentity(id, {
+      metadata: nextMetadata,
+      pathname: options.nextPathname,
+    });
     const currentValue = currentIdentity === nextIdentity ? options.current[id] : undefined;
     // History traversals restore persisted ids first, matching segments keep
     // their current id, and newly-created segments mint a fresh opaque id.
@@ -667,6 +708,7 @@ export async function createPendingNavigationCommit(options: {
     action: {
       bfcacheIds: createNextBfcacheIdMap({
         current: options.currentState.bfcacheIds,
+        currentElements: options.currentState.elements,
         currentPathname: options.currentState.navigationSnapshot.pathname,
         elements,
         nextPathname: options.navigationSnapshot.pathname,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,5 +1,5 @@
 import { stripBasePath } from "../utils/base-path.js";
-import type { RouteManifest } from "../routing/app-route-graph.js";
+import { isInvisibleSegment, type RouteManifest } from "../routing/app-route-graph.js";
 import {
   AppElementsWire,
   getMountedSlotIds,
@@ -168,10 +168,16 @@ function getPathSegments(pathname: string): string[] {
 }
 
 function getVisibleTreePathSegments(treePath: string): string[] {
+  // Tree paths contain raw filesystem segments (route groups, parallel @slots,
+  // and "." default segments). Only URL-visible segments consume a pathname
+  // segment when deriving the identity prefix, so filter the invisible ones
+  // using the same authority the route graph uses (isInvisibleSegment). Missing
+  // @slot/"." here over-counts consumed segments and re-mints bfcache ids for
+  // segments that actually persisted across a parallel-route navigation.
   return treePath
     .split("/")
     .filter(Boolean)
-    .filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")));
+    .filter((segment) => !isInvisibleSegment(segment));
 }
 
 function isCatchAllTreePathSegment(segment: string): boolean {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -1,5 +1,5 @@
 import { stripBasePath } from "../utils/base-path.js";
-import { isInvisibleSegment, type RouteManifest } from "../routing/app-route-graph.js";
+import type { RouteManifest } from "../routing/app-route-graph.js";
 import {
   AppElementsWire,
   getMountedSlotIds,
@@ -33,7 +33,7 @@ import {
   type RouteSnapshotV0,
 } from "./navigation-planner.js";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
-import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import { isInvisibleSegment, normalizePathnameForRouteMatch } from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
 import { INITIAL_BFCACHE_ID } from "./app-bfcache-id.js";
 import { isBfcacheSegmentId, type BfcacheIdMap } from "./app-history-state.js";

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -33,7 +33,12 @@ import {
   type RouteSnapshotV0,
 } from "./navigation-planner.js";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
-import { isInvisibleSegment, normalizePathnameForRouteMatch } from "../routing/utils.js";
+import {
+  countConsumedPathnameSegments,
+  isInvisibleSegment,
+  normalizePathnameForRouteMatch,
+  splitPathSegments,
+} from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
 import { INITIAL_BFCACHE_ID } from "./app-bfcache-id.js";
 import { isBfcacheSegmentId, type BfcacheIdMap } from "./app-history-state.js";
@@ -163,10 +168,6 @@ function mintBfcacheId(): string {
   return `_b_${nextBfcacheId}_`;
 }
 
-function getPathSegments(pathname: string): string[] {
-  return pathname.split("/").filter(Boolean);
-}
-
 function getVisibleTreePathSegments(treePath: string): string[] {
   // Tree paths contain raw filesystem segments (route groups, parallel @slots,
   // and "." default segments). Only URL-visible segments consume a pathname
@@ -174,30 +175,17 @@ function getVisibleTreePathSegments(treePath: string): string[] {
   // using the same authority the route graph uses (isInvisibleSegment). Missing
   // @slot/"." here over-counts consumed segments and re-mints bfcache ids for
   // segments that actually persisted across a parallel-route navigation.
-  return treePath
-    .split("/")
-    .filter(Boolean)
-    .filter((segment) => !isInvisibleSegment(segment));
-}
-
-function isCatchAllTreePathSegment(segment: string): boolean {
-  return (
-    (segment.startsWith("[...") && segment.endsWith("]") && segment.length > 5) ||
-    (segment.startsWith("[[...") && segment.endsWith("]]") && segment.length > 7)
-  );
+  return splitPathSegments(treePath).filter((segment) => !isInvisibleSegment(segment));
 }
 
 function getTreePathIdentityPrefix(pathname: string, treePath: string): string {
-  const pathnameSegments = getPathSegments(pathname);
-  let consumedPathnameSegments = 0;
-
-  for (const segment of getVisibleTreePathSegments(treePath)) {
-    if (isCatchAllTreePathSegment(segment)) {
-      consumedPathnameSegments = pathnameSegments.length;
-      break;
-    }
-    consumedPathnameSegments += 1;
-  }
+  const pathnameSegments = splitPathSegments(pathname);
+  // countConsumedPathnameSegments is the shared, browser-safe slice of the
+  // canonical filesystem-segment → URL-segment mapping in app-route-graph.ts.
+  const consumedPathnameSegments = countConsumedPathnameSegments(
+    getVisibleTreePathSegments(treePath),
+    pathnameSegments.length,
+  );
 
   if (consumedPathnameSegments === 0) return "/";
   const segments = pathnameSegments.slice(0, consumedPathnameSegments);
@@ -206,21 +194,41 @@ function getTreePathIdentityPrefix(pathname: string, treePath: string): string {
 
 type AppElementsMetadata = ReturnType<typeof AppElementsWire.readMetadata>;
 
-function readAppElementsMetadata(elements: AppElements): AppElementsMetadata | null {
+/**
+ * Metadata parsed once per element map, paired with a slotId→binding index so
+ * per-slot identity lookups are O(1) instead of a linear `slotBindings.find`
+ * scan (which made per-commit identity derivation O(slots^2)).
+ */
+type ParsedAppElementsMetadata = {
+  metadata: AppElementsMetadata;
+  slotBindingsBySlotId: ReadonlyMap<string, AppElementsSlotBinding>;
+};
+
+function readAppElementsMetadata(elements: AppElements): ParsedAppElementsMetadata | null {
+  let metadata: AppElementsMetadata;
   try {
-    return AppElementsWire.readMetadata(elements);
+    metadata = AppElementsWire.readMetadata(elements);
   } catch {
+    // Some low-level tests pass partial element maps without metadata.
     return null;
   }
+  const slotBindingsBySlotId = new Map<string, AppElementsSlotBinding>();
+  for (const binding of metadata.slotBindings) {
+    slotBindingsBySlotId.set(binding.slotId, binding);
+  }
+  return { metadata, slotBindingsBySlotId };
 }
 
-function createActiveSlotIdentity(id: string, metadata: AppElementsMetadata | null): string | null {
-  const activeSlotBinding = metadata?.slotBindings.find((binding) => binding.slotId === id);
+function createActiveSlotIdentity(
+  id: string,
+  parsed: ParsedAppElementsMetadata | null,
+): string | null {
+  const activeSlotBinding = parsed?.slotBindingsBySlotId.get(id);
   if (activeSlotBinding?.activeRouteId != null) {
     return `${id}@${activeSlotBinding.activeRouteId}`;
   }
 
-  const interception = metadata?.interception;
+  const interception = parsed?.metadata.interception;
   if (interception?.slotId !== id) return null;
 
   return `${id}@${interception.targetRouteId}`;
@@ -233,7 +241,7 @@ function createActiveSlotIdentity(id: string, metadata: AppElementsMetadata | nu
  */
 function createBfcacheSegmentIdentity(
   id: string,
-  options: { metadata: AppElementsMetadata | null; pathname: string },
+  options: { metadata: ParsedAppElementsMetadata | null; pathname: string },
 ): string | null {
   const parsed = AppElementsWire.parseElementKey(id);
   if (!parsed) return null;
@@ -256,14 +264,16 @@ function createBfcacheSegmentIdentity(
   return null;
 }
 
-function collectBfcacheSegmentIds(elements: AppElements): string[] {
+function collectBfcacheSegmentIds(
+  elements: AppElements,
+  parsed?: ParsedAppElementsMetadata | null,
+): string[] {
   const ids = new Set(Object.keys(elements));
-  try {
-    for (const layoutId of AppElementsWire.readMetadata(elements).layoutIds) {
-      ids.add(layoutId);
-    }
-  } catch {
-    // Some low-level tests pass partial element maps without metadata.
+  // Reuse already-parsed metadata when the caller has it; only fall back to a
+  // fresh parse when metadata was not threaded in (e.g. createInitialBfcacheIdMap).
+  const metadata = parsed === undefined ? readAppElementsMetadata(elements) : parsed;
+  for (const layoutId of metadata?.metadata.layoutIds ?? []) {
+    ids.add(layoutId);
   }
 
   return Array.from(ids).filter(isBfcacheSegmentId);
@@ -295,7 +305,7 @@ export function createNextBfcacheIdMap(options: {
   const currentMetadata = readAppElementsMetadata(options.currentElements);
   const nextMetadata = readAppElementsMetadata(options.elements);
   const ids: Record<string, string> = {};
-  for (const id of collectBfcacheSegmentIds(options.elements)) {
+  for (const id of collectBfcacheSegmentIds(options.elements, nextMetadata)) {
     const currentIdentity = createBfcacheSegmentIdentity(id, {
       metadata: currentMetadata,
       pathname: options.currentPathname,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -46,6 +46,7 @@ import { isBfcacheSegmentId, type BfcacheIdMap } from "./app-history-state.js";
 export {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
+  isHistoryStateBfcacheVersionCurrent,
   readHistoryStateBfcacheIds,
   readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -8,6 +8,7 @@ import {
 } from "./app-elements.js";
 import {
   createPendingNavigationCommit,
+  preserveBfcacheIdsForMergedElements,
   resolvePendingNavigationCommitDispositionDecision,
   type AppNavigationPayloadOrigin,
   type AppRouterAction,
@@ -149,16 +150,22 @@ function reduceApprovedVisibleCommitState(
   const { action } = commit;
   switch (action.type) {
     case "traverse":
-    case "navigate":
+    case "navigate": {
+      const mergedElements = mergeElements(state.elements, action.elements, {
+        clearAbsentSlots: action.type === "traverse",
+        preserveAbsentSlots: commit.decision.preserveAbsentSlots,
+        preserveElementIds: commit.decision.preserveElementIds,
+        preservePreviousSlotIds: commit.decision.preservePreviousSlotIds,
+      });
       return commitVisibleRouterState(
         state,
         {
-          elements: mergeElements(state.elements, action.elements, {
-            clearAbsentSlots: action.type === "traverse",
-            preserveAbsentSlots: commit.decision.preserveAbsentSlots,
-            preserveElementIds: commit.decision.preserveElementIds,
-            preservePreviousSlotIds: commit.decision.preservePreviousSlotIds,
+          bfcacheIds: preserveBfcacheIdsForMergedElements({
+            elements: mergedElements,
+            next: action.bfcacheIds,
+            previous: state.bfcacheIds,
           }),
+          elements: mergedElements,
           interception: action.interception,
           interceptionContext: action.interceptionContext,
           layoutFlags: mergeLayoutFlags(
@@ -181,10 +188,14 @@ function reduceApprovedVisibleCommitState(
         },
         action.operation,
       );
+    }
     case "replace":
       return commitVisibleRouterState(
         state,
         {
+          // Replace commits install the complete payload directly; if they ever
+          // start preserving previous elements, they must preserve bfcache ids too.
+          bfcacheIds: action.bfcacheIds,
           elements: action.elements,
           interception: action.interception,
           interceptionContext: action.interceptionContext,

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -85,6 +85,7 @@ const CACHE_PROOF_REJECTION_CODES = createCacheProofRejectionCodeSet([
 export type AppElementsSlotBindingState = "active" | "default" | "unmatched";
 
 export type AppElementsSlotBinding = Readonly<{
+  activeRouteId?: string | null;
   ownerLayoutId: string | null;
   slotId: string;
   state: AppElementsSlotBindingState;
@@ -519,7 +520,22 @@ function parseSlotBindings(
       throw new Error("[vinext] Invalid __slotBindings in App Router payload: expected state");
     }
 
-    slotBindings.push({ ownerLayoutId, slotId, state });
+    const activeRouteId = entry.activeRouteId;
+    if (
+      activeRouteId !== undefined &&
+      activeRouteId !== null &&
+      (typeof activeRouteId !== "string" ||
+        parseAppElementsWireElementKey(activeRouteId)?.kind !== "route")
+    ) {
+      throw new Error("[vinext] Invalid __slotBindings in App Router payload: expected route ids");
+    }
+
+    slotBindings.push({
+      ...(activeRouteId !== undefined ? { activeRouteId } : {}),
+      ownerLayoutId,
+      slotId,
+      state,
+    });
   }
   return normalizeAppElementsSlotBindings(slotBindings, options);
 }

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -48,6 +48,9 @@ export function createHistoryStateWithNavigationMetadata(
   },
 ): HistoryStateRecord | null {
   const nextState = cloneHistoryState(state);
+  const bfcacheIdsWereCleared =
+    metadata.bfcacheIds !== undefined &&
+    (metadata.bfcacheIds === null || Object.keys(metadata.bfcacheIds).length === 0);
 
   if (metadata.previousNextUrl === null) {
     delete nextState[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
@@ -64,7 +67,7 @@ export function createHistoryStateWithNavigationMetadata(
   }
 
   if (metadata.bfcacheIds !== undefined) {
-    if (metadata.bfcacheIds === null || Object.keys(metadata.bfcacheIds).length === 0) {
+    if (bfcacheIdsWereCleared) {
       delete nextState[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY];
       delete nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
     } else {
@@ -73,7 +76,9 @@ export function createHistoryStateWithNavigationMetadata(
   }
 
   if (metadata.bfcacheVersion !== undefined) {
-    if (isValidBfcacheVersion(metadata.bfcacheVersion)) {
+    if (bfcacheIdsWereCleared) {
+      delete nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
+    } else if (isValidBfcacheVersion(metadata.bfcacheVersion)) {
       nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY] = metadata.bfcacheVersion;
     } else {
       delete nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -1,11 +1,15 @@
+import { AppElementsWire } from "./app-elements.js";
 import type { TraverseDirection } from "./navigation-planner.js";
 
 const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
 const VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY = "__vinext_historyIndex";
+const VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY = "__vinext_bfcacheIds";
 
 type HistoryStateRecord = {
   [key: string]: unknown;
 };
+
+export type BfcacheIdMap = Readonly<Record<string, string>>;
 
 export type HistoryTraversalIntent = {
   direction: TraverseDirection;
@@ -28,13 +32,15 @@ function cloneHistoryState(state: unknown): HistoryStateRecord {
 export function createHistoryStateWithPreviousNextUrl(
   state: unknown,
   previousNextUrl: string | null,
+  bfcacheIds?: BfcacheIdMap | null,
 ): HistoryStateRecord | null {
-  return createHistoryStateWithNavigationMetadata(state, { previousNextUrl });
+  return createHistoryStateWithNavigationMetadata(state, { bfcacheIds, previousNextUrl });
 }
 
 export function createHistoryStateWithNavigationMetadata(
   state: unknown,
   metadata: {
+    bfcacheIds?: BfcacheIdMap | null;
     previousNextUrl: string | null;
     traversalIndex?: number | null;
   },
@@ -55,6 +61,14 @@ export function createHistoryStateWithNavigationMetadata(
     }
   }
 
+  if (metadata.bfcacheIds !== undefined) {
+    if (metadata.bfcacheIds === null || Object.keys(metadata.bfcacheIds).length === 0) {
+      delete nextState[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY];
+    } else {
+      nextState[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY] = { ...metadata.bfcacheIds };
+    }
+  }
+
   return Object.keys(nextState).length > 0 ? nextState : null;
 }
 
@@ -64,12 +78,14 @@ export function createExternalHistoryStatePreservingMetadata(
 ): unknown {
   const previousNextUrl = readHistoryStatePreviousNextUrl(currentHistoryState);
   const traversalIndex = readHistoryStateTraversalIndex(currentHistoryState);
+  const bfcacheIds = readHistoryStateBfcacheIds(currentHistoryState);
 
-  if (previousNextUrl === null && traversalIndex === null) {
+  if (previousNextUrl === null && traversalIndex === null && bfcacheIds === null) {
     return callerState;
   }
 
   return createHistoryStateWithNavigationMetadata(callerState, {
+    bfcacheIds,
     previousNextUrl,
     traversalIndex,
   });
@@ -78,6 +94,32 @@ export function createExternalHistoryStatePreservingMetadata(
 export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
   const value = cloneHistoryState(state)[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
   return typeof value === "string" ? value : null;
+}
+
+function isBfcacheSegmentId(id: string): boolean {
+  const parsed = AppElementsWire.parseElementKey(id);
+  return (
+    parsed?.kind === "layout" ||
+    parsed?.kind === "page" ||
+    parsed?.kind === "slot" ||
+    parsed?.kind === "template"
+  );
+}
+
+export function readHistoryStateBfcacheIds(state: unknown): BfcacheIdMap | null {
+  const value = cloneHistoryState(state)[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY];
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const ids: Record<string, string> = {};
+  for (const [key, id] of Object.entries(value)) {
+    if (!isBfcacheSegmentId(key) || typeof id !== "string") {
+      return null;
+    }
+    ids[key] = id;
+  }
+  return ids;
 }
 
 function isValidHistoryTraversalIndex(value: unknown): value is number {

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -4,6 +4,7 @@ import type { TraverseDirection } from "./navigation-planner.js";
 const VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY = "__vinext_previousNextUrl";
 const VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY = "__vinext_historyIndex";
 const VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY = "__vinext_bfcacheIds";
+const VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY = "__vinext_bfcacheVersion";
 
 type HistoryStateRecord = {
   [key: string]: unknown;
@@ -41,6 +42,7 @@ export function createHistoryStateWithNavigationMetadata(
   state: unknown,
   metadata: {
     bfcacheIds?: BfcacheIdMap | null;
+    bfcacheVersion?: number | null;
     previousNextUrl: string | null;
     traversalIndex?: number | null;
   },
@@ -64,8 +66,17 @@ export function createHistoryStateWithNavigationMetadata(
   if (metadata.bfcacheIds !== undefined) {
     if (metadata.bfcacheIds === null || Object.keys(metadata.bfcacheIds).length === 0) {
       delete nextState[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY];
+      delete nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
     } else {
       nextState[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY] = { ...metadata.bfcacheIds };
+    }
+  }
+
+  if (metadata.bfcacheVersion !== undefined) {
+    if (isValidBfcacheVersion(metadata.bfcacheVersion)) {
+      nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY] = metadata.bfcacheVersion;
+    } else {
+      delete nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
     }
   }
 
@@ -79,6 +90,7 @@ export function createExternalHistoryStatePreservingMetadata(
   const previousNextUrl = readHistoryStatePreviousNextUrl(currentHistoryState);
   const traversalIndex = readHistoryStateTraversalIndex(currentHistoryState);
   const bfcacheIds = readHistoryStateBfcacheIds(currentHistoryState);
+  const bfcacheVersion = readHistoryStateBfcacheVersion(currentHistoryState);
 
   if (previousNextUrl === null && traversalIndex === null && bfcacheIds === null) {
     return callerState;
@@ -86,6 +98,7 @@ export function createExternalHistoryStatePreservingMetadata(
 
   return createHistoryStateWithNavigationMetadata(callerState, {
     bfcacheIds,
+    bfcacheVersion: bfcacheIds === null ? undefined : bfcacheVersion,
     previousNextUrl,
     traversalIndex,
   });
@@ -96,7 +109,7 @@ export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
-function isBfcacheSegmentId(id: string): boolean {
+export function isBfcacheSegmentId(id: string): boolean {
   const parsed = AppElementsWire.parseElementKey(id);
   return (
     parsed?.kind === "layout" ||
@@ -120,6 +133,31 @@ export function readHistoryStateBfcacheIds(state: unknown): BfcacheIdMap | null 
     ids[key] = id;
   }
   return ids;
+}
+
+function isValidBfcacheVersion(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function readHistoryStateBfcacheVersion(state: unknown): number | null {
+  const value = cloneHistoryState(state)[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
+  return isValidBfcacheVersion(value) ? value : null;
+}
+
+export function createHashOnlyHistoryStatePreservingNavigationMetadata(state: unknown): unknown {
+  const previousNextUrl = readHistoryStatePreviousNextUrl(state);
+  const bfcacheIds = readHistoryStateBfcacheIds(state);
+  const bfcacheVersion = readHistoryStateBfcacheVersion(state);
+
+  if (previousNextUrl === null && bfcacheIds === null) {
+    return null;
+  }
+
+  return createHistoryStateWithNavigationMetadata(null, {
+    bfcacheIds,
+    bfcacheVersion: bfcacheIds === null ? undefined : bfcacheVersion,
+    previousNextUrl,
+  });
 }
 
 function isValidHistoryTraversalIndex(value: unknown): value is number {

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -158,6 +158,9 @@ export function createHashOnlyHistoryStatePreservingNavigationMetadata(state: un
     return null;
   }
 
+  // Traversal indices are assigned by the App Router browser entry's
+  // commitHashOnlyNavigation path. This shim fallback only preserves metadata
+  // that can be safely transported without the browser router runtime.
   return createHistoryStateWithNavigationMetadata(null, {
     bfcacheIds,
     bfcacheVersion: bfcacheIds === null ? undefined : bfcacheVersion,

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -30,12 +30,18 @@ function cloneHistoryState(state: unknown): HistoryStateRecord {
   return nextState;
 }
 
+function readHistoryStateRecord(state: unknown): Record<string, unknown> | null {
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    return null;
+  }
+  return state as Record<string, unknown>;
+}
+
 export function createHistoryStateWithPreviousNextUrl(
   state: unknown,
   previousNextUrl: string | null,
-  bfcacheIds?: BfcacheIdMap | null,
 ): HistoryStateRecord | null {
-  return createHistoryStateWithNavigationMetadata(state, { bfcacheIds, previousNextUrl });
+  return createHistoryStateWithNavigationMetadata(state, { previousNextUrl });
 }
 
 export function createHistoryStateWithNavigationMetadata(
@@ -59,7 +65,7 @@ export function createHistoryStateWithNavigationMetadata(
   }
 
   if (metadata.traversalIndex !== undefined) {
-    if (isValidHistoryTraversalIndex(metadata.traversalIndex)) {
+    if (isNonNegativeSafeInteger(metadata.traversalIndex)) {
       nextState[VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY] = metadata.traversalIndex;
     } else {
       delete nextState[VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY];
@@ -78,7 +84,7 @@ export function createHistoryStateWithNavigationMetadata(
   if (metadata.bfcacheVersion !== undefined) {
     if (bfcacheIdsWereCleared) {
       delete nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
-    } else if (isValidBfcacheVersion(metadata.bfcacheVersion)) {
+    } else if (isNonNegativeSafeInteger(metadata.bfcacheVersion)) {
       nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY] = metadata.bfcacheVersion;
     } else {
       delete nextState[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
@@ -110,7 +116,7 @@ export function createExternalHistoryStatePreservingMetadata(
 }
 
 export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
-  const value = cloneHistoryState(state)[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
+  const value = readHistoryStateRecord(state)?.[VINEXT_PREVIOUS_NEXT_URL_HISTORY_STATE_KEY];
   return typeof value === "string" ? value : null;
 }
 
@@ -125,7 +131,7 @@ export function isBfcacheSegmentId(id: string): boolean {
 }
 
 export function readHistoryStateBfcacheIds(state: unknown): BfcacheIdMap | null {
-  const value = cloneHistoryState(state)[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY];
+  const value = readHistoryStateRecord(state)?.[VINEXT_BFCACHE_IDS_HISTORY_STATE_KEY];
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
@@ -140,13 +146,13 @@ export function readHistoryStateBfcacheIds(state: unknown): BfcacheIdMap | null 
   return ids;
 }
 
-function isValidBfcacheVersion(value: unknown): value is number {
+function isNonNegativeSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
 export function readHistoryStateBfcacheVersion(state: unknown): number | null {
-  const value = cloneHistoryState(state)[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
-  return isValidBfcacheVersion(value) ? value : null;
+  const value = readHistoryStateRecord(state)?.[VINEXT_BFCACHE_VERSION_HISTORY_STATE_KEY];
+  return isNonNegativeSafeInteger(value) ? value : null;
 }
 
 export function createHashOnlyHistoryStatePreservingNavigationMetadata(state: unknown): unknown {
@@ -168,13 +174,9 @@ export function createHashOnlyHistoryStatePreservingNavigationMetadata(state: un
   });
 }
 
-function isValidHistoryTraversalIndex(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
-}
-
 export function readHistoryStateTraversalIndex(state: unknown): number | null {
-  const value = cloneHistoryState(state)[VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY];
-  return isValidHistoryTraversalIndex(value) ? value : null;
+  const value = readHistoryStateRecord(state)?.[VINEXT_HISTORY_INDEX_HISTORY_STATE_KEY];
+  return isNonNegativeSafeInteger(value) ? value : null;
 }
 
 export function resolveHistoryTraversalIntent(options: {

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -155,6 +155,23 @@ export function readHistoryStateBfcacheVersion(state: unknown): number | null {
   return isNonNegativeSafeInteger(value) ? value : null;
 }
 
+/**
+ * Whether a history entry's stored bfcache version matches the document's
+ * current version. A missing/invalid stored version (null) is NEVER current:
+ * coercing it to 0 would let un-versioned entries (older builds / external
+ * pushState) pass the gate on a fresh document whose current version is 0,
+ * defeating the document-scoped stale-id rejection. App-written entries always
+ * carry an explicit version, so the legitimate first-document path (0 === 0)
+ * still matches.
+ */
+export function isHistoryStateBfcacheVersionCurrent(
+  state: unknown,
+  currentVersion: number,
+): boolean {
+  const version = readHistoryStateBfcacheVersion(state);
+  return version !== null && version === currentVersion;
+}
+
 export function createHashOnlyHistoryStatePreservingNavigationMetadata(state: unknown): unknown {
   const previousNextUrl = readHistoryStatePreviousNextUrl(state);
   const bfcacheIds = readHistoryStateBfcacheIds(state);

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -356,6 +356,11 @@ function createAppPageSlotBindings<
     slotKey: string,
     slotName: string,
   ) => AppPageSlotOverride<TModule> | undefined,
+  options: {
+    interception: AppElementsInterception | null;
+    interceptionContext: string | null;
+    routePath: string;
+  },
 ): readonly AppElementsSlotBinding[] {
   const bindings: AppElementsSlotBinding[] = [];
   for (const [slotKey, slot] of Object.entries(route.slots ?? {})) {
@@ -363,10 +368,19 @@ function createAppPageSlotBindings<
     const layoutEntry = layoutEntries[targetIndex] ?? null;
     const ownerLayoutId = layoutEntry?.id ?? null;
     const override = resolveSlotOverride(slotKey, slot.name);
+    const slotId = resolveAppPageSlotId(slot, layoutEntry?.treePath ?? "/");
+    const state = resolveAppPageSlotBindingState(slot, override);
+    const activeRouteId =
+      state === "active"
+        ? options.interception?.slotId === slotId
+          ? options.interception.targetRouteId
+          : AppElementsWire.encodeRouteId(options.routePath, options.interceptionContext)
+        : null;
     bindings.push({
+      ...(activeRouteId !== null ? { activeRouteId } : {}),
       ownerLayoutId,
-      slotId: resolveAppPageSlotId(slot, layoutEntry?.treePath ?? "/"),
-      state: resolveAppPageSlotBindingState(slot, override),
+      slotId,
+      state,
     });
   }
   return normalizeAppElementsSlotBindings(bindings, {
@@ -485,7 +499,11 @@ export function buildAppPageElements<
       layoutIds: options.route.ids?.layouts ?? layoutEntries.map((entry) => entry.id),
       rootLayoutTreePath,
       routeId,
-      slotBindings: createAppPageSlotBindings(options.route, layoutEntries, resolveSlotOverride),
+      slotBindings: createAppPageSlotBindings(options.route, layoutEntries, resolveSlotOverride, {
+        interception: options.interception ?? null,
+        interceptionContext,
+        routePath: options.routePath,
+      }),
     }),
   };
   // Surface static-sibling info on the wire so the client router can decide

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -374,7 +374,7 @@ function createAppPageSlotBindings<
       state === "active"
         ? options.interception?.slotId === slotId
           ? options.interception.targetRouteId
-          : AppElementsWire.encodeRouteId(options.routePath, options.interceptionContext)
+          : AppElementsWire.encodeRouteId(options.routePath, null)
         : null;
     bindings.push({
       ...(activeRouteId !== null ? { activeRouteId } : {}),
@@ -500,7 +500,7 @@ export function buildAppPageElements<
       rootLayoutTreePath,
       routeId,
       slotBindings: createAppPageSlotBindings(options.route, layoutEntries, resolveSlotOverride, {
-        interception: options.interception ?? null,
+        interception: renderIdentity?.interception ?? options.interception ?? null,
         interceptionContext,
         routePath: options.routePath,
       }),

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -12,6 +12,7 @@ import {
   ServerInsertedHTMLContext,
   appRouterInstance,
   clearServerInsertedHTML,
+  getBfcacheIdMapContext,
   renderServerInsertedHTML,
   setNavigationContext,
   useServerInsertedHTML,
@@ -40,6 +41,7 @@ import { deferUntilStreamConsumed } from "./app-page-stream.js";
 import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { AppElementsWire, type AppWireElements } from "./app-elements.js";
+import { createInitialBfcacheIdMap } from "./app-browser-state.js";
 import { ElementsContext, Slot } from "vinext/shims/slot";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
@@ -69,6 +71,7 @@ const clientReferencePreloader = createClientReferencePreloader({
     }
   },
 });
+const BfcacheIdMapContext = getBfcacheIdMapContext();
 
 function ssrErrorDigest(input: string): string {
   let hash = 5381;
@@ -311,11 +314,18 @@ export async function handleSsr(
           const wireElements = use(flightRoot);
           const elements = AppElementsWire.decode(wireElements);
           const metadata = AppElementsWire.readMetadata(elements);
-          return createReactElement(
+          const routeTree = createReactElement(
             ElementsContext.Provider,
             { value: elements },
             createReactElement(Slot, { id: metadata.routeId }),
           );
+          return BfcacheIdMapContext
+            ? createReactElement(
+                BfcacheIdMapContext.Provider,
+                { value: createInitialBfcacheIdMap(elements) },
+                routeTree,
+              )
+            : routeTree;
         }
 
         const flightRootElement = createReactElement(VinextFlightRoot);

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -319,6 +319,9 @@ export async function handleSsr(
             { value: elements },
             createReactElement(Slot, { id: metadata.routeId }),
           );
+          // BfcacheSegmentIdContext is intentionally omitted during SSR:
+          // per-segment bfcache ids are browser-only, so useRouter().bfcacheId
+          // returns the hydration sentinel before client context takes over.
           return BfcacheIdMapContext
             ? createReactElement(
                 BfcacheIdMapContext.Provider,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -319,9 +319,12 @@ export async function handleSsr(
             { value: elements },
             createReactElement(Slot, { id: metadata.routeId }),
           );
-          // BfcacheSegmentIdContext is intentionally omitted during SSR:
-          // per-segment bfcache ids are browser-only, so useRouter().bfcacheId
-          // returns the hydration sentinel before client context takes over.
+          // During SSR we only provide the id *map*, seeded entirely with the
+          // INITIAL_BFCACHE_ID sentinel. BfcacheSlotBoundary may still publish a
+          // BfcacheSegmentIdContext value here, but every map entry is the "0"
+          // sentinel, so formatPublicBfcacheId resolves useRouter().bfcacheId to
+          // the public hydration sentinel ("_b_0_") regardless until the client
+          // context takes over. Per-segment minted ids are browser-only.
           return BfcacheIdMapContext
             ? createReactElement(
                 BfcacheIdMapContext.Provider,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1398,6 +1398,20 @@ export function saveScrollPosition(): void {
   );
 }
 
+function createHashOnlyHistoryState(state: unknown): unknown {
+  if (!state || typeof state !== "object") return null;
+
+  const current = state as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  if ("__vinext_previousNextUrl" in current) {
+    next.__vinext_previousNextUrl = current.__vinext_previousNextUrl;
+  }
+  if ("__vinext_bfcacheIds" in current) {
+    next.__vinext_bfcacheIds = current.__vinext_bfcacheIds;
+  }
+  return Object.keys(next).length > 0 ? next : null;
+}
+
 function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scroll: boolean): void {
   const commitAppRouterHashNavigation = getNavigationRuntime()?.functions.commitHashNavigation;
   if (commitAppRouterHashNavigation) {
@@ -1405,10 +1419,11 @@ function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scro
     return;
   }
 
+  const historyState = createHashOnlyHistoryState(window.history.state);
   if (mode === "replace") {
-    replaceHistoryStateWithoutNotify(null, "", href);
+    replaceHistoryStateWithoutNotify(historyState, "", href);
   } else {
-    pushHistoryStateWithoutNotify(null, "", href);
+    pushHistoryStateWithoutNotify(historyState, "", href);
   }
 }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1745,43 +1745,26 @@ const _appRouter = {
   },
 };
 
-const _appRouterByBfcacheId = new Map<string, typeof _appRouter>();
-const MAX_APP_ROUTER_BFCACHE_ID_CACHE_SIZE = 64;
-
-function createAppRouterForBfcacheId(bfcacheId: string): typeof _appRouter {
-  if (bfcacheId === _appRouter.bfcacheId) return _appRouter;
-
-  const cached = _appRouterByBfcacheId.get(bfcacheId);
-  if (cached) {
-    _appRouterByBfcacheId.delete(bfcacheId);
-    _appRouterByBfcacheId.set(bfcacheId, cached);
-    return cached;
-  }
-
-  const router = { ..._appRouter, bfcacheId };
-  _appRouterByBfcacheId.set(bfcacheId, router);
-  while (_appRouterByBfcacheId.size > MAX_APP_ROUTER_BFCACHE_ID_CACHE_SIZE) {
-    const oldest = _appRouterByBfcacheId.keys().next().value;
-    if (oldest === undefined) break;
-    _appRouterByBfcacheId.delete(oldest);
-  }
-  return router;
+function formatPublicBfcacheId(value: string | null | undefined): string {
+  if (!value || value === _appRouter.bfcacheId) return "_b_0_";
+  return value;
 }
 
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
 function readBfcacheIdFromContext(): string {
   const segmentContext = getBfcacheSegmentIdContext();
   const idMapContext = getBfcacheIdMapContext();
-  if (!segmentContext || !idMapContext || typeof React.useContext !== "function") return "0";
+  if (!segmentContext || !idMapContext || typeof React.useContext !== "function") {
+    return formatPublicBfcacheId(null);
+  }
 
   try {
     const segmentId = React.useContext(segmentContext);
     const idMap = React.useContext(idMapContext);
-    if (!segmentId) return "0";
-    return idMap?.[segmentId] ?? "0";
+    return formatPublicBfcacheId(segmentId ? idMap?.[segmentId] : null);
   } catch {
     // Low-level tests and direct module calls can hit this outside render.
-    return "0";
+    return formatPublicBfcacheId(null);
   }
 }
 /* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
@@ -1799,18 +1782,29 @@ export const appRouterInstance = _appRouter;
  * App Router's useRouter — returns push/replace/back/forward/refresh.
  * Different from Pages Router's useRouter (next/router).
  *
- * Returns a stable router reference for the current bfcacheId. The base router
- * methods are shared, while `bfcacheId` is contextual to the nearest segment.
+ * Preserves the mounted AppRouterContext router as the authority for methods
+ * and layers the nearest segment's contextual `bfcacheId` on top.
  */
 export function useRouter() {
-  if (!AppRouterContext || typeof React.useContext !== "function") {
+  if (
+    !AppRouterContext ||
+    typeof React.useContext !== "function" ||
+    typeof React.useMemo !== "function"
+  ) {
     throw new Error("invariant expected app router to be mounted");
   }
   const router = React.useContext(AppRouterContext);
   if (router === null) {
     throw new Error("invariant expected app router to be mounted");
   }
-  return createAppRouterForBfcacheId(readBfcacheIdFromContext());
+  const bfcacheId = readBfcacheIdFromContext();
+  return React.useMemo(
+    () => ({
+      ...router,
+      bfcacheId,
+    }),
+    [router, bfcacheId],
+  );
 }
 
 /**

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1735,7 +1735,7 @@ const _appRouter = {
 };
 
 function formatPublicBfcacheId(value: string | null | undefined): string {
-  if (!value || value === _appRouter.bfcacheId) return "_b_0_";
+  if (!value || value === "0") return "_b_0_";
   return value;
 }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -15,7 +15,10 @@ import { getNavigationRuntime, hasAppNavigationRuntime } from "../client/navigat
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import { AppElementsWire } from "../server/app-elements.js";
 import { resolveManifestNavigationInterceptionContext } from "../server/app-browser-interception-context.js";
-import { createExternalHistoryStatePreservingMetadata } from "../server/app-history-state.js";
+import {
+  createExternalHistoryStatePreservingMetadata,
+  createHashOnlyHistoryStatePreservingNavigationMetadata,
+} from "../server/app-history-state.js";
 import {
   createRscRequestHeaders,
   createRscRequestUrl,
@@ -1398,20 +1401,6 @@ export function saveScrollPosition(): void {
   );
 }
 
-function createHashOnlyHistoryState(state: unknown): unknown {
-  if (!state || typeof state !== "object") return null;
-
-  const current = state as Record<string, unknown>;
-  const next: Record<string, unknown> = {};
-  if ("__vinext_previousNextUrl" in current) {
-    next.__vinext_previousNextUrl = current.__vinext_previousNextUrl;
-  }
-  if ("__vinext_bfcacheIds" in current) {
-    next.__vinext_bfcacheIds = current.__vinext_bfcacheIds;
-  }
-  return Object.keys(next).length > 0 ? next : null;
-}
-
 function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scroll: boolean): void {
   const commitAppRouterHashNavigation = getNavigationRuntime()?.functions.commitHashNavigation;
   if (commitAppRouterHashNavigation) {
@@ -1419,7 +1408,7 @@ function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scro
     return;
   }
 
-  const historyState = createHashOnlyHistoryState(window.history.state);
+  const historyState = createHashOnlyHistoryStatePreservingNavigationMetadata(window.history.state);
   if (mode === "replace") {
     replaceHistoryStateWithoutNotify(historyState, "", href);
   } else {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -13,6 +13,7 @@
 import * as React from "react";
 import { getNavigationRuntime, hasAppNavigationRuntime } from "../client/navigation-runtime.js";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
+import { INITIAL_BFCACHE_ID, PUBLIC_INITIAL_BFCACHE_ID } from "../server/app-bfcache-id.js";
 import { AppElementsWire } from "../server/app-elements.js";
 import { resolveManifestNavigationInterceptionContext } from "../server/app-browser-interception-context.js";
 import {
@@ -1615,7 +1616,7 @@ function releaseScheduledAppRouterNavigationAfterCurrentTask(release: () => void
  * Internal callers in this file continue to use `_appRouter` for brevity.
  */
 const _appRouter = {
-  bfcacheId: "0",
+  bfcacheId: INITIAL_BFCACHE_ID,
   push(href: string, options?: { scroll?: boolean }): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
@@ -1735,7 +1736,7 @@ const _appRouter = {
 };
 
 function formatPublicBfcacheId(value: string | null | undefined): string {
-  if (!value || value === "0") return "_b_0_";
+  if (!value || value === INITIAL_BFCACHE_ID) return PUBLIC_INITIAL_BFCACHE_ID;
   return value;
 }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1752,8 +1752,11 @@ function readBfcacheIdFromContext(): string {
     const segmentId = React.useContext(segmentContext);
     const idMap = React.useContext(idMapContext);
     return formatPublicBfcacheId(segmentId ? idMap?.[segmentId] : null);
-  } catch {
+  } catch (error) {
     // Low-level tests and direct module calls can hit this outside render.
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[vinext] readBfcacheIdFromContext failed:", error);
+    }
     return formatPublicBfcacheId(null);
   }
 }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -52,6 +52,8 @@ import {
 // still line up if Vite loads this shim through multiple resolved module IDs.
 const _LAYOUT_SEGMENT_CTX_KEY = Symbol.for("vinext.layoutSegmentContext");
 const _SERVER_INSERTED_HTML_CTX_KEY = Symbol.for("vinext.serverInsertedHTMLContext");
+const _BFCACHE_ID_MAP_CTX_KEY = Symbol.for("vinext.bfcacheIdMapContext");
+const _BFCACHE_SEGMENT_ID_CTX_KEY = Symbol.for("vinext.bfcacheSegmentIdContext");
 
 /**
  * Map of parallel route key → child segments below the current layout.
@@ -68,6 +70,8 @@ type _LayoutSegmentGlobal = typeof globalThis & {
   [_SERVER_INSERTED_HTML_CTX_KEY]?: React.Context<
     ((callback: () => unknown) => void) | null
   > | null;
+  [_BFCACHE_ID_MAP_CTX_KEY]?: React.Context<Readonly<Record<string, string>> | null> | null;
+  [_BFCACHE_SEGMENT_ID_CTX_KEY]?: React.Context<string | null> | null;
 };
 
 // ─── ServerInsertedHTML context ────────────────────────────────────────────────
@@ -116,6 +120,32 @@ export function getLayoutSegmentContext(): React.Context<SegmentMap> | null {
   }
 
   return globalState[_LAYOUT_SEGMENT_CTX_KEY] ?? null;
+}
+
+export function getBfcacheIdMapContext(): React.Context<Readonly<
+  Record<string, string>
+> | null> | null {
+  if (typeof React.createContext !== "function") return null;
+
+  const globalState = globalThis as _LayoutSegmentGlobal;
+  if (!globalState[_BFCACHE_ID_MAP_CTX_KEY]) {
+    globalState[_BFCACHE_ID_MAP_CTX_KEY] = React.createContext<Readonly<
+      Record<string, string>
+    > | null>(null);
+  }
+
+  return globalState[_BFCACHE_ID_MAP_CTX_KEY] ?? null;
+}
+
+export function getBfcacheSegmentIdContext(): React.Context<string | null> | null {
+  if (typeof React.createContext !== "function") return null;
+
+  const globalState = globalThis as _LayoutSegmentGlobal;
+  if (!globalState[_BFCACHE_SEGMENT_ID_CTX_KEY]) {
+    globalState[_BFCACHE_SEGMENT_ID_CTX_KEY] = React.createContext<string | null>(null);
+  }
+
+  return globalState[_BFCACHE_SEGMENT_ID_CTX_KEY] ?? null;
 }
 
 /**
@@ -1700,6 +1730,47 @@ const _appRouter = {
   },
 };
 
+const _appRouterByBfcacheId = new Map<string, typeof _appRouter>();
+const MAX_APP_ROUTER_BFCACHE_ID_CACHE_SIZE = 64;
+
+function createAppRouterForBfcacheId(bfcacheId: string): typeof _appRouter {
+  if (bfcacheId === _appRouter.bfcacheId) return _appRouter;
+
+  const cached = _appRouterByBfcacheId.get(bfcacheId);
+  if (cached) {
+    _appRouterByBfcacheId.delete(bfcacheId);
+    _appRouterByBfcacheId.set(bfcacheId, cached);
+    return cached;
+  }
+
+  const router = { ..._appRouter, bfcacheId };
+  _appRouterByBfcacheId.set(bfcacheId, router);
+  while (_appRouterByBfcacheId.size > MAX_APP_ROUTER_BFCACHE_ID_CACHE_SIZE) {
+    const oldest = _appRouterByBfcacheId.keys().next().value;
+    if (oldest === undefined) break;
+    _appRouterByBfcacheId.delete(oldest);
+  }
+  return router;
+}
+
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
+function readBfcacheIdFromContext(): string {
+  const segmentContext = getBfcacheSegmentIdContext();
+  const idMapContext = getBfcacheIdMapContext();
+  if (!segmentContext || !idMapContext || typeof React.useContext !== "function") return "0";
+
+  try {
+    const segmentId = React.useContext(segmentContext);
+    const idMap = React.useContext(idMapContext);
+    if (!segmentId) return "0";
+    return idMap?.[segmentId] ?? "0";
+  } catch {
+    // Low-level tests and direct module calls can hit this outside render.
+    return "0";
+  }
+}
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
+
 /**
  * Public App Router instance, exposed for the browser entry so it can wire
  * `window.next.router` to the same singleton returned from `useRouter()`.
@@ -1713,9 +1784,8 @@ export const appRouterInstance = _appRouter;
  * App Router's useRouter — returns push/replace/back/forward/refresh.
  * Different from Pages Router's useRouter (next/router).
  *
- * Returns a stable singleton: the same object reference on every call,
- * matching Next.js behavior so components using referential equality
- * (e.g. useMemo / useEffect deps, React.memo) don't re-render unnecessarily.
+ * Returns a stable router reference for the current bfcacheId. The base router
+ * methods are shared, while `bfcacheId` is contextual to the nearest segment.
  */
 export function useRouter() {
   if (!AppRouterContext || typeof React.useContext !== "function") {
@@ -1725,7 +1795,7 @@ export function useRouter() {
   if (router === null) {
     throw new Error("invariant expected app router to be mounted");
   }
-  return router;
+  return createAppRouterForBfcacheId(readBfcacheIdFromContext());
 }
 
 /**

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1751,7 +1751,7 @@ function readBfcacheIdFromContext(): string {
   try {
     const segmentId = React.useContext(segmentContext);
     const idMap = React.useContext(idMapContext);
-    return formatPublicBfcacheId(segmentId ? idMap?.[segmentId] : null);
+    return formatPublicBfcacheId(segmentId !== null ? idMap?.[segmentId] : null);
   } catch (error) {
     // Low-level tests and direct module calls can hit this outside render.
     if (process.env.NODE_ENV !== "production") {

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -12,7 +12,7 @@ import {
 } from "../server/app-elements.js";
 import type { ArtifactCompatibilityEnvelope } from "../server/artifact-compatibility.js";
 import type { CacheEntryReuseProof } from "../server/cache-proof.js";
-import { notFound } from "./navigation.js";
+import { getBfcacheSegmentIdContext, notFound } from "./navigation.js";
 
 const EMPTY_ELEMENTS: AppElements = Object.freeze({});
 const warnedMissingEntryIds = new Set<string>();
@@ -32,6 +32,7 @@ export const ChildrenContext = React.createContext<React.ReactNode>(null);
 export const ParallelSlotsContext = React.createContext<Readonly<
   Record<string, React.ReactNode>
 > | null>(null);
+const BfcacheSegmentIdContext = getBfcacheSegmentIdContext();
 
 type MergeElementsOptions = {
   clearAbsentSlots?: boolean;
@@ -211,10 +212,16 @@ export function Slot({
     notFound();
   }
 
-  return (
+  const content = (
     <ParallelSlotsContext.Provider value={parallelSlots ?? null}>
       <ChildrenContext.Provider value={children ?? null}>{element}</ChildrenContext.Provider>
     </ParallelSlotsContext.Provider>
+  );
+
+  return BfcacheSegmentIdContext ? (
+    <BfcacheSegmentIdContext.Provider value={id}>{content}</BfcacheSegmentIdContext.Provider>
+  ) : (
+    content
   );
 }
 

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -122,7 +122,8 @@ function warnTransportMetadataEntry(id: string): void {
 }
 
 function BfcacheSlotBoundary({ content, id }: { content: React.ReactNode; id: string }) {
-  const SegmentContext = BfcacheSegmentIdContext!;
+  const SegmentContext = BfcacheSegmentIdContext;
+  if (!SegmentContext) return <>{content}</>;
   return <SegmentContext.Provider value={id}>{content}</SegmentContext.Provider>;
 }
 

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -15,13 +15,8 @@ import type { CacheEntryReuseProof } from "../server/cache-proof.js";
 import { getBfcacheIdMapContext, getBfcacheSegmentIdContext, notFound } from "./navigation.js";
 
 const EMPTY_ELEMENTS: AppElements = Object.freeze({});
-const EMPTY_BFCACHE_IDS: Readonly<Record<string, string>> = Object.freeze({});
 const warnedMissingEntryIds = new Set<string>();
 const warnedTransportMetadataEntryIds = new Set<string>();
-// Mirrors Next's cacheComponents Activity cache size for recently active
-// segment trees. This preserves DOM/React state for back/forward without
-// retaining an unbounded number of hidden subtrees.
-const MAX_SLOT_BFCACHE_ENTRIES = 3;
 
 export { UNMATCHED_SLOT };
 
@@ -39,13 +34,6 @@ export const ParallelSlotsContext = React.createContext<Readonly<
 > | null>(null);
 const BfcacheIdMapContext = getBfcacheIdMapContext();
 const BfcacheSegmentIdContext = getBfcacheSegmentIdContext();
-
-type SlotBfcacheEntry = {
-  content: React.ReactNode;
-  elements: AppElements;
-  next: SlotBfcacheEntry | null;
-  stateKey: string;
-};
 
 type MergeElementsOptions = {
   clearAbsentSlots?: boolean;
@@ -133,81 +121,9 @@ function warnTransportMetadataEntry(id: string): void {
   console.warn("[vinext] Transport metadata value found under App Router render entry: " + id);
 }
 
-function useSlotBfcache(
-  activeContent: React.ReactNode,
-  activeElements: AppElements,
-  activeStateKey: string,
-): SlotBfcacheEntry {
-  const [prevActiveEntry, setPrevActiveEntry] = React.useState<SlotBfcacheEntry>(() => ({
-    content: activeContent,
-    elements: activeElements,
-    next: null,
-    stateKey: activeStateKey,
-  }));
-
-  if (prevActiveEntry.elements === activeElements && prevActiveEntry.stateKey === activeStateKey) {
-    return prevActiveEntry;
-  }
-
-  const newActiveEntry: SlotBfcacheEntry = {
-    content: activeContent,
-    elements: activeElements,
-    next: null,
-    stateKey: activeStateKey,
-  };
-  let entryCount = 1;
-  let oldEntry: SlotBfcacheEntry | null = prevActiveEntry;
-  let clonedEntry = newActiveEntry;
-
-  while (oldEntry !== null && entryCount < MAX_SLOT_BFCACHE_ENTRIES) {
-    if (oldEntry.stateKey === activeStateKey) {
-      clonedEntry.next = oldEntry.next;
-      break;
-    }
-
-    entryCount += 1;
-    const entry: SlotBfcacheEntry = {
-      content: oldEntry.content,
-      elements: oldEntry.elements,
-      next: null,
-      stateKey: oldEntry.stateKey,
-    };
-    clonedEntry.next = entry;
-    clonedEntry = entry;
-    oldEntry = oldEntry.next;
-  }
-
-  setPrevActiveEntry(newActiveEntry);
-  return newActiveEntry;
-}
-
 function BfcacheSlotBoundary({ content, id }: { content: React.ReactNode; id: string }) {
-  const IdMapContext = BfcacheIdMapContext!;
   const SegmentContext = BfcacheSegmentIdContext!;
-  const elements = React.useContext(ElementsContext);
-  const bfcacheIds = React.useContext(IdMapContext) ?? EMPTY_BFCACHE_IDS;
-  const activeStateKey = bfcacheIds[id] ?? "0";
-  const activeEntry = useSlotBfcache(content, elements, activeStateKey);
-  const children: React.ReactNode[] = [];
-  let entry: SlotBfcacheEntry | null = activeEntry;
-
-  while (entry !== null) {
-    const entryBfcacheIds =
-      bfcacheIds[id] === entry.stateKey ? bfcacheIds : { ...bfcacheIds, [id]: entry.stateKey };
-    const mode = entry.stateKey === activeStateKey ? "visible" : "hidden";
-    children.push(
-      <React.Activity key={entry.stateKey} mode={mode} name={id}>
-        <ElementsContext.Provider value={entry.elements}>
-          <IdMapContext.Provider value={entryBfcacheIds}>
-            <SegmentContext.Provider value={id}>{entry.content}</SegmentContext.Provider>
-          </IdMapContext.Provider>
-        </ElementsContext.Provider>
-      </React.Activity>,
-    );
-    entry = entry.next;
-  }
-
-  return children;
+  return <SegmentContext.Provider value={id}>{content}</SegmentContext.Provider>;
 }
 
 export function mergeElements(

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -12,11 +12,16 @@ import {
 } from "../server/app-elements.js";
 import type { ArtifactCompatibilityEnvelope } from "../server/artifact-compatibility.js";
 import type { CacheEntryReuseProof } from "../server/cache-proof.js";
-import { getBfcacheSegmentIdContext, notFound } from "./navigation.js";
+import { getBfcacheIdMapContext, getBfcacheSegmentIdContext, notFound } from "./navigation.js";
 
 const EMPTY_ELEMENTS: AppElements = Object.freeze({});
+const EMPTY_BFCACHE_IDS: Readonly<Record<string, string>> = Object.freeze({});
 const warnedMissingEntryIds = new Set<string>();
 const warnedTransportMetadataEntryIds = new Set<string>();
+// Mirrors Next's cacheComponents Activity cache size for recently active
+// segment trees. This preserves DOM/React state for back/forward without
+// retaining an unbounded number of hidden subtrees.
+const MAX_SLOT_BFCACHE_ENTRIES = 3;
 
 export { UNMATCHED_SLOT };
 
@@ -32,7 +37,15 @@ export const ChildrenContext = React.createContext<React.ReactNode>(null);
 export const ParallelSlotsContext = React.createContext<Readonly<
   Record<string, React.ReactNode>
 > | null>(null);
+const BfcacheIdMapContext = getBfcacheIdMapContext();
 const BfcacheSegmentIdContext = getBfcacheSegmentIdContext();
+
+type SlotBfcacheEntry = {
+  content: React.ReactNode;
+  elements: AppElements;
+  next: SlotBfcacheEntry | null;
+  stateKey: string;
+};
 
 type MergeElementsOptions = {
   clearAbsentSlots?: boolean;
@@ -118,6 +131,83 @@ function warnTransportMetadataEntry(id: string): void {
 
   warnedTransportMetadataEntryIds.add(id);
   console.warn("[vinext] Transport metadata value found under App Router render entry: " + id);
+}
+
+function useSlotBfcache(
+  activeContent: React.ReactNode,
+  activeElements: AppElements,
+  activeStateKey: string,
+): SlotBfcacheEntry {
+  const [prevActiveEntry, setPrevActiveEntry] = React.useState<SlotBfcacheEntry>(() => ({
+    content: activeContent,
+    elements: activeElements,
+    next: null,
+    stateKey: activeStateKey,
+  }));
+
+  if (prevActiveEntry.elements === activeElements && prevActiveEntry.stateKey === activeStateKey) {
+    return prevActiveEntry;
+  }
+
+  const newActiveEntry: SlotBfcacheEntry = {
+    content: activeContent,
+    elements: activeElements,
+    next: null,
+    stateKey: activeStateKey,
+  };
+  let entryCount = 1;
+  let oldEntry: SlotBfcacheEntry | null = prevActiveEntry;
+  let clonedEntry = newActiveEntry;
+
+  while (oldEntry !== null && entryCount < MAX_SLOT_BFCACHE_ENTRIES) {
+    if (oldEntry.stateKey === activeStateKey) {
+      clonedEntry.next = oldEntry.next;
+      break;
+    }
+
+    entryCount += 1;
+    const entry: SlotBfcacheEntry = {
+      content: oldEntry.content,
+      elements: oldEntry.elements,
+      next: null,
+      stateKey: oldEntry.stateKey,
+    };
+    clonedEntry.next = entry;
+    clonedEntry = entry;
+    oldEntry = oldEntry.next;
+  }
+
+  setPrevActiveEntry(newActiveEntry);
+  return newActiveEntry;
+}
+
+function BfcacheSlotBoundary({ content, id }: { content: React.ReactNode; id: string }) {
+  const IdMapContext = BfcacheIdMapContext!;
+  const SegmentContext = BfcacheSegmentIdContext!;
+  const elements = React.useContext(ElementsContext);
+  const bfcacheIds = React.useContext(IdMapContext) ?? EMPTY_BFCACHE_IDS;
+  const activeStateKey = bfcacheIds[id] ?? "0";
+  const activeEntry = useSlotBfcache(content, elements, activeStateKey);
+  const children: React.ReactNode[] = [];
+  let entry: SlotBfcacheEntry | null = activeEntry;
+
+  while (entry !== null) {
+    const entryBfcacheIds =
+      bfcacheIds[id] === entry.stateKey ? bfcacheIds : { ...bfcacheIds, [id]: entry.stateKey };
+    const mode = entry.stateKey === activeStateKey ? "visible" : "hidden";
+    children.push(
+      <React.Activity key={entry.stateKey} mode={mode} name={id}>
+        <ElementsContext.Provider value={entry.elements}>
+          <IdMapContext.Provider value={entryBfcacheIds}>
+            <SegmentContext.Provider value={id}>{entry.content}</SegmentContext.Provider>
+          </IdMapContext.Provider>
+        </ElementsContext.Provider>
+      </React.Activity>,
+    );
+    entry = entry.next;
+  }
+
+  return children;
 }
 
 export function mergeElements(
@@ -211,6 +301,9 @@ export function Slot({
   if (element === UNMATCHED_SLOT) {
     notFound();
   }
+  if (element === null) {
+    return null;
+  }
 
   const content = (
     <ParallelSlotsContext.Provider value={parallelSlots ?? null}>
@@ -218,8 +311,8 @@ export function Slot({
     </ParallelSlotsContext.Provider>
   );
 
-  return BfcacheSegmentIdContext ? (
-    <BfcacheSegmentIdContext.Provider value={id}>{content}</BfcacheSegmentIdContext.Provider>
+  return BfcacheIdMapContext && BfcacheSegmentIdContext ? (
+    <BfcacheSlotBoundary id={id} content={content} />
   ) : (
     content
   );

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -50,7 +50,6 @@ import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
-  createHydratedBfcacheIdMap,
   createInitialBfcacheIdMap,
   createNextBfcacheIdMap,
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
@@ -58,6 +57,7 @@ import {
   createPendingNavigationCommit,
   isCacheRestorableAppPayloadMetadata,
   readHistoryStateBfcacheIds,
+  readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   resolveInterceptionContextFromPreviousNextUrl,
@@ -4316,30 +4316,22 @@ describe("app browser entry bfcacheId helpers", () => {
     });
   });
 
-  it("seeds hydration bfcache ids from history state for current rendered segments", () => {
-    expect(
-      createHydratedBfcacheIdMap(createBfcacheElements(pageX1Id), {
-        [rootLayoutId]: "0",
-        [pageX1Id]: "_b_10_",
-        [pageX2Id]: "_b_11_",
-      }),
-    ).toEqual({
+  it("does not seed hydration bfcache ids from history state", () => {
+    // Next generates the public "_b_0_" hydration sentinel from an internal
+    // zero cache node on both SSR and initial client hydration. Persisted
+    // history maps are restored only for explicit back/forward traversals.
+    const persistedHistoryIds = {
       [rootLayoutId]: "0",
-      [groupLayoutId]: "0",
       [pageX1Id]: "_b_10_",
-    });
-  });
+      [pageX2Id]: "_b_11_",
+    };
 
-  it("falls back to initial bfcache ids when history state has no current segment ids", () => {
-    expect(
-      createHydratedBfcacheIdMap(createBfcacheElements(pageX1Id), {
-        [pageX2Id]: "_b_11_",
-      }),
-    ).toEqual({
+    expect(createInitialBfcacheIdMap(createBfcacheElements(pageX1Id))).toEqual({
       [rootLayoutId]: "0",
       [groupLayoutId]: "0",
       [pageX1Id]: "0",
     });
+    expect(persistedHistoryIds[pageX1Id]).toBe("_b_10_");
   });
 
   it("preserves shared segment ids and mints ids for fresh segments", () => {
@@ -4549,16 +4541,23 @@ describe("app browser entry bfcacheId helpers", () => {
   });
 
   it("serializes and restores bfcache ids through history state", () => {
-    const state = createHistoryStateWithPreviousNextUrl({ __vinext_scrollY: 120 }, "/feed", {
-      [pageX1Id]: "_b_9_",
-    });
+    const state = createHistoryStateWithNavigationMetadata(
+      { __vinext_scrollY: 120 },
+      {
+        bfcacheIds: { [pageX1Id]: "_b_9_" },
+        bfcacheVersion: 3,
+        previousNextUrl: "/feed",
+      },
+    );
 
     expect(state).toEqual({
       __vinext_bfcacheIds: { [pageX1Id]: "_b_9_" },
+      __vinext_bfcacheVersion: 3,
       __vinext_previousNextUrl: "/feed",
       __vinext_scrollY: 120,
     });
     expect(readHistoryStateBfcacheIds(state)).toEqual({ [pageX1Id]: "_b_9_" });
+    expect(readHistoryStateBfcacheVersion(state)).toBe(3);
   });
 
   it("uses restored history bfcache ids for traversal commits", async () => {
@@ -4623,16 +4622,16 @@ describe("app browser entry bfcacheId helpers", () => {
     expect(pending.action.bfcacheIds[groupLayoutId]).not.toBe("0");
   });
 
-  it("keeps future minted bfcache ids ahead of hydrated history state ids", () => {
-    const hydrated = createHydratedBfcacheIdMap(createBfcacheElements(pageX1Id), {
-      [pageX1Id]: "_b_900000_",
-    });
+  it("keeps future minted bfcache ids ahead of restored history state ids", () => {
     const next = createNextBfcacheIdMap({
-      current: hydrated,
+      current: createInitialBfcacheIdMap(createBfcacheElements(pageX1Id)),
       currentElements: createBfcacheElements(pageX1Id),
       currentPathname: "/x/1",
       elements: createBfcacheElements(pageX2Id),
       nextPathname: "/x/2",
+      restored: {
+        [pageX1Id]: "_b_900000_",
+      },
     });
 
     const freshIdNumber = Number(/^_b_(\d+)_$/.exec(next[pageX2Id] ?? "")?.[1]);

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -50,6 +50,7 @@ import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
+  createHydratedBfcacheIdMap,
   createInitialBfcacheIdMap,
   createNextBfcacheIdMap,
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
@@ -4315,6 +4316,32 @@ describe("app browser entry bfcacheId helpers", () => {
     });
   });
 
+  it("seeds hydration bfcache ids from history state for current rendered segments", () => {
+    expect(
+      createHydratedBfcacheIdMap(createBfcacheElements(pageX1Id), {
+        [rootLayoutId]: "0",
+        [pageX1Id]: "_b_10_",
+        [pageX2Id]: "_b_11_",
+      }),
+    ).toEqual({
+      [rootLayoutId]: "0",
+      [groupLayoutId]: "0",
+      [pageX1Id]: "_b_10_",
+    });
+  });
+
+  it("falls back to initial bfcache ids when history state has no current segment ids", () => {
+    expect(
+      createHydratedBfcacheIdMap(createBfcacheElements(pageX1Id), {
+        [pageX2Id]: "_b_11_",
+      }),
+    ).toEqual({
+      [rootLayoutId]: "0",
+      [groupLayoutId]: "0",
+      [pageX1Id]: "0",
+    });
+  });
+
   it("preserves shared segment ids and mints ids for fresh segments", () => {
     const current = {
       [rootLayoutId]: "0",
@@ -4478,6 +4505,21 @@ describe("app browser entry bfcacheId helpers", () => {
     });
 
     expect(pending.action.bfcacheIds[pageX1Id]).toBe("_b_5_");
+  });
+
+  it("keeps future minted bfcache ids ahead of hydrated history state ids", () => {
+    const hydrated = createHydratedBfcacheIdMap(createBfcacheElements(pageX1Id), {
+      [pageX1Id]: "_b_900000_",
+    });
+    const next = createNextBfcacheIdMap({
+      current: hydrated,
+      currentPathname: "/x/1",
+      elements: createBfcacheElements(pageX2Id),
+      nextPathname: "/x/2",
+    });
+
+    const freshIdNumber = Number(/^_b_(\d+)_$/.exec(next[pageX2Id] ?? "")?.[1]);
+    expect(freshIdNumber).toBeGreaterThan(900000);
   });
 });
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -4285,9 +4285,13 @@ describe("app browser entry bfcacheId helpers", () => {
   const nestedGroupLayoutId = AppElementsWire.encodeLayoutId(
     "/nextjs-compat/use-router-bfcache-id/[group]",
   );
+  const catchAllLayoutId = AppElementsWire.encodeLayoutId("/docs/[...slug]");
+  const optionalCatchAllTemplateId = AppElementsWire.encodeTemplateId("/docs/[[...slug]]");
   const pageX1Id = AppElementsWire.encodePageId("/x/1", null);
   const pageX2Id = AppElementsWire.encodePageId("/x/2", null);
   const pageY1Id = AppElementsWire.encodePageId("/y/1", null);
+  const docsCatchAllPageId = AppElementsWire.encodePageId("/docs/[...slug]", null);
+  const docsOptionalCatchAllPageId = AppElementsWire.encodePageId("/docs/[[...slug]]", null);
 
   function createBfcacheElements(pageId: string): AppElements {
     return createResolvedElements(
@@ -4375,6 +4379,62 @@ describe("app browser entry bfcacheId helpers", () => {
 
     expect(next[nestedGroupLayoutId]).toMatch(/^_b_\d+_$/);
     expect(next[nestedGroupLayoutId]).not.toBe("0");
+  });
+
+  it("mints a fresh layout id when a catch-all segment value changes", () => {
+    const current = {
+      [rootLayoutId]: "0",
+      [catchAllLayoutId]: "_b_4_",
+      [docsCatchAllPageId]: "_b_5_",
+    };
+
+    const next = createNextBfcacheIdMap({
+      current,
+      currentPathname: "/docs/a/b",
+      elements: createResolvedElements(
+        "route:/docs/[...slug]",
+        "/",
+        null,
+        {
+          [catchAllLayoutId]: React.createElement("div", null),
+          [docsCatchAllPageId]: React.createElement("main", null),
+        },
+        [rootLayoutId, catchAllLayoutId],
+      ),
+      nextPathname: "/docs/a/c",
+    });
+
+    expect(next[rootLayoutId]).toBe("0");
+    expect(next[catchAllLayoutId]).toMatch(/^_b_\d+_$/);
+    expect(next[catchAllLayoutId]).not.toBe("_b_4_");
+  });
+
+  it("mints a fresh template id when an optional catch-all segment value changes", () => {
+    const current = {
+      [rootLayoutId]: "0",
+      [optionalCatchAllTemplateId]: "_b_8_",
+      [docsOptionalCatchAllPageId]: "_b_9_",
+    };
+
+    const next = createNextBfcacheIdMap({
+      current,
+      currentPathname: "/docs/a/b",
+      elements: createResolvedElements(
+        "route:/docs/[[...slug]]",
+        "/",
+        null,
+        {
+          [optionalCatchAllTemplateId]: React.createElement("div", null),
+          [docsOptionalCatchAllPageId]: React.createElement("main", null),
+        },
+        [rootLayoutId],
+      ),
+      nextPathname: "/docs/a/c",
+    });
+
+    expect(next[rootLayoutId]).toBe("0");
+    expect(next[optionalCatchAllTemplateId]).toMatch(/^_b_\d+_$/);
+    expect(next[optionalCatchAllTemplateId]).not.toBe("_b_8_");
   });
 
   it("serializes and restores bfcache ids through history state", () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -4560,6 +4560,28 @@ describe("app browser entry bfcacheId helpers", () => {
     expect(readHistoryStateBfcacheVersion(state)).toBe(3);
   });
 
+  it("drops bfcache version metadata when bfcache ids are cleared", () => {
+    const state = createHistoryStateWithNavigationMetadata(
+      {
+        __vinext_bfcacheIds: { [pageX1Id]: "_b_9_" },
+        __vinext_bfcacheVersion: 3,
+        custom: "preserve",
+      },
+      {
+        bfcacheIds: {},
+        bfcacheVersion: 4,
+        previousNextUrl: "/feed",
+      },
+    );
+
+    expect(state).toEqual({
+      __vinext_previousNextUrl: "/feed",
+      custom: "preserve",
+    });
+    expect(readHistoryStateBfcacheIds(state)).toBeNull();
+    expect(readHistoryStateBfcacheVersion(state)).toBeNull();
+  });
+
   it("uses restored history bfcache ids for traversal commits", async () => {
     const currentState = createState({
       bfcacheIds: {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -4351,6 +4351,7 @@ describe("app browser entry bfcacheId helpers", () => {
 
     const next = createNextBfcacheIdMap({
       current,
+      currentElements: createBfcacheElements(pageX1Id),
       currentPathname: "/x/1",
       elements: createBfcacheElements(pageX2Id),
       nextPathname: "/x/2",
@@ -4372,6 +4373,7 @@ describe("app browser entry bfcacheId helpers", () => {
 
     const next = createNextBfcacheIdMap({
       current,
+      currentElements: createBfcacheElements(pageX1Id),
       currentPathname: "/x/1",
       elements: createBfcacheElements(pageY1Id),
       nextPathname: "/y/1",
@@ -4391,6 +4393,15 @@ describe("app browser entry bfcacheId helpers", () => {
 
     const next = createNextBfcacheIdMap({
       current,
+      currentElements: createResolvedElements(
+        "route:/nextjs-compat/use-router-bfcache-id/x/1",
+        "/",
+        null,
+        {
+          [pageX1Id]: React.createElement("main", null),
+        },
+        [rootLayoutId, nestedGroupLayoutId],
+      ),
       currentPathname: "/nextjs-compat/use-router-bfcache-id/x/1",
       elements: createResolvedElements(
         "route:/nextjs-compat/use-router-bfcache-id/y/1",
@@ -4417,6 +4428,16 @@ describe("app browser entry bfcacheId helpers", () => {
 
     const next = createNextBfcacheIdMap({
       current,
+      currentElements: createResolvedElements(
+        "route:/docs/[...slug]",
+        "/",
+        null,
+        {
+          [catchAllLayoutId]: React.createElement("div", null),
+          [docsCatchAllPageId]: React.createElement("main", null),
+        },
+        [rootLayoutId, catchAllLayoutId],
+      ),
       currentPathname: "/docs/a/b",
       elements: createResolvedElements(
         "route:/docs/[...slug]",
@@ -4445,6 +4466,16 @@ describe("app browser entry bfcacheId helpers", () => {
 
     const next = createNextBfcacheIdMap({
       current,
+      currentElements: createResolvedElements(
+        "route:/docs/[[...slug]]",
+        "/",
+        null,
+        {
+          [optionalCatchAllTemplateId]: React.createElement("div", null),
+          [docsOptionalCatchAllPageId]: React.createElement("main", null),
+        },
+        [rootLayoutId],
+      ),
       currentPathname: "/docs/a/b",
       elements: createResolvedElements(
         "route:/docs/[[...slug]]",
@@ -4462,6 +4493,59 @@ describe("app browser entry bfcacheId helpers", () => {
     expect(next[rootLayoutId]).toBe("0");
     expect(next[optionalCatchAllTemplateId]).toMatch(/^_b_\d+_$/);
     expect(next[optionalCatchAllTemplateId]).not.toBe("_b_8_");
+  });
+
+  it("mints a fresh intercepted slot id when the active slot target changes", () => {
+    const feedLayoutId = AppElementsWire.encodeLayoutId("/feed");
+    const modalSlotId = AppElementsWire.encodeSlotId("modal", "/feed");
+    const modalSlotBinding = {
+      ownerLayoutId: feedLayoutId,
+      slotId: modalSlotId,
+      state: "active",
+    } satisfies AppElementsSlotBinding;
+    const currentElements = createResolvedElements(
+      "route:/photos/42",
+      "/",
+      "/feed",
+      {
+        [rootLayoutId]: React.createElement("div", null),
+        [feedLayoutId]: React.createElement("div", null),
+        [modalSlotId]: React.createElement("aside", null),
+      },
+      [rootLayoutId, feedLayoutId],
+      [modalSlotBinding],
+      createInterceptionProof("/feed", "/photos/42", modalSlotId),
+    );
+    const nextElements = createResolvedElements(
+      "route:/photos/43",
+      "/",
+      "/feed",
+      {
+        [rootLayoutId]: React.createElement("div", null),
+        [feedLayoutId]: React.createElement("div", null),
+        [modalSlotId]: React.createElement("aside", null),
+      },
+      [rootLayoutId, feedLayoutId],
+      [modalSlotBinding],
+      createInterceptionProof("/feed", "/photos/43", modalSlotId),
+    );
+
+    const next = createNextBfcacheIdMap({
+      current: {
+        [rootLayoutId]: "0",
+        [feedLayoutId]: "_b_4_",
+        [modalSlotId]: "_b_5_",
+      },
+      currentElements,
+      currentPathname: "/photos/42",
+      elements: nextElements,
+      nextPathname: "/photos/43",
+    });
+
+    expect(next[rootLayoutId]).toBe("0");
+    expect(next[feedLayoutId]).toBe("_b_4_");
+    expect(next[modalSlotId]).toMatch(/^_b_\d+_$/);
+    expect(next[modalSlotId]).not.toBe("_b_5_");
   });
 
   it("serializes and restores bfcache ids through history state", () => {
@@ -4507,12 +4591,45 @@ describe("app browser entry bfcacheId helpers", () => {
     expect(pending.action.bfcacheIds[pageX1Id]).toBe("_b_5_");
   });
 
+  it("mints redirected traverse target ids after restored ids are cleared", async () => {
+    const currentState = createState({
+      bfcacheIds: {
+        [rootLayoutId]: "0",
+        [groupLayoutId]: "0",
+        [pageX1Id]: "_b_4_",
+      },
+      elements: createBfcacheElements(pageX1Id),
+      layoutIds: [rootLayoutId, groupLayoutId],
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/x/1", {}),
+      routeId: "route:/x/1",
+    });
+
+    const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      currentState,
+      nextElements: Promise.resolve(createBfcacheElements(pageY1Id)),
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/y/1", {}),
+      operationLane: "navigation",
+      renderId: 1,
+      // navigateRsc clears the source entry's restored ids before committing a
+      // redirected traverse target, otherwise restored ids would win over fresh
+      // ids for changed dynamic segments.
+      restoredBfcacheIds: null,
+      type: "traverse",
+    });
+
+    expect(pending.action.bfcacheIds[rootLayoutId]).toBe("0");
+    expect(pending.action.bfcacheIds[groupLayoutId]).toMatch(/^_b_\d+_$/);
+    expect(pending.action.bfcacheIds[groupLayoutId]).not.toBe("0");
+  });
+
   it("keeps future minted bfcache ids ahead of hydrated history state ids", () => {
     const hydrated = createHydratedBfcacheIdMap(createBfcacheElements(pageX1Id), {
       [pageX1Id]: "_b_900000_",
     });
     const next = createNextBfcacheIdMap({
       current: hydrated,
+      currentElements: createBfcacheElements(pageX1Id),
       currentPathname: "/x/1",
       elements: createBfcacheElements(pageX2Id),
       nextPathname: "/x/2",

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -2605,7 +2605,10 @@ describe("app browser navigation controller", () => {
       expect(stateRef.current.routeId).toBe("route:/photos/42");
       expect(stateRef.current.previousNextUrl).toBeNull();
       expect(syncHistoryStatePreviousNextUrl).toHaveBeenCalledTimes(1);
-      expect(syncHistoryStatePreviousNextUrl).toHaveBeenCalledWith(null);
+      expect(syncHistoryStatePreviousNextUrl).toHaveBeenCalledWith(
+        null,
+        stateRef.current.bfcacheIds,
+      );
     } finally {
       detach();
     }

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -50,10 +50,13 @@ import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
   createHistoryStateWithNavigationMetadata,
   createHistoryStateWithPreviousNextUrl,
+  createInitialBfcacheIdMap,
+  createNextBfcacheIdMap,
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createPendingNavigationCommit,
   isCacheRestorableAppPayloadMetadata,
+  readHistoryStateBfcacheIds,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   resolveInterceptionContextFromPreviousNextUrl,
@@ -134,6 +137,7 @@ function createResolvedElements(
 
 function createState(overrides: Partial<AppRouterState> = {}): AppRouterState {
   return {
+    bfcacheIds: {},
     elements: createResolvedElements("route:/initial", "/"),
     interception: null,
     layoutIds: [AppElementsWire.encodeLayoutId("/")],
@@ -3952,6 +3956,116 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
   });
 
+  it("traverse: preserves bfcacheIds for planner-approved layout elements", async () => {
+    const modalSlotId = AppElementsWire.encodeSlotId("modal", "/feed");
+    const feedLayout = React.createElement("div", null, "feed layout");
+    const modalSlotBinding = {
+      ownerLayoutId: "layout:/feed",
+      slotId: modalSlotId,
+      state: "active",
+    } satisfies AppElementsSlotBinding;
+    const state = createState({
+      bfcacheIds: {
+        "layout:/": "0",
+        "layout:/feed": "_b_4_",
+        [modalSlotId]: "_b_5_",
+      },
+      elements: createResolvedElements(
+        "route:/feed",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          "layout:/feed": feedLayout,
+          [modalSlotId]: React.createElement("div", null, "modal"),
+        },
+        ["layout:/", "layout:/feed"],
+        [modalSlotBinding],
+      ),
+      layoutIds: ["layout:/", "layout:/feed"],
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/feed", {}),
+      routeId: "route:/feed",
+      slotBindings: [modalSlotBinding],
+    });
+    const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      currentState: state,
+      nextElements: Promise.resolve(
+        createResolvedElements(
+          "route:/feed/comments",
+          "/",
+          null,
+          {
+            "page:/feed/comments": React.createElement("main", null, "comments"),
+          },
+          ["layout:/", "layout:/feed", "layout:/feed/comments"],
+          [
+            {
+              ownerLayoutId: "layout:/feed",
+              slotId: modalSlotId,
+              state: "default",
+            },
+          ],
+        ),
+      ),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/feed/comments",
+        {},
+      ),
+      operationLane: "traverse",
+      previousNextUrl: null,
+      renderId: 1,
+      type: "traverse",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 1,
+      currentState: state,
+      pending,
+      routeManifest: createRouteManifestForPendingCommit(state, pending),
+      startedNavigationId: 1,
+      targetHref: "https://example.com/feed/comments",
+    });
+
+    expect(approval.decision.disposition).toBe("commit");
+    if (approval.decision.disposition !== "commit") {
+      throw new Error("Expected visible commit approval");
+    }
+    expect(approval.decision.preserveElementIds).toEqual(["layout:/", "layout:/feed"]);
+    expect(approval.decision.preservePreviousSlotIds).toEqual([]);
+    if (approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+    expect(approval.approvedCommit.action.bfcacheIds["layout:/feed"]).toBe("_b_4_");
+
+    // createPendingNavigationCommit pre-populates common layout ids today.
+    // Remove one to exercise reducer-level preservation for merged elements,
+    // and add a stale slot id to verify the merged element set bounds the map.
+    const reducerBfcacheIdProbe = {
+      ...approval.approvedCommit.action.bfcacheIds,
+      [modalSlotId]: "_b_5_",
+    };
+    delete reducerBfcacheIdProbe["layout:/feed"];
+    const commitWithoutPreservedLayoutBfcacheId = {
+      ...approval.approvedCommit,
+      action: {
+        ...approval.approvedCommit.action,
+        bfcacheIds: reducerBfcacheIdProbe,
+      },
+    };
+    expect(
+      Object.hasOwn(commitWithoutPreservedLayoutBfcacheId.action.bfcacheIds, "layout:/feed"),
+    ).toBe(false);
+    expect(commitWithoutPreservedLayoutBfcacheId.action.bfcacheIds[modalSlotId]).toBe("_b_5_");
+
+    const nextState = applyApprovedVisibleCommit(state, commitWithoutPreservedLayoutBfcacheId);
+    expect(nextState.elements["layout:/feed"]).toBe(feedLayout);
+    expect(nextState.bfcacheIds["layout:/"]).toBe("0");
+    expect(nextState.bfcacheIds["layout:/feed"]).toBe("_b_4_");
+    expect(Object.hasOwn(nextState.elements, modalSlotId)).toBe(false);
+    expect(Object.hasOwn(nextState.bfcacheIds, modalSlotId)).toBe(false);
+  });
+
   it("preserves planner-approved default parallel slots on approved navigate commits", async () => {
     const mountedSlot = React.createElement("div", null, "modal");
     const modalSlotBinding = {
@@ -3995,6 +4109,56 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(true);
     expect(nextState.elements["slot:modal:/feed"]).toBe(mountedSlot);
     expect(nextState.slotBindings).toEqual([modalSlotBinding]);
+  });
+
+  it("preserves bfcache ids for planner-approved default parallel slots", async () => {
+    const modalSlotId = AppElementsWire.encodeSlotId("modal", "/feed");
+    const mountedSlot = React.createElement("div", null, "modal");
+    const modalSlotBinding = {
+      ownerLayoutId: "layout:/feed",
+      slotId: modalSlotId,
+      state: "active",
+    } satisfies AppElementsSlotBinding;
+    const state = createState({
+      bfcacheIds: {
+        "layout:/": "0",
+        "layout:/feed": "_b_4_",
+        [modalSlotId]: "_b_5_",
+      },
+      elements: createResolvedElements(
+        "route:/feed",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          "layout:/feed": React.createElement("div", null, "feed layout"),
+          [modalSlotId]: mountedSlot,
+        },
+        ["layout:/", "layout:/feed"],
+        [modalSlotBinding],
+      ),
+      layoutIds: ["layout:/", "layout:/feed"],
+      slotBindings: [modalSlotBinding],
+    });
+
+    const nextState = await applyApprovedTestCommit(state, {
+      extraEntries: {
+        "page:/feed/comments": React.createElement("main", null, "comments"),
+      },
+      layoutIds: ["layout:/", "layout:/feed", "layout:/feed/comments"],
+      rootLayoutTreePath: "/",
+      routeId: "route:/feed/comments",
+      slotBindings: [
+        {
+          ownerLayoutId: "layout:/feed",
+          slotId: modalSlotId,
+          state: "default",
+        },
+      ],
+    });
+
+    expect(nextState.elements[modalSlotId]).toBe(mountedSlot);
+    expect(nextState.bfcacheIds[modalSlotId]).toBe("_b_5_");
   });
 
   it("keeps previous slot binding proof when the target marks a preserved slot unmatched", async () => {
@@ -4077,7 +4241,13 @@ describe("app browser entry previousNextUrl helpers", () => {
   });
 
   it("does not preserve absent parallel slots when their owner layout is not approved", async () => {
+    const modalSlotId = AppElementsWire.encodeSlotId("modal", "/feed");
     const state = createState({
+      bfcacheIds: {
+        "layout:/": "0",
+        "layout:/feed": "_b_4_",
+        [modalSlotId]: "_b_5_",
+      },
       elements: createResolvedElements(
         "route:/feed",
         "/",
@@ -4085,7 +4255,7 @@ describe("app browser entry previousNextUrl helpers", () => {
         {
           "layout:/": React.createElement("div", null, "root layout"),
           "layout:/feed": React.createElement("div", null, "feed layout"),
-          "slot:modal:/feed": React.createElement("div", null, "modal"),
+          [modalSlotId]: React.createElement("div", null, "modal"),
         },
         ["layout:/", "layout:/feed"],
       ),
@@ -4102,6 +4272,149 @@ describe("app browser entry previousNextUrl helpers", () => {
     });
 
     expect(Object.hasOwn(nextState.elements, "slot:modal:/feed")).toBe(false);
+    expect(Object.hasOwn(nextState.bfcacheIds, modalSlotId)).toBe(false);
+  });
+});
+
+describe("app browser entry bfcacheId helpers", () => {
+  const rootLayoutId = AppElementsWire.encodeLayoutId("/");
+  const groupLayoutId = AppElementsWire.encodeLayoutId("/[group]");
+  const nestedGroupLayoutId = AppElementsWire.encodeLayoutId(
+    "/nextjs-compat/use-router-bfcache-id/[group]",
+  );
+  const pageX1Id = AppElementsWire.encodePageId("/x/1", null);
+  const pageX2Id = AppElementsWire.encodePageId("/x/2", null);
+  const pageY1Id = AppElementsWire.encodePageId("/y/1", null);
+
+  function createBfcacheElements(pageId: string): AppElements {
+    return createResolvedElements(
+      `route:${pageId.slice("page:".length)}`,
+      "/",
+      null,
+      {
+        [rootLayoutId]: React.createElement("div", null),
+        [groupLayoutId]: React.createElement("div", null),
+        [pageId]: React.createElement("main", null),
+      },
+      [rootLayoutId, groupLayoutId],
+    );
+  }
+
+  it("initializes every visible segment with the hydration placeholder", () => {
+    expect(createInitialBfcacheIdMap(createBfcacheElements(pageX1Id))).toEqual({
+      [rootLayoutId]: "0",
+      [groupLayoutId]: "0",
+      [pageX1Id]: "0",
+    });
+  });
+
+  it("preserves shared segment ids and mints ids for fresh segments", () => {
+    const current = {
+      [rootLayoutId]: "0",
+      [groupLayoutId]: "_b_4_",
+      [pageX1Id]: "_b_5_",
+    };
+
+    const next = createNextBfcacheIdMap({
+      current,
+      currentPathname: "/x/1",
+      elements: createBfcacheElements(pageX2Id),
+      nextPathname: "/x/2",
+    });
+
+    expect(next[rootLayoutId]).toBe("0");
+    expect(next[groupLayoutId]).toBe("_b_4_");
+    expect(next[pageX1Id]).toBeUndefined();
+    expect(next[pageX2Id]).toMatch(/^_b_\d+_$/);
+    expect(next[pageX2Id]).not.toBe("_b_5_");
+  });
+
+  it("mints a fresh layout id when a dynamic layout segment changes", () => {
+    const current = {
+      [rootLayoutId]: "0",
+      [groupLayoutId]: "_b_4_",
+      [pageX1Id]: "_b_5_",
+    };
+
+    const next = createNextBfcacheIdMap({
+      current,
+      currentPathname: "/x/1",
+      elements: createBfcacheElements(pageY1Id),
+      nextPathname: "/y/1",
+    });
+
+    expect(next[rootLayoutId]).toBe("0");
+    expect(next[groupLayoutId]).toMatch(/^_b_\d+_$/);
+    expect(next[groupLayoutId]).not.toBe("_b_4_");
+  });
+
+  it("mints a fresh nested layout id when a dynamic layout segment changes", () => {
+    const current = {
+      [rootLayoutId]: "0",
+      [nestedGroupLayoutId]: "0",
+      [pageX1Id]: "0",
+    };
+
+    const next = createNextBfcacheIdMap({
+      current,
+      currentPathname: "/nextjs-compat/use-router-bfcache-id/x/1",
+      elements: createResolvedElements(
+        "route:/nextjs-compat/use-router-bfcache-id/y/1",
+        "/",
+        null,
+        {
+          [pageY1Id]: React.createElement("main", null),
+        },
+        [rootLayoutId, nestedGroupLayoutId],
+      ),
+      nextPathname: "/nextjs-compat/use-router-bfcache-id/y/1",
+    });
+
+    expect(next[nestedGroupLayoutId]).toMatch(/^_b_\d+_$/);
+    expect(next[nestedGroupLayoutId]).not.toBe("0");
+  });
+
+  it("serializes and restores bfcache ids through history state", () => {
+    const state = createHistoryStateWithPreviousNextUrl({ __vinext_scrollY: 120 }, "/feed", {
+      [pageX1Id]: "_b_9_",
+    });
+
+    expect(state).toEqual({
+      __vinext_bfcacheIds: { [pageX1Id]: "_b_9_" },
+      __vinext_previousNextUrl: "/feed",
+      __vinext_scrollY: 120,
+    });
+    expect(readHistoryStateBfcacheIds(state)).toEqual({ [pageX1Id]: "_b_9_" });
+  });
+
+  it("uses restored history bfcache ids for traversal commits", async () => {
+    const currentState = createState({
+      bfcacheIds: {
+        [rootLayoutId]: "0",
+        [groupLayoutId]: "_b_4_",
+        [pageX2Id]: "_b_8_",
+      },
+      elements: createBfcacheElements(pageX2Id),
+      layoutIds: [rootLayoutId, groupLayoutId],
+      routeId: "route:/x/2",
+    });
+
+    const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      currentState,
+      nextElements: Promise.resolve(createBfcacheElements(pageX1Id)),
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/x/1", {}),
+      operationLane: "traverse",
+      renderId: 1,
+      restoredBfcacheIds: {
+        [rootLayoutId]: "0",
+        [groupLayoutId]: "_b_4_",
+        [pageX1Id]: "_b_5_",
+      },
+      type: "traverse",
+    });
+
+    expect(pending.action.bfcacheIds[pageX1Id]).toBe("_b_5_");
   });
 });
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -56,6 +56,7 @@ import {
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createPendingNavigationCommit,
   isCacheRestorableAppPayloadMetadata,
+  isHistoryStateBfcacheVersionCurrent,
   readHistoryStateBfcacheIds,
   readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,
@@ -4644,6 +4645,29 @@ describe("app browser entry bfcacheId helpers", () => {
     });
     expect(readHistoryStateBfcacheIds(state)).toBeNull();
     expect(readHistoryStateBfcacheVersion(state)).toBeNull();
+  });
+
+  it("treats a matching stored bfcache version as current", () => {
+    const state = createHistoryStateWithNavigationMetadata(null, {
+      bfcacheIds: { [pageX1Id]: "_b_9_" },
+      bfcacheVersion: 3,
+      previousNextUrl: null,
+    });
+
+    expect(isHistoryStateBfcacheVersionCurrent(state, 3)).toBe(true);
+    expect(isHistoryStateBfcacheVersionCurrent(state, 4)).toBe(false);
+  });
+
+  it("rejects a missing bfcache version even when the current version is 0", () => {
+    // Regression guard: a history entry carrying bfcache ids but no version key
+    // (older build / external pushState) must NOT pass the document-scoped gate
+    // on a fresh document whose current version is 0. Coercing the missing
+    // version to 0 would let stale ids be restored across documents.
+    const unversioned = { __vinext_bfcacheIds: { [pageX1Id]: "_b_9_" } };
+
+    expect(readHistoryStateBfcacheVersion(unversioned)).toBeNull();
+    expect(isHistoryStateBfcacheVersionCurrent(unversioned, 0)).toBe(false);
+    expect(isHistoryStateBfcacheVersionCurrent(null, 0)).toBe(false);
   });
 
   it("uses restored history bfcache ids for traversal commits", async () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -4316,22 +4316,37 @@ describe("app browser entry bfcacheId helpers", () => {
     });
   });
 
-  it("does not seed hydration bfcache ids from history state", () => {
+  it("does not seed hydration bfcache ids from previously minted ids", () => {
     // Next generates the public "_b_0_" hydration sentinel from an internal
-    // zero cache node on both SSR and initial client hydration. Persisted
-    // history maps are restored only for explicit back/forward traversals.
-    const persistedHistoryIds = {
-      [rootLayoutId]: "0",
-      [pageX1Id]: "_b_10_",
-      [pageX2Id]: "_b_11_",
-    };
+    // zero cache node on both SSR and initial client hydration. Minted ids
+    // (and persisted history maps) are restored only for explicit back/forward
+    // traversals, never folded into the initial map.
+    //
+    // Mint real "_b_N_" ids for these segments first, then prove that building
+    // the initial map for the same elements ignores them and resets every
+    // segment to the raw "0" hydration sentinel. This would fail if
+    // createInitialBfcacheIdMap ever started seeding from prior/minted state.
+    const minted = createNextBfcacheIdMap({
+      current: {
+        [rootLayoutId]: "0",
+        [groupLayoutId]: "_b_4_",
+        [pageX2Id]: "_b_5_",
+      },
+      currentElements: createBfcacheElements(pageX2Id),
+      currentPathname: "/x/2",
+      elements: createBfcacheElements(pageX1Id),
+      nextPathname: "/x/1",
+    });
+    expect(minted[pageX1Id]).toMatch(/^_b_\d+_$/);
 
-    expect(createInitialBfcacheIdMap(createBfcacheElements(pageX1Id))).toEqual({
+    const initial = createInitialBfcacheIdMap(createBfcacheElements(pageX1Id));
+    expect(initial).toEqual({
       [rootLayoutId]: "0",
       [groupLayoutId]: "0",
       [pageX1Id]: "0",
     });
-    expect(persistedHistoryIds[pageX1Id]).toBe("_b_10_");
+    // No segment carries a minted "_b_N_" id into the initial map.
+    expect(Object.values(initial).every((value) => value === "0")).toBe(true);
   });
 
   it("preserves shared segment ids and mints ids for fresh segments", () => {
@@ -4409,6 +4424,55 @@ describe("app browser entry bfcacheId helpers", () => {
 
     expect(next[nestedGroupLayoutId]).toMatch(/^_b_\d+_$/);
     expect(next[nestedGroupLayoutId]).not.toBe("0");
+  });
+
+  it("preserves a parallel-slot layout id when its visible URL prefix is unchanged", () => {
+    // Regression: a layout nested under a parallel slot has a tree path that
+    // contains an invisible "@slot" segment before its visible URL segments
+    // (e.g. app/feed/@modal/photos/layout.tsx -> "/feed/@modal/photos", which
+    // maps to the URL prefix "/feed/photos"). Deriving the identity prefix must
+    // skip the "@modal" segment; otherwise it over-counts consumed pathname
+    // segments and re-mints the layout id on every navigation that keeps the
+    // layout mounted (a divergence from Next.js bfcacheId semantics).
+    const modalPhotosLayoutId = AppElementsWire.encodeLayoutId("/feed/@modal/photos");
+    const photo1Id = AppElementsWire.encodePageId("/feed/photos/1", null);
+    const photo2Id = AppElementsWire.encodePageId("/feed/photos/2", null);
+
+    const next = createNextBfcacheIdMap({
+      current: {
+        [rootLayoutId]: "0",
+        [modalPhotosLayoutId]: "_b_4_",
+        [photo1Id]: "_b_5_",
+      },
+      currentElements: createResolvedElements(
+        "route:/feed/@modal/photos/[id]",
+        "/",
+        null,
+        {
+          [modalPhotosLayoutId]: React.createElement("div", null),
+          [photo1Id]: React.createElement("main", null),
+        },
+        [rootLayoutId, modalPhotosLayoutId],
+      ),
+      currentPathname: "/feed/photos/1",
+      elements: createResolvedElements(
+        "route:/feed/@modal/photos/[id]",
+        "/",
+        null,
+        {
+          [modalPhotosLayoutId]: React.createElement("div", null),
+          [photo2Id]: React.createElement("main", null),
+        },
+        [rootLayoutId, modalPhotosLayoutId],
+      ),
+      nextPathname: "/feed/photos/2",
+    });
+
+    // The layout persists across the navigation, so its id must be preserved.
+    expect(next[modalPhotosLayoutId]).toBe("_b_4_");
+    // The leaf page changes, so it mints a fresh id (sanity check).
+    expect(next[photo2Id]).toMatch(/^_b_\d+_$/);
+    expect(next[photo2Id]).not.toBe("_b_5_");
   });
 
   it("mints a fresh layout id when a catch-all segment value changes", () => {

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -275,7 +275,7 @@ describe("buildPageElements", () => {
 
     expect(record[APP_SLOT_BINDINGS_KEY]).toEqual([
       {
-        activeRouteId: "route:/photos/42\0/feed",
+        activeRouteId: "route:/photos/42",
         ownerLayoutId: "layout:/feed",
         slotId: "slot:modal:/feed",
         state: "active",

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -224,6 +224,7 @@ describe("buildPageElements", () => {
         state: "unmatched",
       },
       {
+        activeRouteId: "route:/dashboard",
         ownerLayoutId: "layout:/",
         slotId: "slot:team:/",
         state: "active",
@@ -274,6 +275,7 @@ describe("buildPageElements", () => {
 
     expect(record[APP_SLOT_BINDINGS_KEY]).toEqual([
       {
+        activeRouteId: "route:/photos/42\0/feed",
         ownerLayoutId: "layout:/feed",
         slotId: "slot:modal:/feed",
         state: "active",

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -59,6 +59,7 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await waitForAppRouterHydration(page);
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText("_b_0_");
+    const reloadedX2BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     await expect(visibleTestId(page, "leaf-bfcache-id")).not.toHaveText(x2BfcacheId ?? "");
 
     await visibleTestId(page, "leaf-input").fill("x2-state-after-reload");
@@ -68,6 +69,10 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     expect(postReloadBackBfcacheId).toMatch(/^_b_\d+_$/);
     expect(postReloadBackBfcacheId).not.toBe(x1BfcacheId);
     await expect(visibleTestId(page, "leaf-input")).not.toHaveValue("x2-state-after-reload");
+
+    await page.goForward();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(reloadedX2BfcacheId ?? "");
   });
 
   test("resets leaf form state when re-entering a route via fresh push", async ({ page }) => {

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Next.js Compat E2E: useRouter().bfcacheId
+ * Ported from: https://github.com/vercel/next.js/blob/56d95137fd6d84f4bc1e5ef2bb31e0136d5fad9c/test/e2e/app-dir/use-router-bfcache-id/use-router-bfcache-id.test.ts
+ */
+
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+const ROUTE = "/nextjs-compat/use-router-bfcache-id";
+
+async function revealAndClick(page: Page, href: string) {
+  await page.locator(`input[data-link-accordion="${href}"]`).first().check();
+  await page.locator(`a[href="${href}"]`).first().click();
+}
+
+test.describe("Next.js compat: useRouter().bfcacheId", () => {
+  test("mints bfcacheIds for fresh leaf navigations and restores them on history traversal", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText("0");
+
+    await revealAndClick(page, `${ROUTE}/x/2`);
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
+    const x2BfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    expect(x2BfcacheId).toMatch(/^_b_\d+_$/);
+
+    await revealAndClick(page, `${ROUTE}/x/1`);
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/1`);
+    const freshX1BfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    expect(freshX1BfcacheId).toMatch(/^_b_\d+_$/);
+    expect(freshX1BfcacheId).not.toBe(x2BfcacheId);
+
+    await page.goBack();
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
+  });
+
+  test("resets leaf form state when re-entering a route via fresh push", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    await page.getByTestId("leaf-input").fill("hello");
+    await revealAndClick(page, `${ROUTE}/x/2`);
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
+
+    await revealAndClick(page, `${ROUTE}/x/1`);
+    await expect(page.getByTestId("leaf-input")).toHaveValue("");
+  });
+
+  test("preserves shared layout state across sibling leaf navigations", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    await page.getByTestId("layout-input").fill("layout");
+    const xLayoutBfcacheId = await page.getByTestId("layout-bfcache-id").textContent();
+
+    await revealAndClick(page, `${ROUTE}/x/2`);
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(page.getByTestId("layout-input")).toHaveValue("layout");
+    await expect(page.getByTestId("layout-bfcache-id")).toHaveText(xLayoutBfcacheId ?? "");
+  });
+
+  test("resets shared layout state when navigating across dynamic groups", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    await page.getByTestId("layout-input").fill("layout");
+    const xLayoutBfcacheId = await page.getByTestId("layout-bfcache-id").textContent();
+
+    await revealAndClick(page, `${ROUTE}/y/1`);
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/y/1`);
+    await expect(page.getByTestId("layout-input")).toHaveValue("");
+    const yLayoutBfcacheId = await page.getByTestId("layout-bfcache-id").textContent();
+    expect(yLayoutBfcacheId).not.toBe(xLayoutBfcacheId);
+  });
+
+  test("preserves bfcacheId across hash/search-param navigation and refresh", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    const initialBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    await revealAndClick(page, `${ROUTE}/x/1#section`);
+    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+
+    await revealAndClick(page, `${ROUTE}/x/1?q=2`);
+    await expect(page.getByTestId("search")).toHaveAttribute("data-value", "q=2");
+    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+
+    await page.getByTestId("refresh").click();
+    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+  });
+});

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -27,24 +27,22 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await waitForAppRouterHydration(page);
 
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText("_b_0_");
+    const x1BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
 
     await revealAndClick(page, `${ROUTE}/x/2`);
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
     const x2BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     expect(x2BfcacheId).toMatch(/^_b_\d+_$/);
-
-    await revealAndClick(page, `${ROUTE}/x/1`);
-    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
-    const freshX1BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
-    expect(freshX1BfcacheId).toMatch(/^_b_\d+_$/);
-    expect(freshX1BfcacheId).not.toBe(x2BfcacheId);
+    await expect(visibleTestId(page, "leaf-input")).toHaveValue("");
 
     await page.goBack();
-    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
-    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x1BfcacheId ?? "");
   });
 
-  test("keeps restored bfcacheIds after hard reload of a history entry", async ({ page }) => {
+  test("uses the hydration bfcacheId after hard reload without leaking leaf state on back", async ({
+    page,
+  }) => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
@@ -60,12 +58,15 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await page.reload();
     await waitForAppRouterHydration(page);
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
-    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText("_b_0_");
+    await expect(visibleTestId(page, "leaf-bfcache-id")).not.toHaveText(x2BfcacheId ?? "");
 
     await visibleTestId(page, "leaf-input").fill("x2-state-after-reload");
     await page.goBack();
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
-    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x1BfcacheId ?? "");
+    const postReloadBackBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    expect(postReloadBackBfcacheId).toMatch(/^_b_\d+_$/);
+    expect(postReloadBackBfcacheId).not.toBe(x1BfcacheId);
     await expect(visibleTestId(page, "leaf-input")).not.toHaveValue("x2-state-after-reload");
   });
 
@@ -73,11 +74,15 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
+    const initialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     await visibleTestId(page, "leaf-input").fill("hello");
     await revealAndClick(page, `${ROUTE}/x/2`);
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
 
     await revealAndClick(page, `${ROUTE}/x/1`);
+    const freshBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    expect(freshBfcacheId).toMatch(/^_b_\d+_$/);
+    expect(freshBfcacheId).not.toBe(initialBfcacheId);
     await expect(visibleTestId(page, "leaf-input")).toHaveValue("");
   });
 
@@ -220,5 +225,32 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
 
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
     await expect(visibleTestId(page, "leaf-input")).toHaveValue("server-action-state");
+  });
+
+  test("does not restore stale history bfcacheIds after a server action invalidates cache", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    const staleX1BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await visibleTestId(page, "leaf-input").fill("stale-x1-state");
+
+    await revealAndClick(page, `${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+
+    const actionResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" && response.url().includes(`${ROUTE}/x/2.rsc`),
+    );
+    await visibleTestId(page, "server-action-refresh").click();
+    await actionResponse;
+
+    await page.goBack();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
+    const restoredAfterInvalidation = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    expect(restoredAfterInvalidation).toMatch(/^_b_\d+_$/);
+    expect(restoredAfterInvalidation).not.toBe(staleX1BfcacheId);
+    await expect(visibleTestId(page, "leaf-input")).toHaveValue("");
   });
 });

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -32,7 +32,6 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
     const x2BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     expect(x2BfcacheId).toMatch(/^_b_\d+_$/);
-    await visibleTestId(page, "leaf-input").fill("x2-state");
 
     await revealAndClick(page, `${ROUTE}/x/1`);
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
@@ -43,7 +42,6 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await page.goBack();
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
-    await expect(visibleTestId(page, "leaf-input")).toHaveValue("x2-state");
   });
 
   test("resets leaf form state when re-entering a route via fresh push", async ({ page }) => {
@@ -90,7 +88,6 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await waitForAppRouterHydration(page);
 
     const initialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
-    await visibleTestId(page, "leaf-input").fill("refresh-state");
     await revealAndClick(page, `${ROUTE}/x/1#section`);
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
 
@@ -100,7 +97,6 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
 
     await visibleTestId(page, "refresh").click();
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
-    await expect(visibleTestId(page, "leaf-input")).toHaveValue("refresh-state");
   });
 
   test("mints bfcacheIds for programmatic push and replace", async ({ page }) => {

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -3,9 +3,11 @@
  * Ported from: https://github.com/vercel/next.js/blob/56d95137fd6d84f4bc1e5ef2bb31e0136d5fad9c/test/e2e/app-dir/use-router-bfcache-id/use-router-bfcache-id.test.ts
  *
  * Next.js also covers Activity-backed form-state preservation on browser back.
- * Vinext does not implement React Activity yet, so those assertions are
- * intentionally omitted here; these tests focus on bfcacheId semantics and
- * same-segment DOM state that vinext preserves today.
+ * Vinext does not implement React Activity yet, so form-state-on-back
+ * assertions are intentionally omitted here; these tests focus on bfcacheId
+ * identity semantics. Same-segment DOM state preservation (e.g. input values
+ * surviving search-param navigation) is tested where it works today without
+ * Activity.
  */
 
 import { test, expect } from "@playwright/test";
@@ -22,6 +24,14 @@ async function revealAndClick(page: Page, href: string) {
 
 function visibleTestId(page: Page, testId: string) {
   return page.locator(`[data-testid="${testId}"]:visible`).first();
+}
+
+function waitForServerActionResponse(page: Page, pathname: string) {
+  return page.waitForResponse((response) => {
+    if (response.request().method() !== "POST") return false;
+    const responsePathname = new URL(response.url()).pathname;
+    return responsePathname === pathname || responsePathname === `${pathname}.rsc`;
+  });
 }
 
 test.describe("Next.js compat: useRouter().bfcacheId", () => {
@@ -228,10 +238,7 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     const initialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     await visibleTestId(page, "leaf-input").fill("server-action-state");
 
-    const actionResponse = page.waitForResponse(
-      (response) =>
-        response.request().method() === "POST" && response.url().includes(`${ROUTE}/x/1.rsc`),
-    );
+    const actionResponse = waitForServerActionResponse(page, `${ROUTE}/x/1`);
     await visibleTestId(page, "server-action-refresh").click();
     await actionResponse;
 
@@ -251,10 +258,7 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await revealAndClick(page, `${ROUTE}/x/2`);
     await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
 
-    const actionResponse = page.waitForResponse(
-      (response) =>
-        response.request().method() === "POST" && response.url().includes(`${ROUTE}/x/2.rsc`),
-    );
+    const actionResponse = waitForServerActionResponse(page, `${ROUTE}/x/2`);
     await visibleTestId(page, "server-action-refresh").click();
     await actionResponse;
 

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -94,4 +94,26 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await page.getByTestId("refresh").click();
     await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
   });
+
+  test("mints bfcacheIds for programmatic push and replace", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    const pushInitialBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    await page.getByTestId("router-push-x-2").click();
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
+    const pushedBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    expect(pushedBfcacheId).toMatch(/^_b_\d+_$/);
+    expect(pushedBfcacheId).not.toBe(pushInitialBfcacheId);
+
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    const replaceInitialBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    await page.getByTestId("router-replace-x-2").click();
+    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
+    const replacedBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    expect(replacedBfcacheId).toMatch(/^_b_\d+_$/);
+    expect(replacedBfcacheId).not.toBe(replaceInitialBfcacheId);
+  });
 });

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -15,6 +15,10 @@ async function revealAndClick(page: Page, href: string) {
   await page.locator(`a[href="${href}"]`).first().click();
 }
 
+function visibleTestId(page: Page, testId: string) {
+  return page.locator(`[data-testid="${testId}"]:visible`).first();
+}
+
 test.describe("Next.js compat: useRouter().bfcacheId", () => {
   test("mints bfcacheIds for fresh leaf navigations and restores them on history traversal", async ({
     page,
@@ -22,60 +26,62 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
-    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText("0");
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText("_b_0_");
 
     await revealAndClick(page, `${ROUTE}/x/2`);
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
-    const x2BfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    const x2BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     expect(x2BfcacheId).toMatch(/^_b_\d+_$/);
+    await visibleTestId(page, "leaf-input").fill("x2-state");
 
     await revealAndClick(page, `${ROUTE}/x/1`);
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/1`);
-    const freshX1BfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
+    const freshX1BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     expect(freshX1BfcacheId).toMatch(/^_b_\d+_$/);
     expect(freshX1BfcacheId).not.toBe(x2BfcacheId);
 
     await page.goBack();
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
-    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
+    await expect(visibleTestId(page, "leaf-input")).toHaveValue("x2-state");
   });
 
   test("resets leaf form state when re-entering a route via fresh push", async ({ page }) => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
-    await page.getByTestId("leaf-input").fill("hello");
+    await visibleTestId(page, "leaf-input").fill("hello");
     await revealAndClick(page, `${ROUTE}/x/2`);
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
 
     await revealAndClick(page, `${ROUTE}/x/1`);
-    await expect(page.getByTestId("leaf-input")).toHaveValue("");
+    await expect(visibleTestId(page, "leaf-input")).toHaveValue("");
   });
 
   test("preserves shared layout state across sibling leaf navigations", async ({ page }) => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
-    await page.getByTestId("layout-input").fill("layout");
-    const xLayoutBfcacheId = await page.getByTestId("layout-bfcache-id").textContent();
+    await visibleTestId(page, "layout-input").fill("layout");
+    const xLayoutBfcacheId = await visibleTestId(page, "layout-bfcache-id").textContent();
 
     await revealAndClick(page, `${ROUTE}/x/2`);
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
-    await expect(page.getByTestId("layout-input")).toHaveValue("layout");
-    await expect(page.getByTestId("layout-bfcache-id")).toHaveText(xLayoutBfcacheId ?? "");
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "layout-input")).toHaveValue("layout");
+    await expect(visibleTestId(page, "layout-bfcache-id")).toHaveText(xLayoutBfcacheId ?? "");
   });
 
   test("resets shared layout state when navigating across dynamic groups", async ({ page }) => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
-    await page.getByTestId("layout-input").fill("layout");
-    const xLayoutBfcacheId = await page.getByTestId("layout-bfcache-id").textContent();
+    await visibleTestId(page, "layout-input").fill("layout");
+    const xLayoutBfcacheId = await visibleTestId(page, "layout-bfcache-id").textContent();
 
     await revealAndClick(page, `${ROUTE}/y/1`);
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/y/1`);
-    await expect(page.getByTestId("layout-input")).toHaveValue("");
-    const yLayoutBfcacheId = await page.getByTestId("layout-bfcache-id").textContent();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/y/1`);
+    await expect(visibleTestId(page, "layout-input")).toHaveValue("");
+    const yLayoutBfcacheId = await visibleTestId(page, "layout-bfcache-id").textContent();
     expect(yLayoutBfcacheId).not.toBe(xLayoutBfcacheId);
   });
 
@@ -83,37 +89,57 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
-    const initialBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    const initialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await visibleTestId(page, "leaf-input").fill("refresh-state");
     await revealAndClick(page, `${ROUTE}/x/1#section`);
-    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
 
     await revealAndClick(page, `${ROUTE}/x/1?q=2`);
-    await expect(page.getByTestId("search")).toHaveAttribute("data-value", "q=2");
-    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+    await expect(visibleTestId(page, "search")).toHaveAttribute("data-value", "q=2");
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
 
-    await page.getByTestId("refresh").click();
-    await expect(page.getByTestId("leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+    await visibleTestId(page, "refresh").click();
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+    await expect(visibleTestId(page, "leaf-input")).toHaveValue("refresh-state");
   });
 
   test("mints bfcacheIds for programmatic push and replace", async ({ page }) => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
-    const pushInitialBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
-    await page.getByTestId("router-push-x-2").click();
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
-    const pushedBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    const pushInitialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await visibleTestId(page, "router-push-x-2").click();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    const pushedBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     expect(pushedBfcacheId).toMatch(/^_b_\d+_$/);
     expect(pushedBfcacheId).not.toBe(pushInitialBfcacheId);
 
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);
 
-    const replaceInitialBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
-    await page.getByTestId("router-replace-x-2").click();
-    await expect(page.getByTestId("pathname")).toHaveText(`${ROUTE}/x/2`);
-    const replacedBfcacheId = await page.getByTestId("leaf-bfcache-id").textContent();
+    const replaceInitialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await visibleTestId(page, "router-replace-x-2").click();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    const replacedBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
     expect(replacedBfcacheId).toMatch(/^_b_\d+_$/);
     expect(replacedBfcacheId).not.toBe(replaceInitialBfcacheId);
+  });
+
+  test("preserves leaf form state across a server action refresh", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    const initialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await visibleTestId(page, "leaf-input").fill("server-action-state");
+
+    const actionResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" && response.url().includes(`${ROUTE}/x/1.rsc`),
+    );
+    await visibleTestId(page, "server-action-refresh").click();
+    await actionResponse;
+
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+    await expect(visibleTestId(page, "leaf-input")).toHaveValue("server-action-state");
   });
 });

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -146,6 +146,64 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     expect(replacedBfcacheId).not.toBe(replaceInitialBfcacheId);
   });
 
+  test("does not reuse restored bfcacheIds after a traverse redirect", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    await visibleTestId(page, "layout-input").fill("stale-layout-state");
+    const staleLayoutBfcacheId = await visibleTestId(page, "layout-bfcache-id").textContent();
+    const staleHistoryState = await page.evaluate(() => structuredClone(window.history.state));
+
+    await revealAndClick(page, `${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+
+    await page.evaluate(
+      ({ currentHref, redirectHref, staleHistoryState }) => {
+        window.history.pushState(staleHistoryState, "", redirectHref);
+        window.history.pushState(window.history.state, "", currentHref);
+      },
+      {
+        currentHref: `${ROUTE}/x/2`,
+        redirectHref: "/nextjs-compat/use-router-bfcache-id-redirect-to-y",
+        staleHistoryState,
+      },
+    );
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}${ROUTE}/y/1`);
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/y/1`);
+    const redirectedLayoutBfcacheId = await visibleTestId(page, "layout-bfcache-id").textContent();
+    expect(redirectedLayoutBfcacheId).toMatch(/^_b_\d+_$/);
+    expect(redirectedLayoutBfcacheId).not.toBe(staleLayoutBfcacheId);
+    await expect(visibleTestId(page, "layout-input")).toHaveValue("");
+  });
+
+  test("mints fresh bfcacheIds for intercepted slot target changes and restores ids on back", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/feed`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#feed-photo-42-link").click();
+    await expect(visibleTestId(page, "photo-modal")).toContainText("Viewing photo 42");
+    const photo42BfcacheId = await visibleTestId(page, "photo-modal-bfcache-id").textContent();
+    expect(photo42BfcacheId).toMatch(/^_b_\d+_$/);
+    await visibleTestId(page, "photo-modal-input").fill("photo-42-state");
+
+    await page.locator("#modal-photo-43-link").click();
+    await expect(visibleTestId(page, "photo-modal")).toContainText("Viewing photo 43");
+    const photo43BfcacheId = await visibleTestId(page, "photo-modal-bfcache-id").textContent();
+    expect(photo43BfcacheId).toMatch(/^_b_\d+_$/);
+    expect(photo43BfcacheId).not.toBe(photo42BfcacheId);
+    await expect(visibleTestId(page, "photo-modal-input")).toHaveValue("");
+    await visibleTestId(page, "photo-modal-input").fill("photo-43-state");
+
+    await page.goBack();
+    await expect(visibleTestId(page, "photo-modal")).toContainText("Viewing photo 42");
+    await expect(visibleTestId(page, "photo-modal-bfcache-id")).toHaveText(photo42BfcacheId ?? "");
+    await expect(visibleTestId(page, "photo-modal-input")).not.toHaveValue("photo-43-state");
+  });
+
   test("preserves leaf form state across a server action refresh", async ({ page }) => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -1,6 +1,11 @@
 /**
  * Next.js Compat E2E: useRouter().bfcacheId
  * Ported from: https://github.com/vercel/next.js/blob/56d95137fd6d84f4bc1e5ef2bb31e0136d5fad9c/test/e2e/app-dir/use-router-bfcache-id/use-router-bfcache-id.test.ts
+ *
+ * Next.js also covers Activity-backed form-state preservation on browser back.
+ * Vinext does not implement React Activity yet, so those assertions are
+ * intentionally omitted here; these tests focus on bfcacheId semantics and
+ * same-segment DOM state that vinext preserves today.
  */
 
 import { test, expect } from "@playwright/test";
@@ -123,12 +128,14 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await waitForAppRouterHydration(page);
 
     const initialBfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await visibleTestId(page, "leaf-input").fill("same-segment-state");
     await revealAndClick(page, `${ROUTE}/x/1#section`);
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
 
     await revealAndClick(page, `${ROUTE}/x/1?q=2`);
     await expect(visibleTestId(page, "search")).toHaveAttribute("data-value", "q=2");
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");
+    await expect(visibleTestId(page, "leaf-input")).toHaveValue("same-segment-state");
 
     await visibleTestId(page, "refresh").click();
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(initialBfcacheId ?? "");

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -44,6 +44,31 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
   });
 
+  test("keeps restored bfcacheIds after hard reload of a history entry", async ({ page }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    const x1BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    expect(x1BfcacheId).toBe("_b_0_");
+
+    await revealAndClick(page, `${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    const x2BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    expect(x2BfcacheId).toMatch(/^_b_\d+_$/);
+    expect(x2BfcacheId).not.toBe(x1BfcacheId);
+
+    await page.reload();
+    await waitForAppRouterHydration(page);
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
+
+    await visibleTestId(page, "leaf-input").fill("x2-state-after-reload");
+    await page.goBack();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x1BfcacheId ?? "");
+    await expect(visibleTestId(page, "leaf-input")).not.toHaveValue("x2-state-after-reload");
+  });
+
   test("resets leaf form state when re-entering a route via fresh push", async ({ page }) => {
     await page.goto(`${BASE}${ROUTE}/x/1`);
     await waitForAppRouterHydration(page);

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/bfcache-probe.tsx
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/bfcache-probe.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function PhotoModalBfcacheProbe() {
+  const router = useRouter();
+
+  return (
+    <>
+      <p data-testid="photo-modal-bfcache-id">{router.bfcacheId}</p>
+      <form key={router.bfcacheId}>
+        <input data-testid="photo-modal-input" defaultValue="" />
+      </form>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/@modal/(...)photos/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { getPhotoLikes } from "./actions";
+import { PhotoModalBfcacheProbe } from "./bfcache-probe";
 import { LikeButton } from "./like-button";
 import { PhotoModalRefreshButton } from "./refresh-button";
 
@@ -15,6 +16,7 @@ export default async function PhotoModal({ params }: { params: { id: string } })
       <Link href="/photos/43" id="modal-photo-43-link">
         Next Photo
       </Link>
+      <PhotoModalBfcacheProbe />
       <PhotoModalRefreshButton />
       <LikeButton id={params.id} initialLikes={initialLikes} />
     </div>

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id-redirect-to-y/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id-redirect-to-y/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RedirectToYPage() {
+  redirect("/nextjs-compat/use-router-bfcache-id/y/1");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
@@ -3,6 +3,8 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { LinkAccordion } from "../../components/link-accordion";
 
+const base = "/nextjs-compat/use-router-bfcache-id";
+
 export function LeafContent() {
   const router = useRouter();
   const pathname = usePathname();
@@ -23,6 +25,20 @@ export function LeafContent() {
       <LinkAccordion href={`${pathname}#section`}>same page (#section)</LinkAccordion>
       <button data-testid="refresh" onClick={() => router.refresh()} type="button">
         refresh
+      </button>
+      <button
+        data-testid="router-push-x-2"
+        onClick={() => router.push(`${base}/x/2`)}
+        type="button"
+      >
+        router push x2
+      </button>
+      <button
+        data-testid="router-replace-x-2"
+        onClick={() => router.replace(`${base}/x/2`)}
+        type="button"
+      >
+        router replace x2
       </button>
     </>
   );

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { LinkAccordion } from "../../components/link-accordion";
+import { refreshAction } from "../../actions";
 
 const base = "/nextjs-compat/use-router-bfcache-id";
 
@@ -26,6 +27,11 @@ export function LeafContent() {
       <button data-testid="refresh" onClick={() => router.refresh()} type="button">
         refresh
       </button>
+      <form action={refreshAction}>
+        <button data-testid="server-action-refresh" type="submit">
+          server action refresh
+        </button>
+      </form>
       <button
         data-testid="router-push-x-2"
         onClick={() => router.push(`${base}/x/2`)}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { LinkAccordion } from "../../components/link-accordion";
+
+export function LeafContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+
+  return (
+    <>
+      <h1 data-testid="pathname">{pathname}</h1>
+      <span data-testid="search" data-value={search}>
+        {search}
+      </span>
+      <p data-testid="leaf-bfcache-id">{router.bfcacheId}</p>
+      <form key={router.bfcacheId}>
+        <input data-testid="leaf-input" defaultValue="" />
+      </form>
+      <LinkAccordion href={`${pathname}?q=2`}>same page (?q=2)</LinkAccordion>
+      <LinkAccordion href={`${pathname}#section`}>same page (#section)</LinkAccordion>
+      <button data-testid="refresh" onClick={() => router.refresh()} type="button">
+        refresh
+      </button>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/page.tsx
@@ -1,0 +1,9 @@
+import { LeafContent } from "./leaf-content";
+
+export default function Page() {
+  return (
+    <main>
+      <LeafContent />
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/layout.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Suspense, type ReactNode } from "react";
+import { LinkAccordion } from "../components/link-accordion";
+
+const base = "/nextjs-compat/use-router-bfcache-id";
+
+export default function GroupLayout({ children }: { children: ReactNode }) {
+  const { bfcacheId } = useRouter();
+
+  return (
+    <section>
+      <nav>
+        <LinkAccordion href={`${base}/x/1`}>/x/1</LinkAccordion>
+        <LinkAccordion href={`${base}/x/2`}>/x/2</LinkAccordion>
+        <LinkAccordion href={`${base}/y/1`}>/y/1</LinkAccordion>
+      </nav>
+      <p data-testid="layout-bfcache-id">{bfcacheId}</p>
+      <form key={bfcacheId}>
+        <input data-testid="layout-input" defaultValue="" />
+      </form>
+      <Suspense fallback={null}>{children}</Suspense>
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { refresh } from "next/cache";
+
+export async function refreshAction() {
+  refresh();
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/components/link-accordion.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/components/link-accordion.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type ReactNode } from "react";
+
+export function LinkAccordion({ children, href }: { children: ReactNode; href: string }) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <>
+      <input
+        data-link-accordion={href}
+        checked={isVisible}
+        onChange={() => setIsVisible((value) => !value)}
+        type="checkbox"
+      />
+      {isVisible ? <Link href={href}>{children}</Link> : `${children} (link is hidden)`}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/page.tsx
@@ -1,0 +1,22 @@
+import { LinkAccordion } from "./components/link-accordion";
+
+const base = "/nextjs-compat/use-router-bfcache-id";
+
+export default function Page() {
+  return (
+    <main>
+      <h1>useRouter bfcacheId</h1>
+      <ul>
+        <li>
+          <LinkAccordion href={`${base}/x/1`}>/x/1</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href={`${base}/x/2`}>/x/2</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href={`${base}/y/1`}>/y/1</LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -155,6 +155,41 @@ describe("next/navigation shim", () => {
     ).toBe("<span>_b_7_</span>");
   });
 
+  it("useRouter() treats an empty string segment id as a valid context key", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const navigation = await import("../packages/vinext/src/shims/navigation.js");
+    const { AppRouterContext } =
+      await import("../packages/vinext/src/shims/internal/app-router-context.js");
+    const BfcacheIdMapContext = navigation.getBfcacheIdMapContext();
+    const BfcacheSegmentIdContext = navigation.getBfcacheSegmentIdContext();
+    if (!AppRouterContext || !BfcacheIdMapContext || !BfcacheSegmentIdContext) {
+      throw new Error("Expected bfcache contexts");
+    }
+
+    function Probe() {
+      return React.createElement("span", null, navigation.useRouter().bfcacheId);
+    }
+
+    expect(
+      renderToStaticMarkup(
+        React.createElement(
+          AppRouterContext.Provider,
+          { value: navigation.appRouterInstance },
+          React.createElement(
+            BfcacheIdMapContext.Provider,
+            { value: { "": "_b_9_" } },
+            React.createElement(
+              BfcacheSegmentIdContext.Provider,
+              { value: "" },
+              React.createElement(Probe),
+            ),
+          ),
+        ),
+      ),
+    ).toBe("<span>_b_9_</span>");
+  });
+
   it("useRouter() materializes the initial bfcacheId in Next-compatible format", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -55,22 +55,30 @@ describe("next/navigation shim", () => {
     );
   });
 
-  // Regression test: within the App Router provider, useRouter() must return
-  // the mounted router instance. Next.js returns a stable router reference from
-  // context, so components using the router in dependency arrays do not
-  // re-render unnecessarily.
-  // Ported from: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/hooks/hooks.test.ts
-  it("useRouter() returns the mounted AppRouterContext router", async () => {
+  // Regression test: within the App Router provider, useRouter() must preserve
+  // the mounted router instance as the source of method behavior and only layer
+  // contextual bfcacheId on top.
+  // Ported from: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/navigation.ts
+  it("useRouter() preserves methods from the mounted AppRouterContext router", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
-    const { useRouter, appRouterInstance } =
-      await import("../packages/vinext/src/shims/navigation.js");
+    const navigation = await import("../packages/vinext/src/shims/navigation.js");
     const { AppRouterContext } =
       await import("../packages/vinext/src/shims/internal/app-router-context.js");
-    const captured: unknown[] = [];
+    const customRefresh = vi.fn();
+    const customMethod = vi.fn(() => "custom");
+    const mountedRouter = {
+      ...navigation.appRouterInstance,
+      refresh: customRefresh,
+      customMethod,
+    };
+    const captured: any[] = [];
 
     function Probe() {
-      captured.push(useRouter(), useRouter());
+      const router = navigation.useRouter() as typeof mountedRouter;
+      captured.push(router);
+      router.refresh();
+      router.customMethod();
       return React.createElement("span", null, "ok");
     }
 
@@ -81,12 +89,18 @@ describe("next/navigation shim", () => {
     renderToStaticMarkup(
       React.createElement(
         AppRouterContext.Provider,
-        { value: appRouterInstance },
+        { value: mountedRouter },
         React.createElement(Probe),
       ),
     );
 
-    expect(captured).toEqual([appRouterInstance, appRouterInstance]);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).not.toBe(mountedRouter);
+    expect(captured[0].refresh).toBe(customRefresh);
+    expect(captured[0].customMethod).toBe(customMethod);
+    expect(captured[0].bfcacheId).toBe("_b_0_");
+    expect(customRefresh).toHaveBeenCalledTimes(1);
+    expect(customMethod).toHaveBeenCalledTimes(1);
   });
 
   it("appRouterInstance singleton exposes the expected navigation methods", async () => {
@@ -139,6 +153,41 @@ describe("next/navigation shim", () => {
         ),
       ),
     ).toBe("<span>_b_7_</span>");
+  });
+
+  it("useRouter() materializes the initial bfcacheId in Next-compatible format", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const navigation = await import("../packages/vinext/src/shims/navigation.js");
+    const { AppRouterContext } =
+      await import("../packages/vinext/src/shims/internal/app-router-context.js");
+    const BfcacheIdMapContext = navigation.getBfcacheIdMapContext();
+    const BfcacheSegmentIdContext = navigation.getBfcacheSegmentIdContext();
+    if (!AppRouterContext || !BfcacheIdMapContext || !BfcacheSegmentIdContext) {
+      throw new Error("Expected bfcache contexts");
+    }
+
+    function Probe() {
+      return React.createElement("span", null, navigation.useRouter().bfcacheId);
+    }
+
+    expect(
+      renderToStaticMarkup(
+        React.createElement(
+          AppRouterContext.Provider,
+          { value: navigation.appRouterInstance },
+          React.createElement(
+            BfcacheIdMapContext.Provider,
+            { value: { "page:/x/1": "0" } },
+            React.createElement(
+              BfcacheSegmentIdContext.Provider,
+              { value: "page:/x/1" },
+              React.createElement(Probe),
+            ),
+          ),
+        ),
+      ),
+    ).toBe("<span>_b_0_</span>");
   });
 
   // Next.js parity: refresh-reducer.ts invalidates the entire segment cache.

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -249,6 +249,7 @@ describe("next/navigation shim", () => {
     const previousDocument = (globalThis as any).document;
     let historyState: unknown = {
       __vinext_bfcacheIds: { "page:/current": "_b_1_" },
+      __vinext_bfcacheVersion: 2,
       __vinext_previousNextUrl: "/feed",
       customState: "drop-me",
     };
@@ -316,6 +317,7 @@ describe("next/navigation shim", () => {
       expect(pushState).toHaveBeenCalledWith(
         {
           __vinext_bfcacheIds: { "page:/current": "_b_1_" },
+          __vinext_bfcacheVersion: 2,
           __vinext_previousNextUrl: "/feed",
         },
         "",

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -195,6 +195,99 @@ describe("next/navigation shim", () => {
     }
   });
 
+  it("hash-only app router navigation preserves bfcache metadata without copying scroll restoration", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    let historyState: unknown = {
+      __vinext_bfcacheIds: { "page:/current": "_b_1_" },
+      __vinext_previousNextUrl: "/feed",
+      customState: "drop-me",
+    };
+    const location = {
+      href: "http://localhost/current",
+      origin: "http://localhost",
+      pathname: "/current",
+      search: "",
+      hash: "",
+      assign: vi.fn(),
+      replace: vi.fn(),
+    };
+    const applyUrl = (url: string | URL | null | undefined) => {
+      if (url == null) return;
+      const next = new URL(String(url), location.href);
+      location.href = next.href;
+      location.pathname = next.pathname;
+      location.search = next.search;
+      location.hash = next.hash;
+    };
+    const pushState = vi.fn((data: unknown, _unused: string, url?: string | URL | null) => {
+      historyState = data;
+      applyUrl(url);
+    });
+    const replaceState = vi.fn((data: unknown, _unused: string, url?: string | URL | null) => {
+      historyState = data;
+      applyUrl(url);
+    });
+
+    const win = {
+      location,
+      history: {
+        get state() {
+          return historyState;
+        },
+        pushState,
+        replaceState,
+      },
+      scrollX: 12,
+      scrollY: 345,
+      scrollTo: vi.fn(),
+      addEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      __VINEXT_RSC_NAVIGATE__: vi.fn(),
+    };
+    const scrollIntoView = vi.fn();
+
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      getElementById: vi.fn(() => ({ scrollIntoView })),
+      getElementsByName: vi.fn(() => []),
+    };
+
+    try {
+      vi.resetModules();
+      const { navigateClientSide } = await import("../packages/vinext/src/shims/navigation.js");
+
+      await navigateClientSide("#content", "push", true, true);
+
+      expect(replaceState).toHaveBeenCalledWith(
+        expect.objectContaining({ __vinext_scrollX: 12, __vinext_scrollY: 345 }),
+        "",
+        undefined,
+      );
+      expect(pushState).toHaveBeenCalledWith(
+        {
+          __vinext_bfcacheIds: { "page:/current": "_b_1_" },
+          __vinext_previousNextUrl: "/feed",
+        },
+        "",
+        "/current#content",
+      );
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (previousDocument === undefined) {
+        delete (globalThis as any).document;
+      } else {
+        (globalThis as any).document = previousDocument;
+      }
+      vi.resetModules();
+    }
+  });
+
   it("keeps pending render snapshot active when external history.pushState syncs the URL", async () => {
     const previousWindow = (globalThis as any).window;
     const win = {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -106,6 +106,41 @@ describe("next/navigation shim", () => {
     expect(appRouterInstance.bfcacheId).toBe("0");
   });
 
+  it("useRouter() reads bfcacheId from the nearest segment context", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const navigation = await import("../packages/vinext/src/shims/navigation.js");
+    const { AppRouterContext } =
+      await import("../packages/vinext/src/shims/internal/app-router-context.js");
+    const BfcacheIdMapContext = navigation.getBfcacheIdMapContext();
+    const BfcacheSegmentIdContext = navigation.getBfcacheSegmentIdContext();
+    if (!AppRouterContext || !BfcacheIdMapContext || !BfcacheSegmentIdContext) {
+      throw new Error("Expected bfcache contexts");
+    }
+
+    function Probe() {
+      return React.createElement("span", null, navigation.useRouter().bfcacheId);
+    }
+
+    expect(
+      renderToStaticMarkup(
+        React.createElement(
+          AppRouterContext.Provider,
+          { value: navigation.appRouterInstance },
+          React.createElement(
+            BfcacheIdMapContext.Provider,
+            { value: { "page:/x/1": "_b_7_" } },
+            React.createElement(
+              BfcacheSegmentIdContext.Provider,
+              { value: "page:/x/1" },
+              React.createElement(Probe),
+            ),
+          ),
+        ),
+      ),
+    ).toBe("<span>_b_7_</span>");
+  });
+
   // Next.js parity: refresh-reducer.ts invalidates the entire segment cache.
   // Our equivalent is clearClientNavigationCaches(), which router.refresh()
   // must call before re-fetching, or stale cached RSC payloads for sibling


### PR DESCRIPTION
## Summary
- Implements segment-scoped `useRouter().bfcacheId` semantics for the App Router shim.
- Persists Vinext-owned bfcache id maps in history state so back/forward traversal can restore previous ids.
- Provides bfcache contexts through the browser/SSR route tree and layers the contextual `bfcacheId` onto the mounted `AppRouterContext` router.
- Preserves bfcache metadata during hash-only navigation while avoiding stale scroll restoration/custom history state.
- Includes two browser redirect lifecycle fixes that affect App Router navigations even when user code does not read `bfcacheId`; these are called out below.

## Feedback addressed
This is a fresh follow-up based on the review feedback from the earlier bfcacheId PR. In particular, this version:
- keeps `AppRouterContext` as the authority for router methods and only adds the contextual `bfcacheId` in `useRouter()`
- formats the public zero sentinel as `_b_0_` while sharing the internal zero sentinel constant across the shim/runtime
- documents the intentional raw `"0"` hydration sentinel inside `BfcacheIdMap`; minted ids use `_b_N_`, and the public hook formats both into the opaque public shape
- documents the intentional hard-reload reset to the zero sentinel and uses version-gated history restoration to avoid cross-document id collisions
- preserves bfcache ids after reducer-level element merges, including planner-approved parallel route state
- clears stale restored ids across redirected traversals and server-action/cache invalidation paths
- includes active slot route identity for intercepted/parallel slot bfcache ids
- adds programmatic `router.push()` / `router.replace()` and forward-after-reload coverage in the E2E fixture
- documents that Next.js Activity-backed form-state-on-back assertions are intentionally omitted until vinext implements React Activity
- verifies same-segment input state survives search-param navigation while the leaf `bfcacheId` stays stable

## Compatibility note
`useRouter()` now returns a memoized wrapper around the mounted context router instead of the old module-level singleton. This is intentional Next.js App Router parity so custom/instrumented context router methods are preserved while the nearest segment's `bfcacheId` is added. This is slightly more permissive than Next.js's explicit method list, but it avoids dropping vinext-provided or user-instrumented router methods.

## Redirect lifecycle fixes included in this PR
These fixes are bundled here because redirect hops need to keep bfcache metadata coherent, but they are genuine browser navigation behavior changes for all App Router users:

- Cached visited-response redirects are now followed. Previously, a cached route whose stored response pointed at a redirect target could be treated as the terminal payload. The browser navigation loop now resolves that redirect lifecycle hop, applies the max-redirect guard, and continues to the final target.
- Flight redirects now realign history bookkeeping. Previously, the `X-Vinext-Rsc-Redirect` path updated `currentHref` and the redirect count, but could leave `currentHistoryMode` and `currentPrevNextUrl` stale. The redirect path now defaults unspecified redirects to `replace` and threads the request's previous/next URL through the redirect chain, preventing redirected navigations from committing with the wrong history mode or previous/next metadata.
- For traversal navigations, every redirect hop that changes the target href clears `restoredBfcacheIds`. This keeps vinext's `restored > currentValue > mint` priority chain from applying stale history-state ids from the pre-redirect entry to the redirected payload.

## Tests
- `pnpm exec vp check packages/vinext/src/server/app-bfcache-id.ts packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/server/app-browser-state.ts packages/vinext/src/shims/navigation.ts packages/vinext/src/shims/slot.tsx tests/shims.test.ts tests/app-browser-entry.test.ts tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts`
- `pnpm exec vp test run --project unit tests/shims.test.ts -t "useRouter|hash-only"`
- `pnpm exec vp test run --project unit tests/app-browser-entry.test.ts -t "bfcache|history state|version|intercepted slot|redirected traverse"`
- `pnpm exec vp check tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts`
