### PR TITLE
fix(routing): preserve dynamic route params key order (#1537)

### DIFF
--- a/packages/vinext/src/routing/route-trie.ts
+++ b/packages/vinext/src/routing/route-trie.ts
@@ -1,4 +1,4 @@
-import { decodeMatchedParams } from "./utils";
+import { buildParams, decodeMatchedParams } from "./utils";
 
 /**
  * Trie (prefix tree) for O(depth) route matching.
@@ -140,34 +140,31 @@ export function trieMatch<R>(
   root: TrieNode<R>,
   urlParts: string[],
 ): { route: R; params: Record<string, string | string[]> } | null {
-  const result = match(root, urlParts, 0);
+  const result = match(root, urlParts, 0, []);
   if (result) {
     decodeMatchedParams(result.params);
   }
   return result;
 }
 
-function createParams(): Record<string, string | string[]> {
-  return Object.create(null);
-}
-
 function match<R>(
   node: TrieNode<R>,
   urlParts: string[],
   index: number,
+  entries: Array<[string, string | string[]]>,
 ): { route: R; params: Record<string, string | string[]> } | null {
   // All URL segments consumed
   if (index === urlParts.length) {
     // Exact match at this node
     if (node.route !== null) {
-      return { route: node.route, params: createParams() };
+      return { route: node.route, params: buildParams(entries) };
     }
 
-    // Optional catch-all with 0 segments
+    // Optional catch-all with 0 segments — param is not materialized
     if (node.optionalCatchAllChild !== null) {
       return {
         route: node.optionalCatchAllChild.route,
-        params: createParams(),
+        params: buildParams(entries),
       };
     }
 
@@ -179,7 +176,7 @@ function match<R>(
   // 1. Try static child (highest priority)
   const staticChild = node.staticChildren.get(segment);
   if (staticChild) {
-    const result = match(staticChild, urlParts, index + 1);
+    const result = match(staticChild, urlParts, index + 1, entries);
     if (result !== null) {
       return result;
     }
@@ -187,26 +184,27 @@ function match<R>(
 
   // 2. Try dynamic child (single segment)
   if (node.dynamicChild !== null) {
-    const result = match(node.dynamicChild.node, urlParts, index + 1);
+    entries.push([node.dynamicChild.paramName, segment]);
+    const result = match(node.dynamicChild.node, urlParts, index + 1, entries);
     if (result !== null) {
-      result.params[node.dynamicChild.paramName] = segment;
       return result;
     }
+    entries.pop();
   }
 
   // 3. Try catch-all (1+ remaining segments)
   if (node.catchAllChild !== null) {
     const remaining = urlParts.slice(index);
-    const params = createParams();
+    const params = buildParams(entries);
     params[node.catchAllChild.paramName] = remaining;
     return { route: node.catchAllChild.route, params };
   }
 
-  // 4. Try optional catch-all (0+ remaining segments)
+  // 4. Try optional catch-all (0+ remaining segments).
+  // At this point index < urlParts.length, so remaining always has ≥1 segment.
   if (node.optionalCatchAllChild !== null) {
-    const remaining = urlParts.slice(index);
-    const params = createParams();
-    params[node.optionalCatchAllChild.paramName] = remaining;
+    const params = buildParams(entries);
+    params[node.optionalCatchAllChild.paramName] = urlParts.slice(index);
     return { route: node.optionalCatchAllChild.route, params };
   }
 

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -147,6 +147,25 @@ function decodeMatchedParam(value: string): string {
 }
 
 /**
+ * Build a params object from ordered entries, preserving insertion order.
+ *
+ * Used by trie matchers to reconstruct the params Record after collecting
+ * entries in declaration order via DFS backtracking. Object.create(null)
+ * avoids prototype pollution.
+ *
+ * @param entries - Ordered [paramName, value] tuples from forward traversal
+ */
+export function buildParams(
+  entries: Array<[string, string | string[]]>,
+): Record<string, string | string[]> {
+  const params = Object.create(null);
+  for (const [key, value] of entries) {
+    params[key] = value;
+  }
+  return params;
+}
+
+/**
  * Decode captured route params with `decodeURIComponent`, mirroring Next.js
  * route-matcher.ts:25-27. Mutates the params object in place. Catch-all
  * arrays are decoded element-wise. Malformed escapes are preserved (the

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -1,7 +1,7 @@
 import { createElement, isValidElement, Suspense } from "react";
 import { isUnknownRecord } from "../utils/record.js";
 import { stripBasePath } from "../utils/base-path.js";
-import { decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
+import { buildParams, decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
 import type { RouteManifest, RouteManifestRoute } from "../routing/app-route-graph.js";
 import { stripRscCacheBustingSearchParam, stripRscSuffix } from "./app-rsc-cache-busting.js";
 import {
@@ -136,15 +136,16 @@ function matchNode(
   node: OptimisticRouteTrieNode,
   urlParts: readonly string[],
   index: number,
+  entries: Array<[string, string | string[]]>,
 ): OptimisticRouteMatch | null {
   if (index === urlParts.length) {
     if (node.route !== null) {
-      return { route: node.route, params: Object.create(null) };
+      return { route: node.route, params: buildParams(entries) };
     }
     if (node.optionalCatchAllChild !== null) {
       return {
         route: node.optionalCatchAllChild.route,
-        params: Object.create(null),
+        params: buildParams(entries),
       };
     }
     return null;
@@ -156,32 +157,27 @@ function matchNode(
     // Static children are authoritative for optimistic routing. If a known
     // static subtree does not contain the remaining URL, do not fall through to
     // a catch-all sibling and render the wrong loading boundary.
-    return matchNode(staticChild, urlParts, index + 1);
+    return matchNode(staticChild, urlParts, index + 1, entries);
   }
 
   if (node.dynamicChild !== null) {
-    const match = matchNode(node.dynamicChild.node, urlParts, index + 1);
-    if (match === null) return null;
-    match.params[node.dynamicChild.paramName] = segment;
-    return match;
+    entries.push([node.dynamicChild.paramName, segment]);
+    const match = matchNode(node.dynamicChild.node, urlParts, index + 1, entries);
+    if (match !== null) return match;
+    entries.pop();
   }
 
   if (node.catchAllChild !== null) {
-    return {
-      route: node.catchAllChild.route,
-      params: {
-        [node.catchAllChild.paramName]: urlParts.slice(index),
-      },
-    };
+    const params = buildParams(entries);
+    params[node.catchAllChild.paramName] = urlParts.slice(index);
+    return { route: node.catchAllChild.route, params };
   }
 
+  // At this point index < urlParts.length, so remaining always has ≥1 segment.
   if (node.optionalCatchAllChild !== null) {
-    return {
-      route: node.optionalCatchAllChild.route,
-      params: {
-        [node.optionalCatchAllChild.paramName]: urlParts.slice(index),
-      },
-    };
+    const params = buildParams(entries);
+    params[node.optionalCatchAllChild.paramName] = urlParts.slice(index);
+    return { route: node.optionalCatchAllChild.route, params };
   }
 
   return null;
@@ -209,7 +205,7 @@ export function matchOptimisticRouteManifestRoute(options: {
   const urlParts = hrefToRouteParts(options.href, options.basePath);
   if (urlParts === null) return null;
 
-  const match = matchNode(getRouteTrie(options.routeManifest), urlParts, 0);
+  const match = matchNode(getRouteTrie(options.routeManifest), urlParts, 0, []);
   if (match === null) return null;
 
   decodeMatchedParams(match.params);

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -158,6 +158,44 @@ describe("App Router optimistic routing", () => {
     ).toBe("route:/blog/featured");
   });
 
+  it("preserves dynamic route param key order", () => {
+    const twoSegment = manifest([
+      route({
+        id: "route:/:category/:id",
+        isDynamic: true,
+        paramNames: ["category", "id"],
+        pattern: "/:category/:id",
+        patternParts: [":category", ":id"],
+      }),
+    ]);
+
+    const twoMatch = matchOptimisticRouteManifestRoute({
+      basePath: "",
+      href: "/electronics/123",
+      routeManifest: twoSegment,
+    });
+    expect(twoMatch).not.toBeNull();
+    expect(Object.keys(twoMatch!.params)).toEqual(["category", "id"]);
+
+    const threeSegment = manifest([
+      route({
+        id: "route:/:a/:b/:c",
+        isDynamic: true,
+        paramNames: ["a", "b", "c"],
+        pattern: "/:a/:b/:c",
+        patternParts: [":a", ":b", ":c"],
+      }),
+    ]);
+
+    const threeMatch = matchOptimisticRouteManifestRoute({
+      basePath: "",
+      href: "/x/y/z",
+      routeManifest: threeSegment,
+    });
+    expect(threeMatch).not.toBeNull();
+    expect(Object.keys(threeMatch!.params)).toEqual(["a", "b", "c"]);
+  });
+
   it("does not fall through from a known static subtree to a catch-all sibling", () => {
     expect(
       matchOptimisticRouteManifestRoute({

--- a/tests/route-trie.test.ts
+++ b/tests/route-trie.test.ts
@@ -87,6 +87,54 @@ describe("buildRouteTrie + trieMatch", () => {
     });
   });
 
+  describe("params key order", () => {
+    it("preserves key order for two dynamic segments", () => {
+      const routes = [r("/:category/:id")];
+      const trie = buildRouteTrie(routes);
+
+      const result = trieMatch(trie, ["electronics", "123"]);
+      expect(result).not.toBeNull();
+      expect(Object.keys(result!.params)).toEqual(["category", "id"]);
+    });
+
+    it("preserves key order for three dynamic segments", () => {
+      const routes = [r("/:a/:b/:c")];
+      const trie = buildRouteTrie(routes);
+
+      const result = trieMatch(trie, ["x", "y", "z"]);
+      expect(result).not.toBeNull();
+      expect(Object.keys(result!.params)).toEqual(["a", "b", "c"]);
+    });
+
+    it("preserves key order for mixed static+dynamic route", () => {
+      const routes = [r("/products/:category/:id")];
+      const trie = buildRouteTrie(routes);
+
+      const result = trieMatch(trie, ["products", "electronics", "123"]);
+      expect(result).not.toBeNull();
+      expect(Object.keys(result!.params)).toEqual(["category", "id"]);
+    });
+
+    it("preserves key order after backtracking to catch-all", () => {
+      const routes = [r("/blog/:id/comments"), r("/blog/:path+")];
+      const trie = buildRouteTrie(routes);
+
+      const result = trieMatch(trie, ["blog", "42", "photos"]);
+      expect(result).not.toBeNull();
+      expect(result!.route.pattern).toBe("/blog/:path+");
+      expect(Object.keys(result!.params)).toEqual(["path"]);
+    });
+
+    it("preserves key order for multiple dynamic segments with static intermediate", () => {
+      const routes = [r("/:a/b/:c")];
+      const trie = buildRouteTrie(routes);
+
+      const result = trieMatch(trie, ["x", "b", "z"]);
+      expect(result).not.toBeNull();
+      expect(Object.keys(result!.params)).toEqual(["a", "c"]);
+    });
+  });
+
   describe("catch-all routes", () => {
     it("matches catch-all with one segment", () => {
       const routes = [r("/docs/:path+")];


### PR DESCRIPTION
Fixes #1537.

App Router dynamic-route params were being returned in reversed key order (deepest segment first) because the recursive trie matcher mutated `result.params` on the way back up the call stack. For a route like `[category]/[id]`, `Object.keys(params)` returned `['id', 'category']` instead of `['category', 'id']`.

**Fix:** Collect param entries into a shared stack during forward DFS traversal, pop on backtrack failure, and materialize the params object from the stack at the terminal node. This preserves declaration order for `Object.keys()`.

**Changes:**
- `route-trie.ts`: `match()` now passes an `entries` array through recursion. Dynamic segments are pushed before descending and popped on backtrack. Terminal nodes build params via `buildParams(entries)`.
- `app-optimistic-routing.ts`: Same fix applied to `matchNode()`.
- `routing/utils.ts`: Extracted shared `buildParams(entries)` helper (uses `Object.create(null)` to avoid prototype pollution).
- Both catch-all branches now correctly preserve ancestor dynamic params via `buildParams(entries)` — the old code created fresh empty objects, relying on the unwind mutation to re-populate them.
- Added tests in `route-trie.test.ts` (5 tests) and `app-optimistic-routing.test.ts` (1 test) covering 2-segment, 3-segment, mixed static+dynamic, and backtracking scenarios.

All 69 route-trie tests, 9 optimistic routing tests, 110 routing tests, and 331 app-router tests pass.