### PR TITLE
fix(pages-router): throw clear error on non-serializable gSP/gSSP props (#1478)

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -47,6 +47,7 @@ import {
 } from "./pages-i18n.js";
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
+import { isSerializableProps } from "./pages-serializable-props.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -602,6 +603,20 @@ export function createSSRHandler(
             );
             return;
           }
+          // Validate that gSSP returned JSON-serializable props. Mirrors
+          // Next.js render.tsx (`isSerializableProps(pathname, "getServerSideProps", data.props)`,
+          // gated on `!metadata.isRedirect && !metadata.isNotFound` — both
+          // short-circuit above). Without this, returning `{ props: { date: new Date() } }`
+          // renders an empty page instead of a clear error. The throw is caught
+          // by the outer try/catch which renders the 500 page. Tracked in
+          // vinext#1478.
+          if (result && "props" in result) {
+            isSerializableProps(
+              patternToNextFormat(route.pattern),
+              "getServerSideProps",
+              pageProps,
+            );
+          }
           // Preserve any status code set by gSSP (e.g. res.statusCode = 201).
           // This takes precedence over the default 200 but not over middleware status.
           if (!statusCode && res.statusCode !== 200) {
@@ -898,6 +913,16 @@ export function createSSRHandler(
               routerShim.wrapWithRouterContext,
             );
             return;
+          }
+          // Validate that gSP returned JSON-serializable props. Mirrors
+          // Next.js render.tsx (`isSerializableProps(pathname, "getStaticProps", data.props)`,
+          // gated on `!metadata.isNotFound` — notFound and redirect both
+          // short-circuit above). Without this, returning `{ props: { date: new Date() } }`
+          // renders an empty page instead of a clear error. The throw is caught
+          // by the outer try/catch which renders the 500 page. Tracked in
+          // vinext#1478.
+          if (result && "props" in result) {
+            isSerializableProps(patternToNextFormat(route.pattern), "getStaticProps", pageProps);
           }
 
           // Extract revalidate period for ISR caching after render

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -12,6 +12,7 @@ import {
   type PagesI18nRenderContext,
 } from "./pages-page-response.js";
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
+import { isSerializableProps } from "./pages-serializable-props.js";
 
 type PagesRedirectResult = {
   destination: string;
@@ -454,6 +455,18 @@ export async function resolvePagesPageData(
       };
     }
 
+    // Mirrors Next.js render.tsx's `isSerializableProps(pathname, "getServerSideProps", data.props)`
+    // check, gated on `!metadata.isRedirect && !metadata.isNotFound` (both
+    // short-circuit above). Throws a friendly `SerializableError` so the
+    // caller's existing try/catch surfaces a clear 500 instead of rendering
+    // an empty page. See
+    // .nextjs-ref/packages/next/src/server/render.tsx (~line 1200) and
+    // .nextjs-ref/packages/next/src/lib/is-serializable-props.ts. Tracked in
+    // vinext#1478.
+    if (result?.props !== undefined) {
+      isSerializableProps(options.routePattern, "getServerSideProps", pageProps);
+    }
+
     gsspRes = res;
   }
 
@@ -598,6 +611,18 @@ export async function resolvePagesPageData(
           ? buildPagesDataNotFoundResponse()
           : buildPagesNotFoundResponse(),
       };
+    }
+
+    // Mirrors Next.js render.tsx's `isSerializableProps(pathname, "getStaticProps", data.props)`
+    // check, gated on `!metadata.isNotFound` (notFound + redirect both
+    // short-circuit above). Throws a friendly `SerializableError` so the
+    // caller's existing try/catch surfaces a clear 500 instead of rendering
+    // an empty page. See
+    // .nextjs-ref/packages/next/src/server/render.tsx (~line 982) and
+    // .nextjs-ref/packages/next/src/lib/is-serializable-props.ts. Tracked in
+    // vinext#1478.
+    if (result?.props !== undefined) {
+      isSerializableProps(options.routePattern, "getStaticProps", pageProps);
     }
 
     if (typeof result?.revalidate === "number" && result.revalidate > 0) {

--- a/packages/vinext/src/server/pages-serializable-props.ts
+++ b/packages/vinext/src/server/pages-serializable-props.ts
@@ -1,0 +1,134 @@
+/**
+ * Validate that the value returned as `props` from `getStaticProps` /
+ * `getServerSideProps` is JSON-serializable. Throws a friendly
+ * `SerializableError` matching Next.js's error shape if it isn't.
+ *
+ * Ported from Next.js:
+ *   .nextjs-ref/packages/next/src/lib/is-serializable-props.ts
+ *   .nextjs-ref/packages/next/src/shared/lib/is-plain-object.ts
+ *
+ * Tested in Next.js by `test/unit/is-serializable-props.test.ts` and the
+ * `non-json` / `non-json-blocking` cases in `test/e2e/prerender.test.ts`.
+ *
+ * Next.js calls this from `packages/next/src/server/render.tsx` for both
+ * `getStaticProps` and `getServerSideProps`. We do the same in
+ * `pages-page-data.ts` so users see a clear error instead of an empty page
+ * when they accidentally return a `Date`, `Map`, or class instance.
+ */
+
+function getObjectClassLabel(value: unknown): string {
+  return Object.prototype.toString.call(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (getObjectClassLabel(value) !== "[object Object]") {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+
+  // Mirrors Next.js's resilient prototype check — see the docstring in
+  // .nextjs-ref/packages/next/src/shared/lib/is-plain-object.ts for the
+  // explanation. `prototype.hasOwnProperty('isPrototypeOf')` lets us treat
+  // cross-realm `Object` instances (vm boundaries, structuredClone) as plain.
+  return prototype === null || Object.prototype.hasOwnProperty.call(prototype, "isPrototypeOf");
+}
+
+const REGEX_PLAIN_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+export class SerializableError extends Error {
+  constructor(page: string, method: string, path: string, message: string) {
+    super(
+      path
+        ? `Error serializing \`${path}\` returned from \`${method}\` in "${page}".\nReason: ${message}`
+        : `Error serializing props returned from \`${method}\` in "${page}".\nReason: ${message}`,
+    );
+    this.name = "SerializableError";
+  }
+}
+
+export function isSerializableProps(page: string, method: string, input: unknown): true {
+  if (!isPlainObject(input)) {
+    throw new SerializableError(
+      page,
+      method,
+      "",
+      `Props must be returned as a plain object from ${method}: \`{ props: { ... } }\` (received: \`${getObjectClassLabel(
+        input,
+      )}\`).`,
+    );
+  }
+
+  function visit(visited: Map<unknown, string>, value: unknown, path: string): void {
+    if (visited.has(value)) {
+      throw new SerializableError(
+        page,
+        method,
+        path,
+        `Circular references cannot be expressed in JSON (references: \`${
+          visited.get(value) || "(self)"
+        }\`).`,
+      );
+    }
+    visited.set(value, path);
+  }
+
+  function isSerializable(refs: Map<unknown, string>, value: unknown, path: string): true {
+    const type = typeof value;
+    if (
+      // `null` is JSON-serializable, but `undefined` is not.
+      value === null ||
+      // `bigint`, `function`, `symbol`, and `undefined` are not serializable;
+      // `object` is special-cased below.
+      type === "boolean" ||
+      type === "number" ||
+      type === "string"
+    ) {
+      return true;
+    }
+
+    if (type === "undefined") {
+      throw new SerializableError(
+        page,
+        method,
+        path,
+        "`undefined` cannot be serialized as JSON. Please use `null` or omit this value.",
+      );
+    }
+
+    if (isPlainObject(value)) {
+      visit(refs, value, path);
+
+      const entries = Object.entries(value);
+      for (const [key, nestedValue] of entries) {
+        const nextPath = REGEX_PLAIN_IDENTIFIER.test(key)
+          ? `${path}.${key}`
+          : `${path}[${JSON.stringify(key)}]`;
+        const newRefs = new Map(refs);
+        isSerializable(newRefs, key, nextPath);
+        isSerializable(newRefs, nestedValue, nextPath);
+      }
+      return true;
+    }
+
+    if (Array.isArray(value)) {
+      visit(refs, value, path);
+
+      value.forEach((nestedValue, index) => {
+        const newRefs = new Map(refs);
+        isSerializable(newRefs, nestedValue, `${path}[${index}]`);
+      });
+      return true;
+    }
+
+    throw new SerializableError(
+      page,
+      method,
+      path,
+      `\`${type}\`${
+        type === "object" ? ` ("${Object.prototype.toString.call(value)}")` : ""
+      } cannot be serialized as JSON. Please only return JSON serializable data types.`,
+    );
+  }
+
+  return isSerializable(new Map(), input, "");
+}

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -529,6 +529,67 @@ describe("pages page data", () => {
     expect(received).toBe("stale");
   });
 
+  // Mirrors Next.js's `isSerializableProps` check from render.tsx (~line 982).
+  // Without this validation vinext silently rendered an empty page for
+  // non-JSON values like `new Date()`. Tracked in vinext#1478.
+  // See .nextjs-ref/packages/next/src/lib/is-serializable-props.ts and the
+  // `non-json`/`non-json-blocking` cases in .nextjs-ref/test/e2e/prerender.test.ts.
+  it("throws a Next.js-style error when getStaticProps returns non-serializable props", async () => {
+    await expect(
+      resolvePagesPageData(
+        createOptions({
+          pageModule: {
+            async getStaticProps() {
+              return { props: { date: new Date(0) } };
+            },
+          },
+          routePattern: "/non-json",
+          routeUrl: "/non-json",
+        }),
+      ),
+    ).rejects.toThrow(
+      /Error serializing `\.date` returned from `getStaticProps` in "\/non-json"\.\s*Reason: `object` \("\[object Date\]"\) cannot be serialized as JSON/,
+    );
+  });
+
+  it("throws a Next.js-style error when getServerSideProps returns non-serializable props", async () => {
+    await expect(
+      resolvePagesPageData(
+        createOptions({
+          pageModule: {
+            async getServerSideProps() {
+              return { props: { fn: () => "nope" } };
+            },
+          },
+          routePattern: "/gssp-bad",
+          routeUrl: "/gssp-bad",
+        }),
+      ),
+    ).rejects.toThrow(
+      /Error serializing `\.fn` returned from `getServerSideProps` in "\/gssp-bad"\.\s*Reason: `function` cannot be serialized as JSON/,
+    );
+  });
+
+  // Redirect and notFound short-circuits must continue to work even if the
+  // page also returns `props` — mirrors Next.js, which only validates when
+  // !metadata.isRedirect && !metadata.isNotFound.
+  it("does not throw on getStaticProps redirect even when props would be invalid", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getStaticProps() {
+            return { redirect: { destination: "/elsewhere", permanent: false } };
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") throw new Error("expected response");
+    expect(result.response.status).toBe(307);
+    expect(result.response.headers.get("location")).toBe("/elsewhere");
+  });
+
   // Matches Next.js behavior: for non-dynamic routes, `params` in
   // getStaticProps context is null (not `{}`).
   it("passes params: null to getStaticProps on non-dynamic routes", async () => {

--- a/tests/pages-serializable-props.test.ts
+++ b/tests/pages-serializable-props.test.ts
@@ -1,0 +1,75 @@
+// Ported from Next.js: test/unit/is-serializable-props.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/unit/is-serializable-props.test.ts
+//
+// vinext implements its own copy of `isSerializableProps` so Pages Router
+// `getStaticProps` / `getServerSideProps` surface a clear error (instead of
+// rendering an empty page) when they return non-JSON-serializable values.
+// Tracked in vinext#1478.
+
+import { describe, expect, it } from "vite-plus/test";
+import {
+  isSerializableProps,
+  SerializableError,
+} from "../packages/vinext/src/server/pages-serializable-props.js";
+
+describe("isSerializableProps", () => {
+  it("allows empty props", () => {
+    expect(isSerializableProps("/", "getStaticProps", {})).toBe(true);
+  });
+
+  it("allows nested JSON-safe values", () => {
+    expect(
+      isSerializableProps("/", "getStaticProps", {
+        str: "foo",
+        num: 0,
+        bool: true,
+        nul: null,
+        arr: [1, "two", null, { a: 1 }],
+        obj: { nested: { deep: "ok" } },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects top-level non-plain values", () => {
+    expect(() => isSerializableProps("/", "getStaticProps", null)).toThrow(SerializableError);
+    expect(() => isSerializableProps("/", "getStaticProps", undefined)).toThrow(SerializableError);
+    expect(() => isSerializableProps("/", "getStaticProps", [])).toThrow(
+      /received: `\[object Array\]`/,
+    );
+  });
+
+  it("rejects Date inside props", () => {
+    expect(() => isSerializableProps("/non-json", "getStaticProps", { date: new Date(0) })).toThrow(
+      /Error serializing `\.date` returned from `getStaticProps` in "\/non-json"/,
+    );
+    expect(() => isSerializableProps("/non-json", "getStaticProps", { date: new Date(0) })).toThrow(
+      /`object` \("\[object Date\]"\) cannot be serialized as JSON/,
+    );
+  });
+
+  it("rejects functions inside props", () => {
+    expect(() => isSerializableProps("/", "getServerSideProps", { fn: () => 1 })).toThrow(
+      /`function` cannot be serialized as JSON/,
+    );
+  });
+
+  it("rejects undefined nested values with a helpful message", () => {
+    expect(() => isSerializableProps("/", "getStaticProps", { foo: undefined })).toThrow(
+      /`undefined` cannot be serialized as JSON\. Please use `null` or omit this value\./,
+    );
+  });
+
+  it("detects circular references", () => {
+    const a: Record<string, unknown> = {};
+    a.self = a;
+    expect(() => isSerializableProps("/", "getStaticProps", a)).toThrow(
+      /Circular references cannot be expressed in JSON/,
+    );
+  });
+
+  it("uses bracket notation for non-identifier keys in the path", () => {
+    expect(() => isSerializableProps("/", "getStaticProps", { "weird key": new Date() })).toThrow(
+      /Error serializing `\["weird key"\]`/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1478. When `getStaticProps` / `getServerSideProps` returns props
containing non-JSON-serializable values (e.g. `Date`, `Map`, class
instances), vinext was silently rendering an empty page. Next.js surfaces
a clear `Error serializing \`.foo\` returned from \`getStaticProps\` in
"/page"` error in the same situation.

- Adds `packages/vinext/src/server/pages-serializable-props.ts`, a direct
  port of `packages/next/src/lib/is-serializable-props.ts` (plus the
  `isPlainObject` helper) with the same `SerializableError` message shape.
- Invokes the check from `pages-page-data.ts` (prod path) and
  `dev-server.ts` (dev path) for both `getStaticProps` and
  `getServerSideProps`, gated on `!notFound && !redirect` to mirror
  Next.js's `render.tsx` (~lines 982 and 1200).
- The thrown error is caught by the existing per-request error boundary,
  which renders the 500 error page in dev and returns a 500 response in
  prod. No new error-handling plumbing required.

## Test plan

- [x] `tests/pages-serializable-props.test.ts` — 8 unit tests ported from
  Next.js's `test/unit/is-serializable-props.test.ts` (Date, function,
  undefined, circular ref, top-level non-plain values, bracket-notation
  paths).
- [x] `tests/pages-page-data.test.ts` — 3 new integration tests covering
  gSP non-serializable, gSSP non-serializable, and that redirect/notFound
  short-circuits still bypass the check (matches Next.js behaviour).
- [x] `vp check` (format + lint + types) passes.
- [x] Full `tests/pages-router.test.ts` (252 tests) still passes.