### PR TITLE
fix(pages-router): make req async-iterable for bodyParser: false (#1479)

### DIFF
--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -138,14 +138,16 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
 
     // Honour `export const config = { api: { bodyParser: ... } }` on the
     // route module. When the handler opts out (`bodyParser: false`) we must
-    // not consume the stream — leave `req.body` as the raw Web
-    // `ReadableStream<Uint8Array>` so user code (e.g. a Stripe/GitHub
-    // webhook) can read the raw bytes for HMAC verification.
+    // not consume the stream — `req.body` stays `undefined` and the raw
+    // bytes are exposed via the async-iterator on `req` itself, matching
+    // Next.js's Node `IncomingMessage` contract. User code (e.g. a Stripe/
+    // GitHub webhook) drains them with `for await (const chunk of req)`.
+    // See issue #1479.
     const bodyParserConfig = resolveBodyParserConfig(route.module.config);
 
     const body = bodyParserConfig.enabled
       ? await parsePagesApiBody(options.request, bodyParserConfig.sizeLimit)
-      : (options.request.body ?? undefined);
+      : undefined;
 
     const { req, res, responsePromise } = createPagesReqRes({
       body,

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -21,6 +21,14 @@ export type PagesReqResRequest = {
   query: PagesRequestQuery;
   body: unknown;
   cookies: Record<string, string>;
+  /**
+   * Async-iterator hook so handlers can `for await (const chunk of req)` —
+   * matching Node's `IncomingMessage` contract. Critical for the
+   * `bodyParser: false` opt-out (webhook signature verification etc.) where
+   * `req.body` is left undefined and user code is expected to drain the raw
+   * stream off `req` itself.
+   */
+  [Symbol.asyncIterator]: () => AsyncIterator<Uint8Array>;
 };
 
 export type PagesReqResHeaders = {
@@ -123,6 +131,48 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     headersObj[key.toLowerCase()] = value;
   }
 
+  // Surface the raw request body as an async-iterator on `req` so handlers
+  // can do `for await (const chunk of req)`, matching Node's
+  // `IncomingMessage` contract. This is the documented escape hatch when
+  // `bodyParser: false` is set (Stripe/GitHub/Slack webhooks need the raw
+  // bytes for HMAC signature verification).
+  //
+  // Cf. Next.js test/e2e/middleware-fetches-with-body fixture
+  // `body_parser_false.js`, which calls `for await (const chunk of req)`
+  // on the `IncomingMessage`-shaped req object. See issue #1479.
+  const requestBody = options.request.body;
+  const reqAsyncIterator = (): AsyncIterator<Uint8Array> => {
+    if (!requestBody) {
+      // No body — yield nothing. Use an inert iterator so `for await` is
+      // a no-op rather than throwing.
+      return {
+        next(): Promise<IteratorResult<Uint8Array>> {
+          return Promise.resolve({ value: undefined, done: true });
+        },
+      };
+    }
+    const reader = requestBody.getReader();
+    return {
+      async next(): Promise<IteratorResult<Uint8Array>> {
+        const { value, done } = await reader.read();
+        if (done) {
+          return { value: undefined, done: true };
+        }
+        return { value, done: false };
+      },
+      async return(): Promise<IteratorResult<Uint8Array>> {
+        // `for await ... break` path — release the lock so the stream is
+        // discardable. Cancellation propagates to the underlying source.
+        try {
+          await reader.cancel();
+        } catch {
+          // Ignore errors during cancellation.
+        }
+        return { value: undefined, done: true };
+      },
+    };
+  };
+
   const req: PagesReqResRequest = {
     method: options.request.method,
     url: options.url,
@@ -130,6 +180,7 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     query: options.query,
     body: options.body,
     cookies: parseCookies(options.request.headers.get("cookie")),
+    [Symbol.asyncIterator]: reqAsyncIterator,
   };
 
   let resStatusCode = 200;

--- a/tests/pages-bodyparser-config.test.ts
+++ b/tests/pages-bodyparser-config.test.ts
@@ -434,36 +434,62 @@ function createMatch(
 }
 
 describe("handlePagesApiRoute body parser config (Workers/prod path)", () => {
-  it("bodyParser: false exposes the raw request body as a ReadableStream on req.body", async () => {
-    let received: unknown = "sentinel";
-    let receivedRaw = "";
+  // Ported from Next.js: test/e2e/middleware-fetches-with-body/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-fetches-with-body/index.test.ts
+  //
+  // The Next.js `body_parser_false` handler iterates `req` directly with
+  // `for await (const chunk of req)` — matching Node's IncomingMessage
+  // contract. Our Workers `req` is a synthetic object, so we must surface
+  // an async-iterator on `req` so this idiom works. Issue #1479.
+  it("bodyParser: false: handler can iterate `req` directly with `for await` (16KiB payload)", async () => {
+    const bodySize = 16 * 1024;
+    const body = "HIJK1L2M3N4O5P6Q7R8S9T0UaVbWcXdY".repeat(bodySize / 32);
 
     const response = await handlePagesApiRoute({
       match: createMatch(
         async (req: any, res: any) => {
-          received = req.body;
-          // Verify it's a ReadableStream and we can read it.
-          if (req.body instanceof ReadableStream) {
-            const reader = (req.body as ReadableStream<Uint8Array>).getReader();
-            const chunks: Uint8Array[] = [];
-            try {
-              for (;;) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                chunks.push(value);
-              }
-            } finally {
-              reader.releaseLock();
-            }
-            const total = chunks.reduce((n, c) => n + c.byteLength, 0);
-            const merged = new Uint8Array(total);
-            let offset = 0;
-            for (const c of chunks) {
-              merged.set(c, offset);
-              offset += c.byteLength;
-            }
-            receivedRaw = new TextDecoder().decode(merged);
+          const chunks: Buffer[] = [];
+          for await (const chunk of req) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
           }
+          const buf = Buffer.concat(chunks);
+          res.json({ rawBody: buf.toString("utf8"), body: req.body });
+        },
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/body_parser_false", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body,
+      }),
+      url: "/api/body_parser_false",
+    });
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as { rawBody: string; body?: unknown };
+    expect(data.body).toBeUndefined();
+    expect(data.rawBody.length).toBe(bodySize);
+    expect(data.rawBody).toBe(body);
+  });
+
+  it("bodyParser: false leaves req.body undefined; handler reads raw bytes by iterating req", async () => {
+    let receivedBody: unknown = "sentinel";
+    let receivedRaw = "";
+
+    const payload = JSON.stringify({ webhook: "stripe", evt: "payment.succeeded" });
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        async (req: any, res: any) => {
+          receivedBody = req.body;
+          // Next.js parity: with bodyParser: false, handler iterates `req`
+          // directly (matching Node IncomingMessage). Cf. test/e2e/middleware-
+          // fetches-with-body fixture `body_parser_false.js`.
+          const chunks: Buffer[] = [];
+          for await (const chunk of req) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          }
+          receivedRaw = Buffer.concat(chunks).toString("utf8");
           res.json({ ok: true });
         },
         { api: { bodyParser: false } },
@@ -474,14 +500,14 @@ describe("handlePagesApiRoute body parser config (Workers/prod path)", () => {
           "content-type": "application/json",
           "stripe-signature": "v1=abc",
         },
-        body: JSON.stringify({ webhook: "stripe", evt: "payment.succeeded" }),
+        body: payload,
       }),
       url: "/api/webhook",
     });
 
     expect(response.status).toBe(200);
-    expect(received).toBeInstanceOf(ReadableStream);
-    expect(receivedRaw).toBe(JSON.stringify({ webhook: "stripe", evt: "payment.succeeded" }));
+    expect(receivedBody).toBeUndefined();
+    expect(receivedRaw).toBe(payload);
   });
 
   it("bodyParser: { sizeLimit: '4mb' } accepts a 2 MB body that the default would reject", async () => {


### PR DESCRIPTION
## Summary

Fixes #1479. Next.js Pages Router API handlers that use `export const config = { api: { bodyParser: false } }` drain the raw bytes by iterating `req` directly:

```js
for await (const chunk of req) { ... }
```

This matches Node's `IncomingMessage` contract. vinext's Workers path used a plain synthetic `req` object with `req.body` set to the underlying `ReadableStream`, so the idiom threw with 500 — breaking webhook handlers (Stripe/GitHub/Slack) and the `middleware-fetches-with-body` deploy suite from the Next.js deploy run.

## Fix

- Surface `[Symbol.asyncIterator]` on the synthetic `PagesReqResRequest` proxying the underlying Web `ReadableStream` reader. `return()` cancels on `break` so `for await ... break` propagates cleanly.
- Leave `req.body` undefined when `bodyParser: false`, matching Next.js's `parse-body.ts` which only assigns `req.body` when `bodyParser !== false`.

The Node/dev path (`api-handler.ts`) already worked because `req` is a real `IncomingMessage` (Node streams are async-iterable).

## Test plan

- [x] Added regression test mirroring the Next.js fixture handler `body_parser_false.js` (16KiB payload + `for await (const chunk of req)`).
- [x] Updated existing `bodyParser: false` Workers-path test to assert the Next.js-parity behavior (`req.body === undefined`, iterate `req`).
- [x] `pnpm test tests/pages-bodyparser-config.test.ts tests/api-handler.test.ts tests/pages-api-route.test.ts` — 87 pass.
- [x] `pnpm lint`, `pnpm fmt`, `tsc --noEmit -p packages/vinext` clean.