### PR TITLE
fix(app-router): ensure streamed SSR body ends with </body></html> (#1532)

### DIFF
--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -362,6 +362,19 @@ function rewriteInlineCssStylesheetLinks(
 const HEAD_OPEN_RE = /<head\b[^>]*>/;
 
 /**
+ * Final closing tags of the streamed HTML document. We track this suffix
+ * separately so we can move it to the very end of the stream — trailing flight
+ * chunks and preinit scripts emitted by `rscEmbed.finalize()` are appended in
+ * `flush()`, which would otherwise land them after `</body></html>` and break
+ * any consumer that asserts the document terminates with a well-formed close.
+ *
+ * Ported from Next.js: packages/next/src/server/stream-utils/node-web-streams-helper.ts
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+ * (see `createMoveSuffixStream` and `CLOSE_TAG`)
+ */
+const DOCUMENT_CLOSE_SUFFIX = "</body></html>";
+
+/**
  * Create the tick-buffered HTML transform that injects RSC scripts between
  * React Fizz flush cycles without corrupting split HTML chunks.
  *
@@ -402,6 +415,7 @@ export function createTickBufferedTransform(
   const insertsPerFlush = typeof injectHTML === "function";
   let injected = false;
   let preHeadInjected = false;
+  let suffixStripped = false;
   let buffered: string[] = [];
   let pendingHtml = "";
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -410,6 +424,22 @@ export function createTickBufferedTransform(
   // split-link boundary buffering and the inline-css link rewrite below.
   const hasInlineCssManifest =
     inlineCssManifest !== undefined && Object.keys(inlineCssManifest).length > 0;
+
+  /**
+   * Strip the first occurrence of `</body></html>` from `chunk` so it can be
+   * re-emitted at the very end of the stream. Returns the rewritten chunk and
+   * a flag indicating whether a suffix was found. If `suffixStripped` is
+   * already true (i.e. an earlier chunk contained the suffix), this is a
+   * no-op — additional matches in later chunks shouldn't happen in practice,
+   * but we leave them alone to avoid corrupting unexpected output.
+   */
+  const stripDocumentCloseSuffix = (chunk: string): string => {
+    if (suffixStripped) return chunk;
+    const index = chunk.indexOf(DOCUMENT_CLOSE_SUFFIX);
+    if (index === -1) return chunk;
+    suffixStripped = true;
+    return chunk.slice(0, index) + chunk.slice(index + DOCUMENT_CLOSE_SUFFIX.length);
+  };
   const readInsertion = (): string =>
     typeof injectHTML === "function" ? injectHTML() : injectHTML;
   const readPreHeadInsertion = (): string =>
@@ -502,7 +532,7 @@ export function createTickBufferedTransform(
       const headEnd = working.indexOf("</head>");
       if (headEnd !== -1) {
         const before = working.slice(0, headEnd);
-        const after = working.slice(headEnd);
+        const after = stripDocumentCloseSuffix(working.slice(headEnd));
         controller.enqueue(
           encoder.encode(before + readInlineCssPrependFallback() + readInsertion() + after),
         );
@@ -510,6 +540,7 @@ export function createTickBufferedTransform(
         return;
       }
     }
+    working = stripDocumentCloseSuffix(working);
     controller.enqueue(encoder.encode(working));
   };
 
@@ -560,6 +591,11 @@ export function createTickBufferedTransform(
       if (finalScripts) {
         controller.enqueue(encoder.encode(finalScripts));
       }
+
+      // Emit `</body></html>` last so the document always terminates with a
+      // well-formed close, after any trailing flight chunks / preinit scripts.
+      // Mirrors Next.js's `createMoveSuffixStream` behaviour (#1532).
+      controller.enqueue(encoder.encode(DOCUMENT_CLOSE_SUFFIX));
     },
   });
 }

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -289,6 +289,20 @@ describe("App Router integration", () => {
     expect(html).toContain("</body></html>");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+  // (regression for #1532)
+  it("ends the streamed body with </body></html> and not after trailing scripts", async () => {
+    const res = await fetch(`${baseUrl}/about`);
+    const html = await res.text();
+
+    const suffix = "</body></html>";
+    expect(html.endsWith(suffix)).toBe(true);
+    // The suffix must not appear anywhere else in the document — trailing
+    // flight chunks and preinit scripts must land before the closing tags.
+    expect(html.slice(0, -suffix.length)).not.toContain(suffix);
+  });
+
   it("SSR renders 'use client' components with initial state", async () => {
     const res = await fetch(`${baseUrl}/interactive`);
     expect(res.status).toBe(200);

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -339,6 +339,66 @@ describe("createTickBufferedTransform pre-head splice", () => {
     expect(out).not.toContain("<script>x</script>");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+  // (regression for #1532)
+  describe("</body></html> suffix is the last thing in the stream", () => {
+    it("moves the </body></html> suffix to the end after trailing scripts and RSC chunks", async () => {
+      // Simulate React Fizz emitting the closing tags BEFORE flush appends
+      // trailing flight chunks / preinit scripts.
+      const rsc = {
+        flush: () => "",
+        finalize: async () => '<script id="trailing-rsc">rsc()</script>',
+        getRawBuffer: async () => new ArrayBuffer(0),
+      };
+      const transform = createTickBufferedTransform(rsc, "", "");
+      const source = createTextStream([
+        "<!DOCTYPE html><html><head></head><body><div>hi</div></body></html>",
+      ]);
+      const out = await new Response(source.pipeThrough(transform)).text();
+
+      const suffix = "</body></html>";
+      expect(out.endsWith(suffix)).toBe(true);
+      // Only one occurrence — the suffix must not appear in the middle.
+      expect(out.slice(0, -suffix.length)).not.toContain(suffix);
+      // Trailing scripts land before the suffix, not after it.
+      expect(out).toContain('<script id="trailing-rsc">rsc()</script></body></html>');
+    });
+
+    it("ensures the suffix is at the end even when injectHTML fallback fires", async () => {
+      // When `<head>` never appears, injectHTML falls back to end-of-stream
+      // emission. The closing tags must still come last.
+      const rsc = {
+        flush: () => "",
+        finalize: async () => "",
+        getRawBuffer: async () => new ArrayBuffer(0),
+      };
+      const transform = createTickBufferedTransform(rsc, "<meta data-injected='1'/>", "");
+      const source = createTextStream(["<!DOCTYPE html><html><body></body></html>"]);
+      const out = await new Response(source.pipeThrough(transform)).text();
+
+      const suffix = "</body></html>";
+      expect(out.endsWith(suffix)).toBe(true);
+      expect(out.slice(0, -suffix.length)).not.toContain(suffix);
+      expect(out).toContain("<meta data-injected='1'/>");
+    });
+
+    it("adds the suffix at the end even when the source stream omits it", async () => {
+      // Defense-in-depth: if React Fizz somehow ends without `</body></html>`,
+      // we still emit a well-formed document close.
+      const rsc = {
+        flush: () => "",
+        finalize: async () => "",
+        getRawBuffer: async () => new ArrayBuffer(0),
+      };
+      const transform = createTickBufferedTransform(rsc, "", "");
+      const source = createTextStream(["<!DOCTYPE html><html><head></head><body>oops"]);
+      const out = await new Response(source.pipeThrough(transform)).text();
+
+      expect(out.endsWith("</body></html>")).toBe(true);
+    });
+  });
+
   it("re-evaluates the insertion getter only when splice runs", async () => {
     // For the function-shaped getter we need to confirm we read it lazily —
     // once at splice time — so callers can pass a getter that snapshots state

--- a/tests/rsc-streaming.test.ts
+++ b/tests/rsc-streaming.test.ts
@@ -280,10 +280,16 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     // Done signal at the end
     expect(output).toContain(RSC_RUNTIME_DONE);
 
-    // The done signal should come AFTER all HTML content
-    const lastHtmlPos = output.indexOf("</html>");
+    // The done signal should appear after the body content but BEFORE the
+    // document-close suffix. See #1532 — `</body></html>` is now suffix-moved
+    // to the very end of the stream so the document terminates with a
+    // well-formed close (mirrors Next.js's `createMoveSuffixStream`).
+    const bodyContentEnd =
+      output.indexOf("<div>Boundary 2</div>") + "<div>Boundary 2</div>".length;
     const donePos = output.indexOf(RSC_RUNTIME_DONE);
-    expect(donePos).toBeGreaterThan(lastHtmlPos);
+    const lastHtmlPos = output.indexOf("</html>");
+    expect(donePos).toBeGreaterThan(bodyContentEnd);
+    expect(lastHtmlPos).toBeGreaterThan(donePos);
   });
 
   it("injects head content before </head>", async () => {

--- a/tests/rsc-streaming.test.ts
+++ b/tests/rsc-streaming.test.ts
@@ -284,8 +284,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
     // document-close suffix. See #1532 — `</body></html>` is now suffix-moved
     // to the very end of the stream so the document terminates with a
     // well-formed close (mirrors Next.js's `createMoveSuffixStream`).
-    const bodyContentEnd =
-      output.indexOf("<div>Boundary 2</div>") + "<div>Boundary 2</div>".length;
+    const bodyContentEnd = output.indexOf("<div>Boundary 2</div>") + "<div>Boundary 2</div>".length;
     const donePos = output.indexOf(RSC_RUNTIME_DONE);
     const lastHtmlPos = output.indexOf("</html>");
     expect(donePos).toBeGreaterThan(bodyContentEnd);


### PR DESCRIPTION
## Summary

The App Router streaming SSR pipeline emitted trailing flight chunks and preinit scripts (from `rscEmbed.finalize()`) *after* React Fizz's `</body></html>` closing tags, leaving the body ending in `<script>...</script>` instead of a well-formed document close. This broke `body.endsWith('</body></html>')` consumer assertions.

The fix mirrors Next.js's `createMoveSuffixStream`: strip the first `</body></html>` we see in buffered chunks and re-emit it at the very end of the transform's `flush()`, after the final RSC scripts.

- Code change: `packages/vinext/src/server/app-ssr-stream.ts` (~25 lines of net logic + comments).
- Unit tests: 3 cases in `tests/app-ssr-stream.test.ts` cover trailing-script reorder, the no-`<head>` fallback path, and the missing-suffix defense-in-depth.
- Integration test: 1 case in `tests/app-router.test.ts` exercises a real App Router render and asserts `html.endsWith('</body></html>')` plus that the suffix appears only once.

Reference (Next.js):
- Test: [test/e2e/app-dir/app/index.test.ts](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts) — "should ensure the </body></html> suffix is at the end of the stream"
- Source: [stream-utils/node-web-streams-helper.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/stream-utils/node-web-streams-helper.ts) — `createMoveSuffixStream` and `CLOSE_TAG`

Fixes #1532.

## Test plan

- [x] `pnpm test tests/app-ssr-stream.test.ts` — 21 tests pass (3 new)
- [x] `pnpm test tests/app-router.test.ts tests/app-page-stream.test.ts` — 347 tests pass (1 new)
- [x] `pnpm test tests/features.test.ts` — 309 tests pass
- [x] `pnpm run check` — formatting, lint, types clean