### PR TITLE
test(app-router): cover stale search params on clean replace 

### DIFF
--- a/tests/e2e/app-router/nextjs-compat/stale-search-params-on-replace-regression.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/stale-search-params-on-replace-regression.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Ported from Next.js:
+ * test/e2e/app-dir/segment-cache/stale-search-params-on-replace-regression/stale-search-params-on-replace-regression.test.ts
+ *
+ * Upstream fix:
+ * https://github.com/vercel/next.js/commit/a7877d776b8a8cb0a5556d84ec75df99b5bdea70
+ */
+
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+const ROUTE = "/nextjs-compat/stale-search-params-on-replace-regression";
+
+test.describe("Next.js compat: stale search params on replace regression", () => {
+  test("router.replace to a clean URL clears the search params from the initial load", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}${ROUTE}?query=param`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#home")).toHaveText("Home");
+    await expect(page.locator("#search-params")).toHaveText("query=param");
+
+    await page.click("#link-to-dummy-1");
+    await expect(page.locator("#dummy-page-1")).toHaveText("Dummy Page 1", {
+      timeout: 10_000,
+    });
+
+    await page.click("#link-to-dummy-2");
+    await expect(page.locator("#dummy-page-2")).toHaveText("Dummy Page 2", {
+      timeout: 10_000,
+    });
+
+    await page.click("#go-home");
+    await expect(page.locator("#home")).toHaveText("Home", { timeout: 10_000 });
+    await expect(page.locator("#search-params")).toHaveText("");
+
+    await expect
+      .poll(() => {
+        const url = new URL(page.url());
+        return { pathname: url.pathname, search: url.search };
+      })
+      .toEqual({ pathname: ROUTE, search: "" });
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-1/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-1/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="dummy-page-1">Dummy Page 1</h1>
+      <Link
+        id="link-to-dummy-2"
+        href="/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-2"
+      >
+        Go to dummy page 2
+      </Link>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-2/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-2/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function Page() {
+  const router = useRouter();
+
+  return (
+    <>
+      <h1 id="dummy-page-2">Dummy Page 2</h1>
+      <button
+        id="go-home"
+        onClick={() => router.replace("/nextjs-compat/stale-search-params-on-replace-regression")}
+      >
+        Go to home
+      </button>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+import { SearchInfo } from "./search-info";
+
+export default function Home() {
+  return (
+    <>
+      <h1 id="home">Home</h1>
+      <SearchInfo />
+      <Link
+        id="link-to-dummy-1"
+        href="/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-1"
+      >
+        Go to dummy page 1
+      </Link>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/search-info.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/search-info.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export function SearchInfo() {
+  const searchParams = useSearchParams();
+
+  return <p id="search-params">{searchParams.toString()}</p>;
+}


### PR DESCRIPTION
Closes #1621.

## Summary

Adds regression coverage for the upstream Next.js segment-cache bug where an initial request search string could be restored after `router.replace()` to a clean URL.

- Adds an App Router fixture that mirrors the upstream reproduction: load the route with `?query=param`, navigate through two `<Link>` hops, then call `router.replace()` back to the same route without a search string.
- Asserts both the browser URL and `useSearchParams()` are clean after the replace.
- Leaves runtime code unchanged: vinext's App Router visited/prefetch cache paths already key on the requested RSC URL, including `url.pathname + url.search`, so the upstream `renderedSearch` write-key bug does not reproduce here.

Reference (Next.js):
- Test: `test/e2e/app-dir/segment-cache/stale-search-params-on-replace-regression/stale-search-params-on-replace-regression.test.ts`
- Fix: https://github.com/vercel/next.js/commit/a7877d776b8a8cb0a5556d84ec75df99b5bdea70

## Test plan

- [x] `vp check tests/e2e/app-router/nextjs-compat/stale-search-params-on-replace-regression.spec.ts tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/search-info.tsx tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/page.tsx tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-1/page.tsx tests/fixtures/app-basic/app/nextjs-compat/stale-search-params-on-replace-regression/dummy-page-2/page.tsx`
- [x] `PLAYWRIGHT_PROJECT=app-router playwright test tests/e2e/app-router/nextjs-compat/stale-search-params-on-replace-regression.spec.ts --project app-router --reporter=list`
