### PR TITLE
fix(app-router): finish default autoscroll parity

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1496,6 +1496,29 @@ export async function navigateClientSide(
 // useEffect dependency arrays, React.memo bailouts).
 // ---------------------------------------------------------------------------
 
+// `router.refresh()` can run in the same outer transition after push/replace
+// while the nested navigation transition is still being scheduled.
+let scheduledAppRouterNavigationCount = 0;
+
+function trackScheduledAppRouterNavigation(): () => void {
+  scheduledAppRouterNavigationCount += 1;
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    scheduledAppRouterNavigationCount = Math.max(0, scheduledAppRouterNavigationCount - 1);
+  };
+}
+
+function hasScheduledAppRouterNavigation(): boolean {
+  return scheduledAppRouterNavigationCount > 0;
+}
+
+function releaseScheduledAppRouterNavigationAfterCurrentTask(release: () => void): void {
+  queueMicrotask(release);
+}
+
 /**
  * App Router public router instance. Mirrors Next.js's
  * `publicAppRouterInstance` from
@@ -1510,16 +1533,30 @@ const _appRouter = {
   push(href: string, options?: { scroll?: boolean }): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
-    React.startTransition(() => {
-      void navigateClientSide(href, "push", options?.scroll !== false, true);
-    });
+    const releaseNavigation = trackScheduledAppRouterNavigation();
+    try {
+      React.startTransition(() => {
+        void navigateClientSide(href, "push", options?.scroll !== false, true);
+      });
+    } catch (error) {
+      releaseNavigation();
+      throw error;
+    }
+    releaseScheduledAppRouterNavigationAfterCurrentTask(releaseNavigation);
   },
   replace(href: string, options?: { scroll?: boolean }): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
-    React.startTransition(() => {
-      void navigateClientSide(href, "replace", options?.scroll !== false, true);
-    });
+    const releaseNavigation = trackScheduledAppRouterNavigation();
+    try {
+      React.startTransition(() => {
+        void navigateClientSide(href, "replace", options?.scroll !== false, true);
+      });
+    } catch (error) {
+      releaseNavigation();
+      throw error;
+    }
+    releaseScheduledAppRouterNavigationAfterCurrentTask(releaseNavigation);
   },
   back(): void {
     if (isServer) return;
@@ -1538,6 +1575,7 @@ const _appRouter = {
     // gated by a session that has since been cleared) would still satisfy a
     // subsequent client navigation and bypass the server's redirect logic.
     getNavigationRuntime()?.functions.clearNavigationCaches?.();
+    if (hasScheduledAppRouterNavigation()) return;
     // Re-fetch the current page's RSC stream
     const rscNavigate = getNavigationRuntime()?.functions.navigate;
     if (rscNavigate) {

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
@@ -7,7 +7,9 @@ const ROUTE_BASE = `${BASE}/nextjs-compat/router-autoscroll`;
 
 type RouterAutoscrollControls = {
   push: (href: string) => void;
+  pushThenRefresh: (href: string) => void;
   pushNoScroll: (href: string) => void;
+  refresh: () => void;
 };
 
 declare global {
@@ -25,11 +27,18 @@ async function waitForControls(page: Page) {
         const controls = window.__vinextRouterAutoscroll;
         return {
           push: typeof controls?.push,
+          pushThenRefresh: typeof controls?.pushThenRefresh,
           pushNoScroll: typeof controls?.pushNoScroll,
+          refresh: typeof controls?.refresh,
         };
       }),
     )
-    .toEqual({ push: "function", pushNoScroll: "function" });
+    .toEqual({
+      push: "function",
+      pushThenRefresh: "function",
+      pushNoScroll: "function",
+      refresh: "function",
+    });
 }
 
 async function push(page: Page, href: string, options: { scroll?: boolean } = {}) {
@@ -83,6 +92,12 @@ async function expectActiveElementTestId(page: Page, testId: string) {
     .toBe(testId);
 }
 
+async function expectActiveElementHref(page: Page, href: string) {
+  await expect
+    .poll(() => page.evaluate(() => document.activeElement?.getAttribute("href") ?? null))
+    .toBe(href);
+}
+
 test.describe("Next.js compat: App Router autoscroll", () => {
   // Ported from Next.js:
   // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -129,6 +144,58 @@ test.describe("Next.js compat: App Router autoscroll", () => {
     await push(page, "/nextjs-compat/router-autoscroll/0/0/10000/10000/page2");
     await expect(page.locator("#page")).toHaveText("page2");
     await expectScroll(page, { x: 1000, y: 0 });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("router.refresh() keeps the current scroll position when called alone", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}/10/10000/100/1000/page1`);
+    await waitForControls(page);
+
+    await scrollTo(page, { x: 0, y: 12000 });
+    await page.evaluate(() => {
+      const controls = window.__vinextRouterAutoscroll;
+      if (!controls) {
+        throw new Error("router autoscroll controls are not installed");
+      }
+      controls.refresh();
+    });
+    await expectScroll(page, { x: 0, y: 12000 });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("router.refresh() does not stop router.push() from scrolling", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}/10/10000/100/1000/page1`);
+    await waitForControls(page);
+    const pageDocumentTop = await readElementDocumentTop(page, "#page");
+
+    await scrollTo(page, { x: 0, y: 12000 });
+    await page.evaluate(() => {
+      const controls = window.__vinextRouterAutoscroll;
+      if (!controls) {
+        throw new Error("router autoscroll controls are not installed");
+      }
+      controls.pushThenRefresh("/nextjs-compat/router-autoscroll/10/10000/100/1000/page2");
+    });
+    await expect(page.locator("#page")).toHaveText("page2");
+    await expectScroll(page, { x: 0, y: pageDocumentTop });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("server action refresh keeps the current scroll position", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}/server-action-refresh`);
+    await waitForControls(page);
+    const initialTimestamp = await page.locator("#server-timestamp").textContent();
+
+    await scrollTo(page, { x: 0, y: 1000 });
+    await page.locator("#refresh-button").click();
+
+    await expect
+      .poll(() => page.locator("#server-timestamp").textContent())
+      .not.toBe(initialTimestamp);
+    await expectScroll(page, { x: 0, y: 1000 });
   });
 
   // Ported from Next.js:
@@ -230,6 +297,89 @@ test.describe("Next.js compat: App Router autoscroll", () => {
     await expect
       .poll(() => page.evaluate(() => document.activeElement?.getAttribute("data-testid") ?? null))
       .toBe("segment-container");
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+  test("focuses a scrollable navigated segment", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await page.locator("#to-scrollable-segment").click();
+    await expect(page.locator('[data-testid="segment-container"]')).toBeVisible();
+    await expectActiveElementTestId(page, "segment-container");
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+  test("keeps focus on the source link for a segment with a focusable descendant", async ({
+    page,
+  }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await page.locator("#to-focusable-descendant").click();
+    await expect(page.locator('[data-testid="focusable-descendant"]')).toBeVisible();
+    await expectActiveElementHref(
+      page,
+      "/nextjs-compat/router-autoscroll/segment-with-focusable-descendant",
+    );
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+  test("keeps focus on the source link for fragment navigation to a new segment", async ({
+    page,
+  }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await page.locator("#to-uri-fragment").click();
+    await expect(page).toHaveURL(`${ROUTE_BASE}/uri-fragments#section-2`);
+    await expectActiveElementHref(page, "/nextjs-compat/router-autoscroll/uri-fragments#section-2");
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+  test("keeps focus on the source link for same-page fragment navigation", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}/uri-fragments`);
+    await waitForControls(page);
+
+    await page.locator("#to-section-1").click();
+    await expect(page).toHaveURL(`${ROUTE_BASE}/uri-fragments#section-1`);
+    await expectActiveElementHref(page, "#section-1");
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("scrolls to top when navigating to a page with new metadata", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await page.evaluate(() => {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+    });
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+    await page.locator("#to-new-metadata").click();
+    await expect(page.locator("#new-metadata-page")).toBeVisible();
+    await expectScroll(page, { x: 0, y: 0 });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("scrolls to top even if React hoists children", async ({ page }) => {
+    await page.goto(`${ROUTE_BASE}`);
+    await waitForControls(page);
+
+    await page.evaluate(() => {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+    });
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+    await page.locator("#to-hoisted").click();
+    await expect(page.locator("#hoisted-page")).toBeVisible();
+    await expectScroll(page, { x: 0, y: 0 });
   });
 
   test("preserves horizontal scroll when focusing the navigated segment", async ({ page }) => {

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/hoisted/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/hoisted/page.tsx
@@ -1,0 +1,11 @@
+export default function HoistedPage() {
+  return (
+    <>
+      <style href="custom-stylesheet" precedence="alpha" />
+      <div id="hoisted-page">Hoisted page</div>
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>{index}</div>
+      ))}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/layout.tsx
@@ -18,6 +18,27 @@ export default function RouterAutoscrollLayout({ children }: { children: ReactNo
         <Link href="/nextjs-compat/router-autoscroll/non-focusable-target" id="to-non-focusable">
           Non-focusable target
         </Link>
+        <Link
+          href="/nextjs-compat/router-autoscroll/scrollable-segment"
+          id="to-scrollable-segment"
+          style={{ marginLeft: 12 }}
+        >
+          Scrollable segment
+        </Link>
+        <Link
+          href="/nextjs-compat/router-autoscroll/segment-with-focusable-descendant"
+          id="to-focusable-descendant"
+          style={{ marginLeft: 12 }}
+        >
+          Focusable descendant
+        </Link>
+        <Link
+          href="/nextjs-compat/router-autoscroll/uri-fragments#section-2"
+          id="to-uri-fragment"
+          style={{ marginLeft: 12 }}
+        >
+          URI fragment
+        </Link>
       </nav>
       {children}
     </>

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/new-metadata/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/new-metadata/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  keywords: ["new-metadata"],
+};
+
+export default function NewMetadataPage() {
+  return (
+    <>
+      <div id="new-metadata-page">New metadata page</div>
+      {Array.from({ length: 500 }, (_, index) => (
+        <div key={index}>{index}</div>
+      ))}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/page.tsx
@@ -15,6 +15,16 @@ export default function RouterAutoscrollIndexPage() {
         </Link>
       </div>
       <div>
+        <Link href="/nextjs-compat/router-autoscroll/new-metadata" id="to-new-metadata">
+          To new metadata
+        </Link>
+      </div>
+      <div>
+        <Link href="/nextjs-compat/router-autoscroll/hoisted" id="to-hoisted">
+          To hoisted
+        </Link>
+      </div>
+      <div>
         <Link
           href="/nextjs-compat/router-autoscroll/skipped-target/display-none"
           id="to-display-none-first-element"

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/router-controls.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/router-controls.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect } from "react";
+import { startTransition, useEffect } from "react";
 import { useRouter } from "next/navigation";
 
 type RouterAutoscrollControls = {
   push: (href: string) => void;
+  pushThenRefresh: (href: string) => void;
   pushNoScroll: (href: string) => void;
+  refresh: () => void;
 };
 
 declare global {
@@ -20,7 +22,14 @@ export function RouterAutoscrollControls() {
   useEffect(() => {
     const controls: RouterAutoscrollControls = {
       push: (href) => router.push(href),
+      pushThenRefresh: (href) => {
+        startTransition(() => {
+          router.push(href);
+          router.refresh();
+        });
+      },
       pushNoScroll: (href) => router.push(href, { scroll: false }),
+      refresh: () => router.refresh(),
     };
     window.__vinextRouterAutoscroll = controls;
 

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/scrollable-segment/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/scrollable-segment/page.tsx
@@ -1,0 +1,14 @@
+export default function ScrollableSegmentPage() {
+  return (
+    <div
+      data-testid="segment-container"
+      style={{
+        height: "50vh",
+        overflow: "scroll",
+        width: 260,
+      }}
+    >
+      <div style={{ height: "60vh" }}>Scroll me</div>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/segment-with-focusable-descendant/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/segment-with-focusable-descendant/page.tsx
@@ -1,0 +1,7 @@
+export default function SegmentWithFocusableDescendantPage() {
+  return (
+    <div data-testid="focusable-descendant">
+      <button type="button">Focusable Button</button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/server-action-refresh/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/server-action-refresh/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { refresh } from "next/cache";
+
+export async function refreshAction() {
+  refresh();
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/server-action-refresh/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/server-action-refresh/page.tsx
@@ -1,0 +1,21 @@
+import { connection } from "next/server";
+import { refreshAction } from "./actions";
+
+export default async function ServerActionRefreshPage() {
+  await connection();
+
+  const timestamp = Date.now();
+
+  return (
+    <>
+      <div style={{ height: "200vh" }} />
+      <form action={refreshAction}>
+        <button id="refresh-button" type="submit">
+          Refresh
+        </button>
+      </form>
+      <div id="server-timestamp">{timestamp}</div>
+      <div style={{ height: "200vh" }} />
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/uri-fragments/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll/uri-fragments/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+export default function UriFragmentsPage() {
+  return (
+    <>
+      <nav aria-label="Table of contents">
+        <ol>
+          <li>
+            <Link href="#section-1" id="to-section-1">
+              Section 1
+            </Link>
+          </li>
+          <li>
+            <Link href="#section-2" id="to-section-2">
+              Section 2
+            </Link>
+          </li>
+          <li>
+            <Link href="#section-3" id="to-section-3">
+              Section 3
+            </Link>
+          </li>
+        </ol>
+      </nav>
+
+      <article style={{ height: "50vh", overflow: "scroll" }}>
+        <h1>A post</h1>
+        <p style={{ height: "100vh" }}>Some long intro</p>
+        <h2 id="section-1">Section 1</h2>
+        <p style={{ height: "100vh" }}>Section 1 body</p>
+        <h2 id="section-2">Section 2</h2>
+        <p style={{ height: "100vh" }}>Section 2 body</p>
+        <h2 id="section-3">Section 3</h2>
+        <p style={{ height: "100vh" }}>Section 3 body</p>
+      </article>
+    </>
+  );
+}


### PR DESCRIPTION
## Overview

| Area | Summary |
| --- | --- |
| Goal | Finish the remaining default App Router scroll and focus parity cases on top of the page-slot scroll target architecture from #1601. |
| Core change | Preserve pending push/replace scheduling when `router.refresh()` is called in the same transition, while still invalidating navigation caches for refresh. |
| Coverage | Adds focused browser parity coverage for refresh, server-action refresh, scrollable segments, focusable descendants, fragments, metadata, and React-hoisted children. |
| Review path | `packages/vinext/src/shims/navigation.ts`, then `tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`, then the new router-autoscroll fixture routes. |

## Why

Default App Router navigation has to let the selected route commit and own the scroll target. A same-transition `router.push()` followed by `router.refresh()` was letting the current-route refresh overtake the scheduled push, which could leave vinext on the old page and skip the pushed page's autoscroll behavior.

## What changed

| Surface | Before | After |
| --- | --- | --- |
| `router.push()` plus same-transition `router.refresh()` | The refresh could dispatch a current-route RSC navigation before the pushed route finished scheduling. | Push/replace scheduling is tracked for the current task, refresh still clears caches, and only the overtaking current-route refresh is skipped. |
| `router.refresh()` alone | Could be under-covered for scroll preservation. | Browser test asserts it keeps the current scroll position. |
| Server action `refresh()` | Not covered in the compat fixture. | Browser test asserts the server timestamp changes without scroll movement. |
| Default focus targets | Remaining Next focus cases were not covered in vinext's router-autoscroll topology. | Browser tests cover scrollable segment focus, focusable descendant behavior, and fragment focus behavior. |
| Metadata and hoisted children | Remaining Next autoscroll cases were not covered. | Browser tests cover new metadata and React-hoisted children routes. |

## Validation

- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts` passed, 23 tests
- `vp test run tests/form.test.ts tests/shims.test.ts` passed, 1006 tests
- `vp check`
- `git diff --check`
- `rg -n "<<<<<<<|=======|>>>>>>>" packages/vinext/src/shims/navigation.ts tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts tests/fixtures/app-basic/app/nextjs-compat/router-autoscroll tests/form.test.ts`

## References

| Reference | Why it matters |
| --- | --- |
| [Next router-autoscroll test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts) | Primary behavior oracle for refresh, server-action refresh, metadata, hoisting, and autoscroll target cases. |
| [Next navigation-focus test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation-focus/navigation-focus.test.ts) | Primary behavior oracle for scrollable segments, focusable descendants, and fragment focus behavior. |
| [Next layout-router source](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/layout-router.tsx) | Source reference for segment focus and scroll handling. |
| [Next segment-cache navigation source](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts) | Source reference for App Router navigation scheduling and refresh behavior. |
| [Next router-autoscroll app page](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/app/page.tsx) | Fixture source for default router-autoscroll entry links. |
| [Next router-autoscroll layout](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/app/layout.tsx) | Fixture source for persistent layout controls. |
| [Next server-action refresh action](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/app/server-action-refresh/actions.ts) | Fixture source for server action `refresh()`. |
| [Next server-action refresh page](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/app/server-action-refresh/page.tsx) | Fixture source for scroll-preserving server-action refresh. |
| [Next hoisted route fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/app/hoisted/page.tsx) | Fixture source for React-hoisted children autoscroll. |
| [Next new metadata route fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/app/new-metadata/page.tsx) | Fixture source for metadata/called-alone autoscroll coverage. |
| [Next navigation-focus layout](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation-focus/app/layout.tsx) | Fixture source for navigation focus links. |
| [Next scrollable segment fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation-focus/app/scrollable-segment/page.tsx) | Fixture source for scrollable segment focus behavior. |
| [Next focusable descendant fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation-focus/app/segment-with-focusable-descendant/page.tsx) | Fixture source for descendant focus behavior. |
| [Next URI fragments fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation-focus/app/uri-fragments/page.tsx) | Fixture source for fragment navigation focus behavior. |

Closes #1368