### PR TITLE
fix(deploy): plain-text 404 for invalid _next/static in Pages Router worker

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -546,6 +546,8 @@ import {
   isOpenRedirectShaped,
   normalizeTrailingSlash,
 } from "vinext/server/request-pipeline";
+import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses";
+import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix";
 import { normalizeDefaultLocalePathname, stripI18nLocaleForApiRoute } from "vinext/server/pages-i18n";
 import { mergeRewriteQuery } from "vinext/utils/query";
 
@@ -570,6 +572,7 @@ interface ExecutionContext {
 
 // Extract config values (embedded at build time in the server entry)
 const basePath: string = vinextConfig?.basePath ?? "";
+const assetPathPrefix: string = assetPrefixPathname(vinextConfig?.assetPrefix ?? "");
 const trailingSlash: boolean = vinextConfig?.trailingSlash ?? false;
 const i18nConfig = vinextConfig?.i18n ?? null;
 const configRedirects = vinextConfig?.redirects ?? [];
@@ -607,6 +610,16 @@ export default {
       // would also navigate to the attacker's origin.
       if (isOpenRedirectShaped(pathname)) {
         return new Response("This page could not be found", { status: 404 });
+      }
+
+      // Invalid \`_next/static/*\` paths short-circuit with a plain-text 404
+      // instead of falling through to renderPage (which would render the full
+      // HTML 404 page with bootstrap scripts + CSS). Valid assets are served
+      // by Cloudflare's ASSETS binding BEFORE the worker runs; only misses
+      // reach this code. Matches Next.js (#1337):
+      //   packages/next/src/server/lib/router-server.ts
+      if (isNextStaticPath(pathname, basePath, assetPathPrefix)) {
+        return notFoundStaticAssetResponse();
       }
 
       // Capture x-nextjs-data before filterInternalHeaders strips it -- the

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -938,6 +938,30 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("!isExternalUrl(redirect.destination)");
     expect(content).toContain("!hasBasePath(redirect.destination, basePath)");
   });
+
+  // Regression for #1337: invalid `_next/static/*` paths must short-circuit
+  // with a plain-text 404 instead of falling through to renderPage (which
+  // would render the full HTML 404 page with bootstrap scripts + CSS).
+  // Matches Next.js: packages/next/src/server/lib/router-server.ts.
+  it("short-circuits invalid `_next/static/*` paths with plain-text 404", () => {
+    const content = generatePagesRouterWorkerEntry();
+    expect(content).toContain(
+      'import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses"',
+    );
+    expect(content).toContain(
+      'import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix"',
+    );
+    expect(content).toContain("assetPrefixPathname(vinextConfig?.assetPrefix");
+    expect(content).toContain("isNextStaticPath(pathname, basePath, assetPathPrefix)");
+    expect(content).toContain("return notFoundStaticAssetResponse();");
+
+    // The short-circuit must fire BEFORE renderPage so the rich HTML 404
+    // is never rendered for asset misses.
+    const staticPos = content.indexOf("isNextStaticPath(pathname, basePath, assetPathPrefix)");
+    const renderPagePos = content.indexOf("renderPage(request, resolvedUrl");
+    expect(staticPos).toBeGreaterThan(-1);
+    expect(renderPagePos).toBeGreaterThan(staticPos);
+  });
 });
 
 // ─── Vite Config Generation ─────────────────────────────────────────────��───


### PR DESCRIPTION
## Summary

- The Pages Router Cloudflare worker template generated by `vinext deploy` was forwarding asset-shaped misses (e.g. `/_next/static/nonexistent.js`) to `renderPage`, which renders the full HTML 404 page with bootstrap scripts + CSS instead of the plain-text `"Not Found"` body Next.js emits.
- Adds the existing `isNextStaticPath` + `notFoundStaticAssetResponse` short-circuit (already used by `app-router-entry`, `prod-server` App Router branch, and `prod-server` Pages Router branch) to `generatePagesRouterWorkerEntry()` so invalid `_next/static/*` requests — including those under `basePath` or `assetPrefix` — return `text/plain; charset=utf-8` `"Not Found"` before the renderer runs.
- Matches Next.js behaviour in `packages/next/src/server/lib/router-server.ts`.

Fixes #1337

## Test plan

- [x] `pnpm test tests/deploy.test.ts` — new regression test asserts the generated Pages Router worker contains the short-circuit and that it precedes the `renderPage` call.
- [x] `pnpm test tests/invalid-static-asset-404.test.ts` — existing end-to-end assertions for the App Router worker entry + prod server (Node) still pass.
- [x] `pnpm test tests/after-deploy.test.ts` — generator metadata tests still pass.
- [x] `pnpm run lint`, `pnpm run fmt:check`.