### PR TITLE
fix(build): implement compiler.removeConsole option

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -242,6 +242,14 @@ export type NextConfig = {
   /** Webpack config (ignored — we use Vite) */
   webpack?: unknown;
   /**
+   * Compiler options for build-time code transforms.
+   * vinext supports the subset that maps to Vite-compatible transforms.
+   */
+  compiler?: {
+    /** Remove `console.*` calls from the client bundle. */
+    removeConsole?: boolean | { exclude?: string[] };
+  };
+  /**
    * Path to a custom cache handler module (e.g., KV, Redis, DynamoDB).
    * Accepts relative paths, absolute paths, or file:// URLs from import.meta.resolve().
    * When "type": "module" is set in package.json, use import.meta.resolve() instead of
@@ -360,6 +368,13 @@ export type ResolvedNextConfig = {
    * the object is forwarded to Sass and may contain any modern Sass option.
    */
   sassOptions: Record<string, unknown> | null;
+  /**
+   * When enabled, strip `console.*` calls from the client bundle.
+   * Mirrors Next.js `compiler.removeConsole` option.
+   * `true` strips all console calls; `{ exclude: ["error"] }` strips all
+   * except the specified method names (case-insensitive).
+   */
+  removeConsole: boolean | { exclude: string[] };
 };
 
 // Mirrors Next.js's accepted set in packages/next/src/shared/lib/constants.ts
@@ -993,6 +1008,7 @@ export async function resolveNextConfig(
       buildId,
       deploymentId,
       sassOptions: null,
+      removeConsole: false,
     };
     detectNextIntlConfig(root, resolved);
     return resolved;
@@ -1204,6 +1220,12 @@ export async function resolveNextConfig(
     buildId,
     deploymentId,
     sassOptions: readOptionalRecord(config.sassOptions) ?? null,
+    removeConsole:
+      config.compiler?.removeConsole === true
+        ? true
+        : isUnknownRecord(config.compiler?.removeConsole)
+          ? { exclude: readStringArray(config.compiler!.removeConsole.exclude) }
+          : false,
   };
 
   // Auto-detect next-intl (lowest priority — explicit aliases from

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3453,8 +3453,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // getBaseSWCOptions, which feeds both isServer:true and isServer:false
     // configs); vinext scopes it to client-only so server-side console logging
     // remains available for debugging. Tracked as a known parity gap.
+    // Production-only — Next.js documents removeConsole as a production-build
+    // feature, and stripping logs in dev would silently hide debugging output.
     {
       name: "vinext:remove-console",
+      apply: "build",
       transform: {
         // Only match source files, not node_modules or virtual modules
         filter: { id: /\.(tsx?|jsx?|mjs)$/ },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -131,6 +131,7 @@ import {
   type BundleBackfillChunk,
 } from "./build/ssr-manifest.js";
 import { stripServerExports } from "./plugins/strip-server-exports.js";
+import { removeConsoleCalls } from "./plugins/remove-console.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -3401,6 +3402,28 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (/\/_(?:app|document|error)\b/.test(relativePath)) return null;
 
           const result = stripServerExports(code);
+          if (!result) return null;
+          return { code: result, map: null };
+        },
+      },
+    },
+    // Strip console.* calls from the client bundle when compiler.removeConsole
+    // is enabled in next.config. Mirrors Next.js's SWC remove_console transform.
+    // Only applies to client builds; SSR/server-side console logging is left
+    // untouched so debugging server code remains possible.
+    {
+      name: "vinext:remove-console",
+      transform: {
+        // Only match source files, not node_modules or virtual modules
+        filter: { id: /\.(tsx?|jsx?|mjs)$/ },
+        handler(code, id) {
+          const ssr = this.environment?.name !== "client";
+          if (ssr) return null;
+          if (!nextConfig.removeConsole) return null;
+          // Skip node_modules — Next.js only strips application code
+          if (id.includes("/node_modules/")) return null;
+
+          const result = removeConsoleCalls(code, nextConfig.removeConsole);
           if (!result) return null;
           return { code: result, map: null };
         },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3448,9 +3448,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
     },
     // Strip console.* calls from the client bundle when compiler.removeConsole
-    // is enabled in next.config. Mirrors Next.js's SWC remove_console transform.
-    // Only applies to client builds; SSR/server-side console logging is left
-    // untouched so debugging server code remains possible.
+    // is enabled in next.config. Inspired by Next.js's SWC remove_console transform.
+    // NOTE: Next.js applies this to both client and server (set in
+    // getBaseSWCOptions, which feeds both isServer:true and isServer:false
+    // configs); vinext scopes it to client-only so server-side console logging
+    // remains available for debugging. Tracked as a known parity gap.
     {
       name: "vinext:remove-console",
       transform: {
@@ -3460,7 +3462,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           const ssr = this.environment?.name !== "client";
           if (ssr) return null;
           if (!nextConfig.removeConsole) return null;
-          // Skip node_modules — Next.js only strips application code
+          // Skip node_modules to avoid transform overhead on application
+          // dependencies. Next.js applies removeConsole to node_modules too
+          // (the SWC option in getBaseSWCOptions runs on every file the SWC
+          // loader processes); this is a minor divergence in exchange for
+          // faster builds.
           if (id.includes("/node_modules/")) return null;
 
           const result = removeConsoleCalls(code, nextConfig.removeConsole);

--- a/packages/vinext/src/plugins/remove-console.ts
+++ b/packages/vinext/src/plugins/remove-console.ts
@@ -20,7 +20,7 @@ import MagicString from "magic-string";
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
 type BindingNode = Extract<ASTNode, { type: string }>;
 
-export type RemoveConsoleConfig = boolean | { exclude: string[] };
+type RemoveConsoleConfig = boolean | { exclude: string[] };
 
 /**
  * Walk the AST body looking for expression statements whose expression is a

--- a/packages/vinext/src/plugins/remove-console.ts
+++ b/packages/vinext/src/plugins/remove-console.ts
@@ -22,6 +22,15 @@ type BindingNode = Extract<ASTNode, { type: string }>;
 
 type RemoveConsoleConfig = boolean | { exclude: string[] };
 
+// Node types that introduce a new function-style scope. Hoisted to a module-
+// level Set so the membership check in walk() is O(1) and doesn't allocate
+// per recursive call.
+const SCOPE_ENTERING_TYPES = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+]);
+
 /**
  * Walk the AST body looking for expression statements whose expression is a
  * CallExpression with a callee of `console.<identifier>`. When found, check
@@ -166,14 +175,7 @@ export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): s
       return; // don't recurse into children of a removed call
     }
 
-    // Scope-entering nodes
-    const scopeEnteringTypes = [
-      "FunctionDeclaration",
-      "FunctionExpression",
-      "ArrowFunctionExpression",
-    ];
-
-    const isScopeEntering = scopeEnteringTypes.includes(node.type);
+    const isScopeEntering = SCOPE_ENTERING_TYPES.has(node.type);
     if (isScopeEntering) {
       pushScope();
 
@@ -187,8 +189,29 @@ export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): s
       }
     }
 
+    // CatchClause introduces a binding for its param (`catch (e) { ... }`).
+    // If the param shadows "console", the catch block must treat console as
+    // local. We push a scope just for the param binding; the BlockStatement
+    // body below will push its own scope on top, which inherits the shadow.
+    const isCatchScope = node.type === "CatchClause";
+    if (isCatchScope) {
+      pushScope();
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const param = (node as any).param as BindingNode | undefined;
+      if (param) {
+        checkBinding(param);
+      }
+    }
+
     // Also enter a new scope for BlockStatement / Program bodies so that
     // variable declarations are checked in the right frame.
+    //
+    // KNOWN LIMITATION: `var` is function-scoped, not block-scoped. A `var
+    // console = ...` inside a nested block (if/for/etc.) is hoisted to the
+    // enclosing function, but we treat it as block-scoped here, so console
+    // references after the block exits its scope frame will be incorrectly
+    // stripped. `let`/`const` are block-scoped so this only affects `var`.
+    // In real-world code, shadowing `console` with `var` is exceedingly rare.
     const isBlockScope =
       node.type === "BlockStatement" || node.type === "Program" || node.type === "SwitchCase";
     if (isBlockScope && !isScopeEntering) {
@@ -221,7 +244,7 @@ export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): s
       }
     }
 
-    if (isScopeEntering || isBlockScope) {
+    if (isScopeEntering || isBlockScope || isCatchScope) {
       popScope();
     }
   }

--- a/packages/vinext/src/plugins/remove-console.ts
+++ b/packages/vinext/src/plugins/remove-console.ts
@@ -86,8 +86,11 @@ export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): s
 
   /**
    * Check if a node introduces a binding named "console" and mark scope.
+   * Recurses into all binding-pattern node types (destructuring shapes,
+   * defaults, rest elements).
    */
-  function checkBinding(node: BindingNode): void {
+  function checkBinding(node: BindingNode | null | undefined): void {
+    if (!node) return;
     // oxlint-disable-next-line typescript/switch-exhaustiveness-check
     switch (node.type) {
       case "Identifier": {
@@ -103,12 +106,35 @@ export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): s
         break;
       }
       case "Property": {
+        // For `{ key: value }` and `{ console }` (shorthand) — the binding name
+        // is in `value`, not `key`. Recurse so AssignmentPattern defaults,
+        // nested patterns, etc. are all handled.
         const propertyNode = node as unknown as { value?: BindingNode };
-        if (propertyNode.value?.type === "Identifier" && propertyNode.value.name === "console") {
-          currentScope().shadowed = true;
-        } else if (propertyNode.value) {
-          checkBinding(propertyNode.value);
+        if (propertyNode.value) checkBinding(propertyNode.value);
+        break;
+      }
+      case "ArrayPattern": {
+        // oxlint-disable-next-line typescript/no-explicit-any
+        const elements = (node as any).elements as Array<BindingNode | null> | undefined;
+        if (elements) {
+          for (const el of elements) {
+            checkBinding(el);
+          }
         }
+        break;
+      }
+      case "AssignmentPattern": {
+        // `x = default` — the binding is `left`, the default value is `right`.
+        // oxlint-disable-next-line typescript/no-explicit-any
+        const left = (node as any).left as BindingNode | undefined;
+        checkBinding(left);
+        break;
+      }
+      case "RestElement": {
+        // `...x` — the binding is `argument`.
+        // oxlint-disable-next-line typescript/no-explicit-any
+        const argument = (node as any).argument as BindingNode | undefined;
+        checkBinding(argument);
         break;
       }
       default:
@@ -175,9 +201,29 @@ export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): s
       return; // don't recurse into children of a removed call
     }
 
+    // `function console() {}` and `class console {}` bind `console` in the
+    // *enclosing* scope (function declarations are hoisted to function/module
+    // scope, class declarations are block-scoped). Check `id` against the
+    // current scope BEFORE pushing the function's own scope, so the binding
+    // is visible both outside and inside the function (via scope inheritance).
+    if (node.type === "FunctionDeclaration" || node.type === "ClassDeclaration") {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const id = (node as any).id as BindingNode | undefined;
+      checkBinding(id);
+    }
+
     const isScopeEntering = SCOPE_ENTERING_TYPES.has(node.type);
     if (isScopeEntering) {
       pushScope();
+
+      // Named FunctionExpressions (`const x = function console() {}`) bind
+      // their name only in their *own* scope — not the enclosing one — so
+      // mark after pushing.
+      if (node.type === "FunctionExpression") {
+        // oxlint-disable-next-line typescript/no-explicit-any
+        const id = (node as any).id as BindingNode | undefined;
+        checkBinding(id);
+      }
 
       // Mark params/destructured params
       // oxlint-disable-next-line typescript/no-explicit-any

--- a/packages/vinext/src/plugins/remove-console.ts
+++ b/packages/vinext/src/plugins/remove-console.ts
@@ -1,0 +1,235 @@
+/**
+ * Strip `console.*` calls from client bundle code.
+ *
+ * Mirrors Next.js's SWC `remove_console` transform:
+ *   - Strips all `console.<method>()` calls regardless of context (top-level,
+ *     JSX expressions, function arguments, return values, ternary branches)
+ *   - Replaces removed calls with `void 0` to keep the AST valid in every
+ *     position a CallExpression can appear
+ *   - Respects `exclude: ["error"]` to preserve certain methods (case-insensitive)
+ *   - Preserves calls when `console` is shadowed (local variable, function
+ *     parameter, or destructured binding)
+ *   - Preserves computed property access `console[prop]()`
+ *
+ * Uses Vite's `parseAst` (OXC/acorn) for parsing and `MagicString` for
+ * surgical source replacement. Returns `null` when no changes are made.
+ */
+import { parseAst } from "vite";
+import MagicString from "magic-string";
+
+type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
+type BindingNode = Extract<ASTNode, { type: string }>;
+
+export type RemoveConsoleConfig = boolean | { exclude: string[] };
+
+/**
+ * Walk the AST body looking for expression statements whose expression is a
+ * CallExpression with a callee of `console.<identifier>`. When found, check
+ * that the name is not in the excluded set and that `console` is not shadowed
+ * at this scope. If all conditions pass, replace the entire statement with `;`.
+ *
+ * Returns `null` if no console calls are removed.
+ */
+export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): string | null {
+  if (config === false) return null;
+
+  const excluded =
+    typeof config === "object"
+      ? new Set(config.exclude.map((s) => s.toLowerCase()))
+      : new Set<string>();
+
+  // Fast path: if there's no bare "console" reference, skip parsing.
+  // This avoids the parse cost for the vast majority of modules.
+  const consoleMatch = code.match(/\bconsole\b/);
+  if (!consoleMatch) return null;
+
+  let ast: ReturnType<typeof parseAst>;
+  try {
+    ast = parseAst(code);
+  } catch {
+    // If parsing fails (shouldn't happen post-transform), bail out
+    return null;
+  }
+
+  // Collect shadowing scopes: tracks whether there's a local binding named
+  // "console" in the current or any parent scope. We do a simple top-down
+  // walk maintaining a stack of scope frames. Each function/arrow/block
+  // introduces a new frame. When we see a declaration/parameter of name
+  // "console", that frame (and its descendants) are shadowed.
+  type Scope = { shadowed: boolean };
+  const scopeStack: Scope[] = [{ shadowed: false }];
+
+  function currentScope(): Scope {
+    return scopeStack[scopeStack.length - 1]!;
+  }
+
+  function pushScope(): void {
+    // Child inherits parent shadowed status
+    scopeStack.push({ shadowed: currentScope().shadowed });
+  }
+
+  function popScope(): void {
+    scopeStack.pop();
+  }
+
+  const s = new MagicString(code);
+  let changed = false;
+
+  /**
+   * Check if a node introduces a binding named "console" and mark scope.
+   */
+  function checkBinding(node: BindingNode): void {
+    // oxlint-disable-next-line typescript/switch-exhaustiveness-check
+    switch (node.type) {
+      case "Identifier": {
+        if (node.name === "console") {
+          currentScope().shadowed = true;
+        }
+        break;
+      }
+      case "ObjectPattern": {
+        for (const prop of node.properties) {
+          checkBinding(prop as BindingNode);
+        }
+        break;
+      }
+      case "Property": {
+        const propertyNode = node as unknown as { value?: BindingNode };
+        if (propertyNode.value?.type === "Identifier" && propertyNode.value.name === "console") {
+          currentScope().shadowed = true;
+        } else if (propertyNode.value) {
+          checkBinding(propertyNode.value);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Check if an identifier refers to the *global* console.
+   * It's global only when:
+   *   1. Its name is "console"
+   *   2. No local binding of that name shadows it at this point
+   */
+  function isGlobalConsole(node: BindingNode): boolean {
+    return node.type === "Identifier" && node.name === "console" && !currentScope().shadowed;
+  }
+
+  /**
+   * Determine if a call expression is a `console.<method>()` that should be
+   * removed. The callee must be a MemberExpression with:
+   *   - object: Identifier "console" (global, not shadowed)
+   *   - property: Identifier (NOT computed — computed access like
+   *     `console[prop]()` is preserved per Next.js behavior)
+   * The method name must NOT be in the excluded set.
+   */
+  function shouldRemove(node: BindingNode): boolean {
+    if (node.type !== "CallExpression") return false;
+    const callee = node.callee;
+    if (callee.type !== "MemberExpression") return false;
+
+    // Only handle dot access: console.log() — skip computed: console[prop]()
+    if (callee.computed) return false;
+
+    // The object must be the global console identifier
+    if (!isGlobalConsole(callee.object)) return false;
+
+    // Property must be an identifier (e.g., "log", "warn")
+    const prop = callee.property;
+    if (prop.type !== "Identifier") return false;
+
+    const method = prop.name.toLowerCase();
+    if (excluded.has(method)) return false;
+
+    return true;
+  }
+
+  /**
+   * Recursively walk a node tree, managing scope for shadow detection.
+   * When a CallExpression matches `console.<method>()`, replace it with
+   * `void 0`. If the call is the sole expression of an ExpressionStatement,
+   * replace the entire statement with `;` for cleaner output.
+   */
+  function walk(node: ASTNode, parent?: ASTNode): void {
+    if (!node) return;
+
+    if (node.type === "CallExpression" && shouldRemove(node)) {
+      if (parent?.type === "ExpressionStatement") {
+        // Replace the whole statement so we don't leave `void 0;` litter
+        s.overwrite(parent.start, parent.end, ";");
+      } else {
+        s.overwrite(node.start, node.end, "void 0");
+      }
+      changed = true;
+      return; // don't recurse into children of a removed call
+    }
+
+    // Scope-entering nodes
+    const scopeEnteringTypes = [
+      "FunctionDeclaration",
+      "FunctionExpression",
+      "ArrowFunctionExpression",
+    ];
+
+    const isScopeEntering = scopeEnteringTypes.includes(node.type);
+    if (isScopeEntering) {
+      pushScope();
+
+      // Mark params/destructured params
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const params = (node as any).params as ASTNode[] | undefined;
+      if (params) {
+        for (const param of params) {
+          checkBinding(param as BindingNode);
+        }
+      }
+    }
+
+    // Also enter a new scope for BlockStatement / Program bodies so that
+    // variable declarations are checked in the right frame.
+    const isBlockScope =
+      node.type === "BlockStatement" || node.type === "Program" || node.type === "SwitchCase";
+    if (isBlockScope && !isScopeEntering) {
+      pushScope();
+    }
+
+    // Check for local variable declarations of "console"
+    if (node.type === "VariableDeclaration") {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      for (const decl of (node as any).declarations ?? []) {
+        checkBinding(decl.id as BindingNode);
+      }
+    }
+
+    // Recurse into child nodes, passing current node as parent
+    for (const key of Object.keys(node)) {
+      if (key === "parent" || key === "start" || key === "end") continue;
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const child = (node as any)[key];
+      if (child && typeof child === "object") {
+        if (Array.isArray(child)) {
+          for (const item of child) {
+            if (item && typeof item === "object" && "type" in item) {
+              walk(item as BindingNode, node);
+            }
+          }
+        } else if ("type" in child) {
+          walk(child as BindingNode, node);
+        }
+      }
+    }
+
+    if (isScopeEntering || isBlockScope) {
+      popScope();
+    }
+  }
+
+  for (const node of ast.body) {
+    walk(node);
+  }
+
+  if (!changed) return null;
+  return s.toString();
+}

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -855,6 +855,48 @@ describe("resolveNextConfig instrumentationClientInject", () => {
   });
 });
 
+describe("resolveNextConfig removeConsole", () => {
+  it("resolves `compiler: { removeConsole: true }` to `true`", async () => {
+    const resolved = await resolveNextConfig({ compiler: { removeConsole: true } });
+    expect(resolved.removeConsole).toBe(true);
+  });
+
+  it("resolves `compiler: { removeConsole: { exclude: ['error'] } }` to the same shape", async () => {
+    const resolved = await resolveNextConfig({
+      compiler: { removeConsole: { exclude: ["error"] } },
+    });
+    expect(resolved.removeConsole).toEqual({ exclude: ["error"] });
+  });
+
+  it("resolves `compiler: { removeConsole: {} }` to `{ exclude: [] }`", async () => {
+    const resolved = await resolveNextConfig({ compiler: { removeConsole: {} } });
+    expect(resolved.removeConsole).toEqual({ exclude: [] });
+  });
+
+  it("resolves missing `compiler` to `false`", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.removeConsole).toBe(false);
+  });
+
+  it("resolves `compiler: {}` (no removeConsole key) to `false`", async () => {
+    const resolved = await resolveNextConfig({ compiler: {} });
+    expect(resolved.removeConsole).toBe(false);
+  });
+
+  it("resolves `compiler: { removeConsole: false }` to `false`", async () => {
+    const resolved = await resolveNextConfig({ compiler: { removeConsole: false } });
+    expect(resolved.removeConsole).toBe(false);
+  });
+
+  it("coerces non-string entries in `exclude` away (sanitization)", async () => {
+    const resolved = await resolveNextConfig({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      compiler: { removeConsole: { exclude: ["error", 42, null, "warn"] as any } },
+    });
+    expect(resolved.removeConsole).toEqual({ exclude: ["error", "warn"] });
+  });
+});
+
 describe("resolveNextConfig htmlLimitedBots", () => {
   it("serializes RegExp config values to their source", async () => {
     const resolved = await resolveNextConfig({ htmlLimitedBots: /Minibot/i });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -952,6 +952,7 @@ describe("detectNextIntlConfig", () => {
       buildId: "test-build-id",
       deploymentId: undefined,
       sassOptions: null,
+      removeConsole: false,
       ...overrides,
     };
   }

--- a/tests/remove-console.test.ts
+++ b/tests/remove-console.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Remove console tests — verifies `compiler.removeConsole` behavior.
+ *
+ * Mirrors Next.js SWC remove_console transform:
+ * - `removeConsole: true` strips all `console.*` calls
+ * - `removeConsole: { exclude: ["error"] }` strips all except excluded methods
+ * - Preserves calls when `console` is shadowed by a local variable/param
+ * - Preserves computed property access `console[prop]()`
+ * - Only strips the global `console` object
+ */
+import { describe, it, expect } from "vite-plus/test";
+import { removeConsoleCalls } from "../packages/vinext/src/plugins/remove-console.js";
+
+describe("removeConsoleCalls", () => {
+  it("returns null when code has no console calls", () => {
+    const code = `
+export default function Page() {
+  return <div>Hello</div>;
+}
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("returns null when removeConsole is disabled", () => {
+    const code = `
+console.log("hello");
+export default function Page() { return null; }
+`;
+    expect(removeConsoleCalls(code, false)).toBeNull();
+  });
+
+  it("strips console.log from top level", () => {
+    const code = `
+console.log("hello world");
+export default function Page() { return null; }
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.log");
+    expect(result).toContain("export default function Page");
+  });
+
+  it("strips console.warn, console.info, console.debug", () => {
+    const code = `
+console.warn("warn");
+console.info("info");
+console.debug("debug");
+export default function Page() { return null; }
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.warn");
+    expect(result).not.toContain("console.info");
+    expect(result).not.toContain("console.debug");
+    expect(result).toContain("export default");
+  });
+
+  it("strips console.error when not excluded", () => {
+    const code = `
+console.error("error");
+export default function Page() { return null; }
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.error");
+  });
+
+  it("preserves console.error when excluded", () => {
+    const code = `
+console.error("keep me");
+console.log("remove me");
+export default function Page() { return null; }
+`;
+    const result = removeConsoleCalls(code, { exclude: ["error"] });
+    expect(result).not.toBeNull();
+    expect(result).toContain('console.error("keep me")');
+    expect(result).not.toContain("console.log");
+  });
+
+  it("preserves console.table and console.assert when excluded (case-insensitive)", () => {
+    const code = `
+console.table([1, 2]);
+console.assert(false, "msg");
+console.log("remove me");
+`;
+    const result = removeConsoleCalls(code, { exclude: ["TABLE", "assert"] });
+    expect(result).not.toBeNull();
+    expect(result).toContain("console.table");
+    expect(result).toContain("console.assert");
+    expect(result).not.toContain("console.log");
+  });
+
+  it("strips console calls inside function bodies", () => {
+    const code = `
+function greet(name) {
+  console.log("Hello, " + name);
+  return "Hello, " + name;
+}
+export default function Page() { return greet("world"); }
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.log");
+    expect(result).toContain("function greet");
+    expect(result).toContain('return "Hello, " + name');
+  });
+
+  it("strips console calls in if/else blocks", () => {
+    const code = `
+if (process.env.NODE_ENV === "development") {
+  console.log("dev mode");
+} else {
+  console.warn("prod mode");
+}
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.log");
+    expect(result).not.toContain("console.warn");
+  });
+
+  it("strips chained console calls on same line", () => {
+    const code = `
+console.log("a"); console.log("b");
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.log");
+  });
+
+  it("preserves console calls when console is shadowed (local variable)", () => {
+    const code = `
+const console = { log: () => {} };
+console.log("custom");
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).toBeNull();
+  });
+
+  it("preserves console calls when console is a function parameter", () => {
+    const code = `
+function foo(console) {
+  console.log("param");
+}
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).toBeNull();
+  });
+
+  it("preserves console calls when console is destructured", () => {
+    const code = `
+function foo({ console }) {
+  console.log("destructured");
+}
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).toBeNull();
+  });
+
+  it("preserves computed property access console[prop]()", () => {
+    const code = `
+const method = "log";
+console[method]("computed");
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).toBeNull();
+  });
+
+  it("preserves calls on non-console objects", () => {
+    const code = `
+const logger = { log: (x) => x };
+logger.log("not console");
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).toBeNull();
+  });
+
+  it("preserves console as an expression value (not a call)", () => {
+    const code = `
+const c = console;
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).toBeNull();
+  });
+
+  it("strips console.group and console.groupEnd", () => {
+    const code = `
+console.group("section");
+console.log("inside");
+console.groupEnd();
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.group");
+    expect(result).not.toContain("console.groupEnd");
+    expect(result).not.toContain("console.log");
+  });
+
+  it("handles console calls without arguments", () => {
+    const code = `
+console.log();
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.log");
+  });
+
+  it("handles console calls with complex arguments", () => {
+    const code = `
+console.log({ a: 1 }, [2, 3], () => 4);
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.log");
+  });
+
+  it("strips console inside nested callbacks", () => {
+    const code = `
+setTimeout(() => {
+  console.log("delayed");
+}, 100);
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("console.log");
+  });
+
+  it("preserves console.time/Console.timeEnd when excluded", () => {
+    const code = `
+console.time("timer");
+doWork();
+console.timeEnd("timer");
+console.log("done");
+`;
+    const result = removeConsoleCalls(code, { exclude: ["time", "timeEnd"] });
+    expect(result).not.toBeNull();
+    expect(result).toContain('console.time("timer")');
+    expect(result).toContain('console.timeEnd("timer")');
+    expect(result).not.toContain("console.log");
+  });
+
+  it("strips console as function argument (replaces with void 0)", () => {
+    const code = `
+foo(console.warn("arg"));
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).toContain("foo(void 0)");
+    expect(result).not.toContain("console.warn");
+  });
+
+  it("strips console in return statement (replaces with void 0)", () => {
+    const code = `
+function run() {
+  return console.info("result");
+}
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).toContain("return void 0");
+    expect(result).not.toContain("console.info");
+  });
+
+  it("strips console in ternary branches (replaces with void 0)", () => {
+    const code = `
+const action = isDev ? console.log("dev") : console.warn("prod");
+`;
+    const result = removeConsoleCalls(code, true);
+    expect(result).not.toBeNull();
+    expect(result).toContain("isDev ? void 0 : void 0");
+    expect(result).not.toContain("console.log");
+    expect(result).not.toContain("console.warn");
+  });
+});

--- a/tests/remove-console.test.ts
+++ b/tests/remove-console.test.ts
@@ -157,6 +157,91 @@ function foo({ console }) {
     expect(result).toBeNull();
   });
 
+  it("preserves console with default in destructured param: ({ console = {} })", () => {
+    const code = `
+function foo({ console = {} }) {
+  console.log("destructured-default");
+}
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console as default-valued positional param: (console = {})", () => {
+    const code = `
+function foo(console = { log: () => {} }) {
+  console.log("default-param");
+}
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console bound as a rest param: (...console)", () => {
+    const code = `
+function foo(...console) {
+  console.log("rest");
+}
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console bound via array destructuring", () => {
+    const code = `
+const [console] = [{ log: () => {} }];
+console.log("array-destructured");
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console bound via nested array destructuring", () => {
+    const code = `
+const [[console]] = [[{ log: () => {} }]];
+console.log("nested-array-destructured");
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console bound via rest in array destructuring", () => {
+    const code = `
+const [, ...console] = [1, 2, 3];
+console.log("rest-destructured");
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console when shadowed by a function declaration name", () => {
+    const code = `
+function console(...args) {}
+console.log("function-decl-name");
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console when shadowed by a class declaration name", () => {
+    const code = `
+class console {}
+console.log("class-decl-name");
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console inside a named FunctionExpression named console", () => {
+    const code = `
+const x = function console() {
+  console.log("named-fn-expr");
+};
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
+  it("preserves console when shadowed by a CatchClause param", () => {
+    const code = `
+try { throw 0; } catch (console) {
+  console.log("catch-param");
+}
+`;
+    expect(removeConsoleCalls(code, true)).toBeNull();
+  });
+
   it("preserves computed property access console[prop]()", () => {
     const code = `
 const method = "log";


### PR DESCRIPTION
Fixes #1497

Implements Next.js parity for `compiler.removeConsole`, which strips `console.*` calls from the client bundle during production builds.

**Behavior:**
- `compiler: { removeConsole: true }` removes all `console.<method>()` calls
- `compiler: { removeConsole: { exclude: ['error'] } }` preserves excluded methods (case-insensitive)
- Shadowed `console` bindings (local vars, params, destructured) are preserved per Next.js SWC behavior
- Computed access `console[prop]()` is preserved
- Removed calls in expression statements become `;`
- Removed calls in other contexts (JSX expressions, function arguments, returns, ternary branches) become `void 0`

**Implementation:**
- Adds `removeConsoleCalls()` transform using Vite's `parseAst` + `MagicString` (same pattern as existing `stripServerExports`)
- Resolves `compiler.removeConsole` from next.config into `ResolvedNextConfig`
- Registers `vinext:remove-console` plugin in the Vite transform pipeline, client-only, skipping node_modules

**Tests:**
- 24 unit tests covering stripping, exclusions, shadowing, destructuring, computed access, nested callbacks, function arguments, returns, and ternary branches
- All 224 tests in affected suites pass (remove-console, build-optimization, next-config)
- Format, lint, and type checks clean on all changed files

**Files changed:**
- `packages/vinext/src/plugins/remove-console.ts` (new)
- `packages/vinext/src/config/next-config.ts`
- `packages/vinext/src/index.ts`
- `tests/remove-console.test.ts` (new)
- `tests/next-config.test.ts`