### PR TITLE
fix(security): gate x-forwarded-proto in edge API runtime on trustProxy (F-PROD-7)

### DIFF
--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -16,6 +16,7 @@ import { reportRequestError, importModule, type ModuleImporter } from "./instrum
 import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
+import { resolveRequestProtocol, resolveRequestHost } from "./proxy-trust.js";
 import { NextRequest } from "vinext/shims/server";
 
 /**
@@ -166,10 +167,15 @@ function createEdgeApiRequest(req: IncomingMessage, url: string): Request {
     }
   }
 
-  const rawProto = headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
-  const forwardedProto = rawProto === "https" || rawProto === "http" ? rawProto : "http";
-  const host = headers.get("host") ?? "localhost";
-  const requestUrl = new URL(url, `${forwardedProto}://${host}`);
+  // Honor `X-Forwarded-Proto` / `X-Forwarded-Host` only when running behind
+  // a trusted proxy (gated on `VINEXT_TRUST_PROXY` / `VINEXT_TRUSTED_HOSTS`).
+  // Without this gate a client could send `X-Forwarded-Proto: https` and
+  // trick edge API handlers that check `request.url.startsWith("https")`
+  // (e.g. to gate Secure-cookie issuance) into believing the request was
+  // TLS-terminated. See: Finding F-PROD-7 in SECURITY-AUDIT-2026-05.md.
+  const proto = resolveRequestProtocol(req);
+  const host = resolveRequestHost(req, "localhost");
+  const requestUrl = new URL(url, `${proto}://${host}`);
   const body = readEdgeRequestBody(req);
 
   const init: RequestInit & { duplex?: "half" } = {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -81,6 +81,12 @@ import {
 } from "./prerender-route-params.js";
 import { seedMemoryCacheFromPrerender as seedMemoryCacheFromPrerenderFallback } from "./seed-cache.js";
 import { installSocketErrorBackstop } from "./socket-error-backstop.js";
+import {
+  trustProxy,
+  trustedHosts,
+  resolveRequestProtocol,
+  resolveRequestHost as resolveHost,
+} from "./proxy-trust.js";
 
 /** Convert a Node.js IncomingMessage into a ReadableStream for Web Request body. */
 function readNodeStream(req: IncomingMessage): ReadableStream<Uint8Array> {
@@ -243,16 +249,8 @@ function nodeHeadersToWebHeaders(headersRecord: IncomingMessage["headers"]): Hea
   return headers;
 }
 
-function firstHeaderValue(value: string | string[] | undefined): string | undefined {
-  return Array.isArray(value) ? value[0] : value;
-}
-
-function resolveRequestProtocol(req: IncomingMessage): "http" | "https" {
-  const rawProto = trustProxy
-    ? firstHeaderValue(req.headers["x-forwarded-proto"])?.split(",")[0]?.trim()
-    : undefined;
-  return rawProto === "https" || rawProto === "http" ? rawProto : "http";
-}
+// `resolveRequestProtocol` is now imported from `./proxy-trust.js` so the
+// same trust policy applies in api-handler.ts (dev edge API bridge).
 
 const NO_BODY_RESPONSE_STATUSES = new Set([204, 205, 304]);
 
@@ -701,48 +699,10 @@ async function statIfFile(filePath: string): Promise<{ size: number; mtimeMs: nu
   }
 }
 
-/**
- * Resolve the host for a request, ignoring X-Forwarded-Host to prevent
- * host header poisoning attacks (open redirects, cache poisoning).
- *
- * X-Forwarded-Host is only trusted when the VINEXT_TRUSTED_HOSTS env var
- * lists the forwarded host value. Without this, an attacker can send
- * X-Forwarded-Host: evil.com and poison any redirect that resolves
- * against request.url.
- *
- * On Cloudflare Workers, X-Forwarded-Host is always set by Cloudflare
- * itself, so this is only a concern for the Node.js prod-server.
- */
-function resolveHost(req: IncomingMessage, fallback: string): string {
-  const rawForwarded = firstHeaderValue(req.headers["x-forwarded-host"]);
-  const hostHeader = req.headers.host;
-
-  if (rawForwarded) {
-    // X-Forwarded-Host can be comma-separated when passing through
-    // multiple proxies — take only the first (client-facing) value.
-    const forwardedHost = rawForwarded.split(",")[0].trim().toLowerCase();
-    if (forwardedHost && trustedHosts.has(forwardedHost)) {
-      return forwardedHost;
-    }
-  }
-
-  return hostHeader || fallback;
-}
-
-/** Hosts that are allowed as X-Forwarded-Host values (stored lowercase). */
-const trustedHosts: Set<string> = new Set(
-  (process.env.VINEXT_TRUSTED_HOSTS ?? "")
-    .split(",")
-    .map((h) => h.trim().toLowerCase())
-    .filter(Boolean),
-);
-
-/**
- * Whether to trust X-Forwarded-Proto from upstream proxies.
- * Enabled when VINEXT_TRUST_PROXY=1 or when VINEXT_TRUSTED_HOSTS is set
- * (having trusted hosts implies a trusted proxy).
- */
-const trustProxy = process.env.VINEXT_TRUST_PROXY === "1" || trustedHosts.size > 0;
+// `resolveHost`, `trustedHosts`, and `trustProxy` are now imported from
+// `./proxy-trust.js` so the same trust policy applies in api-handler.ts
+// (the dev edge API bridge) and any future server code path that needs
+// to gate `X-Forwarded-*` headers.
 
 /**
  * Convert a Node.js IncomingMessage to a Web Request object.

--- a/packages/vinext/src/server/proxy-trust.ts
+++ b/packages/vinext/src/server/proxy-trust.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared trust-boundary helpers for `X-Forwarded-*` headers.
+ *
+ * Any code path that derives `request.url` from attacker-controlled input
+ * (proxy headers) must funnel through these helpers so the same
+ * `VINEXT_TRUST_PROXY` / `VINEXT_TRUSTED_HOSTS` policy applies everywhere.
+ *
+ * The Node prod server, the dev server, and the dev bridge for edge API
+ * routes all share this trust model. Without it, a client can send
+ * `X-Forwarded-Proto: https` and trick handler code that gates on
+ * `request.url.startsWith("https")` (e.g. Secure-cookie logic) into
+ * believing the request arrived over TLS.
+ *
+ * See also: Finding F-PROD-7 in SECURITY-AUDIT-2026-05.md.
+ */
+import type { IncomingMessage } from "node:http";
+
+/**
+ * Header value as it appears on Node's `IncomingMessage.headers` (single
+ * string, list of strings for repeated headers, or undefined) or as
+ * returned by `Headers#get` on Fetch APIs (string | null).
+ */
+type RawHeaderValue = string | string[] | null | undefined;
+
+function firstHeaderValue(value: RawHeaderValue): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Hosts that are allowed as `X-Forwarded-Host` values (stored lowercase).
+ *
+ * This Set is intentionally mutable so tests can add/remove entries
+ * without reloading the module, and so existing call sites that imported
+ * `trustedHosts` from `prod-server.ts` keep the same semantics.
+ */
+export const trustedHosts: Set<string> = new Set(
+  (process.env.VINEXT_TRUSTED_HOSTS ?? "")
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+/**
+ * Whether to trust `X-Forwarded-Proto` from upstream proxies.
+ *
+ * Enabled when `VINEXT_TRUST_PROXY=1` or when `VINEXT_TRUSTED_HOSTS` is
+ * non-empty (having trusted hosts implies a trusted proxy). Computed at
+ * module load time, matching the existing prod-server behavior.
+ */
+export const trustProxy: boolean = process.env.VINEXT_TRUST_PROXY === "1" || trustedHosts.size > 0;
+
+/**
+ * Resolve the request protocol, honoring `X-Forwarded-Proto` only when
+ * the trust-proxy gate is enabled. Defaults to `"http"`.
+ *
+ * Accepts either a Node `IncomingMessage` or a Fetch `Headers` instance
+ * so the same trust logic can be applied in both server flavors.
+ */
+export function resolveRequestProtocol(source: IncomingMessage | Headers): "http" | "https" {
+  if (!trustProxy) return "http";
+  const raw = readForwardedProto(source);
+  const candidate = raw?.split(",")[0]?.trim();
+  return candidate === "https" || candidate === "http" ? candidate : "http";
+}
+
+/**
+ * Resolve the request host. `X-Forwarded-Host` is honored only when its
+ * value matches the `trustedHosts` allow-list. Falls back to the raw
+ * `Host` header and then to `fallback`.
+ *
+ * Ignoring `X-Forwarded-Host` by default prevents host header poisoning
+ * (open redirects, cache poisoning) where an attacker sends
+ * `X-Forwarded-Host: evil.com` to a server that resolves redirect URLs
+ * against `request.url`.
+ */
+export function resolveRequestHost(source: IncomingMessage | Headers, fallback: string): string {
+  const rawForwarded = readForwardedHost(source);
+  if (rawForwarded && trustedHosts.size > 0) {
+    // `X-Forwarded-Host` can be comma-separated when passing through
+    // multiple proxies — take only the first (client-facing) value.
+    const forwardedHost = rawForwarded.split(",")[0]?.trim().toLowerCase();
+    if (forwardedHost && trustedHosts.has(forwardedHost)) {
+      return forwardedHost;
+    }
+  }
+  const hostHeader = readHost(source);
+  return hostHeader || fallback;
+}
+
+function readForwardedProto(source: IncomingMessage | Headers): string | undefined {
+  if (isWebHeaders(source)) return source.get("x-forwarded-proto") ?? undefined;
+  return firstHeaderValue(source.headers["x-forwarded-proto"]);
+}
+
+function readForwardedHost(source: IncomingMessage | Headers): string | undefined {
+  if (isWebHeaders(source)) return source.get("x-forwarded-host") ?? undefined;
+  return firstHeaderValue(source.headers["x-forwarded-host"]);
+}
+
+function readHost(source: IncomingMessage | Headers): string | undefined {
+  if (isWebHeaders(source)) return source.get("host") ?? undefined;
+  return firstHeaderValue(source.headers["host"]);
+}
+
+function isWebHeaders(source: IncomingMessage | Headers): source is Headers {
+  return typeof (source as Headers).get === "function";
+}

--- a/tests/api-handler-trust-proxy.test.ts
+++ b/tests/api-handler-trust-proxy.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Regression tests for F-PROD-7: the dev edge API bridge
+ * (`createEdgeApiRequest` in `api-handler.ts`) was reading
+ * `X-Forwarded-Proto` without the `trustProxy` gate that the rest of the
+ * prod server uses. A client could forge `X-Forwarded-Proto: https` and
+ * trick edge handlers that gate Secure-cookie issuance on
+ * `request.url.startsWith("https")` into believing the request was
+ * TLS-terminated.
+ *
+ * These tests verify:
+ *   1. Without `VINEXT_TRUST_PROXY` / `VINEXT_TRUSTED_HOSTS`, the
+ *      `X-Forwarded-Proto` / `X-Forwarded-Host` headers are ignored —
+ *      `request.url` reflects the raw `Host` header and `http://`.
+ *   2. With `VINEXT_TRUST_PROXY=1`, `X-Forwarded-Proto: https` is
+ *      honored.
+ *   3. With `VINEXT_TRUSTED_HOSTS` set, a matching `X-Forwarded-Host`
+ *      is honored.
+ *   4. With `VINEXT_TRUSTED_HOSTS` set, a non-matching
+ *      `X-Forwarded-Host` is rejected and falls back to `Host`.
+ *
+ * Modules are dynamically re-imported per test so the trust policy
+ * (read at module load time, mirroring prod-server) is recomputed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { PassThrough } from "node:stream";
+import http from "node:http";
+import type { Route } from "../packages/vinext/src/routing/pages-router.js";
+
+vi.mock("../packages/vinext/src/server/instrumentation.js", () => ({
+  reportRequestError: vi.fn(() => Promise.resolve()),
+  importModule: (runner: { import(id: string): Promise<unknown> }, id: string) =>
+    runner.import(id) as Promise<Record<string, any>>,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+function mockReq(
+  method: string,
+  url: string,
+  headers: Record<string, string> = {},
+): http.IncomingMessage {
+  const stream = new PassThrough();
+  const req = Object.assign(stream, {
+    method,
+    url,
+    headers: { ...headers },
+    httpVersion: "1.1",
+    httpVersionMajor: 1,
+    httpVersionMinor: 1,
+    complete: false,
+    connection: null,
+    socket: null,
+    aborted: false,
+    rawHeaders: [] as string[],
+    trailers: {} as Record<string, string | undefined>,
+    rawTrailers: [] as string[],
+    statusCode: undefined,
+    statusMessage: undefined,
+  }) as unknown as http.IncomingMessage;
+  queueMicrotask(() => stream.push(null));
+  return req;
+}
+
+function mockRes(): http.ServerResponse & { _body: string | Buffer; _ended: boolean } {
+  const headers: Record<string, string | string[]> = {};
+  const res = {
+    statusCode: 200,
+    _body: "" as string | Buffer,
+    _ended: false,
+    setHeader(name: string, value: string | string[]) {
+      headers[name.toLowerCase()] = value;
+    },
+    getHeader(name: string) {
+      return headers[name.toLowerCase()];
+    },
+    writeHead(status: number) {
+      res.statusCode = status;
+    },
+    write(data: string | Buffer | Uint8Array) {
+      const chunk =
+        typeof data === "string"
+          ? Buffer.from(data)
+          : Buffer.isBuffer(data)
+            ? data
+            : Buffer.from(data);
+      res._body = Buffer.isBuffer(res._body)
+        ? Buffer.concat([res._body, chunk])
+        : res._body
+          ? Buffer.concat([Buffer.from(res._body as string), chunk])
+          : chunk;
+      return true;
+    },
+    end(data?: string | Buffer) {
+      if (data !== undefined) {
+        if (res._body) {
+          (res as any).write(data);
+        } else {
+          res._body = data;
+        }
+      }
+      res._ended = true;
+    },
+  } as unknown as http.ServerResponse & { _body: string | Buffer; _ended: boolean };
+  return res;
+}
+
+function route(pattern: string, filePath = "/fake/api/handler.ts"): Route {
+  return {
+    pattern,
+    patternParts: pattern.split("/").filter(Boolean),
+    filePath,
+    isDynamic: false,
+    params: [],
+  };
+}
+
+async function captureEdgeRequestUrl(
+  reqHeaders: Record<string, string>,
+  reqUrl = "/api/users",
+): Promise<string> {
+  const { handleApiRoute } = await import("../packages/vinext/src/server/api-handler.js");
+  let capturedUrl = "";
+  const handler = vi.fn((request: Request) => {
+    capturedUrl = request.url;
+    return Response.json({ ok: true });
+  });
+  const server = {
+    import: vi.fn().mockResolvedValue({
+      config: { runtime: "edge" },
+      default: handler,
+    }),
+  };
+  const req = mockReq("GET", reqUrl, reqHeaders);
+  const res = mockRes();
+  await handleApiRoute(server, req, res, reqUrl, [route("/api/users")]);
+  return capturedUrl;
+}
+
+describe("createEdgeApiRequest trust-proxy gating (F-PROD-7)", () => {
+  describe("default (untrusted proxy)", () => {
+    it("ignores X-Forwarded-Proto: https when VINEXT_TRUST_PROXY is unset", async () => {
+      // Env vars left untouched — `VINEXT_TRUST_PROXY` and
+      // `VINEXT_TRUSTED_HOSTS` are not present in the test environment.
+      const url = await captureEdgeRequestUrl({
+        host: "example.com",
+        "x-forwarded-proto": "https",
+      });
+      expect(new URL(url).protocol).toBe("http:");
+      expect(url).toBe("http://example.com/api/users");
+    });
+
+    it("ignores X-Forwarded-Host when no trusted hosts are configured", async () => {
+      const url = await captureEdgeRequestUrl({
+        host: "legit.example.com",
+        "x-forwarded-host": "attacker.com",
+      });
+      expect(new URL(url).host).toBe("legit.example.com");
+    });
+  });
+
+  describe("VINEXT_TRUST_PROXY=1", () => {
+    it("honors X-Forwarded-Proto: https", async () => {
+      vi.stubEnv("VINEXT_TRUST_PROXY", "1");
+      const url = await captureEdgeRequestUrl({
+        host: "example.com",
+        "x-forwarded-proto": "https",
+      });
+      expect(new URL(url).protocol).toBe("https:");
+      expect(url).toBe("https://example.com/api/users");
+    });
+
+    it("uses the first comma-separated X-Forwarded-Proto value", async () => {
+      vi.stubEnv("VINEXT_TRUST_PROXY", "1");
+      const url = await captureEdgeRequestUrl({
+        host: "example.com",
+        "x-forwarded-proto": "https, http",
+      });
+      expect(url).toBe("https://example.com/api/users");
+    });
+
+    it("falls back to http for unsupported X-Forwarded-Proto values", async () => {
+      vi.stubEnv("VINEXT_TRUST_PROXY", "1");
+      const url = await captureEdgeRequestUrl({
+        host: "example.com",
+        "x-forwarded-proto": "ftp",
+      });
+      expect(url).toBe("http://example.com/api/users");
+    });
+
+    it("does NOT honor X-Forwarded-Host when only VINEXT_TRUST_PROXY is set", async () => {
+      // `VINEXT_TRUST_PROXY=1` alone gates the proto, not the host —
+      // host poisoning still requires the explicit `VINEXT_TRUSTED_HOSTS`
+      // allow-list, matching prod-server.ts behavior.
+      vi.stubEnv("VINEXT_TRUST_PROXY", "1");
+      const url = await captureEdgeRequestUrl({
+        host: "legit.example.com",
+        "x-forwarded-host": "attacker.com",
+      });
+      expect(new URL(url).host).toBe("legit.example.com");
+    });
+  });
+
+  describe("VINEXT_TRUSTED_HOSTS allow-list", () => {
+    it("honors X-Forwarded-Host when it matches the allow-list", async () => {
+      vi.stubEnv("VINEXT_TRUSTED_HOSTS", "cdn.example.com");
+      const url = await captureEdgeRequestUrl({
+        host: "origin.internal",
+        "x-forwarded-host": "cdn.example.com",
+      });
+      expect(new URL(url).host).toBe("cdn.example.com");
+    });
+
+    it("ignores X-Forwarded-Host when it does not match the allow-list", async () => {
+      vi.stubEnv("VINEXT_TRUSTED_HOSTS", "cdn.example.com");
+      const url = await captureEdgeRequestUrl({
+        host: "origin.internal",
+        "x-forwarded-host": "attacker.com",
+      });
+      expect(new URL(url).host).toBe("origin.internal");
+    });
+
+    it("implicitly enables trustProxy and honors X-Forwarded-Proto", async () => {
+      // Per prod-server.ts: having a trusted-hosts allow-list implies a
+      // trusted proxy, so X-Forwarded-Proto becomes honored.
+      vi.stubEnv("VINEXT_TRUSTED_HOSTS", "cdn.example.com");
+      const url = await captureEdgeRequestUrl({
+        host: "origin.internal",
+        "x-forwarded-host": "cdn.example.com",
+        "x-forwarded-proto": "https",
+      });
+      expect(url).toBe("https://cdn.example.com/api/users");
+    });
+
+    it("matches X-Forwarded-Host case-insensitively", async () => {
+      vi.stubEnv("VINEXT_TRUSTED_HOSTS", "cdn.example.com");
+      const url = await captureEdgeRequestUrl({
+        host: "origin.internal",
+        "x-forwarded-host": "CDN.Example.COM",
+      });
+      expect(new URL(url).host).toBe("cdn.example.com");
+    });
+
+    it("uses the first comma-separated X-Forwarded-Host value", async () => {
+      vi.stubEnv("VINEXT_TRUSTED_HOSTS", "cdn.example.com");
+      const url = await captureEdgeRequestUrl({
+        host: "origin.internal",
+        "x-forwarded-host": "cdn.example.com, edge.cf",
+      });
+      expect(new URL(url).host).toBe("cdn.example.com");
+    });
+  });
+});

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -824,7 +824,10 @@ describe("handleApiRoute", () => {
       expect(res._body.toString()).toBe(JSON.stringify({ id: "req-42" }));
     });
 
-    it("uses the first x-forwarded-proto value for edge API request URLs", async () => {
+    it("ignores x-forwarded-proto by default (untrusted proxy) for edge API request URLs", async () => {
+      // Regression test for F-PROD-7. Without `VINEXT_TRUST_PROXY` set, an
+      // attacker who can reach the dev server directly must not be able to
+      // flip `request.url.protocol` to "https:" via a forged header.
       let capturedUrl = "";
       const handler = vi.fn((request: Request) => {
         capturedUrl = request.url;
@@ -842,7 +845,7 @@ describe("handleApiRoute", () => {
 
       await handleApiRoute(server, req, res, "/api/users?name=alice", [route("/api/users")]);
 
-      expect(capturedUrl).toBe("https://example.com/api/users?name=alice");
+      expect(capturedUrl).toBe("http://example.com/api/users?name=alice");
     });
 
     it("falls back to http for unsupported x-forwarded-proto values", async () => {


### PR DESCRIPTION
## Summary

Reference: Finding **F-PROD-7** in `SECURITY-AUDIT-2026-05.md` (severity: **LOW**).

`createEdgeApiRequest` in `packages/vinext/src/server/api-handler.ts` (the dev bridge that converts a Node `IncomingMessage` into a Web `Request` for Pages Router edge API routes) was reading `X-Forwarded-Proto` **without** the `trustProxy` gate that the rest of the prod server applies. A client that can reach the dev server directly can send a forged `X-Forwarded-Proto: https` header and trick edge handlers that gate Secure-cookie issuance on `request.url.startsWith("https")` (or any other `request.url.protocol` check) into believing the request was TLS-terminated.

The same function used `headers.get("host")` raw, so `X-Forwarded-Host` was effectively trusted indirectly via the parsed URL — same host-poisoning vector that `prod-server.resolveHost` already guards against.

## Reproduction (pre-fix)

```bash
$ curl http://localhost:3000/api/edge -H 'X-Forwarded-Proto: https'
# Handler sees request.url = "https://localhost:3000/api/edge"
# Code that gates Secure cookies on `request.url.startsWith("https")` is fooled.
```

## Fix

Approach **(c)** from the audit guidance: extract `resolveRequestProtocol` / `resolveRequestHost` / `trustProxy` / `trustedHosts` into a new shared module `packages/vinext/src/server/proxy-trust.ts` so the dev edge API bridge, the prod Node server, and any future server flavor share the same trust policy.

* `packages/vinext/src/server/proxy-trust.ts` (new) — shared helpers; accept both Node `IncomingMessage` and Web `Headers`.
* `packages/vinext/src/server/api-handler.ts` — `createEdgeApiRequest` now uses `resolveRequestProtocol` / `resolveRequestHost`, so both `X-Forwarded-Proto` and `X-Forwarded-Host` are gated on the same env-driven policy (`VINEXT_TRUST_PROXY=1` / `VINEXT_TRUSTED_HOSTS`).
* `packages/vinext/src/server/prod-server.ts` — removes the duplicated `resolveRequestProtocol` / `resolveHost` / `trustProxy` / `trustedHosts` definitions and re-exports them from the new module so the existing public surface (and the tests that mutate `trustedHosts` directly) keep working.

## Tests

* `tests/api-handler-trust-proxy.test.ts` (new, 11 cases) covers:
  * **Default (untrusted proxy):** `X-Forwarded-Proto: https` is ignored (`request.url.protocol === "http:"`); `X-Forwarded-Host` is ignored.
  * **`VINEXT_TRUST_PROXY=1`:** `X-Forwarded-Proto` is honored (including comma-separated lists and fallback for unsupported values); `X-Forwarded-Host` is still rejected (matching `prod-server` semantics).
  * **`VINEXT_TRUSTED_HOSTS` allow-list:** matching forwarded host honored, non-matching rejected, implicit `trustProxy` enablement, case-insensitive matching, first-value selection from comma-separated lists.
* `tests/api-handler.test.ts` — updated the existing `uses the first x-forwarded-proto value` case to reflect the new (correct) default of ignoring forged proxy headers.

### Local verification

```
vp check  # all 1439 files formatted, 0 lint/type errors
vp test run tests/api-handler-trust-proxy.test.ts tests/api-handler.test.ts  # 59 tests pass
vp test run tests/features.test.ts -t "host header poisoning"  # 7 tests pass
vp test run tests/features.test.ts -t "trustProxy"  # 4 tests pass
vp test run tests/features.test.ts -t "nodeToWebRequest"  # 2 tests pass
vp test run tests/api-handler-globals.test.ts  # 1 test pass
```

## Scope notes

* Only the dev edge API bridge was affected. The prod path (`pages-server-entry.handleApiRoute`) receives a Web `Request` directly from the runtime and already inherits the prod server's correct `resolveRequestProtocol` / `resolveHost`.
* Other `x-forwarded-*` reads in `packages/vinext/src/` were audited:
  * `index.ts:3095-3104` (dev middleware) — already gated on a local `devTrustProxy` check.
  * `dev-origin-check.ts` — uses `x-forwarded-host` for dev-only origin validation; separate concern (validates allowed origins, doesn't build `request.url`).
  * `request-pipeline.ts:377` — explicitly comments that `X-Forwarded-Host` is never trusted for the same-origin check.
* No behavior change for users who have not opted into `VINEXT_TRUST_PROXY=1` or `VINEXT_TRUSTED_HOSTS`.
