### PR TITLE
fix(app-router): apply x-edge-runtime header on all App Router response paths

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -622,10 +622,10 @@ export default __createAppRscHandler({
         });
       },
       renderErrorBoundaryPage(renderErr) {
-        return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, scriptNonce, middlewareContext);
+        return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, scriptNonce, middlewareContext, { isEdgeRuntime: __isEdgeRuntime(__segmentConfig.runtime) });
       },
       renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
-        return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, scriptNonce, currentMiddlewareContext);
+        return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, scriptNonce, currentMiddlewareContext, { isEdgeRuntime: __isEdgeRuntime(__segmentConfig.runtime) });
       },
       renderToReadableStream,
       request,
@@ -727,10 +727,15 @@ export default __createAppRscHandler({
     request,
     searchParams,
   }) {
+    const __actionMatch = matchRoute(cleanPathname);
+    const __actionIsEdgeRuntime = __actionMatch
+      ? __isEdgeRuntime(__resolveAppPageSegmentConfig({ layouts: __actionMatch.route.layouts, page: __actionMatch.route.page }).runtime)
+      : false;
     return __handleServerActionRscRequest({
       actionId,
       allowedOrigins: __allowedOrigins,
       basePath: __basePath,
+      isEdgeRuntime: __actionIsEdgeRuntime,
       buildPageElement({
         route: actionRoute,
         params: actionParams,
@@ -827,7 +832,8 @@ export default __createAppRscHandler({
   middlewareModule: ${middlewarePath ? "middlewareModule" : "null"},
   publicFiles: __publicFiles,
   renderNotFound({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
-    return __fallbackRenderer.renderNotFound(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext);
+    const __isEdge = route ? __isEdgeRuntime(__resolveAppPageSegmentConfig({ layouts: route.layouts, page: route.page }).runtime) : false;
+    return __fallbackRenderer.renderNotFound(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext, { isEdgeRuntime: __isEdge });
   },
   ${
     hasPagesDir

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -73,6 +73,16 @@ type AppFallbackRendererOptions<TModule extends AppPageModule = AppPageModule> =
   ssrLoader: () => Promise<AppPageSsrHandler>;
 };
 
+type AppFallbackRendererCallContext = {
+  /**
+   * Whether the matched (or invoking) route opts into Next.js' edge runtime via
+   * `export const runtime = "edge"`. Propagated so boundary/error/not-found
+   * responses carry `x-edge-runtime: 1` for edge routes, matching the page
+   * render path. Defaults to `false` when no route is matched.
+   */
+  isEdgeRuntime?: boolean;
+};
+
 type AppFallbackRenderer<TModule extends AppPageModule = AppPageModule> = {
   renderErrorBoundary: (
     route: AppPageBoundaryRoute<TModule> | null,
@@ -82,6 +92,7 @@ type AppFallbackRenderer<TModule extends AppPageModule = AppPageModule> = {
     matchedParams: AppPageParams | undefined,
     scriptNonce: string | undefined,
     middlewareContext: AppPageMiddlewareContext,
+    callContext?: AppFallbackRendererCallContext,
   ) => Promise<Response | null>;
   renderHttpAccessFallback: (
     route: AppPageBoundaryRoute<TModule> | null,
@@ -95,6 +106,7 @@ type AppFallbackRenderer<TModule extends AppPageModule = AppPageModule> = {
     },
     scriptNonce: string | undefined,
     middlewareContext: AppPageMiddlewareContext,
+    callContext?: AppFallbackRendererCallContext,
   ) => Promise<Response | null>;
   renderNotFound: (
     route: AppPageBoundaryRoute<TModule> | null,
@@ -103,6 +115,7 @@ type AppFallbackRenderer<TModule extends AppPageModule = AppPageModule> = {
     matchedParams: AppPageParams | undefined,
     scriptNonce: string | undefined,
     middlewareContext: AppPageMiddlewareContext,
+    callContext?: AppFallbackRendererCallContext,
   ) => Promise<Response | null>;
 };
 
@@ -149,6 +162,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       opts,
       scriptNonce,
       middlewareContext,
+      callContext,
     ) {
       // global-not-found.tsx replaces the root layout for route-miss 404s.
       // Only applies when:
@@ -176,6 +190,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
             getFontStyles: fontProviders.getFontStyles,
             getNavigationContext,
             globalErrorModule: effectiveGlobalErrorModule,
+            isEdgeRuntime: callContext?.isEdgeRuntime,
             isRscRequest,
             layoutModules: [],
             loadSsrHandler: ssrLoader,
@@ -211,6 +226,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
         getFontStyles: fontProviders.getFontStyles,
         getNavigationContext,
         globalErrorModule: effectiveGlobalErrorModule,
+        isEdgeRuntime: callContext?.isEdgeRuntime,
         isRscRequest,
         layoutModules: opts?.layouts ?? null,
         loadSsrHandler: ssrLoader,
@@ -231,7 +247,15 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       });
     },
 
-    renderNotFound(route, isRscRequest, request, matchedParams, scriptNonce, middlewareContext) {
+    renderNotFound(
+      route,
+      isRscRequest,
+      request,
+      matchedParams,
+      scriptNonce,
+      middlewareContext,
+      callContext,
+    ) {
       return this.renderHttpAccessFallback(
         route,
         404,
@@ -240,6 +264,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
         { matchedParams },
         scriptNonce,
         middlewareContext,
+        callContext,
       );
     },
 
@@ -251,6 +276,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       matchedParams,
       scriptNonce,
       middlewareContext,
+      callContext,
     ) {
       return renderAppPageErrorBoundary({
         basePath,
@@ -265,6 +291,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
         getFontStyles: fontProviders.getFontStyles,
         getNavigationContext,
         globalErrorModule: effectiveGlobalErrorModule,
+        isEdgeRuntime: callContext?.isEdgeRuntime,
         isRscRequest,
         loadSsrHandler: ssrLoader,
         makeThenableParams,

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -68,6 +68,7 @@ type AppPageBoundaryRenderCommonOptions<TModule extends AppPageModule = AppPageM
   getFontStyles: () => string[];
   getNavigationContext: () => unknown;
   globalErrorModule?: TModule | null;
+  isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
   makeThenableParams: (params: AppPageParams) => unknown;
@@ -266,6 +267,7 @@ async function renderAppPageBoundaryElementResponse<TModule extends AppPageModul
         clearRequestContext: options.clearRequestContext,
         fontData,
         fontLinkHeader: options.buildFontLinkHeader(fontData.preloads),
+        isEdgeRuntime: options.isEdgeRuntime,
         middlewareHeaders: options.middlewareContext.headers,
         navigationContext: options.getNavigationContext(),
         rscStream,
@@ -278,6 +280,7 @@ async function renderAppPageBoundaryElementResponse<TModule extends AppPageModul
       return options.createRscOnErrorHandler(pathname, options.routePattern ?? pathname);
     },
     element: payload,
+    isEdgeRuntime: options.isEdgeRuntime,
     isRscRequest: options.isRscRequest,
     middlewareHeaders: options.middlewareContext.headers,
     renderToReadableStream: options.renderToReadableStream,

--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -1,4 +1,5 @@
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
+import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import {
   VINEXT_RSC_CONTENT_TYPE,
@@ -87,6 +88,7 @@ type RenderAppPageBoundaryResponseOptions<TElement> = {
   createHtmlResponse: (rscStream: ReadableStream<Uint8Array>, status: number) => Promise<Response>;
   createRscOnErrorHandler: () => AppPageBoundaryOnError;
   element: TElement;
+  isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   middlewareHeaders?: Headers | null;
   renderToReadableStream: (
@@ -242,6 +244,7 @@ export async function renderAppPageBoundaryResponse<TElement>(
       "Content-Type": VINEXT_RSC_CONTENT_TYPE,
       Vary: VINEXT_RSC_VARY_HEADER,
     });
+    applyEdgeRuntimeHeader(headers, options.isEdgeRuntime);
     mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
     applyRscCompatibilityIdHeader(headers);
 

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -6,6 +6,7 @@ import {
 } from "./app-rsc-cache-busting.js";
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
+import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
@@ -68,6 +69,7 @@ type BuildAppPageCachedResponseOptions = {
   cacheControl?: CacheControlMetadata;
   cacheState: "HIT" | "STALE";
   expireSeconds?: number;
+  isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   middlewareHeaders?: Headers | null;
   middlewareStatus?: number | null;
@@ -78,6 +80,7 @@ type BuildAppPageCachedResponseOptions = {
 type ReadAppPageCacheResponseOptions = {
   cleanPathname: string;
   clearRequestContext: () => void;
+  isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   isrDebug?: AppPageDebugLogger;
   isrGet: AppPageCacheGetter;
@@ -196,6 +199,7 @@ function buildAppPageCachedHeaders(options: {
   cacheControl: string;
   cacheState: BuildAppPageCachedResponseOptions["cacheState"];
   contentType: string;
+  isEdgeRuntime?: boolean;
   middlewareHeaders?: Headers | null;
   mountedSlotsHeader?: string | null;
 }): Headers {
@@ -205,6 +209,7 @@ function buildAppPageCachedHeaders(options: {
     Vary: VINEXT_RSC_VARY_HEADER,
   });
   setCacheStateHeaders(headers, options.cacheState);
+  applyEdgeRuntimeHeader(headers, options.isEdgeRuntime);
 
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
@@ -270,6 +275,7 @@ export function buildAppPageCachedResponse(
       cacheControl,
       cacheState: options.cacheState,
       contentType: VINEXT_RSC_CONTENT_TYPE,
+      isEdgeRuntime: options.isEdgeRuntime,
       middlewareHeaders: options.middlewareHeaders,
       mountedSlotsHeader: options.mountedSlotsHeader,
     });
@@ -289,6 +295,7 @@ export function buildAppPageCachedResponse(
     cacheControl,
     cacheState: options.cacheState,
     contentType: "text/html; charset=utf-8",
+    isEdgeRuntime: options.isEdgeRuntime,
     middlewareHeaders: options.middlewareHeaders,
   });
 
@@ -326,6 +333,7 @@ export async function readAppPageCacheResponse(
         cacheState: "HIT",
         cacheControl: cached?.value.cacheControl,
         expireSeconds: options.expireSeconds,
+        isEdgeRuntime: options.isEdgeRuntime,
         isRscRequest: options.isRscRequest,
         middlewareHeaders: options.middlewareHeaders,
         middlewareStatus: options.middlewareStatus,
@@ -418,6 +426,7 @@ export async function readAppPageCacheResponse(
         cacheState: "STALE",
         cacheControl: cached.value.cacheControl,
         expireSeconds: options.expireSeconds,
+        isEdgeRuntime: options.isEdgeRuntime,
         isRscRequest: options.isRscRequest,
         middlewareHeaders: options.middlewareHeaders,
         middlewareStatus: options.middlewareStatus,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -391,6 +391,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     const cachedPageResponse = await readAppPageCacheResponse({
       cleanPathname: options.cleanPathname,
       clearRequestContext: options.clearRequestContext,
+      isEdgeRuntime: options.isEdgeRuntime,
       isRscRequest: options.isRscRequest,
       isrDebug: options.isrDebug,
       isrGet: options.isrGet,
@@ -776,6 +777,7 @@ async function renderLayoutSpecialError<TRoute extends AppPageDispatchRoute>(
       buildRscRedirectFlightStream(options, rscOptions.digest),
     clearRequestContext: options.clearRequestContext,
     getAndClearPendingCookies,
+    isEdgeRuntime: options.isEdgeRuntime,
     isRscRequest: options.isRscRequest,
     middlewareContext: options.middlewareContext,
     renderFallbackPage(statusCode) {
@@ -814,6 +816,7 @@ async function renderPageSpecialError<TRoute extends AppPageDispatchRoute>(
       buildRscRedirectFlightStream(options, rscOptions.digest),
     clearRequestContext: options.clearRequestContext,
     getAndClearPendingCookies,
+    isEdgeRuntime: options.isEdgeRuntime,
     isRscRequest: options.isRscRequest,
     middlewareContext: options.middlewareContext,
     renderFallbackPage(statusCode) {

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -6,6 +6,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
 import { VINEXT_RSC_REDIRECT_HEADER } from "./headers.js";
+import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
 import { addBasePathToPathname } from "../utils/base-path.js";
@@ -126,6 +127,7 @@ type BuildAppPageSpecialErrorResponseOptions = {
    * the http-access-fallback path leaves cookies to the rendered boundary.
    */
   getAndClearPendingCookies?: () => string[];
+  isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   middlewareContext?: { headers: Headers | null };
   renderFallbackPage?: (statusCode: number) => Promise<Response | null>;
@@ -330,6 +332,7 @@ export async function buildAppPageSpecialErrorResponse(
         // `VINEXT_RSC_REDIRECT_HEADER` in server/headers.ts for the rationale.
         [VINEXT_RSC_REDIRECT_HEADER]: digestUrl,
       });
+      applyEdgeRuntimeHeader(headers, options.isEdgeRuntime);
       // Mirror the regular RSC response by stamping the build-time compatibility
       // ID. Without it, the client treats the response as cross-build and hard-
       // navigates instead of following the redirect through the soft-nav loop.

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -218,6 +218,19 @@ export function resolveAppPageHtmlResponsePolicy(
 
 export { mergeMiddlewareResponseHeaders };
 
+/**
+ * Mirror Next.js' edge-runtime marker (set in edge-ssr-app.ts). Only routes
+ * whose resolved segment config is `runtime = "edge"` should advertise it —
+ * nodejs-runtime routes must not, otherwise downstream consumers can't tell
+ * the configured runtime from the response. Centralized so every response
+ * construction site can opt in without re-deriving the header name.
+ */
+export function applyEdgeRuntimeHeader(headers: Headers, isEdgeRuntime: boolean | undefined): void {
+  if (isEdgeRuntime) {
+    headers.set("x-edge-runtime", "1");
+  }
+}
+
 export function buildAppPageRscResponse(
   body: ReadableStream,
   options: BuildAppPageRscResponseOptions,
@@ -227,13 +240,7 @@ export function buildAppPageRscResponse(
     Vary: VINEXT_RSC_VARY_HEADER,
   });
 
-  // Mirror Next.js' edge-runtime marker (set in edge-ssr-app.ts). Only routes
-  // whose resolved segment config is `runtime = "edge"` should advertise it —
-  // nodejs-runtime routes must not, otherwise downstream consumers can't tell
-  // the configured runtime from the response.
-  if (options.isEdgeRuntime) {
-    headers.set("x-edge-runtime", "1");
-  }
+  applyEdgeRuntimeHeader(headers, options.isEdgeRuntime);
 
   if (options.params && Object.keys(options.params).length > 0) {
     // encodeURIComponent so non-ASCII params (e.g. Korean slugs) survive the
@@ -269,13 +276,7 @@ export function buildAppPageHtmlResponse(
     Vary: VINEXT_RSC_VARY_HEADER,
   });
 
-  // Mirror Next.js' edge-runtime marker (set in edge-ssr-app.ts). Only routes
-  // whose resolved segment config is `runtime = "edge"` should advertise it —
-  // nodejs-runtime routes must not, otherwise downstream consumers can't tell
-  // the configured runtime from the response.
-  if (options.isEdgeRuntime) {
-    headers.set("x-edge-runtime", "1");
-  }
+  applyEdgeRuntimeHeader(headers, options.isEdgeRuntime);
 
   if (options.policy.cacheControl) {
     headers.set("Cache-Control", options.policy.cacheControl);

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -1,6 +1,7 @@
 import type { AppPageFontPreload } from "./app-page-execution.js";
 import type { ReactFormState } from "react-dom/client";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
+import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import type { RootParams } from "vinext/shims/root-params";
 
@@ -55,6 +56,7 @@ type RenderAppPageHtmlStreamOptions = {
 type RenderAppPageHtmlResponseOptions = {
   clearRequestContext: () => void;
   fontLinkHeader?: string;
+  isEdgeRuntime?: boolean;
   middlewareHeaders?: Headers | null;
   status: number;
 } & RenderAppPageHtmlStreamOptions;
@@ -190,6 +192,8 @@ export async function renderAppPageHtmlResponse(
     "Content-Type": "text/html; charset=utf-8",
     Vary: VINEXT_RSC_VARY_HEADER,
   });
+
+  applyEdgeRuntimeHeader(headers, options.isEdgeRuntime);
 
   if (options.fontLinkHeader) {
     headers.set("Link", options.fontLinkHeader);

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -16,6 +16,7 @@ import {
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
 } from "./app-rsc-cache-busting.js";
+import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import {
@@ -186,6 +187,7 @@ export type HandleServerActionRscRequestOptions<
   getDraftModeCookieHeader: () => string | null | undefined;
   getRouteParamNames: (route: TRoute) => readonly string[];
   getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
+  isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   loadServerAction: (actionId: string) => Promise<unknown>;
   matchRoute: (pathname: string) => AppServerActionMatch<TRoute> | null;
@@ -698,6 +700,7 @@ export async function handleServerActionRscRequest<
         "Content-Type": VINEXT_RSC_CONTENT_TYPE,
         Vary: VINEXT_RSC_VARY_HEADER,
       });
+      applyEdgeRuntimeHeader(redirectHeaders, options.isEdgeRuntime);
       mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
       applyRscCompatibilityIdHeader(redirectHeaders);
       // Prefix basePath onto the redirect target. The client-side handler in
@@ -742,6 +745,7 @@ export async function handleServerActionRscRequest<
         "Content-Type": VINEXT_RSC_CONTENT_TYPE,
         Vary: VINEXT_RSC_VARY_HEADER,
       });
+      applyEdgeRuntimeHeader(actionHeaders, options.isEdgeRuntime);
       mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);
       applyRscCompatibilityIdHeader(actionHeaders);
 
@@ -806,6 +810,7 @@ export async function handleServerActionRscRequest<
       "Content-Type": VINEXT_RSC_CONTENT_TYPE,
       Vary: VINEXT_RSC_VARY_HEADER,
     });
+    applyEdgeRuntimeHeader(actionHeaders, options.isEdgeRuntime);
     mergeMiddlewareResponseHeaders(actionHeaders, options.middlewareHeaders);
     applyRscCompatibilityIdHeader(actionHeaders);
     setActionRevalidatedHeader(actionHeaders, actionRevalidationKind);

--- a/tests/app-page-boundary.test.ts
+++ b/tests/app-page-boundary.test.ts
@@ -234,4 +234,53 @@ describe("app page boundary helpers", () => {
     expect(createHtmlResponse).toHaveBeenCalledTimes(1);
     await expect(response.text()).resolves.toBe("200:HTML boundary");
   });
+
+  it("emits the `x-edge-runtime: 1` marker on boundary RSC responses for edge-runtime routes", async () => {
+    const response = await renderAppPageBoundaryResponse({
+      async createHtmlResponse() {
+        return new Response("html");
+      },
+      createRscOnErrorHandler() {
+        return () => null;
+      },
+      element: "boundary",
+      isEdgeRuntime: true,
+      isRscRequest: true,
+      renderToReadableStream(element) {
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(String(element)));
+            controller.close();
+          },
+        });
+      },
+      status: 404,
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("omits the `x-edge-runtime` marker on boundary RSC responses for nodejs-runtime routes", async () => {
+    const response = await renderAppPageBoundaryResponse({
+      async createHtmlResponse() {
+        return new Response("html");
+      },
+      createRscOnErrorHandler() {
+        return () => null;
+      },
+      element: "boundary",
+      isRscRequest: true,
+      renderToReadableStream(element) {
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(String(element)));
+            controller.close();
+          },
+        });
+      },
+      status: 404,
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBeNull();
+  });
 });

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -254,6 +254,46 @@ describe("app page cache helpers", () => {
     ).toBeNull();
   });
 
+  it("emits the `x-edge-runtime: 1` marker on cached responses for edge-runtime routes", () => {
+    const rscData = new TextEncoder().encode("flight").buffer;
+    const cached = buildCachedAppPageValue("<h1>cached</h1>", rscData);
+
+    const htmlResponse = buildAppPageCachedResponse(cached, {
+      cacheState: "HIT",
+      isEdgeRuntime: true,
+      isRscRequest: false,
+      revalidateSeconds: 60,
+    });
+    expect(htmlResponse?.headers.get("x-edge-runtime")).toBe("1");
+
+    const rscResponse = buildAppPageCachedResponse(cached, {
+      cacheState: "HIT",
+      isEdgeRuntime: true,
+      isRscRequest: true,
+      revalidateSeconds: 60,
+    });
+    expect(rscResponse?.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("omits the `x-edge-runtime` marker on cached responses for nodejs-runtime routes", () => {
+    const rscData = new TextEncoder().encode("flight").buffer;
+    const cached = buildCachedAppPageValue("<h1>cached</h1>", rscData);
+
+    const htmlResponse = buildAppPageCachedResponse(cached, {
+      cacheState: "HIT",
+      isRscRequest: false,
+      revalidateSeconds: 60,
+    });
+    expect(htmlResponse?.headers.get("x-edge-runtime")).toBeNull();
+
+    const rscResponse = buildAppPageCachedResponse(cached, {
+      cacheState: "HIT",
+      isRscRequest: true,
+      revalidateSeconds: 60,
+    });
+    expect(rscResponse?.headers.get("x-edge-runtime")).toBeNull();
+  });
+
   it("returns cached HIT responses and clears request state", async () => {
     let didClearRequestContext = false;
     const middlewareHeaders = new Headers({ "X-From-Middleware": "hit" });

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -955,4 +955,43 @@ describe("app page execution helpers", () => {
       "</font-a.woff2>; rel=preload; as=font; type=font/woff2; crossorigin, </font-b.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );
   });
+
+  it("emits the `x-edge-runtime: 1` marker on RSC redirect flight responses for edge-runtime routes", async () => {
+    const response = await buildAppPageSpecialErrorResponse({
+      buildRscRedirectFlightStream: ({ digest }) =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`E:${digest}`));
+            controller.close();
+          },
+        }),
+      clearRequestContext: vi.fn(),
+      isEdgeRuntime: true,
+      isRscRequest: true,
+      request: new Request("https://example.com/start.rsc"),
+      specialError: { kind: "redirect", location: "/redirected", statusCode: 307 },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("omits the `x-edge-runtime` marker on RSC redirect flight responses for nodejs-runtime routes", async () => {
+    const response = await buildAppPageSpecialErrorResponse({
+      buildRscRedirectFlightStream: ({ digest }) =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`E:${digest}`));
+            controller.close();
+          },
+        }),
+      clearRequestContext: vi.fn(),
+      isRscRequest: true,
+      request: new Request("https://example.com/start.rsc"),
+      specialError: { kind: "redirect", location: "/redirected", statusCode: 307 },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-edge-runtime")).toBeNull();
+  });
 });

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -381,4 +381,39 @@ describe("app page stream helpers", () => {
       }),
     ).toBe(false);
   });
+
+  it("emits the `x-edge-runtime: 1` marker on HTML stream responses for edge-runtime routes", async () => {
+    const response = await renderAppPageHtmlResponse({
+      clearRequestContext: vi.fn(),
+      fontData: { links: [], preloads: [], styles: [] },
+      isEdgeRuntime: true,
+      navigationContext: null,
+      rscStream: createStream(["flight"]),
+      ssrHandler: {
+        async handleSsr() {
+          return createStream(["<html>page</html>"]);
+        },
+      },
+      status: 200,
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("omits the `x-edge-runtime` marker on HTML stream responses for nodejs-runtime routes", async () => {
+    const response = await renderAppPageHtmlResponse({
+      clearRequestContext: vi.fn(),
+      fontData: { links: [], preloads: [], styles: [] },
+      navigationContext: null,
+      rscStream: createStream(["flight"]),
+      ssrHandler: {
+        async handleSsr() {
+          return createStream(["<html>page</html>"]);
+        },
+      },
+      status: 200,
+    });
+
+    expect(response.headers.get("x-edge-runtime")).toBeNull();
+  });
 });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1078,6 +1078,54 @@ describe("app server action execution helpers", () => {
       });
     }
   });
+
+  it("emits the `x-edge-runtime: 1` marker on rerendered RSC action responses for edge-runtime routes", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        isEdgeRuntime: true,
+      }),
+    );
+
+    expect(response?.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("omits the `x-edge-runtime` marker on rerendered RSC action responses for nodejs-runtime routes", async () => {
+    const response = await handleServerActionRscRequest(createRscOptions());
+
+    expect(response?.headers.get("x-edge-runtime")).toBeNull();
+  });
+
+  it("emits the `x-edge-runtime: 1` marker on action redirect responses for edge-runtime routes", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        isEdgeRuntime: true,
+        loadServerAction() {
+          return Promise.resolve(() => {
+            throw { digest: "NEXT_REDIRECT;;%2Fdashboard;307" };
+          });
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-edge-runtime")).toBe("1");
+  });
+
+  it("emits the `x-edge-runtime: 1` marker on no-revalidate action responses for edge-runtime routes", async () => {
+    // createRscOptions defaults already return no cookies + no draft cookie,
+    // which selects the no-revalidate branch (skips page rerender).
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        isEdgeRuntime: true,
+        loadServerAction() {
+          return Promise.resolve(async () => "no-revalidate-result");
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("x-edge-runtime")).toBe("1");
+  });
 });
 
 // The client-side counterpart of `createServerActionNotFoundResponse`: when the


### PR DESCRIPTION
Follow-up to #1565 addressing the bonk review's coverage-gap callout.

## Summary
- #1565 added `x-edge-runtime: 1` to `buildAppPageRscResponse` / `buildAppPageHtmlResponse` and gated it on the resolved segment-config `runtime`. Bonk flagged five other App Router response construction paths that bypass those helpers and would skip the marker for edge-runtime routes.
- This PR threads `isEdgeRuntime` into each of those paths, centralized through a single `applyEdgeRuntimeHeader` helper that owns the header name + gating condition.

## Paths now covered
- `app-page-cache.ts` — ISR HIT/STALE responses (`buildAppPageCachedResponse`)
- `app-server-action-execution.ts` — server action RSC responses: redirect, no-revalidate, re-render (`handleServerActionRscRequest`)
- `app-page-boundary.ts` — boundary RSC responses (`renderAppPageBoundaryResponse`)
- `app-page-execution.ts` — 200 + flight-payload redirect responses (`buildAppPageSpecialErrorResponse`)
- `app-page-stream.ts` — HTML stream responses used by the boundary/fallback path (`renderAppPageHtmlResponse`)

Plumbing:
- `applyEdgeRuntimeHeader(headers, isEdgeRuntime)` is the single place that knows the header name and the "only when edge" rule. Both existing builders (RSC/HTML) and the five new sites call it.
- `isEdgeRuntime` is threaded from `dispatchAppPage` options through to `readAppPageCacheResponse` and `buildAppPageSpecialErrorResponse`.
- For the boundary/error fallback path, `AppFallbackRenderer.renderErrorBoundary` / `renderHttpAccessFallback` / `renderNotFound` get an optional `callContext: { isEdgeRuntime }` arg that flows through `AppPageBoundaryRenderCommonOptions` to both response sites.
- For server actions, the rsc-entry resolves the invoking route's runtime via `matchRoute(cleanPathname)` and passes it as a boolean.

## Test plan
- [x] New unit tests in `tests/app-page-cache.test.ts`, `tests/app-page-boundary.test.ts`, `tests/app-page-execution.test.ts`, `tests/app-page-stream.test.ts`, and `tests/app-server-action-execution.test.ts` assert positive (edge route → header present) and negative (nodejs route → header absent) for each path.
- [x] `pnpm test:unit` on the touched test files: 151 tests pass.
- [x] `pnpm check`: clean (one pre-existing unrelated error in `apps/web/worker/index.ts` referencing a missing `isImageOptimizationPath` export — also fails on `main`).

## Follow-up not done here
Bonk also recommended a longer-term refactor to a single outermost response-wrapping layer that applies edge markers / cross-cutting headers. That's a meaningful architecture change worth tracking separately — this PR keeps the threading-based pattern from #1565 and just extends coverage to the remaining sites.