### PR TITLE
test(pages-router): shallow Router.push bypasses redirect for `as` (#1522)

### DIFF
--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1584,6 +1584,64 @@ describe("window.next debug global", () => {
     }
   });
 
+  // Issue #1522 — shallow `Router.push(url, as, { shallow: true })` must
+  // update history to `as` (the visible URL) without fetching the server,
+  // even when `as` matches a server-side redirect rule (e.g. `/redirect-1`
+  // configured in `next.config.js#redirects`). This mirrors the Next.js
+  // bloom-filter "client router filter" bypass for shallow updates.
+  //
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // "should not apply client router filter on shallow"
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+  it("Router.push with shallow=true updates URL to `as` and skips fetch for redirect-matching paths", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const pushState = vi.fn();
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("shallow Router.push must not fetch the page HTML");
+    });
+    const win: any = {
+      location: {
+        pathname: "/",
+        search: "",
+        hash: "",
+        href: "http://localhost/",
+        origin: "http://localhost",
+        hostname: "localhost",
+        assign: vi.fn(),
+        replace: vi.fn(),
+        reload: vi.fn(),
+      },
+      history: { state: null, pushState, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+      __NEXT_DATA__: { page: "/", query: {}, isFallback: false },
+    };
+    (globalThis as any).window = win;
+    globalThis.fetch = fetchSpy as any;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+
+      // Mirror the failing Next.js call exactly:
+      //   window.next.router.push('/', '/redirect-1', { shallow: true })
+      const result = await routerModule.default.push("/", "/redirect-1", { shallow: true });
+
+      expect(result).toBe(true);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // The visible URL is `as` (/redirect-1), even though the underlying
+      // route is `url` (/). The server's redirect rule for /redirect-1
+      // must not fire on a shallow update.
+      expect(pushState).toHaveBeenCalledWith({}, "", "/redirect-1");
+    } finally {
+      (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("appRouterInstance exported from the navigation shim has the public router surface", async () => {
     vi.resetModules();
     const { appRouterInstance } = await import("../packages/vinext/src/shims/navigation.js");


### PR DESCRIPTION
## Summary

Adds a regression test that locks in vinext's current behaviour for the Next.js test [`should not apply client router filter on shallow`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts) (referenced from issue #1522).

The test invokes `Router.push('/', '/redirect-1', { shallow: true })` and asserts:

- `window.history.pushState` is called with `/redirect-1` (the `as` path).
- `fetch` is **not** called — the server-side redirect rule for `/redirect-1` in `next.config.js#redirects` must not run for a shallow update.
- The push resolves to `true`.

## Why this matters

vinext already produces the correct behaviour: `performNavigation` skips `runNavigateClient` when `shallow` is `true`, so the server's redirect table never runs. This is the equivalent of Next.js's `_bfl` shallow-bypass in `packages/next/src/shared/lib/router/router.ts`.

vinext has no client-router bloom filter today, but this test guards the contract so a future Next.js parity work that introduces one cannot silently re-apply it to shallow updates.

## Scope

- The Next.js test in the issue also touches App Router routing from a Pages Router page (`window.next.router` is the Pages Router singleton when `/` is served from `pages/index.js`). That path is what this test exercises directly.
- The wider "Pages Router redirects invoked from App Router do not fire" branch of the issue is a separate code path (RSC redirect lifecycle in `server/app-browser-rsc-redirect.ts`) and is left for a follow-up — keeping this PR small as suggested by the workflow rules.

Refs #1522.

## Test plan

- [x] `pnpm test tests/shims.test.ts -t "shallow=true updates URL"` — new test passes
- [x] `pnpm test tests/shims.test.ts` — full file (1010 tests) passes
- [x] `pnpm test tests/router-javascript-urls.test.ts tests/link-navigation.test.ts` — related router files still pass
- [ ] CI: full Vitest + Playwright E2E (handled in CI)