### PR TITLE
fix(app-router): honor experimental.staleTimes in client prefetch cache (#1490)

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1065,8 +1065,9 @@ const DEFAULT_STALE_TIMES = { dynamic: 0, static: 300 };
  * Parse `experimental.staleTimes` from a raw next.config object.
  *
  * Mirrors Next.js' `build/define-env.ts` parsing logic:
- *   - missing / NaN values fall back to the documented defaults
- *     (`dynamic: 0`, `static: 300`) — matching Next.js parity
+ *   - missing / NaN / negative values fall back to the documented defaults
+ *     (`dynamic: 0`, `static: 300`) — matching Next.js parity and the
+ *     non-negative guard in `resolvePrefetchCacheTtl`
  *   - all values are in seconds
  *
  * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/staleTimes
@@ -1080,8 +1081,9 @@ function resolveStaleTimes(experimental: Record<string, unknown> | undefined): {
   const staticRaw = Number(staleTimes?.static);
 
   return {
-    dynamic: Number.isFinite(dynamicRaw) ? dynamicRaw : DEFAULT_STALE_TIMES.dynamic,
-    static: Number.isFinite(staticRaw) ? staticRaw : DEFAULT_STALE_TIMES.static,
+    dynamic:
+      Number.isFinite(dynamicRaw) && dynamicRaw >= 0 ? dynamicRaw : DEFAULT_STALE_TIMES.dynamic,
+    static: Number.isFinite(staticRaw) && staticRaw >= 0 ? staticRaw : DEFAULT_STALE_TIMES.static,
   };
 }
 
@@ -1448,14 +1450,6 @@ async function probeWebpackConfig(
     const finalConfig = result ?? mockConfig;
     // oxlint-disable-next-line typescript/no-explicit-any
     const rules: any[] = finalConfig.module?.rules ?? mockModuleRules;
-    // Invoke loader callbacks for any side effects they have on
-    // `process.env`. Next.js webpack loaders sometimes mutate
-    // `process.env.X = ...` at compile time (see issue #1500), and vinext
-    // otherwise never sees the value because we don't run the webpack loader
-    // pipeline. We call each loader with a dummy source so build-time env
-    // mutations land in the shared Node process and become visible to defines
-    // (NEXT_PUBLIC_* / next.config env passthrough) and server-side code.
-    invokeLoaderSideEffects(rules, root);
     return {
       aliases: normalizeAliasEntries(finalConfig.resolve?.alias, root),
       mdx: extractMdxOptionsFromRules(rules),
@@ -1463,113 +1457,6 @@ async function probeWebpackConfig(
   } catch {
     return { aliases: {}, mdx: null };
   }
-}
-
-/**
- * Walk webpack module rules and invoke each referenced loader once with a
- * dummy source string. Loaders that mutate `process.env` at compile time (a
- * pattern supported by Next.js' webpack pipeline) get a chance to land their
- * mutations before vinext computes defines. Failures are swallowed: a broken
- * loader must not break the build, since vinext doesn't actually use the
- * loader's transform output.
- */
-// oxlint-disable-next-line typescript/no-explicit-any
-function invokeLoaderSideEffects(rules: any[], root: string): void {
-  const require = createRequire(path.join(root, "package.json"));
-  const seen = new Set<unknown>();
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const visit = (rule: any): void => {
-    if (!rule || typeof rule !== "object") return;
-    if (Array.isArray(rule)) {
-      for (const child of rule) visit(child);
-      return;
-    }
-    if (Array.isArray(rule.oneOf)) for (const child of rule.oneOf) visit(child);
-    if (Array.isArray(rule.rules)) for (const child of rule.rules) visit(child);
-    const uses = Array.isArray(rule.use) ? rule.use : rule.use ? [rule.use] : [];
-    for (const use of uses) invokeLoaderEntry(use);
-    if (rule.loader !== undefined) invokeLoaderEntry(rule.loader, rule.options);
-  };
-
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const invokeLoaderEntry = (entry: any, ruleOptions?: unknown): void => {
-    if (!entry) return;
-    let loaderPath: string | undefined;
-    let loaderFn: unknown;
-    let options: unknown = ruleOptions;
-    if (typeof entry === "string") {
-      loaderPath = entry;
-    } else if (typeof entry === "function") {
-      loaderFn = entry;
-    } else if (typeof entry === "object") {
-      if (typeof entry.loader === "string") loaderPath = entry.loader;
-      else if (typeof entry.loader === "function") loaderFn = entry.loader;
-      if (entry.options !== undefined) options = entry.options;
-    }
-    if (loaderPath !== undefined) {
-      if (seen.has(loaderPath)) return;
-      seen.add(loaderPath);
-      // Skip well-known framework loaders we wouldn't want to import and
-      // execute at probe time. These don't typically mutate process.env and
-      // may pull in heavy dependencies or fail to resolve outside webpack.
-      if (
-        loaderPath.includes("next-babel-loader") ||
-        loaderPath.includes("mdx") ||
-        loaderPath.startsWith("next/dist/build/webpack")
-      ) {
-        return;
-      }
-      try {
-        loaderFn = require(loaderPath);
-        // ESM interop: handle default-export modules
-        if (
-          loaderFn &&
-          typeof loaderFn === "object" &&
-          // oxlint-disable-next-line typescript/no-explicit-any
-          typeof (loaderFn as any).default === "function"
-        ) {
-          // oxlint-disable-next-line typescript/no-explicit-any
-          loaderFn = (loaderFn as any).default;
-        }
-      } catch {
-        return;
-      }
-    }
-    if (typeof loaderFn !== "function") return;
-    if (seen.has(loaderFn)) return;
-    seen.add(loaderFn);
-    try {
-      // Mimic the webpack loader runtime: `this` carries getOptions(),
-      // query, resourcePath, async(), callback(), emitError(), etc. We
-      // stub the minimum a typical loader might touch. We don't care about
-      // the return value — only side effects on process.env.
-      const loaderThis = {
-        // oxlint-disable-next-line typescript/no-unused-vars
-        async: () => () => {},
-        // oxlint-disable-next-line typescript/no-unused-vars
-        callback: () => {},
-        // oxlint-disable-next-line typescript/no-unused-vars
-        emitError: () => {},
-        // oxlint-disable-next-line typescript/no-unused-vars
-        emitWarning: () => {},
-        cacheable: () => {},
-        getOptions: () => options ?? {},
-        query: options ?? {},
-        resourcePath: "",
-        resource: "",
-        rootContext: root,
-        context: root,
-        mode: "production",
-      };
-      // oxlint-disable-next-line typescript/no-unsafe-function-type
-      (loaderFn as Function).call(loaderThis, "");
-    } catch {
-      // Ignore — the loader may have thrown on the dummy source.
-      // process.env mutations made before the throw still apply.
-    }
-  };
-
-  for (const rule of rules) visit(rule);
 }
 
 /**

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -432,6 +432,16 @@ export type ResolvedNextConfig = {
    * Mirrors Next.js: packages/next/src/server/lib/trace/utils.ts (getTracedMetadata).
    */
   clientTraceMetadata: string[] | undefined;
+  /**
+   * App Router client cache freshness windows in seconds, sourced from
+   * `experimental.staleTimes`. Controls how long prefetched route segments
+   * are considered fresh in the client-side router cache.
+   *
+   * `dynamic` applies to partial/dynamic prefetches (default 0 — no reuse).
+   * `static` applies to full-route prefetches (default 300 — 5 minutes).
+   * Mirrors Next.js' `process.env.__NEXT_CLIENT_ROUTER_{DYNAMIC,STATIC}_STALETIME`.
+   */
+  staleTimes: { dynamic: number; static: number };
 };
 
 // Mirrors Next.js's accepted set in packages/next/src/shared/lib/constants.ts
@@ -1046,6 +1056,36 @@ function serializeCompilerDefine(value: unknown): Record<string, string> {
 }
 
 /**
+ * Defaults for `experimental.staleTimes` (in seconds), matching Next.js'
+ * `config-shared.ts` defaults.
+ */
+const DEFAULT_STALE_TIMES = { dynamic: 0, static: 300 };
+
+/**
+ * Parse `experimental.staleTimes` from a raw next.config object.
+ *
+ * Mirrors Next.js' `build/define-env.ts` parsing logic:
+ *   - missing / NaN values fall back to the documented defaults
+ *     (`dynamic: 0`, `static: 300`) — matching Next.js parity
+ *   - all values are in seconds
+ *
+ * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/staleTimes
+ */
+function resolveStaleTimes(experimental: Record<string, unknown> | undefined): {
+  dynamic: number;
+  static: number;
+} {
+  const staleTimes = readOptionalRecord(experimental?.staleTimes);
+  const dynamicRaw = Number(staleTimes?.dynamic);
+  const staticRaw = Number(staleTimes?.static);
+
+  return {
+    dynamic: Number.isFinite(dynamicRaw) ? dynamicRaw : DEFAULT_STALE_TIMES.dynamic,
+    static: Number.isFinite(staticRaw) ? staticRaw : DEFAULT_STALE_TIMES.static,
+  };
+}
+
+/**
  * Resolve a NextConfig into a fully-resolved ResolvedNextConfig.
  * Awaits async functions for redirects/rewrites/headers.
  */
@@ -1091,6 +1131,7 @@ export async function resolveNextConfig(
       compilerDefineServer: {},
       instrumentationClientInject: [],
       clientTraceMetadata: undefined,
+      staleTimes: { ...DEFAULT_STALE_TIMES },
     };
     detectNextIntlConfig(root, resolved);
     return resolved;
@@ -1323,6 +1364,7 @@ export async function resolveNextConfig(
           (value): value is string => typeof value === "string",
         )
       : undefined,
+    staleTimes: resolveStaleTimes(experimental),
   };
 
   // Auto-detect next-intl (lowest priority — explicit aliases from
@@ -1406,6 +1448,14 @@ async function probeWebpackConfig(
     const finalConfig = result ?? mockConfig;
     // oxlint-disable-next-line typescript/no-explicit-any
     const rules: any[] = finalConfig.module?.rules ?? mockModuleRules;
+    // Invoke loader callbacks for any side effects they have on
+    // `process.env`. Next.js webpack loaders sometimes mutate
+    // `process.env.X = ...` at compile time (see issue #1500), and vinext
+    // otherwise never sees the value because we don't run the webpack loader
+    // pipeline. We call each loader with a dummy source so build-time env
+    // mutations land in the shared Node process and become visible to defines
+    // (NEXT_PUBLIC_* / next.config env passthrough) and server-side code.
+    invokeLoaderSideEffects(rules, root);
     return {
       aliases: normalizeAliasEntries(finalConfig.resolve?.alias, root),
       mdx: extractMdxOptionsFromRules(rules),
@@ -1413,6 +1463,113 @@ async function probeWebpackConfig(
   } catch {
     return { aliases: {}, mdx: null };
   }
+}
+
+/**
+ * Walk webpack module rules and invoke each referenced loader once with a
+ * dummy source string. Loaders that mutate `process.env` at compile time (a
+ * pattern supported by Next.js' webpack pipeline) get a chance to land their
+ * mutations before vinext computes defines. Failures are swallowed: a broken
+ * loader must not break the build, since vinext doesn't actually use the
+ * loader's transform output.
+ */
+// oxlint-disable-next-line typescript/no-explicit-any
+function invokeLoaderSideEffects(rules: any[], root: string): void {
+  const require = createRequire(path.join(root, "package.json"));
+  const seen = new Set<unknown>();
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const visit = (rule: any): void => {
+    if (!rule || typeof rule !== "object") return;
+    if (Array.isArray(rule)) {
+      for (const child of rule) visit(child);
+      return;
+    }
+    if (Array.isArray(rule.oneOf)) for (const child of rule.oneOf) visit(child);
+    if (Array.isArray(rule.rules)) for (const child of rule.rules) visit(child);
+    const uses = Array.isArray(rule.use) ? rule.use : rule.use ? [rule.use] : [];
+    for (const use of uses) invokeLoaderEntry(use);
+    if (rule.loader !== undefined) invokeLoaderEntry(rule.loader, rule.options);
+  };
+
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const invokeLoaderEntry = (entry: any, ruleOptions?: unknown): void => {
+    if (!entry) return;
+    let loaderPath: string | undefined;
+    let loaderFn: unknown;
+    let options: unknown = ruleOptions;
+    if (typeof entry === "string") {
+      loaderPath = entry;
+    } else if (typeof entry === "function") {
+      loaderFn = entry;
+    } else if (typeof entry === "object") {
+      if (typeof entry.loader === "string") loaderPath = entry.loader;
+      else if (typeof entry.loader === "function") loaderFn = entry.loader;
+      if (entry.options !== undefined) options = entry.options;
+    }
+    if (loaderPath !== undefined) {
+      if (seen.has(loaderPath)) return;
+      seen.add(loaderPath);
+      // Skip well-known framework loaders we wouldn't want to import and
+      // execute at probe time. These don't typically mutate process.env and
+      // may pull in heavy dependencies or fail to resolve outside webpack.
+      if (
+        loaderPath.includes("next-babel-loader") ||
+        loaderPath.includes("mdx") ||
+        loaderPath.startsWith("next/dist/build/webpack")
+      ) {
+        return;
+      }
+      try {
+        loaderFn = require(loaderPath);
+        // ESM interop: handle default-export modules
+        if (
+          loaderFn &&
+          typeof loaderFn === "object" &&
+          // oxlint-disable-next-line typescript/no-explicit-any
+          typeof (loaderFn as any).default === "function"
+        ) {
+          // oxlint-disable-next-line typescript/no-explicit-any
+          loaderFn = (loaderFn as any).default;
+        }
+      } catch {
+        return;
+      }
+    }
+    if (typeof loaderFn !== "function") return;
+    if (seen.has(loaderFn)) return;
+    seen.add(loaderFn);
+    try {
+      // Mimic the webpack loader runtime: `this` carries getOptions(),
+      // query, resourcePath, async(), callback(), emitError(), etc. We
+      // stub the minimum a typical loader might touch. We don't care about
+      // the return value — only side effects on process.env.
+      const loaderThis = {
+        // oxlint-disable-next-line typescript/no-unused-vars
+        async: () => () => {},
+        // oxlint-disable-next-line typescript/no-unused-vars
+        callback: () => {},
+        // oxlint-disable-next-line typescript/no-unused-vars
+        emitError: () => {},
+        // oxlint-disable-next-line typescript/no-unused-vars
+        emitWarning: () => {},
+        cacheable: () => {},
+        getOptions: () => options ?? {},
+        query: options ?? {},
+        resourcePath: "",
+        resource: "",
+        rootContext: root,
+        context: root,
+        mode: "production",
+      };
+      // oxlint-disable-next-line typescript/no-unsafe-function-type
+      (loaderFn as Function).call(loaderThis, "");
+    } catch {
+      // Ignore — the loader may have thrown on the dummy source.
+      // process.env mutations made before the throw still apply.
+    }
+  };
+
+  for (const rule of rules) visit(rule);
 }
 
 /**

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1115,12 +1115,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
         // Expose basePath to client-side code
         defines["process.env.__NEXT_ROUTER_BASEPATH"] = JSON.stringify(nextConfig.basePath);
-        // Expose experimental.staleTimes to client-side code so the App Router
-        // prefetch cache can honor the configured freshness windows. Values are
-        // in seconds; matches Next.js' `define-env.ts` plumbing for these vars.
-        defines["process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME"] = JSON.stringify(
-          String(nextConfig.staleTimes.dynamic),
-        );
+        // Expose experimental.staleTimes.static to client-side code so the
+        // App Router prefetch cache can honor the configured freshness window.
+        // Value is in seconds; matches Next.js' `define-env.ts` plumbing.
+        //
+        // Note: Next.js also defines `__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME`
+        // to control partial/hover-prefetch TTL, but vinext currently uses
+        // a single PREFETCH_CACHE_TTL for all prefetches without
+        // distinguishing prefetch kind. Wire that up alongside the consumer
+        // when prefetch-kind differentiation lands.
         defines["process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME"] = JSON.stringify(
           String(nextConfig.staleTimes.static),
         );

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1115,6 +1115,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
         // Expose basePath to client-side code
         defines["process.env.__NEXT_ROUTER_BASEPATH"] = JSON.stringify(nextConfig.basePath);
+        // Expose experimental.staleTimes to client-side code so the App Router
+        // prefetch cache can honor the configured freshness windows. Values are
+        // in seconds; matches Next.js' `define-env.ts` plumbing for these vars.
+        defines["process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME"] = JSON.stringify(
+          String(nextConfig.staleTimes.dynamic),
+        );
+        defines["process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME"] = JSON.stringify(
+          String(nextConfig.staleTimes.static),
+        );
         // Expose trailingSlash to client-side code so <Link> can render hrefs
         // in the canonical form and avoid an unnecessary 308 redirect bounce.
         defines["process.env.__VINEXT_TRAILING_SLASH"] = JSON.stringify(

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -339,8 +339,29 @@ export const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 /** Maximum number of entries in the RSC prefetch cache. */
 export const MAX_PREFETCH_CACHE_SIZE = 50;
 
-/** TTL for prefetch cache entries in ms (matches Next.js static prefetch TTL). */
-export const PREFETCH_CACHE_TTL = 30_000;
+/**
+ * TTL for prefetch cache entries in ms.
+ *
+ * Mirrors Next.js' `STATIC_STALETIME_MS` derivation. The plugin injects
+ * `process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME` from
+ * `experimental.staleTimes.static` (in seconds) at build time; we convert
+ * to ms here.
+ *
+ * Falls back to vinext's historical default of 30s when the env var is
+ * absent (e.g. unit tests that import this module without going through
+ * the plugin's `define` pipeline). When the plugin is active and the user
+ * has not set `experimental.staleTimes`, Next.js' 300s default applies
+ * (see `resolveStaleTimes` in `config/next-config.ts`).
+ */
+function resolvePrefetchCacheTtl(): number {
+  const raw = process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME;
+  if (raw === undefined || raw === "") return 30_000;
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds < 0) return 30_000;
+  return seconds * 1000;
+}
+
+export const PREFETCH_CACHE_TTL = resolvePrefetchCacheTtl();
 
 /** A buffered RSC response stored as an ArrayBuffer for replay. */
 export type CachedRscResponse = {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -600,47 +600,6 @@ module.exports = withPlugin({ basePath: "/wrapped" });`,
     expect(config.aliases).toEqual({});
   });
 
-  it("invokes webpack loader callbacks so build-time process.env mutations land in the Node process", async () => {
-    // Regression test for #1500.
-    // Some Next.js webpack loaders mutate `process.env.X = ...` at build
-    // time, expecting the value to be visible to other modules during the
-    // same build. vinext doesn't run the webpack loader pipeline, so the
-    // env mutation never happens. We compensate by invoking each loader's
-    // callback once during config probing with a dummy source.
-    tmpDir = makeTempDir();
-
-    const loaderPath = path.join(tmpDir, "vinext-1500-loader.cjs");
-    fs.writeFileSync(
-      loaderPath,
-      `module.exports = function (source) {\n` +
-        `  process.env.VINEXT_ISSUE_1500_LOADER_RAN = "yes";\n` +
-        `  return source;\n` +
-        `};\n`,
-    );
-
-    const previous = process.env.VINEXT_ISSUE_1500_LOADER_RAN;
-    delete process.env.VINEXT_ISSUE_1500_LOADER_RAN;
-    try {
-      const rawConfig = {
-        webpack: (webpackConfig: any) => {
-          webpackConfig.module = webpackConfig.module || { rules: [] };
-          webpackConfig.module.rules.push({
-            test: /\.svg$/,
-            use: [loaderPath],
-          });
-          return webpackConfig;
-        },
-      };
-
-      await resolveNextConfig(rawConfig, tmpDir);
-
-      expect(process.env.VINEXT_ISSUE_1500_LOADER_RAN).toBe("yes");
-    } finally {
-      if (previous === undefined) delete process.env.VINEXT_ISSUE_1500_LOADER_RAN;
-      else process.env.VINEXT_ISSUE_1500_LOADER_RAN = previous;
-    }
-  });
-
   it("extracts aliases and mdx from a single async webpack probe", async () => {
     tmpDir = makeTempDir();
 
@@ -1767,6 +1726,16 @@ describe("resolveNextConfig staleTimes (#1490)", () => {
       experimental: {
         staleTimes: { dynamic: "oops" as unknown as number, static: undefined },
       },
+    });
+    expect(resolved.staleTimes).toEqual({ dynamic: 0, static: 300 });
+  });
+
+  it("falls back to defaults when staleTimes contains negative values", async () => {
+    // Negative values are rejected at resolution time so we don't pass them
+    // downstream to `resolvePrefetchCacheTtl`, where they'd be re-validated.
+    // Matches the `seconds < 0` guard in `shims/navigation.ts`.
+    const resolved = await resolveNextConfig({
+      experimental: { staleTimes: { dynamic: -5, static: -1 } },
     });
     expect(resolved.staleTimes).toEqual({ dynamic: 0, static: 300 });
   });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -600,6 +600,47 @@ module.exports = withPlugin({ basePath: "/wrapped" });`,
     expect(config.aliases).toEqual({});
   });
 
+  it("invokes webpack loader callbacks so build-time process.env mutations land in the Node process", async () => {
+    // Regression test for #1500.
+    // Some Next.js webpack loaders mutate `process.env.X = ...` at build
+    // time, expecting the value to be visible to other modules during the
+    // same build. vinext doesn't run the webpack loader pipeline, so the
+    // env mutation never happens. We compensate by invoking each loader's
+    // callback once during config probing with a dummy source.
+    tmpDir = makeTempDir();
+
+    const loaderPath = path.join(tmpDir, "vinext-1500-loader.cjs");
+    fs.writeFileSync(
+      loaderPath,
+      `module.exports = function (source) {\n` +
+        `  process.env.VINEXT_ISSUE_1500_LOADER_RAN = "yes";\n` +
+        `  return source;\n` +
+        `};\n`,
+    );
+
+    const previous = process.env.VINEXT_ISSUE_1500_LOADER_RAN;
+    delete process.env.VINEXT_ISSUE_1500_LOADER_RAN;
+    try {
+      const rawConfig = {
+        webpack: (webpackConfig: any) => {
+          webpackConfig.module = webpackConfig.module || { rules: [] };
+          webpackConfig.module.rules.push({
+            test: /\.svg$/,
+            use: [loaderPath],
+          });
+          return webpackConfig;
+        },
+      };
+
+      await resolveNextConfig(rawConfig, tmpDir);
+
+      expect(process.env.VINEXT_ISSUE_1500_LOADER_RAN).toBe("yes");
+    } finally {
+      if (previous === undefined) delete process.env.VINEXT_ISSUE_1500_LOADER_RAN;
+      else process.env.VINEXT_ISSUE_1500_LOADER_RAN = previous;
+    }
+  });
+
   it("extracts aliases and mdx from a single async webpack probe", async () => {
     tmpDir = makeTempDir();
 
@@ -1151,6 +1192,7 @@ describe("detectNextIntlConfig", () => {
       compilerDefineServer: {},
       instrumentationClientInject: [],
       clientTraceMetadata: undefined,
+      staleTimes: { dynamic: 0, static: 300 },
       ...overrides,
     };
   }
@@ -1684,5 +1726,48 @@ describe("resolveNextConfig enablePrerenderSourceMaps", () => {
       enablePrerenderSourceMaps: false,
     });
     expect(resolved.enablePrerenderSourceMaps).toBe(false);
+  });
+});
+
+// Regression for issue #1490:
+// experimental.staleTimes should be surfaced through ResolvedNextConfig so the
+// plugin can inject the values into the client-side router cache.
+describe("resolveNextConfig staleTimes (#1490)", () => {
+  it("defaults to Next.js' { dynamic: 0, static: 300 } when no config is provided", async () => {
+    const resolved = await resolveNextConfig(null);
+    expect(resolved.staleTimes).toEqual({ dynamic: 0, static: 300 });
+  });
+
+  it("defaults to Next.js' { dynamic: 0, static: 300 } when experimental is not set", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.staleTimes).toEqual({ dynamic: 0, static: 300 });
+  });
+
+  it("reads experimental.staleTimes.{dynamic,static} verbatim (in seconds)", async () => {
+    const resolved = await resolveNextConfig({
+      experimental: { staleTimes: { dynamic: 30, static: 180 } },
+    });
+    expect(resolved.staleTimes).toEqual({ dynamic: 30, static: 180 });
+  });
+
+  it("falls back to defaults for individually-omitted keys", async () => {
+    const resolvedDynOnly = await resolveNextConfig({
+      experimental: { staleTimes: { dynamic: 45 } },
+    });
+    expect(resolvedDynOnly.staleTimes).toEqual({ dynamic: 45, static: 300 });
+
+    const resolvedStaticOnly = await resolveNextConfig({
+      experimental: { staleTimes: { static: 600 } },
+    });
+    expect(resolvedStaticOnly.staleTimes).toEqual({ dynamic: 0, static: 600 });
+  });
+
+  it("falls back to defaults when staleTimes contains non-numeric values", async () => {
+    const resolved = await resolveNextConfig({
+      experimental: {
+        staleTimes: { dynamic: "oops" as unknown as number, static: undefined },
+      },
+    });
+    expect(resolved.staleTimes).toEqual({ dynamic: 0, static: 300 });
   });
 });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -409,6 +409,86 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().size).toBe(rest);
   });
 
+  // Regression for issue #1490: experimental.staleTimes.static should be
+  // honored as the prefetch cache freshness window. The plugin injects
+  // `process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME` (in seconds) at
+  // build time; navigation.ts reads it when computing PREFETCH_CACHE_TTL.
+  describe("staleTimes (#1490)", () => {
+    const ORIGINAL_TTL_ENV = process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME;
+
+    afterEach(() => {
+      if (ORIGINAL_TTL_ENV === undefined) {
+        delete process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME;
+      } else {
+        process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME = ORIGINAL_TTL_ENV;
+      }
+    });
+
+    it("uses 30s when __NEXT_CLIENT_ROUTER_STATIC_STALETIME is unset", async () => {
+      delete process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME;
+      vi.resetModules();
+      const nav = await import("../packages/vinext/src/shims/navigation.js");
+      expect(nav.PREFETCH_CACHE_TTL).toBe(30_000);
+    });
+
+    it("converts seconds from __NEXT_CLIENT_ROUTER_STATIC_STALETIME into ms", async () => {
+      process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME = "180";
+      vi.resetModules();
+      const nav = await import("../packages/vinext/src/shims/navigation.js");
+      expect(nav.PREFETCH_CACHE_TTL).toBe(180_000);
+    });
+
+    it("treats a freshly prefetched entry as reusable up to the configured TTL", async () => {
+      process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME = "180";
+      vi.resetModules();
+      const nav = await import("../packages/vinext/src/shims/navigation.js");
+
+      const cache = nav.getPrefetchCache();
+      const prefetched = nav.getPrefetchedUrls();
+      const rscUrl = "/dashboard.rsc";
+      const now = 1_000_000;
+      const snapshot = {
+        buffer: new TextEncoder().encode("flight").buffer,
+        contentType: "text/x-component",
+        mountedSlotsHeader: null,
+        paramsHeader: null,
+        url: rscUrl,
+      };
+
+      cache.set(rscUrl, { outcome: "cache-seeded", snapshot, timestamp: now });
+      prefetched.add(rscUrl);
+
+      // 150 seconds later — within the configured 180s window, must reuse
+      vi.spyOn(Date, "now").mockReturnValue(now + 150_000);
+      expect(nav.consumePrefetchResponse(rscUrl, null, null)).toEqual(snapshot);
+    });
+
+    it("treats a stale entry as expired once the configured TTL elapses", async () => {
+      process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME = "180";
+      vi.resetModules();
+      const nav = await import("../packages/vinext/src/shims/navigation.js");
+
+      const cache = nav.getPrefetchCache();
+      const prefetched = nav.getPrefetchedUrls();
+      const rscUrl = "/dashboard.rsc";
+      const now = 1_000_000;
+      const snapshot = {
+        buffer: new TextEncoder().encode("flight").buffer,
+        contentType: "text/x-component",
+        mountedSlotsHeader: null,
+        paramsHeader: null,
+        url: rscUrl,
+      };
+
+      cache.set(rscUrl, { outcome: "cache-seeded", snapshot, timestamp: now });
+      prefetched.add(rscUrl);
+
+      // 200 seconds later — past the 180s window, must NOT reuse
+      vi.spyOn(Date, "now").mockReturnValue(now + 200_000);
+      expect(nav.consumePrefetchResponse(rscUrl, null, null)).toBeNull();
+    });
+  });
+
   it("does not sweep when cache is below capacity", () => {
     // Use fixed arbitrary values to avoid any dependency on the real wall clock
     const now = 1_000_000;


### PR DESCRIPTION
Closes #1490.

## Summary

- App Router's client-side prefetch cache used a hard-coded 30s TTL and ignored `experimental.staleTimes` from `next.config`. Users could not control how long prefetched route segments were considered fresh — failing parity with Next.js' `test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts`.
- Surface `experimental.staleTimes.{dynamic,static}` through `ResolvedNextConfig` (defaults to Next.js' `{ dynamic: 0, static: 300 }`) and inject `__NEXT_CLIENT_ROUTER_STATIC_STALETIME` into the client bundle — same variable name Next.js plumbs via `build/define-env.ts`. (`DYNAMIC_STALETIME` is not yet injected since vinext does not distinguish prefetch kinds; will land alongside the consumer.)
- `PREFETCH_CACHE_TTL` in `shims/navigation.ts` now reads the static value at module-load time (seconds → ms). When the env var is absent (e.g. unit tests outside the plugin's `define` pipeline), we keep vinext's historical 30s default so existing tests stay green.

## Behavioral change for existing users (10x TTL bump)

When the plugin is active and the user has **not** set `experimental.staleTimes`, the effective production prefetch cache TTL changes from **30s to 300s** (a 10x increase). This is the Next.js default and the intentional parity fix this PR delivers — prefetched route segments will now be served from the client cache for 5 minutes instead of 30 seconds. Users who want the old behavior can opt back in via:

```js
// next.config.js
module.exports = {
  experimental: { staleTimes: { static: 30 } },
};
```

## Test plan

- [x] `pnpm test tests/next-config.test.ts` — added cases covering defaults, explicit values, partial keys, non-numeric inputs, and negative values (all fall back to defaults).
- [x] `pnpm test tests/prefetch-cache.test.ts` — added 4 cases covering the env-driven TTL: fallback when unset, seconds-to-ms conversion, and consume-within-/-past the configured window.
- [x] `pnpm run check` — format/lint/types clean.
- [ ] CI: Vitest + Playwright E2E.

## References

- Next.js source: `.nextjs-ref/packages/next/src/build/define-env.ts` (env injection)
- Next.js source: `.nextjs-ref/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts` (`STATIC_STALETIME_MS`)