### PR TITLE
fix(font): preserve local font binding family

### DIFF
--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -413,6 +413,10 @@ function propertyNameToGoogleFontFamily(prop: string): string {
   return prop.replace(/_/g, " ").replace(/([a-z])([A-Z])/g, "$1 $2");
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // ── Font fetching and caching ─────────────────────────────────────────────────
 
 /**
@@ -1133,9 +1137,13 @@ export function createLocalFontsPlugin(): Plugin {
         // in comments that would be incorrectly rewritten.
         if (id.includes("font-local")) return null;
 
-        // Verify there's actually an import from next/font/local
-        const importRe = /import\s+\w+\s+from\s*['"]next\/font\/local['"]/;
-        if (!importRe.test(code)) return null;
+        // Verify there's actually a default import from next/font/local and
+        // remember its local binding so family payloads only attach to real
+        // localFont calls.
+        const importMatch =
+          /\bimport\s+([A-Za-z_$][A-Za-z0-9_$]*)\s+from\s*(['"])next\/font\/local\2/.exec(code);
+        if (!importMatch) return null;
+        const localFontIdentifier = importMatch[1];
 
         const s = new MagicString(code);
         let hasChanges = false;
@@ -1162,10 +1170,41 @@ export function createLocalFontsPlugin(): Plugin {
           hasChanges = true;
         }
 
+        const localFontCallRe = new RegExp(
+          String.raw`(?:^|[;\n])\s*(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::[^=]+)?=\s*${escapeRegExp(localFontIdentifier)}\s*\(\s*(?=\{)`,
+          "g",
+        );
+        const familyPayloadInsertions = new Set<number>();
+        let localFontCallMatch;
+        while ((localFontCallMatch = localFontCallRe.exec(code)) !== null) {
+          const bindingName = localFontCallMatch[1];
+          const objRange = _findBalancedObject(code, localFontCallRe.lastIndex);
+          if (!objRange) continue;
+          const callEnd = _findCallEnd(code, objRange[1]);
+          if (callEnd === null) continue;
+
+          const insertAt = objRange[1] - 1;
+          if (familyPayloadInsertions.has(insertAt)) continue;
+          const optionsStr = code.slice(objRange[0], objRange[1]);
+          if (/(?:^|[,{])\s*_vinext\s*:/.test(optionsStr)) continue;
+
+          const beforeClosingBrace = optionsStr.slice(0, -1).trim();
+          const separator =
+            beforeClosingBrace.endsWith("{") || beforeClosingBrace.endsWith(",") ? "" : ", ";
+          s.appendLeft(
+            insertAt,
+            `${separator}_vinext: { font: { family: ${JSON.stringify(bindingName)} } }`,
+          );
+          familyPayloadInsertions.add(insertAt);
+          hasChanges = true;
+        }
+
         if (!hasChanges) return null;
 
         // Prepend the asset imports at the top of the file
-        s.prepend(imports.join("\n") + "\n");
+        if (imports.length > 0) {
+          s.prepend(imports.join("\n") + "\n");
+        }
 
         return {
           code: s.toString(),

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -1171,7 +1171,7 @@ export function createLocalFontsPlugin(): Plugin {
         }
 
         const localFontCallRe = new RegExp(
-          String.raw`(?:^|[;\n])\s*(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::[^=]+)?=\s*${escapeRegExp(localFontIdentifier)}\s*\(\s*(?=\{)`,
+          String.raw`(?:^|[;{}\n])\s*(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::[^=]+)?=\s*${escapeRegExp(localFontIdentifier)}\s*\(\s*(?=\{)`,
           "g",
         );
         const familyPayloadInsertions = new Set<number>();

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -1180,8 +1180,7 @@ export function createLocalFontsPlugin(): Plugin {
           const bindingName = localFontCallMatch[1];
           const objRange = _findBalancedObject(code, localFontCallRe.lastIndex);
           if (!objRange) continue;
-          const callEnd = _findCallEnd(code, objRange[1]);
-          if (callEnd === null) continue;
+          if (_findCallEnd(code, objRange[1]) === null) continue;
 
           const insertAt = objRange[1] - 1;
           if (familyPayloadInsertions.has(insertAt)) continue;

--- a/packages/vinext/src/shims/font-local.ts
+++ b/packages/vinext/src/shims/font-local.ts
@@ -37,6 +37,12 @@ function sanitizeCSSProperty(prop: string): string | undefined {
   return undefined;
 }
 
+function sanitizeInternalFontFamily(name: string | undefined): string | undefined {
+  if (!name) return undefined;
+  if (/^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(name)) return name;
+  return undefined;
+}
+
 let classCounter = 0;
 const injectedFonts = new Set<string>();
 
@@ -56,6 +62,11 @@ type LocalFontOptions = {
   variable?: string;
   adjustFontFallback?: boolean | string;
   declarations?: Array<{ prop: string; value: string }>;
+  _vinext?: {
+    font?: {
+      family?: string;
+    };
+  };
 };
 
 type FontResult = {
@@ -277,7 +288,7 @@ export default function localFont(options: LocalFontOptions): FontResult {
   const id = classCounter++;
   const sources = normalizeSources(options);
   const singleSource = sources.length === 1 ? sources[0] : undefined;
-  const family = `__local_font_${id}`;
+  const family = sanitizeInternalFontFamily(options._vinext?.font?.family) ?? `__local_font_${id}`;
   const className = `__font_local_${id}`;
   const fallback = options.fallback ?? ["sans-serif"];
   // Sanitize each fallback name to prevent CSS injection via crafted values

--- a/packages/vinext/src/shims/font-local.ts
+++ b/packages/vinext/src/shims/font-local.ts
@@ -37,8 +37,8 @@ function sanitizeCSSProperty(prop: string): string | undefined {
   return undefined;
 }
 
-function sanitizeInternalFontFamily(name: string | undefined): string | undefined {
-  if (!name) return undefined;
+function sanitizeInternalFontFamily(name: unknown): string | undefined {
+  if (typeof name !== "string" || name.length === 0) return undefined;
   if (/^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(name)) return name;
   return undefined;
 }
@@ -64,7 +64,7 @@ type LocalFontOptions = {
   declarations?: Array<{ prop: string; value: string }>;
   _vinext?: {
     font?: {
-      family?: string;
+      family?: unknown;
     };
   };
 };

--- a/packages/vinext/src/shims/font-local.ts
+++ b/packages/vinext/src/shims/font-local.ts
@@ -311,7 +311,9 @@ export default function localFont(options: LocalFontOptions): FontResult {
 
   // Inject @font-face declarations
   const css = generateFontFaceCSS(family, options, sources);
-  injectFontFaceCSS(css, family);
+  // The exposed family can repeat across modules; the generated class stays
+  // unique for each localFont call and is the correct injection identity.
+  injectFontFaceCSS(css, className);
 
   // Inject the className -> font-family CSS rule
   injectClassNameRule(className, style);

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -131,6 +131,21 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.code).toContain(`_vinext: { font: { family: "myFont" } }`);
   });
 
+  it("passes the local binding name through for same-line block declarations", () => {
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `export default function Layout(){const myFont = localFont({ src: "./font.woff2" }); return null;}`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./font.woff2");
+    expect(result.code).toContain(`_vinext: { font: { family: "myFont" } }`);
+  });
+
   // ── Object src with path property ────────────────────────────
 
   it("transforms a single source object with path property", () => {
@@ -386,6 +401,30 @@ describe("vinext:local-fonts plugin", () => {
 
     expect(result.style.fontFamily).toMatch(/__local_font_\d+/);
     expect(result.style.fontFamily).not.toContain("myFont");
+
+    const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
+    expect(addedStyles).toContain("font-family: '__local_font_");
+    expect(addedStyles).not.toContain("myFont");
+    expect(addedStyles).not.toContain("color: red");
+  });
+
+  it("rejects non-string transform-provided binding names before regex validation", () => {
+    let toStringCalls = 0;
+    const statefulFamily = {
+      toString() {
+        toStringCalls++;
+        return toStringCalls === 1 ? "myFont" : "myFont'} body { color: red; }";
+      },
+    };
+    const beforeCount = getSSRFontStyles().length;
+    const result = localFont({
+      src: "/assets/non-string-family.woff2",
+      _vinext: { font: { family: statefulFamily } },
+    });
+
+    expect(result.style.fontFamily).toMatch(/__local_font_\d+/);
+    expect(result.style.fontFamily).not.toContain("myFont");
+    expect(toStringCalls).toBe(0);
 
     const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
     expect(addedStyles).toContain("font-family: '__local_font_");

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -106,6 +106,31 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.map).toBeDefined();
   });
 
+  it("passes the local binding name through to the runtime font payload", () => {
+    // Ported from Next.js: test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
+    //
+    // Next's font transform passes the variable name into the local font loader,
+    // and the loader uses it as the font-family for generated className styles.
+    // The MDX test observes that through getComputedStyle(document.body).fontFamily.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      ``,
+      `const myFont = localFont({`,
+      `  src: "../fonts/font1_roboto.woff2",`,
+      `  variable: "--font-my-font",`,
+      `});`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "../fonts/font1_roboto.woff2");
+    expect(result.code).toContain(`_vinext: { font: { family: "myFont" } }`);
+  });
+
   // ── Object src with path property ────────────────────────────
 
   it("transforms a single source object with path property", () => {
@@ -302,6 +327,29 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.className).toBeDefined();
     // variable returns a class name, not the variable name
     expect(result.variable).toMatch(/^__variable_local_\d+$/);
+  });
+
+  it("uses the transform-provided binding name as the class font-family", () => {
+    // Ported from Next.js: test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
+    const beforeCount = getSSRFontStyles().length;
+    const options = {
+      src: "/assets/font1_roboto.woff2",
+      variable: "--font-my-font",
+      _vinext: { font: { family: "myFont" } },
+    } satisfies Parameters<typeof localFont>[0] & {
+      _vinext: { font: { family: string } };
+    };
+
+    const result = localFont(options);
+
+    expect(result.style.fontFamily).toContain("myFont");
+    expect(result.style.fontFamily).not.toContain("__local_font");
+
+    const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
+    expect(addedStyles).toContain(`.${result.className}`);
+    expect(addedStyles).toContain("font-family: 'myFont'");
+    expect(addedStyles).not.toContain("__local_font");
   });
 
   it("matches Next.js style exports for a single local source", () => {

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -108,7 +108,7 @@ describe("vinext:local-fonts plugin", () => {
 
   it("passes the local binding name through to the runtime font payload", () => {
     // Ported from Next.js: test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
-    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
     //
     // Next's font transform passes the variable name into the local font loader,
     // and the loader uses it as the font-family for generated className styles.
@@ -331,7 +331,7 @@ describe("vinext:local-fonts plugin", () => {
 
   it("uses the transform-provided binding name as the class font-family", () => {
     // Ported from Next.js: test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
-    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
     const beforeCount = getSSRFontStyles().length;
     const options = {
       src: "/assets/font1_roboto.woff2",
@@ -373,6 +373,24 @@ describe("vinext:local-fonts plugin", () => {
     const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
     expect(addedStyles).toContain("/assets/module-a.woff2");
     expect(addedStyles).toContain("/assets/module-b.woff2");
+  });
+
+  it("rejects invalid transform-provided binding names and uses the generated family", () => {
+    const beforeCount = getSSRFontStyles().length;
+    const result = localFont({
+      src: "/assets/invalid-family.woff2",
+      _vinext: { font: { family: "myFont'} body { color: red; }" } },
+    } satisfies Parameters<typeof localFont>[0] & {
+      _vinext: { font: { family: string } };
+    });
+
+    expect(result.style.fontFamily).toMatch(/__local_font_\d+/);
+    expect(result.style.fontFamily).not.toContain("myFont");
+
+    const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
+    expect(addedStyles).toContain("font-family: '__local_font_");
+    expect(addedStyles).not.toContain("myFont");
+    expect(addedStyles).not.toContain("color: red");
   });
 
   it("matches Next.js style exports for a single local source", () => {

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -352,6 +352,29 @@ describe("vinext:local-fonts plugin", () => {
     expect(addedStyles).not.toContain("__local_font");
   });
 
+  it("does not dedupe distinct font-face rules by repeated transformed binding names", () => {
+    const beforeCount = getSSRFontStyles().length;
+    const first = localFont({
+      src: "/assets/module-a.woff2",
+      _vinext: { font: { family: "myFont" } },
+    } satisfies Parameters<typeof localFont>[0] & {
+      _vinext: { font: { family: string } };
+    });
+    const second = localFont({
+      src: "/assets/module-b.woff2",
+      _vinext: { font: { family: "myFont" } },
+    } satisfies Parameters<typeof localFont>[0] & {
+      _vinext: { font: { family: string } };
+    });
+
+    expect(first.style.fontFamily).toContain("myFont");
+    expect(second.style.fontFamily).toContain("myFont");
+
+    const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
+    expect(addedStyles).toContain("/assets/module-a.woff2");
+    expect(addedStyles).toContain("/assets/module-b.woff2");
+  });
+
   it("matches Next.js style exports for a single local source", () => {
     // Ported from Next.js: test/e2e/next-font/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/next-font/index.test.ts


### PR DESCRIPTION
## Overview

| Item | Details |
| --- | --- |
| Goal | Match Next.js local font family semantics for App Router layouts, including MDX pages. |
| Core change | Thread the `localFont` binding name through the vinext local-font transform into the runtime shim as a private `_vinext.font.family` payload. |
| Boundary | Compile-time transform owns deriving the binding name; runtime shim owns validation and CSS/class generation. |
| Primary files | `packages/vinext/src/plugins/fonts.ts`, `packages/vinext/src/shims/font-local.ts`, `tests/font-local-transform.test.ts` |
| Expected impact | `className={myFont.className}` now computes to a `font-family` containing `myFont`, while font preloads continue to use the transformed asset URL. |

## Why

Next.js passes the caller binding name from its font transform to the local font loader, and the loader uses that name as the generated `font-family`. Vinext rewrote the font asset path but did not preserve that binding, so the font class worked structurally while exposing `__local_font_N` in computed styles.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Transform | The compile step owns call-site-only metadata. | Detects `const/let/var <name> = localFont({...})` and injects a private family payload next to the existing asset URL rewrite. |
| Runtime shim | Internal payloads must be validated at the boundary. | Accepts only identifier-shaped internal family names and falls back to the generated local family otherwise. |
| Regression coverage | Test the lowest honest boundary. | Ports the MDX font-preload failure into transform and runtime tests instead of adding a broad e2e copy. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `const myFont = localFont(...)` | Transform only rewrote `src`/`path` font assets. | Transform also injects `_vinext: { font: { family: "myFont" } }`. |
| `className={myFont.className}` | Runtime class CSS used `'__local_font_N'`. | Runtime class CSS uses `'myFont'` for transformed calls. |
| Invalid or absent internal payload | Not applicable. | Falls back to `__local_font_N`. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/plugins/fonts.ts` - review how the local import binding is captured and how the private family payload is inserted without overlapping asset path rewrites.
2. `packages/vinext/src/shims/font-local.ts` - review the boundary validation and fallback before the family is used by `@font-face`, style exports, and class CSS.
3. `tests/font-local-transform.test.ts` - review the two ported regressions for transform and runtime behavior.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/font-local-transform.test.ts`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no public option is added; `_vinext.font.family` is a private transform-to-runtime payload.
- Existing apps: untransformed or invalid payloads keep the previous generated family fallback.
- Runtime: change is limited to local fonts; Google font behavior is untouched.
- Parsing: the payload is inserted only for variable-declaration local font calls with a balanced object argument, matching the upstream variable-name contract this PR ports.

</details>

<details>
<summary>Non-goals</summary>

- This does not reimplement the entire Next.js font loader pipeline.
- This does not change existing local font preload URL rewriting.
- This does not address custom `declarations` font-family parity beyond preserving the binding-name path needed for the upstream MDX test.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js mdx-font-preload test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts) | The upstream deploy-suite behavior that failed in vinext. |
| [Next.js mdx-font-preload layout fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/mdx-font-preload/app/layout.tsx) | Shows the `const myFont = localFont(...)` call and `myFont.className` layout usage. |
| [Next.js local font loader](https://github.com/vercel/next.js/blob/v16.2.6/packages/font/src/local/loader.ts) | Uses `variableName` as the `font-family` when no custom declaration overrides it. |
| [Next.js next-font loader](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/webpack/loaders/next-font-loader/index.ts) | Shows `variableName` coming from the font transform resource query. |
| [Next.js postcss-next-font](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/webpack/loaders/next-font-loader/postcss-next-font.ts) | Builds the exported style and class rule from the loader-produced family. |

Closes #1514