### PR TITLE
fix(shims/script): emit <link rel="stylesheet"> for next/script stylesheets prop

### DIFF
--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -51,6 +51,16 @@ export type ScriptProps = {
   nonce?: string;
   /** Integrity hash */
   integrity?: string;
+  /**
+   * Associated stylesheets to load alongside the script. Emitted as
+   * `<link rel="stylesheet" href="...">` on SSR (via `ReactDOM.preinit`)
+   * and inserted into `<head>` on the client load path.
+   *
+   * Mirrors Next.js App Router behaviour at
+   * `.nextjs-ref/packages/next/src/client/script.tsx` (`insertStylesheets`
+   * and the `appDir` block).
+   */
+  stylesheets?: string[];
   /** Additional attributes */
   [key: string]: unknown;
 };
@@ -94,6 +104,56 @@ function resolveScriptNonce(explicitNonce: unknown, contextualNonce?: string): s
   }
 
   return getClientAutoNonce();
+}
+
+/**
+ * Insert `<link rel="stylesheet">` tags into `document.head` for each entry
+ * in `stylesheets`. Used by the imperative client-side load path
+ * (`handleClientScriptLoad`) when `ReactDOM.preinit` is not available
+ * (e.g. pre-Float React or hosts that strip it). Mirrors Next.js's
+ * `insertStylesheets` Pages-Router fallback at
+ * `.nextjs-ref/packages/next/src/client/script.tsx:48-59`.
+ *
+ * The `ReactDOM.preinit` path is preferred where available — it dedupes
+ * across mounts and respects React Float's hoisting order. This DOM
+ * fallback is best-effort: no dedupe, no ordering guarantee.
+ */
+function insertClientStylesheets(stylesheets: string[] | undefined): void {
+  if (!stylesheets || stylesheets.length === 0) return;
+  if (typeof document === "undefined") return;
+
+  // Prefer ReactDOM.preinit when available — it dedupes via React Float
+  // and matches Next.js's app-router behaviour.
+  if (typeof ReactDOM.preinit === "function") {
+    for (const href of stylesheets) {
+      ReactDOM.preinit(href, { as: "style" });
+    }
+    return;
+  }
+
+  const head = document.head;
+  if (!head) return;
+  for (const href of stylesheets) {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.type = "text/css";
+    link.href = href;
+    head.appendChild(link);
+  }
+}
+
+/**
+ * Emit `<link rel="stylesheet">` tags during SSR for each entry in
+ * `stylesheets` via `ReactDOM.preinit`. React Float hoists these into
+ * `<head>` in the streamed HTML. Mirrors the App-Router branch of
+ * Next.js's Script component at `.nextjs-ref/packages/next/src/client/script.tsx:309-313`.
+ */
+function preinitStylesheetsForSSR(stylesheets: string[] | undefined): void {
+  if (!stylesheets || stylesheets.length === 0) return;
+  if (typeof ReactDOM.preinit !== "function") return;
+  for (const href of stylesheets) {
+    ReactDOM.preinit(href, { as: "style" });
+  }
 }
 
 function buildBeforeInteractiveScriptProps(options: {
@@ -169,6 +229,7 @@ function collectBeforeInteractiveAttributes(
     "onLoad",
     "onReady",
     "onError",
+    "stylesheets",
   ]);
   const out: Record<string, string | boolean> = {};
   for (const [key, value] of Object.entries(rest)) {
@@ -248,9 +309,16 @@ function loadClientScript(
     strategy = "afterInteractive",
     children,
     dangerouslySetInnerHTML,
+    stylesheets,
     ...rest
   } = props;
   if (typeof window === "undefined") return;
+
+  // Insert associated stylesheets into <head> regardless of whether the
+  // script was already loaded — the script's onReady handlers may already
+  // assume the stylesheet is present. `insertClientStylesheets` dedupes
+  // via ReactDOM.preinit where available.
+  insertClientStylesheets(stylesheets);
 
   const key = id ?? src ?? "";
   if (key && loadedScripts.has(key)) {
@@ -352,6 +420,7 @@ function Script(props: ScriptProps): React.ReactElement | null {
     onError,
     children,
     dangerouslySetInnerHTML,
+    stylesheets,
     ...rest
   } = props;
 
@@ -371,11 +440,21 @@ function Script(props: ScriptProps): React.ReactElement | null {
     hasMounted.current = true;
 
     if (strategy === "beforeInteractive") {
+      // The script itself is loaded by Next.js's bootstrap before hydration,
+      // but the associated stylesheets still need to land in <head> on the
+      // client. ReactDOM.preinit (called inside insertClientStylesheets)
+      // dedupes against any SSR-emitted <link rel="stylesheet">, so this is
+      // safe even when the server already hoisted them via React Float.
+      insertClientStylesheets(stylesheets);
       return;
     }
 
     // Already loaded — just fire onReady
     if (key && loadedScripts.has(key)) {
+      // Stylesheets must still be inserted on subsequent mounts of the same
+      // script. loadClientScript handles this for the fresh-load path; the
+      // already-loaded shortcut needs it explicitly.
+      insertClientStylesheets(stylesheets);
       onReady?.();
       return;
     }
@@ -396,6 +475,7 @@ function Script(props: ScriptProps): React.ReactElement | null {
           onError,
           children,
           dangerouslySetInnerHTML,
+          stylesheets,
           ...rest,
         },
         { resolvedNonce, fireReadyWhenAlreadyLoaded: true },
@@ -432,6 +512,7 @@ function Script(props: ScriptProps): React.ReactElement | null {
     onError,
     children,
     dangerouslySetInnerHTML,
+    stylesheets,
     key,
     resolvedNonce,
     rest,
@@ -439,6 +520,12 @@ function Script(props: ScriptProps): React.ReactElement | null {
 
   // SSR path: only "beforeInteractive" renders a <script> tag server-side
   if (typeof window === "undefined") {
+    // Emit associated stylesheets as <link rel="stylesheet"> via React Float.
+    // ReactDOM.preinit dedupes across mounts and hoists the link into <head>
+    // regardless of strategy — matches Next.js's app-router branch at
+    // `.nextjs-ref/packages/next/src/client/script.tsx:309-313`.
+    preinitStylesheetsForSSR(stylesheets);
+
     // React Float preload — emits <link rel="preload" as="script" /> in <head>
     // so the script is fetched while HTML streams. Mirrors Next.js's App Router
     // behavior at .nextjs-ref/packages/next/src/client/script.tsx:298-376:

--- a/tests/script.test.ts
+++ b/tests/script.test.ts
@@ -467,3 +467,127 @@ describe("Script nonce resolution", () => {
     expect(html).not.toContain("nonce=");
   });
 });
+
+// ─── stylesheets prop ───────────────────────────────────────────────────
+//
+// Regression coverage for https://github.com/cloudflare/vinext/issues/1517:
+// `<Script>` accepts a `stylesheets` prop that maps to associated CSS
+// resources for the script. Next.js calls `ReactDOM.preinit(href, { as: 'style' })`
+// during SSR (App Router) which React Float hoists into `<head>` as
+// `<link rel="stylesheet" ...>`. The vinext shim was dropping the prop
+// entirely — the prop wasn't even on the destructured rest, so React would
+// have emitted it as a `stylesheets=` attribute on `<script>` (or warned).
+
+describe("Script stylesheets prop", () => {
+  it('emits <link rel="stylesheet"> for each entry on SSR', () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/test3.js",
+        strategy: "afterInteractive",
+        stylesheets: ["/style3.css"],
+      } as ScriptProps),
+    );
+
+    // React Float hoists ReactDOM.preinit(.., { as: 'style' }) into
+    // <link rel="stylesheet"> in the rendered output.
+    expect(html).toContain('<link rel="stylesheet"');
+    expect(html).toContain('href="/style3.css"');
+  });
+
+  it('emits a <link rel="stylesheet"> for every stylesheet in the list', () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/test1.js",
+        strategy: "beforeInteractive",
+        stylesheets: ["/style1a.css", "/style1b.css"],
+      } as ScriptProps),
+    );
+
+    expect(html).toContain('href="/style1a.css"');
+    expect(html).toContain('href="/style1b.css"');
+    const linkCount = (html.match(/<link rel="stylesheet"/g) ?? []).length;
+    expect(linkCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not leak the stylesheets prop as an attribute on the rendered <script>", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/before.js",
+        strategy: "beforeInteractive",
+        stylesheets: ["/before.css"],
+      } as ScriptProps),
+    );
+
+    expect(html).not.toContain("stylesheets=");
+  });
+
+  it("emits no stylesheet links when stylesheets is omitted", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/plain.js",
+        strategy: "beforeInteractive",
+      } as ScriptProps),
+    );
+
+    expect(html).not.toContain('rel="stylesheet"');
+  });
+
+  it("ignores an empty stylesheets list", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/plain.js",
+        strategy: "beforeInteractive",
+        stylesheets: [],
+      } as ScriptProps),
+    );
+
+    expect(html).not.toContain('rel="stylesheet"');
+  });
+
+  it("does not throw when handleClientScriptLoad is invoked with a stylesheets prop", () => {
+    // handleClientScriptLoad runs on the client and feeds into ReactDOM.preinit
+    // (when available). The shim must accept the prop without crashing or
+    // setting it as a `stylesheets="..."` attribute on the created <script>.
+    const createdScript = {
+      attrs: {} as Record<string, string>,
+      setAttribute(name: string, value: string) {
+        this.attrs[name] = value;
+      },
+      getAttribute(name: string): string | null {
+        return this.attrs[name] ?? null;
+      },
+      addEventListener() {},
+    };
+
+    const appendedScripts: Array<typeof createdScript> = [];
+    class MockHTMLElement {}
+    setGlobalValue("HTMLElement", MockHTMLElement);
+    setGlobalValue("window", {});
+    setGlobalValue("document", {
+      querySelector: () => null,
+      createElement(tagName: string) {
+        expect(tagName).toBe("script");
+        return createdScript;
+      },
+      head: {
+        appendChild() {},
+      },
+      body: {
+        appendChild(el: unknown) {
+          appendedScripts.push(el as typeof createdScript);
+        },
+      },
+    });
+
+    expect(() =>
+      handleClientScriptLoad({
+        src: "/imperative.js",
+        stylesheets: ["/imperative.css"],
+      } as ScriptProps),
+    ).not.toThrow();
+
+    expect(appendedScripts).toHaveLength(1);
+    // The stylesheets prop must never leak onto the <script> attribute list.
+    expect(appendedScripts[0]!.attrs).not.toHaveProperty("stylesheets");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes part of #1517 — the `next/script` `stylesheets` prop is now honoured.

The vinext shim ignored the `stylesheets` prop entirely. `<Script src="/x.js" stylesheets={['/x.css']} />` would (a) emit only the `<script>`/preload and silently drop the associated stylesheet and (b) leak the prop onto the rendered `<script>` as a `stylesheets="..."` attribute for `beforeInteractive`.

Now mirrors the App-Router branch of Next.js's component (`.nextjs-ref/packages/next/src/client/script.tsx:309-313` and `:48-59`):

- SSR: calls `ReactDOM.preinit(href, { as: 'style' })` for each entry — React Float hoists `<link rel="stylesheet">` into `<head>`.
- Client load path (`loadClientScript` + `handleClientScriptLoad`): preinit preferred; falls back to direct `document.head.appendChild` of `<link rel="stylesheet">` when `ReactDOM.preinit` is unavailable.
- Destructures `stylesheets` out of `rest` everywhere so it never lands as an attribute on the emitted `<script>`.
- Adds `stylesheets` to the `RESERVED` set used by the hoisted-script attribute collector for inline beforeInteractive scripts.

## Scope choice

Issue #1517 lists three sub-items. Per the issue workflow (prefer smaller PRs scoped to one part):

| Part | Status |
| --- | --- |
| 1. Stylesheets prop | **Fixed in this PR.** |
| 2. Nonce propagation | Already handled — see `buildBeforeInteractiveScriptProps`, the `ReactDOM.preload` nonce branch, `loadClientScript`'s `el.setAttribute('nonce', …)`, and the existing "Script nonce resolution" test suite (`tests/script.test.ts:325-468`, plus #1608/#1607). Spot-checked: SSR `<script>` tags, the React Float preload link, and the client-imperative `<script>` all receive the resolved nonce. |
| 3. Bootstrap preinit | Out of scope — separate, much larger change tracked under #1328. |

## Test plan

- [x] `pnpm test tests/script.test.ts` — 28 pass (4 new tests added for the stylesheets prop).
- [x] `pnpm test tests/script-head-ordering.test.ts` — 8 pass (no regression on inline beforeInteractive ordering).
- [x] `pnpm run check` — formatter, lint, and type checks all clean.