### PR TITLE
test(pages-router): regression coverage for edge runtime & OG image API routes (#1338)

### DIFF
--- a/tests/fixtures/pages-basic/pages/api/edge-hello.ts
+++ b/tests/fixtures/pages-basic/pages/api/edge-hello.ts
@@ -1,0 +1,22 @@
+// Ported from Next.js: test/e2e/edge-pages-support/app/pages/api/hello.js
+// https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/app/pages/api/hello.js
+//
+// Pages Router edge runtime API route. The handler receives a NextRequest
+// (Fetch-style) instead of (req, res), and must return a Web Response.
+// Regression coverage for cloudflare/vinext#1338 — edge runtime API routes
+// were reported as returning 500 against the Next.js deploy suite.
+export const config = {
+  runtime: "edge",
+};
+
+type NextRequestLike = Request & { nextUrl: { searchParams: URLSearchParams } };
+
+export default async function handler(req: NextRequestLike): Promise<Response> {
+  return new Response(
+    JSON.stringify({
+      hello: "world",
+      query: Object.fromEntries(req.nextUrl.searchParams),
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+}

--- a/tests/fixtures/pages-basic/pages/api/og.tsx
+++ b/tests/fixtures/pages-basic/pages/api/og.tsx
@@ -1,0 +1,30 @@
+// Ported from Next.js: test/e2e/og-api/app/pages/api/og.js
+// https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/app/pages/api/og.js
+//
+// Pages Router OG image route — uses `next/og` ImageResponse from inside a
+// Pages Router edge API route. Regression coverage for cloudflare/vinext#1338
+// where this combination was reported as returning 404 in the Next.js deploy
+// suite.
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+export default function handler() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 128,
+        background: "lavender",
+      }}
+    >
+      Hello!
+    </div>,
+  );
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -774,6 +774,38 @@ describe("Pages Router integration", () => {
     expect(res.status).toBe(404);
   });
 
+  // Regression coverage for cloudflare/vinext#1338 — Pages Router edge
+  // runtime API routes (`export const config = { runtime: 'edge' }`) must
+  // execute and return the user's Web Response (200), not 500.
+  //
+  // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts
+  it("serves Pages Router edge runtime API routes (export const config = { runtime: 'edge' })", async () => {
+    const res = await fetch(`${baseUrl}/api/edge-hello?a=b`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+
+    const data = await res.json();
+    expect(data).toEqual({
+      hello: "world",
+      query: { a: "b" },
+    });
+  });
+
+  // Regression coverage for cloudflare/vinext#1338 — Pages Router OG image
+  // routes using `next/og` ImageResponse with `runtime: 'edge'` must execute
+  // and return image/png, not 404.
+  //
+  // Ported from Next.js: test/e2e/og-api/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/index.test.ts
+  it("serves Pages Router OG image routes (next/og + edge runtime)", async () => {
+    const res = await fetch(`${baseUrl}/api/og`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("image/png");
+    const body = await res.blob();
+    expect(body.size).toBeGreaterThan(0);
+  });
+
   // --- Client Hydration ---
 
   it("includes hydration script for client-side rendering", async () => {
@@ -3252,6 +3284,23 @@ export default function CounterPage() {
       });
       expect(ldJsonRes.status).toBe(200);
       expect(await ldJsonRes.json()).toEqual({ title: "doc" });
+
+      // Test: Pages Router edge runtime API route. Regression coverage for
+      // cloudflare/vinext#1338 — edge runtime API routes were reported as
+      // returning 500 against the Next.js deploy suite. Verifies the
+      // production server entry correctly dispatches edge handlers.
+      const edgeApiRes = await fetch(`${prodUrl}/api/edge-hello?a=b`);
+      expect(edgeApiRes.status).toBe(200);
+      expect(edgeApiRes.headers.get("content-type")).toContain("application/json");
+      expect(await edgeApiRes.json()).toEqual({ hello: "world", query: { a: "b" } });
+
+      // Test: Pages Router edge runtime OG image route. Regression coverage
+      // for cloudflare/vinext#1338 — OG routes were reported as returning
+      // 404 against the Next.js deploy suite.
+      const ogRes = await fetch(`${prodUrl}/api/og`);
+      expect(ogRes.status).toBe(200);
+      expect(ogRes.headers.get("content-type")).toContain("image/png");
+      expect((await ogRes.blob()).size).toBeGreaterThan(0);
 
       // Test: 404 for unknown route
       const notFoundRes = await fetch(`${prodUrl}/nonexistent`);


### PR DESCRIPTION
## Summary

Adds Pages Router-only fixtures and dev + production integration tests for the two scenarios reported as failing in the Next.js Deploy Suite (cloudflare/vinext#1338):

- `export const config = { runtime: 'edge' }` API route returns a Web `Response` (case 1 — `/api/hello` was observed as 500).
- `next/og` `ImageResponse` with `runtime: 'edge'` inside a Pages Router API route returns `image/png` (case 2 — `/api/og` was observed as 404).

The existing implementation already routes both code paths through `handlePagesApiRoute` and applies the `vinext:og-inline-fetch-assets` Vite transform; this PR locks in regression coverage so a Pages Router-only build cannot silently regress either path. Both new tests pass locally against the current `main`-equivalent code.

Route handlers are ported from Next.js' own e2e fixtures:

- `next.js/test/e2e/edge-pages-support/app/pages/api/hello.js`
- `next.js/test/e2e/og-api/app/pages/api/og.js`

Scoped intentionally — the App Router OG + custom-font (`/font/opengraph-image` 500) and other edge-runtime test-suite gaps remain out of scope for this PR and continue to be tracked under #1338.

Refs #1338

## Test plan
- [x] `pnpm test tests/pages-router.test.ts` — dev + prod regression cases pass (271 tests)
- [x] `pnpm test tests/pages-api-route.test.ts` — direct handler unit tests still pass
- [x] `pnpm run check` — fmt, lint, types clean