### PR TITLE
fix(cache): updateTag throws outside Server Action

### DIFF
--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -445,8 +445,21 @@ export function refresh(): void {
  * Server Actions-only API that expires a tag so the next request
  * fetches fresh data. Unlike `revalidateTag`, which uses stale-while-revalidate,
  * `updateTag` invalidates synchronously within the same request context.
+ *
+ * Throws if called outside a Server Action — e.g. from a Route Handler or
+ * during render — matching Next.js's enforcement. For Route Handlers, callers
+ * should use `revalidateTag` instead.
+ *
+ * @see https://nextjs.org/docs/app/api-reference/functions/updateTag
  */
 export async function updateTag(tag: string): Promise<void> {
+  if (getHeadersAccessPhase() !== "action") {
+    throw new Error(
+      "updateTag can only be called from within a Server Action. " +
+        "To invalidate cache tags in Route Handlers or other contexts, use revalidateTag instead. " +
+        "See more info here: https://nextjs.org/docs/app/api-reference/functions/updateTag",
+    );
+  }
   markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Expire the tag immediately (same as revalidateTag without SWR)
   await _getActiveHandler().revalidateTag(encodeCacheTag(tag));

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3270,9 +3270,10 @@ describe("next/cache shim", () => {
     expect(typeof mod.updateTag).toBe("function");
   });
 
-  it("updateTag invalidates cached entries", async () => {
+  it("updateTag invalidates cached entries when called inside a Server Action", async () => {
     const { unstable_cache, updateTag, setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
 
     setCacheHandler(new MemoryCacheHandler());
 
@@ -3289,14 +3290,48 @@ describe("next/cache shim", () => {
     const r1 = await cached();
     expect(r1).toBe("result-1");
 
-    // updateTag expires the cache
-    await updateTag("user-1");
+    // updateTag expires the cache (must be called from inside a Server Action)
+    const previousPhase = setHeadersAccessPhase("action");
+    try {
+      await updateTag("user-1");
+    } finally {
+      setHeadersAccessPhase(previousPhase);
+    }
 
     const r2 = await cached();
     expect(r2).toBe("result-2");
     expect(callCount).toBe(2);
 
     setCacheHandler(new MemoryCacheHandler());
+  });
+
+  it("updateTag throws when called outside a Server Action (e.g. route handler)", async () => {
+    const { updateTag } = await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    // Simulate a route handler phase
+    const previousPhase = setHeadersAccessPhase("route-handler");
+    try {
+      await expect(updateTag("some-tag")).rejects.toThrow(
+        /updateTag can only be called from within a Server Action/,
+      );
+    } finally {
+      setHeadersAccessPhase(previousPhase);
+    }
+  });
+
+  it("updateTag throws when called during render", async () => {
+    const { updateTag } = await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    const previousPhase = setHeadersAccessPhase("render");
+    try {
+      await expect(updateTag("some-tag")).rejects.toThrow(
+        /updateTag can only be called from within a Server Action/,
+      );
+    } finally {
+      setHeadersAccessPhase(previousPhase);
+    }
   });
 
   it("exports refresh function (Next.js 16)", async () => {


### PR DESCRIPTION
## Summary

- `next/cache`'s `updateTag` now throws the canonical error when called outside a Server Action (e.g. from a Route Handler or during render).
- Inside a Server Action, behavior is unchanged: the tagged cache entry is invalidated via the active cache handler.
- The check uses the existing `getHeadersAccessPhase()` shim, mirroring how Next.js gates `updateTag` to the action phase only.

Fixes #1485

## Test plan

- [x] `pnpm test tests/shims.test.ts -t updateTag` (4 tests pass: existing-action-path test updated to wrap in `setHeadersAccessPhase("action")`, plus new tests for `route-handler` and `render` phases that assert the throw)
- [x] `pnpm test tests/shims.test.ts -t "next/cache shim"` (37 cache-shim tests pass)
- [x] `pnpm run lint`
- [x] `pnpm run fmt:check`