### PR TITLE
fix(navigation): stabilize Pages Router useParams snapshot for SSR

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -436,6 +436,18 @@ function _buildClientPagesNavigationContext(
   return ctx;
 }
 
+// Server-side cache for snapshot stability. React's `useSyncExternalStore`
+// expects `getServerSnapshot` to return a stable reference within a single
+// render so it can use Object.is to decide whether to bail out. The SSR ctx is
+// per-request (ALS-isolated), so a WeakMap keyed on the ctx is concurrent-safe
+// and lets us reuse the same shape across every hook call in a single render.
+//
+// Without this, React logs:
+//   "The result of getServerSnapshot should be cached to avoid an infinite loop"
+// and may re-render until the snapshots stabilize, which is wasteful at best
+// and a hydration-mismatch hazard at worst.
+const _ssrPagesNavCtxCache = new WeakMap<SSRContext, PagesNavigationContextShape>();
+
 /**
  * Cross-router compat shim source for `next/navigation` hooks.
  *
@@ -456,12 +468,16 @@ export function getPagesNavigationContext(): PagesNavigationContextShape | null 
   if (typeof window === "undefined") {
     const ssrCtx = _getSSRContext();
     if (!ssrCtx) return null;
+    // Reuse the cached shape for this request so React's useSyncExternalStore
+    // sees Object.is-equal snapshots across hook calls in the same render.
+    // The WeakMap is keyed on the request-scoped ALS ctx, so this remains
+    // safe under concurrent SSR (each request has its own ctx).
+    const cached = _ssrPagesNavCtxCache.get(ssrCtx);
+    if (cached) return cached;
     // ssrCtx.pathname is the route pattern (e.g. "/blog/[slug]").
     // ssrCtx.asPath is the resolved URL with query string. For useSearchParams
     // we want only the URL search string; for useParams we want only the
-    // dynamic route params. Build a fresh object each call — server scope is
-    // request-isolated via ALS but module state must not be cached across
-    // concurrent requests.
+    // dynamic route params.
     let searchParams: URLSearchParams;
     let resolvedPath: string;
     try {
@@ -473,7 +489,9 @@ export function getPagesNavigationContext(): PagesNavigationContextShape | null 
       resolvedPath = ssrCtx.pathname;
     }
     const params = extractRouteParamsFromPath(ssrCtx.pathname, resolvedPath) ?? {};
-    return { pathname: resolvedPath, searchParams, params };
+    const ctx: PagesNavigationContextShape = { pathname: resolvedPath, searchParams, params };
+    _ssrPagesNavCtxCache.set(ssrCtx, ctx);
+    return ctx;
   }
 
   // Client: derive from window.location + __NEXT_DATA__. __NEXT_DATA__.page

--- a/tests/e2e/app-router/pages-router-use-params.spec.ts
+++ b/tests/e2e/app-router/pages-router-use-params.spec.ts
@@ -1,0 +1,30 @@
+// Regression test for issue #1466 ported from the Next.js deploy suite:
+// .nextjs-ref/test/e2e/app-dir/use-params/use-params.test.ts (`should work on
+// pages router` case).
+//
+// In a project that has BOTH `app/` and `pages/` directories, a Pages Router
+// dynamic page using `useParams()` from `next/navigation` must return the
+// dynamic route params after hydration. The Next.js test asserts:
+//
+//   expect(await browser.elementById('params').text()).toBe('"foobar"')
+//
+// `elementById` waits for the element to become visible; an empty `<div>`
+// (which is what we render when `params?.dynamic` is undefined) has zero
+// height and is therefore not visible, so the failure mode in the deploy
+// suite is a Playwright visibility timeout.
+//
+// Fixture: tests/fixtures/app-basic/pages/pages-dir-use-params/[dynamic]/index.tsx
+import { test, expect } from "@playwright/test";
+import { waitForHydration } from "../helpers";
+
+const BASE = "http://localhost:4174";
+
+test.describe("issue #1466: Pages Router useParams under app+pages project", () => {
+  test("renders dynamic param JSON after hydration", async ({ page }) => {
+    await page.goto(`${BASE}/pages-dir-use-params/foobar`);
+    await waitForHydration(page);
+
+    await expect(page.locator("#params")).toBeVisible();
+    await expect(page.locator("#params")).toHaveText('"foobar"');
+  });
+});

--- a/tests/fixtures/app-basic/pages/pages-dir-use-params/[dynamic]/index.tsx
+++ b/tests/fixtures/app-basic/pages/pages-dir-use-params/[dynamic]/index.tsx
@@ -1,0 +1,17 @@
+// Regression fixture for issue #1466: ensure `useParams()` from
+// `next/navigation` works on a Pages Router page when the fixture ALSO has
+// an App Router (`app/` directory).
+//
+// Ported from Next.js:
+// .nextjs-ref/test/e2e/app-dir/use-params/pages/pages-dir/[dynamic]/index.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/pages/pages-dir/[dynamic]/index.tsx
+import { useParams } from "next/navigation";
+
+export default function Page() {
+  const params = useParams();
+  return (
+    <div>
+      <div id="params">{JSON.stringify(params?.dynamic)}</div>
+    </div>
+  );
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11061,6 +11061,39 @@ describe("next/compat/router shim", () => {
     expect((captured as any).query.slug).toEqual(["a", "b"]);
   });
 
+  // Regression for issue #1466: React's `useSyncExternalStore` calls
+  // `getServerSnapshot` multiple times during SSR/hydration and expects a
+  // stable reference (Object.is) — otherwise it logs:
+  //   "The result of getServerSnapshot should be cached to avoid an infinite loop"
+  // and may re-render until it stabilizes. `useParams`/`useSearchParams`/
+  // `usePathname` from `next/navigation` derive their server snapshot from
+  // `getPagesNavigationContext()`, so its SSR-side return value must be
+  // reference-stable within a single request.
+  it("getPagesNavigationContext returns the same reference for repeated SSR calls in one request", async () => {
+    const { getPagesNavigationContext, setSSRContext } =
+      await import("../packages/vinext/src/shims/router.js");
+
+    setSSRContext({
+      pathname: "/pages-dir/[dynamic]",
+      query: { dynamic: "foobar" },
+      asPath: "/pages-dir/foobar",
+    });
+    try {
+      const first = getPagesNavigationContext();
+      const second = getPagesNavigationContext();
+      expect(first).not.toBeNull();
+      expect(first).toBe(second);
+      expect(first!.params).toEqual({ dynamic: "foobar" });
+      // params and searchParams must also be reference-stable across calls so
+      // hook-level snapshots (`pagesCtx.params`, `pagesCtx.searchParams`) are
+      // Object.is-equal between renders.
+      expect(first!.params).toBe(second!.params);
+      expect(first!.searchParams).toBe(second!.searchParams);
+    } finally {
+      setSSRContext(null);
+    }
+  });
+
   it("preserves route param arrays, repeated search params, and hash in client router state", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");


### PR DESCRIPTION
## Summary

`useParams()` / `useSearchParams()` / `usePathname()` from `next/navigation` act as cross-router compat shims under Pages Router, deriving their state from `getPagesNavigationContext()`. React's `useSyncExternalStore` requires `getServerSnapshot` to return a reference-stable value across calls in a single render — otherwise React logs `"The result of getServerSnapshot should be cached to avoid an infinite loop"` and may re-render until the snapshots stabilize, which is wasteful and a hydration-mismatch hazard.

The SSR branch of `getPagesNavigationContext` was returning a fresh object on every call. This PR caches the shape per-request via a `WeakMap` keyed on the ALS-isolated SSR context, so each hook call inside a single render sees the same `{ pathname, searchParams, params }` reference (with reference-stable `params` / `searchParams`). The WeakMap key is per-request, so concurrency safety is preserved.

## Scope

Pages Router compat shim only. No changes to App Router RSC code paths.

- `packages/vinext/src/shims/router.ts` — request-scoped WeakMap cache for the SSR Pages navigation context.

## Tests

- New Vitest case in `tests/shims.test.ts`: repeated SSR calls to `getPagesNavigationContext()` return the same reference (including `params` / `searchParams`).
- New Playwright regression `tests/e2e/app-router/pages-router-use-params.spec.ts` + fixture `tests/fixtures/app-basic/pages/pages-dir-use-params/[dynamic]/index.tsx`. Mirrors the Next.js deploy-suite case in `.nextjs-ref/test/e2e/app-dir/use-params/use-params.test.ts` ('should work on pages router'): a Pages Router dynamic page using `useParams()` inside a fixture that also has an `app/` directory must render the matched param after hydration.

## Test plan

- [x] `pnpm test tests/shims.test.ts tests/pages-router.test.ts tests/navigation-runtime.test.ts`
- [x] `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/pages-router-use-params.spec.ts`
- [x] `pnpm run check` (format + lint + types)
- [ ] CI green

Fixes #1466