### PR TITLE
fix(shims): throw Pages Router parity error from unstable_retry (#1448)

### DIFF
--- a/packages/vinext/src/shims/error.tsx
+++ b/packages/vinext/src/shims/error.tsx
@@ -11,6 +11,7 @@
  */
 import React from "react";
 import { appRouterInstance, isNextRouterError } from "./navigation.js";
+import { RouterContext } from "./internal/router-context.js";
 
 type ErrorProps = {
   statusCode: number;
@@ -98,14 +99,14 @@ export default ErrorComponent;
 //     client — it calls `appRouterInstance.refresh()` inside a
 //     React.startTransition and then resets the boundary. On the server it
 //     throws (consistent with React class components only running on the
-//     server during SSR setup, where retry isn't meaningful). The
-//     Pages-Router-only error message Next.js throws
-//     (`unstable_retry()` can only be used in the App Router. Use
-//     `reset()` in the Pages Router.) is not currently dispatched because
-//     vinext's boundary doesn't read `PagesRouterContext`. Calling retry
-//     under Pages Router will trigger an App Router refresh, which is a
-//     no-op in that environment — the error remains visible until
-//     `reset()` is called. Tracked as a parity follow-up.
+//     server during SSR setup, where retry isn't meaningful). When the
+//     boundary is rendered under the Pages Router (detected via
+//     `RouterContext` in the wrapper), `unstable_retry()` throws Next.js's
+//     verbatim error message (`unstable_retry() can only be used in the
+//     App Router. Use reset() in the Pages Router.`) — matching
+//     `client/components/catch-error.tsx` in the Next.js source and the
+//     `should throw when unstable_retry is called on Pages Router` test in
+//     `test/e2e/app-dir/catch-error/catch-error.test.ts`.
 //   - Bot-user-agent graceful-degradation, `handleHardNavError`, and
 //     `handleISRError` are not yet supported. Errors always render the
 //     fallback in non-bot contexts.
@@ -136,6 +137,18 @@ class _CatchError<P extends _UserProps> extends React.Component<
   },
   { error: _CatchErrorState }
 > {
+  // Read the Pages Router context via class `contextType` (matching Next.js's
+  // pattern in `client/components/catch-error.tsx` which uses
+  // `static contextType = AppRouterContext`). When `this.context` is non-null
+  // we're rendered under a Pages Router page; `unstable_retry()` then throws
+  // the Next.js parity error message. Using `contextType` rather than
+  // `useContext` in the wrapper keeps the wrapper a pure JSX factory so
+  // existing introspection-style unit tests (which invoke the wrapper as a
+  // bare function to extract the inner class) continue to work without
+  // React's render lifecycle.
+  static contextType = RouterContext;
+  declare context: React.ContextType<typeof RouterContext>;
+
   // Match Next.js's DevTools label so userland tooling/snapshots align.
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/catch-error.tsx
   static displayName = "unstable_catchError(Next.CatchError)";
@@ -156,6 +169,23 @@ class _CatchError<P extends _UserProps> extends React.Component<
   };
 
   unstable_retry = (): void => {
+    // Pages Router has no segment-refresh primitive — Next.js documents
+    // `unstable_retry` as App Router only and throws this exact message
+    // from the boundary itself. Mirrors
+    // packages/next/src/client/components/catch-error.tsx and is asserted
+    // by `should throw when unstable_retry is called on Pages Router` in
+    // test/e2e/app-dir/catch-error/catch-error.test.ts.
+    //
+    // `RouterContext` is populated for every page rendered by the vinext
+    // Pages Router runtime (see `shims/router.ts` wrapWithRouterContext); a
+    // non-null value here means we're under Pages Router. Under App Router
+    // the context default is `null` and we fall through to the refresh
+    // branch below.
+    if (this.context !== null) {
+      throw new Error(
+        "`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.",
+      );
+    }
     // Matches Next.js's App Router branch in
     // packages/next/src/client/components/catch-error.tsx — refresh the
     // current route, then clear the error so children re-render. Wrapped in

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1261,6 +1261,11 @@ describe("next/error shim — unstable_catchError", () => {
       fallback: Fallback,
       forwardedProps: {},
     });
+    // Manually instantiating the class skips React's context machinery,
+    // so `this.context` is undefined. Seed it to `null` (matching the
+    // App Router default) so the Pages Router branch in `unstable_retry`
+    // doesn't fire.
+    (instance as unknown as { context: null }).context = null;
     instance.state = { error: { thrownValue: new Error("boom") } };
 
     // typeof window === "undefined" in this Node test environment, so
@@ -1324,6 +1329,11 @@ describe("next/error shim — unstable_catchError", () => {
         fallback: Fallback,
         forwardedProps: {},
       });
+      // Manually instantiating the class skips React's context machinery,
+      // so `this.context` is undefined. Seed it to `null` (matching the
+      // App Router default) so the Pages Router branch in `unstable_retry`
+      // doesn't fire — this test exercises the App Router branch.
+      (instance as unknown as { context: null }).context = null;
 
       // Seed an error so reset has something to clear, and replace setState
       // with a spy so we can confirm the boundary self-resets.
@@ -1351,6 +1361,53 @@ describe("next/error shim — unstable_catchError", () => {
       }
       vi.resetModules();
     }
+  });
+
+  // Regression for cloudflare/vinext#1448.
+  // Ported from Next.js test:
+  //   .nextjs-ref/test/e2e/app-dir/catch-error/catch-error.test.ts
+  //   "should throw when unstable_retry is called on Pages Router"
+  // Mirrors the App Router-only branch in Next.js's catch-error source:
+  //   .nextjs-ref/packages/next/src/client/components/catch-error.tsx
+  // The boundary detects Pages Router via `RouterContext` (set as the inner
+  // class component's `contextType`). When a non-null Pages Router instance
+  // is in context, `unstable_retry()` must throw the verbatim Next.js
+  // message instead of calling App Router's `refresh()`.
+  it("unstable_retry under Pages Router throws Next.js parity error message", async () => {
+    const React = (await import("react")).default;
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+
+    function Fallback() {
+      return null;
+    }
+    const Boundary = unstable_catchError(Fallback);
+    const wrapperResult = (Boundary as unknown as (p: Record<string, never>) => { type: unknown })(
+      {},
+    );
+    const InnerCatchError = wrapperResult.type as unknown as new (props: object) => {
+      state: { error: { thrownValue: unknown } | null };
+      unstable_retry: () => void;
+    };
+    const instance = new InnerCatchError({
+      fallback: Fallback,
+      forwardedProps: {},
+    });
+    instance.state = { error: { thrownValue: new Error("boom") } };
+
+    // Seed `this.context` with a truthy value so the Pages Router branch
+    // fires. In production React fills this from RouterContext when the
+    // boundary is rendered under `RouterContext.Provider` (every Pages
+    // Router page). Casting via unknown keeps the seed type-safe under
+    // the class's declared `context` type.
+    (instance as unknown as { context: object }).context = {
+      route: "/some-page",
+    };
+
+    void React; // keep React import for parity with sibling tests
+
+    expect(() => instance.unstable_retry()).toThrow(
+      "`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the Pages Router parity gap explicitly tracked as a follow-up in #1206, addressing #1448.

When `unstable_catchError`'s boundary is rendered under the Pages Router, calling `unstable_retry()` previously invoked `appRouterInstance.refresh()` — a no-op under Pages Router that left the error visible until `reset()` was called. Next.js documents `unstable_retry` as App Router only and throws a specific error message from the boundary itself. We now match that behavior verbatim.

- Inner class component reads `RouterContext` via `static contextType` (mirroring Next.js's `static contextType = AppRouterContext` pattern in `client/components/catch-error.tsx`).
- When `this.context !== null` (Pages Router page), `unstable_retry()` throws `` `unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router. ``.
- App Router branch (refresh + reset) is unchanged.
- Wrapper stays a pure JSX factory so existing introspection-style unit tests that invoke it as a bare function continue to work.

Regression test ported from Next.js' own suite: `test/e2e/app-dir/catch-error/catch-error.test.ts` — "should throw when unstable_retry is called on Pages Router".

## Files

- `packages/vinext/src/shims/error.tsx` — wire `RouterContext` as `contextType`, branch in `unstable_retry`, refresh the doc comment.
- `tests/shims.test.ts` — new Pages Router branch test; seed `this.context = null` on the two existing App Router tests (manual class instantiation skips React's context wiring).

## Test plan

- [x] `pnpm test tests/shims.test.ts -t "unstable_catchError"` — 10/10 pass.
- [x] `pnpm test tests/shims.test.ts tests/error-boundary.test.ts` — 1046/1046 pass.
- [x] `pnpm run check` — clean (format + lint + type).
- [ ] CI Vitest / Playwright E2E (will run on PR).

## Out of scope (documented follow-ups remaining from #1206)

- Server Component error recovery via `unstable_retry` (requires Suspense-boundary re-fetch wiring).
- Bot-user-agent graceful-degradation, `handleHardNavError`, `handleISRError`.
- Per-environment shim split (react-server throwing stub vs client implementation).