### PR TITLE
fix(app-router): complete default autoscroll page target parity

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -1,5 +1,6 @@
 import type { RouteManifest, RouteManifestInterception } from "../routing/app-route-graph.js";
 import { isUnknownRecord } from "../utils/record.js";
+import type { AppRouterScrollIntent } from "vinext/shims/app-router-scroll-state";
 
 export type NavigationRuntimeSnapshot = {
   pathname: string;
@@ -33,6 +34,7 @@ export type NavigationRuntimeNavigate = (
   previousNextUrlOverride?: string | null,
   programmaticTransition?: boolean,
   traversalIntent?: NavigationRuntimeTraversalIntent,
+  scrollIntent?: AppRouterScrollIntent | null,
 ) => Promise<void>;
 
 export type NavigationRuntimeFunctions = {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -42,6 +42,11 @@ import {
   type NavigationRuntimeRscBootstrap,
 } from "../client/navigation-runtime.js";
 import { scrollToHashTargetOnNextFrame } from "vinext/shims/hash-scroll";
+import { AppRouterScrollCommitProvider } from "vinext/shims/app-router-scroll";
+import {
+  consumeAppRouterScrollIntent,
+  type AppRouterScrollIntent,
+} from "vinext/shims/app-router-scroll-state";
 import { installWindowNext } from "../client/window-next.js";
 import {
   chunksToReadableStream,
@@ -571,6 +576,7 @@ async function renderNavigationPayload(
   actionType: "navigate" | "replace" | "traverse" = "navigate",
   operationLane: OperationLane = "navigation",
   traversalIntent: HistoryTraversalIntent | null = null,
+  scrollIntent: AppRouterScrollIntent | null | undefined = null,
 ): Promise<NavigationPayloadOutcome> {
   try {
     return await browserNavigationController.renderNavigationPayload({
@@ -587,6 +593,7 @@ async function renderNavigationPayload(
       params,
       pendingRouterState,
       previousNextUrl,
+      scrollIntent,
       targetHistoryIndex: traversalIntent === null ? undefined : traversalIntent.targetHistoryIndex,
       targetHref,
       navId,
@@ -923,15 +930,21 @@ function BrowserRoot({
       )
     : innerTree;
 
+  const scrollScopedTree = createElement(
+    AppRouterScrollCommitProvider,
+    { commitId: treeState.renderId },
+    committedTree,
+  );
+
   const ClientNavigationRenderContext = getClientNavigationRenderContext();
   if (!ClientNavigationRenderContext) {
-    return committedTree;
+    return scrollScopedTree;
   }
 
   return createElement(
     ClientNavigationRenderContext.Provider,
     { value: treeState.navigationSnapshot },
-    committedTree,
+    scrollScopedTree,
   );
 }
 
@@ -1329,6 +1342,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     previousNextUrlOverride?: string | null,
     programmaticTransition = false,
     traversalIntent?: HistoryTraversalIntent,
+    scrollIntent?: AppRouterScrollIntent | null,
   ): Promise<void> {
     let pendingRouterState: PendingBrowserRouterState | null = null;
     // Hoist navId above try so the catch and finally blocks can reference it.
@@ -1351,6 +1365,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             historyState: window.history.state,
           }))
         : null;
+    const performHardNavigationForScrollIntent = (targetHref: string): boolean => {
+      consumeAppRouterScrollIntent(scrollIntent ?? null);
+      return browserNavigationController.performHardNavigation(targetHref);
+    };
 
     try {
       const shouldUsePendingRouterState = programmaticTransition;
@@ -1409,9 +1427,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             responseUrl: cachedRoute.response.url,
           });
           if (compatibilityDecision.kind === "hard-navigate") {
-            browserNavigationController.performHardNavigation(
-              compatibilityDecision.hardNavigationTarget,
-            );
+            performHardNavigationForScrollIntent(compatibilityDecision.hardNavigationTarget);
             return;
           }
           // Check stale-navigation before and after createFromFetch. The pre-check
@@ -1450,6 +1466,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             toActionType(navigationKind),
             toOperationLane(navigationKind),
             activeTraversalIntent,
+            scrollIntent,
           );
           return;
         }
@@ -1515,6 +1532,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
                 toActionType(navigationKind),
                 toOperationLane(navigationKind),
                 activeTraversalIntent,
+                scrollIntent,
               ).catch((error) => {
                 if (browserNavigationController.isCurrentNavigation(navId)) {
                   console.error("[vinext] Optimistic RSC navigation error:", error);
@@ -1556,7 +1574,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const isRscResponse = navContentType.startsWith("text/x-component");
         if (!navResponse.ok || !isRscResponse || !navResponse.body) {
           const responseUrl = navResponseUrl ?? navResponse.url;
-          browserNavigationController.performHardNavigation(
+          performHardNavigationForScrollIntent(
             resolveHardNavigationTargetFromRscResponse(
               responseUrl,
               currentHref,
@@ -1574,9 +1592,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           responseUrl: navResponseUrl ?? navResponse.url,
         });
         if (compatibilityDecision.kind === "hard-navigate") {
-          browserNavigationController.performHardNavigation(
-            compatibilityDecision.hardNavigationTarget,
-          );
+          performHardNavigationForScrollIntent(compatibilityDecision.hardNavigationTarget);
           return;
         }
 
@@ -1595,7 +1611,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
               "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
             );
           }
-          browserNavigationController.performHardNavigation(redirectDecision.href);
+          performHardNavigationForScrollIntent(redirectDecision.href);
           return;
         }
 
@@ -1630,14 +1646,14 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           void navResponse.body?.cancel().catch(() => {});
           const resolvedTarget = new URL(flightRedirectTarget, window.location.origin);
           if (resolvedTarget.origin !== window.location.origin) {
-            browserNavigationController.performHardNavigation(resolvedTarget.href);
+            performHardNavigationForScrollIntent(resolvedTarget.href);
             return;
           }
           if (redirectCount >= MAX_RSC_REDIRECT_DEPTH) {
             console.error(
               "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
             );
-            browserNavigationController.performHardNavigation(resolvedTarget.href);
+            performHardNavigationForScrollIntent(resolvedTarget.href);
             return;
           }
           currentHref = `${resolvedTarget.pathname}${resolvedTarget.search}${resolvedTarget.hash}`;
@@ -1698,6 +1714,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           toActionType(navigationKind),
           toOperationLane(navigationKind),
           activeTraversalIntent,
+          scrollIntent,
         );
         if (renderOutcome !== "committed") return;
         // Don't cache the response if this navigation was superseded during
@@ -1739,7 +1756,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       if (!isPageUnloading) {
         console.error("[vinext] RSC navigation error:", error);
       }
-      browserNavigationController.performHardNavigation(currentHref);
+      performHardNavigationForScrollIntent(currentHref);
     } finally {
       // Single settlement site: covers normal return, early returns on stale-id
       // checks, and error paths. The finally runs even when the catch returns.

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -5,6 +5,11 @@ import {
   commitClientNavigationState,
 } from "vinext/shims/navigation";
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
+import {
+  claimAppRouterScrollIntentForCommit,
+  consumeAppRouterScrollIntent,
+  type AppRouterScrollIntent,
+} from "vinext/shims/app-router-scroll-state";
 import type { RouteManifest } from "../routing/app-route-graph.js";
 import {
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
@@ -88,6 +93,7 @@ type BrowserNavigationController = {
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
+    scrollIntent?: AppRouterScrollIntent | null;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -501,6 +507,7 @@ export function createAppBrowserNavigationController(
     params: Record<string, string | string[]>;
     pendingRouterState: PendingBrowserRouterState | null;
     previousNextUrl: string | null;
+    scrollIntent?: AppRouterScrollIntent | null;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -545,6 +552,7 @@ export function createAppBrowserNavigationController(
       if (approval.decision.disposition === "hard-navigate") {
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationCommits.delete(renderId);
+        consumeAppRouterScrollIntent(options.scrollIntent ?? null);
         return performHardNavigation(options.targetHref) ? "hard-navigate" : "no-commit";
       }
 
@@ -564,6 +572,7 @@ export function createAppBrowserNavigationController(
           targetHistoryIndex: options.targetHistoryIndex,
         }),
       );
+      claimAppRouterScrollIntentForCommit(options.scrollIntent, renderId);
       activateNavigationSnapshot();
       snapshotActivated = true;
       dispatchApprovedVisibleCommit(approvedCommit, options.pendingRouterState);

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -546,6 +546,7 @@ export function createAppBrowserNavigationController(
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationCommits.delete(renderId);
         resolveCommitted?.();
+        consumeAppRouterScrollIntent(options.scrollIntent ?? null);
         return "no-commit";
       }
 

--- a/packages/vinext/src/shims/app-router-scroll-state.ts
+++ b/packages/vinext/src/shims/app-router-scroll-state.ts
@@ -1,4 +1,5 @@
 export type AppRouterScrollIntent = Readonly<{
+  commitId: number | null;
   hash: string | null;
   id: number;
 }>;
@@ -33,6 +34,7 @@ export function beginAppRouterScrollIntent(hash: string | null): AppRouterScroll
   const store = getScrollIntentStore();
   store.nextId += 1;
   const intent = {
+    commitId: null,
     hash,
     id: store.nextId,
   };
@@ -48,13 +50,31 @@ export function getPendingAppRouterScrollIntent(): AppRouterScrollIntent | null 
   return getScrollIntentStore().pending;
 }
 
+export function claimAppRouterScrollIntentForCommit(
+  expected: AppRouterScrollIntent | null | undefined,
+  commitId: number,
+): void {
+  const store = getScrollIntentStore();
+  const intent = store.pending;
+  if (expected === null || expected === undefined || intent === null) return;
+  if (intent.id !== expected.id) return;
+
+  store.pending = {
+    ...intent,
+    commitId,
+  };
+}
+
 export function consumeAppRouterScrollIntent(
-  expected?: AppRouterScrollIntent,
+  expected: AppRouterScrollIntent | null | undefined,
+  commitId?: number,
 ): AppRouterScrollIntent | null {
+  if (expected === null || expected === undefined) return null;
   const store = getScrollIntentStore();
   const intent = store.pending;
   if (intent === null) return null;
-  if (expected && intent.id !== expected.id) return null;
+  if (intent.id !== expected.id) return null;
+  if (commitId !== undefined && intent.commitId !== commitId) return null;
 
   store.pending = null;
   return intent;

--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -104,10 +104,11 @@ function scrollToElement(target: HTMLElement, hash: string | null): void {
   }
 }
 
-// Must stay a class component: findDOMNode() needs a mounted class instance to
-// locate the first DOM node rendered by the children without introducing a
-// wrapper element. Converting this to a function component would break the
-// wrapperless targeting that mirrors Next's default scroll handler.
+// The inner component must stay a class: findDOMNode() needs a mounted
+// class instance to locate the first DOM node rendered by the children
+// without introducing a wrapper element. The outer AppRouterScrollTarget
+// function component reads context and delegates here; only the inner
+// class retains wrapperless targeting.
 export class AppRouterScrollTargetInner extends React.Component<{
   children: React.ReactNode;
   commitId: number | null;

--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -2,12 +2,13 @@
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { decodeHashFragment } from "./hash-scroll.js";
 import {
   consumeAppRouterScrollIntent,
   getPendingAppRouterScrollIntent,
 } from "./app-router-scroll-state.js";
+import { decodeHashFragment } from "./hash-scroll.js";
 
+const AppRouterScrollCommitContext = React.createContext<number | null>(null);
 const reactDomInternalsKey = "__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE";
 const rectProperties = ["bottom", "height", "left", "right", "top", "width", "x", "y"] as const;
 
@@ -107,10 +108,14 @@ function scrollToElement(target: HTMLElement, hash: string | null): void {
 // locate the first DOM node rendered by the children without introducing a
 // wrapper element. Converting this to a function component would break the
 // wrapperless targeting that mirrors Next's default scroll handler.
-export class AppRouterScrollTarget extends React.Component<{ children: React.ReactNode }> {
+export class AppRouterScrollTargetInner extends React.Component<{
+  children: React.ReactNode;
+  commitId: number | null;
+}> {
   handlePotentialScroll = () => {
     const intent = getPendingAppRouterScrollIntent();
     if (intent === null) return;
+    if (this.props.commitId === null || intent.commitId !== this.props.commitId) return;
 
     let target: HTMLElement | null;
     if (intent.hash !== null) {
@@ -121,7 +126,7 @@ export class AppRouterScrollTarget extends React.Component<{ children: React.Rea
     }
     if (target === null) return;
 
-    const consumed = consumeAppRouterScrollIntent(intent);
+    const consumed = consumeAppRouterScrollIntent(intent, this.props.commitId);
     if (consumed === null) return;
 
     scrollToElement(target, consumed.hash);
@@ -142,4 +147,23 @@ export class AppRouterScrollTarget extends React.Component<{ children: React.Rea
   render() {
     return this.props.children;
   }
+}
+
+export function AppRouterScrollCommitProvider({
+  children,
+  commitId,
+}: {
+  children?: React.ReactNode;
+  commitId: number | null;
+}) {
+  return (
+    <AppRouterScrollCommitContext.Provider value={commitId}>
+      {children}
+    </AppRouterScrollCommitContext.Provider>
+  );
+}
+
+export function AppRouterScrollTarget({ children }: { children: React.ReactNode }) {
+  const commitId = React.useContext(AppRouterScrollCommitContext);
+  return <AppRouterScrollTargetInner commitId={commitId}>{children}</AppRouterScrollTargetInner>;
 }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1453,7 +1453,16 @@ export async function navigateClientSide(
   const appNavigate = getNavigationRuntime()?.functions.navigate;
   try {
     if (appNavigate) {
-      await appNavigate(fullHref, 0, "navigate", mode, undefined, programmaticTransition);
+      await appNavigate(
+        fullHref,
+        0,
+        "navigate",
+        mode,
+        undefined,
+        programmaticTransition,
+        undefined,
+        scrollIntent,
+      );
     } else {
       if (mode === "replace") {
         replaceHistoryStateWithoutNotify(null, "", fullHref);

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
@@ -280,8 +280,7 @@ test.describe("Next.js compat: App Router autoscroll", () => {
     await expectScroll(page, { x: 1000, y: 0 });
     await expectActiveElementTestId(page, "race-target");
 
-    await page.waitForTimeout(700);
-    await expect(page).toHaveURL(`${ROUTE_BASE}/race/c`);
+    await expect.poll(() => page.url(), { timeout: 1500 }).toBe(`${ROUTE_BASE}/race/c`);
     await expect(page.locator('[data-testid="race-target"]')).toHaveText("Race target c");
     await expectScroll(page, { x: 1000, y: 0 });
     await expectActiveElementTestId(page, "race-target");

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
@@ -73,6 +73,16 @@ async function readElementDocumentTop(page: Page, selector: string) {
     .evaluate((element) => Math.round(element.getBoundingClientRect().top + window.scrollY));
 }
 
+async function expectActiveElementId(page: Page, id: string) {
+  await expect.poll(() => page.evaluate(() => document.activeElement?.id ?? null)).toBe(id);
+}
+
+async function expectActiveElementTestId(page: Page, testId: string) {
+  await expect
+    .poll(() => page.evaluate(() => document.activeElement?.getAttribute("data-testid") ?? null))
+    .toBe(testId);
+}
+
 test.describe("Next.js compat: App Router autoscroll", () => {
   // Ported from Next.js:
   // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -121,6 +131,54 @@ test.describe("Next.js compat: App Router autoscroll", () => {
     await expectScroll(page, { x: 1000, y: 0 });
   });
 
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  for (const [kind, label] of [
+    ["display-none", "display: none"],
+    ["fixed", "position: fixed"],
+    ["sticky", "position: sticky"],
+  ] as const) {
+    test(`skips first child ${label} and targets the first renderable sibling`, async ({
+      page,
+    }) => {
+      await page.goto(`${ROUTE_BASE}`);
+      await waitForControls(page);
+
+      await scrollTo(page, { x: 1000, y: 500 });
+      await push(page, `/nextjs-compat/router-autoscroll/skipped-target/${kind}`);
+      await expect(page.locator('[data-testid="selected-scroll-target"]')).toHaveText(
+        `Selected target: ${kind}`,
+      );
+      await expectScroll(page, { x: 1000, y: 0 });
+      await expectActiveElementTestId(page, "selected-scroll-target");
+    });
+  }
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("applies scroll when loading commits and keeps it stable for final content", async ({
+    page,
+  }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 1000, y: 500 });
+    await page.evaluate(() => {
+      const controls = window.__vinextRouterAutoscroll;
+      if (!controls) {
+        throw new Error("router autoscroll controls are not installed");
+      }
+      controls.push("/nextjs-compat/router-autoscroll/loading-scroll");
+    });
+    await expectScroll(page, { x: 1000, y: 500 });
+
+    await expect(page.locator("#loading-component")).toBeVisible();
+    await expectScroll(page, { x: 1000, y: 0 });
+
+    await expect(page.locator("#content-that-is-visible")).toBeVisible();
+    await expectScroll(page, { x: 1000, y: 0 });
+  });
+
   test("does not scroll when scroll is false", async ({ page }) => {
     await page.goto(`${ROUTE_BASE}/0/0/100/10000/page1`);
     await waitForControls(page);
@@ -131,6 +189,34 @@ test.describe("Next.js compat: App Router autoscroll", () => {
     });
     await expect(page.locator("#page")).toHaveText("page2");
     await expectScroll(page, { x: 0, y: 1000 });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("scrolls on same-page search param changes while preserving scroll false", async ({
+    page,
+  }) => {
+    await page.goto(`${ROUTE_BASE}/loading-scroll?skipSleep=1`);
+    await waitForControls(page);
+    await expect(page.locator("#content-that-is-visible")).toBeVisible();
+
+    await page.locator("#pages").scrollIntoViewIfNeeded();
+    const samePageScrollY = await page.evaluate(() => Math.round(window.scrollY));
+    expect(samePageScrollY).toBeGreaterThan(0);
+
+    await push(page, "/nextjs-compat/router-autoscroll/loading-scroll?page=2&skipSleep=1");
+    await expect(page.locator("#current-page")).toHaveText("2");
+    await expectScroll(page, { x: 0, y: 0 });
+
+    await page.locator("#pages").scrollIntoViewIfNeeded();
+    const noScrollY = await page.evaluate(() => Math.round(window.scrollY));
+    expect(noScrollY).toBeGreaterThan(0);
+
+    await push(page, "/nextjs-compat/router-autoscroll/loading-scroll?page=3&skipSleep=1", {
+      scroll: false,
+    });
+    await expect(page.locator("#current-page")).toHaveText("3");
+    await expectScroll(page, { x: 0, y: noScrollY });
   });
 
   // Ported from Next.js:
@@ -160,5 +246,44 @@ test.describe("Next.js compat: App Router autoscroll", () => {
       .poll(() => page.evaluate(() => document.activeElement?.getAttribute("data-testid") ?? null))
       .toBe("segment-container");
     await expectScroll(page, { x: 1000, y: 0 });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+  test("does not steal focus for a non-focusable selected target", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 0, y: 500 });
+    await page.click("#to-non-focusable");
+    await expect(page.locator('[data-testid="non-focusable-target"]')).toBeVisible();
+    await expectScroll(page, { x: 0, y: 0 });
+    await expectActiveElementId(page, "to-non-focusable");
+  });
+
+  test("only the latest rapid navigation consumes the scroll intent", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 1000, y: 500 });
+    await page.evaluate(() => {
+      const controls = window.__vinextRouterAutoscroll;
+      if (!controls) {
+        throw new Error("router autoscroll controls are not installed");
+      }
+      controls.push("/nextjs-compat/router-autoscroll/race/a");
+      controls.push("/nextjs-compat/router-autoscroll/race/b");
+      controls.push("/nextjs-compat/router-autoscroll/race/c");
+    });
+
+    await expect(page.locator('[data-testid="race-target"]')).toHaveText("Race target c");
+    await expectScroll(page, { x: 1000, y: 0 });
+    await expectActiveElementTestId(page, "race-target");
+
+    await page.waitForTimeout(700);
+    await expect(page).toHaveURL(`${ROUTE_BASE}/race/c`);
+    await expect(page.locator('[data-testid="race-target"]')).toHaveText("Race target c");
+    await expectScroll(page, { x: 1000, y: 0 });
+    await expectActiveElementTestId(page, "race-target");
   });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/layout.tsx
@@ -1,10 +1,24 @@
 import type { ReactNode } from "react";
+import Link from "next/link";
 import { RouterAutoscrollControls } from "./router-controls";
 
 export default function RouterAutoscrollLayout({ children }: { children: ReactNode }) {
   return (
     <>
       <RouterAutoscrollControls />
+      <nav
+        style={{
+          background: "white",
+          left: 0,
+          position: "fixed",
+          top: 0,
+          zIndex: 1,
+        }}
+      >
+        <Link href="/nextjs-compat/router-autoscroll/non-focusable-target" id="to-non-focusable">
+          Non-focusable target
+        </Link>
+      </nav>
       {children}
     </>
   );

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/loading-scroll/loading.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/loading-scroll/loading.tsx
@@ -1,0 +1,11 @@
+export default function Loading() {
+  return (
+    <>
+      <div id="loading-component">Loading component</div>
+      <div style={{ height: 1, width: 10000 }} />
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>Loading {index}...</div>
+      ))}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/loading-scroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/loading-scroll/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function LoadingScrollPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string; skipSleep?: string }>;
+}) {
+  const search = await searchParams;
+
+  if (search.skipSleep !== "1") {
+    await sleep(1000);
+  }
+
+  return (
+    <>
+      {search.page ? <div id="current-page">{search.page}</div> : null}
+      <div style={{ display: "none" }}>Content that is hidden.</div>
+      <div id="content-that-is-visible">Content which is not hidden.</div>
+      <div style={{ height: 1, width: 10000 }} />
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>{index}</div>
+      ))}
+      <div id="pages">
+        {Array.from({ length: 10 }, (_, index) => {
+          const page = index + 1;
+          return (
+            <Link key={page} href={`?page=${page}&skipSleep=1`}>
+              {page}
+            </Link>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/non-focusable-target/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/non-focusable-target/page.tsx
@@ -1,0 +1,11 @@
+export default function NonFocusableTargetPage() {
+  return (
+    <>
+      <div data-testid="non-focusable-target">Non-focusable target</div>
+      <div style={{ height: 1, width: 10000 }} />
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>Non-focusable target row {index}</div>
+      ))}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/page.tsx
@@ -9,6 +9,36 @@ export default function RouterAutoscrollIndexPage() {
       <Link href="/nextjs-compat/router-autoscroll/focus-target" id="to-focus-target">
         To focus target
       </Link>
+      <div>
+        <Link href="/nextjs-compat/router-autoscroll/loading-scroll" id="to-loading-scroll">
+          To loading scroll
+        </Link>
+      </div>
+      <div>
+        <Link
+          href="/nextjs-compat/router-autoscroll/skipped-target/display-none"
+          id="to-display-none-first-element"
+        >
+          To display none first element
+        </Link>
+      </div>
+      <div>
+        <Link
+          href="/nextjs-compat/router-autoscroll/skipped-target/fixed"
+          id="to-fixed-first-element"
+        >
+          To fixed first element
+        </Link>
+      </div>
+      <div>
+        <Link
+          href="/nextjs-compat/router-autoscroll/skipped-target/sticky"
+          id="to-sticky-first-element"
+        >
+          To sticky first element
+        </Link>
+      </div>
+      <div style={{ height: 1, width: 10000 }} />
     </>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/race/[target]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/race/[target]/page.tsx
@@ -1,0 +1,35 @@
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function delayForTarget(target: string): number {
+  switch (target) {
+    case "a":
+      return 500;
+    case "b":
+      return 300;
+    case "c":
+      return 0;
+    default:
+      return 0;
+  }
+}
+
+export default async function RaceTargetPage({ params }: { params: Promise<{ target: string }> }) {
+  const { target } = await params;
+  await sleep(delayForTarget(target));
+
+  return (
+    <>
+      <button data-testid="race-target" style={{ marginLeft: 1000 }}>
+        Race target {target}
+      </button>
+      <div style={{ height: 1, width: 10000 }} />
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>
+          Race target {target} row {index}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/skipped-target/[kind]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/skipped-target/[kind]/page.tsx
@@ -1,0 +1,52 @@
+import type { CSSProperties } from "react";
+
+function skippedElementStyle(kind: string): CSSProperties {
+  switch (kind) {
+    case "display-none":
+      return { display: "none" };
+    case "fixed":
+      return {
+        background: "white",
+        height: 40,
+        left: 0,
+        position: "fixed",
+        top: 32,
+      };
+    case "sticky":
+      return {
+        background: "white",
+        height: 40,
+        position: "sticky",
+        top: 32,
+      };
+    default:
+      return { display: "none" };
+  }
+}
+
+export default async function SkippedTargetPage({ params }: { params: Promise<{ kind: string }> }) {
+  const { kind } = await params;
+
+  return (
+    <>
+      <div data-testid="skipped-target" style={skippedElementStyle(kind)}>
+        Skipped target: {kind}
+      </div>
+      <button
+        data-testid="selected-scroll-target"
+        style={{
+          display: "block",
+          height: 44,
+          marginLeft: 1000,
+          width: 260,
+        }}
+      >
+        Selected target: {kind}
+      </button>
+      <div style={{ height: 1, width: 10000 }} />
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>Skipped target row {index}</div>
+      ))}
+    </>
+  );
+}

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -278,6 +278,8 @@ describe("Form client GET interception", () => {
       "push",
       undefined,
       false,
+      undefined,
+      expect.objectContaining({ commitId: null, hash: null, id: expect.any(Number) }),
     );
   });
 
@@ -310,6 +312,8 @@ describe("Form client GET interception", () => {
       "push",
       undefined,
       false,
+      undefined,
+      expect.objectContaining({ commitId: null, hash: null, id: expect.any(Number) }),
     );
   });
 
@@ -340,6 +344,8 @@ describe("Form client GET interception", () => {
       "push",
       undefined,
       false,
+      undefined,
+      expect.objectContaining({ commitId: null, hash: null, id: expect.any(Number) }),
     );
   });
 
@@ -384,6 +390,8 @@ describe("Form client GET interception", () => {
       "push",
       undefined,
       false,
+      undefined,
+      expect.objectContaining({ commitId: null, hash: null, id: expect.any(Number) }),
     );
   });
 
@@ -444,6 +452,8 @@ describe("Form client GET interception", () => {
       "replace",
       undefined,
       false,
+      undefined,
+      expect.objectContaining({ commitId: null, hash: null, id: expect.any(Number) }),
     );
   });
 });

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -443,7 +443,20 @@ describe("Link App Router navigation scheduling", () => {
 
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(startTransition).toHaveBeenCalledTimes(1);
-    expect(navigate).toHaveBeenCalledWith("/target", 0, "navigate", "push", undefined, true);
+    expect(navigate).toHaveBeenCalledWith(
+      "/target",
+      0,
+      "navigate",
+      "push",
+      undefined,
+      true,
+      undefined,
+      expect.objectContaining({
+        commitId: null,
+        hash: null,
+        id: expect.any(Number),
+      }),
+    );
     expect(transitionStates).toEqual([true]);
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10986,6 +10986,75 @@ describe("app router scroll intent state", () => {
     expect(consumed?.commitId).toBe(2);
     expect(getPendingAppRouterScrollIntent()).toBeNull();
   });
+
+  it("consuming an unclaimed intent without commitId matches navigateClientSide fallback contract", async () => {
+    const {
+      beginAppRouterScrollIntent,
+      clearAppRouterScrollIntent,
+      consumeAppRouterScrollIntent,
+      getPendingAppRouterScrollIntent,
+    } = await import("../packages/vinext/src/shims/app-router-scroll-state.js");
+
+    // no-commit path: intent was created but never claimed by a render commit.
+    // consumeAppRouterScrollIntent(intent) without a commitId must consume it
+    // so the navigateClientSide fallback (which calls consume without commitId)
+    // finds null and does not apply a scroll for an abandoned navigation.
+    clearAppRouterScrollIntent();
+
+    const intent = beginAppRouterScrollIntent(null);
+    expect(getPendingAppRouterScrollIntent()?.id).toBe(intent.id);
+
+    const consumed = consumeAppRouterScrollIntent(intent);
+    expect(consumed?.id).toBe(intent.id);
+    expect(getPendingAppRouterScrollIntent()).toBeNull();
+  });
+
+  it("consuming an intent with a stale intent reference is a no-op", async () => {
+    const {
+      beginAppRouterScrollIntent,
+      clearAppRouterScrollIntent,
+      consumeAppRouterScrollIntent,
+      getPendingAppRouterScrollIntent,
+    } = await import("../packages/vinext/src/shims/app-router-scroll-state.js");
+
+    // When a newer navigation replaces the pending intent, attempting to consume
+    // the stale reference must be a no-op — this is the safety check that prevents
+    // the fallback from consuming a different navigation's intent.
+    clearAppRouterScrollIntent();
+
+    const firstIntent = beginAppRouterScrollIntent(null);
+    const secondIntent = beginAppRouterScrollIntent(null);
+
+    expect(consumeAppRouterScrollIntent(firstIntent)).toBeNull();
+    expect(getPendingAppRouterScrollIntent()?.id).toBe(secondIntent.id);
+    expect(consumeAppRouterScrollIntent(secondIntent)).not.toBeNull();
+    expect(getPendingAppRouterScrollIntent()).toBeNull();
+  });
+
+  it("consuming a claimed intent without commitId is always allowed for cleanup paths", async () => {
+    const {
+      beginAppRouterScrollIntent,
+      claimAppRouterScrollIntentForCommit,
+      clearAppRouterScrollIntent,
+      consumeAppRouterScrollIntent,
+      getPendingAppRouterScrollIntent,
+    } = await import("../packages/vinext/src/shims/app-router-scroll-state.js");
+
+    // The fallback in navigateClientSide calls consume without a commitId.
+    // An intent claimed by a newer commit must still be consumable without a
+    // commitId check so that explicit cleanup paths (no-commit, hard-navigate)
+    // can clear it. The commitId gate only applies when a commitId is passed.
+    clearAppRouterScrollIntent();
+
+    const intent = beginAppRouterScrollIntent(null);
+    claimAppRouterScrollIntentForCommit(intent, 42);
+    expect(getPendingAppRouterScrollIntent()?.commitId).toBe(42);
+
+    // Consume without commitId — always allowed (no-commit / hard-navigate cleanup).
+    const consumed = consumeAppRouterScrollIntent(intent);
+    expect(consumed?.id).toBe(intent.id);
+    expect(getPendingAppRouterScrollIntent()).toBeNull();
+  });
 });
 
 describe("next/compat/router shim", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10954,6 +10954,40 @@ describe("next/amp shim", () => {
   });
 });
 
+describe("app router scroll intent state", () => {
+  it("only lets the claimed render commit consume its own scroll intent", async () => {
+    const {
+      beginAppRouterScrollIntent,
+      claimAppRouterScrollIntentForCommit,
+      clearAppRouterScrollIntent,
+      consumeAppRouterScrollIntent,
+      getPendingAppRouterScrollIntent,
+    } = await import("../packages/vinext/src/shims/app-router-scroll-state.js");
+
+    clearAppRouterScrollIntent();
+
+    const staleIntent = beginAppRouterScrollIntent(null);
+    const latestIntent = beginAppRouterScrollIntent(null);
+
+    claimAppRouterScrollIntentForCommit(staleIntent, 1);
+    expect(getPendingAppRouterScrollIntent()?.commitId).toBeNull();
+    expect(consumeAppRouterScrollIntent(undefined)).toBeNull();
+    expect(getPendingAppRouterScrollIntent()?.id).toBe(latestIntent.id);
+    expect(consumeAppRouterScrollIntent(null)).toBeNull();
+    expect(getPendingAppRouterScrollIntent()?.id).toBe(latestIntent.id);
+    expect(consumeAppRouterScrollIntent(latestIntent, 1)).toBeNull();
+    expect(getPendingAppRouterScrollIntent()?.id).toBe(latestIntent.id);
+
+    claimAppRouterScrollIntentForCommit(latestIntent, 2);
+    expect(consumeAppRouterScrollIntent(latestIntent, 1)).toBeNull();
+
+    const consumed = consumeAppRouterScrollIntent(latestIntent, 2);
+    expect(consumed?.id).toBe(latestIntent.id);
+    expect(consumed?.commitId).toBe(2);
+    expect(getPendingAppRouterScrollIntent()).toBeNull();
+  });
+});
+
 describe("next/compat/router shim", () => {
   it("exports useRouter as a function", async () => {
     const mod = await import("../packages/vinext/src/shims/compat-router.js");


### PR DESCRIPTION
## Stack note

stacked on [#1599](https://github.com/cloudflare/vinext/pull/1599). The implementation branch is based on `NathanDrake2406:nathan/app-router-scroll-focus-parity` at `d568b6a8`.

## Overview

| Field | Detail |
| --- | --- |
| Goal | Finish default App Router page-target autoscroll and focus parity on top of the committed target architecture from #1599. |
| Core change | Bind scroll intents to the approved render commit before the committed tree can consume them. |
| Main boundary | Default page-target scroll/focus only. This deliberately avoids BFCache, native traversal metadata, prefetch/segment cache ownership, and the experimental Next.js scroll handler. |
| Primary files | `packages/vinext/src/shims/app-router-scroll*.ts*`, `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/server/app-browser-*.ts`, `tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`. |
| Expected impact | Default App Router navigations scroll and focus after commit, preserve horizontal scroll, and ignore stale scroll intents from superseded navigations. |

## Why

Default App Router scrolling is a committed-tree side effect: the browser should choose a page target only after the route tree that owns that target has committed. A navigation-start intent alone is too weak because loading shells, final payloads, hard-navigation fallbacks, and rapid navigations can resolve in a different order than they started.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Commit timing | Scroll/focus belongs to the committed target, not to the initiating shim. | Adds commit-scoped scroll intents and wraps committed trees with the render id that may consume them. |
| Stale protection | Older route work must not clear or consume newer navigation intent. | Claims and consumes scroll intent only when the pending intent id and render commit id both match. |
| Page target parity | Default handler should skip non-renderable/sticky/fixed initial targets and focus the selected target after commit. | Expands the default target selection coverage with fixture routes matching the Next.js cases. |
| Horizontal scroll | Vertical autoscroll and focus should not unexpectedly reset X. | Uses `inline: "nearest"` for explicit scroll and keeps focus from performing a second implicit horizontal scroll. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| First child is `display: none`, `position: fixed`, or `position: sticky` | The selected page target could be the skipped element or miss sibling behavior coverage. | The first renderable sibling becomes the scroll/focus target. |
| `loading.js` commits before final content | Scroll intent could be consumed at the wrong lifecycle point or left to fallback handling. | The loading commit can consume its own intent, and final content replacement stays stable. |
| Same-page search param changes | Coverage did not lock the default scroll and `scroll={false}` behavior together. | Same-page search-param navigation scrolls by default and preserves scroll when opted out. |
| Focus | Focus transfer was not tied to the matching committed render id. | The selected target focuses only after the matching commit, including non-focusable target behavior. |
| Horizontal scroll | Vertical autoscroll plus focus could reset X in focusable-target cases. | Horizontal scroll is preserved across vertical autoscroll and focus cases. |
| Rapid A to B to C navigation | A late route could consume or clear a newer scroll intent. | Only the latest matching commit consumes the active scroll intent. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/app-router-scroll-state.ts`  
   Review the intent lifecycle: begin, claim for commit, consume by expected intent and commit id.

2. `packages/vinext/src/server/app-browser-navigation-controller.ts`  
   Review where approved visible commits claim scroll ownership and where hard-navigation dispositions clear only their own intent.

3. `packages/vinext/src/server/app-browser-entry.ts`  
   Review the render id provider around committed trees and the threading of scroll intent through cached, optimistic, fresh, redirect, and hard-navigation paths.

4. `packages/vinext/src/shims/app-router-scroll.tsx`  
   Review target selection, vertical scroll, horizontal preservation, and post-commit focus behavior.

5. `packages/vinext/src/shims/navigation.ts` and `packages/vinext/src/client/navigation-runtime.ts`  
   Review the public runtime seam that carries the initiating scroll intent to the browser navigation controller.

6. `tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts` plus fixture routes  
   Review the user-visible contracts covered by the browser tests.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/shims.test.ts -t "app router scroll intent state"`
- `vp test run tests/form.test.ts`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts`
- `vp check`
- `vp run vinext#build`

`vp run vinext#build` completed with the existing expected external virtual-module warnings for `private-next-instrumentation-client`, `virtual:vinext-rsc-entry`, and `virtual:vite-rsc/client-references`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Runtime risk is concentrated in App Router client navigation and committed tree rendering.
- Existing hash-only navigation stays owned by the hash path and is covered by the hash popstate suite.
- The runtime seam adds an optional final `scrollIntent` parameter; existing callers remain compatible.
- This intentionally preserves #1599's focus behavior while making ownership stricter for late commits.

</details>

<details>
<summary>Non-goals</summary>

- BFCache behavior.
- Native History API traversal metadata.
- Segment cache or prefetch ownership changes beyond naturally exercising cached payload paths.
- Abort/cancellation semantics.
- Full parallel/intercepted route scroll ownership.
- Next.js `appNewScrollHandler` experimental behavior.

</details>

## References

| Link | Why it matters |
| --- | --- |
| [Next.js default scroll handler implementation](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/layout-router.tsx) | Source for the default committed-tree page target behavior, skipped element handling, and focus timing. |
| [Next.js router autoscroll e2e tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts) | Source for skipped target, loading boundary, same-page URL, and horizontal scroll parity cases. |
| [Next.js navigation focus e2e tests](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation-focus/navigation-focus.test.ts) | Source for interactive and non-focusable target focus behavior. |
| [Next.js segment-cache navigation scroll refs](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts) | Useful reference for stale scroll intent ownership in newer navigation internals, without taking on experimental handler scope. |

Related to #1368