### PR TITLE
fix(cache): attach path tags to prerender-seeded entries so revalidatePath invalidates them

### DIFF
--- a/packages/vinext/src/cloudflare/tpr.ts
+++ b/packages/vinext/src/cloudflare/tpr.ts
@@ -25,6 +25,7 @@ import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { VINEXT_REVALIDATE_HEADER } from "../server/headers.js";
 import { isrCacheKey } from "../server/isr-cache.js";
+import { buildAppPageCacheTags } from "../server/app-page-cache.js";
 import { ENTRY_PREFIX } from "./kv-cache-handler.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -697,6 +698,11 @@ export function buildTprKVPairs(
     // but TPR uses a 24h fallback so pre-warmed entries don't accumulate forever.
     const kvTtl = revalidateSeconds > 0 ? MAX_KV_TTL_SECONDS : 24 * 3600;
 
+    // Path-derived implicit tags so revalidatePath()/revalidateTag() can
+    // invalidate TPR-seeded entries. Without this the seeded entry has no
+    // tags and tag-based invalidation can never reach it (#1486).
+    const tags = buildAppPageCacheTags(routePath, []);
+
     const entry = {
       value: {
         kind: "APP_PAGE" as const,
@@ -704,7 +710,7 @@ export function buildTprKVPairs(
         headers: result.headers,
         status: result.status,
       },
-      tags: [] as string[],
+      tags,
       lastModified: now,
       revalidateAt,
     };

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -85,25 +85,37 @@ export async function isrSet(
 export async function isrSetPrerenderedAppPage(
   key: string,
   data: CachedAppPageValue,
-  metadata: { expireSeconds?: number; revalidateSeconds?: number },
+  metadata: {
+    expireSeconds?: number;
+    revalidateSeconds?: number;
+    /**
+     * Implicit/path tags to attach to the seeded entry. Required so that
+     * `revalidatePath()` (and `revalidateTag()`) can invalidate prerender-seeded
+     * cache entries — without tags the entry is unreachable by tag-based
+     * invalidation and remains stale until natural `revalidateAt` expiry.
+     * See cloudflare/vinext#1486.
+     */
+    tags?: string[];
+  },
 ): Promise<void> {
   const handler = getCacheHandler();
   const revalidateSeconds = metadata.revalidateSeconds;
+  const tags = metadata.tags;
   if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
     console.debug("[vinext] ISR: seed", key);
   }
-  await handler.set(
-    key,
-    data,
-    revalidateSeconds === undefined
-      ? {}
-      : metadata.expireSeconds === undefined
-        ? { cacheControl: { revalidate: revalidateSeconds }, revalidate: revalidateSeconds }
-        : {
-            cacheControl: { revalidate: revalidateSeconds, expire: metadata.expireSeconds },
-            revalidate: revalidateSeconds,
-          },
-  );
+  const ctx: Record<string, unknown> = {};
+  if (revalidateSeconds !== undefined) {
+    ctx.revalidate = revalidateSeconds;
+    ctx.cacheControl =
+      metadata.expireSeconds === undefined
+        ? { revalidate: revalidateSeconds }
+        : { revalidate: revalidateSeconds, expire: metadata.expireSeconds };
+  }
+  if (tags && tags.length > 0) {
+    ctx.tags = tags;
+  }
+  await handler.set(key, data, ctx);
 
   if (revalidateSeconds !== undefined) {
     setRevalidateDuration(key, revalidateSeconds);

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -33,6 +33,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { CachedAppPageValue } from "vinext/shims/cache";
 import { isrCacheKey, isrSetPrerenderedAppPage } from "./isr-cache.js";
+import { buildAppPageCacheTags } from "./app-page-cache.js";
 import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
@@ -57,6 +58,11 @@ type PrerenderManifestRoute = {
 type PrerenderCacheSeedMetadata = {
   expireSeconds?: number;
   revalidateSeconds?: number;
+  /**
+   * Path-derived implicit tags (`/foo`, `_N_T_/foo`, `_N_T_/foo/page`, ...)
+   * required for `revalidatePath()` to invalidate the seeded entry. See #1486.
+   */
+  tags?: string[];
 };
 
 type PrerenderCacheSeedOptions = {
@@ -118,6 +124,11 @@ export async function seedMemoryCacheFromPrerender(
     const revalidateSeconds = typeof route.revalidate === "number" ? route.revalidate : undefined;
     const expireSeconds = typeof route.expire === "number" ? route.expire : undefined;
 
+    // Path-derived implicit tags so revalidatePath()/revalidateTag() can
+    // invalidate seeded entries. Without this the seeded entry has no tags
+    // and tag-based invalidation can never reach it (#1486).
+    const tags = buildAppPageCacheTags(cachePathname, []);
+
     if (
       await seedHtml(
         writeAppPageEntry,
@@ -127,6 +138,7 @@ export async function seedMemoryCacheFromPrerender(
         trailingSlash,
         revalidateSeconds,
         expireSeconds,
+        tags,
       )
     ) {
       await seedRsc(
@@ -136,6 +148,7 @@ export async function seedMemoryCacheFromPrerender(
         artifactPathname,
         revalidateSeconds,
         expireSeconds,
+        tags,
       );
       seeded++;
     }
@@ -168,6 +181,7 @@ async function seedHtml(
   trailingSlash: boolean,
   revalidateSeconds: number | undefined,
   expireSeconds: number | undefined,
+  tags: string[] | undefined,
 ): Promise<boolean> {
   const relPath = getOutputPath(pathname, trailingSlash);
   const fullPath = path.join(prerenderDir, relPath);
@@ -182,7 +196,7 @@ async function seedHtml(
     status: undefined,
   };
 
-  await writeAppPageEntry(key, htmlValue, { expireSeconds, revalidateSeconds });
+  await writeAppPageEntry(key, htmlValue, { expireSeconds, revalidateSeconds, tags });
 
   return true;
 }
@@ -198,6 +212,7 @@ async function seedRsc(
   pathname: string,
   revalidateSeconds: number | undefined,
   expireSeconds: number | undefined,
+  tags: string[] | undefined,
 ): Promise<void> {
   const relPath = getRscOutputPath(pathname);
   const fullPath = path.join(prerenderDir, relPath);
@@ -216,5 +231,5 @@ async function seedRsc(
     status: undefined,
   };
 
-  await writeAppPageEntry(key, rscValue, { expireSeconds, revalidateSeconds });
+  await writeAppPageEntry(key, rscValue, { expireSeconds, revalidateSeconds, tags });
 }

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -10,6 +10,13 @@
 
 import { describe, it, expect, beforeEach, vi } from "vite-plus/test";
 import { KVCacheHandler } from "../packages/vinext/src/cloudflare/kv-cache-handler.js";
+import {
+  revalidatePath,
+  revalidateTag,
+  setCacheHandler,
+  MemoryCacheHandler,
+} from "../packages/vinext/src/shims/cache.js";
+import { buildAppPageCacheTags } from "../packages/vinext/src/server/app-page-cache.js";
 
 // ---------------------------------------------------------------------------
 // Mock KV namespace
@@ -1270,4 +1277,174 @@ describe("KVCacheHandler", () => {
       expect(await handler.get("/big-tags")).toBeNull();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // revalidatePath() — end-to-end via the active handler
+  //
+  // Regression coverage for issue #1486: ensure a server-action style
+  // `revalidatePath()` call invalidates the cached HTML/RSC entry stored in
+  // KV under the full set of tags produced by buildAppPageCacheTags.
+  // -------------------------------------------------------------------------
+  describe("revalidatePath via active handler (#1486)", () => {
+    beforeEach(() => {
+      // Wire KVCacheHandler in as the active handler so the public
+      // `revalidatePath` API exercised by user code routes through KV.
+      setCacheHandler(handler);
+    });
+
+    /** Helper: seed an APP_PAGE entry using the same tag set the dispatcher uses. */
+    async function seedAppPage(pathname: string, html: string): Promise<void> {
+      const tags = buildAppPageCacheTags(pathname, []);
+      await handler.set(
+        pathname,
+        {
+          kind: "APP_PAGE",
+          html,
+          rscData: undefined,
+          headers: undefined,
+          postponed: undefined,
+          status: 200,
+        },
+        { revalidate: 60, tags },
+      );
+    }
+
+    it("invalidates the cached page after revalidatePath('/foo')", async () => {
+      await seedAppPage("/foo", "<html>foo</html>");
+
+      // Sanity: entry is present before invalidation.
+      handler.resetRequestCache();
+      const beforeHit = await handler.get("/foo");
+      expect(beforeHit).not.toBeNull();
+      expect((beforeHit!.value as any).html).toBe("<html>foo</html>");
+
+      // Public revalidatePath API call (no type → bare _N_T_/foo tag).
+      await revalidatePath("/foo");
+
+      // The cached entry must now be a hard miss.
+      handler.resetRequestCache();
+      expect(await handler.get("/foo")).toBeNull();
+    });
+
+    it("invalidates a deep nested page after revalidatePath('/blog/hello')", async () => {
+      await seedAppPage("/blog/hello", "<html>hello</html>");
+      await seedAppPage("/blog/world", "<html>world</html>");
+
+      await revalidatePath("/blog/hello");
+
+      handler.resetRequestCache();
+      expect(await handler.get("/blog/hello")).toBeNull();
+      // Sibling entry must remain — bare path tag is exact.
+      expect(await handler.get("/blog/world")).not.toBeNull();
+    });
+
+    it("invalidates the root page after revalidatePath('/')", async () => {
+      await seedAppPage("/", "<html>home</html>");
+
+      await revalidatePath("/");
+
+      handler.resetRequestCache();
+      expect(await handler.get("/")).toBeNull();
+    });
+
+    it("type='layout' invalidates the page (carries the layout tag)", async () => {
+      await seedAppPage("/dashboard/settings", "<html>settings</html>");
+
+      // /dashboard/layout tag is included in the page's cache tags by
+      // buildAppPageCacheTags. revalidatePath('/dashboard', 'layout') should
+      // therefore invalidate this nested entry.
+      await revalidatePath("/dashboard", "layout");
+
+      handler.resetRequestCache();
+      expect(await handler.get("/dashboard/settings")).toBeNull();
+    });
+
+    it("type='page' invalidates only the exact route's /page tag", async () => {
+      await seedAppPage("/about", "<html>about</html>");
+      await seedAppPage("/about/team", "<html>team</html>");
+
+      await revalidatePath("/about", "page");
+
+      handler.resetRequestCache();
+      expect(await handler.get("/about")).toBeNull();
+      // /about/team has tag _N_T_/about/team/page, not _N_T_/about/page.
+      expect(await handler.get("/about/team")).not.toBeNull();
+    });
+
+    // -------------------------------------------------------------------------
+    // Regression: prerender-seeded entries must carry path tags so
+    // revalidatePath() can invalidate them. Pre-#1486 fix, `isrSetPrerenderedAppPage`
+    // (and TPR uploads) wrote entries with `tags: []`, so revalidatePath would
+    // mark `__tag:_N_T_/foo` but the cached entry had no matching tag — leaving
+    // the stale entry served forever (until natural revalidateAt expiry).
+    // -------------------------------------------------------------------------
+    it("invalidates a prerender-seeded entry via revalidatePath when tags are passed", async () => {
+      const { isrSetPrerenderedAppPage } =
+        await import("../packages/vinext/src/server/isr-cache.js");
+
+      // Simulate the build-time prerender seed for a page at /seeded.
+      // The seeder must attach the path's implicit tags so that a later
+      // revalidatePath('/seeded') call can invalidate this entry. See #1486.
+      const tags = buildAppPageCacheTags("/seeded", []);
+
+      await isrSetPrerenderedAppPage(
+        "/seeded",
+        {
+          kind: "APP_PAGE",
+          html: "<html>seeded</html>",
+          rscData: undefined,
+          headers: undefined,
+          postponed: undefined,
+          status: 200,
+        },
+        { revalidateSeconds: 60, tags },
+      );
+
+      handler.resetRequestCache();
+      const beforeHit = await handler.get("/seeded");
+      expect(beforeHit).not.toBeNull();
+
+      await revalidatePath("/seeded");
+
+      handler.resetRequestCache();
+      expect(await handler.get("/seeded")).toBeNull();
+    });
+
+    it("prerender-seeded entry without tags is NOT invalidated (legacy behavior — regression guard)", async () => {
+      const { isrSetPrerenderedAppPage } =
+        await import("../packages/vinext/src/server/isr-cache.js");
+
+      // Pre-#1486 callers passed no tags. Document the legacy behavior so
+      // future refactors notice the contract: the seeder controls whether
+      // tag-based invalidation works.
+      await isrSetPrerenderedAppPage(
+        "/legacy-seeded",
+        {
+          kind: "APP_PAGE",
+          html: "<html>legacy</html>",
+          rscData: undefined,
+          headers: undefined,
+          postponed: undefined,
+          status: 200,
+        },
+        { revalidateSeconds: 60 },
+      );
+
+      await revalidatePath("/legacy-seeded");
+
+      handler.resetRequestCache();
+      // Entry remains because it has no tags to match against the
+      // revalidatePath tag marker.
+      expect(await handler.get("/legacy-seeded")).not.toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reset to a clean MemoryCacheHandler between top-level test files.
+  // -------------------------------------------------------------------------
 });
+
+// Ensure the active handler is restored after this file runs, so other test
+// files relying on the default MemoryCacheHandler are not affected.
+setCacheHandler(new MemoryCacheHandler());
+void revalidateTag;

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -13,6 +13,7 @@ import {
   MemoryCacheHandler,
   setCacheHandler,
   getCacheHandler,
+  revalidatePath,
   type CacheHandler,
   type CacheHandlerValue,
   type IncrementalCacheValue,
@@ -287,16 +288,25 @@ describe("seedMemoryCacheFromPrerender", () => {
 
     await seedMemoryCacheFromPrerender(serverDir);
 
+    // Path-derived implicit tags are attached so revalidatePath('/isr') can
+    // invalidate seeded entries — see #1486.
+    const expectedTags = [
+      "/isr",
+      "_N_T_/isr",
+      "_N_T_/layout",
+      "_N_T_/isr/layout",
+      "_N_T_/isr/page",
+    ];
     expect(contexts).toEqual([
-      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60 },
-      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60 },
+      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60, tags: expectedTags },
+      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60, tags: expectedTags },
     ]);
   });
 
   it("can write through an injected app page cache writer", async () => {
     const writes: {
       key: string;
-      metadata: { expireSeconds?: number; revalidateSeconds?: number };
+      metadata: { expireSeconds?: number; revalidateSeconds?: number; tags?: string[] };
       valueKind: string;
     }[] = [];
 
@@ -319,15 +329,24 @@ describe("seedMemoryCacheFromPrerender", () => {
     });
 
     const baseKey = isrCacheKey("app", "/isr", "seed-injected-writer-test");
+    // Path-derived implicit tags so revalidatePath('/isr') can invalidate
+    // these entries — see #1486.
+    const expectedTags = [
+      "/isr",
+      "_N_T_/isr",
+      "_N_T_/layout",
+      "_N_T_/isr/layout",
+      "_N_T_/isr/page",
+    ];
     expect(writes).toEqual([
       {
         key: baseKey + ":html",
-        metadata: { expireSeconds: 300, revalidateSeconds: 60 },
+        metadata: { expireSeconds: 300, revalidateSeconds: 60, tags: expectedTags },
         valueKind: "APP_PAGE",
       },
       {
         key: baseKey + ":rsc",
-        metadata: { expireSeconds: 300, revalidateSeconds: 60 },
+        metadata: { expireSeconds: 300, revalidateSeconds: 60, tags: expectedTags },
         valueKind: "APP_PAGE",
       },
     ]);
@@ -382,6 +401,39 @@ describe("seedMemoryCacheFromPrerender", () => {
     const baseKey = isrCacheKey("app", "/static", buildId);
     expect(getRevalidateDuration(baseKey + ":html")).toBeUndefined();
     expect(getRevalidateDuration(baseKey + ":rsc")).toBeUndefined();
+  });
+
+  // ── revalidatePath invalidation of seeded entries (#1486) ─────────────────
+
+  it("revalidatePath invalidates seeded HTML and RSC entries", async () => {
+    const buildId = "revalidate-seeded-test";
+    setupPrerenderFixture(
+      serverDir,
+      {
+        buildId,
+        routes: [{ route: "/posts", status: "rendered", revalidate: 60, router: "app" }],
+      },
+      {
+        "posts.html": "<html>Posts (seeded)</html>",
+        "posts.rsc": "RSC posts seeded",
+      },
+    );
+
+    await seedMemoryCacheFromPrerender(serverDir);
+
+    const baseKey = isrCacheKey("app", "/posts", buildId);
+    const htmlKey = baseKey + ":html";
+    const rscKey = baseKey + ":rsc";
+
+    // Sanity: both seeded entries are present before revalidation.
+    expect(await getCacheHandler().get(htmlKey)).not.toBeNull();
+    expect(await getCacheHandler().get(rscKey)).not.toBeNull();
+
+    // revalidatePath should invalidate both seeded artifacts.
+    await revalidatePath("/posts");
+
+    expect(await getCacheHandler().get(htmlKey)).toBeNull();
+    expect(await getCacheHandler().get(rscKey)).toBeNull();
   });
 
   // ── Static routes (revalidate: false) ─────────────────────────────────────

--- a/tests/tpr-kv-keys.test.ts
+++ b/tests/tpr-kv-keys.test.ts
@@ -76,7 +76,15 @@ describe("TPR KV key format", () => {
     expect(parsed.value.html).toBe("<html>/test</html>");
     expect(parsed.value.headers).toEqual({ "content-type": "text/html" });
     expect(parsed.value.status).toBe(200);
-    expect(parsed.tags).toEqual([]);
+    // Path-derived implicit tags so revalidatePath('/test') can invalidate
+    // TPR-seeded entries — see #1486.
+    expect(parsed.tags).toEqual([
+      "/test",
+      "_N_T_/test",
+      "_N_T_/layout",
+      "_N_T_/test/layout",
+      "_N_T_/test/page",
+    ]);
     expect(parsed.lastModified).toBeTypeOf("number");
   });
 });


### PR DESCRIPTION
## Problem

Build-time prerender seeding (`isrSetPrerenderedAppPage`) and TPR upload were writing cache entries with `tags: []`. Tag-based invalidation could never reach those entries, so after a server action called `revalidatePath('/foo')`, vinext kept serving the stale prerendered HTML/RSC until the natural `revalidateAt` expiry. This matches the failure reported from the Next.js Deploy Suite (`expect.not.toBe(...)` — same value persists after `revalidatePath()`).

## Fix

Compute the path-derived implicit tags via `buildAppPageCacheTags(pathname, [])` in both seed paths and forward them through to the cache handler:

- `packages/vinext/src/server/seed-cache.ts` — compute tags from the cache pathname and thread them through `seedHtml`/`seedRsc`.
- `packages/vinext/src/server/isr-cache.ts` — `isrSetPrerenderedAppPage` accepts an optional `tags` array and forwards it into the cache handler context.
- `packages/vinext/src/cloudflare/tpr.ts` — TPR KV pairs now carry the path tags instead of `tags: []`.

With tags attached, `revalidatePath()` / `revalidateTag()` can match and evict prerender-seeded entries.

## Tests

- `tests/kv-cache-handler.test.ts` — end-to-end `revalidatePath()` through the active KV handler, including a prerender-seeded entry, plus a regression guard documenting that an entry seeded without tags is (correctly) not invalidated.
- `tests/seed-cache.test.ts` — asserts the seeded HTML/RSC contexts carry the expected path tags and that `revalidatePath('/posts')` evicts both seeded artifacts.
- `tests/tpr-kv-keys.test.ts` — asserts TPR-seeded entries carry path tags rather than `[]`.

## Scope

This covers plain path invalidation. Rewrite-aware invalidation (canonical-vs-rewrite key mismatch — the second failing suite below) is a known follow-up.

## Next.js reference tests

- https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
- https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/revalidate-path-with-rewrites/revalidate-path-with-rewrites.test.ts (rewrite case — follow-up)

Fixes #1486