### PR TITLE
fix(app-router): preserve history index on external state writes

### DIFF
--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -63,11 +63,16 @@ export function createExternalHistoryStatePreservingMetadata(
   currentHistoryState: unknown,
 ): unknown {
   const previousNextUrl = readHistoryStatePreviousNextUrl(currentHistoryState);
-  if (previousNextUrl === null) {
+  const traversalIndex = readHistoryStateTraversalIndex(currentHistoryState);
+
+  if (previousNextUrl === null && traversalIndex === null) {
     return callerState;
   }
 
-  return createHistoryStateWithPreviousNextUrl(callerState, previousNextUrl);
+  return createHistoryStateWithNavigationMetadata(callerState, {
+    previousNextUrl,
+    traversalIndex,
+  });
 }
 
 export function readHistoryStatePreviousNextUrl(state: unknown): string | null {

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -183,7 +183,18 @@ test.describe("Intercepting Routes", () => {
       const nextState =
         currentState && typeof currentState === "object" ? Object.assign({}, currentState) : {};
       Reflect.set(nextState, "__vinext_previousNextUrl", "/feed");
-      window.history.replaceState(nextState, "", window.location.href);
+
+      const clientNavigationState = Reflect.get(window, Symbol.for("vinext.clientNavigationState"));
+      const originalReplaceState =
+        clientNavigationState && typeof clientNavigationState === "object"
+          ? Reflect.get(clientNavigationState, "originalReplaceState")
+          : null;
+
+      if (typeof originalReplaceState !== "function") {
+        throw new Error("Expected Vinext original history.replaceState to be installed");
+      }
+
+      originalReplaceState.call(window.history, nextState, "", window.location.href);
     });
     await expect
       .poll(() =>

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -253,7 +253,8 @@ describe("next/navigation shim", () => {
     // Covered by Next.js shallow-routing tests for object, null, and undefined state:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts
     const previousWindow = (globalThis as any).window;
-    const historyMetadataKey = "__vinext_previousNextUrl";
+    const historyPreviousNextUrlKey = "__vinext_previousNextUrl";
+    const historyTraversalIndexKey = "__vinext_historyIndex";
     const win = {
       location: {
         pathname: "/photo/1",
@@ -263,7 +264,10 @@ describe("next/navigation shim", () => {
         origin: "http://localhost",
       },
       history: {
-        state: { [historyMetadataKey]: "/feed" } as unknown,
+        state: {
+          [historyPreviousNextUrlKey]: "/feed",
+          [historyTraversalIndexKey]: 4,
+        } as unknown,
         pushState(data: unknown, _unused: string, url?: string | URL | null) {
           this.state = data;
           if (!url) return;
@@ -293,23 +297,34 @@ describe("next/navigation shim", () => {
 
       win.history.pushState({ myData: { foo: "bar" } }, "", "/photo/1?filter=active");
       expect(win.history.state).toEqual({
+        [historyPreviousNextUrlKey]: "/feed",
+        [historyTraversalIndexKey]: 4,
         myData: { foo: "bar" },
-        [historyMetadataKey]: "/feed",
       });
 
       win.history.pushState(null, "", "/photo/1?filter=pending");
       expect(win.history.state).toEqual({
-        [historyMetadataKey]: "/feed",
+        [historyPreviousNextUrlKey]: "/feed",
+        [historyTraversalIndexKey]: 4,
       });
 
       win.history.replaceState(null, "", "/photo/1?filter=archived");
       expect(win.history.state).toEqual({
-        [historyMetadataKey]: "/feed",
+        [historyPreviousNextUrlKey]: "/feed",
+        [historyTraversalIndexKey]: 4,
       });
 
       win.history.replaceState(undefined, "", "/photo/1?filter=all");
       expect(win.history.state).toEqual({
-        [historyMetadataKey]: "/feed",
+        [historyPreviousNextUrlKey]: "/feed",
+        [historyTraversalIndexKey]: 4,
+      });
+
+      win.history.state = { [historyTraversalIndexKey]: 7 };
+      win.history.pushState({ next: true }, "", "/photo/1?filter=done");
+      expect(win.history.state).toEqual({
+        [historyTraversalIndexKey]: 7,
+        next: true,
       });
     } finally {
       vi.resetModules();


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Preserve vinext App Router history metadata across userland `history.pushState` and `history.replaceState` calls. |
| Core change | `createExternalHistoryStatePreservingMetadata()` now carries `__vinext_historyIndex` with `__vinext_previousNextUrl`. |
| Boundary | The public History API wrapper remains the only changed runtime boundary. |
| Primary files | `packages/vinext/src/server/app-history-state.ts`, `tests/shims.test.ts` |
| Expected impact | External shallow history writes keep traversal metadata instead of creating metadata-partial entries. |

## Why

App Router owns a small set of private history-state metadata. When userland or a library writes caller state through the browser History API, vinext should merge caller data with the current framework-owned metadata rather than dropping part of that metadata set.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| External History API wrapper | Caller data must not erase App Router traversal metadata. | Preserves traversal index when copying current vinext metadata into caller state. |
| Interception state | `previousNextUrl` and traversal index describe the same app-owned history entry. | Keeps both keys together when either current metadata key is present. |
| Next.js parity | Next.js copies internal App Router history state before external `pushState` and `replaceState` writes. | Applies the same boundary rule to vinext private metadata keys. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| External `pushState({ ... })` from an intercepted entry | Caller data plus `__vinext_previousNextUrl`, but no `__vinext_historyIndex`. | Caller data plus both vinext metadata keys. |
| External `pushState(null)` or `replaceState(undefined)` | Preserved interception context but dropped traversal index. | Preserves traversal index with the interception context. |
| External write when only traversal index is present | Traversal index was lost because `previousNextUrl` was null. | Traversal index is preserved. |

<details>
<summary>Maintainer review path</summary>

1. Review `packages/vinext/src/server/app-history-state.ts` first. The runtime change is the small merge policy in `createExternalHistoryStatePreservingMetadata()`.
2. Review `tests/shims.test.ts` next. The regression exercises the actual patched History API wrapper, including object, null, undefined, and index-only caller/current-state cases.

</details>

<details>
<summary>Validation</summary>

- Red check before the fix: `vp test run tests/shims.test.ts -t "preserves App Router history metadata"` failed because `__vinext_historyIndex` was missing from the resulting history state.
- `vp test run tests/shims.test.ts` passed, 988 tests.
- `vp test run tests/app-browser-entry.test.ts -t "app browser entry previousNextUrl helpers"` passed, 17 tests in the focused slice.
- `vp check` passed format, lint, and type checks.
- `vp run vinext#build` passed. It emitted the existing virtual-module externalization warnings for `virtual:vinext-rsc-entry`, `virtual:vite-rsc/client-references`, and `private-next-instrumentation-client`.

</details>

<details>
<summary>Risk and compatibility</summary>

- Public API: no public API change.
- Runtime: scoped to external browser History API writes after the navigation shim is installed.
- Compatibility: aligns with Next.js App Router preserving internal history state across external `pushState` and `replaceState` calls.
- Existing-app risk: low. Caller-owned state is still preserved; only vinext private metadata from the current entry is added back when present.

</details>

<details>
<summary>Non-goals</summary>

- Does not change traversal index allocation policy for app-owned navigations.
- Does not add new browser-visible shallow-routing behaviours beyond preserving existing metadata.
- Does not alter Pages Router history handling.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `copyNextJsInternalHistoryState`](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/packages/next/src/client/components/app-router.tsx#L114-L127) | Shows the upstream helper copying current App Router history internals into external caller state. |
| [Next.js external `pushState` wrapper](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/packages/next/src/client/components/app-router.tsx#L327-L348) | Shows the public History API boundary where internal state is preserved. |
| [Next.js external `replaceState` wrapper](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/packages/next/src/client/components/app-router.tsx#L351-L369) | Same preservation contract for replace writes. |
| [Next.js shallow-routing tests](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts#L9-L70) | Covers userland `pushState` data, pathname, and search-param behaviour. |
| [Next.js hash plus History API coverage](https://github.com/vercel/next.js/blob/a80e0d5668aaffb87b5953ebedb389bd678ac988/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts#L450-L475) | Confirms hash navigation and external History API calls must continue to compose. |

Closes #1541