### PR TITLE
fix(shims/head): match Next.js charset/viewport order and merge _document.getInitialProps head

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -224,7 +224,7 @@ export async function runMiddleware(request) {
 import ${JSON.stringify(_serverGlobalsPath)};
 import React from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
-import { resetSSRHead, getSSRHeadHTML } from "next/head";
+import { resetSSRHead, getSSRHeadHTML, setDocumentInitialHead } from "next/head";
 import { flushPreloads } from "next/dynamic";
 import { setSSRContext, wrapWithRouterContext } from "next/router";
 import { _runWithCacheState } from "next/cache";
@@ -946,6 +946,8 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
           return renderToReadableStream(element);
         },
         resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
+        setDocumentInitialHead:
+          typeof setDocumentInitialHead === "function" ? setDocumentInitialHead : undefined,
         routePattern,
         routeUrl,
         safeJsonStringify,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -108,6 +108,12 @@ async function streamPageToResponse(
     extraHeaders?: Record<string, string | string[]>;
     /** Called after renderToReadableStream resolves (shell ready) to collect head HTML */
     getHeadHTML: () => string;
+    /**
+     * Optional: hand a list of `<head>` ReactNodes (returned by user
+     * `_document.getInitialProps()`) to the head shim so they're merged
+     * into `getSSRHeadHTML()`'s output. Called before `getHeadHTML()`.
+     */
+    setDocumentInitialHead?: (head: React.ReactNode[]) => void;
   },
 ): Promise<void> {
   const {
@@ -119,6 +125,7 @@ async function streamPageToResponse(
     statusCode = 200,
     extraHeaders,
     getHeadHTML,
+    setDocumentInitialHead,
   } = options;
 
   // Start the React body stream FIRST — the promise resolves when the
@@ -126,7 +133,30 @@ async function streamPageToResponse(
   // This triggers the render which populates <Head> tags.
   const bodyStream = await renderToReadableStream(element);
 
-  // Now that the shell has rendered, collect head HTML
+  // If the user defined `_document.getInitialProps()`, call it now so any
+  // additional head tags it returns are folded into the same dedupe pipeline
+  // as user `next/head` tags. Matches Next.js's `_document` contract.
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const DocAny = DocumentComponent as any;
+  if (DocAny && typeof DocAny.getInitialProps === "function" && setDocumentInitialHead) {
+    try {
+      const initialProps = await DocAny.getInitialProps({
+        // Minimal context — vinext does not currently plumb the full
+        // DocumentContext (req/res/renderPage/defaultGetInitialProps) for
+        // SSR. User code that depends on those fields receives `undefined`,
+        // matching the documented shim limitation in `shims/document.tsx`.
+        defaultGetInitialProps: async () => ({ html: "", head: [], styles: undefined }),
+        renderPage: () => ({ html: "" }),
+      });
+      const initialHead = Array.isArray(initialProps?.head) ? initialProps.head : [];
+      setDocumentInitialHead(initialHead);
+    } catch (err) {
+      console.error("[vinext] _document.getInitialProps() threw:", err);
+    }
+  }
+
+  // Now that the shell has rendered (and any _document.getInitialProps
+  // has injected its tags), collect head HTML.
   const headHTML = getHeadHTML();
 
   // Build the document shell with a placeholder for the body
@@ -151,11 +181,12 @@ async function streamPageToResponse(
     }
     shellTemplate = docHtml;
   } else {
+    // charset + viewport are emitted via getSSRHeadHTML() (next/head's
+    // defaultHead seeds them with data-next-head=""), matching Next.js's
+    // canonical ordering. Don't duplicate them here.
     shellTemplate = `<!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
   ${fontHeadHTML}${headHTML}
 </head>
 <body>
@@ -1195,6 +1226,10 @@ hydrate();
             const traceHTML = getClientTraceMetadataHTML(clientTraceMetadata);
             return traceHTML ? `${headHTML}\n  ${traceHTML}` : headHTML;
           },
+          setDocumentInitialHead:
+            typeof headShim.setDocumentInitialHead === "function"
+              ? headShim.setDocumentInitialHead
+              : undefined,
         });
         _renderEnd = now();
 

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -50,6 +50,7 @@ import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 import { loadUserDocumentInitialProps } from "./pages-document-initial-props.js";
+import { callDocumentGetInitialProps } from "./document-initial-head.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -135,25 +136,13 @@ async function streamPageToResponse(
 
   // If the user defined `_document.getInitialProps()`, call it now so any
   // additional head tags it returns are folded into the same dedupe pipeline
-  // as user `next/head` tags. Matches Next.js's `_document` contract.
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const DocAny = DocumentComponent as any;
-  if (DocAny && typeof DocAny.getInitialProps === "function" && setDocumentInitialHead) {
-    try {
-      const initialProps = await DocAny.getInitialProps({
-        // Minimal context — vinext does not currently plumb the full
-        // DocumentContext (req/res/renderPage/defaultGetInitialProps) for
-        // SSR. User code that depends on those fields receives `undefined`,
-        // matching the documented shim limitation in `shims/document.tsx`.
-        defaultGetInitialProps: async () => ({ html: "", head: [], styles: undefined }),
-        renderPage: () => ({ html: "" }),
-      });
-      const initialHead = Array.isArray(initialProps?.head) ? initialProps.head : [];
-      setDocumentInitialHead(initialHead);
-    } catch (err) {
-      console.error("[vinext] _document.getInitialProps() threw:", err);
-    }
-  }
+  // as user `next/head` tags. Matches Next.js's `_document` contract. The
+  // helper skips the call entirely when the resolved `getInitialProps` is the
+  // unmodified default from vinext's `next/document` shim — extending Document
+  // without overriding the method inherits the base implementation, and the
+  // default returns no head tags, so dispatching it on every render is wasted
+  // work.
+  await callDocumentGetInitialProps(DocumentComponent, setDocumentInitialHead);
 
   // Now that the shell has rendered (and any _document.getInitialProps
   // has injected its tags), collect head HTML.

--- a/packages/vinext/src/server/document-initial-head.ts
+++ b/packages/vinext/src/server/document-initial-head.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared helper: invoke a user-defined `_document.getInitialProps()` and feed
+ * any returned head tags into the shared dedupe pipeline via
+ * `setDocumentInitialHead()`.
+ *
+ * Both the dev-server streaming path (`server/dev-server.ts`) and the unified
+ * Pages Router response path (`server/pages-page-response.ts`) need the exact
+ * same behavior — constructing the minimal `DocumentContext`, awaiting the
+ * call inside a try/catch, defensively unwrapping `head`. Living here keeps
+ * the contract in one place and lets the (mostly-static) implementation be
+ * tested in isolation.
+ *
+ * The behaviour mirrors Next.js's `_document` contract:
+ * - skip the call entirely when the resolved `DocumentComponent` is null
+ *   (no user `_document.tsx`)
+ * - skip the call when the resolved `getInitialProps` is the unmodified
+ *   default inherited from vinext's `next/document` shim — that default
+ *   returns `{ html: "" }` and `head` is always `undefined`, so calling it
+ *   is wasted work on every render for apps that don't customise it.
+ * - otherwise: await, defensively normalise the result, forward the head
+ *   array to the shim.
+ *
+ * Errors are logged but never thrown — a buggy `_document.getInitialProps`
+ * must not take the whole response down. Matches Next.js's runtime, which
+ * treats `_document` failures as non-fatal head merges.
+ */
+import type React from "react";
+import Document, { type DocumentContext } from "vinext/shims/document";
+
+/**
+ * Reference to the unmodified `Document.getInitialProps` static. Used to
+ * detect when a user `_document.tsx` did NOT override the method (i.e. they
+ * extend `Document` but only redefine `render`), so we can skip the call.
+ *
+ * Captured via an indexed access (`Document["getInitialProps"]`) rather than
+ * a dotted access so oxlint's `unbound-method` rule doesn't flag this as a
+ * possible `this` escape — `getInitialProps` is a static method with no
+ * `this` dependency, so capturing the function reference is safe.
+ */
+const DEFAULT_GET_INITIAL_PROPS: unknown = Document["getInitialProps"];
+
+type DocumentLike = {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  getInitialProps?: (ctx: DocumentContext) => Promise<{ head?: unknown } | undefined>;
+};
+
+export async function callDocumentGetInitialProps(
+  DocumentComponent: React.ComponentType | null | undefined,
+  setDocumentInitialHead: ((head: React.ReactNode[]) => void) | undefined,
+): Promise<void> {
+  if (!DocumentComponent || !setDocumentInitialHead) return;
+
+  const DocCtor = DocumentComponent as unknown as DocumentLike;
+  const getInitialProps = DocCtor.getInitialProps;
+
+  // Skip when the component does not expose `getInitialProps` at all, or
+  // when it still resolves to the default inherited from vinext's shim.
+  // Comparing against the captured `DEFAULT_GET_INITIAL_PROPS` reference is
+  // what distinguishes a user override from the default — extending the
+  // shim's `Document` without overriding inherits the same static function.
+  if (typeof getInitialProps !== "function" || getInitialProps === DEFAULT_GET_INITIAL_PROPS) {
+    return;
+  }
+
+  try {
+    const initialProps = await getInitialProps({
+      // Minimal DocumentContext — vinext does not yet plumb the full context
+      // (req/res/renderPage/defaultGetInitialProps) for SSR. User code that
+      // relies on those fields receives no-op stand-ins; matches the
+      // documented limitation in `shims/document.tsx`.
+      defaultGetInitialProps: async () => ({ html: "", head: [], styles: undefined }),
+      renderPage: () => ({ html: "" }),
+    });
+    const initialHead = Array.isArray(initialProps?.head)
+      ? (initialProps.head as React.ReactNode[])
+      : [];
+    setDocumentInitialHead(initialHead);
+  } catch (err) {
+    console.error("[vinext] _document.getInitialProps() threw:", err);
+  }
+}

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -50,6 +50,7 @@ type RenderPagesPageResponseOptions = {
    * head. Undefined or empty disables emission.
    */
   clientTraceMetadata?: readonly string[] | undefined;
+  setDocumentInitialHead?: ((head: ReactNode[]) => void) | undefined;
   gsspRes: PagesGsspResponse | null;
   isrCacheKey: (router: string, pathname: string) => string;
   expireSeconds?: number;
@@ -183,10 +184,11 @@ async function buildPagesShellHtml(
     return html;
   }
 
+  // charset + viewport are emitted via getSSRHeadHTML() (next/head's
+  // defaultHead seeds them with data-next-head=""), matching Next.js's
+  // canonical ordering. Don't duplicate them here.
   return (
     "<!DOCTYPE html>\n<html>\n<head>\n" +
-    '  <meta charset="utf-8" />\n' +
-    '  <meta name="viewport" content="width=device-width, initial-scale=1" />\n' +
     `  ${fontHeadHTML}${options.ssrHeadHTML}\n` +
     `  ${options.assetTags}\n` +
     "</head>\n<body>\n" +
@@ -347,6 +349,28 @@ export async function renderPagesPageResponse(
   // Mirrors Next.js fix: vercel/next.js@9853944
   const bodyStream = await options.renderToReadableStream(pageElement);
 
+  // If the user defined `_document.getInitialProps()`, run it now so any
+  // head tags it returns can join the dedupe pipeline before getSSRHeadHTML
+  // serialises the final <head>. Mirrors Next.js's `_document` contract.
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  const DocCtor = options.DocumentComponent as any;
+  if (DocCtor && typeof DocCtor.getInitialProps === "function" && options.setDocumentInitialHead) {
+    try {
+      const docInitialProps = await DocCtor.getInitialProps({
+        // Minimal DocumentContext shim — vinext does not yet plumb the full
+        // context (req/res/renderPage/defaultGetInitialProps). User code that
+        // relies on those fields receives no-op stand-ins; matches the
+        // documented limitation in `shims/document.tsx`.
+        defaultGetInitialProps: async () => ({ html: "", head: [], styles: undefined }),
+        renderPage: () => ({ html: "" }),
+      });
+      const initialHead = Array.isArray(docInitialProps?.head) ? docInitialProps.head : [];
+      options.setDocumentInitialHead(initialHead);
+    } catch (err) {
+      console.error("[vinext] _document.getInitialProps() threw:", err);
+    }
+  }
+
   const headFromShim = options.getSSRHeadHTML?.() ?? "";
   // Trace meta tags from the active OpenTelemetry context. When the
   // allow-list is unset (the common case) or OTel is not installed,
@@ -354,6 +378,7 @@ export async function renderPagesPageResponse(
   // verbatim — keeping the no-op path zero-overhead.
   const traceMetaHTML = getClientTraceMetadataHTML(options.clientTraceMetadata);
   const ssrHeadHTML = traceMetaHTML ? `${headFromShim}\n  ${traceMetaHTML}` : headFromShim;
+
   const shellHtml = await buildPagesShellHtml(bodyMarker, fontHeadHTML, nextDataScript, {
     assetTags: options.assetTags,
     DocumentComponent: options.DocumentComponent,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -10,6 +10,7 @@ import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { reportRequestError } from "./instrumentation.js";
 import { loadUserDocumentInitialProps } from "./pages-document-initial-props.js";
 import { readStreamAsText } from "../utils/text-stream.js";
+import { callDocumentGetInitialProps } from "./document-initial-head.js";
 
 type PagesFontPreload = {
   href: string;
@@ -352,24 +353,9 @@ export async function renderPagesPageResponse(
   // If the user defined `_document.getInitialProps()`, run it now so any
   // head tags it returns can join the dedupe pipeline before getSSRHeadHTML
   // serialises the final <head>. Mirrors Next.js's `_document` contract.
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  const DocCtor = options.DocumentComponent as any;
-  if (DocCtor && typeof DocCtor.getInitialProps === "function" && options.setDocumentInitialHead) {
-    try {
-      const docInitialProps = await DocCtor.getInitialProps({
-        // Minimal DocumentContext shim — vinext does not yet plumb the full
-        // context (req/res/renderPage/defaultGetInitialProps). User code that
-        // relies on those fields receives no-op stand-ins; matches the
-        // documented limitation in `shims/document.tsx`.
-        defaultGetInitialProps: async () => ({ html: "", head: [], styles: undefined }),
-        renderPage: () => ({ html: "" }),
-      });
-      const initialHead = Array.isArray(docInitialProps?.head) ? docInitialProps.head : [];
-      options.setDocumentInitialHead(initialHead);
-    } catch (err) {
-      console.error("[vinext] _document.getInitialProps() threw:", err);
-    }
-  }
+  // The shared helper also skips the call when the resolved method is the
+  // unmodified default from the shim — see comment in dev-server.ts.
+  await callDocumentGetInitialProps(options.DocumentComponent, options.setDocumentInitialHead);
 
   const headFromShim = options.getSSRHeadHTML?.() ?? "";
   // Trace meta tags from the active OpenTelemetry context. When the

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -22,15 +22,15 @@ export function Html({
 /**
  * Document Head - renders <head> with children.
  * The dev server injects meta tags, styles, etc.
+ *
+ * Note: charset and viewport are intentionally NOT hardcoded here. Those
+ * defaults are seeded by `next/head`'s `defaultHead()` and emitted alongside
+ * user `<Head>` tags via `getSSRHeadHTML()`, matching Next.js's canonical
+ * ordering (`<meta charset>` first, then `<meta viewport>`, then user tags,
+ * all with `data-next-head=""`). See `test/e2e/next-head/index.test.ts`.
  */
 export function Head({ children }: { children?: React.ReactNode }) {
-  return (
-    <head>
-      <meta charSet="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      {children}
-    </head>
-  );
+  return <head>{children}</head>;
 }
 
 /**

--- a/packages/vinext/src/shims/head-state.ts
+++ b/packages/vinext/src/shims/head-state.ts
@@ -23,6 +23,7 @@ import {
 
 export type HeadState = {
   ssrHeadChildren: React.ReactNode[];
+  documentInitialHead: React.ReactNode[];
 };
 
 const _FALLBACK_KEY = Symbol.for("vinext.head.fallback");
@@ -31,6 +32,7 @@ const _als = getOrCreateAls<HeadState>("vinext.head.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   ssrHeadChildren: [],
+  documentInitialHead: [],
 } satisfies HeadState) as HeadState;
 
 function _getState(): HeadState {
@@ -51,11 +53,13 @@ export function runWithHeadState<T>(fn: () => T | Promise<T>): T | Promise<T> {
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {
       uCtx.ssrHeadChildren = [];
+      uCtx.documentInitialHead = [];
     }, fn);
   }
 
   const state: HeadState = {
     ssrHeadChildren: [],
+    documentInitialHead: [],
   };
   return _als.run(state, fn);
 }
@@ -70,6 +74,16 @@ _registerHeadStateAccessors({
   },
 
   resetSSRHead(): void {
-    _getState().ssrHeadChildren = [];
+    const s = _getState();
+    s.ssrHeadChildren = [];
+    s.documentInitialHead = [];
+  },
+
+  getDocumentInitialHead(): React.ReactNode[] {
+    return _getState().documentInitialHead;
+  },
+
+  setDocumentInitialHead(head: React.ReactNode[]): void {
+    _getState().documentInitialHead = head;
   },
 });

--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -18,11 +18,17 @@ type HeadProps = {
 // browser. The ALS-backed implementation lives in head-state.ts (server-only).
 
 let _ssrHeadChildren: React.ReactNode[] = [];
+let _documentInitialHead: React.ReactNode[] = [];
 const _clientHeadChildren = new Map<symbol, React.ReactNode>();
 
 let _getSSRHeadChildren = (): React.ReactNode[] => _ssrHeadChildren;
 let _resetSSRHeadImpl = (): void => {
   _ssrHeadChildren = [];
+  _documentInitialHead = [];
+};
+let _getDocumentInitialHead = (): React.ReactNode[] => _documentInitialHead;
+let _setDocumentInitialHead = (head: React.ReactNode[]): void => {
+  _documentInitialHead = head;
 };
 
 /**
@@ -32,9 +38,17 @@ let _resetSSRHeadImpl = (): void => {
 export function _registerHeadStateAccessors(accessors: {
   getSSRHeadChildren: () => React.ReactNode[];
   resetSSRHead: () => void;
+  getDocumentInitialHead?: () => React.ReactNode[];
+  setDocumentInitialHead?: (head: React.ReactNode[]) => void;
 }): void {
   _getSSRHeadChildren = accessors.getSSRHeadChildren;
   _resetSSRHeadImpl = accessors.resetSSRHead;
+  if (accessors.getDocumentInitialHead) {
+    _getDocumentInitialHead = accessors.getDocumentInitialHead;
+  }
+  if (accessors.setDocumentInitialHead) {
+    _setDocumentInitialHead = accessors.setDocumentInitialHead;
+  }
 }
 
 /** Reset the SSR head collector. Call before render. */
@@ -42,9 +56,56 @@ export function resetSSRHead(): void {
   _resetSSRHeadImpl();
 }
 
+/**
+ * Register head tags returned by a user `_document.getInitialProps()` call.
+ * Mirrors Next.js: `_document` may extend the head array passed to its render,
+ * and those tags are merged into the final `<head>` output. We treat them the
+ * same as `next/head` children — they go through the same dedupe pipeline so
+ * later tags (by key or meta-type) win, matching Next.js semantics.
+ *
+ * Pass an empty array (or simply don't call this) to skip the merge.
+ */
+export function setDocumentInitialHead(head: React.ReactNode[]): void {
+  _setDocumentInitialHead(head);
+}
+
+/**
+ * Default head tags emitted alongside every Pages Router render — charset
+ * first, then viewport. Mirrors Next.js's `defaultHead()` in
+ * `packages/next/src/shared/lib/head.tsx`, which seeds the head array used
+ * by `HeadManagerContext` before any user `<Head>` reduces over it.
+ *
+ * The canonical Next.js order is `<meta charset>` then `<meta viewport>`
+ * then user tags, all with `data-next-head=""`. See assertion in
+ * `test/e2e/next-head/index.test.ts`.
+ */
+function defaultHead(): React.ReactElement[] {
+  return [
+    React.createElement("meta", { charSet: "utf-8", key: "charset" }),
+    React.createElement("meta", {
+      name: "viewport",
+      content: "width=device-width",
+      key: "viewport",
+    }),
+  ];
+}
+
 /** Get collected head HTML. Call after render. */
 export function getSSRHeadHTML(): string {
-  return reduceHeadChildren(_getSSRHeadChildren())
+  // Order mirrors Next.js's `_document.tsx`: defaultHead seeds the head array,
+  // user `next/head` tags reduce over it, and then `_document.getInitialProps`
+  // may extend the array. The final `_document` render emits `{head}` (which
+  // contains the defaults + user tags + initial-props tags) ahead of any
+  // children declared inside `_document`'s own `<Head>`. Because the user
+  // children inside `_document`'s `<Head>` are tracked via React tree render
+  // (not next/head), they don't appear in this collector — so emitting
+  // `defaultHead + user + initialProps` here matches Next.js's serialised
+  // output up to that boundary.
+  return reduceHeadChildren([
+    ...defaultHead(),
+    ..._getSSRHeadChildren(),
+    ..._getDocumentInitialHead(),
+  ])
     .map((child) => headChildToHTML(child.type as string, child.props as Record<string, unknown>))
     .filter(Boolean)
     .join("\n  ");
@@ -207,6 +268,30 @@ export function isSafeAttrName(name: string): boolean {
 }
 
 /**
+ * Map React JSX attribute names to their HTML serialised form for the small
+ * set of head-relevant attributes where the two differ. React's own renderer
+ * normalises these automatically, but we serialise tags by hand so they reach
+ * the final HTML in the canonical lowercase / kebab-case shape that browsers
+ * (and Next.js's `test/e2e/next-head/index.test.ts`) expect.
+ */
+const JSX_TO_HTML_ATTR_MAP: Record<string, string> = {
+  charSet: "charset",
+  httpEquiv: "http-equiv",
+  acceptCharset: "accept-charset",
+  itemProp: "itemprop",
+  itemType: "itemtype",
+  itemID: "itemid",
+  itemRef: "itemref",
+  itemScope: "itemscope",
+  crossOrigin: "crossorigin",
+  referrerPolicy: "referrerpolicy",
+};
+
+function jsxAttrToHtml(name: string): string {
+  return JSX_TO_HTML_ATTR_MAP[name] ?? name;
+}
+
+/**
  * Convert props + tag to an HTML string for SSR head injection.
  * Callers must only pass tags that have already been validated against
  * ALLOWED_HEAD_TAGS (e.g. via reduceHeadChildren / collectHeadElements).
@@ -236,10 +321,10 @@ function headChildToHTML(tag: string, props: Record<string, unknown>): string {
       attrs.push(`class="${escapeAttr(String(value))}"`);
     } else if (typeof value === "string") {
       if (!isSafeAttrName(key)) continue;
-      attrs.push(`${key}="${escapeAttr(value)}"`);
+      attrs.push(`${jsxAttrToHtml(key)}="${escapeAttr(value)}"`);
     } else if (typeof value === "boolean" && value) {
       if (!isSafeAttrName(key)) continue;
-      attrs.push(key);
+      attrs.push(jsxAttrToHtml(key));
     }
   }
 

--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -401,10 +401,17 @@ export function _applyHeadPropsToElement(
       domEl.setAttribute("class", String(value));
     } else if (typeof value === "boolean" && value) {
       if (!isSafeAttrName(key)) continue;
-      domEl.setAttribute(key, "");
+      // Map JSX attribute names (charSet, httpEquiv, ...) to the HTML form
+      // (charset, http-equiv, ...) so the client-side mutation matches the
+      // SSR output. `setAttribute` is case-insensitive for HTML elements, so
+      // `charSet` would land as `charset` by coincidence, but `httpEquiv`
+      // would lowercase to `httpequiv` rather than `http-equiv` and produce
+      // a hydration mismatch. The shared mapping in jsxAttrToHtml keeps both
+      // paths in lockstep.
+      domEl.setAttribute(jsxAttrToHtml(key), "");
     } else if (typeof value === "string") {
       if (!isSafeAttrName(key)) continue;
-      domEl.setAttribute(key, value);
+      domEl.setAttribute(jsxAttrToHtml(key), value);
     }
   }
 }

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -108,6 +108,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     requestCache: new WeakMap(),
     ssrContext: null,
     ssrHeadChildren: [],
+    documentInitialHead: [],
     rootParams: null,
     ...opts,
   };

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -32,20 +32,27 @@ describe("NextScript", () => {
 });
 
 describe("Head", () => {
-  it("injects default charset and viewport meta tags", () => {
+  // Charset and viewport defaults are intentionally NOT emitted by the
+  // `_document` Head shim. They are seeded into `next/head`'s collector via
+  // `defaultHead()` and serialised by `getSSRHeadHTML()` — see the comment in
+  // `shims/document.tsx`. This mirrors Next.js's pipeline, where the defaults
+  // flow through the same `data-next-head=""` dedupe step as user tags.
+  it("renders an empty <head> when given no children (defaults flow via next/head)", () => {
     const html = render(React.createElement(Head));
-    expect(html).toContain('charSet="utf-8"');
-    expect(html).toContain('content="width=device-width, initial-scale=1"');
+    expect(html).toBe("<head></head>");
   });
 
-  it("preserves custom children alongside defaults", () => {
+  it("renders only user-provided children — defaults are not duplicated here", () => {
     const html = render(
       React.createElement(Head, null, React.createElement("title", null, "My App")),
     );
     // Custom content rendered
     expect(html).toContain("<title>My App</title>");
-    // Defaults still present
-    expect(html).toContain('charSet="utf-8"');
+    // The shim must NOT also emit charset/viewport — those flow through
+    // next/head's defaultHead() instead, so they go through the same dedupe
+    // pipeline as user-supplied tags.
+    expect(html).not.toContain("charSet=");
+    expect(html).not.toContain('name="viewport"');
   });
 });
 

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -538,6 +538,29 @@ describe("Head client sync", () => {
     expect(element.textContent).toBe("abc");
     expect(element.innerHTML).toBe("");
   });
+
+  it("maps JSX attribute names to HTML form when applying to DOM", () => {
+    // The SSR path emits `<meta http-equiv="..." />` (hyphenated). The client
+    // path must use the same mapping or hydration will mismatch. setAttribute
+    // is case-insensitive for HTML elements, so `charSet` would lowercase to
+    // `charset` by coincidence — but `httpEquiv` would become `httpequiv`
+    // (no hyphen), not `http-equiv`.
+    const element = createElementDouble();
+    _applyHeadPropsToElement(element, {
+      httpEquiv: "X-UA-Compatible",
+      content: "IE=edge",
+    });
+    expect(element.attributes.get("http-equiv")).toBe("X-UA-Compatible");
+    expect(element.attributes.get("httpEquiv")).toBeUndefined();
+    expect(element.attributes.get("content")).toBe("IE=edge");
+  });
+
+  it("maps JSX charSet attribute to HTML charset when applying to DOM", () => {
+    const element = createElementDouble();
+    _applyHeadPropsToElement(element, { charSet: "utf-8" });
+    expect(element.attributes.get("charset")).toBe("utf-8");
+    expect(element.attributes.get("charSet")).toBeUndefined();
+  });
 });
 
 // ─── escapeAttr utility ─────────────────────────────────────────────────

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -13,6 +13,7 @@ import Head, {
   getSSRHeadHTML,
   escapeAttr,
   reduceHeadChildren,
+  setDocumentInitialHead,
   _applyHeadPropsToElement,
 } from "../packages/vinext/src/shims/head.js";
 
@@ -173,9 +174,15 @@ describe("Head SSR collection", () => {
     expect(headHtml).not.toContain("Page 1");
   });
 
-  it("returns empty string when no head elements", () => {
+  it("returns only default charset/viewport when no user head elements", () => {
+    // Even without any user `<Head>`, vinext emits next/head's defaultHead()
+    // (charset + viewport) to match Next.js's canonical head ordering.
     const headHtml = getSSRHeadHTML();
-    expect(headHtml).toBe("");
+    expect(headHtml).toContain('<meta charset="utf-8"');
+    expect(headHtml).toContain('<meta name="viewport"');
+    // No other tags.
+    expect(headHtml).not.toContain("<title");
+    expect(headHtml).not.toContain("<link");
   });
 
   it("dedupes keyed tags across multiple Head instances and keeps the last one", () => {
@@ -305,7 +312,7 @@ describe("Head disallowed tags", () => {
     );
     const headHtml = getSSRHeadHTML();
     expect(headHtml).not.toContain("<div");
-    expect(headHtml).toBe("");
+    expect(headHtml).not.toContain("bad");
     warn.mockRestore();
   });
 
@@ -316,7 +323,7 @@ describe("Head disallowed tags", () => {
     );
     const headHtml = getSSRHeadHTML();
     expect(headHtml).not.toContain("<iframe");
-    expect(headHtml).toBe("");
+    expect(headHtml).not.toContain("evil.com");
     warn.mockRestore();
   });
 
@@ -329,7 +336,7 @@ describe("Head disallowed tags", () => {
     );
     const headHtml = getSSRHeadHTML();
     // Component elements are ignored because child.type is not a string
-    expect(headHtml).toBe("");
+    expect(headHtml).not.toContain('name="custom"');
   });
 
   it("keeps allowed tags while ignoring disallowed ones", () => {
@@ -554,5 +561,133 @@ describe("escapeAttr", () => {
 
   it("escapes all special chars together", () => {
     expect(escapeAttr('&"<>')).toBe("&amp;&quot;&lt;&gt;");
+  });
+});
+
+// ─── charset / viewport ordering (issue #1569) ─────────────────────────────
+//
+// Mirrors Next.js's test/e2e/next-head/index.test.ts assertion that
+// `<meta charset>` is emitted first, then `<meta viewport>`, then user tags,
+// all carrying `data-next-head=""`. Next.js's `defaultHead()` in
+// shared/lib/head.tsx is what seeds those defaults — vinext must include the
+// same defaults via getSSRHeadHTML().
+
+describe("Head default tags (charset/viewport ordering, issue #1569)", () => {
+  beforeEach(() => {
+    resetSSRHead();
+    setDocumentInitialHead([]);
+  });
+
+  it("emits charset first, then viewport, before user tags", () => {
+    ReactDOMServer.renderToString(
+      React.createElement(
+        Head,
+        null,
+        React.createElement("meta", { name: "test-head-1", content: "hello" }),
+      ),
+    );
+
+    const html = getSSRHeadHTML();
+    const charsetIdx = html.indexOf('charset="utf-8"');
+    const viewportIdx = html.indexOf('name="viewport"');
+    const userIdx = html.indexOf('name="test-head-1"');
+
+    expect(charsetIdx).toBeGreaterThanOrEqual(0);
+    expect(viewportIdx).toBeGreaterThan(charsetIdx);
+    expect(userIdx).toBeGreaterThan(viewportIdx);
+  });
+
+  it("default tags carry data-next-head attribute", () => {
+    const html = getSSRHeadHTML();
+    // Match the segment from the charset tag through the next "/>"
+    const charsetMatch = html.match(/<meta charset="utf-8"[^/]*\/>/);
+    expect(charsetMatch).not.toBeNull();
+    expect(charsetMatch?.[0]).toContain('data-next-head=""');
+
+    const viewportMatch = html.match(/<meta name="viewport"[^/]*\/>/);
+    expect(viewportMatch).not.toBeNull();
+    expect(viewportMatch?.[0]).toContain('data-next-head=""');
+  });
+
+  it("user-supplied charset overrides the default (charSet meta-type dedupe)", () => {
+    // charSet is special: META_TYPES dedupe always treats it as unique-only,
+    // so any user-supplied charset replaces the default regardless of key.
+    ReactDOMServer.renderToString(
+      React.createElement(Head, null, React.createElement("meta", { charSet: "utf-16" })),
+    );
+
+    const html = getSSRHeadHTML();
+    expect(html).toContain('charset="utf-16"');
+    expect(html).not.toContain('charset="utf-8"');
+  });
+
+  it("user-supplied viewport with key='viewport' overrides the default", () => {
+    // The default viewport carries `key="viewport"`. User tags must use the
+    // same key to dedupe — matches Next.js's `key`-based merge semantics.
+    ReactDOMServer.renderToString(
+      React.createElement(
+        Head,
+        null,
+        React.createElement("meta", {
+          name: "viewport",
+          content: "width=500",
+          key: "viewport",
+        }),
+      ),
+    );
+
+    const html = getSSRHeadHTML();
+    expect(html).toContain('content="width=500"');
+    expect(html).not.toContain('content="width=device-width"');
+  });
+
+  it("emits defaults even when no user <Head> is mounted", () => {
+    const html = getSSRHeadHTML();
+    expect(html).toContain('<meta charset="utf-8"');
+    expect(html).toContain('<meta name="viewport"');
+  });
+});
+
+// ─── _document.getInitialProps() head merge (issue #1569) ──────────────────
+//
+// Mirrors Next.js's test/e2e/next-head/index.test.ts assertion that head tags
+// returned from a user `_document.getInitialProps()` appear in the rendered
+// `<head>`. vinext's SSR pipeline forwards them to the head shim via
+// setDocumentInitialHead() so they flow through the same dedupe pipeline.
+
+describe("Head _document.getInitialProps() merge (issue #1569)", () => {
+  beforeEach(() => {
+    resetSSRHead();
+    setDocumentInitialHead([]);
+  });
+
+  it("includes meta tags returned by setDocumentInitialHead in the output", () => {
+    ReactDOMServer.renderToString(
+      React.createElement(
+        Head,
+        null,
+        React.createElement("meta", { name: "test-head-1", content: "hello" }),
+      ),
+    );
+    setDocumentInitialHead([
+      React.createElement("meta", { name: "test-head-initial-props", content: "hello" }),
+    ]);
+
+    const html = getSSRHeadHTML();
+    expect(html).toContain('name="test-head-initial-props"');
+    expect(html).toContain('content="hello"');
+    // The user's next/head tag still appears.
+    expect(html).toContain('name="test-head-1"');
+  });
+
+  it("resets between renders so initial-props head does not leak", () => {
+    setDocumentInitialHead([
+      React.createElement("meta", { name: "leaked", content: "should-be-gone" }),
+    ]);
+    expect(getSSRHeadHTML()).toContain('name="leaked"');
+
+    resetSSRHead();
+
+    expect(getSSRHeadHTML()).not.toContain('name="leaked"');
   });
 });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17008,7 +17008,11 @@ describe("next/head SSR security", () => {
       React.createElement("iframe" as any, { src: "https://evil.com" }),
     ]);
 
-    expect(html).toBe("");
+    // After issue #1569, the default head (charset + viewport) is always
+    // emitted, so the output is never an empty string. The disallowed tag
+    // must still not appear.
+    expect(html).not.toContain("<iframe");
+    expect(html).not.toContain("evil.com");
     expect(consoleWarn).toHaveBeenCalledWith(
       expect.stringContaining("ignoring disallowed tag <iframe>"),
     );
@@ -17025,7 +17029,10 @@ describe("next/head SSR security", () => {
       React.createElement("form" as any, { action: "https://evil.com" }),
     ]);
 
-    expect(html).toBe("");
+    expect(html).not.toContain("<object");
+    expect(html).not.toContain("<embed");
+    expect(html).not.toContain("<form");
+    expect(html).not.toContain("evil.com");
     consoleWarn.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

Fixes #1569.

- `next/head` shim now seeds `defaultHead()` (charset + viewport) into the SSR head collector before user tags, mirroring Next.js's `defaultHead()` in `packages/next/src/shared/lib/head.tsx`. They flow through the same dedupe pipeline so users can still override via `key="charset"` / `key="viewport"`. Output now matches the exact-string assertion in Next.js's `test/e2e/next-head/index.test.ts`:

  ```
  <meta charset="utf-8" data-next-head=""><meta name="viewport" content="width=device-width" data-next-head=""><meta name="test-head-1" content="hello" data-next-head="">
  ```

- Serialised attribute names follow HTML conventions (`charSet` -> `charset`, `httpEquiv` -> `http-equiv`, `crossOrigin` -> `crossorigin`, etc.). Previously these were emitted verbatim from the JSX prop name.

- `next/document` shim no longer hardcodes charset / viewport in its `<Head>` — the defaults now flow through `next/head`'s collector with `data-next-head=""`. Fallback HTML shells in `dev-server.ts` and `pages-page-response.ts` likewise drop the duplicates.

- New `setDocumentInitialHead()` accessor (plus ALS-backed state in `head-state.ts`) lets the SSR pipeline forward head tags returned by user `_document.getInitialProps()` into the same dedupe pipeline as `next/head` children. Both the dev server and the prod `renderPagesPageResponse` now invoke `_document.getInitialProps()` when present and pass the result through.

## Test plan

- [x] `pnpm test tests/head.test.ts`
- [x] `pnpm test tests/pages-page-response.test.ts`
- [x] `pnpm test tests/pages-router.test.ts`
- [x] `pnpm test tests/shims.test.ts`
- [x] `pnpm test tests/app-page-head.test.ts tests/script-head-ordering.test.ts`
- [x] `pnpm test tests/nextjs-compat/metadata.test.ts`
- [x] `pnpm test tests/static-export.test.ts -t "charset"`
- [x] `vp check` (lint, format, types)