### PR TITLE
fix(link): forward href/onClick to child in legacyBehavior

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -773,8 +773,16 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     [onTouchStart, prefetchOnIntent],
   );
 
-  const handleClick = async (e: MouseEvent<HTMLAnchorElement>) => {
-    if (onClick) onClick(e);
+  const handleClick = async (
+    e: MouseEvent<HTMLAnchorElement>,
+    options: { skipLinkOnClick?: boolean } = {},
+  ) => {
+    // In legacyBehavior, the onClick prop on <Link> itself is ignored — the
+    // child's onClick is the one that runs (and Next.js even warns when
+    // `onClick` is passed to <Link> alongside `legacyBehavior`). Skip the
+    // preamble that calls Link's own onClick when invoked from that path.
+    // See: .nextjs-ref/packages/next/src/client/link.tsx (legacyBehavior branch).
+    if (!options.skipLinkOnClick && onClick) onClick(e);
     if (e.defaultPrevented) return;
 
     // Native download links must keep the browser's default behavior.
@@ -904,10 +912,42 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // via React's event-handler runtime when `router.push` throws.
     // Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
-    const handleDangerousClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    const handleDangerousClick = (event: MouseEvent<HTMLAnchorElement>): void => {
       if (onClick) onClick(event);
       reportBlockedDangerousNavigation();
     };
+    // In legacyBehavior, clone the child instead of wrapping it in our own
+    // <a>. Otherwise the dangerous-href branch would still produce nested
+    // anchors. We do not forward the dangerous href to the child — Next.js's
+    // safety guarantee is that the navigation never happens; the child can
+    // keep its own (sanitized) href if it wants.
+    if (legacyBehavior) {
+      const child = React.Children.only(children) as React.ReactElement<{
+        onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+        ref?: React.Ref<HTMLAnchorElement>;
+      }>;
+      const childOnClick = child.props.onClick;
+      const childRef = child.props.ref;
+      const setDangerousRefs = (node: HTMLAnchorElement | null): void => {
+        internalRef.current = node;
+        if (typeof childRef === "function") {
+          childRef(node);
+        } else if (childRef) {
+          (childRef as React.MutableRefObject<HTMLAnchorElement | null>).current = node;
+        }
+      };
+      return (
+        <LinkStatusContext.Provider value={linkStatusValue}>
+          {React.cloneElement(child, {
+            ref: setDangerousRefs,
+            onClick: (event: MouseEvent<HTMLAnchorElement>) => {
+              if (childOnClick) childOnClick(event);
+              reportBlockedDangerousNavigation();
+            },
+          })}
+        </LinkStatusContext.Provider>
+      );
+    }
     return (
       <LinkStatusContext.Provider value={linkStatusValue}>
         <a
@@ -933,12 +973,27 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   if (legacyBehavior) {
     const child = React.Children.only(children) as React.ReactElement<{
       href?: string;
+      ref?: React.Ref<HTMLAnchorElement>;
       onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
       onMouseEnter?: (event: MouseEvent<HTMLAnchorElement>) => void;
       onTouchStart?: (event: TouchEvent<HTMLAnchorElement>) => void;
     }>;
+    if (process.env.NODE_ENV !== "production") {
+      if (onClick) {
+        console.warn(
+          `"onClick" was passed to <Link> with \`href\` of \`${resolveHref(href)}\` but "legacyBehavior" was set. The legacy behavior requires onClick be set on the child of next/link`,
+        );
+      }
+      if (onMouseEnter) {
+        console.warn(
+          `"onMouseEnter" was passed to <Link> with \`href\` of \`${resolveHref(href)}\` but "legacyBehavior" was set. The legacy behavior requires onMouseEnter be set on the child of next/link`,
+        );
+      }
+    }
     const childPropsExisting = child.props;
-    const childHasOwnHref = child.type === "a" ? childPropsExisting.href !== undefined : false;
+    // Use `'href' in props` (matches Next.js) so `href={undefined}` on the
+    // child is treated as "the child owns its href" — we won't overwrite it.
+    const childHasOwnHref = child.type === "a" ? "href" in childPropsExisting : false;
     // Match Next.js: forward href when `passHref` is set OR the child is a
     // plain <a> that does not already have an href. Otherwise, leave the
     // child's href alone.
@@ -946,12 +1001,28 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     const childOnClick = childPropsExisting.onClick;
     const childOnMouseEnter = childPropsExisting.onMouseEnter;
     const childOnTouchStart = childPropsExisting.onTouchStart;
+    // Mirror Next.js: in legacy mode, the ref source is the child's own
+    // ref (e.g. `<a ref={myRef}>`), not Link's `forwardedRef`. In React 19
+    // `ref` is a regular prop on the element. Merge with our intersection
+    // observer ref via `setRefs` so prefetching still works.
+    const childRef = childPropsExisting.ref;
+    const setLegacyRefs = (node: HTMLAnchorElement | null): void => {
+      internalRef.current = node;
+      if (typeof childRef === "function") {
+        childRef(node);
+      } else if (childRef) {
+        (childRef as React.MutableRefObject<HTMLAnchorElement | null>).current = node;
+      }
+    };
     const clonedProps: Record<string, unknown> = {
-      ref: setRefs,
+      ref: setLegacyRefs,
       onClick: (event: MouseEvent<HTMLAnchorElement>) => {
+        // Next.js parity: only the child's onClick runs in legacy mode. The
+        // onClick prop on <Link> is intentionally ignored (and a dev warning
+        // surfaces it above).
         if (childOnClick) childOnClick(event);
         if (event.defaultPrevented) return;
-        void handleClick(event);
+        void handleClick(event, { skipLinkOnClick: true });
       },
       onMouseEnter: (event: MouseEvent<HTMLAnchorElement>) => {
         if (childOnMouseEnter) childOnMouseEnter(event);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -94,6 +94,14 @@ type LinkProps = {
   unstable_dynamicOnHover?: boolean;
   /** Whether to pass the href to the child element */
   passHref?: boolean;
+  /**
+   * Pre-Next.js-13 link behaviour. When true, <Link> expects its child to be
+   * an `<a>` (or a component that renders one) and forwards `href`, click,
+   * and prefetch handlers to the child via `React.cloneElement` instead of
+   * rendering its own wrapping `<a>`. Required when the user wants to
+   * style/instrument the anchor themselves.
+   */
+  legacyBehavior?: boolean;
   /** Scroll to top on navigation (default: true) */
   scroll?: boolean;
   /**
@@ -605,18 +613,30 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     prefetch: prefetchProp,
     scroll = true,
     shallow = false,
-    children,
+    children: childrenProp,
     onClick,
     onMouseEnter,
     onTouchStart,
     onNavigate,
     unstable_dynamicOnHover = false,
+    legacyBehavior = false,
+    passHref = false,
     ...rest
   },
   forwardedRef,
 ) {
   // Extract locale from rest props
   const { locale, ...restWithoutLocale } = rest;
+
+  // Next.js parity: in legacyBehavior, a string or number child is wrapped in
+  // a plain <a> so the cloneElement path below has an element to clone. The
+  // wrapper anchor receives the forwarded href + handlers from Link.
+  // Ported from Next.js: packages/next/src/client/link.tsx (around line 334)
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx
+  let children: React.ReactNode = childrenProp;
+  if (legacyBehavior && (typeof childrenProp === "string" || typeof childrenProp === "number")) {
+    children = React.createElement("a", null, childrenProp);
+  }
 
   // If `as` is provided, use it as the actual URL (legacy Next.js pattern
   // where href is a route pattern like "/user/[id]" and as is "/user/1")
@@ -867,8 +887,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     }
   };
 
-  // Remove props that shouldn't be on <a>
-  const { passHref: _p, ...anchorProps } = restWithoutLocale;
+  const anchorProps = restWithoutLocale;
 
   const linkStatusValue = React.useMemo(() => ({ pending }), [pending]);
 
@@ -900,6 +919,55 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         >
           {children}
         </a>
+      </LinkStatusContext.Provider>
+    );
+  }
+
+  // Next.js parity: in legacyBehavior, forward href/handlers to the single
+  // child via React.cloneElement instead of wrapping in our own <a>. This
+  // avoids the nested-anchor markup that broke onClick propagation and
+  // produced duplicated/hidden child content (issue #1469).
+  //
+  // Ported from Next.js: packages/next/src/client/link.tsx (around line 499)
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx
+  if (legacyBehavior) {
+    const child = React.Children.only(children) as React.ReactElement<{
+      href?: string;
+      onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+      onMouseEnter?: (event: MouseEvent<HTMLAnchorElement>) => void;
+      onTouchStart?: (event: TouchEvent<HTMLAnchorElement>) => void;
+    }>;
+    const childPropsExisting = child.props;
+    const childHasOwnHref = child.type === "a" ? childPropsExisting.href !== undefined : false;
+    // Match Next.js: forward href when `passHref` is set OR the child is a
+    // plain <a> that does not already have an href. Otherwise, leave the
+    // child's href alone.
+    const shouldForwardHref = passHref || (child.type === "a" && !childHasOwnHref);
+    const childOnClick = childPropsExisting.onClick;
+    const childOnMouseEnter = childPropsExisting.onMouseEnter;
+    const childOnTouchStart = childPropsExisting.onTouchStart;
+    const clonedProps: Record<string, unknown> = {
+      ref: setRefs,
+      onClick: (event: MouseEvent<HTMLAnchorElement>) => {
+        if (childOnClick) childOnClick(event);
+        if (event.defaultPrevented) return;
+        void handleClick(event);
+      },
+      onMouseEnter: (event: MouseEvent<HTMLAnchorElement>) => {
+        if (childOnMouseEnter) childOnMouseEnter(event);
+        prefetchOnIntent();
+      },
+      onTouchStart: (event: TouchEvent<HTMLAnchorElement>) => {
+        if (childOnTouchStart) childOnTouchStart(event);
+        prefetchOnIntent();
+      },
+    };
+    if (shouldForwardHref) {
+      clonedProps.href = fullHref;
+    }
+    return (
+      <LinkStatusContext.Provider value={linkStatusValue}>
+        {React.cloneElement(child, clonedProps)}
       </LinkStatusContext.Provider>
     );
   }

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -1302,3 +1302,135 @@ describe("Link href trailing-slash (trailingSlash: false default)", () => {
     expect(trailing).toContain('href="https://nextjs.org/"');
   });
 });
+
+// ─── legacyBehavior (parity with Next.js) ───────────────────────────────
+//
+// Ported from Next.js: test/e2e/legacy-link-behavior-pages/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/legacy-link-behavior-pages/index.test.ts
+//
+// In legacy behavior, <Link> must not wrap its child in an extra <a>.
+// Instead it forwards `href` (and click handlers) to the single child
+// element via React.cloneElement. Otherwise, a Link wrapping a custom
+// `<a id="custom-button">` produces nested anchors which are illegal HTML
+// and break onClick propagation.
+
+describe("Link legacyBehavior", () => {
+  it("does not wrap a child <a> in an extra anchor and forwards href", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        Link,
+        { href: "/about", legacyBehavior: true } as any,
+        React.createElement("a", { id: "custom-button" }, "About"),
+      ),
+    );
+
+    // Exactly one anchor in the output (no nested <a><a></a></a>).
+    const anchorOpens = (html.match(/<a\b/g) ?? []).length;
+    expect(anchorOpens).toBe(1);
+
+    // The child anchor must keep its id and visible text.
+    expect(html).toContain('id="custom-button"');
+    expect(html).toContain("About");
+
+    // The href is forwarded to the child anchor.
+    expect(html).toContain('href="/about"');
+
+    // No duplicated children text (e.g. "AboutAbout").
+    expect(html).not.toMatch(/About\s*About/);
+  });
+
+  it("wraps a string child in an <a> with the forwarded href", () => {
+    // Per Next.js: when the child is a string or number, Next wraps it in an
+    // <a> so the legacy behaviour still works. We mirror that here.
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Link, { href: "/about", legacyBehavior: true } as any, "About"),
+    );
+
+    const anchorOpens = (html.match(/<a\b/g) ?? []).length;
+    expect(anchorOpens).toBe(1);
+    expect(html).toContain('href="/about"');
+    expect(html).toContain("About");
+  });
+
+  it("wraps a numeric child in an <a> with the forwarded href", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Link, { href: "/about", legacyBehavior: true } as any, 1000),
+    );
+
+    const anchorOpens = (html.match(/<a\b/g) ?? []).length;
+    expect(anchorOpens).toBe(1);
+    expect(html).toContain('href="/about"');
+    expect(html).toContain("1000");
+  });
+
+  it("does not forward href when the child <a> already has one (no passHref)", () => {
+    // Next.js: when legacyBehavior is set, href is only forwarded if
+    // `passHref` is true OR the child is an <a> without a href.
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        Link,
+        { href: "/about", legacyBehavior: true } as any,
+        React.createElement("a", { href: "/manual", id: "custom-button" }, "Manual"),
+      ),
+    );
+
+    const anchorOpens = (html.match(/<a\b/g) ?? []).length;
+    expect(anchorOpens).toBe(1);
+    expect(html).toContain('href="/manual"');
+    expect(html).toContain('id="custom-button"');
+    expect(html).not.toContain('href="/about"');
+  });
+
+  it("forwards href to a custom component child when passHref is set", () => {
+    // Matches the Next.js passHref/legacyBehavior fixture: a custom anchor
+    // component should receive `href` via React.cloneElement.
+    function CustomAnchor(props: { href?: string; children?: React.ReactNode }) {
+      return React.createElement("a", { href: props.href, id: "custom-button" }, props.children);
+    }
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        Link,
+        { href: "/about", legacyBehavior: true, passHref: true } as any,
+        React.createElement(CustomAnchor, null, "About"),
+      ),
+    );
+
+    const anchorOpens = (html.match(/<a\b/g) ?? []).length;
+    expect(anchorOpens).toBe(1);
+    expect(html).toContain('href="/about"');
+    expect(html).toContain('id="custom-button"');
+    expect(html).toContain("About");
+  });
+
+  it("preserves the child's onClick handler (parity-shape check via cloneElement props)", () => {
+    // We can't dispatch a real DOM click in this Node-only test environment.
+    // Instead, verify that React.cloneElement preserves the child's onClick
+    // by introspecting the rendered tree via a custom child that records its
+    // own props on render. If the legacyBehavior path were still wrapping the
+    // child in an extra <a>, the child's onClick would NOT be installed on
+    // the outer <a> the user actually clicks; the wrapper would swallow it.
+    let receivedProps: { href?: string; onClick?: unknown } | null = null;
+
+    function Probe(props: { href?: string; onClick?: () => void; children?: React.ReactNode }) {
+      receivedProps = props;
+      return React.createElement("a", props, props.children);
+    }
+
+    const childOnClick = (): void => {};
+    ReactDOMServer.renderToString(
+      React.createElement(
+        Link,
+        { href: "/about", legacyBehavior: true, passHref: true } as any,
+        React.createElement(Probe, { onClick: childOnClick }, "About"),
+      ),
+    );
+
+    // The legacy path must clone the child with Link's href.
+    expect(receivedProps).not.toBeNull();
+    expect(receivedProps!.href).toBe("/about");
+    // The child's own onClick is preserved (the Link wraps it inside its
+    // synthesized handler — verifying the prop exists on the child).
+    expect(typeof receivedProps!.onClick).toBe("function");
+  });
+});

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -1403,6 +1403,74 @@ describe("Link legacyBehavior", () => {
     expect(html).toContain("About");
   });
 
+  it("does not call the onClick prop passed to <Link> (warns in dev)", () => {
+    // Next.js parity: in legacyBehavior, <Link>'s own onClick prop is ignored
+    // (the child's onClick is the canonical handler) and a dev console.warn
+    // is emitted. Asserting the warning here also implicitly confirms we are
+    // not silently dropping the user's intent.
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      ReactDOMServer.renderToString(
+        React.createElement(
+          Link,
+          { href: "/about", legacyBehavior: true, onClick: () => {} } as any,
+          React.createElement("a", { id: "custom-button" }, "About"),
+        ),
+      );
+      const messages = consoleSpy.mock.calls.map((args) => String(args[0]));
+      expect(
+        messages.some(
+          (m) =>
+            m.includes(`"onClick" was passed to <Link>`) && m.includes(`"legacyBehavior" was set`),
+        ),
+      ).toBe(true);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("treats `href={undefined}` on the child <a> as the child owning its href", () => {
+    // Next.js uses `!('href' in child.props)` rather than `child.props.href !== undefined`.
+    // If the child explicitly passed `href={undefined}`, we must NOT forward
+    // Link's href onto it — the developer indicated they want to control it.
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        Link,
+        { href: "/about", legacyBehavior: true } as any,
+        React.createElement("a", { href: undefined, id: "custom-button" }, "About"),
+      ),
+    );
+
+    const anchorOpens = (html.match(/<a\b/g) ?? []).length;
+    expect(anchorOpens).toBe(1);
+    // The forwarded href should NOT be set, because the child's props
+    // include the key `href` (even if its value is undefined).
+    expect(html).not.toContain('href="/about"');
+  });
+
+  it("clones the child (does not wrap) when the href is a blocked dangerous scheme", () => {
+    // Even when Link blocks the href (javascript:, data:, vbscript:), the
+    // legacyBehavior contract still applies: we must clone the child rather
+    // than wrap it. Otherwise developers would see a hidden second anchor.
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const html = ReactDOMServer.renderToString(
+        React.createElement(
+          Link,
+          { href: "javascript:alert(1)", legacyBehavior: true } as any,
+          React.createElement("a", { id: "custom-button" }, "Blocked"),
+        ),
+      );
+      const anchorOpens = (html.match(/<a\b/g) ?? []).length;
+      expect(anchorOpens).toBe(1);
+      expect(html).toContain('id="custom-button"');
+      // The dangerous href is NOT propagated to the child.
+      expect(html).not.toContain("javascript:");
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
   it("preserves the child's onClick handler (parity-shape check via cloneElement props)", () => {
     // We can't dispatch a real DOM click in this Node-only test environment.
     // Instead, verify that React.cloneElement preserves the child's onClick


### PR DESCRIPTION
## Summary

- When `<Link legacyBehavior>` is set, vinext's `next/link` shim previously rendered its own wrapping `<a>` around the user's child anchor. That produced nested anchors and a hidden `<a id="custom-button"></a>` (with duplicated content like `AboutAbout`) and broke `onClick` propagation.
- Mirror Next.js: when `legacyBehavior` is true, forward `href`/`onClick`/`onMouseEnter`/`onTouchStart` to the single child via `React.cloneElement` instead of wrapping in an extra `<a>`. `href` is only forwarded when `passHref` is set or the child is a plain `<a>` without its own `href`. String/number children are wrapped in a plain `<a>` first, matching Next.js.
- Added 6 unit tests in `tests/link.test.ts` that mirror the Next.js E2E coverage: no nested anchor, href forwarded, string/number children, manual-href child keeps its own `href`, `passHref` forwards to custom anchor components, and child `onClick` is preserved on the cloned element.

Reference Next.js test (the source of the assertions):
- https://github.com/vercel/next.js/blob/canary/test/e2e/legacy-link-behavior-pages/index.test.ts

Reference Next.js implementation (the legacyBehavior branch):
- https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx

Fixes #1469

## Test plan

- [x] `pnpm test tests/link.test.ts` (114 passed)
- [x] `pnpm test tests/shims.test.ts` (1002 passed)
- [x] `pnpm test tests/link-navigation.test.ts` (35 passed)
- [x] `vp check packages/vinext/src/shims/link.tsx tests/link.test.ts` (no errors)
- [ ] CI: Check, Vitest, Playwright E2E