### PR TITLE
fix(app-router): preserve middleware headers on metadata routes

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -92,6 +92,24 @@ type AppRscRouteMatch<TRoute> = {
   route: TRoute;
 };
 
+function applyMiddlewareContextToResponse(
+  response: Response,
+  middlewareContext: AppRscMiddlewareContext,
+): Response {
+  if (!middlewareContext.headers && middlewareContext.status == null) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  mergeMiddlewareResponseHeaders(headers, middlewareContext.headers);
+
+  return new Response(response.body, {
+    status: middlewareContext.status ?? response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 type DispatchMatchedPageOptions<TRoute> = {
   cleanPathname: string;
   formState: ReactFormState | null;
@@ -478,7 +496,9 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     cleanPathname,
     makeThenableParams: options.makeThenableParams,
   });
-  if (metadataRouteResponse) return metadataRouteResponse;
+  if (metadataRouteResponse) {
+    return applyMiddlewareContextToResponse(metadataRouteResponse, middlewareContext);
+  }
 
   const publicFileResponse = resolvePublicFileRoute({
     cleanPathname,

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -740,6 +740,44 @@ describe("createAppRscHandler", () => {
     expect(matchRoute).not.toHaveBeenCalled();
   });
 
+  it("lets middleware Cache-Control override static metadata route defaults", async () => {
+    // Ported from Next.js: test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts
+    const handler = createHandler({
+      configHeaders: [],
+      matchRoute: () => null,
+      metadataRoutes: [
+        {
+          type: "favicon",
+          isDynamic: false,
+          filePath: "/tmp/app/favicon.ico",
+          routePrefix: "",
+          routeSegments: [],
+          servedUrl: "/favicon.ico",
+          contentType: "image/x-icon",
+          fileDataBase64: btoa("icon-bytes"),
+        },
+      ],
+      middlewareModule: {
+        middleware() {
+          return new Response(null, {
+            headers: {
+              "Cache-Control": "max-age=1234",
+              "x-middleware-next": "1",
+            },
+          });
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/favicon.ico"), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("max-age=1234");
+    expect(response.headers.get("content-type")).toBe("image/x-icon");
+    await expect(response.text()).resolves.toBe("icon-bytes");
+  });
+
   it("lets server actions short-circuit routing while still applying final headers", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
     const handleServerActionRequest = vi.fn(


### PR DESCRIPTION
## Overview

| Area | Details |
| --- | --- |
| Goal | Match Next.js when middleware sets response headers for App Router metadata routes such as `app/favicon.ico`. |
| Core change | Merge the App Router middleware response context into metadata route responses before returning them. |
| Primary files | `packages/vinext/src/server/app-rsc-handler.ts`, `tests/app-rsc-handler.test.ts` |
| Expected impact | Middleware `Cache-Control` and other singular response headers now win over static metadata route defaults. |

## Why

For this request path to match Next.js, middleware response headers must be part of the response header state before framework/static defaults are applied. Next.js carries middleware headers into routing response headers, then static cache defaults check whether `cache-control` is already set. Vinext already followed that rule for pages, route handlers, and public-file signals, but metadata routes returned before that merge.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| App Router metadata routes | Middleware response headers own singular response keys like `Cache-Control`. | Wrap metadata route responses with the same middleware header/status merge used by other App Router response paths. |
| Static metadata defaults | Defaults should not erase a middleware response header. | `app/favicon.ico` now preserves middleware `Cache-Control: max-age=1234` instead of emitting `public, max-age=0, must-revalidate`. |
| Regression coverage | Port the observable Next.js behaviour at the lowest owner boundary. | Adds a `createAppRscHandler` regression for middleware plus static metadata route dispatch. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `middleware.ts` returns `NextResponse.next({ headers: { "Cache-Control": "max-age=1234" } })` for `/favicon.ico` | Static metadata route default cache-control overwrote the middleware value. | The metadata route response carries the middleware cache-control value. |
| Metadata route response with middleware status/header context | Metadata route returned before context merge. | Response headers are cloned, middleware response headers are merged, and middleware status is preserved when present. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-rsc-handler.ts` verifies the metadata route response now goes through the App Router middleware response context before return.
2. `tests/app-rsc-handler.test.ts` ports the upstream fixture behaviour without running the full deploy harness in normal unit coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-rsc-handler.test.ts -t "middleware Cache-Control"` failed before the fix with `public, max-age=0, must-revalidate`, then passed after the fix.
- `vp test run tests/app-rsc-handler.test.ts`
- `vp test run tests/app-rsc-handler.test.ts tests/metadata-route-response.test.ts`
- `vp run vinext#build`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no API surface change.
- Runtime: limited to App Router metadata route responses after middleware has continued.
- Compatibility: aligns with Next.js header precedence for the upstream `no-duplicate-headers-middleware` fixture.
- Existing apps: metadata route framework defaults still apply when middleware does not set the same header.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts#L8-L11) | Defines the expected `Cache-Control: max-age=1234` result for `favicon.ico`. |
| [Next.js middleware header propagation](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/lib/router-utils/resolve-routes.ts#L620-L645) | Middleware response headers are copied into routing response headers. |
| [Next.js response header application](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/lib/router-server.ts#L430-L434) | Routing response headers are set on the outgoing response before serving matched output. |
| [Next.js static cache default guard](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/lib/router-server.ts#L482-L486) | Static cache-control defaults are skipped when `cache-control` already exists. |
