### PR TITLE
fix(build): land process.env mutations from webpack loaders (#1500)

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1392,6 +1392,14 @@ async function probeWebpackConfig(
     const finalConfig = result ?? mockConfig;
     // oxlint-disable-next-line typescript/no-explicit-any
     const rules: any[] = finalConfig.module?.rules ?? mockModuleRules;
+    // Invoke loader callbacks for any side effects on `process.env`.
+    // Next.js webpack loaders sometimes mutate `process.env.X = ...` at
+    // compile time (see issue #1500), and vinext otherwise never sees the
+    // value because we don't run the webpack loader pipeline. Calling each
+    // loader once with a dummy source lets build-time env mutations land in
+    // the shared Node process so they become visible to defines and
+    // server-side code during the same build.
+    invokeLoaderSideEffects(rules, root);
     return {
       aliases: normalizeAliasEntries(finalConfig.resolve?.alias, root),
       mdx: extractMdxOptionsFromRules(rules),
@@ -1399,6 +1407,111 @@ async function probeWebpackConfig(
   } catch {
     return { aliases: {}, mdx: null };
   }
+}
+
+/**
+ * Walk webpack module rules and invoke each referenced loader once with a
+ * dummy source string. Loaders that mutate `process.env` at compile time (a
+ * pattern supported by Next.js' webpack pipeline — see issue #1500) get a
+ * chance to land their mutations before vinext computes its defines.
+ * Failures are swallowed: a loader throwing on dummy input must not break
+ * the build, since vinext doesn't actually use the loader's transform output.
+ */
+// oxlint-disable-next-line typescript/no-explicit-any
+function invokeLoaderSideEffects(rules: any[], root: string): void {
+  const require = createRequire(path.join(root, "package.json"));
+  const seen = new Set<unknown>();
+
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const invokeLoaderEntry = (entry: any, ruleOptions?: unknown): void => {
+    if (!entry) return;
+    let loaderPath: string | undefined;
+    let loaderFn: unknown;
+    let options: unknown = ruleOptions;
+    if (typeof entry === "string") {
+      loaderPath = entry;
+    } else if (typeof entry === "function") {
+      loaderFn = entry;
+    } else if (typeof entry === "object") {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const e = entry as any;
+      if (typeof e.loader === "string") loaderPath = e.loader;
+      else if (typeof e.loader === "function") loaderFn = e.loader;
+      if (e.options !== undefined) options = e.options;
+    }
+    if (loaderPath !== undefined) {
+      if (seen.has(loaderPath)) return;
+      seen.add(loaderPath);
+      // Skip well-known framework loaders. These don't typically mutate
+      // process.env and may pull in heavy dependencies or fail to resolve
+      // outside webpack's loader runtime.
+      if (
+        loaderPath.includes("next-babel-loader") ||
+        loaderPath.includes("mdx") ||
+        loaderPath.startsWith("next/dist/build/webpack")
+      ) {
+        return;
+      }
+      try {
+        loaderFn = require(loaderPath);
+        if (
+          loaderFn &&
+          typeof loaderFn === "object" &&
+          // oxlint-disable-next-line typescript/no-explicit-any
+          typeof (loaderFn as any).default === "function"
+        ) {
+          // oxlint-disable-next-line typescript/no-explicit-any
+          loaderFn = (loaderFn as any).default;
+        }
+      } catch {
+        return;
+      }
+    }
+    if (typeof loaderFn !== "function") return;
+    if (seen.has(loaderFn)) return;
+    seen.add(loaderFn);
+    try {
+      // Mimic the webpack loader runtime: `this` carries getOptions(),
+      // query, callback(), async(), etc. We stub the minimum a typical
+      // loader might touch. We don't care about the return value — only
+      // side effects on process.env.
+      const loaderThis = {
+        async: () => () => {},
+        callback: () => {},
+        emitError: () => {},
+        emitWarning: () => {},
+        cacheable: () => {},
+        getOptions: () => options ?? {},
+        query: options ?? {},
+        resourcePath: "",
+        resource: "",
+        rootContext: root,
+        context: root,
+        mode: "production",
+      };
+      // oxlint-disable-next-line typescript/no-unsafe-function-type
+      (loaderFn as Function).call(loaderThis, "");
+    } catch {
+      // Ignore — the loader may have thrown on the dummy source.
+      // process.env mutations made before the throw still apply.
+    }
+  };
+
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const visit = (rule: any): void => {
+    if (!rule || typeof rule !== "object") return;
+    if (Array.isArray(rule)) {
+      for (const child of rule) visit(child);
+      return;
+    }
+    if (Array.isArray(rule.oneOf)) for (const child of rule.oneOf) visit(child);
+    if (Array.isArray(rule.rules)) for (const child of rule.rules) visit(child);
+    const uses = Array.isArray(rule.use) ? rule.use : rule.use ? [rule.use] : [];
+    for (const use of uses) invokeLoaderEntry(use);
+    if (rule.loader !== undefined) invokeLoaderEntry(rule.loader, rule.options);
+  };
+
+  for (const rule of rules) visit(rule);
 }
 
 /**

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -600,6 +600,47 @@ module.exports = withPlugin({ basePath: "/wrapped" });`,
     expect(config.aliases).toEqual({});
   });
 
+  it("invokes webpack loader callbacks so build-time process.env mutations land in the Node process", async () => {
+    // Regression test for #1500.
+    // Some Next.js webpack loaders mutate `process.env.X = ...` at build
+    // time, expecting the value to be visible to other modules during the
+    // same build. vinext doesn't run the webpack loader pipeline, so the
+    // env mutation never happens. We compensate by invoking each loader's
+    // callback once during config probing with a dummy source.
+    tmpDir = makeTempDir();
+
+    const loaderPath = path.join(tmpDir, "vinext-1500-loader.cjs");
+    fs.writeFileSync(
+      loaderPath,
+      `module.exports = function (source) {\n` +
+        `  process.env.VINEXT_ISSUE_1500_LOADER_RAN = "yes";\n` +
+        `  return source;\n` +
+        `};\n`,
+    );
+
+    const previous = process.env.VINEXT_ISSUE_1500_LOADER_RAN;
+    delete process.env.VINEXT_ISSUE_1500_LOADER_RAN;
+    try {
+      const rawConfig = {
+        webpack: (webpackConfig: any) => {
+          webpackConfig.module = webpackConfig.module || { rules: [] };
+          webpackConfig.module.rules.push({
+            test: /\.svg$/,
+            use: [loaderPath],
+          });
+          return webpackConfig;
+        },
+      };
+
+      await resolveNextConfig(rawConfig, tmpDir);
+
+      expect(process.env.VINEXT_ISSUE_1500_LOADER_RAN).toBe("yes");
+    } finally {
+      if (previous === undefined) delete process.env.VINEXT_ISSUE_1500_LOADER_RAN;
+      else process.env.VINEXT_ISSUE_1500_LOADER_RAN = previous;
+    }
+  });
+
   it("extracts aliases and mdx from a single async webpack probe", async () => {
     tmpDir = makeTempDir();
 


### PR DESCRIPTION
## Summary

Closes part of #1500. Some Next.js webpack loaders mutate `process.env.X = ...` at compile time, expecting the value to be visible to other modules during the same build. vinext doesn't run the webpack loader pipeline, so the env mutation never landed — downstream code (defines, `NEXT_PUBLIC_*`, server-side reads) saw `undefined`.

This PR walks the rules collected from the user's `webpack(config)` function and invokes each referenced loader once with a dummy source. Loaders that only mutate `process.env` get a chance to land their changes in the shared Node process before vinext computes its defines.

- Failures are swallowed (a loader throwing on dummy source must not break the build, since vinext does not consume the loader's transform output).
- Well-known framework loaders (`next-babel-loader`, `@next/mdx*`, `next/dist/build/webpack/*`) are skipped to avoid pulling in webpack-runtime-dependent code at probe time.
- Loaders that need the full webpack loader context will still no-op cleanly — they just won't run their env-mutation side effect, which matches the prior behavior.

Note: this fixes the env-mutation portion of the failing test. The original Next.js test (`webpack-loader-set-environment-variable`) also exercises an SVG-to-JS loader transform, which is a separate "webpack loaders are not portable" gap.

## Test plan

- [x] `pnpm test tests/next-config.test.ts` (136/136 pass; new regression test for #1500 exercises a loader file written to disk that mutates `process.env`)
- [x] Confirmed the new test fails on `origin/main` (asserts the env var is `undefined` without the fix)
- [x] `pnpm run lint` clean
- [x] `pnpm run fmt:check` clean