### PR TITLE
fix(build): inline process.env.NEXT_DEPLOYMENT_ID for client and worker bundles

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1165,6 +1165,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.__VINEXT_DEPLOYMENT_ID"] = JSON.stringify(
           nextConfig.deploymentId ?? "",
         );
+        // Public `process.env.NEXT_DEPLOYMENT_ID` — Next.js statically inlines
+        // this into client (and web worker) bundles via its DefinePlugin so
+        // that user code like `new Worker(new URL('./w.ts', import.meta.url))`
+        // can read `process.env.NEXT_DEPLOYMENT_ID` from inside the worker.
+        // Workers can't easily share a globalThis with the main thread, so
+        // inlining at compile time is the only reliable channel.
+        //
+        // We keep parity by exposing the same identifier in vinext: when a
+        // deploymentId is configured we inline the string, otherwise inline
+        // `false` to mirror Next.js' behavior when the value is absent.
+        // See: packages/next/src/build/define-env.ts (`isClient` branch).
+        defines["process.env.NEXT_DEPLOYMENT_ID"] = nextConfig.deploymentId
+          ? JSON.stringify(nextConfig.deploymentId)
+          : "false";
         // Next.js version compat — mirrors Next.js' `process.env.__NEXT_VERSION`,
         // which is substituted by their webpack DefinePlugin at build time
         // (see `packages/next/src/client/next.ts` line 5 and

--- a/tests/deployment-id-define.test.ts
+++ b/tests/deployment-id-define.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Verifies that vinext inlines `process.env.NEXT_DEPLOYMENT_ID` into the
+ * global Vite `define` map.
+ *
+ * This define must be present in all bundles (client, SSR, RSC, and Vite
+ * worker bundles) so that user code such as:
+ *
+ *   new Worker(new URL('./worker.ts', import.meta.url));
+ *
+ * — and the `worker.ts` it loads — can read the deployment id via
+ * `process.env.NEXT_DEPLOYMENT_ID`. Web Workers can't easily share a
+ * `globalThis` with the main thread, so inlining at compile time is the
+ * only reliable channel. Mirrors Next.js' DefinePlugin behavior in
+ * `packages/next/src/build/define-env.ts`.
+ *
+ * Regression test for cloudflare/vinext#1538.
+ */
+import { describe, it, expect } from "vite-plus/test";
+import os from "node:os";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+type VinextPlugin = {
+  name: string;
+  config?: (config: unknown, env: { command: string }) => unknown;
+};
+
+async function setupTmpProject(nextConfigBody: string): Promise<string> {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-deployment-id-define-"));
+  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+  await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+  await fsp.writeFile(
+    path.join(tmpDir, "pages", "index.tsx"),
+    `export default function Home() { return <h1>Home</h1>; }`,
+  );
+  await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), nextConfigBody);
+  return tmpDir;
+}
+
+async function runConfig(tmpDir: string): Promise<Record<string, string>> {
+  const vinext = (await import("../packages/vinext/src/index.js")).default;
+  const plugins = vinext() as VinextPlugin[];
+  const mainPlugin = plugins.find(
+    (p) => p.name === "vinext:config" && typeof p.config === "function",
+  );
+  expect(mainPlugin).toBeDefined();
+  const result = (await mainPlugin!.config!(
+    { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+    { command: "build" },
+  )) as { define?: Record<string, string> };
+  expect(result.define).toBeDefined();
+  return result.define!;
+}
+
+describe("process.env.NEXT_DEPLOYMENT_ID is inlined via Vite define", () => {
+  it("inlines the configured deploymentId as a JSON string literal", async () => {
+    const tmpDir = await setupTmpProject(`export default { deploymentId: "deploy-123" };`);
+    try {
+      const define = await runConfig(tmpDir);
+      // The value is fed to Vite as a JSON-encoded source replacement, so
+      // the user's worker code `process.env.NEXT_DEPLOYMENT_ID` becomes the
+      // literal string `"deploy-123"`.
+      expect(define["process.env.NEXT_DEPLOYMENT_ID"]).toBe('"deploy-123"');
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("falls back to NEXT_DEPLOYMENT_ID env var when next.config has no deploymentId", async () => {
+    const previous = process.env.NEXT_DEPLOYMENT_ID;
+    process.env.NEXT_DEPLOYMENT_ID = "env-deploy-456";
+    const tmpDir = await setupTmpProject(`export default {};`);
+    try {
+      const define = await runConfig(tmpDir);
+      expect(define["process.env.NEXT_DEPLOYMENT_ID"]).toBe('"env-deploy-456"');
+    } finally {
+      if (previous === undefined) delete process.env.NEXT_DEPLOYMENT_ID;
+      else process.env.NEXT_DEPLOYMENT_ID = previous;
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("inlines `false` when no deploymentId is configured (matches Next.js parity)", async () => {
+    const previous = process.env.NEXT_DEPLOYMENT_ID;
+    delete process.env.NEXT_DEPLOYMENT_ID;
+    const tmpDir = await setupTmpProject(`export default {};`);
+    try {
+      const define = await runConfig(tmpDir);
+      expect(define["process.env.NEXT_DEPLOYMENT_ID"]).toBe("false");
+    } finally {
+      if (previous !== undefined) process.env.NEXT_DEPLOYMENT_ID = previous;
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

Fixes #1538. Web Workers spawned from App Router client code (`new Worker(new URL('./w.ts', import.meta.url))`) saw `process.env.NEXT_DEPLOYMENT_ID` as `undefined`, breaking all 7 tests in Next.js' `test/e2e/app-dir/worker/worker.test.ts`.

Vinext was already inlining its internal `__VINEXT_DEPLOYMENT_ID` mirror, but the public Next.js identifier was never registered with Vite's `define` map. The fix mirrors Next.js' webpack DefinePlugin (`packages/next/src/build/define-env.ts`) and inlines the value at build time. Because the same `define` map is also applied to Vite's worker bundles, workers transparently see the deployment id without needing a `globalThis` bridge — which would not survive the main-thread / worker boundary.

When no `deploymentId` is configured we inline `false`, matching Next.js so `if (process.env.NEXT_DEPLOYMENT_ID)` style checks remain dead-code eliminated.

## Test plan

- [x] `pnpm test tests/deployment-id-define.test.ts` (new file, 3 cases)
- [x] `pnpm test tests/compiler-define.test.ts` (regression — define map plumbing)
- [x] `pnpm test tests/shims.test.ts -t "deployment"` (cache-runtime fallback unchanged)
- [ ] Full CI (Vitest + Playwright E2E)