### PR TITLE
fix(app-router): isolate global-not-found chunk to fix CSS cascade (#1549)

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -197,7 +197,7 @@ export function generateRscEntry(
     rootUnauthorizedVar,
     rootLayoutVars,
     globalErrorVar,
-    globalNotFoundVar,
+    globalNotFoundImportSpecifier,
   } = manifestCode;
   const loadPrerenderPagesRoutesCode = hasPagesDir
     ? `
@@ -395,12 +395,21 @@ const rootNotFoundModule = ${rootNotFoundVar ? rootNotFoundVar : "null"};
 const rootForbiddenModule = ${rootForbiddenVar ? rootForbiddenVar : "null"};
 const rootUnauthorizedModule = ${rootUnauthorizedVar ? rootUnauthorizedVar : "null"};
 const rootLayouts = [${rootLayoutVars.join(", ")}];
-// Root-level app/global-not-found module. When present, route-miss 404s render
+// Root-level app/global-not-found loader. When present, route-miss 404s render
 // this module standalone (it provides its own html/body) instead of wrapping
 // the not-found.tsx boundary inside the root layout. Page-triggered notFound()
 // calls still use the regular not-found.tsx boundary inside the layouts.
+//
+// The module is loaded via dynamic \`import()\` (not a static \`import * as\`)
+// so the bundler emits it in its own JS+CSS chunk. Without that isolation,
+// global-not-found's CSS gets concatenated with the root layout's CSS into a
+// single file, where the CSS minifier (lightningcss) drops overlapping
+// declarations as dead code — breaking the cascade for route-miss 404s.
 // See https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
-const globalNotFoundModule = ${globalNotFoundVar ? globalNotFoundVar : "null"};
+// See Next.js test: test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
+const __loadGlobalNotFoundModule = ${
+    globalNotFoundImportSpecifier ? `() => import(${globalNotFoundImportSpecifier})` : "null"
+  };
 
 const createRscOnErrorHandler = (request, pathname, routePath) =>
   createAppRscOnErrorHandler(_reportRequestError, request, pathname, routePath);
@@ -414,7 +423,7 @@ const __fallbackRenderer = __createAppFallbackRenderer({
     rootUnauthorizedModule,
   },
   globalErrorModule: ${globalErrorVar ? globalErrorVar : "null"},
-  globalNotFoundModule,
+  loadGlobalNotFoundModule: __loadGlobalNotFoundModule,
   metadataRoutes,
   ssrLoader() {
     return import.meta.viteRsc.loadModule("ssr", "index");

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -14,7 +14,27 @@ type AppRscManifestCode = {
   rootUnauthorizedVar: string | null;
   rootLayoutVars: string[];
   globalErrorVar: string | null;
-  globalNotFoundVar: string | null;
+  /**
+   * Path expression for the `app/global-not-found.{tsx,ts,js,jsx}` module
+   * suitable for embedding in a generated `import()` call (already JSON-encoded
+   * with platform path separators normalized). `null` when the user did not
+   * define `global-not-found.tsx`.
+   *
+   * We intentionally do NOT register this module as a static `import * as`
+   * in the manifest. Statically importing it puts global-not-found.tsx in
+   * the same JS chunk as the root layout, which causes the CSS bundler to
+   * concatenate their stylesheets into a single CSS file. The CSS minifier
+   * (lightningcss) then drops overlapping declarations as dead code, so any
+   * rule in global-not-found's CSS that the layout's CSS also defines gets
+   * silently removed — breaking the cascade on route-miss 404s where only
+   * global-not-found is supposed to render.
+   *
+   * By emitting a dynamic `import()` instead, the bundler gives
+   * global-not-found.tsx its own chunk with its own CSS asset.
+   *
+   * @see Next.js test: test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
+   */
+  globalNotFoundImportSpecifier: string | null;
 };
 
 type BuildAppRscManifestCodeOptions = {
@@ -319,8 +339,11 @@ export function buildAppRscManifestCode(
   const globalErrorVar = options.globalErrorPath
     ? imports.getImportVar(options.globalErrorPath)
     : null;
-  const globalNotFoundVar = options.globalNotFoundPath
-    ? imports.getImportVar(options.globalNotFoundPath)
+  // Intentionally NOT registered as a static `import * as` — see the docstring
+  // on `AppRscManifestCode.globalNotFoundImportSpecifier` for the chunk/CSS
+  // isolation rationale. We emit a dynamic `import()` from the entry instead.
+  const globalNotFoundImportSpecifier = options.globalNotFoundPath
+    ? JSON.stringify(normalizePathSeparators(options.globalNotFoundPath))
     : null;
 
   const dynamicMetadataRoutes = metadataRoutes.filter((r) => r.isDynamic);
@@ -345,6 +368,6 @@ export function buildAppRscManifestCode(
     rootUnauthorizedVar,
     rootLayoutVars,
     globalErrorVar,
-    globalNotFoundVar,
+    globalNotFoundImportSpecifier,
   };
 }

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -49,13 +49,23 @@ type AppFallbackRendererOptions<TModule extends AppPageModule = AppPageModule> =
   getNavigationContext: () => unknown;
   globalErrorModule?: TModule | null;
   /**
-   * Optional `app/global-not-found.tsx` module. When provided, route-miss 404s
-   * render this module as a standalone document (skipping the root layout)
-   * because it ships its own `<html>` and `<body>`. Page-triggered `notFound()`
-   * calls continue to use the regular `not-found.tsx` boundary inside layouts.
+   * Loader for the user's `app/global-not-found.tsx` module. When provided,
+   * route-miss 404s render this module as a standalone document (skipping the
+   * root layout) because it ships its own `<html>` and `<body>`. Page-triggered
+   * `notFound()` calls continue to use the regular `not-found.tsx` boundary
+   * inside layouts.
+   *
+   * Passed as a deferred loader (rather than the resolved module) so the
+   * generated RSC entry can use `() => import(...)` for chunk isolation.
+   * Without that isolation, the bundler co-locates global-not-found's CSS
+   * with the root layout's CSS in a single chunk and the CSS minifier
+   * (lightningcss) drops overlapping declarations as dead code — breaking
+   * the cascade for route-miss 404s where only global-not-found is rendered.
+   *
    * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx
+   * @see Next.js test: test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
    */
-  globalNotFoundModule?: TModule | null;
+  loadGlobalNotFoundModule?: (() => Promise<TModule | null | undefined>) | null;
   makeThenableParams: (params: AppPageParams) => unknown;
   metadataRoutes: MetadataFileRoute[];
   /** Configured next.config `basePath`, threaded into file-based metadata href emission. */
@@ -132,7 +142,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
     fontProviders,
     getNavigationContext,
     globalErrorModule,
-    globalNotFoundModule,
+    loadGlobalNotFoundModule,
     makeThenableParams,
     metadataRoutes,
     resolveChildSegments,
@@ -164,8 +174,21 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
   const effectiveRootNotFoundModule: TModule | null =
     rootNotFoundModule ?? (DEFAULT_NOT_FOUND_MODULE as unknown as TModule);
 
+  // Cache the result of `loadGlobalNotFoundModule()` so subsequent route-miss
+  // 404s in the same worker hit a warm import instead of re-resolving the
+  // dynamic chunk. The loader itself is invoked at most once per worker;
+  // failures are surfaced on every call so they don't get swallowed.
+  let globalNotFoundModulePromise: Promise<TModule | null | undefined> | null = null;
+  function resolveGlobalNotFoundModule(): Promise<TModule | null | undefined> | null {
+    if (!loadGlobalNotFoundModule) return null;
+    if (globalNotFoundModulePromise === null) {
+      globalNotFoundModulePromise = Promise.resolve().then(loadGlobalNotFoundModule);
+    }
+    return globalNotFoundModulePromise;
+  }
+
   return {
-    renderHttpAccessFallback(
+    async renderHttpAccessFallback(
       route,
       statusCode,
       isRscRequest,
@@ -184,9 +207,10 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       // regular not-found.tsx boundary inside the route's layouts.
       // See https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L495-L520
       const useGlobalNotFound =
-        statusCode === 404 && !!globalNotFoundModule && !route && !opts?.boundaryComponent;
+        statusCode === 404 && !!loadGlobalNotFoundModule && !route && !opts?.boundaryComponent;
 
       if (useGlobalNotFound) {
+        const globalNotFoundModule = await resolveGlobalNotFoundModule();
         const globalNotFoundComponent = globalNotFoundModule?.default ?? null;
         if (globalNotFoundComponent) {
           return renderAppPageHttpAccessFallback({

--- a/tests/app-fallback-renderer.test.ts
+++ b/tests/app-fallback-renderer.test.ts
@@ -71,7 +71,9 @@ function createRenderer(overrides?: {
         return { pathname: "/posts/missing" };
       },
       globalErrorModule: null,
-      globalNotFoundModule: overrides?.globalNotFoundModule ?? null,
+      loadGlobalNotFoundModule: overrides?.globalNotFoundModule
+        ? async () => overrides.globalNotFoundModule ?? null
+        : null,
       makeThenableParams<T>(params: T) {
         return params;
       },
@@ -447,7 +449,7 @@ describe("app fallback renderer default global error UI", () => {
       },
       getNavigationContext: () => ({ pathname: "/server-error" }),
       globalErrorModule: userGlobalErrorModule,
-      globalNotFoundModule: null,
+      loadGlobalNotFoundModule: null,
       makeThenableParams: (p) => p,
       metadataRoutes: [],
       resolveChildSegments: () => [],

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -455,11 +455,19 @@ describe("App Router generated manifest construction", () => {
     ]);
   });
 
-  it("imports the global-not-found module and exposes its var when provided", () => {
+  it("emits a dynamic-import specifier for the global-not-found module when provided", () => {
     // Mirrors how vinext scans `app/global-not-found.tsx` in
     // packages/vinext/src/index.ts and threads it into the manifest so the
     // generated RSC entry can hand it to createAppFallbackRenderer.
+    //
+    // The module is intentionally NOT registered as a static `import * as` —
+    // statically importing it co-locates global-not-found's CSS with the root
+    // layout's CSS in a single chunk, and the CSS minifier (lightningcss) then
+    // drops overlapping declarations as dead code, breaking the cascade for
+    // route-miss 404s. Emitting a JSON-encoded specifier lets the entry
+    // generator wrap the path in a dynamic `import()` for chunk isolation.
     // See https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
+    // See Next.js test: test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
     const manifest = buildAppRscManifestCode({
       routes: minimalAppRoutes,
       metadataRoutes: [],
@@ -467,12 +475,13 @@ describe("App Router generated manifest construction", () => {
       globalNotFoundPath: "/tmp/test/app/global-not-found.tsx",
     });
 
-    const imports = manifest.imports.join("\n");
-    expect(imports).toContain('from "/tmp/test/app/global-not-found.tsx"');
-    expect(manifest.globalNotFoundVar).toBeTruthy();
+    // Must NOT appear in the static imports — that would defeat the chunk
+    // isolation. The entry generator embeds it via `() => import(<specifier>)`.
+    expect(manifest.imports.join("\n")).not.toContain("global-not-found");
+    expect(manifest.globalNotFoundImportSpecifier).toBe('"/tmp/test/app/global-not-found.tsx"');
   });
 
-  it("does not import a global-not-found module when the path is absent", () => {
+  it("does not emit a global-not-found specifier when the path is absent", () => {
     const manifest = buildAppRscManifestCode({
       routes: minimalAppRoutes,
       metadataRoutes: [],
@@ -481,7 +490,7 @@ describe("App Router generated manifest construction", () => {
     });
 
     expect(manifest.imports.join("\n")).not.toContain("global-not-found");
-    expect(manifest.globalNotFoundVar).toBeNull();
+    expect(manifest.globalNotFoundImportSpecifier).toBeNull();
   });
 
   it("serializes graph-minted ids without leaking the filesystem root", async () => {
@@ -715,24 +724,32 @@ describe("App Router entry templates", () => {
 
   it("generateRscEntry threads globalNotFoundPath from config into the fallback renderer", () => {
     // The generated entry's createAppFallbackRenderer call must receive a
-    // globalNotFoundModule binding so route-miss 404s can render
-    // app/global-not-found.tsx standalone.
+    // loader so route-miss 404s can render app/global-not-found.tsx standalone.
+    //
+    // The loader is a dynamic `import()` (not a static `import * as`) so the
+    // bundler emits global-not-found.tsx in its own JS+CSS chunk. Without that
+    // isolation, the CSS minifier (lightningcss) drops overlapping declarations
+    // between the root layout's CSS and global-not-found's CSS, breaking the
+    // cascade for route-miss 404s.
     // See packages/vinext/src/entries/app-rsc-entry.ts and
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/global-not-found
+    // See Next.js test: test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false, {
       globalNotFoundPath: "/tmp/test/app/global-not-found.tsx",
     });
 
-    expect(code).toContain('from "/tmp/test/app/global-not-found.tsx"');
-    // The renderer is wired with the module binding (not just `null`).
-    expect(code).toContain("globalNotFoundModule,");
-    expect(code).not.toContain("const globalNotFoundModule = null;");
+    // Loader uses dynamic `import()` — NOT a static `import * as`.
+    expect(code).toContain('() => import("/tmp/test/app/global-not-found.tsx")');
+    expect(code).not.toContain('from "/tmp/test/app/global-not-found.tsx"');
+    // The renderer is wired with the loader binding (not just `null`).
+    expect(code).toContain("loadGlobalNotFoundModule: __loadGlobalNotFoundModule");
+    expect(code).not.toContain("const __loadGlobalNotFoundModule = null;");
   });
 
-  it("generateRscEntry emits a null globalNotFoundModule when no path is provided", () => {
+  it("generateRscEntry emits a null global-not-found loader when no path is provided", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain("const globalNotFoundModule = null;");
+    expect(code).toContain("const __loadGlobalNotFoundModule = null;");
     expect(code).not.toContain("global-not-found.tsx");
   });
 

--- a/tests/fixtures/global-not-found-basic/app/global-not-found.tsx
+++ b/tests/fixtures/global-not-found-basic/app/global-not-found.tsx
@@ -4,6 +4,13 @@
 // `global-not-found.tsx` owns its own <html>/<body>. When present, vinext
 // renders this module standalone for route-miss 404s, replacing the root
 // layout (see createAppFallbackRenderer in app-fallback-renderer.ts).
+//
+// red.css is imported here so we can assert global-not-found CSS overrides
+// the root layout's CSS — the global-not-found document fully replaces the
+// layout, so its CSS link must appear after any layout CSS that may still
+// be served (or, ideally, instead of it). Mirrors:
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/initial-css-order/app/global-not-found.tsx
+import "./red.css";
 
 export default function GlobalNotFound() {
   return (

--- a/tests/fixtures/global-not-found-basic/app/green.css
+++ b/tests/fixtures/global-not-found-basic/app/green.css
@@ -1,0 +1,3 @@
+body {
+  background-color: green;
+}

--- a/tests/fixtures/global-not-found-basic/app/layout.tsx
+++ b/tests/fixtures/global-not-found-basic/app/layout.tsx
@@ -1,3 +1,14 @@
+// Mirrors Next.js fixture:
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/initial-css-order/app/layout.tsx
+//
+// The order of CSS imports matters: red.css is imported first, then green.css.
+// On matched routes the layout wins (green wins over red), so the body should
+// be green. On route-miss 404s the global-not-found document replaces the root
+// layout — its `red.css` import must therefore win, regardless of the layout's
+// imports.
+import "./red.css";
+import "./green.css";
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">

--- a/tests/fixtures/global-not-found-basic/app/red.css
+++ b/tests/fixtures/global-not-found-basic/app/red.css
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/tests/nextjs-compat/global-not-found.test.ts
+++ b/tests/nextjs-compat/global-not-found.test.ts
@@ -25,6 +25,25 @@ import { startFixtureServer, fetchHtml } from "../helpers.js";
 
 const FIXTURE_DIR = path.resolve(import.meta.dirname, "../fixtures/global-not-found-basic");
 
+/**
+ * Extract the href of every `<link rel="stylesheet">` tag in the SSR markup,
+ * preserving document order. CSS cascade is order-sensitive — for the
+ * initial-css-order regression we need to assert which stylesheet is emitted
+ * (and which is NOT) for route-miss 404s.
+ */
+function extractCssLinks(html: string): string[] {
+  const hrefs: string[] = [];
+  // The link tag emitted by React Float / @vitejs/plugin-rsc uses
+  // `rel="stylesheet"`. We only care about visible stylesheets, so skip
+  // preload/preconnect/etc.
+  const linkRe = /<link\b[^>]*\brel="stylesheet"[^>]*>/gi;
+  for (const m of html.matchAll(linkRe)) {
+    const hrefMatch = /\bhref="([^"]+)"/i.exec(m[0]);
+    if (hrefMatch) hrefs.push(hrefMatch[1]);
+  }
+  return hrefs;
+}
+
 describe("Next.js compat: global-not-found (basic)", () => {
   let server: ViteDevServer;
   let baseUrl: string;
@@ -70,6 +89,40 @@ describe("Next.js compat: global-not-found (basic)", () => {
     const bodyTags = (html.match(/<body/gi) ?? []).length;
     expect(htmlTags, `expected 1 <html> tag, got ${htmlTags}`).toBe(1);
     expect(bodyTags, `expected 1 <body> tag, got ${bodyTags}`).toBe(1);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/initial-css-order/initial-css-order.test.ts
+  //
+  // global-not-found.tsx replaces the root layout for route-miss 404s, so the
+  // response must serve ONLY global-not-found's CSS — not the layout's. If
+  // both stylesheets render on the 404 page the CSS cascade ends with the
+  // layout's rules (e.g., layout's green.css overrides global-not-found's
+  // red.css) and the document paints the wrong colours.
+  //
+  // The vinext fixture mirrors Next.js: layout.tsx imports red.css then
+  // green.css (so green wins on matched routes), and global-not-found.tsx
+  // imports red.css (so red wins on route-miss 404s).
+  // See: https://github.com/cloudflare/vinext/issues/1549
+  it("only emits global-not-found's CSS link on route-miss 404 (not the layout's)", async () => {
+    const homeResp = await fetchHtml(baseUrl, "/");
+    expect(homeResp.res.status).toBe(200);
+    // Matched routes load the layout's CSS chain. Matching upstream Next.js,
+    // both red.css and green.css are linked in import order so green wins.
+    const homeLinks = extractCssLinks(homeResp.html);
+    expect(homeLinks).toEqual([
+      expect.stringMatching(/red\.css/),
+      expect.stringMatching(/green\.css/),
+    ]);
+
+    const nfResp = await fetchHtml(baseUrl, "/does-not-exist");
+    expect(nfResp.res.status).toBe(404);
+    // The 404 response must NOT carry the root layout's CSS — the layout was
+    // skipped (skipLayoutWrapping) so its CSS imports must not appear in the
+    // SSR markup. Only global-not-found's red.css should be linked.
+    const nfLinks = extractCssLinks(nfResp.html);
+    expect(nfLinks).toEqual([expect.stringMatching(/red\.css/)]);
+    expect(nfLinks.some((href) => /green\.css/.test(href))).toBe(false);
   });
 
   // Ported from Next.js: test/e2e/app-dir/global-not-found/basic/global-not-found-basic.test.ts


### PR DESCRIPTION
## Summary

- Closes #1549.
- When `app/global-not-found.tsx` is defined, route-miss 404s render that module standalone (skipping the root layout). The entry was registering it as a static `import * as`, so the bundler co-located its CSS with the root layout's CSS in a single chunk. Lightningcss then dropped overlapping declarations between the two stylesheets as dead code, breaking the CSS cascade — the layout's rules silently overrode global-not-found's.
- Switch to `() => import("…/global-not-found.tsx")` so the module gets its own JS chunk, and have the fallback renderer accept a (cached) loader instead of the eagerly-imported module.
- Adds a regression test asserting the SSR markup for `/does-not-exist` links only global-not-found's stylesheet — never the layout's — so the cascade can never resolve to the wrong color.

Ported from Next.js: `test/e2e/app-dir/initial-css-order/initial-css-order.test.ts`.

## Test plan

- [x] `vp test run tests/app-fallback-renderer.test.ts tests/entry-templates.test.ts tests/nextjs-compat/global-not-found.test.ts` — all 41 tests pass (including the new CSS-link-order test).
- [x] `vp test run tests/app-router.test.ts` — full app-router suite (332 tests) still passes.
- [x] `vp check` — types and lints clean.