### PR TITLE
fix(pages-router): dedupe in-flight _next/data fetches by URL (#1464)

### DIFF
--- a/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
+++ b/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
@@ -1,0 +1,74 @@
+/**
+ * In-flight request dedup for the Pages Router `/_next/data/<id>/<page>.json`
+ * endpoint.
+ *
+ * Why this exists: when a user (or app code) triggers several near-simultaneous
+ * navigations to the same gSSP route — e.g. clicking the same `<Link>` multiple
+ * times before the first navigation lands — each call to `Router.push` would
+ * otherwise enter its own `navigateClientData()` flow and dispatch its own
+ * `fetch()` against the data endpoint. That balloons server load and breaks
+ * Next.js' documented "one fetch per unique data URL" guarantee.
+ *
+ * Ported from Next.js: `fetchNextData()` in
+ * `packages/next/src/shared/lib/router/router.ts`. Next.js maintains an
+ * `inflightCache` (keyed by the resolved data URL) and reuses the existing
+ * Promise when a concurrent caller asks for the same URL. The entry is
+ * dropped once the fetch settles (success or rejection) so the next
+ * navigation re-fetches fresh.
+ *
+ * Design notes:
+ *
+ * - Callers receive a cloned Response, so each can independently consume the
+ *   body (`.json()`, `.text()`, etc.). The originating Response is never read
+ *   directly by anyone, which keeps subsequent clones legal even after one
+ *   caller has consumed its copy.
+ *
+ * - No `AbortSignal` is honored at the shared layer. Each `Router.push` cycle
+ *   has its own AbortController that supersedes prior navigations via
+ *   `_navigationId`; aborting the shared fetch on behalf of one caller would
+ *   destroy the dedup gain for every other concurrent caller. Cancellation is
+ *   handled by the caller's `assertStillCurrent()` checkpoints after `await`,
+ *   not by abort propagation.
+ *
+ * - The map is module-scoped (one per realm). The Pages Router runs in the
+ *   browser only, so a single `Map` is sufficient.
+ */
+
+/** Inflight fetch promises keyed by the resolved data URL. */
+const inflight = new Map<string, Promise<Response>>();
+
+/**
+ * Dedupe a `fetch()` against the `_next/data` endpoint. Multiple concurrent
+ * callers for the same `dataHref` share one underlying network request.
+ *
+ * Each call returns a freshly-cloned `Response` so consumers can read the
+ * body independently. Once the in-flight Promise settles (resolve or reject)
+ * the entry is removed, and the next call will hit the network again.
+ *
+ * Errors propagate to every concurrent caller — the in-flight entry is
+ * dropped on failure so the next navigation can retry.
+ */
+export function dedupedPagesDataFetch(dataHref: string, init?: RequestInit): Promise<Response> {
+  let entry = inflight.get(dataHref);
+  if (!entry) {
+    entry = fetch(dataHref, init).finally(() => {
+      // Only drop the entry if it still matches the one we set. A racing
+      // caller could in principle overwrite, but inflight is keyed by URL
+      // and we never overwrite on a hit, so this check is defensive.
+      if (inflight.get(dataHref) === entry) inflight.delete(dataHref);
+    });
+    inflight.set(dataHref, entry);
+  }
+  // Always return a clone so each consumer gets an independently-readable
+  // body. The original `entry` Response is never consumed directly, so
+  // cloning remains valid for every caller (including the first).
+  return entry.then((res) => res.clone());
+}
+
+/**
+ * Drop every cached in-flight entry. Intended for tests; production code
+ * does not need to call this because entries self-evict on settle.
+ */
+export function clearPagesDataInflight(): void {
+  inflight.clear();
+}

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -33,6 +33,7 @@ import {
   getPagesRouterComponentsMap,
   markAppRouteDetectedOnPrefetch,
 } from "./internal/app-route-detection.js";
+import { dedupedPagesDataFetch } from "./internal/pages-data-fetch-dedup.js";
 import { installWindowNext, type PagesRouterPublicInstance } from "../client/window-next.js";
 import { isUnknownRecord } from "../utils/record.js";
 import {
@@ -766,17 +767,23 @@ async function resolveMiddlewareDataRedirect(
   const dataUrl = getMiddlewarePagesDataFetchUrl(browserUrl);
   if (!dataUrl) return null;
 
+  // We deliberately do NOT thread `signal` into the shared fetch — see the
+  // dedup helper for why. Stale callers bail out via `assertStillCurrent()`
+  // after the await; we still surface a pre-await abort via this check so
+  // callers see the documented AbortError on supersession.
+  if (signal.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
   try {
-    const res = await fetch(dataUrl, {
+    const res = await dedupedPagesDataFetch(dataUrl, {
       headers: {
         Accept: "application/json",
         "x-nextjs-data": "1",
       },
-      signal,
     });
     return res.headers.get("x-nextjs-redirect");
-  } catch (err: unknown) {
-    if (err instanceof DOMException && err.name === "AbortError") throw err;
+  } catch {
     return null;
   }
 }
@@ -809,11 +816,24 @@ async function navigateClientData(
   }
 
   // Fetch the page-data JSON.
+  //
+  // We dedupe by URL: concurrent `Router.push` calls (or back-to-back link
+  // clicks) for the same destination share a single underlying request.
+  // The shared fetch deliberately ignores `controller.signal` — each caller
+  // still bails out of their navigation via `assertStillCurrent()` after the
+  // await, but the shared network request itself runs to completion so other
+  // racing callers still benefit. This matches Next.js's `inflightCache`
+  // semantics in `fetchNextData()`.
+  //
+  // Pre-await abort still throws so callers see the documented cancellation
+  // surface when supersession happened before the fetch was even attempted.
+  if (controller.signal.aborted) {
+    throw new NavigationCancelledError(url);
+  }
   let res: Response;
   try {
-    res = await fetch(target.dataHref, {
+    res = await dedupedPagesDataFetch(target.dataHref, {
       headers: { Accept: "application/json", "x-nextjs-data": "1" },
-      signal: controller.signal,
     });
   } catch (err: unknown) {
     if (err instanceof DOMException && err.name === "AbortError") {

--- a/tests/pages-data-fetch-dedup.test.ts
+++ b/tests/pages-data-fetch-dedup.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Pages Router `/_next/data/<id>/<page>.json` client-side fetch dedup parity.
+ *
+ * Ported from Next.js: `test/e2e/getserversideprops/test/index.test.ts`
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/test/index.test.ts
+ * (specifically the `should dedupe server data requests` case, which clicks
+ * the same link four times in rapid succession and asserts the gSSP "hit"
+ * counter only ticks once on the server.)
+ *
+ * Next.js implements this via an in-flight Promise cache keyed by the resolved
+ * data URL — see `fetchNextData()` in
+ * `packages/next/src/shared/lib/router/router.ts` and the `inflightCache`
+ * parameter. The first call seeds `inflightCache[cacheKey]` with the fetch
+ * Promise; subsequent concurrent calls for the same key reuse that Promise
+ * instead of starting a new network request. The entry is dropped once the
+ * fetch settles (success or failure) so the next navigation re-fetches fresh.
+ *
+ * This file pins the parity fix at the helper level: concurrent calls to
+ * `dedupedPagesDataFetch()` for the same URL must share a single `fetch()`
+ * invocation, and each caller must receive an independently-readable Response.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+
+let dedupedPagesDataFetch: (typeof import("../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js"))["dedupedPagesDataFetch"];
+let clearPagesDataInflight: (typeof import("../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js"))["clearPagesDataInflight"];
+
+beforeEach(async () => {
+  vi.resetModules();
+  const mod = await import("../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js");
+  dedupedPagesDataFetch = mod.dedupedPagesDataFetch;
+  clearPagesDataInflight = mod.clearPagesDataInflight;
+  clearPagesDataInflight();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as { fetch?: unknown }).fetch;
+});
+
+describe("dedupedPagesDataFetch", () => {
+  it("shares a single fetch across concurrent calls for the same URL", async () => {
+    // Hold the fetch open so all 10 callers race the same in-flight Promise.
+    let resolveFetch: (res: Response) => void = () => {};
+    const fetchPromise = new Promise<Response>((r) => {
+      resolveFetch = r;
+    });
+    const fetchSpy = vi.fn(() => fetchPromise);
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const url = "/_next/data/build-id/foo.json";
+    const consumers = Array.from({ length: 10 }, () =>
+      dedupedPagesDataFetch(url, { headers: { Accept: "application/json" } }),
+    );
+
+    // Single network request despite 10 concurrent consumers.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Resolve the shared fetch; every caller should observe its own Response
+    // (each consumer must be able to read .json() independently).
+    resolveFetch(
+      new Response(JSON.stringify({ pageProps: { hit: 1 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const results = await Promise.all(consumers);
+    for (const res of results) {
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { pageProps: { hit: number } };
+      expect(body.pageProps.hit).toBe(1);
+    }
+  });
+
+  it("re-fetches once the previous request settles", async () => {
+    const fetchSpy = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ pageProps: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const url = "/_next/data/build-id/foo.json";
+    await dedupedPagesDataFetch(url);
+    await dedupedPagesDataFetch(url);
+
+    // Two sequential (non-overlapping) calls should each hit the network —
+    // dedup only applies while a fetch is in flight.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("dedupes per-URL: different URLs do not share a fetch", async () => {
+    const fetchSpy = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ pageProps: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    await Promise.all([
+      dedupedPagesDataFetch("/_next/data/id/a.json"),
+      dedupedPagesDataFetch("/_next/data/id/b.json"),
+    ]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the inflight entry on fetch rejection so the next call retries", async () => {
+    let attempt = 0;
+    const fetchSpy = vi.fn(() => {
+      attempt += 1;
+      if (attempt === 1) return Promise.reject(new Error("network fail"));
+      return Promise.resolve(
+        new Response(JSON.stringify({ pageProps: { ok: true } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const url = "/_next/data/build-id/retry.json";
+    await expect(dedupedPagesDataFetch(url)).rejects.toThrow("network fail");
+
+    const res = await dedupedPagesDataFetch(url);
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1464: client-side `_next/data` request dedup parity for the Pages Router.
- Concurrent `Router.push` calls (or back-to-back `<Link>` clicks) for the same destination now share a single underlying fetch instead of each firing their own request.
- Add a module-scoped in-flight Promise cache in `shims/internal/pages-data-fetch-dedup.ts`, keyed by the resolved `/_next/data/<id>/<page>.json` URL, mirroring `fetchNextData()`'s `inflightCache` in `packages/next/src/shared/lib/router/router.ts`.
- Wired into both `navigateClientData()` (the JSON navigation fast path) and `resolveMiddlewareDataRedirect()` (the soft-redirect probe). Each caller gets a cloned Response so bodies remain independently readable.

### Design notes

- The shared fetch deliberately ignores per-caller `AbortSignal`s: stale navigations are already detected via `_navigationId` + `assertStillCurrent()` checkpoints after the await. Aborting the shared request on behalf of one superseded caller would destroy the dedup gain for every other concurrent caller.
- Pre-await abort still surfaces so callers see the documented `NavigationCancelledError` / `AbortError` when supersession happened before the fetch was even attempted.
- Entries self-evict on settle (success or rejection) so the next navigation always re-fetches fresh.

## Test plan

- [x] New unit test (`tests/pages-data-fetch-dedup.test.ts`) covers: shared fetch under concurrency, sequential re-fetch, per-URL keying, and rejection eviction.
- [x] `pnpm test tests/pages-data-fetch-dedup.test.ts tests/pages-data-url.test.ts tests/pages-data-route.test.ts tests/router-prefetch-invalid-url.test.ts tests/link-navigation.test.ts tests/navigation-runtime.test.ts tests/shims.test.ts` — 1101 tests pass.
- [x] `pnpm run check` — format, lint, and type clean.
- [ ] CI: Vitest, Playwright E2E.

Ported from Next.js: https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/test/index.test.ts (`should dedupe server data requests`).