### PR TITLE
fix(app-router): cache pages with revalidate=Infinity/false (#1487)

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -239,7 +239,7 @@ function resolveAppPageCacheWritePolicy(options: {
     expireSeconds = requestCacheLife.expire;
   }
 
-  if (revalidateSeconds === null || revalidateSeconds <= 0 || !Number.isFinite(revalidateSeconds)) {
+  if (revalidateSeconds === null || Number.isNaN(revalidateSeconds) || revalidateSeconds <= 0) {
     return null;
   }
 

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -206,10 +206,16 @@ export function resolveAppPageHtmlResponsePolicy(
   }
 
   if (options.revalidateSeconds === Infinity) {
+    // `revalidate = false` / `revalidate = Infinity` ask for indefinite caching.
+    // The downstream Cache-Control header remains STATIC (1y s-maxage), but we
+    // also write to the ISR cache so repeated requests inside the same vinext
+    // process return identical bytes instead of re-rendering on every hit.
+    // This matches Next.js: indefinite-revalidate pages cache their rendered
+    // output and only re-render when their tags are explicitly invalidated.
     return {
       cacheControl: STATIC_CACHE_CONTROL,
-      cacheState: "STATIC",
-      shouldWriteToCache: false,
+      cacheState: options.isProduction ? "MISS" : "STATIC",
+      shouldWriteToCache: options.isProduction,
     };
   }
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -193,6 +193,23 @@ describe("app page response helpers", () => {
       }),
     ).toEqual({
       cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheState: "MISS",
+      shouldWriteToCache: true,
+    });
+
+    expect(
+      resolveAppPageHtmlResponsePolicy({
+        dynamicUsedDuringRender: false,
+        hasScriptNonce: false,
+        isDraftMode: false,
+        isDynamicError: false,
+        isForceDynamic: false,
+        isForceStatic: false,
+        isProduction: false,
+        revalidateSeconds: Infinity,
+      }),
+    ).toEqual({
+      cacheControl: "s-maxage=31536000, stale-while-revalidate",
       cacheState: "STATIC",
       shouldWriteToCache: false,
     });

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -2370,6 +2370,52 @@ describe("App Router Production server (startProdServer)", () => {
     expect(nestedRes.headers.get("e2e-headers")).toBe("middleware");
   });
 
+  // Regression test for issue 1487 — App Router page-segment `revalidate`
+  // should produce a stable cached response. Two requests inside the
+  // revalidate window must return identical HTML bytes (same Date.now()
+  // embedded), not re-render on every request. /revalidate-test exports
+  // `revalidate = 60` and renders Date.now() into the HTML.
+  it("export const revalidate: second request inside the cache window is a HIT with identical HTML", async () => {
+    const res1 = await fetch(`${baseUrl}/revalidate-test`);
+    expect(res1.status).toBe(200);
+    const html1 = await res1.text();
+    const ts1 = html1.match(/data-testid="timestamp">(?:<!--[^>]*-->)*\s*(\d+)\s*</)?.[1];
+    expect(ts1).toBeTruthy();
+
+    const res2 = await fetch(`${baseUrl}/revalidate-test`);
+    expect(res2.status).toBe(200);
+    const html2 = await res2.text();
+    const ts2 = html2.match(/data-testid="timestamp">(?:<!--[^>]*-->)*\s*(\d+)\s*</)?.[1];
+
+    // The HIT response must return the same timestamp baked into the HTML on
+    // the MISS render. If vinext re-renders on every request, ts2 will be a
+    // fresher Date.now() than ts1.
+    expect(res2.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(ts2).toBe(ts1);
+  });
+
+  // Regression test for issue 1487 — App Router page-segment `revalidate = Infinity`
+  // (and `revalidate = false`) should produce a stable cached response. Two
+  // requests must return identical HTML bytes; the first MISS render writes
+  // to the cache and the second is a HIT. This was historically broken
+  // because `resolveAppPageCacheWritePolicy` rejected non-finite revalidate
+  // intervals, so indefinite-cache pages re-rendered on every request.
+  it("export const revalidate = Infinity: second request is a HIT with identical HTML", async () => {
+    const res1 = await fetch(`${baseUrl}/revalidate-infinity-test`);
+    expect(res1.status).toBe(200);
+    const html1 = await res1.text();
+    const ts1 = html1.match(/data-testid="timestamp">(?:<!--[^>]*-->)*\s*(\d+)\s*</)?.[1];
+    expect(ts1).toBeTruthy();
+
+    const res2 = await fetch(`${baseUrl}/revalidate-infinity-test`);
+    expect(res2.status).toBe(200);
+    const html2 = await res2.text();
+    const ts2 = html2.match(/data-testid="timestamp">(?:<!--[^>]*-->)*\s*(\d+)\s*</)?.[1];
+
+    expect(res2.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(ts2).toBe(ts1);
+  });
+
   it("applies middleware request header overrides before App->Pages fallback rendering in production", async () => {
     const res = await fetch(`${baseUrl}/pages-header-override-delete`, {
       headers: {

--- a/tests/fixtures/app-basic/app/revalidate-infinity-test/page.tsx
+++ b/tests/fixtures/app-basic/app/revalidate-infinity-test/page.tsx
@@ -1,7 +1,15 @@
 // Fixture for classifyAppRoute integration test: revalidate=Infinity → static.
 // Next.js treats revalidate=Infinity as "never revalidate" (fully static).
+// Also used by app-router.test.ts to assert ISR cache stability across
+// requests when the page declares an indefinite cache policy.
 export const revalidate = Infinity;
 
 export default function RevalidateInfinityPage() {
-  return <p>revalidate-infinity</p>;
+  const timestamp = Date.now();
+  return (
+    <div data-testid="revalidate-infinity-test-page">
+      <p>revalidate-infinity</p>
+      <span data-testid="timestamp">{timestamp}</span>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

App Router pages exporting `revalidate = Infinity` (or `revalidate = false`, which resolves to Infinity in segment config) were re-rendered on every request inside the same vinext process. The HTML response policy returned `shouldWriteToCache: false` and the cache-write policy rejected non-finite revalidate values, so even though the downstream `Cache-Control` header was correct (1y s-maxage), vinext itself never served identical bytes for repeat requests.

This PR treats `revalidate = Infinity` as "cache indefinitely":

- `resolveAppPageHtmlResponsePolicy` writes the rendered HTML/RSC bundle to the ISR cache in production and reports `MISS` on first render, matching the normal ISR write flow. Dev mode still emits `STATIC` with no cache write.
- `resolveAppPageCacheWritePolicy` accepts `Infinity` as a valid revalidate interval; only `null`, `NaN`, and non-positive values reject the write. The `MemoryCacheHandler` already keeps `Infinity`-revalidate entries fresh forever (`now + Infinity` never expires), and tag invalidation still drops them.

Scoped to one symptom from #1487 with the smallest fix path. Other symptoms listed there (`unstable_cache`, fetch cache directives, `force-static`, `force-no-store`, on-demand revalidate) are deferred to follow-up PRs.

## Test plan

- [x] New regression test: `export const revalidate = 60` second request is a HIT with identical HTML
- [x] New regression test: `export const revalidate = Infinity` second request is a HIT with identical HTML (fails on `main`, passes here)
- [x] Existing app-page-cache unit tests still pass (28/28)
- [x] Existing cache-related unit tests still pass (225/225 across `app-page-cache`, `isr-cache`, `fetch-cache`, `cache-control`, `seed-cache`)
- [x] Full `app-router.test.ts` passes (334/334)
- [x] Full `features.test.ts` passes (309/309)
- [x] `prerender.test.ts` + `build-report.test.ts` pass (172/172) — fixture timestamp didn't disturb prerender classification
- [x] `pnpm vp check` clean (format, lint, type)