### PR TITLE
fix(app-router): accept icons.other as single descriptor (#1492)

### DIFF
--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -275,11 +275,16 @@ type AppleIconDescriptor = {
 type IconInput = string | URL | IconDescriptor;
 type AppleIconInput = string | URL | AppleIconDescriptor;
 
+type OtherIconDescriptor = { rel: string; url: string | URL; sizes?: string; type?: string };
+
 type IconsMap = {
   icon?: IconInput | IconInput[];
   shortcut?: string | URL | Array<string | URL>;
   apple?: AppleIconInput | AppleIconInput[];
-  other?: Array<{ rel: string; url: string | URL; sizes?: string; type?: string }>;
+  // Next.js accepts a single descriptor or an array (see resolveIcons in
+  // .nextjs-ref/packages/next/src/lib/metadata/resolvers/resolve-icons.ts —
+  // values pass through resolveAsArrayOrUndefined before iteration).
+  other?: OtherIconDescriptor | OtherIconDescriptor[];
 };
 
 type IconsMetadata = IconInput | IconInput[] | IconsMap;
@@ -1115,15 +1120,20 @@ export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
         );
       }
     }
-    // Other custom icon relations
+    // Other custom icon relations. Next.js accepts a single descriptor or an
+    // array; normalize before iterating.
     if (isIconsMap(metadata.icons) && metadata.icons.other) {
-      for (const o of metadata.icons.other) {
+      const others = Array.isArray(metadata.icons.other)
+        ? metadata.icons.other
+        : [metadata.icons.other];
+      for (const o of others) {
         elements.push(
           <link
             key={key++}
             rel={o.rel}
             href={stringifyUrl(o.url)}
             {...(o.sizes ? { sizes: o.sizes } : {})}
+            {...(o.type ? { type: o.type } : {})}
           />,
         );
       }

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -3601,6 +3601,50 @@ describe("metadata routes integration (App Router)", () => {
     );
   });
 
+  it("emits exactly one favicon link plus icons metadata shortcut/apple/other in root segment", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-icons/metadata-icons.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-icons/metadata-icons.test.ts
+    const res = await fetch(`${baseUrl}/metadata-icons-mix`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // Exactly one favicon.ico link (no duplicates from icon merging or file-based metadata).
+    const faviconMatches = html.match(/<link[^>]+href="[^"]*\/favicon\.ico(?:\?[^"]*)?"[^>]*>/g);
+    expect(faviconMatches?.length ?? 0).toBe(1);
+
+    // metadata.icons.shortcut emits rel="shortcut icon".
+    expect(html).toMatch(/<link[^>]+rel="shortcut icon"[^>]+href="\/shortcut-icon\.png"[^>]*>/);
+
+    // metadata.icons.apple emits rel="apple-touch-icon".
+    expect(html).toMatch(/<link[^>]+rel="apple-touch-icon"[^>]+href="\/apple-icon\.png"[^>]*>/);
+
+    // metadata.icons.other emits a custom rel link.
+    expect(html).toMatch(
+      /<link[^>]+rel="apple-touch-icon-precomposed"[^>]+href="\/apple-touch-icon-precomposed\.png"[^>]*>/,
+    );
+  });
+
+  it("emits exactly one favicon link plus nested icons metadata shortcut/apple/other on nested page", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-icons/metadata-icons.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-icons/metadata-icons.test.ts
+    const res = await fetch(`${baseUrl}/metadata-icons-mix/nested`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    const faviconMatches = html.match(/<link[^>]+href="[^"]*\/favicon\.ico(?:\?[^"]*)?"[^>]*>/g);
+    expect(faviconMatches?.length ?? 0).toBe(1);
+
+    expect(html).toMatch(
+      /<link[^>]+rel="shortcut icon"[^>]+href="\/shortcut-icon-nested\.png"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<link[^>]+rel="apple-touch-icon"[^>]+href="\/apple-icon-nested\.png"[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<link[^>]+rel="apple-touch-icon-precomposed-nested"[^>]+href="\/apple-touch-icon-precomposed-nested\.png"[^>]*>/,
+    );
+  });
+
   it("injects dynamic metadata image routes into the head", async () => {
     // Ported from Next.js: test/e2e/app-dir/metadata/metadata.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/metadata.test.ts

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2663,6 +2663,47 @@ describe("MetadataHead rendering", () => {
     expect(html).toContain('rel="shortcut icon"');
   });
 
+  // Regression for #1492: Next.js accepts icons.other as a single descriptor
+  // or an array; vinext previously iterated it directly and crashed when
+  // given a non-array. Matches resolveAsArrayOrUndefined in
+  // .nextjs-ref/packages/next/src/lib/metadata/resolvers/resolve-icons.ts.
+  it("renders icons.other as a single descriptor (not just an array)", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          icons: {
+            other: {
+              rel: "apple-touch-icon-precomposed",
+              url: "/apple-touch-icon-precomposed.png",
+            },
+          },
+        },
+      }),
+    );
+    expect(html).toContain('rel="apple-touch-icon-precomposed"');
+    expect(html).toContain('href="/apple-touch-icon-precomposed.png"');
+  });
+
+  it("renders icons.other as an array of descriptors", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          icons: {
+            other: [
+              { rel: "mask-icon", url: "/mask.svg", type: "image/svg+xml" },
+              { rel: "apple-touch-icon-precomposed", url: "/apple.png" },
+            ],
+          },
+        },
+      }),
+    );
+    expect(html).toContain('rel="mask-icon"');
+    expect(html).toContain('href="/mask.svg"');
+    expect(html).toContain('type="image/svg+xml"');
+    expect(html).toContain('rel="apple-touch-icon-precomposed"');
+    expect(html).toContain('href="/apple.png"');
+  });
+
   it("serializes rich metadata for the streaming body outlet", () => {
     const html = renderMetadataToHtml(
       {

--- a/tests/fixtures/app-basic/app/metadata-icons-mix/nested/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-icons-mix/nested/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  icons: {
+    shortcut: "/shortcut-icon-nested.png",
+    apple: "/apple-icon-nested.png",
+    other: {
+      rel: "apple-touch-icon-precomposed-nested",
+      url: "/apple-touch-icon-precomposed-nested.png",
+    },
+  },
+};
+
+export default function MetadataIconsMixNestedPage() {
+  return <p>hello world</p>;
+}

--- a/tests/fixtures/app-basic/app/metadata-icons-mix/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-icons-mix/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  icons: {
+    shortcut: "/shortcut-icon.png",
+    apple: "/apple-icon.png",
+    other: {
+      rel: "apple-touch-icon-precomposed",
+      url: "/apple-touch-icon-precomposed.png",
+    },
+  },
+};
+
+export default function MetadataIconsMixPage() {
+  return <p>hello world</p>;
+}


### PR DESCRIPTION
## Summary

Fixes #1492 — App Router metadata icons broke page rendering when
`metadata.icons.other` was a single descriptor object.

Next.js accepts either a single `IconDescriptor` or an array
(see `resolveIcons` in
`.nextjs-ref/packages/next/src/lib/metadata/resolvers/resolve-icons.ts`),
but `MetadataHead` iterated `metadata.icons.other` directly. With a
single-object value (the documented Next.js form) that crashed with
`TypeError: metadata.icons.other is not iterable`, which propagated
into the page render so the file-based `favicon.ico`, the
`shortcut`/`apple`/`other` `<link>`s, and effectively the whole head
were lost.

This PR scopes itself to the basic head emission per the issue brief.
The body→head reinjection script is intentionally not included.

### Changes

- `packages/vinext/src/shims/metadata.tsx`: widen `IconsMap.other` to
  `OtherIconDescriptor | OtherIconDescriptor[]`, normalize at render
  time, and forward the optional `type` attribute.
- Unit tests in `tests/features.test.ts` for the single-descriptor
  and array shapes.
- Integration tests in `tests/app-router.test.ts` (+ fixture under
  `tests/fixtures/app-basic/app/metadata-icons-mix/`) ported from
  Next.js's `test/e2e/app-dir/metadata-icons/metadata-icons.test.ts`,
  asserting exactly one `/favicon.ico` link plus the expected
  `shortcut` / `apple-touch-icon` / custom-rel `<link>` tags on both
  the root segment and a nested page.

## Test plan

- [x] `pnpm test tests/features.test.ts -t "icons.other"`
- [x] `pnpm test tests/app-router.test.ts -t "favicon link plus"`
- [x] `pnpm test tests/app-router.test.ts -t "icon"` (12 passing)
- [x] `pnpm test tests/file-based-metadata.test.ts`
- [x] `pnpm run check` on touched files

## Out of scope

- Body→head icon reinjection script (the
  `'should re-insert ...'` and `'should ... contain icon insertion
  script'` tests from the Next.js suite). Per the issue brief this
  is deferred to a follow-up.

Refs cloudflare/vinext#1492