### PR TITLE
fix(route-handler): default Path=/ on returned Set-Cookie when merging mutable cookies

### DIFF
--- a/packages/vinext/src/server/app-route-handler-response.ts
+++ b/packages/vinext/src/server/app-route-handler-response.ts
@@ -149,7 +149,58 @@ function getSetCookieName(cookie: string): string | null {
   if (equalsIndex <= 0) {
     return null;
   }
-  return cookie.slice(0, equalsIndex);
+  // The attribute portion (after the first ';') must not be considered part
+  // of the name. Bounding by the first ';' covers headers such as
+  // `name=value; Path=/`.
+  const semicolonIndex = cookie.indexOf(";");
+  const end = semicolonIndex === -1 ? equalsIndex : Math.min(equalsIndex, semicolonIndex);
+  return cookie.slice(0, end);
+}
+
+/**
+ * Returns true when the given Set-Cookie string already declares any of the
+ * attributes that follow the first `;` (case-insensitively). Used to detect
+ * whether a user-emitted Set-Cookie line already carries an explicit `Path=`,
+ * matching Next.js's `appendMutableCookies` which re-runs every cookie through
+ * `ResponseCookies.set` (and therefore picks up the `Path=/` default for any
+ * cookie that didn't supply one).
+ */
+function hasCookieAttribute(cookie: string, attributeName: string): boolean {
+  const target = attributeName.toLowerCase();
+  // Skip past the first '=' (the cookie value separator) so we don't match
+  // `attributeName=` inside the cookie value itself.
+  let i = cookie.indexOf(";");
+  while (i !== -1) {
+    // Trim leading whitespace after the ';'
+    let start = i + 1;
+    while (start < cookie.length && cookie[start] === " ") start++;
+    const next = cookie.indexOf(";", start);
+    const end = next === -1 ? cookie.length : next;
+    const eq = cookie.indexOf("=", start);
+    const attrEnd = eq === -1 || eq > end ? end : eq;
+    const attr = cookie.slice(start, attrEnd).trim().toLowerCase();
+    if (attr === target) {
+      return true;
+    }
+    i = next;
+  }
+  return false;
+}
+
+/**
+ * Ensure each Set-Cookie line carries `Path=/` by default — Next.js's
+ * `appendMutableCookies` re-runs every returned cookie through
+ * `ResponseCookies.set`, which normalises a missing `path` to `/`. Without
+ * this, a raw `new Response(..., { headers: [['Set-Cookie', 'bar=bar2']] })`
+ * lands without `Path=/` and tests that assert on the full attribute set
+ * (e.g. Next.js's `app-action.test.ts` route-handler-overrides case, see
+ * issue #1484) break.
+ */
+function normalizeReturnedCookie(cookie: string): string {
+  if (hasCookieAttribute(cookie, "Path")) {
+    return cookie;
+  }
+  return `${cookie}; Path=/`;
 }
 
 function applyMutableCookieFallbacks(headers: Headers, pendingCookies: string[]): void {
@@ -188,7 +239,7 @@ function applyMutableCookieFallbacks(headers: Headers, pendingCookies: string[])
     headers.append("Set-Cookie", cookie);
   }
   for (const cookie of returnedCookies) {
-    headers.append("Set-Cookie", cookie);
+    headers.append("Set-Cookie", normalizeReturnedCookie(cookie));
   }
 }
 

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/handler-cookie-overrides/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/handler-cookie-overrides/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Mirrors Next.js's `app/handler/route.js` test fixture used by
+ * `test/e2e/app-dir/actions/app-action.test.ts` ("should support setting
+ * cookies in route handlers with the correct overrides").
+ *
+ * The route exercises four sources of Set-Cookie attributes:
+ *   - `cookies().set(name, value)` (no options) → gets default `Path=/`
+ *   - `cookies().set(name, value, { secure: true })` → keeps Path=/ + Secure
+ *   - `cookies().set({ ..., httpOnly, path: '/handler' })` → object form
+ *   - returned `new Response(..., { headers: [['Set-Cookie', 'bar=bar2'], ...] })`
+ *     which overrides the mutable cookie for `bar` and adds a brand-new `baz`.
+ *
+ * Each entry must end up as its own Set-Cookie line carrying its full
+ * attribute set. https://github.com/cloudflare/vinext/issues/1484
+ */
+import { cookies } from "next/headers";
+
+export async function GET(): Promise<Response> {
+  const localCookies = await cookies();
+  localCookies.set("foo", "foo1");
+  localCookies.set("bar", "bar1");
+
+  // Key, value, options
+  localCookies.set("test1", "value1", { secure: true });
+
+  // One object — different Path than the default.
+  localCookies.set({
+    name: "test2",
+    value: "value2",
+    httpOnly: true,
+    path: "/handler",
+  });
+
+  // Cookies here will be merged with the ones above — `bar` overrides the
+  // mutable value, `baz` is a brand-new cookie only set on the response.
+  return new Response("Hello, world!", {
+    headers: [
+      ["Content-Type", "text/custom"],
+      ["Set-Cookie", "bar=bar2"],
+      ["Set-Cookie", "baz=baz2"],
+    ],
+  });
+}

--- a/tests/nextjs-compat/set-cookies.test.ts
+++ b/tests/nextjs-compat/set-cookies.test.ts
@@ -63,6 +63,24 @@ describe("Next.js compat: set-cookies", () => {
     expect(setCookies.some((c) => c.includes("theme=dark"))).toBe(true);
   });
 
+  it("route handler cookies().set() overrides preserve per-cookie attributes", async () => {
+    // Issue #1484 — mirrors Next.js's app/handler/route.js test fixture used by
+    // test/e2e/app-dir/actions/app-action.test.ts ("should support setting
+    // cookies in route handlers with the correct overrides").
+    //
+    // Each Set-Cookie line must carry its own attribute set; mutable cookies
+    // overridden by the returned Response's headers must still receive a
+    // `Path=/` default (matching Next.js's `appendMutableCookies`).
+    // https://github.com/cloudflare/vinext/issues/1484
+    const res = await fetch(`${baseUrl}/nextjs-compat/api/handler-cookie-overrides`);
+    const setCookieHeader = res.headers.get("set-cookie") ?? "";
+    expect(setCookieHeader).toContain("bar=bar2; Path=/");
+    expect(setCookieHeader).toContain("baz=baz2; Path=/");
+    expect(setCookieHeader).toContain("foo=foo1; Path=/");
+    expect(setCookieHeader).toContain("test1=value1; Path=/; Secure");
+    expect(setCookieHeader).toContain("test2=value2; Path=/handler; HttpOnly");
+  });
+
   it("returned response cookies take precedence over mutable cookies with the same name", async () => {
     // Next.js app route handlers merge mutable cookies as fallbacks before
     // reapplying returned response cookies as the final values.


### PR DESCRIPTION
## Summary

Fixes #1484.

When a route handler called `cookies().set()` alongside a returned `Response` that carried raw `Set-Cookie` headers without a `Path` attribute, vinext appended the raw line verbatim. The resulting comma-joined `set-cookie` view read like `bar=bar2, baz=baz2` (no per-cookie `Path=/`), diverging from Next.js which normalises missing `path` to `/` via `ResponseCookies.set` inside [`appendMutableCookies`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts).

`applyMutableCookieFallbacks` now ensures each returned cookie carries an explicit `Path=` attribute. Pending-mutable cookies were already serialised via our `serializeSetCookie` helper (which already defaults `Path=/`) — this change only normalises the returned ones.

Test coverage ported from Next.js's [`test/e2e/app-dir/actions/app-action.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts) (`"should support setting cookies in route handlers with the correct overrides"`), backed by a new `app/nextjs-compat/api/handler-cookie-overrides/route.ts` fixture mirroring Next.js's `app/handler/route.js`.

## Test plan

- [x] `pnpm test tests/nextjs-compat/set-cookies.test.ts` — new test fails before the fix, passes after.
- [x] `pnpm test tests/app-route-handler-response.test.ts tests/app-route-handler-execution.test.ts tests/shims.test.ts` — 1025 passing.
- [x] `pnpm test tests/app-router.test.ts tests/app-route-handler-runtime.test.ts tests/app-route-handler-dispatch.test.ts tests/app-route-handler-policy.test.ts` — 357 passing.
- [x] `pnpm run lint` — clean.
- [x] `pnpm run fmt:check` — clean.