### PR TITLE
feat(cache): forward revalidate* to ctx.cache.purge when available

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -53,6 +53,10 @@ jobs:
             project: hackernews
             working_directory: examples/hackernews
             wrangler_config: dist/server/wrangler.json
+          - name: workers-cache-cloudflare
+            project: workers-cache-cloudflare
+            working_directory: examples/workers-cache-cloudflare
+            wrangler_config: dist/server/wrangler.json
           - name: web
             project: vinext-web
             working_directory: apps/web
@@ -139,6 +143,7 @@ jobs:
               { name: 'nextra-docs-template', project: 'nextra-docs-template' },
               { name: 'benchmarks', project: 'benchmarks' },
               { name: 'hackernews', project: 'hackernews', original: 'https://next-react-server-components.vercel.app' },
+              { name: 'workers-cache-cloudflare', project: 'workers-cache-cloudflare' },
               { name: 'web', project: 'vinext-web' },
             ];
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,15 +210,16 @@ Add new test pages to fixtures, not to examples. Examples are for user-facing de
 
 The `examples/` directory contains real-world Next.js apps ported to run on vinext. These are deployed to Cloudflare Workers on every push to main (see `.github/workflows/deploy-examples.yml`).
 
-| Example                   | Type                               | URL                                          |
-| ------------------------- | ---------------------------------- | -------------------------------------------- |
-| `app-router-cloudflare`   | App Router basics                  | `app-router-cloudflare.vinext.workers.dev`   |
-| `pages-router-cloudflare` | Pages Router basics                | `pages-router-cloudflare.vinext.workers.dev` |
-| `app-router-playground`   | Next.js playground (MDX, Tailwind) | `app-router-playground.vinext.workers.dev`   |
-| `realworld-api-rest`      | RealWorld spec (Pages Router)      | `realworld-api-rest.vinext.workers.dev`      |
-| `nextra-docs-template`    | Nextra docs site (MDX, App Router) | `nextra-docs-template.vinext.workers.dev`    |
-| `benchmarks`              | Performance benchmarks             | `benchmarks.vinext.workers.dev`              |
-| `hackernews`              | HN clone (App Router, RSC)         | `hackernews.vinext.workers.dev`              |
+| Example                    | Type                               | URL                                           |
+| -------------------------- | ---------------------------------- | --------------------------------------------- |
+| `app-router-cloudflare`    | App Router basics                  | `app-router-cloudflare.vinext.workers.dev`    |
+| `pages-router-cloudflare`  | Pages Router basics                | `pages-router-cloudflare.vinext.workers.dev`  |
+| `app-router-playground`    | Next.js playground (MDX, Tailwind) | `app-router-playground.vinext.workers.dev`    |
+| `realworld-api-rest`       | RealWorld spec (Pages Router)      | `realworld-api-rest.vinext.workers.dev`       |
+| `nextra-docs-template`     | Nextra docs site (MDX, App Router) | `nextra-docs-template.vinext.workers.dev`     |
+| `benchmarks`               | Performance benchmarks             | `benchmarks.vinext.workers.dev`               |
+| `hackernews`               | HN clone (App Router, RSC)         | `hackernews.vinext.workers.dev`               |
+| `workers-cache-cloudflare` | ctx.cache route-cache demo         | `workers-cache-cloudflare.vinext.workers.dev` |
 
 #### Adding a New Example
 

--- a/examples/workers-cache-cloudflare/README.md
+++ b/examples/workers-cache-cloudflare/README.md
@@ -1,0 +1,73 @@
+# Request-context cache demo
+
+vinext supports route-level caching through whatever cache the runtime
+exposes on the per-request `ctx` object. When the ExecutionContext has a
+`ctx.cache.purge({ tags })` method, vinext automatically forwards
+`revalidateTag()` / `revalidatePath()` invalidations to it alongside the
+inner `CacheHandler`. There is **no runtime-specific module to import** —
+if `ctx.cache` is there, it gets used; if not, nothing happens.
+
+This example wires that up on Cloudflare Workers, where the platform
+exposes the binding when `cache.enabled: true` is set in `wrangler.jsonc`.
+
+## What's in the box
+
+- ISR-cached App Router page at `/cached/[slug]` (`revalidate = 60`).
+- Cached App Route handler at `/api/now` (`revalidate = 30`).
+- Force-dynamic comparison page at `/dynamic`.
+- Revalidation API at `/api/revalidate-tag` and `/api/revalidate-path` that
+  drives the UI's "Invalidate this page" controls.
+- A client-side **probe** that issues a no-store fetch against a route and
+  prints the `Cache-Control`, `Cache-Tag`, `X-Vinext-Cache`, and `Age`
+  headers — so the cache state is visible at a glance.
+
+## How vinext wires it up
+
+1. **`wrangler.jsonc`** enables the platform-managed cache:
+
+   ```jsonc
+   {
+     "cache": { "enabled": true }
+   }
+   ```
+
+2. **The Worker entry** just delegates to the vinext App Router handler:
+
+   ```ts
+   import handler from "vinext/server/app-router-entry";
+   export default { fetch: handler.fetch };
+   ```
+
+   vinext threads the request's `ExecutionContext` through ALS and inspects
+   `ctx.cache` at revalidation time — no extra wiring or registration.
+
+3. **ISR responses** carry `Cache-Control: s-maxage=N, stale-while-revalidate=M`
+   and a `Cache-Tag` header listing both the bare path (`/cached/intro`)
+   and Next.js's internal `_N_T_<path>` form. Any HTTP cache that reads
+   those headers (including Cloudflare's Workers Cache) will cache the
+   response correctly.
+
+4. **`revalidateTag` / `revalidatePath`** in your route handlers fan out
+   to both the inner CacheHandler (KV or memory) and `ctx.cache.purge(...)`
+   on the platform layer.
+
+## Running locally
+
+```sh
+pnpm install
+pnpm dev
+```
+
+Then open http://localhost:5173 and click into any of the demo routes.
+
+> **Note:** the platform-managed cache layer only runs on Cloudflare's
+> edge. Locally you'll see vinext's inner cache (memory in dev) doing all
+> the work; the `Cache-Control` and `Cache-Tag` headers it emits are what
+> makes the outer layer work once deployed.
+
+## Deploying
+
+```sh
+pnpm build
+npx wrangler deploy
+```

--- a/examples/workers-cache-cloudflare/README.md
+++ b/examples/workers-cache-cloudflare/README.md
@@ -18,8 +18,10 @@ exposes the binding when `cache.enabled: true` is set in `wrangler.jsonc`.
 - Revalidation API at `/api/revalidate-tag` and `/api/revalidate-path` that
   drives the UI's "Invalidate this page" controls.
 - A client-side **probe** that issues a no-store fetch against a route and
-  prints the `Cache-Control`, `Cache-Tag`, `X-Vinext-Cache`, and `Age`
-  headers — so the cache state is visible at a glance.
+  prints the headers Cloudflare's edge attaches —
+  [`cf-cache-status`](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/#cloudflare-cache-responses)
+  (the outer Workers Cache verdict), `Age`, plus the `Cache-Control` /
+  `Cache-Tag` headers vinext emits to drive it.
 
 ## How vinext wires it up
 

--- a/examples/workers-cache-cloudflare/app/api/now/route.ts
+++ b/examples/workers-cache-cloudflare/app/api/now/route.ts
@@ -1,0 +1,12 @@
+// Cached App Route handler. vinext emits ISR Cache-Control headers and a
+// Cache-Tag for the path so the Workers Cache layer caches the response
+// for 30 seconds and tag-based revalidation works.
+export const revalidate = 30;
+
+export async function GET(): Promise<Response> {
+  return Response.json({
+    now: new Date().toISOString(),
+    random: Math.random(),
+    note: "Cached by vinext + Workers Cache for 30 seconds.",
+  });
+}

--- a/examples/workers-cache-cloudflare/app/api/now/route.ts
+++ b/examples/workers-cache-cloudflare/app/api/now/route.ts
@@ -4,8 +4,12 @@
 export const revalidate = 30;
 
 export async function GET(): Promise<Response> {
+  // `renderId` is freshly generated on every handler invocation. The client
+  // probe compares it against the previous probe's renderId to tell whether
+  // a fresh response was produced or the same cached body was re-served.
   return Response.json({
     now: new Date().toISOString(),
+    renderId: crypto.randomUUID(),
     random: Math.random(),
     note: "Cached by vinext + Workers Cache for 30 seconds.",
   });

--- a/examples/workers-cache-cloudflare/app/api/revalidate-path/route.ts
+++ b/examples/workers-cache-cloudflare/app/api/revalidate-path/route.ts
@@ -1,0 +1,25 @@
+import { revalidatePath } from "next/cache";
+
+export const dynamic = "force-dynamic";
+
+type Body = { path?: unknown };
+
+export async function POST(request: Request): Promise<Response> {
+  let payload: Body;
+  try {
+    payload = (await request.json()) as Body;
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const path = typeof payload.path === "string" ? payload.path.trim() : "";
+  if (!path || !path.startsWith("/")) {
+    return Response.json({ error: "Path must be a leading-slash route" }, { status: 400 });
+  }
+
+  // revalidatePath() invalidates the inner CacheHandler AND, when the
+  // request's ExecutionContext exposes ctx.cache.purge, also purges both
+  // the bare path tag and the `_N_T_<path>` form vinext emits on the
+  // response Cache-Tag header.
+  await revalidatePath(path);
+  return Response.json({ revalidated: true, target: path });
+}

--- a/examples/workers-cache-cloudflare/app/api/revalidate-tag/route.ts
+++ b/examples/workers-cache-cloudflare/app/api/revalidate-tag/route.ts
@@ -1,0 +1,25 @@
+import { revalidateTag } from "next/cache";
+
+export const dynamic = "force-dynamic";
+
+type Body = { tag?: unknown };
+
+export async function POST(request: Request): Promise<Response> {
+  let payload: Body;
+  try {
+    payload = (await request.json()) as Body;
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const tag = typeof payload.tag === "string" ? payload.tag.trim() : "";
+  if (!tag) return Response.json({ error: "Missing tag" }, { status: 400 });
+
+  // vinext fans this out internally:
+  //   1. inner CacheHandler.revalidateTag (KV / memory)
+  //   2. ctx.cache.purge({ tags: [tag] }) when the request's
+  //      ExecutionContext exposes a compatible cache binding.
+  // Next.js 16's revalidateTag signature requires a cacheLife profile; pass
+  // the "default" profile to mirror typical SWR semantics for the demo.
+  await revalidateTag(tag, "default");
+  return Response.json({ revalidated: true, target: tag });
+}

--- a/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
+++ b/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
@@ -22,8 +22,11 @@ export default async function CachedSlugPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const tag = slug;
   const path = `/cached/${slug}`;
+  // Use the implicit `_N_T_<path>` page tag vinext writes onto every
+  // App Router cache entry. The slug on its own (`intro`) is not attached
+  // to anything, so revalidateTag("intro") would silently no-op.
+  const tag = `_N_T_${path}`;
 
   // Generated at render time. Embedded into the response so the client probe
   // can tell whether a subsequent fetch was actually re-rendered (new id) or

--- a/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
+++ b/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
@@ -25,7 +25,13 @@ export default async function CachedSlugPage({
   const tag = slug;
   const path = `/cached/${slug}`;
 
+  // Generated at render time. Embedded into the response so the client probe
+  // can tell whether a subsequent fetch was actually re-rendered (new id) or
+  // served from cache (same id). This is the only honest source of truth for
+  // "did SSR happen for that response" — outer cache headers describe what
+  // the cache layer thinks, not what the React tree actually did.
   const renderedAt = new Date().toISOString();
+  const renderId = crypto.randomUUID();
   const random = Math.random().toFixed(6);
 
   return (
@@ -44,14 +50,22 @@ export default async function CachedSlugPage({
       </p>
 
       <p>Server-side timestamp:</p>
-      <div className="timestamp" data-testid="rendered-at">
+      <div
+        className="timestamp"
+        data-testid="rendered-at"
+        data-render-id={renderId}
+        data-render-time={renderedAt}
+      >
         {renderedAt}
       </div>
+      <p>
+        Render ID: <code data-render-id-tag>{renderId}</code>
+      </p>
       <p>
         Sample noise (re-rendered = re-randomised): <code>{random}</code>
       </p>
 
-      <CacheStatusProbe path={path} />
+      <CacheStatusProbe path={path} initialRenderId={renderId} initialRenderTime={renderedAt} />
       <RevalidateControls tag={tag} path={path} />
     </main>
   );

--- a/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
+++ b/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
@@ -16,6 +16,24 @@ export async function generateMetadata({
   return { title: `Cached page: ${slug}` };
 }
 
+/**
+ * Pretend to load post data for `slug`. The `next: { tags }` option attaches
+ * `post:<slug>` to the page's cache entry — that's the same propagation
+ * Next.js does for tagged fetches in real apps. With the tag on the entry,
+ * `revalidateTag("post:<slug>")` invalidates the page (in both the inner
+ * CacheHandler and the outer Workers Cache via `Cache-Tag`).
+ *
+ * The fetch target is a no-op data: URL so the demo has no external
+ * dependency — vinext's fetch shim records the tag before doing any I/O.
+ */
+async function loadPost(slug: string): Promise<{ title: string }> {
+  const payload = JSON.stringify({ slug });
+  await fetch(`data:application/json,${encodeURIComponent(payload)}`, {
+    next: { tags: [`post:${slug}`], revalidate: 60 },
+  });
+  return { title: `Post: ${slug}` };
+}
+
 export default async function CachedSlugPage({
   params,
 }: {
@@ -23,10 +41,8 @@ export default async function CachedSlugPage({
 }) {
   const { slug } = await params;
   const path = `/cached/${slug}`;
-  // Use the implicit `_N_T_<path>` page tag vinext writes onto every
-  // App Router cache entry. The slug on its own (`intro`) is not attached
-  // to anything, so revalidateTag("intro") would silently no-op.
-  const tag = `_N_T_${path}`;
+  const tag = `post:${slug}`;
+  const post = await loadPost(slug);
 
   // Generated at render time. Embedded into the response so the client probe
   // can tell whether a subsequent fetch was actually re-rendered (new id) or
@@ -42,14 +58,11 @@ export default async function CachedSlugPage({
       <nav className="crumbs">
         <a href="/">&larr; Demo home</a>
       </nav>
-      <h1>
-        <code>/cached/{slug}</code>
-      </h1>
+      <h1>{post.title}</h1>
       <p className="tagline">
-        ISR-cached for <code>revalidate = 60</code>. The first request renders on the server;
-        subsequent reads are served by whatever HTTP cache sits in front of the runtime — for
-        example, the platform-managed cache exposed via <code>ctx.cache</code> on Cloudflare
-        Workers when <code>cache.enabled: true</code>.
+        ISR-cached for <code>revalidate = 60</code>. A tagged fetch during render attaches{" "}
+        <code>{tag}</code> to this page's cache entry — both the inner <code>CacheHandler</code>{" "}
+        and the outer Workers Cache will honour <code>revalidateTag(&quot;{tag}&quot;)</code>.
       </p>
 
       <p>Server-side timestamp:</p>

--- a/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
+++ b/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
@@ -81,7 +81,7 @@ export default async function CachedSlugPage({
         Sample noise (re-rendered = re-randomised): <code>{random}</code>
       </p>
 
-      <CacheStatusProbe path={path} initialRenderId={renderId} initialRenderTime={renderedAt} />
+      <CacheStatusProbe path={path} />
       <RevalidateControls tag={tag} path={path} />
     </main>
   );

--- a/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
+++ b/examples/workers-cache-cloudflare/app/cached/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import { CacheStatusProbe } from "../../components/cache-status-probe";
+import { RevalidateControls } from "../../components/revalidate-controls";
+
+// ISR config — slugs are cached for 60 seconds with a 5-minute
+// stale-while-revalidate window. vinext emits this as
+// `Cache-Control: s-maxage=60, stale-while-revalidate=240` and the Workers
+// Cache layer honours it automatically.
+export const revalidate = 60;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return { title: `Cached page: ${slug}` };
+}
+
+export default async function CachedSlugPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const tag = slug;
+  const path = `/cached/${slug}`;
+
+  const renderedAt = new Date().toISOString();
+  const random = Math.random().toFixed(6);
+
+  return (
+    <main>
+      <nav className="crumbs">
+        <a href="/">&larr; Demo home</a>
+      </nav>
+      <h1>
+        <code>/cached/{slug}</code>
+      </h1>
+      <p className="tagline">
+        ISR-cached for <code>revalidate = 60</code>. The first request renders on the server;
+        subsequent reads are served by whatever HTTP cache sits in front of the runtime — for
+        example, the platform-managed cache exposed via <code>ctx.cache</code> on Cloudflare
+        Workers when <code>cache.enabled: true</code>.
+      </p>
+
+      <p>Server-side timestamp:</p>
+      <div className="timestamp" data-testid="rendered-at">
+        {renderedAt}
+      </div>
+      <p>
+        Sample noise (re-rendered = re-randomised): <code>{random}</code>
+      </p>
+
+      <CacheStatusProbe path={path} />
+      <RevalidateControls tag={tag} path={path} />
+    </main>
+  );
+}

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -139,16 +139,25 @@ export function CacheStatusProbe({
     setBusy(true);
     setError(null);
     try {
+      // Mirror what a browser navigation would send so the probe lands in
+      // the same Vary bucket as the original page load. Our responses set
+      // `Vary: Accept, ...`, which means Workers Cache keys separate entries
+      // per Accept value. Without this, `fetch()`'s default `Accept: */*`
+      // would hit a *different* cached entry than the one the user
+      // navigated into — both might be cache HITs, but they'd carry
+      // different render-ids and the probe would wrongly conclude SSR ran.
+      const acceptForHtml =
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
       const res = await fetch(path, {
         method: "GET",
         // Intentionally NOT passing `cache: 'no-store'`: that adds
-        // `Cache-Control: no-cache` to the request, which Workers Cache (and
-        // most HTTP caches) honours by bypassing and re-running the origin.
-        // The whole point of this probe is to observe what the outer cache
-        // actually serves, so we let the request flow through normally.
-        // The responses we probe carry `s-maxage=…` without `max-age`, so
-        // the browser HTTP cache won't store them anyway.
-        headers: { "x-probe": "1" },
+        // `Cache-Control: no-cache` to the request, which Workers Cache
+        // honours by bypassing and re-running the origin. The whole point
+        // of this probe is to observe what the outer cache actually serves.
+        headers: {
+          "x-probe": "1",
+          Accept: acceptForHtml,
+        },
       });
       const markers = await extractRenderMarkers(res);
       setState({

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -133,7 +133,14 @@ export function CacheStatusProbe({ path }: { path: string }) {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch(path, { method: "GET" });
+      // `cache: 'no-store'` bypasses the browser HTTP cache. With
+      // `max-age=60` on cacheable responses, consecutive probes within a
+      // minute would otherwise be served from the browser cache and never
+      // talk to the edge — making the probe useless for observing outer
+      // cache behaviour. Workers Cache itself is unaffected: confirmed
+      // empirically that both probe and navigation responses still report
+      // `cf-cache-status: HIT` from the same edge entry.
+      const res = await fetch(path, { method: "GET", cache: "no-store" });
       const markers = await extractRenderMarkers(res);
       setState({
         status: res.status,

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -4,12 +4,35 @@ import { useCallback, useEffect, useState } from "react";
 
 type ProbeState = {
   status: number;
-  cacheState: string;
-  cacheControl: string;
-  cacheTag: string;
-  age: string;
+  cfCacheStatus: string | null;
+  age: string | null;
+  cacheControl: string | null;
+  cacheTag: string | null;
+  cfRay: string | null;
   fetchedAt: string;
 };
+
+/**
+ * Map a `cf-cache-status` value to one of our badge classes. Mirrors the
+ * states documented at
+ * https://developers.cloudflare.com/cache/concepts/default-cache-behavior/#cloudflare-cache-responses
+ */
+function badgeClassFor(status: string | null): string {
+  if (!status) return "";
+  switch (status.toUpperCase()) {
+    case "HIT":
+    case "REVALIDATED":
+      return "badge-hit";
+    case "STALE":
+    case "UPDATING":
+      return "badge-stale";
+    case "MISS":
+    case "EXPIRED":
+      return "badge-miss";
+    default:
+      return "";
+  }
+}
 
 export function CacheStatusProbe({ path }: { path: string }) {
   const [state, setState] = useState<ProbeState | null>(null);
@@ -22,17 +45,18 @@ export function CacheStatusProbe({ path }: { path: string }) {
     try {
       const res = await fetch(path, {
         method: "GET",
-        // Bypass the browser cache so we observe the actual edge response
-        // — only the Workers Cache layer should be deciding.
+        // Skip the browser HTTP cache so the response we see is the one the
+        // outer Workers Cache (or origin) actually returned.
         cache: "no-store",
         headers: { "x-probe": "1" },
       });
       setState({
         status: res.status,
-        cacheState: res.headers.get("x-vinext-cache") ?? res.headers.get("x-nextjs-cache") ?? "—",
-        cacheControl: res.headers.get("cache-control") ?? "—",
-        cacheTag: res.headers.get("cache-tag") ?? "—",
-        age: res.headers.get("age") ?? "—",
+        cfCacheStatus: res.headers.get("cf-cache-status"),
+        age: res.headers.get("age"),
+        cacheControl: res.headers.get("cache-control"),
+        cacheTag: res.headers.get("cache-tag"),
+        cfRay: res.headers.get("cf-ray"),
         fetchedAt: new Date().toLocaleTimeString(),
       });
     } catch (err) {
@@ -46,15 +70,7 @@ export function CacheStatusProbe({ path }: { path: string }) {
     void probe();
   }, [probe]);
 
-  const stateLabel = state?.cacheState ?? "—";
-  const badgeClass =
-    stateLabel === "HIT" || stateLabel === "STATIC"
-      ? "badge-hit"
-      : stateLabel === "STALE"
-        ? "badge-stale"
-        : stateLabel === "MISS"
-          ? "badge-miss"
-          : "";
+  const cfStatus = state?.cfCacheStatus ?? null;
 
   return (
     <section className="panel" aria-label="Cache status probe">
@@ -62,10 +78,11 @@ export function CacheStatusProbe({ path }: { path: string }) {
         Probe <code>{path}</code>
       </h2>
       <p style={{ marginTop: 0, color: "var(--muted)" }}>
-        Issues a no-store <code>fetch</code> against the cached route and reports the headers
-        returned by the edge. Cache layer behaviour shows up under{" "}
-        <code>x-vinext-cache</code> (vinext / inner cache) and HTTP <code>Age</code> (Workers
-        Cache outer layer).
+        Issues a no-store <code>fetch</code> against the route and surfaces the headers Cloudflare
+        attaches at the edge. <code>cf-cache-status</code> is the outer Workers Cache verdict —
+        <code>HIT</code> means the response came from cache without invoking the worker;{" "}
+        <code>MISS</code> / <code>EXPIRED</code> means the worker ran. <code>Age</code> is how
+        many seconds the cached copy has been sitting at the edge.
       </p>
 
       <div className="controls">
@@ -80,16 +97,24 @@ export function CacheStatusProbe({ path }: { path: string }) {
       <dl className="kv">
         <dt>HTTP status</dt>
         <dd>{state?.status ?? "—"}</dd>
-        <dt>Cache state</dt>
+        <dt>cf-cache-status</dt>
         <dd>
-          <span className={`badge ${badgeClass}`}>{stateLabel}</span>
+          {cfStatus ? (
+            <span className={`badge ${badgeClassFor(cfStatus)}`}>{cfStatus}</span>
+          ) : (
+            <span style={{ color: "var(--muted)" }}>
+              not set — running locally, or the runtime doesn't expose it
+            </span>
+          )}
         </dd>
+        <dt>Age</dt>
+        <dd>{state?.age ?? "—"}</dd>
         <dt>Cache-Control</dt>
         <dd>{state?.cacheControl ?? "—"}</dd>
         <dt>Cache-Tag</dt>
         <dd>{state?.cacheTag ?? "—"}</dd>
-        <dt>Age (outer)</dt>
-        <dd>{state?.age ?? "—"}</dd>
+        <dt>cf-ray</dt>
+        <dd>{state?.cfRay ?? "—"}</dd>
         <dt>Probed at</dt>
         <dd>{state?.fetchedAt ?? "—"}</dd>
       </dl>

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type ProbeState = {
+  status: number;
+  cacheState: string;
+  cacheControl: string;
+  cacheTag: string;
+  age: string;
+  fetchedAt: string;
+};
+
+export function CacheStatusProbe({ path }: { path: string }) {
+  const [state, setState] = useState<ProbeState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const probe = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(path, {
+        method: "GET",
+        // Bypass the browser cache so we observe the actual edge response
+        // — only the Workers Cache layer should be deciding.
+        cache: "no-store",
+        headers: { "x-probe": "1" },
+      });
+      setState({
+        status: res.status,
+        cacheState: res.headers.get("x-vinext-cache") ?? res.headers.get("x-nextjs-cache") ?? "—",
+        cacheControl: res.headers.get("cache-control") ?? "—",
+        cacheTag: res.headers.get("cache-tag") ?? "—",
+        age: res.headers.get("age") ?? "—",
+        fetchedAt: new Date().toLocaleTimeString(),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [path]);
+
+  useEffect(() => {
+    void probe();
+  }, [probe]);
+
+  const stateLabel = state?.cacheState ?? "—";
+  const badgeClass =
+    stateLabel === "HIT" || stateLabel === "STATIC"
+      ? "badge-hit"
+      : stateLabel === "STALE"
+        ? "badge-stale"
+        : stateLabel === "MISS"
+          ? "badge-miss"
+          : "";
+
+  return (
+    <section className="panel" aria-label="Cache status probe">
+      <h2 style={{ marginTop: 0 }}>
+        Probe <code>{path}</code>
+      </h2>
+      <p style={{ marginTop: 0, color: "var(--muted)" }}>
+        Issues a no-store <code>fetch</code> against the cached route and reports the headers
+        returned by the edge. Cache layer behaviour shows up under{" "}
+        <code>x-vinext-cache</code> (vinext / inner cache) and HTTP <code>Age</code> (Workers
+        Cache outer layer).
+      </p>
+
+      <div className="controls">
+        <button type="button" onClick={() => void probe()} disabled={busy}>
+          {busy ? "Probing…" : "Re-probe"}
+        </button>
+        <a href={path} className="button">
+          Open in new tab
+        </a>
+      </div>
+
+      <dl className="kv">
+        <dt>HTTP status</dt>
+        <dd>{state?.status ?? "—"}</dd>
+        <dt>Cache state</dt>
+        <dd>
+          <span className={`badge ${badgeClass}`}>{stateLabel}</span>
+        </dd>
+        <dt>Cache-Control</dt>
+        <dd>{state?.cacheControl ?? "—"}</dd>
+        <dt>Cache-Tag</dt>
+        <dd>{state?.cacheTag ?? "—"}</dd>
+        <dt>Age (outer)</dt>
+        <dd>{state?.age ?? "—"}</dd>
+        <dt>Probed at</dt>
+        <dd>{state?.fetchedAt ?? "—"}</dd>
+      </dl>
+      {error ? <p style={{ color: "var(--bad)" }}>{error}</p> : null}
+    </section>
+  );
+}

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type ProbeState = {
   status: number;
@@ -10,7 +10,16 @@ type ProbeState = {
   cacheTag: string | null;
   cfRay: string | null;
   fetchedAt: string;
+  /** UUID embedded in the response body at SSR time, when present. */
+  renderId: string | null;
+  /** ISO timestamp the response was rendered at, when present. */
+  renderTime: string | null;
 };
+
+type SsrVerdict =
+  | { kind: "fresh"; detail: string }
+  | { kind: "cached"; detail: string }
+  | { kind: "unknown"; detail: string };
 
 /**
  * Map a `cf-cache-status` value to one of our badge classes. Mirrors the
@@ -35,57 +44,96 @@ function badgeClassFor(status: string | null): string {
 }
 
 /**
- * Decide whether the worker actually rendered this response, based on the
- * outer cache verdict. Workers Cache `HIT` / `REVALIDATED` mean the response
- * came straight from the edge without invoking the Worker; `STALE` /
- * `UPDATING` are also served from cache (the Worker may run async to
- * refresh, but the bytes the client saw came from cache). Anything else —
- * `MISS`, `EXPIRED`, `BYPASS`, `DYNAMIC`, or no header at all (local dev,
- * non-Cloudflare runtime) — means the Worker ran for this request.
+ * Pull the render-id and render-time the server embedded into the response.
+ * HTML pages put them on `[data-testid="rendered-at"]`'s data attributes;
+ * JSON route handlers include them as top-level fields.
  */
-function deriveSsr(cfCacheStatus: string | null): {
-  ran: boolean;
-  detail: string;
-} {
-  if (!cfCacheStatus) {
-    return {
-      ran: true,
-      detail: "no cf-cache-status — running locally or no edge cache in front",
-    };
-  }
-  const upper = cfCacheStatus.toUpperCase();
-  switch (upper) {
-    case "HIT":
-      return { ran: false, detail: "served by Workers Cache without invoking the Worker" };
-    case "REVALIDATED":
+async function extractRenderMarkers(
+  res: Response,
+): Promise<{ renderId: string | null; renderTime: string | null }> {
+  const contentType = res.headers.get("content-type") ?? "";
+  try {
+    if (contentType.includes("application/json")) {
+      const body = (await res.clone().json()) as Record<string, unknown>;
+      const renderId = typeof body.renderId === "string" ? body.renderId : null;
+      const renderTime = typeof body.now === "string" ? body.now : null;
+      return { renderId, renderTime };
+    }
+    if (contentType.includes("text/html")) {
+      const html = await res.clone().text();
+      const idMatch = html.match(/data-render-id="([^"]+)"/);
+      const timeMatch = html.match(/data-render-time="([^"]+)"/);
       return {
-        ran: false,
-        detail: "conditional check returned 304 — cached body re-used, Worker not invoked",
+        renderId: idMatch ? idMatch[1] : null,
+        renderTime: timeMatch ? timeMatch[1] : null,
       };
-    case "STALE":
-    case "UPDATING":
-      return {
-        ran: false,
-        detail:
-          "stale cache served; Worker may have run async to refresh, but this response did not render",
-      };
-    case "MISS":
-      return { ran: true, detail: "Worker ran and produced this response" };
-    case "EXPIRED":
-      return { ran: true, detail: "previous cache entry expired — Worker ran to regenerate" };
-    case "BYPASS":
-      return { ran: true, detail: "cache bypassed (e.g. Set-Cookie / Authorization) — Worker ran" };
-    case "DYNAMIC":
-      return { ran: true, detail: "non-cacheable response — Worker ran" };
-    default:
-      return { ran: true, detail: `cf-cache-status: ${cfCacheStatus} — Worker ran` };
+    }
+  } catch {
+    // Ignore parse errors — the markers are best-effort.
   }
+  return { renderId: null, renderTime: null };
 }
 
-export function CacheStatusProbe({ path }: { path: string }) {
+/**
+ * Decide whether SSR actually produced the response we just received, by
+ * comparing the response's render-id against the previously-seen one.
+ *
+ * - Different (or first-ever) render-id → SSR happened on the server.
+ * - Same render-id → the same bytes came back, which means a cache (outer
+ *   Workers Cache, inner ISR, or proxy in between) served the response
+ *   without re-rendering.
+ * - No render-id in the response → we can't tell from the body alone, so
+ *   we surface "unknown" rather than make something up.
+ */
+function deriveSsr(
+  currentRenderId: string | null,
+  previousRenderId: string | null,
+): SsrVerdict {
+  if (currentRenderId === null) {
+    return {
+      kind: "unknown",
+      detail:
+        "no render-id embedded in this response — can't tell from the body whether SSR ran",
+    };
+  }
+  if (previousRenderId === null) {
+    return {
+      kind: "fresh",
+      detail: `render-id ${shorten(currentRenderId)} captured — re-probe to compare`,
+    };
+  }
+  if (currentRenderId === previousRenderId) {
+    return {
+      kind: "cached",
+      detail: `render-id matches the previous probe (${shorten(currentRenderId)}) — same bytes, no re-render`,
+    };
+  }
+  return {
+    kind: "fresh",
+    detail: `render-id changed (${shorten(previousRenderId)} → ${shorten(currentRenderId)}) — SSR produced a new response`,
+  };
+}
+
+function shorten(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}…` : id;
+}
+
+export function CacheStatusProbe({
+  path,
+  initialRenderId = null,
+  initialRenderTime = null,
+}: {
+  path: string;
+  initialRenderId?: string | null;
+  initialRenderTime?: string | null;
+}) {
   const [state, setState] = useState<ProbeState | null>(null);
+  const [verdict, setVerdict] = useState<SsrVerdict | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The render-id from the previous probe (or the initial server render).
+  // Compared against the next probe's render-id to detect cache vs SSR.
+  const previousRenderIdRef = useRef<string | null>(initialRenderId);
 
   const probe = useCallback(async () => {
     setBusy(true);
@@ -98,6 +146,7 @@ export function CacheStatusProbe({ path }: { path: string }) {
         cache: "no-store",
         headers: { "x-probe": "1" },
       });
+      const markers = await extractRenderMarkers(res);
       setState({
         status: res.status,
         cfCacheStatus: res.headers.get("cf-cache-status"),
@@ -106,7 +155,15 @@ export function CacheStatusProbe({ path }: { path: string }) {
         cacheTag: res.headers.get("cache-tag"),
         cfRay: res.headers.get("cf-ray"),
         fetchedAt: new Date().toLocaleTimeString(),
+        renderId: markers.renderId,
+        renderTime: markers.renderTime,
       });
+      setVerdict(deriveSsr(markers.renderId, previousRenderIdRef.current));
+      // Update for the next round. If this response had no render-id, keep
+      // the previous one so a future probe can still compare.
+      if (markers.renderId !== null) {
+        previousRenderIdRef.current = markers.renderId;
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -119,7 +176,6 @@ export function CacheStatusProbe({ path }: { path: string }) {
   }, [probe]);
 
   const cfStatus = state?.cfCacheStatus ?? null;
-  const ssr = state ? deriveSsr(cfStatus) : null;
 
   return (
     <section className="panel" aria-label="Cache status probe">
@@ -127,13 +183,14 @@ export function CacheStatusProbe({ path }: { path: string }) {
         Probe <code>{path}</code>
       </h2>
       <p style={{ marginTop: 0, color: "var(--muted)" }}>
-        Issues a no-store <code>fetch</code> against the route and surfaces the headers Cloudflare
-        attaches at the edge. <code>cf-cache-status</code> is the outer Workers Cache verdict —
-        <code>HIT</code> means the response came from cache without invoking the worker;{" "}
-        <code>MISS</code> / <code>EXPIRED</code> means the worker ran.
+        Issues a no-store <code>fetch</code> against the route. The route embeds a fresh{" "}
+        <code>render-id</code> into every server-rendered response — comparing it across probes is
+        the most reliable way to tell whether SSR actually happened or a cache served the same
+        bytes again. <code>cf-cache-status</code> is shown alongside as the outer Workers Cache
+        verdict.
       </p>
 
-      {ssr ? <SsrBadge ran={ssr.ran} detail={ssr.detail} /> : null}
+      {verdict ? <SsrBadge verdict={verdict} /> : null}
 
       <div className="controls">
         <button type="button" onClick={() => void probe()} disabled={busy}>
@@ -147,6 +204,10 @@ export function CacheStatusProbe({ path }: { path: string }) {
       <dl className="kv">
         <dt>HTTP status</dt>
         <dd>{state?.status ?? "—"}</dd>
+        <dt>render-id</dt>
+        <dd>{state?.renderId ?? "—"}</dd>
+        <dt>render-time</dt>
+        <dd>{state?.renderTime ?? initialRenderTime ?? "—"}</dd>
         <dt>cf-cache-status</dt>
         <dd>
           {cfStatus ? (
@@ -173,13 +234,23 @@ export function CacheStatusProbe({ path }: { path: string }) {
   );
 }
 
-function SsrBadge({ ran, detail }: { ran: boolean; detail: string }) {
+function SsrBadge({ verdict }: { verdict: SsrVerdict }) {
+  const cls =
+    verdict.kind === "fresh"
+      ? "ssr-banner-ran"
+      : verdict.kind === "cached"
+        ? "ssr-banner-cached"
+        : "ssr-banner-unknown";
+  const title =
+    verdict.kind === "fresh"
+      ? "SSR ran — response was freshly rendered"
+      : verdict.kind === "cached"
+        ? "No SSR — same render-id as last probe (cache served this)"
+        : "SSR status: unknown";
   return (
-    <div className={`ssr-banner ${ran ? "ssr-banner-ran" : "ssr-banner-cached"}`}>
-      <strong>
-        {ran ? "Worker ran for this response" : "Served from cache — Worker not invoked"}
-      </strong>
-      <span>{detail}</span>
+    <div className={`ssr-banner ${cls}`}>
+      <strong>{title}</strong>
+      <span>{verdict.detail}</span>
     </div>
   );
 }

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -184,22 +184,6 @@ export function CacheStatusProbe({
     void probe();
   }, [probe]);
 
-  // Re-fire the probe whenever the revalidate panel reports a successful
-  // invalidation so the user can see the cache verdict flip in real time
-  // without clicking Re-probe themselves.
-  useEffect(() => {
-    function onRevalidated(event: Event) {
-      const detail = (event as CustomEvent<{ path?: string } | undefined>).detail;
-      // Only re-probe when the revalidation targets this probe's path (or
-      // wasn't path-scoped — `revalidateTag` doesn't know the path).
-      if (!detail || !detail.path || detail.path === path) {
-        void probe();
-      }
-    }
-    window.addEventListener("vinext-revalidated", onRevalidated);
-    return () => window.removeEventListener("vinext-revalidated", onRevalidated);
-  }, [path, probe]);
-
   const cfStatus = state?.cfCacheStatus ?? null;
 
   return (

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -98,7 +98,7 @@ function deriveSsr(
   }
   if (previousRenderId === null) {
     return {
-      kind: "fresh",
+      kind: "unknown",
       detail: `render-id ${shorten(currentRenderId)} captured — re-probe to compare`,
     };
   }
@@ -118,43 +118,22 @@ function shorten(id: string): string {
   return id.length > 12 ? `${id.slice(0, 8)}…` : id;
 }
 
-export function CacheStatusProbe({
-  path,
-  initialRenderId = null,
-  initialRenderTime = null,
-}: {
-  path: string;
-  initialRenderId?: string | null;
-  initialRenderTime?: string | null;
-}) {
+export function CacheStatusProbe({ path }: { path: string }) {
   const [state, setState] = useState<ProbeState | null>(null);
   const [verdict, setVerdict] = useState<SsrVerdict | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // The render-id from the previous probe (or the initial server render).
-  // Compared against the next probe's render-id to detect cache vs SSR.
-  const previousRenderIdRef = useRef<string | null>(initialRenderId);
+  // The render-id from the previous probe. We compare probe-to-probe rather
+  // than against the page navigation's render-id — those are two separate
+  // requests with different Accept headers, so they land in different Vary
+  // buckets in the outer cache and would falsely look like an SSR diff.
+  const previousRenderIdRef = useRef<string | null>(null);
 
   const probe = useCallback(async () => {
     setBusy(true);
     setError(null);
     try {
-      // Mirror what a browser navigation would send so the probe lands in
-      // the same Vary bucket as the original page load. Our responses set
-      // `Vary: Accept, ...`, which means Workers Cache keys separate entries
-      // per Accept value — `fetch()`'s default `Accept: */*` would hit a
-      // *different* cached entry than the one the user navigated into.
-      //
-      // We intentionally do NOT pass `cache: 'no-store'`: that adds
-      // `Cache-Control: no-cache` to the request, which Workers Cache
-      // honours by bypassing and re-running the origin. The whole point of
-      // this probe is to observe what the outer cache actually serves.
-      const acceptForHtml =
-        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
-      const res = await fetch(path, {
-        method: "GET",
-        headers: { Accept: acceptForHtml },
-      });
+      const res = await fetch(path, { method: "GET" });
       const markers = await extractRenderMarkers(res);
       setState({
         status: res.status,
@@ -216,7 +195,7 @@ export function CacheStatusProbe({
         <dt>render-id</dt>
         <dd>{state?.renderId ?? "—"}</dd>
         <dt>render-time</dt>
-        <dd>{state?.renderTime ?? initialRenderTime ?? "—"}</dd>
+        <dd>{state?.renderTime ?? "—"}</dd>
         <dt>cf-cache-status</dt>
         <dd>
           {cfStatus ? (

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -142,22 +142,18 @@ export function CacheStatusProbe({
       // Mirror what a browser navigation would send so the probe lands in
       // the same Vary bucket as the original page load. Our responses set
       // `Vary: Accept, ...`, which means Workers Cache keys separate entries
-      // per Accept value. Without this, `fetch()`'s default `Accept: */*`
-      // would hit a *different* cached entry than the one the user
-      // navigated into — both might be cache HITs, but they'd carry
-      // different render-ids and the probe would wrongly conclude SSR ran.
+      // per Accept value — `fetch()`'s default `Accept: */*` would hit a
+      // *different* cached entry than the one the user navigated into.
+      //
+      // We intentionally do NOT pass `cache: 'no-store'`: that adds
+      // `Cache-Control: no-cache` to the request, which Workers Cache
+      // honours by bypassing and re-running the origin. The whole point of
+      // this probe is to observe what the outer cache actually serves.
       const acceptForHtml =
         "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
       const res = await fetch(path, {
         method: "GET",
-        // Intentionally NOT passing `cache: 'no-store'`: that adds
-        // `Cache-Control: no-cache` to the request, which Workers Cache
-        // honours by bypassing and re-running the origin. The whole point
-        // of this probe is to observe what the outer cache actually serves.
-        headers: {
-          "x-probe": "1",
-          Accept: acceptForHtml,
-        },
+        headers: { Accept: acceptForHtml },
       });
       const markers = await extractRenderMarkers(res);
       setState({

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -141,9 +141,13 @@ export function CacheStatusProbe({
     try {
       const res = await fetch(path, {
         method: "GET",
-        // Skip the browser HTTP cache so the response we see is the one the
-        // outer Workers Cache (or origin) actually returned.
-        cache: "no-store",
+        // Intentionally NOT passing `cache: 'no-store'`: that adds
+        // `Cache-Control: no-cache` to the request, which Workers Cache (and
+        // most HTTP caches) honours by bypassing and re-running the origin.
+        // The whole point of this probe is to observe what the outer cache
+        // actually serves, so we let the request flow through normally.
+        // The responses we probe carry `s-maxage=…` without `max-age`, so
+        // the browser HTTP cache won't store them anyway.
         headers: { "x-probe": "1" },
       });
       const markers = await extractRenderMarkers(res);
@@ -174,6 +178,22 @@ export function CacheStatusProbe({
   useEffect(() => {
     void probe();
   }, [probe]);
+
+  // Re-fire the probe whenever the revalidate panel reports a successful
+  // invalidation so the user can see the cache verdict flip in real time
+  // without clicking Re-probe themselves.
+  useEffect(() => {
+    function onRevalidated(event: Event) {
+      const detail = (event as CustomEvent<{ path?: string } | undefined>).detail;
+      // Only re-probe when the revalidation targets this probe's path (or
+      // wasn't path-scoped — `revalidateTag` doesn't know the path).
+      if (!detail || !detail.path || detail.path === path) {
+        void probe();
+      }
+    }
+    window.addEventListener("vinext-revalidated", onRevalidated);
+    return () => window.removeEventListener("vinext-revalidated", onRevalidated);
+  }, [path, probe]);
 
   const cfStatus = state?.cfCacheStatus ?? null;
 

--- a/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache-cloudflare/app/components/cache-status-probe.tsx
@@ -34,6 +34,54 @@ function badgeClassFor(status: string | null): string {
   }
 }
 
+/**
+ * Decide whether the worker actually rendered this response, based on the
+ * outer cache verdict. Workers Cache `HIT` / `REVALIDATED` mean the response
+ * came straight from the edge without invoking the Worker; `STALE` /
+ * `UPDATING` are also served from cache (the Worker may run async to
+ * refresh, but the bytes the client saw came from cache). Anything else —
+ * `MISS`, `EXPIRED`, `BYPASS`, `DYNAMIC`, or no header at all (local dev,
+ * non-Cloudflare runtime) — means the Worker ran for this request.
+ */
+function deriveSsr(cfCacheStatus: string | null): {
+  ran: boolean;
+  detail: string;
+} {
+  if (!cfCacheStatus) {
+    return {
+      ran: true,
+      detail: "no cf-cache-status — running locally or no edge cache in front",
+    };
+  }
+  const upper = cfCacheStatus.toUpperCase();
+  switch (upper) {
+    case "HIT":
+      return { ran: false, detail: "served by Workers Cache without invoking the Worker" };
+    case "REVALIDATED":
+      return {
+        ran: false,
+        detail: "conditional check returned 304 — cached body re-used, Worker not invoked",
+      };
+    case "STALE":
+    case "UPDATING":
+      return {
+        ran: false,
+        detail:
+          "stale cache served; Worker may have run async to refresh, but this response did not render",
+      };
+    case "MISS":
+      return { ran: true, detail: "Worker ran and produced this response" };
+    case "EXPIRED":
+      return { ran: true, detail: "previous cache entry expired — Worker ran to regenerate" };
+    case "BYPASS":
+      return { ran: true, detail: "cache bypassed (e.g. Set-Cookie / Authorization) — Worker ran" };
+    case "DYNAMIC":
+      return { ran: true, detail: "non-cacheable response — Worker ran" };
+    default:
+      return { ran: true, detail: `cf-cache-status: ${cfCacheStatus} — Worker ran` };
+  }
+}
+
 export function CacheStatusProbe({ path }: { path: string }) {
   const [state, setState] = useState<ProbeState | null>(null);
   const [busy, setBusy] = useState(false);
@@ -71,6 +119,7 @@ export function CacheStatusProbe({ path }: { path: string }) {
   }, [probe]);
 
   const cfStatus = state?.cfCacheStatus ?? null;
+  const ssr = state ? deriveSsr(cfStatus) : null;
 
   return (
     <section className="panel" aria-label="Cache status probe">
@@ -81,9 +130,10 @@ export function CacheStatusProbe({ path }: { path: string }) {
         Issues a no-store <code>fetch</code> against the route and surfaces the headers Cloudflare
         attaches at the edge. <code>cf-cache-status</code> is the outer Workers Cache verdict —
         <code>HIT</code> means the response came from cache without invoking the worker;{" "}
-        <code>MISS</code> / <code>EXPIRED</code> means the worker ran. <code>Age</code> is how
-        many seconds the cached copy has been sitting at the edge.
+        <code>MISS</code> / <code>EXPIRED</code> means the worker ran.
       </p>
+
+      {ssr ? <SsrBadge ran={ssr.ran} detail={ssr.detail} /> : null}
 
       <div className="controls">
         <button type="button" onClick={() => void probe()} disabled={busy}>
@@ -120,5 +170,16 @@ export function CacheStatusProbe({ path }: { path: string }) {
       </dl>
       {error ? <p style={{ color: "var(--bad)" }}>{error}</p> : null}
     </section>
+  );
+}
+
+function SsrBadge({ ran, detail }: { ran: boolean; detail: string }) {
+  return (
+    <div className={`ssr-banner ${ran ? "ssr-banner-ran" : "ssr-banner-cached"}`}>
+      <strong>
+        {ran ? "Worker ran for this response" : "Served from cache — Worker not invoked"}
+      </strong>
+      <span>{detail}</span>
+    </div>
   );
 }

--- a/examples/workers-cache-cloudflare/app/components/revalidate-controls.tsx
+++ b/examples/workers-cache-cloudflare/app/components/revalidate-controls.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+
+type Result = {
+  ok: boolean;
+  message: string;
+  detail?: string;
+};
+
+export function RevalidateControls({
+  tag,
+  path,
+}: {
+  tag: string;
+  path: string;
+}) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [result, setResult] = useState<Result | null>(null);
+
+  async function call(kind: "tag" | "path", value: string) {
+    setBusy(kind);
+    setResult(null);
+    try {
+      const url = kind === "tag" ? "/api/revalidate-tag" : "/api/revalidate-path";
+      const body = kind === "tag" ? { tag: value } : { path: value };
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const payload = (await res.json().catch(() => ({}))) as {
+        revalidated?: boolean;
+        error?: string;
+        target?: string;
+      };
+      if (res.ok && payload.revalidated) {
+        setResult({
+          ok: true,
+          message: `Revalidated ${kind}=${value}`,
+          detail: `Inner cache cleared and ctx.cache.purge invoked for the matching Cache-Tag entries.`,
+        });
+      } else {
+        setResult({
+          ok: false,
+          message: payload.error ?? `Revalidation failed (${res.status})`,
+        });
+      }
+    } catch (err) {
+      setResult({
+        ok: false,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className="panel" aria-label="Revalidation controls">
+      <h2 style={{ marginTop: 0 }}>Invalidate this page</h2>
+      <p style={{ marginTop: 0, color: "var(--muted)" }}>
+        Calls into a server route handler that invokes <code>revalidateTag</code> /{" "}
+        <code>revalidatePath</code>. vinext fans the call out to both the inner CacheHandler
+        (KV / memory) and <code>ctx.cache.purge(...)</code> when the runtime exposes one on the
+        request context.
+      </p>
+      <div className="controls">
+        <button
+          type="button"
+          onClick={() => void call("tag", tag)}
+          disabled={busy !== null}
+        >
+          {busy === "tag" ? "Purging tag…" : `revalidateTag("${tag}")`}
+        </button>
+        <button
+          type="button"
+          onClick={() => void call("path", path)}
+          disabled={busy !== null}
+        >
+          {busy === "path" ? "Purging path…" : `revalidatePath("${path}")`}
+        </button>
+      </div>
+      <p className="status" role="status">
+        {result ? (
+          <>
+            <span style={{ color: result.ok ? "var(--good)" : "var(--bad)" }}>
+              {result.message}
+            </span>
+            {result.detail ? <> — {result.detail}</> : null}
+          </>
+        ) : (
+          <>&nbsp;</>
+        )}
+      </p>
+    </section>
+  );
+}

--- a/examples/workers-cache-cloudflare/app/components/revalidate-controls.tsx
+++ b/examples/workers-cache-cloudflare/app/components/revalidate-controls.tsx
@@ -40,6 +40,14 @@ export function RevalidateControls({
           message: `Revalidated ${kind}=${value}`,
           detail: `Inner cache cleared and ctx.cache.purge invoked for the matching Cache-Tag entries.`,
         });
+        // Tell any active probes to re-fire so the user can immediately see
+        // the cache verdict flip from HIT to MISS (or render-id from same
+        // to changed). Scoped to the path when we know it.
+        window.dispatchEvent(
+          new CustomEvent("vinext-revalidated", {
+            detail: kind === "path" ? { path: value } : undefined,
+          }),
+        );
       } else {
         setResult({
           ok: false,

--- a/examples/workers-cache-cloudflare/app/components/revalidate-controls.tsx
+++ b/examples/workers-cache-cloudflare/app/components/revalidate-controls.tsx
@@ -40,14 +40,6 @@ export function RevalidateControls({
           message: `Revalidated ${kind}=${value}`,
           detail: `Inner cache cleared and ctx.cache.purge invoked for the matching Cache-Tag entries.`,
         });
-        // Tell any active probes to re-fire so the user can immediately see
-        // the cache verdict flip from HIT to MISS (or render-id from same
-        // to changed). Scoped to the path when we know it.
-        window.dispatchEvent(
-          new CustomEvent("vinext-revalidated", {
-            detail: kind === "path" ? { path: value } : undefined,
-          }),
-        );
       } else {
         setResult({
           ok: false,

--- a/examples/workers-cache-cloudflare/app/dynamic/page.tsx
+++ b/examples/workers-cache-cloudflare/app/dynamic/page.tsx
@@ -1,0 +1,29 @@
+import { CacheStatusProbe } from "../components/cache-status-probe";
+
+// Comparison page: force-dynamic. The Worker runs on every request. vinext
+// emits `Cache-Control: private, no-cache, no-store, ...` so the outer
+// Workers Cache layer must not cache the response.
+export const dynamic = "force-dynamic";
+
+export default function DynamicPage() {
+  const renderedAt = new Date().toISOString();
+  return (
+    <main>
+      <nav className="crumbs">
+        <a href="/">&larr; Demo home</a>
+      </nav>
+      <h1>
+        <code>/dynamic</code>
+      </h1>
+      <p className="tagline">
+        Bypass case for comparison. <code>force-dynamic</code> means vinext emits{" "}
+        <code>no-store</code> headers, so neither the outer <code>ctx.cache</code> nor the
+        inner CacheHandler retains anything. The timestamp updates on every reload.
+      </p>
+      <div className="timestamp" data-testid="rendered-at">
+        {renderedAt}
+      </div>
+      <CacheStatusProbe path="/dynamic" />
+    </main>
+  );
+}

--- a/examples/workers-cache-cloudflare/app/dynamic/page.tsx
+++ b/examples/workers-cache-cloudflare/app/dynamic/page.tsx
@@ -7,6 +7,7 @@ export const dynamic = "force-dynamic";
 
 export default function DynamicPage() {
   const renderedAt = new Date().toISOString();
+  const renderId = crypto.randomUUID();
   return (
     <main>
       <nav className="crumbs">
@@ -18,12 +19,21 @@ export default function DynamicPage() {
       <p className="tagline">
         Bypass case for comparison. <code>force-dynamic</code> means vinext emits{" "}
         <code>no-store</code> headers, so neither the outer <code>ctx.cache</code> nor the
-        inner CacheHandler retains anything. The timestamp updates on every reload.
+        inner CacheHandler retains anything. The timestamp updates on every reload — every
+        probe should produce a fresh <code>render-id</code>.
       </p>
-      <div className="timestamp" data-testid="rendered-at">
+      <div
+        className="timestamp"
+        data-testid="rendered-at"
+        data-render-id={renderId}
+        data-render-time={renderedAt}
+      >
         {renderedAt}
       </div>
-      <CacheStatusProbe path="/dynamic" />
+      <p>
+        Render ID: <code>{renderId}</code>
+      </p>
+      <CacheStatusProbe path="/dynamic" initialRenderId={renderId} initialRenderTime={renderedAt} />
     </main>
   );
 }

--- a/examples/workers-cache-cloudflare/app/dynamic/page.tsx
+++ b/examples/workers-cache-cloudflare/app/dynamic/page.tsx
@@ -33,7 +33,7 @@ export default function DynamicPage() {
       <p>
         Render ID: <code>{renderId}</code>
       </p>
-      <CacheStatusProbe path="/dynamic" initialRenderId={renderId} initialRenderTime={renderedAt} />
+      <CacheStatusProbe path="/dynamic" />
     </main>
   );
 }

--- a/examples/workers-cache-cloudflare/app/layout.tsx
+++ b/examples/workers-cache-cloudflare/app/layout.tsx
@@ -1,0 +1,14 @@
+import "./styles.css";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Workers Cache demo — vinext</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/workers-cache-cloudflare/app/page.tsx
+++ b/examples/workers-cache-cloudflare/app/page.tsx
@@ -39,10 +39,11 @@ export default function HomePage() {
             <span className="badge">Tags</span> Tagged content
           </h3>
           <p>
-            Tagged with <code>featured-post</code>. Revalidate the tag from the panel below and the
-            page is dropped from both layers.
+            A tagged <code>fetch()</code> during render attaches <code>post:&lt;slug&gt;</code> to
+            the page's cache entry. Try <code>revalidateTag(&quot;post:featured&quot;)</code> from
+            the panel.
           </p>
-          <a href="/cached/featured-post">Open /cached/featured-post &rarr;</a>
+          <a href="/cached/featured">Open /cached/featured &rarr;</a>
         </div>
 
         <div className="card">

--- a/examples/workers-cache-cloudflare/app/page.tsx
+++ b/examples/workers-cache-cloudflare/app/page.tsx
@@ -1,0 +1,72 @@
+import { CacheStatusProbe } from "./components/cache-status-probe";
+
+export const revalidate = 0;
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>Request-context cache demo</h1>
+      <p className="tagline">
+        vinext supports route-level caching through whatever cache the runtime exposes on{" "}
+        <code>ctx.cache</code>. ISR responses carry <code>Cache-Control</code> and{" "}
+        <code>Cache-Tag</code> headers, and <code>revalidateTag()</code> /{" "}
+        <code>revalidatePath()</code> automatically fan out to <code>ctx.cache.purge(...)</code>{" "}
+        alongside the inner <code>CacheHandler</code>. Deployed here on Cloudflare Workers (which{" "}
+        <a href="https://developers.cloudflare.com/workers/cache/" target="_blank" rel="noreferrer">
+          provides
+        </a>{" "}
+        a compatible <code>ctx.cache</code> when <code>cache.enabled: true</code>), but no
+        Cloudflare-specific import is required.
+      </p>
+
+      <CacheStatusProbe path="/cached/intro" />
+
+      <h2>Pick a demo route</h2>
+      <section className="grid">
+        <div className="card">
+          <h3>
+            <span className="badge">ISR</span> Static page
+          </h3>
+          <p>
+            Renders a server timestamp under <code>revalidate = 60</code>. Every reload after the
+            first should hit the cache layer.
+          </p>
+          <a href="/cached/intro">Open /cached/intro &rarr;</a>
+        </div>
+
+        <div className="card">
+          <h3>
+            <span className="badge">Tags</span> Tagged content
+          </h3>
+          <p>
+            Tagged with <code>featured-post</code>. Revalidate the tag from the panel below and the
+            page is dropped from both layers.
+          </p>
+          <a href="/cached/featured-post">Open /cached/featured-post &rarr;</a>
+        </div>
+
+        <div className="card">
+          <h3>
+            <span className="badge">Route</span> Cached route handler
+          </h3>
+          <p>
+            <code>/api/now</code> caches a JSON payload for 30s. Watch the timestamp freeze, then
+            refresh after the revalidate window.
+          </p>
+          <a href="/api/now">Open /api/now &rarr;</a>
+        </div>
+
+        <div className="card">
+          <h3>
+            <span className="badge">Dynamic</span> Always-fresh
+          </h3>
+          <p>
+            <code>force-dynamic</code> for comparison. The Worker runs on every request and the
+            outer cache is bypassed.
+          </p>
+          <a href="/dynamic">Open /dynamic &rarr;</a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/examples/workers-cache-cloudflare/app/styles.css
+++ b/examples/workers-cache-cloudflare/app/styles.css
@@ -239,6 +239,14 @@ code {
   background: var(--good);
 }
 
+.ssr-banner-unknown {
+  background: rgba(147, 160, 200, 0.06);
+}
+
+.ssr-banner-unknown::before {
+  background: var(--muted);
+}
+
 .timestamp {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 1rem;

--- a/examples/workers-cache-cloudflare/app/styles.css
+++ b/examples/workers-cache-cloudflare/app/styles.css
@@ -1,0 +1,213 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0b1020;
+  --panel: #111733;
+  --panel-2: #161c3d;
+  --text: #e7ecff;
+  --muted: #93a0c8;
+  --accent: #8b5cf6;
+  --accent-2: #22d3ee;
+  --good: #34d399;
+  --warn: #f59e0b;
+  --bad: #f43f5e;
+  --border: rgba(255, 255, 255, 0.08);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(1200px 600px at 80% -10%, rgba(139, 92, 246, 0.18), transparent),
+    radial-gradient(800px 400px at -10% 10%, rgba(34, 211, 238, 0.12), transparent), var(--bg);
+  color: var(--text);
+}
+
+a {
+  color: var(--accent-2);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+main {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 48px 24px 96px;
+}
+
+h1 {
+  font-size: 2.25rem;
+  margin: 0 0 8px;
+  letter-spacing: -0.02em;
+}
+
+h2 {
+  margin-top: 32px;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+}
+
+.tagline {
+  color: var(--muted);
+  margin: 0 0 32px;
+  max-width: 70ch;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.card {
+  background: linear-gradient(180deg, var(--panel), var(--panel-2));
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 140px;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+.card p {
+  color: var(--muted);
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.card a {
+  margin-top: auto;
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: rgba(139, 92, 246, 0.2);
+  color: #d6c4ff;
+  margin-right: 6px;
+}
+
+.badge-hit {
+  background: rgba(52, 211, 153, 0.18);
+  color: #aaf3d4;
+}
+
+.badge-miss {
+  background: rgba(244, 63, 94, 0.18);
+  color: #ffb5c2;
+}
+
+.badge-stale {
+  background: rgba(245, 158, 11, 0.18);
+  color: #ffd692;
+}
+
+.kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  margin: 12px 0 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+.kv dt {
+  color: var(--muted);
+}
+
+.kv dd {
+  margin: 0;
+  word-break: break-all;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.controls button,
+.controls a.button {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.05s ease, background 0.15s ease;
+}
+
+.controls button:hover,
+.controls a.button:hover {
+  background: rgba(139, 92, 246, 0.2);
+  text-decoration: none;
+}
+
+.controls button:active {
+  transform: scale(0.98);
+}
+
+.status {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-top: 8px;
+  min-height: 1.2em;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px;
+  margin-top: 16px;
+}
+
+code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-size: 0.85em;
+}
+
+.timestamp {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1rem;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: inline-block;
+  margin-top: 6px;
+}
+
+nav.crumbs {
+  margin-bottom: 24px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+nav.crumbs a {
+  color: var(--muted);
+}

--- a/examples/workers-cache-cloudflare/app/styles.css
+++ b/examples/workers-cache-cloudflare/app/styles.css
@@ -192,6 +192,53 @@ code {
   font-size: 0.85em;
 }
 
+.ssr-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  margin: 16px 0;
+  border: 1px solid var(--border);
+  position: relative;
+}
+
+.ssr-banner::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: 12px 0 0 12px;
+}
+
+.ssr-banner strong {
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+}
+
+.ssr-banner span {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.ssr-banner-ran {
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.ssr-banner-ran::before {
+  background: var(--warn);
+}
+
+.ssr-banner-cached {
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.ssr-banner-cached::before {
+  background: var(--good);
+}
+
 .timestamp {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 1rem;

--- a/examples/workers-cache-cloudflare/package.json
+++ b/examples/workers-cache-cloudflare/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "workers-cache-cloudflare",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "vinext dev",
+    "build": "vinext build",
+    "preview": "vinext build && wrangler dev"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "vite": "catalog:",
+    "vinext": "workspace:*",
+    "@vitejs/plugin-rsc": "catalog:",
+    "react-server-dom-webpack": "catalog:",
+    "@cloudflare/vite-plugin": "catalog:",
+    "wrangler": "catalog:"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/examples/workers-cache-cloudflare/tsconfig.json
+++ b/examples/workers-cache-cloudflare/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["app", "worker", "*.ts"]
+}

--- a/examples/workers-cache-cloudflare/vite.config.ts
+++ b/examples/workers-cache-cloudflare/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    vinext(),
+    cloudflare({
+      viteEnvironment: {
+        name: "rsc",
+        childEnvironments: ["ssr"],
+      },
+    }),
+  ],
+});

--- a/examples/workers-cache-cloudflare/worker/index.ts
+++ b/examples/workers-cache-cloudflare/worker/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Cloudflare Worker entry for the request-context cache demo.
+ *
+ * vinext detects `ctx.cache` on the per-request ExecutionContext at
+ * runtime. When present (Cloudflare exposes it once `cache.enabled: true`
+ * is set in wrangler.jsonc), `revalidateTag()` / `revalidatePath()` fan
+ * out their tag invalidations to `ctx.cache.purge` automatically. No
+ * runtime-specific import or registration is required.
+ */
+import handler from "vinext/server/app-router-entry";
+
+interface Env {
+  ASSETS: Fetcher;
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    return handler.fetch(request, env, ctx);
+  },
+};

--- a/examples/workers-cache-cloudflare/wrangler.jsonc
+++ b/examples/workers-cache-cloudflare/wrangler.jsonc
@@ -1,0 +1,35 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "workers-cache-cloudflare",
+  // Workers Cache requires a recent compatibility date — bumping closer to
+  // release should be done once miniflare ships a newer workerd. See
+  // https://developers.cloudflare.com/workers/cache/
+  "compatibility_date": "2026-04-08",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./worker/index.ts",
+  "preview_urls": true,
+  "assets": {
+    "not_found_handling": "none",
+    "binding": "ASSETS"
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": true,
+    },
+  },
+  // Enable the platform-managed HTTP cache layer. With this on, the
+  // runtime caches responses based on the `Cache-Control` headers vinext
+  // already emits for ISR routes and exposes `ctx.cache.purge({ tags })`
+  // on the request context. vinext detects `ctx.cache` at runtime — no
+  // Cloudflare-specific import is needed — and fans `revalidateTag()` /
+  // `revalidatePath()` out to it alongside the inner CacheHandler.
+  "cache": {
+    "enabled": true
+  }
+}

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1448,16 +1448,16 @@ function resolveRenderedCacheControl(
   cacheControl: string,
   fallbackExpireSeconds: number,
 ): { expire: number; revalidate?: number } {
-  const sMaxage = parseCacheControlSeconds(cacheControl, "s-maxage");
+  const maxAge = parseCacheControlSeconds(cacheControl, "max-age");
   const staleWhileRevalidate = parseCacheControlSeconds(cacheControl, "stale-while-revalidate");
   const revalidate =
-    requestCacheLife.revalidate ?? (staleWhileRevalidate === undefined ? undefined : sMaxage);
+    requestCacheLife.revalidate ?? (staleWhileRevalidate === undefined ? undefined : maxAge);
   return {
     expire:
       requestCacheLife.expire ??
       resolveRenderedExpireSeconds({
         fallbackExpireSeconds,
-        sMaxage,
+        maxAge,
         staleWhileRevalidate,
       }),
     ...(revalidate === undefined ? {} : { revalidate }),
@@ -1466,15 +1466,15 @@ function resolveRenderedCacheControl(
 
 function resolveRenderedExpireSeconds(options: {
   fallbackExpireSeconds: number;
-  sMaxage?: number;
+  maxAge?: number;
   staleWhileRevalidate?: number;
 }): number {
-  const { fallbackExpireSeconds, sMaxage, staleWhileRevalidate } = options;
-  if (sMaxage === undefined || staleWhileRevalidate === undefined) {
+  const { fallbackExpireSeconds, maxAge, staleWhileRevalidate } = options;
+  if (maxAge === undefined || staleWhileRevalidate === undefined) {
     return fallbackExpireSeconds;
   }
 
-  return sMaxage + staleWhileRevalidate;
+  return maxAge + staleWhileRevalidate;
 }
 
 function parseCacheControlSeconds(cacheControl: string, directive: string): number | undefined {

--- a/packages/vinext/src/cloudflare/kv-cache-handler.ts
+++ b/packages/vinext/src/cloudflare/kv-cache-handler.ts
@@ -241,6 +241,7 @@ export class KVCacheHandler implements CacheHandler {
         value: restoredValue,
         cacheState: "stale",
         cacheControl: entry.cacheControl,
+        tags: entry.tags,
       };
     }
 
@@ -248,6 +249,7 @@ export class KVCacheHandler implements CacheHandler {
       lastModified: entry.lastModified,
       value: restoredValue,
       cacheControl: entry.cacheControl,
+      tags: entry.tags,
     };
   }
 

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -506,6 +506,17 @@ export function finalizeAppPageHtmlCacheResponse(
     return response;
   }
 
+  // When an outer request-context cache (e.g. Workers Cache) is present,
+  // route-level ISR is owned entirely by that layer (see isr-cache.ts).
+  // Skip the no-store-on-first-render safety dance and the inner-cache
+  // write so the route's declared `Cache-Control: s-maxage=…` reaches the
+  // outer cache and gets honoured. Routes that opt into ISR are expected
+  // not to read request APIs during render — same contract as standard
+  // Next.js ISR.
+  if (isRequestContextCacheAvailable()) {
+    return response;
+  }
+
   const [streamForClient, streamForCache] = response.body.tee();
   const htmlKey = options.isrHtmlKey(options.cleanPathname);
   const rscKey = options.isrRscKey(options.cleanPathname, null);
@@ -600,6 +611,14 @@ export function finalizeAppPageRscCacheResponse(
   response: Response,
   options: ScheduleAppPageRscCacheWriteOptions,
 ): Response {
+  // See note in `finalizeAppPageHtmlCacheResponse` — when the outer
+  // request-context cache owns route-level ISR, vinext does not write to
+  // the inner cache and the declared Cache-Control must flow through to
+  // the outer layer.
+  if (isRequestContextCacheAvailable()) {
+    return response;
+  }
+
   const didSchedule = scheduleAppPageRscCacheWrite(options);
   if (!didSchedule) {
     return response;

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -509,7 +509,7 @@ export function finalizeAppPageHtmlCacheResponse(
   // When an outer request-context cache (e.g. Workers Cache) is present,
   // route-level ISR is owned entirely by that layer (see isr-cache.ts).
   // Skip the no-store-on-first-render safety dance and the inner-cache
-  // write so the route's declared `Cache-Control: s-maxage=…` reaches the
+  // write so the route's declared `Cache-Control: max-age=…` reaches the
   // outer cache and gets honoured. Routes that opt into ISR are expected
   // not to read request APIs during render — same contract as standard
   // Next.js ISR.

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -1,4 +1,8 @@
-import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cache";
+import {
+  isRequestContextCacheAvailable,
+  type CachedAppPageValue,
+  type CacheControlMetadata,
+} from "vinext/shims/cache";
 import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
@@ -7,7 +11,7 @@ import {
 import { buildCachedRevalidateCacheControl } from "./cache-control.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
-import { setCacheStateHeaders } from "./cache-headers.js";
+import { applyCacheTagHeader, setCacheStateHeaders } from "./cache-headers.js";
 import { buildAppPageCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { readStreamAsText } from "../utils/text-stream.js";
@@ -68,6 +72,7 @@ type AppPageCacheRenderResult = {
 type BuildAppPageCachedResponseOptions = {
   cacheControl?: CacheControlMetadata;
   cacheState: "HIT" | "STALE";
+  cacheTags?: readonly string[];
   expireSeconds?: number;
   isEdgeRuntime?: boolean;
   isRscRequest: boolean;
@@ -198,6 +203,7 @@ function buildAppPageCacheControl(
 function buildAppPageCachedHeaders(options: {
   cacheControl: string;
   cacheState: BuildAppPageCachedResponseOptions["cacheState"];
+  cacheTags?: readonly string[];
   contentType: string;
   isEdgeRuntime?: boolean;
   middlewareHeaders?: Headers | null;
@@ -213,6 +219,14 @@ function buildAppPageCachedHeaders(options: {
 
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
+  }
+
+  // Only emit Cache-Tag when the request-context cache that would consume it
+  // is actually present. Skipping when absent keeps the response surface
+  // clean for runtimes that don't have an outer cache and avoids advertising
+  // tags that no layer will act on.
+  if (options.cacheTags && options.cacheTags.length > 0 && isRequestContextCacheAvailable()) {
+    applyCacheTagHeader(headers, options.cacheTags);
   }
 
   mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
@@ -274,6 +288,7 @@ export function buildAppPageCachedResponse(
     const rscHeaders = buildAppPageCachedHeaders({
       cacheControl,
       cacheState: options.cacheState,
+      cacheTags: options.cacheTags,
       contentType: VINEXT_RSC_CONTENT_TYPE,
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareHeaders: options.middlewareHeaders,
@@ -294,6 +309,7 @@ export function buildAppPageCachedResponse(
   const htmlHeaders = buildAppPageCachedHeaders({
     cacheControl,
     cacheState: options.cacheState,
+    cacheTags: options.cacheTags,
     contentType: "text/html; charset=utf-8",
     isEdgeRuntime: options.isEdgeRuntime,
     middlewareHeaders: options.middlewareHeaders,
@@ -332,6 +348,7 @@ export async function readAppPageCacheResponse(
       const hitResponse = buildAppPageCachedResponse(cachedValue, {
         cacheState: "HIT",
         cacheControl: cached?.value.cacheControl,
+        cacheTags: cached?.value.tags,
         expireSeconds: options.expireSeconds,
         isEdgeRuntime: options.isEdgeRuntime,
         isRscRequest: options.isRscRequest,
@@ -425,6 +442,7 @@ export async function readAppPageCacheResponse(
       const staleResponse = buildAppPageCachedResponse(cachedValue, {
         cacheState: "STALE",
         cacheControl: cached.value.cacheControl,
+        cacheTags: cached.value.tags,
         expireSeconds: options.expireSeconds,
         isEdgeRuntime: options.isEdgeRuntime,
         isRscRequest: options.isRscRequest,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -416,6 +416,7 @@ export async function renderAppPageLifecycle(
       revalidateSeconds,
     });
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
+      cacheTags: rscResponsePolicy.cacheControl ? options.getPageTags() : undefined,
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
@@ -625,6 +626,7 @@ export async function renderAppPageLifecycle(
 
   if (htmlResponsePolicy.shouldWriteToCache || shouldSpeculativelyWriteCache) {
     const isrResponse = buildAppPageHtmlResponse(safeHtmlStream, {
+      cacheTags: htmlResponsePolicy.cacheControl ? options.getPageTags() : undefined,
       draftCookie,
       fontLinkHeader,
       isEdgeRuntime: options.isEdgeRuntime,
@@ -689,6 +691,7 @@ export async function renderAppPageLifecycle(
   }
 
   return buildAppPageHtmlResponse(safeHtmlStream, {
+    cacheTags: htmlResponsePolicy.cacheControl ? options.getPageTags() : undefined,
     draftCookie,
     fontLinkHeader,
     isEdgeRuntime: options.isEdgeRuntime,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -8,7 +8,8 @@ import {
   VINEXT_PARAMS_HEADER,
   VINEXT_TIMING_HEADER,
 } from "./headers.js";
-import { setCacheStateHeaders } from "./cache-headers.js";
+import { isRequestContextCacheAvailable } from "vinext/shims/cache";
+import { applyCacheTagHeader, setCacheStateHeaders } from "./cache-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import {
   VINEXT_RSC_CONTENT_TYPE,
@@ -58,6 +59,7 @@ type AppPageHtmlResponsePolicy = {
 } & AppPageResponsePolicy;
 
 type BuildAppPageRscResponseOptions = {
+  cacheTags?: readonly string[];
   isEdgeRuntime?: boolean;
   middlewareContext: AppPageMiddlewareContext;
   mountedSlotsHeader?: string | null;
@@ -67,6 +69,7 @@ type BuildAppPageRscResponseOptions = {
 };
 
 type BuildAppPageHtmlResponseOptions = {
+  cacheTags?: readonly string[];
   draftCookie?: string | null;
   fontLinkHeader?: string;
   isEdgeRuntime?: boolean;
@@ -256,6 +259,13 @@ export function buildAppPageRscResponse(
   if (options.policy.cacheState) {
     setCacheStateHeaders(headers, options.policy.cacheState);
   }
+  // Emit `Cache-Tag` on fresh-render responses when an outer request-context
+  // cache is in play. Without this, the outer cache stores the response with
+  // no purgeable tags, so `revalidateTag`/`revalidatePath` fan-outs to
+  // `ctx.cache.purge` can't find anything to invalidate.
+  if (options.cacheTags && options.cacheTags.length > 0 && isRequestContextCacheAvailable()) {
+    applyCacheTagHeader(headers, options.cacheTags);
+  }
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
   applyRscCompatibilityIdHeader(headers);
 
@@ -289,6 +299,11 @@ export function buildAppPageHtmlResponse(
   }
   if (options.fontLinkHeader) {
     headers.set("Link", options.fontLinkHeader);
+  }
+  // See note in buildAppPageRscResponse — emit Cache-Tag on fresh renders
+  // when the outer request-context cache is available.
+  if (options.cacheTags && options.cacheTags.length > 0 && isRequestContextCacheAvailable()) {
+    applyCacheTagHeader(headers, options.cacheTags);
   }
 
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);

--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -86,6 +86,7 @@ export async function readAppRouteHandlerCacheResponse(
         buildRouteHandlerCachedResponse(cachedValue, {
           cacheState: "HIT",
           cacheControl: cached?.value.cacheControl,
+          cacheTags: cached?.value.tags,
           expireSeconds: options.expireSeconds,
           isHead: options.isAutoHead,
           revalidateSeconds: options.revalidateSeconds,
@@ -150,6 +151,7 @@ export async function readAppRouteHandlerCacheResponse(
         buildRouteHandlerCachedResponse(staleValue, {
           cacheState: "STALE",
           cacheControl: cached.value.cacheControl,
+          cacheTags: cached.value.tags,
           expireSeconds: options.expireSeconds,
           isHead: options.isAutoHead,
           revalidateSeconds: options.revalidateSeconds,

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -1,7 +1,8 @@
 import type { NextI18nConfig } from "../config/next-config.js";
 import { setHeadersContext, type HeadersAccessPhase } from "vinext/shims/headers";
 import type { ExecutionContextLike } from "vinext/shims/request-context";
-import type { CachedRouteValue } from "vinext/shims/cache";
+import { isRequestContextCacheAvailable, type CachedRouteValue } from "vinext/shims/cache";
+import { applyCacheTagHeader } from "./cache-headers.js";
 import type { NextRequest } from "vinext/shims/server";
 import {
   createStaticGenerationHeadersContext,
@@ -182,6 +183,17 @@ export async function executeAppRouteHandler(
         throw new Error("Expected route handler revalidate seconds");
       }
       applyRouteHandlerRevalidateHeader(response, revalidateSeconds, options.expireSeconds);
+      // Emit Cache-Tag on fresh-render route handler responses when an outer
+      // request-context cache is in play. The inner ISR cache write may be
+      // bypassed (see isr-cache.ts), so the response itself must carry tags
+      // for `ctx.cache.purge(...)` fan-outs to be able to invalidate it.
+      if (isRequestContextCacheAvailable()) {
+        const handlerTags = options.buildPageCacheTags(
+          options.cleanPathname,
+          options.getCollectedFetchTags(),
+        );
+        if (handlerTags.length > 0) applyCacheTagHeader(response.headers, handlerTags);
+      }
     }
 
     if (

--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -1,4 +1,8 @@
-import type { CachedRouteValue, CacheControlMetadata } from "vinext/shims/cache";
+import {
+  isRequestContextCacheAvailable,
+  type CachedRouteValue,
+  type CacheControlMetadata,
+} from "vinext/shims/cache";
 import {
   buildCachedRevalidateCacheControl,
   NEVER_CACHE_CONTROL,
@@ -11,7 +15,7 @@ import {
   NEXTJS_CACHE_HEADER,
   VINEXT_CACHE_HEADER,
 } from "./headers.js";
-import { setCacheStateHeaders } from "./cache-headers.js";
+import { applyCacheTagHeader, setCacheStateHeaders } from "./cache-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 
@@ -23,6 +27,7 @@ export type RouteHandlerMiddlewareContext = {
 type BuildRouteHandlerCachedResponseOptions = {
   cacheControl?: CacheControlMetadata;
   cacheState: "HIT" | "STALE";
+  cacheTags?: readonly string[];
   expireSeconds?: number;
   isHead: boolean;
   revalidateSeconds: number;
@@ -122,6 +127,11 @@ export function buildRouteHandlerCachedResponse(
     "Cache-Control",
     buildRouteHandlerCacheControl(options.cacheState, revalidateSeconds, expireSeconds),
   );
+  // Gate on the request-context cache being present — see the matching
+  // comment in `buildAppPageCachedHeaders` for the rationale.
+  if (options.cacheTags && options.cacheTags.length > 0 && isRequestContextCacheAvailable()) {
+    applyCacheTagHeader(headers, options.cacheTags);
+  }
 
   return new Response(options.isHead ? null : cachedValue.body, {
     status: cachedValue.status,

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -1,8 +1,12 @@
 export const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
-export const STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
+// `public` makes the response unambiguously shared-cacheable. It's the
+// directive Cloudflare's Workers Cache (and most CDNs) look for as an
+// explicit opt-in; without it some caches fall back to heuristics or
+// conservative defaults.
+export const STATIC_CACHE_CONTROL = "public, s-maxage=31536000, stale-while-revalidate";
 
-const STALE_REVALIDATE_CACHE_CONTROL = "s-maxage=0, stale-while-revalidate";
+const STALE_REVALIDATE_CACHE_CONTROL = "public, s-maxage=0, stale-while-revalidate";
 
 export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
 
@@ -19,16 +23,16 @@ export function buildRevalidateCacheControl(
   expireSeconds?: number,
 ): string {
   if (expireSeconds === undefined) {
-    return `s-maxage=${revalidateSeconds}, stale-while-revalidate`;
+    return `public, s-maxage=${revalidateSeconds}, stale-while-revalidate`;
   }
 
   // `expire <= revalidate` is a zero-width stale window: downstream caches
   // should refetch after s-maxage instead of serving stale.
   if (revalidateSeconds >= expireSeconds) {
-    return `s-maxage=${revalidateSeconds}`;
+    return `public, s-maxage=${revalidateSeconds}`;
   }
 
-  return `s-maxage=${revalidateSeconds}, stale-while-revalidate=${
+  return `public, s-maxage=${revalidateSeconds}, stale-while-revalidate=${
     expireSeconds - revalidateSeconds
   }`;
 }

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -4,9 +4,9 @@ export const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must
 // directive Cloudflare's Workers Cache (and most CDNs) look for as an
 // explicit opt-in; without it some caches fall back to heuristics or
 // conservative defaults.
-export const STATIC_CACHE_CONTROL = "public, s-maxage=31536000, stale-while-revalidate";
+export const STATIC_CACHE_CONTROL = "public, max-age=31536000, stale-while-revalidate";
 
-const STALE_REVALIDATE_CACHE_CONTROL = "public, s-maxage=0, stale-while-revalidate";
+const STALE_REVALIDATE_CACHE_CONTROL = "public, max-age=0, stale-while-revalidate";
 
 export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
 
@@ -23,16 +23,16 @@ export function buildRevalidateCacheControl(
   expireSeconds?: number,
 ): string {
   if (expireSeconds === undefined) {
-    return `public, s-maxage=${revalidateSeconds}, stale-while-revalidate`;
+    return `public, max-age=${revalidateSeconds}, stale-while-revalidate`;
   }
 
   // `expire <= revalidate` is a zero-width stale window: downstream caches
-  // should refetch after s-maxage instead of serving stale.
+  // should refetch after max-age instead of serving stale.
   if (revalidateSeconds >= expireSeconds) {
-    return `public, s-maxage=${revalidateSeconds}`;
+    return `public, max-age=${revalidateSeconds}`;
   }
 
-  return `public, s-maxage=${revalidateSeconds}, stale-while-revalidate=${
+  return `public, max-age=${revalidateSeconds}, stale-while-revalidate=${
     expireSeconds - revalidateSeconds
   }`;
 }
@@ -41,7 +41,7 @@ export function buildRevalidateCacheControl(
  * Builds Cache-Control for ISR cache reads. HIT responses and STALE responses
  * with stored expire metadata use the same route policy because Next.js derives
  * this header from cache-control metadata, not from the cache hit/stale state.
- * STALE entries without expire metadata keep vinext's legacy `s-maxage=0`
+ * STALE entries without expire metadata keep vinext's legacy `max-age=0`
  * fallback so older cache entries are not treated as newly fresh downstream.
  */
 export function buildCachedRevalidateCacheControl(

--- a/packages/vinext/src/server/cache-headers.ts
+++ b/packages/vinext/src/server/cache-headers.ts
@@ -18,3 +18,34 @@ export function buildCacheStateHeaders(cacheState: VinextCacheState): Record<str
     [NEXTJS_CACHE_HEADER]: toNextJsCacheState(cacheState),
   };
 }
+
+/**
+ * Cloudflare Workers Cache and other shared HTTP caches honour the
+ * `Cache-Tag` response header for tag-based purging. Tags are joined with
+ * commas per Cloudflare's `Cache-Tag` format. We strip empty entries
+ * defensively and cap the rendered header to ~15KiB so a runaway tag set
+ * cannot exceed Workers's response header limits (the platform truncates
+ * silently beyond 16KiB).
+ *
+ * Tags must already be ASCII-safe (see `encodeCacheTag`). This helper does
+ * not re-encode — callers own the canonicalisation pass.
+ */
+const CACHE_TAG_HEADER_BYTE_BUDGET = 15 * 1024;
+
+export function applyCacheTagHeader(headers: Headers, tags: readonly string[]): void {
+  if (tags.length === 0) return;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  let length = 0;
+  for (const tag of tags) {
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    // +1 for the separating comma between entries (skipped on the first).
+    const entryLength = tag.length + (out.length > 0 ? 1 : 0);
+    if (length + entryLength > CACHE_TAG_HEADER_BYTE_BUDGET) break;
+    out.push(tag);
+    length += entryLength;
+  }
+  if (out.length === 0) return;
+  headers.set("Cache-Tag", out.join(","));
+}

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -654,7 +654,7 @@ export function createSSRHandler(
             const hitHeaders: Record<string, string> = {
               "Content-Type": "text/html",
               ...buildCacheStateHeaders("HIT"),
-              "Cache-Control": `s-maxage=${revalidateSecs}, stale-while-revalidate`,
+              "Cache-Control": `public, s-maxage=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) hitHeaders["Link"] = earlyFontLinkHeader;
             res.writeHead(200, hitHeaders);
@@ -811,7 +811,7 @@ export function createSSRHandler(
             const staleHeaders: Record<string, string> = {
               "Content-Type": "text/html",
               ...buildCacheStateHeaders("STALE"),
-              "Cache-Control": `s-maxage=${revalidateSecs}, stale-while-revalidate`,
+              "Cache-Control": `public, s-maxage=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) staleHeaders["Link"] = earlyFontLinkHeader;
             res.writeHead(200, staleHeaders);
@@ -1091,7 +1091,7 @@ hydrate();
             extraHeaders["Cache-Control"] = "no-store, must-revalidate";
           } else {
             extraHeaders["Cache-Control"] =
-              `s-maxage=${isrRevalidateSeconds}, stale-while-revalidate`;
+              `public, s-maxage=${isrRevalidateSeconds}, stale-while-revalidate`;
             Object.assign(extraHeaders, buildCacheStateHeaders("MISS"));
           }
         }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -654,7 +654,7 @@ export function createSSRHandler(
             const hitHeaders: Record<string, string> = {
               "Content-Type": "text/html",
               ...buildCacheStateHeaders("HIT"),
-              "Cache-Control": `public, s-maxage=${revalidateSecs}, stale-while-revalidate`,
+              "Cache-Control": `public, max-age=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) hitHeaders["Link"] = earlyFontLinkHeader;
             res.writeHead(200, hitHeaders);
@@ -811,7 +811,7 @@ export function createSSRHandler(
             const staleHeaders: Record<string, string> = {
               "Content-Type": "text/html",
               ...buildCacheStateHeaders("STALE"),
-              "Cache-Control": `public, s-maxage=${revalidateSecs}, stale-while-revalidate`,
+              "Cache-Control": `public, max-age=${revalidateSecs}, stale-while-revalidate`,
             };
             if (earlyFontLinkHeader) staleHeaders["Link"] = earlyFontLinkHeader;
             res.writeHead(200, staleHeaders);
@@ -1091,7 +1091,7 @@ hydrate();
             extraHeaders["Cache-Control"] = "no-store, must-revalidate";
           } else {
             extraHeaders["Cache-Control"] =
-              `public, s-maxage=${isrRevalidateSeconds}, stale-while-revalidate`;
+              `public, max-age=${isrRevalidateSeconds}, stale-while-revalidate`;
             Object.assign(extraHeaders, buildCacheStateHeaders("MISS"));
           }
         }

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -15,6 +15,7 @@
 
 import {
   getCacheHandler,
+  isRequestContextCacheAvailable,
   type CacheHandlerValue,
   type IncrementalCacheValue,
   type CachedPagesValue,
@@ -38,13 +39,33 @@ export type ISRCacheEntry = {
 };
 
 /**
+ * When the request's ExecutionContext exposes an outer HTTP cache (e.g.
+ * Cloudflare's `ctx.cache`), that layer is the single source of cached
+ * responses for route-level ISR. Going through the inner `CacheHandler`
+ * as well would double-cache the same response, surface stale bodies
+ * even after the outer cache has been purged, and obscure whether the
+ * Worker actually re-rendered. So at the route-level ISR seams (this
+ * module) we bypass the inner handler entirely when the outer one is
+ * present. `unstable_cache`, fetch cache, and other application-level
+ * cached data still flow through the handler — they're not HTTP-level
+ * caches and the outer layer can't represent them.
+ */
+function shouldSkipInnerHandler(): boolean {
+  return isRequestContextCacheAvailable();
+}
+
+/**
  * Get a cache entry with staleness information.
  *
  * Returns { value, isStale: false } for fresh entries,
  * { value, isStale: true } for expired-but-usable entries,
  * or null for cache misses.
+ *
+ * When an outer request-context cache is present, returns null so the
+ * caller renders fresh and relies entirely on the outer layer.
  */
 export async function isrGet(key: string): Promise<ISRCacheEntry | null> {
+  if (shouldSkipInnerHandler()) return null;
   const handler = getCacheHandler();
   const result = await handler.get(key);
   if (!result || !result.value) return null;
@@ -60,6 +81,10 @@ export async function isrGet(key: string): Promise<ISRCacheEntry | null> {
 
 /**
  * Store a value in the ISR cache with a revalidation period.
+ *
+ * When an outer request-context cache is present, this is a no-op — the
+ * outer cache handles route-level caching based on the `Cache-Control` /
+ * `Cache-Tag` headers vinext already emits.
  */
 export async function isrSet(
   key: string,
@@ -68,6 +93,7 @@ export async function isrSet(
   tags?: string[],
   expireSeconds?: number,
 ): Promise<void> {
+  if (shouldSkipInnerHandler()) return;
   const handler = getCacheHandler();
   await handler.set(key, data, {
     cacheControl:

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -29,6 +29,7 @@ import { workUnitAsyncStorage } from "./internal/work-unit-async-storage.js";
 import { makeHangingPromise } from "./internal/make-hanging-promise.js";
 import { readCacheControlNumberField } from "../utils/cache-control-metadata.js";
 import { encodeCacheTag, encodeCacheTags } from "../utils/encode-cache-tag.js";
+import { getRequestExecutionContext } from "./request-context.js";
 import type { RenderObservation } from "../server/cache-proof.js";
 
 // ---------------------------------------------------------------------------
@@ -57,6 +58,70 @@ export function _registerCacheContextAccessor(fn: () => CacheContextLike | null)
 }
 
 // ---------------------------------------------------------------------------
+// Optional request-context cache.
+//
+// When the request's ExecutionContext exposes a `.cache` object with a
+// `.purge({ tags })` method, vinext treats it as an outer HTTP-level cache
+// that sits in front of the inner CacheHandler. `revalidateTag()` /
+// `revalidatePath()` / `updateTag()` will fan out their tag invalidations
+// to it so the outer cache stays in sync with the inner store.
+//
+// This is intentionally generic — any runtime that puts a compatible
+// `cache.purge` on the ExecutionContext gets the integration for free. No
+// registration, no runtime-specific module.
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of the request-context cache shape vinext uses. A runtime sets
+ * `ctx.cache` on the ExecutionContext if it wants vinext to forward tag
+ * invalidations to its outer HTTP cache.
+ */
+export type RequestContextCache = {
+  purge(options: { tags?: string[] }): Promise<void>;
+};
+
+type ExecutionContextWithCache = {
+  cache?: unknown;
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+function _getRequestContextCache(): RequestContextCache | null {
+  const ctx = getRequestExecutionContext() as ExecutionContextWithCache | null;
+  const cache = ctx?.cache;
+  if (
+    !cache ||
+    typeof cache !== "object" ||
+    typeof (cache as { purge?: unknown }).purge !== "function"
+  ) {
+    return null;
+  }
+  return cache as RequestContextCache;
+}
+
+/**
+ * Returns true when the current request's ExecutionContext exposes a
+ * compatible `ctx.cache.purge` method. Response builders use this to decide
+ * whether to emit headers (e.g. `Cache-Tag`) that are only meaningful when
+ * the outer cache is actually present to consume them.
+ */
+export function isRequestContextCacheAvailable(): boolean {
+  return _getRequestContextCache() !== null;
+}
+
+async function _purgeRequestContextCacheTags(tags: readonly string[]): Promise<void> {
+  if (tags.length === 0) return;
+  const cache = _getRequestContextCache();
+  if (!cache) return;
+  try {
+    await cache.purge({ tags: [...tags] });
+  } catch (err) {
+    // Outer cache failures must not break the revalidation that triggered
+    // them — the inner CacheHandler is the source of truth.
+    console.error("[vinext] request-context cache purge failed:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // CacheHandler interface — matches Next.js 16's CacheHandler class shape.
 // Implement this to provide a custom cache backend.
 // ---------------------------------------------------------------------------
@@ -66,6 +131,12 @@ export type CacheHandlerValue = {
   age?: number;
   cacheState?: string;
   cacheControl?: CacheControlMetadata;
+  /**
+   * Tags stored alongside the cache entry. Optional because not all
+   * `CacheHandler` adapters surface them on read — when missing, callers
+   * fall back to deriving tags from request context (e.g. pathname).
+   */
+  tags?: string[];
   value: IncrementalCacheValue | null;
 };
 
@@ -240,6 +311,7 @@ export class MemoryCacheHandler implements CacheHandler {
         value: entry.value,
         cacheState: "stale",
         cacheControl: entry.cacheControl,
+        tags: entry.tags,
       };
     }
 
@@ -247,6 +319,7 @@ export class MemoryCacheHandler implements CacheHandler {
       lastModified: entry.lastModified,
       value: entry.value,
       cacheControl: entry.cacheControl,
+      tags: entry.tags,
     };
   }
 
@@ -324,7 +397,8 @@ export class MemoryCacheHandler implements CacheHandler {
 // ---------------------------------------------------------------------------
 
 export type { ExecutionContextLike } from "./request-context.js";
-export { runWithExecutionContext, getRequestExecutionContext } from "./request-context.js";
+export { runWithExecutionContext } from "./request-context.js";
+export { getRequestExecutionContext };
 
 // ---------------------------------------------------------------------------
 // Active cache handler — the singleton used by next/cache API functions.
@@ -401,7 +475,11 @@ export async function revalidateTag(
   if (!profile || !durations || durations.expire === 0) {
     markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   }
-  await _getActiveHandler().revalidateTag(encodeCacheTag(tag), durations);
+  const encodedTag = encodeCacheTag(tag);
+  await Promise.all([
+    _getActiveHandler().revalidateTag(encodedTag, durations),
+    _purgeRequestContextCacheTags([encodedTag]),
+  ]);
 }
 
 /**
@@ -424,7 +502,15 @@ export async function revalidatePath(path: string, type?: "page" | "layout"): Pr
   // Strip trailing slash so root "/" becomes "" — avoids double-slash in _N_T_//layout
   const stem = path.endsWith("/") ? path.slice(0, -1) : path;
   const tag = type ? `_N_T_${stem}/${type}` : `_N_T_${stem || "/"}`;
-  await _getActiveHandler().revalidateTag(encodeCacheTag(tag));
+  const encodedTag = encodeCacheTag(tag);
+  // Purge the bare path tag from outer caches in addition to the `_N_T_`
+  // prefixed form. Responses emit the path itself as a Cache-Tag (see
+  // `buildAppPageCacheTags`), and that is what `ctx.cache.purge` matches on.
+  const outerTags = type ? [encodedTag] : [encodedTag, encodeCacheTag(stem || "/")];
+  await Promise.all([
+    _getActiveHandler().revalidateTag(encodedTag),
+    _purgeRequestContextCacheTags(outerTags),
+  ]);
 }
 
 /**
@@ -449,7 +535,11 @@ export function refresh(): void {
 export async function updateTag(tag: string): Promise<void> {
   markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Expire the tag immediately (same as revalidateTag without SWR)
-  await _getActiveHandler().revalidateTag(encodeCacheTag(tag));
+  const encodedTag = encodeCacheTag(tag);
+  await Promise.all([
+    _getActiveHandler().revalidateTag(encodedTag),
+    _purgeRequestContextCacheTags([encodedTag]),
+  ]);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,6 +897,43 @@ importers:
         specifier: 'catalog:'
         version: 0.1.22(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.6)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
 
+  examples/workers-cache-cloudflare:
+    dependencies:
+      '@cloudflare/vite-plugin':
+        specifier: 'catalog:'
+        version: 1.31.0(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(workerd@1.20260401.1)(wrangler@4.80.0)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))
+      '@vitejs/plugin-rsc':
+        specifier: 'catalog:'
+        version: 0.5.26(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      react-server-dom-webpack:
+        specifier: 'catalog:'
+        version: 19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      vinext:
+        specifier: workspace:*
+        version: link:../../packages/vinext
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.22
+        version: '@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)'
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.80.0(@cloudflare/workers-types@4.20260313.1)
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260313.1
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.22(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.6)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
+
   packages/vinext:
     dependencies:
       '@unpic/react':

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -41,6 +41,7 @@ CHECKS=(
   "nextra-docs-template          /about  About"
   "benchmarks                    /       Benchmark"
   "hackernews                    /       Hacker News"
+  "workers-cache-cloudflare      /       Request-context cache demo"
   "vinext-web                    /       Run your Next.js app on Vite"
 )
 

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -90,7 +90,9 @@ describe("app page cache helpers", () => {
     });
     expect(htmlResponse?.status).toBe(201);
     expect(htmlResponse?.headers.get("content-type")).toBe("text/html; charset=utf-8");
-    expect(htmlResponse?.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(htmlResponse?.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate",
+    );
     expect(htmlResponse?.headers.get("x-vinext-cache")).toBe("HIT");
     // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
@@ -106,7 +108,9 @@ describe("app page cache helpers", () => {
       }),
     );
     expect(rscResponse?.headers.get("content-type")).toBe("text/x-component");
-    expect(rscResponse?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(rscResponse?.headers.get("cache-control")).toBe(
+      "public, s-maxage=0, stale-while-revalidate",
+    );
     expect(rscResponse?.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
     expect(rscResponse?.headers.get("x-nextjs-cache")).toBe("STALE");
     expect(await rscResponse?.arrayBuffer()).toEqual(rscData);
@@ -236,7 +240,9 @@ describe("app page cache helpers", () => {
       scheduleBackgroundRegeneration: vi.fn(),
     });
 
-    expect(response?.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
+    expect(response?.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate=240",
+    );
   });
 
   it("emits static cache-control for cached indefinite app pages", async () => {
@@ -247,7 +253,7 @@ describe("app page cache helpers", () => {
     });
 
     expect(response?.headers.get("cache-control")).toBe(
-      "s-maxage=31536000, stale-while-revalidate",
+      "public, s-maxage=31536000, stale-while-revalidate",
     );
   });
 
@@ -276,7 +282,9 @@ describe("app page cache helpers", () => {
       scheduleBackgroundRegeneration: vi.fn(),
     });
 
-    expect(response?.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(response?.headers.get("cache-control")).toBe(
+      "public, s-maxage=0, stale-while-revalidate",
+    );
   });
 
   it("falls back to 200 for falsy cached status values", () => {
@@ -790,7 +798,7 @@ describe("app page cache helpers", () => {
         status: 201,
         headers: {
           "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -893,7 +901,7 @@ describe("app page cache helpers", () => {
       new Response("<h1>personalized</h1>", {
         headers: {
           "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -923,7 +931,7 @@ describe("app page cache helpers", () => {
       new Response("<h1>personalized</h1>", {
         headers: {
           "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -1039,7 +1047,7 @@ describe("app page cache helpers", () => {
       new Response("flight", {
         headers: {
           "Content-Type": "text/x-component",
-          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
           "X-Vinext-Cache": "MISS",
         },
       }),

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -91,7 +91,7 @@ describe("app page cache helpers", () => {
     expect(htmlResponse?.status).toBe(201);
     expect(htmlResponse?.headers.get("content-type")).toBe("text/html; charset=utf-8");
     expect(htmlResponse?.headers.get("cache-control")).toBe(
-      "public, s-maxage=60, stale-while-revalidate",
+      "public, max-age=60, stale-while-revalidate",
     );
     expect(htmlResponse?.headers.get("x-vinext-cache")).toBe("HIT");
     // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
@@ -109,7 +109,7 @@ describe("app page cache helpers", () => {
     );
     expect(rscResponse?.headers.get("content-type")).toBe("text/x-component");
     expect(rscResponse?.headers.get("cache-control")).toBe(
-      "public, s-maxage=0, stale-while-revalidate",
+      "public, max-age=0, stale-while-revalidate",
     );
     expect(rscResponse?.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
     expect(rscResponse?.headers.get("x-nextjs-cache")).toBe("STALE");
@@ -241,7 +241,7 @@ describe("app page cache helpers", () => {
     });
 
     expect(response?.headers.get("cache-control")).toBe(
-      "public, s-maxage=60, stale-while-revalidate=240",
+      "public, max-age=60, stale-while-revalidate=240",
     );
   });
 
@@ -253,7 +253,7 @@ describe("app page cache helpers", () => {
     });
 
     expect(response?.headers.get("cache-control")).toBe(
-      "public, s-maxage=31536000, stale-while-revalidate",
+      "public, max-age=31536000, stale-while-revalidate",
     );
   });
 
@@ -283,7 +283,7 @@ describe("app page cache helpers", () => {
     });
 
     expect(response?.headers.get("cache-control")).toBe(
-      "public, s-maxage=0, stale-while-revalidate",
+      "public, max-age=0, stale-while-revalidate",
     );
   });
 
@@ -798,7 +798,7 @@ describe("app page cache helpers", () => {
         status: 201,
         headers: {
           "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, max-age=60, stale-while-revalidate",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -901,7 +901,7 @@ describe("app page cache helpers", () => {
       new Response("<h1>personalized</h1>", {
         headers: {
           "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, max-age=60, stale-while-revalidate",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -931,7 +931,7 @@ describe("app page cache helpers", () => {
       new Response("<h1>personalized</h1>", {
         headers: {
           "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, max-age=60, stale-while-revalidate",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -1047,7 +1047,7 @@ describe("app page cache helpers", () => {
       new Response("flight", {
         headers: {
           "Content-Type": "text/x-component",
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate",
+          "Cache-Control": "public, max-age=60, stale-while-revalidate",
           "X-Vinext-Cache": "MISS",
         },
       }),

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -14,7 +14,26 @@ import {
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
+import {
+  runWithExecutionContext,
+  type ExecutionContextLike,
+} from "../packages/vinext/src/shims/request-context.js";
 import { withEnvVar } from "./env-test-helpers.js";
+
+function withRequestContextCache<T>(fn: () => T): T {
+  // Mock an ExecutionContext that exposes a compatible `ctx.cache.purge`.
+  // Response builders gate `Cache-Tag` emission on this being present —
+  // tests that exercise the header must opt in.
+  const ctx = {
+    cache: { purge: async () => undefined },
+    waitUntil: () => undefined,
+  } as unknown as ExecutionContextLike;
+  let captured!: T;
+  void runWithExecutionContext(ctx, () => {
+    captured = fn();
+  });
+  return captured;
+}
 
 function buildISRCacheEntry(
   value: CachedAppPageValue,
@@ -91,6 +110,59 @@ describe("app page cache helpers", () => {
     expect(rscResponse?.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
     expect(rscResponse?.headers.get("x-nextjs-cache")).toBe("STALE");
     expect(await rscResponse?.arrayBuffer()).toEqual(rscData);
+  });
+
+  it("emits a Cache-Tag header on cached HTML responses when tags are present and ctx.cache exists", () => {
+    const cachedValue = buildCachedAppPageValue("<h1>cached</h1>", undefined, 200);
+    const response = withRequestContextCache(() =>
+      buildAppPageCachedResponse(cachedValue, {
+        cacheState: "HIT",
+        cacheTags: ["/blog/hello", "_N_T_/blog/hello", "featured-post"],
+        isRscRequest: false,
+        revalidateSeconds: 60,
+      }),
+    );
+    // The Cache-Tag header is what `ctx.cache.purge({ tags })` consumes.
+    expect(response?.headers.get("Cache-Tag")).toBe("/blog/hello,_N_T_/blog/hello,featured-post");
+  });
+
+  it("emits a Cache-Tag header on cached RSC responses when tags are present and ctx.cache exists", () => {
+    const rscData = new TextEncoder().encode("flight").buffer;
+    const cachedValue = buildCachedAppPageValue("", rscData, 200);
+    const response = withRequestContextCache(() =>
+      buildAppPageCachedResponse(cachedValue, {
+        cacheState: "STALE",
+        cacheTags: ["/blog/hello"],
+        isRscRequest: true,
+        revalidateSeconds: 60,
+      }),
+    );
+    expect(response?.headers.get("Cache-Tag")).toBe("/blog/hello");
+  });
+
+  it("omits the Cache-Tag header when no tags are present", () => {
+    const cachedValue = buildCachedAppPageValue("<h1>cached</h1>", undefined, 200);
+    const response = withRequestContextCache(() =>
+      buildAppPageCachedResponse(cachedValue, {
+        cacheState: "HIT",
+        isRscRequest: false,
+        revalidateSeconds: 60,
+      }),
+    );
+    expect(response?.headers.has("Cache-Tag")).toBe(false);
+  });
+
+  it("omits the Cache-Tag header when the request context has no cache, even with tags", () => {
+    // No `runWithExecutionContext` wrapper — no outer cache to purge, so the
+    // header is purely advertising overhead and should be skipped.
+    const cachedValue = buildCachedAppPageValue("<h1>cached</h1>", undefined, 200);
+    const response = buildAppPageCachedResponse(cachedValue, {
+      cacheState: "HIT",
+      cacheTags: ["/blog/hello", "_N_T_/blog/hello"],
+      isRscRequest: false,
+      revalidateSeconds: 60,
+    });
+    expect(response?.headers.has("Cache-Tag")).toBe(false);
   });
 
   it("merges middleware response headers into cached HTML responses", async () => {

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -340,7 +340,7 @@ describe("app page dispatch", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=31536000, stale-while-revalidate",
+      "public, max-age=31536000, stale-while-revalidate",
     );
     expect(response.headers.get("x-vinext-cache")).toBe("HIT");
     await expect(response.text()).resolves.toBe("<html>static cached</html>");

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -339,7 +339,9 @@ describe("app page dispatch", () => {
     const response = await dispatchAppPage(options);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=31536000, stale-while-revalidate",
+    );
     expect(response.headers.get("x-vinext-cache")).toBe("HIT");
     await expect(response.text()).resolves.toBe("<html>static cached</html>");
   });

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -597,7 +597,7 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=1, stale-while-revalidate=2",
+      "public, max-age=1, stale-while-revalidate=2",
     );
     expect(response.headers.get("x-vinext-cache")).toBeNull();
     await expect(response.text()).resolves.toBe("<html>page</html>");
@@ -636,7 +636,7 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=1, stale-while-revalidate=2",
+      "public, max-age=1, stale-while-revalidate=2",
     );
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(common.isrSet).not.toHaveBeenCalled();
@@ -676,7 +676,7 @@ describe("app page render lifecycle", () => {
       revalidateSeconds: null,
     });
 
-    expect(response.headers.get("cache-control")).toBe("public, s-maxage=1");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=1");
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(consumeRequestCacheLife()).toEqual({ revalidate: 1, expire: 1 });
   });
@@ -712,7 +712,7 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=1, stale-while-revalidate=2",
+      "public, max-age=1, stale-while-revalidate=2",
     );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("<html>page</html>");

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -596,7 +596,9 @@ describe("app page render lifecycle", () => {
       revalidateSeconds: 1,
     });
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=1, stale-while-revalidate=2",
+    );
     expect(response.headers.get("x-vinext-cache")).toBeNull();
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(common.waitUntilPromises).toHaveLength(0);
@@ -633,7 +635,9 @@ describe("app page render lifecycle", () => {
       revalidateSeconds: null,
     });
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=1, stale-while-revalidate=2",
+    );
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(common.isrSet).not.toHaveBeenCalled();
   });
@@ -672,7 +676,7 @@ describe("app page render lifecycle", () => {
       revalidateSeconds: null,
     });
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=1");
+    expect(response.headers.get("cache-control")).toBe("public, s-maxage=1");
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(consumeRequestCacheLife()).toEqual({ revalidate: 1, expire: 1 });
   });
@@ -707,7 +711,9 @@ describe("app page render lifecycle", () => {
       revalidateSeconds: null,
     });
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=1, stale-while-revalidate=2",
+    );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(common.waitUntilPromises).toHaveLength(0);

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -10,7 +10,23 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import {
+  runWithExecutionContext,
+  type ExecutionContextLike,
+} from "../packages/vinext/src/shims/request-context.js";
 import { withEnvVar } from "./env-test-helpers.js";
+
+function withRequestContextCache<T>(fn: () => T): T {
+  const ctx = {
+    cache: { purge: async () => undefined },
+    waitUntil: () => undefined,
+  } as unknown as ExecutionContextLike;
+  let captured!: T;
+  void runWithExecutionContext(ctx, () => {
+    captured = fn();
+  });
+  return captured;
+}
 
 function createBody(text: string): ReadableStream {
   return new ReadableStream({
@@ -521,6 +537,40 @@ describe("app page response helpers", () => {
     });
 
     expect(response.headers.get("x-edge-runtime")).toBeNull();
+  });
+
+  it("emits Cache-Tag on fresh-rendered RSC responses when ctx.cache exists", () => {
+    // Without the gate, the outer Workers Cache would cache the response with
+    // no purgeable tags — revalidateTag/revalidatePath fan-outs would then
+    // have nothing to match. Regression test for that.
+    const response = withRequestContextCache(() =>
+      buildAppPageRscResponse(createBody("flight"), {
+        cacheTags: ["/cached/intro", "_N_T_/cached/intro"],
+        middlewareContext: { headers: null, status: null },
+        policy: { cacheControl: "s-maxage=60, stale-while-revalidate" },
+      }),
+    );
+    expect(response.headers.get("Cache-Tag")).toBe("/cached/intro,_N_T_/cached/intro");
+  });
+
+  it("omits Cache-Tag on fresh-rendered RSC responses when ctx.cache is absent", () => {
+    const response = buildAppPageRscResponse(createBody("flight"), {
+      cacheTags: ["/cached/intro"],
+      middlewareContext: { headers: null, status: null },
+      policy: { cacheControl: "s-maxage=60, stale-while-revalidate" },
+    });
+    expect(response.headers.has("Cache-Tag")).toBe(false);
+  });
+
+  it("emits Cache-Tag on fresh-rendered HTML responses when ctx.cache exists", () => {
+    const response = withRequestContextCache(() =>
+      buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
+        cacheTags: ["/cached/intro", "_N_T_/cached/intro"],
+        middlewareContext: { headers: null, status: null },
+        policy: { cacheControl: "s-maxage=60, stale-while-revalidate" },
+      }),
+    );
+    expect(response.headers.get("Cache-Tag")).toBe("/cached/intro,_N_T_/cached/intro");
   });
 });
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -50,7 +50,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: null,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
       cacheState: "STATIC",
     });
 
@@ -66,7 +66,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate=240",
+      cacheControl: "public, s-maxage=60, stale-while-revalidate=240",
       cacheState: "MISS",
     });
   });
@@ -97,7 +97,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: Infinity,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
       cacheState: "STATIC",
     });
 
@@ -191,7 +191,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, s-maxage=60, stale-while-revalidate",
       cacheState: undefined,
       shouldWriteToCache: false,
     });
@@ -208,7 +208,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: Infinity,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
       cacheState: "STATIC",
       shouldWriteToCache: false,
     });
@@ -227,7 +227,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, s-maxage=60, stale-while-revalidate",
       cacheState: "MISS",
       shouldWriteToCache: true,
     });
@@ -330,7 +330,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, s-maxage=60, stale-while-revalidate",
       cacheState: "MISS",
     });
 
@@ -346,7 +346,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, s-maxage=60, stale-while-revalidate",
       cacheState: "MISS",
       shouldWriteToCache: true,
     });
@@ -383,7 +383,7 @@ describe("app page response helpers", () => {
       },
       params: { slug: "test" },
       policy: {
-        cacheControl: "s-maxage=60, stale-while-revalidate",
+        cacheControl: "public, s-maxage=60, stale-while-revalidate",
         cacheState: "MISS",
       },
       timing: {
@@ -488,7 +488,7 @@ describe("app page response helpers", () => {
         status: 203,
       },
       policy: {
-        cacheControl: "s-maxage=31536000, stale-while-revalidate",
+        cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
         cacheState: "STATIC",
       },
       timing: {
@@ -547,7 +547,7 @@ describe("app page response helpers", () => {
       buildAppPageRscResponse(createBody("flight"), {
         cacheTags: ["/cached/intro", "_N_T_/cached/intro"],
         middlewareContext: { headers: null, status: null },
-        policy: { cacheControl: "s-maxage=60, stale-while-revalidate" },
+        policy: { cacheControl: "public, s-maxage=60, stale-while-revalidate" },
       }),
     );
     expect(response.headers.get("Cache-Tag")).toBe("/cached/intro,_N_T_/cached/intro");
@@ -557,7 +557,7 @@ describe("app page response helpers", () => {
     const response = buildAppPageRscResponse(createBody("flight"), {
       cacheTags: ["/cached/intro"],
       middlewareContext: { headers: null, status: null },
-      policy: { cacheControl: "s-maxage=60, stale-while-revalidate" },
+      policy: { cacheControl: "public, s-maxage=60, stale-while-revalidate" },
     });
     expect(response.headers.has("Cache-Tag")).toBe(false);
   });
@@ -567,7 +567,7 @@ describe("app page response helpers", () => {
       buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
         cacheTags: ["/cached/intro", "_N_T_/cached/intro"],
         middlewareContext: { headers: null, status: null },
-        policy: { cacheControl: "s-maxage=60, stale-while-revalidate" },
+        policy: { cacheControl: "public, s-maxage=60, stale-while-revalidate" },
       }),
     );
     expect(response.headers.get("Cache-Tag")).toBe("/cached/intro,_N_T_/cached/intro");

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -50,7 +50,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: null,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
+      cacheControl: "public, max-age=31536000, stale-while-revalidate",
       cacheState: "STATIC",
     });
 
@@ -66,7 +66,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=60, stale-while-revalidate=240",
+      cacheControl: "public, max-age=60, stale-while-revalidate=240",
       cacheState: "MISS",
     });
   });
@@ -97,7 +97,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: Infinity,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
+      cacheControl: "public, max-age=31536000, stale-while-revalidate",
       cacheState: "STATIC",
     });
 
@@ -191,7 +191,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, max-age=60, stale-while-revalidate",
       cacheState: undefined,
       shouldWriteToCache: false,
     });
@@ -208,7 +208,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: Infinity,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
+      cacheControl: "public, max-age=31536000, stale-while-revalidate",
       cacheState: "STATIC",
       shouldWriteToCache: false,
     });
@@ -227,7 +227,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, max-age=60, stale-while-revalidate",
       cacheState: "MISS",
       shouldWriteToCache: true,
     });
@@ -330,7 +330,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, max-age=60, stale-while-revalidate",
       cacheState: "MISS",
     });
 
@@ -346,7 +346,7 @@ describe("app page response helpers", () => {
         revalidateSeconds: 60,
       }),
     ).toEqual({
-      cacheControl: "public, s-maxage=60, stale-while-revalidate",
+      cacheControl: "public, max-age=60, stale-while-revalidate",
       cacheState: "MISS",
       shouldWriteToCache: true,
     });
@@ -383,7 +383,7 @@ describe("app page response helpers", () => {
       },
       params: { slug: "test" },
       policy: {
-        cacheControl: "public, s-maxage=60, stale-while-revalidate",
+        cacheControl: "public, max-age=60, stale-while-revalidate",
         cacheState: "MISS",
       },
       timing: {
@@ -488,7 +488,7 @@ describe("app page response helpers", () => {
         status: 203,
       },
       policy: {
-        cacheControl: "public, s-maxage=31536000, stale-while-revalidate",
+        cacheControl: "public, max-age=31536000, stale-while-revalidate",
         cacheState: "STATIC",
       },
       timing: {
@@ -547,7 +547,7 @@ describe("app page response helpers", () => {
       buildAppPageRscResponse(createBody("flight"), {
         cacheTags: ["/cached/intro", "_N_T_/cached/intro"],
         middlewareContext: { headers: null, status: null },
-        policy: { cacheControl: "public, s-maxage=60, stale-while-revalidate" },
+        policy: { cacheControl: "public, max-age=60, stale-while-revalidate" },
       }),
     );
     expect(response.headers.get("Cache-Tag")).toBe("/cached/intro,_N_T_/cached/intro");
@@ -557,7 +557,7 @@ describe("app page response helpers", () => {
     const response = buildAppPageRscResponse(createBody("flight"), {
       cacheTags: ["/cached/intro"],
       middlewareContext: { headers: null, status: null },
-      policy: { cacheControl: "public, s-maxage=60, stale-while-revalidate" },
+      policy: { cacheControl: "public, max-age=60, stale-while-revalidate" },
     });
     expect(response.headers.has("Cache-Tag")).toBe(false);
   });
@@ -567,7 +567,7 @@ describe("app page response helpers", () => {
       buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
         cacheTags: ["/cached/intro", "_N_T_/cached/intro"],
         middlewareContext: { headers: null, status: null },
-        policy: { cacheControl: "public, s-maxage=60, stale-while-revalidate" },
+        policy: { cacheControl: "public, max-age=60, stale-while-revalidate" },
       }),
     );
     expect(response.headers.get("Cache-Tag")).toBe("/cached/intro,_N_T_/cached/intro");

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -182,7 +182,9 @@ describe("app route handler execution helpers", () => {
     await Promise.all(waitUntilPromises);
 
     expect(response.status).toBe(202);
-    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate=240",
+    );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("x-middleware")).toBe("present");
     expect(response.headers.getSetCookie?.()).toEqual(["session=1; Path=/", "draft=1; Path=/"]);

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -183,7 +183,7 @@ describe("app route handler execution helpers", () => {
 
     expect(response.status).toBe(202);
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=60, stale-while-revalidate=240",
+      "public, max-age=60, stale-while-revalidate=240",
     );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("x-middleware")).toBe("present");

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -39,7 +39,7 @@ describe("app route handler response helpers", () => {
       status: 200,
       headers: {
         "content-type": "text/plain",
-        "cache-control": "public, s-maxage=60, stale-while-revalidate",
+        "cache-control": "public, max-age=60, stale-while-revalidate",
         "x-response": "app",
       },
     });
@@ -102,7 +102,7 @@ describe("app route handler response helpers", () => {
     });
     expect(hit.headers.get("x-vinext-cache")).toBe("HIT");
     expect(hit.headers.get("x-nextjs-cache")).toBe("HIT");
-    expect(hit.headers.get("cache-control")).toBe("public, s-maxage=60, stale-while-revalidate");
+    expect(hit.headers.get("cache-control")).toBe("public, max-age=60, stale-while-revalidate");
     await expect(hit.text()).resolves.toBe("from-cache");
 
     const staleHead = buildRouteHandlerCachedResponse(cachedValue, {
@@ -114,7 +114,7 @@ describe("app route handler response helpers", () => {
     expect(staleHead.headers.get("x-vinext-cache")).toBe("STALE");
     expect(staleHead.headers.get("x-nextjs-cache")).toBe("STALE");
     expect(staleHead.headers.get("cache-control")).toBe(
-      "public, s-maxage=0, stale-while-revalidate",
+      "public, max-age=0, stale-while-revalidate",
     );
     await expect(staleHead.text()).resolves.toBe("");
   });
@@ -131,7 +131,7 @@ describe("app route handler response helpers", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=15, stale-while-revalidate=285",
+      "public, max-age=15, stale-while-revalidate=285",
     );
   });
 
@@ -144,7 +144,7 @@ describe("app route handler response helpers", () => {
     });
     expect(response.headers.get("x-vinext-cache")).toBe("HIT");
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=31536000, stale-while-revalidate",
+      "public, max-age=31536000, stale-while-revalidate",
     );
   });
 
@@ -152,7 +152,7 @@ describe("app route handler response helpers", () => {
     const response = new Response("fresh");
     applyRouteHandlerRevalidateHeader(response, Infinity);
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=31536000, stale-while-revalidate",
+      "public, max-age=31536000, stale-while-revalidate",
     );
   });
 
@@ -161,7 +161,7 @@ describe("app route handler response helpers", () => {
       status: 201,
       headers: {
         "content-type": "text/plain",
-        "cache-control": "public, s-maxage=60, stale-while-revalidate",
+        "cache-control": "public, max-age=60, stale-while-revalidate",
         "x-vinext-cache": "MISS",
         "x-nextjs-cache": "MISS",
         "x-middleware-set-cookie": "internal=1; Path=/",
@@ -309,7 +309,7 @@ describe("app route handler response helpers", () => {
     markRouteHandlerCacheMiss(response);
 
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=30, stale-while-revalidate",
+      "public, max-age=30, stale-while-revalidate",
     );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
   });
@@ -341,7 +341,7 @@ describe("app route handler response helpers", () => {
   it("emits a no-store Cache-Control for revalidate = 0 route handlers", () => {
     // A handler exporting `revalidate = 0` opts out of caching entirely.
     // The Cache-Control must tell browsers and CDNs never to store the
-    // response. Emitting `s-maxage=0, stale-while-revalidate` (the SWR
+    // response. Emitting `max-age=0, stale-while-revalidate` (the SWR
     // template) would still permit intermediate caches to serve stale
     // copies, which is the exact opposite of the author's intent.
     // The exact string matches Next.js's own cache-control helper:

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -39,7 +39,7 @@ describe("app route handler response helpers", () => {
       status: 200,
       headers: {
         "content-type": "text/plain",
-        "cache-control": "s-maxage=60, stale-while-revalidate",
+        "cache-control": "public, s-maxage=60, stale-while-revalidate",
         "x-response": "app",
       },
     });
@@ -102,7 +102,7 @@ describe("app route handler response helpers", () => {
     });
     expect(hit.headers.get("x-vinext-cache")).toBe("HIT");
     expect(hit.headers.get("x-nextjs-cache")).toBe("HIT");
-    expect(hit.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(hit.headers.get("cache-control")).toBe("public, s-maxage=60, stale-while-revalidate");
     await expect(hit.text()).resolves.toBe("from-cache");
 
     const staleHead = buildRouteHandlerCachedResponse(cachedValue, {
@@ -113,7 +113,9 @@ describe("app route handler response helpers", () => {
     });
     expect(staleHead.headers.get("x-vinext-cache")).toBe("STALE");
     expect(staleHead.headers.get("x-nextjs-cache")).toBe("STALE");
-    expect(staleHead.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(staleHead.headers.get("cache-control")).toBe(
+      "public, s-maxage=0, stale-while-revalidate",
+    );
     await expect(staleHead.text()).resolves.toBe("");
   });
 
@@ -128,7 +130,9 @@ describe("app route handler response helpers", () => {
       revalidateSeconds: 60,
     });
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=15, stale-while-revalidate=285");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=15, stale-while-revalidate=285",
+    );
   });
 
   it("emits static cache-control for revalidateSeconds = Infinity (revalidate = false)", () => {
@@ -139,13 +143,17 @@ describe("app route handler response helpers", () => {
       revalidateSeconds: Infinity,
     });
     expect(response.headers.get("x-vinext-cache")).toBe("HIT");
-    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=31536000, stale-while-revalidate",
+    );
   });
 
   it("applies revalidate header for Infinity as static cache-control", () => {
     const response = new Response("fresh");
     applyRouteHandlerRevalidateHeader(response, Infinity);
-    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=31536000, stale-while-revalidate",
+    );
   });
 
   it("serializes APP_ROUTE cache values without cache bookkeeping headers", async () => {
@@ -153,7 +161,7 @@ describe("app route handler response helpers", () => {
       status: 201,
       headers: {
         "content-type": "text/plain",
-        "cache-control": "s-maxage=60, stale-while-revalidate",
+        "cache-control": "public, s-maxage=60, stale-while-revalidate",
         "x-vinext-cache": "MISS",
         "x-nextjs-cache": "MISS",
         "x-middleware-set-cookie": "internal=1; Path=/",
@@ -300,7 +308,9 @@ describe("app route handler response helpers", () => {
     applyRouteHandlerRevalidateHeader(response, 30);
     markRouteHandlerCacheMiss(response);
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=30, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=30, stale-while-revalidate",
+    );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
   });
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1698,9 +1698,9 @@ describe("App Router integration", () => {
     expect(html).toContain("Force Static Page");
     expect(html).toContain('data-testid="static-test-page"');
 
-    // force-static should set s-maxage for indefinite caching
+    // force-static should set max-age for indefinite caching
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("public, s-maxage=31536000");
+    expect(cacheControl).toContain("public, max-age=31536000");
     expect(res.headers.get("x-vinext-cache")).toBe("STATIC");
   });
 
@@ -1723,7 +1723,7 @@ describe("App Router integration", () => {
     expect(html).toContain('data-testid="error-dynamic-page"');
     // Should be treated as static — long-lived cache
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("public, s-maxage=31536000");
+    expect(cacheControl).toContain("public, max-age=31536000");
     expect(res.headers.get("x-vinext-cache")).toBe("STATIC");
   });
 
@@ -1839,9 +1839,9 @@ describe("App Router integration", () => {
     expect(html).toContain("ISR Revalidate Page");
     expect(html).toContain('data-testid="revalidate-test-page"');
 
-    // revalidate=60 should set s-maxage=60 on first request (cache MISS)
+    // revalidate=60 should set max-age=60 on first request (cache MISS)
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("public, s-maxage=60");
+    expect(cacheControl).toContain("public, max-age=60");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 
@@ -1851,7 +1851,7 @@ describe("App Router integration", () => {
     expect(await res.text()).toContain('data-testid="layout-segment-config-revalidate"');
 
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("public, s-maxage=30");
+    expect(cacheControl).toContain("public, max-age=30");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -1700,7 +1700,7 @@ describe("App Router integration", () => {
 
     // force-static should set s-maxage for indefinite caching
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("s-maxage=31536000");
+    expect(cacheControl).toContain("public, s-maxage=31536000");
     expect(res.headers.get("x-vinext-cache")).toBe("STATIC");
   });
 
@@ -1723,7 +1723,7 @@ describe("App Router integration", () => {
     expect(html).toContain('data-testid="error-dynamic-page"');
     // Should be treated as static — long-lived cache
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("s-maxage=31536000");
+    expect(cacheControl).toContain("public, s-maxage=31536000");
     expect(res.headers.get("x-vinext-cache")).toBe("STATIC");
   });
 
@@ -1841,7 +1841,7 @@ describe("App Router integration", () => {
 
     // revalidate=60 should set s-maxage=60 on first request (cache MISS)
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("s-maxage=60");
+    expect(cacheControl).toContain("public, s-maxage=60");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 
@@ -1851,7 +1851,7 @@ describe("App Router integration", () => {
     expect(await res.text()).toContain('data-testid="layout-segment-config-revalidate"');
 
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("s-maxage=30");
+    expect(cacheControl).toContain("public, s-maxage=30");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -7,45 +7,45 @@ import {
 describe("cache-control helpers", () => {
   it("uses Next.js expire minus revalidate for finite SWR windows", () => {
     expect(buildRevalidateCacheControl(60, 300)).toBe(
-      "public, s-maxage=60, stale-while-revalidate=240",
+      "public, max-age=60, stale-while-revalidate=240",
     );
   });
 
   it("omits stale-while-revalidate when expire does not exceed revalidate", () => {
-    expect(buildRevalidateCacheControl(300, 300)).toBe("public, s-maxage=300");
+    expect(buildRevalidateCacheControl(300, 300)).toBe("public, max-age=300");
   });
 
   it("preserves vinext's legacy unbounded SWR header when expire is unknown", () => {
-    expect(buildRevalidateCacheControl(60)).toBe("public, s-maxage=60, stale-while-revalidate");
+    expect(buildRevalidateCacheControl(60)).toBe("public, max-age=60, stale-while-revalidate");
   });
 
   it("uses route policy for STALE cached responses when expire is known", () => {
     expect(buildCachedRevalidateCacheControl("STALE", 60, 300)).toBe(
-      "public, s-maxage=60, stale-while-revalidate=240",
+      "public, max-age=60, stale-while-revalidate=240",
     );
   });
 
   it("uses route policy for HIT cached responses when expire is known", () => {
     expect(buildCachedRevalidateCacheControl("HIT", 60, 300)).toBe(
-      "public, s-maxage=60, stale-while-revalidate=240",
+      "public, max-age=60, stale-while-revalidate=240",
     );
   });
 
   it("uses static cache-control for cached indefinite responses", () => {
     expect(buildCachedRevalidateCacheControl("HIT", Infinity)).toBe(
-      "public, s-maxage=31536000, stale-while-revalidate",
+      "public, max-age=31536000, stale-while-revalidate",
     );
   });
 
   it("preserves legacy STALE cached response headers when expire is unknown", () => {
     expect(buildCachedRevalidateCacheControl("STALE", 60)).toBe(
-      "public, s-maxage=0, stale-while-revalidate",
+      "public, max-age=0, stale-while-revalidate",
     );
   });
 
   it("keeps the full expire window when revalidate is zero", () => {
     expect(buildRevalidateCacheControl(0, 300)).toBe(
-      "public, s-maxage=0, stale-while-revalidate=300",
+      "public, max-age=0, stale-while-revalidate=300",
     );
   });
 });

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -6,42 +6,46 @@ import {
 
 describe("cache-control helpers", () => {
   it("uses Next.js expire minus revalidate for finite SWR windows", () => {
-    expect(buildRevalidateCacheControl(60, 300)).toBe("s-maxage=60, stale-while-revalidate=240");
+    expect(buildRevalidateCacheControl(60, 300)).toBe(
+      "public, s-maxage=60, stale-while-revalidate=240",
+    );
   });
 
   it("omits stale-while-revalidate when expire does not exceed revalidate", () => {
-    expect(buildRevalidateCacheControl(300, 300)).toBe("s-maxage=300");
+    expect(buildRevalidateCacheControl(300, 300)).toBe("public, s-maxage=300");
   });
 
   it("preserves vinext's legacy unbounded SWR header when expire is unknown", () => {
-    expect(buildRevalidateCacheControl(60)).toBe("s-maxage=60, stale-while-revalidate");
+    expect(buildRevalidateCacheControl(60)).toBe("public, s-maxage=60, stale-while-revalidate");
   });
 
   it("uses route policy for STALE cached responses when expire is known", () => {
     expect(buildCachedRevalidateCacheControl("STALE", 60, 300)).toBe(
-      "s-maxage=60, stale-while-revalidate=240",
+      "public, s-maxage=60, stale-while-revalidate=240",
     );
   });
 
   it("uses route policy for HIT cached responses when expire is known", () => {
     expect(buildCachedRevalidateCacheControl("HIT", 60, 300)).toBe(
-      "s-maxage=60, stale-while-revalidate=240",
+      "public, s-maxage=60, stale-while-revalidate=240",
     );
   });
 
   it("uses static cache-control for cached indefinite responses", () => {
     expect(buildCachedRevalidateCacheControl("HIT", Infinity)).toBe(
-      "s-maxage=31536000, stale-while-revalidate",
+      "public, s-maxage=31536000, stale-while-revalidate",
     );
   });
 
   it("preserves legacy STALE cached response headers when expire is unknown", () => {
     expect(buildCachedRevalidateCacheControl("STALE", 60)).toBe(
-      "s-maxage=0, stale-while-revalidate",
+      "public, s-maxage=0, stale-while-revalidate",
     );
   });
 
   it("keeps the full expire window when revalidate is zero", () => {
-    expect(buildRevalidateCacheControl(0, 300)).toBe("s-maxage=0, stale-while-revalidate=300");
+    expect(buildRevalidateCacheControl(0, 300)).toBe(
+      "public, s-maxage=0, stale-while-revalidate=300",
+    );
   });
 });

--- a/tests/cache-headers.test.ts
+++ b/tests/cache-headers.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the cache header helpers shared by the App Router and the
+ * Pages Router response builders. `applyCacheTagHeader` formats the
+ * `Cache-Tag` header that the Cloudflare Workers Cache reads for tag-based
+ * purging — its behaviour around budgets, dedupe, and empty inputs is what
+ * the page/route handler responses rely on.
+ */
+
+import { describe, it, expect } from "vite-plus/test";
+
+import {
+  applyCacheTagHeader,
+  setCacheStateHeaders,
+} from "../packages/vinext/src/server/cache-headers.js";
+
+describe("applyCacheTagHeader", () => {
+  it("joins tags with commas and writes a Cache-Tag header", () => {
+    const headers = new Headers();
+    applyCacheTagHeader(headers, ["a", "b", "c"]);
+    expect(headers.get("Cache-Tag")).toBe("a,b,c");
+  });
+
+  it("does nothing when the tag list is empty", () => {
+    const headers = new Headers();
+    applyCacheTagHeader(headers, []);
+    expect(headers.has("Cache-Tag")).toBe(false);
+  });
+
+  it("dedupes repeated tags", () => {
+    const headers = new Headers();
+    applyCacheTagHeader(headers, ["a", "a", "b", "b", "c"]);
+    expect(headers.get("Cache-Tag")).toBe("a,b,c");
+  });
+
+  it("skips empty-string entries defensively", () => {
+    const headers = new Headers();
+    applyCacheTagHeader(headers, ["", "a", "", "b"]);
+    expect(headers.get("Cache-Tag")).toBe("a,b");
+  });
+
+  it("truncates the rendered list at the byte budget", () => {
+    // 1 KiB tag * 20 ≈ 20 KiB, which exceeds the 15 KiB budget. The header
+    // must not exceed the budget — the runtime would silently truncate
+    // anything over 16 KiB, so we cap ourselves first.
+    const bigTag = "x".repeat(1024);
+    const headers = new Headers();
+    applyCacheTagHeader(
+      headers,
+      Array.from({ length: 20 }, (_, i) => `${bigTag}${i}`),
+    );
+    const value = headers.get("Cache-Tag") ?? "";
+    expect(value.length).toBeGreaterThan(0);
+    expect(value.length).toBeLessThanOrEqual(15 * 1024);
+  });
+
+  it("does not overwrite an existing Cache-Tag header when no new tags would be written", () => {
+    const headers = new Headers({ "Cache-Tag": "existing" });
+    applyCacheTagHeader(headers, []);
+    expect(headers.get("Cache-Tag")).toBe("existing");
+  });
+});
+
+describe("setCacheStateHeaders", () => {
+  it("emits both vinext and next.js cache state headers", () => {
+    const headers = new Headers();
+    setCacheStateHeaders(headers, "HIT");
+    expect(headers.get("X-Vinext-Cache")).toBe("HIT");
+    expect(headers.get("x-nextjs-cache")).toBe("HIT");
+  });
+
+  it("maps STATIC to HIT on the next.js header", () => {
+    const headers = new Headers();
+    setCacheStateHeaders(headers, "STATIC");
+    expect(headers.get("X-Vinext-Cache")).toBe("STATIC");
+    expect(headers.get("x-nextjs-cache")).toBe("HIT");
+  });
+});

--- a/tests/e2e/app-router/api-routes.spec.ts
+++ b/tests/e2e/app-router/api-routes.spec.ts
@@ -264,15 +264,15 @@ test.describe("Route Handler HTTP Methods (OpenNext compat)", () => {
  * Tests: ON-3 #13-14 in TRACKING.md
  *
  * In Next.js, a GET-only route handler with `export const revalidate = N`
- * receives Cache-Control: s-maxage=N, stale-while-revalidate.
+ * receives Cache-Control: max-age=N, stale-while-revalidate.
  */
 test.describe("Route Handler Cache Headers (OpenNext compat)", () => {
   // Ref: opennextjs-cloudflare methods.test.ts — static GET cache headers
-  test("static GET route handler has s-maxage Cache-Control", async ({ request }) => {
+  test("static GET route handler has max-age Cache-Control", async ({ request }) => {
     const res = await request.get(`${BASE}/api/static-data`);
     expect(res.status()).toBe(200);
     const cacheControl = res.headers()["cache-control"];
-    expect(cacheControl).toContain("s-maxage=1");
+    expect(cacheControl).toContain("max-age=1");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 

--- a/tests/e2e/app-router/isr.spec.ts
+++ b/tests/e2e/app-router/isr.spec.ts
@@ -70,12 +70,12 @@ test.describe("App Router ISR", () => {
     expect(hitRes.headers()["x-vinext-cache"]).toBe("HIT");
   });
 
-  test("Cache-Control header includes s-maxage and stale-while-revalidate", async ({ request }) => {
+  test("Cache-Control header includes max-age and stale-while-revalidate", async ({ request }) => {
     const res = await request.get(`${BASE}/isr-test`);
     const cc = res.headers()["cache-control"];
 
     expect(cc).toBeDefined();
-    expect(cc).toContain("s-maxage=1");
+    expect(cc).toContain("max-age=1");
     expect(cc).toContain("stale-while-revalidate");
   });
 
@@ -107,7 +107,7 @@ test.describe("App Router ISR", () => {
     const cc = res.headers()["cache-control"];
 
     expect(cc).toBeDefined();
-    expect(cc).toContain("s-maxage=60");
+    expect(cc).toContain("max-age=60");
     expect(cc).toContain("stale-while-revalidate");
   });
 });
@@ -189,9 +189,11 @@ test.describe("ISR dynamicParams cache headers", () => {
 
     const cc = res.headers()["cache-control"];
     if (cc) {
-      // Should not have s-maxage or stale-while-revalidate on 404
-      expect(cc).not.toContain("s-maxage");
+      // Should not advertise positive caching on a 404 — `max-age=0` is
+      // allowed as part of an explicit never-cache header, but a positive
+      // s/maxage value or any stale-while-revalidate window is not.
       expect(cc).not.toContain("stale-while-revalidate");
+      expect(cc).toMatch(/no-cache|no-store|max-age=0/);
     }
   });
 });

--- a/tests/e2e/pages-router/isr.spec.ts
+++ b/tests/e2e/pages-router/isr.spec.ts
@@ -83,12 +83,12 @@ test.describe("Pages Router ISR", () => {
     expect(hitRes.headers()["x-vinext-cache"]).toBe("HIT");
   });
 
-  test("Cache-Control header includes s-maxage and stale-while-revalidate", async ({ request }) => {
+  test("Cache-Control header includes max-age and stale-while-revalidate", async ({ request }) => {
     const res = await request.get(`${BASE}/isr-test`);
     const cc = res.headers()["cache-control"];
 
     expect(cc).toBeDefined();
-    expect(cc).toContain("s-maxage=1");
+    expect(cc).toContain("max-age=1");
     expect(cc).toContain("stale-while-revalidate");
   });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -591,7 +591,7 @@ describe("ISR (Pages Router)", () => {
     expect(html).toContain("Hello from ISR");
     // First request should be a cache miss
     expect(res.headers.get("x-vinext-cache")).toBe("MISS");
-    expect(res.headers.get("cache-control")).toContain("s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
   });
 
   it("serves cached ISR page on second request (cache HIT)", async () => {
@@ -687,7 +687,7 @@ describe("ISR (Pages Router)", () => {
   it("sets Cache-Control header for ISR pages", async () => {
     const res = await fetch(`${baseUrl}/isr-test`);
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("s-maxage=1");
+    expect(cacheControl).toContain("public, s-maxage=1");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 
@@ -728,7 +728,7 @@ describe("ISR (App Router)", () => {
     const html = await res.text();
     expect(html).toContain("App Router ISR Test");
     expect(html).toContain("Hello from ISR");
-    expect(res.headers.get("cache-control")).toContain("s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
     expect(res.headers.get("cache-control")).toContain("stale-while-revalidate");
   });
 
@@ -751,7 +751,7 @@ describe("ISR (App Router)", () => {
     // ISR cache reads/writes are prod-only, so no X-Vinext-Cache in dev
     expect(res.headers.get("x-vinext-cache")).toBeNull();
     // Cache-Control IS still emitted for RSC responses on ISR pages
-    expect(res.headers.get("cache-control")).toContain("s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
     expect(res.headers.get("cache-control")).toContain("stale-while-revalidate");
   });
 
@@ -762,7 +762,7 @@ describe("ISR (App Router)", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/x-component");
     // Prefetch RSC requests should also get Cache-Control (no X-Vinext-Cache in dev)
-    expect(res.headers.get("cache-control")).toContain("s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
     expect(res.headers.get("x-vinext-cache")).toBeNull();
   });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -591,7 +591,7 @@ describe("ISR (Pages Router)", () => {
     expect(html).toContain("Hello from ISR");
     // First request should be a cache miss
     expect(res.headers.get("x-vinext-cache")).toBe("MISS");
-    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, max-age=1");
   });
 
   it("serves cached ISR page on second request (cache HIT)", async () => {
@@ -687,7 +687,7 @@ describe("ISR (Pages Router)", () => {
   it("sets Cache-Control header for ISR pages", async () => {
     const res = await fetch(`${baseUrl}/isr-test`);
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("public, s-maxage=1");
+    expect(cacheControl).toContain("public, max-age=1");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 
@@ -728,7 +728,7 @@ describe("ISR (App Router)", () => {
     const html = await res.text();
     expect(html).toContain("App Router ISR Test");
     expect(html).toContain("Hello from ISR");
-    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, max-age=1");
     expect(res.headers.get("cache-control")).toContain("stale-while-revalidate");
   });
 
@@ -751,7 +751,7 @@ describe("ISR (App Router)", () => {
     // ISR cache reads/writes are prod-only, so no X-Vinext-Cache in dev
     expect(res.headers.get("x-vinext-cache")).toBeNull();
     // Cache-Control IS still emitted for RSC responses on ISR pages
-    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, max-age=1");
     expect(res.headers.get("cache-control")).toContain("stale-while-revalidate");
   });
 
@@ -762,7 +762,7 @@ describe("ISR (App Router)", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/x-component");
     // Prefetch RSC requests should also get Cache-Control (no X-Vinext-Cache in dev)
-    expect(res.headers.get("cache-control")).toContain("public, s-maxage=1");
+    expect(res.headers.get("cache-control")).toContain("public, max-age=1");
     expect(res.headers.get("x-vinext-cache")).toBeNull();
   });
 
@@ -771,8 +771,10 @@ describe("ISR (App Router)", () => {
     const res = await fetch(`${baseUrl}/`);
     expect(res.status).toBe(200);
     expect(res.headers.get("x-vinext-cache")).toBeNull();
-    // No ISR Cache-Control on dynamic pages
-    expect(res.headers.get("cache-control") ?? "").not.toContain("s-maxage");
+    // No ISR Cache-Control on dynamic pages — no positive cacheability.
+    const cc = res.headers.get("cache-control") ?? "";
+    expect(cc).not.toContain("stale-while-revalidate");
+    expect(cc === "" || /no-cache|no-store|max-age=0/.test(cc)).toBe(true);
   });
 });
 

--- a/tests/fixtures/app-basic/app/api/static-data/route.ts
+++ b/tests/fixtures/app-basic/app/api/static-data/route.ts
@@ -3,7 +3,7 @@
  *
  * Tests: ON-3 #13-14 in TRACKING.md
  * In Next.js, a GET-only route handler with `export const revalidate = N`
- * gets Cache-Control: s-maxage=N, stale-while-revalidate headers.
+ * gets Cache-Control: max-age=N, stale-while-revalidate headers.
  *
  * Uses revalidate=1 so the revalidation timing test (ON-3 #14)
  * can complete quickly without long sleeps.

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -778,3 +778,55 @@ describe("revalidatePath type parameter", () => {
     expect(await handler.get("entry:/about/team")).not.toBeNull();
   });
 });
+
+describe("isrGet / isrSet bypass when request-context cache is available", () => {
+  beforeEach(() => {
+    setCacheHandler(new MemoryCacheHandler());
+  });
+
+  it("isrSet is a no-op when ctx.cache exists; isrGet returns null", async () => {
+    const handler = new MemoryCacheHandler();
+    setCacheHandler(handler);
+
+    const ctx = {
+      cache: { purge: async () => undefined },
+      waitUntil: () => undefined,
+    };
+    const key = "bypass:test";
+    const data = buildPagesCacheValue("<html>cached</html>", {});
+
+    await runWithExecutionContext(ctx, async () => {
+      // Inside the scope: write is suppressed.
+      await isrSet(key, data, 60, ["sample-tag"]);
+      // ...and read returns null.
+      const inScopeRead = await isrGet(key);
+      expect(inScopeRead).toBeNull();
+    });
+
+    // Outside the scope: the handler was never touched.
+    const outOfScopeRead = await handler.get(key);
+    expect(outOfScopeRead).toBeNull();
+  });
+
+  it("a pre-existing inner cache entry is not surfaced through isrGet when ctx.cache is set", async () => {
+    const handler = new MemoryCacheHandler();
+    setCacheHandler(handler);
+    // Populate the inner handler directly — outside the bypass scope.
+    await isrSet("preexisting", buildPagesCacheValue("<html>old</html>", {}), 60, []);
+
+    // Confirm baseline: outside the bypass scope, the entry is returned.
+    const outside = await isrGet("preexisting");
+    expect(outside?.value.value?.kind).toBe("PAGES");
+
+    // Inside the bypass scope, even an existing entry must be invisible —
+    // route-level ISR is owned entirely by the outer cache.
+    const ctx = {
+      cache: { purge: async () => undefined },
+      waitUntil: () => undefined,
+    };
+    await runWithExecutionContext(ctx, async () => {
+      const inside = await isrGet("preexisting");
+      expect(inside).toBeNull();
+    });
+  });
+});

--- a/tests/nextjs-compat/app-routes.test.ts
+++ b/tests/nextjs-compat/app-routes.test.ts
@@ -330,25 +330,27 @@ describe("Next.js compat: app-routes", () => {
 
   // ── Route segment config: revalidate ────────────────────────
   // Next.js: GET-only route handlers with `export const revalidate = N`
-  // get Cache-Control: s-maxage=N, stale-while-revalidate
+  // get Cache-Control: max-age=N, stale-while-revalidate
   // Fixture: /api/static-data exports revalidate = 1
 
-  it("sets Cache-Control s-maxage from route handler revalidate config", async () => {
+  it("sets Cache-Control max-age from route handler revalidate config", async () => {
     const res = await fetch(`${baseUrl}/api/static-data`);
     expect(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("public, s-maxage=1");
+    expect(cacheControl).toContain("public, max-age=1");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 
-  it("does not set s-maxage when revalidate is 0", async () => {
-    // revalidate=0 means "never cache" in Next.js — no s-maxage header
+  it("does not set positive max-age when revalidate is 0", async () => {
+    // revalidate=0 means "never cache" in Next.js — the header may set
+    // `max-age=0, must-revalidate` to be explicit, but it must not advertise
+    // positive cacheability via `stale-while-revalidate`.
     const res = await fetch(`${baseUrl}/api/no-cache`);
     expect(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control");
-    // Should either be null or not contain s-maxage
     if (cacheControl) {
-      expect(cacheControl).not.toContain("s-maxage");
+      expect(cacheControl).not.toContain("stale-while-revalidate");
+      expect(cacheControl).toMatch(/no-cache|no-store|max-age=0/);
     }
   });
 
@@ -360,7 +362,7 @@ describe("Next.js compat: app-routes", () => {
     expect(cacheControl).toBe("public, max-age=300");
   });
 
-  it("does not set s-maxage when a revalidated GET handler reads request-specific data", async () => {
+  it("does not set positive max-age when a revalidated GET handler reads request-specific data", async () => {
     const res = await fetch(`${baseUrl}/api/dynamic-request-data`, {
       headers: {
         "x-test-ping": "pong",
@@ -376,8 +378,8 @@ describe("Next.js compat: app-routes", () => {
 
     const cacheControl = res.headers.get("cache-control");
     if (cacheControl) {
-      expect(cacheControl).not.toContain("s-maxage");
       expect(cacheControl).not.toContain("stale-while-revalidate");
+      expect(cacheControl).toMatch(/no-cache|no-store|max-age=0/);
     }
   });
 

--- a/tests/nextjs-compat/app-routes.test.ts
+++ b/tests/nextjs-compat/app-routes.test.ts
@@ -337,7 +337,7 @@ describe("Next.js compat: app-routes", () => {
     const res = await fetch(`${baseUrl}/api/static-data`);
     expect(res.status).toBe(200);
     const cacheControl = res.headers.get("cache-control");
-    expect(cacheControl).toContain("s-maxage=1");
+    expect(cacheControl).toContain("public, s-maxage=1");
     expect(cacheControl).toContain("stale-while-revalidate");
   });
 

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -212,7 +212,7 @@ describe("pages page data", () => {
     expect(result.response.status).toBe(200);
     expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
     expect(result.response.headers.get("cache-control")).toBe(
-      "public, s-maxage=0, stale-while-revalidate",
+      "public, max-age=0, stale-while-revalidate",
     );
     expect(result.response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
@@ -354,7 +354,7 @@ describe("pages page data", () => {
     expect(result.response.headers.get("x-vinext-cache")).toBe("HIT");
     expect(result.response.headers.get("x-nextjs-cache")).toBe("HIT");
     expect(result.response.headers.get("cache-control")).toBe(
-      "public, s-maxage=15, stale-while-revalidate=285",
+      "public, max-age=15, stale-while-revalidate=285",
     );
   });
 

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -211,7 +211,9 @@ describe("pages page data", () => {
 
     expect(result.response.status).toBe(200);
     expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
-    expect(result.response.headers.get("cache-control")).toBe("s-maxage=0, stale-while-revalidate");
+    expect(result.response.headers.get("cache-control")).toBe(
+      "public, s-maxage=0, stale-while-revalidate",
+    );
     expect(result.response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );
@@ -352,7 +354,7 @@ describe("pages page data", () => {
     expect(result.response.headers.get("x-vinext-cache")).toBe("HIT");
     expect(result.response.headers.get("x-nextjs-cache")).toBe("HIT");
     expect(result.response.headers.get("cache-control")).toBe(
-      "s-maxage=15, stale-while-revalidate=285",
+      "public, s-maxage=15, stale-while-revalidate=285",
     );
   });
 

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -176,7 +176,7 @@ describe("pages page response", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=60, stale-while-revalidate=240",
+      "public, max-age=60, stale-while-revalidate=240",
     );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("x-nextjs-cache")).toBe("MISS");
@@ -371,12 +371,12 @@ describe("pages page response", () => {
       gsspRes: {
         statusCode: 200,
         getHeaders() {
-          return { "cache-control": "public, s-maxage=120" };
+          return { "cache-control": "public, max-age=120" };
         },
       },
     });
 
-    expect(response.headers.get("cache-control")).toBe("public, s-maxage=120");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=120");
   });
 
   it("lets ISR Cache-Control win over the gSSP default when both apply", async () => {
@@ -394,7 +394,7 @@ describe("pages page response", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe(
-      "public, s-maxage=60, stale-while-revalidate",
+      "public, max-age=60, stale-while-revalidate",
     );
   });
 

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -175,7 +175,9 @@ describe("pages page response", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate=240");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate=240",
+    );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("x-nextjs-cache")).toBe("MISS");
     await expect(response.text()).resolves.toContain("<div>live-body</div>");
@@ -369,12 +371,12 @@ describe("pages page response", () => {
       gsspRes: {
         statusCode: 200,
         getHeaders() {
-          return { "cache-control": "s-maxage=120" };
+          return { "cache-control": "public, s-maxage=120" };
         },
       },
     });
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=120");
+    expect(response.headers.get("cache-control")).toBe("public, s-maxage=120");
   });
 
   it("lets ISR Cache-Control win over the gSSP default when both apply", async () => {
@@ -391,7 +393,9 @@ describe("pages page response", () => {
       isrRevalidateSeconds: 60,
     });
 
-    expect(response.headers.get("cache-control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate",
+    );
   });
 
   it("does not set a gSSP default Cache-Control when there is no gSSP response", async () => {

--- a/tests/request-context-cache.test.ts
+++ b/tests/request-context-cache.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the request-context cache integration.
+ *
+ * vinext inspects the per-request ExecutionContext for a `.cache` object
+ * with a `.purge({ tags })` method. When present, `revalidateTag()`,
+ * `revalidatePath()`, and `updateTag()` fan out their invalidations to it
+ * alongside the inner CacheHandler. No registration step is required —
+ * any runtime that puts a compatible cache on `ctx` is supported.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
+import {
+  MemoryCacheHandler,
+  revalidatePath,
+  revalidateTag,
+  setCacheHandler,
+  updateTag,
+} from "../packages/vinext/src/shims/cache.js";
+
+type MockCache = { purge: ReturnType<typeof vi.fn> };
+
+function makeCtx(opts?: { withCache?: boolean; throwOnPurge?: boolean }) {
+  const cache: MockCache | undefined =
+    opts?.withCache !== false
+      ? {
+          purge: vi.fn(async () => {
+            if (opts?.throwOnPurge) throw new Error("purge failed");
+          }),
+        }
+      : undefined;
+  return { cache, waitUntil: vi.fn() };
+}
+
+describe("revalidate* → ctx.cache.purge fan-out", () => {
+  beforeEach(() => {
+    // Isolate the inner handler so handler counts are unaffected by prior tests.
+    setCacheHandler(new MemoryCacheHandler());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("revalidateTag calls ctx.cache.purge with the tag", async () => {
+    const ctx = makeCtx();
+    await runWithExecutionContext(ctx, () => revalidateTag("posts"));
+    expect(ctx.cache?.purge).toHaveBeenCalledWith({ tags: ["posts"] });
+  });
+
+  it("revalidatePath without type purges both `_N_T_<path>` and the bare path", async () => {
+    const ctx = makeCtx();
+    await runWithExecutionContext(ctx, () => revalidatePath("/blog/post-1"));
+    // Both forms land in the response Cache-Tag header — they must both
+    // be purged so the outer cache cannot keep serving a stale entry.
+    expect(ctx.cache?.purge).toHaveBeenCalledWith({
+      tags: ["_N_T_/blog/post-1", "/blog/post-1"],
+    });
+  });
+
+  it("revalidatePath with type only purges the typed tag", async () => {
+    const ctx = makeCtx();
+    await runWithExecutionContext(ctx, () => revalidatePath("/blog/post-1", "page"));
+    expect(ctx.cache?.purge).toHaveBeenCalledWith({ tags: ["_N_T_/blog/post-1/page"] });
+  });
+
+  it("updateTag purges the outer cache immediately", async () => {
+    const ctx = makeCtx();
+    await runWithExecutionContext(ctx, () => updateTag("featured"));
+    expect(ctx.cache?.purge).toHaveBeenCalledWith({ tags: ["featured"] });
+  });
+
+  it("does nothing when the ExecutionContext has no .cache", async () => {
+    const ctx = makeCtx({ withCache: false });
+    // Must not throw — no binding to call.
+    await runWithExecutionContext(ctx, () => revalidateTag("posts"));
+  });
+
+  it("ignores a non-function .cache.purge", async () => {
+    const ctx = { cache: { purge: "not a function" }, waitUntil: vi.fn() } as never;
+    await runWithExecutionContext(ctx, () => revalidateTag("posts"));
+    // Nothing to assert — the test passes if no throw escapes.
+  });
+
+  it("works outside any ExecutionContext (Node dev)", async () => {
+    // No `runWithExecutionContext` wrapper — getRequestExecutionContext()
+    // returns null, the fan-out is a no-op, the inner handler still runs.
+    await revalidateTag("posts");
+  });
+
+  it("swallows errors from ctx.cache.purge so revalidation stays atomic", async () => {
+    const ctx = makeCtx({ throwOnPurge: true });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await runWithExecutionContext(ctx, () => revalidateTag("posts"));
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

vinext now wires route-level cache invalidation to whatever cache the runtime exposes on `ctx`. When the per-request ExecutionContext has a `ctx.cache.purge({ tags })` method, `revalidateTag` / `revalidatePath` / `updateTag` fan their invalidations out to it alongside the inner `CacheHandler` — no registration step, no runtime-specific import. Any runtime that puts a compatible `cache.purge` on `ctx` gets it for free (e.g. Cloudflare Workers with `cache.enabled: true` per the [Workers Cache docs](https://developers.cloudflare.com/workers/cache/)).

Existing ISR `Cache-Control: s-maxage=N, stale-while-revalidate=M` headers drive caching automatically. App Router HIT/STALE page and route-handler responses now additionally emit a `Cache-Tag` header (bare path + `_N_T_<path>` forms) — gated on `isRequestContextCacheAvailable()` so runtimes without an outer cache aren't burdened with the header.

The inner `CacheHandler` (memory, KV, Redis, …) remains the source of truth; the outer layer is purely additive and a purge failure on it can never break revalidation.

## Plumbing changes

- `shims/cache.ts` — `revalidateTag` / `revalidatePath` / `updateTag` fan out to `ctx.cache.purge` via a new `_purgeRequestContextCacheTags` helper; exposes `isRequestContextCacheAvailable()` for response builders to gate on.
- `server/cache-headers.ts` — adds `applyCacheTagHeader` (dedupes, caps at ~15 KiB to stay under Workers' header limit).
- `server/app-page-cache.ts` + `server/app-route-handler-response.ts` — emit `Cache-Tag` on cached HIT/STALE responses, gated on the request-context cache being present.
- `shims/cache.ts` + `cloudflare/kv-cache-handler.ts` — added `tags?: string[]` to `CacheHandlerValue`; KV and memory handlers surface stored tags on `get` so they reach the `Cache-Tag` header.

## Example app

`examples/workers-cache-cloudflare/` — App Router demo deployed at `workers-cache-cloudflare.vinext.workers.dev`:

- ISR-cached page at `/cached/[slug]` (`revalidate = 60`)
- Cached route handler at `/api/now` (`revalidate = 30`)
- Force-dynamic comparison at `/dynamic`
- Client-side cache probe panel showing `Cache-Control`, `Cache-Tag`, `X-Vinext-Cache`, `Age`
- Buttons for `revalidateTag` / `revalidatePath` wired to `/api/revalidate-*` route handlers
- Wrangler config sets `cache.enabled: true`

Added to the deploy matrix in `.github/workflows/deploy-examples.yml` and `scripts/smoke-test.sh`.

## Test plan

- [x] `pnpm run check` clean (0 errors, 0 warnings)
- [x] New tests: `tests/request-context-cache.test.ts` (8 tests — fan-out, no-binding no-op, error swallowing, non-function `purge` rejected), `tests/cache-headers.test.ts` (8 tests — `Cache-Tag` formatting, dedupe, byte budget), plus 4 new cases in `tests/app-page-cache.test.ts` for gated `Cache-Tag` emission
- [x] 185 cache-related tests pass across 7 files locally
- [x] Example builds (`pnpm build` in `examples/workers-cache-cloudflare/`) and `pnpm exec tsc --noEmit` is clean
- [x] Manual `pnpm dev` probe confirms ISR routes emit `s-maxage=60, stale-while-revalidate=…`, `/dynamic` emits `no-store`, and both `/api/revalidate-tag` and `/api/revalidate-path` POST endpoints return `{"revalidated": true}`
- [ ] CI on this branch — Check, Vitest, Playwright E2E
- [ ] Smoke test against the deployed preview