### PR TITLE
fix(app-router): preserve source identity for intercepted renders

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -29,6 +29,12 @@ type AppPageCacheSetter = (
   expireSeconds?: number,
 ) => Promise<void>;
 type AppPageBackgroundRegenerator = (key: string, renderFn: () => Promise<void>) => void;
+type AppPageRscCacheKeyBuilder = (
+  pathname: string,
+  mountedSlotsHeader?: string | null,
+  renderMode?: AppRscRenderMode,
+  interceptionContext?: string | null,
+) => string;
 type AppPageRequestCacheLife = {
   revalidate?: number;
   expire?: number;
@@ -85,12 +91,9 @@ type ReadAppPageCacheResponseOptions = {
   isrDebug?: AppPageDebugLogger;
   isrGet: AppPageCacheGetter;
   isrHtmlKey: (pathname: string) => string;
-  isrRscKey: (
-    pathname: string,
-    mountedSlotsHeader?: string | null,
-    renderMode?: AppRscRenderMode,
-  ) => string;
+  isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
+  interceptionContext?: string | null;
   middlewareHeaders?: Headers | null;
   middlewareStatus?: number | null;
   mountedSlotsHeader?: string | null;
@@ -114,12 +117,9 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   getRequestCacheLife?: () => AppPageRequestCacheLife | null;
   isrDebug?: AppPageDebugLogger;
   isrHtmlKey: (pathname: string) => string;
-  isrRscKey: (
-    pathname: string,
-    mountedSlotsHeader?: string | null,
-    renderMode?: AppRscRenderMode,
-  ) => string;
+  isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
+  interceptionContext?: string | null;
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
@@ -136,12 +136,9 @@ type ScheduleAppPageRscCacheWriteOptions = {
   getPageTags: () => string[];
   getRequestCacheLife?: () => AppPageRequestCacheLife | null;
   isrDebug?: AppPageDebugLogger;
-  isrRscKey: (
-    pathname: string,
-    mountedSlotsHeader?: string | null,
-    renderMode?: AppRscRenderMode,
-  ) => string;
+  isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
+  interceptionContext?: string | null;
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
   preserveClientResponseHeaders?: boolean;
@@ -309,7 +306,12 @@ export async function readAppPageCacheResponse(
   options: ReadAppPageCacheResponseOptions,
 ): Promise<Response | null> {
   const isrKey = options.isRscRequest
-    ? options.isrRscKey(options.cleanPathname, options.mountedSlotsHeader, options.renderMode)
+    ? options.isrRscKey(
+        options.cleanPathname,
+        options.mountedSlotsHeader,
+        options.renderMode,
+        options.interceptionContext,
+      )
     : options.isrHtmlKey(options.cleanPathname);
   const artifact = options.isRscRequest ? "rsc" : "html";
 
@@ -367,7 +369,12 @@ export async function readAppPageCacheResponse(
 
     if (cached?.isStale && cachedValue) {
       const regenerationKey = options.isRscRequest
-        ? options.isrRscKey(options.cleanPathname, options.mountedSlotsHeader, options.renderMode)
+        ? options.isrRscKey(
+            options.cleanPathname,
+            options.mountedSlotsHeader,
+            options.renderMode,
+            options.interceptionContext,
+          )
         : options.isrHtmlKey(options.cleanPathname);
 
       // Preserve the legacy behavior from the inline generator: stale entries
@@ -384,6 +391,7 @@ export async function readAppPageCacheResponse(
               options.cleanPathname,
               options.mountedSlotsHeader,
               options.renderMode,
+              options.interceptionContext,
             ),
             buildAppPageCacheValue(
               "",
@@ -490,7 +498,12 @@ export function finalizeAppPageHtmlCacheResponse(
 
   const [streamForClient, streamForCache] = response.body.tee();
   const htmlKey = options.isrHtmlKey(options.cleanPathname);
-  const rscKey = options.isrRscKey(options.cleanPathname, null);
+  const rscKey = options.isrRscKey(
+    options.cleanPathname,
+    null,
+    undefined,
+    options.interceptionContext,
+  );
   const clientHeaders = new Headers(response.headers);
   if (options.preserveClientResponseHeaders !== true) {
     // HTML Server Components can access request APIs while the stream is being
@@ -617,6 +630,7 @@ export function scheduleAppPageRscCacheWrite(
     options.cleanPathname,
     options.mountedSlotsHeader,
     options.renderMode,
+    options.interceptionContext,
   );
   const cachePromise = (async () => {
     try {

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -45,6 +45,7 @@ import {
 import { resolveAppPageMethodResponse } from "./app-page-method.js";
 import {
   buildAppPageElement,
+  resolveAppPageInterceptionRerenderTarget,
   resolveAppPageIntercept,
   validateAppPageDynamicParams,
   type ValidateAppPageDynamicParamsOptions,
@@ -413,28 +414,47 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       // cacheLife-only routes discover their actual revalidate during the
       // fresh render; this seed only gets them into the cache read path.
       revalidateSeconds: currentRevalidateSeconds ?? 0,
-      renderFreshPageForCache: async () =>
-        runAppPageRevalidationContext(
+      renderFreshPageForCache: async () => {
+        const revalidationTarget = resolveAppPageInterceptionRerenderTarget({
+          cleanPathname: options.cleanPathname,
+          currentParams: options.params,
+          currentRoute: route,
+          findIntercept: options.findIntercept,
+          getRouteParamNames(sourceRoute) {
+            return sourceRoute.params;
+          },
+          getSourceRoute(sourceRouteIndex) {
+            return options.getSourceRoute(sourceRouteIndex);
+          },
+          isRscRequest: options.isRscRequest,
+          toInterceptOpts(intercept) {
+            return toInterceptOptions(options.interceptionContext, intercept);
+          },
+        });
+
+        return runAppPageRevalidationContext(
           {
             cleanPathname: options.cleanPathname,
-            currentFetchCacheMode: options.fetchCache ?? null,
+            currentFetchCacheMode:
+              options.resolveRouteFetchCacheMode?.(revalidationTarget.route) ??
+              (revalidationTarget.route === route ? (options.fetchCache ?? null) : null),
             draftModeSecret: options.draftModeSecret,
             dynamicConfig,
-            params: options.params,
-            routePattern: route.pattern,
-            routeSegments: route.routeSegments,
+            params: revalidationTarget.navigationParams,
+            routePattern: revalidationTarget.route.pattern,
+            routeSegments: revalidationTarget.route.routeSegments,
             setNavigationContext: options.setNavigationContext,
           },
           async () => {
             const revalidatedElement = await options.buildPageElement(
-              route,
-              options.params,
-              undefined,
+              revalidationTarget.route,
+              revalidationTarget.params,
+              revalidationTarget.interceptOpts,
               new URLSearchParams(),
             );
             const revalidatedOnError = options.createRscOnErrorHandler(
               options.cleanPathname,
-              route.pattern,
+              revalidationTarget.route.pattern,
             );
             // No inner runWithFetchDedupe here: this renderFn is already
             // wrapped in runWithFetchDedupe by runAppPageRevalidationContext.
@@ -472,7 +492,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
             const tags = buildAppPageTags(
               options.cleanPathname,
               getCollectedFetchTags(),
-              route.routeSegments,
+              revalidationTarget.route.routeSegments,
             );
             // Consume once: HTML and RSC artifacts are produced by the same
             // regeneration render and should carry the same observation set.
@@ -492,9 +512,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
                   element: revalidatedElement,
                   renderEpoch: null,
                   rootBoundaryId: null,
-                  routePattern: route.pattern,
+                  routePattern: revalidationTarget.route.pattern,
                 }),
-                params: options.params,
+                params: revalidationTarget.navigationParams,
                 state: observationState,
               }),
               rscData,
@@ -509,9 +529,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
                   mountedSlotsHeader: options.mountedSlotsHeader,
                   renderEpoch: null,
                   rootBoundaryId: null,
-                  routePattern: route.pattern,
+                  routePattern: revalidationTarget.route.pattern,
                 }),
-                params: options.params,
+                params: revalidationTarget.navigationParams,
                 state: observationState,
               }),
               tags,
@@ -521,7 +541,8 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
                   : undefined,
             };
           },
-        ),
+        );
+      },
       scheduleBackgroundRegeneration(key, renderFn) {
         options.scheduleBackgroundRegeneration(key, renderFn, {
           routerKind: "App Router",

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -186,6 +186,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
     pathname: string,
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
+    interceptionContext?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
@@ -403,6 +404,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       isrHtmlKey: options.isrHtmlKey,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
+      interceptionContext: options.interceptionContext,
       middlewareHeaders: options.middlewareContext.headers,
       middlewareStatus: options.middlewareContext.status,
       mountedSlotsHeader: options.mountedSlotsHeader,
@@ -676,6 +678,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     isrHtmlKey: options.isrHtmlKey,
     isrRscKey: options.isrRscKey,
     isrSet: options.isrSet,
+    interceptionContext: options.interceptionContext,
     expireSeconds: options.expireSeconds,
     layoutCount: route.layouts.length,
     loadSsrHandler: options.loadSsrHandler,

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -10,11 +10,10 @@ import {
   type AppPageRouteWiringRoute,
   type AppPageSlotOverride,
 } from "./app-page-route-wiring.js";
-import { AppElementsWire, type AppElements, type AppElementsInterception } from "./app-elements.js";
+import { AppElementsWire, type AppElements } from "./app-elements.js";
 import type { AppPageParams } from "./app-page-boundary.js";
 import { DEFAULT_GLOBAL_ERROR_MODULE } from "./default-global-error-module.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
-import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
 import { APP_RSC_RENDER_MODE_NAVIGATION, type AppRscRenderMode } from "./app-rsc-render-mode.js";
 import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -16,7 +16,7 @@ import { DEFAULT_GLOBAL_ERROR_MODULE } from "./default-global-error-module.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
 import { APP_RSC_RENDER_MODE_NAVIGATION, type AppRscRenderMode } from "./app-rsc-render-mode.js";
-import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
+import { createAppPageRenderIdentity } from "./app-page-render-identity.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 
 export type { AppPageErrorModule, AppPageRouteWiringRoute } from "./app-page-route-wiring.js";
@@ -130,11 +130,14 @@ export async function buildPageElements<
   const pageModule: AppPageModule | null | undefined = route.page;
   const PageComponent = pageModule?.default;
   const hasPageModule = !!pageModule;
-  const interception = createAppPageInterceptionProof(routePath, opts);
+  const renderIdentity = createAppPageRenderIdentity({
+    displayPathname: routePath,
+    interceptionContext: opts?.interceptionContext ?? null,
+    interceptSourceMatchedUrl: opts?.interceptSourceMatchedUrl ?? null,
+    interceptSlotId: opts?.interceptSlotId ?? null,
+  });
 
   if (hasPageModule && !PageComponent) {
-    const interceptionContext = opts?.interceptionContext ?? null;
-    const noExportRouteId = AppElementsWire.encodeRouteId(routePath, interceptionContext);
     let noExportRootLayout: string | null = null;
     const noExportLayoutIds =
       route.ids?.layouts ??
@@ -149,13 +152,13 @@ export async function buildPageElements<
     }
     return {
       ...AppElementsWire.createMetadataEntries({
-        interception,
-        interceptionContext,
+        interception: renderIdentity.interception,
+        interceptionContext: renderIdentity.interceptionContext,
         layoutIds: noExportLayoutIds,
         rootLayoutTreePath: noExportRootLayout,
-        routeId: noExportRouteId,
+        routeId: renderIdentity.routeId,
       }),
-      [noExportRouteId]: createElement("div", null, "Page has no default export"),
+      [renderIdentity.routeId]: createElement("div", null, "Page has no default export"),
     };
   }
 
@@ -223,8 +226,7 @@ export async function buildPageElements<
     resolvedMetadata,
     resolvedMetadataPathname: routePath,
     resolvedViewport,
-    interceptionContext: opts?.interceptionContext ?? null,
-    interception,
+    renderIdentity,
     routePath,
     rootNotFoundModule: rootNotFoundModule ?? null,
     rootForbiddenModule: rootForbiddenModule ?? null,
@@ -233,32 +235,6 @@ export async function buildPageElements<
     slotOverrides,
     renderMode,
   });
-}
-
-function createAppPageInterceptionProof<TModule extends AppPageModule>(
-  routePath: string,
-  opts?: AppPageInterceptOptions<TModule> | null,
-): AppElementsInterception | null {
-  const sourceMatchedUrl = normalizeInterceptionProofMatchedUrl(
-    opts?.interceptSourceMatchedUrl ?? null,
-  );
-  const targetMatchedUrl = normalizeInterceptionProofMatchedUrl(routePath);
-  const slotId = opts?.interceptSlotId ?? null;
-  if (sourceMatchedUrl === null || targetMatchedUrl === null || slotId === null) return null;
-
-  return {
-    sourceMatchedUrl,
-    sourceRouteId: AppElementsWire.encodeRouteId(sourceMatchedUrl, null),
-    slotId,
-    targetMatchedUrl,
-    targetRouteId: AppElementsWire.encodeRouteId(targetMatchedUrl, null),
-  };
-}
-
-function normalizeInterceptionProofMatchedUrl(value: string | null): string | null {
-  if (value === null || !isInterceptionMatchedUrlPath(value)) return null;
-
-  return normalizePath(normalizePathnameForRouteMatch(value));
 }
 
 /**

--- a/packages/vinext/src/server/app-page-render-identity.ts
+++ b/packages/vinext/src/server/app-page-render-identity.ts
@@ -19,24 +19,24 @@ export type AppPageRenderIdentity = {
   targetMatchedPathname: string;
 };
 
-function normalizeMatchedPathname(pathname: string): string {
+function normalizeAppPageRenderMatchedPathname(pathname: string): string {
   if (!pathname.startsWith("/")) {
     throw new Error(`[vinext] App Router render pathname must be absolute: ${pathname}`);
   }
   return normalizePath(normalizePathnameForRouteMatch(pathname));
 }
 
-function normalizeInterceptionProofPathname(pathname: string | null): string | null {
+export function normalizeAppPageInterceptionProofPathname(pathname: string | null): string | null {
   if (pathname === null || !isInterceptionMatchedUrlPath(pathname)) return null;
-  return normalizeMatchedPathname(pathname);
+  return normalizeAppPageRenderMatchedPathname(pathname);
 }
 
 export function createAppPageRenderIdentity(
   input: AppPageRenderIdentityInput,
 ): AppPageRenderIdentity {
   const interceptionContext = input.interceptionContext ?? null;
-  const targetMatchedPathname = normalizeMatchedPathname(input.displayPathname);
-  const sourceMatchedPathname = normalizeInterceptionProofPathname(
+  const targetMatchedPathname = normalizeAppPageRenderMatchedPathname(input.displayPathname);
+  const sourceMatchedPathname = normalizeAppPageInterceptionProofPathname(
     input.interceptSourceMatchedUrl ?? null,
   );
   const slotId = input.interceptSlotId ?? null;

--- a/packages/vinext/src/server/app-page-render-identity.ts
+++ b/packages/vinext/src/server/app-page-render-identity.ts
@@ -1,0 +1,66 @@
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import { AppElementsWire, type AppElementsInterception } from "./app-elements.js";
+import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
+
+type AppPageRenderIdentityInput = {
+  displayPathname: string;
+  interceptionContext?: string | null;
+  interceptSourceMatchedUrl?: string | null;
+  interceptSlotId?: string | null;
+};
+
+export type AppPageRenderIdentity = {
+  displayPathname: string;
+  interception: AppElementsInterception | null;
+  interceptionContext: string | null;
+  matchedRoutePathname: string;
+  pageId: string;
+  routeId: string;
+  targetMatchedPathname: string;
+};
+
+function normalizeMatchedPathname(pathname: string): string {
+  if (!pathname.startsWith("/")) {
+    throw new Error(`[vinext] App Router render pathname must be absolute: ${pathname}`);
+  }
+  return normalizePath(normalizePathnameForRouteMatch(pathname));
+}
+
+function normalizeInterceptionProofPathname(pathname: string | null): string | null {
+  if (pathname === null || !isInterceptionMatchedUrlPath(pathname)) return null;
+  return normalizeMatchedPathname(pathname);
+}
+
+export function createAppPageRenderIdentity(
+  input: AppPageRenderIdentityInput,
+): AppPageRenderIdentity {
+  const interceptionContext = input.interceptionContext ?? null;
+  const targetMatchedPathname = normalizeMatchedPathname(input.displayPathname);
+  const sourceMatchedPathname = normalizeInterceptionProofPathname(
+    input.interceptSourceMatchedUrl ?? null,
+  );
+  const slotId = input.interceptSlotId ?? null;
+  const matchedRoutePathname = sourceMatchedPathname ?? targetMatchedPathname;
+  const routeId = AppElementsWire.encodeRouteId(matchedRoutePathname, null);
+  const pageId = AppElementsWire.encodePageId(matchedRoutePathname, null);
+  const interception =
+    sourceMatchedPathname === null || slotId === null
+      ? null
+      : {
+          sourceMatchedUrl: sourceMatchedPathname,
+          sourceRouteId: AppElementsWire.encodeRouteId(sourceMatchedPathname, null),
+          slotId,
+          targetMatchedUrl: targetMatchedPathname,
+          targetRouteId: AppElementsWire.encodeRouteId(targetMatchedPathname, null),
+        };
+
+  return {
+    displayPathname: input.displayPathname,
+    interception,
+    interceptionContext,
+    matchedRoutePathname,
+    pageId,
+    routeId,
+    targetMatchedPathname,
+  };
+}

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -103,8 +103,10 @@ type RenderAppPageLifecycleOptions = {
     pathname: string,
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
+    interceptionContext?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
+  interceptionContext?: string | null;
   layoutCount: number;
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
   middlewareContext: AppPageMiddlewareContext;
@@ -474,6 +476,7 @@ export async function renderAppPageLifecycle(
       isrDebug: options.isrDebug,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
+      interceptionContext: options.interceptionContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
       renderMode: options.renderMode,
       preserveClientResponseHeaders: rscResponsePolicy.cacheState !== "MISS",
@@ -679,6 +682,7 @@ export async function renderAppPageLifecycle(
       isrHtmlKey: options.isrHtmlKey,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
+      interceptionContext: options.interceptionContext,
       preserveClientResponseHeaders: !htmlResponsePolicy.shouldWriteToCache,
       expireSeconds,
       revalidateSeconds,

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -76,7 +76,7 @@ type AppPageInterceptState<TRoute, TPage> =
   | { kind: "current-route"; intercept: AppPageInterceptMatch<TPage> }
   | { kind: "source-route"; intercept: AppPageInterceptMatch<TPage>; sourceRoute: TRoute };
 
-type ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts> = {
+type ResolveAppPageInterceptionRerenderTargetOptions<TRoute, TPage, TInterceptOpts> = {
   cleanPathname: string;
   currentParams: AppPageParams;
   currentRoute: TRoute;
@@ -87,12 +87,18 @@ type ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts> = 
   toInterceptOpts: (intercept: AppPageInterceptMatch<TPage>) => TInterceptOpts;
 };
 
-type ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> = {
+type ResolveAppPageInterceptionRerenderTargetResult<TRoute, TInterceptOpts> = {
   interceptOpts: TInterceptOpts | undefined;
   navigationParams: AppPageParams;
   params: AppPageParams;
   route: TRoute;
 };
+
+type ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts> =
+  ResolveAppPageInterceptionRerenderTargetOptions<TRoute, TPage, TInterceptOpts>;
+
+type ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> =
+  ResolveAppPageInterceptionRerenderTargetResult<TRoute, TInterceptOpts>;
 
 type ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts, TElement> = {
   buildPageElement: (
@@ -333,9 +339,9 @@ function resolveAppPageInterceptState<TRoute, TPage, TInterceptOpts>(
   return { kind: "source-route", intercept, sourceRoute };
 }
 
-export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts>(
-  options: ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts>,
-): ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> {
+export function resolveAppPageInterceptionRerenderTarget<TRoute, TPage, TInterceptOpts>(
+  options: ResolveAppPageInterceptionRerenderTargetOptions<TRoute, TPage, TInterceptOpts>,
+): ResolveAppPageInterceptionRerenderTargetResult<TRoute, TInterceptOpts> {
   const interceptState = resolveAppPageInterceptState({
     cleanPathname: options.cleanPathname,
     currentRoute: options.currentRoute,
@@ -367,6 +373,12 @@ export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts
     params: options.currentParams,
     route: options.currentRoute,
   };
+}
+
+export function resolveAppPageActionRerenderTarget<TRoute, TPage, TInterceptOpts>(
+  options: ResolveAppPageActionRerenderTargetOptions<TRoute, TPage, TInterceptOpts>,
+): ResolveAppPageActionRerenderTargetResult<TRoute, TInterceptOpts> {
+  return resolveAppPageInterceptionRerenderTarget(options);
 }
 
 export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts, TElement>(

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -44,6 +44,7 @@ import {
   resolveAppPageRouteStateKey,
   resolveAppPageSegmentStateKey,
 } from "./app-page-segment-state.js";
+import type { AppPageRenderIdentity } from "./app-page-render-identity.js";
 
 export { resolveAppPageChildSegments } from "./app-page-segment-state.js";
 
@@ -171,6 +172,7 @@ type BuildAppPageElementsOptions<
   interceptionContext?: string | null;
   isRscRequest?: boolean;
   mountedSlotIds?: ReadonlySet<string> | null;
+  renderIdentity?: AppPageRenderIdentity;
   renderMode?: AppRscRenderMode;
   routePath: string;
 };
@@ -390,12 +392,17 @@ export function buildAppPageElements<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
 >(options: BuildAppPageElementsOptions<TModule, TErrorModule>): AppElements {
-  const interceptionContext = options.interceptionContext ?? null;
+  const renderIdentity = options.renderIdentity;
+  const interceptionContext =
+    renderIdentity?.interceptionContext ?? options.interceptionContext ?? null;
   const renderMode = options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION;
   const routeSegments = options.route.routeSegments ?? [];
   const routeResetKey = resolveAppPageRouteStateKey(routeSegments, options.matchedParams);
-  const routeId = AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
-  const pageId = AppElementsWire.encodePageId(options.routePath, interceptionContext);
+  const routeId =
+    renderIdentity?.routeId ??
+    AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
+  const pageId =
+    renderIdentity?.pageId ?? AppElementsWire.encodePageId(options.routePath, interceptionContext);
   const layoutEntries = createAppPageLayoutEntries(options.route);
   const templateEntries = createAppPageTemplateEntries(options.route);
   const errorEntries = createAppPageErrorEntries(options.route);
@@ -454,7 +461,7 @@ export function buildAppPageElements<
     ReactNode | string | null | AppElementsInterception | readonly AppElementsSlotBinding[]
   > = {
     ...AppElementsWire.createMetadataEntries({
-      interception: options.interception ?? null,
+      interception: renderIdentity?.interception ?? options.interception ?? null,
       interceptionContext,
       layoutIds: options.route.ids?.layouts ?? layoutEntries.map((entry) => entry.id),
       rootLayoutTreePath,

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -262,8 +262,8 @@ export function appIsrHtmlKey(pathname: string): string {
   return appIsrCacheKey(pathname, "html");
 }
 
-function normalizeInterceptionContextCacheVariant(interceptionContext: string): string {
-  if (!isInterceptionMatchedUrlPath(interceptionContext)) return interceptionContext;
+function normalizeInterceptionContextCacheVariant(interceptionContext: string): string | null {
+  if (!isInterceptionMatchedUrlPath(interceptionContext)) return null;
   return normalizePath(normalizePathnameForRouteMatch(interceptionContext));
 }
 

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -29,6 +29,8 @@ import {
   getRscRenderModeCacheVariant,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
+import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import type { RenderObservation } from "./cache-proof.js";
 export { normalizeMountedSlotsHeader };
 
@@ -260,6 +262,11 @@ export function appIsrHtmlKey(pathname: string): string {
   return appIsrCacheKey(pathname, "html");
 }
 
+function normalizeInterceptionContextCacheVariant(interceptionContext: string): string {
+  if (!isInterceptionMatchedUrlPath(interceptionContext)) return interceptionContext;
+  return normalizePath(normalizePathnameForRouteMatch(interceptionContext));
+}
+
 /**
  * Build the ISR cache key for an RSC payload.
  *
@@ -275,8 +282,12 @@ export function appIsrRscKey(
   interceptionContext?: string | null,
 ): string {
   const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
+  const sourceVariant =
+    interceptionContext === undefined || interceptionContext === null
+      ? null
+      : normalizeInterceptionContextCacheVariant(interceptionContext);
   const variant = [
-    interceptionContext ? `source:${fnv1a64(interceptionContext)}` : null,
+    sourceVariant ? `source:${fnv1a64(sourceVariant)}` : null,
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,
     getRscRenderModeCacheVariant(renderMode),
   ]

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -29,8 +29,7 @@ import {
   getRscRenderModeCacheVariant,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
-import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
-import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import { normalizeAppPageInterceptionProofPathname } from "./app-page-render-identity.js";
 import type { RenderObservation } from "./cache-proof.js";
 export { normalizeMountedSlotsHeader };
 
@@ -263,8 +262,7 @@ export function appIsrHtmlKey(pathname: string): string {
 }
 
 function normalizeInterceptionContextCacheVariant(interceptionContext: string): string | null {
-  if (!isInterceptionMatchedUrlPath(interceptionContext)) return null;
-  return normalizePath(normalizePathnameForRouteMatch(interceptionContext));
+  return normalizeAppPageInterceptionProofPathname(interceptionContext);
 }
 
 /**

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -261,17 +261,19 @@ export function appIsrHtmlKey(pathname: string): string {
   return appIsrCacheKey(pathname, "html");
 }
 
-function normalizeInterceptionContextCacheVariant(interceptionContext: string): string | null {
+function normalizeInterceptionContextForCacheKey(interceptionContext: string): string | null {
   return normalizeAppPageInterceptionProofPathname(interceptionContext);
 }
 
 /**
  * Build the ISR cache key for an RSC payload.
  *
- * Note: the key format changed from `rsc:<hash>` to `rsc:slots:<hash>` (and
- * optionally `rsc:slots:<hash>:<render-mode-variant>`). Existing cached entries under
- * the old format will become unreachable after deployment. This is acceptable
- * because ISR entries have TTLs and will be regenerated on the next request.
+ * Variants are sequenced in order: `source:<hash>` (intercepted source context,
+ * only when an interception context is present), `slots:<hash>` (mounted parallel
+ * route slots), and optionally `<render-mode-variant>` (e.g. `preserve-ui` or
+ * `prefetch-loading-shell`). Existing cached entries under the old format will
+ * become unreachable after deployment. This is acceptable because ISR entries
+ * have TTLs and will be regenerated on the next request.
  */
 export function appIsrRscKey(
   pathname: string,
@@ -283,7 +285,7 @@ export function appIsrRscKey(
   const sourceVariant =
     interceptionContext === undefined || interceptionContext === null
       ? null
-      : normalizeInterceptionContextCacheVariant(interceptionContext);
+      : normalizeInterceptionContextForCacheKey(interceptionContext);
   const variant = [
     sourceVariant ? `source:${fnv1a64(sourceVariant)}` : null,
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -272,9 +272,11 @@ export function appIsrRscKey(
   pathname: string,
   mountedSlotsHeader?: string | null,
   renderMode: AppRscRenderMode = APP_RSC_RENDER_MODE_NAVIGATION,
+  interceptionContext?: string | null,
 ): string {
   const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
   const variant = [
+    interceptionContext ? `source:${fnv1a64(interceptionContext)}` : null,
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,
     getRscRenderModeCacheVariant(renderMode),
   ]

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -934,11 +934,11 @@ describe("app browser entry state helpers", () => {
       currentState: createState(),
       nextElements: Promise.resolve(
         createResolvedElements(
-          "route:/photos/42\0/feed",
+          "route:/feed",
           "/",
           "/feed",
           {
-            "page:/photos/42": React.createElement("main", null, "photo"),
+            "page:/feed": React.createElement("main", null, "feed"),
           },
           [AppElementsWire.encodeLayoutId("/")],
           [],
@@ -952,7 +952,7 @@ describe("app browser entry state helpers", () => {
       type: "navigate",
     });
 
-    expect(pending.routeId).toBe("route:/photos/42\0/feed");
+    expect(pending.routeId).toBe("route:/feed");
     expect(pending.interception).toEqual(createInterceptionProof("/feed", "/photos/42"));
     expect(pending.interceptionContext).toBe("/feed");
     expect(pending.previousNextUrl).toBe("/feed");
@@ -969,7 +969,7 @@ describe("app browser entry state helpers", () => {
     const interceptedState = createState({
       interceptionContext: "/feed",
       previousNextUrl: "/feed",
-      routeId: "route:/photos/42\0/feed",
+      routeId: "route:/feed",
     });
 
     const pending = await createPendingNavigationCommit({
@@ -1449,11 +1449,11 @@ describe("app browser entry state helpers", () => {
       currentState,
       nextElements: Promise.resolve(
         createResolvedElements(
-          AppElementsWire.encodeRouteId("/photos/café", "/caf%C3%A9"),
+          AppElementsWire.encodeRouteId("/café", null),
           "/",
           "/caf%C3%A9",
           {
-            "page:/photos/café": React.createElement("main", null, "photo"),
+            "page:/café": React.createElement("main", null, "source"),
           },
           [AppElementsWire.encodeLayoutId("/"), AppElementsWire.encodeLayoutId("/café")],
           [
@@ -1523,7 +1523,7 @@ describe("app browser entry state helpers", () => {
       navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/photos/42", {}),
       previousNextUrl: "/feed",
       rootLayoutTreePath: "/",
-      routeId: AppElementsWire.encodeRouteId("/photos/42", "/feed"),
+      routeId: AppElementsWire.encodeRouteId("/feed", null),
     });
 
     const pending = await createPendingNavigationCommit({
@@ -1531,11 +1531,11 @@ describe("app browser entry state helpers", () => {
       currentState,
       nextElements: Promise.resolve(
         createResolvedElements(
-          AppElementsWire.encodeRouteId("/feed", "/feed"),
+          AppElementsWire.encodeRouteId("/feed", null),
           "/",
           "/feed",
           {
-            [AppElementsWire.encodePageId("/feed", "/feed")]: React.createElement(
+            [AppElementsWire.encodePageId("/feed", null)]: React.createElement(
               "main",
               null,
               "feed",
@@ -1579,21 +1579,21 @@ describe("app browser entry state helpers", () => {
     const contextOnlyState = applyApprovedVisibleCommit(currentState, approval.approvedCommit);
     expect(contextOnlyState.interception).toBeNull();
     expect(contextOnlyState.previousNextUrl).toBeNull();
-    expect(contextOnlyState.routeId).toBe(AppElementsWire.encodeRouteId("/feed", "/feed"));
+    expect(contextOnlyState.routeId).toBe(AppElementsWire.encodeRouteId("/feed", null));
 
     const interceptedPending = await createPendingNavigationCommit({
       payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
       currentState: contextOnlyState,
       nextElements: Promise.resolve(
         createResolvedElements(
-          AppElementsWire.encodeRouteId("/photos/42", "/feed"),
+          AppElementsWire.encodeRouteId("/feed", null),
           "/",
           "/feed",
           {
-            [AppElementsWire.encodeRouteId("/photos/42", "/feed")]: React.createElement(
+            [AppElementsWire.encodePageId("/feed", null)]: React.createElement(
               "main",
               null,
-              "photo",
+              "feed",
             ),
             [AppElementsWire.encodeSlotId("modal", "/feed")]: React.createElement(
               "div",
@@ -1972,7 +1972,7 @@ describe("app browser entry state helpers", () => {
       navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/photos/42", {}),
       previousNextUrl: "/feed",
       rootLayoutTreePath: "/",
-      routeId: "route:/photos/42\0/feed",
+      routeId: "route:/feed",
       slotBindings: [
         {
           ownerLayoutId: AppElementsWire.encodeLayoutId("/feed"),
@@ -2385,7 +2385,7 @@ describe("app browser navigation controller", () => {
       interceptionContext: "/feed",
       previousNextUrl: "/feed",
       rootLayoutTreePath: "/",
-      routeId: "route:/photos/42\0/feed",
+      routeId: "route:/feed",
       navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/photos/42", {}),
     });
     const syncHistoryStatePreviousNextUrl = vi.fn();

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -71,20 +71,29 @@ function createRoute(overrides: Partial<TestRoute> = {}): TestRoute {
 function createDispatchOptions(
   overrides: {
     buildPageElement?: DispatchOptions["buildPageElement"];
+    cleanPathname?: string;
     clearRequestContext?: DispatchOptions["clearRequestContext"];
+    findIntercept?: DispatchOptions["findIntercept"];
     generateStaticParams?: DispatchOptions["generateStaticParams"];
     formState?: DispatchOptions["formState"];
+    getSourceRoute?: DispatchOptions["getSourceRoute"];
     actionError?: DispatchOptions["actionError"];
     actionFailed?: DispatchOptions["actionFailed"];
+    interceptionContext?: string | null;
     isProgressiveActionRender?: DispatchOptions["isProgressiveActionRender"];
     isProduction?: boolean;
     isRscRequest?: boolean;
+    isrRscKey?: DispatchOptions["isrRscKey"];
     isrGet?: DispatchOptions["isrGet"];
+    loadSsrHandler?: DispatchOptions["loadSsrHandler"];
     middlewareContext?: AppPageMiddlewareContext;
+    mountedSlotsHeader?: string | null;
     renderToReadableStream?: DispatchOptions["renderToReadableStream"];
     request?: Request;
     revalidateSeconds?: number | null;
+    resolveRouteFetchCacheMode?: DispatchOptions["resolveRouteFetchCacheMode"];
     route?: TestRoute;
+    scheduleBackgroundRegeneration?: DispatchOptions["scheduleBackgroundRegeneration"];
     searchParams?: URLSearchParams;
     setNavigationContext?: DispatchOptions["setNavigationContext"];
   } = {},
@@ -97,17 +106,22 @@ function createDispatchOptions(
   const setNavigationContext = overrides.setNavigationContext ?? (() => {});
   const renderToReadableStream: DispatchOptions["renderToReadableStream"] =
     overrides.renderToReadableStream ?? (() => createStream(["flight"]));
+  const loadSsrHandler: DispatchOptions["loadSsrHandler"] =
+    overrides.loadSsrHandler ??
+    (async () => ({
+      async handleSsr() {
+        return createStream(["<html>page</html>"]);
+      },
+    }));
   const options: DispatchOptions = {
     buildPageElement,
-    cleanPathname: "/posts/hello",
+    cleanPathname: overrides.cleanPathname ?? "/posts/hello",
     clearRequestContext,
     createRscOnErrorHandler() {
       return () => null;
     },
     draftModeSecret: "draft-secret",
-    findIntercept() {
-      return null;
-    },
+    findIntercept: overrides.findIntercept ?? (() => null),
     generateStaticParams: overrides.generateStaticParams ?? null,
     getFontLinks() {
       return [];
@@ -121,9 +135,7 @@ function createDispatchOptions(
     getNavigationContext() {
       return { pathname: "/posts/hello" };
     },
-    getSourceRoute() {
-      return undefined;
-    },
+    getSourceRoute: overrides.getSourceRoute ?? (() => undefined),
     hasGenerateStaticParams: typeof overrides.generateStaticParams === "function",
     hasPageDefaultExport: true,
     hasPageModule: true,
@@ -131,7 +143,7 @@ function createDispatchOptions(
     formState: overrides.formState,
     actionError: overrides.actionError,
     actionFailed: overrides.actionFailed,
-    interceptionContext: null,
+    interceptionContext: overrides.interceptionContext ?? null,
     isProgressiveActionRender: overrides.isProgressiveActionRender,
     isProduction: overrides.isProduction ?? false,
     isRscRequest: overrides.isRscRequest ?? false,
@@ -139,21 +151,17 @@ function createDispatchOptions(
     isrHtmlKey(pathname: string) {
       return `html:${pathname}`;
     },
-    isrRscKey(pathname: string, mountedSlotsHeader?: string | null) {
-      return mountedSlotsHeader ? `rsc:${pathname}:${mountedSlotsHeader}` : `rsc:${pathname}`;
-    },
+    isrRscKey:
+      overrides.isrRscKey ??
+      ((pathname: string, mountedSlotsHeader?: string | null) =>
+        mountedSlotsHeader ? `rsc:${pathname}:${mountedSlotsHeader}` : `rsc:${pathname}`),
     isrSet: vi.fn(async () => {}),
-    async loadSsrHandler() {
-      return {
-        async handleSsr() {
-          return createStream(["<html>page</html>"]);
-        },
-      };
-    },
+    loadSsrHandler,
     middlewareContext: overrides.middlewareContext ?? {
       headers: null,
       status: null,
     },
+    mountedSlotsHeader: overrides.mountedSlotsHeader,
     params: { slug: "hello" },
     probeLayoutAt() {
       return null;
@@ -166,11 +174,12 @@ function createDispatchOptions(
     renderToReadableStream,
     request: overrides.request ?? new Request("https://example.test/posts/hello"),
     revalidateSeconds: overrides.revalidateSeconds ?? null,
+    resolveRouteFetchCacheMode: overrides.resolveRouteFetchCacheMode,
     route,
     runWithSuppressedHookWarning<T>(probe: () => Promise<T>) {
       return probe();
     },
-    scheduleBackgroundRegeneration: vi.fn(),
+    scheduleBackgroundRegeneration: overrides.scheduleBackgroundRegeneration ?? vi.fn(),
     searchParams: overrides.searchParams ?? new URLSearchParams(),
     setNavigationContext,
   };
@@ -420,5 +429,110 @@ describe("app page dispatch", () => {
     expect(response.headers.get("content-type")).toBe("text/x-component");
     expect(response.headers.get("x-from-middleware")).toBe("yes");
     await expect(response.text()).resolves.toBe("/feed:{}:modal@app/feed/@modal");
+  });
+
+  it("regenerates stale intercepted RSC cache entries from the source route", async () => {
+    const sourceRoute = createRoute({ params: [], pattern: "/feed", routeSegments: ["feed"] });
+    const currentRoute = createRoute({
+      params: ["id"],
+      pattern: "/photos/[id]",
+      routeSegments: ["photos", "[id]"],
+    });
+    const staleRscData = new TextEncoder().encode("stale-flight").buffer;
+    const buildPageElement = vi.fn(
+      async (
+        route: TestRoute,
+        params: Record<string, string | string[]>,
+        opts: Parameters<DispatchOptions["buildPageElement"]>[2],
+        searchParams: URLSearchParams,
+      ) =>
+        JSON.stringify({
+          params,
+          route: route.pattern,
+          search: searchParams.toString(),
+          slot: opts?.interceptSlotKey ?? "direct",
+        }),
+    );
+    let scheduledRender: unknown = null;
+    const scheduleBackgroundRegeneration: DispatchOptions["scheduleBackgroundRegeneration"] = (
+      _key,
+      renderFn,
+    ) => {
+      scheduledRender = renderFn;
+    };
+    const resolveRouteFetchCacheMode = vi.fn((route: TestRoute) =>
+      route === sourceRoute ? "force-cache" : null,
+    );
+    const { options } = createDispatchOptions({
+      buildPageElement,
+      cleanPathname: "/photos/123",
+      findIntercept: () => ({
+        matchedParams: { id: "123" },
+        page: { default: "modal-page" },
+        slotId: "slot:modal:/feed",
+        slotKey: "modal@app/feed/@modal",
+        sourceRouteIndex: 1,
+      }),
+      getSourceRoute(sourceRouteIndex) {
+        return sourceRouteIndex === 1 ? sourceRoute : undefined;
+      },
+      interceptionContext: "/feed",
+      isProduction: true,
+      isRscRequest: true,
+      isrGet: vi.fn(async () =>
+        buildISRCacheEntry(buildCachedAppPageValue("", staleRscData), true),
+      ),
+      isrRscKey(pathname, mountedSlotsHeader, _renderMode, interceptionContext) {
+        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}:${interceptionContext ?? "none"}`;
+      },
+      loadSsrHandler: async () => ({
+        async handleSsr(_rscStream, _navigationContext, _fontData, captureOptions) {
+          if (captureOptions?.capturedRscDataRef) {
+            captureOptions.capturedRscDataRef.value = Promise.resolve(
+              new TextEncoder().encode("fresh-intercepted-flight").buffer,
+            );
+          }
+          void captureOptions?.sideStream?.cancel().catch(() => {});
+          return createStream(["<html>fresh</html>"]);
+        },
+      }),
+      mountedSlotsHeader: "slot:modal:/feed",
+      revalidateSeconds: 60,
+      resolveRouteFetchCacheMode,
+      route: currentRoute,
+      scheduleBackgroundRegeneration,
+      searchParams: new URLSearchParams("tab=popular"),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.headers.get("x-vinext-cache")).toBe("STALE");
+    await expect(response.text()).resolves.toBe("stale-flight");
+    expect(typeof scheduledRender).toBe("function");
+    if (typeof scheduledRender !== "function") {
+      throw new Error("expected stale intercepted RSC response to schedule regeneration");
+    }
+
+    await scheduledRender();
+
+    const [routeArg, paramsArg, optsArg, searchParamsArg] = buildPageElement.mock.calls[0];
+    expect(resolveRouteFetchCacheMode).toHaveBeenCalledWith(sourceRoute);
+    expect(routeArg).toBe(sourceRoute);
+    expect(paramsArg).toEqual({});
+    expect(searchParamsArg.toString()).toBe("");
+    expect(optsArg).toMatchObject({
+      interceptionContext: "/feed",
+      interceptParams: { id: "123" },
+      interceptSlotId: "slot:modal:/feed",
+      interceptSlotKey: "modal@app/feed/@modal",
+      interceptSourceMatchedUrl: "/feed",
+    });
+    expect(options.isrSet).toHaveBeenCalledWith(
+      "rsc:/photos/123:slot:modal:/feed:/feed",
+      expect.objectContaining({ kind: "APP_PAGE" }),
+      60,
+      expect.arrayContaining(["/photos/123", "_N_T_/feed/page"]),
+      undefined,
+    );
   });
 });

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -113,7 +113,7 @@ describe("buildPageElements", () => {
     expect(record["route:/test"]).toBeDefined();
   });
 
-  it("includes interception context in the error payload route ID", async () => {
+  it("keeps interception context out of the error payload route ID", async () => {
     const route = createSyntheticRoute({
       page: createSyntheticPageModuleWithoutDefault(),
       layouts: [],
@@ -130,7 +130,8 @@ describe("buildPageElements", () => {
     );
 
     const record = result as Record<string, unknown>;
-    expect(record[APP_ROUTE_KEY]).toBe("route:/intercepted\u0000ctx-abc");
+    expect(record[APP_ROUTE_KEY]).toBe("route:/intercepted");
+    expect(record[APP_INTERCEPTION_CONTEXT_KEY]).toBe("ctx-abc");
   });
 
   it("computes root layout tree path for error payload when layouts exist", async () => {
@@ -278,6 +279,63 @@ describe("buildPageElements", () => {
         state: "active",
       },
     ]);
+  });
+
+  it("uses the source route identity for intercepted source-route payload keys", async () => {
+    function TestPage(): React.ReactNode {
+      return React.createElement("div", null, "Feed");
+    }
+    function TestLayout({ children }: { children?: React.ReactNode }): React.ReactNode {
+      return children;
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(TestPage),
+      layouts: [createSyntheticPageModule(TestLayout), createSyntheticPageModule(TestLayout)],
+      layoutTreePositions: [0, 1],
+      routeSegments: ["feed"],
+      pattern: "/feed",
+      slots: {
+        "modal@feed/@modal": {
+          id: "slot:modal:/feed",
+          name: "modal",
+          default: createSyntheticPageModule(() => null),
+          layoutIndex: 1,
+          routeSegments: null,
+        },
+      },
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/photos/42",
+        opts: {
+          interceptionContext: "/feed",
+          interceptSourceMatchedUrl: "/feed",
+          interceptSlotId: "slot:modal:/feed",
+          interceptSlotKey: "modal@feed/@modal",
+          interceptPage: createSyntheticPageModule(() =>
+            React.createElement("div", null, "Intercepted"),
+          ),
+          interceptParams: { id: "42" },
+        } as Record<string, unknown>,
+      }),
+    );
+    const record = result as Record<string, unknown>;
+
+    expect(record[APP_ROUTE_KEY]).toBe("route:/feed");
+    expect(Object.prototype.hasOwnProperty.call(record, "route:/feed")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(record, "page:/feed")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(record, "route:/photos/42\0/feed")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(record, "page:/photos/42\0/feed")).toBe(false);
+    expect(record[APP_INTERCEPTION_KEY]).toEqual({
+      sourceMatchedUrl: "/feed",
+      sourceRouteId: "route:/feed",
+      slotId: "slot:modal:/feed",
+      targetMatchedUrl: "/photos/42",
+      targetRouteId: "route:/photos/42",
+    });
   });
 
   it("normalizes encoded interception proof paths before encoding route IDs", async () => {

--- a/tests/app-page-render-identity.test.ts
+++ b/tests/app-page-render-identity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createAppPageRenderIdentity } from "../packages/vinext/src/server/app-page-render-identity.js";
+
+describe("createAppPageRenderIdentity", () => {
+  it("uses the display pathname as the route identity for direct renders", () => {
+    const identity = createAppPageRenderIdentity({ displayPathname: "/photos/42" });
+
+    expect(identity).toEqual({
+      displayPathname: "/photos/42",
+      interception: null,
+      interceptionContext: null,
+      matchedRoutePathname: "/photos/42",
+      pageId: "page:/photos/42",
+      routeId: "route:/photos/42",
+      targetMatchedPathname: "/photos/42",
+    });
+  });
+
+  it("uses the source route as the route identity for intercepted source renders", () => {
+    const identity = createAppPageRenderIdentity({
+      displayPathname: "/photos/42",
+      interceptionContext: "/feed",
+      interceptSourceMatchedUrl: "/feed",
+      interceptSlotId: "slot:modal:/feed",
+    });
+
+    expect(identity.routeId).toBe("route:/feed");
+    expect(identity.pageId).toBe("page:/feed");
+    expect(identity.matchedRoutePathname).toBe("/feed");
+    expect(identity.targetMatchedPathname).toBe("/photos/42");
+    expect(identity.interception).toEqual({
+      sourceMatchedUrl: "/feed",
+      sourceRouteId: "route:/feed",
+      slotId: "slot:modal:/feed",
+      targetMatchedUrl: "/photos/42",
+      targetRouteId: "route:/photos/42",
+    });
+  });
+
+  it("normalizes encoded source and target pathnames before encoding route IDs", () => {
+    const identity = createAppPageRenderIdentity({
+      displayPathname: "/photos/caf%C3%A9",
+      interceptionContext: "/caf%C3%A9",
+      interceptSourceMatchedUrl: "/caf%C3%A9",
+      interceptSlotId: "slot:modal:/café",
+    });
+
+    expect(identity.routeId).toBe("route:/café");
+    expect(identity.pageId).toBe("page:/café");
+    expect(identity.matchedRoutePathname).toBe("/café");
+    expect(identity.targetMatchedPathname).toBe("/photos/café");
+    expect(identity.interception?.sourceMatchedUrl).toBe("/café");
+    expect(identity.interception?.targetMatchedUrl).toBe("/photos/café");
+  });
+
+  it("ignores invalid source proof and falls back to direct target identity", () => {
+    const identity = createAppPageRenderIdentity({
+      displayPathname: "/photos/42",
+      interceptionContext: "/feed?tab=popular",
+      interceptSourceMatchedUrl: "/feed?tab=popular",
+      interceptSlotId: "slot:modal:/feed",
+    });
+
+    expect(identity.interception).toBeNull();
+    expect(identity.routeId).toBe("route:/photos/42");
+    expect(identity.pageId).toBe("page:/photos/42");
+    expect(identity.matchedRoutePathname).toBe("/photos/42");
+    expect(identity.interceptionContext).toBe("/feed?tab=popular");
+  });
+
+  it("rejects relative display pathnames", () => {
+    expect(() => createAppPageRenderIdentity({ displayPathname: "photos/42" })).toThrow(
+      "[vinext] App Router render pathname must be absolute: photos/42",
+    );
+  });
+});

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -771,10 +771,9 @@ describe("App Router integration", () => {
     expect(rscPayload).toContain("__interceptionContext");
     expect(rscPayload).toContain("/feed");
     const nul = String.fromCharCode(0);
-    expect(
-      rscPayload.includes("route:/photos/42\\u0000/feed") ||
-        rscPayload.includes(`route:/photos/42${nul}/feed`),
-    ).toBe(true);
+    expect(rscPayload).toContain("route:/feed");
+    expect(rscPayload.includes("route:/photos/42\\u0000/feed")).toBe(false);
+    expect(rscPayload.includes(`route:/photos/42${nul}/feed`)).toBe(false);
   });
 
   // --- Intercepting routes with dynamic source route ---

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -1,7 +1,21 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
+const FEED_DRAFT_VALUE = "source draft survives";
+
+async function fillFeedSourceState(page: Page, value: string = FEED_DRAFT_VALUE): Promise<void> {
+  await expect(page.getByTestId("feed-draft-input")).toBeVisible();
+  await page.getByTestId("feed-draft-input").fill(value);
+}
+
+async function expectFeedSourceState(
+  page: Page,
+  options: { draft?: string; tab?: string } = {},
+): Promise<void> {
+  await expect(page.getByTestId("feed-draft-input")).toHaveValue(options.draft ?? FEED_DRAFT_VALUE);
+  await expect(page.getByTestId("feed-tab-state")).toHaveText(`tab:${options.tab ?? "default"}`);
+}
 
 test.describe("Parallel Routes", () => {
   test("dashboard renders all parallel slot content", async ({ page }) => {
@@ -71,6 +85,13 @@ test.describe("Parallel Routes", () => {
 });
 
 test.describe("Intercepting Routes", () => {
+  // Ported and strengthened from Next.js intercepted route coverage:
+  // - test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+  //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+  // - test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+  //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+  // - test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+  //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
   test("direct navigation to photo shows full page", async ({ page }) => {
     await page.goto(`${BASE}/photos/42`);
 
@@ -116,16 +137,19 @@ test.describe("Intercepting Routes", () => {
   test("chained intercepted navigations keep the original source context", async ({ page }) => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);
+    await fillFeedSourceState(page);
 
     await page.click("#feed-photo-42-link");
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 42");
+    await expectFeedSourceState(page);
 
     await page.click("#modal-photo-43-link");
 
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 43");
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
   });
 
@@ -137,21 +161,38 @@ test.describe("Intercepting Routes", () => {
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);
+    await fillFeedSourceState(page);
 
     await page.click("#feed-photo-42-link");
     await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 42");
+    await expectFeedSourceState(page);
 
     await page.click("#modal-photo-43-link");
     await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 43");
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
 
     await page.click('[data-testid="photo-modal-refresh"]');
 
     await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 43");
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/photos/43");
+  });
+
+  test("intercepted navigation preserves source search and client state", async ({ page }) => {
+    await page.goto(`${BASE}/feed?tab=popular`);
+    await waitForAppRouterHydration(page);
+    await fillFeedSourceState(page);
+
+    await page.click("#feed-photo-42-link");
+
+    await expect(page.locator('[data-testid="photo-modal"]')).toContainText("Viewing photo 42");
+    await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page, { tab: "popular" });
+    await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
   });
 
   test("refresh on direct photo load preserves the full-page render", async ({ page }) => {
@@ -260,24 +301,29 @@ test.describe("Intercepting Routes", () => {
   test("router.refresh preserves intercepted modal view", async ({ page }) => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);
+    await fillFeedSourceState(page);
 
     await page.click("#feed-photo-42-link");
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
+    await expectFeedSourceState(page);
 
     await page.click('[data-testid="photo-modal-refresh"]');
 
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
   });
 
   test("server action from intercepted modal preserves modal tree", async ({ page }) => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);
+    await fillFeedSourceState(page);
 
     await page.click("#feed-photo-42-link");
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
 
     const likesLocator = page.locator('[data-testid="photo-likes"]');
     const baselineText = (await likesLocator.textContent()) ?? "";
@@ -299,6 +345,7 @@ test.describe("Intercepting Routes", () => {
     // direct /photos/[id] page NOT rendered, URL unchanged.
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/photos/42");
 
@@ -377,18 +424,22 @@ test.describe("Intercepting Routes", () => {
   test("back then forward restores intercepted modal view", async ({ page }) => {
     await page.goto(`${BASE}/feed`);
     await waitForAppRouterHydration(page);
+    await fillFeedSourceState(page);
 
     await page.click("#feed-photo-42-link");
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
 
     await page.goBack();
     await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
 
     await page.goForward();
     await expect(page.locator('[data-testid="photo-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="feed-page"]')).toBeVisible();
+    await expectFeedSourceState(page);
     await expect(page.locator('[data-testid="photo-page"]')).not.toBeVisible();
   });
 });

--- a/tests/fixtures/app-basic/app/feed/feed-state.tsx
+++ b/tests/fixtures/app-basic/app/feed/feed-state.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+
+export function FeedState({ initialTab }: { initialTab: string }) {
+  const [draft, setDraft] = useState("");
+  const [tab] = useState(initialTab);
+
+  return (
+    <div>
+      <p data-testid="feed-tab-state">tab:{tab}</p>
+      <input
+        aria-label="Feed draft"
+        data-testid="feed-draft-input"
+        onChange={(event) => {
+          setDraft(event.currentTarget.value);
+        }}
+        value={draft}
+      />
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/feed/page.tsx
+++ b/tests/fixtures/app-basic/app/feed/page.tsx
@@ -1,11 +1,28 @@
 import Link from "next/link";
+import { FeedState } from "./feed-state";
 
-export default async function FeedPage() {
+type FeedSearchParams = {
+  tab?: string | string[];
+};
+
+function getTab(searchParams: FeedSearchParams | undefined): string {
+  const tab = searchParams?.tab;
+  if (Array.isArray(tab)) return tab[0] ?? "default";
+  return tab ?? "default";
+}
+
+export default async function FeedPage({
+  searchParams,
+}: {
+  searchParams?: FeedSearchParams | Promise<FeedSearchParams>;
+}) {
   await fetch("data:text/plain,feed-source", { cache: "no-store" });
+  const resolvedSearchParams = await searchParams;
 
   return (
     <div data-testid="feed-page">
       <h1>Photo Feed</h1>
+      <FeedState initialTab={getTab(resolvedSearchParams)} />
       <ul>
         <li>
           <Link href="/photos/1">Photo 1</Link>

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -199,9 +199,9 @@ describe("App Router ISR cache key primitives", () => {
   it("keys intercepted RSC variants by source context", () => {
     delete process.env.__VINEXT_BUILD_ID;
 
-    const fromFeed = appIsrRscKey("/photos/42", "modal", undefined, "/feed");
-    const fromGallery = appIsrRscKey("/photos/42", "modal", undefined, "/gallery");
-    const direct = appIsrRscKey("/photos/42", "modal");
+    const fromFeed = appIsrRscKey("/photos/42", "slot:modal:/", undefined, "/feed");
+    const fromGallery = appIsrRscKey("/photos/42", "slot:modal:/", undefined, "/gallery");
+    const direct = appIsrRscKey("/photos/42", "slot:modal:/");
 
     expect(fromFeed).not.toBe(fromGallery);
     expect(fromFeed).not.toBe(direct);

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -208,6 +208,17 @@ describe("App Router ISR cache key primitives", () => {
     expect(fromFeed).toMatch(/^app:\/photos\/42:rsc:source:[a-z0-9]+:slots:[a-z0-9]+$/);
   });
 
+  it("normalizes source context before keying intercepted RSC variants", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const encoded = appIsrRscKey("/photos/café", "modal", undefined, "/caf%C3%A9");
+    const decoded = appIsrRscKey("/photos/café", "modal", undefined, "/café");
+    const duplicateSlash = appIsrRscKey("/photos/café", "modal", undefined, "/café//");
+
+    expect(encoded).toBe(decoded);
+    expect(duplicateSlash).toBe(decoded);
+  });
+
   it("keys RSC refresh variants separately from normal navigation variants", () => {
     delete process.env.__VINEXT_BUILD_ID;
 

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -196,6 +196,18 @@ describe("App Router ISR cache key primitives", () => {
     expect(keys.values().next().value).toBe("app:/feed:rsc");
   });
 
+  it("keys intercepted RSC variants by source context", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const fromFeed = appIsrRscKey("/photos/42", "modal", undefined, "/feed");
+    const fromGallery = appIsrRscKey("/photos/42", "modal", undefined, "/gallery");
+    const direct = appIsrRscKey("/photos/42", "modal");
+
+    expect(fromFeed).not.toBe(fromGallery);
+    expect(fromFeed).not.toBe(direct);
+    expect(fromFeed).toMatch(/^app:\/photos\/42:rsc:source:[a-z0-9]+:slots:[a-z0-9]+$/);
+  });
+
   it("keys RSC refresh variants separately from normal navigation variants", () => {
     delete process.env.__VINEXT_BUILD_ID;
 

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -219,6 +219,15 @@ describe("App Router ISR cache key primitives", () => {
     expect(duplicateSlash).toBe(decoded);
   });
 
+  it("ignores invalid source context before keying intercepted RSC variants", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const invalidSource = appIsrRscKey("/photos/42", "modal", undefined, "/feed?tab=popular");
+    const direct = appIsrRscKey("/photos/42", "modal");
+
+    expect(invalidSource).toBe(direct);
+  });
+
   it("keys RSC refresh variants separately from normal navigation variants", () => {
     delete process.env.__VINEXT_BUILD_ID;
 


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Preserve the retained source page during intercepted App Router renders. |
| Core change | Split render identity into display pathname, matched source route pathname, target matched pathname, and interception context. |
| Main boundary | Source route/page payload ids now come from the retained source route. The visible target path stays in URL state and interception proof. |
| Primary files | `app-page-render-identity.ts`, `app-page-element-builder.ts`, `app-page-route-wiring.tsx`, `isr-cache.ts`, `advanced.spec.ts` |
| Expected impact | Intercepted modals keep background client/search state across modal changes, refreshes, server actions, and history traversal. |

## Why

An intercepted render has two route identities: the route that remains mounted in the client tree, and the URL target that proves which slot content is being rendered. Treating one pathname as both makes the target modal replace the source page's route/page keys.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Render identity | Retained source tree identity must be source-route based. | Adds `createAppPageRenderIdentity()` and feeds source route ids into element construction. |
| Interception proof | Target path is proof and display state, not background page identity. | Keeps `/photos/42` in `APP_INTERCEPTION_KEY.targetMatchedUrl` and target route proof only. |
| RSC cache variants | Cache keys must vary by source context when response semantics do. | Adds source-context hashing to App Router RSC ISR cache keys. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| `/feed` to `/photos/42` modal | Source route payload could be keyed as `route:/photos/42\0/feed`. | Source route payload is keyed as `route:/feed`; modal target remains in interception proof. |
| Modal 42 to modal 43 | The retained feed tree could be treated as target identity. | Feed route/page identity remains stable while modal slot content changes. |
| `router.refresh()` or server action in modal | RSC cache and rerender requests could rely on target path plus mounted slots only. | RSC cache key includes source context and the source tree keeps its payload identity. |
| Direct `/photos/42` load | Full page should render. | Still full page, no modal, no source context. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-page-render-identity.ts`  
   Review the source/display/target derivation and normalization rules.

2. `packages/vinext/src/server/app-page-element-builder.ts` and `packages/vinext/src/server/app-page-route-wiring.tsx`  
   Check that route/page ids use the helper while metadata still carries interception context and proof.

3. `packages/vinext/src/server/isr-cache.ts`, `app-page-cache.ts`, `app-page-dispatch.ts`, `app-page-render.ts`  
   Check that RSC cache reads and writes now receive the source/interception context.

4. `tests/e2e/app-router/advanced.spec.ts` and `tests/fixtures/app-basic/app/feed/*`  
   Check the browser contract for source client state, source search state, refreshes, actions, chained modals, and history.

</details>

<details>
<summary>Validation</summary>

Run locally:

```bash
vp test run tests/app-page-element-builder.test.ts tests/isr-cache.test.ts tests/app-page-cache.test.ts tests/app-page-render.test.ts tests/app-page-dispatch.test.ts tests/app-browser-entry.test.ts
vp check
PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/advanced.spec.ts
vp run vinext#build
```

Commit hook also ran:

```bash
vp fmt --write
vp check
knip --no-progress
```

</details>

<details>
<summary>Risk / Compatibility</summary>

- App Router RSC cache keys change for intercepted source-context variants. Existing entries simply miss and regenerate.
- Route/page payload ids for intercepted source-route renders intentionally become source-route stable. Tests update browser-state fixtures to model this.
- Public API surface is unchanged.
- Direct target loads remain full-page renders.

</details>

<details>
<summary>Non-goals</summary>

- Does not redesign the client router state model.
- Does not add the requested performance phase measurements. Correctness is now covered first; perf instrumentation can be layered separately.
- Does not change Next.js's interception semantics. This follows the `Next-URL` source-context model where applicable.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js interception route rewrite generation](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/generate-interception-routes-rewrites.ts) | Uses request pathname as the intercepted target and `Next-URL` as the source/intercepting route gate. |
| [Next.js interception route utilities](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/interception-routes.ts) | Defines intercepting route versus intercepted route terminology. |
| [Next.js refresh reducer](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts) | Sends previous/current `nextUrl` for refreshes when the current tree has interception. |
| [Next.js server action reducer](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts) | Sends source `nextUrl` for server actions from intercepted trees. |
| [Next.js app-page route module vary handling](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-page/module.ts) | Interception route responses vary by `Next-URL`. |
| [Next.js parallel routes revalidation tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts) | Upstream refresh/action/search-param active-slot behavior mirrored and strengthened here. |
| [Next.js dynamic interception tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts) | Upstream back/forward interception restoration coverage. |
| [Next.js parallel routes and interception tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts) | Upstream direct versus intercepted modal behavior coverage. |

Closes #730