### PR TITLE
fix(pages-router): render custom pages/500 on SSR throw

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -594,6 +594,11 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
   const statusCode = options && typeof options.statusCode === "number" ? options.statusCode : undefined;
   const asPath = options && typeof options.asPath === "string" ? options.asPath : undefined;
   const renderErrorPageOnMiss = !(options && options.renderErrorPageOnMiss === false);
+  // Guard against infinite recursion when the user's custom 500/error page
+  // itself throws during render. When this flag is set, the catch block below
+  // returns the plain "Internal Server Error" text response instead of trying
+  // to render an error page again. Fixes #1458.
+  const isInternalErrorRender = !!(options && options.__isInternalErrorRender);
   const localeInfo = i18nConfig
     ? resolvePagesI18nRequest(
         url,
@@ -615,7 +620,13 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
     return new Response(null, { status: 307, headers: { Location: localeInfo.redirectUrl } });
   }
 
-  let match = matchRoute(routeUrl, pageRoutes);
+  // Internal error render path: caller has pinned a specific route (the
+  // user's pages/500 or pages/_error) to render in response to an SSR throw.
+  // Skip route matching so we don't accidentally double-route, and skip the
+  // missing-route 404 fallback. See catch block below. Fixes #1458.
+  let match = options && options.__forcedRoute
+    ? { route: options.__forcedRoute, params: {} }
+    : matchRoute(routeUrl, pageRoutes);
   let renderStatusCodeOverride = statusCode;
   let renderAsPath = asPath;
   if (!match) {
@@ -950,6 +961,37 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
         { path: url, method: request.method, headers: Object.fromEntries(request.headers.entries()) },
         { routerKind: "Pages Router", routePath: route.pattern, routeType: "render" },
       ).catch(() => { /* ignore reporting errors */ });
+      // Data (_next/data) requests can't render HTML, and avoid recursion if
+      // we're already in the middle of rendering the error page itself.
+      // Mirrors Next.js base-server.ts which renders /500 (or _error) when
+      // SSR throws. Fixes #1458.
+      if (!isInternalErrorRender && !isDataReq) {
+        // Look for an explicit pages/500.tsx first, then fall back to _error.
+        // Only match the literal /500 pattern — never a catch-all/dynamic route.
+        let errorRoute = null;
+        for (var __i = 0; __i < pageRoutes.length; __i++) {
+          if (pageRoutes[__i].pattern === "/500") {
+            errorRoute = pageRoutes[__i];
+            break;
+          }
+        }
+        if (!errorRoute && _errorPageRoute) {
+          errorRoute = _errorPageRoute;
+        }
+        if (errorRoute) {
+          try {
+            return await _renderPage(request, url, manifest, middlewareHeaders, {
+              statusCode: 500,
+              asPath: url,
+              renderErrorPageOnMiss: false,
+              __isInternalErrorRender: true,
+              __forcedRoute: errorRoute,
+            });
+          } catch (errorPageErr) {
+            console.error("[vinext] Error page render failed:", errorPageErr);
+          }
+        }
+      }
       return new Response("Internal Server Error", { status: 500 });
     }
   });

--- a/tests/fixtures/pages-basic/pages/500.tsx
+++ b/tests/fixtures/pages-basic/pages/500.tsx
@@ -1,0 +1,6 @@
+// Custom pages/500.tsx — Next.js renders this when SSR/getServerSideProps
+// throws. Without it, vinext would fall back to plain text "Internal Server
+// Error". Used to regression-test issue #1458.
+export default function Custom500() {
+  return <p data-testid="custom-500">custom pages/500</p>;
+}

--- a/tests/fixtures/pages-basic/pages/gssp-throw.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-throw.tsx
@@ -1,0 +1,10 @@
+// Regression fixture for issue #1458: when getServerSideProps throws, the
+// server should render the user's custom pages/500.tsx (or _error fallback)
+// rather than collapsing the request into a plain "Internal Server Error".
+export default function GsspThrow() {
+  return <div>This page never renders.</div>;
+}
+
+export async function getServerSideProps() {
+  throw new Error("intentional gSSP throw — fixture for vinext#1458");
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -549,6 +549,18 @@ describe("Pages Router integration", () => {
     expect(html).toContain("app-wrapper");
   });
 
+  // Regression for #1458: when getServerSideProps throws, dev (and prod) must
+  // render the user's custom pages/500.tsx with status 500 rather than the
+  // plain "Internal Server Error" text. Mirrors Next.js test/e2e/getserversideprops
+  // "should handle throw ENOENT correctly".
+  it("getServerSideProps throwing renders custom 500 page (dev)", async () => {
+    const res = await fetch(`${baseUrl}/gssp-throw`);
+    expect(res.status).toBe(500);
+    const html = await res.text();
+    expect(html).toContain("custom pages/500");
+    expect(html).not.toBe("Internal Server Error");
+  });
+
   it("renders dynamic routes with params", async () => {
     const res = await fetch(`${baseUrl}/posts/42`);
     expect(res.status).toBe(200);
@@ -3367,6 +3379,17 @@ export default function CounterPage() {
       const asyncModHtml = await asyncModRes.text();
       expect(asyncModHtml).toContain('<div id="app-value">hello</div>');
       expect(asyncModHtml).toContain('<div id="page-value">42</div>');
+
+      // Regression for #1458: when getServerSideProps throws, the production
+      // server must render the user's custom pages/500.tsx with status 500
+      // instead of returning a plain "Internal Server Error" text response.
+      // Mirrors Next.js test/e2e/getserversideprops "should handle throw
+      // ENOENT correctly" (.nextjs-ref/test/e2e/getserversideprops/test/index.test.ts:377).
+      const gsspThrowRes = await fetch(`${prodUrl}/gssp-throw`);
+      expect(gsspThrowRes.status).toBe(500);
+      const gsspThrowHtml = await gsspThrowRes.text();
+      expect(gsspThrowHtml).toContain("custom pages/500");
+      expect(gsspThrowHtml).not.toBe("Internal Server Error");
     } finally {
       httpServer.close();
     }


### PR DESCRIPTION
## Summary

When `getServerSideProps` (or any other render-time code) throws in the production server entry, vinext currently collapses the response into a plain `Internal Server Error` text body. Next.js instead renders the user's custom `pages/500.tsx` (falling back to `pages/_error.tsx`). This PR matches that behaviour so frameworks that rely on custom error pages — and the Next.js `getserversideprops` deploy suite — see the expected output.

- The catch in `_renderPage` now re-renders through the same entry using `pages/500.tsx` (or the `_error` route) with status 500.
- A new `__isInternalErrorRender` guard prevents infinite recursion if the error page itself throws.
- `/_next/data/...` requests still short-circuit to the plain text body (they can't return HTML).
- Dev server already rendered custom 500/_error pages via `renderErrorPage()`; this aligns prod and adds explicit regression coverage for both paths via a new `pages/gssp-throw.tsx` + `pages/500.tsx` fixture.

Mirrors Next.js `base-server.ts` `renderToResponseImpl` 500 fallback (`.nextjs-ref/packages/next/src/server/base-server.ts:2694-2702`).

Refs #1458

## Test plan

- [x] `pnpm test tests/pages-router.test.ts -t "production build"` — new prod assertion (`/gssp-throw` returns 500 + `custom pages/500`)
- [x] `pnpm test tests/pages-router.test.ts -t "getServerSideProps throwing renders custom 500 page"` — new dev assertion
- [x] `pnpm test tests/pages-router.test.ts -t "getServerSideProps"` — 17 gssp tests still pass
- [x] `pnpm test tests/pages-page-data.test.ts` — 17 tests pass
- [x] `pnpm test tests/prerender.test.ts` — 77 tests pass (covers `error-throw` fixture)
- [x] `pnpm run check` — clean