### PR TITLE
fix: reject server-only imports from client-reachable modules

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -169,6 +169,61 @@ function createRscCompatibilityId(nextConfig: ResolvedNextConfig): string {
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
 
+function hasServerOnlyMarkerImport(code: string): boolean {
+  if (!code.includes("server-only")) return false;
+
+  let ast: ReturnType<typeof parseAst>;
+  try {
+    ast = parseAst(code);
+  } catch {
+    return false;
+  }
+
+  function walk(node: ASTNode | ASTNode[] | null | undefined): boolean {
+    if (!node) return false;
+    if (Array.isArray(node)) return node.some((child) => walk(child));
+    if (typeof node !== "object") return false;
+
+    if (node.type === "ImportDeclaration") {
+      const source = (node as ASTNode & { source?: { value?: unknown } }).source?.value;
+      if (source === "server-only") return true;
+    }
+
+    if (node.type === "CallExpression") {
+      const call = node as ASTNode & {
+        callee?: { type?: string; name?: string };
+        arguments?: Array<{ type?: string; value?: unknown }>;
+      };
+      if (
+        call.callee?.type === "Identifier" &&
+        call.callee.name === "require" &&
+        call.arguments?.[0]?.type === "Literal" &&
+        call.arguments[0].value === "server-only"
+      ) {
+        return true;
+      }
+    }
+
+    for (const key of Object.keys(node)) {
+      if (key === "type" || key === "start" || key === "end" || key === "loc" || key === "parent") {
+        continue;
+      }
+      const value = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        if (value.some((child) => child && typeof child === "object" && walk(child as ASTNode))) {
+          return true;
+        }
+      } else if (value && typeof value === "object" && "type" in value) {
+        if (walk(value as ASTNode)) return true;
+      }
+    }
+
+    return false;
+  }
+
+  return walk(ast.body);
+}
+
 const __dirname = import.meta.dirname;
 type VitePluginReactModule = typeof import("@vitejs/plugin-react");
 
@@ -3502,6 +3557,30 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             void handlePagesMiddleware(req, res, next);
           });
         };
+      },
+    },
+    // Match Next.js's server-only boundary for browser/client graphs. The
+    // marker is valid in App Router Server Components and middleware/server
+    // targets, but importing it from client-reachable code (including Pages
+    // Router browser bundles) must fail instead of silently resolving to the
+    // empty shim.
+    //
+    // Ported behavior from Next.js:
+    // test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+    // packages/next/src/build/webpack-config.ts (server-only/client-only layers)
+    {
+      name: "vinext:validate-server-only-client-imports",
+      transform: {
+        filter: { id: /\.(tsx?|jsx?|mjs)$/, code: "server-only" },
+        handler(code, id) {
+          if (this.environment?.name !== "client") return null;
+          if (id.startsWith("\0")) return null;
+          if (!hasServerOnlyMarkerImport(code)) return null;
+
+          throw new Error(
+            `You're importing a module that depends on "server-only". This API is only available in Server Components in the App Router, but this module is reachable from a client bundle.`,
+          );
+        },
       },
     },
     // Strip server-only data-fetching exports (getServerSideProps, getStaticProps,

--- a/tests/middleware-server-only.test.ts
+++ b/tests/middleware-server-only.test.ts
@@ -145,6 +145,50 @@ export const config = { matcher: ["/"] };
   return { tmpDir };
 }
 
+async function buildPagesClientServerOnlyViolationFixture(): Promise<void> {
+  const workspaceRoot = path.resolve(import.meta.dirname, "..");
+  const workspaceNodeModules = path.join(workspaceRoot, "node_modules");
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-server-only-"));
+
+  await writeFile(
+    path.join(tmpDir, "pages", "index.tsx"),
+    `import Comp from "../components/Comp";
+
+export default function Page() {
+  return <Comp />;
+}
+`,
+  );
+  await writeFile(
+    path.join(tmpDir, "components", "Comp.tsx"),
+    `import "server-only";
+
+export default function Comp() {
+  return <p>hello world</p>;
+}
+`,
+  );
+
+  await fsp.symlink(workspaceNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+  const { default: vinext } = await import(
+    pathToFileURL(path.join(workspaceRoot, "packages/vinext/src/index.ts")).href
+  );
+  const { createBuilder } = await import("vite");
+  const rscOutDir = path.join(tmpDir, "dist", "server");
+  const ssrOutDir = path.join(tmpDir, "dist", "server", "ssr");
+  const clientOutDir = path.join(tmpDir, "dist", "client");
+
+  const builder = await createBuilder({
+    root: tmpDir,
+    configFile: false,
+    plugins: [vinext({ appDir: tmpDir, rscOutDir, ssrOutDir, clientOutDir })],
+    logLevel: "error",
+  });
+
+  await builder.buildApp();
+}
+
 describe("middleware can import server-only", () => {
   let tmpDir: string;
 
@@ -215,5 +259,15 @@ describe("middleware can import server-only", () => {
       found.some(Boolean),
       "expected lib/auth's __AUTH_TAG sentinel to appear in at least one server artifact",
     ).toBe(true);
+  });
+});
+
+describe("Pages Router client builds reject server-only", () => {
+  it("errors when a Pages client graph imports server-only", async () => {
+    // Ported from Next.js: test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+    await expect(buildPagesClientServerOnlyViolationFixture()).rejects.toThrow(
+      /server-only.*Server Components in the App Router/s,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Reject `server-only` imports from modules reachable by client/browser builds, while preserving valid middleware and server-side usage.

## Details

Next.js treats `server-only` as an environment boundary marker:
- allowed from App Router Server Components
- allowed from middleware/server targets
- rejected from client-reachable modules, including Pages Router browser graphs

Vinext already had middleware-specific handling so middleware can import `server-only`. This PR adds the complementary client-environment validation so browser-reachable modules fail instead of resolving the empty shim.

The check is AST-based to avoid matching comments or string literals.

## References

Ported behavior from Next.js:
- `test/development/acceptance/server-component-compiler-errors-in-pages.test.ts`
- `packages/next/src/build/webpack-config.ts` server-only/client-only layer rules

## Tests

Updated `tests/middleware-server-only.test.ts`:
- existing middleware import coverage still passes
- new Pages Router client graph fixture rejects `server-only` imports