### PR TITLE
fix(pages-router): cancel in-flight nav on gSSP/gSP data redirect (#1465)

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -79,6 +79,41 @@ async function renderIsrPassToStringAsync(element: React.ReactElement): Promise<
   );
 }
 
+/**
+ * Emit a `getServerSideProps` / `getStaticProps` `{ redirect }` result.
+ *
+ * For an HTML request we write a real HTTP redirect (`Location`). For a
+ * `_next/data` request we instead reply 200 with `__N_REDIRECT` /
+ * `__N_REDIRECT_STATUS` in pageProps so the client router re-dispatches a
+ * fresh client navigation (which supersedes the in-flight one) rather than
+ * the fetch transparently following an HTTP redirect to non-JSON HTML. This
+ * mirrors the production path in `pages-page-data.ts`
+ * (`buildPagesRedirectResponse`) and Next.js's `render.tsx` `__N_REDIRECT`
+ * handling. See AGENTS.md "dev and prod server parity".
+ */
+function writeGsspRedirect(
+  res: ServerResponse,
+  redirect: { destination: string; statusCode?: number; permanent?: boolean },
+  isDataReq: boolean,
+): void {
+  const status = redirect.statusCode ?? (redirect.permanent ? 308 : 307);
+  // Sanitize destination to prevent open redirect via protocol-relative URLs.
+  // Also normalize backslashes — browsers treat \ as / in URL contexts.
+  let dest = redirect.destination;
+  if (!dest.startsWith("http://") && !dest.startsWith("https://")) {
+    dest = dest.replace(/^[\\/]+/, "/");
+  }
+
+  if (isDataReq) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ pageProps: { __N_REDIRECT: dest, __N_REDIRECT_STATUS: status } }));
+    return;
+  }
+
+  res.writeHead(status, { Location: dest });
+  res.end();
+}
+
 /** Body placeholder used to split the document shell for streaming. */
 const STREAM_BODY_MARKER = "<!--VINEXT_STREAM_BODY-->";
 
@@ -582,18 +617,7 @@ export function createSSRHandler(
             pageProps = await Promise.resolve(result.props);
           }
           if (result && "redirect" in result) {
-            const { redirect } = result;
-            const status = redirect.statusCode ?? (redirect.permanent ? 308 : 307);
-            // Sanitize destination to prevent open redirect via protocol-relative URLs.
-            // Also normalize backslashes — browsers treat \ as / in URL contexts.
-            let dest = redirect.destination;
-            if (!dest.startsWith("http://") && !dest.startsWith("https://")) {
-              dest = dest.replace(/^[\\/]+/, "/");
-            }
-            res.writeHead(status, {
-              Location: dest,
-            });
-            res.end();
+            writeGsspRedirect(res, result.redirect, isDataReq);
             return;
           }
           if (result && "notFound" in result && result.notFound) {
@@ -893,18 +917,7 @@ export function createSSRHandler(
             pageProps = result.props;
           }
           if (result && "redirect" in result) {
-            const { redirect } = result;
-            const status = redirect.statusCode ?? (redirect.permanent ? 308 : 307);
-            // Sanitize destination to prevent open redirect via protocol-relative URLs.
-            // Also normalize backslashes — browsers treat \ as / in URL contexts.
-            let dest = redirect.destination;
-            if (!dest.startsWith("http://") && !dest.startsWith("https://")) {
-              dest = dest.replace(/^[\\/]+/, "/");
-            }
-            res.writeHead(status, {
-              Location: dest,
-            });
-            res.end();
+            writeGsspRedirect(res, result.redirect, isDataReq);
             return;
           }
           if (result && "notFound" in result && result.notFound) {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -12,6 +12,7 @@ import {
   type PagesI18nRenderContext,
 } from "./pages-page-response.js";
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
+import { buildNextDataJsonResponse } from "./pages-data-route.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 
 type PagesRedirectResult = {
@@ -220,6 +221,52 @@ function buildPagesDataNotFoundResponse(): Response {
 
 function resolvePagesRedirectStatus(redirect: PagesRedirectResult): number {
   return redirect.statusCode != null ? redirect.statusCode : redirect.permanent ? 308 : 307;
+}
+
+/**
+ * Build the response for a `getServerSideProps` / `getStaticProps`
+ * `{ redirect }` result.
+ *
+ * For an HTML page request we emit a real HTTP redirect (`Location` header) so
+ * a hard navigation lands on the destination.
+ *
+ * For a `/_next/data/<buildId>/<page>.json` request (a client-side navigation)
+ * we must NOT emit an HTTP redirect: the client's `fetch()` would transparently
+ * follow it to the destination's HTML, which is not a valid data envelope and
+ * would force a hard reload (and console error noise). Instead we mirror
+ * Next.js and return a 200 JSON envelope carrying `__N_REDIRECT` /
+ * `__N_REDIRECT_STATUS` inside `pageProps`. The client router detects these
+ * markers and performs a fresh client navigation to the destination, which
+ * supersedes (cancels) the in-flight navigation.
+ *
+ * Ported from Next.js: `packages/next/src/server/render.tsx` — the
+ * `__N_REDIRECT` / `__N_REDIRECT_STATUS` props assignment for gSSP/gSP
+ * redirects (search `__N_REDIRECT`), consumed in
+ * `packages/next/src/shared/lib/router/router.ts` (`pageProps.__N_REDIRECT`).
+ */
+function buildPagesRedirectResponse(
+  redirect: PagesRedirectResult,
+  options: Pick<
+    ResolvePagesPageDataOptions,
+    "isDataReq" | "sanitizeDestination" | "safeJsonStringify"
+  >,
+): Response {
+  const destination = options.sanitizeDestination(redirect.destination);
+
+  if (options.isDataReq) {
+    return buildNextDataJsonResponse(
+      {
+        __N_REDIRECT: destination,
+        __N_REDIRECT_STATUS: resolvePagesRedirectStatus(redirect),
+      },
+      options.safeJsonStringify,
+    );
+  }
+
+  return new Response(null, {
+    status: resolvePagesRedirectStatus(redirect),
+    headers: { Location: destination },
+  });
 }
 
 /**
@@ -439,10 +486,7 @@ export async function resolvePagesPageData(
     if (result?.redirect) {
       return {
         kind: "response",
-        response: new Response(null, {
-          status: resolvePagesRedirectStatus(result.redirect),
-          headers: { Location: options.sanitizeDestination(result.redirect.destination) },
-        }),
+        response: buildPagesRedirectResponse(result.redirect, options),
       };
     }
 
@@ -597,10 +641,7 @@ export async function resolvePagesPageData(
     if (result?.redirect) {
       return {
         kind: "response",
-        response: new Response(null, {
-          status: resolvePagesRedirectStatus(result.redirect),
-          headers: { Location: options.sanitizeDestination(result.redirect.destination) },
-        }),
+        response: buildPagesRedirectResponse(result.redirect, options),
       };
     }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -806,14 +806,13 @@ async function resolveMiddlewareDataRedirect(
 function handleDataRedirect(
   destination: string,
   redirectBasePath: unknown,
-  fallbackUrl: string,
   mode: "push" | "replace" = "push",
 ): void {
   const isInternal = destination.startsWith("/") && redirectBasePath !== false;
   if (!isInternal) {
-    // External or basePath-less redirect — hard navigate, mirroring Next.js's
-    // handleHardNavigation fallback.
-    scheduleHardNavigationAndThrow(fallbackUrl, "Navigation redirected externally");
+    // External or basePath-less redirect — hard navigate to the redirect
+    // destination, mirroring Next.js's `handleHardNavigation({ url: destination })`.
+    scheduleHardNavigationAndThrow(destination, "Navigation redirected externally");
   }
 
   // Re-dispatch as a fresh navigation. `locale: false` matches Next.js, which
@@ -908,7 +907,7 @@ async function navigateClientData(
   // packages/next/src/shared/lib/router/router.ts (`this.change(method, ...)`).
   const redirectDestination = pageProps.__N_REDIRECT;
   if (typeof redirectDestination === "string") {
-    handleDataRedirect(redirectDestination, pageProps.__N_REDIRECT_BASE_PATH, url, options.mode);
+    handleDataRedirect(redirectDestination, pageProps.__N_REDIRECT_BASE_PATH, options.mode);
     throw new NavigationCancelledError(url);
   }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -655,6 +655,13 @@ function scheduleHardNavigationAndThrow(url: string, message: string): never {
 
 type NavigateClientOptions = {
   allowNotFoundResponse?: boolean;
+  /**
+   * The history mode of the originating navigation. Used when a gSSP/gSP data
+   * response carries a `__N_REDIRECT` marker so the re-entrant navigation to
+   * the redirect destination preserves push-vs-replace semantics, matching
+   * Next.js's `this.change(method, ...)` re-dispatch.
+   */
+  mode?: "push" | "replace";
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -782,6 +789,39 @@ async function resolveMiddlewareDataRedirect(
 }
 
 /**
+ * React to a gSSP/gSP `__N_REDIRECT` marker returned on a client data
+ * navigation.
+ *
+ * Internal destinations (absolute paths, unless the redirect opted out of
+ * basePath via `__N_REDIRECT_BASE_PATH === false`) are followed with a fresh
+ * client-side navigation that preserves the originating push/replace mode. The
+ * fresh navigation increments the navigation id, so the navigation that
+ * produced this redirect is superseded and never commits the intermediate
+ * page. External (or non-absolute) destinations fall back to a hard navigation.
+ *
+ * Ported from Next.js: packages/next/src/shared/lib/router/router.ts
+ * (`pageProps.__N_REDIRECT` handling — internal `this.change` vs
+ * `handleHardNavigation`).
+ */
+function handleDataRedirect(
+  destination: string,
+  redirectBasePath: unknown,
+  fallbackUrl: string,
+  mode: "push" | "replace" = "push",
+): void {
+  const isInternal = destination.startsWith("/") && redirectBasePath !== false;
+  if (!isInternal) {
+    // External or basePath-less redirect — hard navigate, mirroring Next.js's
+    // handleHardNavigation fallback.
+    scheduleHardNavigationAndThrow(fallbackUrl, "Navigation redirected externally");
+  }
+
+  // Re-dispatch as a fresh navigation. `locale: false` matches Next.js, which
+  // does not re-apply the locale prefix to a redirect destination.
+  void performNavigation(destination, undefined, { locale: false }, mode);
+}
+
+/**
  * Perform client-side navigation via the `/_next/data/<id>/<page>.json`
  * endpoint. Used when `__VINEXT_PAGE_LOADERS__` has a matching code-split
  * loader for the target pattern (the prod hot path). Falls back to the
@@ -800,6 +840,7 @@ async function navigateClientData(
   controller: AbortController,
   navId: number,
   assertStillCurrent: () => void,
+  options: NavigateClientOptions = {},
 ): Promise<void> {
   const root = window.__VINEXT_ROOT__;
   if (!root) {
@@ -856,6 +897,20 @@ async function navigateClientData(
 
   const pageProps: Record<string, unknown> =
     body.pageProps && typeof body.pageProps === "object" ? body.pageProps : {};
+
+  // gSSP/gSP redirect marker. When getServerSideProps/getStaticProps returns
+  // `{ redirect }`, the data endpoint replies 200 with `__N_REDIRECT` /
+  // `__N_REDIRECT_STATUS` inside pageProps (rather than an HTTP redirect, which
+  // fetch would transparently follow to non-JSON HTML). Re-enter a fresh
+  // navigation to the destination — this increments the navigation id, which
+  // supersedes (cancels) the current navigation so the intermediate page is
+  // never committed. Mirrors Next.js's `pageProps.__N_REDIRECT` handling in
+  // packages/next/src/shared/lib/router/router.ts (`this.change(method, ...)`).
+  const redirectDestination = pageProps.__N_REDIRECT;
+  if (typeof redirectDestination === "string") {
+    handleDataRedirect(redirectDestination, pageProps.__N_REDIRECT_BASE_PATH, url, options.mode);
+    throw new NavigationCancelledError(url);
+  }
 
   // Load the page module via the registered code-split loader. Vite has
   // already split each page into its own chunk; the loader is just the
@@ -1200,7 +1255,14 @@ async function navigateClient(
       }
 
       if (dataTarget) {
-        await navigateClientData(browserUrl, dataTarget, controller, navId, assertStillCurrent);
+        await navigateClientData(
+          browserUrl,
+          dataTarget,
+          controller,
+          navId,
+          assertStillCurrent,
+          options,
+        );
       } else {
         await navigateClientHtml(
           browserUrl,
@@ -1413,8 +1475,8 @@ async function performNavigation(
   const errorRouteHtmlFetchUrl = resolvePagesErrorHtmlFetchUrl(url, navigationLocale);
   const htmlFetchUrl = errorRouteHtmlFetchUrl ?? getPagesHtmlFetchUrl(full, navigationLocale);
   const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
-    ? { allowNotFoundResponse: true }
-    : {};
+    ? { allowNotFoundResponse: true, mode }
+    : { mode };
   const shallow = options?.shallow ?? false;
   const doScroll = options?.scroll !== false;
 

--- a/tests/e2e/pages-router/gssp-redirect-cancellation.spec.ts
+++ b/tests/e2e/pages-router/gssp-redirect-cancellation.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "../fixtures";
+import { waitForHydration } from "../helpers";
+
+// Ported from Next.js: test/e2e/getserversideprops/test/index.test.ts
+// "should not trigger an error when a data request is cancelled due to another
+// navigation"
+// https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/test/index.test.ts
+//
+// Regression test for vinext#1465: when a getServerSideProps/getStaticProps
+// data response carries a redirect, the in-flight client navigation to the
+// intermediate page must be cancelled and the navigation must land on the
+// redirect destination — without a hard reload or console errors.
+
+const BASE = "http://localhost:4173";
+
+test.describe("Pages Router gSSP redirect cancellation (#1465)", () => {
+  // The consoleErrors fixture auto-fails the test on any console error, which
+  // is exactly what the upstream Next.js test asserts.
+  test("Link click to a gSSP-redirect page lands on the destination, not the intermediate page", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await page.goto(`${BASE}/gssp-redirect-test`);
+    await expect(page.locator("h1")).toHaveText("gSSP Redirect Test");
+    await waitForHydration(page);
+
+    // Marker to detect a full page reload (a reload wipes it).
+    await page.evaluate(() => {
+      (window as any).__NAV_MARKER__ = true;
+    });
+
+    await page.click('[data-testid="link-redirect"]');
+
+    // Must land on the redirect destination ("a normal page"), never commit
+    // the intermediate "Redirect Page".
+    await expect(page.locator('[data-testid="normal-text"]')).toHaveText("a normal page");
+    expect(page.url()).toBe(`${BASE}/gssp-redirect-target`);
+    await expect(page.locator('[data-testid="redirect-page"]')).toHaveCount(0);
+
+    // No full reload — the gSSP redirect resolves via a client navigation.
+    const marker = await page.evaluate(() => (window as any).__NAV_MARKER__);
+    expect(marker).toBe(true);
+
+    void consoleErrors;
+  });
+
+  test("router.push to a gSSP-redirect page lands on the destination", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await page.goto(`${BASE}/gssp-redirect-test`);
+    await expect(page.locator("h1")).toHaveText("gSSP Redirect Test");
+    await waitForHydration(page);
+
+    await page.evaluate(() => {
+      (window as any).__NAV_MARKER__ = true;
+    });
+
+    await page.click('[data-testid="push-redirect"]');
+
+    await expect(page.locator('[data-testid="normal-text"]')).toHaveText("a normal page");
+    expect(page.url()).toBe(`${BASE}/gssp-redirect-target`);
+    await expect(page.locator('[data-testid="redirect-page"]')).toHaveCount(0);
+
+    const marker = await page.evaluate(() => (window as any).__NAV_MARKER__);
+    expect(marker).toBe(true);
+
+    void consoleErrors;
+  });
+});

--- a/tests/fixtures/pages-basic/pages/gssp-redirect-external.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-redirect-external.tsx
@@ -1,0 +1,17 @@
+// A getServerSideProps page that redirects to an EXTERNAL destination. On a
+// client `_next/data` navigation the destination is carried verbatim in
+// `pageProps.__N_REDIRECT`; the client router hard-navigates to it (it is not
+// an internal path), so the destination must be preserved exactly.
+
+export default function GsspRedirectExternalPage() {
+  return <h1 data-testid="redirect-page">External Redirect Page</h1>;
+}
+
+export async function getServerSideProps() {
+  return {
+    redirect: {
+      destination: "https://example.com/landing",
+      permanent: false,
+    },
+  };
+}

--- a/tests/fixtures/pages-basic/pages/gssp-redirect-target.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-redirect-target.tsx
@@ -1,0 +1,7 @@
+// Destination of /gssp-redirect's getServerSideProps redirect. The cancellation
+// test asserts navigation lands here ("a normal page") instead of committing
+// the intermediate Redirect Page.
+
+export default function GsspRedirectTargetPage() {
+  return <p data-testid="normal-text">a normal page</p>;
+}

--- a/tests/fixtures/pages-basic/pages/gssp-redirect-test.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-redirect-test.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import Router from "next/router";
+
+// Launch page for the gSSP-redirect cancellation test. Offers two ways to
+// trigger the navigation to /gssp-redirect (which redirects to
+// /gssp-redirect-target via getServerSideProps): a Link click and a
+// router.push, mirroring the upstream Next.js test that clicks a link to a
+// page whose data request resolves to a redirect.
+
+export default function GsspRedirectTestPage() {
+  return (
+    <div>
+      <h1>gSSP Redirect Test</h1>
+      <Link href="/gssp-redirect" data-testid="link-redirect">
+        Go to redirect page (link)
+      </Link>
+      <button data-testid="push-redirect" onClick={() => Router.push("/gssp-redirect")}>
+        Go to redirect page (push)
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/gssp-redirect.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-redirect.tsx
@@ -1,0 +1,24 @@
+// A getServerSideProps page that always redirects. On a client-side navigation
+// the data endpoint replies 200 with `pageProps.__N_REDIRECT`, and the client
+// router re-enters a fresh navigation to the destination — which supersedes
+// (cancels) this navigation so this page never commits.
+//
+// Mirrors Next.js: test/e2e/getserversideprops/test/index.test.ts
+// "should not trigger an error when a data request is cancelled due to another
+// navigation".
+
+export default function GsspRedirectPage() {
+  return <h1 data-testid="redirect-page">Redirect Page</h1>;
+}
+
+export async function getServerSideProps() {
+  // Small delay so the navigation is observably in-flight, matching the
+  // "slow nav cancelled by a redirect" shape of the upstream test.
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  return {
+    redirect: {
+      destination: "/gssp-redirect-target",
+      permanent: false,
+    },
+  };
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -549,6 +549,40 @@ describe("Pages Router integration", () => {
     expect(html).toContain("app-wrapper");
   });
 
+  // Regression for #1465: a getServerSideProps `{ redirect }` on an HTML
+  // request emits a real HTTP redirect (so a hard navigation lands on the
+  // destination).
+  it("getServerSideProps returning redirect emits an HTTP redirect on HTML requests", async () => {
+    const res = await fetch(`${baseUrl}/gssp-redirect`, { redirect: "manual" });
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("/gssp-redirect-target");
+  });
+
+  // Regression for #1465: a getServerSideProps `{ redirect }` on a `_next/data`
+  // request must NOT emit an HTTP redirect (fetch would follow it to non-JSON
+  // HTML). Instead Next.js returns a 200 JSON envelope carrying `__N_REDIRECT`
+  // / `__N_REDIRECT_STATUS` in pageProps, which the client router uses to
+  // re-dispatch a fresh navigation (superseding the in-flight one). See
+  // packages/next/src/server/render.tsx (`__N_REDIRECT`).
+  it("getServerSideProps redirect returns __N_REDIRECT JSON on _next/data requests", async () => {
+    // The dev `_next/data` endpoint matches the build id
+    // `nextConfig.buildId ?? __VINEXT_BUILD_ID ?? "development"`; this fixture's
+    // next.config.mjs sets `generateBuildId: () => "test-build-id"` (see
+    // index.ts `_next/data` normalization).
+    const res = await fetch(`${baseUrl}/_next/data/test-build-id/gssp-redirect.json`, {
+      headers: { Accept: "application/json", "x-nextjs-data": "1" },
+      redirect: "manual",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("location")).toBeNull();
+
+    const body = (await res.json()) as { pageProps?: Record<string, unknown> };
+    expect(body.pageProps?.__N_REDIRECT).toBe("/gssp-redirect-target");
+    expect(body.pageProps?.__N_REDIRECT_STATUS).toBe(307);
+  });
+
   // Regression for #1458: when getServerSideProps throws, dev (and prod) must
   // render the user's custom pages/500.tsx with status 500 rather than the
   // plain "Internal Server Error" text. Mirrors Next.js test/e2e/getserversideprops

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -583,6 +583,21 @@ describe("Pages Router integration", () => {
     expect(body.pageProps?.__N_REDIRECT_STATUS).toBe(307);
   });
 
+  // The data envelope must carry an EXTERNAL redirect destination verbatim so
+  // the client router hard-navigates to the right place (the client must not
+  // fall back to the originating page URL — that would loop). See
+  // handleDataRedirect() in shims/router.ts.
+  it("preserves an external destination in __N_REDIRECT on _next/data requests", async () => {
+    const res = await fetch(`${baseUrl}/_next/data/test-build-id/gssp-redirect-external.json`, {
+      headers: { Accept: "application/json", "x-nextjs-data": "1" },
+      redirect: "manual",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pageProps?: Record<string, unknown> };
+    expect(body.pageProps?.__N_REDIRECT).toBe("https://example.com/landing");
+  });
+
   // Regression for #1458: when getServerSideProps throws, dev (and prod) must
   // render the user's custom pages/500.tsx with status 500 rather than the
   // plain "Internal Server Error" text. Mirrors Next.js test/e2e/getserversideprops


### PR DESCRIPTION
## Summary

Fixes #1465 — Pages Router navigation cancellation: when a slow navigation is superseded by a redirect, vinext ended up on the wrong page (e.g. `Redirect Page` instead of `a normal page`).

The root cause was the `getServerSideProps`/`getStaticProps` `{ redirect }` path for **client-side `_next/data` navigations**. vinext emitted a real HTTP redirect for data requests. The client's `fetch()` transparently follows it to the destination's **HTML** (not a valid `{ pageProps }` envelope), which forced a hard reload (with console errors) and left navigation on the wrong page.

This mirrors how Next.js handles it: for a data request, the server replies **200** with `__N_REDIRECT` / `__N_REDIRECT_STATUS` in `pageProps`, and the client router re-dispatches a **fresh** client navigation to the destination. That fresh navigation increments the navigation id and supersedes (cancels) the in-flight one via the existing `_navigationId` / `assertStillCurrent()` / `AbortController` machinery — so the intermediate page never commits.

## Changes

- **Server (prod):** `buildPagesRedirectResponse()` in `pages-page-data.ts` — for `isDataReq`, emit `{ pageProps: { __N_REDIRECT, __N_REDIRECT_STATUS } }` (200 JSON); otherwise a real HTTP redirect.
- **Server (dev):** `writeGsspRedirect()` in `dev-server.ts` — same `isDataReq` branch, applied to both the gSSP and gSP redirect blocks (dev/prod parity per AGENTS.md).
- **Client:** `navigateClientData()` in `shims/router.ts` detects `pageProps.__N_REDIRECT` and calls `handleDataRedirect()`, which re-enters `performNavigation()` for the destination (preserving push/replace mode, `locale: false`) then throws `NavigationCancelledError` so the superseded navigation unwinds cleanly. Internal-vs-external routing mirrors Next.js (`this.change` vs `handleHardNavigation`).

HTML page requests are unchanged (still a real HTTP redirect).

## Tests

- `tests/pages-router.test.ts` (vitest): gSSP redirect emits an HTTP 307 on HTML requests, and a 200 `__N_REDIRECT` JSON envelope (no `Location`) on `_next/data` requests.
- `tests/e2e/pages-router/gssp-redirect-cancellation.spec.ts` (Playwright): clicking a Link / `router.push` to a gSSP-redirect page lands on the destination (`a normal page`), never commits the intermediate `Redirect Page`, does not full-reload, and produces no console errors (the `consoleErrors` fixture). Ported from Next.js `test/e2e/getserversideprops`.
- New fixture pages: `gssp-redirect.tsx`, `gssp-redirect-target.tsx`, `gssp-redirect-test.tsx`.

## Verification

Ran locally (targeted):
- `vp test run tests/pages-router.test.ts -t "Pages Router integration"` → 116 passed
- `vp test run tests/pages-data-route.test.ts tests/pages-data-url.test.ts` → 39 passed
- `PLAYWRIGHT_PROJECT=pages-router playwright test --grep "gSSP redirect cancellation"` → 2 passed