### PR TITLE
fix(routing): @children slot explicit page wins over catchall (#1535)

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -824,6 +824,16 @@ export async function buildAppRouteGraph(
   // (slot pages are not standalone routes — they're rendered as props of their parent layout)
   // and _private folders (Next.js convention for colocated non-route files).
   //
+  // The `@children` directory is special: Next.js treats `@children` as
+  // transparent — `app/@children/page.tsx` provides the layout's children
+  // prop for `/` and registers a real page route at `/`. This mirrors the
+  // Next.js types plugin (which skips `@children` when enumerating slots)
+  // and `normalizeAppPath` (which strips any `@` segment including
+  // `@children` from the URL). See:
+  //   - packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+  //   - packages/next/src/shared/lib/router/utils/app-paths.ts
+  //   - packages/next/src/build/normalize-catchall-routes.ts
+  //
   // Interception marker directories (e.g. `(.)photo`, `(..)showcase`,
   // `(..)(..)hoge`, `(...)photos`) are also excluded from the global page
   // scan because the marker is not a real URL segment — Next.js treats these
@@ -836,7 +846,9 @@ export async function buildAppRouteGraph(
   const routes: AppRouteGraphRoute[] = [];
 
   const excludeDir = (name: string) =>
-    name.startsWith("@") || name.startsWith("_") || isInterceptionMarkerDir(name);
+    (name.startsWith("@") && name !== "@children") ||
+    name.startsWith("_") ||
+    isInterceptionMarkerDir(name);
 
   // Process page files in a single pass
   // Use function form of exclude for Node < 22.14 compatibility (string arrays require >= 22.14)
@@ -911,9 +923,13 @@ export async function buildAppRouteGraph(
 
 function hasParallelSlotDirectory(dir: string): boolean {
   try {
-    return fs
-      .readdirSync(dir, { withFileTypes: true })
-      .some((entry) => entry.isDirectory() && entry.name.startsWith("@"));
+    return fs.readdirSync(dir, { withFileTypes: true }).some(
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name.startsWith("@") &&
+        // `@children` is not a parallel slot — see discoverParallelSlots.
+        entry.name !== "@children",
+    );
   } catch {
     return false;
   }
@@ -1230,7 +1246,21 @@ function fileToAppRoute(
   matcher: ValidFileMatcher,
 ): AppRouteGraphRoute | null {
   // Remove the filename (page.tsx or route.ts)
-  const dir = path.dirname(file);
+  let dir = path.dirname(file);
+
+  // `@children` is transparent in routing: `app/foo/@children/page.tsx`
+  // provides the children prop for `/foo` and registers a real page route
+  // at `/foo`. Strip a trailing `@children` segment so the route is
+  // anchored at its parent directory — that way slot discovery treats
+  // sibling `@slot` directories as owned (not inherited) and the route's
+  // layouts/boundaries are sourced from the parent. Mirrors Next.js'
+  // `normalizeAppPath` which drops any `@` segment (including `@children`)
+  // from the URL. See packages/next/src/shared/lib/router/utils/app-paths.ts.
+  if (type === "page" && dir !== "." && path.basename(dir) === "@children") {
+    const parent = path.dirname(dir);
+    dir = parent === "" || parent === "." ? "." : parent;
+  }
+
   return directoryToAppRoute(
     dir,
     appDir,
@@ -1862,6 +1892,12 @@ function discoverParallelSlots(
 
   for (const entry of entries) {
     if (!entry.isDirectory() || !entry.name.startsWith("@")) continue;
+    // `@children` is not a parallel slot — Next.js maps it to the layout's
+    // `children` prop, i.e., it provides the route's page rather than an
+    // independent slot. Skip it here so it never appears in parallelSlots.
+    // See packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+    // and packages/next/src/build/normalize-catchall-routes.ts.
+    if (entry.name === "@children") continue;
 
     const slotName = entry.name.slice(1); // "@team" -> "team"
     const slotDir = path.join(dir, entry.name);

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -292,6 +292,61 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  // Regression for https://github.com/cloudflare/vinext/issues/1535
+  // Ported from Next.js: test/e2e/app-dir/parallel-routes-catchall-children-slot/
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-catchall-children-slot/parallel-routes-catchall-children-slot.test.ts
+  describe("@children slot priority (issue #1535)", () => {
+    it("uses @children/page.tsx as the page for '/' over a sibling [...catchAll]", async () => {
+      // app/@children/page.tsx provides the layout's `children` prop at '/'.
+      // app/[...catchAll]/page.tsx is a catch-all that should NOT win for '/'.
+      // Next.js parity: see normalize-catchall-routes.ts (@children is not
+      // a "matchable slot" so the catchall does not displace it).
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "@children/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[...catchAll]/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((r) => r.pattern).sort();
+
+        // The root URL must resolve as a real page, sourced from @children/page.tsx.
+        expect(patterns).toContain("/");
+        const root = findRoute(graph.routes, "/");
+        expect(root.pagePath).toBe(path.join(appDir, "@children/page.tsx"));
+
+        // The catch-all must still cover deeper paths.
+        expect(patterns).toContain("/:catchAll+");
+
+        // The @slot slot is attached to '/', not consumed as a top-level route.
+        const slotNames = root.parallelSlots.map((s) => s.name).sort();
+        expect(slotNames).toContain("slot");
+      });
+    });
+
+    it("resolves '/nested' to @children/page when only the @children slot exists (no default)", async () => {
+      // The nested directory has a layout and a @children slot with a page,
+      // but no default.tsx for the children slot. The route '/nested' must
+      // still materialize and the page must come from @children/page.tsx.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "@slot/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[...catchAll]/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "nested/layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "nested/@children/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((r) => r.pattern).sort();
+
+        expect(patterns).toContain("/nested");
+        const nested = findRoute(graph.routes, "/nested");
+        expect(nested.pagePath).toBe(path.join(appDir, "nested/@children/page.tsx"));
+      });
+    });
+  });
+
   it("keeps route groups transparent in materialized URL patterns", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);


### PR DESCRIPTION
## Summary

- Fixes #1535 — `app/foo/@children/page.tsx` now registers a real page route at `/foo` and beats a sibling `[...catchAll]` catch-all, matching Next.js.
- `@children` is treated as transparent in routing: it is allowed through the page scan, stripped when computing the anchored route directory, and skipped by `discoverParallelSlots` / `hasParallelSlotDirectory` so it never appears in `parallelSlots`.
- Adds focused regression tests in `tests/app-route-graph.test.ts` ported from Next.js' `parallel-routes-catchall-children-slot` e2e fixture, covering both the root case and the no-`default.tsx` nested case.

## Why this matches Next.js

`@children` is the way to name the layout's `children` prop, not a parallel slot. Next.js mirrors this in three places we cite in the code:

- `packages/next/src/shared/lib/router/utils/app-paths.ts` — `normalizeAppPath` strips every `@` segment (including `@children`) from the URL.
- `packages/next/src/build/normalize-catchall-routes.ts` — `isMatchableSlot` explicitly excludes `@children` so a `[...catchAll]` is not pushed onto a path that already has an `@children/page` entry.
- `packages/next/src/build/webpack/plugins/next-types-plugin/index.ts` — the slot enumerator skips `@children` because it is matched to the `children` prop.

## Test plan

- [x] `pnpm test tests/app-route-graph.test.ts` (40 tests, including 2 new)
- [x] `pnpm test tests/routing.test.ts tests/route-sorting.test.ts tests/app-rsc-route-matching.test.ts tests/slot.test.ts tests/route-classification-manifest.test.ts tests/app-router.test.ts tests/intercepting-routes-build.test.ts tests/metadata-routes.test.ts` (no regressions)
- [x] `pnpm run check` (format/lint/types clean)
- [ ] CI exercises the rest of the Vitest suite and Playwright E2E

## Scope note

Issue #1535 listed a second symptom from `test/e2e/app-dir/parallel-routes-catchall` ("explicit slot but no page times out"). That one is more invasive (catch-all route slot mirroring across a parent that has no `default.tsx` for children) and is best handled in a separate PR — this change deliberately stays focused on the `@children`-vs-catchall priority fix the issue's recommendation called out first.