### PR TITLE
fix(config): resolve next.config baseUrl imports from tsconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ These are gaps we'd like to close — distinct from the [intentional exclusions]
 - **Route segment config** — `runtime` and `preferredRegion` are ignored (everything runs in the same environment).
 - **Node.js production server (`vinext start`)** works for testing but is less complete than Workers deployment. Cloudflare Workers is the primary target.
 - **Native Node modules (sharp, resvg, satori, lightningcss, @napi-rs/canvas)** crash Vite's RSC dev environment. Dynamic OG image/icon routes using these work in production builds but not in dev mode. These are auto-stubbed during `vinext deploy`.
+- **`next.config.ts` `baseUrl` bare imports require Vite 8.** A `next.config.ts` that imports a bare specifier resolved through `tsconfig.json`'s `compilerOptions.baseUrl` (e.g. `import { bar } from "bar"` resolving to a local `bar.ts`) relies on Vite 8's native `resolve.tsconfigPaths` (Rolldown/oxc-resolver). On Vite 7 there is no native equivalent, so these imports are not resolved. `compilerOptions.paths` aliases (e.g. `@/foo`) work on both Vite 7 and 8.
 
 ## Benchmarks
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -878,6 +878,7 @@ export async function loadNextConfig(
   if (!configPath) return null;
 
   const filename = path.basename(configPath);
+  const isTypeScriptConfig = /\.[cm]?ts$/.test(configPath);
 
   // Mirror Next.js: read `compilerOptions.paths` from the project's
   // tsconfig.json so aliased imports inside next.config.ts (e.g.
@@ -885,6 +886,7 @@ export async function loadNextConfig(
   // passes `paths` and `baseUrl` to SWC; we thread both into Vite's resolver.
   // See packages/next/src/build/next-config-ts/transpile-config.ts.
   const tsconfigResolution = loadTsconfigResolutionForRoot(root);
+  const tsconfigBaseUrl = isTypeScriptConfig ? tsconfigResolution.baseUrl : null;
 
   // Symlink-resolved config path, used by the `commonjs()` filter below to
   // exclude the config file itself. macOS uses /private/var symlinks, so
@@ -898,17 +900,22 @@ export async function loadNextConfig(
       root,
       logLevel: "error",
       clearScreen: false,
-      environments: {
-        inline: {
-          resolve: {
-            // Vite's module runner externalizes installed bare packages before
-            // calling resolveId. next.config.ts needs tsconfig baseUrl to get
-            // the first lookup, so keep config imports inside the resolver
-            // pipeline and let unresolved local lookups fall through to packages.
-            noExternal: true,
-          },
-        },
-      },
+      ...(tsconfigBaseUrl
+        ? {
+            environments: {
+              inline: {
+                resolve: {
+                  // Vite's module runner externalizes installed bare packages
+                  // before calling resolveId. TypeScript next.config files need
+                  // tsconfig baseUrl to get the first lookup, so keep those
+                  // config imports inside the resolver pipeline and let
+                  // unresolved local lookups fall through to packages.
+                  noExternal: true,
+                },
+              },
+            },
+          }
+        : {}),
       resolve: {
         alias: tsconfigResolution.aliases,
         // Include `.cjs` and `.cts` so `vite-plugin-commonjs` recognises
@@ -939,10 +946,8 @@ export async function loadNextConfig(
       // same source produces an `Identifier 'module' has already been
       // declared` syntax error.
       plugins: [
-        ...(/\.[cm]?ts$/.test(configPath) ? [cjsGlobalsInjectorPlugin(configPath)] : []),
-        ...(tsconfigResolution.baseUrl
-          ? [tsconfigBaseUrlResolverPlugin(root, tsconfigResolution.baseUrl)]
-          : []),
+        ...(isTypeScriptConfig ? [cjsGlobalsInjectorPlugin(configPath)] : []),
+        ...(tsconfigBaseUrl ? [tsconfigBaseUrlResolverPlugin(root, tsconfigBaseUrl)] : []),
         commonjs({
           filter: (id: string) => {
             const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -9,13 +9,14 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
+import type { Plugin } from "vite";
 import commonjs from "vite-plugin-commonjs";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
 import { getHtmlLimitedBotRegex } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
-import { loadTsconfigPathAliasesForRoot } from "./tsconfig-paths.js";
+import { loadTsconfigResolutionForRoot } from "./tsconfig-paths.js";
 
 /**
  * Parse a body size limit value (string or number) into bytes.
@@ -507,6 +508,31 @@ function warnConfigLoadFailure(filename: string, err: Error): void {
   }
 }
 
+function isBareModuleSpecifier(id: string): boolean {
+  return (
+    !id.startsWith(".") &&
+    !id.startsWith("/") &&
+    !id.startsWith("\\") &&
+    !id.startsWith("\0") &&
+    !/^[A-Za-z][A-Za-z\d+.-]*:/.test(id)
+  );
+}
+
+function tsconfigBaseUrlResolverPlugin(baseUrl: string): Plugin {
+  return {
+    name: "vinext:next-config-tsconfig-base-url",
+    enforce: "post",
+    async resolveId(id, importer, options) {
+      if (!importer || !isBareModuleSpecifier(id)) return null;
+
+      return await this.resolve(path.resolve(baseUrl, id), importer, {
+        ...options,
+        skipSelf: true,
+      });
+    },
+  };
+}
+
 /**
  * Resolve a Next-style config value, calling it if it's a function-form config
  * (Next.js supports `module.exports = (phase, opts) => config`).
@@ -803,9 +829,9 @@ export async function loadNextConfig(
   // Mirror Next.js: read `compilerOptions.paths` from the project's
   // tsconfig.json so aliased imports inside next.config.ts (e.g.
   // `import { foo } from '@/foo'`) resolve at config-load time. Next.js
-  // passes these to SWC; we pass them to Vite's resolver as `resolve.alias`.
+  // passes `paths` and `baseUrl` to SWC; we thread both into Vite's resolver.
   // See packages/next/src/build/next-config-ts/transpile-config.ts.
-  const tsconfigAliases = loadTsconfigPathAliasesForRoot(root);
+  const tsconfigResolution = loadTsconfigResolutionForRoot(root);
 
   // Symlink-resolved config path, used by the `commonjs()` filter below to
   // exclude the config file itself. macOS uses /private/var symlinks, so
@@ -820,7 +846,7 @@ export async function loadNextConfig(
       logLevel: "error",
       clearScreen: false,
       resolve: {
-        alias: tsconfigAliases,
+        alias: tsconfigResolution.aliases,
         // Include `.cjs` and `.cts` so `vite-plugin-commonjs` recognises
         // those extensions (the plugin keys off `config.resolve.extensions`,
         // which on Vite defaults to `[.mjs, .js, .mts, .ts, .jsx, .tsx,
@@ -850,6 +876,9 @@ export async function loadNextConfig(
       // declared` syntax error.
       plugins: [
         ...(/\.[cm]?ts$/.test(configPath) ? [cjsGlobalsInjectorPlugin(configPath)] : []),
+        ...(tsconfigResolution.baseUrl
+          ? [tsconfigBaseUrlResolverPlugin(tsconfigResolution.baseUrl)]
+          : []),
         commonjs({
           filter: (id: string) => {
             const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -518,12 +518,65 @@ function isBareModuleSpecifier(id: string): boolean {
   );
 }
 
-function tsconfigBaseUrlResolverPlugin(baseUrl: string): Plugin {
+function stripViteRequestSuffix(id: string): string {
+  const queryIndex = id.indexOf("?");
+  const hashIndex = id.indexOf("#");
+  const endIndex =
+    queryIndex === -1
+      ? hashIndex === -1
+        ? id.length
+        : hashIndex
+      : hashIndex === -1
+        ? queryIndex
+        : Math.min(queryIndex, hashIndex);
+  return id.slice(0, endIndex);
+}
+
+function fsPathFromImporter(importer: string): string | null {
+  const cleanImporter = stripViteRequestSuffix(importer);
+  if (cleanImporter.startsWith("file://")) {
+    try {
+      return fileURLToPath(cleanImporter);
+    } catch {
+      return null;
+    }
+  }
+
+  return path.isAbsolute(cleanImporter) ? cleanImporter : null;
+}
+
+function hasNodeModulesSegment(id: string): boolean {
+  return id.split(/[\\/]+/).includes("node_modules");
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function isProjectOwnedImporter(importer: string, projectRoot: string): boolean {
+  const importerPath = fsPathFromImporter(importer);
+  if (!importerPath || hasNodeModulesSegment(importerPath)) return false;
+
+  const realImporterPath = safeRealpath(path.resolve(importerPath));
+  if (hasNodeModulesSegment(realImporterPath)) return false;
+
+  return isPathInside(projectRoot, realImporterPath);
+}
+
+function tsconfigBaseUrlResolverPlugin(projectRoot: string, baseUrl: string): Plugin {
+  const realProjectRoot = safeRealpath(path.resolve(projectRoot));
   return {
     name: "vinext:next-config-tsconfig-base-url",
-    enforce: "post",
+    // Vite's alias plugin runs before user `pre` plugins, and the core package
+    // resolver runs after them. That gives tsconfig paths first priority,
+    // then baseUrl-local files, then package fallback.
+    enforce: "pre",
     async resolveId(id, importer, options) {
       if (!importer || !isBareModuleSpecifier(id)) return null;
+      if (!isProjectOwnedImporter(importer, realProjectRoot)) return null;
 
       return await this.resolve(path.resolve(baseUrl, id), importer, {
         ...options,
@@ -845,6 +898,17 @@ export async function loadNextConfig(
       root,
       logLevel: "error",
       clearScreen: false,
+      environments: {
+        inline: {
+          resolve: {
+            // Vite's module runner externalizes installed bare packages before
+            // calling resolveId. next.config.ts needs tsconfig baseUrl to get
+            // the first lookup, so keep config imports inside the resolver
+            // pipeline and let unresolved local lookups fall through to packages.
+            noExternal: true,
+          },
+        },
+      },
       resolve: {
         alias: tsconfigResolution.aliases,
         // Include `.cjs` and `.cts` so `vite-plugin-commonjs` recognises
@@ -877,7 +941,7 @@ export async function loadNextConfig(
       plugins: [
         ...(/\.[cm]?ts$/.test(configPath) ? [cjsGlobalsInjectorPlugin(configPath)] : []),
         ...(tsconfigResolution.baseUrl
-          ? [tsconfigBaseUrlResolverPlugin(tsconfigResolution.baseUrl)]
+          ? [tsconfigBaseUrlResolverPlugin(root, tsconfigResolution.baseUrl)]
           : []),
         commonjs({
           filter: (id: string) => {

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -9,7 +9,6 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
-import type { Plugin } from "vite";
 import commonjs from "vite-plugin-commonjs";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
@@ -17,6 +16,7 @@ import { getHtmlLimitedBotRegex } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
 import { loadTsconfigResolutionForRoot } from "./tsconfig-paths.js";
+import { getViteMajorVersion } from "../utils/vite-version.js";
 
 /**
  * Parse a body size limit value (string or number) into bytes.
@@ -521,84 +521,6 @@ function warnConfigLoadFailure(filename: string, err: Error): void {
   }
 }
 
-function isBareModuleSpecifier(id: string): boolean {
-  return (
-    !id.startsWith(".") &&
-    !id.startsWith("/") &&
-    !id.startsWith("\\") &&
-    !id.startsWith("\0") &&
-    !/^[A-Za-z][A-Za-z\d+.-]*:/.test(id)
-  );
-}
-
-function stripViteRequestSuffix(id: string): string {
-  const queryIndex = id.indexOf("?");
-  const hashIndex = id.indexOf("#");
-  const endIndex =
-    queryIndex === -1
-      ? hashIndex === -1
-        ? id.length
-        : hashIndex
-      : hashIndex === -1
-        ? queryIndex
-        : Math.min(queryIndex, hashIndex);
-  return id.slice(0, endIndex);
-}
-
-function fsPathFromImporter(importer: string): string | null {
-  const cleanImporter = stripViteRequestSuffix(importer);
-  if (cleanImporter.startsWith("file://")) {
-    try {
-      return fileURLToPath(cleanImporter);
-    } catch {
-      return null;
-    }
-  }
-
-  return path.isAbsolute(cleanImporter) ? cleanImporter : null;
-}
-
-function hasNodeModulesSegment(id: string): boolean {
-  return id.split(/[\\/]+/).includes("node_modules");
-}
-
-function isPathInside(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child);
-  return (
-    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
-  );
-}
-
-function isProjectOwnedImporter(importer: string, projectRoot: string): boolean {
-  const importerPath = fsPathFromImporter(importer);
-  if (!importerPath || hasNodeModulesSegment(importerPath)) return false;
-
-  const realImporterPath = safeRealpath(path.resolve(importerPath));
-  if (hasNodeModulesSegment(realImporterPath)) return false;
-
-  return isPathInside(projectRoot, realImporterPath);
-}
-
-function tsconfigBaseUrlResolverPlugin(projectRoot: string, baseUrl: string): Plugin {
-  const realProjectRoot = safeRealpath(path.resolve(projectRoot));
-  return {
-    name: "vinext:next-config-tsconfig-base-url",
-    // Vite's alias plugin runs before user `pre` plugins, and the core package
-    // resolver runs after them. That gives tsconfig paths first priority,
-    // then baseUrl-local files, then package fallback.
-    enforce: "pre",
-    async resolveId(id, importer, options) {
-      if (!importer || !isBareModuleSpecifier(id)) return null;
-      if (!isProjectOwnedImporter(importer, realProjectRoot)) return null;
-
-      return await this.resolve(path.resolve(baseUrl, id), importer, {
-        ...options,
-        skipSelf: true,
-      });
-    },
-  };
-}
-
 /**
  * Resolve a Next-style config value, calling it if it's a function-form config
  * (Next.js supports `module.exports = (phase, opts) => config`).
@@ -901,6 +823,13 @@ export async function loadNextConfig(
   const tsconfigResolution = loadTsconfigResolutionForRoot(root);
   const tsconfigBaseUrl = isTypeScriptConfig ? tsconfigResolution.baseUrl : null;
 
+  // Vite 8 (Rolldown) resolves tsconfig `baseUrl` bare imports natively via
+  // `resolve.tsconfigPaths` (oxc-resolver). Vite 7 has no equivalent option,
+  // so baseUrl-based imports in `next.config.ts` are a documented Vite 7/8
+  // capability gap (see docs). `paths` aliases still work on both via
+  // `resolve.alias`. Mirrors the Vite-major gate used in index.ts.
+  const useNativeTsconfigPaths = !!tsconfigBaseUrl && getViteMajorVersion() >= 8;
+
   // Symlink-resolved config path, used by the `commonjs()` filter below to
   // exclude the config file itself. macOS uses /private/var symlinks, so
   // string-compare without realpath would falsely include the config.
@@ -913,16 +842,16 @@ export async function loadNextConfig(
       root,
       logLevel: "error",
       clearScreen: false,
-      ...(tsconfigBaseUrl
+      ...(useNativeTsconfigPaths
         ? {
             environments: {
               inline: {
                 resolve: {
                   // Vite's module runner externalizes installed bare packages
-                  // before calling resolveId. TypeScript next.config files need
-                  // tsconfig baseUrl to get the first lookup, so keep those
-                  // config imports inside the resolver pipeline and let
-                  // unresolved local lookups fall through to packages.
+                  // before calling resolveId, which would let a package win over
+                  // a baseUrl-local file of the same name. Keep those config
+                  // imports inside the resolver pipeline so the native tsconfig
+                  // resolver gets first lookup, then fall through to packages.
                   noExternal: true,
                 },
               },
@@ -931,6 +860,14 @@ export async function loadNextConfig(
         : {}),
       resolve: {
         alias: tsconfigResolution.aliases,
+        // On Vite 8, use native tsconfig resolution (oxc-resolver
+        // `tsconfig: 'auto'`), which mirrors Next.js's SWC `paths` + `baseUrl`
+        // handling: it follows `extends`, resolves baseUrl-local bare imports
+        // before package fallback, and scopes the app baseUrl to project-owned
+        // importers via per-importer tsconfig discovery. Vite 7 has no native
+        // equivalent, so baseUrl bare imports in next.config.ts are unsupported
+        // there (documented gap); `resolve.alias` still covers `paths` aliases.
+        ...(useNativeTsconfigPaths ? { tsconfigPaths: true } : {}),
         // Include `.cjs` and `.cts` so `vite-plugin-commonjs` recognises
         // those extensions (the plugin keys off `config.resolve.extensions`,
         // which on Vite defaults to `[.mjs, .js, .mts, .ts, .jsx, .tsx,
@@ -960,7 +897,6 @@ export async function loadNextConfig(
       // declared` syntax error.
       plugins: [
         ...(isTypeScriptConfig ? [cjsGlobalsInjectorPlugin(configPath)] : []),
-        ...(tsconfigBaseUrl ? [tsconfigBaseUrlResolverPlugin(root, tsconfigBaseUrl)] : []),
         commonjs({
           filter: (id: string) => {
             const idPath = id.startsWith("file://") ? fileURLToPath(id) : id.split("?")[0];

--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -6,8 +6,9 @@
  * through Vite's `runnerImport`.
  *
  * Next.js's own `next.config.ts` loader (packages/next/src/build/next-config-ts/
- * transpile-config.ts) reads `compilerOptions.paths` from the project's
- * `tsconfig.json` and passes them to SWC so that imports like
+ * transpile-config.ts) reads `compilerOptions.paths` and
+ * `compilerOptions.baseUrl` from the project's `tsconfig.json` and passes them
+ * to SWC so that imports like
  * `import { foo } from '@/foo'` and `import { bar } from 'bar'` resolve at
  * config load time. We do the same here with Vite resolver settings.
  *

--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -124,12 +124,7 @@ function loadResolutionFromTsconfigFile(
   if (!parsed) return emptyResolution();
 
   let resolution = emptyResolution();
-  const extendsList =
-    typeof parsed.extends === "string"
-      ? [parsed.extends]
-      : Array.isArray(parsed.extends)
-        ? parsed.extends.filter((value): value is string => typeof value === "string")
-        : [];
+  const extendsList = typeof parsed.extends === "string" ? [parsed.extends] : [];
 
   for (const extendsSpecifier of extendsList) {
     const extendedPath = resolveTsconfigExtends(configPath, extendsSpecifier);

--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -2,13 +2,14 @@
  * tsconfig.json `compilerOptions.paths` loader.
  *
  * Used to make tsconfig path aliases (e.g. `@/foo` mapping to `./src/foo`)
- * available when vinext loads `next.config.ts` through Vite's `runnerImport`.
+ * and `baseUrl` bare imports available when vinext loads `next.config.ts`
+ * through Vite's `runnerImport`.
  *
  * Next.js's own `next.config.ts` loader (packages/next/src/build/next-config-ts/
  * transpile-config.ts) reads `compilerOptions.paths` from the project's
  * `tsconfig.json` and passes them to SWC so that imports like
- * `import { foo } from '@/foo'` resolve at config load time. We do the same
- * here, but as Vite `resolve.alias` entries.
+ * `import { foo } from '@/foo'` and `import { bar } from 'bar'` resolve at
+ * config load time. We do the same here with Vite resolver settings.
  *
  * The implementation is intentionally minimal:
  *   - Static JSON-style parse of tsconfig.json (handles trailing commas /
@@ -26,6 +27,11 @@ import { createRequire } from "node:module";
 import { parseStaticObjectLiteral } from "../plugins/fonts.js";
 
 const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
+
+type TsconfigPathResolution = {
+  aliases: Record<string, string>;
+  baseUrl: string | null;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -98,57 +104,92 @@ function materializeAliases(
   return aliases;
 }
 
-function loadAliasesFromTsconfigFile(
+function emptyResolution(): TsconfigPathResolution {
+  return { aliases: {}, baseUrl: null };
+}
+
+function loadResolutionFromTsconfigFile(
   configPath: string,
   seen: Set<string>,
-): Record<string, string> {
-  if (seen.has(configPath)) return {};
+): TsconfigPathResolution {
+  if (seen.has(configPath)) return emptyResolution();
   seen.add(configPath);
 
   let parsed: Record<string, unknown> | null = null;
   try {
     parsed = parseStaticObjectLiteral(fs.readFileSync(configPath, "utf-8"));
   } catch {
-    return {};
+    return emptyResolution();
   }
-  if (!parsed) return {};
+  if (!parsed) return emptyResolution();
 
-  let aliases: Record<string, string> = {};
-  if (typeof parsed.extends === "string") {
-    const extendedPath = resolveTsconfigExtends(configPath, parsed.extends);
+  let resolution = emptyResolution();
+  const extendsList =
+    typeof parsed.extends === "string"
+      ? [parsed.extends]
+      : Array.isArray(parsed.extends)
+        ? parsed.extends.filter((value): value is string => typeof value === "string")
+        : [];
+
+  for (const extendsSpecifier of extendsList) {
+    const extendedPath = resolveTsconfigExtends(configPath, extendsSpecifier);
     if (extendedPath) {
-      aliases = loadAliasesFromTsconfigFile(extendedPath, seen);
+      const parent = loadResolutionFromTsconfigFile(extendedPath, seen);
+      resolution = {
+        aliases: { ...resolution.aliases, ...parent.aliases },
+        baseUrl: parent.baseUrl ?? resolution.baseUrl,
+      };
     }
   }
 
   const compilerOptions = isRecord(parsed.compilerOptions) ? parsed.compilerOptions : null;
+  const ownBaseUrl =
+    compilerOptions && typeof compilerOptions.baseUrl === "string"
+      ? path.resolve(path.dirname(configPath), compilerOptions.baseUrl)
+      : null;
+  const baseUrl = ownBaseUrl ?? resolution.baseUrl;
+
   const pathsConfig =
     compilerOptions && isRecord(compilerOptions.paths) ? compilerOptions.paths : null;
-  if (!pathsConfig) return aliases;
+  if (!pathsConfig) {
+    return {
+      aliases: resolution.aliases,
+      baseUrl,
+    };
+  }
 
-  const baseUrl =
-    compilerOptions && typeof compilerOptions.baseUrl === "string" ? compilerOptions.baseUrl : ".";
-  const resolvedBaseUrl = path.resolve(path.dirname(configPath), baseUrl);
+  const pathsBaseUrl = baseUrl ?? path.dirname(configPath);
 
   return {
-    ...aliases,
-    ...materializeAliases(pathsConfig, resolvedBaseUrl),
+    aliases: {
+      ...resolution.aliases,
+      ...materializeAliases(pathsConfig, pathsBaseUrl),
+    },
+    baseUrl,
   };
 }
 
 /**
  * Read the project's tsconfig.json (or jsconfig.json) and return its
- * `compilerOptions.paths` as absolute-path Vite `resolve.alias` entries.
+ * path-resolution settings as absolute paths.
  *
- * Returns an empty object if no config is found or no paths are configured.
+ * Returns an empty resolution if no config is found or no relevant compiler
+ * options are configured.
  * Errors during parsing are swallowed — this is a best-effort helper that
  * must not break config loading.
  */
-export function loadTsconfigPathAliasesForRoot(projectRoot: string): Record<string, string> {
+export function loadTsconfigResolutionForRoot(projectRoot: string): TsconfigPathResolution {
   for (const name of TSCONFIG_FILES) {
     const candidate = path.join(projectRoot, name);
     if (!fs.existsSync(candidate)) continue;
-    return loadAliasesFromTsconfigFile(candidate, new Set());
+    return loadResolutionFromTsconfigFile(candidate, new Set());
   }
-  return {};
+  return emptyResolution();
+}
+
+/**
+ * Back-compat helper for call sites that only need `compilerOptions.paths`.
+ */
+export function loadTsconfigPathAliasesForRoot(projectRoot: string): Record<string, string> {
+  return loadTsconfigResolutionForRoot(projectRoot).aliases;
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -146,6 +146,7 @@ import { removeConsoleCalls } from "./plugins/remove-console.js";
 import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
+import { getViteMajorVersion } from "./utils/vite-version.js";
 import tsconfigPaths from "vite-tsconfig-paths";
 import type { Options as VitePluginReactOptions } from "@vitejs/plugin-react";
 import MagicString from "magic-string";
@@ -409,40 +410,6 @@ function loadTsconfigPathAliases(
     ...aliases,
     ...materializeTsconfigPathAliases(pathsConfig, resolvedBaseUrl, projectRoot),
   };
-}
-
-/**
- * Detect Vite major version at runtime by resolving from cwd.
- * The plugin may be installed in a workspace root with Vite 7 but used
- * by a project that has Vite 8 — so we resolve from cwd, not from
- * the plugin's own location.
- */
-function getViteMajorVersion(): number {
-  try {
-    const require = createRequire(path.join(process.cwd(), "package.json"));
-    const vitePkg = require("vite/package.json");
-
-    const viteMajor = parseInt(vitePkg?.version, 10);
-    if (vitePkg?.name === "vite" && Number.isFinite(viteMajor)) {
-      return viteMajor;
-    }
-
-    const bundledViteMajor = parseInt(vitePkg?.bundledVersions?.vite, 10);
-    if (Number.isFinite(bundledViteMajor)) {
-      return bundledViteMajor;
-    }
-
-    // npm aliases like `vite: npm:@voidzero-dev/vite-plus-core@...` expose the
-    // aliased package.json, whose own version is not Vite's version.
-    console.warn(
-      `[vinext] Could not determine Vite major version from ${vitePkg?.name ?? "vite/package.json"}; assuming Vite 7`,
-    );
-    return 7;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[vinext] Failed to resolve vite/package.json (${message}); assuming Vite 7`);
-    return 7;
-  }
 }
 
 /**

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -1,0 +1,44 @@
+/**
+ * Vite major-version detection.
+ *
+ * Several vinext behaviors depend on whether the host project is running Vite 8
+ * (Rolldown-based, with native `resolve.tsconfigPaths`, `oxc` transforms, and
+ * `rolldownOptions`) or Vite 7 (Rollup/esbuild). This helper centralizes the
+ * detection so the Vite-major gate is computed the same way everywhere.
+ */
+import path from "node:path";
+import { createRequire } from "node:module";
+
+/**
+ * Detect Vite major version at runtime by resolving from cwd.
+ * The plugin may be installed in a workspace root with Vite 7 but used
+ * by a project that has Vite 8 — so we resolve from cwd, not from
+ * the plugin's own location.
+ */
+export function getViteMajorVersion(): number {
+  try {
+    const require = createRequire(path.join(process.cwd(), "package.json"));
+    const vitePkg = require("vite/package.json");
+
+    const viteMajor = parseInt(vitePkg?.version, 10);
+    if (vitePkg?.name === "vite" && Number.isFinite(viteMajor)) {
+      return viteMajor;
+    }
+
+    const bundledViteMajor = parseInt(vitePkg?.bundledVersions?.vite, 10);
+    if (Number.isFinite(bundledViteMajor)) {
+      return bundledViteMajor;
+    }
+
+    // npm aliases like `vite: npm:@voidzero-dev/vite-plus-core@...` expose the
+    // aliased package.json, whose own version is not Vite's version.
+    console.warn(
+      `[vinext] Could not determine Vite major version from ${vitePkg?.name ?? "vite/package.json"}; assuming Vite 7`,
+    );
+    return 7;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[vinext] Failed to resolve vite/package.json (${message}); assuming Vite 7`);
+    return 7;
+  }
+}

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -571,6 +571,28 @@ describe("loadNextConfig with tsconfig path aliases", () => {
     expect(config?.env?.BAR).toBe("package");
   });
 
+  it("does not apply tsconfig baseUrl package shadowing to next.config.mjs", async () => {
+    tmpDir = makeTempDir();
+
+    fs.writeFileSync(path.join(tmpDir, "bar.ts"), `export const bar = "local";\n`);
+    writeBarePackage("bar", `export const bar = "package";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mjs"),
+      `import { bar } from "bar";\nexport default { env: { BAR: bar } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.BAR).toBe("package");
+  });
+
   it("does not apply the app baseUrl to package dependency imports", async () => {
     tmpDir = makeTempDir();
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -375,6 +375,32 @@ describe("loadNextConfig with tsconfig path aliases", () => {
 
   let tmpDir: string;
 
+  function writePackage(
+    name: string,
+    packageJson: Record<string, string>,
+    files: Record<string, string>,
+  ): void {
+    const packageDir = path.join(tmpDir, "node_modules", name);
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name, version: "1.0.0", ...packageJson }),
+    );
+    for (const [filename, source] of Object.entries(files)) {
+      fs.writeFileSync(path.join(packageDir, filename), source);
+    }
+  }
+
+  function writeBarePackage(name: string, source: string): void {
+    writePackage(
+      name,
+      { type: "module", exports: "./index.js" },
+      {
+        "index.js": source,
+      },
+    );
+  }
+
   afterEach(() => {
     if (tmpDir) {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -500,6 +526,127 @@ describe("loadNextConfig with tsconfig path aliases", () => {
 
     const config = await loadNextConfig(tmpDir);
     expect(config?.env?.VALUE).toBe("foobar");
+  });
+
+  it("resolves baseUrl local imports before packages with the same bare name", async () => {
+    tmpDir = makeTempDir();
+
+    fs.writeFileSync(path.join(tmpDir, "bar.ts"), `export const bar = "local";\n`);
+    writeBarePackage("bar", `export const bar = "package";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { bar } from "bar";\nexport default { env: { BAR: bar } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.BAR).toBe("local");
+  });
+
+  it("falls through to packages when baseUrl has no local match", async () => {
+    tmpDir = makeTempDir();
+
+    writeBarePackage("bar", `export const bar = "package";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { bar } from "bar";\nexport default { env: { BAR: bar } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.BAR).toBe("package");
+  });
+
+  it("does not apply the app baseUrl to package dependency imports", async () => {
+    tmpDir = makeTempDir();
+
+    fs.writeFileSync(path.join(tmpDir, "shared.ts"), `export const shared = "app";\n`);
+    writeBarePackage(
+      "fake-plugin",
+      `import { shared } from "shared";\nexport const pluginValue = shared;\n`,
+    );
+    writeBarePackage("shared", `export const shared = "package";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { pluginValue } from "fake-plugin";\n` +
+        `export default { env: { VALUE: pluginValue } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.VALUE).toBe("package");
+  });
+
+  it("imports ESM and CommonJS packages from next.config.ts", async () => {
+    // Ported from Next.js: test/e2e/app-dir/next-config-ts/import-from-node-modules/
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts/import-from-node-modules/next.config.ts
+    tmpDir = makeTempDir();
+
+    writePackage(
+      "cjs",
+      { type: "commonjs", main: "index.cjs" },
+      {
+        "index.cjs": `module.exports = "cjs";\n`,
+      },
+    );
+    writePackage(
+      "mjs",
+      { type: "commonjs", main: "index.mjs" },
+      {
+        "index.mjs": `export default "mjs";\n`,
+      },
+    );
+    writePackage(
+      "js-cjs",
+      { type: "commonjs", main: "index.js" },
+      {
+        "index.js": `module.exports = "jsCJS";\n`,
+      },
+    );
+    writePackage(
+      "js-esm",
+      { type: "module", main: "index.js" },
+      {
+        "index.js": `export default "jsESM";\n`,
+      },
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import cjs from "cjs";\n` +
+        `import mjs from "mjs";\n` +
+        `import jsCJS from "js-cjs";\n` +
+        `import jsESM from "js-esm";\n` +
+        `export default { env: { cjs, mjs, jsCJS, jsESM } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env).toMatchObject({
+      cjs: "cjs",
+      mjs: "mjs",
+      jsCJS: "jsCJS",
+      jsESM: "jsESM",
+    });
   });
 
   it("loads config without tsconfig.json (no aliases needed)", async () => {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -368,10 +368,10 @@ describe("loadNextConfig with tsconfig path aliases", () => {
   // Ported from Next.js: test/e2e/app-dir/next-config-ts/import-alias-paths-only/
   //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts/import-alias-paths-only/
   // and import-alias-paths-with-baseurl/.
-  // Next.js's transpile-config.ts reads compilerOptions.paths from tsconfig.json
-  // and passes them to SWC so that next.config.ts can import via tsconfig
-  // aliases. vinext mirrors this by passing tsconfig paths to Vite as
-  // resolve.alias when calling runnerImport.
+  // Next.js's transpile-config.ts reads compilerOptions.paths/baseUrl from
+  // tsconfig.json and passes them to SWC so that next.config.ts can import via
+  // tsconfig aliases and baseUrl bare specifiers. vinext mirrors this with
+  // Vite resolver settings when calling runnerImport.
 
   let tmpDir: string;
 
@@ -458,6 +458,48 @@ describe("loadNextConfig with tsconfig path aliases", () => {
 
     const config = await loadNextConfig(tmpDir);
     expect(config?.env?.BAZ).toBe("baz");
+  });
+
+  it("follows extended tsconfig baseUrl when resolving bare imports", async () => {
+    // Ported from Next.js: test/e2e/app-dir/next-config-ts/tsconfig-extends/
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts/tsconfig-extends/next-config-ts-tsconfig-extends-cjs.test.ts
+    tmpDir = makeTempDir();
+
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "foo.ts"), `export const foo = "foo";\n`);
+    fs.writeFileSync(path.join(tmpDir, "bar.ts"), `export const bar = "bar";\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        type: "module",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.base.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        extends: "./tsconfig.base.json",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { foo } from "@/foo";\n` +
+        `import { bar } from "bar";\n` +
+        `export default { env: { VALUE: foo + bar } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.VALUE).toBe("foobar");
   });
 
   it("loads config without tsconfig.json (no aliases needed)", async () => {


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Match Next.js `next.config.ts` resolution when `tsconfig.json` inherits `compilerOptions.baseUrl`, including local-before-package priority. |
| Core change | Carry effective tsconfig `baseUrl` into TypeScript config evaluation, keep those config imports inside Vite's resolver pipeline, and resolve baseUrl-local bare imports before package fallback. |
| Main boundary | TypeScript config files only: `next.config.ts`, `next.config.mts`, and `next.config.cts`. Non-TypeScript config files keep their existing package resolution behavior. |
| Primary files | `packages/vinext/src/config/next-config.ts`, `packages/vinext/src/config/tsconfig-paths.ts`, `tests/next-config.test.ts` |
| Expected impact | Next.js deploy-suite fixtures and real apps can import local config helpers via inherited `baseUrl` from `next.config.ts` without changing `next.config.mjs` package shadowing semantics. |

## Why

`next.config.ts` has to be evaluated under the same tsconfig module-resolution contract Next.js applies before app build starts. Next.js reads `paths` and `baseUrl`, follows `extends`, and passes those options into its TypeScript config transpilation path. That contract also means a bare import that exists both under `baseUrl` and in `node_modules` resolves to the local baseUrl target first, with package resolution as fallback. The same rule should not leak into plain `.mjs`, `.js`, or `.cjs` config loading.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| TypeScript config loading | `next.config.ts` imports should observe tsconfig resolution before config values are read. | `loadNextConfig()` now receives both alias entries and the effective `baseUrl`. |
| Resolver priority | `paths` aliases win first, then baseUrl-local files, then packages. | The baseUrl resolver is a Vite `pre` plugin, while aliases still run before user `pre` plugins. |
| Vite runner externalization | Installed packages must not bypass TypeScript config baseUrl lookup before `resolveId()` runs. | TypeScript config loading sets inline `noExternal: true`, so installed bare imports still pass through the resolver pipeline. |
| Non-TypeScript config boundary | TypeScript/SWC config-loader semantics must not rewrite plain Node/ESM config imports. | The baseUrl resolver and `noExternal` override are gated to TypeScript config extensions. |
| Dependency isolation | The app's `baseUrl` must not rewrite imports made from inside package code. | The baseUrl resolver only runs for project-owned importers and rejects `node_modules` importers, including symlink-resolved paths. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `next.config.ts` imports `@/foo` from inherited `paths` | Resolved. | Still resolved. |
| `next.config.ts` imports `bar` from inherited `baseUrl` | Treated as an npm package and failed with `Cannot find module 'bar'` when no package existed. | Resolves to local `bar.ts`. |
| `next.config.ts` has local `bar.ts` and `node_modules/bar` | Package could win first because Vite externalized it before the baseUrl resolver ran. | Local `bar.ts` wins first. |
| `next.config.ts` has no local `bar.ts`, but `node_modules/bar` exists | Package resolution worked. | Package resolution still works. |
| `next.config.mjs` has local `bar.ts`, `node_modules/bar`, and tsconfig `baseUrl` | Could be hijacked by the new TypeScript baseUrl resolver. | Resolves the package, preserving non-TypeScript config semantics. |
| A package imported by `next.config.ts` imports its own bare dependency | Could be hijacked by a naive pre resolver. | Package dependency imports are not rewritten through the app baseUrl. |
| CJS and ESM packages imported from `next.config.ts` | Existing behavior needed to survive `noExternal: true`. | Covered by a focused port of Next's `import-from-node_modules` fixture. |

<details>
<summary>Maintainer Review Path</summary>

1. `packages/vinext/src/config/next-config.ts` - review the TypeScript-only `tsconfigBaseUrl` gate, `tsconfigBaseUrlResolverPlugin()`, the project-owned importer guard, and the inline `noExternal: true` setting that prevents Vite's runner from externalizing installed packages before TypeScript config baseUrl lookup.
2. `packages/vinext/src/config/tsconfig-paths.ts` - review the narrow tsconfig resolution shape. This PR carries `baseUrl` for the existing string `extends` path and deliberately does not claim array-extends parity.
3. `tests/next-config.test.ts` - review the regression matrix: inherited `baseUrl`, local-over-package shadowing, package fallback, non-TypeScript config boundary, package dependency isolation, and CJS/ESM package imports.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/next-config.test.ts -t "extended tsconfig baseUrl"`
- `vp test run tests/next-config.test.ts -t "baseUrl local imports|falls through to packages|package dependency imports|imports ESM and CommonJS packages|extended tsconfig baseUrl"`
- `vp test run tests/next-config.test.ts -t "does not apply tsconfig baseUrl package shadowing to next.config.mjs|resolves baseUrl local imports before packages"`
- `vp test run tests/next-config.test.ts tests/next-config-extensions.test.ts tests/tsconfig-paths-config-loader.test.ts`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/next-config-ts/tsconfig-extends/next-config-ts-tsconfig-extends-cjs.test.ts`

Red/green notes:

- The inherited-baseUrl regression failed before the first fix with `Cannot find module 'bar'`.
- The local-over-package regression failed before the resolver-priority fix with `Received: "package"` where `"local"` was expected.
- The `next.config.mjs` boundary regression failed before the TypeScript-only gate with `Received: "local"` where `"package"` was expected.

</details>

<details>
<summary>Risk / Compatibility</summary>

- Public API impact: none.
- Config impact: TypeScript config files now accept the same inherited `baseUrl` local imports that Next.js accepts.
- Non-TypeScript config impact: the new baseUrl resolver and `noExternal` override do not apply to `.mjs`, `.js`, or `.cjs` configs.
- Runtime impact: limited to config-file evaluation during dev/build/start setup.
- Existing-app risk: bounded to TypeScript config evaluation. The added CJS/ESM package-import test covers the main compatibility shape from Next's suite after disabling runner externalization for TypeScript configs.
- Compatibility: intentionally follows Next.js config transpilation semantics for `paths` and `baseUrl` without widening that behavior to every config file type.

</details>

<details>
<summary>Non-Goals</summary>

- This does not change application source module resolution.
- This does not add support for `typescript.tsconfigPath` while loading `next.config.ts`; Next.js notes that as a current chicken-and-egg restriction in its loader implementation.
- This does not claim full `extends` array parity. The PR stays scoped to the single-extends behavior covered by the failing upstream deploy-suite fixture.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js CJS deploy test](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/next-config-ts/tsconfig-extends/next-config-ts-tsconfig-extends-cjs.test.ts#L8-L10) | Upstream observable contract: rendering `/` must produce `foobar`. |
| [Upstream `next.config.ts` fixture](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/next-config-ts/tsconfig-extends/next.config.ts#L1-L12) | Shows the mixed `@/foo` path alias and bare `bar` import that must resolve. |
| [Upstream extended tsconfig base](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/next-config-ts/tsconfig-extends/tsconfig.base.json#L1-L8) | Defines `baseUrl` and `paths` inherited by the test tsconfig. |
| [Next.js SWC config options](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/next-config-ts/transpile-config.ts#L12-L27) | Next.js passes `paths` and `baseUrl` into TypeScript config transpilation. |
| [Next.js tsconfig extends loader](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/next-config-ts/transpile-config.ts#L77-L128) | Shows Next.js following `extends` before loading `next.config.ts`. |
| [Next.js import-from-node_modules fixture](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/next-config-ts/import-from-node-modules/next.config.ts#L1-L16) | Covers CJS and ESM package imports from `next.config.ts`, which is the main compatibility risk after disabling runner externalization for TypeScript configs. |
