### PR TITLE
fix(build): emit CSS url() assets to _next/static/media/ instead of data URIs

### DIFF
--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -1,6 +1,81 @@
 import type { UserConfig } from "vite";
 
 /**
+ * Extensions that Next.js routes through webpack's `asset/resource` loader and
+ * emits as hashed files under `_next/static/media/`. Mirrors the media
+ * extensions Vite/webpack treat as "assets" referenced from CSS `url(...)`,
+ * JS imports, etc. — images, fonts, video, audio. Stylesheets (`.css`) are
+ * intentionally excluded so they stay at the top of `assetsDir` where the
+ * client manifest and `<link>` injection expect them.
+ *
+ * @see .nextjs-ref/packages/next/src/build/webpack/config/blocks/css/index.ts
+ *   (the `type: 'asset/resource'` rule for CSS `url()` references)
+ */
+const MEDIA_ASSET_EXTENSIONS = new Set([
+  // images
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "avif",
+  "ico",
+  "bmp",
+  // fonts
+  "woff",
+  "woff2",
+  "eot",
+  "ttf",
+  "otf",
+  // media
+  "mp4",
+  "webm",
+  "ogg",
+  "mp3",
+  "wav",
+  "flac",
+  "aac",
+  "mov",
+]);
+
+type AssetInfo = { names?: readonly string[]; name?: string };
+
+/**
+ * Build an `assetFileNames` template function that routes media assets
+ * (images, fonts, video, audio) into a `media/` subdirectory of `assetsDir`,
+ * matching Next.js's `_next/static/media/<name>.<HASH>.<ext>` layout, while
+ * leaving every other asset (notably stylesheets) at the top of `assetsDir`
+ * with Vite's default naming.
+ *
+ * Providing any `assetFileNames` disables Vite's implicit `assetsDir` prefix,
+ * so the returned templates include `assetsDir` explicitly. The default
+ * (non-media) branch reproduces Vite's own `<assetsDir>/[name]-[hash][extname]`
+ * shape so CSS files — and the directory Vite derives for them via
+ * `path.dirname(assetFileNames(...))` — land exactly where they did before.
+ *
+ * Media files use a dotted `[name].[hash][extname]` separator to match the
+ * `dark.<HASH>.svg` shape the Next.js SCSS deploy suites assert against.
+ *
+ * `assetsDir` is the already-resolved `build.assetsDir` (e.g. `_next/static`
+ * or `<prefix>/_next/static`); paths use POSIX separators because emitted
+ * asset references are URLs.
+ */
+export function createAssetFileNames(assetsDir: string): (info: AssetInfo) => string {
+  const base = assetsDir.replace(/\/+$/, "");
+  const mediaDir = base ? `${base}/media` : "media";
+  const flatDir = base ? `${base}` : "";
+  return function assetFileNames(info: AssetInfo): string {
+    const name = info.names?.[0] ?? info.name ?? "";
+    const ext = name.includes(".") ? name.slice(name.lastIndexOf(".") + 1).toLowerCase() : "";
+    if (MEDIA_ASSET_EXTENSIONS.has(ext)) {
+      return `${mediaDir}/[name].[hash][extname]`;
+    }
+    return flatDir ? `${flatDir}/[name]-[hash][extname]` : "[name]-[hash][extname]";
+  };
+}
+
+/**
  * Extract the npm package name from a module ID (file path).
  * Returns null if not in node_modules.
  *
@@ -85,10 +160,14 @@ export function createClientManualChunks(shimsDir: string) {
  * compression efficiency — small files restart the compression dictionary,
  * adding ~5-15% wire overhead vs fewer larger chunks.
  */
-export function createClientOutputConfig(clientManualChunks: (id: string) => string | undefined) {
+export function createClientOutputConfig(
+  clientManualChunks: (id: string) => string | undefined,
+  assetFileNames?: (info: AssetInfo) => string,
+) {
   return {
     manualChunks: clientManualChunks,
     experimentalMinChunkSize: 10_000,
+    ...(assetFileNames ? { assetFileNames } : {}),
   };
 }
 

--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -62,7 +62,11 @@ type AssetInfo = { names?: readonly string[]; name?: string };
  * asset references are URLs.
  */
 export function createAssetFileNames(assetsDir: string): (info: AssetInfo) => string {
-  const base = assetsDir.replace(/\/+$/, "");
+  // Strip trailing slashes with an explicit loop instead of `replace(/\/+$/, "")`
+  // so CodeQL doesn't flag the regex as polynomial-time on uncontrolled input
+  // (same rationale as resolveAssetsDir in utils/asset-prefix.ts).
+  let base = assetsDir;
+  while (base.endsWith("/")) base = base.slice(0, -1);
   const mediaDir = base ? `${base}/media` : "media";
   const flatDir = base ? `${base}` : "";
   return function assetFileNames(info: AssetInfo): string {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -130,6 +130,7 @@ import {
   createClientManualChunks,
   createClientOutputConfig,
   createClientCodeSplittingConfig,
+  createAssetFileNames,
   getClientTreeshakeConfigForVite,
   getBuildBundlerOptions,
   withBuildBundlerOptions,
@@ -552,11 +553,16 @@ const _reactServerShims = new Map<string, string>([
 ]);
 
 const clientManualChunks = createClientManualChunks(_shimsDir);
-const clientOutputConfig = createClientOutputConfig(clientManualChunks);
 const clientCodeSplittingConfig = createClientCodeSplittingConfig(clientManualChunks);
 
-function getClientOutputConfigForVite(viteMajorVersion: number) {
-  return viteMajorVersion >= 8 ? { codeSplitting: clientCodeSplittingConfig } : clientOutputConfig;
+function getClientOutputConfigForVite(viteMajorVersion: number, assetsDir: string) {
+  // Route media `url(...)` assets into `<assetsDir>/media/` so the emitted
+  // URL/on-disk layout matches Next.js's `_next/static/media/...`. CSS and
+  // other assets keep Vite's default naming (see createAssetFileNames).
+  const assetFileNames = createAssetFileNames(assetsDir);
+  return viteMajorVersion >= 8
+    ? { codeSplitting: clientCodeSplittingConfig, assetFileNames }
+    : createClientOutputConfig(clientManualChunks, assetFileNames);
 }
 
 export type VinextOptions = {
@@ -1454,6 +1460,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // (on the client env), not globally — otherwise it leaks into RSC/SSR
         // environments where it can cause asset resolution issues.
         const isMultiEnv = hasAppDir || hasCloudflarePlugin || hasNitroPlugin;
+        // Canonical on-disk asset directory (e.g. `_next/static`), threaded
+        // into `build.assetsDir` and the client `assetFileNames` template so
+        // media `url(...)` references land under `<assetsDir>/media/`.
+        const resolvedAssetsDir = resolveAssetsDir(nextConfig.assetPrefix ?? "");
 
         const viteConfig: UserConfig = {
           // Disable Vite's default HTML serving - we handle all routing
@@ -1534,7 +1544,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // and any static file server can resolve
             // `<assetPrefix?>/_next/static/...` requests directly, and
             // misses naturally fall through as plain-text 404s.
-            assetsDir: resolveAssetsDir(nextConfig.assetPrefix ?? ""),
+            assetsDir: resolvedAssetsDir,
+            // Never inline `url(...)` assets (or imported assets) as `data:`
+            // URIs. Next.js routes every CSS `url(./foo.svg)` reference through
+            // webpack's `asset/resource` loader, which *always* emits a hashed
+            // file under `_next/static/media/` and rewrites the URL — it never
+            // inlines. Vite's default inlines assets below 4096 bytes, which
+            // diverges from Next.js and breaks suites that assert on the
+            // emitted media URL (e.g. app-dir/scss/url-global). Setting the
+            // threshold to 0 forces every asset to be emitted as a file.
+            // See https://github.com/cloudflare/vinext/issues/1450 and
+            // .nextjs-ref/packages/next/src/build/webpack/config/blocks/css/index.ts
+            assetsInlineLimit: 0,
             ...withBuildBundlerOptions(viteMajorVersion, {
               // Suppress "Module level directives cause errors when bundled"
               // warnings for "use client" / "use server" directives. Our shims
@@ -1608,7 +1629,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // manualChunks is set per-environment on the client env below
               // to avoid leaking into RSC/SSR environments.
               ...(!isSSR && !isMultiEnv
-                ? { output: getClientOutputConfigForVite(viteMajorVersion) }
+                ? { output: getClientOutputConfigForVite(viteMajorVersion, resolvedAssetsDir) }
                 : {}),
             }),
           },
@@ -1988,7 +2009,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ...(hasCloudflarePlugin ? { manifest: true } : {}),
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_APP_BROWSER_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfigForVite(viteMajorVersion, resolvedAssetsDir),
                   treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
                 }),
               },
@@ -2009,7 +2030,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ssrManifest: true,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_CLIENT_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfigForVite(viteMajorVersion, resolvedAssetsDir),
                   treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
                 }),
               },
@@ -2035,7 +2056,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ssrManifest: true,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_CLIENT_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfigForVite(viteMajorVersion, resolvedAssetsDir),
                   treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
                 }),
               },

--- a/tests/scss-url-asset.test.ts
+++ b/tests/scss-url-asset.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests that CSS/SCSS `url(...)` asset references are emitted as hashed
+ * files under `/_next/static/media/` rather than inlined as `data:` URIs.
+ *
+ * Next.js routes every `url(./foo.svg)` reference in a stylesheet through
+ * webpack's `asset/resource` loader, which *always* emits the asset to a
+ * hashed file under `_next/static/media/` and rewrites the `url()` to point
+ * at it — it never inlines as a data URI (see
+ * `.nextjs-ref/packages/next/src/build/webpack/config/blocks/css/index.ts`,
+ * the `type: 'asset/resource'` rule). The upstream SCSS suites assert exactly
+ * this:
+ *
+ *   url("/_next/static/media/dark.<HASH>.svg")
+ *
+ * Vite, by contrast, inlines assets smaller than `build.assetsInlineLimit`
+ * (4096 bytes by default) as `data:` URIs. A small `.svg` referenced from
+ * SCSS therefore came out as `url("data:image/svg+xml,...")`, diverging from
+ * Next.js and breaking the `app-dir/scss/url-global` and
+ * `app-dir/scss/url-global-partial` deploy-suite tests.
+ *
+ * vinext sets `build.assetsInlineLimit: 0` and an `assetFileNames` template
+ * routing media assets into the `media/` subdirectory so the emitted URL and
+ * on-disk layout match Next.js's `_next/static/media/<name>.<HASH>.<ext>`.
+ *
+ * Ported from Next.js:
+ *   test/e2e/app-dir/scss/url-global/url-global.test.ts
+ *   test/e2e/app-dir/scss/url-global-partial/url-global-partial.test.ts
+ *
+ * Closes: https://github.com/cloudflare/vinext/issues/1450
+ */
+
+import { describe, it, expect } from "vite-plus/test";
+import { build } from "vite-plus";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vinext from "../packages/vinext/src/index.js";
+
+// SCSS preprocessing requires the optional `sass` peer dependency. Skip the
+// suite when it is not installed (matches tests/scss.test.ts).
+let sassAvailable = false;
+try {
+  // @ts-ignore Optional peer dependency, not declared in this repo
+  await import("sass");
+  sassAvailable = true;
+} catch {
+  sassAvailable = false;
+}
+
+const describeIfSass = sassAvailable ? describe : describe.skip;
+
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+// A tiny inline SVG. At ~120 bytes it sits well under Vite's default 4096-byte
+// inline threshold, so without `assetsInlineLimit: 0` Vite would inline it as
+// a `data:` URI — the exact regression this test guards against.
+const DARK_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect fill="#222" width="1" height="1"/></svg>\n';
+
+async function makeFixture(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-scss-url-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const stylesDir = path.join(tmpDir, "styles");
+  await fs.mkdir(stylesDir, { recursive: true });
+  await fs.writeFile(path.join(stylesDir, "dark.svg"), DARK_SVG);
+  await fs.writeFile(
+    path.join(stylesDir, "global.scss"),
+    "$var: red;\n.red-text {\n  color: $var;\n  background-image: url('./dark.svg');\n}\n",
+  );
+
+  const pagesDir = path.join(tmpDir, "pages");
+  await fs.mkdir(pagesDir, { recursive: true });
+  await fs.writeFile(
+    path.join(pagesDir, "_app.tsx"),
+    'import "../styles/global.scss";\n' +
+      "export default function App({ Component, pageProps }: any) {\n" +
+      "  return <Component {...pageProps} />;\n" +
+      "}\n",
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.tsx"),
+    "export default function Home() {\n" +
+      '  return <div className="red-text">SCSS url() test</div>;\n' +
+      "}\n",
+  );
+
+  return tmpDir;
+}
+
+async function readAllFiles(dir: string): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const entries = await fs.readdir(dir, { withFileTypes: true, recursive: true });
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const parent =
+      (entry as { parentPath?: string; path?: string }).parentPath ??
+      (entry as { path?: string }).path ??
+      dir;
+    out.set(path.join(parent, entry.name), entry.name);
+  }
+  return out;
+}
+
+describeIfSass("SCSS url() asset emission", () => {
+  it("emits url() references as hashed files under _next/static/media/ (not data: URIs)", async () => {
+    const tmpDir = await makeFixture();
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-scss-url-out-"));
+    try {
+      const clientDir = path.join(outDir, "client");
+      await build({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ disableAppRouter: true })],
+        logLevel: "silent",
+        build: {
+          outDir: clientDir,
+          manifest: true,
+          ssrManifest: true,
+          rollupOptions: { input: "virtual:vinext-client-entry" },
+        },
+      });
+
+      const files = await readAllFiles(clientDir);
+
+      // Locate the compiled stylesheet.
+      const cssFiles = [...files.keys()].filter((p) => p.endsWith(".css"));
+      expect(cssFiles.length).toBeGreaterThan(0);
+      const allCss = (await Promise.all(cssFiles.map((p) => fs.readFile(p, "utf8")))).join("\n");
+
+      // The SVG must NOT be inlined as a data URI...
+      expect(allCss).not.toMatch(/url\(\s*["']?data:/);
+
+      // ...it must be rewritten to a `/_next/static/media/dark.<hash>.svg` URL.
+      expect(allCss).toMatch(
+        /url\(\s*["']?\/_next\/static\/media\/dark\.[A-Za-z0-9_-]+\.svg["']?\s*\)/,
+      );
+
+      // And the referenced asset must actually exist on disk under that path.
+      const mediaSvg = [...files.keys()].find(
+        (p) =>
+          /[/\\]_next[/\\]static[/\\]media[/\\]/.test(p) && /dark\.[A-Za-z0-9_-]+\.svg$/.test(p),
+      );
+      expect(mediaSvg, "expected emitted dark.<hash>.svg under _next/static/media/").toBeTruthy();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      await fs.rm(outDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Problem

Closes #1450.

When a CSS/SCSS file references an asset via `url(./foo.svg)`, vinext inlined it as a `data:` URI. Next.js routes every CSS `url()` reference through webpack's `asset/resource` loader, which **always** emits the asset to a hashed file under `_next/static/media/` and rewrites the URL — it never inlines (see `.nextjs-ref/packages/next/src/build/webpack/config/blocks/css/index.ts`, the `type: 'asset/resource'` rule).

vinext relied on Vite's default asset pipeline, which inlines any asset below `build.assetsInlineLimit` (4096 bytes) as a `data:` URI:

```
Expected pattern: /url\(".*\/_next\/static\/media\/dark.*\.svg/
Received: "url(\"data:image/svg+xml,...\")"
```

This broke the `app-dir/scss/url-global` and `app-dir/scss/url-global-partial` deploy-suite tests (~4 failures).

## Fix

- **`build.assetsInlineLimit: 0`** — every asset is emitted as a file, matching Next.js's `asset/resource` behaviour (never inline).
- **`assetFileNames` template** — media assets (images, fonts, video, audio) are routed into `<assetsDir>/media/` (`_next/static/media/<name>.<hash>.<ext>`), matching Next.js's layout. Stylesheets and other assets keep Vite's default naming at the top of `assetsDir`, so the client manifest and `<link>` injection are unchanged. Applied across all client build environments (standalone Pages Router, App Router, Cloudflare).

## Tests

Adds `tests/scss-url-asset.test.ts`: builds a Pages Router fixture importing an SCSS file with `background-image: url('./dark.svg')` and asserts the compiled stylesheet references `/_next/static/media/dark.<hash>.svg` (not a `data:` URI) and that the asset is emitted on disk. The test fails before the fix and passes after.

Verified locally: `scss-url-asset`, `scss`, `css-modules-data-urls`, `inline-css-build`, `pages-css-url-encoding`, `asset-prefix`, `font-google-build`, `ssr-css-assets`, `build-optimization`, `clean-build-output`, `standalone-build`, `deploy`.