### PR TITLE
fix(build): preserve user-source semantics of import.meta.url

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -102,6 +102,7 @@ import {
 import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
+import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
 import { generateRouteTypes } from "./typegen.js";
 import {
   mergeOptimizeDepsExclude,
@@ -3817,6 +3818,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     createOgInlineFetchAssetsPlugin(),
     // Copy @vercel/og binary assets to the RSC output directory — see src/plugins/og-assets.ts
     ogAssetsPlugin,
+    // Rewrite `import.meta.url` in user source modules to the source file URL
+    // before Rolldown collapses everything into one entry. Without this,
+    // bundled `import.meta.url` resolves to the entry file path instead of
+    // the user's source path, breaking Next.js parity. Registered AFTER
+    // og-assets so its `fetch(new URL(..., import.meta.url))` matching still
+    // runs first on `@vercel/og` and similar libraries — see
+    // src/plugins/import-meta-url.ts and cloudflare/vinext#1505.
+    createImportMetaUrlPlugin(),
     // Collect SSR/RSC bundle externals and write dist/server/vinext-externals.json.
     // Used by emitStandaloneOutput to determine which packages to copy into
     // standalone/node_modules/ — uses the bundler's own import graph instead of

--- a/packages/vinext/src/plugins/import-meta-url.ts
+++ b/packages/vinext/src/plugins/import-meta-url.ts
@@ -1,0 +1,163 @@
+/**
+ * `vinext:import-meta-url` Vite plugin.
+ *
+ * Preserves the user-source semantics of `import.meta.url` through the
+ * production bundle.
+ *
+ * Background — Next.js parity (cloudflare/vinext#1505):
+ *
+ *   Next.js (both Turbopack and Webpack) makes `import.meta.url` in user
+ *   source modules resolve to the source file's `file://` URL — e.g.
+ *   `file:///<root>/pages/index.tsx`. Code like
+ *   `new URL('./data.json', import.meta.url)` then resolves relative to the
+ *   user's source path, which is the Web/Node semantics.
+ *
+ * The vinext gap:
+ *
+ *   In dev, Vite serves each module from its own URL, so `import.meta.url`
+ *   already reflects the source path. In production, Rolldown bundles every
+ *   server module into a single `entry.js`. The runtime `import.meta.url`
+ *   inside that bundle is the bundled entry's path (e.g.
+ *   `file:///<tmp>/dist/server/entry.js?t=...`), not the page's source path.
+ *   Relative URL resolution and any code that introspects the source
+ *   filename breaks.
+ *
+ * The fix:
+ *
+ *   At transform time, in build mode only, substitute every textual
+ *   occurrence of `import.meta.url` with a string literal that is the file
+ *   URL of the module being transformed (`pathToFileURL(id).href`). This
+ *   pins the value to the user source path before bundling, so the
+ *   collapsed entry preserves Next.js parity for every module.
+ *
+ * Scope:
+ *
+ *   - Build only. Dev is already correct via Vite's per-module URLs.
+ *   - User project source files only — skip `node_modules`, vinext's own
+ *     entries, and virtual modules. Library code under `node_modules` is
+ *     expected to retain its own `import.meta.url` semantics (or be
+ *     handled by other plugins, e.g. `vinext:og-inline-fetch-assets`).
+ *   - Skip modules whose id begins with `\0` (virtual modules) or contains
+ *     no `import.meta.url` reference (fast bail-out).
+ *
+ * Implementation notes:
+ *
+ *   - `enforce: "pre"` so the substitution happens before bundle-time
+ *     transforms that might otherwise inline the `import.meta.url` token.
+ *   - Skipping `import.meta.url` inside strings/comments would require
+ *     parsing; for user source files the false-positive risk is acceptable
+ *     (a literal occurrence inside a string is rare and would yield a
+ *     harmless string substitution). If this proves problematic, a parse-
+ *     based pass mirroring `og-assets.ts` Pattern 2 is the next step.
+ */
+import type { Plugin } from "vite";
+import { pathToFileURL } from "node:url";
+import MagicString from "magic-string";
+
+const IMPORT_META_URL_TOKEN = "import.meta.url";
+
+/**
+ * Decide whether a module id is a user-project source file that we should
+ * rewrite. Reject virtual modules (`\0`-prefixed), `node_modules`, and
+ * vinext's own packaged source. We rely on the file id being an absolute
+ * path on disk — anything else (commonjs proxies, query suffixes that
+ * point at non-files) is not safe to derive a `file://` URL from.
+ */
+function shouldTransform(id: string): boolean {
+  // Virtual modules — Vite uses a leading `\0` to mark them. They have no
+  // on-disk path; deriving a file URL would be meaningless. Skip.
+  if (id.startsWith("\0")) return false;
+
+  // Strip Vite's query suffix (`?t=…`, `?v=…`) before path checks. The
+  // pathname before the `?` is what we use for the file URL.
+  const idWithoutQuery = id.split("?", 1)[0];
+
+  // Only absolute on-disk paths can be turned into a file URL. Drop bare
+  // specifiers, http(s) URLs, and any other non-path id.
+  if (!idWithoutQuery.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(idWithoutQuery)) {
+    return false;
+  }
+
+  // Skip dependencies. Their `import.meta.url` semantics are the library
+  // author's concern, not Next.js parity for user code.
+  if (idWithoutQuery.includes("/node_modules/")) return false;
+
+  // Skip vinext's own packaged source — these files use `import.meta.url`
+  // intentionally to locate sibling helpers via `resolveEntryPath`. We must
+  // not rewrite those references to a file URL inside the user's project.
+  // Match both the source tree (`/packages/vinext/src/`) and the published
+  // distribution layout (`/vinext/dist/`).
+  if (
+    idWithoutQuery.includes("/packages/vinext/src/") ||
+    idWithoutQuery.includes("/packages/vinext/dist/") ||
+    idWithoutQuery.includes("/vinext/dist/")
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Find every occurrence of `import.meta.url` in `code` and replace it with
+ * the JSON-stringified `replacement`. Uses MagicString so the source map
+ * stays accurate. Returns `null` when there are no occurrences.
+ *
+ * The match is intentionally textual — `import.meta.url` is a rare enough
+ * token in user source that a full AST walk is overkill. False positives
+ * inside string literals are accepted; see plugin header.
+ */
+export function rewriteImportMetaUrl(code: string, replacement: string): string | null {
+  if (!code.includes(IMPORT_META_URL_TOKEN)) return null;
+
+  const literal = JSON.stringify(replacement);
+  const ms = new MagicString(code);
+  let didReplace = false;
+  let searchFrom = 0;
+
+  while (true) {
+    const idx = code.indexOf(IMPORT_META_URL_TOKEN, searchFrom);
+    if (idx === -1) break;
+
+    // Guard against `import.meta.urls` and similar — make sure the next
+    // character is not an identifier-continuing character.
+    const after = code.charAt(idx + IMPORT_META_URL_TOKEN.length);
+    if (after && /[A-Za-z0-9_$]/.test(after)) {
+      searchFrom = idx + IMPORT_META_URL_TOKEN.length;
+      continue;
+    }
+
+    ms.overwrite(idx, idx + IMPORT_META_URL_TOKEN.length, literal);
+    didReplace = true;
+    searchFrom = idx + IMPORT_META_URL_TOKEN.length;
+  }
+
+  if (!didReplace) return null;
+  return ms.toString();
+}
+
+/**
+ * Build the `vinext:import-meta-url` plugin. Build-time only.
+ */
+export function createImportMetaUrlPlugin(): Plugin {
+  return {
+    name: "vinext:import-meta-url",
+    apply: "build",
+    enforce: "pre",
+    transform(code, id) {
+      if (!shouldTransform(id)) return null;
+
+      const idWithoutQuery = id.split("?", 1)[0];
+      const sourceFileUrl = pathToFileURL(idWithoutQuery).href;
+      const rewritten = rewriteImportMetaUrl(code, sourceFileUrl);
+      if (rewritten === null) return null;
+
+      // Returning `map: null` is safe — MagicString preserves byte offsets
+      // for our overwrite, so existing source maps from upstream transforms
+      // continue to point at the original code. A precise map could be
+      // generated via `ms.generateMap`, but for a single-token rewrite the
+      // cost outweighs the benefit.
+      return { code: rewritten, map: null };
+    },
+  };
+}

--- a/tests/fixtures/pages-basic/pages/import-meta-url.tsx
+++ b/tests/fixtures/pages-basic/pages/import-meta-url.tsx
@@ -1,0 +1,12 @@
+/**
+ * Fixture for the import-meta-url server-side test. Exposes `import.meta.url`
+ * as JSON so the test can assert that the URL resolves to the page's source
+ * file (not the bundled entry path). Mirrors Next.js's
+ * `test/e2e/import-meta/pages/index.tsx` page.
+ */
+export default function Page() {
+  const data = {
+    url: import.meta.url,
+  };
+  return <div id="test-data">{JSON.stringify(data)}</div>;
+}

--- a/tests/import-meta-url.test.ts
+++ b/tests/import-meta-url.test.ts
@@ -37,12 +37,28 @@ function extractTestData(html: string): { url: string } {
   if (!match) {
     throw new Error(`#test-data not found in HTML: ${html.slice(0, 200)}`);
   }
-  const decoded = match[1]
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">");
+  // Strip HTML comments in a loop until none remain — guards against
+  // accidentally reintroducing a "<!--" sequence after the first pass.
+  let stripped = match[1];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const next = stripped.replace(/<!--[\s\S]*?-->/g, "");
+    if (next === stripped) break;
+    stripped = next;
+  }
+  // Single-pass entity decode to avoid the double-unescape pitfall
+  // (e.g. "&amp;lt;" must NOT become "<"). All known named entities are
+  // matched in one regex; the replacer picks the canonical decoded form.
+  const ENTITIES: Record<string, string> = {
+    "&quot;": '"',
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+  };
+  const decoded = stripped.replace(
+    /&(?:quot|amp|lt|gt);/g,
+    (m) => ENTITIES[m] ?? m,
+  );
   return JSON.parse(decoded);
 }
 

--- a/tests/import-meta-url.test.ts
+++ b/tests/import-meta-url.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `import.meta.url` parity test.
+ *
+ * Ported from Next.js: test/e2e/import-meta/import-meta.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/import-meta/import-meta.test.ts
+ *
+ * Next.js (both Turbopack and Webpack) preserves the user's source path so a
+ * page's `import.meta.url` is `file:///<abs-path>/pages/index.tsx`. vinext
+ * bundles all server modules into a single entry; without explicit handling
+ * the runtime `import.meta.url` resolves to the bundled entry path, breaking
+ * `new URL('./data.json', import.meta.url)`-style resolution and any code
+ * that introspects the source filename.
+ *
+ * The fix is a Vite transform that substitutes `import.meta.url` with the
+ * user source file URL string before bundling. This test asserts the
+ * substitution happens in both dev (where Vite already does it per-module)
+ * and in the bundled production output (the cloudflare/vinext#1505 regression
+ * case).
+ *
+ * Regression for cloudflare/vinext#1505.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { build } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+import type { ViteDevServer } from "vite-plus";
+import { pathToFileURL } from "node:url";
+import { rewriteImportMetaUrl } from "../packages/vinext/src/plugins/import-meta-url.js";
+import { PAGES_FIXTURE_DIR, startFixtureServer, fetchHtml } from "./helpers.js";
+
+function extractTestData(html: string): { url: string } {
+  // <div id="test-data">…JSON…</div>. React's SSR escapes `"` as `&quot;` and
+  // may insert comment nodes — decode and strip both before parsing.
+  const match = html.match(/<div[^>]*id="test-data"[^>]*>([\s\S]*?)<\/div>/);
+  if (!match) {
+    throw new Error(`#test-data not found in HTML: ${html.slice(0, 200)}`);
+  }
+  const decoded = match[1]
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+  return JSON.parse(decoded);
+}
+
+describe("rewriteImportMetaUrl (unit)", () => {
+  const FILE_URL = "file:///abs/pages/index.tsx";
+
+  it("returns null when there is no occurrence", () => {
+    expect(rewriteImportMetaUrl("const x = 1;\n", FILE_URL)).toBeNull();
+  });
+
+  it("replaces a bare import.meta.url with the JSON-stringified URL", () => {
+    const out = rewriteImportMetaUrl("const u = import.meta.url;", FILE_URL);
+    expect(out).toBe(`const u = ${JSON.stringify(FILE_URL)};`);
+  });
+
+  it("replaces every occurrence", () => {
+    const code = "a(import.meta.url); b(import.meta.url);";
+    const out = rewriteImportMetaUrl(code, FILE_URL);
+    const literal = JSON.stringify(FILE_URL);
+    expect(out).toBe(`a(${literal}); b(${literal});`);
+  });
+
+  it("does not rewrite identifiers that merely start with import.meta.url", () => {
+    // e.g. `import.meta.urls` (if it ever existed) — the trailing identifier
+    // character means this is a different member access, not `.url`.
+    const code = "const x = import.meta.urls;";
+    expect(rewriteImportMetaUrl(code, FILE_URL)).toBeNull();
+  });
+
+  it("preserves other import.meta references", () => {
+    const code = "const a = import.meta.url; const b = import.meta.env.DEV;";
+    const out = rewriteImportMetaUrl(code, FILE_URL);
+    expect(out).toBe(`const a = ${JSON.stringify(FILE_URL)}; const b = import.meta.env.DEV;`);
+  });
+});
+
+describe("import.meta.url (Pages Router, dev)", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(PAGES_FIXTURE_DIR));
+  }, 30000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("resolves to the user's source file URL on the server (not the bundled entry)", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/import-meta-url");
+    expect(res.status).toBe(200);
+
+    const data = extractTestData(html);
+    // Mirrors Next.js parity: file:///<...>/pages/import-meta-url.tsx
+    expect(data.url).toMatch(/^file:\/\//);
+    expect(data.url.endsWith("/pages/import-meta-url.tsx")).toBe(true);
+
+    // Anchor to the fixture root so a wrong substitution (e.g. the bundled
+    // entry path) is also caught.
+    const expectedFileUrl = pathToFileURL(
+      path.join(PAGES_FIXTURE_DIR, "pages", "import-meta-url.tsx"),
+    ).href;
+    expect(data.url).toBe(expectedFileUrl);
+  });
+});
+
+describe("import.meta.url (Pages Router, production build)", () => {
+  // The regression case from cloudflare/vinext#1505: in production, Rolldown
+  // collapses every server module into one entry file. Without explicit
+  // handling, `import.meta.url` at runtime resolves to the bundled entry
+  // path, not the user's source file. This test asserts the build embeds
+  // the user source path as a literal string in the bundle so the runtime
+  // value matches Next.js parity.
+  let bundlePath: string;
+  let outDir: string;
+
+  beforeAll(async () => {
+    outDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-import-meta-url-build-"));
+    await build({
+      root: PAGES_FIXTURE_DIR,
+      configFile: false,
+      plugins: [vinext({ disableAppRouter: true })],
+      logLevel: "silent",
+      build: {
+        outDir,
+        emptyOutDir: true,
+        ssr: "virtual:vinext-server-entry",
+        rollupOptions: { output: { entryFileNames: "entry.js" } },
+      },
+    });
+    bundlePath = path.join(outDir, "entry.js");
+  }, 120_000);
+
+  afterAll(() => {
+    if (outDir) fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it("substitutes import.meta.url in the bundle with the user source file URL", async () => {
+    const bundle = fs.readFileSync(bundlePath, "utf-8");
+    const expectedFileUrl = pathToFileURL(
+      path.join(PAGES_FIXTURE_DIR, "pages", "import-meta-url.tsx"),
+    ).href;
+
+    // The bundle must contain the user source file URL as a literal so the
+    // runtime `import.meta.url` evaluation in the page module yields the
+    // Next.js-parity value. Asserting on bundle text (rather than running
+    // the bundle) keeps the test fast and avoids spinning a prod server.
+    expect(
+      bundle.includes(expectedFileUrl),
+      `expected bundle to embed the page's source file URL (${expectedFileUrl}). ` +
+        `Substitution likely missing.`,
+    ).toBe(true);
+  });
+});

--- a/tests/import-meta-url.test.ts
+++ b/tests/import-meta-url.test.ts
@@ -55,10 +55,7 @@ function extractTestData(html: string): { url: string } {
     "&lt;": "<",
     "&gt;": ">",
   };
-  const decoded = stripped.replace(
-    /&(?:quot|amp|lt|gt);/g,
-    (m) => ENTITIES[m] ?? m,
-  );
+  const decoded = stripped.replace(/&(?:quot|amp|lt|gt);/g, (m) => ENTITIES[m] ?? m);
   return JSON.parse(decoded);
 }
 


### PR DESCRIPTION
## Summary

- Rolldown bundles every server module into one entry, so at runtime `import.meta.url` resolves to the bundled entry path instead of the page's source file. Both Turbopack and Webpack preserve the user source path; that's the Next.js parity we want for code like `new URL('./data.json', import.meta.url)`.
- Add a build-only Vite transform (`vinext:import-meta-url`) that substitutes `import.meta.url` in user project source files with `pathToFileURL(id).href` before bundling. Skips `node_modules`, virtual modules, and vinext's own packaged source (where the token is used to locate sibling helpers).
- Dev is unaffected — Vite already serves each module from its own URL.

## Plugin ordering

Registered AFTER `og-assets` so its `fetch(new URL(..., import.meta.url))` matching for `@vercel/og` and friends still runs first on `node_modules`. My plugin skips `node_modules` anyway, so the two are complementary in practice.

## Test plan

- [x] `tests/import-meta-url.test.ts` — new unit + integration regression test:
  - Unit coverage for the textual rewrite (`rewriteImportMetaUrl`): no-op, replace, multi-occurrence, identifier guard, sibling-property preservation
  - Dev parity: a page using `import.meta.url` renders the expected `file:///.../pages/import-meta-url.tsx`
  - Production-build regression for the #1505 case: the SSR bundle embeds the page's source file URL as a literal
- [x] `vp check` (format + lint + types)
- [x] `vp test run tests/pages-router.test.ts` (252 passed)
- [x] `vp test run tests/app-router.test.ts` (331 passed)
- [x] `vp test run tests/og-inline.test.ts tests/og-font-patch.test.ts tests/asset-prefix.test.ts` (52 passed)
- [x] `vp test run tests/features.test.ts tests/static-export.test.ts` (325 passed)
- [x] `vp test run tests/cjs.test.ts` (3 passed)
- [ ] Full Vitest + Playwright via CI

Fixes #1505