### PR TITLE
fix(middleware): stop merging original query into middleware rewrite target

### DIFF
--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -17,7 +17,6 @@ import { MatcherConfig, matchesMiddleware } from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "./middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 import { badRequestResponse, internalServerErrorResponse } from "./http-error-responses.js";
-import { mergeRewriteQuery } from "../utils/query.js";
 
 export type MiddlewareModule = Record<string, unknown>;
 
@@ -338,13 +337,18 @@ export async function executeMiddleware(
       const rewriteParsed = new URL(rewriteUrl, options.request.url);
       const requestOrigin = new URL(options.request.url).origin;
       if (rewriteParsed.origin === requestOrigin) {
-        // Preserve the original request's query params on internal rewrites.
-        // Next.js merges via `Object.assign(parsedUrl.query, rewrittenParsedUrl.query)`
-        // — original query first, rewrite-target overrides on key conflicts.
-        rewritePath = mergeRewriteQuery(
-          options.request.url,
-          rewriteParsed.pathname + rewriteParsed.search,
-        );
+        // Middleware constructs the rewrite-target URL itself (e.g. by
+        // modifying `request.nextUrl` or by passing a fresh path). Whatever
+        // search params that URL carries IS the final query — vinext must not
+        // silently re-merge the original request's query, or middleware that
+        // deletes keys (e.g. `searchParams.delete('foo')`) would see them
+        // resurrected on the rewrite target. Mirrors Next.js' middleware
+        // adapter: the `x-middleware-rewrite` URL is parsed directly with no
+        // original-side merging.
+        // See test/e2e/middleware-rewrites/test/index.test.ts
+        //   ("should clear query parameters")
+        // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+        rewritePath = rewriteParsed.pathname + rewriteParsed.search;
       } else {
         // External rewrites are proxied as-is; don't smuggle local query params
         // into the upstream URL.

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4547,6 +4547,21 @@ describe("App Router middleware with NextRequest", () => {
     expect(html).toContain("from-rewrite");
   });
 
+  // Regression for cloudflare/vinext#1342: when middleware rewrites a request,
+  // the ORIGINAL request's query params must survive into the rewrite target.
+  // Next.js merges via `Object.assign(parsedUrl.query, rewrittenParsedUrl.query)`,
+  // i.e. original-first, rewrite-target overrides on key conflicts.
+  // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts
+  it("middleware rewrite preserves original request query params into the rewrite target", async () => {
+    const res = await fetch(
+      `${baseUrl}/middleware-rewrite-keep-original-query?searchParams=from-original`,
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("from-original");
+  });
+
   it("does not leak x-middleware-next or x-middleware-rewrite headers to the client", async () => {
     // NextResponse.next() sets x-middleware-next internally.
     // The dev server must strip it (and all x-middleware-* headers) before

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -4547,12 +4547,15 @@ describe("App Router middleware with NextRequest", () => {
     expect(html).toContain("from-rewrite");
   });
 
-  // Regression for cloudflare/vinext#1342: when middleware rewrites a request,
-  // the ORIGINAL request's query params must survive into the rewrite target.
-  // Next.js merges via `Object.assign(parsedUrl.query, rewrittenParsedUrl.query)`,
-  // i.e. original-first, rewrite-target overrides on key conflicts.
-  // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts
-  // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts
+  // Regression for cloudflare/vinext#1342: when middleware preserves the
+  // original request's query — by mutating `request.nextUrl` (which already
+  // carries the original search) rather than constructing a fresh path-only
+  // URL — those params must survive into the rewrite target. The destination
+  // URL is the source of truth; vinext does not auto-merge any extra original
+  // query on top.
+  // Mirrors the Next.js middleware idiom in test/e2e/middleware-rewrites/app/middleware.js
+  // (`url.pathname = "/x"; NextResponse.rewrite(url)`).
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/app/middleware.js
   it("middleware rewrite preserves original request query params into the rewrite target", async () => {
     const res = await fetch(
       `${baseUrl}/middleware-rewrite-keep-original-query?searchParams=from-original`,

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -97,6 +97,17 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     );
   }
 
+  // Issue #1342 / Next.js parity: middleware preserves the original request's
+  // query by mutating `request.nextUrl` (which carries the existing search)
+  // rather than constructing a fresh path-only URL. Mirrors Next.js:
+  // test/e2e/middleware-rewrites/app/middleware.js — `url.pathname = '/x'` then
+  // `NextResponse.rewrite(url)`.
+  if (pathname === "/middleware-rewrite-keep-original-query") {
+    const target = request.nextUrl.clone();
+    target.pathname = "/search-query";
+    return NextResponse.rewrite(target);
+  }
+
   // Rewrite with custom status code
   // Ref: opennextjs-cloudflare middleware.ts — NextResponse.rewrite with status
   if (pathname === "/middleware-rewrite-status") {
@@ -304,6 +315,7 @@ export const config = {
     "/middleware-rewritten-use-pathname",
     "/middleware-external-rewrite",
     "/middleware-rewrite-query",
+    "/middleware-rewrite-keep-original-query",
     "/middleware-rewrite-status",
     "/middleware-blocked",
     "/middleware-throw",

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -32,22 +32,48 @@ export function middleware(request: NextRequest) {
 
   // Rewrite /mw-rewrite-query to /ssr-query — preserves the original
   // request's query params on the rewrite target so getServerSideProps
-  // sees them. Mirrors Next.js: test/e2e/edge-pages-support.
+  // sees them. Middleware preserves query by mutating `request.nextUrl`
+  // (which carries the original search) rather than constructing a new
+  // path-only URL. Mirrors Next.js: test/e2e/middleware-rewrites/app/middleware.js.
   if (url.pathname === "/mw-rewrite-query") {
-    return NextResponse.rewrite(new URL("/ssr-query", request.url));
+    const target = request.nextUrl.clone();
+    target.pathname = "/ssr-query";
+    return NextResponse.rewrite(target);
   }
 
   // Rewrite /mw-rewrite-dynamic-query to /posts/first — the rewrite
   // target is dynamic, so the resulting query should contain both the
   // dynamic param (id=first) and the original query (?hello=world).
   if (url.pathname === "/mw-rewrite-dynamic-query") {
-    return NextResponse.rewrite(new URL("/posts/first", request.url));
+    const target = request.nextUrl.clone();
+    target.pathname = "/posts/first";
+    return NextResponse.rewrite(target);
   }
 
-  // Rewrite target carries its own query — rewrite-target params should
-  // win over original request params on key conflicts.
+  // Rewrite target carries its own query — middleware overlays its key onto
+  // the existing nextUrl search before rewriting. The resulting query is the
+  // exact final URL (not an auto-merge): keys explicitly set by middleware
+  // override, untouched keys carry over because the middleware mutated the
+  // same NextURL instance that already has them.
   if (url.pathname === "/mw-rewrite-merge-query") {
-    return NextResponse.rewrite(new URL("/ssr-query?hello=from-rewrite", request.url));
+    const target = request.nextUrl.clone();
+    target.pathname = "/ssr-query";
+    target.searchParams.set("hello", "from-rewrite");
+    return NextResponse.rewrite(target);
+  }
+
+  // Issue #1342 / Next.js parity (test/e2e/middleware-rewrites
+  //   "should clear query parameters"):
+  // when middleware modifies `request.nextUrl.searchParams` (delete keys) and
+  // rewrites to it, the resulting query must match the modified destination
+  // exactly — vinext must NOT silently re-merge the original request's query.
+  if (url.pathname === "/mw-clear-query-params") {
+    const allowedKeys = new Set(["allowed"]);
+    for (const key of [...url.searchParams.keys()]) {
+      if (!allowedKeys.has(key)) url.searchParams.delete(key);
+    }
+    url.pathname = "/ssr-query";
+    return NextResponse.rewrite(url);
   }
 
   if (url.pathname === "/rewrite-with-cookie") {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3868,6 +3868,24 @@ describe("Production server middleware (Pages Router)", () => {
     expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
   });
 
+  // Regression for cloudflare/vinext#1342 (production): middleware that
+  // explicitly deletes search params from `request.nextUrl` and rewrites to
+  // it must observe only the keys it kept. Dev coverage of the same shared
+  // code path exists in the integration describe above; this proves the
+  // prod-server path agrees.
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ("should clear query parameters")
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("middleware rewrite respects searchParams.delete on the rewrite-target URL in production", async () => {
+    const res = await fetch(`${prodUrl}/mw-clear-query-params?a=1&b=2&foo=bar&allowed=kept`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toEqual({ allowed: "kept" });
+  });
+
   // /_next/data fetch for a middleware-rewritten page must also surface the
   // original request query params in the JSON props envelope. Client-side
   // navigations go through this code path, so a regression here would silently

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1220,6 +1220,22 @@ describe("Pages Router integration", () => {
     expect(nextData.props.pageProps.query).toEqual({});
   });
 
+  // Regression for cloudflare/vinext#1342: middleware that explicitly deletes
+  // search params from `request.nextUrl` and rewrites to it must observe only
+  // the keys it kept — vinext must NOT silently re-merge the original query.
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ("should clear query parameters")
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("middleware rewrite respects searchParams.delete on the rewrite-target URL", async () => {
+    const res = await fetch(`${baseUrl}/mw-clear-query-params?a=1&b=2&foo=bar&allowed=kept`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toEqual({ allowed: "kept" });
+  });
+
   it("middleware blocks /blocked with 403", async () => {
     const res = await fetch(`${baseUrl}/blocked`);
     expect(res.status).toBe(403);
@@ -3825,6 +3841,47 @@ describe("Production server middleware (Pages Router)", () => {
     expect(res.headers.get("x-rewrite-source-header")).toBe("1");
     const html = await res.text();
     expect(html).toContain("Server-Side Rendered");
+  });
+
+  // Regression for cloudflare/vinext#1342: original request query params must
+  // survive a middleware rewrite into the rewrite target's getServerSideProps.
+  // Mirrors the dev-server coverage so the production prod-server is exercised.
+  // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts
+  it("middleware rewrite preserves original query params into getServerSideProps in production", async () => {
+    const res = await fetch(`${prodUrl}/mw-rewrite-query?hello=world`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toMatchObject({ hello: "world" });
+  });
+
+  it("middleware rewrite to a dynamic route merges original query with route params in production", async () => {
+    const res = await fetch(`${prodUrl}/mw-rewrite-dynamic-query?hello=world`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
+  });
+
+  // /_next/data fetch for a middleware-rewritten page must also surface the
+  // original request query params in the JSON props envelope. Client-side
+  // navigations go through this code path, so a regression here would silently
+  // break query state after a rewrite even when the HTML render is correct.
+  it("middleware rewrite preserves original query params on _next/data JSON in production", async () => {
+    const res = await fetch(
+      `${prodUrl}/_next/data/test-build-id/mw-rewrite-query.json?hello=world`,
+      { headers: { "x-nextjs-data": "1" } },
+    );
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      pageProps: { query: Record<string, string | string[]> };
+    };
+    expect(data.pageProps.query).toMatchObject({ hello: "world" });
   });
 
   // Ported from Next.js:


### PR DESCRIPTION
## Summary

- Next.js middleware constructs the rewrite-target URL itself (via `request.nextUrl` mutation or passing a fresh URL); whatever search params it carries IS the final query. vinext was silently re-merging the original request's query on top, which resurrected keys that middleware had explicitly removed via `searchParams.delete(...)`.
- Drop the `mergeRewriteQuery` call inside `executeMiddleware` so the destination URL is the source of truth — matching Next.js' `x-middleware-rewrite` resolution in `packages/next/src/server/lib/router-utils/resolve-routes.ts`.
- Config rewrites (next.config.js) keep their existing query-merge behaviour — those are unchanged.
- Update Pages and App Router fixture middleware that wanted the *original* query preserved to use `request.nextUrl.clone()` (the Next.js-idiomatic pattern).

## Tests

- New Pages Router test ported from Next.js `test/e2e/middleware-rewrites/test/index.test.ts` ("should clear query parameters") — confirms `searchParams.delete` actually deletes.
- New Pages Router prod-server tests for the original-query-preservation paths.
- New App Router parity test for original-query-preservation.

Fixes #1342

## Test plan
- [x] `pnpm test tests/pages-router.test.ts` (256/256 pass)
- [x] `pnpm test tests/app-router.test.ts` (332/332 pass)
- [x] `pnpm test tests/middleware-runtime.test.ts tests/middleware-runtime-trailing-slash.test.ts tests/app-post-middleware-context.test.ts tests/query.test.ts` (40/40 pass)
- [x] `pnpm run check`