### PR TITLE
fix(security): bound x-vinext-mounted-slots cache key cardinality (F-PROD-1)

### DIFF
--- a/packages/vinext/src/server/app-interception-context-header.ts
+++ b/packages/vinext/src/server/app-interception-context-header.ts
@@ -1,0 +1,45 @@
+/**
+ * Normalize the `x-vinext-interception-context` header from inbound requests.
+ *
+ * The browser sends the current pathname (e.g. `/feed`) as interception context
+ * so the server can decide whether to render an intercepted parallel route.
+ * The legitimate value is always a same-origin URL pathname produced by the
+ * vinext browser entry — never an arbitrary string.
+ *
+ * Security: this value flows into cache-key construction (via
+ * `getOptimisticRouteTemplateKey`, `getOptimisticPrefetchSourceKey`, and
+ * outbound RSC payload cache keys). Without bounds, an attacker who controls
+ * this header can fabricate unbounded distinct values to fragment the cache
+ * or drive per-write KV billing. See `SECURITY-AUDIT-2026-05.md` finding
+ * F-PROD-1.
+ *
+ * Bounds applied:
+ *   - Null bytes are stripped (header-injection defense).
+ *   - The value must start with `/` (a pathname).
+ *   - Whitespace is rejected (real pathnames do not contain raw whitespace;
+ *     legitimate spaces would be percent-encoded).
+ *   - Length capped at MAX_INTERCEPTION_CONTEXT_LENGTH bytes. Values that
+ *     exceed the cap are treated as absent so the request is still served,
+ *     just without interception.
+ *
+ * Anything that fails validation returns null, matching the prior behavior of
+ * an absent header. This is intentionally more permissive than rejecting the
+ * whole request — interception is a progressive enhancement.
+ */
+
+/** Hard cap on the byte length of the interception-context header value. */
+const MAX_INTERCEPTION_CONTEXT_LENGTH = 1024;
+
+export function normalizeInterceptionContextHeader(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  // Strip null bytes first so length bounds can't be evaded by padding with \0.
+  const stripped = raw.replaceAll("\0", "");
+  if (stripped.length === 0) return null;
+  if (stripped.length > MAX_INTERCEPTION_CONTEXT_LENGTH) return null;
+  // Must look like a same-origin pathname. Anything else (a full URL, a token,
+  // junk bytes) is not a legitimate value the browser would emit.
+  if (!stripped.startsWith("/")) return null;
+  // Raw whitespace is not legitimate inside a pathname.
+  if (/\s/.test(stripped)) return null;
+  return stripped;
+}

--- a/packages/vinext/src/server/app-mounted-slots-header.ts
+++ b/packages/vinext/src/server/app-mounted-slots-header.ts
@@ -17,17 +17,20 @@
  *     if exceeded so the request is treated as if the header were absent).
  *   - Each token capped at MAX_TOKEN_LENGTH bytes.
  *   - Token count capped at MAX_SLOT_TOKENS (extras are dropped after sort + dedup).
- *   - Each token must match the legitimate `slot:<name>:<treePath>` shape where
- *     `<name>` is non-empty and `<treePath>` starts with `/`. Malformed tokens
- *     are dropped silently rather than rejecting the whole request — this matches
- *     the prior forgiving behavior for browsers that send legitimate but stale
- *     formats during rolling deploys.
+ *   - Each token must match the legitimate slot-id shape, as defined by the
+ *     AppElements wire codec (`AppElementsWire.isSlotId`). Wire-format details
+ *     are intentionally kept inside the codec so this module does not duplicate
+ *     them. Malformed tokens are dropped silently rather than rejecting the
+ *     whole request — this matches the prior forgiving behavior for browsers
+ *     that send legitimate but stale formats during rolling deploys.
  *
  * Consumed by:
  *   - app-rsc-request-normalization (request lifecycle, reads incoming header)
  *   - app-elements (outgoing x-vinext-mounted-slots construction)
  *   - isr-cache (RSC cache key generation)
  */
+
+import { AppElementsWire } from "./app-elements-wire.js";
 
 /** Hard cap on the raw header value byte length. Real values are <1 KB. */
 const MAX_RAW_HEADER_LENGTH = 4096;
@@ -37,21 +40,14 @@ const MAX_TOKEN_LENGTH = 256;
 const MAX_SLOT_TOKENS = 16;
 
 /**
- * Validate a single mounted-slot token against the wire format.
- *
- * Format: `slot:<name>:<treePath>` where:
- *   - `<name>` is non-empty and contains no `:` (matches `parseAppElementsWireElementKey`
- *     which splits on the first `:` in the body).
- *   - `<treePath>` starts with `/` (matches `parseTreePath`).
+ * Validate a single mounted-slot token. Shape validation is delegated to the
+ * AppElements wire codec so the wire format definition lives in exactly one
+ * place. This module only enforces the additional security cap on token byte
+ * length to bound cache-key cardinality.
  */
 function isValidSlotToken(token: string): boolean {
   if (token.length === 0 || token.length > MAX_TOKEN_LENGTH) return false;
-  if (!token.startsWith("slot:")) return false;
-  const body = token.slice("slot:".length);
-  const separatorIndex = body.indexOf(":");
-  if (separatorIndex <= 0) return false;
-  // body[separatorIndex + 1] must be `/` so the tree path is absolute.
-  return body.charCodeAt(separatorIndex + 1) === 0x2f;
+  return AppElementsWire.isSlotId(token);
 }
 
 export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {

--- a/packages/vinext/src/server/app-mounted-slots-header.ts
+++ b/packages/vinext/src/server/app-mounted-slots-header.ts
@@ -5,15 +5,60 @@
  * rendered, which changes across navigations. This normalizes to a canonical form
  * (sorted, deduplicated) so equivalent slot sets map to the same RSC cache entry.
  *
+ * Security: the value flows into the ISR RSC cache key (`appIsrRscKey`). Without
+ * bounds, an attacker who controls this header can fabricate unbounded distinct
+ * values to fan out KV writes (per-write billing) or fragment the cache. See
+ * `SECURITY-AUDIT-2026-05.md` finding F-PROD-1. The legitimate wire format is a
+ * whitespace-separated list of `slot:<name>:<treePath>` tokens (see
+ * `createAppPayloadSlotId` in `app-elements-wire.ts`); anything else is rejected.
+ *
+ * Bounds applied:
+ *   - Total raw header value capped at MAX_RAW_HEADER_LENGTH bytes (returns null
+ *     if exceeded so the request is treated as if the header were absent).
+ *   - Each token capped at MAX_TOKEN_LENGTH bytes.
+ *   - Token count capped at MAX_SLOT_TOKENS (extras are dropped after sort + dedup).
+ *   - Each token must match the legitimate `slot:<name>:<treePath>` shape where
+ *     `<name>` is non-empty and `<treePath>` starts with `/`. Malformed tokens
+ *     are dropped silently rather than rejecting the whole request — this matches
+ *     the prior forgiving behavior for browsers that send legitimate but stale
+ *     formats during rolling deploys.
+ *
  * Consumed by:
  *   - app-rsc-request-normalization (request lifecycle, reads incoming header)
  *   - app-elements (outgoing x-vinext-mounted-slots construction)
  *   - isr-cache (RSC cache key generation)
  */
+
+/** Hard cap on the raw header value byte length. Real values are <1 KB. */
+const MAX_RAW_HEADER_LENGTH = 4096;
+/** Hard cap on a single slot token byte length. */
+const MAX_TOKEN_LENGTH = 256;
+/** Hard cap on the number of slot tokens kept after normalization. */
+const MAX_SLOT_TOKENS = 16;
+
+/**
+ * Validate a single mounted-slot token against the wire format.
+ *
+ * Format: `slot:<name>:<treePath>` where:
+ *   - `<name>` is non-empty and contains no `:` (matches `parseAppElementsWireElementKey`
+ *     which splits on the first `:` in the body).
+ *   - `<treePath>` starts with `/` (matches `parseTreePath`).
+ */
+function isValidSlotToken(token: string): boolean {
+  if (token.length === 0 || token.length > MAX_TOKEN_LENGTH) return false;
+  if (!token.startsWith("slot:")) return false;
+  const body = token.slice("slot:".length);
+  const separatorIndex = body.indexOf(":");
+  if (separatorIndex <= 0) return false;
+  // body[separatorIndex + 1] must be `/` so the tree path is absolute.
+  return body.charCodeAt(separatorIndex + 1) === 0x2f;
+}
+
 export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {
   if (!raw) return null;
-  const normalized = Array.from(new Set(raw.split(/\s+/).filter(Boolean)))
-    .sort()
-    .join(" ");
+  if (raw.length > MAX_RAW_HEADER_LENGTH) return null;
+  const validTokens = raw.split(/\s+/).filter((token) => token && isValidSlotToken(token));
+  if (validTokens.length === 0) return null;
+  const normalized = Array.from(new Set(validTokens)).sort().slice(0, MAX_SLOT_TOKENS).join(" ");
   return normalized || null;
 }

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -12,6 +12,7 @@ import {
   parseClientReuseManifestHeader,
   type ClientReuseManifestParseResult,
 } from "./client-reuse-manifest.js";
+import { normalizeInterceptionContextHeader } from "./app-interception-context-header.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import { stripRscSuffix } from "./app-rsc-cache-busting.js";
 import {
@@ -111,10 +112,16 @@ export function normalizeRscRequest(
   const isRscRequest = pathname.endsWith(".rsc");
   const cleanPathname = stripRscSuffix(pathname);
 
-  // Step 8: Sanitize X-Vinext-Interception-Context.
-  // Null bytes in header values can be used for injection in some HTTP stacks.
-  const interceptionContextHeader =
-    request.headers.get(VINEXT_INTERCEPTION_CONTEXT_HEADER)?.replaceAll("\0", "") || null;
+  // Step 8: Validate and sanitize X-Vinext-Interception-Context.
+  //
+  // The legitimate value is always a same-origin URL pathname (`/feed`,
+  // `/photos/42`, …) emitted by the vinext browser entry. We strip null bytes
+  // (header-injection defense), bound length, and require a pathname-shaped
+  // value so an attacker cannot fan out unbounded distinct values into the
+  // RSC / optimistic-route cache keys. See SECURITY-AUDIT-2026-05.md F-PROD-1.
+  const interceptionContextHeader = normalizeInterceptionContextHeader(
+    request.headers.get(VINEXT_INTERCEPTION_CONTEXT_HEADER),
+  );
 
   // Step 9: Normalize mounted-slots header for canonical cache keying.
   const mountedSlotsHeader = normalizeMountedSlotsHeader(

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -248,23 +248,18 @@ describe("normalizeRscRequest — interception context sanitization", () => {
     expect(result.interceptionContextHeader).toBeNull();
   });
 
-  it("preserves legitimate interception context value", () => {
+  it("preserves a legitimate same-origin pathname interception context", () => {
     const result = normalized(
-      normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": "(.)/slot/page" }), ""),
+      normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": "/feed" }), ""),
     );
-    expect(result.interceptionContextHeader).toBe("(.)/slot/page");
+    expect(result.interceptionContextHeader).toBe("/feed");
   });
 
-  it("preserves interception context value with nested separators", () => {
+  it("preserves a nested-pathname interception context", () => {
     const result = normalized(
-      normalizeRscRequest(
-        req("/page", {
-          "X-Vinext-Interception-Context": "(..)/(.)slot/nested",
-        }),
-        "",
-      ),
+      normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": "/feed/photos/42" }), ""),
     );
-    expect(result.interceptionContextHeader).toBe("(..)/(.)slot/nested");
+    expect(result.interceptionContextHeader).toBe("/feed/photos/42");
   });
 
   it("strips null bytes from interception context header to prevent header injection", () => {
@@ -274,7 +269,7 @@ describe("normalizeRscRequest — interception context sanitization", () => {
       headers: {
         get(name: string) {
           if (name.toLowerCase() === "x-vinext-interception-context") {
-            return "foo\0bar";
+            return "/fe\0ed";
           }
           return null;
         },
@@ -282,7 +277,42 @@ describe("normalizeRscRequest — interception context sanitization", () => {
     } as unknown as Request;
 
     const result = normalized(normalizeRscRequest(request, ""));
-    expect(result.interceptionContextHeader).toBe("foobar");
+    expect(result.interceptionContextHeader).toBe("/feed");
+  });
+
+  it("rejects non-pathname interception context values", () => {
+    // Attacker-supplied values that don't start with `/` are not legitimate
+    // browser-emitted pathnames; treat them as absent so they cannot influence
+    // cache keys. See F-PROD-1.
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": "evil" }), ""),
+    );
+    expect(result.interceptionContextHeader).toBeNull();
+  });
+
+  it("rejects an oversized interception context value", () => {
+    const huge = "/" + "a".repeat(2048);
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": huge }), ""),
+    );
+    expect(result.interceptionContextHeader).toBeNull();
+  });
+
+  it("bounds cache-key cardinality across many attacker-supplied values", () => {
+    // The fix's purpose: even if an attacker fans out 1000 distinct header
+    // values, the cache-key derived from the normalized value is bounded.
+    const distinct = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      const result = normalizeRscRequest(
+        // 2KiB payload — exceeds the 1KiB cap.
+        req("/page", { "X-Vinext-Interception-Context": "/" + "x".repeat(2048) + String(i) }),
+        "",
+      );
+      if (result instanceof Response) continue;
+      distinct.add(result.interceptionContextHeader ?? "null");
+    }
+    // All 1000 attacker values collapse to a single normalized result.
+    expect(distinct.size).toBe(1);
   });
 });
 
@@ -293,16 +323,19 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
     // If not sorted, a client sending slots in navigation order (b a) and another
     // sending (a b) would get different cache keys, causing unnecessary cache misses.
     const result = normalized(
-      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "slot:b slot:a" }), ""),
+      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "slot:b:/ slot:a:/" }), ""),
     );
-    expect(result.mountedSlotsHeader).toBe("slot:a slot:b");
+    expect(result.mountedSlotsHeader).toBe("slot:a:/ slot:b:/");
   });
 
   it("deduplicates slot ids", () => {
     const result = normalized(
-      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "slot:a slot:b slot:a" }), ""),
+      normalizeRscRequest(
+        req("/page", { "x-vinext-mounted-slots": "slot:a:/ slot:b:/ slot:a:/" }),
+        "",
+      ),
     );
-    expect(result.mountedSlotsHeader).toBe("slot:a slot:b");
+    expect(result.mountedSlotsHeader).toBe("slot:a:/ slot:b:/");
   });
 
   it("returns null for absent mounted-slots header", () => {
@@ -315,6 +348,57 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
       normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "   \t  " }), ""),
     );
     expect(result.mountedSlotsHeader).toBeNull();
+  });
+
+  it("drops tokens that do not match the legitimate slot:<name>:<treePath> wire format", () => {
+    // Attacker-supplied tokens without the wire shape (no tree path, missing
+    // `slot:` prefix, etc.) must not influence the cache key. See F-PROD-1.
+    const result = normalized(
+      normalizeRscRequest(
+        req("/page", { "x-vinext-mounted-slots": "slot:a slot:b modal slot:c:/ junk" }),
+        "",
+      ),
+    );
+    expect(result.mountedSlotsHeader).toBe("slot:c:/");
+  });
+
+  it("returns null when every token is malformed", () => {
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": "modal drawer overlay" }), ""),
+    );
+    expect(result.mountedSlotsHeader).toBeNull();
+  });
+
+  it("bounds the number of mounted-slot tokens that reach the cache key", () => {
+    // Cap at 16 tokens. An attacker who supplies 100 legitimately-shaped tokens
+    // would otherwise be able to fan out unique cache keys.
+    const attackerTokens = Array.from({ length: 100 }, (_, i) => `slot:s${i}:/`).join(" ");
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": attackerTokens }), ""),
+    );
+    const tokens = result.mountedSlotsHeader?.split(" ") ?? [];
+    expect(tokens.length).toBeLessThanOrEqual(16);
+  });
+
+  it("rejects an oversized mounted-slots header value", () => {
+    // Cap raw header length to bound cache-key cardinality. An attacker that
+    // supplies a multi-megabyte payload must not blow up KV writes.
+    const huge = "slot:a:/" + "x".repeat(8192);
+    const result = normalized(
+      normalizeRscRequest(req("/page", { "x-vinext-mounted-slots": huge }), ""),
+    );
+    expect(result.mountedSlotsHeader).toBeNull();
+  });
+
+  it("drops a single oversized token but keeps short legitimate tokens", () => {
+    const longToken = `slot:overlong:${"/a".repeat(200)}`;
+    const result = normalized(
+      normalizeRscRequest(
+        req("/page", { "x-vinext-mounted-slots": `slot:a:/ ${longToken} slot:b:/` }),
+        "",
+      ),
+    );
+    expect(result.mountedSlotsHeader).toBe("slot:a:/ slot:b:/");
   });
 
   it("normalizes the semantic render mode marker", () => {
@@ -454,12 +538,23 @@ describe("normalizeMountedSlotsHeader", () => {
   });
 
   it("deduplicates and sorts whitespace-separated slot ids", () => {
-    expect(normalizeMountedSlotsHeader(" sidebar  modal sidebar\tcart ")).toBe(
-      "cart modal sidebar",
-    );
+    expect(
+      normalizeMountedSlotsHeader(" slot:sidebar:/  slot:modal:/ slot:sidebar:/\tslot:cart:/ "),
+    ).toBe("slot:cart:/ slot:modal:/ slot:sidebar:/");
   });
 
   it("handles single slot id", () => {
-    expect(normalizeMountedSlotsHeader("modal")).toBe("modal");
+    expect(normalizeMountedSlotsHeader("slot:modal:/")).toBe("slot:modal:/");
+  });
+
+  it("rejects tokens that do not match the slot:<name>:<treePath> wire format", () => {
+    // SECURITY-AUDIT-2026-05 F-PROD-1: external requests must not be able to
+    // inject arbitrary strings into the cache key. Anything that does not
+    // match the legitimate wire format is dropped.
+    expect(normalizeMountedSlotsHeader("modal")).toBeNull();
+    expect(normalizeMountedSlotsHeader("attacker:value")).toBeNull();
+    expect(normalizeMountedSlotsHeader("slot:nopath")).toBeNull();
+    expect(normalizeMountedSlotsHeader("slot::/")).toBeNull();
+    expect(normalizeMountedSlotsHeader("slot:name:notabspath")).toBeNull();
   });
 });

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -156,11 +156,44 @@ describe("App Router ISR cache key primitives", () => {
   it("keys mounted-slot RSC variants by normalized mounted-slot header", () => {
     delete process.env.__VINEXT_BUILD_ID;
 
-    const first = appIsrRscKey("/feed", "modal sidebar");
-    const second = appIsrRscKey("/feed", "sidebar modal");
+    const first = appIsrRscKey("/feed", "slot:modal:/ slot:sidebar:/");
+    const second = appIsrRscKey("/feed", "slot:sidebar:/ slot:modal:/");
 
     expect(first).toBe(second);
     expect(first).toMatch(/^app:\/feed:rsc:slots:[a-z0-9]+$/);
+  });
+
+  it("bounds RSC cache-key cardinality against attacker-supplied mounted-slot values", () => {
+    // SECURITY-AUDIT-2026-05 F-PROD-1: an attacker who forges
+    // X-Vinext-Mounted-Slots: <unique-value> must not be able to fan out
+    // unbounded distinct cache keys (per-write KV billing / wallet attack).
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const keys = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      // Each of these violates the legitimate slot:<name>:<treePath> wire
+      // shape and must be dropped by normalization.
+      keys.add(appIsrRscKey("/feed", `attacker-${i}`));
+    }
+    // All 1000 distinct attacker values collapse to the same "no slots" key.
+    expect(keys.size).toBe(1);
+    expect(keys.values().next().value).toBe("app:/feed:rsc");
+  });
+
+  it("caps cache-key cardinality when an attacker pads the mounted-slots header", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    // Even when every token has the legitimate wire shape, the raw header
+    // length is capped (4096 bytes). When attacker payloads exceed the cap
+    // they are dropped to null, collapsing into the no-slots cache key.
+    const keys = new Set<string>();
+    for (let batch = 0; batch < 100; batch++) {
+      // 1000 legitimate tokens per batch easily exceeds the 4 KiB length cap.
+      const tokens = Array.from({ length: 1000 }, (_, i) => `slot:b${batch}_s${i}:/`).join(" ");
+      keys.add(appIsrRscKey("/feed", tokens));
+    }
+    expect(keys.size).toBe(1);
+    expect(keys.values().next().value).toBe("app:/feed:rsc");
   });
 
   it("keys RSC refresh variants separately from normal navigation variants", () => {
@@ -169,7 +202,7 @@ describe("App Router ISR cache key primitives", () => {
     expect(appIsrRscKey("/feed", null, APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI)).toBe(
       "app:/feed:rsc:preserve-ui",
     );
-    expect(appIsrRscKey("/feed", "modal", APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI)).toMatch(
+    expect(appIsrRscKey("/feed", "slot:modal:/", APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI)).toMatch(
       /^app:\/feed:rsc:slots:[a-z0-9]+:preserve-ui$/,
     );
   });
@@ -180,9 +213,9 @@ describe("App Router ISR cache key primitives", () => {
     expect(appIsrRscKey("/feed", null, APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL)).toBe(
       "app:/feed:rsc:prefetch-loading-shell",
     );
-    expect(appIsrRscKey("/feed", "modal", APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL)).toMatch(
-      /^app:\/feed:rsc:slots:[a-z0-9]+:prefetch-loading-shell$/,
-    );
+    expect(
+      appIsrRscKey("/feed", "slot:modal:/", APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL),
+    ).toMatch(/^app:\/feed:rsc:slots:[a-z0-9]+:prefetch-loading-shell$/);
   });
 
   it("round-trips normal and preserve-current-UI RSC payloads under separate keys", async () => {
@@ -221,9 +254,9 @@ describe("normalizeMountedSlotsHeader", () => {
   });
 
   it("deduplicates and sorts whitespace-separated slot ids", () => {
-    expect(normalizeMountedSlotsHeader(" sidebar  modal sidebar\tcart ")).toBe(
-      "cart modal sidebar",
-    );
+    expect(
+      normalizeMountedSlotsHeader(" slot:sidebar:/  slot:modal:/ slot:sidebar:/\tslot:cart:/ "),
+    ).toBe("slot:cart:/ slot:modal:/ slot:sidebar:/");
   });
 });
 


### PR DESCRIPTION
## Severity

**HIGH** — production cache flooding / Cloudflare KV wallet attack.

## Vulnerability

Vinext invents two internal headers (`X-Vinext-Mounted-Slots`, `X-Vinext-Interception-Context`) that are legitimately set by the browser's RSC navigation client and flow into:

- The ISR RSC cache key (`appIsrRscKey` in `packages/vinext/src/server/isr-cache.ts:271-284`, via `fnv1a64`)
- Optimistic-routing template / source keys (`getOptimisticRouteTemplateKey`, `getOptimisticPrefetchSourceKey`)

Because these headers were accepted verbatim from external requests, an attacker who controls the browser can fan out unbounded distinct values:

```bash
for i in $(seq 1 100000); do
  curl -s "https://target.example/blog.rsc?_rsc=0" \\
    -H "X-Vinext-Mounted-Slots: attacker-$i" \\
    -H "RSC: 1" > /dev/null &
done
```

Each unique header value maps to a unique cache-key hash, producing one Cloudflare KV write per request. Cloudflare KV bills per write — this is a wallet attack — and the cache also fragments and pollutes content for legitimate users.

## Why we can't just strip the headers

The browser-to-server RSC fetch IS the user's external request. There is no separate internal hop where these headers are added server-side. Stripping them at the request boundary (the approach used for `INTERNAL_HEADERS` / `VINEXT_INTERNAL_HEADERS`) would break legitimate parallel-route and intercepting-route navigation.

## Fix

Input-shape validation + bounds at the boundary, before the value reaches any cache key.

**`x-vinext-mounted-slots`** (`normalizeMountedSlotsHeader`):
- Raw header value capped at **4096 bytes** (oversized → null).
- Each token must match the legitimate `slot:<name>:<treePath>` wire format produced by `encodeSlotId` (name non-empty and contains no `:`, treePath starts with `/`). Anything else (e.g. arbitrary `attacker-N` bytes) is dropped.
- Each token capped at **256 bytes**.
- Token count capped at **16** after dedup + sort.

**`x-vinext-interception-context`** (new `normalizeInterceptionContextHeader`):
- Null bytes stripped (header-injection defense, preserved from prior behavior).
- Value capped at **1024 bytes**.
- Must start with `/` (legitimate values are same-origin pathnames like `/feed`, `/photos/42` — see `resolveManifestNavigationInterceptionContext`).
- Raw whitespace is rejected.

Anything that fails validation is treated as if the header were absent, so the request is still served (just without interception or with the no-slots cache key). This matches the prior forgiving behavior for browsers that may send legitimate but stale formats during rolling deploys.

## Files changed

- `packages/vinext/src/server/app-mounted-slots-header.ts` — strict shape validation + length/count caps.
- `packages/vinext/src/server/app-interception-context-header.ts` (new) — pathname-shape validation + length cap.
- `packages/vinext/src/server/app-rsc-request-normalization.ts` — wire the new interception-context normalizer.
- `tests/app-rsc-request-normalization.test.ts` — updated existing tests to use the real wire format; added security-focused tests.
- `tests/isr-cache.test.ts` — updated existing tests to use the real wire format; added cardinality-bound tests.

## Test coverage added

| Test | What it asserts |
| --- | --- |
| `bounds RSC cache-key cardinality against attacker-supplied mounted-slot values` | 1000 distinct `attacker-${i}` values all collapse to the same `app:/feed:rsc` cache key. |
| `caps cache-key cardinality when an attacker pads the mounted-slots header` | 100 batches of 1000 legitimately-shaped tokens (each exceeding the 4 KiB cap) all collapse to the same cache key. |
| `drops tokens that do not match the legitimate slot:<name>:<treePath> wire format` | Only legitimately-shaped tokens reach the cache key. |
| `bounds the number of mounted-slot tokens that reach the cache key` | Token count cap is enforced. |
| `rejects an oversized mounted-slots header value` | Raw length cap is enforced. |
| `rejects non-pathname interception context values` | Non-pathname values are dropped. |
| `bounds cache-key cardinality across many attacker-supplied values` (interception) | 1000 distinct oversized interception values collapse to a single normalized result. |
| Updated existing tests | Confirm legitimate browser-emitted values (`slot:modal:/`, `/feed`) continue to round-trip. |

All targeted test files pass locally:

- `tests/app-rsc-request-normalization.test.ts` (56 tests)
- `tests/isr-cache.test.ts` (60 tests)
- `tests/app-rsc-cache-busting.test.ts`, `tests/app-rsc-handler.test.ts`, `tests/app-page-cache.test.ts`, `tests/app-page-element-builder.test.ts`, `tests/app-page-route-wiring.test.ts`, `tests/app-page-dispatch.test.ts`, `tests/prefetch-cache.test.ts`, `tests/request-pipeline.test.ts`, `tests/app-server-action-execution.test.ts` (284 tests combined)
- `tests/app-optimistic-routing.test.ts`, `tests/app-browser-interception-context.test.ts` (12 tests combined)

## Follow-up (out of scope)

The audit also suggests validating slot IDs against the route's declared parallel-route slots and rejecting unknown slot IDs (matching Next.js's `Next-Router-State-Tree` approach). That requires route-manifest access at the cache-key construction point and is a larger structural change tracked separately.

Audit also flagged **F-PROD-6** (`x-vinext-static-file`) as a similar response-side issue — not in this PR's scope.

---

Identified in internal security audit — see `SECURITY-AUDIT-2026-05.md` finding **F-PROD-1**.