### PR TITLE
fix: bound default memory cache size with LRU eviction

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -129,6 +129,8 @@ type AppRouterConfig = {
   assetPrefix?: string;
   /** Route-level expire fallback in seconds for ISR entries with numeric revalidate. */
   expireTime?: number;
+  /** Maximum in-memory cache size in bytes. 0 disables the default memory cache. */
+  cacheMaxMemorySize?: number;
   /** Inline app CSS into production HTML (from experimental.inlineCss). */
   inlineCss?: boolean;
   /** Internationalization routing config for middleware matcher locale handling. */
@@ -186,6 +188,7 @@ export function generateRscEntry(
   const clientTraceMetadata = config?.clientTraceMetadata;
   const assetPrefix = config?.assetPrefix ?? "";
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
+  const cacheMaxMemorySize = config?.cacheMaxMemorySize;
   const inlineCss = config?.inlineCss === true;
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
@@ -234,6 +237,7 @@ import { createRscRenderer } from ${JSON.stringify(rscStreamHintsPath)};
 const renderToReadableStream = createRscRenderer(_renderToReadableStream);
 import { createElement } from "react";
 import { getNavigationContext as _getNavigationContext } from "next/navigation";
+import { configureMemoryCacheHandler as __configureMemoryCacheHandler } from "next/cache";
 import { headersContextFromRequest, getDraftModeCookieHeader, getAndClearPendingCookies, consumeDynamicUsage, consumeInvalidDynamicUsageError, setHeadersAccessPhase } from "next/headers";
 import { mergeMetadata, resolveModuleMetadata, mergeViewport, resolveModuleViewport } from "vinext/metadata";
 ${middlewarePath ? `import * as middlewareModule from ${JSON.stringify(normalizePathSeparators(middlewarePath))};` : ""}
@@ -319,6 +323,8 @@ ${hasPagesDir ? `// Pages Router routes are loaded lazily from the SSR environme
 // so per-route dispatch can opt into suppression via .run(true, ...).
 import { suppressHookWarningAls } from ${JSON.stringify(appHookWarningSuppressionPath)};
 import { clearAppRequestContext as __clearRequestContext, setAppNavigationContext as setNavigationContext } from ${JSON.stringify(appRequestContextPath)};
+
+__configureMemoryCacheHandler({ cacheMaxMemorySize: ${JSON.stringify(cacheMaxMemorySize)} });
 import { createAppPrerenderStaticParamsResolver as __createAppPrerenderStaticParamsResolver } from ${JSON.stringify(appPrerenderStaticParamsPath)};
 import { seedMemoryCacheFromPrerender as __seedMemoryCacheFromPrerender } from ${JSON.stringify(seedCachePath)};
 

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -122,6 +122,7 @@ export async function generateServerEntry(
     rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
     headers: nextConfig?.headers ?? [],
     expireTime: nextConfig?.expireTime,
+    cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
     i18n: nextConfig?.i18n ?? null,
     // Mirrors Next.js `experimental.disableOptimizedLoading` — when false
     // (the default), page scripts are emitted with `defer` in <head>. See
@@ -227,7 +228,7 @@ import { renderToReadableStream } from "react-dom/server.edge";
 import { resetSSRHead, getSSRHeadHTML } from "next/head";
 import { flushPreloads } from "next/dynamic";
 import { setSSRContext, wrapWithRouterContext } from "next/router";
-import { _runWithCacheState } from "next/cache";
+import { _runWithCacheState, configureMemoryCacheHandler as __configureMemoryCacheHandler } from "next/cache";
 import { runWithPrivateCache } from "vinext/cache-runtime";
 import { ensureFetchPatch, runWithFetchCache } from "vinext/fetch-cache";
 import { runWithRequestContext as _runWithUnifiedCtx, createRequestContext as _createUnifiedCtx } from "vinext/unified-request-context";
@@ -275,6 +276,8 @@ const __hasMiddleware = ${JSON.stringify(Boolean(middlewarePath))};
 
 // Full resolved config for production server (embedded at build time)
 export const vinextConfig = ${vinextConfigJson};
+
+__configureMemoryCacheHandler({ cacheMaxMemorySize: vinextConfig.cacheMaxMemorySize });
 
 // Path to the user's pages/_app file (or null). Used to look up the
 // _app's CSS/JS chunks in the SSR manifest so any global styles imported

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2370,6 +2370,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               clientTraceMetadata: nextConfig?.clientTraceMetadata,
               assetPrefix: nextConfig?.assetPrefix,
               expireTime: nextConfig?.expireTime,
+              cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
               inlineCss: nextConfig?.inlineCss,
               i18n: nextConfig?.i18n,
               hasPagesDir,

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -193,6 +193,64 @@ type MemoryEntry = {
   cacheControl?: CacheControlMetadata;
 };
 
+const DEFAULT_MEMORY_CACHE_MAX_SIZE = 50 * 1024 * 1024;
+const MAX_REVALIDATED_TAG_ENTRIES = 10_000;
+
+type MemoryCacheHandlerOptions = Pick<CacheHandlerContext, "maxMemoryCacheSize"> & {
+  cacheMaxMemorySize?: number;
+};
+
+function estimateStringMapSize(map: Record<string, string | string[]> | undefined): number {
+  if (!map) return 0;
+  let size = 0;
+  for (const [key, value] of Object.entries(map)) {
+    size += key.length;
+    if (Array.isArray(value)) {
+      for (const item of value) size += item.length;
+    } else {
+      size += value.length;
+    }
+  }
+  return size;
+}
+
+function estimateIncrementalCacheValueSize(value: IncrementalCacheValue | null): number {
+  if (value === null) return 25;
+
+  switch (value.kind) {
+    case "FETCH":
+      return JSON.stringify(value.data ?? "").length;
+    case "PAGES":
+      return (
+        value.html.length +
+        JSON.stringify(value.pageData ?? {}).length +
+        estimateStringMapSize(value.headers)
+      );
+    case "APP_PAGE":
+      return (
+        value.html.length +
+        (value.rscData?.byteLength ?? 0) +
+        (value.postponed?.length ?? 0) +
+        estimateStringMapSize(value.headers)
+      );
+    case "APP_ROUTE":
+      return value.body.byteLength + estimateStringMapSize(value.headers);
+    case "REDIRECT":
+      return JSON.stringify(value.props ?? {}).length;
+    case "IMAGE":
+      return value.buffer.byteLength + value.extension.length + value.etag.length;
+    default:
+      return JSON.stringify(value).length;
+  }
+}
+
+function resolveMemoryCacheMaxSize(options?: number | MemoryCacheHandlerOptions): number {
+  if (typeof options === "number") return options;
+  if (typeof options?.cacheMaxMemorySize === "number") return options.cacheMaxMemorySize;
+  if (typeof options?.maxMemoryCacheSize === "number") return options.maxMemoryCacheSize;
+  return DEFAULT_MEMORY_CACHE_MAX_SIZE;
+}
+
 function readStringArrayField(ctx: Record<string, unknown> | undefined, field: string): string[] {
   const value = ctx?.[field];
   if (!Array.isArray(value)) return [];
@@ -202,6 +260,40 @@ function readStringArrayField(ctx: Record<string, unknown> | undefined, field: s
 export class MemoryCacheHandler implements CacheHandler {
   private store = new Map<string, MemoryEntry>();
   private tagRevalidatedAt = new Map<string, number>();
+  private readonly maxMemoryCacheSize: number;
+  private currentMemoryCacheSize = 0;
+
+  constructor(options?: number | MemoryCacheHandlerOptions) {
+    this.maxMemoryCacheSize = resolveMemoryCacheMaxSize(options);
+  }
+
+  private estimateEntrySize(entry: MemoryEntry): number {
+    return (
+      estimateIncrementalCacheValueSize(entry.value) +
+      entry.tags.reduce((sum, tag) => sum + tag.length, 0) +
+      64
+    );
+  }
+
+  private deleteEntry(key: string): void {
+    const existing = this.store.get(key);
+    if (!existing) return;
+    this.currentMemoryCacheSize -= this.estimateEntrySize(existing);
+    this.store.delete(key);
+  }
+
+  private touchEntry(key: string, entry: MemoryEntry): void {
+    this.store.delete(key);
+    this.store.set(key, entry);
+  }
+
+  private evictLeastRecentlyUsed(): void {
+    while (this.maxMemoryCacheSize > 0 && this.currentMemoryCacheSize > this.maxMemoryCacheSize) {
+      const oldestKey = this.store.keys().next().value;
+      if (oldestKey === undefined) return;
+      this.deleteEntry(oldestKey);
+    }
+  }
 
   async get(key: string, _ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null> {
     const entry = this.store.get(key);
@@ -213,7 +305,7 @@ export class MemoryCacheHandler implements CacheHandler {
     for (const tag of entry.tags) {
       const revalidatedAt = this.tagRevalidatedAt.get(tag);
       if (revalidatedAt && revalidatedAt >= entry.lastModified) {
-        this.store.delete(key);
+        this.deleteEntry(key);
         return null;
       }
     }
@@ -228,9 +320,11 @@ export class MemoryCacheHandler implements CacheHandler {
     // Check hard expiry first. Past `expire`, Next.js blocks on fresh
     // regeneration instead of serving stale with background work.
     if (entry.expireAt !== null && Date.now() > entry.expireAt) {
-      this.store.delete(key);
+      this.deleteEntry(key);
       return null;
     }
+
+    this.touchEntry(key, entry);
 
     // Check time-based revalidation — return stale entry with cacheState="stale"
     // instead of deleting, so ISR can serve stale-while-revalidate
@@ -291,14 +385,26 @@ export class MemoryCacheHandler implements CacheHandler {
           : { revalidate: effectiveRevalidate, expire: effectiveExpire }
         : undefined;
 
-    this.store.set(key, {
+    if (this.maxMemoryCacheSize === 0) return;
+
+    const entry = {
       value: data,
       tags,
       lastModified: now,
       revalidateAt,
       expireAt,
       cacheControl,
-    });
+    };
+    const entrySize = this.estimateEntrySize(entry);
+    if (entrySize > this.maxMemoryCacheSize) {
+      this.deleteEntry(key);
+      return;
+    }
+
+    this.deleteEntry(key);
+    this.store.set(key, entry);
+    this.currentMemoryCacheSize += entrySize;
+    this.evictLeastRecentlyUsed();
   }
 
   async revalidateTag(tags: string | string[], _durations?: { expire?: number }): Promise<void> {
@@ -306,6 +412,11 @@ export class MemoryCacheHandler implements CacheHandler {
     const now = Date.now();
     for (const tag of tagList) {
       this.tagRevalidatedAt.set(tag, now);
+      while (this.tagRevalidatedAt.size > MAX_REVALIDATED_TAG_ENTRIES) {
+        const oldest = this.tagRevalidatedAt.keys().next().value;
+        if (oldest === undefined) break;
+        this.tagRevalidatedAt.delete(oldest);
+      }
     }
   }
 
@@ -343,6 +454,12 @@ const _gHandler = globalThis as unknown as Record<PropertyKey, CacheHandler>;
 
 function _getActiveHandler(): CacheHandler {
   return _gHandler[_HANDLER_KEY] ?? (_gHandler[_HANDLER_KEY] = new MemoryCacheHandler());
+}
+
+export function configureMemoryCacheHandler(options?: MemoryCacheHandlerOptions): void {
+  const current = _gHandler[_HANDLER_KEY];
+  if (current && !(current instanceof MemoryCacheHandler)) return;
+  _gHandler[_HANDLER_KEY] = new MemoryCacheHandler(options);
 }
 
 /**

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -674,6 +674,7 @@ declare module "next/cache" {
     | { kind: "IMAGE"; etag: string; buffer: ArrayBuffer; extension: string; revalidate?: number };
 
   export class MemoryCacheHandler implements CacheHandler {
+    constructor(options?: number | { cacheMaxMemorySize?: number; maxMemoryCacheSize?: number });
     get(key: string, ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null>;
     set(
       key: string,
@@ -686,6 +687,10 @@ declare module "next/cache" {
 
   export function setCacheHandler(handler: CacheHandler): void;
   export function getCacheHandler(): CacheHandler;
+  export function configureMemoryCacheHandler(options?: {
+    cacheMaxMemorySize?: number;
+    maxMemoryCacheSize?: number;
+  }): void;
   export function revalidateTag(tag: string, profile?: string | { expire?: number }): Promise<void>;
   export function revalidatePath(path: string, type?: "page" | "layout"): Promise<void>;
   export function updateTag(tag: string): Promise<void>;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3675,6 +3675,61 @@ describe("next/cache shim", () => {
     }
   });
 
+  it("MemoryCacheHandler evicts least-recently-used entries when max size is exceeded", async () => {
+    const { MemoryCacheHandler } = await import("../packages/vinext/src/shims/cache.js");
+
+    const handler = new MemoryCacheHandler({ cacheMaxMemorySize: 250 });
+    const makeEntry = (body: string) => ({
+      kind: "PAGES" as const,
+      html: body,
+      pageData: {},
+      headers: undefined,
+      status: 200,
+    });
+
+    await handler.set("a", makeEntry("a".repeat(80)));
+    await handler.set("b", makeEntry("b".repeat(80)));
+
+    expect(await handler.get("a")).toBeNull();
+    expect(await handler.get("b")).not.toBeNull();
+  });
+
+  it("MemoryCacheHandler refreshes LRU order on get", async () => {
+    const { MemoryCacheHandler } = await import("../packages/vinext/src/shims/cache.js");
+
+    const handler = new MemoryCacheHandler({ cacheMaxMemorySize: 360 });
+    const makeEntry = (body: string) => ({
+      kind: "PAGES" as const,
+      html: body,
+      pageData: {},
+      headers: undefined,
+      status: 200,
+    });
+
+    await handler.set("a", makeEntry("a".repeat(80)));
+    await handler.set("b", makeEntry("b".repeat(80)));
+    expect(await handler.get("a")).not.toBeNull();
+    await handler.set("c", makeEntry("c".repeat(80)));
+
+    expect(await handler.get("a")).not.toBeNull();
+    expect(await handler.get("b")).toBeNull();
+    expect(await handler.get("c")).not.toBeNull();
+  });
+
+  it("MemoryCacheHandler with max size 0 disables storage", async () => {
+    const { MemoryCacheHandler } = await import("../packages/vinext/src/shims/cache.js");
+
+    const handler = new MemoryCacheHandler({ cacheMaxMemorySize: 0 });
+    await handler.set("disabled", {
+      kind: "FETCH",
+      data: { headers: {}, body: '"cached"', url: "test" },
+      tags: [],
+      revalidate: 3600,
+    });
+
+    expect(await handler.get("disabled")).toBeNull();
+  });
+
   it("MemoryCacheHandler respects tag invalidation", async () => {
     const { MemoryCacheHandler } = await import("../packages/vinext/src/shims/cache.js");
 


### PR DESCRIPTION
## Summary

Bound the default in-memory cache with approximate byte sizing and least-recently-used eviction.

## Details

`MemoryCacheHandler` previously stored entries in an unbounded `Map`. This change adds a Next-style memory cap:

- default max size: 50 MiB
- `cacheMaxMemorySize: 0`: disables default memory storage
- oversized entries are not stored
- `get()` refreshes LRU order
- tag invalidation metadata is capped to 10k entries

The configured `cacheMaxMemorySize` is wired into both generated App and Pages entries via `configureMemoryCacheHandler()`.

## Tests

Adds focused `MemoryCacheHandler` coverage for:
- least-recently-used eviction when max size is exceeded
- `get()` refreshing recency
- max size `0` disabling storage