### PR TITLE
test(routing): regression for /api-… page prefixes (#1542)

### DIFF
--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -339,6 +339,58 @@ describe("apiRouter - route discovery", () => {
       expect(routes).toEqual([]);
     });
   });
+
+  // Regression for #1542: pages whose path *starts with* `/api-…` (e.g.
+  // `/api-docs/[...slug]`, `/api-info`) must be classified as PAGE routes,
+  // not API routes. Next.js only treats files under `pages/api/` (with the
+  // trailing slash) as API routes — substring matches against `api-` are a
+  // false positive. The upstream Next.js fixture at
+  // `.nextjs-ref/test/e2e/prerender/pages/api-docs/[...slug].js` is the
+  // canonical case.
+  it("does not treat pages/api-docs/* as API routes (issue #1542)", async () => {
+    await withTempDir("vinext-issue-1542-api-docs-", async (tmpDir) => {
+      const pagesDir = path.join(tmpDir, "pages");
+      await mkdir(path.join(pagesDir, "api-docs"), { recursive: true });
+      await writeFile(path.join(pagesDir, "api-docs", "[...slug].tsx"), EMPTY_PAGE);
+      await mkdir(path.join(pagesDir, "api-info"), { recursive: true });
+      await writeFile(path.join(pagesDir, "api-info", "index.tsx"), EMPTY_PAGE);
+      // A real API route co-exists so we also verify the positive case.
+      await mkdir(path.join(pagesDir, "api"), { recursive: true });
+      await writeFile(path.join(pagesDir, "api", "hello.ts"), EMPTY_ROUTE);
+
+      invalidateRouteCache(pagesDir);
+
+      const pages = await pagesRouter(pagesDir);
+      const apis = await apiRouter(pagesDir);
+
+      const pagePatterns = pages.map((r) => r.pattern);
+      const apiPatterns = apis.map((r) => r.pattern);
+
+      // `/api-docs/[...slug]` and `/api-info` are pages, not API routes.
+      expect(pagePatterns).toContain("/api-docs/:slug+");
+      expect(pagePatterns).toContain("/api-info");
+      expect(apiPatterns).not.toContain("/api-docs/:slug+");
+      expect(apiPatterns).not.toContain("/api-info");
+
+      // The real API route is still discovered correctly.
+      expect(apiPatterns).toContain("/api/hello");
+      expect(pagePatterns).not.toContain("/api/hello");
+
+      // matchRoute against the page table resolves the `/api-…` URLs to
+      // their page files. A regression would either yield null (no match)
+      // or match against the API trie instead.
+      const matchedDocs = matchRoute("/api-docs/first", pages);
+      expect(matchedDocs).not.toBeNull();
+      expect(matchedDocs!.route.pattern).toBe("/api-docs/:slug+");
+      expect(matchedDocs!.route.filePath).toBe(
+        path.join(pagesDir, "api-docs", "[...slug].tsx"),
+      );
+
+      const matchedInfo = matchRoute("/api-info", pages);
+      expect(matchedInfo).not.toBeNull();
+      expect(matchedInfo!.route.pattern).toBe("/api-info");
+    });
+  });
 });
 
 // ---------------------------------------------------------------

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -382,9 +382,7 @@ describe("apiRouter - route discovery", () => {
       const matchedDocs = matchRoute("/api-docs/first", pages);
       expect(matchedDocs).not.toBeNull();
       expect(matchedDocs!.route.pattern).toBe("/api-docs/:slug+");
-      expect(matchedDocs!.route.filePath).toBe(
-        path.join(pagesDir, "api-docs", "[...slug].tsx"),
-      );
+      expect(matchedDocs!.route.filePath).toBe(path.join(pagesDir, "api-docs", "[...slug].tsx"));
 
       const matchedInfo = matchRoute("/api-info", pages);
       expect(matchedInfo).not.toBeNull();


### PR DESCRIPTION
## Summary

Adds a focused unit test in `tests/routing.test.ts` that pins down the routing-layer behaviour called out in #1542: pages whose path starts with `/api-…` (for example `/api-docs/[...slug]`, `/api-info`) must be classified as **page routes**, not API routes.

The test mirrors the upstream Next.js fixture at `.nextjs-ref/test/e2e/prerender/pages/api-docs/[...slug].js` — a regular SSG page that the Next.js prerender suite expects to render normally.

## Findings

Walking the existing code, every relevant API-route gate already requires the trailing slash and never matches the substring `api-`:

- `packages/vinext/src/index.ts:3337` (dev SSR middleware)
- `packages/vinext/src/server/prod-server.ts:1902` (prod server)
- `packages/vinext/src/deploy.ts:868` (Workers deploy entry)
- `packages/vinext/src/entries/app-rsc-entry.ts:888` (hybrid app→pages bridge)
- `packages/vinext/src/server/request-pipeline.ts:270,317` (trailing-slash normalization)
- `packages/vinext/src/cloudflare/tpr.ts:466`
- `packages/vinext/src/shims/router.ts:698`

And the file-system scanner only excludes the literal `"api"` directory name (`packages/vinext/src/routing/pages-router.ts:82`).

So the test passes on `main`. It's added as a regression guard so a future refactor cannot reintroduce the substring-`api-` false positive (e.g. by dropping the trailing slash from one of those `startsWith` checks).

The deploy-suite symptom described in #1542 (the 3 prerender e2e failures) likely lives below the routing layer — most plausibly in the prerender fallback shell rendering or `/_next/data/…` resolution for explicit `fallback: true` paths. That fix is left for a follow-up PR scoped to whichever pipeline stage actually hangs; this PR is intentionally just the test pin.

Refs #1542.

## Test plan

- [x] `pnpm test tests/routing.test.ts -t "issue #1542"` (new test passes)
- [x] `pnpm test tests/routing.test.ts` (all 112 tests pass)
- [x] `pnpm test tests/request-pipeline.test.ts` (93 tests pass — existing `/api-docs` coverage still green)
- [ ] CI Vitest + Playwright