### PR TITLE
test(pages-router): regression coverage for URL-encoded CSS paths

### DIFF
--- a/tests/pages-css-url-encoding.test.ts
+++ b/tests/pages-css-url-encoding.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Pages Router: CSS files with non-URL-safe characters in their filename
+ * must be served correctly when the browser percent-encodes the path.
+ *
+ * Regression test for https://github.com/cloudflare/vinext/issues/1472
+ *
+ * Mirrors Next.js's resource-url-encoding fixture:
+ *   - test/e2e/app-dir/resource-url-encoding/pages/pages.tsx imports
+ *     `../my@style.css` and expects `rgb(0, 0, 255)` background.
+ *   - https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resource-url-encoding/resource-url-encoding.test.ts
+ *
+ * The browser percent-encodes the `@` (and any other non-URL-safe chars)
+ * when fetching the asset, so the server-side static-asset layer must
+ * decode the path before looking up the file on disk.
+ */
+
+import { describe, it, expect, afterAll } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { build } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+function setupFixture(registerCleanup: (cleanup: () => void) => void): {
+  tmpDir: string;
+  outDir: string;
+} {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-css-url-encoding-"));
+  registerCleanup(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  fs.symlinkSync(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+  fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ type: "module" }));
+  fs.writeFileSync(path.join(tmpDir, "next.config.mjs"), `export default {};\n`);
+
+  fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
+  // Use the same filename as the Next.js fixture: `my@style.css` has an `@`
+  // which browsers leave intact in the path component, but the issue's
+  // original example used spaces — exercise both shapes via two source CSS
+  // files imported from a single page.
+  fs.writeFileSync(path.join(tmpDir, "my@style.css"), "body { background: rgb(0, 0, 255); }\n");
+  fs.writeFileSync(path.join(tmpDir, "with space.css"), "html { color: rgb(255, 0, 0); }\n");
+  fs.writeFileSync(
+    path.join(tmpDir, "pages", "index.tsx"),
+    `import "../my@style.css";
+import "../with space.css";
+export default function HomePage() {
+  return <p>hello world</p>;
+}
+`,
+  );
+  return { tmpDir, outDir: path.join(tmpDir, "dist") };
+}
+
+async function buildPagesFixture(tmpDir: string, outDir: string): Promise<void> {
+  await build({
+    root: tmpDir,
+    configFile: false,
+    plugins: [vinext({ disableAppRouter: true })],
+    logLevel: "silent",
+    build: {
+      outDir: path.join(outDir, "server"),
+      ssr: "virtual:vinext-server-entry",
+      rollupOptions: { output: { entryFileNames: "entry.js" } },
+    },
+  });
+  await build({
+    root: tmpDir,
+    configFile: false,
+    plugins: [vinext({ disableAppRouter: true })],
+    logLevel: "silent",
+    build: {
+      outDir: path.join(outDir, "client"),
+      manifest: true,
+      ssrManifest: true,
+      rollupOptions: { input: "virtual:vinext-client-entry" },
+    },
+  });
+}
+
+describe("Pages Router CSS with URL-encoded characters in path (issue #1472)", () => {
+  const cleanups: Array<() => void> = [];
+  afterAll(() => {
+    for (const c of cleanups) c();
+  });
+  const register = (cleanup: () => void) => cleanups.push(cleanup);
+
+  it("serves CSS files emitted under /_next/static/ regardless of special chars in the filename", async () => {
+    const { tmpDir, outDir } = setupFixture(register);
+    await buildPagesFixture(tmpDir, outDir);
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://127.0.0.1:${port}`;
+
+      // Fetch the home page and pull every stylesheet href out of the HTML.
+      const homeRes = await fetch(`${baseUrl}/`);
+      expect(homeRes.status).toBe(200);
+      const html = await homeRes.text();
+
+      const hrefRe = /<link\s+rel="stylesheet"[^>]*\shref="([^"]+\.css)"/g;
+      const hrefs: string[] = [];
+      for (const m of html.matchAll(hrefRe)) {
+        hrefs.push(m[1]);
+      }
+      expect(
+        hrefs.length,
+        `expected at least one stylesheet link in the HTML; got:\n${html}`,
+      ).toBeGreaterThan(0);
+
+      // Every stylesheet URL must resolve to a 200 — this is the actual bug
+      // surfaced by issue #1472. Pass each href through encodeURI so the
+      // browser-style percent-encoding of spaces (or other non-URL-safe
+      // chars) is applied before the request hits the server.
+      for (const href of hrefs) {
+        const encoded = encodeURI(href);
+        const res = await fetch(`${baseUrl}${encoded}`);
+        expect(res.status, `expected 200 for stylesheet ${encoded}`).toBe(200);
+        expect(res.headers.get("content-type")).toMatch(/^text\/css/);
+        const body = await res.text();
+        expect(body.length).toBeGreaterThan(0);
+      }
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+});

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -640,6 +640,95 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(captured.body.length).toBe(0);
   });
 
+  // ── URL-encoded characters in path ─────────────────────────────
+  //
+  // Regression test for https://github.com/cloudflare/vinext/issues/1472
+  //
+  // Browser requests for CSS files emitted with non-URL-safe characters in
+  // their filename (e.g. spaces, `@`, `#`) arrive percent-encoded. The
+  // static-asset server must decode the path before looking it up against
+  // the on-disk filename, otherwise the asset 404s and the page renders
+  // without its stylesheet.
+  //
+  // Matches Next.js test/e2e/app-dir/resource-url-encoding.
+
+  it("serves a CSS file requested via a percent-encoded URL", async () => {
+    const cssContent = "body { background: rgb(0, 0, 255); }\n";
+    // File on disk has literal characters (spaces, @) in its name; the
+    // emitted stylesheet URL percent-encodes them.
+    await writeFile(clientDir, "_next/static/css/my@style with spaces.css", cssContent);
+
+    const cache = await StaticFileCache.create(clientDir);
+    const req = mockReq();
+    const { res, captured } = mockRes();
+
+    const served = await tryServeStatic(
+      req,
+      res,
+      clientDir,
+      "/_next/static/css/my%40style%20with%20spaces.css",
+      true,
+      cache,
+    );
+
+    await captured.ended;
+    expect(served).toBe(true);
+    expect(captured.status).toBe(200);
+    expect(captured.headers["Content-Type"]).toBe("text/css");
+    expect(captured.body.toString()).toBe(cssContent);
+  });
+
+  it("slow path serves a CSS file requested via a percent-encoded URL", async () => {
+    const cssContent = "body { background: rgb(0, 0, 255); }\n";
+    await writeFile(clientDir, "_next/static/css/my@style with spaces.css", cssContent);
+
+    const req = mockReq();
+    const { res, captured } = mockRes();
+
+    const served = await tryServeStatic(
+      req,
+      res,
+      clientDir,
+      "/_next/static/css/my%40style%20with%20spaces.css",
+      false,
+    );
+
+    await captured.ended;
+    expect(served).toBe(true);
+    expect(captured.status).toBe(200);
+    expect(captured.headers["Content-Type"]).toBe("text/css");
+    expect(captured.body.toString()).toBe(cssContent);
+  });
+
+  it("serves a CSS file whose URL was decoded upstream (literal chars in pathname)", async () => {
+    // Simulates the Pages/App Router flow: the request pipeline runs
+    // normalizePathnameForRouteMatchStrict before tryServeStatic, which
+    // decodes each segment. By the time tryServeStatic is called, the
+    // pathname may contain literal special chars (no percent signs) — the
+    // cache still has to match against the literal on-disk filename.
+    const cssContent = "body { background: rgb(0, 0, 255); }\n";
+    await writeFile(clientDir, "_next/static/css/my@style with spaces.css", cssContent);
+
+    const cache = await StaticFileCache.create(clientDir);
+    const req = mockReq();
+    const { res, captured } = mockRes();
+
+    const served = await tryServeStatic(
+      req,
+      res,
+      clientDir,
+      "/_next/static/css/my@style with spaces.css",
+      true,
+      cache,
+    );
+
+    await captured.ended;
+    expect(served).toBe(true);
+    expect(captured.status).toBe(200);
+    expect(captured.headers["Content-Type"]).toBe("text/css");
+    expect(captured.body.toString()).toBe(cssContent);
+  });
+
   // ── Malformed pathname handling ─────────────────────────────────
 
   it("returns false for malformed percent-encoded pathname", async () => {


### PR DESCRIPTION
## Summary

Regression coverage for #1472 (Pages Router: CSS files with URL-encoded characters in path not served / not applied).

- Three focused unit tests against `tryServeStatic` in `tests/serve-static.test.ts`: cache fast-path with percent-encoded URL, slow path with percent-encoded URL, and the literal-character pathname produced by the request pipeline after `normalizePathnameForRouteMatchStrict`.
- A new `tests/pages-css-url-encoding.test.ts` that builds a minimal Pages Router fixture importing `my@style.css` and `with space.css` from `pages/index.tsx`, then asserts every emitted stylesheet link resolves to a 200 after `encodeURI` is applied (matching browser behaviour).

## Findings

I was unable to reproduce the 404 described in #1472 against the current `main`:

- `tryServeStatic`'s cache fast-path already decodes percent-encoded paths before cache lookup, and the cache indexes files by their literal on-disk names. The slow path does the same.
- Building a Pages Router fixture that imports CSS files with `@` and spaces in their source filenames results in Vite/Rolldown emitting a sanitised single-bundle CSS asset (e.g. `pages-Cv7pxP5X.css`); the on-disk filename has no special characters, so the URL is clean and the lookup succeeds.
- All added tests pass against the current implementation. They document the expected contract and guard against future regressions.

The deploy-suite failure that prompted #1472 may stem from a different code path (e.g. the App Router CSS emission via React Flight, the `public/` directory, or a Vite configuration that disables filename sanitisation) — further investigation would be needed to reproduce it.

## Test plan

- [x] `pnpm test tests/serve-static.test.ts tests/pages-css-url-encoding.test.ts`
- [x] `pnpm run check`

Refs #1472