### PR TITLE
fix(middleware): shim __filename and __dirname for user proxy/middleware (#1546)

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -317,6 +317,18 @@ function findSourceFiles(
 }
 
 /**
+ * Detect whether a project-root-relative source path is the user
+ * `middleware.*` or `proxy.*` file that vinext's middleware-cjs-globals
+ * plugin shims `__filename` / `__dirname` into. Mirrors the locations
+ * scanned by `findMiddlewareFile` in server/middleware.ts (project root and
+ * `src/`).
+ */
+function isShimmedMiddlewareFile(relPath: string): boolean {
+  const normalized = relPath.split(path.sep).join("/");
+  return /^(?:src\/)?(?:middleware|proxy)\.[cm]?[jt]sx?$/.test(normalized);
+}
+
+/**
  * Scan source files for `import ... from 'next/...'` statements.
  */
 export function scanImports(root: string): CheckItem[] {
@@ -631,6 +643,15 @@ export function checkConventions(root: string): CheckItem[] {
 
     if (viewTransitionRegex.test(content)) {
       viewTransitionFiles.push(rel);
+    }
+
+    // Skip the `middleware.{ts,tsx,js,jsx}` / `proxy.{ts,tsx,js,jsx}` file at
+    // the project root (or under src/) — vinext's middleware-cjs-globals
+    // plugin injects `__filename` / `__dirname` shims for those modules to
+    // match Next.js webpack template behaviour, so a reference there is
+    // benign. See plugins/middleware-cjs-globals.ts. Issue: #1546.
+    if (isShimmedMiddlewareFile(rel)) {
+      continue;
     }
 
     cjsGlobalScanRegex.lastIndex = 0;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -99,6 +99,7 @@ import {
   generateInstrumentationClientInjectModule,
   INSTRUMENTATION_CLIENT_EMPTY_MODULE,
 } from "./client/instrumentation-client-inject.js";
+import { createMiddlewareCjsGlobalsPlugin } from "./plugins/middleware-cjs-globals.js";
 import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
@@ -977,6 +978,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       getCanonicalMiddlewarePath: () =>
         middlewarePath ? (tryRealpathSync(middlewarePath) ?? middlewarePath) : null,
       serverOnlyShimPath: resolveShimModulePath(shimsDir, "server-only"),
+    }),
+    // Inject `__filename` / `__dirname` shims into the user proxy/middleware
+    // module so references to those CommonJS globals do not throw a
+    // `ReferenceError` at runtime. Mirrors what Next.js's webpack template
+    // does for `middleware.ts` / `proxy.ts`. Without this, the upstream
+    // `proxy-nfc-traced` fixture crashes on any request that hits its
+    // `console.log(__filename)` fall-through branch, and vinext returns a
+    // 500 with an empty body. See plugins/middleware-cjs-globals.ts.
+    createMiddlewareCjsGlobalsPlugin({
+      getMiddlewarePath: () => middlewarePath,
     }),
     // Resolve `data:text/css[+module],...` imports into virtual CSS files so
     // Vite's CSS pipeline (LightningCSS, CSS modules) processes them instead

--- a/packages/vinext/src/plugins/middleware-cjs-globals.ts
+++ b/packages/vinext/src/plugins/middleware-cjs-globals.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Plugin } from "vite";
+
+/**
+ * Inject CommonJS-style globals (`__filename`, `__dirname`) into the user's
+ * middleware/proxy module so references to them do not throw a ReferenceError
+ * at runtime.
+ *
+ * Background
+ * ----------
+ * Next.js bundles `middleware.ts` / `proxy.ts` via webpack with the `node`
+ * target plus its own template wrapper, which sets `__filename` and
+ * `__dirname` on the module scope (see packages/next/src/build/templates/
+ * middleware.ts and the standard CJS globals webpack injects for the `node`
+ * target). The upstream `proxy-nfc-traced` fixture relies on this — its
+ * proxy.ts logs `__filename` to coerce the NFT trace to include the file:
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/proxy-nfc-traced/proxy.ts
+ *
+ * vinext bundles the proxy through Rolldown as pure ESM, where `__filename`
+ * and `__dirname` are not defined. Without this plugin, any middleware that
+ * references them throws `ReferenceError: __filename is not defined`, which
+ * vinext catches and turns into a 500 "Internal Server Error" response. In
+ * the upstream `proxy-nfc-traced` deploy test, that empty 500 body surfaces
+ * as `Expected: "hello world" / Received: ""` (the client follows the
+ * `/home → /` redirect into the crashing fall-through branch).
+ *
+ * The same `cjsGlobalsInjectorPlugin` exists for `next.config.ts` in
+ * config/next-config.ts. This plugin mirrors it for user middleware/proxy.
+ *
+ * Issue: https://github.com/cloudflare/vinext/issues/1546
+ */
+
+const CJS_GLOBAL_SCAN_REGEX = /\b(?:__filename|__dirname)\b/;
+
+export function createMiddlewareCjsGlobalsPlugin(options: {
+  getMiddlewarePath: () => string | null;
+}): Plugin {
+  let canonicalTarget: string | null = null;
+  let canonicalFilename: string | null = null;
+  let canonicalDirname: string | null = null;
+
+  function refreshTarget(): void {
+    const middlewarePath = options.getMiddlewarePath();
+    if (!middlewarePath) {
+      canonicalTarget = null;
+      canonicalFilename = null;
+      canonicalDirname = null;
+      return;
+    }
+    // Resolve symlinks once. On macOS, /var/folders resolves to /private/var/
+    // folders, so the temp-dir path used by tests would otherwise mismatch.
+    canonicalTarget = safeRealpath(path.resolve(middlewarePath));
+    canonicalFilename = canonicalTarget;
+    canonicalDirname = path.dirname(canonicalTarget);
+  }
+
+  return {
+    name: "vinext:middleware-cjs-globals",
+    enforce: "pre",
+
+    buildStart() {
+      refreshTarget();
+    },
+
+    transform: {
+      // Filter to skip un-related files cheaply. The transform body still has
+      // the canonical-path check below for correctness.
+      filter: { id: /\.(?:[cm]?[jt]sx?)(?:\?.*)?$/ },
+      handler(code: string, id: string) {
+        if (!canonicalTarget) return null;
+
+        // Fast path: skip the transform when the source contains no bareword
+        // reference to either shimmed global. Most middlewares are pure ESM
+        // and pay no cost from this plugin.
+        if (!CJS_GLOBAL_SCAN_REGEX.test(code)) return null;
+
+        // Vite may pass an id with a query suffix (?v=...) or as a file URL.
+        const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];
+        const resolvedId = safeRealpath(path.resolve(idPath));
+        if (resolvedId !== canonicalTarget) return null;
+
+        // JSON.stringify produces safe JS string literals for paths.
+        const filenameLiteral = JSON.stringify(canonicalFilename);
+        const dirnameLiteral = JSON.stringify(canonicalDirname);
+
+        // Preamble runs after ESM imports are hoisted; the const bindings
+        // shadow any global lookups the source would otherwise perform.
+        const preamble =
+          `const __filename = ${filenameLiteral};\n` + `const __dirname = ${dirnameLiteral};\n`;
+
+        return {
+          code: preamble + code,
+          map: null,
+        };
+      },
+    },
+  };
+}
+
+function safeRealpath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
+}

--- a/tests/proxy-nfc-traced.test.ts
+++ b/tests/proxy-nfc-traced.test.ts
@@ -1,0 +1,246 @@
+/**
+ * proxy-nfc-traced regression test
+ *
+ * Ported from Next.js: test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
+ *
+ * Issue: #1546
+ *
+ * The Next.js fixture's `proxy.ts` has two notable properties:
+ *
+ *   1. The default-exported proxy function redirects `/home` → `/`.
+ *   2. The fall-through code path references `__filename`, a CommonJS global
+ *      that does not exist in ESM. In Next.js the bundler injects a stub for
+ *      `__filename`, so the middleware merely logs a string.
+ *
+ * vinext bundles user middleware as ESM. Before this fix, an unguarded
+ * reference to `__filename` would throw `ReferenceError: __filename is not
+ * defined` on every request that did NOT match the redirect branch — including
+ * the `/` request after the `/home` redirect was followed by the client. Fetch
+ * then surfaced an empty 500 body to the test, matching the deploy-suite
+ * symptom `Expected: "hello world" / Received: ""`.
+ *
+ * The fix shims `__filename` and `__dirname` for the user proxy/middleware
+ * module the same way Next.js's bundler does so the user code can reference
+ * them harmlessly.
+ *
+ * Note: vitest itself defines `__filename` on the module scope, which masks
+ * the production-runtime failure (the dist bundle is loaded via `node`, where
+ * ESM modules genuinely have no `__filename`). The structural assertion on
+ * the bundled output below is the actual regression guard — the HTTP test
+ * exercises the happy path end-to-end.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createBuilder } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+
+/**
+ * Build a minimal fixture in a tmp dir that mirrors the Next.js
+ * proxy-nfc-traced fixture layout exactly:
+ *   /app/layout.tsx
+ *   /app/page.tsx      → renders <p>hello world</p>
+ *   /proxy.ts          → default-exports a function that redirects /home → /
+ *                        and references `__filename`
+ *
+ * Uses a workspace node_modules symlink so vinext, react, etc. resolve.
+ */
+function buildMinimalProxyFixture(prefix: string): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const appDir = path.join(tmpDir, "app");
+  fs.mkdirSync(appDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(appDir, "layout.tsx"),
+    `import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+`,
+  );
+
+  fs.writeFileSync(
+    path.join(appDir, "page.tsx"),
+    `export default function Page() {
+  return <p>hello world</p>
+}
+`,
+  );
+
+  fs.writeFileSync(
+    path.join(tmpDir, "proxy.ts"),
+    `import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export default function proxy(request: NextRequest) {
+  if (request.nextUrl.pathname === '/home') {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  // \`__filename\` included in the bundle makes the NFT to trace it.
+  // This will result creating "proxy.js" to be traced into the NFT file.
+  // However, as Next.js renames "proxy.js" to "middleware.js" during build,
+  // the files in NFT will differ from the actual outputs, which will fail for
+  // the providers like Vercel that checks for the files in NFT.
+  console.log(__filename)
+  // \`__dirname\` is also commonly referenced by middleware that reads files
+  // relative to its own location — the shim must cover it too. Reference it
+  // so Rolldown does not tree-shake the binding out of the bundle.
+  console.log(__dirname)
+
+  return NextResponse.next()
+}
+`,
+  );
+
+  fs.writeFileSync(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "proxy-nfc-traced-fixture",
+        private: true,
+        type: "module",
+        dependencies: {
+          react: "*",
+          "react-dom": "*",
+          vinext: "*",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  fs.writeFileSync(
+    path.join(tmpDir, "next.config.ts"),
+    `import type { NextConfig } from "vinext";
+const nextConfig: NextConfig = {};
+export default nextConfig;
+`,
+  );
+
+  // Symlink node_modules from workspace root so vinext, react, etc. resolve.
+  const workspaceNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  fs.symlinkSync(workspaceNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+  return tmpDir;
+}
+
+describe("proxy-nfc-traced (#1546)", () => {
+  let tmpDir: string;
+  let outDir: string;
+  let bundleSource: string;
+  let server: import("node:http").Server | undefined;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    tmpDir = buildMinimalProxyFixture("vinext-proxy-nfc-min-");
+    outDir = path.join(tmpDir, "dist");
+    fs.rmSync(outDir, { recursive: true, force: true });
+
+    const builder = await createBuilder({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      logLevel: "silent",
+    });
+    await builder.buildApp();
+
+    // Mirror the deploy suite: prerender after build so the prod server has
+    // cached HTML to seed. The HTTP test below uses the seeded cache.
+    const { runPrerender } = await import("../packages/vinext/src/build/run-prerender.js");
+    await runPrerender({ root: tmpDir });
+
+    bundleSource = fs.readFileSync(path.join(outDir, "server", "index.js"), "utf-8");
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    ({ server } = await startProdServer({ port: 0, outDir, noCompression: false }));
+    const addr = server!.address();
+    const port = typeof addr === "object" && addr ? addr.port : 4210;
+    baseUrl = `http://localhost:${port}`;
+  }, 120000);
+
+  afterAll(() => {
+    server?.close();
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Structural regression guards ──────────────────────────────────────────
+  //
+  // These check the BUNDLED output. They catch the bug even though vitest's
+  // own runtime defines `__filename` on the test module's scope, masking the
+  // production-Node failure mode.
+
+  it("the bundled proxy module declares its own __filename binding", () => {
+    // The build-time plugin in vinext/plugins/middleware-cjs-globals.ts must
+    // inject a `__filename` const into the user proxy/middleware source. The
+    // generated bundle preserves Rolldown's region marker, so we anchor on
+    // that to scope the assertion to the user proxy module specifically.
+    const region = extractProxyRegion(bundleSource);
+    expect(region).toMatch(/(?:var|const|let)\s+__filename\s*=\s*"/);
+  });
+
+  it("the bundled proxy module declares its own __dirname binding", () => {
+    const region = extractProxyRegion(bundleSource);
+    expect(region).toMatch(/(?:var|const|let)\s+__dirname\s*=\s*"/);
+  });
+
+  it("the bundled proxy module still references __filename in proxy()", () => {
+    // Sanity check: the original `console.log(__filename)` must still be in
+    // the bundle. If a future change accidentally elides the reference, the
+    // structural guards above would also be vacuously satisfied.
+    const region = extractProxyRegion(bundleSource);
+    expect(region).toContain("console.log(__filename)");
+  });
+
+  // ── End-to-end checks ─────────────────────────────────────────────────────
+
+  it("renders 'hello world' after the proxy redirects /home to /", async () => {
+    // Mirrors `next.render$('/home')` from the Next.js test — default fetch
+    // follows the middleware redirect, lands on `/`, and parses the body.
+    const res = await fetch(`${baseUrl}/home`);
+    const html = await res.text();
+    expect(res.status).toBe(200);
+    expect(res.url.endsWith("/")).toBe(true);
+    expect(html).toContain("hello world");
+  });
+
+  it("redirects /home → / with status 307", async () => {
+    const res = await fetch(`${baseUrl}/home`, { redirect: "manual" });
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/");
+  });
+
+  it("renders the page on a non-redirect path that references __filename", async () => {
+    const res = await fetch(`${baseUrl}/`);
+    const html = await res.text();
+    expect(res.status).toBe(200);
+    expect(html).toContain("hello world");
+  });
+});
+
+/**
+ * Extract the bundled region for the user proxy module from
+ * `dist/server/index.js`. Rolldown emits `//#region <abs path>/proxy.ts`
+ * comments around each input module, so we slice between the matching
+ * region/endregion markers.
+ */
+function extractProxyRegion(bundle: string): string {
+  const start = bundle.search(/\/\/#region\s.*\bproxy\.ts$/m);
+  if (start === -1) {
+    throw new Error("Could not find proxy.ts region marker in bundled output");
+  }
+  const remainder = bundle.slice(start);
+  const endRelative = remainder.indexOf("//#endregion");
+  if (endRelative === -1) {
+    throw new Error("Could not find matching endregion for proxy.ts");
+  }
+  return remainder.slice(0, endRelative);
+}


### PR DESCRIPTION
## Summary

- User `proxy.ts` / `middleware.ts` files that reference `__filename` or `__dirname` threw `ReferenceError` at runtime because vinext bundles them as ESM. The middleware runtime caught the error and returned a 500, which the upstream `proxy-nfc-traced` deploy test sees as an empty body when following the `/home → /` redirect into the crashing branch.
- Add a Vite plugin (`createMiddlewareCjsGlobalsPlugin`) that injects `const __filename` / `const __dirname` at the top of the resolved middleware/proxy module's source, matching Next.js's webpack template behaviour. This is the same pattern already used by `cjsGlobalsInjectorPlugin` for `next.config.ts`.
- Skip the corresponding `vinext check` warning for the shimmed middleware/proxy file.

Fixes #1546.

## Test plan

- [x] New `tests/proxy-nfc-traced.test.ts` builds a minimal app + `proxy.ts` fixture, then asserts both that the bundled output contains the injected `__filename` / `__dirname` const declarations (the structural guard — vitest itself provides `__filename`, masking the production failure) and that the HTTP responses for `/home` (with redirect follow) and `/` render `hello world`.
- [x] `pnpm test tests/proxy-nfc-traced.test.ts` — 6/6 pass
- [x] `pnpm test tests/app-router.test.ts` — 331/331 pass
- [x] `pnpm test tests/prerender.test.ts` — 77/77 pass
- [x] `pnpm test tests/pages-router.test.ts` — 252/252 pass
- [x] `pnpm test tests/middleware-runtime.test.ts tests/middleware-runtime-trailing-slash.test.ts tests/middleware-server-only.test.ts tests/shims.test.ts` — 1016/1016 pass
- [x] `pnpm test tests/check.test.ts` — 99/99 pass
- [x] `pnpm run check` — clean (format + lint + types)
- [x] Manual: `vinext build --prerender-all && vinext start` against the upstream fixture now serves `<p>hello world</p>` for `GET /home` (previously returned `Internal Server Error`)