### PR TITLE
fix(otel): inject experimental.clientTraceMetadata into SSR head

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -424,6 +424,14 @@ export type ResolvedNextConfig = {
    * identifier (typically resolving to `undefined`).
    */
   compilerDefineServer: Record<string, string>;
+  /**
+   * Allow-list of keys, sourced from `experimental.clientTraceMetadata`,
+   * to forward from the active OpenTelemetry context into the SSR HTML head
+   * as `<meta>` tags. `undefined` (or empty) disables injection.
+   *
+   * Mirrors Next.js: packages/next/src/server/lib/trace/utils.ts (getTracedMetadata).
+   */
+  clientTraceMetadata: string[] | undefined;
 };
 
 // Mirrors Next.js's accepted set in packages/next/src/shared/lib/constants.ts
@@ -1082,6 +1090,7 @@ export async function resolveNextConfig(
       compilerDefine: {},
       compilerDefineServer: {},
       instrumentationClientInject: [],
+      clientTraceMetadata: undefined,
     };
     detectNextIntlConfig(root, resolved);
     return resolved;
@@ -1309,6 +1318,11 @@ export async function resolveNextConfig(
     disableOptimizedLoading: experimental?.disableOptimizedLoading === true,
     compilerDefine: serializeCompilerDefine(config.compiler?.define),
     compilerDefineServer: serializeCompilerDefine(config.compiler?.defineServer),
+    clientTraceMetadata: Array.isArray(experimental?.clientTraceMetadata)
+      ? (experimental.clientTraceMetadata as unknown[]).filter(
+          (value): value is string => typeof value === "string",
+        )
+      : undefined,
   };
 
   // Auto-detect next-intl (lowest priority — explicit aliases from

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -180,7 +180,7 @@ export function generateRscEntry(
   const allowedOrigins = config?.allowedOrigins ?? [];
   const bodySizeLimit = config?.bodySizeLimit ?? 1 * 1024 * 1024;
   const htmlLimitedBots = config?.htmlLimitedBots;
-  const clientTraceMetadata = config?.clientTraceMetadata ?? null;
+  const clientTraceMetadata = config?.clientTraceMetadata;
   const assetPrefix = config?.assetPrefix ?? "";
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
   const i18nConfig = config?.i18n ?? null;

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -112,6 +112,12 @@ type AppRouterConfig = {
   /** Serialized next.config htmlLimitedBots regexp source. */
   htmlLimitedBots?: string;
   /**
+   * Allow-list of keys (from `experimental.clientTraceMetadata`) to surface
+   * from the active OpenTelemetry context as `<meta>` tags in the SSR head.
+   * Undefined or empty disables emission entirely.
+   */
+  clientTraceMetadata?: string[] | undefined;
+  /**
    * Resolved `assetPrefix` from next.config. Empty string when unset.
    * Embedded in the generated entry so the App Router prod-server reads
    * it from the imported module instead of a sidecar JSON file —
@@ -174,6 +180,7 @@ export function generateRscEntry(
   const allowedOrigins = config?.allowedOrigins ?? [];
   const bodySizeLimit = config?.bodySizeLimit ?? 1 * 1024 * 1024;
   const htmlLimitedBots = config?.htmlLimitedBots;
+  const clientTraceMetadata = config?.clientTraceMetadata ?? null;
   const assetPrefix = config?.assetPrefix ?? "";
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
   const i18nConfig = config?.i18n ?? null;
@@ -484,6 +491,7 @@ const __publicFiles = new Set(${JSON.stringify(publicFiles)});
 const __allowedOrigins = ${JSON.stringify(allowedOrigins)};
 const __expireTime = ${JSON.stringify(expireTime)};
 const __htmlLimitedBots = ${JSON.stringify(htmlLimitedBots)};
+const __clientTraceMetadata = ${JSON.stringify(clientTraceMetadata)};
 // Re-exported for the App Router prod-server to consume at startup —
 // mirrors the embedded \`__basePath\` pattern (and Pages Router's
 // \`vinextConfig\` export). Empty string when unset.
@@ -567,6 +575,7 @@ export default __createAppRscHandler({
     const _asyncRouteParams = makeThenableParams(params);
     return __dispatchAppPage({
       basePath: __basePath,
+      clientTraceMetadata: __clientTraceMetadata,
       buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
         return buildPageElements(targetRoute, targetParams, cleanPathname, {
           opts: targetOpts,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -126,7 +126,7 @@ export async function generateServerEntry(
     // (the default), page scripts are emitted with `defer` in <head>. See
     // `.nextjs-ref/packages/next/src/pages/_document.tsx` getScripts().
     disableOptimizedLoading: nextConfig?.disableOptimizedLoading === true,
-    clientTraceMetadata: nextConfig?.clientTraceMetadata ?? null,
+    clientTraceMetadata: nextConfig?.clientTraceMetadata,
     images: {
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
@@ -912,7 +912,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
           }
         },
         getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
-        clientTraceMetadata: vinextConfig.clientTraceMetadata ?? undefined,
+        clientTraceMetadata: vinextConfig.clientTraceMetadata,
         gsspRes,
         isrCacheKey,
         expireSeconds: vinextConfig.expireTime,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -126,6 +126,7 @@ export async function generateServerEntry(
     // (the default), page scripts are emitted with `defer` in <head>. See
     // `.nextjs-ref/packages/next/src/pages/_document.tsx` getScripts().
     disableOptimizedLoading: nextConfig?.disableOptimizedLoading === true,
+    clientTraceMetadata: nextConfig?.clientTraceMetadata ?? null,
     images: {
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
@@ -911,6 +912,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
           }
         },
         getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
+        clientTraceMetadata: vinextConfig.clientTraceMetadata ?? undefined,
         gsspRes,
         isrCacheKey,
         expireSeconds: vinextConfig.expireTime,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2271,6 +2271,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               allowedDevOrigins: nextConfig?.allowedDevOrigins,
               bodySizeLimit: nextConfig?.serverActionsBodySizeLimit,
               htmlLimitedBots: nextConfig?.htmlLimitedBots,
+              clientTraceMetadata: nextConfig?.clientTraceMetadata,
               assetPrefix: nextConfig?.assetPrefix,
               expireTime: nextConfig?.expireTime,
               i18n: nextConfig?.i18n,
@@ -3402,6 +3403,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 nextConfig?.basePath ?? "",
                 nextConfig?.trailingSlash ?? false,
                 middlewarePath !== null,
+                nextConfig?.clientTraceMetadata,
               );
               const mwStatus = req.__vinextMiddlewareStatus;
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -150,9 +150,9 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   /**
    * Allow-list of OpenTelemetry propagation keys (from
    * `experimental.clientTraceMetadata`) to surface as `<meta>` tags in the
-   * SSR head. Undefined or null disables emission entirely.
+   * SSR head. Undefined or empty disables emission entirely.
    */
-  clientTraceMetadata?: readonly string[] | null;
+  clientTraceMetadata?: readonly string[];
   buildPageElement: (
     route: TRoute,
     params: AppPageParams,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -147,6 +147,12 @@ type AppPageDispatchRoute = {
 type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   /** Configured basePath (e.g. "/blog"). Used to prefix redirect Locations. */
   basePath?: string;
+  /**
+   * Allow-list of OpenTelemetry propagation keys (from
+   * `experimental.clientTraceMetadata`) to surface as `<meta>` tags in the
+   * SSR head. Undefined or null disables emission entirely.
+   */
+  clientTraceMetadata?: readonly string[] | null;
   buildPageElement: (
     route: TRoute,
     params: AppPageParams,
@@ -476,6 +482,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
               },
               {
                 basePath: options.basePath,
+                clientTraceMetadata: options.clientTraceMetadata,
                 rootParams: options.rootParams,
                 ...(revalidatedRscCapture.sideStream
                   ? {
@@ -651,6 +658,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
 
   return renderAppPageLifecycle({
     basePath: options.basePath,
+    clientTraceMetadata: options.clientTraceMetadata,
     cleanPathname: options.cleanPathname,
     clearRequestContext: options.clearRequestContext,
     consumeDynamicUsage,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -76,7 +76,7 @@ type RenderAppPageLifecycleOptions = {
    * the SSR head. From `experimental.clientTraceMetadata` in `next.config`.
    * Undefined or empty disables emission.
    */
-  clientTraceMetadata?: readonly string[] | null;
+  clientTraceMetadata?: readonly string[];
   cleanPathname: string;
   clearRequestContext: () => void;
   consumeDynamicUsage: () => boolean;

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -71,6 +71,12 @@ type AppPageRequestCacheLife = {
 
 type RenderAppPageLifecycleOptions = {
   basePath?: string;
+  /**
+   * Allow-list of OpenTelemetry propagation keys to emit as `<meta>` tags in
+   * the SSR head. From `experimental.clientTraceMetadata` in `next.config`.
+   * Undefined or empty disables emission.
+   */
+  clientTraceMetadata?: readonly string[] | null;
   cleanPathname: string;
   clearRequestContext: () => void;
   consumeDynamicUsage: () => boolean;
@@ -512,6 +518,7 @@ export async function renderAppPageLifecycle(
         fontData,
         navigationContext: options.getNavigationContext(),
         basePath: options.basePath,
+        clientTraceMetadata: options.clientTraceMetadata,
         rootParams: options.rootParams,
         formState: options.formState ?? null,
         rscStream: rscForResponse,

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -30,7 +30,7 @@ export type AppPageSsrHandler = {
        * Allow-list of OpenTelemetry propagation keys to emit as `<meta>` tags
        * in the SSR head. Sourced from `experimental.clientTraceMetadata`.
        */
-      clientTraceMetadata?: readonly string[] | null;
+      clientTraceMetadata?: readonly string[];
       rootParams?: RootParams;
       sideStream?: ReadableStream<Uint8Array>;
       capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
@@ -50,9 +50,9 @@ type RenderAppPageHtmlStreamOptions = {
   /**
    * Allow-list of OpenTelemetry propagation keys (from
    * `experimental.clientTraceMetadata`) to surface as `<meta>` tags in
-   * the SSR head. Undefined or null disables emission.
+   * the SSR head. Undefined or empty disables emission.
    */
-  clientTraceMetadata?: readonly string[] | null;
+  clientTraceMetadata?: readonly string[];
   rootParams?: RootParams;
   ssrHandler: AppPageSsrHandler;
   /** Pre-split side stream for fused embed+capture (#981). When set,

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -26,6 +26,11 @@ export type AppPageSsrHandler = {
       formState?: ReactFormState | null;
       scriptNonce?: string;
       basePath?: string;
+      /**
+       * Allow-list of OpenTelemetry propagation keys to emit as `<meta>` tags
+       * in the SSR head. Sourced from `experimental.clientTraceMetadata`.
+       */
+      clientTraceMetadata?: readonly string[] | null;
       rootParams?: RootParams;
       sideStream?: ReadableStream<Uint8Array>;
       capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
@@ -42,6 +47,12 @@ type RenderAppPageHtmlStreamOptions = {
   rscStream: ReadableStream<Uint8Array>;
   scriptNonce?: string;
   basePath?: string;
+  /**
+   * Allow-list of OpenTelemetry propagation keys (from
+   * `experimental.clientTraceMetadata`) to surface as `<meta>` tags in
+   * the SSR head. Undefined or null disables emission.
+   */
+  clientTraceMetadata?: readonly string[] | null;
   rootParams?: RootParams;
   ssrHandler: AppPageSsrHandler;
   /** Pre-split side stream for fused embed+capture (#981). When set,
@@ -106,6 +117,7 @@ export async function renderAppPageHtmlStream(
     formState: options.formState ?? null,
     scriptNonce: options.scriptNonce,
     basePath: options.basePath,
+    clientTraceMetadata: options.clientTraceMetadata,
     rootParams: options.rootParams,
     sideStream: options.sideStream,
     capturedRscDataRef: options.capturedRscDataRef,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -248,9 +248,9 @@ export async function handleSsr(
     /**
      * Allow-list of OpenTelemetry propagation keys (from
      * `experimental.clientTraceMetadata`) to render as `<meta>` tags in the
-     * SSR head. Undefined or null disables emission entirely.
+     * SSR head. Undefined or empty disables emission entirely.
      */
-    clientTraceMetadata?: readonly string[] | null;
+    clientTraceMetadata?: readonly string[];
     rootParams?: RootParams;
     /** When true, wait for the full React tree (including Suspense boundaries)
      *  to resolve before returning the HTML stream. Used for static prerender
@@ -422,7 +422,7 @@ export async function handleSsr(
         let traceMetaHTML: string | null = null;
         const getTraceMetaHTML = (): string => {
           if (traceMetaHTML === null) {
-            traceMetaHTML = getClientTraceMetadataHTML(options?.clientTraceMetadata ?? undefined);
+            traceMetaHTML = getClientTraceMetadataHTML(options?.clientTraceMetadata);
           }
           return traceMetaHTML;
         };

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -38,6 +38,7 @@ import {
 } from "./app-ssr-stream.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
 import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
+import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { AppElementsWire, type AppWireElements } from "./app-elements.js";
 import { ElementsContext, Slot } from "vinext/shims/slot";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
@@ -244,6 +245,12 @@ export async function handleSsr(
     capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
     formState?: ReactFormState | null;
     basePath?: string;
+    /**
+     * Allow-list of OpenTelemetry propagation keys (from
+     * `experimental.clientTraceMetadata`) to render as `<meta>` tags in the
+     * SSR head. Undefined or null disables emission entirely.
+     */
+    clientTraceMetadata?: readonly string[] | null;
     rootParams?: RootParams;
     /** When true, wait for the full React tree (including Suspense boundaries)
      *  to resolve before returning the HTML stream. Used for static prerender
@@ -408,6 +415,17 @@ export async function handleSsr(
         }
 
         const fontHTML = renderFontHtml(fontData, options?.scriptNonce);
+        // Trace meta tags only need to land in the document head once.
+        // Read the active OTel context lazily so the value reflects the
+        // span that was active when the SSR shell rendered. When
+        // clientTraceMetadata is unset (the common case) this is empty.
+        let traceMetaHTML: string | null = null;
+        const getTraceMetaHTML = (): string => {
+          if (traceMetaHTML === null) {
+            traceMetaHTML = getClientTraceMetadataHTML(options?.clientTraceMetadata ?? undefined);
+          }
+          return traceMetaHTML;
+        };
         let didInjectHeadHTML = false;
         const getInsertedHTML = (): string => {
           const insertedHTML = renderInsertedHtml(renderServerInsertedHTML());
@@ -419,7 +437,7 @@ export async function handleSsr(
             navContext,
             bootstrapModuleUrl,
             options?.formState ?? null,
-            insertedHTML + errorMetaHTML,
+            insertedHTML + errorMetaHTML + getTraceMetaHTML(),
             fontHTML,
             options?.scriptNonce,
           );

--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -1,0 +1,123 @@
+/**
+ * Client trace metadata renderer.
+ *
+ * When `experimental.clientTraceMetadata` is configured in `next.config`,
+ * vinext emits `<meta name="..." content="...">` tags in the SSR HTML head
+ * for each configured key. The values are sourced from the active
+ * OpenTelemetry context via the registered propagator.
+ *
+ * This mirrors Next.js' implementation:
+ *  - packages/next/src/server/lib/trace/utils.ts (getTracedMetadata)
+ *  - packages/next/src/server/app-render/make-get-server-inserted-html.tsx (traceMetaTags)
+ *
+ * OpenTelemetry is an optional peer — we resolve `@opentelemetry/api` at
+ * runtime and silently no-op when it is not installed. This matches user
+ * expectations: apps that don't configure OTel get no meta tags, and apps
+ * that do get the filtered subset they asked for in `clientTraceMetadata`.
+ */
+import { escapeHtmlAttr } from "./html.js";
+
+export type ClientTraceDataEntry = {
+  key: string;
+  value: string;
+};
+
+type TextMapSetter = {
+  set(carrier: ClientTraceDataEntry[], key: string, value: string): void;
+};
+
+const carrierSetter: TextMapSetter = {
+  set(carrier, key, value) {
+    if (typeof key !== "string" || typeof value !== "string") return;
+    carrier.push({ key, value });
+  },
+};
+
+/**
+ * Pull entries off the active OpenTelemetry context via the registered
+ * propagator. Returns an empty array when `@opentelemetry/api` is not
+ * installed or when no propagator has been registered.
+ *
+ * The implementation mirrors Next.js's `NextTracerImpl.getTracePropagationData`:
+ * we call `propagation.inject(activeContext, entries, setter)` and let the
+ * setter push entries into our carrier array.
+ */
+type OpenTelemetryApi = {
+  context: { active(): unknown };
+  propagation: {
+    inject(context: unknown, carrier: ClientTraceDataEntry[], setter: TextMapSetter): void;
+  };
+};
+
+export function getOpenTelemetryTraceData(): ClientTraceDataEntry[] {
+  let api: OpenTelemetryApi | undefined;
+  try {
+    // Use require() at runtime so `@opentelemetry/api` is an optional peer.
+    // Bundlers (Vite/esbuild) leave the `require` reference alone, so apps
+    // that don't install the package never hit this branch.
+    const req = (globalThis as { require?: (id: string) => unknown }).require;
+    if (typeof req === "function") {
+      api = req("@opentelemetry/api") as OpenTelemetryApi;
+    }
+  } catch {
+    return [];
+  }
+
+  if (!api) return [];
+
+  try {
+    const activeContext = api.context.active();
+    const entries: ClientTraceDataEntry[] = [];
+    api.propagation.inject(activeContext, entries, carrierSetter);
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Filter an entry list against the configured `clientTraceMetadata` allow-list.
+ * Returns `undefined` when the allow-list is unset so callers can skip
+ * rendering altogether.
+ */
+export function filterClientTraceMetadata(
+  entries: readonly ClientTraceDataEntry[],
+  allowList: readonly string[] | undefined,
+): ClientTraceDataEntry[] | undefined {
+  if (!allowList || allowList.length === 0) return undefined;
+  const allowSet = new Set(allowList);
+  return entries.filter(({ key }) => allowSet.has(key));
+}
+
+/**
+ * Render the filtered entries as a sequence of self-closing `<meta>` tags.
+ * Names and values are HTML-attribute escaped. Returns an empty string when
+ * `entries` is empty or undefined so callers can append unconditionally.
+ */
+export function renderClientTraceMetadataTags(
+  entries: readonly ClientTraceDataEntry[] | undefined,
+): string {
+  if (!entries || entries.length === 0) return "";
+  let html = "";
+  for (const { key, value } of entries) {
+    html += `<meta name="${escapeHtmlAttr(key)}" content="${escapeHtmlAttr(value)}"/>`;
+  }
+  return html;
+}
+
+/**
+ * Convenience helper: read OTel propagation data, filter against the
+ * configured allow-list, and render the resulting `<meta>` tags. Returns an
+ * empty string when the allow-list is unset, OTel is not installed, or no
+ * matching keys were emitted by the propagator.
+ *
+ * Safe to call unconditionally on every SSR render — when nothing is
+ * configured/active this is a few `try/catch`-bounded operations and returns
+ * `""`.
+ */
+export function getClientTraceMetadataHTML(allowList: readonly string[] | undefined): string {
+  if (!allowList || allowList.length === 0) return "";
+  const entries = getOpenTelemetryTraceData();
+  const filtered = filterClientTraceMetadata(entries, allowList);
+  return renderClientTraceMetadataTags(filtered);
+}

--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -49,7 +49,7 @@ type OpenTelemetryApi = {
   };
 };
 
-export function getOpenTelemetryTraceData(): ClientTraceDataEntry[] {
+function getOpenTelemetryTraceData(): ClientTraceDataEntry[] {
   let api: OpenTelemetryApi | undefined;
   try {
     // Use require() at runtime so `@opentelemetry/api` is an optional peer.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -28,6 +28,7 @@ import { runWithHeadState } from "vinext/shims/head-state";
 import { runWithServerInsertedHTMLState } from "vinext/shims/navigation-state";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import { createInlineScriptTag, createNonceAttribute, safeJsonStringify } from "./html.js";
+import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { getScriptNonceFromNodeHeaderSources } from "./csp.js";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
 import path from "node:path";
@@ -256,6 +257,12 @@ export function createSSRHandler(
   basePath = "",
   trailingSlash = false,
   hasMiddleware = false,
+  /**
+   * Allow-list of OpenTelemetry propagation keys to emit as `<meta>` tags
+   * in the SSR head. Sourced from `experimental.clientTraceMetadata` in
+   * `next.config`. When undefined or empty, no meta tags are emitted.
+   */
+  clientTraceMetadata?: readonly string[],
 ) {
   const matcher = fileMatcher ?? createValidFileMatcher();
 
@@ -1174,8 +1181,16 @@ hydrate();
           // Collect head HTML AFTER the shell renders (inside streamPageToResponse,
           // after renderToReadableStream resolves). Head tags from Suspense
           // children arrive late — this matches Next.js behavior.
-          getHeadHTML: () =>
-            typeof headShim.getSSRHeadHTML === "function" ? headShim.getSSRHeadHTML() : "",
+          //
+          // Trace metadata is appended after Head shim output so it always
+          // lands in the final document head. When clientTraceMetadata is
+          // unset (the common case) this is a no-op.
+          getHeadHTML: () => {
+            const headHTML =
+              typeof headShim.getSSRHeadHTML === "function" ? headShim.getSSRHeadHTML() : "";
+            const traceHTML = getClientTraceMetadataHTML(clientTraceMetadata);
+            return traceHTML ? `${headHTML}\n  ${traceHTML}` : headHTML;
+          },
         });
         _renderEnd = now();
 

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -6,6 +6,7 @@ import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { buildRevalidateCacheControl } from "./cache-control.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
 import { createInlineScriptTag, createNonceAttribute, escapeHtmlAttr } from "./html.js";
+import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { reportRequestError } from "./instrumentation.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 
@@ -42,6 +43,12 @@ type RenderPagesPageResponseOptions = {
   getFontLinks: () => string[];
   getFontStyles: () => string[];
   getSSRHeadHTML?: (() => string) | undefined;
+  /**
+   * Allow-list of OpenTelemetry propagation keys (from
+   * `experimental.clientTraceMetadata`) to emit as `<meta>` tags in the SSR
+   * head. Undefined or empty disables emission.
+   */
+  clientTraceMetadata?: readonly string[] | undefined;
   gsspRes: PagesGsspResponse | null;
   isrCacheKey: (router: string, pathname: string) => string;
   expireSeconds?: number;
@@ -335,11 +342,18 @@ export async function renderPagesPageResponse(
   // Mirrors Next.js fix: vercel/next.js@9853944
   const bodyStream = await options.renderToReadableStream(pageElement);
 
+  const headFromShim = options.getSSRHeadHTML?.() ?? "";
+  // Trace meta tags from the active OpenTelemetry context. When the
+  // allow-list is unset (the common case) or OTel is not installed,
+  // `getClientTraceMetadataHTML` returns "" and we forward the head HTML
+  // verbatim — keeping the no-op path zero-overhead.
+  const traceMetaHTML = getClientTraceMetadataHTML(options.clientTraceMetadata);
+  const ssrHeadHTML = traceMetaHTML ? `${headFromShim}\n  ${traceMetaHTML}` : headFromShim;
   const shellHtml = await buildPagesShellHtml(bodyMarker, fontHeadHTML, nextDataScript, {
     assetTags: options.assetTags,
     DocumentComponent: options.DocumentComponent,
     renderDocumentToString: options.renderDocumentToString,
-    ssrHeadHTML: options.getSSRHeadHTML?.() ?? "",
+    ssrHeadHTML,
   });
 
   options.clearSsrContext();

--- a/tests/client-trace-metadata.test.ts
+++ b/tests/client-trace-metadata.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the client trace metadata renderer.
+ *
+ * Mirrors Next.js: test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts
+ * Source: packages/next/src/server/lib/trace/utils.ts (getTracedMetadata)
+ *         packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+ */
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  filterClientTraceMetadata,
+  getClientTraceMetadataHTML,
+  renderClientTraceMetadataTags,
+  type ClientTraceDataEntry,
+} from "../packages/vinext/src/server/client-trace-metadata.js";
+
+describe("client trace metadata: filterClientTraceMetadata", () => {
+  const entries: ClientTraceDataEntry[] = [
+    { key: "my-test-key-1", value: "my-test-value-1" },
+    { key: "my-test-key-2", value: "my-test-value-2" },
+    { key: "non-metadata-key-3", value: "non-metadata-key-3" },
+    { key: "my-parent-span-id", value: "abc123def4567890" },
+  ];
+
+  it("returns undefined when the allow-list is not configured", () => {
+    expect(filterClientTraceMetadata(entries, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty allow-list", () => {
+    expect(filterClientTraceMetadata(entries, [])).toBeUndefined();
+  });
+
+  it("returns only the entries whose keys are in the allow-list", () => {
+    const result = filterClientTraceMetadata(entries, [
+      "my-test-key-1",
+      "my-test-key-2",
+      "my-parent-span-id",
+    ]);
+    expect(result).toEqual([
+      { key: "my-test-key-1", value: "my-test-value-1" },
+      { key: "my-test-key-2", value: "my-test-value-2" },
+      { key: "my-parent-span-id", value: "abc123def4567890" },
+    ]);
+  });
+
+  it("excludes keys that are not in the allow-list", () => {
+    const result = filterClientTraceMetadata(entries, ["my-test-key-1"]);
+    expect(result).toEqual([{ key: "my-test-key-1", value: "my-test-value-1" }]);
+  });
+});
+
+describe("client trace metadata: renderClientTraceMetadataTags", () => {
+  it("renders nothing for undefined or empty entries", () => {
+    expect(renderClientTraceMetadataTags(undefined)).toBe("");
+    expect(renderClientTraceMetadataTags([])).toBe("");
+  });
+
+  it("renders one <meta> per entry preserving order", () => {
+    const html = renderClientTraceMetadataTags([
+      { key: "my-test-key-1", value: "my-test-value-1" },
+      { key: "my-test-key-2", value: "my-test-value-2" },
+      { key: "my-parent-span-id", value: "abc123def4567890" },
+    ]);
+
+    expect(html).toContain('<meta name="my-test-key-1" content="my-test-value-1"/>');
+    expect(html).toContain('<meta name="my-test-key-2" content="my-test-value-2"/>');
+    expect(html).toContain('<meta name="my-parent-span-id" content="abc123def4567890"/>');
+    // Order is preserved.
+    expect(html.indexOf("my-test-key-1")).toBeLessThan(html.indexOf("my-test-key-2"));
+    expect(html.indexOf("my-test-key-2")).toBeLessThan(html.indexOf("my-parent-span-id"));
+  });
+
+  it("HTML-escapes attribute values to prevent injection", () => {
+    const html = renderClientTraceMetadataTags([
+      { key: 'evil"name', value: '"><script>alert(1)</script>' },
+    ]);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&quot;");
+  });
+});
+
+describe("client trace metadata: getClientTraceMetadataHTML", () => {
+  // The default global has no `require`, so any optional OTel resolution
+  // returns no entries.
+  type WithRequire = { require?: (id: string) => unknown };
+
+  afterEach(() => {
+    delete (globalThis as WithRequire).require;
+  });
+
+  it("returns empty string when the allow-list is unset", () => {
+    expect(getClientTraceMetadataHTML(undefined)).toBe("");
+    expect(getClientTraceMetadataHTML([])).toBe("");
+  });
+
+  it("returns empty string when @opentelemetry/api is not installed", () => {
+    (globalThis as WithRequire).require = (id: string) => {
+      const err = new Error(`Cannot find module '${id}'`) as Error & { code?: string };
+      err.code = "MODULE_NOT_FOUND";
+      throw err;
+    };
+    expect(getClientTraceMetadataHTML(["my-test-key-1"])).toBe("");
+  });
+
+  it("renders <meta> tags for keys in the allow-list when an OTel propagator is registered", () => {
+    const propagator = {
+      inject(
+        _ctx: unknown,
+        carrier: ClientTraceDataEntry[],
+        setter: { set(carrier: ClientTraceDataEntry[], key: string, value: string): void },
+      ) {
+        setter.set(carrier, "my-test-key-1", "my-test-value-1");
+        setter.set(carrier, "my-test-key-2", "my-test-value-2");
+        setter.set(carrier, "non-metadata-key-3", "non-metadata-key-3");
+        setter.set(carrier, "my-parent-span-id", "abc123def4567890");
+      },
+    };
+
+    const fakeApi = {
+      context: { active: () => ({}) },
+      propagation: propagator,
+    };
+
+    (globalThis as WithRequire).require = (id: string) => {
+      if (id === "@opentelemetry/api") return fakeApi;
+      throw new Error(`Cannot find module '${id}'`);
+    };
+
+    const html = getClientTraceMetadataHTML([
+      "my-test-key-1",
+      "my-test-key-2",
+      "my-parent-span-id",
+    ]);
+
+    expect(html).toContain('<meta name="my-test-key-1" content="my-test-value-1"/>');
+    expect(html).toContain('<meta name="my-test-key-2" content="my-test-value-2"/>');
+    expect(html).toMatch(/<meta name="my-parent-span-id" content="[a-f0-9]{16}"\/>/);
+    // Keys not on the allow-list MUST NOT appear in the head.
+    expect(html).not.toContain("non-metadata-key-3");
+  });
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -870,6 +870,59 @@ describe("resolveNextConfig instrumentationClientInject", () => {
   });
 });
 
+describe("resolveNextConfig clientTraceMetadata", () => {
+  it("defaults to undefined when no config is provided", async () => {
+    const resolved = await resolveNextConfig(null);
+    expect(resolved.clientTraceMetadata).toBeUndefined();
+  });
+
+  it("defaults to undefined when experimental is not set", async () => {
+    const resolved = await resolveNextConfig({ env: {} });
+    expect(resolved.clientTraceMetadata).toBeUndefined();
+  });
+
+  it("defaults to undefined when experimental.clientTraceMetadata is omitted", async () => {
+    const resolved = await resolveNextConfig({ experimental: {} });
+    expect(resolved.clientTraceMetadata).toBeUndefined();
+  });
+
+  it("resolves a string array from experimental.clientTraceMetadata", async () => {
+    const resolved = await resolveNextConfig({
+      experimental: {
+        clientTraceMetadata: ["my-test-key-1", "my-test-key-2", "my-parent-span-id"],
+      },
+    });
+    expect(resolved.clientTraceMetadata).toEqual([
+      "my-test-key-1",
+      "my-test-key-2",
+      "my-parent-span-id",
+    ]);
+  });
+
+  it("filters out non-string entries", async () => {
+    const resolved = await resolveNextConfig({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      experimental: { clientTraceMetadata: ["valid-key", 42, null, "another-key"] as any },
+    });
+    expect(resolved.clientTraceMetadata).toEqual(["valid-key", "another-key"]);
+  });
+
+  it("returns undefined for a non-array value", async () => {
+    const resolved = await resolveNextConfig({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      experimental: { clientTraceMetadata: "not-an-array" as any },
+    });
+    expect(resolved.clientTraceMetadata).toBeUndefined();
+  });
+
+  it("resolves to an empty array when experimental.clientTraceMetadata is an empty array", async () => {
+    const resolved = await resolveNextConfig({
+      experimental: { clientTraceMetadata: [] },
+    });
+    expect(resolved.clientTraceMetadata).toEqual([]);
+  });
+});
+
 describe("resolveNextConfig removeConsole", () => {
   it("resolves `compiler: { removeConsole: true }` to `true`", async () => {
     const resolved = await resolveNextConfig({ compiler: { removeConsole: true } });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1097,6 +1097,7 @@ describe("detectNextIntlConfig", () => {
       compilerDefine: {},
       compilerDefineServer: {},
       instrumentationClientInject: [],
+      clientTraceMetadata: undefined,
       ...overrides,
     };
   }


### PR DESCRIPTION
## Summary

Fixes #1494.

- Adds support for `experimental.clientTraceMetadata` in `next.config`: when configured, vinext reads the active OpenTelemetry propagation context and emits `<meta name="..." content="...">` tags in the SSR HTML head for each allow-listed key.
- Covers both App Router and Pages Router, dev and prod servers (`app-ssr-entry.ts`, `dev-server.ts`, `pages-page-response.ts`).
- `@opentelemetry/api` is resolved as an optional peer via runtime `require(...)`. Apps that don't install OTel get a zero-cost no-op; the path returns `""` and the head HTML is forwarded verbatim.
- Mirrors Next.js: [`packages/next/src/server/lib/trace/utils.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/trace/utils.ts) (`getTracedMetadata`) and [`packages/next/src/server/app-render/make-get-server-inserted-html.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/make-get-server-inserted-html.tsx) (`traceMetaTags`).
- Ports the Next.js test setup from [`test/e2e/opentelemetry/client-trace-metadata/`](https://github.com/vercel/next.js/blob/canary/test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts) into `tests/client-trace-metadata.test.ts` (uses the same test keys `my-test-key-1`, `my-test-key-2`, `my-parent-span-id`, and verifies `non-metadata-key-3` is excluded).

## Test plan

- [x] `pnpm test tests/client-trace-metadata.test.ts` — new unit tests cover filter, render, and end-to-end with a mocked OTel propagator
- [x] `pnpm test tests/next-config.test.ts tests/app-page-dispatch.test.ts tests/app-page-render.test.ts tests/app-page-stream.test.ts tests/head.test.ts tests/pages-page-response.test.ts` — 248 tests pass
- [x] `pnpm run check` — format, lint, types all green
- [ ] CI deploy suite (cloudflare/vinext Next.js Deploy Suite) — should resolve the 5 failures listed in #1494

## Follow-ups

- The Next.js dev/prod static-page split (dev injects on statically rendered pages, prod doesn't) is not modeled here — meta tags are emitted whenever an active OTel span is present, regardless of static vs dynamic. Worth confirming against the deploy-suite expectations.
- **ISR / cached static rendering interaction (deferred):** when ISR (or any other cache that serves rendered HTML) regenerates a page inside an OTel-instrumented request, the resulting `<meta name="...">` tags capture the *regeneration* span's trace IDs and are then served verbatim to subsequent requests until the next revalidation. This can mislead client-side tracing that joins on `trace-id` / `parent-span-id`. Out of scope for this PR — needs a dedicated design pass (likely "skip injection for cacheable static renders" or "stamp + rewrite on each serve") and matching Next.js parity work. Tracked as future follow-up.
