### PR TITLE
feat: recognize Sparkle experimental flags (varyParams, optimisticRouting, cachedNavigations)

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -227,6 +227,18 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     detail:
       "App Router production HTML inlines stylesheet links as <style> in <head>; next/font CSS is merged into the first inline style",
   },
+  "experimental.varyParams": {
+    status: "partial",
+    detail: "config recognized; vinext does not implement root-param-aware cache keying",
+  },
+  "experimental.optimisticRouting": {
+    status: "partial",
+    detail: "config recognized; vinext does not implement optimistic client navigation",
+  },
+  "experimental.cachedNavigations": {
+    status: "partial",
+    detail: "config recognized; vinext does not implement navigation result caching",
+  },
   "i18n.domains": {
     status: "partial",
     detail: "supported for Pages Router; App Router unchanged",

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1258,6 +1258,15 @@ export async function resolveNextConfig(
     );
   }
 
+  // Warn when experimental.cachedNavigations is set without cacheComponents.
+  // Next.js throws in this case; vinext warns because the feature is a no-op without it.
+  if (experimental?.cachedNavigations === true && !config.cacheComponents) {
+    console.warn(
+      "[vinext] `experimental.cachedNavigations` requires `cacheComponents: true` to have any effect. " +
+        "Set `cacheComponents: true` in your next.config, or remove `experimental.cachedNavigations`.",
+    );
+  }
+
   // Warn about unsupported webpack usage. We preserve alias injection and
   // extract MDX settings, but all other webpack customization is still ignored.
   if (config.webpack !== undefined) {

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -378,6 +378,48 @@ describe("analyzeConfig", () => {
     expect(items.find((i) => i.name === "experimental.prefetchInlining")?.status).toBe("partial");
   });
 
+  it("detects experimental.varyParams as partial", () => {
+    writeFile(
+      "next.config.mjs",
+      `export default {
+        experimental: {
+          varyParams: true,
+        },
+      };`,
+    );
+
+    const items = analyzeConfig(tmpDir);
+    expect(items.find((i) => i.name === "experimental.varyParams")?.status).toBe("partial");
+  });
+
+  it("detects experimental.optimisticRouting as partial", () => {
+    writeFile(
+      "next.config.mjs",
+      `export default {
+        experimental: {
+          optimisticRouting: true,
+        },
+      };`,
+    );
+
+    const items = analyzeConfig(tmpDir);
+    expect(items.find((i) => i.name === "experimental.optimisticRouting")?.status).toBe("partial");
+  });
+
+  it("detects experimental.cachedNavigations as partial", () => {
+    writeFile(
+      "next.config.mjs",
+      `export default {
+        experimental: {
+          cachedNavigations: true,
+        },
+      };`,
+    );
+
+    const items = analyzeConfig(tmpDir);
+    expect(items.find((i) => i.name === "experimental.cachedNavigations")?.status).toBe("partial");
+  });
+
   it("detects experimental.swcEnvOptions as unsupported", () => {
     writeFile(
       "next.config.mjs",
@@ -433,6 +475,9 @@ describe("analyzeConfig", () => {
     ["experimental.prefetchInlining", "experimental", "prefetchInlining: true"],
     ["experimental.swcEnvOptions", "experimental", 'swcEnvOptions: { mode: "usage" }'],
     ["experimental.appShells", "experimental", "appShells: true"],
+    ["experimental.varyParams", "experimental", "varyParams: true"],
+    ["experimental.optimisticRouting", "experimental", "optimisticRouting: true"],
+    ["experimental.cachedNavigations", "experimental", "cachedNavigations: true"],
     ["i18n.domains", "i18n", "domains: []"],
   ])("detects %s via generic dot-notation handling", (name, parent, body) => {
     writeFile("next.config.mjs", `export default { ${parent}: { ${body} } };`);

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1609,6 +1609,33 @@ describe("resolveNextConfig swcEnvOptions warning", () => {
   });
 });
 
+describe("resolveNextConfig cachedNavigations warning", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a warning when experimental.cachedNavigations is set without cacheComponents", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await resolveNextConfig({
+      experimental: { cachedNavigations: true },
+    });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("experimental.cachedNavigations"));
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn when experimental.cachedNavigations is set with cacheComponents", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await resolveNextConfig({
+      cacheComponents: true,
+      experimental: { cachedNavigations: true },
+    });
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("experimental.cachedNavigations"),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
 describe("resolveNextConfig rootParams deprecation warning", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1615,24 +1615,59 @@ describe("resolveNextConfig cachedNavigations warning", () => {
   });
 
   it("emits a warning when experimental.cachedNavigations is set without cacheComponents", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     await resolveNextConfig({
       experimental: { cachedNavigations: true },
     });
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("experimental.cachedNavigations"));
-    warnSpy.mockRestore();
+
+    const cachedNavigationsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("cachedNavigations"),
+    );
+
+    expect(cachedNavigationsWarning).toBeDefined();
+    expect(cachedNavigationsWarning![0]).toContain("experimental.cachedNavigations");
+    expect(cachedNavigationsWarning![0]).toContain("cacheComponents: true");
   });
 
   it("does not warn when experimental.cachedNavigations is set with cacheComponents", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     await resolveNextConfig({
       cacheComponents: true,
       experimental: { cachedNavigations: true },
     });
-    expect(warnSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining("experimental.cachedNavigations"),
+
+    const cachedNavigationsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("cachedNavigations"),
     );
-    warnSpy.mockRestore();
+    expect(cachedNavigationsWarning).toBeUndefined();
+  });
+
+  it("does not warn when experimental.cachedNavigations is not set", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      experimental: {},
+    });
+
+    const cachedNavigationsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("cachedNavigations"),
+    );
+    expect(cachedNavigationsWarning).toBeUndefined();
+  });
+
+  it("does not warn when experimental.cachedNavigations is false", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      experimental: { cachedNavigations: false },
+    });
+
+    const cachedNavigationsWarning = warn.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("cachedNavigations"),
+    );
+    expect(cachedNavigationsWarning).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #1425

Adds three Next.js Sparkle experimental flags to vinext's config schema without triggering compatibility warnings:

- `experimental.varyParams` — config recognized; vinext does not implement root-param-aware cache keying
- `experimental.optimisticRouting` — config recognized; vinext does not implement optimistic client navigation
- `experimental.cachedNavigations` — config recognized; vinext does not implement navigation result caching

Also adds a warning when `experimental.cachedNavigations` is set without `cacheComponents: true` (Next.js throws in this case; vinext warns because the feature is a no-op without it).

### Validation
- `pnpm test tests/check.test.ts` — 105 tests passed
- `pnpm test tests/next-config.test.ts` — 133 tests passed
- `pnpm run check` — format passed; no new type errors introduced