### PR TITLE
fix(ci): grant contents:read to publish workflow's CI gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ permissions: {}
 jobs:
   ci:
     name: CI Gate
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
 
   publish:


### PR DESCRIPTION
## Summary
- The publish workflow declares `permissions: {}` at the top level, revoking all permissions for every job.
- When the `ci` job invokes the reusable `ci.yml` workflow via `uses:`, the called workflow can't request `contents: read` (needed for `actions/checkout`) because the caller only allows `contents: none`.
- Grant `contents: read` explicitly on the `ci` job so the reusable workflow can use it.

Error this fixes:
> The workflow is requesting 'contents: read', but is only allowed 'contents: none'.

## Test plan
- [ ] Trigger the `Publish to npm` workflow (workflow_dispatch) and confirm the CI gate runs successfully instead of failing to start.