### PR TITLE
fix(security): honor pages API bodyParser config (F-PROD-4)

### DIFF
--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -16,6 +16,10 @@ import { reportRequestError, importModule, type ModuleImporter } from "./instrum
 import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
+import {
+  DEFAULT_PAGES_API_BODY_SIZE_LIMIT,
+  resolveBodyParserConfig,
+} from "./pages-body-parser-config.js";
 import { NextRequest } from "vinext/shims/server";
 
 /**
@@ -54,24 +58,33 @@ type EdgeApiRouteModule = {
 };
 
 /**
- * Maximum request body size (1 MB). Matches Next.js default bodyParser sizeLimit.
+ * Default request body size (1 MB). Matches Next.js default bodyParser sizeLimit.
  * @see https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config
  * Prevents denial-of-service via unbounded request body buffering.
  */
-const MAX_BODY_SIZE = 1 * 1024 * 1024;
+const MAX_BODY_SIZE = DEFAULT_PAGES_API_BODY_SIZE_LIMIT;
 
 /**
  * Parse the request body based on content-type.
  * Enforces a size limit to prevent memory exhaustion attacks.
+ *
+ * The `sizeLimit` argument honours `export const config = { api: { bodyParser:
+ * { sizeLimit: '4mb' } } }` on the route module. To opt out of parsing
+ * entirely (`bodyParser: false`), callers must skip this function so the
+ * underlying readable stream stays intact on `req` (critical for webhook
+ * HMAC signature verification).
  */
-async function parseBody(req: IncomingMessage): Promise<unknown> {
+async function parseBody(
+  req: IncomingMessage,
+  sizeLimit: number = MAX_BODY_SIZE,
+): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalSize = 0;
     let settled = false;
     req.on("data", (chunk: Buffer) => {
       totalSize += chunk.length;
-      if (totalSize > MAX_BODY_SIZE) {
+      if (totalSize > sizeLimit) {
         settled = true;
         req.destroy();
         reject(new PagesBodyParseError("Request body too large", 413));
@@ -352,8 +365,19 @@ export async function handleApiRoute(
     // params so a query string cannot change the dynamic route value.
     const query = mergeRouteParamsIntoQuery(parseQueryString(url), params);
 
-    // Parse body
-    const body = await parseBody(req);
+    // Honour `export const config = { api: { bodyParser: ... } }` on the
+    // route module. When the handler opts out (`bodyParser: false`) we must
+    // not consume the stream — leave `req` intact so user code (e.g. a
+    // Stripe/GitHub webhook) can read the raw bytes for HMAC verification.
+    const bodyParserConfig = resolveBodyParserConfig(
+      (apiModule as { config?: { api?: { bodyParser?: unknown } } }).config as
+        | { api?: { bodyParser?: boolean | { sizeLimit?: string | number } } }
+        | undefined,
+    );
+
+    const body = bodyParserConfig.enabled
+      ? await parseBody(req, bodyParserConfig.sizeLimit)
+      : undefined;
 
     // Enhance req/res with Next.js helpers
     const { apiReq, apiRes } = enhanceApiObjects(req, res, query, body);

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -9,6 +9,7 @@ import {
   type PagesReqResResponse,
   PagesApiBodyParseError,
 } from "./pages-node-compat.js";
+import { resolveBodyParserConfig } from "./pages-body-parser-config.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
@@ -16,6 +17,22 @@ import { NextRequest } from "vinext/shims/server";
 
 type PagesApiRouteConfig = {
   runtime?: string;
+  /**
+   * `export const config = { api: { bodyParser: false | { sizeLimit: '4mb' } } }`
+   * — controls whether vinext parses the request body for the route handler.
+   *
+   * `bodyParser: false` is critical for webhook handlers (Stripe, GitHub,
+   * Slack, etc.) that need to read the raw bytes to verify an HMAC
+   * signature. With it set, `req.body` is left undefined and the raw stream
+   * is exposed on `req.body` as a Web `ReadableStream<Uint8Array>` so user
+   * code can consume it.
+   *
+   * @see https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config
+   */
+  api?: {
+    bodyParser?: boolean | { sizeLimit?: string | number };
+    responseLimit?: boolean | string | number;
+  };
 };
 
 type PagesNodeApiRouteHandler = (
@@ -118,7 +135,18 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     }
 
     const query = buildPagesApiQuery(options.url, params);
-    const body = await parsePagesApiBody(options.request);
+
+    // Honour `export const config = { api: { bodyParser: ... } }` on the
+    // route module. When the handler opts out (`bodyParser: false`) we must
+    // not consume the stream — leave `req.body` as the raw Web
+    // `ReadableStream<Uint8Array>` so user code (e.g. a Stripe/GitHub
+    // webhook) can read the raw bytes for HMAC verification.
+    const bodyParserConfig = resolveBodyParserConfig(route.module.config);
+
+    const body = bodyParserConfig.enabled
+      ? await parsePagesApiBody(options.request, bodyParserConfig.sizeLimit)
+      : (options.request.body ?? undefined);
+
     const { req, res, responsePromise } = createPagesReqRes({
       body,
       query,

--- a/packages/vinext/src/server/pages-body-parser-config.ts
+++ b/packages/vinext/src/server/pages-body-parser-config.ts
@@ -1,0 +1,105 @@
+/**
+ * Resolve the Pages Router `api.bodyParser` config from a route module export.
+ *
+ * Next.js API routes can opt out of automatic body parsing or raise the
+ * default 1 MB size limit:
+ *
+ *   export const config = { api: { bodyParser: false } };
+ *   export const config = { api: { bodyParser: { sizeLimit: '4mb' } } };
+ *
+ * `bodyParser: false` is critical for webhook handlers (Stripe, GitHub,
+ * Slack, etc.) that must read the raw request bytes to verify an HMAC
+ * signature. Silently parsing the body would consume the stream and break
+ * signature verification — usually failing closed, sometimes failing open.
+ *
+ * @see https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config
+ * @see Next.js: packages/next/src/server/api-utils/node/api-resolver.ts
+ *
+ * The format of `sizeLimit` mirrors what Next.js accepts via the `bytes`
+ * package: a number of bytes, or a string with a unit suffix
+ * (`"500b"`, `"100kb"`, `"4mb"`, `"1gb"`).
+ */
+
+/**
+ * Default Pages Router API body size limit, matching Next.js.
+ */
+export const DEFAULT_PAGES_API_BODY_SIZE_LIMIT = 1 * 1024 * 1024;
+
+/**
+ * Resolved bodyParser configuration. When `enabled` is `false`, the body
+ * MUST be passed through to the handler as a raw stream (or left unparsed
+ * with `req.body === undefined`), so user code can read it itself.
+ */
+export type ResolvedBodyParserConfig = { enabled: false } | { enabled: true; sizeLimit: number };
+
+const SIZE_UNITS: Record<string, number> = {
+  b: 1,
+  kb: 1024,
+  mb: 1024 * 1024,
+  gb: 1024 * 1024 * 1024,
+  tb: 1024 * 1024 * 1024 * 1024,
+};
+
+/**
+ * Parse a Next.js-style `sizeLimit` string (e.g. `"4mb"`, `"100kb"`, `"1gb"`)
+ * or numeric byte value into a number of bytes. Returns `undefined` for
+ * inputs that can't be parsed — callers should fall back to the default.
+ *
+ * Matches the format accepted by Next.js (the `bytes` package); we
+ * implement it inline to avoid pulling a dependency for a tiny parser.
+ */
+export function parseSizeLimit(value: string | number | undefined): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return undefined;
+
+  // Match `<number><unit?>` where number can be int/decimal and unit is one
+  // of b/kb/mb/gb/tb. The unit is optional — a bare number is bytes.
+  const match = /^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb)?$/.exec(trimmed);
+  if (!match) return undefined;
+
+  const amount = Number.parseFloat(match[1]);
+  if (!Number.isFinite(amount) || amount < 0) return undefined;
+
+  const unit = match[2] ?? "b";
+  const multiplier = SIZE_UNITS[unit];
+  if (multiplier === undefined) return undefined;
+
+  return Math.floor(amount * multiplier);
+}
+
+/**
+ * Read the resolved `bodyParser` config from a route module's `config`
+ * export. Defaults to enabled with the 1 MB Next.js default.
+ */
+export function resolveBodyParserConfig(
+  moduleConfig: { api?: { bodyParser?: boolean | { sizeLimit?: string | number } } } | undefined,
+  defaultSizeLimit: number = DEFAULT_PAGES_API_BODY_SIZE_LIMIT,
+): ResolvedBodyParserConfig {
+  const bodyParser = moduleConfig?.api?.bodyParser;
+
+  // Explicit opt-out: leave the body untouched so handlers can read raw bytes.
+  if (bodyParser === false) {
+    return { enabled: false };
+  }
+
+  // `true` or `undefined` → default behaviour.
+  if (bodyParser === undefined || bodyParser === true) {
+    return { enabled: true, sizeLimit: defaultSizeLimit };
+  }
+
+  // Object form: honour `sizeLimit` if present and parseable, else default.
+  if (typeof bodyParser === "object" && bodyParser !== null) {
+    const parsed = parseSizeLimit(bodyParser.sizeLimit);
+    return { enabled: true, sizeLimit: parsed ?? defaultSizeLimit };
+  }
+
+  // Anything else (truthy non-object/non-true) — be conservative and use
+  // the default, matching Next.js's `!== false` check.
+  return { enabled: true, sizeLimit: defaultSizeLimit };
+}

--- a/packages/vinext/src/server/pages-body-parser-config.ts
+++ b/packages/vinext/src/server/pages-body-parser-config.ts
@@ -30,7 +30,7 @@ export const DEFAULT_PAGES_API_BODY_SIZE_LIMIT = 1 * 1024 * 1024;
  * MUST be passed through to the handler as a raw stream (or left unparsed
  * with `req.body === undefined`), so user code can read it itself.
  */
-export type ResolvedBodyParserConfig = { enabled: false } | { enabled: true; sizeLimit: number };
+type ResolvedBodyParserConfig = { enabled: false } | { enabled: true; sizeLimit: number };
 
 const SIZE_UNITS: Record<string, number> = {
   b: 1,

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -1,9 +1,10 @@
 import { decode as decodeQueryString } from "node:querystring";
 import { parseCookies } from "../config/config-matchers.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
+import { DEFAULT_PAGES_API_BODY_SIZE_LIMIT } from "./pages-body-parser-config.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 
-const MAX_PAGES_API_BODY_SIZE = 1 * 1024 * 1024;
+const MAX_PAGES_API_BODY_SIZE = DEFAULT_PAGES_API_BODY_SIZE_LIMIT;
 
 /**
  * @deprecated Use PagesBodyParseError from pages-media-type.ts instead.
@@ -63,6 +64,16 @@ async function readPagesRequestBodyWithLimit(request: Request, maxBytes: number)
   });
 }
 
+/**
+ * Read and parse a Pages Router API request body for the Workers/prod path.
+ *
+ * `maxBytes` defaults to the 1 MB Next.js default but may be overridden by
+ * `export const config = { api: { bodyParser: { sizeLimit: '4mb' } } }` on
+ * the route module. Handlers that opt out entirely (`bodyParser: false`)
+ * MUST skip this function so the body stream stays intact for user code.
+ *
+ * @see https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config
+ */
 export async function parsePagesApiBody(
   request: Request,
   maxBytes = MAX_PAGES_API_BODY_SIZE,

--- a/tests/pages-bodyparser-config.test.ts
+++ b/tests/pages-bodyparser-config.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Tests for Pages Router `api.bodyParser` config support.
+ *
+ * Covers F-PROD-4: vinext previously ignored
+ * `export const config = { api: { bodyParser: ... } }` and silently parsed
+ * the body with a hard-coded 1 MB limit, breaking webhook handlers (Stripe,
+ * GitHub, Slack) that need the raw stream for HMAC verification.
+ *
+ * Exercises both code paths:
+ *   - Node/dev:  packages/vinext/src/server/api-handler.ts
+ *   - Workers:   packages/vinext/src/server/pages-api-route.ts +
+ *                packages/vinext/src/server/pages-node-compat.ts
+ *
+ * Next.js reference:
+ *   packages/next/src/server/api-utils/node/api-resolver.ts (lines ~350-385)
+ *   honours `config.api?.bodyParser !== false` and
+ *   `config.api?.bodyParser?.sizeLimit`.
+ */
+import { PassThrough } from "node:stream";
+import { Buffer } from "node:buffer";
+import http from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { handleApiRoute } from "../packages/vinext/src/server/api-handler.js";
+import {
+  handlePagesApiRoute,
+  type PagesApiRouteMatch,
+} from "../packages/vinext/src/server/pages-api-route.js";
+import {
+  parseSizeLimit,
+  resolveBodyParserConfig,
+} from "../packages/vinext/src/server/pages-body-parser-config.js";
+import type { ModuleImporter } from "../packages/vinext/src/server/instrumentation.js";
+import type { Route } from "../packages/vinext/src/routing/pages-router.js";
+
+vi.mock("../packages/vinext/src/server/instrumentation.js", () => ({
+  reportRequestError: vi.fn(() => Promise.resolve()),
+  importModule: (runner: { import(id: string): Promise<unknown> }, id: string) =>
+    runner.import(id) as Promise<Record<string, any>>,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── parseSizeLimit ───────────────────────────────────────────────────────
+
+describe("parseSizeLimit", () => {
+  it("parses unit-suffixed strings (case-insensitive)", () => {
+    expect(parseSizeLimit("1b")).toBe(1);
+    expect(parseSizeLimit("100kb")).toBe(100 * 1024);
+    expect(parseSizeLimit("4mb")).toBe(4 * 1024 * 1024);
+    expect(parseSizeLimit("1gb")).toBe(1024 * 1024 * 1024);
+    expect(parseSizeLimit("4MB")).toBe(4 * 1024 * 1024);
+    expect(parseSizeLimit("  4mb  ")).toBe(4 * 1024 * 1024);
+  });
+
+  it("parses decimal numbers", () => {
+    expect(parseSizeLimit("1.5mb")).toBe(Math.floor(1.5 * 1024 * 1024));
+  });
+
+  it("treats a bare number as bytes", () => {
+    expect(parseSizeLimit("1024")).toBe(1024);
+    expect(parseSizeLimit(1024)).toBe(1024);
+  });
+
+  it("returns undefined for unparseable input", () => {
+    expect(parseSizeLimit("")).toBeUndefined();
+    expect(parseSizeLimit("nope")).toBeUndefined();
+    expect(parseSizeLimit("4xb")).toBeUndefined();
+    expect(parseSizeLimit(undefined)).toBeUndefined();
+    expect(parseSizeLimit(-1)).toBeUndefined();
+    expect(parseSizeLimit(Number.NaN)).toBeUndefined();
+  });
+});
+
+// ── resolveBodyParserConfig ──────────────────────────────────────────────
+
+describe("resolveBodyParserConfig", () => {
+  const DEFAULT = 1024 * 1024;
+
+  it("defaults to enabled with 1 MB when config is missing", () => {
+    expect(resolveBodyParserConfig(undefined)).toEqual({
+      enabled: true,
+      sizeLimit: DEFAULT,
+    });
+    expect(resolveBodyParserConfig({})).toEqual({
+      enabled: true,
+      sizeLimit: DEFAULT,
+    });
+    expect(resolveBodyParserConfig({ api: {} })).toEqual({
+      enabled: true,
+      sizeLimit: DEFAULT,
+    });
+  });
+
+  it("treats `bodyParser: false` as disabled", () => {
+    expect(resolveBodyParserConfig({ api: { bodyParser: false } })).toEqual({
+      enabled: false,
+    });
+  });
+
+  it("treats `bodyParser: true` as default-enabled", () => {
+    expect(resolveBodyParserConfig({ api: { bodyParser: true } })).toEqual({
+      enabled: true,
+      sizeLimit: DEFAULT,
+    });
+  });
+
+  it("honours `sizeLimit` from the object form", () => {
+    expect(resolveBodyParserConfig({ api: { bodyParser: { sizeLimit: "4mb" } } })).toEqual({
+      enabled: true,
+      sizeLimit: 4 * 1024 * 1024,
+    });
+    expect(resolveBodyParserConfig({ api: { bodyParser: { sizeLimit: "100kb" } } })).toEqual({
+      enabled: true,
+      sizeLimit: 100 * 1024,
+    });
+    expect(resolveBodyParserConfig({ api: { bodyParser: { sizeLimit: 2048 } } })).toEqual({
+      enabled: true,
+      sizeLimit: 2048,
+    });
+  });
+
+  it("falls back to default when sizeLimit is unparseable", () => {
+    expect(
+      resolveBodyParserConfig({
+        api: { bodyParser: { sizeLimit: "bogus" as unknown as string } },
+      }),
+    ).toEqual({ enabled: true, sizeLimit: DEFAULT });
+  });
+});
+
+// ── Helpers shared by the integration tests below ────────────────────────
+
+function mockReq(
+  method: string,
+  url: string,
+  body?: string | Buffer,
+  headers: Record<string, string> = {},
+): http.IncomingMessage {
+  const stream = new PassThrough();
+  const req = Object.assign(stream, {
+    method,
+    url,
+    headers: { ...headers },
+    httpVersion: "1.1",
+    httpVersionMajor: 1,
+    httpVersionMinor: 1,
+    complete: false,
+    connection: null,
+    socket: null,
+    aborted: false,
+    rawHeaders: [] as string[],
+    trailers: {} as Record<string, string | undefined>,
+    rawTrailers: [] as string[],
+    statusCode: undefined,
+    statusMessage: undefined,
+  }) as unknown as http.IncomingMessage;
+
+  if (body !== undefined && body !== null) {
+    const buf = Buffer.isBuffer(body) ? body : Buffer.from(body, "utf-8");
+    queueMicrotask(() => {
+      stream.push(buf);
+      stream.push(null);
+    });
+  } else {
+    queueMicrotask(() => stream.push(null));
+  }
+
+  return req;
+}
+
+function mockReqChunked(
+  method: string,
+  url: string,
+  chunks: Buffer[],
+  headers: Record<string, string> = {},
+): http.IncomingMessage {
+  const stream = new PassThrough();
+  const req = Object.assign(stream, {
+    method,
+    url,
+    headers: { ...headers },
+    httpVersion: "1.1",
+    httpVersionMajor: 1,
+    httpVersionMinor: 1,
+    complete: false,
+    connection: null,
+    socket: null,
+    aborted: false,
+    rawHeaders: [] as string[],
+    trailers: {} as Record<string, string | undefined>,
+    rawTrailers: [] as string[],
+    statusCode: undefined,
+    statusMessage: undefined,
+  }) as unknown as http.IncomingMessage;
+
+  queueMicrotask(() => {
+    for (const c of chunks) {
+      if (!stream.destroyed) stream.push(c);
+    }
+    if (!stream.destroyed) stream.push(null);
+  });
+
+  return req;
+}
+
+function mockRes(): http.ServerResponse & {
+  _body: string | Buffer;
+  _headers: Record<string, string | string[]>;
+  _statusCode: number;
+  _ended: boolean;
+} {
+  const headers: Record<string, string | string[]> = {};
+  const res = {
+    statusCode: 200,
+    _body: "" as string | Buffer,
+    _headers: headers,
+    _statusCode: 200,
+    _ended: false,
+    setHeader(name: string, value: string | string[]) {
+      headers[name.toLowerCase()] = value;
+    },
+    getHeader(name: string) {
+      return headers[name.toLowerCase()];
+    },
+    writeHead(status: number, hdrs?: Record<string, string>) {
+      res.statusCode = status;
+      res._statusCode = status;
+      if (hdrs) {
+        for (const [k, v] of Object.entries(hdrs)) {
+          headers[k.toLowerCase()] = v;
+        }
+      }
+    },
+    write(data: string | Buffer | Uint8Array) {
+      const chunk =
+        typeof data === "string"
+          ? Buffer.from(data)
+          : Buffer.isBuffer(data)
+            ? data
+            : Buffer.from(data);
+      res._body = Buffer.isBuffer(res._body)
+        ? Buffer.concat([res._body, chunk])
+        : res._body
+          ? Buffer.concat([Buffer.from(res._body), chunk])
+          : chunk;
+      return true;
+    },
+    end(data?: string | Buffer) {
+      if (data !== undefined) {
+        res._body = data;
+      }
+      res._ended = true;
+      res._statusCode = res.statusCode;
+    },
+  } as unknown as http.ServerResponse & {
+    _body: string | Buffer;
+    _headers: Record<string, string | string[]>;
+    _statusCode: number;
+    _ended: boolean;
+  };
+  return res;
+}
+
+function route(pattern: string, filePath = "/fake/api/handler.ts"): Route {
+  return {
+    pattern,
+    patternParts: pattern.split("/").filter(Boolean),
+    filePath,
+    isDynamic: false,
+    params: [],
+  };
+}
+
+function mockServer(moduleExport: Record<string, unknown>): ModuleImporter {
+  return { import: vi.fn().mockResolvedValue(moduleExport) };
+}
+
+// ── Node/dev path: api-handler.ts ────────────────────────────────────────
+
+describe("handleApiRoute body parser config (Node/dev path)", () => {
+  it("bodyParser: false leaves req intact so handler can read the raw stream", async () => {
+    let receivedBodyField: unknown = "sentinel";
+    let receivedRaw = "";
+    const handler = vi.fn(async (req: any) => {
+      receivedBodyField = req.body;
+      // Read directly from the underlying stream (the IncomingMessage).
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      receivedRaw = Buffer.concat(chunks).toString("utf-8");
+    });
+    const server = mockServer({
+      default: handler,
+      config: { api: { bodyParser: false } },
+    });
+
+    const payload = JSON.stringify({ webhook: "stripe", evt: "payment.succeeded" });
+    const req = mockReq("POST", "/api/webhook", payload, {
+      "content-type": "application/json",
+      "stripe-signature": "v1=abc",
+    });
+    const res = mockRes();
+
+    await handleApiRoute(server, req, res, "/api/webhook", [route("/api/webhook")]);
+
+    expect(handler).toHaveBeenCalledOnce();
+    // With bodyParser: false, req.body is undefined; raw bytes are intact.
+    expect(receivedBodyField).toBeUndefined();
+    expect(receivedRaw).toBe(payload);
+  });
+
+  it("bodyParser: { sizeLimit: '4mb' } accepts a 2 MB body that the default would reject", async () => {
+    let capturedSize = 0;
+    const handler = vi.fn((req: any) => {
+      capturedSize = typeof req.body === "string" ? req.body.length : 0;
+    });
+    const server = mockServer({
+      default: handler,
+      config: { api: { bodyParser: { sizeLimit: "4mb" } } },
+    });
+
+    // 2 MB of plain text — would exceed the hard-coded 1 MB default.
+    const twoMB = 2 * 1024 * 1024;
+    const chunks = [Buffer.alloc(twoMB, 0x41)];
+    const req = mockReqChunked("POST", "/api/upload", chunks, {
+      "content-type": "text/plain",
+    });
+    const res = mockRes();
+
+    await handleApiRoute(server, req, res, "/api/upload", [route("/api/upload")]);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(res._statusCode).not.toBe(413);
+    expect(capturedSize).toBe(twoMB);
+  });
+
+  it("bodyParser: { sizeLimit: '4mb' } rejects a 5 MB body with 413", async () => {
+    const handler = vi.fn();
+    const server = mockServer({
+      default: handler,
+      config: { api: { bodyParser: { sizeLimit: "4mb" } } },
+    });
+
+    // Push 5 chunks of 1 MB each — 5 MB total.
+    const chunks = Array.from({ length: 5 }, () => Buffer.alloc(1024 * 1024, 0x41));
+    const req = mockReqChunked("POST", "/api/upload", chunks, {
+      "content-type": "text/plain",
+    });
+    const res = mockRes();
+
+    await handleApiRoute(server, req, res, "/api/upload", [route("/api/upload")]);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(413);
+    expect(res._body).toBe("Request body too large");
+  });
+
+  it("bodyParser: { sizeLimit: '100kb' } rejects a 200 KB body with 413", async () => {
+    const handler = vi.fn();
+    const server = mockServer({
+      default: handler,
+      config: { api: { bodyParser: { sizeLimit: "100kb" } } },
+    });
+
+    const chunks = [Buffer.alloc(200 * 1024, 0x41)];
+    const req = mockReqChunked("POST", "/api/upload", chunks, {
+      "content-type": "text/plain",
+    });
+    const res = mockRes();
+
+    await handleApiRoute(server, req, res, "/api/upload", [route("/api/upload")]);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(413);
+  });
+
+  it("no config preserves the 1 MB default", async () => {
+    const handler = vi.fn();
+    const server = mockServer({ default: handler });
+
+    const chunks = Array.from({ length: 5 }, () => Buffer.alloc(256 * 1024, 0x41));
+    const req = mockReqChunked("POST", "/api/upload", chunks, {
+      "content-type": "text/plain",
+    });
+    const res = mockRes();
+
+    await handleApiRoute(server, req, res, "/api/upload", [route("/api/upload")]);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(413);
+  });
+
+  it("bodyParser: true behaves like the default 1 MB limit", async () => {
+    const handler = vi.fn();
+    const server = mockServer({
+      default: handler,
+      config: { api: { bodyParser: true } },
+    });
+
+    const chunks = Array.from({ length: 5 }, () => Buffer.alloc(256 * 1024, 0x41));
+    const req = mockReqChunked("POST", "/api/upload", chunks, {
+      "content-type": "text/plain",
+    });
+    const res = mockRes();
+
+    await handleApiRoute(server, req, res, "/api/upload", [route("/api/upload")]);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res._statusCode).toBe(413);
+  });
+});
+
+// ── Workers/prod path: pages-api-route.ts ────────────────────────────────
+
+type PagesApiRouteModule = PagesApiRouteMatch["route"]["module"];
+
+function createMatch(
+  handler: PagesApiRouteModule["default"],
+  moduleConfig?: PagesApiRouteModule["config"],
+): PagesApiRouteMatch {
+  return {
+    params: {},
+    route: {
+      pattern: "/api/webhook",
+      module: {
+        config: moduleConfig,
+        default: handler,
+      },
+    },
+  };
+}
+
+describe("handlePagesApiRoute body parser config (Workers/prod path)", () => {
+  it("bodyParser: false exposes the raw request body as a ReadableStream on req.body", async () => {
+    let received: unknown = "sentinel";
+    let receivedRaw = "";
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        async (req: any, res: any) => {
+          received = req.body;
+          // Verify it's a ReadableStream and we can read it.
+          if (req.body instanceof ReadableStream) {
+            const reader = (req.body as ReadableStream<Uint8Array>).getReader();
+            const chunks: Uint8Array[] = [];
+            try {
+              for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                chunks.push(value);
+              }
+            } finally {
+              reader.releaseLock();
+            }
+            const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+            const merged = new Uint8Array(total);
+            let offset = 0;
+            for (const c of chunks) {
+              merged.set(c, offset);
+              offset += c.byteLength;
+            }
+            receivedRaw = new TextDecoder().decode(merged);
+          }
+          res.json({ ok: true });
+        },
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/webhook", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "stripe-signature": "v1=abc",
+        },
+        body: JSON.stringify({ webhook: "stripe", evt: "payment.succeeded" }),
+      }),
+      url: "/api/webhook",
+    });
+
+    expect(response.status).toBe(200);
+    expect(received).toBeInstanceOf(ReadableStream);
+    expect(receivedRaw).toBe(JSON.stringify({ webhook: "stripe", evt: "payment.succeeded" }));
+  });
+
+  it("bodyParser: { sizeLimit: '4mb' } accepts a 2 MB body that the default would reject", async () => {
+    const payload = "A".repeat(2 * 1024 * 1024);
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (req: any, res: any) => {
+          const size = typeof req.body === "string" ? req.body.length : 0;
+          res.json({ size });
+        },
+        { api: { bodyParser: { sizeLimit: "4mb" } } },
+      ),
+      request: new Request("https://example.com/api/upload", {
+        method: "POST",
+        headers: {
+          "content-type": "text/plain",
+          "content-length": String(payload.length),
+        },
+        body: payload,
+      }),
+      url: "/api/upload",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ size: 2 * 1024 * 1024 });
+  });
+
+  it("bodyParser: { sizeLimit: '4mb' } rejects a 5 MB body with 413", async () => {
+    const payload = "A".repeat(5 * 1024 * 1024);
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (_req: any, res: any) => {
+          res.json({ ok: true });
+        },
+        { api: { bodyParser: { sizeLimit: "4mb" } } },
+      ),
+      request: new Request("https://example.com/api/upload", {
+        method: "POST",
+        headers: {
+          "content-type": "text/plain",
+          "content-length": String(payload.length),
+        },
+        body: payload,
+      }),
+      url: "/api/upload",
+    });
+
+    expect(response.status).toBe(413);
+  });
+
+  it("bodyParser: { sizeLimit: '100kb' } rejects a 200 KB body with 413", async () => {
+    const payload = "A".repeat(200 * 1024);
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (_req: any, res: any) => {
+          res.json({ ok: true });
+        },
+        { api: { bodyParser: { sizeLimit: "100kb" } } },
+      ),
+      request: new Request("https://example.com/api/upload", {
+        method: "POST",
+        headers: {
+          "content-type": "text/plain",
+          "content-length": String(payload.length),
+        },
+        body: payload,
+      }),
+      url: "/api/upload",
+    });
+
+    expect(response.status).toBe(413);
+  });
+
+  it("no config preserves the 1 MB default", async () => {
+    const payload = "A".repeat(2 * 1024 * 1024);
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req: any, res: any) => {
+        res.json({ ok: true });
+      }),
+      request: new Request("https://example.com/api/upload", {
+        method: "POST",
+        headers: {
+          "content-type": "text/plain",
+          "content-length": String(payload.length),
+        },
+        body: payload,
+      }),
+      url: "/api/upload",
+    });
+
+    expect(response.status).toBe(413);
+  });
+
+  it("bodyParser: true behaves like the default 1 MB limit", async () => {
+    const payload = "A".repeat(2 * 1024 * 1024);
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (_req: any, res: any) => {
+          res.json({ ok: true });
+        },
+        { api: { bodyParser: true } },
+      ),
+      request: new Request("https://example.com/api/upload", {
+        method: "POST",
+        headers: {
+          "content-type": "text/plain",
+          "content-length": String(payload.length),
+        },
+        body: payload,
+      }),
+      url: "/api/upload",
+    });
+
+    expect(response.status).toBe(413);
+  });
+});


### PR DESCRIPTION
## Severity

**MEDIUM-HIGH** — silent webhook security downgrade. Webhook handlers (Stripe, GitHub, Slack, etc.) that depend on `export const config = { api: { bodyParser: false } }` to read the raw request stream for HMAC signature verification were silently broken: vinext consumed the stream and pre-parsed the body before the handler ran, so HMAC verification either fails closed (no match) or fails open (handlers that fall back to an empty body for unsupported content types).

The same code path also rejected legitimate large uploads with 413 even when the route declared a higher `sizeLimit`.

Reference: **Finding F-PROD-4 in `SECURITY-AUDIT-2026-05.md`**.

## Reproduction

```ts
// pages/api/stripe-webhook.ts
export const config = { api: { bodyParser: false } };
export default async function handler(req, res) {
  const rawBody = await getRawBody(req);
  // Before this PR: rawBody is empty — vinext already parsed the body.
  //                 HMAC signature verification fails open/closed.
  // After this PR:  rawBody is the full raw stream contents. HMAC works.
  if (!verifyStripeSignature(rawBody, req.headers['stripe-signature'])) {
    return res.status(400).json({ error: 'bad signature' });
  }
  // ...
}
```

```ts
// pages/api/upload.ts
export const config = { api: { bodyParser: { sizeLimit: '4mb' } } };
export default function handler(req, res) {
  // Before this PR: any body > 1 MB is rejected with 413, even though
  //                 the user explicitly asked for 4 MB.
  // After this PR:  body up to 4 MB is accepted.
  res.json({ ok: true });
}
```

## Fix

Vinext now honours `export const config = { api: { bodyParser: ... } }` on Pages Router API routes, matching Next.js (`packages/next/src/server/api-utils/node/api-resolver.ts:352-385`).

**Both code paths are patched:**

- **Node / dev path** — `packages/vinext/src/server/api-handler.ts`
- **Workers / prod path** — `packages/vinext/src/server/pages-api-route.ts` (+ `pages-node-compat.ts`)

A shared helper `packages/vinext/src/server/pages-body-parser-config.ts` resolves the config:

| Config | Behaviour |
| --- | --- |
| `bodyParser: false` | **Skip parsing.** Node handlers receive the raw `IncomingMessage` stream (unchanged on `req`). Workers handlers receive `request.body` as a `ReadableStream<Uint8Array>` on `req.body` so user code can drain it. |
| `bodyParser: { sizeLimit: '4mb' }` | Parse with the user-supplied limit. Strings (`'500b'`, `'100kb'`, `'4mb'`, `'1gb'`) and bare numbers (bytes) are supported, matching the grammar Next.js accepts via the `bytes` package. Implemented inline — no new dependency. |
| `bodyParser: true` / `undefined` | Existing default behaviour — parse with the 1 MB Next.js default. |

## Tests

New: `tests/pages-bodyparser-config.test.ts` (21 cases, all passing) covering both paths plus parser unit tests:

- `parseSizeLimit` parses `b`/`kb`/`mb`/`gb`/`tb` (case-insensitive), decimals, bare numbers, and returns `undefined` for unparseable input
- `resolveBodyParserConfig` defaulting + each config form
- **Node path**:
  - `bodyParser: false` → handler reads raw stream from `req` for HMAC parity
  - `sizeLimit: '4mb'` → 2 MB POST succeeds (used to 413)
  - `sizeLimit: '4mb'` → 5 MB POST → 413
  - `sizeLimit: '100kb'` → 200 KB POST → 413
  - No config → 1 MB default still applies
  - `bodyParser: true` → 1 MB default
- **Workers path**: equivalent matrix, plus verifying `req.body` is a `ReadableStream` when `bodyParser: false`

All 268 existing pages-router and 66 api-handler/pages-api-route tests still pass.

## Out of scope / follow-ups

- `config.api.responseLimit` (warn / enforce response body cap) — Next.js supports it; vinext doesn't. Not included here to keep the diff focused. Tracked as a follow-up.
- Refactoring to share the size-limit parser with `parseBodySizeLimit` in `packages/vinext/src/config/next-config.ts` (used for the Server Actions limit). They have slightly different defaulting and error semantics today; unifying them would be a separate refactor.
