### PR TITLE
test(link): cover javascript: URL console.error for App + Pages Router Link

### DIFF
--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1554,53 +1554,90 @@ describe("Link prefetch scheduling", () => {
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
   // The Next.js test asserts a console.error log appears whose message
   // includes "has blocked a javascript: URL as a security precaution.".
-  it("emits a console.error matching Next.js when a dangerous Link is clicked", async () => {
-    const userOnClick = vi.fn();
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = await renderIsolatedLink({
-      href: "javascript:alert(1)",
-      nodeEnv: "development",
-      props: {
-        onClick: userOnClick,
-      },
-      requireRef: false,
-    });
+  //
+  // Coverage matrix (see issue #1576): the same Next.js E2E suite asserts the
+  // console.error for four Link-flavoured scenarios — App Router `href`,
+  // App Router `as`, Pages Router `href`, Pages Router `as`. The Link shim
+  // serves both routers, so each variant is exercised by toggling
+  // `appNavigation` and swapping `href` <-> `as`.
+  const dangerousLinkScenarios: Array<{
+    name: string;
+    appNavigation: boolean;
+    linkProps: { href: string; as?: string };
+  }> = [
+    {
+      name: "App Router Link with dangerous href",
+      appNavigation: true,
+      linkProps: { href: "javascript:alert(1)" },
+    },
+    {
+      name: "App Router Link with dangerous `as`",
+      appNavigation: true,
+      linkProps: { href: "/safe", as: "javascript:alert(1)" },
+    },
+    {
+      name: "Pages Router Link with dangerous href",
+      appNavigation: false,
+      linkProps: { href: "javascript:alert(1)" },
+    },
+    {
+      name: "Pages Router Link with dangerous `as`",
+      appNavigation: false,
+      linkProps: { href: "/safe", as: "javascript:alert(1)" },
+    },
+  ];
 
-    try {
-      const onClick = result.capturedAnchorProps.onClick;
-      expect(onClick).toBeTypeOf("function");
-      const clickEvent = {
-        button: 0,
-        currentTarget: { hasAttribute: () => false, target: "" },
-        defaultPrevented: false,
-        preventDefault() {
-          this.defaultPrevented = true;
+  for (const scenario of dangerousLinkScenarios) {
+    it(`emits a console.error matching Next.js when a ${scenario.name} is clicked`, async () => {
+      const userOnClick = vi.fn();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const result = await renderIsolatedLink({
+        appNavigation: scenario.appNavigation,
+        href: scenario.linkProps.href,
+        nodeEnv: "development",
+        props: {
+          ...(scenario.linkProps.as !== undefined ? { as: scenario.linkProps.as } : {}),
+          onClick: userOnClick,
         },
-      } satisfies CapturedClickEvent;
+        requireRef: false,
+      });
 
-      await onClick?.(clickEvent);
+      try {
+        const onClick = result.capturedAnchorProps.onClick;
+        expect(onClick).toBeTypeOf("function");
+        const clickEvent = {
+          button: 0,
+          currentTarget: { hasAttribute: () => false, target: "" },
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+        } satisfies CapturedClickEvent;
 
-      // User onClick still fires so callers can run analytics/preventDefault.
-      expect(userOnClick).toHaveBeenCalledWith(clickEvent);
-      // Navigation never happens.
-      expect(result.navigate).not.toHaveBeenCalled();
-      expect(result.fetch).not.toHaveBeenCalled();
-      // Next.js parity: a console.error is emitted that includes the block
-      // message — the E2E suite asserts on `.includes(...)` against this text.
-      expect(
-        consoleError.mock.calls.some((call) =>
-          call.some(
-            (arg) =>
-              typeof arg === "string" &&
-              arg.includes("has blocked a javascript: URL as a security precaution."),
+        await onClick?.(clickEvent);
+
+        // User onClick still fires so callers can run analytics/preventDefault.
+        expect(userOnClick).toHaveBeenCalledWith(clickEvent);
+        // Navigation never happens (App Router) / fetch never fires.
+        expect(result.navigate).not.toHaveBeenCalled();
+        expect(result.fetch).not.toHaveBeenCalled();
+        // Next.js parity: a console.error is emitted that includes the block
+        // message — the E2E suite asserts on `.includes(...)` against this text.
+        expect(
+          consoleError.mock.calls.some((call) =>
+            call.some(
+              (arg) =>
+                typeof arg === "string" &&
+                arg.includes("has blocked a javascript: URL as a security precaution."),
+            ),
           ),
-        ),
-      ).toBe(true);
-    } finally {
-      consoleError.mockRestore();
-      consoleWarn.mockRestore();
-      result.restoreNodeEnv();
-    }
-  });
+        ).toBe(true);
+      } finally {
+        consoleError.mockRestore();
+        consoleWarn.mockRestore();
+        result.restoreNodeEnv();
+      }
+    });
+  }
 });


### PR DESCRIPTION
Fixes #1576. Follow-up to #1575.

## Summary
- PR #1575 hoisted the dangerous-scheme guard out of the async `performNavigation` body for Pages Router `router.push`/`router.replace`, covering two of the six scenarios asserted by Next.js's `test/e2e/app-dir/javascript-urls/javascript-urls.test.ts`. This PR adds the remaining regression coverage for the four Link-flavoured scenarios — App Router + Pages Router, both `href` and `as`.
- The Link shim's existing `handleDangerousClick` path (`packages/vinext/src/shims/link.tsx`, lines 879-905) and the `assertSafeNavigationUrl` guard inside the App Router `push`/`replace`/`prefetch` (`packages/vinext/src/shims/navigation.ts:1499-1543`) already emit the matching `console.error("Next.js has blocked a javascript: URL as a security precaution.")`. The new tests lock that contract behind a matrix so a future Link / navigation refactor cannot regress it silently.
- Each new test clicks the rendered anchor and asserts:
  - `console.error` is emitted with a message containing "has blocked a javascript: URL as a security precaution." (the substring the Next.js E2E matcher asserts on).
  - `navigate` / `fetch` are never invoked, so navigation does not proceed.
  - A user-provided `onClick` still fires.

## Coverage breakdown vs. the four scenarios in #1576

| Scenario | Covered in |
| -------- | ---------- |
| App Router `<Link href="javascript:...">` click | `tests/link-navigation.test.ts` (this PR) |
| App Router `<Link as="javascript:...">` click | `tests/link-navigation.test.ts` (this PR) |
| Pages Router `<Link href="javascript:...">` click | `tests/link-navigation.test.ts` (this PR) |
| Pages Router `<Link as="javascript:...">` click | `tests/link-navigation.test.ts` (this PR) |
| App Router `router.push('javascript:...')` | `tests/router-javascript-urls.test.ts:96-128` (already) |
| App Router `router.replace('javascript:...')` | `tests/router-javascript-urls.test.ts:108-118` (already) |
| Pages Router `Router.push('javascript:...')` | `tests/router-javascript-urls.test.ts:180-302` (#1575) |
| Pages Router `Router.replace('javascript:...')` | `tests/router-javascript-urls.test.ts:198-211` (#1575) |

## Out of scope

- An e2e Playwright spec + fixture pages mirroring `test/e2e/app-dir/javascript-urls/javascript-urls.test.ts` end-to-end. The shared `Link` shim plus the existing scenario coverage in `tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts` (action-redirect + link-onclick) already exercise the same code path through Playwright; a full port would balloon this PR with router-specific fixture pages (`/app/link-href`, `/app/link-as`, `/pages/link-href`, `/pages/link-as`, `/app/router-push`, `/app/router-replace`) without changing the test contract.

Reference (Next.js):
- `packages/next/src/client/link.tsx` (Link click handler that calls `router.push`/`router.replace`)
- `packages/next/src/client/components/app-router-instance.ts:343,400,440,458` (App Router push/replace/prefetch synchronous guards)
- `test/e2e/app-dir/javascript-urls/javascript-urls.test.ts` (the suite the assertions are ported from)

## Test plan
- [x] `vp test run tests/link-navigation.test.ts` (38 tests passing, 3 new)
- [x] `vp test run tests/link.test.ts tests/link-navigation.test.ts tests/url-safety.test.ts tests/router-javascript-urls.test.ts` (206 tests passing)
- [x] `vp check` clean