### PR TITLE
fix(script): translate React prop names to HTML attrs in hoisted beforeInteractive scripts

### DIFF
--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -150,11 +150,31 @@ function extractBeforeInteractiveInlineContent(
 }
 
 /**
+ * Map of React DOM prop names to their HTML attribute equivalents. Mirrors
+ * Next.js's `set-attributes-from-props.ts`:
+ *   .nextjs-ref/packages/next/src/client/set-attributes-from-props.ts
+ * HTML parses attribute names case-insensitively, so without this translation
+ * `className="foo"` round-trips as `classname="foo"` and CSS selectors on
+ * `.foo` never match. Same hazard for `htmlFor`/`for`, `httpEquiv`/`http-equiv`,
+ * `acceptCharset`/`accept-charset`.
+ */
+const REACT_TO_HTML_ATTR: Record<string, string> = {
+  acceptCharset: "accept-charset",
+  className: "class",
+  htmlFor: "for",
+  httpEquiv: "http-equiv",
+};
+
+/**
  * Convert the residual `<Script>` props into a plain string-attributes record
  * for emission inside a hoisted `<script>` tag. Drops React-only props
  * (event handlers, children, etc.) and reserved keys already handled by the
  * pre-head-injection emitter (id, nonce). Skips `undefined`/`null` so they
  * round-trip as "attribute absent" rather than `attr="undefined"`.
+ *
+ * React DOM prop names (className, htmlFor, etc.) are translated to their
+ * HTML attribute names so the output parses correctly — see comment on
+ * `REACT_TO_HTML_ATTR`.
  */
 function collectBeforeInteractiveAttributes(
   rest: Record<string, unknown>,
@@ -174,12 +194,13 @@ function collectBeforeInteractiveAttributes(
   for (const [key, value] of Object.entries(rest)) {
     if (RESERVED.has(key)) continue;
     if (value === undefined || value === null || value === false) continue;
+    const attrName = REACT_TO_HTML_ATTR[key] ?? key;
     if (typeof value === "boolean") {
-      out[key] = true;
+      out[attrName] = true;
       continue;
     }
     if (typeof value === "string" || typeof value === "number") {
-      out[key] = String(value);
+      out[attrName] = String(value);
       continue;
     }
     // Skip anything else (functions, objects) — they cannot serialise into an

--- a/tests/script.test.ts
+++ b/tests/script.test.ts
@@ -14,6 +14,10 @@ import Script, {
   type ScriptProps,
 } from "../packages/vinext/src/shims/script.js";
 import { ScriptNonceProvider } from "../packages/vinext/src/shims/script-nonce-context.js";
+import {
+  BeforeInteractiveContext,
+  type BeforeInteractiveInlineScript,
+} from "../packages/vinext/src/shims/before-interactive-context.js";
 
 const originalDocument = globalThis.document;
 const originalWindow = globalThis.window;
@@ -195,6 +199,71 @@ describe("Script SSR rendering", () => {
     );
     expect(html).toContain("<script");
     expect(html).toContain('src="/secure.js"');
+  });
+
+  // Regression for cloudflare/vinext#1518.
+  //
+  // Ported from Next.js: test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts
+  //
+  // React DOM prop names (className, htmlFor, httpEquiv, acceptCharset) must be
+  // translated to their HTML attribute equivalents (class, for, http-equiv,
+  // accept-charset) when an inline `<Script strategy="beforeInteractive">` is
+  // hoisted into <head> via BeforeInteractiveContext. Without the translation
+  // they round-trip as `classname="..."` etc., which the browser parses as an
+  // unrelated attribute — so the script lacks the requested CSS class and any
+  // selector on `.example-class` fails to match.
+  it("translates React DOM prop names to HTML attributes on hoisted beforeInteractive scripts", () => {
+    const captured: BeforeInteractiveInlineScript[] = [];
+    ReactDOMServer.renderToString(
+      React.createElement(
+        BeforeInteractiveContext.Provider,
+        { value: (script: BeforeInteractiveInlineScript) => captured.push(script) },
+        React.createElement(Script, {
+          id: "example-script",
+          strategy: "beforeInteractive",
+          className: "example-class",
+          htmlFor: "target-id",
+          httpEquiv: "x-foo",
+          acceptCharset: "utf-8",
+          dangerouslySetInnerHTML: {
+            __html: "window.beforeInteractiveExecuted = true;",
+          },
+        } as ScriptProps),
+      ),
+    );
+
+    expect(captured).toHaveLength(1);
+    const attrs = captured[0]?.attributes ?? {};
+    // HTML attribute names — not the React camelCase prop names.
+    expect(attrs).toMatchObject({
+      class: "example-class",
+      for: "target-id",
+      "http-equiv": "x-foo",
+      "accept-charset": "utf-8",
+    });
+    // The React camelCase forms must NOT round-trip as attribute keys. HTML
+    // parses attribute names case-insensitively, so `className="x"` would be
+    // read as `classname="x"` — see the Next.js test for this exact assertion.
+    expect(attrs).not.toHaveProperty("className");
+    expect(attrs).not.toHaveProperty("htmlFor");
+    expect(attrs).not.toHaveProperty("httpEquiv");
+    expect(attrs).not.toHaveProperty("acceptCharset");
+  });
+
+  // Even outside the App Router head-hoisting path (no provider in context),
+  // React still owns the rendering of the <script> tag and must emit
+  // `class="..."` not `classname="..."`.
+  it("emits class= (not className=) for beforeInteractive scripts with src and className", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/before.js",
+        strategy: "beforeInteractive",
+        className: "example-class",
+      } as ScriptProps),
+    );
+    expect(html).toContain('class="example-class"');
+    expect(html).not.toContain('classname="example-class"');
   });
 
   it("uses the request nonce for beforeInteractive scripts when none is passed explicitly", () => {


### PR DESCRIPTION
## Summary

- Inline `<Script strategy=\"beforeInteractive\">` content is captured via `BeforeInteractiveContext` and spliced directly into `<head>` as raw HTML by the SSR pipeline (`renderBeforeInteractiveInlineScripts` in `app-ssr-entry.ts`). The attribute collector preserved React's camelCase prop names verbatim, so `className=\"foo\"` round-tripped as `classname=\"foo\"` (HTML attribute names are case-insensitive), making CSS selectors on `.foo` fail to match. Same hazard for `htmlFor`, `httpEquiv`, `acceptCharset`.
- Translate those four prop names to their HTML attribute equivalents at the collection boundary in `collectBeforeInteractiveAttributes`, mirroring [Next.js's `set-attributes-from-props.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/set-attributes-from-props.ts).
- Ported the relevant assertions from Next.js's [`script-before-interactive.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts) as a focused unit regression in `tests/script.test.ts` (24 tests, all passing).

Fixes #1518

## Test plan

- [x] `pnpm test tests/script.test.ts` — 24/24 pass; new tests fail without the fix.
- [x] `pnpm test tests/script-head-ordering.test.ts` — 8/8 pass (integration path unchanged).
- [x] `pnpm run lint` and `pnpm run fmt:check` clean.
- [ ] CI green.