### PR TITLE
fix: include i18n context in Pages ISR cache keys

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -617,6 +617,14 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
     ? (localeInfo.domainLocale ? localeInfo.domainLocale.defaultLocale : i18nConfig.defaultLocale)
     : undefined;
   const domainLocales = i18nConfig ? i18nConfig.domains : undefined;
+  const i18nCacheVariant = i18nConfig
+    ? (localeInfo.domainLocale
+      ? "domain:" + String(localeInfo.domainLocale.domain).toLowerCase()
+      : "locale:" + String(locale))
+    : null;
+  const pageIsrCacheKey = i18nCacheVariant
+    ? (router, pathname) => isrCacheKey(router, pathname + "::i18n=" + encodeURIComponent(i18nCacheVariant))
+    : isrCacheKey;
 
   if (localeInfo.redirectUrl) {
     return new Response(null, { status: 307, headers: { Location: localeInfo.redirectUrl } });
@@ -769,7 +777,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
           defaultLocale: currentDefaultLocale,
           domainLocales: domainLocales,
         },
-        isrCacheKey,
+        isrCacheKey: pageIsrCacheKey,
         isrGet,
         isrSet,
         expireSeconds: vinextConfig.expireTime,
@@ -926,7 +934,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
         getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
         clientTraceMetadata: vinextConfig.clientTraceMetadata,
         gsspRes,
-        isrCacheKey,
+        isrCacheKey: pageIsrCacheKey,
         expireSeconds: vinextConfig.expireTime,
         isrRevalidateSeconds,
         isrSet,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -323,6 +323,7 @@ export function createSSRHandler(
     let locale: string | undefined;
     let localeStrippedUrl = url;
     let currentDefaultLocale: string | undefined;
+    let currentDomainLocaleDomain: string | undefined;
     const domainLocales = i18nConfig?.domains;
 
     if (i18nConfig) {
@@ -337,6 +338,7 @@ export function createSSRHandler(
       locale = resolved.locale;
       localeStrippedUrl = resolved.url;
       currentDefaultLocale = resolved.domainLocale?.defaultLocale ?? i18nConfig.defaultLocale;
+      currentDomainLocaleDomain = resolved.domainLocale?.domain;
 
       if (resolved.redirectUrl) {
         res.writeHead(307, { Location: resolved.redirectUrl });
@@ -344,6 +346,20 @@ export function createSSRHandler(
         return;
       }
     }
+
+    const i18nCacheVariant = i18nConfig
+      ? currentDomainLocaleDomain
+        ? "domain:" + currentDomainLocaleDomain.toLowerCase()
+        : "locale:" + String(locale)
+      : null;
+    const pagesIsrCacheKey = i18nCacheVariant
+      ? (pathname: string) =>
+          isrCacheKey(
+            "pages",
+            pathname + "::i18n=" + encodeURIComponent(i18nCacheVariant),
+            process.env.__VINEXT_BUILD_ID,
+          )
+      : (pathname: string) => isrCacheKey("pages", pathname, process.env.__VINEXT_BUILD_ID);
 
     const match = matchRoute(localeStrippedUrl, routes);
 
@@ -687,13 +703,7 @@ export function createSSRHandler(
 
         if (typeof pageModule.getStaticProps === "function" && !isFallbackRender) {
           // Check ISR cache before calling getStaticProps
-          const cacheKey = isrCacheKey(
-            "pages",
-            url.split("?")[0],
-            // __VINEXT_BUILD_ID is a compile-time define — undefined in dev,
-            // which is fine: dev doesn't need cross-deploy cache isolation.
-            process.env.__VINEXT_BUILD_ID,
-          );
+          const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
           const cached = await isrGet(cacheKey);
 
           if (
@@ -1220,13 +1230,7 @@ hydrate();
             withScriptNonce(isrElement, scriptNonce),
           );
           const isrHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${isrBodyHtml}</div>${allScripts}</body></html>`;
-          const cacheKey = isrCacheKey(
-            "pages",
-            url.split("?")[0],
-            // __VINEXT_BUILD_ID is a compile-time define — undefined in dev,
-            // which is fine: dev doesn't need cross-deploy cache isolation.
-            process.env.__VINEXT_BUILD_ID,
-          );
+          const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
           await isrSet(cacheKey, buildPagesCacheValue(isrHtml, pageProps), isrRevalidateSeconds);
           setRevalidateDuration(cacheKey, isrRevalidateSeconds);
         }

--- a/tests/fixtures/pages-i18n-domains/pages/isr-about.tsx
+++ b/tests/fixtures/pages-i18n-domains/pages/isr-about.tsx
@@ -1,0 +1,21 @@
+export function getStaticProps({ locale, defaultLocale }) {
+  return {
+    props: {
+      locale,
+      defaultLocale,
+      renderedAt: Date.now(),
+    },
+    revalidate: 60,
+  };
+}
+
+export default function IsrAbout({ locale, defaultLocale, renderedAt }) {
+  return (
+    <main>
+      <h1>ISR About</h1>
+      <p id="locale">{locale}</p>
+      <p id="defaultLocale">{defaultLocale}</p>
+      <p id="renderedAt">{renderedAt}</p>
+    </main>
+  );
+}

--- a/tests/pages-i18n-prod.test.ts
+++ b/tests/pages-i18n-prod.test.ts
@@ -145,6 +145,26 @@ describe("Pages i18n domain routing (production)", () => {
     );
   });
 
+  it("keys Pages ISR entries by i18n domain context", async () => {
+    const fr = await requestNodeServerWithHost(prodPort, "/isr-about", "example.fr");
+    expect(fr.status).toBe(200);
+    expect(fr.headers["x-vinext-cache"]).toBe("MISS");
+    expect(fr.body).toContain('<p id="locale">fr</p>');
+    expect(fr.body).toContain('<p id="defaultLocale">fr</p>');
+
+    const en = await requestNodeServerWithHost(prodPort, "/isr-about", "example.com");
+    expect(en.status).toBe(200);
+    expect(en.headers["x-vinext-cache"]).toBe("MISS");
+    expect(en.body).toContain('<p id="locale">en</p>');
+    expect(en.body).toContain('<p id="defaultLocale">en</p>');
+    expect(en.body).not.toContain('<p id="locale">fr</p>');
+
+    const enHit = await requestNodeServerWithHost(prodPort, "/isr-about", "example.com");
+    expect(enHit.status).toBe(200);
+    expect(enHit.headers["x-vinext-cache"]).toBe("HIT");
+    expect(enHit.body).toContain('<p id="locale">en</p>');
+  });
+
   // Issue #1336 item 3: locale prefix must be stripped before API route matching.
   //
   // Ported from Next.js: test/e2e/middleware-redirects/test/index.test.ts


### PR DESCRIPTION
## Summary

Pages Router ISR cache keys now include the active i18n context so domain-localized pages do not share cache entries for the same pathname.

## Details

Pages ISR entries were keyed only by pathname. With i18n domain routing, the same pathname can render different content depending on the matched domain and default locale.

This change adds an i18n cache variant when i18n is configured:
- `domain:<domain>` for matched domain-locale requests
- `locale:<locale>` otherwise

The variant is only used in the cache key. It does not change the visible route URL or page props.

## Tests

Adds a Pages i18n production fixture page with `getStaticProps` + `revalidate` and verifies:
- `example.fr /isr-about` renders and caches `fr`
- `example.com /isr-about` renders and caches `en`
- the second `example.com` request is a HIT for the `en` cache entry