### PR TITLE
fix(pages-router): return 405 with Allow: GET, HEAD on POST to static pages

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -23,6 +23,7 @@ const _pagesPageResponsePath = resolveEntryPath(
   import.meta.url,
 );
 const _pagesPageDataPath = resolveEntryPath("../server/pages-page-data.js", import.meta.url);
+const _pagesPageMethodPath = resolveEntryPath("../server/pages-page-method.js", import.meta.url);
 const _pagesDataRoutePath = resolveEntryPath("../server/pages-data-route.js", import.meta.url);
 const _pagesDefault404Path = resolveEntryPath("../server/pages-default-404.js", import.meta.url);
 const _pagesNodeCompatPath = resolveEntryPath("../server/pages-node-compat.js", import.meta.url);
@@ -248,6 +249,7 @@ import {
 } from ${JSON.stringify(_isrCachePath)};
 import { getScriptNonceFromHeaderSources as __getScriptNonceFromHeaderSources } from ${JSON.stringify(_cspPath)};
 import { resolvePagesPageData as __resolvePagesPageData } from ${JSON.stringify(_pagesPageDataPath)};
+import { resolvePagesPageMethodResponse as __resolvePagesPageMethodResponse } from ${JSON.stringify(_pagesPageMethodPath)};
 import { buildNextDataJsonResponse as __buildNextDataJsonResponse, buildNextDataNotFoundResponse as __buildNextDataNotFoundResponse, isNextDataPathname as __isNextDataPathname, parseNextDataPathname as __parseNextDataPathname } from ${JSON.stringify(_pagesDataRoutePath)};
 import { buildDefaultPagesNotFoundResponse as __buildDefaultPagesNotFoundResponse } from ${JSON.stringify(_pagesDefault404Path)};
 import { renderPagesPageResponse as __renderPagesPageResponse } from ${JSON.stringify(_pagesPageResponsePath)};
@@ -664,6 +666,29 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
       if (!PageComponent) {
         return new Response("Page has no default export", { status: 500 });
       }
+
+      // Refs #1463: reject non-GET/HEAD methods on static (no
+      // getServerSideProps) Pages routes with 405 + Allow: GET, HEAD.
+      // Skip for error/status pages (/_error, /404, /500), data requests
+      // (those go through the JSON envelope path and have their own shape),
+      // and renders that are already an error-page miss-render override.
+      // Mirrors Next.js's base-server.ts L2277 carve-outs.
+      if (
+        !isDataReq &&
+        routePattern !== "/_error" &&
+        routePattern !== "/404" &&
+        routePattern !== "/500" &&
+        renderStatusCodeOverride === undefined
+      ) {
+        const methodResponse = __resolvePagesPageMethodResponse({
+          hasGetServerSideProps: typeof pageModule.getServerSideProps === "function",
+          method: request.method,
+        });
+        if (methodResponse) {
+          return methodResponse;
+        }
+      }
+
       const pageModuleUrl = resolveClientModuleUrl(manifest, route.filePath);
       const appModuleUrl = resolveClientModuleUrl(manifest, _appAssetPath);
       const scriptNonce = __getScriptNonceFromHeaderSources(request.headers, middlewareHeaders);

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -46,6 +46,7 @@ import {
   resolvePagesI18nRequest,
 } from "./pages-i18n.js";
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
+import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -412,6 +413,36 @@ export function createSSRHandler(
           res.statusCode = 500;
           res.end("Page has no default export");
           return;
+        }
+
+        // Refs #1463: reject non-GET/HEAD methods on static (no
+        // getServerSideProps) Pages routes with 405 + Allow: GET, HEAD.
+        // Skip for error/status pages (/_error, /404, /500), data requests
+        // (those go through the JSON envelope path), and renders that are
+        // already a status-override (e.g. middleware-set 404). Mirrors
+        // Next.js's base-server.ts L2277 carve-outs.
+        {
+          const routePattern = patternToNextFormat(route.pattern);
+          if (
+            !isDataReq &&
+            routePattern !== "/_error" &&
+            routePattern !== "/404" &&
+            routePattern !== "/500" &&
+            statusCode === undefined
+          ) {
+            const methodResponse = resolvePagesPageMethodResponse({
+              hasGetServerSideProps: typeof pageModule.getServerSideProps === "function",
+              method: req.method ?? "GET",
+            });
+            if (methodResponse) {
+              res.statusCode = methodResponse.status;
+              const allow = methodResponse.headers.get("allow");
+              if (allow) res.setHeader("Allow", allow);
+              res.setHeader("Content-Type", "text/plain;charset=UTF-8");
+              res.end(await methodResponse.text());
+              return;
+            }
+          }
         }
 
         // Collect page props via data fetching methods

--- a/packages/vinext/src/server/pages-page-method.ts
+++ b/packages/vinext/src/server/pages-page-method.ts
@@ -1,0 +1,63 @@
+import { methodNotAllowedResponse } from "./http-error-responses.js";
+
+/**
+ * Pages Router method-allow policy.
+ *
+ * Mirrors Next.js's behavior in
+ * `.nextjs-ref/packages/next/src/server/base-server.ts` around L2277:
+ *
+ *   if (
+ *     !isPossibleServerAction &&
+ *     !minimalPostponed &&
+ *     !is404Page &&
+ *     !is500Page &&
+ *     pathname !== '/_error' &&
+ *     req.method !== 'HEAD' &&
+ *     req.method !== 'GET' &&
+ *     (typeof components.Component === 'string' || isSSG)
+ *   ) {
+ *     res.statusCode = 405
+ *     res.setHeader('Allow', ['GET', 'HEAD'])
+ *     res.body('Method Not Allowed').send()
+ *     return null
+ *   }
+ *
+ * In vinext, a Pages Router route is "static" (no SSR per-request work) when
+ * it does not export `getServerSideProps`. Such routes — including plain
+ * components and `getStaticProps` (GSP) pages — must reject non-GET/HEAD
+ * requests with 405 + `Allow: GET, HEAD`.
+ *
+ * Server Actions (Pages Router supports `"use server"` for forms in newer
+ * Next.js versions) are out of scope here: vinext's Pages Router does not
+ * implement them, so there's no carve-out to add. If/when it does, this
+ * helper should grow an `isPossibleServerAction` opt-out parameter mirroring
+ * the App Router's `resolveAppPageMethodResponse`.
+ *
+ * Refs #1463.
+ */
+
+type PagesPageMethodOptions = {
+  hasGetServerSideProps: boolean;
+  method: string;
+};
+
+function isNonGetOrHead(method: string): boolean {
+  const normalizedMethod = method.toUpperCase();
+  return normalizedMethod !== "GET" && normalizedMethod !== "HEAD";
+}
+
+/**
+ * Returns a 405 `Response` when the request method is not allowed for a
+ * static (no `getServerSideProps`) Pages Router page, otherwise `null`.
+ */
+export function resolvePagesPageMethodResponse(options: PagesPageMethodOptions): Response | null {
+  if (!isNonGetOrHead(options.method)) {
+    return null;
+  }
+
+  if (options.hasGetServerSideProps) {
+    return null;
+  }
+
+  return methodNotAllowedResponse("GET, HEAD");
+}

--- a/tests/pages-page-method.test.ts
+++ b/tests/pages-page-method.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolvePagesPageMethodResponse } from "../packages/vinext/src/server/pages-page-method.js";
+
+describe("pages page method policy", () => {
+  it("returns 405 with Allow for POST to a static (no gSSP) page", async () => {
+    const response = resolvePagesPageMethodResponse({
+      hasGetServerSideProps: false,
+      method: "POST",
+    });
+
+    if (!response) {
+      throw new Error("Expected a Method Not Allowed response");
+    }
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD");
+    await expect(response.text()).resolves.toBe("Method Not Allowed");
+  });
+
+  it.each(["PUT", "DELETE", "PATCH", "OPTIONS"])(
+    "returns 405 for %s on a static page",
+    (method) => {
+      const response = resolvePagesPageMethodResponse({
+        hasGetServerSideProps: false,
+        method,
+      });
+      expect(response?.status).toBe(405);
+    },
+  );
+
+  it.each(["GET", "HEAD", "get", "head"])("returns null for %s requests", (method) => {
+    expect(
+      resolvePagesPageMethodResponse({
+        hasGetServerSideProps: false,
+        method,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the page has getServerSideProps (SSR is allowed any method)", () => {
+    expect(
+      resolvePagesPageMethodResponse({
+        hasGetServerSideProps: true,
+        method: "POST",
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -357,6 +357,43 @@ describe("Pages Router integration", () => {
     expect(html).toContain("This is the about page.");
   });
 
+  // Refs #1463: Pages Router should reject non-GET/HEAD methods to static
+  // (no `getServerSideProps`) pages with a 405 + `Allow: GET, HEAD`.
+  // Ported from Next.js: test/e2e/prerender.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/prerender.test.ts
+  // ('should respond with 405 for POST to static page').
+  it("returns 405 with Allow: GET, HEAD on POST to a static Pages page", async () => {
+    const res = await fetch(`${baseUrl}/about`, { method: "POST" });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET, HEAD");
+    expect(await res.text()).toContain("Method Not Allowed");
+  });
+
+  // Refs #1463: GSP (getStaticProps) pages are also "static" from the
+  // routing perspective; POST should produce 405. Mirrors the Next.js
+  // condition `(typeof components.Component === 'string' || isSSG)` in
+  // `.nextjs-ref/packages/next/src/server/base-server.ts` around L2287.
+  it("returns 405 with Allow: GET, HEAD on POST to a GSP page", async () => {
+    const res = await fetch(`${baseUrl}/isr-test`, { method: "POST" });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET, HEAD");
+  });
+
+  // GET/HEAD must continue to work — guards against an over-broad fix.
+  it("HEAD on a static Pages page still returns 200", async () => {
+    const res = await fetch(`${baseUrl}/about`, { method: "HEAD" });
+    expect(res.status).toBe(200);
+  });
+
+  // SSR pages (those with getServerSideProps) must NOT be blocked: the
+  // page may legitimately read req.method inside getServerSideProps.
+  // Next.js gates 405 on `(typeof components.Component === 'string' || isSSG)`
+  // — gSSP routes are neither.
+  it("does not return 405 on POST to a getServerSideProps page", async () => {
+    const res = await fetch(`${baseUrl}/ssr`, { method: "POST" });
+    expect(res.status).not.toBe(405);
+  });
+
   // Tests that React 19 SSR preserves literal string action attributes.
   // Note: This is NOT testing server action invocation (unlike the upstream
   // Next.js test action-in-pages-router.test.ts which tests "use server" functions).
@@ -3486,6 +3523,18 @@ describe("Production server middleware (Pages Router)", () => {
     const res = await fetch(`${prodUrl}/old-page`, { redirect: "manual" });
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("/about");
+  });
+
+  // Refs #1463: prod-server parity for the dev-server 405 check. POST to a
+  // static Pages Router page must return 405 + Allow: GET, HEAD.
+  // Ported from Next.js: test/e2e/prerender.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/prerender.test.ts
+  // ('should respond with 405 for POST to static page').
+  it("returns 405 with Allow: GET, HEAD on POST to a static Pages page (prod)", async () => {
+    const res = await fetch(`${prodUrl}/about`, { method: "POST" });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET, HEAD");
+    expect(await res.text()).toContain("Method Not Allowed");
   });
 
   // Regression for #1331: after a middleware rewrite, the rewrite target


### PR DESCRIPTION
## Summary

Partially addresses #1463 (POST → 405 on static Pages Router pages).

Pages Router previously rendered HTML for any HTTP method, including POST/PUT/DELETE, on static (no `getServerSideProps`) pages — masking client bugs that Next.js surfaces as 405.

- Mirrors Next.js's behavior in `base-server.ts` (the `(typeof components.Component === 'string' || isSSG)` gate around L2287): reject non-GET/HEAD methods on static pages with `Allow: GET, HEAD` and a `Method Not Allowed` body.
- Pages with `getServerSideProps` continue to accept any method, since user code may legitimately read `req.method` inside gSSP.
- The new `resolvePagesPageMethodResponse` helper is wired into both the dev-server SSR handler and the prod-server pages-server-entry, and skips `/_error`, `/404`, `/500`, data requests, and explicit status overrides — matching the upstream carve-outs.

References:
- Next.js source: `.nextjs-ref/packages/next/src/server/base-server.ts` around L2277-L2293.
- Next.js test: `.nextjs-ref/test/e2e/prerender.test.ts` — "should respond with 405 for POST to static page".

## Out of scope (follow-up)

The other half of #1463 — `res.revalidate()` with preview cookies — is **deliberately deferred** to a separate PR. That work involves preview-mode plumbing into the Pages Router cache path and is a larger change. Issue #1463 stays open for it.

## Test plan

- [x] Unit tests for `resolvePagesPageMethodResponse` in `tests/pages-page-method.test.ts`.
- [x] Dev-server integration tests in `tests/pages-router.test.ts`:
  - POST to a static page (`/about`) → 405 + `Allow: GET, HEAD`.
  - POST to a GSP page (`/isr-test`) → 405 + `Allow: GET, HEAD`.
  - HEAD on a static page → 200 (regression guard).
  - POST to a gSSP page (`/ssr`) → not 405 (regression guard).
- [x] Prod-server integration test in `tests/pages-router.test.ts`:
  - POST to a static page (`/about`) → 405 + `Allow: GET, HEAD`.
- [x] `pnpm test tests/pages-router.test.ts` → 257 passed.
- [x] `pnpm test tests/pages-page-method.test.ts` → 10 passed.
- [x] `pnpm run check` → clean.