### PR TITLE
fix(pages-router): mark app routes as detected on prefetch (#1526)

### DIFF
--- a/packages/vinext/src/client/window-next.ts
+++ b/packages/vinext/src/client/window-next.ts
@@ -85,6 +85,13 @@ export type PagesRouterPublicInstance = {
     off: (event: string, handler: (...args: unknown[]) => void) => void;
     emit: (event: string, ...args: unknown[]) => void;
   };
+  /**
+   * Mirrors Next.js's `Router.components`. Read by external tooling (and the
+   * Next.js deploy test suite) to detect routes that have been seen via
+   * prefetch — App Router targets land here as `{ __appRouter: true }`.
+   * See: `packages/next/src/shared/lib/router/router.ts:2525`.
+   */
+  components: Record<string, unknown>;
 };
 
 // Declare the `next` property on Window here, alongside the type, so this

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -17,12 +17,8 @@ export function generateBrowserEntry(
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
   const prefetchRoutes: VinextLinkPrefetchRoute[] = routes
-    .filter((route) => isLinkPrefetchRoute(route))
-    .map((route) => ({
-      canPrefetchLoadingShell: route.loadingPath !== null,
-      patternParts: [...route.patternParts],
-      isDynamic: route.isDynamic,
-    }));
+    .filter(isLinkPrefetchRoute)
+    .map(toLinkPrefetchRoute);
 
   return `import { registerNavigationRuntimeBootstrap } from ${JSON.stringify(navigationRuntimePath)};
 
@@ -33,9 +29,24 @@ registerNavigationRuntimeBootstrap({
 import ${JSON.stringify(entryPath)};`;
 }
 
-function isLinkPrefetchRoute(route: AppRoute): boolean {
+/**
+ * Filter for routes that should appear in the `__VINEXT_LINK_PREFETCH_ROUTES__`
+ * manifest. Exported so the Pages Router client entry can reuse it when
+ * emitting the same manifest for hybrid builds — see issue #1526 and
+ * `pages-client-entry.ts`.
+ */
+export function isLinkPrefetchRoute(route: AppRoute): boolean {
   if (route.pagePath !== null) return true;
   return route.routePath === null && route.layouts.length > 0;
+}
+
+/** Project an `AppRoute` down to the public `VinextLinkPrefetchRoute` shape. */
+export function toLinkPrefetchRoute(route: AppRoute): VinextLinkPrefetchRoute {
+  return {
+    canPrefetchLoadingShell: route.loadingPath !== null,
+    patternParts: [...route.patternParts],
+    isDynamic: route.isDynamic,
+  };
 }
 
 function buildRouteManifestExpression(routeManifest: RouteManifest | null): string {

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -16,6 +16,7 @@ import {
 } from "../routing/pages-router.js";
 import { createValidFileMatcher } from "../routing/file-matcher.js";
 import { type ResolvedNextConfig } from "../config/next-config.js";
+import type { VinextLinkPrefetchRoute } from "../client/vinext-next-data.js";
 import { findFileWithExts } from "./pages-entry-helpers.js";
 import { normalizePathSeparators } from "./runtime-entry-module.js";
 
@@ -23,11 +24,13 @@ export async function generateClientEntry(
   pagesDir: string,
   nextConfig: ResolvedNextConfig,
   fileMatcher: ReturnType<typeof createValidFileMatcher>,
+  options: { appPrefetchRoutes?: readonly VinextLinkPrefetchRoute[] } = {},
 ): Promise<string> {
   const pageRoutes = await pagesRouter(pagesDir, nextConfig?.pageExtensions, fileMatcher);
 
   const appFilePath = findFileWithExts(pagesDir, "_app", fileMatcher);
   const hasApp = appFilePath !== null;
+  const appPrefetchRoutes = options.appPrefetchRoutes ?? [];
 
   // Build a map of route pattern -> dynamic import.
   // Keys must use Next.js bracket format (e.g. "/user/[id]") to match
@@ -90,6 +93,21 @@ const appLoader = undefined;
 window.__VINEXT_PAGE_LOADERS__ = pageLoaders;
 window.__VINEXT_PAGE_PATTERNS__ = Object.keys(pageLoaders);
 window.__VINEXT_APP_LOADER__ = appLoader;
+// Expose the App Router prefetch manifest so Pages Router \`<Link>\`s and
+// \`Router.prefetch\` can detect when a prefetch target is actually an App
+// Router route, and mark it on \`Router.components[urlPathname]\` with
+// \`{ __appRouter: true }\`. Mirrors Next.js's \`_bfl\`-driven marker write at
+// .nextjs-ref/packages/next/src/shared/lib/router/router.ts:2525, which the
+// Next.js deploy test
+//   test/e2e/app-dir/app/index.test.ts → "should successfully detect app
+//   route during prefetch"
+// asserts via \`window.next.router.components[<path>]\`. Issue #1526.
+//
+// In a hybrid Pages + App Router build, this entry runs when the user lands
+// on a Pages Router page. The App Router browser entry sets the same global
+// when the user lands on an App Router page (see app-browser-entry.ts) — the
+// two writes do not race because only one entry executes per page load.
+window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(appPrefetchRoutes)};
 
 async function hydrate() {
   const nextData = window.__NEXT_DATA__;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -20,7 +20,11 @@ import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
 import { generateRscEntry } from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
-import { generateBrowserEntry } from "./entries/app-browser-entry.js";
+import {
+  generateBrowserEntry,
+  isLinkPrefetchRoute,
+  toLinkPrefetchRoute,
+} from "./entries/app-browser-entry.js";
 import {
   collectRouteClassificationManifest,
   type RouteClassificationManifest,
@@ -719,7 +723,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
    * __NEXT_DATA__ to determine which page to hydrate.
    */
   async function generateClientEntry(): Promise<string> {
-    return _generateClientEntry(pagesDir, nextConfig, fileMatcher);
+    // In a hybrid Pages + App Router build, expose the App Router prefetch
+    // manifest to the Pages Router client entry so `<Link>`s and
+    // `Router.prefetch` can mark App Router targets on `Router.components`
+    // with `{ __appRouter: true }`. See `pages-client-entry.ts` and issue
+    // #1526 for the Next.js parity rationale.
+    const appPrefetchRoutes = hasAppDir
+      ? (await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher))
+          .filter(isLinkPrefetchRoute)
+          .map(toLinkPrefetchRoute)
+      : [];
+    return _generateClientEntry(pagesDir, nextConfig, fileMatcher, { appPrefetchRoutes });
   }
 
   async function writeRouteTypes(): Promise<void> {

--- a/packages/vinext/src/shims/internal/app-route-detection.ts
+++ b/packages/vinext/src/shims/internal/app-route-detection.ts
@@ -54,10 +54,7 @@ declare global {
  * Vinext only writes the marker variant; reads are by test code that checks
  * for `__appRouter: true`.
  */
-export type PagesRouterComponentsMap = Record<
-  string,
-  { __appRouter: true } | Record<string, unknown>
->;
+type PagesRouterComponentsMap = Record<string, { __appRouter: true } | Record<string, unknown>>;
 
 const _COMPONENTS_KEY = Symbol.for("vinext.pagesRouter.components");
 type _GlobalWithComponents = typeof globalThis & {
@@ -102,7 +99,7 @@ function resolveSameOriginPathname(href: string, basePath: string): string | nul
  * prefetch manifest (static or dynamic). Returns false when the manifest is
  * absent (Pages-Router-only build), the URL is external, or no route matches.
  */
-export function matchesAppRoute(href: string, basePath: string): boolean {
+function matchesAppRoute(href: string, basePath: string): boolean {
   if (typeof window === "undefined") return false;
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes || routes.length === 0) return false;

--- a/packages/vinext/src/shims/internal/app-route-detection.ts
+++ b/packages/vinext/src/shims/internal/app-route-detection.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared helper for marking an App Router route as "detected" on the Pages
+ * Router singleton when a `<Link>` or `Router.prefetch` targets it.
+ *
+ * Ported from Next.js: `packages/next/src/shared/lib/router/router.ts:2525`
+ *
+ *     if (await this._bfl(asPath, resolvedAs, options.locale, true)) {
+ *       this.components[urlPathname] = { __appRouter: true } as any
+ *     }
+ *
+ * Next.js uses a bloom filter (`_bfl`) of App Router routes that the Pages
+ * Router cannot handle. When the prefetch target matches the filter, the
+ * Pages Router records the route on `this.components` with
+ * `{ __appRouter: true }`. The Next.js deploy test
+ *   test/e2e/app-dir/app/index.test.ts → "should successfully detect app
+ *   route during prefetch"
+ * reads this through `window.next.router.components["/dashboard"]`.
+ *
+ * Vinext does not need a bloom filter — the App Router prefetch route
+ * manifest (`__VINEXT_LINK_PREFETCH_ROUTES__`) already lives on the client
+ * for Link's App Router auto-prefetch decisions. This helper reuses that
+ * manifest and the shared trie matcher to decide whether a prefetch target
+ * is an App Router route.
+ *
+ * Lives in `shims/internal/` so both the Pages Router (`router.ts`) and the
+ * Link shim's Pages-mode branch (`link.tsx`) can call it without pulling in
+ * the other shim at module init.
+ *
+ * The components map is stored behind a `Symbol.for` global so the Pages
+ * Router (`router.ts`) and the Link shim (`link.tsx`) both write through the
+ * same instance even when Vite loads the router shim through a different
+ * resolved module ID than the link shim (mirrors the same module-split
+ * mitigation used by `navigation.ts`'s GLOBAL_ACCESSORS_KEY).
+ *
+ * Issue: https://github.com/cloudflare/vinext/issues/1526
+ */
+import type { VinextLinkPrefetchRoute } from "../../client/vinext-next-data.js";
+import { createRouteTrieCache, matchRouteWithTrie } from "../../routing/route-matching.js";
+import { stripBasePath } from "../../utils/base-path.js";
+
+const appRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
+
+declare global {
+  // oxlint-disable-next-line typescript-eslint/consistent-type-definitions
+  interface Window {
+    __VINEXT_LINK_PREFETCH_ROUTES__?: VinextLinkPrefetchRoute[];
+  }
+}
+
+/**
+ * Pages Router `components` map shape. Next.js types this loosely (route
+ * pattern → `PrivateRouteInfo`), but for the App Router-detected case it
+ * stores `{ __appRouter: true }` as a marker (see Next.js source link above).
+ * Vinext only writes the marker variant; reads are by test code that checks
+ * for `__appRouter: true`.
+ */
+export type PagesRouterComponentsMap = Record<
+  string,
+  { __appRouter: true } | Record<string, unknown>
+>;
+
+const _COMPONENTS_KEY = Symbol.for("vinext.pagesRouter.components");
+type _GlobalWithComponents = typeof globalThis & {
+  [_COMPONENTS_KEY]?: PagesRouterComponentsMap;
+};
+
+/**
+ * Get-or-create the Pages Router `components` map. Returns the same object
+ * on every call so `router.components` and `window.next.router.components`
+ * have referential identity.
+ */
+export function getPagesRouterComponentsMap(): PagesRouterComponentsMap {
+  const globalState = globalThis as _GlobalWithComponents;
+  let components = globalState[_COMPONENTS_KEY];
+  if (!components) {
+    components = {};
+    globalState[_COMPONENTS_KEY] = components;
+  }
+  return components;
+}
+
+/**
+ * Resolve a prefetch href to a same-origin pathname (basePath-stripped),
+ * suitable as the key used by Next.js for `router.components[urlPathname]`.
+ *
+ * Returns null for external URLs, malformed URLs, or non-browser contexts.
+ */
+function resolveSameOriginPathname(href: string, basePath: string): string | null {
+  if (typeof window === "undefined") return null;
+  let url: URL;
+  try {
+    url = new URL(href, window.location.href);
+  } catch {
+    return null;
+  }
+  if (url.origin !== window.location.origin) return null;
+  return stripBasePath(url.pathname, basePath);
+}
+
+/**
+ * Returns true when the prefetch href matches any route in the App Router
+ * prefetch manifest (static or dynamic). Returns false when the manifest is
+ * absent (Pages-Router-only build), the URL is external, or no route matches.
+ */
+export function matchesAppRoute(href: string, basePath: string): boolean {
+  if (typeof window === "undefined") return false;
+  const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
+  if (!routes || routes.length === 0) return false;
+
+  const pathname = resolveSameOriginPathname(href, basePath);
+  if (pathname === null) return false;
+
+  return matchRouteWithTrie(pathname, routes, appRouteTrieCache) !== null;
+}
+
+/**
+ * Record `components[pathname] = { __appRouter: true }` on the shared
+ * Pages Router map when the href matches an App Router route. No-op when the
+ * manifest is absent, the URL is external, or no app route matches.
+ *
+ * `pathname` is the basePath-stripped path — matching Next.js's
+ * `router.components[urlPathname]` key (see the source link in this file's
+ * leading comment).
+ */
+export function markAppRouteDetectedOnPrefetch(href: string, basePath: string): void {
+  if (typeof window === "undefined") return;
+  if (!matchesAppRoute(href, basePath)) return;
+
+  const pathname = resolveSameOriginPathname(href, basePath);
+  if (pathname === null) return;
+
+  getPagesRouterComponentsMap()[pathname] = { __appRouter: true };
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -69,6 +69,7 @@ import {
   prefetchPagesData,
   resolvePagesDataNavigationTarget,
 } from "./internal/pages-data-target.js";
+import { markAppRouteDetectedOnPrefetch } from "./internal/app-route-detection.js";
 import { getCurrentBrowserLocale } from "./client-locale.js";
 
 type NavigateEvent = {
@@ -400,6 +401,14 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         if (dataTarget) {
           prefetchPagesData(dataTarget);
         } else {
+          // The target is not a Pages Router route — mark it on the Pages
+          // Router `components` map if it matches an App Router route in the
+          // shared prefetch manifest. Mirrors Next.js's `_bfl` marker write at
+          // `packages/next/src/shared/lib/router/router.ts:2525`; the Next.js
+          // deploy test reads `window.next.router.components[<path>]` to
+          // assert prefetch detection. See issue #1526.
+          markAppRouteDetectedOnPrefetch(fullHref, __basePath);
+
           // Legacy fallback: hint the browser to preload the HTML document.
           // Used in dev (no loader map populated) and for routes not in the
           // client loader map.

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -29,6 +29,10 @@ import {
   type PagesDataTarget,
 } from "./internal/pages-data-target.js";
 import { buildPagesDataHref } from "./internal/pages-data-url.js";
+import {
+  getPagesRouterComponentsMap,
+  markAppRouteDetectedOnPrefetch,
+} from "./internal/app-route-detection.js";
 import { installWindowNext, type PagesRouterPublicInstance } from "../client/window-next.js";
 import { isUnknownRecord } from "../utils/record.js";
 import {
@@ -1475,6 +1479,13 @@ async function prefetchUrl(url: string): Promise<void> {
     return;
   }
 
+  // The target is not a Pages Router route — mark it on `components` if the
+  // App Router prefetch manifest recognises it. Mirrors Next.js's `_bfl`
+  // marker write at `packages/next/src/shared/lib/router/router.ts:2525`;
+  // the Next.js deploy test reads `window.next.router.components[<path>]` to
+  // assert prefetch detection. See issue #1526.
+  markAppRouteDetectedOnPrefetch(url, __basePath);
+
   // Legacy fallback for routes without a registered loader (e.g. dev).
   // Hints the browser to preload the HTML document so the next click feels
   // faster, even though we can't resolve the chunk ahead of time.
@@ -1711,7 +1722,29 @@ export function withRouter<P extends WithRouterProps>(
 // error rather than a `ReferenceError: window is not defined`. The throws are
 // synchronous (not via the returned Promise) so render-time callers see the
 // error inline — matching Next.js behaviour and avoiding unhandled rejections.
+/**
+ * Pages Router `components` map exposed on the singleton.
+ *
+ * In Next.js, `Router.components` doubles as (a) the cached `PrivateRouteInfo`
+ * keyed by route pattern after a real page render, and (b) a marker store
+ * (`{ __appRouter: true }`) for App Router routes detected via prefetch (see
+ * `packages/next/src/shared/lib/router/router.ts:2525`). The Next.js deploy
+ * test suite asserts the latter through `window.next.router.components`.
+ *
+ * vinext only writes the marker variant — the cached-page-info side is handled
+ * by Vite's module graph + our own loader manifest — but the property must be
+ * present and mutable so the deploy assertion can find it. The map lives
+ * behind a `Symbol.for` global so the Link shim's Pages-mode prefetch branch
+ * writes to the same instance even when Vite resolves the router shim and
+ * the link shim through different module IDs.
+ *
+ * Issue: https://github.com/cloudflare/vinext/issues/1526
+ */
+const _components = getPagesRouterComponentsMap();
+
 const RouterMethods = {
+  /** See `_components` comment above for the dual role this map plays. */
+  components: _components,
   push: (url: string | UrlObject, as?: string, options?: TransitionOptions) => {
     if (typeof window === "undefined") throwNoRouterInstance();
     // Synchronously guard dangerous URI schemes (javascript:, data:, vbscript:)

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Pages Router → App Router prefetch detection.
+ *
+ * Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+ *   it('should successfully detect app route during prefetch', ...)
+ *
+ * In a hybrid Pages Router + App Router app, when the Pages Router prefetches
+ * a `<Link href="/path">` whose target is actually an App Router route, Next.js
+ * marks the route on the Pages Router singleton with
+ * `router.components[urlPathname] = { __appRouter: true }` so the subsequent
+ * navigation handoff to the App Router can be detected.
+ *
+ * See: .nextjs-ref/packages/next/src/shared/lib/router/router.ts:2525 — when
+ * the bloom-filter `_bfl` check matches (i.e., the target is an app route),
+ * Next.js records the route on `this.components` with `__appRouter: true`.
+ *
+ * Vinext does not use a bloom filter; the App Router prefetch route manifest
+ * (`__VINEXT_LINK_PREFETCH_ROUTES__`) is available on the client and the same
+ * pattern matcher used by Link's App Router auto-prefetch decides if the
+ * target is an app route. This file pins that signal.
+ *
+ * Issue: https://github.com/cloudflare/vinext/issues/1526
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+afterEach(() => {
+  vi.resetModules();
+  delete (globalThis as { window?: unknown }).window;
+  delete (globalThis as { document?: unknown }).document;
+});
+
+function installFakeBrowserGlobals(
+  prefetchRoutes: Array<{
+    canPrefetchLoadingShell: boolean;
+    patternParts: string[];
+    isDynamic: boolean;
+  }>,
+): void {
+  // Minimal fake window/document so importing shims/router.ts (which touches
+  // window at module load to attach popstate) does not crash.
+  (globalThis as { window?: unknown }).window = {
+    location: {
+      pathname: "/",
+      search: "",
+      hash: "",
+      href: "http://localhost/",
+      origin: "http://localhost",
+    },
+    history: { state: null, pushState() {}, replaceState() {} },
+    addEventListener() {},
+    dispatchEvent() {},
+    __VINEXT_LINK_PREFETCH_ROUTES__: prefetchRoutes,
+  };
+  (globalThis as { document?: unknown }).document = {
+    addEventListener() {},
+    createElement: () => ({
+      setAttribute() {},
+      set rel(_: string) {},
+      set href(_: string) {},
+      set as(_: string) {},
+      set crossOrigin(_: string) {},
+    }),
+    head: { appendChild() {} },
+  };
+}
+
+describe("Pages Router records app routes as detected on prefetch", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("exposes a `components` object on the Pages Router singleton", async () => {
+    installFakeBrowserGlobals([]);
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+    expect(Router.components).toBeDefined();
+    expect(typeof Router.components).toBe("object");
+  });
+
+  it("marks a prefetched App Router target as { __appRouter: true } on components", async () => {
+    installFakeBrowserGlobals([
+      // /dashboard is a static App Router route
+      { canPrefetchLoadingShell: false, patternParts: ["dashboard"], isDynamic: false },
+    ]);
+
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    await Router.prefetch("/dashboard");
+
+    expect(Router.components["/dashboard"]).toEqual({ __appRouter: true });
+  });
+
+  it("does not mark unrelated routes that are not in the App Router manifest", async () => {
+    installFakeBrowserGlobals([
+      { canPrefetchLoadingShell: false, patternParts: ["dashboard"], isDynamic: false },
+    ]);
+
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    await Router.prefetch("/some-random-pages-route");
+
+    expect(Router.components["/some-random-pages-route"]).toBeUndefined();
+  });
+
+  it("is exposed via window.next.router.components", async () => {
+    installFakeBrowserGlobals([
+      { canPrefetchLoadingShell: false, patternParts: ["dashboard"], isDynamic: false },
+    ]);
+
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    await Router.prefetch("/dashboard");
+
+    // The Next.js test reads through window.next.router.components — verify
+    // the singleton wired into window.next is the same object.
+    const win = (
+      globalThis as { window: { next?: { router?: { components?: Record<string, unknown> } } } }
+    ).window;
+    expect(win.next?.router?.components?.["/dashboard"]).toEqual({ __appRouter: true });
+    expect(win.next?.router).toBe(Router);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1526.
- In a hybrid Pages + App Router app, when the Pages Router prefetches a `<Link href>` whose target is actually an App Router route, Next.js marks the route on the Pages Router singleton with `router.components[urlPathname] = { __appRouter: true }` (see `packages/next/src/shared/lib/router/router.ts:2525`). The Next.js deploy test `test/e2e/app-dir/app/index.test.ts` ("should successfully detect app route during prefetch") asserts this via `window.next.router.components["/dashboard"]`.
- Vinext previously did not expose a `components` map and did not record App Router prefetch targets, so the assertion never resolved.

## Changes

- New `shims/internal/app-route-detection.ts` — shared App-route matcher + components-map accessor (behind a `Symbol.for` global so the router shim and the link shim write through the same instance across Vite module splits).
- `shims/router.ts` — adds `components` to the Pages Router singleton (mirrored onto `window.next.router.components`), marks the target on prefetch when it matches the App Router manifest.
- `shims/link.tsx` — Pages-mode prefetch branch also marks the target via the shared helper.
- `entries/pages-client-entry.ts` — accepts the App Router prefetch manifest and emits it as `window.__VINEXT_LINK_PREFETCH_ROUTES__` so the same matcher Link uses for App Router auto-prefetch is also available on Pages-only entries.
- `entries/app-browser-entry.ts` — extracts `isLinkPrefetchRoute` / `toLinkPrefetchRoute` so the Pages Router client entry can reuse the projection.
- `index.ts` — threads the App Router prefetch manifest through to `generateClientEntry` when `hasAppDir`.

## Test plan

- [x] New `tests/pages-router-app-prefetch-detection.test.ts` — pins the `components[<path>] = { __appRouter: true }` write driven by `Router.prefetch`, the no-match negative case, and that `window.next.router` exposes the same map.
- [x] `pnpm test tests/pages-router-app-prefetch-detection.test.ts tests/pages-router.test.ts tests/app-browser-entry.test.ts tests/link.test.ts tests/link-navigation.test.ts tests/router-javascript-urls.test.ts tests/router-prefetch-invalid-url.test.ts tests/prefetch-cache.test.ts tests/shims.test.ts` — all green locally.
- [x] `pnpm run check` (fmt + lint + types) — green.