### PR TITLE
fix(shims/head): dedupe Pages Router <Head> tags on re-render

### DIFF
--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -341,6 +341,11 @@ export function _applyHeadPropsToElement(
  * See: https://bugs.chromium.org/p/chromium/issues/detail?id=1211471#c12
  */
 export function isEqualHeadNode(oldTag: Element, newTag: Element): boolean {
+  // In production this only runs on the client (the reconciler is invoked
+  // from `syncClientHead`, gated by `typeof window !== "undefined"`). The
+  // `typeof HTMLElement` guard exists for the Node test environment, where
+  // unit tests drive `_reconcileClientHead` directly with DOM doubles and
+  // `HTMLElement` may be undefined.
   if (
     typeof HTMLElement !== "undefined" &&
     oldTag instanceof HTMLElement &&
@@ -370,8 +375,10 @@ export type HeadDocumentLike = {
   createElement(tag: string): Element;
 };
 type HeadEl = {
+  querySelector(selector: string): Element | null;
   querySelectorAll(selector: string): ArrayLike<Element>;
   appendChild(el: Element): unknown;
+  prepend(el: Element): unknown;
 };
 
 /**
@@ -426,6 +433,28 @@ export function _reconcileClientHead(
     bucket.add(el);
   }
 
+  // Adopt template-injected `<meta charset>` into the managed meta bucket so a
+  // `<Head><meta charSet="..." /></Head>` replaces it instead of duplicating.
+  // Mirrors the special case in Next.js's `updateElements`. We only adopt when
+  // `<Head>` itself declares a charset meta — Next.js adopts unconditionally,
+  // which removes a template `<meta charset>` even when `<Head>` never touches
+  // charset; that drop is arguably a Next.js bug and breaks templates that
+  // rely on the meta-charset tag staying put.
+  const desiredHasCharsetMeta = desiredByType
+    .get("meta")
+    ?.some((c) => (c.props as Record<string, unknown>).charSet !== undefined);
+  if (desiredHasCharsetMeta) {
+    const templateCharset = headEl.querySelector("meta[charset]");
+    if (templateCharset) {
+      let metaBucket = existingByType.get("meta");
+      if (!metaBucket) {
+        metaBucket = new Set();
+        existingByType.set("meta", metaBucket);
+      }
+      metaBucket.add(templateCharset);
+    }
+  }
+
   const tagTypes = new Set<string>([...desiredByType.keys(), ...existingByType.keys()]);
   for (const tagType of tagTypes) {
     const desiredForType = desiredByType.get(tagType) ?? [];
@@ -452,7 +481,19 @@ export function _reconcileClientHead(
       oldTag.parentNode?.removeChild(oldTag);
     }
     for (const newTag of toAppend) {
-      headEl.appendChild(newTag);
+      // `<meta charset>` must remain first in `<head>` for the HTML parser to
+      // honour it, so prepend rather than append. Matches Next.js's behaviour.
+      // React surfaces the prop as `charSet`; real DOM stores it as `charset`.
+      // Real browsers treat `getAttribute` as case-insensitive, but we accept
+      // both spellings so test doubles don't need to normalize.
+      if (
+        tagType === "meta" &&
+        (newTag.getAttribute("charset") !== null || newTag.getAttribute("charSet") !== null)
+      ) {
+        headEl.prepend(newTag);
+      } else {
+        headEl.appendChild(newTag);
+      }
     }
   }
 }

--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -324,19 +324,150 @@ export function _applyHeadPropsToElement(
   }
 }
 
-function syncClientHead(): void {
-  document.querySelectorAll("[data-next-head]").forEach((el) => el.remove());
-
-  for (const child of reduceHeadChildren([..._clientHeadChildren.values()])) {
-    if (typeof child.type !== "string") continue;
-
-    const domEl = document.createElement(child.type);
-    const props = child.props as Record<string, unknown>;
-    _applyHeadPropsToElement(domEl, props);
-
-    domEl.setAttribute("data-next-head", "");
-    document.head.appendChild(domEl);
+/**
+ * When a `nonce` is present on an element, browsers such as Chrome and Firefox
+ * strip it out of the actual HTML attributes for security reasons *when the
+ * element is added to the document*. Thus, two equivalent elements that have
+ * nonces will compare as unequal with `Element.isEqualNode()` once one has
+ * been added to the document. Although the `element.nonce` property will be
+ * the same for both elements, the one that was added to the document will
+ * return an empty string for its nonce HTML attribute value.
+ *
+ * This helper therefore strips the nonce value from `newTag` (preserving the
+ * typed `.nonce` property) before comparing it to `oldTag`. Mirrors Next.js's
+ * head-manager isEqualNode:
+ * .nextjs-ref/packages/next/src/client/head-manager.ts
+ *
+ * See: https://bugs.chromium.org/p/chromium/issues/detail?id=1211471#c12
+ */
+export function isEqualHeadNode(oldTag: Element, newTag: Element): boolean {
+  if (
+    typeof HTMLElement !== "undefined" &&
+    oldTag instanceof HTMLElement &&
+    newTag instanceof HTMLElement
+  ) {
+    const nonce = newTag.getAttribute("nonce");
+    // Only strip the nonce if `oldTag` has had it stripped. An element's nonce
+    // attribute is only stripped by the browser when a CSP nonce policy is
+    // active; otherwise the attribute remains and the values compare normally.
+    if (nonce && !oldTag.getAttribute("nonce")) {
+      const cloneTag = newTag.cloneNode(true) as HTMLElement;
+      cloneTag.setAttribute("nonce", "");
+      cloneTag.nonce = nonce;
+      return nonce === oldTag.nonce && oldTag.isEqualNode(cloneTag);
+    }
   }
+  return oldTag.isEqualNode(newTag);
+}
+
+/**
+ * Minimal `Document` surface required by the head reconciler. Exported (as a
+ * type) so tests can build a focused DOM double without dragging in a full
+ * `Document` polyfill.
+ */
+export type HeadDocumentLike = {
+  head: HeadEl | null;
+  createElement(tag: string): Element;
+};
+type HeadEl = {
+  querySelectorAll(selector: string): ArrayLike<Element>;
+  appendChild(el: Element): unknown;
+};
+
+/**
+ * Reconcile `desired` head elements against existing `[data-next-head]` tags
+ * inside `doc.head`. Mirrors Next.js's head-manager
+ * (`.nextjs-ref/packages/next/src/client/head-manager.ts`): instead of
+ * purging every managed element and recreating it (which would re-execute
+ * `<script>` tags and re-fetch `<link>` resources on every render), we diff
+ * desired against existing per tag type and only touch the DOM for the diff.
+ *
+ * Extracted from `syncClientHead` so tests can drive it with a DOM double
+ * without setting global `document`.
+ *
+ * @internal exported for tests only.
+ */
+export function _reconcileClientHead(
+  doc: HeadDocumentLike,
+  desired: readonly React.ReactElement[],
+): void {
+  const headEl = doc.head;
+  if (!headEl) return;
+
+  // Bucket desired elements by tag type so we diff each bucket independently.
+  // Matches Next.js's per-type reconciliation; `data-next-head` is scoped per
+  // tag, and a desired `<meta>` should never accidentally match an existing
+  // `<link>` even if their attribute shapes overlap.
+  const desiredByType = new Map<string, React.ReactElement[]>();
+  for (const child of desired) {
+    if (typeof child.type !== "string") continue;
+    let list = desiredByType.get(child.type);
+    if (!list) {
+      list = [];
+      desiredByType.set(child.type, list);
+    }
+    list.push(child);
+  }
+
+  // Snapshot existing managed elements once. We will mutate the per-type sets
+  // as we match new tags to old ones; anything left over is genuinely stale
+  // and must be removed.
+  const existingByType = new Map<string, Set<Element>>();
+  const managed = headEl.querySelectorAll("[data-next-head]");
+  for (let i = 0; i < managed.length; i++) {
+    const el = managed[i];
+    if (!el) continue;
+    const tag = el.tagName.toLowerCase();
+    let bucket = existingByType.get(tag);
+    if (!bucket) {
+      bucket = new Set();
+      existingByType.set(tag, bucket);
+    }
+    bucket.add(el);
+  }
+
+  const tagTypes = new Set<string>([...desiredByType.keys(), ...existingByType.keys()]);
+  for (const tagType of tagTypes) {
+    const desiredForType = desiredByType.get(tagType) ?? [];
+    const oldTags = existingByType.get(tagType) ?? new Set<Element>();
+    const toAppend: Element[] = [];
+
+    for (const component of desiredForType) {
+      const newTag = doc.createElement(tagType);
+      _applyHeadPropsToElement(newTag, component.props as Record<string, unknown>);
+      newTag.setAttribute("data-next-head", "");
+
+      let matched = false;
+      for (const oldTag of oldTags) {
+        if (isEqualHeadNode(oldTag, newTag)) {
+          oldTags.delete(oldTag);
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) toAppend.push(newTag);
+    }
+
+    for (const oldTag of oldTags) {
+      oldTag.parentNode?.removeChild(oldTag);
+    }
+    for (const newTag of toAppend) {
+      headEl.appendChild(newTag);
+    }
+  }
+}
+
+/**
+ * Synchronise the client `<head>` with the reduced projection of all mounted
+ * `<Head>` instances. Thin wrapper around `_reconcileClientHead` that pulls
+ * the desired set from the live `_clientHeadChildren` map and dispatches to
+ * the global `document`.
+ */
+function syncClientHead(): void {
+  _reconcileClientHead(
+    document as unknown as HeadDocumentLike,
+    reduceHeadChildren([..._clientHeadChildren.values()]),
+  );
 }
 
 // --- Component ---

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -14,6 +14,8 @@ import Head, {
   escapeAttr,
   reduceHeadChildren,
   _applyHeadPropsToElement,
+  _reconcileClientHead,
+  type HeadDocumentLike,
 } from "../packages/vinext/src/shims/head.js";
 
 // ─── SSR rendering (mirrors Next.js test/unit/next-head-rendering.test.ts) ──
@@ -554,5 +556,227 @@ describe("escapeAttr", () => {
 
   it("escapes all special chars together", () => {
     expect(escapeAttr('&"<>')).toBe("&amp;&quot;&lt;&gt;");
+  });
+});
+
+// ─── Head client reconciliation (dedupe on re-render) ───────────────────
+//
+// Regression coverage for issue #1473: the Pages Router head manager must
+// dedupe by attribute identity so `<script>` and `<link>` tags inside
+// `<Head>` are preserved across re-renders (instead of being removed and
+// re-appended, which re-executes scripts / re-fetches resources). Mirrors
+// `.nextjs-ref/packages/next/src/client/head-manager.ts:updateElements`
+// and the e2e test at `.nextjs-ref/test/e2e/nonce-head-manager/index.test.ts`.
+
+describe("Head client reconciliation", () => {
+  type FakeAttrEntry = { name: string; value: string };
+
+  let nextFakeElementId = 0;
+  class FakeElement {
+    public readonly tagName: string;
+    public readonly attributes: FakeAttrEntry[] = [];
+    public innerHTML = "";
+    public textContent = "";
+    public parentNode: FakeHead | null = null;
+    // Surfaced so we can detect re-execution: if the test observes the same
+    // FakeElement instance pre- and post-render, the underlying DOM node was
+    // preserved (no script re-execution). A different instance would mean the
+    // reconciler removed-then-recreated, which is the bug we are guarding
+    // against.
+    public readonly id: number;
+
+    constructor(tag: string) {
+      this.tagName = tag.toUpperCase();
+      this.id = ++nextFakeElementId;
+    }
+
+    setAttribute(name: string, value: string): void {
+      const existing = this.attributes.find((a) => a.name === name);
+      if (existing) existing.value = value;
+      else this.attributes.push({ name, value });
+    }
+
+    getAttribute(name: string): string | null {
+      return this.attributes.find((a) => a.name === name)?.value ?? null;
+    }
+
+    hasAttribute(name: string): boolean {
+      return this.attributes.some((a) => a.name === name);
+    }
+
+    isEqualNode(other: FakeElement): boolean {
+      if (this.tagName !== other.tagName) return false;
+      // Compare attribute sets order-independently so reconciliation matches
+      // the spec-level definition (HTML attributes are unordered).
+      if (this.attributes.length !== other.attributes.length) return false;
+      const otherMap = new Map(other.attributes.map((a) => [a.name, a.value]));
+      for (const { name, value } of this.attributes) {
+        if (otherMap.get(name) !== value) return false;
+      }
+      return this.innerHTML === other.innerHTML && this.textContent === other.textContent;
+    }
+  }
+
+  class FakeHead {
+    public readonly children: FakeElement[] = [];
+
+    appendChild(el: FakeElement): FakeElement {
+      el.parentNode = this;
+      this.children.push(el);
+      return el;
+    }
+
+    removeChild(el: FakeElement): FakeElement {
+      const idx = this.children.indexOf(el);
+      if (idx !== -1) this.children.splice(idx, 1);
+      el.parentNode = null;
+      return el;
+    }
+
+    querySelectorAll(selector: string): FakeElement[] {
+      if (selector !== "[data-next-head]") {
+        throw new Error(`FakeHead.querySelectorAll only supports [data-next-head]`);
+      }
+      return this.children.filter((c) => c.hasAttribute("data-next-head"));
+    }
+  }
+
+  type FakeDoc = HeadDocumentLike & { readonly head: FakeHead };
+
+  function createFakeDocument(): FakeDoc {
+    const head = new FakeHead();
+    // The internal reconciler is typed against a real DOM Element/Document
+    // shape; cast through `unknown` because FakeElement is intentionally a
+    // narrower duck-type (just enough for the reconciler's calls).
+    const doc = {
+      head,
+      createElement(tag: string): Element {
+        return new FakeElement(tag) as unknown as Element;
+      },
+    };
+    return doc as unknown as FakeDoc;
+  }
+
+  function makeScript(props: Record<string, unknown>): React.ReactElement {
+    return React.createElement("script", props);
+  }
+
+  it("preserves identical script tags across re-renders (no re-execution)", () => {
+    // The canonical issue #1473 scenario: a <script src="..."> inside <Head>
+    // must NOT be removed-and-re-appended when the host component re-renders.
+    // The reconciler returns the exact same DOM node instance for matching
+    // tags, which the browser then leaves in place — preserving the loaded
+    // state of the script.
+    const doc = createFakeDocument();
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js" })]);
+    expect(doc.head.children).toHaveLength(1);
+    const firstNode = doc.head.children[0]!;
+    expect(firstNode.getAttribute("src")).toBe("/src-1.js");
+
+    // Re-render with the exact same projection — equivalent to a parent
+    // component re-rendering without changing any head content.
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js" })]);
+    expect(doc.head.children).toHaveLength(1);
+    // Same node instance survives — no DOM churn, so the browser won't
+    // re-execute the script.
+    expect(doc.head.children[0]).toBe(firstNode);
+  });
+
+  it("appends a new tag when the script src actually changes", () => {
+    const doc = createFakeDocument();
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js" })]);
+    const firstNode = doc.head.children[0]!;
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-2.js" })]);
+    expect(doc.head.children).toHaveLength(1);
+    expect(doc.head.children[0]!.getAttribute("src")).toBe("/src-2.js");
+    // The previous /src-1.js node was removed (different src) — the new
+    // /src-2.js is a distinct node.
+    expect(doc.head.children[0]).not.toBe(firstNode);
+  });
+
+  it("preserves the script node even when a CSP nonce is present", () => {
+    // Mirrors the `/csp` variant of the upstream nonce-head-manager test.
+    // Browsers strip the `nonce` attribute from serialised HTML once the
+    // element is in the document, so `isEqualNode` would naively report
+    // unequal — the reconciler must compensate.
+    const doc = createFakeDocument();
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js", nonce: "abc123" })]);
+    const firstNode = doc.head.children[0]!;
+    expect(firstNode.getAttribute("nonce")).toBe("abc123");
+
+    // Simulate the browser stripping `nonce` from the live attribute (it
+    // remains on the element's `.nonce` property in real DOM). We only have
+    // attributes in this double, so for the equality test the "stripped"
+    // form just means the attribute string match still works because both
+    // sides carry the same nonce attribute.
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js", nonce: "abc123" })]);
+    expect(doc.head.children).toHaveLength(1);
+    expect(doc.head.children[0]).toBe(firstNode);
+  });
+
+  it("removes managed tags that are no longer desired", () => {
+    const doc = createFakeDocument();
+
+    _reconcileClientHead(doc, [
+      makeScript({ src: "/keep.js" }),
+      React.createElement("link", { rel: "stylesheet", href: "/drop.css" }),
+    ]);
+    expect(doc.head.children).toHaveLength(2);
+
+    _reconcileClientHead(doc, [makeScript({ src: "/keep.js" })]);
+    expect(doc.head.children).toHaveLength(1);
+    expect(doc.head.children[0]!.tagName).toBe("SCRIPT");
+    expect(doc.head.children[0]!.getAttribute("src")).toBe("/keep.js");
+  });
+
+  it("leaves unmanaged head children alone", () => {
+    // Tags without `data-next-head` (e.g. a `<meta charset>` written into the
+    // HTML template) must never be touched by the reconciler. This guards
+    // against accidentally widening the selector.
+    const doc = createFakeDocument();
+    const unmanaged = new FakeElement("meta");
+    unmanaged.setAttribute("charset", "utf-8");
+    doc.head.appendChild(unmanaged);
+
+    _reconcileClientHead(doc, [
+      React.createElement("meta", { name: "description", content: "hello" }),
+    ]);
+
+    // Original unmanaged tag is still present, plus the newly managed one.
+    expect(doc.head.children).toContain(unmanaged);
+    expect(doc.head.children).toHaveLength(2);
+  });
+
+  it("matches Next.js nonce-head-manager sequence: render, re-render, change, change back", () => {
+    // End-to-end shape of the upstream e2e test (without a real browser):
+    //   1. Render with src-1.js
+    //   2. Re-render with identical content (force-rerender click)
+    //   3. Change to src-2.js
+    //   4. Change back to src-1.js
+    //
+    // Expectation: step 2 preserves the node (no churn). Steps 3 and 4 each
+    // produce a fresh node (different src). The reconciler must never leave
+    // duplicate tags behind.
+    const doc = createFakeDocument();
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js", nonce: "abc123" })]);
+    const node1 = doc.head.children[0]!;
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js", nonce: "abc123" })]);
+    expect(doc.head.children).toHaveLength(1);
+    expect(doc.head.children[0]).toBe(node1);
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-2.js", nonce: "abc123" })]);
+    expect(doc.head.children).toHaveLength(1);
+    expect(doc.head.children[0]).not.toBe(node1);
+    expect(doc.head.children[0]!.getAttribute("src")).toBe("/src-2.js");
+
+    _reconcileClientHead(doc, [makeScript({ src: "/src-1.js", nonce: "abc123" })]);
+    expect(doc.head.children).toHaveLength(1);
+    expect(doc.head.children[0]!.getAttribute("src")).toBe("/src-1.js");
   });
 });

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -5,7 +5,7 @@
  * plus comprehensive coverage for vinext's Head SSR collection, HTML
  * generation, allowed tags, and escaping.
  */
-import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vite-plus/test";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
 import Head, {
@@ -15,6 +15,7 @@ import Head, {
   reduceHeadChildren,
   _applyHeadPropsToElement,
   _reconcileClientHead,
+  isEqualHeadNode,
   type HeadDocumentLike,
 } from "../packages/vinext/src/shims/head.js";
 
@@ -626,6 +627,12 @@ describe("Head client reconciliation", () => {
       return el;
     }
 
+    prepend(el: FakeElement): FakeElement {
+      el.parentNode = this;
+      this.children.unshift(el);
+      return el;
+    }
+
     removeChild(el: FakeElement): FakeElement {
       const idx = this.children.indexOf(el);
       if (idx !== -1) this.children.splice(idx, 1);
@@ -638,6 +645,15 @@ describe("Head client reconciliation", () => {
         throw new Error(`FakeHead.querySelectorAll only supports [data-next-head]`);
       }
       return this.children.filter((c) => c.hasAttribute("data-next-head"));
+    }
+
+    querySelector(selector: string): FakeElement | null {
+      if (selector !== "meta[charset]") {
+        throw new Error(`FakeHead.querySelector only supports meta[charset]`);
+      }
+      return (
+        this.children.find((c) => c.tagName === "META" && c.hasAttribute("charset")) ?? null
+      );
     }
   }
 
@@ -778,5 +794,211 @@ describe("Head client reconciliation", () => {
     _reconcileClientHead(doc, [makeScript({ src: "/src-1.js", nonce: "abc123" })]);
     expect(doc.head.children).toHaveLength(1);
     expect(doc.head.children[0]!.getAttribute("src")).toBe("/src-1.js");
+  });
+
+  it("dedupes template-injected meta[charset] when <Head> declares its own", () => {
+    // Next.js-parity behaviour: a template `<meta charset>` (no
+    // `data-next-head`) is adopted into the meta bucket when `<Head>`
+    // declares its own charSet, so we replace rather than duplicate.
+    const doc = createFakeDocument();
+    const templateCharset = new FakeElement("meta");
+    templateCharset.setAttribute("charset", "utf-8");
+    doc.head.appendChild(templateCharset);
+
+    _reconcileClientHead(doc, [React.createElement("meta", { charSet: "utf-8" })]);
+
+    // Only one charset meta survives, and it is first in head (prepended).
+    const charsets = doc.head.children.filter((c) => c.tagName === "META");
+    expect(charsets).toHaveLength(1);
+    expect(doc.head.children[0]!.getAttribute("data-next-head")).toBe("");
+  });
+
+  it("prepends a managed meta[charset] so it stays first in <head>", () => {
+    // The HTML parser only honours `<meta charset>` if it appears in the
+    // first 1024 bytes of `<head>`. New charset metas must be prepended.
+    const doc = createFakeDocument();
+    // Pre-existing managed link/script to ensure prepend (not append) is
+    // exercised — appendChild would land it after them.
+    _reconcileClientHead(doc, [
+      React.createElement("link", { rel: "stylesheet", href: "/a.css" }),
+    ]);
+    expect(doc.head.children).toHaveLength(1);
+
+    _reconcileClientHead(doc, [
+      React.createElement("link", { rel: "stylesheet", href: "/a.css" }),
+      React.createElement("meta", { charSet: "utf-8" }),
+    ]);
+
+    expect(doc.head.children).toHaveLength(2);
+    expect(doc.head.children[0]!.tagName).toBe("META");
+    expect(doc.head.children[1]!.tagName).toBe("LINK");
+  });
+});
+
+// ─── isEqualHeadNode (nonce stripping) ──────────────────────────────────
+//
+// Direct unit coverage for the nonce-compensation branch of `isEqualHeadNode`.
+// The reconciler tests above use a structural-equality FakeElement that
+// never enters the `instanceof HTMLElement` branch, so we drive the helper
+// here with focused doubles that simulate Chrome/Firefox stripping the
+// `nonce` HTML attribute once an element is in the document (the `.nonce`
+// JS property is preserved).
+//
+// Vitest's default `node` environment doesn't provide `HTMLElement`, so we
+// install a minimal global stub. The helper's only requirements on the
+// `HTMLElement` constructor are that `instanceof` succeeds and the standard
+// `getAttribute` / `setAttribute` / `cloneNode` / `isEqualNode` / `.nonce`
+// surface is reachable.
+
+describe("isEqualHeadNode", () => {
+  type Attr = { name: string; value: string };
+  class StubHTMLElement {
+    public attrs: Attr[] = [];
+    public stripNonceAttribute = false;
+    public nonce: string | undefined;
+    public equalsTarget: StubHTMLElement | null = null;
+
+    getAttribute(name: string): string | null {
+      if (name === "nonce" && this.stripNonceAttribute) return "";
+      return this.attrs.find((a) => a.name === name)?.value ?? null;
+    }
+
+    setAttribute(name: string, value: string): void {
+      const existing = this.attrs.find((a) => a.name === name);
+      if (existing) existing.value = value;
+      else this.attrs.push({ name, value });
+    }
+
+    cloneNode(_deep?: boolean): StubHTMLElement {
+      const clone = new StubHTMLElement();
+      clone.attrs = this.attrs.map((a) => ({ ...a }));
+      return clone;
+    }
+
+    isEqualNode(other: StubHTMLElement | null): boolean {
+      return other === this.equalsTarget;
+    }
+  }
+
+  // Capture the original HTMLElement once (before our beforeEach ever runs)
+  // so afterAll restores the env even after multiple installs.
+  const originalHTMLElement = (globalThis as { HTMLElement?: typeof HTMLElement })
+    .HTMLElement;
+
+  beforeEach(() => {
+    // Vitest globals snapshot has HTMLElement undefined under the node env.
+    // Install our stub before each test so `instanceof HTMLElement` matches.
+    (globalThis as { HTMLElement?: unknown }).HTMLElement = StubHTMLElement;
+  });
+
+  it("treats two nonced elements as equal when the browser stripped oldTag's nonce attribute", () => {
+    // Scenario:
+    //  - oldTag is in the document: its `nonce` HTML attribute was stripped
+    //    (Chrome/Firefox behaviour under CSP), but `.nonce` still holds the
+    //    real value.
+    //  - newTag is freshly created and still has the `nonce` attribute.
+    // Expected: `isEqualHeadNode` enters the nonce-stripping branch, clones
+    // newTag with nonce="" and `.nonce` preserved, then compares.
+    const oldTag = new StubHTMLElement();
+    oldTag.setAttribute("src", "/app.js");
+    oldTag.setAttribute("nonce", "abc123");
+    oldTag.stripNonceAttribute = true;
+    oldTag.nonce = "abc123";
+
+    const newTag = new StubHTMLElement();
+    newTag.setAttribute("src", "/app.js");
+    newTag.setAttribute("nonce", "abc123");
+
+    // The branch calls oldTag.isEqualNode(cloneTag). Capture the clone so we
+    // can assert its shape (nonce attribute stripped, .nonce preserved).
+    let capturedClone: StubHTMLElement | null = null;
+    oldTag.isEqualNode = function (other: StubHTMLElement | null): boolean {
+      capturedClone = other;
+      return true;
+    };
+
+    expect(isEqualHeadNode(oldTag as unknown as Element, newTag as unknown as Element)).toBe(true);
+    expect(capturedClone).not.toBe(newTag);
+    // The clone's nonce attribute must be the stripped sentinel.
+    expect(capturedClone!.getAttribute("nonce")).toBe("");
+    // ...but the typed .nonce property must be preserved so the live element
+    // can still satisfy CSP after replacement.
+    expect(capturedClone!.nonce).toBe("abc123");
+  });
+
+  it("requires .nonce on oldTag to match the new tag's attribute nonce", () => {
+    // If a stale element claims to be CSP-compliant via attribute-stripping
+    // but its `.nonce` property doesn't match, the comparison must fail.
+    const oldTag = new StubHTMLElement();
+    oldTag.setAttribute("nonce", "abc123");
+    oldTag.stripNonceAttribute = true;
+    oldTag.nonce = "different-nonce";
+
+    const newTag = new StubHTMLElement();
+    newTag.setAttribute("nonce", "abc123");
+
+    // Even if structural isEqualNode would say true, the .nonce mismatch
+    // short-circuits to false.
+    oldTag.isEqualNode = (): boolean => true;
+
+    expect(isEqualHeadNode(oldTag as unknown as Element, newTag as unknown as Element)).toBe(
+      false,
+    );
+  });
+
+  it("falls through to plain isEqualNode when neither tag carries a nonce", () => {
+    // The optimization only matters when a nonce is present. Without one,
+    // the helper must defer entirely to the native isEqualNode result.
+    const oldTag = new StubHTMLElement();
+    const newTag = new StubHTMLElement();
+    oldTag.equalsTarget = newTag;
+
+    expect(isEqualHeadNode(oldTag as unknown as Element, newTag as unknown as Element)).toBe(true);
+
+    // Inequality propagates too: a different target makes isEqualNode return false.
+    const otherTag = new StubHTMLElement();
+    expect(isEqualHeadNode(oldTag as unknown as Element, otherTag as unknown as Element)).toBe(
+      false,
+    );
+  });
+
+  it("falls through to plain isEqualNode when oldTag's nonce attribute is still present", () => {
+    // If oldTag still has its `nonce` attribute (CSP isn't stripping it),
+    // the nonce-stripping branch must NOT be taken — we fall straight
+    // through to plain `isEqualNode`.
+    const oldTag = new StubHTMLElement();
+    oldTag.setAttribute("nonce", "abc123");
+    // stripNonceAttribute stays false: getAttribute returns the real value.
+
+    const newTag = new StubHTMLElement();
+    newTag.setAttribute("nonce", "abc123");
+
+    let usedFallback = false;
+    oldTag.isEqualNode = function (other: StubHTMLElement | null): boolean {
+      usedFallback = other === newTag;
+      return usedFallback;
+    };
+
+    expect(isEqualHeadNode(oldTag as unknown as Element, newTag as unknown as Element)).toBe(true);
+    expect(usedFallback).toBe(true);
+  });
+
+  it("falls through to plain isEqualNode when neither side is an HTMLElement", () => {
+    // Important: the FakeElement used by the reconciler tests above is NOT
+    // an HTMLElement, so isEqualHeadNode must skip the strip branch entirely
+    // and defer to whatever `oldTag.isEqualNode` returns.
+    const oldTag = { isEqualNode: (other: unknown): boolean => other === newTag };
+    const newTag = {};
+    expect(isEqualHeadNode(oldTag as unknown as Element, newTag as unknown as Element)).toBe(true);
+  });
+
+  // Restore HTMLElement after this describe so other tests aren't polluted.
+  // Using `afterEach` would restore between tests; we want restore after all.
+  afterAll(() => {
+    if (originalHTMLElement === undefined) {
+      delete (globalThis as { HTMLElement?: unknown }).HTMLElement;
+    } else {
+      (globalThis as { HTMLElement?: unknown }).HTMLElement = originalHTMLElement;
+    }
   });
 });

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -651,9 +651,7 @@ describe("Head client reconciliation", () => {
       if (selector !== "meta[charset]") {
         throw new Error(`FakeHead.querySelector only supports meta[charset]`);
       }
-      return (
-        this.children.find((c) => c.tagName === "META" && c.hasAttribute("charset")) ?? null
-      );
+      return this.children.find((c) => c.tagName === "META" && c.hasAttribute("charset")) ?? null;
     }
   }
 
@@ -819,9 +817,7 @@ describe("Head client reconciliation", () => {
     const doc = createFakeDocument();
     // Pre-existing managed link/script to ensure prepend (not append) is
     // exercised — appendChild would land it after them.
-    _reconcileClientHead(doc, [
-      React.createElement("link", { rel: "stylesheet", href: "/a.css" }),
-    ]);
+    _reconcileClientHead(doc, [React.createElement("link", { rel: "stylesheet", href: "/a.css" })]);
     expect(doc.head.children).toHaveLength(1);
 
     _reconcileClientHead(doc, [
@@ -882,8 +878,7 @@ describe("isEqualHeadNode", () => {
 
   // Capture the original HTMLElement once (before our beforeEach ever runs)
   // so afterAll restores the env even after multiple installs.
-  const originalHTMLElement = (globalThis as { HTMLElement?: typeof HTMLElement })
-    .HTMLElement;
+  const originalHTMLElement = (globalThis as { HTMLElement?: typeof HTMLElement }).HTMLElement;
 
   beforeEach(() => {
     // Vitest globals snapshot has HTMLElement undefined under the node env.
@@ -941,9 +936,7 @@ describe("isEqualHeadNode", () => {
     // short-circuits to false.
     oldTag.isEqualNode = (): boolean => true;
 
-    expect(isEqualHeadNode(oldTag as unknown as Element, newTag as unknown as Element)).toBe(
-      false,
-    );
+    expect(isEqualHeadNode(oldTag as unknown as Element, newTag as unknown as Element)).toBe(false);
   });
 
   it("falls through to plain isEqualNode when neither tag carries a nonce", () => {


### PR DESCRIPTION
## Summary

The Pages Router `<Head>` client manager previously purged every `[data-next-head]` element and re-appended a fresh DOM node on every re-render. For `<script src="...">` (and `<link>`) tags inside `<Head>`, this caused the browser to re-execute the script on each parent re-render — even when nothing in the head projection had actually changed.

Mirror Next.js's [`head-manager.ts:updateElements`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/head-manager.ts) reconciliation:

- Bucket desired and existing managed tags by tag type.
- For each desired tag, look for an equal existing tag (`isEqualNode`) and keep the live DOM node when matched.
- Only remove the genuinely-stale existing tags and only append the genuinely-new ones.

Also handle the browser's nonce-stripping quirk (Chrome/Firefox strip `nonce` from the serialised attribute once an element is in the document) so CSP-tagged scripts still compare equal across renders — matches the upstream behaviour.

## Test plan

- [x] New unit tests in `tests/head.test.ts` cover:
  - Identical script tags preserved across re-renders (same DOM node).
  - Tags with a different `src` produce a fresh node.
  - Nonce-tagged scripts dedupe across re-renders.
  - Stale managed tags removed when no longer desired.
  - Unmanaged head children (no `data-next-head`) left untouched.
  - End-to-end shape of the upstream e2e: render → re-render → change src → change back.
- [x] `pnpm test tests/head.test.ts tests/script.test.ts tests/shims.test.ts` — 1068 tests pass.
- [x] `pnpm run check` — format, lint, type check clean.
- [ ] CI green.

## References

- Fixes #1473
- Mirrors the canonical Next.js e2e: `.nextjs-ref/test/e2e/nonce-head-manager/index.test.ts`
- Upstream impl: `.nextjs-ref/packages/next/src/client/head-manager.ts`