### PR TITLE
fix(app-router): isolate global-not-found CSS

### DIFF
--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -17,19 +17,29 @@
  *     detection — matches the subset Next.js supports
  *   - Only the common `"@/*": ["./src/*"]` / `"@/*": ["src/*"]` pattern is
  *     supported; non-wildcard paths and exact aliases also work
- *   - Returned alias values are always absolute paths so they work with
- *     `runnerImport`'s inline environment (which has its own root).
+ *   - Returned alias values default to absolute paths so they work with
+ *     `runnerImport`'s inline environment (which has its own root). Callers
+ *     that need project-root-relative Vite aliases can request `format: "vite"`.
  */
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
 import { parseStaticObjectLiteral } from "../plugins/fonts.js";
+import { relativeWithinRoot, tryRealpathSync } from "../build/ssr-manifest.js";
+import { isUnknownRecord } from "../utils/record.js";
 
 const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
+type AliasFormat = "absolute" | "vite";
+
+type TsconfigPathAliasOptions = {
+  format?: AliasFormat;
+};
+
+type TsconfigPathAliasResolution = {
+  projectRoot: string;
+  aliases: Record<string, string>;
+};
 
 function resolveTsconfigPathCandidate(candidate: string): string | null {
   const candidates = candidate.endsWith(".json")
@@ -63,9 +73,42 @@ function resolveTsconfigExtends(configPath: string, specifier: string): string |
   return null;
 }
 
+function toViteAliasReplacement(absolutePath: string, projectRoot: string): string {
+  const normalizedPath = absolutePath.replace(/\\/g, "/");
+  const rootCandidates = new Set<string>([projectRoot]);
+  const realRoot = tryRealpathSync(projectRoot);
+  if (realRoot) rootCandidates.add(realRoot);
+
+  const pathCandidates = new Set<string>([absolutePath]);
+  const realPath = tryRealpathSync(absolutePath);
+  if (realPath) pathCandidates.add(realPath);
+
+  for (const rootCandidate of rootCandidates) {
+    for (const pathCandidate of pathCandidates) {
+      if (pathCandidate === rootCandidate) {
+        return normalizedPath;
+      }
+      const relativeId = relativeWithinRoot(rootCandidate, pathCandidate);
+      if (relativeId) return "/" + relativeId;
+    }
+  }
+
+  return normalizedPath;
+}
+
+function formatAliasReplacement(
+  absolutePath: string,
+  projectRoot: string,
+  format: AliasFormat,
+): string {
+  return format === "vite" ? toViteAliasReplacement(absolutePath, projectRoot) : absolutePath;
+}
+
 function materializeAliases(
   pathsConfig: Record<string, unknown>,
   baseUrl: string,
+  projectRoot: string,
+  format: AliasFormat,
 ): Record<string, string> {
   const aliases: Record<string, string> = {};
 
@@ -88,11 +131,15 @@ function materializeAliases(
       const targetDir = target.slice(0, -2);
       if (!aliasKey || !targetDir) continue;
 
-      aliases[aliasKey] = path.resolve(baseUrl, targetDir);
+      aliases[aliasKey] = formatAliasReplacement(
+        path.resolve(baseUrl, targetDir),
+        projectRoot,
+        format,
+      );
       continue;
     }
 
-    aliases[find] = path.resolve(baseUrl, target);
+    aliases[find] = formatAliasReplacement(path.resolve(baseUrl, target), projectRoot, format);
   }
 
   return aliases;
@@ -100,7 +147,9 @@ function materializeAliases(
 
 function loadAliasesFromTsconfigFile(
   configPath: string,
+  projectRoot: string,
   seen: Set<string>,
+  format: AliasFormat,
 ): Record<string, string> {
   if (seen.has(configPath)) return {};
   seen.add(configPath);
@@ -117,13 +166,13 @@ function loadAliasesFromTsconfigFile(
   if (typeof parsed.extends === "string") {
     const extendedPath = resolveTsconfigExtends(configPath, parsed.extends);
     if (extendedPath) {
-      aliases = loadAliasesFromTsconfigFile(extendedPath, seen);
+      aliases = loadAliasesFromTsconfigFile(extendedPath, projectRoot, seen, format);
     }
   }
 
-  const compilerOptions = isRecord(parsed.compilerOptions) ? parsed.compilerOptions : null;
+  const compilerOptions = isUnknownRecord(parsed.compilerOptions) ? parsed.compilerOptions : null;
   const pathsConfig =
-    compilerOptions && isRecord(compilerOptions.paths) ? compilerOptions.paths : null;
+    compilerOptions && isUnknownRecord(compilerOptions.paths) ? compilerOptions.paths : null;
   if (!pathsConfig) return aliases;
 
   const baseUrl =
@@ -132,23 +181,63 @@ function loadAliasesFromTsconfigFile(
 
   return {
     ...aliases,
-    ...materializeAliases(pathsConfig, resolvedBaseUrl),
+    ...materializeAliases(pathsConfig, resolvedBaseUrl, projectRoot, format),
   };
+}
+
+function findTsconfigPath(projectRoot: string): string | null {
+  for (const name of TSCONFIG_FILES) {
+    const candidate = path.join(projectRoot, name);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 /**
  * Read the project's tsconfig.json (or jsconfig.json) and return its
- * `compilerOptions.paths` as absolute-path Vite `resolve.alias` entries.
+ * `compilerOptions.paths` as Vite `resolve.alias` entries.
  *
  * Returns an empty object if no config is found or no paths are configured.
  * Errors during parsing are swallowed — this is a best-effort helper that
  * must not break config loading.
  */
-export function loadTsconfigPathAliasesForRoot(projectRoot: string): Record<string, string> {
-  for (const name of TSCONFIG_FILES) {
-    const candidate = path.join(projectRoot, name);
-    if (!fs.existsSync(candidate)) continue;
-    return loadAliasesFromTsconfigFile(candidate, new Set());
+export function loadTsconfigPathAliasesForRoot(
+  projectRoot: string,
+  options: TsconfigPathAliasOptions = {},
+): Record<string, string> {
+  const configPath = findTsconfigPath(projectRoot);
+  if (!configPath) return {};
+
+  return loadAliasesFromTsconfigFile(
+    configPath,
+    projectRoot,
+    new Set(),
+    options.format ?? "absolute",
+  );
+}
+
+export function loadNearestTsconfigPathAliases(
+  fromPath: string,
+  options: TsconfigPathAliasOptions = {},
+): TsconfigPathAliasResolution | null {
+  let dir =
+    fs.existsSync(fromPath) && fs.statSync(fromPath).isDirectory()
+      ? fromPath
+      : path.dirname(fromPath);
+
+  while (true) {
+    if (findTsconfigPath(dir)) {
+      return {
+        projectRoot: dir,
+        aliases: loadTsconfigPathAliasesForRoot(dir, options),
+      };
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
   }
-  return {};
 }

--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -196,6 +196,10 @@ function findTsconfigPath(projectRoot: string): string | null {
   return null;
 }
 
+// Cache materialized aliases per (root, format) so the `config` hook (run once
+// per Vite environment: RSC, SSR, client) does not re-parse tsconfig per env.
+const aliasCache = new Map<string, Record<string, string>>();
+
 /**
  * Read the project's tsconfig.json (or jsconfig.json) and return its
  * `compilerOptions.paths` as Vite `resolve.alias` entries.
@@ -208,15 +212,18 @@ export function loadTsconfigPathAliasesForRoot(
   projectRoot: string,
   options: TsconfigPathAliasOptions = {},
 ): Record<string, string> {
-  const configPath = findTsconfigPath(projectRoot);
-  if (!configPath) return {};
+  const format = options.format ?? "absolute";
+  const cacheKey = `${format}\0${projectRoot}`;
+  const cached = aliasCache.get(cacheKey);
+  if (cached) return cached;
 
-  return loadAliasesFromTsconfigFile(
-    configPath,
-    projectRoot,
-    new Set(),
-    options.format ?? "absolute",
-  );
+  const configPath = findTsconfigPath(projectRoot);
+  const aliases = configPath
+    ? loadAliasesFromTsconfigFile(configPath, projectRoot, new Set(), format)
+    : {};
+
+  aliasCache.set(cacheKey, aliases);
+  return aliases;
 }
 
 export function loadNearestTsconfigPathAliases(

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -191,6 +191,7 @@ export function generateRscEntry(
     rootLayoutVars,
     globalErrorVar,
     globalNotFoundVar,
+    globalNotFoundStyleVars,
   } = manifestCode;
   const loadPrerenderPagesRoutesCode = hasPagesDir
     ? `
@@ -391,6 +392,7 @@ const rootLayouts = [${rootLayoutVars.join(", ")}];
 // calls still use the regular not-found.tsx boundary inside the layouts.
 // See https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
 const globalNotFoundModule = ${globalNotFoundVar ? globalNotFoundVar : "null"};
+const globalNotFoundStyles = [${globalNotFoundStyleVars.join(", ")}];
 
 const createRscOnErrorHandler = (request, pathname, routePath) =>
   createAppRscOnErrorHandler(_reportRequestError, request, pathname, routePath);
@@ -405,6 +407,7 @@ const __fallbackRenderer = __createAppFallbackRenderer({
   },
   globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
   globalNotFoundModule,
+  globalNotFoundStyles,
   metadataRoutes,
   ssrLoader() {
     return import.meta.viteRsc.loadModule("ssr", "index");

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -1,6 +1,7 @@
 import { convertSegmentsToRouteParts, type AppRoute } from "../routing/app-router.js";
 import { createMetadataRouteEntriesSource } from "../server/metadata-route-build-data.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
+import { collectStandaloneCssImports } from "../utils/static-css-imports.js";
 import { normalizePathSeparators } from "./runtime-entry-module.js";
 
 type AppRscManifestCode = {
@@ -15,6 +16,7 @@ type AppRscManifestCode = {
   rootLayoutVars: string[];
   globalErrorVar: string | null;
   globalNotFoundVar: string | null;
+  globalNotFoundStyleVars: string[];
 };
 
 type BuildAppRscManifestCodeOptions = {
@@ -322,6 +324,15 @@ export function buildAppRscManifestCode(
   const globalNotFoundVar = options.globalNotFoundPath
     ? imports.getImportVar(options.globalNotFoundPath)
     : null;
+  const globalNotFoundStyleVars = options.globalNotFoundPath
+    ? collectStandaloneCssImports(options.globalNotFoundPath).map((cssPath, idx) => {
+        const varName = `globalNotFoundCss_${idx}`;
+        imports.imports.push(
+          `import ${varName} from ${JSON.stringify(`${normalizePathSeparators(cssPath)}?inline`)};`,
+        );
+        return varName;
+      })
+    : [];
 
   const dynamicMetadataRoutes = metadataRoutes.filter((r) => r.isDynamic);
   for (const route of dynamicMetadataRoutes) {
@@ -346,5 +357,6 @@ export function buildAppRscManifestCode(
     rootLayoutVars,
     globalErrorVar,
     globalNotFoundVar,
+    globalNotFoundStyleVars,
   };
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -106,7 +106,6 @@ import { createServerExternalsManifestPlugin } from "./plugins/server-externals-
 import {
   VIRTUAL_GOOGLE_FONTS,
   RESOLVED_VIRTUAL_GOOGLE_FONTS,
-  parseStaticObjectLiteral,
   generateGoogleFontsVirtualModule,
   createGoogleFontsPlugin,
   createLocalFontsPlugin,
@@ -126,12 +125,12 @@ import {
 import {
   augmentSsrManifestFromBundle,
   tryRealpathSync,
-  relativeWithinRoot,
   type BundleBackfillChunk,
 } from "./build/ssr-manifest.js";
 import { stripServerExports } from "./plugins/strip-server-exports.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
+import { loadTsconfigPathAliasesForRoot } from "./config/tsconfig-paths.js";
 import tsconfigPaths from "vite-tsconfig-paths";
 import type { Options as VitePluginReactOptions } from "@vitejs/plugin-react";
 import MagicString from "magic-string";
@@ -206,142 +205,6 @@ function toRelativeFileEntry(root: string, absPath: string): string {
   return path.relative(root, absPath).split(path.sep).join("/");
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
-
-const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
-
-function resolveTsconfigPathCandidate(candidate: string): string | null {
-  const candidates = candidate.endsWith(".json")
-    ? [candidate]
-    : [candidate, `${candidate}.json`, path.join(candidate, "tsconfig.json")];
-
-  for (const item of candidates) {
-    if (fs.existsSync(item) && fs.statSync(item).isFile()) {
-      return item;
-    }
-  }
-
-  return null;
-}
-
-function resolveTsconfigExtends(configPath: string, specifier: string): string | null {
-  const fromDir = path.dirname(configPath);
-  if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("\\")) {
-    return resolveTsconfigPathCandidate(path.resolve(fromDir, specifier));
-  }
-
-  const requireFromConfig = createRequire(configPath);
-  const candidates = [specifier, `${specifier}.json`, path.join(specifier, "tsconfig.json")];
-
-  for (const item of candidates) {
-    try {
-      return requireFromConfig.resolve(item);
-    } catch {}
-  }
-
-  return null;
-}
-
-function materializeTsconfigPathAliases(
-  pathsConfig: Record<string, unknown>,
-  baseUrl: string,
-  projectRoot: string,
-): Record<string, string> {
-  const aliases: Record<string, string> = {};
-
-  for (const [find, rawTargets] of Object.entries(pathsConfig)) {
-    const target = Array.isArray(rawTargets)
-      ? rawTargets.find((value): value is string => typeof value === "string")
-      : typeof rawTargets === "string"
-        ? rawTargets
-        : null;
-    if (!target) continue;
-
-    if (find.includes("*") || target.includes("*")) {
-      if (!find.endsWith("/*") || !target.endsWith("/*")) continue;
-      if (find.indexOf("*") !== find.length - 1 || target.indexOf("*") !== target.length - 1) {
-        continue;
-      }
-
-      const aliasKey = find.slice(0, -2);
-      const targetDir = target.slice(0, -2);
-      if (!aliasKey || !targetDir) continue;
-
-      aliases[aliasKey] = toViteAliasReplacement(path.resolve(baseUrl, targetDir), projectRoot);
-      continue;
-    }
-
-    aliases[find] = toViteAliasReplacement(path.resolve(baseUrl, target), projectRoot);
-  }
-
-  return aliases;
-}
-
-function toViteAliasReplacement(absolutePath: string, projectRoot: string): string {
-  const normalizedPath = absolutePath.replace(/\\/g, "/");
-  const rootCandidates = new Set<string>([projectRoot]);
-  const realRoot = tryRealpathSync(projectRoot);
-  if (realRoot) rootCandidates.add(realRoot);
-
-  const pathCandidates = new Set<string>([absolutePath]);
-  const realPath = tryRealpathSync(absolutePath);
-  if (realPath) pathCandidates.add(realPath);
-
-  for (const rootCandidate of rootCandidates) {
-    for (const pathCandidate of pathCandidates) {
-      if (pathCandidate === rootCandidate) {
-        return normalizedPath;
-      }
-      const relativeId = relativeWithinRoot(rootCandidate, pathCandidate);
-      if (relativeId) return "/" + relativeId;
-    }
-  }
-
-  return normalizedPath;
-}
-
-function loadTsconfigPathAliases(
-  configPath: string,
-  projectRoot: string,
-  seen = new Set<string>(),
-): Record<string, string> {
-  const normalizedPath = tryRealpathSync(configPath) ?? configPath;
-  if (seen.has(normalizedPath)) return {};
-  seen.add(normalizedPath);
-
-  let parsed: Record<string, unknown> | null = null;
-  try {
-    parsed = parseStaticObjectLiteral(fs.readFileSync(normalizedPath, "utf-8"));
-  } catch {
-    return {};
-  }
-  if (!parsed) return {};
-
-  let aliases: Record<string, string> = {};
-  if (typeof parsed.extends === "string") {
-    const extendedPath = resolveTsconfigExtends(normalizedPath, parsed.extends);
-    if (extendedPath) {
-      aliases = loadTsconfigPathAliases(extendedPath, projectRoot, seen);
-    }
-  }
-
-  const compilerOptions = isRecord(parsed.compilerOptions) ? parsed.compilerOptions : null;
-  const pathsConfig =
-    compilerOptions && isRecord(compilerOptions.paths) ? compilerOptions.paths : null;
-  if (!pathsConfig) return aliases;
-
-  const baseUrl =
-    compilerOptions && typeof compilerOptions.baseUrl === "string" ? compilerOptions.baseUrl : ".";
-  const resolvedBaseUrl = path.resolve(path.dirname(normalizedPath), baseUrl);
-
-  return {
-    ...aliases,
-    ...materializeTsconfigPathAliases(pathsConfig, resolvedBaseUrl, projectRoot),
-  };
-}
-
 /**
  * Detect Vite major version at runtime by resolving from cwd.
  * The plugin may be installed in a workspace root with Vite 7 but used
@@ -401,27 +264,6 @@ function getVinextVersion(): string {
 type UserResolveConfigWithTsconfigPaths = NonNullable<UserConfig["resolve"]> & {
   tsconfigPaths?: boolean;
 };
-
-// Cache materialized tsconfig/jsconfig aliases so Vite's glob and dynamic-import
-// transforms can see them via resolve.alias without re-reading config files per env.
-const _tsconfigAliasCache = new Map<string, Record<string, string>>();
-
-function resolveTsconfigAliases(projectRoot: string): Record<string, string> {
-  if (_tsconfigAliasCache.has(projectRoot)) {
-    return _tsconfigAliasCache.get(projectRoot)!;
-  }
-
-  let aliases: Record<string, string> = {};
-  for (const name of TSCONFIG_FILES) {
-    const candidate = path.join(projectRoot, name);
-    if (!fs.existsSync(candidate)) continue;
-    aliases = loadTsconfigPathAliases(candidate, projectRoot);
-    break;
-  }
-
-  _tsconfigAliasCache.set(projectRoot, aliases);
-  return aliases;
-}
 
 // Virtual module IDs for Pages Router production build
 const VIRTUAL_SERVER_ENTRY = "virtual:vinext-server-entry";
@@ -981,7 +823,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
         const shouldEnableNativeTsconfigPaths =
           viteMajorVersion >= 8 && userResolve?.tsconfigPaths === undefined;
-        const tsconfigPathAliases = resolveTsconfigAliases(root);
+        const tsconfigPathAliases = loadTsconfigPathAliasesForRoot(root, { format: "vite" });
 
         // Load .env files into process.env before anything else.
         // Next.js loads .env files before evaluating next.config.js, so

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -55,6 +55,12 @@ type AppFallbackRendererOptions<TModule extends AppPageModule = AppPageModule> =
    * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx
    */
   globalNotFoundModule?: TModule | null;
+  /**
+   * Compiled CSS imported by `app/global-not-found.*`. Next keeps this
+   * standalone entry's CSS isolated from route/layout CSS; vinext injects the
+   * compiled CSS only for route-miss global-not-found HTML responses.
+   */
+  globalNotFoundStyles?: readonly string[];
   makeThenableParams: (params: AppPageParams) => unknown;
   metadataRoutes: MetadataFileRoute[];
   /** Configured next.config `basePath`, threaded into file-based metadata href emission. */
@@ -119,6 +125,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
     getNavigationContext,
     globalErrorModule,
     globalNotFoundModule,
+    globalNotFoundStyles,
     makeThenableParams,
     metadataRoutes,
     resolveChildSegments,
@@ -193,6 +200,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
             renderToReadableStream: rscRenderer,
             scriptNonce,
             skipLayoutWrapping: true,
+            standaloneStyles: globalNotFoundStyles,
             statusCode,
           });
         }

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -1,6 +1,7 @@
 import { Fragment, createElement, type ComponentType, type ReactNode } from "react";
 import { buildClientHookErrorMessage } from "vinext/shims/client-hook-error";
 import { ErrorBoundary } from "vinext/shims/error-boundary";
+import { escapeInlineContent } from "vinext/shims/head";
 import { LayoutSegmentProvider } from "vinext/shims/layout-segment-context";
 import { MetadataHead, ViewportHead } from "vinext/shims/metadata";
 import type { AppPageFontPreload } from "./app-page-execution.js";
@@ -21,6 +22,7 @@ import {
 } from "./app-page-stream.js";
 import { AppElementsWire, type AppElements } from "./app-elements.js";
 import { createAppPageLayoutEntries } from "./app-page-route-wiring.js";
+import { createNonceAttribute } from "./html.js";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AppPageComponent = ComponentType<any>;
@@ -87,6 +89,7 @@ type AppPageBoundaryRenderCommonOptions<TModule extends AppPageModule = AppPageM
   ) => string[];
   rootLayouts: readonly (TModule | null | undefined)[];
   scriptNonce?: string;
+  extraHeadHTML?: string;
 };
 
 type RenderAppPageHttpAccessFallbackOptions<TModule extends AppPageModule = AppPageModule> = {
@@ -105,6 +108,11 @@ type RenderAppPageHttpAccessFallbackOptions<TModule extends AppPageModule = AppP
    * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
    */
   skipLayoutWrapping?: boolean;
+  /**
+   * Standalone CSS that should apply only to this access-fallback document,
+   * after React-emitted shared stylesheet links.
+   */
+  standaloneStyles?: readonly string[];
   statusCode: number;
 } & AppPageBoundaryRenderCommonOptions<TModule>;
 
@@ -264,6 +272,7 @@ async function renderAppPageBoundaryElementResponse<TModule extends AppPageModul
       const ssrHandler = await options.loadSsrHandler();
       return renderAppPageHtmlResponse({
         clearRequestContext: options.clearRequestContext,
+        extraHeadHTML: options.extraHeadHTML,
         fontData,
         fontLinkHeader: options.buildFontLinkHeader(fontData.preloads),
         middlewareHeaders: options.middlewareContext.headers,
@@ -351,10 +360,31 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
     // would expect a root-layout tree path that doesn't exist in the markup.
     element,
     layoutModules: skipLayoutWrapping ? [] : layoutModules,
+    extraHeadHTML: renderStandaloneStyles(options.standaloneStyles, options.scriptNonce),
     route: skipLayoutWrapping ? null : options.route,
     routePattern: options.route?.pattern,
     status: options.statusCode,
   });
+}
+
+function renderStandaloneStyles(
+  styles: readonly string[] | undefined,
+  nonce: string | undefined,
+): string | undefined {
+  if (!styles || styles.length === 0) {
+    return undefined;
+  }
+
+  const nonceAttr = createNonceAttribute(nonce);
+  return styles
+    .map(
+      (style, index) =>
+        `<style data-vinext-standalone-style="${index}"${nonceAttr}>${escapeInlineContent(
+          style,
+          "style",
+        )}</style>`,
+    )
+    .join("\n");
 }
 
 export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -360,7 +360,9 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
     // would expect a root-layout tree path that doesn't exist in the markup.
     element,
     layoutModules: skipLayoutWrapping ? [] : layoutModules,
-    extraHeadHTML: renderStandaloneStyles(options.standaloneStyles, options.scriptNonce),
+    extraHeadHTML: skipLayoutWrapping
+      ? renderStandaloneStyles(options.standaloneStyles, options.scriptNonce)
+      : undefined,
     route: skipLayoutWrapping ? null : options.route,
     routePattern: options.route?.pattern,
     status: options.statusCode,

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -28,6 +28,7 @@ export type AppPageSsrHandler = {
       rootParams?: RootParams;
       sideStream?: ReadableStream<Uint8Array>;
       capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+      extraHeadHTML?: string;
       /** When true, wait for the full React tree before emitting bytes. */
       waitForAllReady?: boolean;
     },
@@ -48,6 +49,7 @@ type RenderAppPageHtmlStreamOptions = {
   sideStream?: ReadableStream<Uint8Array>;
   /** Out-parameter filled with accumulated raw RSC bytes after stream consumption. */
   capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+  extraHeadHTML?: string;
   /** When true, wait for the full React tree before emitting bytes. */
   waitForAllReady?: boolean;
 };
@@ -107,6 +109,7 @@ export async function renderAppPageHtmlStream(
     rootParams: options.rootParams,
     sideStream: options.sideStream,
     capturedRscDataRef: options.capturedRscDataRef,
+    extraHeadHTML: options.extraHeadHTML,
     waitForAllReady: options.waitForAllReady,
   };
 

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -203,6 +203,7 @@ function buildHeadInjectionHtml(
   formState: ReactFormState | null,
   insertedHTML: string,
   fontHTML: string,
+  extraHeadHTML: string | undefined,
   scriptNonce?: string,
 ): string {
   const navPayload = {
@@ -226,7 +227,8 @@ function buildHeadInjectionHtml(
     formStateScript +
     buildModulePreloadHtml(bootstrapModuleUrl, scriptNonce) +
     insertedHTML +
-    fontHTML
+    fontHTML +
+    (extraHeadHTML ?? "")
   );
 }
 
@@ -242,6 +244,7 @@ export async function handleSsr(
     sideStream?: ReadableStream<Uint8Array>;
     /** Out-parameter: filled with accumulated raw RSC bytes when sideStream is consumed. */
     capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+    extraHeadHTML?: string;
     formState?: ReactFormState | null;
     basePath?: string;
     rootParams?: RootParams;
@@ -421,6 +424,7 @@ export async function handleSsr(
             options?.formState ?? null,
             insertedHTML + errorMetaHTML,
             fontHTML,
+            options?.extraHeadHTML,
             options?.scriptNonce,
           );
         };

--- a/packages/vinext/src/utils/static-css-imports.ts
+++ b/packages/vinext/src/utils/static-css-imports.ts
@@ -1,10 +1,22 @@
 import fs from "node:fs";
 import path from "node:path";
+import { loadNearestTsconfigPathAliases } from "../config/tsconfig-paths.js";
 
-const STATIC_IMPORT_RE =
-  /^\s*import\s+(?:[^'"]*?\s+from\s*)?["']([^"']+)["']\s*;?\s*(?:\/\/.*)?$/gm;
+const STATIC_MODULE_SPECIFIER_RE =
+  /^\s*(?:import\s+(?!type\b)(?:[^'"]*?\s+from\s*)?["']([^"']+)["']|export\s+(type\s+)?(\*(?:\s+as\s+[\w$]+)?|\{[^}]*\})\s+from\s*["']([^"']+)["'])\s*;?\s*(?:\/\/.*)?$/gm;
 const CSS_IMPORT_RE = /\.(?:css|scss|sass|less|styl|stylus|pcss|postcss)$/i;
-const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"];
+const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mts", ".mjs", ".cts", ".cjs"];
+const EXPLICIT_JS_SOURCE_EXTENSIONS: Record<string, string[]> = {
+  ".js": [".tsx", ".ts", ".jsx"],
+  ".jsx": [".tsx", ".ts"],
+  ".mjs": [".mts"],
+  ".cjs": [".cts"],
+};
+
+type AliasEntry = {
+  find: string;
+  replacement: string;
+};
 
 function hasQueryOrHash(specifier: string): boolean {
   return specifier.includes("?") || specifier.includes("#");
@@ -19,37 +31,89 @@ function isCssSpecifier(specifier: string): boolean {
   return CSS_IMPORT_RE.test(specifierPath(specifier));
 }
 
-function isResolvableLocalSpecifier(specifier: string): boolean {
-  return specifier.startsWith(".") || specifier.startsWith("/");
+function existsFile(filePath: string): boolean {
+  return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
 }
 
-function resolveCssSpecifier(importerPath: string, specifier: string): string {
-  if (!isResolvableLocalSpecifier(specifier)) {
+function existsDirectory(filePath: string): boolean {
+  return fs.existsSync(filePath) && fs.statSync(filePath).isDirectory();
+}
+
+function resolveAliasedSpecifier(specifier: string, aliases: readonly AliasEntry[]): string | null {
+  for (const alias of aliases) {
+    if (specifier === alias.find) {
+      return alias.replacement;
+    }
+
+    const slashPrefix = `${alias.find}/`;
+    if (specifier.startsWith(slashPrefix)) {
+      return path.join(alias.replacement, specifier.slice(slashPrefix.length));
+    }
+  }
+
+  return null;
+}
+
+function resolveSpecifierBasePath(
+  importerPath: string,
+  specifier: string,
+  aliases: readonly AliasEntry[],
+): string | null {
+  if (specifier.startsWith(".")) {
+    return path.resolve(path.dirname(importerPath), specifierPath(specifier));
+  }
+
+  if (specifier.startsWith("/")) {
+    return path.resolve(specifierPath(specifier));
+  }
+
+  const aliasedPath = resolveAliasedSpecifier(specifierPath(specifier), aliases);
+  return aliasedPath ? path.resolve(aliasedPath) : null;
+}
+
+function resolveCssSpecifier(
+  importerPath: string,
+  specifier: string,
+  aliases: readonly AliasEntry[],
+): string {
+  const resolved = resolveSpecifierBasePath(importerPath, specifier, aliases);
+  if (!resolved) {
     return specifier;
   }
 
-  const unresolvedPath = specifierPath(specifier);
-  return specifier.startsWith(".")
-    ? path.resolve(path.dirname(importerPath), unresolvedPath)
-    : path.resolve(unresolvedPath);
+  return resolved;
 }
 
 function resolveSourceFile(basePath: string): string | null {
-  if (path.extname(basePath)) {
-    return fs.existsSync(basePath) && fs.statSync(basePath).isFile() ? basePath : null;
+  const extension = path.extname(basePath);
+  if (extension) {
+    if (existsFile(basePath)) {
+      return basePath;
+    }
+
+    const sourceExtensions = EXPLICIT_JS_SOURCE_EXTENSIONS[extension] ?? [];
+    const withoutExtension = basePath.slice(0, -extension.length);
+    for (const sourceExtension of sourceExtensions) {
+      const candidate = `${withoutExtension}${sourceExtension}`;
+      if (existsFile(candidate)) {
+        return candidate;
+      }
+    }
+
+    return null;
   }
 
   for (const extension of SOURCE_EXTENSIONS) {
     const candidate = `${basePath}${extension}`;
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+    if (existsFile(candidate)) {
       return candidate;
     }
   }
 
-  if (fs.existsSync(basePath) && fs.statSync(basePath).isDirectory()) {
+  if (existsDirectory(basePath)) {
     for (const extension of SOURCE_EXTENSIONS) {
       const candidate = path.join(basePath, `index${extension}`);
-      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      if (existsFile(candidate)) {
         return candidate;
       }
     }
@@ -58,19 +122,32 @@ function resolveSourceFile(basePath: string): string | null {
   return null;
 }
 
-function resolveSourceSpecifier(importerPath: string, specifier: string): string | null {
-  if (!isResolvableLocalSpecifier(specifier) || hasQueryOrHash(specifier)) {
+function resolveSourceSpecifier(
+  importerPath: string,
+  specifier: string,
+  aliases: readonly AliasEntry[],
+): string | null {
+  if (hasQueryOrHash(specifier)) {
     return null;
   }
 
-  const unresolvedPath = specifierPath(specifier);
-  const basePath = specifier.startsWith(".")
-    ? path.resolve(path.dirname(importerPath), unresolvedPath)
-    : path.resolve(unresolvedPath);
-  return resolveSourceFile(basePath);
+  const basePath = resolveSpecifierBasePath(importerPath, specifier, aliases);
+  return basePath ? resolveSourceFile(basePath) : null;
 }
 
-function readStaticImportSpecifiers(filePath: string): string[] {
+function isTypeOnlyNamedExportClause(clause: string): boolean {
+  if (!clause.startsWith("{")) {
+    return false;
+  }
+
+  const specifiers = clause
+    .slice(1, -1)
+    .split(",")
+    .map((specifier) => specifier.trim());
+  return specifiers.length > 0 && specifiers.every((specifier) => specifier.startsWith("type "));
+}
+
+function readStaticModuleSpecifiers(filePath: string): string[] {
   let source: string;
   try {
     source = fs.readFileSync(filePath, "utf8");
@@ -79,32 +156,58 @@ function readStaticImportSpecifiers(filePath: string): string[] {
   }
 
   const specifiers: string[] = [];
-  for (const match of source.matchAll(STATIC_IMPORT_RE)) {
-    const specifier = match[1];
-    if (specifier) {
-      specifiers.push(specifier);
+  for (const match of source.matchAll(STATIC_MODULE_SPECIFIER_RE)) {
+    const importSpecifier = match[1];
+    if (importSpecifier) {
+      specifiers.push(importSpecifier);
+      continue;
+    }
+
+    const exportKind = match[2];
+    const exportClause = match[3];
+    const exportSpecifier = match[4];
+    if (
+      exportSpecifier &&
+      exportKind !== "type " &&
+      exportClause &&
+      !isTypeOnlyNamedExportClause(exportClause)
+    ) {
+      specifiers.push(exportSpecifier);
     }
   }
   return specifiers;
 }
 
+function createAliasEntries(entryPath: string): AliasEntry[] {
+  const resolution = loadNearestTsconfigPathAliases(entryPath);
+  if (!resolution) {
+    return [];
+  }
+
+  return Object.entries(resolution.aliases)
+    .map(([find, replacement]) => ({ find, replacement }))
+    .sort((a, b) => b.find.length - a.find.length);
+}
+
 /**
  * Collect CSS imported by a standalone entry without relying on Rollup's
  * shared-entry CSS de-duplication. This intentionally follows only local
- * static JS/TS imports; non-local specifiers still work when they are CSS
- * imports because Vite can resolve them from the generated module.
+ * static JS/TS imports and configured tsconfig aliases; non-local specifiers
+ * still work when they are CSS imports because Vite can resolve them from the
+ * generated module.
  */
 export function collectStandaloneCssImports(entryPath: string): string[] {
   const seenSources = new Set<string>();
   const seenCss = new Set<string>();
   const cssImports: string[] = [];
+  const aliases = createAliasEntries(entryPath);
 
   function appendCssImport(importerPath: string, specifier: string): void {
     if (hasQueryOrHash(specifier)) {
       return;
     }
 
-    const resolved = resolveCssSpecifier(importerPath, specifier);
+    const resolved = resolveCssSpecifier(importerPath, specifier, aliases);
     if (!seenCss.has(resolved)) {
       seenCss.add(resolved);
       cssImports.push(resolved);
@@ -118,13 +221,13 @@ export function collectStandaloneCssImports(entryPath: string): string[] {
     }
 
     seenSources.add(resolvedPath);
-    for (const specifier of readStaticImportSpecifiers(resolvedPath)) {
+    for (const specifier of readStaticModuleSpecifiers(resolvedPath)) {
       if (isCssSpecifier(specifier)) {
         appendCssImport(resolvedPath, specifier);
         continue;
       }
 
-      const childSource = resolveSourceSpecifier(resolvedPath, specifier);
+      const childSource = resolveSourceSpecifier(resolvedPath, specifier, aliases);
       if (childSource) {
         visitSource(childSource);
       }

--- a/packages/vinext/src/utils/static-css-imports.ts
+++ b/packages/vinext/src/utils/static-css-imports.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const STATIC_IMPORT_RE =
+  /^\s*import\s+(?:[^'"]*?\s+from\s*)?["']([^"']+)["']\s*;?\s*(?:\/\/.*)?$/gm;
+const CSS_IMPORT_RE = /\.(?:css|scss|sass|less|styl|stylus|pcss|postcss)$/i;
+const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"];
+
+function hasQueryOrHash(specifier: string): boolean {
+  return specifier.includes("?") || specifier.includes("#");
+}
+
+function specifierPath(specifier: string): string {
+  const queryIndex = specifier.search(/[?#]/);
+  return queryIndex === -1 ? specifier : specifier.slice(0, queryIndex);
+}
+
+function isCssSpecifier(specifier: string): boolean {
+  return CSS_IMPORT_RE.test(specifierPath(specifier));
+}
+
+function isResolvableLocalSpecifier(specifier: string): boolean {
+  return specifier.startsWith(".") || specifier.startsWith("/");
+}
+
+function resolveCssSpecifier(importerPath: string, specifier: string): string {
+  if (!isResolvableLocalSpecifier(specifier)) {
+    return specifier;
+  }
+
+  const unresolvedPath = specifierPath(specifier);
+  return specifier.startsWith(".")
+    ? path.resolve(path.dirname(importerPath), unresolvedPath)
+    : path.resolve(unresolvedPath);
+}
+
+function resolveSourceFile(basePath: string): string | null {
+  if (path.extname(basePath)) {
+    return fs.existsSync(basePath) && fs.statSync(basePath).isFile() ? basePath : null;
+  }
+
+  for (const extension of SOURCE_EXTENSIONS) {
+    const candidate = `${basePath}${extension}`;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  if (fs.existsSync(basePath) && fs.statSync(basePath).isDirectory()) {
+    for (const extension of SOURCE_EXTENSIONS) {
+      const candidate = path.join(basePath, `index${extension}`);
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function resolveSourceSpecifier(importerPath: string, specifier: string): string | null {
+  if (!isResolvableLocalSpecifier(specifier) || hasQueryOrHash(specifier)) {
+    return null;
+  }
+
+  const unresolvedPath = specifierPath(specifier);
+  const basePath = specifier.startsWith(".")
+    ? path.resolve(path.dirname(importerPath), unresolvedPath)
+    : path.resolve(unresolvedPath);
+  return resolveSourceFile(basePath);
+}
+
+function readStaticImportSpecifiers(filePath: string): string[] {
+  let source: string;
+  try {
+    source = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(STATIC_IMPORT_RE)) {
+    const specifier = match[1];
+    if (specifier) {
+      specifiers.push(specifier);
+    }
+  }
+  return specifiers;
+}
+
+/**
+ * Collect CSS imported by a standalone entry without relying on Rollup's
+ * shared-entry CSS de-duplication. This intentionally follows only local
+ * static JS/TS imports; non-local specifiers still work when they are CSS
+ * imports because Vite can resolve them from the generated module.
+ */
+export function collectStandaloneCssImports(entryPath: string): string[] {
+  const seenSources = new Set<string>();
+  const seenCss = new Set<string>();
+  const cssImports: string[] = [];
+
+  function appendCssImport(importerPath: string, specifier: string): void {
+    if (hasQueryOrHash(specifier)) {
+      return;
+    }
+
+    const resolved = resolveCssSpecifier(importerPath, specifier);
+    if (!seenCss.has(resolved)) {
+      seenCss.add(resolved);
+      cssImports.push(resolved);
+    }
+  }
+
+  function visitSource(filePath: string): void {
+    const resolvedPath = resolveSourceFile(filePath);
+    if (!resolvedPath || seenSources.has(resolvedPath)) {
+      return;
+    }
+
+    seenSources.add(resolvedPath);
+    for (const specifier of readStaticImportSpecifiers(resolvedPath)) {
+      if (isCssSpecifier(specifier)) {
+        appendCssImport(resolvedPath, specifier);
+        continue;
+      }
+
+      const childSource = resolveSourceSpecifier(resolvedPath, specifier);
+      if (childSource) {
+        visitSource(childSource);
+      }
+    }
+  }
+
+  visitSource(entryPath);
+  return cssImports;
+}

--- a/packages/vinext/src/utils/static-css-imports.ts
+++ b/packages/vinext/src/utils/static-css-imports.ts
@@ -45,11 +45,19 @@ function isCssSpecifier(specifier: string): boolean {
 }
 
 function existsFile(filePath: string): boolean {
-  return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function existsDirectory(filePath: string): boolean {
-  return fs.existsSync(filePath) && fs.statSync(filePath).isDirectory();
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 function resolveAliasedSpecifier(specifier: string, aliases: readonly AliasEntry[]): string | null {

--- a/packages/vinext/src/utils/static-css-imports.ts
+++ b/packages/vinext/src/utils/static-css-imports.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import { parseSync } from "vite";
+import type { ESTree } from "vite";
 import { loadNearestTsconfigPathAliases } from "../config/tsconfig-paths.js";
 
-const STATIC_MODULE_SPECIFIER_RE =
-  /^\s*(?:import\s+(?!type\b)(?:[^'"]*?\s+from\s*)?["']([^"']+)["']|export\s+(type\s+)?(\*(?:\s+as\s+[\w$]+)?|\{[^}]*\})\s+from\s*["']([^"']+)["'])\s*;?\s*(?:\/\/.*)?$/gm;
 const CSS_IMPORT_RE = /\.(?:css|scss|sass|less|styl|stylus|pcss|postcss)$/i;
 const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mts", ".mjs", ".cts", ".cjs"];
 const EXPLICIT_JS_SOURCE_EXTENSIONS: Record<string, string[]> = {
@@ -16,6 +16,19 @@ const EXPLICIT_JS_SOURCE_EXTENSIONS: Record<string, string[]> = {
 type AliasEntry = {
   find: string;
   replacement: string;
+};
+
+type ParseLang = "js" | "jsx" | "ts" | "tsx";
+
+const SOURCE_PARSE_LANGS: Record<string, readonly ParseLang[]> = {
+  ".ts": ["ts"],
+  ".mts": ["ts"],
+  ".cts": ["ts"],
+  ".tsx": ["tsx"],
+  ".js": ["jsx", "js"],
+  ".mjs": ["jsx", "js"],
+  ".cjs": ["jsx", "js"],
+  ".jsx": ["jsx"],
 };
 
 function hasQueryOrHash(specifier: string): boolean {
@@ -135,16 +148,59 @@ function resolveSourceSpecifier(
   return basePath ? resolveSourceFile(basePath) : null;
 }
 
-function isTypeOnlyNamedExportClause(clause: string): boolean {
-  if (!clause.startsWith("{")) {
-    return false;
+function parseModule(filePath: string, source: string): ESTree.Program | null {
+  const langs = SOURCE_PARSE_LANGS[path.extname(filePath)] ?? ["tsx", "ts"];
+
+  for (const lang of langs) {
+    try {
+      const result = parseSync(filePath, source, {
+        astType: "ts",
+        lang,
+        sourceType: "module",
+      });
+
+      if (result.errors.some((error) => error.severity === "Error")) {
+        continue;
+      }
+
+      return result.program;
+    } catch {
+      continue;
+    }
   }
 
-  const specifiers = clause
-    .slice(1, -1)
-    .split(",")
-    .map((specifier) => specifier.trim());
-  return specifiers.length > 0 && specifiers.every((specifier) => specifier.startsWith("type "));
+  return null;
+}
+
+function moduleSpecifierValue(
+  node: ESTree.ImportDeclaration | ESTree.ExportNamedDeclaration | ESTree.ExportAllDeclaration,
+): string | null {
+  const sourceValue = node.source?.value;
+  return typeof sourceValue === "string" ? sourceValue : null;
+}
+
+function isTypeOnlyImport(node: ESTree.ImportDeclaration): boolean {
+  if (node.importKind === "type") {
+    return true;
+  }
+
+  return (
+    node.specifiers.length > 0 &&
+    node.specifiers.every(
+      (specifier) => specifier.type === "ImportSpecifier" && specifier.importKind === "type",
+    )
+  );
+}
+
+function isTypeOnlyNamedExport(node: ESTree.ExportNamedDeclaration): boolean {
+  if (node.exportKind === "type") {
+    return true;
+  }
+
+  return (
+    node.specifiers.length > 0 &&
+    node.specifiers.every((specifier) => specifier.exportKind === "type")
+  );
 }
 
 function readStaticModuleSpecifiers(filePath: string): string[] {
@@ -155,24 +211,32 @@ function readStaticModuleSpecifiers(filePath: string): string[] {
     return [];
   }
 
+  const program = parseModule(filePath, source);
+  if (!program) {
+    return [];
+  }
+
   const specifiers: string[] = [];
-  for (const match of source.matchAll(STATIC_MODULE_SPECIFIER_RE)) {
-    const importSpecifier = match[1];
-    if (importSpecifier) {
-      specifiers.push(importSpecifier);
+  for (const node of program.body) {
+    if (node.type === "ImportDeclaration") {
+      if (!isTypeOnlyImport(node)) {
+        const specifier = moduleSpecifierValue(node);
+        if (specifier) specifiers.push(specifier);
+      }
       continue;
     }
 
-    const exportKind = match[2];
-    const exportClause = match[3];
-    const exportSpecifier = match[4];
-    if (
-      exportSpecifier &&
-      exportKind !== "type " &&
-      exportClause &&
-      !isTypeOnlyNamedExportClause(exportClause)
-    ) {
-      specifiers.push(exportSpecifier);
+    if (node.type === "ExportNamedDeclaration") {
+      if (!isTypeOnlyNamedExport(node)) {
+        const specifier = moduleSpecifierValue(node);
+        if (specifier) specifiers.push(specifier);
+      }
+      continue;
+    }
+
+    if (node.type === "ExportAllDeclaration" && node.exportKind !== "type") {
+      const specifier = moduleSpecifierValue(node);
+      if (specifier) specifiers.push(specifier);
     }
   }
   return specifiers;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1328,6 +1328,31 @@ importers:
         specifier: 'catalog:'
         version: 0.1.22(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.6)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
 
+  tests/fixtures/global-not-found-css-order:
+    dependencies:
+      '@vitejs/plugin-rsc':
+        specifier: 'catalog:'
+        version: 0.5.26(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      react-server-dom-webpack:
+        specifier: 'catalog:'
+        version: 19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      vinext:
+        specifier: workspace:*
+        version: link:../../../packages/vinext
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.22
+        version: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)'
+    devDependencies:
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.22(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.6)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
+
   tests/fixtures/pages-basic:
     dependencies:
       react:

--- a/tests/fixtures/global-not-found-css-order/app/global-not-found.tsx
+++ b/tests/fixtures/global-not-found-css-order/app/global-not-found.tsx
@@ -1,0 +1,9 @@
+import "./red.css";
+
+export default function GlobalNotFound() {
+  return (
+    <html>
+      <body>not found</body>
+    </html>
+  );
+}

--- a/tests/fixtures/global-not-found-css-order/app/green.css
+++ b/tests/fixtures/global-not-found-css-order/app/green.css
@@ -1,0 +1,3 @@
+body {
+  background-color: green;
+}

--- a/tests/fixtures/global-not-found-css-order/app/layout.tsx
+++ b/tests/fixtures/global-not-found-css-order/app/layout.tsx
@@ -1,0 +1,10 @@
+import "./red.css";
+import "./green.css";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/global-not-found-css-order/app/page.tsx
+++ b/tests/fixtures/global-not-found-css-order/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>abc</p>;
+}

--- a/tests/fixtures/global-not-found-css-order/app/red.css
+++ b/tests/fixtures/global-not-found-css-order/app/red.css
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/tests/fixtures/global-not-found-css-order/next.config.js
+++ b/tests/fixtures/global-not-found-css-order/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    globalNotFound: true,
+  },
+};

--- a/tests/fixtures/global-not-found-css-order/next.config.mjs
+++ b/tests/fixtures/global-not-found-css-order/next.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   experimental: {
     globalNotFound: true,
   },

--- a/tests/fixtures/global-not-found-css-order/package.json
+++ b/tests/fixtures/global-not-found-css-order/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "global-not-found-css-order-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vitejs/plugin-rsc": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-server-dom-webpack": "catalog:",
+    "vinext": "workspace:*",
+    "vite": "catalog:"
+  },
+  "devDependencies": {
+    "vite-plus": "catalog:"
+  }
+}

--- a/tests/fixtures/global-not-found-css-order/tsconfig.json
+++ b/tests/fixtures/global-not-found-css-order/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "noEmit": true
+  }
+}

--- a/tests/fixtures/global-not-found-css-order/vite.config.ts
+++ b/tests/fixtures/global-not-found-css-order/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});

--- a/tests/nextjs-compat/global-not-found.test.ts
+++ b/tests/nextjs-compat/global-not-found.test.ts
@@ -18,12 +18,17 @@
  * layout, a homepage, a `/call-not-found` page, and `global-not-found.tsx`.
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
 import type { ViteDevServer } from "vite-plus";
-import { startFixtureServer, fetchHtml } from "../helpers.js";
+import { buildAppFixture, startFixtureServer, fetchHtml } from "../helpers.js";
 
 const FIXTURE_DIR = path.resolve(import.meta.dirname, "../fixtures/global-not-found-basic");
+const CSS_ORDER_FIXTURE_DIR = path.resolve(
+  import.meta.dirname,
+  "../fixtures/global-not-found-css-order",
+);
 
 describe("Next.js compat: global-not-found (basic)", () => {
   let server: ViteDevServer;
@@ -93,3 +98,115 @@ describe("Next.js compat: global-not-found (basic)", () => {
     expect(html).not.toContain('id="global-error-title"');
   });
 });
+
+describe("Next.js compat: global-not-found initial CSS order", () => {
+  // Ported from Next.js: test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
+  it("serves global-not-found styles independently from the root layout CSS", async () => {
+    const rscBundlePath = await buildAppFixture(CSS_ORDER_FIXTURE_DIR);
+    const outDir = path.dirname(path.dirname(rscBundlePath));
+    const { startProdServer } = await import("../../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({ port: 0, outDir, noCompression: true });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      const homeHtml = await fetchText(`${baseUrl}/`);
+      expect(await findFinalBodyBackground(baseUrl, outDir, homeHtml)).toBe("green");
+
+      const notFoundRes = await fetch(`${baseUrl}/404`);
+      expect(notFoundRes.status).toBe(404);
+      const notFoundHtml = await notFoundRes.text();
+      expect(notFoundHtml).toContain("not found");
+      expect(await findFinalBodyBackground(baseUrl, outDir, notFoundHtml)).toBe("red");
+    } finally {
+      server.close();
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  }, 120_000);
+});
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url);
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+async function findFinalBodyBackground(
+  baseUrl: string,
+  outDir: string,
+  html: string,
+): Promise<string | undefined> {
+  const cssBlocks = await collectStylesheetBlocks(baseUrl, outDir, html);
+  let finalColor: string | undefined;
+
+  for (const css of cssBlocks) {
+    const bodyBackground = /body\s*\{[^}]*\bbackground(?:-color)?\s*:\s*([^;}]+)/gi;
+    for (const match of css.matchAll(bodyBackground)) {
+      finalColor = match[1]?.trim().toLowerCase();
+    }
+  }
+
+  return finalColor;
+}
+
+async function collectStylesheetBlocks(
+  baseUrl: string,
+  outDir: string,
+  html: string,
+): Promise<string[]> {
+  const blocks: string[] = [];
+  const stylesheetTags = /<link\b[^>]*>|<style\b[^>]*>[\s\S]*?<\/style>/gi;
+
+  for (const tagMatch of html.matchAll(stylesheetTags)) {
+    const tag = tagMatch[0];
+    if (/^<style\b/i.test(tag)) {
+      blocks.push(tag.replace(/^<style\b[^>]*>/i, "").replace(/<\/style>$/i, ""));
+      continue;
+    }
+
+    if (!/\brel=["']stylesheet["']/i.test(tag)) {
+      continue;
+    }
+
+    const href = extractHtmlAttribute(tag, "href");
+    if (!href) {
+      continue;
+    }
+
+    const stylesheetUrl = new URL(href, baseUrl);
+    const localStaticAsset = readBuiltStaticAsset(outDir, stylesheetUrl.pathname);
+    if (localStaticAsset !== undefined) {
+      blocks.push(localStaticAsset);
+      continue;
+    }
+
+    const stylesheetUrlString = stylesheetUrl.toString();
+    const stylesheetRes = await fetch(stylesheetUrlString);
+    expect(stylesheetRes.status, `expected stylesheet ${stylesheetUrlString} to load`).toBe(200);
+    blocks.push(await stylesheetRes.text());
+  }
+
+  return blocks;
+}
+
+function extractHtmlAttribute(tag: string, name: string): string | undefined {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return tag.match(new RegExp(`\\b${escapedName}=["']([^"']+)["']`, "i"))?.[1];
+}
+
+function readBuiltStaticAsset(outDir: string, pathname: string): string | undefined {
+  if (!pathname.startsWith("/_next/static/")) {
+    return undefined;
+  }
+
+  for (const bundleDir of ["client", "server"]) {
+    const assetPath = path.join(outDir, bundleDir, pathname);
+    if (fs.existsSync(assetPath)) {
+      return fs.readFileSync(assetPath, "utf8");
+    }
+  }
+
+  return undefined;
+}

--- a/tests/nextjs-compat/global-not-found.test.ts
+++ b/tests/nextjs-compat/global-not-found.test.ts
@@ -115,7 +115,9 @@ describe("Next.js compat: global-not-found initial CSS order", () => {
       const homeHtml = await fetchText(`${baseUrl}/`);
       expect(await findFinalBodyBackground(baseUrl, outDir, homeHtml)).toBe("green");
 
-      const notFoundRes = await fetch(`${baseUrl}/404`);
+      // Use an arbitrary unmatched path, not `/404`, so the assertion exercises
+      // the route-miss global-not-found path rather than any literal `/404` route.
+      const notFoundRes = await fetch(`${baseUrl}/does-not-exist`);
       expect(notFoundRes.status).toBe(404);
       const notFoundHtml = await notFoundRes.text();
       expect(notFoundHtml).toContain("not found");

--- a/tests/static-css-imports.test.ts
+++ b/tests/static-css-imports.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { collectStandaloneCssImports } from "../packages/vinext/src/utils/static-css-imports.js";
+
+describe("collectStandaloneCssImports", () => {
+  it("follows static imports, re-exports, TS .js specifiers, and tsconfig aliases", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-static-css-imports-"));
+    try {
+      fs.mkdirSync(path.join(root, "app"), { recursive: true });
+      fs.mkdirSync(path.join(root, "src"), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(root, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            paths: {
+              "@/*": ["src/*"],
+            },
+          },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(root, "app", "global-not-found.tsx"),
+        [
+          'import "./entry.css";',
+          'export { palette } from "./barrel.js";',
+          'import "@/aliased";',
+          "",
+        ].join("\n"),
+      );
+      fs.writeFileSync(path.join(root, "app", "entry.css"), "body { color: red; }\n");
+      fs.writeFileSync(
+        path.join(root, "app", "barrel.ts"),
+        ['export * from "./theme";', 'export type { Palette } from "./types";', ""].join("\n"),
+      );
+      fs.writeFileSync(
+        path.join(root, "app", "theme.ts"),
+        ['import "./theme.css";', 'export const palette = "green";', ""].join("\n"),
+      );
+      fs.writeFileSync(path.join(root, "app", "theme.css"), "body { color: green; }\n");
+      fs.writeFileSync(path.join(root, "app", "types.ts"), 'import "./ignored-type.css";\n');
+      fs.writeFileSync(path.join(root, "app", "ignored-type.css"), "body { color: black; }\n");
+      fs.writeFileSync(path.join(root, "src", "aliased.ts"), 'import "./aliased.css";\n');
+      fs.writeFileSync(path.join(root, "src", "aliased.css"), "body { color: blue; }\n");
+
+      expect(collectStandaloneCssImports(path.join(root, "app", "global-not-found.tsx"))).toEqual([
+        path.join(root, "app", "entry.css"),
+        path.join(root, "app", "theme.css"),
+        path.join(root, "src", "aliased.css"),
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/static-css-imports.test.ts
+++ b/tests/static-css-imports.test.ts
@@ -54,4 +54,51 @@ describe("collectStandaloneCssImports", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("does not follow type-only named imports", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-static-css-imports-"));
+    try {
+      fs.mkdirSync(path.join(root, "app"), { recursive: true });
+      fs.mkdirSync(path.join(root, "src"), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(root, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            paths: {
+              "@/*": ["src/*"],
+            },
+          },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(root, "app", "global-not-found.tsx"),
+        [
+          'import { type ButtonProps } from "@/button";',
+          "import {",
+          "  type LinkProps,",
+          '} from "@/link";',
+          'import "./entry.css";',
+          "",
+        ].join("\n"),
+      );
+      fs.writeFileSync(path.join(root, "app", "entry.css"), "body { color: red; }\n");
+      fs.writeFileSync(
+        path.join(root, "src", "button.tsx"),
+        'import "./button.css"; export type ButtonProps = {};\n',
+      );
+      fs.writeFileSync(path.join(root, "src", "button.css"), "body { color: blue; }\n");
+      fs.writeFileSync(
+        path.join(root, "src", "link.tsx"),
+        'import "./link.css"; export type LinkProps = {};\n',
+      );
+      fs.writeFileSync(path.join(root, "src", "link.css"), "body { color: green; }\n");
+
+      expect(collectStandaloneCssImports(path.join(root, "app", "global-not-found.tsx"))).toEqual([
+        path.join(root, "app", "entry.css"),
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/tsconfig-paths-config-loader.test.ts
+++ b/tests/tsconfig-paths-config-loader.test.ts
@@ -52,6 +52,23 @@ describe("loadTsconfigPathAliasesForRoot", () => {
     expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
   });
 
+  it("can return Vite-root relative alias replacements", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir, { format: "vite" });
+    expect(aliases["@"]).toBe("/src");
+  });
+
   it("follows 'extends' for inherited paths", () => {
     tmpDir = makeTempDir();
     fs.writeFileSync(


### PR DESCRIPTION
## Overview

| Item | Details |
| --- | --- |
| Goal | Match Next's CSS order for `app/global-not-found` |
| Core change | Collect static CSS imports for the standalone global-not-found entry, import them through Vite with `?inline`, and inject them only for route-miss global-not-found HTML responses. |
| Review path | `app-rsc-manifest`, `static-css-imports`, `app-page-boundary-render`, compat test |
| Impact | `/` keeps layout CSS order. `/404` uses global-not-found CSS after shared app CSS. |

## Why

`app/global-not-found` is a standalone document. It must not lose its own initial CSS just because the root layout imports the same stylesheet before later layout CSS. Next enforces this by treating `global-not-found` as a standalone bundle and skipping cross-entry CSS de-duping for it.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| App RSC manifest | Standalone documents own their initial CSS | Adds generated `?inline` imports for CSS reachable from `app/global-not-found` |
| Fallback renderer | Only route-miss 404s use `global-not-found` | Threads standalone styles only through the `!route && statusCode === 404` branch |
| SSR head injection | Later CSS wins in the cascade | Inserts standalone styles before `</head>` after React-emitted shared stylesheet links |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Normal page | `red.css`, then `green.css`, final body background green | unchanged |
| Route-miss `/404` with `global-not-found` | shared app CSS collapsed to green | global-not-found CSS is injected last, final body background red |
| Page-level `notFound()` | uses normal route fallback path | unchanged |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/entries/app-rsc-manifest.ts` and `packages/vinext/src/utils/static-css-imports.ts`: collect standalone CSS and emit Vite `?inline` imports.
2. `packages/vinext/src/server/app-fallback-renderer.ts`: confines the payload to route-miss global-not-found rendering.
3. `packages/vinext/src/server/app-page-boundary-render.ts`, `app-page-stream.ts`, and `app-ssr-entry.ts`: pass and inject escaped nonce-aware standalone style HTML.
4. `tests/nextjs-compat/global-not-found.test.ts`: production regression ported from the Next fixture.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/nextjs-compat/global-not-found.test.ts tests/entry-templates.test.ts tests/app-fallback-renderer.test.ts`
- `vp run vinext#build`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/initial-css-order/initial-css-order.test.ts`
- `vp check`
- Commit hook also reran `tests/entry-templates.test.ts`, formatting, lint/type checks, and knip.

</details>

<details>
<summary>Risk and compatibility</summary>

- No public API change.
- Applies only when `app/global-not-found.*` exists and the fallback is a route-miss 404.
- Uses Vite-compiled CSS via `?inline`, so PostCSS and CSS-module transforms stay on the build path.
- The static import collector intentionally follows local static imports. Runtime dynamic imports are not initial CSS and remain out of scope.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next initial-css-order test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/initial-css-order/initial-css-order.test.ts#L16-L22) | Defines the global-not-found computed style expectation. |
| [Next fixture layout CSS order](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/initial-css-order/app/layout.tsx#L1-L2) | Shows normal pages import red then green. |
| [Next fixture global-not-found CSS](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/initial-css-order/app/global-not-found.tsx#L1-L7) | Shows the standalone 404 document imports only red. |
| [Next standalone loader tree](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/app-render/app-render.tsx#L457-L477) | Shows global-not-found replaces the layout tree as a standalone document. |
| [Next CSS dedupe rule](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts#L127-L180) | Shows `global-not-found` is the standalone bundle convention and skips cross-entry CSS dedupe. |

Closes #1549