### PR TITLE
fix(pages-router): emit page scripts with defer in <head> by default

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -382,6 +382,17 @@ export type ResolvedNextConfig = {
    * except the specified method names (case-insensitive).
    */
   removeConsole: boolean | { exclude: string[] };
+  /**
+   * Mirrors Next.js `experimental.disableOptimizedLoading`. When `false`
+   * (the default), Pages Router page scripts are emitted with `defer` in
+   * `<head>` so the browser can prefetch them in parallel with HTML parsing.
+   * When `true`, scripts are emitted without `defer` (legacy behaviour).
+   *
+   * See `.nextjs-ref/packages/next/src/pages/_document.tsx` (`getScripts` →
+   * `defer={!disableOptimizedLoading}`) and the upstream
+   * `test/e2e/optimized-loading` test fixture.
+   */
+  disableOptimizedLoading: boolean;
 };
 
 // Mirrors Next.js's accepted set in packages/next/src/shared/lib/constants.ts
@@ -1016,6 +1027,7 @@ export async function resolveNextConfig(
       deploymentId,
       sassOptions: null,
       removeConsole: false,
+      disableOptimizedLoading: false,
       instrumentationClientInject: [],
     };
     detectNextIntlConfig(root, resolved);
@@ -1239,6 +1251,9 @@ export async function resolveNextConfig(
         : isUnknownRecord(config.compiler?.removeConsole)
           ? { exclude: readStringArray(config.compiler!.removeConsole.exclude) }
           : false,
+    // Next.js stores this under `experimental.disableOptimizedLoading`.
+    // Default `false` matches Next.js: page scripts get `defer` in <head>.
+    disableOptimizedLoading: experimental?.disableOptimizedLoading === true,
   };
 
   // Auto-detect next-intl (lowest priority — explicit aliases from

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -121,6 +121,10 @@ export async function generateServerEntry(
     headers: nextConfig?.headers ?? [],
     expireTime: nextConfig?.expireTime,
     i18n: nextConfig?.i18n ?? null,
+    // Mirrors Next.js `experimental.disableOptimizedLoading` — when false
+    // (the default), page scripts are emitted with `defer` in <head>. See
+    // `.nextjs-ref/packages/next/src/pages/_document.tsx` getScripts().
+    disableOptimizedLoading: nextConfig?.disableOptimizedLoading === true,
     images: {
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
@@ -454,6 +458,13 @@ function collectAssetTags(manifest, moduleIds, scriptNonce) {
   const tags = [];
   const seen = new Set();
   const nonceAttr = __createNonceAttribute(scriptNonce);
+  // Mirrors Next.js \`_document\` behaviour: when \`experimental.disableOptimizedLoading\`
+  // is false (the default), page scripts are emitted with \`defer\` in <head>. See
+  // .nextjs-ref/packages/next/src/pages/_document.tsx getScripts() — \`defer={!disableOptimizedLoading}\`.
+  // vinext always emits \`type="module"\` (which already defers implicitly), but
+  // upstream tests (e.g. test/e2e/optimized-loading) assert the literal \`defer\`
+  // attribute, and adding it preserves parity without changing browser behaviour.
+  const deferAttr = vinextConfig.disableOptimizedLoading ? "" : " defer";
 
   // Load the set of lazy chunk filenames (only reachable via dynamic imports).
   // These should NOT get <link rel="modulepreload"> or <script type="module">
@@ -467,7 +478,7 @@ function collectAssetTags(manifest, moduleIds, scriptNonce) {
     const entry = globalThis.__VINEXT_CLIENT_ENTRY__;
     seen.add(entry);
     tags.push('<link rel="modulepreload"' + nonceAttr + ' href="/' + entry + '" />');
-    tags.push('<script type="module"' + nonceAttr + ' src="/' + entry + '" crossorigin></script>');
+    tags.push('<script type="module"' + deferAttr + nonceAttr + ' src="/' + entry + '" crossorigin></script>');
   }
   if (m) {
     // Always inject shared chunks (framework, vinext runtime, entry) and
@@ -537,7 +548,7 @@ function collectAssetTags(manifest, moduleIds, scriptNonce) {
         // (React.lazy, next/dynamic) and should only be fetched on demand.
         if (lazySet && lazySet.has(tf)) continue;
         tags.push('<link rel="modulepreload"' + nonceAttr + ' href="/' + tf + '" />');
-        tags.push('<script type="module"' + nonceAttr + ' src="/' + tf + '" crossorigin></script>');
+        tags.push('<script type="module"' + deferAttr + nonceAttr + ' src="/' + tf + '" crossorigin></script>');
       }
     }
   }

--- a/tests/e2e/cloudflare-pages-router/hydration.spec.ts
+++ b/tests/e2e/cloudflare-pages-router/hydration.spec.ts
@@ -9,8 +9,11 @@ test.describe("Pages Router client hydration on Cloudflare Workers", () => {
   test("client JS bundle is loaded", async ({ page }) => {
     const response = await page.goto(BASE + "/");
     const html = await response!.text();
-    // The HTML should contain a script tag for the client entry
-    expect(html).toMatch(/script\s+type="module"\s+src="\/_next\/static\/[^"]+\.js"/);
+    // The HTML should contain a script tag for the client entry. The
+    // `defer` attribute is emitted by default (Next.js optimized loading);
+    // allow optional whitespace-separated attributes between `type="module"`
+    // and `src="…"` so the regex remains stable as attributes shift.
+    expect(html).toMatch(/script\s+type="module"(?:\s+\w+)*\s+src="\/_next\/static\/[^"]+\.js"/);
   });
 
   test("counter becomes interactive after hydration", async ({ page }) => {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -781,6 +781,21 @@ describe("resolveNextConfig serverActionsBodySizeLimit", () => {
     });
     expect(resolved.serverActionsBodySizeLimit).toBe(5242880);
   });
+
+  // Regression for #1519: `experimental.disableOptimizedLoading` defaults to
+  // `false` and is read into the resolved config. The default drives the
+  // `defer`-in-head behaviour for Pages Router scripts in production.
+  it("defaults disableOptimizedLoading to false", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.disableOptimizedLoading).toBe(false);
+  });
+
+  it("reads experimental.disableOptimizedLoading from next.config", async () => {
+    const resolved = await resolveNextConfig({
+      experimental: { disableOptimizedLoading: true },
+    });
+    expect(resolved.disableOptimizedLoading).toBe(true);
+  });
 });
 
 describe("resolveNextConfig hashSalt", () => {
@@ -1018,6 +1033,7 @@ describe("detectNextIntlConfig", () => {
       deploymentId: undefined,
       sassOptions: null,
       removeConsole: false,
+      disableOptimizedLoading: false,
       instrumentationClientInject: [],
       ...overrides,
     };

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3643,8 +3643,34 @@ describe("Production server middleware (Pages Router)", () => {
 
     const html = await res.text();
     expect(html).toContain('<script nonce="pages-prod">window.__NEXT_DATA__ = ');
-    expect(html).toMatch(/<script type="module" nonce="pages-prod" src="\/[^"]+"/);
+    expect(html).toMatch(/<script type="module" defer nonce="pages-prod" src="\/[^"]+"/);
     expect(html).toMatch(/<link rel="modulepreload" nonce="pages-prod" href="\/[^"]+"/);
+  });
+
+  // Ported from Next.js: test/e2e/optimized-loading/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/optimized-loading/test/index.test.ts
+  //
+  // Regression for #1519: optimized loading is enabled by default in Next.js
+  // (`experimental.disableOptimizedLoading: false`). Page scripts must be
+  // emitted with `defer` in <head>, not as plain scripts at the end of <body>
+  // (and never as `async`). The Next.js E2E asserts both `script[async]
+  // .length === 0` and `head script[defer].length > 0`.
+  it("emits page scripts with defer in <head> by default (optimized loading)", async () => {
+    const res = await fetch(`${prodUrl}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // No async script tags (matches `script[async].length === 0` upstream).
+    expect(html).not.toMatch(/<script[^>]*\sasync(\s|>|=)/);
+
+    // Locate the head so we can search just that slice for defer scripts.
+    const headEnd = html.indexOf("</head>");
+    expect(headEnd).toBeGreaterThan(-1);
+    const head = html.slice(0, headEnd);
+
+    // Matches `head script[defer].length > 0` upstream.
+    const deferInHead = head.match(/<script[^>]*\sdefer(\s|>|=)[^>]*>/g) ?? [];
+    expect(deferInHead.length).toBeGreaterThan(0);
   });
 
   it("does not serve cached production Pages ISR HTML to CSP nonce requests", async () => {


### PR DESCRIPTION
## Summary

- Page scripts emitted by `collectAssetTags` (Pages Router production entry) now carry the `defer` attribute when `experimental.disableOptimizedLoading` is unset/false (the default), matching Next.js' `_document.tsx` `getScripts()` behaviour (`defer={!disableOptimizedLoading}`).
- Adds `disableOptimizedLoading` to `ResolvedNextConfig`, reading from `experimental.disableOptimizedLoading` so users can opt out.
- Browser behaviour is unchanged — `type="module"` scripts already defer implicitly — but the literal attribute is required by upstream parity tests (`test/e2e/optimized-loading`).

Fixes #1519.

## Test plan

- [x] Added a regression test in `tests/pages-router.test.ts` that asserts `<head>` contains at least one `<script ... defer ...>` and no `<script async ...>` tags, mirroring the upstream `test/e2e/optimized-loading/test/index.test.ts` assertions.
- [x] Updated the existing CSP nonce production test to expect the new `defer` attribute.
- [x] Added two `tests/next-config.test.ts` cases covering the default (`false`) and explicit opt-out (`true`).
- [x] `pnpm test tests/pages-router.test.ts tests/next-config.test.ts` — 384 passing.
- [x] `pnpm run check` clean.