### PR TITLE
fix(pages-router): minify styled-jsx CSS in SSR head (#1556)

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -93,6 +93,7 @@ import {
 import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
 import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
+import { styledJsxPlugin } from "./plugins/styled-jsx.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import {
@@ -984,6 +985,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // load. Matches Turbopack's behaviour for the Next.js
     // `css-modules-data-urls` fixture. See plugins/css-data-url.ts.
     dataUrlCssPlugin(),
+    // Minify CSS inside `<style jsx>` blocks so the SSR HTML matches
+    // Next.js's canonical styled-jsx output shape (e.g. `p{color:blue}`).
+    // Next.js's compiler runs the styled-jsx transform; vinext's OXC JSX
+    // transform does not. See plugins/styled-jsx.ts and issue #1556.
+    styledJsxPlugin(),
     {
       name: "vinext:config",
       enforce: "pre",

--- a/packages/vinext/src/plugins/styled-jsx.ts
+++ b/packages/vinext/src/plugins/styled-jsx.ts
@@ -1,0 +1,151 @@
+/**
+ * vinext styled-jsx plugin
+ *
+ * Minifies the inline CSS inside `<style jsx>` (and `<style jsx global>`)
+ * blocks at transform time, so the SSR HTML matches Next.js's canonical
+ * minified output shape.
+ *
+ * ## Background
+ *
+ * Next.js's compiler (SWC/Babel) ships a styled-jsx transform that rewrites
+ *
+ *   <style jsx>{`p { color: blue; }`}</style>
+ *
+ * into a `JSXStyle` element whose `css` payload is already minified by
+ * styled-jsx's stylis fork (e.g. `p{color:blue}`). The SSR head therefore
+ * emits `<style>p{color:blue}</style>`, which is what the Next.js
+ * `test/e2e/streaming-ssr` regression expects:
+ *
+ *   expect(html).toMatch(/color:(?:blue|#00f)/)
+ *
+ * vinext uses Vite's OXC JSX transform, which does not include the styled-jsx
+ * compiler step. Without intervention, the JSX child template literal is
+ * passed through verbatim and React renders it as raw text content of a
+ * `<style>` element — preserving every newline and indent the developer
+ * wrote in source. That breaks the `color:blue` (no-space) match.
+ *
+ * ## Strategy
+ *
+ * We run a `enforce: "pre"` source transform that finds `<style jsx ...>`
+ * blocks containing a single template-literal CSS payload and rewrites the
+ * inner literal to its minified form. We also strip the boolean `jsx` /
+ * `global` JSX attributes so React does not warn about unknown DOM props.
+ *
+ * Full styled-jsx semantics (scoped class hashing, dynamic interpolations,
+ * `<style jsx global>` vs. component scope) are not implemented — only the
+ * minification step required to match the canonical SSR-rendered shape.
+ * Pages that rely on selector scoping fall back to writing global rules,
+ * which is the same behaviour a developer would get from the issue's
+ * fixture (`p { color: blue }` with a single `<p>` on the page).
+ *
+ * Related: https://github.com/cloudflare/vinext/issues/1556
+ */
+
+import type { Plugin } from "vite";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Cheap pre-filter: only run the regex on sources that actually contain `<style jsx`. */
+const STYLE_JSX_HINT = "<style jsx";
+
+/**
+ * Matches `<style jsx ...>{`...`}</style>` (and `<style jsx global ...>`).
+ *
+ * Groups:
+ *   1. attribute span between `<style` and `>` (preserved so callers can
+ *      strip just the `jsx`/`global` flags and keep `nonce`, `id`, …)
+ *   2. template literal source (raw CSS, including any `${…}` expressions)
+ *
+ * Limitations:
+ *   - Only handles a single template literal child wrapped in JSX braces.
+ *     `<style jsx>{`a`}{`b`}</style>` is rare in real code; the styled-jsx
+ *     compiler also only minifies the literal it can see.
+ *   - Does not match `<style jsx>{someVar}</style>` — without a literal we
+ *     have nothing to minify at build time.
+ */
+const STYLE_JSX_RE = /<style((?:\s+[^>]*?)?)\s*>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style>/g;
+
+/** Attribute regex: matches `jsx` or `global` as standalone boolean attrs. */
+const JSX_FLAG_ATTR_RE = /\s+(jsx|global)(?=\s|$|=)(?:=\{?\s*true\s*\}?)?/g;
+
+// ── CSS minifier ──────────────────────────────────────────────────────────────
+
+/**
+ * Minify a CSS string the same way styled-jsx's stylis fork does for the
+ * common shape produced by `<style jsx>` blocks. We do *not* aim for full
+ * stylis parity — only what the streaming-ssr regression cares about:
+ *
+ *   1. Strip CSS comments (`/* … *\/`).
+ *   2. Collapse all whitespace runs (including newlines) to nothing where
+ *      the surrounding tokens already disambiguate (around `{ } : ; ,`),
+ *      otherwise to a single space.
+ *   3. Trim trailing whitespace and the final optional `;` before `}`.
+ *
+ * The result for `p { color: blue; }` is `p{color:blue}`.
+ *
+ * Interpolations (`${foo}`) are preserved verbatim — styled-jsx routes them
+ * through the dynamic-rule path; here we keep the text untouched so the
+ * (rare) page that uses them still renders something readable, even if
+ * scoping/minification of the dynamic chunk is lossy.
+ */
+export function minifyStyledJsxCss(css: string): string {
+  // Strip /* … */ comments.
+  let out = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  // Drop whitespace adjacent to structural punctuation.
+  out = out.replace(/\s*([{}:;,])\s*/g, "$1");
+  // Collapse remaining runs of whitespace (between value tokens) to one space.
+  out = out.replace(/\s+/g, " ");
+  // Remove the final `;` before a closing `}` — purely cosmetic, matches
+  // stylis output.
+  out = out.replace(/;}/g, "}");
+  return out.trim();
+}
+
+// ── Plugin ────────────────────────────────────────────────────────────────────
+
+/** File extensions we should scan. Mirrors the JSX-capable set vinext uses elsewhere. */
+const JSX_EXT_RE = /\.(?:[cm]?jsx?|tsx)$/;
+
+export function styledJsxPlugin(): Plugin {
+  return {
+    name: "vinext:styled-jsx",
+    // Run before `vite:oxc` / `@vitejs/plugin-react` so the JSX transform
+    // sees the rewritten (already-minified) template literal.
+    enforce: "pre",
+
+    transform(code, id) {
+      // Skip non-JSX-capable files and virtual modules.
+      if (id.startsWith("\0")) return null;
+      const cleanId = id.split("?")[0];
+      if (!JSX_EXT_RE.test(cleanId)) return null;
+      // Skip files inside node_modules — library code that ships JSX
+      // typically pre-compiles styled-jsx at publish time.
+      if (cleanId.includes("/node_modules/")) return null;
+      // Cheap pre-check so we don't run the regex on every module.
+      if (!code.includes(STYLE_JSX_HINT)) return null;
+
+      let mutated = false;
+      const rewritten = code.replace(STYLE_JSX_RE, (_match, attrSpan: string, cssBody: string) => {
+        // Only act on tags that actually have the `jsx` flag (so we don't
+        // touch unrelated `<style>{`…`}</style>` JSX a developer wrote
+        // intentionally).
+        if (!/\bjsx\b/.test(attrSpan)) {
+          return _match;
+        }
+        const minified = minifyStyledJsxCss(cssBody);
+        // Drop the boolean `jsx`/`global` flags so React doesn't warn
+        // about unknown attributes on the rendered <style> element.
+        const cleanedAttrs = attrSpan.replace(JSX_FLAG_ATTR_RE, "");
+        mutated = true;
+        return `<style${cleanedAttrs}>{\`${minified}\`}</style>`;
+      });
+
+      if (!mutated) return null;
+      // No source map: we collapse whitespace inside a template literal but
+      // keep the surrounding JSX structure intact, so line numbers outside
+      // the literal are preserved. Returning a map would only help debug
+      // the minified CSS itself, which is not source the developer wrote.
+      return { code: rewritten, map: null };
+    },
+  };
+}

--- a/tests/styled-jsx.test.ts
+++ b/tests/styled-jsx.test.ts
@@ -1,0 +1,125 @@
+/**
+ * styled-jsx CSS minification at JSX transform time.
+ *
+ * Next.js's compiler (SWC/Babel) ships a styled-jsx pass that rewrites
+ * `<style jsx>` into a `JSXStyle` element with already-minified CSS.
+ * vinext's OXC JSX transform does not, so without intervention the
+ * template literal flows through to React verbatim and the SSR HTML
+ * contains the developer's original `\n p {\n   color: blue;\n }`
+ * formatting — failing Next.js's streaming-ssr regression which expects
+ * the canonical `color:blue` (no-space) match.
+ *
+ * The vinext styled-jsx plugin pre-transforms source so the literal is
+ * minified before the JSX transform runs.
+ *
+ * Mirrors Next.js: test/e2e/streaming-ssr/index.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/streaming-ssr/index.test.ts
+ *
+ * Closes: https://github.com/cloudflare/vinext/issues/1556
+ */
+
+import { describe, it, expect } from "vite-plus/test";
+import { styledJsxPlugin, minifyStyledJsxCss } from "../packages/vinext/src/plugins/styled-jsx.js";
+
+type TransformFn = (code: string, id: string) => null | { code: string; map: null } | undefined;
+
+function getTransform(): TransformFn {
+  const plugin = styledJsxPlugin() as { transform: TransformFn };
+  return plugin.transform.bind(plugin);
+}
+
+describe("minifyStyledJsxCss", () => {
+  it("collapses the canonical `p { color: blue; }` shape to minified form", () => {
+    const out = minifyStyledJsxCss("\n        p {\n          color: blue;\n        }\n      ");
+    expect(out).toBe("p{color:blue}");
+  });
+
+  it("handles multiple rules and selectors", () => {
+    const out = minifyStyledJsxCss(`
+      p { color: red; }
+      .x, .y { margin: 0; padding: 0; }
+    `);
+    expect(out).toBe("p{color:red}.x,.y{margin:0;padding:0}");
+  });
+
+  it("strips /* … */ comments before collapsing whitespace", () => {
+    const out = minifyStyledJsxCss(`
+      /* this is a comment */
+      a { color: blue; }
+    `);
+    expect(out).toBe("a{color:blue}");
+  });
+
+  it("preserves a single space between value tokens that need separation", () => {
+    const out = minifyStyledJsxCss(`
+      div { margin: 1px 2px 3px 4px; }
+    `);
+    expect(out).toBe("div{margin:1px 2px 3px 4px}");
+  });
+});
+
+describe("vinext:styled-jsx transform", () => {
+  it("minifies the CSS inside <style jsx>{`...`}</style> blocks", () => {
+    const transform = getTransform();
+    const source = [
+      "export default function Page() {",
+      "  return (",
+      "    <div>",
+      "      <style jsx>{`",
+      "        p {",
+      "          color: blue;",
+      "        }",
+      "      `}</style>",
+      "      <p>index</p>",
+      "    </div>",
+      "  );",
+      "}",
+    ].join("\n");
+
+    const result = transform(source, "/project/pages/index.tsx");
+    expect(result).not.toBeNull();
+    // The rewritten source must contain the minified rule so the canonical
+    // Next.js streaming-ssr match `/color:(?:blue|#00f)/` succeeds at SSR.
+    expect(result?.code).toMatch(/color:blue/);
+    // The boolean `jsx` flag is stripped so React does not warn about an
+    // unknown DOM attribute on the rendered <style> element.
+    expect(result?.code).not.toMatch(/<style[^>]*\bjsx\b/);
+    // Source structure outside the literal is preserved.
+    expect(result?.code).toContain("<p>index</p>");
+  });
+
+  it("also handles `<style jsx global>`", () => {
+    const transform = getTransform();
+    const source = "const x = <style jsx global>{`body { margin: 0; }`}</style>;\n";
+    const result = transform(source, "/project/pages/index.tsx");
+    expect(result?.code).toContain("body{margin:0}");
+    expect(result?.code).not.toMatch(/\bjsx\b/);
+    expect(result?.code).not.toMatch(/\bglobal\b/);
+  });
+
+  it("leaves <style> tags without the `jsx` flag untouched", () => {
+    const transform = getTransform();
+    // `<style jsx` hint is not present, so the cheap pre-check short-circuits.
+    const source = "const x = <style>{`body { margin: 0; }`}</style>;\n";
+    const result = transform(source, "/project/pages/index.tsx");
+    expect(result).toBeNull();
+  });
+
+  it("skips files outside JSX-capable extensions", () => {
+    const transform = getTransform();
+    const source = "<style jsx>{`p { color: blue; }`}</style>";
+    expect(transform(source, "/project/styles.css")).toBeNull();
+    expect(transform(source, "/project/notes.md")).toBeNull();
+  });
+
+  it("skips node_modules sources (library code is already compiled)", () => {
+    const transform = getTransform();
+    const source = "<style jsx>{`p { color: blue; }`}</style>";
+    expect(transform(source, "/project/node_modules/lib/index.jsx")).toBeNull();
+  });
+
+  it("returns null when no <style jsx> block is present", () => {
+    const transform = getTransform();
+    expect(transform("export default function P() { return null; }", "/a.tsx")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `vinext:styled-jsx`, a pre-transform Vite plugin that minifies the CSS inside `<style jsx>` (and `<style jsx global>`) template-literal blocks before the JSX transform runs, and strips the boolean `jsx`/`global` JSX flags so React doesn't warn about unknown DOM attrs on the rendered `<style>`.
- Restores Next.js's canonical SSR shape (`<style>p{color:blue}</style>`) so the streaming-ssr deploy-suite regression that matches `/color:(?:blue|#00f)/` passes.

## Background

Next.js's compiler (SWC/Babel) ships a styled-jsx pass that rewrites `<style jsx>{`p { color: blue; }`}</style>` into a `JSXStyle` element with already-minified CSS via styled-jsx's stylis fork. vinext uses Vite's OXC JSX transform, which has no styled-jsx step, so the developer's original `\n  p {\n    color: blue;\n  }` formatting flows through to React and the SSR HTML preserves every newline and indent — failing the `color:blue` (no-space) match.

This PR implements the minimum source rewrite needed to match Next.js's canonical minified shape. Full selector-scoping semantics are out of scope here; the issue test fixture uses a single-rule global selector (`p { color: blue }`) on a page with one `<p>`, so the no-scoping fallback produces equivalent visible output.

## Test plan

- [x] `pnpm test tests/styled-jsx.test.ts` — 10 new unit tests covering the minifier (basic, multi-rule, comments, value-token preservation) and the transform hook (rewrite, `global` flag, non-jsx skip, extension filter, node_modules skip, fast-path null)
- [x] `pnpm test tests/pages-page-response.test.ts tests/pages-router.test.ts` — 279 existing Pages Router tests still pass
- [x] `pnpm run check` — format, lint, and type checks pass
- [ ] CI: streaming-ssr deploy-suite regression resolves once this lands

Refs: vercel/next.js `test/e2e/streaming-ssr/index.test.ts`.
Closes: #1556