### PR TITLE
fix(build): bundle nested copies of serverExternalPackages (#1503)

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -109,6 +109,7 @@ import {
   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
 } from "./plugins/rsc-client-shim-excludes.js";
 import { createServerExternalsManifestPlugin } from "./plugins/server-externals-manifest.js";
+import { createTransitiveExternalsPlugin } from "./plugins/transitive-externals.js";
 import {
   VIRTUAL_GOOGLE_FONTS,
   RESOLVED_VIRTUAL_GOOGLE_FONTS,
@@ -3891,6 +3892,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // standalone/node_modules/ — uses the bundler's own import graph instead of
     // fragile regex scanning of emitted files.
     createServerExternalsManifestPlugin(),
+    // Force-bundle transitive copies of `serverExternalPackages` whose
+    // installed version differs from the project-root copy. Without this,
+    // both copies collapse to the same runtime `node_modules/<dep>/` lookup
+    // and one version silently wins — see #1503.
+    createTransitiveExternalsPlugin({
+      getRoot: () => root ?? null,
+      getExternalPackages: () => nextConfig?.serverExternalPackages ?? [],
+    }),
     // Write image config JSON for the App Router production server.
     // The App Router RSC entry doesn't export vinextConfig (that's a Pages
     // Router pattern), so we write a separate JSON file at build time that

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -4,6 +4,16 @@ import { createRequire } from "node:module";
 import type { Plugin } from "vite";
 
 /**
+ * Transitive-externals resolution for `serverExternalPackages`.
+ *
+ * This plugin is inert on Cloudflare / Nitro deployment targets: those
+ * builds bundle everything (no `resolve.external` entries), so the
+ * configured external set is empty and `resolveId` short-circuits on the
+ * `set.size === 0` check. It only does work for Node-server targets that
+ * actually populate `serverExternalPackages`.
+ */
+
+/**
  * Decide whether an external request from `importer` would resolve to a
  * different installed copy than the same request from the project root.
  *
@@ -120,6 +130,10 @@ export function createTransitiveExternalsPlugin(options: {
     },
 
     resolveId(source, importer) {
+      // `resolve.external` is only configured on server environments (rsc,
+      // ssr), so the client environment has nothing to disambiguate.
+      // Bail out immediately to avoid per-import work on client builds.
+      if (this.environment?.name === "client") return null;
       const set = externalSet;
       const resolver = rootResolver;
       if (!set || !resolver) return null;

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import type { Plugin } from "vite";
+
+/**
+ * Decide whether an external request from `importer` would resolve to a
+ * different installed copy than the same request from the project root.
+ *
+ * Returns the absolute resolved path (i.e. the importer's nested copy)
+ * when the resolutions differ, or `null` when they're identical (or when
+ * resolution fails — in that case we leave the request external and let
+ * Vite/Node handle it normally).
+ *
+ * This mirrors Next.js's webpack handler, which refuses to externalize a
+ * request when the resolution from the importer context differs from the
+ * project-root resolution (`baseResolveCheck`). Once the request is
+ * resolved to an absolute path, Vite no longer matches it against
+ * `resolve.external` (which is a list of bare specifiers), so the module
+ * gets bundled with the importer instead of being left as a runtime
+ * `import "lodash"` that would resolve to the wrong version.
+ *
+ * See:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/build/handle-externals.ts
+ */
+export function resolveTransitiveExternal(
+  request: string,
+  importer: string,
+  rootResolver: NodeRequire,
+): string | null {
+  let importerResolved: string;
+  try {
+    const importerRequire = createRequire(importer);
+    importerResolved = importerRequire.resolve(request);
+  } catch {
+    return null;
+  }
+
+  let rootResolved: string;
+  try {
+    rootResolved = rootResolver.resolve(request);
+  } catch {
+    // Request can't be resolved from the root at all — that's a stronger
+    // signal that the importer's nested copy is the only valid one.
+    // Returning the importer-resolved path forces Vite to bundle it.
+    try {
+      return fs.realpathSync(importerResolved);
+    } catch {
+      return importerResolved;
+    }
+  }
+
+  let importerReal: string;
+  let rootReal: string;
+  try {
+    importerReal = fs.realpathSync(importerResolved);
+  } catch {
+    importerReal = importerResolved;
+  }
+  try {
+    rootReal = fs.realpathSync(rootResolved);
+  } catch {
+    rootReal = rootResolved;
+  }
+
+  if (importerReal === rootReal) {
+    return null;
+  }
+  return importerReal;
+}
+
+/**
+ * vinext:transitive-externals
+ *
+ * Force Vite to bundle (rather than externalize) imports of packages listed
+ * in `serverExternalPackages` when the importer resolves them to a different
+ * installed copy than the project root. Without this, two nested copies of
+ * a transitive dependency collapse to a single version at runtime — the
+ * importer ends up loading whichever copy happens to sit at the top-level
+ * `node_modules/<dep>/`, regardless of the version it actually expects.
+ *
+ * Example layout:
+ *
+ *   node_modules/lodash/                  # v3.10.1 (root)
+ *   node_modules/dep-a/                   # depends on lodash@3
+ *   node_modules/dep-b/                   # depends on lodash@4
+ *   node_modules/dep-b/node_modules/lodash/  # v4.17.21 (nested)
+ *
+ * With `serverExternalPackages: ['lodash']`, Vite would normally leave
+ * every `import 'lodash'` as a bare runtime require. Both dep-a and dep-b
+ * would then resolve `lodash` from the same `dist/server/node_modules/`
+ * directory at runtime — only one version can win. This plugin detects
+ * dep-b's case, returns the absolute path to its nested lodash copy, and
+ * lets Vite bundle that copy alongside dep-b's code.
+ *
+ * Ports the `baseResolveCheck` behaviour from Next.js's webpack handler:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/build/handle-externals.ts
+ */
+export function createTransitiveExternalsPlugin(options: {
+  /**
+   * Lazy getters so the plugin can read the project root and the
+   * resolved next.config values that are populated during
+   * `configResolved` — after the plugin factory has already run.
+   */
+  getRoot: () => string | null;
+  getExternalPackages: () => string[];
+}): Plugin {
+  let externalSet: Set<string> | null = null;
+  let rootResolver: NodeRequire | null = null;
+
+  return {
+    name: "vinext:transitive-externals",
+    enforce: "pre",
+
+    configResolved() {
+      const root = options.getRoot();
+      if (!root) return;
+      externalSet = new Set(options.getExternalPackages());
+      rootResolver = createRequire(path.join(root, "package.json"));
+    },
+
+    resolveId(source, importer) {
+      const set = externalSet;
+      const resolver = rootResolver;
+      if (!set || !resolver) return null;
+      if (!importer || set.size === 0) return null;
+      // Only act on bare specifiers that match an externalised package.
+      // Match either an exact package name or a subpath import (e.g.
+      // "lodash/package.json"). Handle scoped packages too.
+      let pkgName: string | null = null;
+      if (source.startsWith("@")) {
+        const parts = source.split("/");
+        if (parts.length >= 2) pkgName = `${parts[0]}/${parts[1]}`;
+      } else {
+        pkgName = source.split("/")[0] ?? null;
+      }
+      if (!pkgName || !set.has(pkgName)) return null;
+
+      // Skip importers that aren't real on-disk files (virtual modules,
+      // \0-prefixed ids, etc.) — we can't anchor a Node resolver on them.
+      if (importer.startsWith("\0") || importer.includes("?")) return null;
+      if (!path.isAbsolute(importer)) return null;
+
+      // Skip importers that don't live inside a node_modules tree —
+      // imports from the user's own source code are always resolved against
+      // the project root anyway, so there's nothing to disambiguate.
+      if (!importer.includes(`${path.sep}node_modules${path.sep}`)) return null;
+
+      const resolved = resolveTransitiveExternal(source, importer, resolver);
+      if (!resolved) return null;
+      return resolved;
+    },
+  };
+}
+
+/** Test helper: build a plugin from a pre-resolved root and package list. */
+export function _createPluginForTest(options: {
+  root: string;
+  externalPackages: string[];
+}): Plugin {
+  return createTransitiveExternalsPlugin({
+    getRoot: () => options.root,
+    getExternalPackages: () => options.externalPackages,
+  });
+}

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -155,11 +155,6 @@ export function createTransitiveExternalsPlugin(options: {
       if (importer.startsWith("\0") || importer.includes("?")) return null;
       if (!path.isAbsolute(importer)) return null;
 
-      // Skip importers that don't live inside a node_modules tree —
-      // imports from the user's own source code are always resolved against
-      // the project root anyway, so there's nothing to disambiguate.
-      if (!importer.includes(`${path.sep}node_modules${path.sep}`)) return null;
-
       const resolved = resolveTransitiveExternal(source, importer, resolver);
       if (!resolved) return null;
       return resolved;

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -1,7 +1,38 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
-import type { Plugin } from "vite";
+import { createIdResolver, type Plugin, type Rollup } from "vite";
+
+type ExternalModuleMode = "import" | "require";
+
+type ResolvedExternal = {
+  path: string;
+  mode: ExternalModuleMode;
+};
+
+function realpath(resolvedPath: string): string {
+  try {
+    return fs.realpathSync(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+}
+
+function getExternalModuleMode(kind: Rollup.ImportKind | undefined): ExternalModuleMode {
+  return kind === "require-call" ? "require" : "import";
+}
+
+export function compareTransitiveExternalResolutions(
+  importerResolved: ResolvedExternal,
+  rootResolved: ResolvedExternal | null,
+): string | null {
+  const importerReal = realpath(importerResolved.path);
+  if (!rootResolved) return importerReal;
+
+  const rootReal = realpath(rootResolved.path);
+  if (importerReal === rootReal && importerResolved.mode === rootResolved.mode) return null;
+  return importerReal;
+}
 
 /**
  * Transitive-externals resolution for `serverExternalPackages`.
@@ -53,30 +84,13 @@ export function resolveTransitiveExternal(
     // Request can't be resolved from the root at all — that's a stronger
     // signal that the importer's nested copy is the only valid one.
     // Returning the importer-resolved path forces Vite to bundle it.
-    try {
-      return fs.realpathSync(importerResolved);
-    } catch {
-      return importerResolved;
-    }
+    return realpath(importerResolved);
   }
 
-  let importerReal: string;
-  let rootReal: string;
-  try {
-    importerReal = fs.realpathSync(importerResolved);
-  } catch {
-    importerReal = importerResolved;
-  }
-  try {
-    rootReal = fs.realpathSync(rootResolved);
-  } catch {
-    rootReal = rootResolved;
-  }
-
-  if (importerReal === rootReal) {
-    return null;
-  }
-  return importerReal;
+  return compareTransitiveExternalResolutions(
+    { path: importerResolved, mode: "require" },
+    { path: rootResolved, mode: "require" },
+  );
 }
 
 /**
@@ -117,26 +131,44 @@ export function createTransitiveExternalsPlugin(options: {
 }): Plugin {
   let externalSet: Set<string> | null = null;
   let rootResolver: NodeRequire | null = null;
+  let rootImporter: string | null = null;
+  let importResolver: ReturnType<typeof createIdResolver> | null = null;
+  let requireResolver: ReturnType<typeof createIdResolver> | null = null;
 
   return {
     name: "vinext:transitive-externals",
     enforce: "pre",
 
-    configResolved() {
+    configResolved(config) {
       const root = options.getRoot();
       if (!root) return;
       externalSet = new Set(options.getExternalPackages());
-      rootResolver = createRequire(path.join(root, "package.json"));
+      rootImporter = path.join(root, "package.json");
+      rootResolver = createRequire(rootImporter);
+      importResolver = createIdResolver(config, {
+        external: [],
+        isRequire: false,
+        noExternal: true,
+      });
+      requireResolver = createIdResolver(config, {
+        external: [],
+        isRequire: true,
+        noExternal: true,
+      });
     },
 
-    resolveId(source, importer) {
+    resolveId(source, importer, resolveOptions) {
       // `resolve.external` is only configured on server environments (rsc,
       // ssr), so the client environment has nothing to disambiguate.
       // Bail out immediately to avoid per-import work on client builds.
       if (this.environment?.name === "client") return null;
       const set = externalSet;
       const resolver = rootResolver;
-      if (!set || !resolver) return null;
+      const rootAnchor = rootImporter;
+      const viteImportResolver = importResolver;
+      const viteRequireResolver = requireResolver;
+      if (!set || !resolver || !rootAnchor || !viteImportResolver || !viteRequireResolver)
+        return null;
       if (!importer || set.size === 0) return null;
       // Only act on bare specifiers that match an externalised package.
       // Match either an exact package name or a subpath import (e.g.
@@ -155,9 +187,25 @@ export function createTransitiveExternalsPlugin(options: {
       if (importer.startsWith("\0") || importer.includes("?")) return null;
       if (!path.isAbsolute(importer)) return null;
 
-      const resolved = resolveTransitiveExternal(source, importer, resolver);
-      if (!resolved) return null;
-      return resolved;
+      if (typeof this.resolve !== "function") {
+        return resolveTransitiveExternal(source, importer, resolver);
+      }
+
+      const kind = resolveOptions.kind;
+      const mode = getExternalModuleMode(kind);
+      const environmentResolver = mode === "require" ? viteRequireResolver : viteImportResolver;
+      return (async () => {
+        const importerResolution = await environmentResolver(this.environment, source, importer);
+        if (!importerResolution || !path.isAbsolute(importerResolution)) {
+          return resolveTransitiveExternal(source, importer, resolver);
+        }
+
+        const rootResolution = await environmentResolver(this.environment, source, rootAnchor);
+        return compareTransitiveExternalResolutions(
+          { path: importerResolution, mode },
+          rootResolution && path.isAbsolute(rootResolution) ? { path: rootResolution, mode } : null,
+        );
+      })();
     },
   };
 }

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -197,7 +197,7 @@ export function createTransitiveExternalsPlugin(options: {
       return (async () => {
         const importerResolution = await environmentResolver(this.environment, source, importer);
         if (!importerResolution || !path.isAbsolute(importerResolution)) {
-          return resolveTransitiveExternal(source, importer, resolver);
+          return mode === "require" ? resolveTransitiveExternal(source, importer, resolver) : null;
         }
 
         const rootResolution = await environmentResolver(this.environment, source, rootAnchor);

--- a/tests/externals-transitive.test.ts
+++ b/tests/externals-transitive.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import type { Server } from "node:http";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { startProdServer } from "../packages/vinext/src/server/prod-server.js";
+
+const tempDirs: string[] = [];
+const servers: Server[] = [];
+
+function writeFixtureFile(root: string, filePath: string, content: string): void {
+  const absolutePath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+}
+
+function writePackage(root: string, packagePath: string, version: string, source: string): void {
+  writeFixtureFile(
+    root,
+    `${packagePath}/package.json`,
+    JSON.stringify({ name: path.basename(packagePath), version, type: "module", main: "index.js" }),
+  );
+  writeFixtureFile(root, `${packagePath}/index.js`, source);
+}
+
+function linkPackage(root: string, packageName: string): void {
+  fs.symlinkSync(
+    path.join(root, "packages", packageName),
+    path.join(root, "node_modules", packageName),
+    "junction",
+  );
+}
+
+async function createFixture(): Promise<string> {
+  const root = await mkdtemp(path.join(import.meta.dirname, ".tmp-externals-transitive-"));
+  tempDirs.push(root);
+
+  writeFixtureFile(
+    root,
+    "package.json",
+    JSON.stringify({ name: "vinext-externals-transitive", private: true, type: "module" }),
+  );
+  writeFixtureFile(
+    root,
+    "next.config.mjs",
+    `export default { serverExternalPackages: ["shared-version", "nested-only"] };\n`,
+  );
+  writeFixtureFile(
+    root,
+    "app/layout.tsx",
+    `export default function Layout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}\n`,
+  );
+  writeFixtureFile(
+    root,
+    "app/page.tsx",
+    `import depA from "dep-a";
+import depB from "dep-b";
+import rootVersion from "shared-version";
+
+export default function Page() {
+  return <p id="versions">{depA}, {depB}, root:{rootVersion}</p>;
+}\n`,
+  );
+
+  writePackage(root, "node_modules/shared-version", "1.0.0", `export default "root";\n`);
+  writePackage(
+    root,
+    "packages/dep-a",
+    "1.0.0",
+    `import version from "shared-version";
+import nestedOnly from "nested-only";
+export default "dep-a:" + version + ":" + nestedOnly;\n`,
+  );
+  writePackage(
+    root,
+    "packages/dep-a/node_modules/shared-version",
+    "2.0.0",
+    `export default "nested-a";\n`,
+  );
+  writePackage(
+    root,
+    "packages/dep-a/node_modules/nested-only",
+    "1.0.0",
+    `export default "nested-only";\n`,
+  );
+  writePackage(
+    root,
+    "packages/dep-b",
+    "1.0.0",
+    `import version from "shared-version";
+import packageJson from "shared-version/package.json" with { type: "json" };
+export default "dep-b:" + version + ":" + packageJson.version;\n`,
+  );
+  writePackage(
+    root,
+    "packages/dep-b/node_modules/shared-version",
+    "3.0.0",
+    `export default "nested-b";\n`,
+  );
+  linkPackage(root, "dep-a");
+  linkPackage(root, "dep-b");
+
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        ),
+    ),
+  );
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("transitive server externals", () => {
+  // Ported from Next.js: test/e2e/externals-transitive/externals-transitive.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/externals-transitive/externals-transitive.test.ts
+  it("resolves external package versions relative to each importing dependency", async () => {
+    const root = await createFixture();
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [
+        vinext({
+          appDir: root,
+          rscOutDir: path.join(root, "dist/server"),
+          ssrOutDir: path.join(root, "dist/server/ssr"),
+          clientOutDir: path.join(root, "dist/client"),
+        }),
+      ],
+    });
+    await builder.buildApp();
+
+    const started = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir: path.join(root, "dist"),
+    });
+    servers.push(started.server);
+    const address = started.server.address();
+    if (!address || typeof address === "string") throw new Error("Production server did not bind");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+    const html = await response.text();
+    const normalizedHtml = html.replaceAll("<!-- -->", "");
+    expect(response.status, html).toBe(200);
+    expect(normalizedHtml).toContain("dep-a:nested-a:nested-only, dep-b:nested-b:3.0.0, root:root");
+  }, 30_000);
+});

--- a/tests/externals-transitive.test.ts
+++ b/tests/externals-transitive.test.ts
@@ -87,7 +87,7 @@ async function createFixture(): Promise<string> {
   writeFixtureFile(
     root,
     "next.config.mjs",
-    `export default { serverExternalPackages: ["shared-version", "nested-only"] };\n`,
+    `export default { serverExternalPackages: ["shared-version", "nested-only", "require-only"] };\n`,
   );
   writeFixtureFile(
     root,
@@ -147,9 +147,24 @@ export default "dep-b:" + version + ":" + feature + ":" + packageJson.version;\n
     "packages/dep-c/index.cjs",
     `const version = require("shared-version");
 const feature = require("shared-version/feature");
-module.exports = "dep-c:" + version + ":" + feature;\n`,
+const requireOnly = require("require-only");
+module.exports = "dep-c:" + version + ":" + feature + ":" + requireOnly;\n`,
   );
   writeConditionalPackage(root, "packages/dep-c/node_modules/shared-version", "4.0.0", "nested-c");
+  writeFixtureFile(
+    root,
+    "packages/dep-c/node_modules/require-only/package.json",
+    JSON.stringify({
+      name: "require-only",
+      version: "1.0.0",
+      exports: { require: "./index.cjs" },
+    }),
+  );
+  writeFixtureFile(
+    root,
+    "packages/dep-c/node_modules/require-only/index.cjs",
+    `module.exports = "nested-require-only";\n`,
+  );
   linkPackage(root, "dep-a");
   linkPackage(root, "dep-b");
   linkPackage(root, "dep-c");
@@ -205,8 +220,75 @@ describe("transitive server externals", () => {
     expect(normalizedHtml).toContain(
       "dep-a:nested-a-import:nested-a-feature-import:nested-only, " +
         "dep-b:nested-b-import:nested-b-feature-import:3.0.0, " +
-        "dep-c:nested-c-require:nested-c-feature-require, " +
+        "dep-c:nested-c-require:nested-c-feature-require:nested-require-only, " +
         "root:root-import:root-feature-import",
     );
+  }, 30_000);
+
+  it("does not fall back to require-only exports for ESM imports from linked packages", async () => {
+    const root = await mkdtemp(path.join(import.meta.dirname, ".tmp-externals-require-only-"));
+    tempDirs.push(root);
+
+    writeFixtureFile(
+      root,
+      "package.json",
+      JSON.stringify({ name: "vinext-externals-require-only", private: true, type: "module" }),
+    );
+    writeFixtureFile(
+      root,
+      "next.config.mjs",
+      `export default { serverExternalPackages: ["require-only"] };\n`,
+    );
+    writeFixtureFile(
+      root,
+      "app/layout.tsx",
+      `export default function Layout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}\n`,
+    );
+    writeFixtureFile(
+      root,
+      "app/page.tsx",
+      `import dependency from "linked-dependency";
+export default function Page() { return <p>{dependency}</p>; }\n`,
+    );
+    writePackage(
+      root,
+      "packages/linked-dependency",
+      "1.0.0",
+      `import value from "require-only";\nexport default value;\n`,
+    );
+    writeFixtureFile(
+      root,
+      "packages/linked-dependency/node_modules/require-only/package.json",
+      JSON.stringify({
+        name: "require-only",
+        version: "1.0.0",
+        exports: { require: "./index.cjs" },
+      }),
+    );
+    writeFixtureFile(
+      root,
+      "packages/linked-dependency/node_modules/require-only/index.cjs",
+      `module.exports = "must-not-load-for-import";\n`,
+    );
+    fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+    linkPackage(root, "linked-dependency");
+
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [
+        vinext({
+          appDir: root,
+          rscOutDir: path.join(root, "dist/server"),
+          ssrOutDir: path.join(root, "dist/server/ssr"),
+          clientOutDir: path.join(root, "dist/client"),
+        }),
+      ],
+    });
+
+    await expect(builder.buildApp()).rejects.toThrow(/require-only/);
   }, 30_000);
 });

--- a/tests/externals-transitive.test.ts
+++ b/tests/externals-transitive.test.ts
@@ -16,13 +16,55 @@ function writeFixtureFile(root: string, filePath: string, content: string): void
   fs.writeFileSync(absolutePath, content);
 }
 
-function writePackage(root: string, packagePath: string, version: string, source: string): void {
+function writePackage(
+  root: string,
+  packagePath: string,
+  version: string,
+  source: string,
+  packageJson: Record<string, unknown> = {},
+): void {
   writeFixtureFile(
     root,
     `${packagePath}/package.json`,
-    JSON.stringify({ name: path.basename(packagePath), version, type: "module", main: "index.js" }),
+    JSON.stringify({ name: path.basename(packagePath), version, type: "module", ...packageJson }),
   );
   writeFixtureFile(root, `${packagePath}/index.js`, source);
+}
+
+function writeConditionalPackage(
+  root: string,
+  packagePath: string,
+  version: string,
+  label: string,
+): void {
+  writePackage(
+    root,
+    packagePath,
+    version,
+    `export default ${JSON.stringify(`${label}-import`)};\n`,
+    {
+      exports: {
+        ".": { import: "./index.js", require: "./index.cjs" },
+        "./feature": { import: "./feature.js", require: "./feature.cjs" },
+        "./package.json": "./package.json",
+      },
+    },
+  );
+  writeFixtureFile(
+    root,
+    `${packagePath}/index.cjs`,
+    `module.exports = ${JSON.stringify(`${label}-require`)};\n`,
+  );
+  writeFixtureFile(
+    root,
+    `${packagePath}/feature.js`,
+    `export default ${JSON.stringify(`${label}-feature-import`)};\n`,
+  );
+  writeFixtureFile(
+    root,
+    `${packagePath}/feature.cjs`,
+    `module.exports = ${JSON.stringify(`${label}-feature-require`)};\n`,
+  );
 }
 
 function linkPackage(root: string, packageName: string): void {
@@ -59,28 +101,26 @@ async function createFixture(): Promise<string> {
     "app/page.tsx",
     `import depA from "dep-a";
 import depB from "dep-b";
+import depC from "dep-c";
 import rootVersion from "shared-version";
+import rootFeature from "shared-version/feature";
 
 export default function Page() {
-  return <p id="versions">{depA}, {depB}, root:{rootVersion}</p>;
+  return <p id="versions">{depA}, {depB}, {depC}, root:{rootVersion}:{rootFeature}</p>;
 }\n`,
   );
 
-  writePackage(root, "node_modules/shared-version", "1.0.0", `export default "root";\n`);
+  writeConditionalPackage(root, "node_modules/shared-version", "1.0.0", "root");
   writePackage(
     root,
     "packages/dep-a",
     "1.0.0",
     `import version from "shared-version";
+import feature from "shared-version/feature";
 import nestedOnly from "nested-only";
-export default "dep-a:" + version + ":" + nestedOnly;\n`,
+export default "dep-a:" + version + ":" + feature + ":" + nestedOnly;\n`,
   );
-  writePackage(
-    root,
-    "packages/dep-a/node_modules/shared-version",
-    "2.0.0",
-    `export default "nested-a";\n`,
-  );
+  writeConditionalPackage(root, "packages/dep-a/node_modules/shared-version", "2.0.0", "nested-a");
   writePackage(
     root,
     "packages/dep-a/node_modules/nested-only",
@@ -92,17 +132,27 @@ export default "dep-a:" + version + ":" + nestedOnly;\n`,
     "packages/dep-b",
     "1.0.0",
     `import version from "shared-version";
+import feature from "shared-version/feature";
 import packageJson from "shared-version/package.json" with { type: "json" };
-export default "dep-b:" + version + ":" + packageJson.version;\n`,
+export default "dep-b:" + version + ":" + feature + ":" + packageJson.version;\n`,
   );
-  writePackage(
+  writeConditionalPackage(root, "packages/dep-b/node_modules/shared-version", "3.0.0", "nested-b");
+  writeFixtureFile(
     root,
-    "packages/dep-b/node_modules/shared-version",
-    "3.0.0",
-    `export default "nested-b";\n`,
+    "packages/dep-c/package.json",
+    JSON.stringify({ name: "dep-c", version: "1.0.0", main: "index.cjs" }),
   );
+  writeFixtureFile(
+    root,
+    "packages/dep-c/index.cjs",
+    `const version = require("shared-version");
+const feature = require("shared-version/feature");
+module.exports = "dep-c:" + version + ":" + feature;\n`,
+  );
+  writeConditionalPackage(root, "packages/dep-c/node_modules/shared-version", "4.0.0", "nested-c");
   linkPackage(root, "dep-a");
   linkPackage(root, "dep-b");
+  linkPackage(root, "dep-c");
 
   return root;
 }
@@ -152,6 +202,11 @@ describe("transitive server externals", () => {
     const html = await response.text();
     const normalizedHtml = html.replaceAll("<!-- -->", "");
     expect(response.status, html).toBe(200);
-    expect(normalizedHtml).toContain("dep-a:nested-a:nested-only, dep-b:nested-b:3.0.0, root:root");
+    expect(normalizedHtml).toContain(
+      "dep-a:nested-a-import:nested-a-feature-import:nested-only, " +
+        "dep-b:nested-b-import:nested-b-feature-import:3.0.0, " +
+        "dep-c:nested-c-require:nested-c-feature-require, " +
+        "root:root-import:root-feature-import",
+    );
   }, 30_000);
 });

--- a/tests/transitive-externals.test.ts
+++ b/tests/transitive-externals.test.ts
@@ -139,78 +139,91 @@ describe("resolveTransitiveExternal", () => {
 });
 
 describe("vinext:transitive-externals plugin", () => {
-  function runResolveId(
-    plugin: ReturnType<typeof _createPluginForTest>,
-    source: string,
-    importer: string,
-  ): string | null {
-    const hook = plugin.resolveId;
-    if (typeof hook !== "function") throw new Error("plugin.resolveId must be a function");
-    // Wire up configResolved so the plugin captures its root resolver.
+  /**
+   * Build a plugin instance and call `configResolved` once, matching Vite's
+   * real lifecycle (lifecycle hooks fire once per build, not per resolveId
+   * call). Tests then invoke the returned `resolveId` helper as many times
+   * as they need against the same initialized instance.
+   */
+  function setupPlugin(options: {
+    root: string;
+    externalPackages: string[];
+    environment?: string;
+  }) {
+    const plugin = _createPluginForTest({
+      root: options.root,
+      externalPackages: options.externalPackages,
+    });
     const configResolved = plugin.configResolved;
     if (typeof configResolved === "function") {
       // biome-ignore lint/suspicious/noExplicitAny: invoking lifecycle hooks manually for testing
       (configResolved as any).call({});
     }
-    // biome-ignore lint/suspicious/noExplicitAny: invoking lifecycle hooks manually for testing
-    const result = (hook as any).call({}, source, importer);
-    if (result == null) return null;
-    if (typeof result === "string") return result;
-    if (typeof result === "object" && result !== null && "id" in result) {
-      return (result as { id: string }).id;
-    }
-    return null;
+    const hook = plugin.resolveId;
+    if (typeof hook !== "function") throw new Error("plugin.resolveId must be a function");
+    const ctx = { environment: { name: options.environment ?? "ssr" } };
+    const resolveId = (source: string, importer: string): string | null => {
+      // biome-ignore lint/suspicious/noExplicitAny: invoking lifecycle hooks manually for testing
+      const result = (hook as any).call(ctx, source, importer);
+      if (result == null) return null;
+      if (typeof result === "string") return result;
+      if (typeof result === "object" && result !== null && "id" in result) {
+        return (result as { id: string }).id;
+      }
+      return null;
+    };
+    return { plugin, resolveId };
   }
 
   it("redirects the import to the nested copy when versions differ (#1503)", () => {
     const { depB } = buildFixture(tmpDir);
-    const plugin = _createPluginForTest({
+    const { resolveId } = setupPlugin({
       root: tmpDir,
       externalPackages: ["lodash"],
     });
-    const result = runResolveId(plugin, "lodash", path.join(depB, "index.js"));
+    const result = resolveId("lodash", path.join(depB, "index.js"));
     expect(result).toBe(fs.realpathSync(path.join(depB, "node_modules", "lodash", "index.js")));
   });
 
   it("leaves the import alone when the importer would resolve to the root copy", () => {
     const { depA } = buildFixture(tmpDir);
-    const plugin = _createPluginForTest({
+    const { resolveId } = setupPlugin({
       root: tmpDir,
       externalPackages: ["lodash"],
     });
-    const result = runResolveId(plugin, "lodash", path.join(depA, "index.js"));
+    const result = resolveId("lodash", path.join(depA, "index.js"));
     expect(result).toBeNull();
   });
 
   it("ignores packages that are not in the externals list", () => {
     const { depB } = buildFixture(tmpDir);
-    const plugin = _createPluginForTest({
+    const { resolveId } = setupPlugin({
       root: tmpDir,
       externalPackages: ["@storybook/global"],
     });
-    const result = runResolveId(plugin, "lodash", path.join(depB, "index.js"));
+    const result = resolveId("lodash", path.join(depB, "index.js"));
     expect(result).toBeNull();
   });
 
   it("ignores user-source importers (outside node_modules)", () => {
     buildFixture(tmpDir);
     writeFile(tmpDir, "app/page.js", "import 'lodash';\n");
-    const plugin = _createPluginForTest({
+    const { resolveId } = setupPlugin({
       root: tmpDir,
       externalPackages: ["lodash"],
     });
-    const result = runResolveId(plugin, "lodash", path.join(tmpDir, "app/page.js"));
+    const result = resolveId("lodash", path.join(tmpDir, "app/page.js"));
     expect(result).toBeNull();
   });
 
   it("ignores virtual / non-absolute importers", () => {
     buildFixture(tmpDir);
-    const plugin = _createPluginForTest({
+    const { resolveId } = setupPlugin({
       root: tmpDir,
       externalPackages: ["lodash"],
     });
-    expect(runResolveId(plugin, "lodash", "\0virtual:vinext-server-entry")).toBeNull();
-    expect(runResolveId(plugin, "lodash", "virtual:some-module")).toBeNull();
+    expect(resolveId("lodash", "\0virtual:vinext-server-entry")).toBeNull();
+    expect(resolveId("lodash", "virtual:some-module")).toBeNull();
   });
 
   it("matches scoped package names correctly", () => {
@@ -220,13 +233,83 @@ describe("vinext:transitive-externals plugin", () => {
     const depRoot = path.join(tmpDir, "node_modules", "@scope/dep");
     writePackage(tmpDir, "@scope/lib", "2.0.0", {}, { parent: path.join(depRoot, "node_modules") });
 
-    const plugin = _createPluginForTest({
+    const { resolveId } = setupPlugin({
       root: tmpDir,
       externalPackages: ["@scope/lib"],
     });
-    const result = runResolveId(plugin, "@scope/lib", path.join(depRoot, "index.js"));
+    const result = resolveId("@scope/lib", path.join(depRoot, "index.js"));
     expect(result).toBe(
       fs.realpathSync(path.join(depRoot, "node_modules", "@scope/lib", "index.js")),
     );
+  });
+
+  it("resolves subpath imports against the nested copy (e.g. lodash/cloneDeep)", () => {
+    // Layout: root has lodash@3, dep-b has nested lodash@4 with a subpath file.
+    writeFile(
+      tmpDir,
+      "package.json",
+      JSON.stringify({ name: "app", dependencies: { lodash: "3.10.1" } }, null, 2),
+    );
+    writePackage(tmpDir, "lodash", "3.10.1");
+    // Add a subpath file (cloneDeep.js) to the root copy so it resolves.
+    writeFile(
+      tmpDir,
+      "node_modules/lodash/cloneDeep.js",
+      "module.exports = function cloneDeep() {};\n",
+    );
+    const depB = writePackage(tmpDir, "dep-b", "1.0.0", { lodash: "4.17.21" });
+    writePackage(tmpDir, "lodash", "4.17.21", {}, { parent: path.join(depB, "node_modules") });
+    writeFile(
+      tmpDir,
+      "node_modules/dep-b/node_modules/lodash/cloneDeep.js",
+      "module.exports = function cloneDeep4() {};\n",
+    );
+
+    const { resolveId } = setupPlugin({
+      root: tmpDir,
+      externalPackages: ["lodash"],
+    });
+    const result = resolveId("lodash/cloneDeep", path.join(depB, "index.js"));
+    // Subpath should resolve through pkgName extraction ("lodash") and
+    // return the nested copy's cloneDeep.js, not the root's.
+    expect(result).toBe(fs.realpathSync(path.join(depB, "node_modules", "lodash", "cloneDeep.js")));
+  });
+
+  it("resolves scoped subpath imports against the nested copy (e.g. @scope/lib/utils)", () => {
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "app" }, null, 2));
+    writePackage(tmpDir, "@scope/dep", "1.0.0", { "@scope/lib": "2.0.0" });
+    writePackage(tmpDir, "@scope/lib", "1.0.0");
+    writeFile(tmpDir, "node_modules/@scope/lib/utils.js", "module.exports = { which: 'root' };\n");
+    const depRoot = path.join(tmpDir, "node_modules", "@scope/dep");
+    writePackage(tmpDir, "@scope/lib", "2.0.0", {}, { parent: path.join(depRoot, "node_modules") });
+    writeFile(
+      tmpDir,
+      path.join("node_modules", "@scope/dep", "node_modules", "@scope/lib", "utils.js"),
+      "module.exports = { which: 'nested' };\n",
+    );
+
+    const { resolveId } = setupPlugin({
+      root: tmpDir,
+      externalPackages: ["@scope/lib"],
+    });
+    const result = resolveId("@scope/lib/utils", path.join(depRoot, "index.js"));
+    // Scoped subpath: pkgName extraction takes "@scope/lib", then the
+    // subpath ("utils") resolves against the nested copy.
+    expect(result).toBe(
+      fs.realpathSync(path.join(depRoot, "node_modules", "@scope/lib", "utils.js")),
+    );
+  });
+
+  it("is inert in the client environment", () => {
+    const { depB } = buildFixture(tmpDir);
+    const { resolveId } = setupPlugin({
+      root: tmpDir,
+      externalPackages: ["lodash"],
+      environment: "client",
+    });
+    // Even with a real version mismatch, the plugin must return null in
+    // client builds (resolve.external is never configured there).
+    const result = resolveId("lodash", path.join(depB, "index.js"));
+    expect(result).toBeNull();
   });
 });

--- a/tests/transitive-externals.test.ts
+++ b/tests/transitive-externals.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import {
+  _createPluginForTest,
+  resolveTransitiveExternal,
+} from "../packages/vinext/src/plugins/transitive-externals.js";
+
+let tmpDir: string;
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vinext-transitive-externals-"));
+}
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const target = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content, "utf-8");
+}
+
+type PackageOptions = {
+  parent?: string; // node_modules location to install under
+};
+
+function writePackage(
+  root: string,
+  packageName: string,
+  version: string,
+  dependencies: Record<string, string> = {},
+  opts: PackageOptions = {},
+): string {
+  const nestedNm = opts.parent ?? path.join(root, "node_modules");
+  const packageRoot = path.join(nestedNm, packageName);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({ name: packageName, version, main: "index.js", dependencies }, null, 2),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "index.js"),
+    `module.exports = { name: ${JSON.stringify(packageName)}, version: ${JSON.stringify(version)} };\n`,
+    "utf-8",
+  );
+  return packageRoot;
+}
+
+/**
+ * Build a layout matching Next.js's `externals-transitive` fixture:
+ *
+ *   <root>/node_modules/lodash@3.10.1            (root copy)
+ *   <root>/node_modules/dep-a/                   (depends on lodash@3, resolves to root copy)
+ *   <root>/node_modules/dep-b/                   (depends on lodash@4)
+ *   <root>/node_modules/dep-b/node_modules/lodash@4.17.21  (nested copy)
+ */
+function buildFixture(root: string): { depA: string; depB: string } {
+  writeFile(
+    root,
+    "package.json",
+    JSON.stringify({ name: "app", dependencies: { lodash: "3.10.1" } }, null, 2),
+  );
+  writePackage(root, "lodash", "3.10.1");
+  const depA = writePackage(root, "dep-a", "1.0.0", { lodash: "3.10.1" });
+  const depB = writePackage(root, "dep-b", "1.0.0", { lodash: "4.17.21" });
+  writePackage(
+    root,
+    "lodash",
+    "4.17.21",
+    {},
+    {
+      parent: path.join(depB, "node_modules"),
+    },
+  );
+  return { depA, depB };
+}
+
+beforeEach(() => {
+  tmpDir = createTmpDir();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("resolveTransitiveExternal", () => {
+  it("returns the nested copy when the importer resolves to a different version than root", () => {
+    buildFixture(tmpDir);
+
+    const rootResolver = createRequire(path.join(tmpDir, "package.json"));
+    const depBIndex = path.join(tmpDir, "node_modules", "dep-b", "index.js");
+
+    const resolved = resolveTransitiveExternal("lodash", depBIndex, rootResolver);
+
+    expect(resolved).not.toBeNull();
+    // The resolved path must point at dep-b's nested lodash copy, not the
+    // root-level one.
+    expect(resolved).toBe(
+      fs.realpathSync(
+        path.join(tmpDir, "node_modules", "dep-b", "node_modules", "lodash", "index.js"),
+      ),
+    );
+  });
+
+  it("returns null when the importer's resolution matches the root resolution", () => {
+    buildFixture(tmpDir);
+
+    const rootResolver = createRequire(path.join(tmpDir, "package.json"));
+    // dep-a depends on lodash@3 which is already at the root — no disambiguation needed.
+    const depAIndex = path.join(tmpDir, "node_modules", "dep-a", "index.js");
+
+    const resolved = resolveTransitiveExternal("lodash", depAIndex, rootResolver);
+    expect(resolved).toBeNull();
+  });
+
+  it("returns null when the request cannot be resolved from the importer", () => {
+    buildFixture(tmpDir);
+
+    const rootResolver = createRequire(path.join(tmpDir, "package.json"));
+    const depAIndex = path.join(tmpDir, "node_modules", "dep-a", "index.js");
+
+    const resolved = resolveTransitiveExternal("does-not-exist", depAIndex, rootResolver);
+    expect(resolved).toBeNull();
+  });
+
+  it("returns the importer-side resolution when the root cannot resolve the request", () => {
+    // Layout: only dep-b has lodash in its nested node_modules (no root-level lodash).
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "app" }, null, 2));
+    const depB = writePackage(tmpDir, "dep-b", "1.0.0", { lodash: "4.17.21" });
+    writePackage(tmpDir, "lodash", "4.17.21", {}, { parent: path.join(depB, "node_modules") });
+
+    const rootResolver = createRequire(path.join(tmpDir, "package.json"));
+    const depBIndex = path.join(depB, "index.js");
+
+    const resolved = resolveTransitiveExternal("lodash", depBIndex, rootResolver);
+    expect(resolved).toBe(fs.realpathSync(path.join(depB, "node_modules", "lodash", "index.js")));
+  });
+});
+
+describe("vinext:transitive-externals plugin", () => {
+  function runResolveId(
+    plugin: ReturnType<typeof _createPluginForTest>,
+    source: string,
+    importer: string,
+  ): string | null {
+    const hook = plugin.resolveId;
+    if (typeof hook !== "function") throw new Error("plugin.resolveId must be a function");
+    // Wire up configResolved so the plugin captures its root resolver.
+    const configResolved = plugin.configResolved;
+    if (typeof configResolved === "function") {
+      // biome-ignore lint/suspicious/noExplicitAny: invoking lifecycle hooks manually for testing
+      (configResolved as any).call({});
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: invoking lifecycle hooks manually for testing
+    const result = (hook as any).call({}, source, importer);
+    if (result == null) return null;
+    if (typeof result === "string") return result;
+    if (typeof result === "object" && result !== null && "id" in result) {
+      return (result as { id: string }).id;
+    }
+    return null;
+  }
+
+  it("redirects the import to the nested copy when versions differ (#1503)", () => {
+    const { depB } = buildFixture(tmpDir);
+    const plugin = _createPluginForTest({
+      root: tmpDir,
+      externalPackages: ["lodash"],
+    });
+    const result = runResolveId(plugin, "lodash", path.join(depB, "index.js"));
+    expect(result).toBe(fs.realpathSync(path.join(depB, "node_modules", "lodash", "index.js")));
+  });
+
+  it("leaves the import alone when the importer would resolve to the root copy", () => {
+    const { depA } = buildFixture(tmpDir);
+    const plugin = _createPluginForTest({
+      root: tmpDir,
+      externalPackages: ["lodash"],
+    });
+    const result = runResolveId(plugin, "lodash", path.join(depA, "index.js"));
+    expect(result).toBeNull();
+  });
+
+  it("ignores packages that are not in the externals list", () => {
+    const { depB } = buildFixture(tmpDir);
+    const plugin = _createPluginForTest({
+      root: tmpDir,
+      externalPackages: ["@storybook/global"],
+    });
+    const result = runResolveId(plugin, "lodash", path.join(depB, "index.js"));
+    expect(result).toBeNull();
+  });
+
+  it("ignores user-source importers (outside node_modules)", () => {
+    buildFixture(tmpDir);
+    writeFile(tmpDir, "app/page.js", "import 'lodash';\n");
+    const plugin = _createPluginForTest({
+      root: tmpDir,
+      externalPackages: ["lodash"],
+    });
+    const result = runResolveId(plugin, "lodash", path.join(tmpDir, "app/page.js"));
+    expect(result).toBeNull();
+  });
+
+  it("ignores virtual / non-absolute importers", () => {
+    buildFixture(tmpDir);
+    const plugin = _createPluginForTest({
+      root: tmpDir,
+      externalPackages: ["lodash"],
+    });
+    expect(runResolveId(plugin, "lodash", "\0virtual:vinext-server-entry")).toBeNull();
+    expect(runResolveId(plugin, "lodash", "virtual:some-module")).toBeNull();
+  });
+
+  it("matches scoped package names correctly", () => {
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "app" }, null, 2));
+    writePackage(tmpDir, "@scope/dep", "1.0.0", { "@scope/lib": "2.0.0" });
+    writePackage(tmpDir, "@scope/lib", "1.0.0");
+    const depRoot = path.join(tmpDir, "node_modules", "@scope/dep");
+    writePackage(tmpDir, "@scope/lib", "2.0.0", {}, { parent: path.join(depRoot, "node_modules") });
+
+    const plugin = _createPluginForTest({
+      root: tmpDir,
+      externalPackages: ["@scope/lib"],
+    });
+    const result = runResolveId(plugin, "@scope/lib", path.join(depRoot, "index.js"));
+    expect(result).toBe(
+      fs.realpathSync(path.join(depRoot, "node_modules", "@scope/lib", "index.js")),
+    );
+  });
+});

--- a/tests/transitive-externals.test.ts
+++ b/tests/transitive-externals.test.ts
@@ -216,6 +216,33 @@ describe("vinext:transitive-externals plugin", () => {
     expect(result).toBeNull();
   });
 
+  it("bundles nested-only externals imported from a linked package realpath", () => {
+    writeFile(tmpDir, "package.json", JSON.stringify({ name: "app" }, null, 2));
+    const linkedPackage = path.join(tmpDir, "packages", "dep-b");
+    writePackage(
+      tmpDir,
+      "dep-b",
+      "1.0.0",
+      { lodash: "4.17.21" },
+      { parent: path.join(tmpDir, "packages") },
+    );
+    writePackage(
+      tmpDir,
+      "lodash",
+      "4.17.21",
+      {},
+      { parent: path.join(linkedPackage, "node_modules") },
+    );
+
+    const { resolveId } = setupPlugin({
+      root: tmpDir,
+      externalPackages: ["lodash"],
+    });
+    const result = resolveId("lodash", path.join(linkedPackage, "index.js"));
+
+    expect(result).toBe(fs.realpathSync(path.join(linkedPackage, "node_modules/lodash/index.js")));
+  });
+
   it("ignores virtual / non-absolute importers", () => {
     buildFixture(tmpDir);
     const { resolveId } = setupPlugin({

--- a/tests/transitive-externals.test.ts
+++ b/tests/transitive-externals.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { createRequire } from "node:module";
 import {
   _createPluginForTest,
+  compareTransitiveExternalResolutions,
   resolveTransitiveExternal,
 } from "../packages/vinext/src/plugins/transitive-externals.js";
 
@@ -85,6 +86,18 @@ afterEach(() => {
 });
 
 describe("resolveTransitiveExternal", () => {
+  it("bundles when the resolved path matches but the module mode differs", () => {
+    writeFile(tmpDir, "shared.js", "export default 'shared';\n");
+    const sharedPath = path.join(tmpDir, "shared.js");
+
+    expect(
+      compareTransitiveExternalResolutions(
+        { path: sharedPath, mode: "import" },
+        { path: sharedPath, mode: "require" },
+      ),
+    ).toBe(fs.realpathSync(sharedPath));
+  });
+
   it("returns the nested copy when the importer resolves to a different version than root", () => {
     buildFixture(tmpDir);
 


### PR DESCRIPTION
## Summary

- Adds `vinext:transitive-externals` plugin that mirrors Next.js's webpack `baseResolveCheck`: when a non-external package nested in `node_modules` imports an externalised package (e.g. `serverExternalPackages: ['lodash']`) and its installed version differs from the project-root copy, the plugin returns the importer's nested absolute path so Vite bundles that copy alongside the importer.
- Without this, both copies collapse to a single runtime `node_modules/<dep>/` lookup and one version silently wins — the symptom reported in Next.js's `externals-transitive` deploy test.
- Reference: [Next.js `handle-externals.ts` baseResolveCheck](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/handle-externals.ts).

## Test plan

- [x] `pnpm test tests/transitive-externals.test.ts` — 10 new unit tests cover: nested-vs-root version mismatch, same-version no-op, unresolvable request, scoped packages, ignoring user-source / virtual / non-external importers.
- [x] `pnpm test tests/server-externals-manifest.test.ts tests/standalone-build.test.ts` — adjacent existing suites still pass.
- [x] `pnpm run check`.
- [ ] CI: `externals-transitive` adapter-api-e2e suite passes.

Refs #1503.