### PR TITLE
fix(app-router): propagate cookies/headers from no-JS server actions (#1483)

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -15,6 +15,7 @@ import {
 } from "../config/config-matchers.js";
 import { headersContextFromRequest } from "vinext/shims/headers";
 import {
+  ACTION_REVALIDATED_HEADER,
   NEXT_ACTION_HEADER,
   RSC_ACTION_HEADER,
   RSC_HEADER,
@@ -135,17 +136,30 @@ type HandleProgressiveActionRequestOptions = {
   request: Request;
 };
 
+/**
+ * Side-effect headers captured during a progressive (no-JS) server action's
+ * non-redirect execution. Forwarded onto the page render response so that
+ * `cookies().set(...)` and revalidation kinds reach the browser. See
+ * `app-server-action-execution.ts` and issue #1483 for the full rationale.
+ */
+type ProgressiveActionSideEffects = {
+  pendingCookies: string[];
+  draftCookie: string | null | undefined;
+  /** Numeric revalidation kind: `0` (none), `1` (static+dynamic), etc. */
+  revalidationKind: number;
+};
+
 type ProgressiveActionFormStateResult =
-  | {
+  | ({
       formState: ReactFormState | null;
       kind: "form-state";
-    }
-  | {
+    } & ProgressiveActionSideEffects)
+  | ({
       actionError: unknown;
       actionFailed: true;
       formState: null;
       kind: "form-state";
-    };
+    } & ProgressiveActionSideEffects);
 
 type HandleServerActionRequestOptions = {
   actionId: string | null;
@@ -653,7 +667,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     });
   }
 
-  return options.dispatchMatchedPage({
+  const pageResponse = await options.dispatchMatchedPage({
     cleanPathname,
     formState,
     actionError,
@@ -673,6 +687,66 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     searchParams: url.searchParams,
     renderMode,
   });
+
+  // No-JS progressive form actions write cookies via cookies().set() / draftMode()
+  // *during action execution*, before the page rerender begins. Those writes only
+  // exist on the request-scoped headers state; the page-render path never flushes
+  // them. We attach them here so the rendered Response carries the action's
+  // Set-Cookie headers and revalidation marker, mirroring Next.js'
+  // res.setHeader('set-cookie', ...) flush in action-handler.ts / app-render.tsx.
+  // Issue: https://github.com/cloudflare/vinext/issues/1483
+  if (isProgressiveActionRender) {
+    return applyProgressiveActionSideEffects(pageResponse, progressiveActionResult);
+  }
+  return pageResponse;
+}
+
+/**
+ * Append `Set-Cookie` headers and the `x-action-revalidated` marker captured
+ * during progressive (no-JS) server action execution to the page render
+ * response. See issue #1483.
+ *
+ * Falls back to rebuilding the response when the headers object is immutable
+ * (e.g. `Response.redirect()`), so cookies set by the action ride out on a
+ * redirect issued during the rerender too.
+ */
+function applyProgressiveActionSideEffects(
+  response: Response,
+  sideEffects: ProgressiveActionFormStateResult,
+): Response {
+  const hasPendingCookies = sideEffects.pendingCookies.length > 0;
+  const hasDraftCookie = Boolean(sideEffects.draftCookie);
+  const hasRevalidationKind = sideEffects.revalidationKind !== 0;
+  if (!hasPendingCookies && !hasDraftCookie && !hasRevalidationKind) {
+    return response;
+  }
+
+  const applyTo = (headers: Headers): void => {
+    for (const cookie of sideEffects.pendingCookies) {
+      headers.append("Set-Cookie", cookie);
+    }
+    if (sideEffects.draftCookie) {
+      headers.append("Set-Cookie", sideEffects.draftCookie);
+    }
+    if (hasRevalidationKind) {
+      headers.set(ACTION_REVALIDATED_HEADER, JSON.stringify(sideEffects.revalidationKind));
+    }
+  };
+
+  try {
+    applyTo(response.headers);
+    return response;
+  } catch {
+    // Headers were immutable (Response.redirect()/Response.error()) — rebuild
+    // with a fresh mutable Headers seeded from the original response.
+    const headers = new Headers(response.headers);
+    applyTo(headers);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
 }
 
 export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -77,17 +77,38 @@ type AppServerActionRoute = {
   pattern: string;
 };
 
+/**
+ * Side-effect headers captured during a progressive (no-JS) server action's
+ * non-redirect execution. The caller (app-rsc-handler) must apply these to the
+ * page render response so that `cookies().set(...)` and revalidation kinds
+ * propagate to the browser. Without this, no-JS form submissions silently
+ * lose cookie/header mutations — see issue #1483.
+ *
+ * Next.js' equivalent path mutates `res.setHeader('set-cookie', ...)` during
+ * action execution (action-handler.ts → app-render.tsx), then `sendResponse`
+ * merges those headers with the rendered Response. vinext works with Response
+ * objects directly so the cookies must ride out via the result instead.
+ */
+type ProgressiveServerActionSideEffects = {
+  /** `Set-Cookie` headers from `cookies().set(...)` / `cookies().delete(...)`. */
+  pendingCookies: string[];
+  /** `Set-Cookie` header from `draftMode().enable()/disable()` (if any). */
+  draftCookie: string | null | undefined;
+  /** Resolved revalidation kind to emit via `x-action-revalidated`. */
+  revalidationKind: ActionRevalidationKind;
+};
+
 type ProgressiveServerActionResult =
-  | {
+  | ({
       formState: ReactFormState | null;
       kind: "form-state";
-    }
-  | {
+    } & ProgressiveServerActionSideEffects)
+  | ({
       actionError: unknown;
       actionFailed: true;
       formState: null;
       kind: "form-state";
-    };
+    } & ProgressiveServerActionSideEffects);
 
 type AppServerActionMatch<TRoute extends AppServerActionRoute> = {
   params: AppPageParams;
@@ -512,13 +533,38 @@ export async function handleProgressiveServerActionRequest(
     }
 
     if (!actionRedirect) {
-      getAndClearActionRevalidationKind();
+      // Capture cookies/headers set during action execution so the caller can
+      // apply them to the rendered page response. Mirrors Next.js'
+      // `res.setHeader('set-cookie', ...)` path in app-render.tsx, which
+      // flushes `requestStore.mutableCookies` onto the response before SSR
+      // streaming begins. Without this, no-JS server-action form POSTs lose
+      // cookies/headers — see issue #1483.
+      const actionPendingCookies = options.getAndClearPendingCookies();
+      const actionDraftCookie = options.getDraftModeCookieHeader();
+      const revalidationKind = resolveActionRevalidationKind(
+        actionPendingCookies.length > 0 || Boolean(actionDraftCookie),
+      );
+
       if (actionFailed) {
-        return { kind: "form-state", formState: null, actionError, actionFailed };
+        return {
+          kind: "form-state",
+          formState: null,
+          actionError,
+          actionFailed,
+          pendingCookies: actionPendingCookies,
+          draftCookie: actionDraftCookie,
+          revalidationKind,
+        };
       }
 
       const formState = await options.decodeFormState(actionResult, body);
-      return { kind: "form-state", formState: formState ?? null };
+      return {
+        kind: "form-state",
+        formState: formState ?? null,
+        pendingCookies: actionPendingCookies,
+        draftCookie: actionDraftCookie,
+        revalidationKind,
+      };
     }
 
     const actionPendingCookies = options.getAndClearPendingCookies();

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -104,7 +104,13 @@ describe("createAppRscHandler", () => {
       configHeaders: [],
       dispatchMatchedPage,
       async handleProgressiveActionRequest() {
-        return { kind: "form-state", formState: null };
+        return {
+          kind: "form-state",
+          formState: null,
+          pendingCookies: [],
+          draftCookie: null,
+          revalidationKind: 0,
+        };
       },
     });
 
@@ -123,6 +129,89 @@ describe("createAppRscHandler", () => {
         isProgressiveActionRender: true,
       }),
     );
+  });
+
+  // Regression for issue #1483 — `cookies().set(...)` / `cookies().delete(...)`
+  // and `draftMode().enable()` invoked inside a no-JS server action must flow
+  // through to the page rerender response. Before the fix, those Set-Cookie
+  // headers (plus the x-action-revalidated marker) were dropped on the floor
+  // because the handler returned the dispatcher's response untouched.
+  it("propagates cookies, draft cookie, and revalidation marker from a progressive action to the page response (#1483)", async () => {
+    const dispatchMatchedPage = vi.fn(
+      async () =>
+        new Response("page", {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      async handleProgressiveActionRequest() {
+        return {
+          kind: "form-state",
+          formState: null,
+          pendingCookies: ["session=abc; Path=/", "theme=dark; Path=/"],
+          draftCookie: "__prerender_bypass=secret; Path=/",
+          revalidationKind: 1,
+        };
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "content-type": "multipart/form-data; boundary=vinext" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.getSetCookie()).toEqual([
+      "session=abc; Path=/",
+      "theme=dark; Path=/",
+      "__prerender_bypass=secret; Path=/",
+    ]);
+    expect(response.headers.get("x-action-revalidated")).toBe("1");
+  });
+
+  // When an action did not mutate cookies and did not request a revalidation,
+  // the page response should NOT carry an x-action-revalidated marker — that
+  // header tells the client router cache to invalidate, and emitting it
+  // spuriously would force unnecessary refetches.
+  it("does not add x-action-revalidated when a progressive action made no mutations (#1483)", async () => {
+    const dispatchMatchedPage = vi.fn(
+      async () =>
+        new Response("page", {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      async handleProgressiveActionRequest() {
+        return {
+          kind: "form-state",
+          formState: null,
+          pendingCookies: [],
+          draftCookie: null,
+          revalidationKind: 0,
+        };
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "content-type": "multipart/form-data; boundary=vinext" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.getSetCookie()).toEqual([]);
+    expect(response.headers.has("x-action-revalidated")).toBe(false);
   });
 
   it("uses encoded prerender route params for rendering while retaining decoded params for static validation", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -428,6 +428,74 @@ describe("app server action execution helpers", () => {
     expect(clearContext).toHaveBeenCalledTimes(1);
   });
 
+  // Regression for issue #1483 — no-JS form POST actions that set cookies but
+  // do not redirect must still surface those Set-Cookie headers (and the
+  // revalidation marker) on the rerender response. Before the fix, the
+  // pending cookies and draft-mode cookie set during action execution were
+  // silently dropped because the non-redirect path returned only the
+  // form-state and never read them out of the request scope.
+  it("captures pending cookies, draft cookie, and revalidation kind from non-redirect actions (#1483)", async () => {
+    const formData = new FormData();
+    formData.set("$ACTION_ID_test", "");
+    const phaseCalls: string[] = [];
+
+    const result = await handleProgressiveServerActionRequest(
+      createOptions({
+        async decodeAction() {
+          return () => undefined;
+        },
+        getAndClearPendingCookies: vi.fn(() => ["session=abc; Path=/", "theme=dark; Path=/"]),
+        getDraftModeCookieHeader: vi.fn(() => "__prerender_bypass=secret; Path=/"),
+        readFormDataWithLimit() {
+          return Promise.resolve(formData);
+        },
+        setHeadersAccessPhase(phase) {
+          phaseCalls.push(phase);
+          return "render";
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "form-state",
+      formState: null,
+      // Non-zero revalidation kind because cookies were mutated.
+      revalidationKind: 1,
+      pendingCookies: ["session=abc; Path=/", "theme=dark; Path=/"],
+      draftCookie: "__prerender_bypass=secret; Path=/",
+    });
+    // Headers access phase must still be flipped back after the action runs
+    // so the subsequent page rerender sees the regular render phase.
+    expect(phaseCalls).toEqual(["action", "render"]);
+  });
+
+  // Issue #1483 — when an action reads cookies but does not mutate them and
+  // doesn't redirect, the result should report a zero revalidation kind so the
+  // client router cache is not unnecessarily invalidated.
+  it("reports a zero revalidation kind when a non-redirect action does not mutate cookies (#1483)", async () => {
+    const formData = new FormData();
+    formData.set("$ACTION_ID_test", "");
+
+    const result = await handleProgressiveServerActionRequest(
+      createOptions({
+        async decodeAction() {
+          return () => undefined;
+        },
+        readFormDataWithLimit() {
+          return Promise.resolve(formData);
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "form-state",
+      formState: null,
+      pendingCookies: [],
+      draftCookie: null,
+      revalidationKind: 0,
+    });
+  });
+
   it("returns decoded form state after successful non-redirect actions without consuming the original body", async () => {
     const formData = new FormData();
     formData.set("$ACTION_ID_test", "");
@@ -458,7 +526,13 @@ describe("app server action execution helpers", () => {
       }),
     );
 
-    expect(result).toEqual({ kind: "form-state", formState });
+    expect(result).toEqual({
+      kind: "form-state",
+      formState,
+      pendingCookies: [],
+      draftCookie: null,
+      revalidationKind: 0,
+    });
     expect(actionRan).toBe(true);
     expect((await request.formData()).get("field")).toBe("value");
   });
@@ -487,6 +561,9 @@ describe("app server action execution helpers", () => {
         formState: null,
         actionError: { digest },
         actionFailed: true,
+        pendingCookies: [],
+        draftCookie: null,
+        revalidationKind: 0,
       });
       expect(reportedErrors).toEqual([]);
       expect(clearContext).not.toHaveBeenCalled(); // Let app-rsc-handler clear it after render
@@ -495,6 +572,8 @@ describe("app server action execution helpers", () => {
 
   it("passes action execution failures as actionError to be rendered by error boundaries", async () => {
     const reportedErrors: Error[] = [];
+    // Failure-path renders still need to flush action-set cookies onto the
+    // error page response (issue #1483), so the handler captures them here.
     const clearedCookies = vi.fn(() => ["session=1; Path=/"]);
     const clearContext = vi.fn();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -521,9 +600,12 @@ describe("app server action execution helpers", () => {
       formState: null,
       actionError: error,
       actionFailed: true,
+      pendingCookies: ["session=1; Path=/"],
+      draftCookie: null,
+      revalidationKind: 1,
     });
     expect(reportedErrors.map((e) => e.message)).toEqual(["boom"]);
-    expect(clearedCookies).not.toHaveBeenCalled(); // Only cleared if response is rendered here
+    expect(clearedCookies).toHaveBeenCalledTimes(1);
     expect(clearContext).not.toHaveBeenCalled(); // Handled by app-rsc-handler
 
     errorSpy.mockRestore();
@@ -548,6 +630,9 @@ describe("app server action execution helpers", () => {
         formState: null,
         actionError: 0,
         actionFailed: true,
+        pendingCookies: [],
+        draftCookie: null,
+        revalidationKind: 0,
       });
     } finally {
       errorSpy.mockRestore();


### PR DESCRIPTION
## Summary

Fixes #1483 — no-JS (progressive) `<form action={action}>` submissions whose server action calls `cookies().set(...)` / `draftMode().enable()` and returns *without* redirecting were silently losing those mutations: the `Set-Cookie` and `x-action-revalidated` headers never made it onto the response.

The non-redirect branch of `handleProgressiveServerActionRequest` returned only `{ kind: "form-state", formState }` and never read the pending cookies out of the request-scoped headers context. The follow-up page rerender pulled the draft cookie but not the action's pending cookies, so the writes evaporated.

Now the progressive action handler captures `pendingCookies`, `draftCookie`, and `revalidationKind` at the end of the non-redirect path and surfaces them on the form-state result. The app RSC handler appends them onto the rendered page response (and emits the `x-action-revalidated` marker when needed), mirroring Next.js' `res.setHeader('set-cookie', ...)` flush in `action-handler.ts` / `app-render.tsx`. A try/catch fallback rebuilds the response when headers are immutable so cookies still ride a `redirect()` issued during the rerender.

## Test plan

- [x] `pnpm test tests/app-server-action-execution.test.ts` — adds two regression tests covering the non-redirect cookie/draft/revalidation capture and the no-mutation no-op case; existing form-state shape assertions updated.
- [x] `pnpm test tests/app-rsc-handler.test.ts` — adds two end-to-end tests asserting that Set-Cookie + `x-action-revalidated` flow to the page response and that no spurious revalidation marker is emitted when the action made no mutations.
- [x] `pnpm test tests/app-page-render.test.ts tests/app-page-dispatch.test.ts tests/app-page-response.test.ts` — verify the surrounding render path still passes (70 tests).
- [x] `pnpm run lint` / `pnpm run fmt:check` — clean.
- [ ] Full Vitest / Playwright runs deferred to CI per `AGENTS.md`.