### PR TITLE
fix(app-router): align RSC navigation scroll targeting with Next.js

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -14,6 +14,7 @@ import {
   RedirectBoundary,
   UnauthorizedBoundary,
 } from "vinext/shims/error-boundary";
+import { AppRouterScrollTarget } from "vinext/shims/app-router-scroll";
 import type { AppRouteSemanticIds } from "../routing/app-route-graph.js";
 import { LayoutSegmentProvider } from "vinext/shims/layout-segment-context";
 import { MetadataHead, ViewportHead, type Metadata, type Viewport } from "vinext/shims/metadata";
@@ -645,7 +646,9 @@ export function buildAppPageElements<
 
   let routeChildren: ReactNode = (
     <LayoutSegmentProvider segmentMap={{ children: [] }}>
-      <Slot id={pageId} />
+      <AppRouterScrollTarget>
+        <Slot id={pageId} />
+      </AppRouterScrollTarget>
     </LayoutSegmentProvider>
   );
 

--- a/packages/vinext/src/shims/app-router-scroll-state.ts
+++ b/packages/vinext/src/shims/app-router-scroll-state.ts
@@ -1,0 +1,36 @@
+export type AppRouterScrollIntent = Readonly<{
+  hash: string | null;
+  id: number;
+}>;
+
+let nextAppRouterScrollIntentId = 0;
+let pendingAppRouterScrollIntent: AppRouterScrollIntent | null = null;
+
+export function beginAppRouterScrollIntent(hash: string | null): AppRouterScrollIntent {
+  nextAppRouterScrollIntentId += 1;
+  const intent = {
+    hash,
+    id: nextAppRouterScrollIntentId,
+  };
+  pendingAppRouterScrollIntent = intent;
+  return intent;
+}
+
+export function clearAppRouterScrollIntent(): void {
+  pendingAppRouterScrollIntent = null;
+}
+
+export function getPendingAppRouterScrollIntent(): AppRouterScrollIntent | null {
+  return pendingAppRouterScrollIntent;
+}
+
+export function consumeAppRouterScrollIntent(
+  expected?: AppRouterScrollIntent,
+): AppRouterScrollIntent | null {
+  const intent = pendingAppRouterScrollIntent;
+  if (intent === null) return null;
+  if (expected && intent.id !== expected.id) return null;
+
+  pendingAppRouterScrollIntent = null;
+  return intent;
+}

--- a/packages/vinext/src/shims/app-router-scroll-state.ts
+++ b/packages/vinext/src/shims/app-router-scroll-state.ts
@@ -3,34 +3,59 @@ export type AppRouterScrollIntent = Readonly<{
   id: number;
 }>;
 
-let nextAppRouterScrollIntentId = 0;
-let pendingAppRouterScrollIntent: AppRouterScrollIntent | null = null;
+// A scroll intent is staged by `navigateClientSide` (next/navigation) before an
+// RSC navigation and consumed by the committed `AppRouterScrollTarget`. Both run
+// in the browser, but next/navigation and this module can be loaded through
+// separate Vite module instances (see the Symbol.for navigation state in
+// navigation.ts and AGENTS.md "RSC and SSR Are Separate Vite Environments"). If
+// the writer and consumer held different module-level copies, the staged intent
+// would be invisible to the consumer and scroll/focus would silently no-op.
+// Store the single pending intent and the id counter on a Symbol.for global so
+// every instance shares one slot, matching the rest of the navigation state.
+const _SCROLL_INTENT_KEY = Symbol.for("vinext.appRouterScrollIntent");
+
+type ScrollIntentStore = {
+  nextId: number;
+  pending: AppRouterScrollIntent | null;
+};
+
+type ScrollIntentGlobal = typeof globalThis & {
+  [_SCROLL_INTENT_KEY]?: ScrollIntentStore;
+};
+
+function getScrollIntentStore(): ScrollIntentStore {
+  const globalState = globalThis as ScrollIntentGlobal;
+  globalState[_SCROLL_INTENT_KEY] ??= { nextId: 0, pending: null };
+  return globalState[_SCROLL_INTENT_KEY]!;
+}
 
 export function beginAppRouterScrollIntent(hash: string | null): AppRouterScrollIntent {
-  nextAppRouterScrollIntentId += 1;
+  const store = getScrollIntentStore();
+  store.nextId += 1;
   const intent = {
     hash,
-    id: nextAppRouterScrollIntentId,
+    id: store.nextId,
   };
-  pendingAppRouterScrollIntent = intent;
+  store.pending = intent;
   return intent;
 }
 
 export function clearAppRouterScrollIntent(): void {
-  pendingAppRouterScrollIntent = null;
+  getScrollIntentStore().pending = null;
 }
 
 export function getPendingAppRouterScrollIntent(): AppRouterScrollIntent | null {
-  return pendingAppRouterScrollIntent;
+  return getScrollIntentStore().pending;
 }
 
 export function consumeAppRouterScrollIntent(
   expected?: AppRouterScrollIntent,
 ): AppRouterScrollIntent | null {
-  const intent = pendingAppRouterScrollIntent;
+  const store = getScrollIntentStore();
+  const intent = store.pending;
   if (intent === null) return null;
   if (expected && intent.id !== expected.id) return null;
 
-  pendingAppRouterScrollIntent = null;
+  store.pending = null;
   return intent;
 }

--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { decodeHashFragment } from "./hash-scroll.js";
+import {
+  consumeAppRouterScrollIntent,
+  getPendingAppRouterScrollIntent,
+} from "./app-router-scroll-state.js";
+
+const reactDomInternalsKey = "__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE";
+const rectProperties = ["bottom", "height", "left", "right", "top", "width", "x", "y"] as const;
+
+function readFindDOMNode(): ((instance: React.ReactInstance | null | undefined) => unknown) | null {
+  const internals = Reflect.get(ReactDOM, reactDomInternalsKey);
+  if (typeof internals !== "object" || internals === null) {
+    return null;
+  }
+
+  const findDOMNode = Reflect.get(internals, "findDOMNode");
+  return typeof findDOMNode === "function" ? findDOMNode : null;
+}
+
+function findDOMNode(instance: React.ReactInstance | null | undefined): Element | Text | null {
+  if (typeof window === "undefined") return null;
+
+  const findDOMNodeImpl = readFindDOMNode();
+  if (!findDOMNodeImpl) return null;
+
+  const node = findDOMNodeImpl(instance);
+  return node instanceof Element || node instanceof Text ? node : null;
+}
+
+function shouldSkipElement(element: HTMLElement): boolean {
+  const position = getComputedStyle(element).position;
+  if (position === "fixed" || position === "sticky") {
+    return true;
+  }
+
+  const rect = element.getBoundingClientRect();
+  return rectProperties.every((property) => rect[property] === 0);
+}
+
+function topOfElementInViewport(element: HTMLElement, viewportHeight: number): boolean {
+  const rects = element.getClientRects();
+  if (rects.length === 0) {
+    return false;
+  }
+
+  let elementTop = Number.POSITIVE_INFINITY;
+  for (const rect of rects) {
+    if (rect.top < elementTop) {
+      elementTop = rect.top;
+    }
+  }
+
+  return elementTop >= 0 && elementTop <= viewportHeight;
+}
+
+function getHashFragmentDomNode(hash: string): HTMLElement | null {
+  const fragment = decodeHashFragment(hash.startsWith("#") ? hash.slice(1) : hash);
+  if (fragment === "top") {
+    return document.body;
+  }
+
+  const element = document.getElementById(fragment) ?? document.getElementsByName(fragment)[0];
+  return element instanceof HTMLElement ? element : null;
+}
+
+function findNextScrollTarget(node: Element | Text | null): HTMLElement | null {
+  if (!(node instanceof Element)) {
+    return null;
+  }
+
+  let target: Element = node;
+  while (!(target instanceof HTMLElement) || shouldSkipElement(target)) {
+    if (target.nextElementSibling === null) {
+      return null;
+    }
+    target = target.nextElementSibling;
+  }
+
+  return target;
+}
+
+function scrollToElement(target: HTMLElement, hash: string | null): void {
+  if (hash !== null) {
+    target.scrollIntoView({ behavior: "auto" });
+    return;
+  }
+
+  const htmlElement = document.documentElement;
+  const viewportHeight = htmlElement.clientHeight;
+
+  if (topOfElementInViewport(target, viewportHeight)) {
+    return;
+  }
+
+  htmlElement.scrollTop = 0;
+
+  if (!topOfElementInViewport(target, viewportHeight)) {
+    target.scrollIntoView({ behavior: "auto", block: "start", inline: "nearest" });
+  }
+}
+
+export class AppRouterScrollTarget extends React.Component<{ children: React.ReactNode }> {
+  handlePotentialScroll = () => {
+    const intent = getPendingAppRouterScrollIntent();
+    if (intent === null) return;
+
+    let target: HTMLElement | null;
+    if (intent.hash !== null) {
+      target = getHashFragmentDomNode(intent.hash);
+    } else {
+      // oxlint-disable-next-line react/no-find-dom-node -- Next's default App Router scroll handler targets wrapperless route content after commit.
+      target = findNextScrollTarget(findDOMNode(this));
+    }
+    if (target === null) return;
+
+    const consumed = consumeAppRouterScrollIntent(intent);
+    if (consumed === null) return;
+
+    scrollToElement(target, consumed.hash);
+    target.focus();
+  };
+
+  componentDidMount() {
+    this.handlePotentialScroll();
+  }
+
+  componentDidUpdate() {
+    this.handlePotentialScroll();
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -121,7 +121,10 @@ export class AppRouterScrollTarget extends React.Component<{ children: React.Rea
     if (consumed === null) return;
 
     scrollToElement(target, consumed.hash);
-    target.focus();
+    // Next's default handler uses plain focus(), but that lets the browser run
+    // a second implicit scroll after our explicit navigation scroll. Keep the
+    // focus transfer while preserving the scroll position we just chose.
+    target.focus({ preventScroll: true });
   };
 
   componentDidMount() {

--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -103,6 +103,10 @@ function scrollToElement(target: HTMLElement, hash: string | null): void {
   }
 }
 
+// Must stay a class component: findDOMNode() needs a mounted class instance to
+// locate the first DOM node rendered by the children without introducing a
+// wrapper element. Converting this to a function component would break the
+// wrapperless targeting that mirrors Next's default scroll handler.
 export class AppRouterScrollTarget extends React.Component<{ children: React.ReactNode }> {
   handlePotentialScroll = () => {
     const intent = getPendingAppRouterScrollIntent();

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -34,6 +34,12 @@ import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
 import { AppRouterContext } from "./internal/app-router-context.js";
 import { scrollToHashTarget } from "./hash-scroll.js";
+import {
+  beginAppRouterScrollIntent,
+  clearAppRouterScrollIntent,
+  consumeAppRouterScrollIntent,
+  type AppRouterScrollIntent,
+} from "./app-router-scroll-state.js";
 
 // ─── Layout segment context ───────────────────────────────────────────────────
 // Stores the child segments below the current layout. Each layout wraps its
@@ -1323,6 +1329,19 @@ function commitHashOnlyHistoryState(href: string, mode: "push" | "replace", scro
   }
 }
 
+function applyAppRouterScrollFallback(intent: AppRouterScrollIntent): void {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return;
+  }
+
+  if (intent.hash !== null) {
+    scrollToHashTarget(intent.hash);
+    return;
+  }
+
+  document.documentElement.scrollTop = 0;
+}
+
 /**
  * Restore scroll position from a history state object (used on popstate).
  *
@@ -1417,6 +1436,10 @@ export async function navigateClientSide(
   // Extract hash for post-navigation scrolling
   const hashIdx = fullHref.indexOf("#");
   const hash = hashIdx !== -1 ? fullHref.slice(hashIdx) : "";
+  const scrollIntent = scroll ? beginAppRouterScrollIntent(hash || null) : null;
+  if (!scroll) {
+    clearAppRouterScrollIntent();
+  }
 
   // Trigger RSC re-fetch if available, and wait for the new content to render
   // before scrolling. This prevents the old page from visibly jumping to the
@@ -1427,22 +1450,28 @@ export async function navigateClientSide(
   // double-push and ensures window.location still reflects the *current* URL
   // when navigateRsc publishes the committed URL.
   const appNavigate = getNavigationRuntime()?.functions.navigate;
-  if (appNavigate) {
-    await appNavigate(fullHref, 0, "navigate", mode, undefined, programmaticTransition);
-  } else {
-    if (mode === "replace") {
-      replaceHistoryStateWithoutNotify(null, "", fullHref);
+  try {
+    if (appNavigate) {
+      await appNavigate(fullHref, 0, "navigate", mode, undefined, programmaticTransition);
     } else {
-      pushHistoryStateWithoutNotify(null, "", fullHref);
+      if (mode === "replace") {
+        replaceHistoryStateWithoutNotify(null, "", fullHref);
+      } else {
+        pushHistoryStateWithoutNotify(null, "", fullHref);
+      }
+      commitClientNavigationState();
     }
-    commitClientNavigationState();
+  } catch (error) {
+    if (scrollIntent) {
+      consumeAppRouterScrollIntent(scrollIntent);
+    }
+    throw error;
   }
 
-  if (scroll) {
-    if (hash) {
-      scrollToHashTarget(hash);
-    } else {
-      window.scrollTo(0, 0);
+  if (scrollIntent) {
+    const fallbackIntent = consumeAppRouterScrollIntent(scrollIntent);
+    if (fallbackIntent) {
+      applyAppRouterScrollFallback(fallbackIntent);
     }
   }
 }

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
@@ -1,0 +1,148 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+const ROUTE_BASE = `${BASE}/nextjs-compat/router-autoscroll`;
+
+type RouterAutoscrollControls = {
+  push: (href: string) => void;
+  pushNoScroll: (href: string) => void;
+};
+
+declare global {
+  // oxlint-disable-next-line typescript/consistent-type-definitions -- Window augmentation requires interface merging.
+  interface Window {
+    __vinextRouterAutoscroll?: RouterAutoscrollControls;
+  }
+}
+
+async function waitForControls(page: Page) {
+  await waitForAppRouterHydration(page);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const controls = window.__vinextRouterAutoscroll;
+        return {
+          push: typeof controls?.push,
+          pushNoScroll: typeof controls?.pushNoScroll,
+        };
+      }),
+    )
+    .toEqual({ push: "function", pushNoScroll: "function" });
+}
+
+async function push(page: Page, href: string, options: { scroll?: boolean } = {}) {
+  await page.evaluate(
+    ({ href: targetHref, scroll }) => {
+      const controls = window.__vinextRouterAutoscroll;
+      if (!controls) {
+        throw new Error("router autoscroll controls are not installed");
+      }
+      if (scroll === false) {
+        controls.pushNoScroll(targetHref);
+      } else {
+        controls.push(targetHref);
+      }
+    },
+    { href, scroll: options.scroll },
+  );
+}
+
+async function scrollTo(page: Page, position: { x: number; y: number }) {
+  await page.evaluate(({ x, y }) => {
+    window.scrollTo(x, y);
+  }, position);
+  await expectScroll(page, position);
+}
+
+async function expectScroll(page: Page, position: { x: number; y: number }) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        x: document.documentElement.scrollLeft,
+        y: document.documentElement.scrollTop,
+      })),
+    )
+    .toEqual(position);
+}
+
+async function readElementDocumentTop(page: Page, selector: string) {
+  return page
+    .locator(selector)
+    .evaluate((element) => Math.round(element.getBoundingClientRect().top + window.scrollY));
+}
+
+test.describe("Next.js compat: App Router autoscroll", () => {
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("scrolls to top of document when navigating between pages without layout offset", async ({
+    page,
+  }) => {
+    await page.goto(`${ROUTE_BASE}/0/0/100/10000/page1`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 0, y: 1000 });
+    await push(page, "/nextjs-compat/router-autoscroll/0/0/100/10000/page2");
+    await expect(page.locator("#page")).toHaveText("page2");
+    await expectScroll(page, { x: 0, y: 0 });
+  });
+
+  test("scrolls down to the navigated page when it is below the viewport", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}/0/1000/100/1000/page1`);
+    await waitForControls(page);
+    await expectScroll(page, { x: 0, y: 0 });
+    const pageDocumentTop = await readElementDocumentTop(page, "#page");
+
+    await push(page, "/nextjs-compat/router-autoscroll/0/1000/100/1000/page2");
+    await expect(page.locator("#page")).toHaveText("page2");
+    await expectScroll(page, { x: 0, y: pageDocumentTop });
+  });
+
+  test("does not scroll when the navigated page top is already in the viewport", async ({
+    page,
+  }) => {
+    await page.goto(`${ROUTE_BASE}/10/1000/100/1000/page1`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 0, y: 800 });
+    await push(page, "/nextjs-compat/router-autoscroll/10/1000/100/1000/page2");
+    await expect(page.locator("#page")).toHaveText("page2");
+    await expectScroll(page, { x: 0, y: 800 });
+  });
+
+  test("preserves horizontal scroll while vertically autoscrolling", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}/0/0/10000/10000/page1`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 1000, y: 1000 });
+    await push(page, "/nextjs-compat/router-autoscroll/0/0/10000/10000/page2");
+    await expect(page.locator("#page")).toHaveText("page2");
+    await expectScroll(page, { x: 1000, y: 0 });
+  });
+
+  test("does not scroll when scroll is false", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}/0/0/100/10000/page1`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 0, y: 1000 });
+    await push(page, "/nextjs-compat/router-autoscroll/0/0/100/10000/page2", {
+      scroll: false,
+    });
+    await expect(page.locator("#page")).toHaveText("page2");
+    await expectScroll(page, { x: 0, y: 1000 });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+  test("focuses the interactive navigated segment", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await push(page, "/nextjs-compat/router-autoscroll/focus-target");
+    await expect(page.locator('[data-testid="segment-container"]')).toBeVisible();
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.getAttribute("data-testid") ?? null))
+      .toBe("segment-container");
+  });
+});

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
@@ -145,4 +145,20 @@ test.describe("Next.js compat: App Router autoscroll", () => {
       .poll(() => page.evaluate(() => document.activeElement?.getAttribute("data-testid") ?? null))
       .toBe("segment-container");
   });
+
+  test("preserves horizontal scroll when focusing the navigated segment", async ({ page }) => {
+    // Next's horizontal autoscroll coverage uses a non-focusable route root, so it
+    // misses the second browser scroll caused by focusing an offscreen target.
+    // Vinext intentionally prevents that extra focus scroll.
+    await page.goto(`${ROUTE_BASE}/0/0/10000/10000/page1`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 1000, y: 1000 });
+    await push(page, "/nextjs-compat/router-autoscroll/focus-target");
+    await expect(page.locator('[data-testid="segment-container"]')).toHaveCount(1);
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.getAttribute("data-testid") ?? null))
+      .toBe("segment-container");
+    await expectScroll(page, { x: 1000, y: 0 });
+  });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/[layoutPaddingWidth]/[layoutPaddingHeight]/[pageWidth]/[pageHeight]/[param]/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/[layoutPaddingWidth]/[layoutPaddingHeight]/[pageWidth]/[pageHeight]/[param]/layout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+export default async function AutoscrollPositionLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{
+    layoutPaddingWidth: string;
+    layoutPaddingHeight: string;
+    pageWidth: string;
+    pageHeight: string;
+  }>;
+}) {
+  const { layoutPaddingHeight, layoutPaddingWidth, pageWidth, pageHeight } = await params;
+
+  return (
+    <div
+      style={{
+        background: "pink",
+        display: "flex",
+        height: Number(pageHeight),
+        paddingBottom: Number(layoutPaddingHeight),
+        paddingLeft: Number(layoutPaddingWidth),
+        paddingRight: Number(layoutPaddingWidth),
+        paddingTop: Number(layoutPaddingHeight),
+        width: Number(pageWidth),
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/[layoutPaddingWidth]/[layoutPaddingHeight]/[pageWidth]/[pageHeight]/[param]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/[layoutPaddingWidth]/[layoutPaddingHeight]/[pageWidth]/[pageHeight]/[param]/page.tsx
@@ -1,0 +1,19 @@
+export default async function AutoscrollPositionPage({
+  params,
+}: {
+  params: Promise<{ param: string }>;
+}) {
+  const { param } = await params;
+
+  return (
+    <div
+      id="page"
+      style={{
+        background: "#63d471",
+        flexGrow: 1,
+      }}
+    >
+      {param}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/focus-target/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/focus-target/page.tsx
@@ -1,0 +1,5 @@
+export default function FocusTargetPage() {
+  return (
+    <textarea data-testid="segment-container" placeholder="Type here" style={{ height: "50vh" }} />
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/focus-target/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/focus-target/page.tsx
@@ -1,5 +1,12 @@
 export default function FocusTargetPage() {
   return (
-    <textarea data-testid="segment-container" placeholder="Type here" style={{ height: "50vh" }} />
+    <>
+      <textarea
+        data-testid="segment-container"
+        placeholder="Type here"
+        style={{ height: "50vh", width: 120 }}
+      />
+      <div style={{ height: 10000, width: 10000 }} />
+    </>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+import { RouterAutoscrollControls } from "./router-controls";
+
+export default function RouterAutoscrollLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <RouterAutoscrollControls />
+      {children}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function RouterAutoscrollIndexPage() {
+  return (
+    <>
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>{index}</div>
+      ))}
+      <Link href="/nextjs-compat/router-autoscroll/focus-target" id="to-focus-target">
+        To focus target
+      </Link>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/router-controls.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/router-controls.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+type RouterAutoscrollControls = {
+  push: (href: string) => void;
+  pushNoScroll: (href: string) => void;
+};
+
+declare global {
+  interface Window {
+    __vinextRouterAutoscroll?: RouterAutoscrollControls;
+  }
+}
+
+export function RouterAutoscrollControls() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const controls: RouterAutoscrollControls = {
+      push: (href) => router.push(href),
+      pushNoScroll: (href) => router.push(href, { scroll: false }),
+    };
+    window.__vinextRouterAutoscroll = controls;
+
+    return () => {
+      if (window.__vinextRouterAutoscroll === controls) {
+        delete window.__vinextRouterAutoscroll;
+      }
+    };
+  }, [router]);
+
+  return null;
+}

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -257,7 +257,7 @@ describe("Form useActionState", () => {
 
 describe("Form client GET interception", () => {
   it("strips existing query params from the action URL and warns in development", async () => {
-    const { navigate, scrollTo } = installClientGlobals({ supportsSubmitter: true });
+    const { navigate } = installClientGlobals({ supportsSubmitter: true });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { onSubmit } = renderClientForm({ action: "/search?lang=en" });
     const event = createSubmitEvent({
@@ -279,7 +279,6 @@ describe("Form client GET interception", () => {
       undefined,
       false,
     );
-    expect(scrollTo).toHaveBeenCalledWith(0, 0);
   });
 
   it("honors submitter formAction, formMethod, and submitter name/value", async () => {


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Improve App Router normal RSC navigation scroll/focus parity with Next.js. |
| Core change | Stage a scroll intent before navigation, consume it from newly committed page content, and leave hash-only/popstate paths separate. |
| Main boundary | URL/history mutation stays commit-owned; scroll/focus side effects move to committed App Router page content. |
| Primary files | `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/shims/app-router-scroll.tsx`, `packages/vinext/src/server/app-page-route-wiring.tsx` |
| Expected impact | Normal App Router navigation now preserves horizontal scroll, skips vertical scroll when the new page target is already visible, scrolls the page segment when document top is insufficient, and focuses the consumed target. |

## Why

App Router navigation correctness depends on side effects matching the committed route tree, not the pre-commit document. Next.js treats normal navigation scroll as a per-navigation intent consumed by the newly navigated segment after commit. vinext already had commit-owned URL/history mutation, but normal scroll still ran coarsely from `next/navigation` after `appNavigate` resolved.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| RSC navigation | Scroll/focus belongs to committed content, not the initiating shim. | Adds a small App Router scroll intent and a client target around the page slot. |
| `scroll={false}` | Explicit opt-out must not create a scroll/focus side effect. | Clears pending scroll intent when scroll is disabled. |
| Hash/popstate | Existing hash-only and traversal restoration behavior should remain isolated. | Leaves hash-only branch in `navigation.ts` intact and keeps existing hash/popstate e2e coverage green. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Normal RSC navigation | `navigation.ts` did hash scroll or `window.scrollTo(0, 0)` after `appNavigate`. | The committed page target consumes a scroll intent and applies Next-style segment scroll/focus. |
| Target already visible | Always jumped to document top for non-hash scroll. | Preserves current vertical scroll when the page target top is already in the viewport. |
| Wide pages | `window.scrollTo(0, 0)` reset horizontal scroll. | Vertical document-top scroll preserves horizontal position. |
| `scroll={false}` | Relied on bypassing the old post-navigation scroll path. | Explicitly clears pending intent so no later committed target consumes it. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/app-router-scroll-state.ts`: small id-gated intent state for stale navigation protection.
2. `packages/vinext/src/shims/navigation.ts`: intent setup/cleanup around the existing App Router navigation path, with hash-only branch left alone.
3. `packages/vinext/src/shims/app-router-scroll.tsx`: Next-style committed target selection, viewport check, vertical scroll, and focus.
4. `packages/vinext/src/server/app-page-route-wiring.tsx`: wraps the page slot with the scroll target without changing layout ownership.
5. `tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`: browser-visible parity tests ported from Next.js.

</details>

<details>
<summary>Validation</summary>

- `vp check`
- `vp test run tests/shims.test.ts tests/link-navigation.test.ts tests/app-browser-entry.test.ts tests/app-page-element-builder.test.ts`
- `vp run vinext#build`
- `CI=1 PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts --workers=1`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public API surface.
- Runtime: introduces one client component wrapper around the page slot to observe committed content and apply scroll/focus.
- Compatibility: intentionally follows Next.js default App Router scroll handler behavior, including focusing the consumed target. The experimental new Next.js scroll handler is not implemented here.
- Existing hash-only/popstate behavior: preserved and covered by the existing hash-popstate browser spec.

</details>

<details>
<summary>Non-goals</summary>

- Implementing Next.js experimental `appNewScrollHandler` behavior.
- Changing existing hash-only navigation semantics.
- Reworking parallel-route scroll ownership beyond the page-slot parity slice.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `InnerScrollAndFocusHandlerOld`](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/packages/next/src/client/components/layout-router.tsx#L146-L239) | Defines the current default committed scroll/focus behavior that this PR mirrors. |
| [Next.js element skip and viewport helpers](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/packages/next/src/client/components/layout-router.tsx#L73-L119) | Source for fixed/sticky/hidden skipping and top-edge viewport checks. |
| [Next.js scroll intent selection](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/packages/next/src/client/components/segment-cache/navigation.ts#L605-L693) | Shows `scroll={false}`, hash-only, and default scroll ref behavior. |
| [Next.js router autoscroll tests](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts#L38-L119) | Source tests for vertical and horizontal autoscroll expectations. |
| [Next.js navigation focus test](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/test/e2e/app-dir/navigation-focus/navigation-focus.test.ts#L12-L30) | Source test for focusing an interactive segment under the default scroll handler. |

Related to #1368