### PR TITLE
fix(pages-router): run instrumentation-client.ts before hydration (#1474)

### DIFF
--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -24,13 +24,17 @@ export async function generateClientEntry(
   pagesDir: string,
   nextConfig: ResolvedNextConfig,
   fileMatcher: ReturnType<typeof createValidFileMatcher>,
-  options: { appPrefetchRoutes?: readonly VinextLinkPrefetchRoute[] } = {},
+  options: {
+    appPrefetchRoutes?: readonly VinextLinkPrefetchRoute[];
+    instrumentationClientPath?: string | null;
+  } = {},
 ): Promise<string> {
   const pageRoutes = await pagesRouter(pagesDir, nextConfig?.pageExtensions, fileMatcher);
 
   const appFilePath = findFileWithExts(pagesDir, "_app", fileMatcher);
   const hasApp = appFilePath !== null;
   const appPrefetchRoutes = options.appPrefetchRoutes ?? [];
+  const instrumentationClientPath = options.instrumentationClientPath ?? null;
 
   // Build a map of route pattern -> dynamic import.
   // Keys must use Next.js bracket format (e.g. "/user/[id]") to match
@@ -46,7 +50,25 @@ export async function generateClientEntry(
 
   const appFileBase = appFilePath ? normalizePathSeparators(appFilePath) : undefined;
 
-  return `
+  // Refs #1474: Side-effect-import the user's `instrumentation-client.{ts,js}`
+  // (when present at project root or in `src/`) BEFORE any other module so its
+  // top-level statements run before `hydrateRoot()` is called. Mirrors
+  // Next.js's `page-bootstrap.ts`, which side-effect-imports
+  // `require-instrumentation-client` ahead of `initialize`/`hydrate`
+  // (.nextjs-ref/packages/next/src/client/page-bootstrap.ts L1).
+  //
+  // The `vinext/instrumentation-client` import below pulls in the hook
+  // surface (`onRouterTransitionStart`) for navigation events. It also
+  // re-imports the user file via the `private-next-instrumentation-client`
+  // alias, but tree-shakers can be conservative about the side effects of
+  // an indirectly-loaded module. Importing the user's file directly here
+  // makes the contract explicit: bare side-effect imports are always
+  // preserved by Vite/Rolldown's import-analysis pipeline.
+  const userInstrumentationImport = instrumentationClientPath
+    ? `import ${JSON.stringify(normalizePathSeparators(instrumentationClientPath))};\n`
+    : "";
+
+  return `${userInstrumentationImport}
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -734,7 +734,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           .filter(isLinkPrefetchRoute)
           .map(toLinkPrefetchRoute)
       : [];
-    return _generateClientEntry(pagesDir, nextConfig, fileMatcher, { appPrefetchRoutes });
+    return _generateClientEntry(pagesDir, nextConfig, fileMatcher, {
+      appPrefetchRoutes,
+      instrumentationClientPath,
+    });
   }
 
   async function writeRouteTypes(): Promise<void> {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from "vite-plus/test";
 import { generateBrowserEntry } from "../packages/vinext/src/entries/app-browser-entry.js";
 import { buildAppRscManifestCode } from "../packages/vinext/src/entries/app-rsc-manifest.js";
 import { generateRscEntry } from "../packages/vinext/src/entries/app-rsc-entry.js";
+import { generateClientEntry } from "../packages/vinext/src/entries/pages-client-entry.js";
 import { generateServerEntry } from "../packages/vinext/src/entries/pages-server-entry.js";
 import { resolveNextConfig } from "../packages/vinext/src/config/next-config.js";
 import { buildAppRouteGraph } from "../packages/vinext/src/routing/app-route-graph.js";
@@ -794,6 +795,80 @@ describe("Pages Router entry template", () => {
       expect(globalsImportIndex).toBeGreaterThanOrEqual(0);
       expect(firstUserImportIndex).toBeGreaterThanOrEqual(0);
       expect(globalsImportIndex).toBeLessThan(firstUserImportIndex);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // Refs #1474: Pages Router client entry must import the user's
+  // `instrumentation-client.ts` (at the project root) as a side-effect import
+  // before calling `hydrateRoot()`. Mirrors Next.js's `page-bootstrap.ts`
+  // which side-effect-imports `require-instrumentation-client` ahead of
+  // `initialize` / `hydrate` (see
+  // .nextjs-ref/packages/next/src/client/page-bootstrap.ts line 1).
+  //
+  // Ported from Next.js: test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
+  it("imports the user's instrumentation-client.ts before calling hydrateRoot()", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    const instrumentationClientPath = path.join(tmpDir, "instrumentation-client.ts");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+      fs.writeFileSync(
+        instrumentationClientPath,
+        "(window as any).__INSTRUMENTATION_CLIENT_EXECUTED_AT = performance.now();",
+      );
+
+      const code = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({}),
+        createValidFileMatcher(),
+        { instrumentationClientPath },
+      );
+
+      // The user's `instrumentation-client.ts` must be imported as a
+      // side-effect import (no `from`, no `as`) so its top-level statements
+      // execute when the client entry module is evaluated.
+      const userImportIndex = code.indexOf(`import ${JSON.stringify(instrumentationClientPath)}`);
+      const hydrateRootIndex = code.indexOf("hydrateRoot(");
+
+      expect(userImportIndex).toBeGreaterThanOrEqual(0);
+      expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
+      expect(userImportIndex).toBeLessThan(hydrateRootIndex);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits the user instrumentation-client import when no file is present", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-empty-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      const code = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({}),
+        createValidFileMatcher(),
+        { instrumentationClientPath: null },
+      );
+
+      // Sanity check: the entry still wires up hydration and the hooks alias.
+      expect(code).toContain("hydrateRoot(");
+      expect(code).toContain("vinext/instrumentation-client");
+      // No spurious bare imports referring to a non-existent project file.
+      expect(code).not.toMatch(/import "[^"]*instrumentation-client\.ts"/);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Side-effect-import the user's `instrumentation-client.{ts,js}` from the generated Pages Router client entry, before `hydrateRoot()`. Previously the contract was implicit (transitive load via `private-next-instrumentation-client`), which left the user's top-level statements vulnerable to tree-shaking and ordering surprises.
- Mirrors Next.js's `page-bootstrap.ts`, which side-effect-imports `require-instrumentation-client` before `initialize` / `hydrate` (`.nextjs-ref/packages/next/src/client/page-bootstrap.ts` L1).
- Adds focused unit coverage in `tests/entry-templates.test.ts`:
  - The generated client entry imports the user's `instrumentation-client.ts` and that import precedes `hydrateRoot(`.
  - Nothing spurious is emitted when no file is present.

Closes #1474 once CI passes.

## Test plan

- [x] `pnpm test tests/entry-templates.test.ts tests/pages-router.test.ts tests/instrumentation.test.ts` — 320 tests pass locally.
- [x] `pnpm run check` clean.
- [ ] CI green (Vitest + Playwright `tests/e2e/pages-router/instrumentation-client.spec.ts`).