### PR TITLE
fix(pages-router): keep 'use server' files outside app/ as normal modules (#1476)

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -100,6 +100,7 @@ import {
   INSTRUMENTATION_CLIENT_EMPTY_MODULE,
 } from "./client/instrumentation-client-inject.js";
 import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
+import { createStripNonAppUseServerPlugin } from "./plugins/strip-non-app-use-server.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
 import { generateRouteTypes } from "./typegen.js";
@@ -977,6 +978,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       getCanonicalMiddlewarePath: () =>
         middlewarePath ? (tryRealpathSync(middlewarePath) ?? middlewarePath) : null,
       serverOnlyShimPath: resolveShimModulePath(shimsDir, "server-only"),
+    }),
+    // Strip `"use server"` directives from files outside the `app/` directory
+    // so Pages Router imports of such files aren't rewritten by
+    // @vitejs/plugin-rsc into server-reference proxies. Server Actions are
+    // an App Router-only feature; in Next.js the server-actions SWC pass
+    // only runs for the App Router layer. Regression test for
+    // https://github.com/cloudflare/vinext/issues/1476.
+    // See packages/vinext/src/plugins/strip-non-app-use-server.ts.
+    createStripNonAppUseServerPlugin({
+      getAppDir: () => appDir,
+      hasAppDir: () => hasAppDir,
     }),
     // Resolve `data:text/css[+module],...` imports into virtual CSS files so
     // Vite's CSS pipeline (LightningCSS, CSS modules) processes them instead

--- a/packages/vinext/src/plugins/strip-non-app-use-server.ts
+++ b/packages/vinext/src/plugins/strip-non-app-use-server.ts
@@ -1,0 +1,153 @@
+import path from "node:path";
+
+import type { Plugin } from "vite";
+
+/**
+ * Strip the React `"use server"` directive from files that live outside the
+ * App Router (`app/`) directory.
+ *
+ * Background: `"use server"` is an App Router-only feature. Pages Router does
+ * not support Server Actions. In Next.js, the SWC `server-actions` transform
+ * is only applied to files compiled in the App Router layer; Pages Router has
+ * a separate bundling pipeline that ignores the directive. See
+ * `packages/next/src/build/swc/options.ts` (`isAppRouterPagesLayer`).
+ *
+ * `@vitejs/plugin-rsc`'s `rsc:use-server` transform, however, fires on any
+ * file whose source contains `"use server"`, regardless of where the file
+ * lives. When a Pages Router page imports such a file, the export gets
+ * rewritten into a server-reference proxy and calling it from
+ * `getServerSideProps` throws "Server Functions cannot be called during
+ * initial render."
+ *
+ * This plugin removes the directive prologue from files NOT under `app/`
+ * BEFORE plugin-rsc's transform runs. With the directive gone, plugin-rsc's
+ * cheap `code.includes("use server")` gate no longer fires, the module is
+ * left untransformed, and exports behave as normal JavaScript.
+ *
+ * Ported in spirit from Next.js:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/build/swc/options.ts
+ *
+ * Regression test for https://github.com/cloudflare/vinext/issues/1476
+ * (`test/e2e/app-dir/action-in-pages-router/action-in-pages-router.test.ts`
+ * in the Next.js test suite).
+ */
+export function createStripNonAppUseServerPlugin(options: {
+  getAppDir: () => string;
+  hasAppDir: () => boolean;
+}): Plugin {
+  // Pre-normalize once configResolved fires so the per-transform path
+  // comparison is cheap.
+  let appDirWithSep = "";
+
+  return {
+    name: "vinext:strip-non-app-use-server",
+    enforce: "pre",
+
+    configResolved() {
+      const appDir = options.getAppDir();
+      if (appDir) appDirWithSep = appDir.endsWith(path.sep) ? appDir : appDir + path.sep;
+    },
+
+    transform(code, id) {
+      // Cheap pre-check — most files don't carry the directive.
+      if (!code.includes("use server")) return null;
+
+      // Only relevant when an `app/` directory exists. Without one, the RSC
+      // plugin is not even registered (see vinext()'s `earlyAppDirExists`
+      // gate) and the directive is harmless.
+      if (!options.hasAppDir()) return null;
+
+      // Strip query string and any null-byte prefixes Vite/Rolldown attach
+      // to virtual modules (e.g. `\0virtual:...`). Virtual modules are
+      // never inside `app/`, so they fall through to the strip path.
+      let cleanId = id;
+      const queryIndex = cleanId.indexOf("?");
+      if (queryIndex !== -1) cleanId = cleanId.slice(0, queryIndex);
+      if (cleanId.startsWith("\0")) cleanId = cleanId.slice(1);
+
+      // Files inside app/ are valid Server Action sources — leave them alone.
+      if (appDirWithSep && cleanId.startsWith(appDirWithSep)) return null;
+
+      // Locate and strip a `"use server"` directive prologue, if present.
+      // We mirror ECMA-262's Directive Prologue rules: only the leading
+      // ExpressionStatements consisting solely of a string literal qualify.
+      const stripped = stripUseServerDirective(code);
+      if (stripped === null) return null;
+
+      return { code: stripped, map: null };
+    },
+  };
+}
+
+/**
+ * Returns `code` with a leading `"use server"` (or `'use server'`) directive
+ * removed, or `null` if no such directive is present at the top of the
+ * module's Directive Prologue. Other directives (e.g. `"use strict"`,
+ * `"use client"`) are preserved.
+ */
+function stripUseServerDirective(code: string): string | null {
+  let i = 0;
+  const len = code.length;
+
+  // Strip BOM.
+  if (code.charCodeAt(0) === 0xfeff) i = 1;
+
+  // Strip hashbang.
+  if (code[i] === "#" && code[i + 1] === "!") {
+    const nl = code.indexOf("\n", i);
+    if (nl === -1) return null;
+    i = nl + 1;
+  }
+
+  while (i < len) {
+    // Skip whitespace.
+    while (i < len && /\s/.test(code[i] ?? "")) i++;
+    if (i >= len) return null;
+
+    // Skip line comments.
+    if (code[i] === "/" && code[i + 1] === "/") {
+      const nl = code.indexOf("\n", i + 2);
+      if (nl === -1) return null;
+      i = nl + 1;
+      continue;
+    }
+
+    // Skip block comments.
+    if (code[i] === "/" && code[i + 1] === "*") {
+      const end = code.indexOf("*/", i + 2);
+      if (end === -1) return null;
+      i = end + 2;
+      continue;
+    }
+
+    // At first non-comment, non-whitespace token. Must be a string literal
+    // directive to qualify (per ECMA-262 Directive Prologue grammar).
+    const quote = code[i];
+    if (quote !== '"' && quote !== "'") return null;
+    const directiveStart = i;
+    const closing = code.indexOf(quote, i + 1);
+    if (closing === -1) return null;
+    const directive = code.slice(i + 1, closing);
+
+    // Advance past the statement terminator (semicolon or newline) so the
+    // strip range covers `'use server';\n` cleanly.
+    let cursor = closing + 1;
+    while (cursor < len && (code[cursor] === " " || code[cursor] === "\t")) cursor++;
+    if (code[cursor] === ";") cursor++;
+    while (cursor < len && (code[cursor] === " " || code[cursor] === "\t")) cursor++;
+    if (code[cursor] === "\n") cursor++;
+    else if (code[cursor] === "\r") {
+      cursor++;
+      if (code[cursor] === "\n") cursor++;
+    }
+
+    if (directive === "use server") {
+      return code.slice(0, directiveStart) + code.slice(cursor);
+    }
+
+    // Other directives (e.g. "use strict", "use client") may precede the
+    // React directive. Continue scanning past this statement.
+    i = cursor;
+  }
+  return null;
+}

--- a/tests/app-router.test.ts
+++ b/tests/app-router.test.ts
@@ -251,6 +251,24 @@ describe("App Router integration", () => {
     expect(html).toContain("Old School Pages Directory");
   });
 
+  // Ported from Next.js:
+  // test/e2e/app-dir/action-in-pages-router/action-in-pages-router.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/action-in-pages-router/action-in-pages-router.test.ts
+  //
+  // Pages Router does not support Server Actions. A file with `"use server"`
+  // imported from a pages/ route must NOT be turned into a server-reference
+  // proxy by the RSC plugin — it must behave like a normal module so the
+  // function returns its real value (here, the literal string "action:foo").
+  // Regression test for https://github.com/cloudflare/vinext/issues/1476.
+  it("does not transform 'use server' imports from pages router into server-reference proxies", async () => {
+    const res = await fetch(`${baseUrl}/action-import-test`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('data-testid="action-result"');
+    expect(html).toContain(">action:foo<");
+  });
+
   it("returns RSC stream for .rsc requests", async () => {
     const res = await fetch(`${baseUrl}/.rsc`);
     expect(res.status).toBe(200);

--- a/tests/fixtures/app-basic/lib/pages-fake-action.ts
+++ b/tests/fixtures/app-basic/lib/pages-fake-action.ts
@@ -1,0 +1,16 @@
+"use server";
+
+// This file is imported from pages/action-import-test.tsx — a Pages Router
+// page that does NOT support Server Actions. With the RSC plugin active
+// (app-basic fixture has both app/ and pages/), the `"use server"` directive
+// would normally cause this file to be transformed into a server-reference
+// proxy. For Pages Router we need vinext to keep it as a normal module so
+// `actionFoo()` returns the real string.
+//
+// Regression test for issue #1476:
+// https://github.com/cloudflare/vinext/issues/1476
+// Mirrors Next.js fixture
+// test/e2e/app-dir/action-in-pages-router/actions.ts
+export async function actionFoo() {
+  return "action:foo";
+}

--- a/tests/fixtures/app-basic/pages/action-import-test.tsx
+++ b/tests/fixtures/app-basic/pages/action-import-test.tsx
@@ -1,0 +1,19 @@
+// Ported (in spirit) from Next.js fixture:
+// test/e2e/app-dir/action-in-pages-router/pages/foo.tsx
+//
+// A Pages Router page importing a function from a `"use server"` module.
+// Pages Router does not support Server Actions — the call must return the
+// real string, not be turned into a server-reference proxy. Regression test
+// for https://github.com/cloudflare/vinext/issues/1476.
+import { actionFoo } from "../lib/pages-fake-action";
+
+type Props = { result: string };
+
+export default function ActionImportTest({ result }: Props) {
+  return <div data-testid="action-result">{result}</div>;
+}
+
+export async function getServerSideProps(): Promise<{ props: Props }> {
+  const result = await actionFoo();
+  return { props: { result } };
+}


### PR DESCRIPTION
## Summary

- Server Actions are an App Router-only feature. When a Pages Router page imports a file containing `"use server"`, `@vitejs/plugin-rsc`'s `rsc:use-server` transform rewrites the exports into server-reference proxies. Calling such a function from `getServerSideProps` then throws "Server Functions cannot be called during initial render."
- Add `vinext:strip-non-app-use-server` (an `enforce: "pre"` transform) that strips the `"use server"` directive prologue from any file outside the `app/` directory before plugin-rsc sees it. Files inside `app/` are unaffected, so existing server-action behaviour is preserved.
- This mirrors Next.js's SWC pipeline, where the server-actions transform only runs for the App Router layer (`packages/next/src/build/swc/options.ts` `isAppRouterPagesLayer`).

Fixes #1476.

## Test plan

- [x] New regression test in `tests/app-router.test.ts` reproduces the failure on `main` and passes with the fix:
  - `pnpm test tests/app-router.test.ts -t "use server"`
- [x] Full `tests/app-router.test.ts` suite still green (333 tests, including the existing server-action coverage).
- [x] Full `tests/pages-router.test.ts` suite still green (265 tests).
- [x] `tests/form.test.ts`, `tests/app-rsc-handler.test.ts`, `tests/app-server-action-execution.test.ts` still green.
- [x] `pnpm run check` (format, lint, types) green.
- [ ] CI runs the full Vitest + Playwright matrices.

Ported from Next.js: [`test/e2e/app-dir/action-in-pages-router/action-in-pages-router.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/action-in-pages-router/action-in-pages-router.test.ts).