### PR TITLE
fix(app-router): handle Vite ref errors that elide #exportName (#1340)

### DIFF
--- a/packages/vinext/src/server/server-action-not-found.ts
+++ b/packages/vinext/src/server/server-action-not-found.ts
@@ -57,11 +57,28 @@ export function isServerActionNotFoundError(error: unknown, actionId: string | n
   //
   // See: @vitejs/plugin-rsc dist/rsc.js (`server reference not found`) and
   // dist/plugin-*.js (`[vite-rsc] invalid <type> reference`).
+  //
+  // Action ids resolved from request headers carry the `#<exportName>` suffix
+  // (e.g. `/app/foo.ts#bar`), but `loadServerAction(id)` strips that suffix
+  // before calling `requireModule(file)`. The dev-mode validator therefore
+  // emits the module path WITHOUT the `#<exportName>` — so we also check the
+  // pre-`#` portion to match either shape (#1340).
   if (actionId) {
-    if (message.includes(`[vite-rsc] invalid server reference '${actionId}'`)) {
+    const moduleId = actionId.split("#")[0];
+    if (
+      message.includes(`[vite-rsc] invalid server reference '${actionId}'`) ||
+      (moduleId &&
+        moduleId !== actionId &&
+        message.includes(`[vite-rsc] invalid server reference '${moduleId}'`))
+    ) {
       return true;
     }
-    if (message.includes(`server reference not found '${actionId}'`)) {
+    if (
+      message.includes(`server reference not found '${actionId}'`) ||
+      (moduleId &&
+        moduleId !== actionId &&
+        message.includes(`server reference not found '${moduleId}'`))
+    ) {
       return true;
     }
     return false;

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -849,6 +849,43 @@ describe("app server action execution helpers", () => {
     expect(decodeReply).not.toHaveBeenCalled();
   });
 
+  // Regression coverage for #1340: realistic action ids include `#<exportName>`,
+  // but @vitejs/plugin-rsc's reference-validation virtual module only knows the
+  // module path portion. The dev-mode "invalid server reference '<id>'" error
+  // therefore contains the module path WITHOUT the `#<exportName>` suffix,
+  // while the caller's actionId still has it. The 404 detection has to match
+  // either form so an unknown server action does not surface as an unrelated
+  // 500.
+  it("returns action-not-found when the Vite error elides the #exportName suffix", async () => {
+    const renderToReadableStream = vi.fn();
+    const reportRequestError = vi.fn();
+    const clearRequestContext = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        actionId: "/app/actions/actions.ts#staleAction",
+        clearRequestContext,
+        loadServerAction() {
+          // Vite's reference-validation virtual module reports only the module
+          // path — the `#staleAction` suffix is dropped because the validator
+          // sees the require call, not the action id.
+          return Promise.reject(
+            new Error("[vite-rsc] invalid server reference '/app/actions/actions.ts'"),
+          );
+        },
+        renderToReadableStream,
+        reportRequestError,
+      }),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await response?.text()).toBe("Server action not found.");
+    expect(renderToReadableStream).not.toHaveBeenCalled();
+    expect(reportRequestError).not.toHaveBeenCalled();
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+  });
+
   // Ported from Next.js: test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
   it("returns the Next.js action-not-found response for stale fetch action ids", async () => {
@@ -1077,6 +1114,46 @@ describe("app server action execution helpers", () => {
         returnValue: { ok: false, data: fallbackError },
       });
     }
+  });
+
+  // Regression coverage for #1340: when a server action throws `notFound()` AND
+  // the action also revalidates (so the page rerendering path runs instead of
+  // the skip-rerender shortcut), the response must still carry the 404 status
+  // and the rejected actionResult — not 200 with the original page.
+  //
+  // Mirrors Next.js: when isHTTPAccessFallbackError(err) is true, the
+  // action-handler sets res.statusCode = getAccessFallbackHTTPStatus(err)
+  // before generating the Flight payload.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts
+  it("preserves the 404 status when notFound() is thrown by a revalidating fetch action", async () => {
+    let renderedModel: TestActionModel | null = null;
+    const fallbackError = { digest: "NEXT_HTTP_ERROR_FALLBACK;404" };
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        // Pending cookie forces the revalidating page-rerender branch instead
+        // of the no-revalidate shortcut that already had coverage above.
+        getAndClearPendingCookies() {
+          return ["action=1; Path=/"];
+        },
+        loadServerAction() {
+          return Promise.resolve(() => {
+            throw fallbackError;
+          });
+        },
+        renderToReadableStream(model) {
+          renderedModel = model;
+          return new Response("notfound-flight").body;
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(await response?.text()).toBe("notfound-flight");
+    expect(renderedModel).toMatchObject({
+      returnValue: { ok: false, data: fallbackError },
+    });
+    expect(response?.headers.get("x-action-revalidated")).toBe("1");
   });
 
   it("emits the `x-edge-runtime: 1` marker on rerendered RSC action responses for edge-runtime routes", async () => {

--- a/tests/fixtures/app-basic/app/actions/actions.ts
+++ b/tests/fixtures/app-basic/app/actions/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 // Simple in-memory counter for testing server actions
 let likeCount = 0;
@@ -31,6 +31,17 @@ export async function redirectAction(): Promise<void> {
  */
 export async function errorAction(): Promise<string> {
   throw new Error("Action failed intentionally");
+}
+
+/**
+ * Server action that calls notFound() — should produce a 404 response
+ * with the rejected actionResult propagated to the client error boundary.
+ *
+ * Regression coverage for #1340: Next.js sets statusCode = 404 when an
+ * action throws via `notFound()`; vinext must match that contract.
+ */
+export async function notFoundAction(): Promise<void> {
+  notFound();
 }
 
 /**

--- a/tests/nextjs-compat/not-found.test.ts
+++ b/tests/nextjs-compat/not-found.test.ts
@@ -373,6 +373,74 @@ describe("Next.js compat: not-found", () => {
     }
   });
 
+  // ── notFound() from a server action ─────────────────────────
+  // Regression coverage for issue #1340: when a fetch (RSC) server action
+  // throws via `notFound()`, the response must be 404 — not 500.
+  //
+  // Mirrors Next.js: when `isHTTPAccessFallbackError(err)` is true, the
+  // action handler sets `res.statusCode = getAccessFallbackHTTPStatus(err)`
+  // (i.e. 404) before generating the Flight payload.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts
+  //
+  // Browser-style flow tested in Next.js:
+  // test/e2e/app-dir/actions/app-action.test.ts — "should support notFound".
+  it("server action calling notFound() returns 404 (fetch action)", async () => {
+    // Visit the actions page first so the dev server transforms and registers
+    // the "use server" module in @vitejs/plugin-rsc's serverReferenceMetaMap.
+    await fetch(`${baseUrl}/actions`).catch(() => {});
+
+    // The action ID for non-anonymous "use server" exports follows the
+    // `/app/<file path>#<exportName>` convention (see action-headers.test.ts).
+    const actionId = "/app/actions/actions.ts#notFoundAction";
+
+    const res = await fetch(`${baseUrl}/actions.rsc`, {
+      method: "POST",
+      headers: {
+        "x-rsc-action": actionId,
+        Origin: baseUrl,
+        Host: new URL(baseUrl).host,
+        "Content-Type": "text/plain",
+      },
+      body: "[]",
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    // The flight payload should carry the rejected actionResult so the
+    // client error boundary can recognise the not-found digest.
+    const body = await res.text();
+    expect(body.length).toBeGreaterThan(0);
+    // Should NOT surface as a generic 500 / internal-server-error body.
+    expect(body).not.toContain("Server action failed");
+  });
+
+  it("server action calling notFound() returns 404 (progressive form action)", async () => {
+    // Visit the page first so the action manifest is populated in dev.
+    await fetch(`${baseUrl}/actions`).catch(() => {});
+
+    // Progressive (no-JS) form submissions send multipart/form-data with the
+    // action id embedded in the body as `$ACTION_ID_<actionId>`, no
+    // `x-rsc-action` header. Mirrors Next.js' MPA action POST flow:
+    // packages/next/src/server/app-render/action-handler.ts.
+    const formData = new FormData();
+    formData.set("$ACTION_ID_/app/actions/actions.ts#notFoundAction", "");
+
+    const res = await fetch(`${baseUrl}/actions`, {
+      method: "POST",
+      headers: {
+        Origin: baseUrl,
+        Host: new URL(baseUrl).host,
+      },
+      body: formData,
+    });
+
+    expect(res.status).toBe(404);
+    // Should NOT surface as a generic 500.
+    const body = await res.text();
+    expect(body).not.toContain("Server action failed");
+    expect(body).not.toContain("Internal Server Error");
+  });
+
   // ── Browser-only tests (need Playwright, documented here) ──
   // These tests require clicking a button client-side which triggers notFound()
   // in a client component. Cannot be tested via HTTP fetch alone.


### PR DESCRIPTION
## Summary

- Vite's reference-validation virtual module emits `[vite-rsc] invalid server reference '<moduleId>'` without the `#<exportName>` suffix, because `loadServerAction(id)` splits the id at `#` before calling `requireModule(file)`. `isServerActionNotFoundError` only compared the full action id against the Vite error, so stale/missing references surfaced as a generic 500 instead of Next.js' 404 + `x-nextjs-action-not-found` response.
- Accept both the full-actionId and pre-`#` module-path forms for the dev (`[vite-rsc] invalid server reference '<id>'`) and prod (`server reference not found '<id>'`) error shapes.

Scoped fix for issue #1340 — the `notFound()`-from-server-action 404 status path. Other parts of #1340 (error-boundary propagation for `text/plain` action responses, unrecognized-action client behaviour) remain in scope for follow-up PRs.

## Test plan

- [x] `pnpm test tests/app-server-action-execution.test.ts` — new unit test fails on `main`, passes after fix
- [x] `pnpm test tests/nextjs-compat/not-found.test.ts` — integration coverage that `notFound()` from a server action returns 404 for both fetch and progressive form action paths
- [x] `pnpm run check` (format / lint / type) clean
- [ ] CI: Check, Vitest, Playwright E2E