### PR TITLE
fix(app-router): allow draftMode() reads inside cache scopes (#1489)

### DIFF
--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -907,10 +907,16 @@ function requireActiveDraftModeContext(
  * - `isEnabled`: true if the bypass cookie is present in the request
  * - `enable()`: sets the bypass cookie (for Route Handlers)
  * - `disable()`: clears the bypass cookie
+ *
+ * Unlike `headers()` / `cookies()`, calling `draftMode()` itself is allowed
+ * inside `"use cache"` and `unstable_cache()` scopes — reads of `isEnabled`
+ * are non-dynamic and supported in cached functions. Only the mutating
+ * `enable()` / `disable()` methods throw when invoked inside a cache scope.
+ * Ported from Next.js: packages/next/src/server/request/draft-mode.ts
+ * (`getDraftModeProviderForCacheScope` + `trackDynamicDraftMode`).
  */
 export async function draftMode(): Promise<DraftModeResult> {
   markRenderRequestApiUsage("draftMode");
-  throwIfInsideCacheScope("draftMode()");
 
   const state = _getState();
   const context = state.headersContext;
@@ -932,12 +938,16 @@ export async function draftMode(): Promise<DraftModeResult> {
       return context.cookies.get(DRAFT_MODE_COOKIE) === secret;
     },
     enable(): void {
+      // Mutating draft mode inside a cache scope would freeze a Set-Cookie
+      // side-effect into the cached entry, so Next.js throws here. Match that.
+      throwIfInsideCacheScope("draftMode().enable()");
       const activeContext = requireActiveDraftModeContext(state, context, "draftMode().enable()");
       markDynamicUsage();
       activeContext.cookies.set(DRAFT_MODE_COOKIE, secret);
       state.draftModeCookieHeader = `${DRAFT_MODE_COOKIE}=${secret}; ${draftModeCookieAttributes()}`;
     },
     disable(): void {
+      throwIfInsideCacheScope("draftMode().disable()");
       const activeContext = requireActiveDraftModeContext(state, context, "draftMode().disable()");
       markDynamicUsage();
       activeContext.cookies.delete(DRAFT_MODE_COOKIE);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17321,7 +17321,67 @@ describe("cache scope guards for dynamic APIs", () => {
     setHeadersContext(null);
   });
 
-  it('draftMode() throws inside "use cache" scope', async () => {
+  // Ported from Next.js: packages/next/src/server/request/draft-mode.ts
+  // (`getDraftModeProviderForCacheScope` + `trackDynamicDraftMode`).
+  // Reading `draftMode()` / `.isEnabled` is allowed inside cache scopes;
+  // only the mutating `enable()` / `disable()` methods throw. Issue #1489.
+  it('draftMode().isEnabled reads inside "use cache" scope', async () => {
+    const { cacheContextStorage } = await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { draftMode, setHeadersContext } =
+      await import("../packages/vinext/src/shims/headers.js");
+
+    setHeadersContext({
+      headers: new Headers({ cookie: "__prerender_bypass=test-secret" }),
+      cookies: new Map([["__prerender_bypass", "test-secret"]]),
+      draftModeSecret: "test-secret",
+    });
+
+    await cacheContextStorage.run(
+      {
+        tags: [],
+        lifeConfigs: [],
+        variant: "default",
+        hasExplicitRevalidate: false,
+        hasExplicitExpire: false,
+        dynamicNestedCacheError: undefined,
+      },
+      async () => {
+        const dm = await draftMode();
+        expect(dm.isEnabled).toBe(true);
+      },
+    );
+
+    setHeadersContext(null);
+  });
+
+  it("draftMode().isEnabled reads inside unstable_cache() scope", async () => {
+    const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { draftMode, setHeadersContext } =
+      await import("../packages/vinext/src/shims/headers.js");
+
+    setCacheHandler(new MemoryCacheHandler());
+    setHeadersContext({
+      headers: new Headers({ cookie: "__prerender_bypass=test-secret" }),
+      cookies: new Map([["__prerender_bypass", "test-secret"]]),
+      draftModeSecret: "test-secret",
+    });
+
+    let observed: boolean | undefined;
+    const cached = unstable_cache(async () => {
+      const dm = await draftMode();
+      observed = dm.isEnabled;
+      return observed;
+    }, ["test-draftmode-in-cache"]);
+
+    await expect(cached()).resolves.toBe(true);
+    expect(observed).toBe(true);
+
+    setHeadersContext(null);
+    setCacheHandler(new MemoryCacheHandler());
+  });
+
+  it('draftMode().enable() throws inside "use cache" scope', async () => {
     const { cacheContextStorage } = await import("../packages/vinext/src/shims/cache-runtime.js");
     const { draftMode, setHeadersContext } =
       await import("../packages/vinext/src/shims/headers.js");
@@ -17338,14 +17398,16 @@ describe("cache scope guards for dynamic APIs", () => {
         dynamicNestedCacheError: undefined,
       },
       async () => {
-        await expect(draftMode()).rejects.toThrow(/cannot be called inside "use cache"/);
+        const dm = await draftMode();
+        expect(() => dm.enable()).toThrow(/cannot be called inside "use cache"/);
+        expect(() => dm.disable()).toThrow(/cannot be called inside "use cache"/);
       },
     );
 
     setHeadersContext(null);
   });
 
-  it("draftMode() throws inside unstable_cache() scope", async () => {
+  it("draftMode().enable() throws inside unstable_cache() scope", async () => {
     const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
     const { draftMode, setHeadersContext } =
@@ -17355,8 +17417,9 @@ describe("cache scope guards for dynamic APIs", () => {
     setHeadersContext({ headers: new Headers(), cookies: new Map() });
 
     const cached = unstable_cache(async () => {
-      await draftMode();
-    }, ["test-draftmode-in-cache"]);
+      const dm = await draftMode();
+      dm.enable();
+    }, ["test-draftmode-enable-in-cache"]);
 
     await expect(cached()).rejects.toThrow(/unstable_cache/);
 


### PR DESCRIPTION
## Summary

- `await draftMode()` and `.isEnabled` reads now work inside `"use cache"` and `unstable_cache()` callbacks, matching Next.js. Only the mutating `enable()` / `disable()` methods throw inside cache scopes, mirroring `trackDynamicDraftMode` upstream.
- Prior behavior was to throw on `draftMode()` itself, which caused Next.js's `app-static` deploy suite to see empty/undefined `isEnabled` values in fixtures like `unstable-cache/dynamic` that call `(await draftMode()).isEnabled` inside the cached function.
- Scoped narrowly per #1489: this PR addresses the `draftMode().isEnabled` read path. Bypassing `unstable_cache` writes when draft mode is enabled is deferred to a follow-up.

Ported from `packages/next/src/server/request/draft-mode.ts` (`getDraftModeProviderForCacheScope`).

Fixes #1489 (partial — read path).

## Test plan

- [x] `pnpm test tests/shims.test.ts` — new regression tests:
  - `draftMode().isEnabled reads inside "use cache" scope` returns `true` when the bypass cookie is present.
  - `draftMode().isEnabled reads inside unstable_cache() scope` returns `true` when the bypass cookie is present.
  - `draftMode().enable()` / `disable()` still throw inside cache scopes.
- [x] `pnpm test tests/nextjs-compat/draft-mode.test.ts tests/cache-proof.test.ts tests/draft-secret-exposure.test.ts` — all green.
- [x] `pnpm test tests/app-page-dispatch.test.ts tests/app-route-handler-dispatch.test.ts tests/unified-request-context.test.ts tests/app-rsc-handler.test.ts` — all green.
- [x] `pnpm run lint` and `pnpm run fmt:check` — clean.