### PR TITLE
test(link): port Next.js OnNavigate fixture as Pages Router regression (#1357)

### DIFF
--- a/tests/e2e/pages-router/link-advanced.spec.ts
+++ b/tests/e2e/pages-router/link-advanced.spec.ts
@@ -117,3 +117,82 @@ test.describe("Link advanced props (Pages Router)", () => {
     expect(reportedUrl).toBe("/link-test?page=2");
   });
 });
+
+// Ported from Next.js: test/e2e/link-on-navigate-prop/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/link-on-navigate-prop/index.test.ts
+//
+// Mirrors the upstream OnNavigate scenarios for Pages Router: onClick always
+// fires, onNavigate fires only for client-side internal navigation, calling
+// `event.preventDefault()` cancels navigation, and modifier-key / target=_blank
+// / download / external links skip onNavigate while still firing onClick.
+test.describe("Link onNavigate prop (Pages Router, OnNavigate fixture)", () => {
+  const PAGE = "/on-navigate-fixture";
+
+  test("toggle-lock button hydrates and updates isLocked", async ({ page }) => {
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    await expect(page.locator("#is-locked")).toHaveText("isLocked: false");
+    await page.click("#toggle-lock");
+    await expect(page.locator("#is-locked")).toHaveText("isLocked: true");
+  });
+
+  test("fires onClick and onNavigate for an internal click", async ({ page }) => {
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    await expect(page.locator("#is-clicked")).toHaveText("isClicked: false");
+    await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
+
+    await page.click("#link-to-subpage");
+
+    await expect(page.locator("#subpage-heading")).toHaveText("Subpage");
+  });
+
+  test("cancels navigation when onNavigate calls preventDefault", async ({ page }) => {
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    await page.click("#toggle-lock");
+    await expect(page.locator("#is-locked")).toHaveText("isLocked: true");
+
+    await page.click("#link-to-subpage");
+    // Still on the same page (onNavigate.preventDefault cancelled navigation)
+    await expect(page.locator("#is-clicked")).toHaveText("isClicked: true");
+    await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
+    expect(page.url()).toBe(`${BASE}${PAGE}`);
+  });
+
+  test("download links fire onClick but not onNavigate", async ({ page }) => {
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    // Block the actual download so the test doesn't hang waiting for a file.
+    await page.evaluate(() => {
+      document.getElementById("download-link")?.addEventListener("click", (e) => {
+        e.preventDefault();
+      });
+    });
+
+    await page.click("#download-link");
+    await expect(page.locator("#is-clicked")).toHaveText("isClicked: true");
+    await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
+  });
+
+  test('target="_blank" links fire onClick but not onNavigate', async ({ page }) => {
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    // The browser would normally open a new tab; intercept so the test
+    // process stays on the original page and we can read its state.
+    await page.evaluate(() => {
+      document
+        .getElementById("external-link-with-target")
+        ?.addEventListener("click", (e) => e.preventDefault());
+    });
+
+    await page.click("#external-link-with-target");
+    await expect(page.locator("#is-clicked")).toHaveText("isClicked: true");
+    await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
+  });
+});

--- a/tests/e2e/pages-router/link-advanced.spec.ts
+++ b/tests/e2e/pages-router/link-advanced.spec.ts
@@ -144,6 +144,32 @@ test.describe("Link onNavigate prop (Pages Router, OnNavigate fixture)", () => {
     await expect(page.locator("#is-clicked")).toHaveText("isClicked: false");
     await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
 
+    // Upstream's fixture mounts `OnNavigate.tsx` in `_app.tsx` so the state
+    // pills survive a client-side transition and can be asserted against
+    // the post-navigation DOM. This port keeps the fixture as a single
+    // page (to avoid polluting the rest of `pages-basic`), so the source
+    // `OnNavigate` component unmounts on navigation. We stub `pushState` to
+    // a no-op so vinext's Link calls it during navigation but the browser
+    // never commits the URL change — the React synthetic handlers
+    // (`onClick` + `onNavigate`) have already run synchronously at this
+    // point and their `setIsClicked` / `setIsNavigated` state updates have
+    // flushed, so we can assert against the in-place DOM.
+    await page.evaluate(() => {
+      window.history.pushState = () => {};
+      window.history.replaceState = () => {};
+    });
+
+    await page.click("#link-to-subpage");
+
+    // Mirrors the upstream assertions on `isClicked` / `isNavigated`.
+    await expect(page.locator("#is-clicked")).toHaveText("isClicked: true");
+    await expect(page.locator("#is-navigated")).toHaveText("isNavigated: true");
+  });
+
+  test("internal click navigates to the subpage", async ({ page }) => {
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
     await page.click("#link-to-subpage");
 
     await expect(page.locator("#subpage-heading")).toHaveText("Subpage");
@@ -168,6 +194,17 @@ test.describe("Link onNavigate prop (Pages Router, OnNavigate fixture)", () => {
     await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
 
     // Block the actual download so the test doesn't hang waiting for a file.
+    //
+    // This native `click` listener is added directly to the anchor element,
+    // so it runs in the DOM event-listener phase — *after* React's synthetic
+    // event delegation has already dispatched `onClick` and `onNavigate` to
+    // the React handlers. React listens at the root and re-dispatches from
+    // there during the bubble phase of the native event, so by the time our
+    // native listener calls `e.preventDefault()`, both `setIsClicked(true)`
+    // and the `onNavigate` decision (which here is a no-op for download
+    // links because vinext's Link short-circuits before calling it) have
+    // already happened. The `preventDefault()` only blocks the browser's
+    // default download behaviour, not the React handlers.
     await page.evaluate(() => {
       document.getElementById("download-link")?.addEventListener("click", (e) => {
         e.preventDefault();
@@ -194,5 +231,82 @@ test.describe("Link onNavigate prop (Pages Router, OnNavigate fixture)", () => {
     await page.click("#external-link-with-target");
     await expect(page.locator("#is-clicked")).toHaveText("isClicked: true");
     await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
+  });
+
+  test("modifier-key click fires onClick but not onNavigate", async ({ page }) => {
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    await expect(page.locator("#is-clicked")).toHaveText("isClicked: false");
+    await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
+
+    // A modifier-key click would normally open the link in a new tab/window.
+    // Block the default to keep the test on the source page so we can read
+    // the state in place; the React synthetic handlers still run first.
+    await page.evaluate(() => {
+      document
+        .getElementById("link-to-subpage")
+        ?.addEventListener("click", (e) => e.preventDefault());
+    });
+
+    // macOS uses Meta (Cmd), every other platform uses Control. Mirrors the
+    // upstream `process.platform === 'darwin' ? 'Meta' : 'Control'` choice.
+    const modifierKey = process.platform === "darwin" ? "Meta" : "Control";
+    await page.click("#link-to-subpage", { modifiers: [modifierKey] });
+
+    await expect(page.locator("#is-clicked")).toHaveText("isClicked: true");
+    await expect(page.locator("#is-navigated")).toHaveText("isNavigated: false");
+  });
+
+  test("external link without target only fires onClick (via alert)", async ({ page }) => {
+    const alerts: string[] = [];
+    page.on("dialog", (dialog) => {
+      alerts.push(dialog.message());
+      void dialog.dismiss();
+    });
+
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    // The link points off-origin (example.org) — block the navigation so the
+    // test doesn't actually leave the fixture. React's synthetic onClick
+    // (which calls alert("onClick")) still runs before our preventDefault.
+    await page.evaluate(() => {
+      document
+        .getElementById("external-link")
+        ?.addEventListener("click", (e) => e.preventDefault());
+    });
+
+    await page.click("#external-link");
+
+    // Only `onClick` should have fired; `onNavigate` is skipped for plain
+    // external links (no `target`, no `download`).
+    await expect.poll(() => alerts).toEqual(["onClick"]);
+  });
+
+  test("external link with replace doesn't change history length", async ({ page }) => {
+    page.on("dialog", (dialog) => {
+      void dialog.dismiss();
+    });
+
+    await page.goto(`${BASE}${PAGE}`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    // Block the off-origin navigation so we can read history.length after
+    // the synthetic handlers run.
+    await page.evaluate(() => {
+      document
+        .getElementById("external-link-with-replace")
+        ?.addEventListener("click", (e) => e.preventDefault());
+    });
+
+    const initialLength = await page.evaluate(() => history.length);
+
+    await page.click("#external-link-with-replace");
+    // Give any pending history mutation a tick to settle.
+    await page.waitForTimeout(50);
+
+    const finalLength = await page.evaluate(() => history.length);
+    expect(finalLength).toBe(initialLength);
   });
 });

--- a/tests/fixtures/pages-basic/pages/on-navigate-fixture/index.tsx
+++ b/tests/fixtures/pages-basic/pages/on-navigate-fixture/index.tsx
@@ -31,7 +31,10 @@ export default function OnNavigateFixture() {
           id="toggle-lock"
           type="button"
           onClick={() => {
-            setIsLocked((v) => !v);
+            // Matches upstream `setIsLocked(!isLocked)` for parity. The
+            // functional form would be safer in general, but the goal here
+            // is a 1:1 port of `.nextjs-ref/.../shared/OnNavigate.tsx`.
+            setIsLocked(!isLocked);
           }}
         >
           {isLocked ? "Unlock" : "Lock"}
@@ -80,6 +83,29 @@ export default function OnNavigateFixture() {
             target="_blank"
           >
             External Link with Target
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href="https://example.org"
+            id="external-link"
+            onClick={() => alert("onClick")}
+            onNavigate={() => alert("onNavigate")}
+          >
+            External Link
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href="https://example.org"
+            id="external-link-with-replace"
+            onClick={() => alert("onClick")}
+            onNavigate={() => alert("onNavigate")}
+            replace
+          >
+            External Link with replace
           </Link>
         </div>
 

--- a/tests/fixtures/pages-basic/pages/on-navigate-fixture/index.tsx
+++ b/tests/fixtures/pages-basic/pages/on-navigate-fixture/index.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+import { useState } from "react";
+
+/**
+ * Mirrors the Next.js fixture at
+ * .nextjs-ref/test/e2e/link-on-navigate-prop/shared/OnNavigate.tsx
+ * so we can exercise the same Link `onNavigate` parity scenarios under
+ * Pages Router locally. Kept as a regular Pages Router page (rather than
+ * the upstream pages/_app.tsx wrapper) so it doesn't interfere with the
+ * rest of the pages-basic fixture's apps.
+ *
+ * Ported from Next.js: test/e2e/link-on-navigate-prop/shared/OnNavigate.tsx
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/link-on-navigate-prop/shared/OnNavigate.tsx
+ */
+export default function OnNavigateFixture() {
+  const [isClicked, setIsClicked] = useState(false);
+  const [isNavigated, setIsNavigated] = useState(false);
+  const [isLocked, setIsLocked] = useState(false);
+
+  const rootPath = "/on-navigate-fixture";
+
+  return (
+    <div>
+      <nav>
+        <div id="navigation-state">
+          <p id="is-clicked">isClicked: {isClicked ? "true" : "false"}</p>
+          <p id="is-navigated">isNavigated: {isNavigated ? "true" : "false"}</p>
+          <p id="is-locked">isLocked: {isLocked ? "true" : "false"}</p>
+        </div>
+        <button
+          id="toggle-lock"
+          type="button"
+          onClick={() => {
+            setIsLocked((v) => !v);
+          }}
+        >
+          {isLocked ? "Unlock" : "Lock"}
+        </button>
+
+        <div>
+          <Link
+            href={rootPath}
+            id="link-to-main"
+            onClick={() => setIsClicked(true)}
+            onNavigate={(e) => {
+              if (isLocked) {
+                e.preventDefault();
+              } else {
+                setIsNavigated(true);
+              }
+            }}
+          >
+            Client Side Navigation to Main Page
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href={`${rootPath}/subpage`}
+            id="link-to-subpage"
+            onClick={() => setIsClicked(true)}
+            onNavigate={(e) => {
+              if (isLocked) {
+                e.preventDefault();
+              } else {
+                setIsNavigated(true);
+              }
+            }}
+          >
+            Client Side Navigation to Subpage
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            href="https://example.org"
+            id="external-link-with-target"
+            onClick={() => setIsClicked(true)}
+            onNavigate={() => setIsNavigated(true)}
+            target="_blank"
+          >
+            External Link with Target
+          </Link>
+        </div>
+
+        <div>
+          <Link
+            download
+            href="/zip.zip"
+            id="download-link"
+            onClick={() => setIsClicked(true)}
+            onNavigate={() => {
+              setIsNavigated(true);
+            }}
+          >
+            Download Link with download attribute
+          </Link>
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/on-navigate-fixture/subpage/index.tsx
+++ b/tests/fixtures/pages-basic/pages/on-navigate-fixture/subpage/index.tsx
@@ -1,0 +1,7 @@
+export default function Subpage() {
+  return (
+    <div>
+      <h1 id="subpage-heading">Subpage</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Refs #1357.

`<Link onNavigate>` was implemented in #1371 and is covered by unit tests in `tests/link-navigation.test.ts` (all 35 cases passing). The most recent nightly Next.js deploy suite ([run 26552059147](https://github.com/cloudflare/vinext/actions/runs/26552059147)) still reports failures under `test/e2e/link-on-navigate-prop/index.test.ts` — but only for the **Pages Router** half of the upstream suite. The App Router half passes, and the Pages Router failures show that even a plain `<button onClick={() => setIsLocked(...)}>` does not update its state. That points at a Pages Router-specific hydration regression rather than a missing `onNavigate` implementation.

This PR ports the upstream `OnNavigate` shared fixture (`.nextjs-ref/test/e2e/link-on-navigate-prop/shared/OnNavigate.tsx`) into `tests/fixtures/pages-basic/pages/on-navigate-fixture/` and adds Playwright tests mirroring the upstream scenarios, so the same scenarios run in vinext's own CI without depending on the full deploy harness. If the Playwright suite passes locally, that narrows the deploy-suite failure to harness/deployment differences; if it fails, we have a small, local reproduction to debug against.

- Adds `tests/fixtures/pages-basic/pages/on-navigate-fixture/{index,subpage}.tsx` mirroring the upstream `OnNavigate` shared fixture (hydration, `useState`, multiple Link variants).
- Adds Playwright cases under `tests/e2e/pages-router/link-advanced.spec.ts` covering: stateful hydration of the `toggle-lock` button, internal navigation firing both `onClick` and `onNavigate`, `event.preventDefault()` cancelling navigation, and the `download` / `target=_blank` parity branches.
- Reference: the Next.js test the deploy suite runs against us is at [`test/e2e/link-on-navigate-prop/index.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/link-on-navigate-prop/index.test.ts).

The shim itself is unchanged — the implementation, unit tests, and existing App Router e2e all already cover the contract, so this PR is intentionally test-only.

## Test plan

- [x] `pnpm test tests/link-navigation.test.ts` — 35/35 passing locally
- [ ] CI Playwright `pages-router` project runs the new specs
- [ ] CI Vitest passes