### PR TITLE
fix(app-router): emit streamed not-found/redirect meta tags in Next.js byte-exact format (#1491)

### DIFF
--- a/packages/vinext/src/server/app-ssr-error-meta.ts
+++ b/packages/vinext/src/server/app-ssr-error-meta.ts
@@ -44,9 +44,14 @@ function renderSsrErrorMetaTag(error: unknown, options: SsrErrorMetaRenderOption
 
   const httpError = parseNextHttpErrorDigest(digest);
   if (httpError) {
-    let html = '<meta name="robots" content="noindex" />';
+    // Output format matches Next.js's `make-get-server-inserted-html.tsx`,
+    // which serializes these meta tags via React's HTML renderer. React's
+    // void-element output uses no space before `/>`, and Next.js tests assert
+    // on that exact substring (e.g. `'<meta name="robots" content="noindex"/>'`).
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+    let html = '<meta name="robots" content="noindex"/>';
     if ((options.nodeEnv ?? process.env.NODE_ENV) === "development") {
-      html += '<meta name="next-error" content="not-found" />';
+      html += '<meta name="next-error" content="not-found"/>';
     }
     return html;
   }
@@ -61,7 +66,7 @@ function renderSsrErrorMetaTag(error: unknown, options: SsrErrorMetaRenderOption
     delay +
     ";url=" +
     escapeHtmlAttr(location) +
-    '" />'
+    '"/>'
   );
 }
 

--- a/tests/app-ssr-error-meta.test.ts
+++ b/tests/app-ssr-error-meta.test.ts
@@ -11,11 +11,11 @@ function digestError(digest: string): Error & { digest: string } {
 describe("App SSR error meta tags", () => {
   it("renders noindex meta tags for streamed notFound and HTTP access fallback errors", () => {
     expect(renderSsrErrorMetaTags([digestError("NEXT_NOT_FOUND")])).toBe(
-      '<meta name="robots" content="noindex" />',
+      '<meta name="robots" content="noindex"/>',
     );
 
     expect(renderSsrErrorMetaTags([digestError("NEXT_HTTP_ERROR_FALLBACK;403")])).toBe(
-      '<meta name="robots" content="noindex" />',
+      '<meta name="robots" content="noindex"/>',
     );
   });
 
@@ -23,17 +23,17 @@ describe("App SSR error meta tags", () => {
     expect(
       renderSsrErrorMetaTags([digestError("NEXT_NOT_FOUND")], { nodeEnv: "development" }),
     ).toBe(
-      '<meta name="robots" content="noindex" />' + '<meta name="next-error" content="not-found" />',
+      '<meta name="robots" content="noindex"/>' + '<meta name="next-error" content="not-found"/>',
     );
   });
 
   it("renders refresh meta tags for streamed temporary and permanent redirects", () => {
     expect(renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/target;307")])).toBe(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target"/>',
     );
 
     expect(renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/target;308")])).toBe(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="0;url=/target" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="0;url=/target"/>',
     );
   });
 
@@ -43,7 +43,7 @@ describe("App SSR error meta tags", () => {
         basePath: "/docs",
       }),
     ).toBe(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs/target?ok=1#done" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs/target?ok=1#done"/>',
     );
 
     expect(
@@ -51,7 +51,7 @@ describe("App SSR error meta tags", () => {
         basePath: "/docs",
       }),
     ).toBe(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=https://example.com" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=https://example.com"/>',
     );
 
     expect(
@@ -59,14 +59,14 @@ describe("App SSR error meta tags", () => {
         basePath: "/docs",
       }),
     ).toBe(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs?from=checkout" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs?from=checkout"/>',
     );
 
     expect(
       renderSsrErrorMetaTags([digestError("NEXT_REDIRECT;replace;/docs%23top;307")], {
         basePath: "/docs",
       }),
-    ).toBe('<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs#top" />');
+    ).toBe('<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/docs#top"/>');
   });
 
   it("escapes redirect meta URLs before inserting them into HTML", () => {
@@ -75,7 +75,7 @@ describe("App SSR error meta tags", () => {
         digestError("NEXT_REDIRECT;replace;/target%3Fnext%3D%26%22%3Cscript%3E;307"),
       ]),
     ).toBe(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target?next=&amp;&quot;&lt;script&gt;" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target?next=&amp;&quot;&lt;script&gt;"/>',
     );
   });
 
@@ -83,12 +83,12 @@ describe("App SSR error meta tags", () => {
     const renderer = createSsrErrorMetaRenderer({ nodeEnv: "production" });
 
     renderer.capture(digestError("NEXT_NOT_FOUND"));
-    expect(renderer.flush()).toBe('<meta name="robots" content="noindex" />');
+    expect(renderer.flush()).toBe('<meta name="robots" content="noindex"/>');
     expect(renderer.flush()).toBe("");
 
     renderer.capture(digestError("NEXT_REDIRECT;replace;/target;307"));
     expect(renderer.flush()).toBe(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/target"/>',
     );
     expect(renderer.flush()).toBe("");
   });

--- a/tests/nextjs-compat/navigation.test.ts
+++ b/tests/nextjs-compat/navigation.test.ts
@@ -83,6 +83,32 @@ describe("Next.js compat: navigation", () => {
     expect(html).toMatch(NOINDEX_META_TAG_RE);
   });
 
+  // ── Streaming meta tags for not-found / redirect ─────────────
+  // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts#L732-L772
+  //
+  // When notFound() or redirect() is called from inside a Suspense
+  // boundary, the error surfaces AFTER the shell has already started
+  // streaming. The response can no longer return a 4xx/3xx status, so
+  // Next.js communicates the not-found / redirect intent via inline
+  // <meta> tags injected into the HTML stream. The exact substring is
+  // asserted in Next.js tests, so vinext must use the same format
+  // (React's void-element serialization — no space before `/>`).
+  //
+  // Source: packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+
+  it("notFound() in Suspense streams noindex robots meta tag (exact substring)", async () => {
+    const { html } = await fetchHtml(baseUrl, "/suspense-notfound-test");
+    expect(html).toContain('<meta name="robots" content="noindex"/>');
+  });
+
+  it("redirect() in Suspense streams refresh meta tag (exact substring)", async () => {
+    const { html } = await fetchHtml(baseUrl, "/suspense-redirect-test");
+    expect(html).toContain(
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/about"/>',
+    );
+  });
+
   // ── Browser-only tests (documented, not ported) ──────────────
   //
   // The following tests ALL require Playwright and are N/A for HTTP-level testing:
@@ -140,7 +166,4 @@ describe("Next.js compat: navigation", () => {
   //
   // N/A: Metadata await promise during navigation
   //   Tests async metadata loading during client nav
-  //
-  // N/A: Redirect refresh meta tag
-  //   Tests HTML meta refresh tag — would need streaming-specific fixture
 });

--- a/tests/rsc-streaming.test.ts
+++ b/tests/rsc-streaming.test.ts
@@ -451,7 +451,7 @@ describe("Tick-buffered RSC streaming (behavioral)", () => {
 
     const shellPos = output.indexOf("<main>shell</main>");
     const redirectMetaPos = output.indexOf(
-      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/redirect/result" />',
+      '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/redirect/result"/>',
     );
     const boundaryPos = output.indexOf("<template>resolved boundary</template>");
 


### PR DESCRIPTION
## Summary

- When `notFound()` or `redirect()` is called from inside a Suspense boundary the error fires after the shell has streamed; the not-found / redirect intent is communicated via inline `<meta>` tags injected into `<head>` (`<meta name="robots" content="noindex"/>`, `<meta id="__next-page-redirect" http-equiv="refresh" content="...">`).
- vinext was emitting these as `<meta ... content="..." />` (a space before `/>`), but Next.js serializes them via React's HTML renderer which produces `<meta ... content="..."/>` (no space). The Next.js navigation deploy suite asserts on that exact substring, so the mismatch caused ~5 failures.
- Drop the extra space in `app-ssr-error-meta.ts` and update the focused unit tests / stream-injection test to match. Added two ported regression tests (`tests/nextjs-compat/navigation.test.ts`) that assert the exact streamed substrings against the existing `suspense-notfound-test` / `suspense-redirect-test` fixtures.

Closes #1491

## Test plan

- [x] `pnpm test tests/app-ssr-error-meta.test.ts` — unit tests for the renderer
- [x] `pnpm test tests/rsc-streaming.test.ts` — covers the streaming injection ordering test
- [x] `pnpm test tests/nextjs-compat/navigation.test.ts` — new exact-substring suspense assertions
- [x] `pnpm test tests/nextjs-compat/not-found.test.ts tests/nextjs-compat/metadata.test.ts tests/app-page-boundary-render.test.ts` — adjacent paths unaffected
- [x] `pnpm run check` — format + lint + types green

## References

- Next.js source: `packages/next/src/server/app-render/make-get-server-inserted-html.tsx`
- Next.js tests: `test/e2e/app-dir/navigation/navigation.test.ts` (SEO describe block, lines 732-772)