### PR TITLE
fix(build): forward pageExtensions to Vite resolve.extensions

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -10,7 +10,7 @@ import { generateServerEntry as _generateServerEntry } from "./entries/pages-ser
 import { generateClientEntry as _generateClientEntry } from "./entries/pages-client-entry.js";
 import { appRouteGraph, appRouter, invalidateAppRouteCache } from "./routing/app-router.js";
 import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
-import { createValidFileMatcher } from "./routing/file-matcher.js";
+import { buildViteResolveExtensions, createValidFileMatcher } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
 import { isImageOptimizationPath } from "./server/image-optimization.js";
@@ -1584,6 +1584,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               ...nextConfig.aliases,
               ...nextShimMap,
             },
+            // Mirror Next.js `pageExtensions` into Vite's `resolve.extensions`
+            // so extensionless imports of files with custom extensions
+            // (`.mdx`, `.platform.tsx`, `.web.tsx`, etc.) resolve. Without
+            // this the build crashes with "Custom deploy script failed:
+            // undefined (1)" when the user configures pageExtensions beyond
+            // Vite's default set. See cloudflare/vinext#1502.
+            extensions: buildViteResolveExtensions(nextConfig.pageExtensions),
             // Dedupe React packages to prevent dual-instance errors.
             // When vinext is linked (npm link / bun link) or any dependency
             // brings its own React copy, multiple React instances can load,

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -91,6 +91,41 @@ export function findFileWithExtensions(basePath: string, matcher: ValidFileMatch
 }
 
 /**
+ * Vite's default `resolve.extensions` covers `.tsx/.ts/.jsx/.js/.json` (and
+ * `.mjs/.mts`). When the user configures `pageExtensions` with values Vite
+ * does not know about — e.g. `["platform.tsx", "tsx", "mdx"]` from the
+ * Next.js `resolve-extensions` fixture — extensionless imports of those
+ * files fail to resolve, and the build crashes with "Custom deploy script
+ * failed: undefined (1)".
+ *
+ * Build the merged extension list that Vite should use:
+ *
+ *  1. User-configured pageExtensions go first (each prefixed with `.`) so
+ *     the user's priority wins. e.g. `.platform.tsx` resolves before `.tsx`.
+ *  2. Vite's defaults follow, with duplicates removed.
+ *
+ * The user's pageExtensions retain their relative order, which is what
+ * Next.js / Turbopack do via the `resolveExtensions` config option.
+ *
+ * See: cloudflare/vinext#1502
+ */
+export function buildViteResolveExtensions(
+  pageExtensions?: readonly string[] | null,
+  viteDefaults: readonly string[] = [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"],
+): string[] {
+  const normalized = normalizePageExtensions(pageExtensions);
+  const dotted = normalized.map((ext) => `.${ext}`);
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const ext of [...dotted, ...viteDefaults]) {
+    if (seen.has(ext)) continue;
+    seen.add(ext);
+    result.push(ext);
+  }
+  return result;
+}
+
+/**
  * Use function-form exclude for Node < 22.14 compatibility.
  */
 export async function* scanWithExtensions(

--- a/tests/page-extensions-resolve.test.ts
+++ b/tests/page-extensions-resolve.test.ts
@@ -1,0 +1,115 @@
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vite-plus/test";
+import { buildViteResolveExtensions } from "../packages/vinext/src/routing/file-matcher.js";
+
+// Ported in spirit from Next.js: test/e2e/app-dir/resolve-extensions/
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resolve-extensions/
+//
+// When users configure custom extensions via `pageExtensions` or
+// `turbopack.resolveExtensions` (e.g. `.platform.tsx` or `.mdx`), Vite must
+// know to attempt those extensions when resolving extensionless imports.
+// Otherwise extensionless imports of files with those custom extensions
+// fail to resolve and the build crashes.
+//
+// Regression test for cloudflare/vinext#1502.
+describe("buildViteResolveExtensions", () => {
+  it("applies Next.js default pageExtensions priority when pageExtensions is undefined", () => {
+    // Even without a user-set pageExtensions, vinext normalises to the
+    // Next.js defaults `["tsx", "ts", "jsx", "js"]` and uses that order.
+    const extensions = buildViteResolveExtensions(undefined);
+    expect(extensions).toEqual([".tsx", ".ts", ".jsx", ".js", ".mjs", ".mts", ".json"]);
+  });
+
+  it("returns the same list when pageExtensions matches the Next.js defaults", () => {
+    const extensions = buildViteResolveExtensions(["tsx", "ts", "jsx", "js"]);
+    expect(extensions).toEqual([".tsx", ".ts", ".jsx", ".js", ".mjs", ".mts", ".json"]);
+  });
+
+  it("prepends configured pageExtensions so user priority wins", () => {
+    // Next.js resolve-extensions fixture places `.web.tsx` before `.tsx`.
+    // The user's order must be preserved so `Component` resolves to
+    // `Component.web.tsx` before `Component.tsx`.
+    const extensions = buildViteResolveExtensions(["web.tsx", "tsx", "ts", "jsx", "js"]);
+    expect(extensions[0]).toBe(".web.tsx");
+    expect(extensions.indexOf(".web.tsx")).toBeLessThan(extensions.indexOf(".tsx"));
+  });
+
+  it("includes custom multi-segment extensions like .platform.tsx", () => {
+    // This is what made cloudflare/vinext#1502 surface: a user-configured
+    // multi-segment extension that Vite's defaults can't resolve.
+    const extensions = buildViteResolveExtensions(["platform.tsx", "tsx", "ts", "jsx", "js"]);
+    expect(extensions).toContain(".platform.tsx");
+    expect(extensions[0]).toBe(".platform.tsx");
+  });
+
+  it("includes .mdx when configured", () => {
+    const extensions = buildViteResolveExtensions(["tsx", "ts", "jsx", "js", "mdx"]);
+    expect(extensions).toContain(".mdx");
+  });
+
+  it("dedupes overlapping entries", () => {
+    const extensions = buildViteResolveExtensions(["tsx", "js"]);
+    expect(extensions.filter((e) => e === ".tsx").length).toBe(1);
+    expect(extensions.filter((e) => e === ".js").length).toBe(1);
+  });
+
+  it("strips leading dots and whitespace before normalising", () => {
+    const extensions = buildViteResolveExtensions([".platform.tsx", " tsx ", ""]);
+    expect(extensions[0]).toBe(".platform.tsx");
+    expect(extensions).toContain(".tsx");
+  });
+});
+
+describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () => {
+  it("forwards configured pageExtensions to config.resolve.extensions", async () => {
+    // Ported in spirit from Next.js: test/e2e/app-dir/resolve-extensions/
+    // The deploy suite failure surfaced when pageExtensions/resolveExtensions
+    // were configured beyond Vite's defaults — Vite couldn't resolve
+    // extensionless imports of files like `Component.platform.tsx`.
+    // Regression test for cloudflare/vinext#1502.
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const mainPlugin = plugins.find(
+      // oxlint-disable-next-line typescript/no-explicit-any
+      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-ext-resolve-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+    await fs.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default { pageExtensions: ["platform.tsx", "tsx", "ts", "jsx", "js", "mdx"] };`,
+    );
+
+    try {
+      const mockConfig = {
+        root: tmpDir,
+        build: {},
+        plugins: [],
+      };
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const extensions: string[] = result.resolve?.extensions ?? [];
+      expect(extensions).toContain(".platform.tsx");
+      expect(extensions).toContain(".mdx");
+      expect(extensions).toContain(".tsx");
+      // User priority must win — `.platform.tsx` resolves before `.tsx`
+      // so a bare `./Component` import lands on `Component.platform.tsx`
+      // (mirrors Next.js / Turbopack resolveExtensions semantics).
+      expect(extensions.indexOf(".platform.tsx")).toBeLessThan(extensions.indexOf(".tsx"));
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

Fixes #1502.

When `next.config.{js,ts}` configured `pageExtensions` with values beyond Vite's defaults (for example `["platform.tsx", "tsx", "mdx"]`), extensionless imports of files with those extensions failed to resolve and the build crashed with `Custom deploy script failed: undefined (1)`.

This change mirrors Next.js / Turbopack `resolveExtensions` semantics: the user-configured `pageExtensions` are prepended (each prefixed with `.`) to Vite's default extension list, preserving the user's priority — so `.web.tsx` resolves before `.tsx` and `.platform.tsx` resolves before `.tsx`, matching how Turbopack/webpack pick extension priority in Next.js.

The page scanner already accepted `pageExtensions`; this PR fills in the remaining gap on the Vite resolver side.

Ported from Next.js: [`test/e2e/app-dir/resolve-extensions/`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resolve-extensions/).

## Test plan

- [x] `vp test run tests/page-extensions-resolve.test.ts` (new tests cover the helper and verify the Vite config wiring)
- [x] `vp test run tests/file-matcher.test.ts tests/page-extensions-routing.test.ts tests/build-optimization.test.ts` (no regressions)
- [x] `vp test run tests/next-config.test.ts tests/next-config-extensions.test.ts` (config tests still pass)
- [x] `vp check tests/page-extensions-resolve.test.ts packages/vinext/src/routing/file-matcher.ts packages/vinext/src/index.ts`
- [ ] CI Vitest + Playwright E2E green