### PR TITLE
fix(app-router): implement experimental.inlineCss

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -222,6 +222,11 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     detail:
       "App Shell prefetching not yet implemented; requires cacheComponents and other co-flags vinext does not support",
   },
+  "experimental.inlineCss": {
+    status: "supported",
+    detail:
+      'production builds inline App Router CSS as <style> tags in <head> instead of <link rel="stylesheet">',
+  },
   "i18n.domains": {
     status: "partial",
     detail: "supported for Pages Router; App Router unchanged",

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -432,6 +432,15 @@ export type ResolvedNextConfig = {
    * Mirrors Next.js: packages/next/src/server/lib/trace/utils.ts (getTracedMetadata).
    */
   clientTraceMetadata: string[] | undefined;
+  /**
+   * Inline compiled CSS as `<style>` tags in `<head>` instead of emitting
+   * `<link rel="stylesheet">` references. Sourced from
+   * `experimental.inlineCss` in next.config. Production-only (Next.js
+   * disables inlining in dev because it breaks HMR).
+   *
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/inlineCss
+   */
+  inlineCss: boolean;
 };
 
 // Mirrors Next.js's accepted set in packages/next/src/shared/lib/constants.ts
@@ -1091,6 +1100,7 @@ export async function resolveNextConfig(
       compilerDefineServer: {},
       instrumentationClientInject: [],
       clientTraceMetadata: undefined,
+      inlineCss: false,
     };
     detectNextIntlConfig(root, resolved);
     return resolved;
@@ -1323,6 +1333,11 @@ export async function resolveNextConfig(
           (value): value is string => typeof value === "string",
         )
       : undefined,
+    // Production-only: Next.js skips inlining in dev because HMR keeps
+    // inserting/removing <style> nodes that conflict with the inlined ones.
+    // We mirror the Next.js gate at the transform site, but still expose
+    // the resolved flag so build-time wiring can decide what to emit.
+    inlineCss: experimental?.inlineCss === true,
   };
 
   // Auto-detect next-intl (lowest priority — explicit aliases from

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -152,6 +152,17 @@ type AppRouterConfig = {
   publicFiles?: string[];
   /** Server-only token used to validate the draft-mode bypass cookie. */
   draftModeSecret?: string;
+  /**
+   * When true, the App Router rewrites RSC stylesheet links to inline
+   * `<style>` tags during SSR. Sourced from `experimental.inlineCss` in
+   * next.config. Re-exported as `__inlineCss` so the production server
+   * (Node prod-server and the Cloudflare build step) can read CSS contents
+   * from disk and populate `globalThis.__VINEXT_INLINE_CSS_MAP__` at
+   * startup.
+   *
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/inlineCss
+   */
+  inlineCss?: boolean;
 };
 
 /**
@@ -182,6 +193,7 @@ export function generateRscEntry(
   const htmlLimitedBots = config?.htmlLimitedBots;
   const clientTraceMetadata = config?.clientTraceMetadata;
   const assetPrefix = config?.assetPrefix ?? "";
+  const inlineCss = config?.inlineCss === true;
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
@@ -496,6 +508,10 @@ const __clientTraceMetadata = ${JSON.stringify(clientTraceMetadata)};
 // mirrors the embedded \`__basePath\` pattern (and Pages Router's
 // \`vinextConfig\` export). Empty string when unset.
 export const __assetPrefix = ${JSON.stringify(assetPrefix)};
+// Re-exported so prod-server / cloudflare-build know whether to populate
+// \`globalThis.__VINEXT_INLINE_CSS_MAP__\`. Mirrors \`experimental.inlineCss\`
+// from next.config; production-only, dev is a no-op.
+export const __inlineCss = ${JSON.stringify(inlineCss)};
 
 export function seedMemoryCacheFromPrerender(serverDir) {
   return __seedMemoryCacheFromPrerender(serverDir, {

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -247,6 +247,21 @@ declare global {
   var __VINEXT_CLIENT_ENTRY__: string | undefined;
 
   /**
+   * Map of CSS asset URLs (as emitted by `@vitejs/plugin-rsc`'s Resources
+   * component, e.g. `"/_next/static/foo.css"`) to their full file contents.
+   * Populated when `experimental.inlineCss` is enabled in `next.config`:
+   * Cloudflare worker entries get this inlined at build time; the Node
+   * production server populates it from disk on startup. Read by the App
+   * Router SSR HTML stream transform to replace
+   * `<link rel="stylesheet" data-rsc-css-href="…">` tags with inline
+   * `<style>…</style>` blocks. Mirrors Next.js `experimental.inlineCss`.
+   *
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/inlineCss
+   */
+  // oxlint-disable-next-line no-var
+  var __VINEXT_INLINE_CSS_MAP__: Record<string, string> | undefined;
+
+  /**
    * Current active locale, set on `globalThis` for server-side SSR rendering
    * (Pages Router with i18n).  Mirrors `window.__VINEXT_LOCALE__` for use in
    * environments where `window` is not available (e.g. Cloudflare Workers).

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -119,6 +119,7 @@ import {
 } from "./plugins/fonts.js";
 import { hasWranglerConfig, formatMissingCloudflarePluginError } from "./deploy.js";
 import { computeLazyChunks } from "./utils/lazy-chunks.js";
+import { collectInlineCssMap } from "./utils/inline-css.js";
 import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
 import { buildSassPreprocessorOptions } from "./plugins/sass.js";
 import {
@@ -2279,6 +2280,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               publicFiles: scanPublicFileRoutes(root),
               globalNotFoundPath,
               draftModeSecret,
+              inlineCss: nextConfig?.inlineCss,
             },
             instrumentationPath,
           );
@@ -4237,13 +4239,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             }
           }
 
+          // When `experimental.inlineCss` is enabled, build a URL→content
+          // map of every CSS file under `dist/client/` so the Workers
+          // runtime (which has no fs access at request time) can rewrite
+          // App Router stylesheet links into inline `<style>` blocks. The
+          // Node prod-server walks the same directory at startup instead.
+          let inlineCssMap: Record<string, string> | null = null;
+          if (nextConfig?.inlineCss === true) {
+            inlineCssMap = collectInlineCssMap(clientDir);
+          }
+
           if (hasAppDir) {
             // App Router: the RSC plugin handles __VINEXT_CLIENT_ENTRY__
             // via loadBootstrapScriptContent(), but we still need to inject
             // __VINEXT_LAZY_CHUNKS__ and __VINEXT_SSR_MANIFEST__ into the
             // worker entry at dist/server/index.js.
             const workerEntry = path.resolve(distDir, "server", "index.js");
-            if (fs.existsSync(workerEntry) && (lazyChunksData || ssrManifestData)) {
+            if (fs.existsSync(workerEntry) && (lazyChunksData || ssrManifestData || inlineCssMap)) {
               let code = fs.readFileSync(workerEntry, "utf-8");
               const globals: string[] = [];
               if (ssrManifestData) {
@@ -4254,6 +4266,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               if (lazyChunksData) {
                 globals.push(
                   `globalThis.__VINEXT_LAZY_CHUNKS__ = ${JSON.stringify(lazyChunksData)};`,
+                );
+              }
+              if (inlineCssMap && Object.keys(inlineCssMap).length > 0) {
+                globals.push(
+                  `globalThis.__VINEXT_INLINE_CSS_MAP__ = ${JSON.stringify(inlineCssMap)};`,
                 );
               }
               code = globals.join("\n") + "\n" + code;

--- a/packages/vinext/src/server/app-inline-css.ts
+++ b/packages/vinext/src/server/app-inline-css.ts
@@ -1,0 +1,163 @@
+/**
+ * App Router CSS inlining (`experimental.inlineCss`).
+ *
+ * When the flag is enabled in `next.config`, vinext rewrites the
+ * `<link rel="stylesheet" data-rsc-css-href="…">` tags that
+ * `@vitejs/plugin-rsc` emits into the React tree to inline `<style>` blocks
+ * containing the CSS file contents. This mirrors Next.js's
+ * `experimental.inlineCss` behavior — see
+ * https://nextjs.org/docs/app/api-reference/config/next-config-js/inlineCss
+ * and `test/e2e/app-dir/app-inline-css/` in vercel/next.js.
+ *
+ * The lookup map is built once at server startup and exposed via
+ * `globalThis.__VINEXT_INLINE_CSS_MAP__`. Two sources populate it:
+ *
+ *   1. Node prod server: walks `dist/client` at startup and reads each
+ *      `.css` file into memory, keyed by the URL the RSC plugin will use
+ *      (Vite's `base` + relative path). See `prod-server.ts`.
+ *   2. Cloudflare Workers: the Vite plugin reads CSS contents from disk
+ *      at build time and prepends a `globalThis.__VINEXT_INLINE_CSS_MAP__ = …`
+ *      assignment to `dist/server/index.js`. See `index.ts`.
+ *
+ * Dev is a deliberate no-op — Next.js disables inlining in dev because HMR
+ * keeps inserting/removing `<style>` nodes that conflict with the inlined
+ * ones, and the e2e test that motivates this feature is itself gated to
+ * production only.
+ */
+
+/**
+ * Map of CSS asset URLs (e.g. `"/_next/static/foo.css"`) to file contents.
+ * Returns `undefined` when no map has been registered — callers should
+ * keep the original `<link rel="stylesheet">` tag in that case.
+ */
+export function getInlineCssMap(): Record<string, string> | undefined {
+  return globalThis.__VINEXT_INLINE_CSS_MAP__;
+}
+
+/**
+ * Register the inline CSS map. Used by the Node prod server (which builds
+ * the map at startup) and by tests that want to seed a fake map.
+ */
+export function setInlineCssMap(map: Record<string, string> | undefined): void {
+  if (map === undefined) {
+    delete globalThis.__VINEXT_INLINE_CSS_MAP__;
+  } else {
+    globalThis.__VINEXT_INLINE_CSS_MAP__ = map;
+  }
+}
+
+/**
+ * Match the `<link rel="stylesheet" … data-rsc-css-href="…">` tags emitted
+ * by `@vitejs/plugin-rsc`'s `Resources` component. The `data-rsc-css-href`
+ * attribute is what we key the inline CSS map on — it's the URL the plugin
+ * would normally use as the `href`. We deliberately match only tags that
+ * carry the `data-rsc-css-href` marker so user-authored `<link rel="stylesheet">`
+ * tags (e.g. for fonts) are left untouched.
+ *
+ * React Fizz serialises the tag as a self-closing void element, but defensive
+ * code shouldn't assume self-closing — the regex tolerates both `/>` and `>`.
+ */
+const RSC_CSS_LINK_RE = /<link\s[^>]*\bdata-rsc-css-href="([^"]*)"[^>]*?\/?>/g;
+
+/**
+ * Decode the small subset of HTML entities React Fizz emits inside attribute
+ * values (`&` and `"`). We deliberately do not try to be a full HTML decoder
+ * here — only the entities React itself produces when serialising an attribute
+ * value can show up in this position.
+ */
+function decodeRscCssHref(value: string): string {
+  return value.replaceAll("&amp;", "&").replaceAll("&quot;", '"');
+}
+
+/**
+ * Escape `</style>` and `</STYLE>` so user-authored CSS can't break out of the
+ * inline `<style>` element. The CSS spec doesn't recognize `</style>` as a
+ * comment terminator, but the HTML parser does — once it sees the closing
+ * tag, everything after is parsed as HTML. The minimal mitigation is to
+ * escape the `<` in `</style>` to `\3C` (the CSS-escape for `<`), which
+ * leaves the rule grammar intact and the HTML tokenizer doesn't see a
+ * matching tag. Case-insensitive because the HTML tokenizer is.
+ *
+ * See https://html.spec.whatwg.org/multipage/parsing.html#parse-error-end-tag-in-style
+ */
+function escapeStyleTagBoundary(css: string): string {
+  // `<style>` itself can't appear meaningfully in CSS, but the same escape
+  // rule applies and being symmetric keeps the substitution easier to audit.
+  return css.replaceAll(/<\/(style)/gi, "<\\/$1");
+}
+
+/**
+ * Rewrite a chunk of HTML so that every recognised RSC stylesheet link tag
+ * becomes an inline `<style>` element using the contents from `map`. When
+ * the URL is not present in `map` (e.g. a stale entry, a third-party CSS,
+ * or no map was registered) the link tag is left in place — the page still
+ * works, just without the inlining optimisation.
+ */
+export function rewriteRscCssLinksToInline(
+  html: string,
+  map: Record<string, string> | undefined,
+): string {
+  if (!map) return html;
+  return html.replace(RSC_CSS_LINK_RE, (match, hrefAttr: string) => {
+    const href = decodeRscCssHref(hrefAttr);
+    const css = map[href];
+    if (css === undefined) return match;
+    return `<style data-vinext-inline-css="${hrefAttr}">${escapeStyleTagBoundary(css)}</style>`;
+  });
+}
+
+/**
+ * Create a transform stream that inlines RSC CSS link tags as `<style>`
+ * blocks using the registered inline CSS map. When no map is registered
+ * (dev, or `experimental.inlineCss` disabled) this is the identity transform
+ * — bytes pass through unchanged.
+ *
+ * The transform decodes the chunk to UTF-8 with `{ stream: true }` and
+ * buffers each tick's output until the chunk ends with a complete `>`. In
+ * the unlikely event the React renderer splits a `<link …>` tag across two
+ * chunks, the partial tag is held until the rest of the tag arrives — the
+ * regex would otherwise fail to match a tag whose `data-rsc-css-href`
+ * attribute lands in the next chunk.
+ */
+export function createInlineCssTransform(): TransformStream<Uint8Array, Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let pending = "";
+
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      const map = getInlineCssMap();
+      const text = pending + decoder.decode(chunk, { stream: true });
+      if (!map) {
+        // Map registered as undefined → pass-through. Still flush any
+        // pending bytes from a previous chunk before the map cleared.
+        if (text) controller.enqueue(encoder.encode(text));
+        pending = "";
+        return;
+      }
+      // Hold the chunk back when it ends inside a tag — the regex below
+      // can only match a complete `<link … data-rsc-css-href="…" …>` and
+      // we'd otherwise emit a half-tag that the next pass would already
+      // have rewritten.
+      const lastOpen = text.lastIndexOf("<");
+      const lastClose = text.lastIndexOf(">");
+      let emit: string;
+      if (lastOpen > lastClose) {
+        emit = text.slice(0, lastOpen);
+        pending = text.slice(lastOpen);
+      } else {
+        emit = text;
+        pending = "";
+      }
+      const rewritten = rewriteRscCssLinksToInline(emit, map);
+      if (rewritten) controller.enqueue(encoder.encode(rewritten));
+    },
+    flush(controller) {
+      if (!pending) return;
+      const map = getInlineCssMap();
+      const out = rewriteRscCssLinksToInline(pending, map);
+      pending = "";
+      controller.enqueue(encoder.encode(out));
+    },
+  });
+}

--- a/packages/vinext/src/server/app-inline-css.ts
+++ b/packages/vinext/src/server/app-inline-css.ts
@@ -24,6 +24,7 @@
  * ones, and the e2e test that motivates this feature is itself gated to
  * production only.
  */
+import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
 
 /**
  * Map of CSS asset URLs (e.g. `"/_next/static/foo.css"`) to file contents.
@@ -70,13 +71,39 @@ function decodeRscCssHref(value: string): string {
 }
 
 /**
- * Escape `</style>` and `</STYLE>` so user-authored CSS can't break out of the
- * inline `<style>` element. The CSS spec doesn't recognize `</style>` as a
- * comment terminator, but the HTML parser does — once it sees the closing
- * tag, everything after is parsed as HTML. The minimal mitigation is to
- * escape the `<` in `</style>` to `\3C` (the CSS-escape for `<`), which
- * leaves the rule grammar intact and the HTML tokenizer doesn't see a
- * matching tag. Case-insensitive because the HTML tokenizer is.
+ * Normalise the URL the RSC plugin put in `data-rsc-css-href` to a key that
+ * could appear in our map. We always store keys as the on-disk relative
+ * path with a leading slash (`/_next/static/foo.css`). When `assetPrefix`
+ * is configured as an absolute URL (e.g. `https://cdn.example.com`), the
+ * plugin emits a fully-qualified URL and the bare-path lookup would miss
+ * — so we yield both the original string *and* the path portion so callers
+ * can probe in order. Path-prefix assetPrefix (`/cdn/_next/static/foo.css`)
+ * works without normalisation because the on-disk layout matches the URL
+ * 1-for-1.
+ */
+function inlineCssMapKeyCandidates(href: string): string[] {
+  // Cheap fast-path: bare paths are the common case.
+  if (href.startsWith("/")) return [href];
+  // `https://…/_next/static/foo.css` → also try `/_next/static/foo.css`.
+  try {
+    const url = new URL(href);
+    return [href, url.pathname];
+  } catch {
+    return [href];
+  }
+}
+
+/**
+ * Escape `</style>` and `</STYLE>` so user-authored CSS can't break out of
+ * the inline `<style>` element. The CSS spec doesn't recognize `</style>`
+ * as a comment terminator, but the HTML parser does — once it sees the
+ * closing tag, everything after is parsed as HTML. The minimal mitigation
+ * is to insert a backslash so the HTML tokenizer no longer matches the
+ * closing tag (CSS itself happily ignores the backslash since it's not
+ * inside a recognised escape sequence; the literal text `<\/style>` is not
+ * a valid CSS production but the rule containing it is already inside a
+ * `content:` string literal or comment, so the parser drops the rule
+ * rather than emitting it). Case-insensitive because the HTML tokenizer is.
  *
  * See https://html.spec.whatwg.org/multipage/parsing.html#parse-error-end-tag-in-style
  */
@@ -92,17 +119,31 @@ function escapeStyleTagBoundary(css: string): string {
  * the URL is not present in `map` (e.g. a stale entry, a third-party CSS,
  * or no map was registered) the link tag is left in place — the page still
  * works, just without the inlining optimisation.
+ *
+ * `nonce` is forwarded to the emitted `<style>` so CSP policies that use
+ * `style-src 'nonce-…'` continue to apply — the original `<link>` tags
+ * don't carry nonces, but inline `<style>` blocks must (otherwise CSP
+ * blocks them and the page renders unstyled).
  */
 export function rewriteRscCssLinksToInline(
   html: string,
   map: Record<string, string> | undefined,
+  nonce?: string,
 ): string {
   if (!map) return html;
+  const nonceAttr = createNonceAttribute(nonce);
   return html.replace(RSC_CSS_LINK_RE, (match, hrefAttr: string) => {
     const href = decodeRscCssHref(hrefAttr);
-    const css = map[href];
+    let css: string | undefined;
+    for (const key of inlineCssMapKeyCandidates(href)) {
+      css = map[key];
+      if (css !== undefined) break;
+    }
     if (css === undefined) return match;
-    return `<style data-vinext-inline-css="${hrefAttr}">${escapeStyleTagBoundary(css)}</style>`;
+    return (
+      `<style data-vinext-inline-css="${escapeHtmlAttr(href)}"${nonceAttr}>` +
+      `${escapeStyleTagBoundary(css)}</style>`
+    );
   });
 }
 
@@ -118,8 +159,12 @@ export function rewriteRscCssLinksToInline(
  * chunks, the partial tag is held until the rest of the tag arrives — the
  * regex would otherwise fail to match a tag whose `data-rsc-css-href`
  * attribute lands in the next chunk.
+ *
+ * `nonce` is the SSR-time script/style nonce — when present, the inlined
+ * `<style>` tags carry `nonce="…"` so they pass CSP policies that gate
+ * inline styles behind `style-src 'nonce-…'`.
  */
-export function createInlineCssTransform(): TransformStream<Uint8Array, Uint8Array> {
+export function createInlineCssTransform(nonce?: string): TransformStream<Uint8Array, Uint8Array> {
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
   let pending = "";
@@ -149,13 +194,13 @@ export function createInlineCssTransform(): TransformStream<Uint8Array, Uint8Arr
         emit = text;
         pending = "";
       }
-      const rewritten = rewriteRscCssLinksToInline(emit, map);
+      const rewritten = rewriteRscCssLinksToInline(emit, map, nonce);
       if (rewritten) controller.enqueue(encoder.encode(rewritten));
     },
     flush(controller) {
       if (!pending) return;
       const map = getInlineCssMap();
-      const out = rewriteRscCssLinksToInline(pending, map);
+      const out = rewriteRscCssLinksToInline(pending, map, nonce);
       pending = "";
       controller.enqueue(encoder.encode(out));
     },

--- a/packages/vinext/src/server/app-inline-css.ts
+++ b/packages/vinext/src/server/app-inline-css.ts
@@ -31,7 +31,7 @@ import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
  * Returns `undefined` when no map has been registered — callers should
  * keep the original `<link rel="stylesheet">` tag in that case.
  */
-export function getInlineCssMap(): Record<string, string> | undefined {
+function getInlineCssMap(): Record<string, string> | undefined {
   return globalThis.__VINEXT_INLINE_CSS_MAP__;
 }
 

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -36,6 +36,7 @@ import {
   createRscEmbedTransform,
   createTickBufferedTransform,
 } from "./app-ssr-stream.js";
+import { createInlineCssTransform } from "./app-inline-css.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
 import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
@@ -454,12 +455,19 @@ export async function handleSsr(
         const getBeforeInteractiveHeadHTML = (): string =>
           renderBeforeInteractiveInlineScripts(beforeInteractiveInlineScripts);
 
-        return deferUntilStreamConsumed(
-          htmlStream.pipeThrough(
+        // When `experimental.inlineCss` is enabled, an inline-css map will
+        // have been registered (Node prod server: built from disk at
+        // startup; Cloudflare worker: inlined at build time). When the map
+        // is absent (dev, or feature disabled) the transform is a
+        // pass-through. Run AFTER the tick-buffered transform so its
+        // re-emit of RSC chunks doesn't accidentally feed a partial tag
+        // into the link-tag rewriter.
+        const transformed = htmlStream
+          .pipeThrough(
             createTickBufferedTransform(rscEmbed, getInsertedHTML, getBeforeInteractiveHeadHTML),
-          ),
-          cleanup,
-        );
+          )
+          .pipeThrough(createInlineCssTransform());
+        return deferUntilStreamConsumed(transformed, cleanup);
       } catch (error) {
         cleanup();
         throw error;

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -461,12 +461,15 @@ export async function handleSsr(
         // is absent (dev, or feature disabled) the transform is a
         // pass-through. Run AFTER the tick-buffered transform so its
         // re-emit of RSC chunks doesn't accidentally feed a partial tag
-        // into the link-tag rewriter.
+        // into the link-tag rewriter. The SSR-time `scriptNonce` is
+        // forwarded so emitted `<style>` blocks pass CSP `style-src
+        // 'nonce-…'` policies — the `<link>` tags they replace don't need
+        // nonces, but inline styles do.
         const transformed = htmlStream
           .pipeThrough(
             createTickBufferedTransform(rscEmbed, getInsertedHTML, getBeforeInteractiveHeadHTML),
           )
-          .pipeThrough(createInlineCssTransform());
+          .pipeThrough(createInlineCssTransform(options?.scriptNonce));
         return deferUntilStreamConsumed(transformed, cleanup);
       } catch (error) {
         cleanup();

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1028,6 +1028,54 @@ export function resolveAppRouterAssetPath(
 }
 
 /**
+ * Walk `clientDir` and build a URL→CSS-content map for every `.css` file
+ * discovered. The URL key matches the `href` emitted by
+ * `@vitejs/plugin-rsc`'s `Resources` component — that's Vite's `base`
+ * (defaulting to `/`) followed by the file's relative path under
+ * `dist/client`. Used by the App Router SSR transform to inline stylesheets
+ * when `experimental.inlineCss` is enabled.
+ *
+ * Errors reading individual files are logged but not fatal — a partial map
+ * is better than a startup failure, and the SSR transform falls back to the
+ * original `<link rel="stylesheet">` tag for any URL not in the map.
+ */
+async function buildInlineCssMap(clientDir: string): Promise<Record<string, string>> {
+  const map: Record<string, string> = {};
+
+  async function walk(dir: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      // Skip Vite's internal metadata directory (`.vite/`).
+      if (entry.isDirectory()) {
+        if (entry.name === ".vite") continue;
+        await walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".css")) continue;
+      try {
+        const content = await fsp.readFile(full, "utf-8");
+        const relative = path.relative(clientDir, full).split(path.sep).join("/");
+        map["/" + relative] = content;
+      } catch (error) {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[vinext] failed to read inline-CSS source:", full, error);
+        }
+      }
+    }
+  }
+
+  await walk(clientDir);
+  return map;
+}
+
+/**
  * Start the App Router production server.
  *
  * The App Router entry (dist/server/index.js) can export either:
@@ -1099,6 +1147,19 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
   // stat() calls — all lookups are pure in-memory Map.get(). Precompressed
   // .br/.gz/.zst variants (generated at build time) are detected automatically.
   const staticCache = await StaticFileCache.create(clientDir);
+
+  // When `experimental.inlineCss` is enabled, build a URL→CSS-content map
+  // from the CSS files Vite emitted to dist/client/. The App Router SSR
+  // stream transform consumes this map to rewrite
+  // `<link rel="stylesheet" data-rsc-css-href="…">` tags into inline
+  // `<style>` blocks. Mirrors Next.js's
+  // `experimental.inlineCss` (production-only).
+  if (rscModule.__inlineCss === true) {
+    const inlineMap = await buildInlineCssMap(clientDir);
+    if (Object.keys(inlineMap).length > 0) {
+      globalThis.__VINEXT_INLINE_CSS_MAP__ = inlineMap;
+    }
+  }
 
   const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     const rawUrl = req.url ?? "/";

--- a/packages/vinext/src/utils/inline-css.ts
+++ b/packages/vinext/src/utils/inline-css.ts
@@ -1,0 +1,52 @@
+/**
+ * Build-time helper for `experimental.inlineCss`.
+ *
+ * Walks a directory looking for `.css` files and returns a URL→content
+ * map keyed on the URL `@vitejs/plugin-rsc` will emit in `data-rsc-css-href`
+ * (Vite's `base` is `/` by default; the URL is therefore `/<relativePath>`).
+ *
+ * Used by `vinext:cloudflare-build` to inline the map into the Worker
+ * bundle. The Node prod server uses an async variant in
+ * `server/prod-server.ts` for the same purpose at startup.
+ *
+ * Errors reading individual files are logged but not fatal — a partial map
+ * is better than a build failure and the SSR transform falls back to the
+ * original `<link rel="stylesheet">` tag for any URL not in the map.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+export function collectInlineCssMap(clientDir: string): Record<string, string> {
+  const map: Record<string, string> = {};
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Skip Vite's internal metadata directory; nothing inside is
+        // served at request time and we don't want to inline source maps.
+        if (entry.name === ".vite") continue;
+        walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".css")) continue;
+      try {
+        const content = fs.readFileSync(full, "utf-8");
+        const relative = path.relative(clientDir, full).split(path.sep).join("/");
+        map["/" + relative] = content;
+      } catch (error) {
+        console.warn("[vinext] failed to read inline-CSS source:", full, error);
+      }
+    }
+  }
+
+  walk(clientDir);
+  return map;
+}

--- a/tests/app-inline-css.test.ts
+++ b/tests/app-inline-css.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the HTML stream transform that powers
+ * `experimental.inlineCss`. Validates the rewrite-only rules in isolation
+ * from the SSR pipeline so we can be confident about:
+ *
+ *   - User-authored `<link rel="stylesheet">` (e.g. fonts) is untouched.
+ *   - The RSC-emitted `<link rel="stylesheet" data-rsc-css-href="…">` is
+ *     replaced with an inline `<style>` block when the URL is in the map.
+ *   - An unknown URL is left as a `<link>` (graceful degradation).
+ *   - The transform is a pass-through when no map is registered.
+ *   - CSS contents that contain `</style>` cannot break out of the tag.
+ *
+ * See `packages/vinext/src/server/app-inline-css.ts` for the implementation.
+ */
+
+import { afterEach, describe, it, expect } from "vite-plus/test";
+import {
+  createInlineCssTransform,
+  rewriteRscCssLinksToInline,
+  setInlineCssMap,
+} from "../packages/vinext/src/server/app-inline-css.js";
+
+async function runTransform(html: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const transform = createInlineCssTransform();
+  const writer = transform.writable.getWriter();
+  const reader = transform.readable.getReader();
+  const out: string[] = [];
+
+  const readPromise = (async (): Promise<void> => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(decoder.decode(value));
+    }
+  })();
+
+  await writer.write(encoder.encode(html));
+  await writer.close();
+  await readPromise;
+
+  return out.join("");
+}
+
+describe("rewriteRscCssLinksToInline", () => {
+  it("replaces RSC stylesheet links with <style> blocks using the map", () => {
+    const html =
+      `<head><link rel="stylesheet" precedence="vite-rsc/importer-resources" ` +
+      `href="/_next/static/foo.css" data-rsc-css-href="/_next/static/foo.css"/></head>`;
+    const map = { "/_next/static/foo.css": "p { color: red; }" };
+    const out = rewriteRscCssLinksToInline(html, map);
+    expect(out).toContain('<style data-vinext-inline-css="/_next/static/foo.css">');
+    expect(out).toContain("p { color: red; }");
+    expect(out).not.toContain('<link rel="stylesheet"');
+  });
+
+  it("leaves user-authored stylesheet links (no data-rsc-css-href) alone", () => {
+    const html = `<head><link rel="stylesheet" href="https://fonts/foo.css"/></head>`;
+    const out = rewriteRscCssLinksToInline(html, { "/_next/static/foo.css": "x" });
+    expect(out).toBe(html);
+  });
+
+  it("leaves the link tag when the URL is not in the map", () => {
+    const html =
+      `<link rel="stylesheet" href="/_next/static/missing.css" ` +
+      `data-rsc-css-href="/_next/static/missing.css"/>`;
+    const out = rewriteRscCssLinksToInline(html, { "/_next/static/other.css": "x" });
+    expect(out).toBe(html);
+  });
+
+  it("is a no-op when no map is provided", () => {
+    const html = `<link rel="stylesheet" data-rsc-css-href="/x.css" href="/x.css"/>`;
+    expect(rewriteRscCssLinksToInline(html, undefined)).toBe(html);
+  });
+
+  it("escapes </style> inside CSS contents to prevent tag breakout", () => {
+    const evil = "p::before { content: '</style><script>x</script>'; }";
+    const html = `<link rel="stylesheet" data-rsc-css-href="/x.css" href="/x.css"/>`;
+    const out = rewriteRscCssLinksToInline(html, { "/x.css": evil });
+    // The hostile `</style>` from the source CSS must have been escaped.
+    expect(out).toContain("<\\/style>");
+    // Only one literal `</style>` is left — the one that closes our
+    // injected block. A second un-escaped occurrence would mean the
+    // injected `<script>` payload could escape into HTML.
+    expect(out.match(/<\/style>/g)?.length).toBe(1);
+    // Sanity check: the `<script>` text from the CSS is now inside our
+    // single, contiguous `<style>…</style>` element (it lies between the
+    // opening tag and the closing one).
+    const open = out.indexOf("<style");
+    const close = out.indexOf("</style>");
+    expect(open).toBeGreaterThanOrEqual(0);
+    expect(close).toBeGreaterThan(open);
+    expect(out.slice(open, close)).toContain("<script");
+  });
+
+  it("decodes the &amp; entity in the data-rsc-css-href attribute", () => {
+    // Vite hrefs don't normally contain `&`, but if React Fizz serialises
+    // any future tag with one we still need to look up by the decoded URL.
+    const html = `<link rel="stylesheet" data-rsc-css-href="/a.css?x=1&amp;y=2" href="/a.css?x=1&amp;y=2"/>`;
+    const out = rewriteRscCssLinksToInline(html, { "/a.css?x=1&y=2": "z" });
+    expect(out).toContain("<style");
+    expect(out).toContain(">z</style>");
+  });
+});
+
+describe("createInlineCssTransform", () => {
+  afterEach(() => setInlineCssMap(undefined));
+
+  it("rewrites complete tags in a single chunk", async () => {
+    setInlineCssMap({ "/x.css": "a {}" });
+    const html = `<head><link rel="stylesheet" data-rsc-css-href="/x.css" href="/x.css"/></head>`;
+    const out = await runTransform(html);
+    expect(out).toContain("<style");
+    expect(out).toContain("a {}");
+    expect(out).not.toContain("<link");
+  });
+
+  it("is a pass-through when no map is registered", async () => {
+    const html = `<link rel="stylesheet" data-rsc-css-href="/x.css" href="/x.css"/>`;
+    expect(await runTransform(html)).toBe(html);
+  });
+});

--- a/tests/app-inline-css.test.ts
+++ b/tests/app-inline-css.test.ts
@@ -20,10 +20,17 @@ import {
   setInlineCssMap,
 } from "../packages/vinext/src/server/app-inline-css.js";
 
-async function runTransform(html: string): Promise<string> {
+/**
+ * Drive the transform with one or more pre-encoded chunks. Splitting input
+ * across chunks exercises the cross-chunk tag-buffering codepath — the
+ * transform must hold partial `<link …>` openings until a chunk completes
+ * the tag, otherwise the regex misses the rewrite and we'd silently emit
+ * the original `<link rel="stylesheet">`.
+ */
+async function runTransform(chunks: string | string[], nonce?: string): Promise<string> {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
-  const transform = createInlineCssTransform();
+  const transform = createInlineCssTransform(nonce);
   const writer = transform.writable.getWriter();
   const reader = transform.readable.getReader();
   const out: string[] = [];
@@ -36,7 +43,10 @@ async function runTransform(html: string): Promise<string> {
     }
   })();
 
-  await writer.write(encoder.encode(html));
+  const list = Array.isArray(chunks) ? chunks : [chunks];
+  for (const piece of list) {
+    await writer.write(encoder.encode(piece));
+  }
   await writer.close();
   await readPromise;
 
@@ -53,6 +63,33 @@ describe("rewriteRscCssLinksToInline", () => {
     expect(out).toContain('<style data-vinext-inline-css="/_next/static/foo.css">');
     expect(out).toContain("p { color: red; }");
     expect(out).not.toContain('<link rel="stylesheet"');
+  });
+
+  it("emits nonce on the inlined <style> tag when provided", () => {
+    // Without a nonce, sites that ship `Content-Security-Policy:
+    // style-src 'nonce-…'` see the inlined block blocked at parse time
+    // and render unstyled. The `<link>` tag the feature replaces wasn't
+    // subject to the same rule, so the nonce has to land on the new
+    // `<style>` to preserve parity.
+    const html = `<link rel="stylesheet" data-rsc-css-href="/x.css" href="/x.css"/>`;
+    const out = rewriteRscCssLinksToInline(html, { "/x.css": "a {}" }, "abc123");
+    expect(out).toContain('<style data-vinext-inline-css="/x.css" nonce="abc123">');
+  });
+
+  it("looks up CSS by URL pathname when assetPrefix yields an absolute URL", () => {
+    // With `assetPrefix: "https://cdn.example.com"`, the RSC plugin emits a
+    // fully-qualified URL in `data-rsc-css-href`. The map is keyed by the
+    // path portion (matching the on-disk relative path under dist/client),
+    // so the lookup needs to try both forms.
+    const html =
+      `<link rel="stylesheet" ` +
+      `data-rsc-css-href="https://cdn.example.com/_next/static/foo.css" ` +
+      `href="https://cdn.example.com/_next/static/foo.css"/>`;
+    const map = { "/_next/static/foo.css": "p { color: blue; }" };
+    const out = rewriteRscCssLinksToInline(html, map);
+    expect(out).toContain("<style");
+    expect(out).toContain("p { color: blue; }");
+    expect(out).not.toContain("<link");
   });
 
   it("leaves user-authored stylesheet links (no data-rsc-css-href) alone", () => {
@@ -119,5 +156,26 @@ describe("createInlineCssTransform", () => {
   it("is a pass-through when no map is registered", async () => {
     const html = `<link rel="stylesheet" data-rsc-css-href="/x.css" href="/x.css"/>`;
     expect(await runTransform(html)).toBe(html);
+  });
+
+  it("forwards the SSR nonce onto the inlined <style> tag", async () => {
+    setInlineCssMap({ "/x.css": "a {}" });
+    const html = `<link rel="stylesheet" data-rsc-css-href="/x.css" href="/x.css"/>`;
+    const out = await runTransform(html, "nonce-abc");
+    expect(out).toContain('nonce="nonce-abc"');
+    expect(out).toContain("<style");
+  });
+
+  it("rewrites a tag that React Fizz split across two chunks", async () => {
+    // The transform buffers the open angle bracket until the closing `>`
+    // arrives in a later chunk — otherwise the regex would see just
+    // `<link rel="stylesheet" data-r` and miss the rewrite.
+    setInlineCssMap({ "/x.css": "a {}" });
+    const before = `<head><link rel="stylesheet" data-rsc-`;
+    const after = `css-href="/x.css" href="/x.css"/></head>`;
+    const out = await runTransform([before, after]);
+    expect(out).toContain("<style");
+    expect(out).toContain("a {}");
+    expect(out).not.toContain("<link");
   });
 });

--- a/tests/inline-css.test.ts
+++ b/tests/inline-css.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `experimental.inlineCss` — App Router CSS inlining.
+ *
+ * When `next.config` sets `experimental.inlineCss: true`, App Router pages
+ * must serve their CSS as inline `<style>` tags in `<head>` instead of
+ * `<link rel="stylesheet" href="...">` references. This matches Next.js's
+ * behavior for the same flag — see
+ * `.nextjs-ref/test/e2e/app-dir/app-inline-css/index.test.ts` and
+ * https://nextjs.org/docs/app/api-reference/config/next-config-js/inlineCss
+ *
+ * Ported from Next.js:
+ *   test/e2e/app-dir/app-inline-css/index.test.ts
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-inline-css
+ *
+ * Production only — Next.js disables inlining in dev because HMR keeps
+ * mutating the document `<style>` set, which conflicts with the inlined
+ * ones (`(isNextDev ? describe.skip : describe)('Production only', …)` in
+ * the source test).
+ *
+ * Related to vinext issue #1499.
+ */
+
+import { describe, it, expect, afterAll, beforeEach } from "vite-plus/test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createBuilder } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+import { setInlineCssMap } from "../packages/vinext/src/server/app-inline-css.js";
+
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+async function makeInlineCssFixture(opts: { inlineCss: boolean }): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-inline-css-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const appDir = path.join(tmpDir, "app");
+  await fs.mkdir(appDir, { recursive: true });
+
+  // The CSS content needs a distinctive marker that survives Vite's CSS
+  // minifier — comments are stripped, but a class selector inside an
+  // otherwise-valid rule isn't.
+  await fs.writeFile(
+    path.join(appDir, "global.css"),
+    ".vinext-inline-css-marker { color: rgb(255, 255, 0); }\n",
+  );
+
+  await fs.writeFile(
+    path.join(appDir, "layout.tsx"),
+    `import "./global.css";\nexport default function RootLayout({ children }: { children: React.ReactNode }) {\n  return (<html lang="en"><body>{children}</body></html>);\n}\n`,
+  );
+
+  await fs.writeFile(
+    path.join(appDir, "page.tsx"),
+    `export default function Home() {\n  return <p id="home">Hello inline CSS</p>;\n}\n`,
+  );
+
+  // Tell Node to load `.js` chunks as ESM. `next.config.js` ships as CJS,
+  // so it must be renamed to `next.config.cjs` (or use a `.mjs`). Vite
+  // labels generated chunks with `.js` and relies on the fixture's
+  // package.json to declare them as modules.
+  await fs.writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name: "vinext-inline-css-fixture", private: true, type: "module" }),
+  );
+
+  await fs.writeFile(
+    path.join(tmpDir, "next.config.cjs"),
+    `module.exports = ${JSON.stringify({ experimental: { inlineCss: opts.inlineCss } }, null, 2)};\n`,
+  );
+
+  return tmpDir;
+}
+
+async function buildFixture(fixtureDir: string): Promise<{ outDir: string }> {
+  // Build in-place into `<fixtureDir>/dist/` so the standard production
+  // layout (`dist/server/index.js`, `dist/client/_next/static/...`) lines
+  // up with what `startProdServer` expects. Mirrors
+  // `tests/invalid-static-asset-404.test.ts`.
+  const builder = await createBuilder({
+    root: fixtureDir,
+    configFile: false,
+    plugins: [vinext({ appDir: fixtureDir })],
+    logLevel: "warn",
+  });
+  await builder.buildApp();
+
+  const outDir = path.join(fixtureDir, "dist");
+  const rscEntry = path.join(outDir, "server", "index.js");
+  try {
+    await fs.access(rscEntry);
+  } catch {
+    const listing = (await fs.readdir(outDir)).join(", ");
+    throw new Error(`Build did not produce ${rscEntry}; got: ${listing}`);
+  }
+
+  return { outDir };
+}
+
+async function fetchHomeHtml(outDir: string): Promise<string> {
+  const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+  const { server } = await startProdServer({
+    port: 0,
+    outDir,
+    noCompression: true,
+  });
+  try {
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    const res = await fetch(`http://localhost:${port}/`);
+    expect(res.status).toBe(200);
+    return await res.text();
+  } finally {
+    server.close();
+  }
+}
+
+describe("App Router experimental.inlineCss (#1499)", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+  afterAll(async () => {
+    for (const c of cleanups) await c().catch(() => {});
+  });
+
+  // The inline-CSS map lives on `globalThis` — clear it between cases so
+  // the no-inlining test isn't accidentally serviced by the prior case's
+  // map (and vice-versa).
+  beforeEach(() => setInlineCssMap(undefined));
+
+  // We accept either layout the upstream RSC plugin chooses: the bare
+  // `<link rel="stylesheet" href="...">` (older releases) or one that
+  // additionally carries `data-rsc-css-href` (current). Both forms must
+  // disappear when inlining is on.
+  const STYLESHEET_LINK_RE = /<link[^>]*\brel="stylesheet"[^>]*>/i;
+
+  it("inlines CSS as <style> in <head> when experimental.inlineCss is true", async () => {
+    const fixture = await makeInlineCssFixture({ inlineCss: true });
+    const built = await buildFixture(fixture);
+    cleanups.push(async () => {
+      await fs.rm(fixture, { recursive: true, force: true });
+      await fs.rm(built.outDir, { recursive: true, force: true });
+    });
+
+    const html = await fetchHomeHtml(built.outDir);
+
+    // The page CSS must appear inside a <style> tag in <head>.
+    expect(html).toContain("<style");
+    expect(html).toContain(".vinext-inline-css-marker");
+
+    // And the stylesheet link tag the RSC plugin would normally emit must
+    // not be present (font / user-authored <link rel="stylesheet"> tags
+    // remain valid, but this fixture has none).
+    expect(html).not.toMatch(STYLESHEET_LINK_RE);
+  }, 180_000);
+
+  it('emits <link rel="stylesheet"> when experimental.inlineCss is not set', async () => {
+    const fixture = await makeInlineCssFixture({ inlineCss: false });
+    const built = await buildFixture(fixture);
+    cleanups.push(async () => {
+      await fs.rm(fixture, { recursive: true, force: true });
+      await fs.rm(built.outDir, { recursive: true, force: true });
+    });
+
+    const html = await fetchHomeHtml(built.outDir);
+
+    // Baseline sanity check: without the flag, vinext keeps the link tag
+    // and does not inline the CSS contents.
+    expect(html).toMatch(STYLESHEET_LINK_RE);
+    expect(html).not.toContain(".vinext-inline-css-marker");
+  }, 180_000);
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1151,6 +1151,7 @@ describe("detectNextIntlConfig", () => {
       compilerDefineServer: {},
       instrumentationClientInject: [],
       clientTraceMetadata: undefined,
+      inlineCss: false,
       ...overrides,
     };
   }


### PR DESCRIPTION
## Summary

- Implements `experimental.inlineCss` for the App Router — when enabled in `next.config`, vinext now serves CSS as inline `<style>` tags in `<head>` instead of `<link rel="stylesheet">` references, matching Next.js's behavior.
- Adds an HTML-stream transform (`server/app-inline-css.ts`) that rewrites the `<link rel="stylesheet" data-rsc-css-href="…">` tags `@vitejs/plugin-rsc` emits. User-authored stylesheet links (e.g. fonts) are left alone because they don't carry the `data-rsc-css-href` marker.
- URL→CSS-content map is built once at server startup. Node prod-server walks `dist/client/`; the Cloudflare build step inlines the map into the Worker entry alongside the existing `__VINEXT_SSR_MANIFEST__` / `__VINEXT_LAZY_CHUNKS__` globals.
- Dev is a deliberate no-op, mirroring Next.js (HMR breaks inlining; the upstream e2e test is gated to production only).

Fixes #1499

## Test plan

- [x] `vp test run tests/app-inline-css.test.ts` — unit tests for the rewrite + stream transform (entity decode, `</style>` escape, unknown URL fallback, no-map pass-through).
- [x] `vp test run tests/inline-css.test.ts` — end-to-end build + `startProdServer` smoke test: with the flag on, HTML contains `<style>…</style>` and no `<link rel="stylesheet">`; with it off, the link tag is present and CSS is not inlined.
- [x] `vp test run tests/ssr-css-assets.test.ts tests/invalid-static-asset-404.test.ts tests/app-ssr-stream.test.ts tests/next-config.test.ts tests/check.test.ts` — adjacent suites still pass.
- [x] `vp check` on all touched files (formatting + types + lint).
- [ ] CI Vitest + Playwright full suites.

## Notes / follow-ups

- Pages Router is unchanged. Next.js's `experimental.inlineCss` only affects the App Router renderer, but a follow-up could extend it to `entries/pages-server-entry.ts` if needed.
- Currently inlines every CSS file under `dist/client/` into the map. This is fine for typical apps (CSS is dwarfed by JS bundles), but a future optimisation could scope it per-route via the SSR manifest if memory becomes a concern.

Ported from Next.js: [`test/e2e/app-dir/app-inline-css/index.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-inline-css/index.test.ts). See [Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/inlineCss).