### PR TITLE
fix(config): implement compiler.define / compiler.defineServer

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -254,6 +254,17 @@ export type NextConfig = {
   compiler?: {
     /** Remove `console.*` calls from the client bundle. */
     removeConsole?: boolean | { exclude?: string[] };
+    /**
+     * Inline compile-time constants in both client and server bundles.
+     * Mirrors Next.js `compiler.define`.
+     * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/compiler#define
+     */
+    define?: Record<string, string | number | boolean>;
+    /**
+     * Inline compile-time constants in server bundles only (not client).
+     * Mirrors Next.js `compiler.defineServer`.
+     */
+    defineServer?: Record<string, string | number | boolean>;
   };
   /**
    * Path to a custom cache handler module (e.g., KV, Redis, DynamoDB).
@@ -393,6 +404,26 @@ export type ResolvedNextConfig = {
    * `test/e2e/optimized-loading` test fixture.
    */
   disableOptimizedLoading: boolean;
+  /**
+   * Build-time constant replacement map applied to BOTH client and server
+   * bundles. Sourced from `compiler.define` in next.config. Values are
+   * pre-serialized via `JSON.stringify` so they can be fed straight into
+   * Vite's `define` config (which expects strings of source code).
+   *
+   * Mirrors Next.js — strings, numbers, and booleans are accepted; other
+   * value shapes are dropped.
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/compiler#define
+   */
+  compilerDefine: Record<string, string>;
+  /**
+   * Build-time constant replacement map applied to SERVER bundles only
+   * (RSC + SSR + middleware). Sourced from `compiler.defineServer` in
+   * next.config. Same serialization rules as `compilerDefine`. Client
+   * bundles intentionally never see these substitutions, so referencing
+   * a `defineServer` identifier from the browser stays as the raw
+   * identifier (typically resolving to `undefined`).
+   */
+  compilerDefineServer: Record<string, string>;
 };
 
 // Mirrors Next.js's accepted set in packages/next/src/shared/lib/constants.ts
@@ -987,6 +1018,26 @@ function readStringArray(value: unknown): string[] {
 }
 
 /**
+ * Serialize a `compiler.define` / `compiler.defineServer` map into the
+ * Vite-friendly `Record<string, string>` shape where each value is already
+ * a JSON-encoded literal of source code. Entries whose values are not a
+ * string/number/boolean are silently dropped, matching how Next.js types
+ * the API (other shapes are not part of the contract).
+ *
+ * Mirrors Next.js: packages/next/src/build/define-env.ts (serializeDefineEnv).
+ */
+function serializeCompilerDefine(value: unknown): Record<string, string> {
+  if (!isUnknownRecord(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean") {
+      out[key] = JSON.stringify(raw);
+    }
+  }
+  return out;
+}
+
+/**
  * Resolve a NextConfig into a fully-resolved ResolvedNextConfig.
  * Awaits async functions for redirects/rewrites/headers.
  */
@@ -1028,6 +1079,8 @@ export async function resolveNextConfig(
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      compilerDefine: {},
+      compilerDefineServer: {},
       instrumentationClientInject: [],
     };
     detectNextIntlConfig(root, resolved);
@@ -1254,6 +1307,8 @@ export async function resolveNextConfig(
     // Next.js stores this under `experimental.disableOptimizedLoading`.
     // Default `false` matches Next.js: page scripts get `defer` in <head>.
     disableOptimizedLoading: experimental?.disableOptimizedLoading === true,
+    compilerDefine: serializeCompilerDefine(config.compiler?.define),
+    compilerDefineServer: serializeCompilerDefine(config.compiler?.defineServer),
   };
 
   // Auto-detect next-intl (lowest priority — explicit aliases from

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1179,6 +1179,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // See: https://github.com/vercel/next.js/pull/93997
         defines["process.env.__NEXT_APP_SHELLS"] = JSON.stringify(false);
 
+        // User-defined compile-time constants from `compiler.define` in
+        // next.config. Applied to BOTH client and server bundles via Vite's
+        // top-level `define`. Values are already JSON-stringified by
+        // resolveNextConfig (matching Webpack DefinePlugin semantics).
+        // Server-only `compiler.defineServer` entries are layered in below
+        // via `configEnvironment` so they never leak into the client bundle.
+        // See: https://nextjs.org/docs/app/api-reference/config/next-config-js/compiler#define
+        for (const [key, value] of Object.entries(nextConfig.compilerDefine)) {
+          defines[key] = value;
+        }
+
         // Build the shim alias map. Exact `.js` variants are included for the
         // public Next entrypoints that are file-backed in `next/package.json`.
         // Some libraries (for example `nuqs`) import `next/navigation.js`
@@ -3476,6 +3487,32 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (!result) return null;
           return { code: result, map: null };
         },
+      },
+    },
+    // Inject `compiler.defineServer` substitutions into server environments
+    // only. The universal `compiler.define` map is already merged into the
+    // top-level Vite `define` config above, so it applies to both client
+    // and server bundles. `defineServer` MUST NOT leak into the browser
+    // bundle (it can contain secrets), so we layer it in via the
+    // per-environment `define` hook, which Vite merges over the top-level
+    // value for that environment only.
+    //
+    // Mirrors Next.js: packages/next/src/build/define-env.ts — the
+    // `defineServer` entries are only added to the `nodejs` / `edge`
+    // serialized define environments, never to `client`.
+    //
+    // Returning `null`/`undefined` means "no change"; the explicit empty
+    // check keeps the hook a no-op when the user never configured it.
+    {
+      name: "vinext:compiler-define-server",
+      configEnvironment(name) {
+        if (Object.keys(nextConfig.compilerDefineServer).length === 0) return null;
+        // The client environment is never given the server-only defines.
+        // All other environments (rsc, ssr, custom worker envs, etc.) are
+        // server-side per Vite's `consumer: "server"` default and receive
+        // the substitutions.
+        if (name === "client") return null;
+        return { define: { ...nextConfig.compilerDefineServer } };
       },
     },
     // Local image import transform:

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1185,9 +1185,34 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // resolveNextConfig (matching Webpack DefinePlugin semantics).
         // Server-only `compiler.defineServer` entries are layered in below
         // via `configEnvironment` so they never leak into the client bundle.
+        //
+        // Parity with Next.js: collide against any internal define (e.g.
+        // `process.env.NODE_ENV`, `process.env.__NEXT_*`, `__VINEXT_*`) and
+        // throw, instead of silently overwriting. Mirrors the check in
+        // packages/next/src/build/define-env.ts.
         // See: https://nextjs.org/docs/app/api-reference/config/next-config-js/compiler#define
         for (const [key, value] of Object.entries(nextConfig.compilerDefine)) {
+          if (key in defines) {
+            throw new Error(
+              `The \`compiler.define\` option is configured to replace the \`${key}\` variable. ` +
+                `This variable is either part of a built-in or is already configured.`,
+            );
+          }
           defines[key] = value;
+        }
+        // `compiler.defineServer` is applied per-environment below, but we
+        // still validate collisions here against (a) vinext's internal
+        // defines and (b) the user's own `compiler.define` map — Next.js
+        // rejects both cases. Doing the check eagerly keeps the failure
+        // mode predictable: misconfigured projects fail at config resolution
+        // instead of producing subtly wrong output.
+        for (const key of Object.keys(nextConfig.compilerDefineServer)) {
+          if (key in defines) {
+            throw new Error(
+              `The \`compiler.defineServer\` option is configured to replace the \`${key}\` variable. ` +
+                `This variable is either part of a built-in or is already configured.`,
+            );
+          }
         }
 
         // Build the shim alias map. Exact `.js` variants are included for the

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -160,6 +160,64 @@ describe("compiler.define forwarding to Vite", () => {
     }
   }, 15000);
 
+  // Mirrors Next.js: packages/next/src/build/define-env.ts (collision check)
+  it("throws when `compiler.define` collides with a vinext built-in", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await setupTmpProject(
+      `export default {
+        compiler: {
+          define: { "process.env.NODE_ENV": "evil" },
+        },
+      };`,
+    );
+
+    try {
+      await expect(
+        mainPlugin!.config!(
+          { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+          { command: "build" },
+        ),
+      ).rejects.toThrow(/compiler\.define.*process\.env\.NODE_ENV/);
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("throws when `compiler.defineServer` collides with `compiler.define` or a built-in", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await setupTmpProject(
+      `export default {
+        compiler: {
+          define: { SHARED: "client" },
+          defineServer: { SHARED: "server" },
+        },
+      };`,
+    );
+
+    try {
+      await expect(
+        mainPlugin!.config!(
+          { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+          { command: "build" },
+        ),
+      ).rejects.toThrow(/compiler\.defineServer.*SHARED/);
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
   it("no-ops the configEnvironment hook when `defineServer` is not configured", async () => {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
     const plugins = vinext() as VinextPlugin[];

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -1,0 +1,185 @@
+/**
+ * compiler.define / compiler.defineServer tests.
+ *
+ * Verifies that vinext forwards `next.config.compiler.define` to Vite's
+ * top-level `define` (applies to client + server) and forwards
+ * `compiler.defineServer` only to non-client Vite environments via the
+ * `configEnvironment` hook.
+ *
+ * Ported from Next.js: test/e2e/define/define.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/define/define.test.ts
+ */
+import { describe, it, expect } from "vite-plus/test";
+import os from "node:os";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+// Standard `@types/...` for these Node built-ins live in the workspace, so
+// the imports above are fully typed without explicit casts.
+
+type VinextPlugin = {
+  name: string;
+  config?: (config: unknown, env: { command: string }) => unknown;
+  configEnvironment?: (
+    name: string,
+    config: unknown,
+    env: { command: string },
+  ) => { define?: Record<string, string> } | null | void;
+};
+
+async function setupTmpProject(nextConfigBody: string): Promise<string> {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-compiler-define-"));
+  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+  await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+  await fsp.writeFile(
+    path.join(tmpDir, "pages", "index.tsx"),
+    `export default function Home() { return <h1>Home</h1>; }`,
+  );
+  await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), nextConfigBody);
+  return tmpDir;
+}
+
+describe("compiler.define forwarding to Vite", () => {
+  it("merges `compiler.define` entries into the top-level Vite `define`", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await setupTmpProject(
+      `export default {
+        compiler: {
+          define: {
+            MY_MAGIC_VARIABLE: "foobar",
+            "process.env.MY_MAGIC_EXPR": "barbaz",
+            MY_NUMBER_VARIABLE: 42,
+            MY_BOOLEAN_VARIABLE: true,
+          },
+        },
+      };`,
+    );
+
+    try {
+      const result = (await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      )) as { define?: Record<string, string> };
+
+      expect(result.define).toBeDefined();
+      expect(result.define!.MY_MAGIC_VARIABLE).toBe('"foobar"');
+      expect(result.define!["process.env.MY_MAGIC_EXPR"]).toBe('"barbaz"');
+      expect(result.define!.MY_NUMBER_VARIABLE).toBe("42");
+      expect(result.define!.MY_BOOLEAN_VARIABLE).toBe("true");
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("does NOT merge `compiler.defineServer` into the top-level Vite `define`", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await setupTmpProject(
+      `export default {
+        compiler: {
+          defineServer: { MY_SERVER_VARIABLE: "server" },
+        },
+      };`,
+    );
+
+    try {
+      const result = (await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      )) as { define?: Record<string, string> };
+
+      // Server-only defines must not leak into the global Vite define;
+      // they're layered in per-environment instead.
+      expect(result.define?.MY_SERVER_VARIABLE).toBeUndefined();
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("applies `compiler.defineServer` to non-client environments via configEnvironment", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    const serverDefinePlugin = plugins.find((p) => p.name === "vinext:compiler-define-server");
+    expect(mainPlugin).toBeDefined();
+    expect(serverDefinePlugin).toBeDefined();
+
+    const tmpDir = await setupTmpProject(
+      `export default {
+        compiler: {
+          define: { CLIENT_SAFE: "shared" },
+          defineServer: {
+            MY_SERVER_VARIABLE: "server",
+            "process.env.MY_MAGIC_SERVER_EXPR": "serverbarbaz",
+          },
+        },
+      };`,
+    );
+
+    try {
+      // `config` must run first so the plugin reads nextConfig.
+      await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      );
+
+      const rscResult = serverDefinePlugin!.configEnvironment!("rsc", {}, { command: "build" });
+      const ssrResult = serverDefinePlugin!.configEnvironment!("ssr", {}, { command: "build" });
+      const clientResult = serverDefinePlugin!.configEnvironment!(
+        "client",
+        {},
+        { command: "build" },
+      );
+
+      expect(rscResult?.define).toEqual({
+        MY_SERVER_VARIABLE: '"server"',
+        "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+      });
+      expect(ssrResult?.define).toEqual({
+        MY_SERVER_VARIABLE: '"server"',
+        "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+      });
+      // Client environment must never receive server-only defines.
+      expect(clientResult).toBeNull();
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("no-ops the configEnvironment hook when `defineServer` is not configured", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    const serverDefinePlugin = plugins.find((p) => p.name === "vinext:compiler-define-server");
+    expect(mainPlugin).toBeDefined();
+    expect(serverDefinePlugin).toBeDefined();
+
+    const tmpDir = await setupTmpProject(`export default {};`);
+    try {
+      await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      );
+      const rscResult = serverDefinePlugin!.configEnvironment!("rsc", {}, { command: "build" });
+      expect(rscResult).toBeNull();
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -912,6 +912,66 @@ describe("resolveNextConfig removeConsole", () => {
   });
 });
 
+// Ported from Next.js: test/e2e/define/define.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/define/define.test.ts
+describe("resolveNextConfig compiler.define / defineServer", () => {
+  it("defaults to empty maps when `compiler` is unset", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.compilerDefine).toEqual({});
+    expect(resolved.compilerDefineServer).toEqual({});
+  });
+
+  it("JSON-stringifies string, number, and boolean values for `define`", async () => {
+    const resolved = await resolveNextConfig({
+      compiler: {
+        define: {
+          MY_MAGIC_VARIABLE: "foobar",
+          "process.env.MY_MAGIC_EXPR": "barbaz",
+          MY_NUMBER_VARIABLE: 42,
+          MY_BOOLEAN_VARIABLE: true,
+        },
+      },
+    });
+    expect(resolved.compilerDefine).toEqual({
+      MY_MAGIC_VARIABLE: '"foobar"',
+      "process.env.MY_MAGIC_EXPR": '"barbaz"',
+      MY_NUMBER_VARIABLE: "42",
+      MY_BOOLEAN_VARIABLE: "true",
+    });
+    expect(resolved.compilerDefineServer).toEqual({});
+  });
+
+  it("JSON-stringifies values for `defineServer` and keeps them separate from `define`", async () => {
+    const resolved = await resolveNextConfig({
+      compiler: {
+        define: { CLIENT_SAFE: "shared" },
+        defineServer: {
+          MY_SERVER_VARIABLE: "server",
+          "process.env.MY_MAGIC_SERVER_EXPR": "serverbarbaz",
+        },
+      },
+    });
+    expect(resolved.compilerDefine).toEqual({ CLIENT_SAFE: '"shared"' });
+    expect(resolved.compilerDefineServer).toEqual({
+      MY_SERVER_VARIABLE: '"server"',
+      "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+    });
+  });
+
+  it("ignores entries whose values are not string/number/boolean", async () => {
+    const resolved = await resolveNextConfig({
+      compiler: {
+        // oxlint-disable-next-line typescript/no-explicit-any
+        define: { OK: "yes", BAD_OBJ: { nope: 1 } as any, BAD_NULL: null as any },
+        // oxlint-disable-next-line typescript/no-explicit-any
+        defineServer: { OK_SRV: 1, BAD_ARR: [1, 2] as any },
+      },
+    });
+    expect(resolved.compilerDefine).toEqual({ OK: '"yes"' });
+    expect(resolved.compilerDefineServer).toEqual({ OK_SRV: "1" });
+  });
+});
+
 describe("resolveNextConfig htmlLimitedBots", () => {
   it("serializes RegExp config values to their source", async () => {
     const resolved = await resolveNextConfig({ htmlLimitedBots: /Minibot/i });
@@ -1034,6 +1094,8 @@ describe("detectNextIntlConfig", () => {
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      compilerDefine: {},
+      compilerDefineServer: {},
       instrumentationClientInject: [],
       ...overrides,
     };


### PR DESCRIPTION
## Summary

- Implements `compiler.define` and `compiler.defineServer` from `next.config.{js,ts}`
- `compiler.define` is forwarded to Vite's top-level `define` so substitutions apply to both client and server bundles
- `compiler.defineServer` is forwarded via a new `vinext:compiler-define-server` plugin's `configEnvironment` hook so the entries are only injected into non-`client` Vite environments (RSC, SSR, worker) and never leak into the browser bundle
- Values are JSON-stringified at config resolution time (`serializeCompilerDefine` in `next-config.ts`), matching Next.js's `serializeDefineEnv` and Webpack `DefinePlugin` semantics: strings/numbers/booleans only, other shapes are dropped

Mirrors Next.js source: `packages/next/src/build/define-env.ts`.

Ported test scenarios from Next.js: `test/e2e/define/define.test.ts`.

Fixes #1496

## Test plan

- [x] `vp test run tests/next-config.test.ts` — schema and resolver behavior (4 new cases under `resolveNextConfig compiler.define / defineServer`)
- [x] `vp test run tests/compiler-define.test.ts` — Vite plugin wiring (top-level `define` merge, `defineServer` does not leak to top-level, `configEnvironment` returns server-only defines for `rsc`/`ssr`, returns `null` for `client`)
- [x] `vp check` — format/lint/type clean
- [ ] CI: Check, Vitest, Playwright E2E