### PR TITLE
fix(app-router): preserve encoded prerender params

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -40,7 +40,15 @@ import { runWithHeadersContext, headersContextFromRequest } from "vinext/shims/h
 import { createValidFileMatcher, findFileWithExtensions } from "../routing/file-matcher.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import { navigationRuntimeRscBootstrapExpression } from "../server/app-ssr-stream.js";
-import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
+import {
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+} from "../server/headers.js";
+import {
+  encodePrerenderRouteParams,
+  serializePrerenderRouteParamsHeader,
+  type PrerenderRouteParams,
+} from "../server/prerender-route-params.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
@@ -1014,6 +1022,7 @@ export async function prerenderApp({
       urlPath: string;
       /** The file-system route pattern this URL was expanded from (e.g. `/blog/:slug`). */
       routePattern: string;
+      prerenderRouteParams: PrerenderRouteParams | null;
       revalidate: number | false;
       isSpeculative: boolean; // 'unknown' route — mark skipped if render fails
     };
@@ -1158,6 +1167,7 @@ export async function prerenderApp({
             urlsToRender.push({
               urlPath,
               routePattern: route.pattern,
+              prerenderRouteParams: encodePrerenderRouteParams(route.pattern, params),
               revalidate,
               isSpeculative: false,
             });
@@ -1178,6 +1188,7 @@ export async function prerenderApp({
         urlsToRender.push({
           urlPath: route.pattern,
           routePattern: route.pattern,
+          prerenderRouteParams: null,
           revalidate: false,
           isSpeculative: true,
         });
@@ -1186,6 +1197,7 @@ export async function prerenderApp({
         urlsToRender.push({
           urlPath: route.pattern,
           routePattern: route.pattern,
+          prerenderRouteParams: null,
           revalidate,
           isSpeculative: false,
         });
@@ -1203,6 +1215,7 @@ export async function prerenderApp({
     async function renderUrl({
       urlPath,
       routePattern,
+      prerenderRouteParams,
       revalidate,
       isSpeculative,
     }: UrlToRender): Promise<PrerenderRouteResult> {
@@ -1216,7 +1229,13 @@ export async function prerenderApp({
         // (devWorker.fetch) so the ALS context set up here on the Node side never
         // reaches the worker isolate. The wrapping is a no-op for the CF path but
         // harmless — and it keeps renderUrl() shape-compatible across both modes.
-        const htmlRequest = new Request(`http://localhost${urlPath}`);
+        const prerenderRouteParamsHeader =
+          serializePrerenderRouteParamsHeader(prerenderRouteParams);
+        const htmlHeaders = new Headers();
+        if (prerenderRouteParamsHeader !== null) {
+          htmlHeaders.set(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, prerenderRouteParamsHeader);
+        }
+        const htmlRequest = new Request(`http://localhost${urlPath}`, { headers: htmlHeaders });
         const htmlRender = await runWithHeadersContext(
           headersContextFromRequest(htmlRequest),
           async () => {
@@ -1286,8 +1305,12 @@ export async function prerenderApp({
         // response that never went through createRscEmbedTransform.
         let rscData = extractRscPayloadFromPrerenderedHtml(html);
         if (rscData === null) {
+          const rscHeaders = new Headers({ Accept: "text/x-component", RSC: "1" });
+          if (prerenderRouteParamsHeader !== null) {
+            rscHeaders.set(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, prerenderRouteParamsHeader);
+          }
           const rscRequest = new Request(`http://localhost${urlPath}`, {
-            headers: { Accept: "text/x-component", RSC: "1" },
+            headers: rscHeaders,
           });
           const rscRes = await runWithHeadersContext(headersContextFromRequest(rscRequest), () =>
             rscHandler(rscRequest),

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -47,7 +47,7 @@ import {
 import {
   encodePrerenderRouteParams,
   serializePrerenderRouteParamsHeader,
-  type PrerenderRouteParams,
+  type PrerenderRouteParamsPayload,
 } from "../server/prerender-route-params.js";
 import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
@@ -1022,7 +1022,7 @@ export async function prerenderApp({
       urlPath: string;
       /** The file-system route pattern this URL was expanded from (e.g. `/blog/:slug`). */
       routePattern: string;
-      prerenderRouteParams: PrerenderRouteParams | null;
+      prerenderRouteParams: PrerenderRouteParamsPayload | null;
       revalidate: number | false;
       isSpeculative: boolean; // 'unknown' route — mark skipped if render fails
     };

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -15,6 +15,7 @@ import type {
 import {
   MIDDLEWARE_HEADER_PREFIX,
   VINEXT_MW_CTX_HEADER,
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "../server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
@@ -1219,6 +1220,7 @@ export async function proxyExternalRequest(
   // external rewrite destinations. It authorizes hidden production endpoints
   // used only by vinext's own prerender pipeline.
   headers.delete(VINEXT_PRERENDER_SECRET_HEADER);
+  headers.delete(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER);
   // Internal App Router dev middleware context must never leave the dev server.
   headers.delete(VINEXT_MW_CTX_HEADER);
 

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -536,6 +536,7 @@ export default __createAppRscHandler({
     middlewareContext,
     mountedSlotsHeader,
     params,
+    staticParamsValidationParams,
     rootParams,
     request,
     route,
@@ -614,6 +615,7 @@ export default __createAppRscHandler({
       middlewareContext,
       mountedSlotsHeader,
       params,
+      staticParamsValidationParams,
       rootParams,
       probeLayoutAt(li) {
         const LayoutComp = route.layouts[li]?.default;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -59,6 +59,7 @@ import {
   INTERNAL_HEADERS,
   isOpenRedirectShaped,
   normalizeTrailingSlash,
+  VINEXT_INTERNAL_HEADERS,
 } from "./server/request-pipeline.js";
 import {
   findInstrumentationClientFile,
@@ -2976,6 +2977,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // (which reads req.headers directly) must see clean headers.
               const nodeRequestHeaders = filterInternalHeaders(rawHeaders);
               for (const header of INTERNAL_HEADERS) {
+                delete req.headers[header];
+              }
+              for (const header of VINEXT_INTERNAL_HEADERS) {
                 delete req.headers[header];
               }
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -192,6 +192,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   middlewareContext: AppPageMiddlewareContext;
   mountedSlotsHeader?: string | null;
   params: AppPageParams;
+  staticParamsValidationParams?: AppPageParams;
   rootParams?: RootParams;
   probeLayoutAt: (layoutIndex: number) => unknown;
   probePage: () => unknown;
@@ -537,7 +538,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     enforceStaticParamsOnly: options.dynamicParamsConfig === false,
     generateStaticParams: options.generateStaticParams,
     isDynamicRoute: route.isDynamic,
-    params: options.params,
+    params: options.staticParamsValidationParams ?? options.params,
   });
   if (dynamicParamsResponse) {
     return dynamicParamsResponse;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -586,7 +586,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   }
 
   const { route, params } = match;
-  const prerenderRouteParams = readTrustedPrerenderRouteParams(request);
+  const prerenderRouteParamsPayload = readTrustedPrerenderRouteParams(request);
+  const prerenderRouteParams =
+    prerenderRouteParamsPayload?.routePattern === route.pattern
+      ? prerenderRouteParamsPayload.params
+      : null;
   const renderParams = prerenderRouteParams ?? params;
   options.setNavigationContext({
     pathname: canonicalPathname,
@@ -659,12 +663,14 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     // protocol needs to know whether the inbound request was a `_next/data`
     // fetch to emit `x-nextjs-redirect` instead of an HTTP redirect.
     const isDataRequest = rawRequest.headers.get("x-nextjs-data") === "1";
-    const prerenderRouteParams = readTrustedPrerenderRouteParams(rawRequest);
+    const prerenderRouteParamsPayload = readTrustedPrerenderRouteParams(rawRequest);
     const filteredHeaders = filterInternalHeaders(rawRequest.headers);
     if (mwCtx !== null) {
       filteredHeaders.set(VINEXT_MW_CTX_HEADER, mwCtx);
     }
-    const prerenderRouteParamsHeader = serializePrerenderRouteParamsHeader(prerenderRouteParams);
+    const prerenderRouteParamsHeader = serializePrerenderRouteParamsHeader(
+      prerenderRouteParamsPayload,
+    );
     if (prerenderRouteParamsHeader !== null) {
       filteredHeaders.set(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, prerenderRouteParamsHeader);
     }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -61,6 +61,7 @@ import {
   validateImageUrl,
 } from "./request-pipeline.js";
 import {
+  prerenderRouteParamsPayloadMatchesRoute,
   readTrustedPrerenderRouteParams,
   serializePrerenderRouteParamsHeader,
 } from "./prerender-route-params.js";
@@ -587,10 +588,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
 
   const { route, params } = match;
   const prerenderRouteParamsPayload = readTrustedPrerenderRouteParams(request);
-  const prerenderRouteParams =
-    prerenderRouteParamsPayload?.routePattern === route.pattern
-      ? prerenderRouteParamsPayload.params
-      : null;
+  const prerenderRouteParams = prerenderRouteParamsPayloadMatchesRoute(
+    prerenderRouteParamsPayload,
+    route.pattern,
+    params,
+  )
+    ? prerenderRouteParamsPayload.params
+    : null;
   const renderParams = prerenderRouteParams ?? params;
   options.setNavigationContext({
     pathname: canonicalPathname,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -667,6 +667,14 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     // protocol needs to know whether the inbound request was a `_next/data`
     // fetch to emit `x-nextjs-redirect` instead of an HTTP redirect.
     const isDataRequest = rawRequest.headers.get("x-nextjs-data") === "1";
+    // Read the trusted prerender route params before filtering strips the
+    // route-params header (it IS in VINEXT_INTERNAL_HEADERS), then re-attach the
+    // validated value below so the second read in handleAppRscRequest still sees
+    // it. The secret was already verified upstream at prod-server's
+    // nodeToWebRequest boundary; the surviving secret header (NOT in either
+    // internal-header list) lets readTrustedPrerenderRouteParams's
+    // VINEXT_PRERENDER gate pass on the reconstructed request. If the secret
+    // header is ever added to VINEXT_INTERNAL_HEADERS, that second read breaks.
     const prerenderRouteParamsPayload = readTrustedPrerenderRouteParams(rawRequest);
     const filteredHeaders = filterInternalHeaders(rawRequest.headers);
     if (mwCtx !== null) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -19,6 +19,7 @@ import {
   RSC_ACTION_HEADER,
   RSC_HEADER,
   VINEXT_MW_CTX_HEADER,
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
 } from "./headers.js";
 import { ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
@@ -59,6 +60,10 @@ import {
   resolvePublicFileRoute,
   validateImageUrl,
 } from "./request-pipeline.js";
+import {
+  readTrustedPrerenderRouteParams,
+  serializePrerenderRouteParamsHeader,
+} from "./prerender-route-params.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
@@ -97,6 +102,7 @@ type DispatchMatchedPageOptions<TRoute> = {
   middlewareContext: AppRscMiddlewareContext;
   mountedSlotsHeader: string | null;
   params: AppPageParams;
+  staticParamsValidationParams?: AppPageParams;
   rootParams?: RootParams;
   request: Request;
   route: TRoute;
@@ -580,12 +586,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   }
 
   const { route, params } = match;
+  const prerenderRouteParams = readTrustedPrerenderRouteParams(request);
+  const renderParams = prerenderRouteParams ?? params;
   options.setNavigationContext({
     pathname: canonicalPathname,
     searchParams: url.searchParams,
-    params,
+    params: renderParams,
   });
-  const rootParams = pickRootParams(params, route.rootParamNames);
+  const rootParams = pickRootParams(renderParams, route.rootParamNames);
   setRootParams(rootParams);
 
   if (route.routeHandler) {
@@ -599,7 +607,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       // bookkeeping above (navigation context, root params) keeps the matched
       // object (always `{}` for non-dynamic) so `useParams()` etc. still see
       // an object shape; only the user-facing handler context surfaces null.
-      params: route.isDynamic ? params : null,
+      params: route.isDynamic ? renderParams : null,
       request,
       route,
       searchParams: url.searchParams,
@@ -617,7 +625,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     isRscRequest,
     middlewareContext,
     mountedSlotsHeader,
-    params,
+    params: renderParams,
+    staticParamsValidationParams: prerenderRouteParams === null ? undefined : params,
     rootParams,
     request,
     route,
@@ -650,9 +659,14 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     // protocol needs to know whether the inbound request was a `_next/data`
     // fetch to emit `x-nextjs-redirect` instead of an HTTP redirect.
     const isDataRequest = rawRequest.headers.get("x-nextjs-data") === "1";
+    const prerenderRouteParams = readTrustedPrerenderRouteParams(rawRequest);
     const filteredHeaders = filterInternalHeaders(rawRequest.headers);
     if (mwCtx !== null) {
       filteredHeaders.set(VINEXT_MW_CTX_HEADER, mwCtx);
+    }
+    const prerenderRouteParamsHeader = serializePrerenderRouteParamsHeader(prerenderRouteParams);
+    if (prerenderRouteParamsHeader !== null) {
+      filteredHeaders.set(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, prerenderRouteParamsHeader);
     }
     const request = cloneRequestWithHeaders(rawRequest, filteredHeaders);
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -31,6 +31,9 @@ export const VINEXT_TIMING_HEADER = "x-vinext-timing";
 /** Build-time prerender authentication secret. */
 export const VINEXT_PRERENDER_SECRET_HEADER = "x-vinext-prerender-secret";
 
+/** URL-encoded JSON route params for build-time prerender renders. */
+export const VINEXT_PRERENDER_ROUTE_PARAMS_HEADER = "x-vinext-prerender-route-params";
+
 /** TPR (Tailored Per-Request) revalidation interval in seconds. */
 export const VINEXT_REVALIDATE_HEADER = "x-vinext-revalidate";
 
@@ -184,4 +187,5 @@ export const INTERNAL_HEADERS = [
   NEXTJS_DATA_HEADER,
   NEXT_RESUME_STATE_LENGTH_HEADER,
   ACTION_FORWARDED_HEADER,
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
 ];

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -187,5 +187,7 @@ export const INTERNAL_HEADERS = [
   NEXTJS_DATA_HEADER,
   NEXT_RESUME_STATE_LENGTH_HEADER,
   ACTION_FORWARDED_HEADER,
-  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
 ];
+
+/** Vinext-only internal headers stripped alongside Next.js protocol internals. */
+export const VINEXT_INTERNAL_HEADERS = [VINEXT_PRERENDER_ROUTE_PARAMS_HEADER];

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -30,6 +30,11 @@ function isPrerenderRouteParamsPayload(value: unknown): value is PrerenderRouteP
   );
 }
 
+// A payload with no dynamic params serializes to `null`, which is
+// indistinguishable from an absent header on the read side. This is intentional:
+// the only producer, `encodePrerenderRouteParams`, already returns `null` for
+// param-less patterns, so an empty-params payload never carries information worth
+// propagating. Routes with no dynamic segments need no encoded-render override.
 export function serializePrerenderRouteParamsHeader(
   payload: PrerenderRouteParamsPayload | null,
 ): string | null {
@@ -65,6 +70,15 @@ export function readTrustedPrerenderRouteParamsFromHeaders(
   return params;
 }
 
+// Convenience wrapper for reads that happen AFTER the prerender secret has
+// already been verified at the trust boundary. The only entry point that
+// receives raw external input, `prod-server`'s `nodeToWebRequest`, calls
+// `readTrustedPrerenderRouteParamsFromHeaders` WITH `expectedSecret` and
+// re-serializes the validated payload onto a clean header. Every downstream
+// reader (the App Router handler) therefore operates on an already-trusted
+// request and deliberately omits `expectedSecret`. The `VINEXT_PRERENDER=1`
+// gate still ensures this never activates outside the build-time prerender
+// phase. Do not call this on unverified external input.
 export function readTrustedPrerenderRouteParams(
   request: Request,
 ): PrerenderRouteParamsPayload | null {

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -1,0 +1,85 @@
+import { VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, VINEXT_PRERENDER_SECRET_HEADER } from "./headers.js";
+
+export type PrerenderRouteParams = Record<string, string | string[]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPrerenderRouteParams(value: unknown): value is PrerenderRouteParams {
+  if (!isRecord(value)) return false;
+
+  for (const key in value) {
+    const param = value[key];
+    if (typeof param === "string") continue;
+    if (Array.isArray(param) && param.every((item) => typeof item === "string")) continue;
+    return false;
+  }
+
+  return true;
+}
+
+export function serializePrerenderRouteParamsHeader(
+  params: PrerenderRouteParams | null,
+): string | null {
+  if (params === null || Object.keys(params).length === 0) return null;
+  return encodeURIComponent(JSON.stringify(params));
+}
+
+function parsePrerenderRouteParamsHeader(value: string | null): PrerenderRouteParams | null {
+  if (value === null || value === "") return null;
+
+  try {
+    const parsed: unknown = JSON.parse(decodeURIComponent(value));
+    return isPrerenderRouteParams(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readTrustedPrerenderRouteParamsFromHeaders(
+  headers: Headers,
+  expectedSecret?: string,
+): PrerenderRouteParams | null {
+  if (process.env.VINEXT_PRERENDER !== "1") return null;
+  const secret = headers.get(VINEXT_PRERENDER_SECRET_HEADER);
+  if (secret === null) return null;
+  if (expectedSecret !== undefined && secret !== expectedSecret) return null;
+  const header = headers.get(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER);
+  if (header === null) return null;
+  const params = parsePrerenderRouteParamsHeader(header);
+  if (params === null) {
+    throw new Error("[vinext] Invalid internal prerender route params header.");
+  }
+  return params;
+}
+
+export function readTrustedPrerenderRouteParams(request: Request): PrerenderRouteParams | null {
+  return readTrustedPrerenderRouteParamsFromHeaders(request.headers);
+}
+
+export function encodePrerenderRouteParams(
+  pattern: string,
+  params: PrerenderRouteParams,
+): PrerenderRouteParams | null {
+  const encoded: PrerenderRouteParams = {};
+
+  for (const part of pattern.split("/").filter(Boolean)) {
+    let paramName: string | null = null;
+    if (part.startsWith(":") && (part.endsWith("+") || part.endsWith("*"))) {
+      paramName = part.slice(1, -1);
+    } else if (part.startsWith(":")) {
+      paramName = part.slice(1);
+    }
+
+    if (paramName === null) continue;
+    const value = params[paramName];
+    if (Array.isArray(value)) {
+      encoded[paramName] = value.map((item) => encodeURIComponent(item));
+    } else if (typeof value === "string") {
+      encoded[paramName] = encodeURIComponent(value);
+    }
+  }
+
+  return Object.keys(encoded).length > 0 ? encoded : null;
+}

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -71,6 +71,52 @@ export function readTrustedPrerenderRouteParams(
   return readTrustedPrerenderRouteParamsFromHeaders(request.headers);
 }
 
+function decodePrerenderRouteParam(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function decodedPrerenderRouteParamEquals(
+  prerenderValue: string | string[],
+  matchedValue: string | string[],
+): boolean {
+  if (Array.isArray(prerenderValue) || Array.isArray(matchedValue)) {
+    if (!Array.isArray(prerenderValue) || !Array.isArray(matchedValue)) return false;
+    if (prerenderValue.length !== matchedValue.length) return false;
+
+    return prerenderValue.every((item, index) => {
+      const decoded = decodePrerenderRouteParam(item);
+      return decoded !== null && decoded === matchedValue[index];
+    });
+  }
+
+  const decoded = decodePrerenderRouteParam(prerenderValue);
+  return decoded !== null && decoded === matchedValue;
+}
+
+export function prerenderRouteParamsPayloadMatchesRoute(
+  payload: PrerenderRouteParamsPayload | null,
+  routePattern: string,
+  params: PrerenderRouteParams,
+): payload is PrerenderRouteParamsPayload {
+  if (payload === null) return false;
+  if (payload.routePattern !== routePattern) return false;
+
+  const prerenderParamKeys = Object.keys(payload.params);
+  if (prerenderParamKeys.length !== Object.keys(params).length) return false;
+
+  for (const [key, prerenderValue] of Object.entries(payload.params)) {
+    const matchedValue = params[key];
+    if (matchedValue === undefined) return false;
+    if (!decodedPrerenderRouteParamEquals(prerenderValue, matchedValue)) return false;
+  }
+
+  return true;
+}
+
 export function encodePrerenderRouteParams(
   pattern: string,
   params: PrerenderRouteParams,

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -1,13 +1,10 @@
 import { VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, VINEXT_PRERENDER_SECRET_HEADER } from "./headers.js";
+import { isUnknownRecord } from "../utils/record.js";
 
 export type PrerenderRouteParams = Record<string, string | string[]>;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isPrerenderRouteParams(value: unknown): value is PrerenderRouteParams {
-  if (!isRecord(value)) return false;
+  if (!isUnknownRecord(value)) return false;
 
   for (const key in value) {
     const param = value[key];

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -3,11 +3,15 @@ import { isUnknownRecord } from "../utils/record.js";
 
 export type PrerenderRouteParams = Record<string, string | string[]>;
 
+export type PrerenderRouteParamsPayload = {
+  params: PrerenderRouteParams;
+  routePattern: string;
+};
+
 function isPrerenderRouteParams(value: unknown): value is PrerenderRouteParams {
   if (!isUnknownRecord(value)) return false;
 
-  for (const key in value) {
-    const param = value[key];
+  for (const [, param] of Object.entries(value)) {
     if (typeof param === "string") continue;
     if (Array.isArray(param) && param.every((item) => typeof item === "string")) continue;
     return false;
@@ -16,19 +20,29 @@ function isPrerenderRouteParams(value: unknown): value is PrerenderRouteParams {
   return true;
 }
 
-export function serializePrerenderRouteParamsHeader(
-  params: PrerenderRouteParams | null,
-): string | null {
-  if (params === null || Object.keys(params).length === 0) return null;
-  return encodeURIComponent(JSON.stringify(params));
+function isPrerenderRouteParamsPayload(value: unknown): value is PrerenderRouteParamsPayload {
+  if (!isUnknownRecord(value)) return false;
+  if (Object.keys(value).length !== 2) return false;
+  return (
+    typeof value.routePattern === "string" &&
+    value.routePattern.startsWith("/") &&
+    isPrerenderRouteParams(value.params)
+  );
 }
 
-function parsePrerenderRouteParamsHeader(value: string | null): PrerenderRouteParams | null {
+export function serializePrerenderRouteParamsHeader(
+  payload: PrerenderRouteParamsPayload | null,
+): string | null {
+  if (payload === null || Object.keys(payload.params).length === 0) return null;
+  return encodeURIComponent(JSON.stringify(payload));
+}
+
+function parsePrerenderRouteParamsHeader(value: string | null): PrerenderRouteParamsPayload | null {
   if (value === null || value === "") return null;
 
   try {
     const parsed: unknown = JSON.parse(decodeURIComponent(value));
-    return isPrerenderRouteParams(parsed) ? parsed : null;
+    return isPrerenderRouteParamsPayload(parsed) ? parsed : null;
   } catch {
     return null;
   }
@@ -37,7 +51,7 @@ function parsePrerenderRouteParamsHeader(value: string | null): PrerenderRoutePa
 export function readTrustedPrerenderRouteParamsFromHeaders(
   headers: Headers,
   expectedSecret?: string,
-): PrerenderRouteParams | null {
+): PrerenderRouteParamsPayload | null {
   if (process.env.VINEXT_PRERENDER !== "1") return null;
   const secret = headers.get(VINEXT_PRERENDER_SECRET_HEADER);
   if (secret === null) return null;
@@ -51,14 +65,16 @@ export function readTrustedPrerenderRouteParamsFromHeaders(
   return params;
 }
 
-export function readTrustedPrerenderRouteParams(request: Request): PrerenderRouteParams | null {
+export function readTrustedPrerenderRouteParams(
+  request: Request,
+): PrerenderRouteParamsPayload | null {
   return readTrustedPrerenderRouteParamsFromHeaders(request.headers);
 }
 
 export function encodePrerenderRouteParams(
   pattern: string,
   params: PrerenderRouteParams,
-): PrerenderRouteParams | null {
+): PrerenderRouteParamsPayload | null {
   const encoded: PrerenderRouteParams = {};
 
   for (const part of pattern.split("/").filter(Boolean)) {
@@ -78,5 +94,5 @@ export function encodePrerenderRouteParams(
     }
   }
 
-  return Object.keys(encoded).length > 0 ? encoded : null;
+  return Object.keys(encoded).length > 0 ? { routePattern: pattern, params: encoded } : null;
 }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -70,7 +70,15 @@ import { manifestFileWithBase } from "../utils/manifest-paths.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import type { ExecutionContextLike } from "vinext/shims/request-context";
 import { readPrerenderSecret } from "../build/server-manifest.js";
-import { VINEXT_PRERENDER_SECRET_HEADER, VINEXT_STATIC_FILE_HEADER } from "./headers.js";
+import {
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+  VINEXT_STATIC_FILE_HEADER,
+} from "./headers.js";
+import {
+  readTrustedPrerenderRouteParamsFromHeaders,
+  serializePrerenderRouteParamsHeader,
+} from "./prerender-route-params.js";
 import { seedMemoryCacheFromPrerender as seedMemoryCacheFromPrerenderFallback } from "./seed-cache.js";
 import { installSocketErrorBackstop } from "./socket-error-backstop.js";
 
@@ -717,7 +725,11 @@ const trustProxy = process.env.VINEXT_TRUST_PROXY === "1" || trustedHosts.size >
  * Router prod server normalizes before static-asset lookup, and can pass
  * the result here so the downstream RSC handler doesn't re-normalize).
  */
-function nodeToWebRequest(req: IncomingMessage, urlOverride?: string): Request {
+function nodeToWebRequest(
+  req: IncomingMessage,
+  urlOverride?: string,
+  prerenderSecret?: string,
+): Request {
   const rawProto = trustProxy
     ? (req.headers["x-forwarded-proto"] as string)?.split(",")[0]?.trim()
     : undefined;
@@ -735,8 +747,16 @@ function nodeToWebRequest(req: IncomingMessage, urlOverride?: string): Request {
       rawHeaders.set(key, value);
     }
   }
+  const prerenderRouteParams = readTrustedPrerenderRouteParamsFromHeaders(
+    rawHeaders,
+    prerenderSecret,
+  );
   // Strip internal headers that should not be honored from external requests.
   const headers = filterInternalHeaders(rawHeaders);
+  const prerenderRouteParamsHeader = serializePrerenderRouteParamsHeader(prerenderRouteParams);
+  if (prerenderRouteParamsHeader !== null) {
+    headers.set(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, prerenderRouteParamsHeader);
+  }
 
   const method = req.method ?? "GET";
   const hasBody = method !== "GET" && method !== "HEAD";
@@ -1234,7 +1254,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       const normalizedUrl = pathname + qs;
 
       // Convert Node.js request to Web Request and call the RSC handler
-      const request = nodeToWebRequest(req, normalizedUrl);
+      const request = nodeToWebRequest(req, normalizedUrl, prerenderSecret);
       const response = await rscHandler(request);
 
       const staticFileSignal = response.headers.get(VINEXT_STATIC_FILE_HEADER);

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -217,13 +217,41 @@ function mergeResponseHeaders(
 function toWebHeaders(headersRecord: Record<string, string | string[]>): Headers {
   const headers = new Headers();
   for (const [key, value] of Object.entries(headersRecord)) {
-    if (Array.isArray(value)) {
-      for (const item of value) headers.append(key, item);
-    } else {
-      headers.set(key, value);
-    }
+    appendWebHeader(headers, key, value);
   }
   return headers;
+}
+
+function appendWebHeader(
+  headers: Headers,
+  key: string,
+  value: string | string[] | undefined,
+): void {
+  if (value === undefined) return;
+  if (Array.isArray(value)) {
+    for (const item of value) headers.append(key, item);
+    return;
+  }
+  headers.set(key, value);
+}
+
+function nodeHeadersToWebHeaders(headersRecord: IncomingMessage["headers"]): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(headersRecord)) {
+    appendWebHeader(headers, key, value);
+  }
+  return headers;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function resolveRequestProtocol(req: IncomingMessage): "http" | "https" {
+  const rawProto = trustProxy
+    ? firstHeaderValue(req.headers["x-forwarded-proto"])?.split(",")[0]?.trim()
+    : undefined;
+  return rawProto === "https" || rawProto === "http" ? rawProto : "http";
 }
 
 const NO_BODY_RESPONSE_STATUSES = new Set([204, 205, 304]);
@@ -686,7 +714,7 @@ async function statIfFile(filePath: string): Promise<{ size: number; mtimeMs: nu
  * itself, so this is only a concern for the Node.js prod-server.
  */
 function resolveHost(req: IncomingMessage, fallback: string): string {
-  const rawForwarded = req.headers["x-forwarded-host"] as string | undefined;
+  const rawForwarded = firstHeaderValue(req.headers["x-forwarded-host"]);
   const hostHeader = req.headers.host;
 
   if (rawForwarded) {
@@ -730,23 +758,12 @@ function nodeToWebRequest(
   urlOverride?: string,
   prerenderSecret?: string,
 ): Request {
-  const rawProto = trustProxy
-    ? (req.headers["x-forwarded-proto"] as string)?.split(",")[0]?.trim()
-    : undefined;
-  const proto = rawProto === "https" || rawProto === "http" ? rawProto : "http";
+  const proto = resolveRequestProtocol(req);
   const host = resolveHost(req, "localhost");
   const origin = `${proto}://${host}`;
   const url = new URL(urlOverride ?? req.url ?? "/", origin);
 
-  const rawHeaders = new Headers();
-  for (const [key, value] of Object.entries(req.headers)) {
-    if (value === undefined) continue;
-    if (Array.isArray(value)) {
-      for (const v of value) rawHeaders.append(key, v);
-    } else {
-      rawHeaders.set(key, value);
-    }
-  }
+  const rawHeaders = nodeHeadersToWebHeaders(req.headers);
   const prerenderRouteParams = readTrustedPrerenderRouteParamsFromHeaders(
     rawHeaders,
     prerenderSecret,
@@ -1647,15 +1664,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       }
 
       // Convert Node.js req to Web Request for the server entry
-      const rawProtocol = trustProxy
-        ? (req.headers["x-forwarded-proto"] as string)?.split(",")[0]?.trim()
-        : undefined;
-      const protocol = rawProtocol === "https" || rawProtocol === "http" ? rawProtocol : "http";
+      const protocol = resolveRequestProtocol(req);
       const hostHeader = resolveHost(req, `${host}:${port}`);
-      const rawReqHeaders = Object.entries(req.headers).reduce((h, [k, v]) => {
-        if (v) h.set(k, Array.isArray(v) ? v.join(", ") : v);
-        return h;
-      }, new Headers());
+      const rawReqHeaders = nodeHeadersToWebHeaders(req.headers);
       // Capture `x-nextjs-data` before filterInternalHeaders strips it — the
       // middleware redirect protocol needs to know whether the inbound request
       // was a `_next/data` fetch to emit `x-nextjs-redirect` instead of a 3xx.

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -764,13 +764,15 @@ function nodeToWebRequest(
   const url = new URL(urlOverride ?? req.url ?? "/", origin);
 
   const rawHeaders = nodeHeadersToWebHeaders(req.headers);
-  const prerenderRouteParams = readTrustedPrerenderRouteParamsFromHeaders(
+  const prerenderRouteParamsPayload = readTrustedPrerenderRouteParamsFromHeaders(
     rawHeaders,
     prerenderSecret,
   );
   // Strip internal headers that should not be honored from external requests.
   const headers = filterInternalHeaders(rawHeaders);
-  const prerenderRouteParamsHeader = serializePrerenderRouteParamsHeader(prerenderRouteParams);
+  const prerenderRouteParamsHeader = serializePrerenderRouteParamsHeader(
+    prerenderRouteParamsPayload,
+  );
   if (prerenderRouteParamsHeader !== null) {
     headers.set(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, prerenderRouteParamsHeader);
   }

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -5,6 +5,7 @@ import { matchHeaders } from "../config/config-matchers.js";
 import {
   INTERNAL_HEADERS,
   MIDDLEWARE_HEADER_PREFIX,
+  VINEXT_INTERNAL_HEADERS,
   VINEXT_STATIC_FILE_HEADER,
 } from "./headers.js";
 import { forbiddenResponse, notFoundResponse } from "./http-error-responses.js";
@@ -603,7 +604,9 @@ export function processMiddlewareHeaders(headers: Headers): void {
  *
  * @see `./headers.ts` for the canonical definition.
  */
-export { INTERNAL_HEADERS } from "./headers.js";
+export { INTERNAL_HEADERS, VINEXT_INTERNAL_HEADERS } from "./headers.js";
+
+const STRIPPED_INTERNAL_HEADERS = new Set([...INTERNAL_HEADERS, ...VINEXT_INTERNAL_HEADERS]);
 
 type RequestInitWithCf = RequestInit & { cf?: unknown };
 
@@ -620,12 +623,12 @@ type RequestInitWithCf = RequestInit & { cf?: unknown };
  * for the same cloning pattern).
  *
  * @param headers - The source Headers (never modified)
- * @returns A new Headers with INTERNAL_HEADERS removed
+ * @returns A new Headers with internal framework headers removed
  */
 export function filterInternalHeaders(headers: Headers): Headers {
   const filtered = new Headers();
   for (const [key, value] of headers) {
-    if (!INTERNAL_HEADERS.includes(key.toLowerCase())) {
+    if (!STRIPPED_INTERNAL_HEADERS.has(key.toLowerCase())) {
       filtered.append(key, value);
     }
   }

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -34,6 +34,8 @@ import path from "node:path";
 import type { CachedAppPageValue } from "vinext/shims/cache";
 import { isrCacheKey, isrSetPrerenderedAppPage } from "./isr-cache.js";
 import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import { normalizePath } from "./normalize-path.js";
 
 // ─── Manifest types ───────────────────────────────────────────────────────────
 
@@ -105,13 +107,14 @@ export async function seedMemoryCacheFromPrerender(
     if (route.status !== "rendered") continue;
     if (route.router !== "app") continue;
 
-    const pathname = route.path ?? route.route;
+    const artifactPathname = route.path ?? route.route;
+    const cachePathname = normalizePrerenderCachePathname(artifactPathname);
     // Fallback keys support older generated entries that do not export their
     // runtime key builders. Current App Router entries inject buildAppPage*Key
     // so seeded keys match process.env.__VINEXT_BUILD_ID exactly.
-    const baseKey = isrCacheKey("app", pathname, buildId);
-    const htmlKey = options?.buildAppPageHtmlKey?.(pathname) ?? baseKey + ":html";
-    const rscKey = options?.buildAppPageRscKey?.(pathname) ?? baseKey + ":rsc";
+    const baseKey = isrCacheKey("app", cachePathname, buildId);
+    const htmlKey = options?.buildAppPageHtmlKey?.(cachePathname) ?? baseKey + ":html";
+    const rscKey = options?.buildAppPageRscKey?.(cachePathname) ?? baseKey + ":rsc";
     const revalidateSeconds = typeof route.revalidate === "number" ? route.revalidate : undefined;
     const expireSeconds = typeof route.expire === "number" ? route.expire : undefined;
 
@@ -120,7 +123,7 @@ export async function seedMemoryCacheFromPrerender(
         writeAppPageEntry,
         prerenderDir,
         htmlKey,
-        pathname,
+        artifactPathname,
         trailingSlash,
         revalidateSeconds,
         expireSeconds,
@@ -130,7 +133,7 @@ export async function seedMemoryCacheFromPrerender(
         writeAppPageEntry,
         prerenderDir,
         rscKey,
-        pathname,
+        artifactPathname,
         revalidateSeconds,
         expireSeconds,
       );
@@ -142,6 +145,10 @@ export async function seedMemoryCacheFromPrerender(
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────────
+
+function normalizePrerenderCachePathname(pathname: string): string {
+  return normalizePath(normalizePathnameForRouteMatch(pathname));
+}
 
 function createDefaultAppPageEntryWriter(): NonNullable<
   PrerenderCacheSeedOptions["writeAppPageEntry"]

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -121,6 +121,110 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  it("uses encoded prerender route params for rendering while retaining decoded params for static validation", async () => {
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+    process.env.VINEXT_PRERENDER = "1";
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const prerenderRoute = createPageRoute({
+      isDynamic: true,
+      pattern: "/prerender-encoding/:id",
+      routeSegments: ["prerender-encoding", "[id]"],
+    });
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchRoute(pathname: string) {
+        return pathname === "/prerender-encoding/sticks & stones"
+          ? {
+              params: { id: "sticks & stones" },
+              route: prerenderRoute,
+            }
+          : null;
+      },
+    });
+
+    try {
+      const response = await handler(
+        new Request("https://example.test/docs/prerender-encoding/sticks%20%26%20stones", {
+          headers: {
+            "x-vinext-prerender-secret": "test-secret",
+            "x-vinext-prerender-route-params": encodeURIComponent(
+              JSON.stringify({ id: "sticks%20%26%20stones" }),
+            ),
+          },
+        }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(dispatchMatchedPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { id: "sticks%20%26%20stones" },
+          staticParamsValidationParams: { id: "sticks & stones" },
+        }),
+      );
+    } finally {
+      if (previousPrerender === undefined) {
+        delete process.env.VINEXT_PRERENDER;
+      } else {
+        process.env.VINEXT_PRERENDER = previousPrerender;
+      }
+    }
+  });
+
+  it("ignores forged prerender route params outside trusted prerender requests", async () => {
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+    delete process.env.VINEXT_PRERENDER;
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const prerenderRoute = createPageRoute({
+      isDynamic: true,
+      pattern: "/prerender-encoding/:id",
+      routeSegments: ["prerender-encoding", "[id]"],
+    });
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchRoute(pathname: string) {
+        return pathname === "/prerender-encoding/sticks & stones"
+          ? {
+              params: { id: "sticks & stones" },
+              route: prerenderRoute,
+            }
+          : null;
+      },
+    });
+
+    try {
+      const response = await handler(
+        new Request("https://example.test/docs/prerender-encoding/sticks%20%26%20stones", {
+          headers: {
+            "x-vinext-prerender-secret": "test-secret",
+            "x-vinext-prerender-route-params": encodeURIComponent(JSON.stringify({ id: "forged" })),
+          },
+        }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(dispatchMatchedPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { id: "sticks & stones" },
+        }),
+      );
+      expect(dispatchMatchedPage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          staticParamsValidationParams: expect.anything(),
+        }),
+      );
+    } finally {
+      if (previousPrerender === undefined) {
+        delete process.env.VINEXT_PRERENDER;
+      } else {
+        process.env.VINEXT_PRERENDER = previousPrerender;
+      }
+    }
+  });
+
   it("returns config redirects before route dispatch and skips finalization", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
     const handler = createHandler({

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -81,6 +81,10 @@ function createHandler(overrides: Partial<HandlerOptions> = {}) {
   });
 }
 
+function prerenderRouteParamsHeader(payload: unknown): string {
+  return encodeURIComponent(JSON.stringify(payload));
+}
+
 describe("createAppRscHandler", () => {
   it("wraps dispatch responses with request-scoped finalization", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
@@ -148,9 +152,10 @@ describe("createAppRscHandler", () => {
         new Request("https://example.test/docs/prerender-encoding/sticks%20%26%20stones", {
           headers: {
             "x-vinext-prerender-secret": "test-secret",
-            "x-vinext-prerender-route-params": encodeURIComponent(
-              JSON.stringify({ id: "sticks%20%26%20stones" }),
-            ),
+            "x-vinext-prerender-route-params": prerenderRouteParamsHeader({
+              routePattern: "/prerender-encoding/:id",
+              params: { id: "sticks%20%26%20stones" },
+            }),
           },
         }),
         null,
@@ -161,6 +166,64 @@ describe("createAppRscHandler", () => {
         expect.objectContaining({
           params: { id: "sticks%20%26%20stones" },
           staticParamsValidationParams: { id: "sticks & stones" },
+        }),
+      );
+    } finally {
+      if (previousPrerender === undefined) {
+        delete process.env.VINEXT_PRERENDER;
+      } else {
+        process.env.VINEXT_PRERENDER = previousPrerender;
+      }
+    }
+  });
+
+  it("ignores encoded prerender route params from a different rewritten route pattern", async () => {
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+    process.env.VINEXT_PRERENDER = "1";
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const productRoute = createPageRoute({
+      isDynamic: true,
+      pattern: "/product/:id",
+      routeSegments: ["product", "[id]"],
+    });
+    const handler = createHandler({
+      configHeaders: [],
+      configRewrites: {
+        beforeFiles: [{ source: "/source/:slug", destination: "/product/:slug" }],
+        afterFiles: [],
+        fallback: [],
+      },
+      dispatchMatchedPage,
+      matchRoute(pathname: string) {
+        return pathname === "/product/sticks & stones"
+          ? {
+              params: { id: "sticks & stones" },
+              route: productRoute,
+            }
+          : null;
+      },
+    });
+
+    try {
+      const response = await handler(
+        new Request("https://example.test/docs/source/sticks%20%26%20stones", {
+          headers: {
+            "x-vinext-prerender-secret": "test-secret",
+            "x-vinext-prerender-route-params": prerenderRouteParamsHeader({
+              routePattern: "/source/:slug",
+              params: { slug: "sticks%20%26%20stones" },
+            }),
+          },
+        }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(dispatchMatchedPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cleanPathname: "/product/sticks & stones",
+          params: { id: "sticks & stones" },
+          staticParamsValidationParams: undefined,
         }),
       );
     } finally {
@@ -199,7 +262,10 @@ describe("createAppRscHandler", () => {
         new Request("https://example.test/docs/prerender-encoding/sticks%20%26%20stones", {
           headers: {
             "x-vinext-prerender-secret": "test-secret",
-            "x-vinext-prerender-route-params": encodeURIComponent(JSON.stringify({ id: "forged" })),
+            "x-vinext-prerender-route-params": prerenderRouteParamsHeader({
+              routePattern: "/prerender-encoding/:id",
+              params: { id: "forged" },
+            }),
           },
         }),
         null,

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -235,6 +235,64 @@ describe("createAppRscHandler", () => {
     }
   });
 
+  it("ignores encoded prerender route params when a same-pattern rewrite changes the matched params", async () => {
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+    process.env.VINEXT_PRERENDER = "1";
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const productRoute = createPageRoute({
+      isDynamic: true,
+      pattern: "/product/:id",
+      routeSegments: ["product", "[id]"],
+    });
+    const handler = createHandler({
+      configHeaders: [],
+      configRewrites: {
+        beforeFiles: [{ source: "/product/:id", destination: "/product/sticks-and-stones" }],
+        afterFiles: [],
+        fallback: [],
+      },
+      dispatchMatchedPage,
+      matchRoute(pathname: string) {
+        return pathname === "/product/sticks-and-stones"
+          ? {
+              params: { id: "sticks-and-stones" },
+              route: productRoute,
+            }
+          : null;
+      },
+    });
+
+    try {
+      const response = await handler(
+        new Request("https://example.test/docs/product/sticks%20%26%20stones", {
+          headers: {
+            "x-vinext-prerender-secret": "test-secret",
+            "x-vinext-prerender-route-params": prerenderRouteParamsHeader({
+              routePattern: "/product/:id",
+              params: { id: "sticks%20%26%20stones" },
+            }),
+          },
+        }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(dispatchMatchedPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cleanPathname: "/product/sticks-and-stones",
+          params: { id: "sticks-and-stones" },
+          staticParamsValidationParams: undefined,
+        }),
+      );
+    } finally {
+      if (previousPrerender === undefined) {
+        delete process.env.VINEXT_PRERENDER;
+      } else {
+        process.env.VINEXT_PRERENDER = previousPrerender;
+      }
+    }
+  });
+
   it("ignores forged prerender route params outside trusted prerender requests", async () => {
     const previousPrerender = process.env.VINEXT_PRERENDER;
     delete process.env.VINEXT_PRERENDER;

--- a/tests/fixtures/app-basic/app/prerender-encoding/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/prerender-encoding/[id]/page.tsx
@@ -1,0 +1,17 @@
+export const dynamicParams = false;
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const id = (await params).id;
+
+  return (
+    <main>
+      <div data-testid="prerender-encoding-id">params.id is {id}</div>
+    </main>
+  );
+}
+
+export function generateStaticParams() {
+  const id = "sticks & stones";
+
+  return [{ id }];
+}

--- a/tests/prerender-route-params.test.ts
+++ b/tests/prerender-route-params.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  prerenderRouteParamsPayloadMatchesRoute,
+  type PrerenderRouteParamsPayload,
+} from "../packages/vinext/src/server/prerender-route-params.js";
+
+describe("prerenderRouteParamsPayloadMatchesRoute", () => {
+  it("requires the decoded prerender params to match the final route params", () => {
+    const payload: PrerenderRouteParamsPayload = {
+      routePattern: "/product/:id",
+      params: { id: "sticks%20%26%20stones" },
+    };
+
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+        id: "sticks & stones",
+      }),
+    ).toBe(true);
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+        id: "sticks-and-stones",
+      }),
+    ).toBe(false);
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/source/:slug", {
+        id: "sticks & stones",
+      }),
+    ).toBe(false);
+  });
+
+  it("compares catch-all params element-by-element after decoding", () => {
+    const payload: PrerenderRouteParamsPayload = {
+      routePattern: "/docs/:slug+",
+      params: { slug: ["sticks%20%26%20stones", "more%20words"] },
+    };
+
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/docs/:slug+", {
+        slug: ["sticks & stones", "more words"],
+      }),
+    ).toBe(true);
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/docs/:slug+", {
+        slug: ["more words", "sticks & stones"],
+      }),
+    ).toBe(false);
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/docs/:slug+", {
+        slug: "sticks & stones",
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -16,7 +16,9 @@ import {
   validateServerActionPayload,
   validateImageUrl,
   processMiddlewareHeaders,
+  VINEXT_INTERNAL_HEADERS,
 } from "../packages/vinext/src/server/request-pipeline.js";
+import { VINEXT_PRERENDER_ROUTE_PARAMS_HEADER } from "../packages/vinext/src/server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../packages/vinext/src/server/middleware-request-headers.js";
 
 // ── guardProtocolRelativeUrl ────────────────────────────────────────────
@@ -716,6 +718,20 @@ describe("filterInternalHeaders", () => {
     }
     expect(result.get("user-agent")).toBe("test");
     expect(result.get("cookie")).toBe("session=abc");
+  });
+
+  it("strips vinext-only internal headers without extending Next.js INTERNAL_HEADERS", () => {
+    const headers = new Headers({
+      [VINEXT_PRERENDER_ROUTE_PARAMS_HEADER]: "forged",
+      "user-agent": "test",
+    });
+
+    const result = filterInternalHeaders(headers);
+
+    expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER);
+    expect(VINEXT_INTERNAL_HEADERS).toEqual([VINEXT_PRERENDER_ROUTE_PARAMS_HEADER]);
+    expect(result.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)).toBe(false);
+    expect(result.get("user-agent")).toBe("test");
   });
 
   it("strips headers case-insensitively", () => {

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -163,6 +163,44 @@ describe("seedMemoryCacheFromPrerender", () => {
     expect(htmlEntry?.value?.kind).toBe("APP_PAGE");
   });
 
+  it("seeds encoded dynamic App Router paths under the runtime-normalized cache key", async () => {
+    const buildId = "encoded-path-test";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [
+          {
+            route: "/:id",
+            status: "rendered",
+            revalidate: false,
+            path: "/sticks%20%26%20stones",
+            router: "app",
+          },
+        ],
+      },
+      {
+        "sticks%20%26%20stones.html":
+          "<html><body>params.id is sticks%20%26%20stones</body></html>",
+        "sticks%20%26%20stones.rsc": "RSC encoded payload",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const htmlKey = isrCacheKey("app", "/sticks & stones", buildId) + ":html";
+    const htmlEntry = await getCacheHandler().get(htmlKey);
+    expect(htmlEntry).not.toBeNull();
+    if (htmlEntry?.value?.kind === "APP_PAGE") {
+      expect(htmlEntry.value.html).toBe(
+        "<html><body>params.id is sticks%20%26%20stones</body></html>",
+      );
+    }
+
+    const staleEncodedKey = isrCacheKey("app", "/sticks%20%26%20stones", buildId) + ":html";
+    expect(await getCacheHandler().get(staleEncodedKey)).toBeNull();
+  });
+
   // ── Return value ──────────────────────────────────────────────────────────
 
   it("returns the number of seeded routes", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9318,6 +9318,7 @@ describe("proxyExternalRequest", () => {
         "x-middleware-rewrite": "/internal",
         "x-middleware-next": "1",
         "x-vinext-prerender-secret": "build-secret-123",
+        "x-vinext-prerender-route-params": "%7B%22id%22%3A%22forged%22%7D",
         "x-custom-header": "keep-me",
         "user-agent": "vinext-test",
       },
@@ -9342,6 +9343,7 @@ describe("proxyExternalRequest", () => {
       expect(capturedHeaders!.get("x-middleware-rewrite")).toBeNull();
       expect(capturedHeaders!.get("x-middleware-next")).toBeNull();
       expect(capturedHeaders!.get("x-vinext-prerender-secret")).toBeNull();
+      expect(capturedHeaders!.get("x-vinext-prerender-route-params")).toBeNull();
       // Non-sensitive headers must be preserved
       expect(capturedHeaders!.get("x-custom-header")).toBe("keep-me");
       expect(capturedHeaders!.get("user-agent")).toBe("vinext-test");

--- a/tests/static-export.test.ts
+++ b/tests/static-export.test.ts
@@ -19,6 +19,34 @@ const APP_FIXTURE = path.resolve(import.meta.dirname, "./fixtures/app-basic");
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+function decodeHtmlText(text: string): string {
+  return text
+    .replaceAll("<!-- -->", "")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+function textContentByTestId(html: string, testId: string): string {
+  const attrIndex = html.indexOf(`data-testid="${testId}"`);
+  if (attrIndex === -1) {
+    throw new Error(`Missing data-testid="${testId}"`);
+  }
+
+  const contentStart = html.indexOf(">", attrIndex);
+  if (contentStart === -1) {
+    throw new Error(`Missing opening tag end for data-testid="${testId}"`);
+  }
+
+  const contentEnd = html.indexOf("</", contentStart);
+  if (contentEnd === -1) {
+    throw new Error(`Missing closing tag for data-testid="${testId}"`);
+  }
+
+  return decodeHtmlText(html.slice(contentStart + 1, contentEnd));
+}
+
 /** Simple static file server for testing. */
 function createStaticServer(rootDir: string): Promise<{ server: Server; baseUrl: string }> {
   const MIME_TYPES: Record<string, string> = {
@@ -261,6 +289,17 @@ describe("Static export — App Router (served via HTTP)", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("image/png");
     expect((await res.arrayBuffer()).byteLength).toBeGreaterThan(0);
+  });
+
+  it("serves pre-rendered encoded dynamic route params from generateStaticParams", async () => {
+    // Ported from Next.js: test/e2e/app-dir/prerender-encoding/prerender-encoding.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/prerender-encoding/prerender-encoding.test.ts
+    const res = await fetch(`${baseUrl}/prerender-encoding/sticks%20%26%20stones`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(textContentByTestId(html, "prerender-encoding-id")).toBe(
+      "params.id is sticks%20%26%20stones",
+    );
   });
 
   it("serves 404.html for missing pages", async () => {


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Match Next.js for App Router prerendered dynamic params that require URL encoding. |
| Core change | Preserve encoded `generateStaticParams` values through prerender rendering, while keeping decoded params for `dynamicParams = false` validation. |
| Runtime boundary | Seed prerendered App Router artifacts under the same normalized cache key used by live production requests. |
| Route-param proof | The prerender-only encoded params are only used when they prove both the final route pattern and the final decoded matched params. |
| Primary files | `build/prerender.ts`, `server/app-rsc-handler.ts`, `server/seed-cache.ts`, `server/prerender-route-params.ts` |
| Impact | The upstream `prerender-encoding` deploy test now serves the prerendered HTML instead of falling through to a decoded dynamic render. |

## Why

App Router prerender has two separate path shapes that both need to remain true: the artifact path on disk is URL-encoded, while the live production request path is normalized before cache lookup. The page render itself also needs the encoded param value for the prerendered artifact, but static-param validation must still compare decoded matched params against the raw `generateStaticParams` result.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Prerender render | The prerendered page should receive the encoded dynamic params associated with the concrete output path. | Adds a trusted prerender-only route-param header that is created by the build prerenderer and stripped from external input. |
| Route matching authority | Encoded prerender params are route-relative and must describe the final matched route after middleware/config rewrites. | Binds the header payload to the source route pattern and only applies it when decoded payload params equal the final matched params, including catch-all arrays. |
| Static validation | `dynamicParams = false` should validate against the decoded route match, not against the encoded render value. | Passes a separate decoded validation param object through page dispatch. |
| Production cache seed | The first live request must hit the artifact generated at build time. | Reads artifacts from encoded paths but seeds ISR cache keys using the runtime-normalized pathname. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `/sticks%20%26%20stones` from `generateStaticParams()` | Build/runtime route matching decoded params, and production cache seeding missed the live request key. The page rendered `sticks & stones`. | The prerender render sees `sticks%20%26%20stones`, and production startup seeds the cache under `/sticks & stones`, so the first request serves the prerendered artifact. |
| Rewrites during prerender render | Encoded params could float across rewrite boundaries if they were not tied to the final route match. | Encoded params are ignored unless their route pattern matches and their decoded params exactly match the final route params. |
| Forged prerender route-param headers | No such header existed. | Header is only honored during `VINEXT_PRERENDER=1` with the prerender secret, is filtered from normal requests, and is stripped from external rewrites. |

## Validation

- `vp test run tests/app-rsc-handler.test.ts -t "same-pattern rewrite"` (red before the decoded-match guard, green after)
- `vp test run tests/prerender-route-params.test.ts tests/app-rsc-handler.test.ts -t "prerenderRouteParamsPayloadMatchesRoute|same-pattern rewrite|encoded prerender route params|different rewritten route pattern"`
- `vp test run tests/seed-cache.test.ts tests/prod-server-prerender-seeder.test.ts tests/app-rsc-handler.test.ts tests/prerender-route-params.test.ts tests/static-export.test.ts tests/prerender.test.ts tests/request-pipeline.test.ts`
- `vp test run --project unit`
- `vp check`
- `vp run knip`
- `VINEXT_DIR="$PWD" ADAPTER_DIR="$PWD" vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/prerender-encoding/prerender-encoding.test.ts`

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js prerender encoding test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/prerender-encoding/prerender-encoding.test.ts) | Upstream observable behavior this ports. |
| [Next.js fixture page](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/prerender-encoding/app/%5Bid%5D/page.tsx) | Shows `dynamicParams = false` and `generateStaticParams()` returning `sticks & stones`. |
| [Next.js static path replacements](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.ts#L723-L738) | Shows encoded and non-encoded path construction for App Router prerender routes. |
| [Next.js app prerendered route generation](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.ts#L968-L1055) | Shows how prerendered routes retain concrete path data. |
| [Next.js route matcher decoding](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/route-matcher.ts#L17-L43) | Confirms normal live route matching decodes params, which must remain distinct from prerender artifact params. |
| [Next.js `generateStaticParams` docs](https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/04-functions/generate-static-params.mdx) | Documents that returned params are used to statically generate dynamic routes. |

Closes #1544