### PR TITLE
fix(app-router): prerender cacheComponents root-param fallback shells

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -54,6 +54,7 @@ import { startProdServer } from "../server/prod-server.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
+import { createAppPprFallbackShells } from "../server/app-ppr-fallback-shell.js";
 export { readPrerenderSecret } from "./server-manifest.js";
 
 function getErrorMessageWithStack(err: Error): string {
@@ -1154,6 +1155,7 @@ export async function prerenderApp({
             continue;
           }
 
+          const queuedRouteUrls = new Set<string>();
           for (const params of paramSets) {
             // Defensively guard against a generateStaticParams() that returns
             // entries with no params object. Next.js's app static-paths code
@@ -1167,6 +1169,7 @@ export async function prerenderApp({
               );
             }
             const urlPath = buildUrlFromParams(route.pattern, params);
+            queuedRouteUrls.add(urlPath);
             urlsToRender.push({
               urlPath,
               routePattern: route.pattern,
@@ -1174,6 +1177,24 @@ export async function prerenderApp({
               revalidate,
               isSpeculative: false,
             });
+
+            if (config.cacheComponents === true) {
+              for (const fallbackShell of createAppPprFallbackShells(route, params)) {
+                if (queuedRouteUrls.has(fallbackShell.pathname)) continue;
+                queuedRouteUrls.add(fallbackShell.pathname);
+                urlsToRender.push({
+                  urlPath: fallbackShell.pathname,
+                  routePattern: route.pattern,
+                  prerenderRouteParams: encodePrerenderRouteParams(
+                    route.pattern,
+                    fallbackShell.params,
+                    fallbackShell.fallbackParamNames,
+                  ),
+                  revalidate,
+                  isSpeculative: false,
+                });
+              }
+            }
           }
         } catch (e) {
           const err = e as Error;

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -71,6 +71,18 @@ class PrerenderProgress {
   }
 }
 
+function readBuiltBuildId(serverDir: string): string | null {
+  try {
+    const buildId = fs.readFileSync(path.join(serverDir, "BUILD_ID"), "utf-8").trim();
+    return buildId.length > 0 ? buildId : null;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
 // ─── Shared runner ────────────────────────────────────────────────────────────
 
 type RunPrerenderOptions = {
@@ -143,6 +155,8 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   // cleaned with the rest of vinext's build output on rebuild and co-located
   // with server artifacts.
   const manifestDir = path.join(root, "dist", "server");
+  const rscBundlePath = options.rscBundlePath ?? path.join(root, "dist", "server", "index.js");
+  const serverDir = path.dirname(rscBundlePath);
 
   const loadedConfig = await resolveNextConfig(await loadNextConfig(root), root);
   const config = options.nextConfigOverride
@@ -151,7 +165,11 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
       // nextConfigOverride replace the entire nested object from loadedConfig.
       // This is intentional for test usage (top-level overrides only); a deep
       // merge would be needed to support partial nested overrides in the future.
-      loadedConfig;
+      { ...loadedConfig };
+  const builtBuildId = readBuiltBuildId(serverDir);
+  if (builtBuildId) {
+    config.buildId = builtBuildId;
+  }
   // Activate export mode when next.config.js sets `output: 'export'`.
   // In export mode, SSR routes and any dynamic routes without static params are
   // build errors rather than silently skipped.
@@ -180,9 +198,6 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
     mode === "export"
       ? path.join(root, "dist", "client")
       : path.join(root, "dist", "server", "prerendered-routes");
-
-  const rscBundlePath = options.rscBundlePath ?? path.join(root, "dist", "server", "index.js");
-  const serverDir = path.dirname(rscBundlePath);
 
   // For hybrid builds (both app/ and pages/ present), start a single shared
   // prod server and pass it to both phases. This avoids spinning up two servers

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -166,6 +166,14 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
       // This is intentional for test usage (top-level overrides only); a deep
       // merge would be needed to support partial nested overrides in the future.
       { ...loadedConfig };
+  // Prerender must reuse the exact BUILD_ID that `vinext build` wrote to disk
+  // rather than re-resolving a fresh one. `config.buildId` is consumed when
+  // computing prerendered-output identity (prerender.ts), so re-resolving here
+  // would produce artifacts keyed to a different buildId than the deployed
+  // bundle. Reading it back from the built `BUILD_ID` file keeps prerender
+  // output aligned with the bundle it was generated from. (Spreading
+  // `loadedConfig` above is required so this assignment does not mutate the
+  // shared loaded config.)
   const builtBuildId = readBuiltBuildId(serverDir);
   if (builtBuildId) {
     config.buildId = builtBuildId;

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -133,6 +133,8 @@ type AppRouterConfig = {
   cacheMaxMemorySize?: number;
   /** Inline app CSS into production HTML (from experimental.inlineCss). */
   inlineCss?: boolean;
+  /** Enables Next.js Cache Components semantics for App Router document HTML. */
+  cacheComponents?: boolean;
   /** Internationalization routing config for middleware matcher locale handling. */
   i18n?: NextI18nConfig | null;
   /**

--- a/packages/vinext/src/server/app-ppr-fallback-shell.ts
+++ b/packages/vinext/src/server/app-ppr-fallback-shell.ts
@@ -1,0 +1,134 @@
+import { createInlineScriptTag } from "./html.js";
+import { createNavigationRuntimeRscMetadataScript } from "./app-ssr-stream.js";
+
+type AppPprFallbackShellRoute = {
+  params: readonly string[];
+  pattern: string;
+  rootParamNames?: readonly string[] | null;
+};
+
+type AppPprFallbackShell = {
+  fallbackParamNames: readonly string[];
+  pathname: string;
+  params: Record<string, string | string[]>;
+};
+
+function routeRootParamNames(route: AppPprFallbackShellRoute): Set<string> {
+  return new Set(route.rootParamNames ?? []);
+}
+
+function placeholderForParam(part: string, paramName: string): string | string[] {
+  if (part.endsWith("+")) return [`[...${paramName}]`];
+  if (part.endsWith("*")) return [`[[...${paramName}]]`];
+  return `[${paramName}]`;
+}
+
+function pushParamValue(segments: string[], value: string | string[] | undefined): boolean {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return false;
+    segments.push(...value.map((item) => encodeURIComponent(item)));
+    return true;
+  }
+
+  if (typeof value !== "string") return false;
+  segments.push(encodeURIComponent(value));
+  return true;
+}
+
+export function createAppPprFallbackShell(
+  route: AppPprFallbackShellRoute,
+  matchedParams: Record<string, string | string[]>,
+): AppPprFallbackShell | null {
+  return createAppPprFallbackShells(route, matchedParams).at(-1) ?? null;
+}
+
+export function createAppPprFallbackShells(
+  route: AppPprFallbackShellRoute,
+  matchedParams: Record<string, string | string[]>,
+): AppPprFallbackShell[] {
+  const rootParamNames = routeRootParamNames(route);
+  if (rootParamNames.size === 0) return [];
+
+  let minKeptParamCount = 0;
+  for (const rootParamName of rootParamNames) {
+    const rootParamIndex = route.params.indexOf(rootParamName);
+    if (rootParamIndex === -1 || matchedParams[rootParamName] === undefined) return [];
+    minKeptParamCount = Math.max(minKeptParamCount, rootParamIndex + 1);
+  }
+
+  if (minKeptParamCount >= route.params.length) {
+    return [];
+  }
+
+  const shells: AppPprFallbackShell[] = [];
+  for (
+    let keptParamCount = route.params.length - 1;
+    keptParamCount >= minKeptParamCount;
+    keptParamCount--
+  ) {
+    const keptParamNames = new Set(route.params.slice(0, keptParamCount));
+    const fallbackParamNames = route.params.filter((name) => !keptParamNames.has(name));
+    if (fallbackParamNames.length === 0) continue;
+
+    const fallbackParamNameSet = new Set(fallbackParamNames);
+    const segments: string[] = [];
+    const fallbackParams: Record<string, string | string[]> = {};
+
+    let isValidShell = true;
+    for (const part of route.pattern.split("/").filter(Boolean)) {
+      if (part.startsWith(":")) {
+        const isCatchAll = part.endsWith("+") || part.endsWith("*");
+        const paramName = isCatchAll ? part.slice(1, -1) : part.slice(1);
+
+        if (fallbackParamNameSet.has(paramName)) {
+          const placeholder = placeholderForParam(part, paramName);
+          segments.push(...(Array.isArray(placeholder) ? placeholder : [placeholder]));
+          fallbackParams[paramName] = placeholder;
+          continue;
+        }
+
+        const value = matchedParams[paramName];
+        if (!pushParamValue(segments, value)) {
+          isValidShell = false;
+          break;
+        }
+        fallbackParams[paramName] = value;
+        continue;
+      }
+
+      segments.push(part);
+    }
+
+    if (!isValidShell) continue;
+    shells.push({
+      fallbackParamNames,
+      pathname: "/" + segments.join("/"),
+      params: fallbackParams,
+    });
+  }
+
+  return shells;
+}
+
+export function rewriteAppPprFallbackShellHtmlNavigation(options: {
+  html: string;
+  params: Record<string, string | string[]>;
+  pathname: string;
+  searchParams: URLSearchParams;
+}): string {
+  const metadataScript = createInlineScriptTag(
+    createNavigationRuntimeRscMetadataScript(options.params, {
+      pathname: options.pathname,
+      searchParams: [...options.searchParams.entries()],
+    }),
+  );
+
+  const headCloseIndex = options.html.indexOf("</head>");
+  if (headCloseIndex !== -1) {
+    return (
+      options.html.slice(0, headCloseIndex) + metadataScript + options.html.slice(headCloseIndex)
+    );
+  }
+
+  return metadataScript + options.html;
+}

--- a/packages/vinext/src/server/app-ppr-fallback-shell.ts
+++ b/packages/vinext/src/server/app-ppr-fallback-shell.ts
@@ -105,6 +105,13 @@ export function createAppPprFallbackShells(
     // prerender render path must supply params via the prerender-params header
     // rather than URL matching, because encoded brackets won't match the route
     // pattern's literal brackets.
+    //
+    // Note: this describes the intended end-state. As of this PR
+    // (generation-only), `prerenderRouteParamsPayloadMatchesRoute` accepts only
+    // `kind === "exact"` payloads, so a fallback-shell render currently resolves
+    // params from the URL (the literal `[slug]` placeholder) rather than the
+    // prerender-params header. The header-supplied placeholder params are wired
+    // up by the fallback-shell render-lifecycle follow-up (#1715).
     shells.push({
       fallbackParamNames,
       pathname: "/" + segments.join("/"),

--- a/packages/vinext/src/server/app-ppr-fallback-shell.ts
+++ b/packages/vinext/src/server/app-ppr-fallback-shell.ts
@@ -100,6 +100,11 @@ export function createAppPprFallbackShells(
     }
 
     if (!isValidShell) continue;
+    // Placeholder brackets (`[slug]`, `[...slug]`) become literal `[`/`]` in the
+    // shell pathname, which `new URL()` percent-encodes at fetch time. The
+    // prerender render path must supply params via the prerender-params header
+    // rather than URL matching, because encoded brackets won't match the route
+    // pattern's literal brackets.
     shells.push({
       fallbackParamNames,
       pathname: "/" + segments.join("/"),

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -4,9 +4,21 @@ import { isUnknownRecord } from "../utils/record.js";
 export type PrerenderRouteParams = Record<string, string | string[]>;
 
 export type PrerenderRouteParamsPayload = {
+  fallbackParamNames?: readonly string[];
   params: PrerenderRouteParams;
   routePattern: string;
 };
+
+type PrerenderRouteParamsRouteMatch =
+  | {
+      kind: "exact";
+      params: PrerenderRouteParams;
+    }
+  | {
+      fallbackParamNames: readonly string[];
+      kind: "fallback-shell";
+      params: PrerenderRouteParams;
+    };
 
 function isPrerenderRouteParams(value: unknown): value is PrerenderRouteParams {
   if (!isUnknownRecord(value)) return false;
@@ -22,7 +34,20 @@ function isPrerenderRouteParams(value: unknown): value is PrerenderRouteParams {
 
 function isPrerenderRouteParamsPayload(value: unknown): value is PrerenderRouteParamsPayload {
   if (!isUnknownRecord(value)) return false;
-  if (Object.keys(value).length !== 2) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== 2 && keys.length !== 3) return false;
+  if (
+    keys.some((key) => key !== "fallbackParamNames" && key !== "params" && key !== "routePattern")
+  ) {
+    return false;
+  }
+  if (
+    "fallbackParamNames" in value &&
+    (!Array.isArray(value.fallbackParamNames) ||
+      !value.fallbackParamNames.every((name) => typeof name === "string"))
+  ) {
+    return false;
+  }
   return (
     typeof value.routePattern === "string" &&
     value.routePattern.startsWith("/") &&
@@ -116,24 +141,55 @@ export function prerenderRouteParamsPayloadMatchesRoute(
   routePattern: string,
   params: PrerenderRouteParams,
 ): payload is PrerenderRouteParamsPayload {
-  if (payload === null) return false;
-  if (payload.routePattern !== routePattern) return false;
+  const match = matchPrerenderRouteParamsPayload(payload, routePattern, params);
+  return match?.kind === "exact";
+}
 
+function matchPrerenderRouteParamsPayload(
+  payload: PrerenderRouteParamsPayload | null,
+  routePattern: string,
+  params: PrerenderRouteParams,
+): PrerenderRouteParamsRouteMatch | null {
+  if (payload === null) return null;
+  if (payload.routePattern !== routePattern) return null;
   const prerenderParamKeys = Object.keys(payload.params);
-  if (prerenderParamKeys.length !== Object.keys(params).length) return false;
+  if (prerenderParamKeys.length !== Object.keys(params).length) return null;
 
   for (const [key, prerenderValue] of Object.entries(payload.params)) {
     const matchedValue = params[key];
-    if (matchedValue === undefined) return false;
-    if (!decodedPrerenderRouteParamEquals(prerenderValue, matchedValue)) return false;
+    if (matchedValue === undefined) return null;
+    if (!decodedPrerenderRouteParamEquals(prerenderValue, matchedValue)) return null;
   }
 
-  return true;
+  if (payload.fallbackParamNames) {
+    const routeParamNames = new Set(
+      routePattern
+        .split("/")
+        .filter((part) => part.startsWith(":"))
+        .map((part) =>
+          part.endsWith("+") || part.endsWith("*") ? part.slice(1, -1) : part.slice(1),
+        ),
+    );
+    const fallbackParamNames = payload.fallbackParamNames.filter(
+      (name, index, names) => routeParamNames.has(name) && names.indexOf(name) === index,
+    );
+    if (fallbackParamNames.length !== payload.fallbackParamNames.length) return null;
+    if (fallbackParamNames.length === 0) return null;
+
+    return {
+      fallbackParamNames,
+      kind: "fallback-shell",
+      params: payload.params,
+    };
+  }
+
+  return { kind: "exact", params: payload.params };
 }
 
 export function encodePrerenderRouteParams(
   pattern: string,
   params: PrerenderRouteParams,
+  fallbackParamNames?: readonly string[],
 ): PrerenderRouteParamsPayload | null {
   const encoded: PrerenderRouteParams = {};
 
@@ -154,5 +210,11 @@ export function encodePrerenderRouteParams(
     }
   }
 
-  return Object.keys(encoded).length > 0 ? { routePattern: pattern, params: encoded } : null;
+  return Object.keys(encoded).length > 0
+    ? {
+        ...(fallbackParamNames && fallbackParamNames.length > 0 ? { fallbackParamNames } : {}),
+        routePattern: pattern,
+        params: encoded,
+      }
+    : null;
 }

--- a/tests/app-ppr-fallback-shell.test.ts
+++ b/tests/app-ppr-fallback-shell.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createAppPprFallbackShell,
+  createAppPprFallbackShells,
+  rewriteAppPprFallbackShellHtmlNavigation,
+} from "../packages/vinext/src/server/app-ppr-fallback-shell.js";
+
+describe("createAppPprFallbackShell", () => {
+  it("builds a cacheComponents fallback shell from known root params and missing child params", () => {
+    const shell = createAppPprFallbackShell(
+      {
+        params: ["locale", "slug"],
+        pattern: "/:locale/blog/:slug",
+        rootParamNames: ["locale"],
+      },
+      { locale: "en", slug: "new-post" },
+    );
+
+    expect(shell).toEqual({
+      fallbackParamNames: ["slug"],
+      pathname: "/en/blog/[slug]",
+      params: { locale: "en", slug: "[slug]" },
+    });
+  });
+
+  it("preserves catch-all placeholder shape in the shell path and params", () => {
+    const shell = createAppPprFallbackShell(
+      {
+        params: ["locale", "slug"],
+        pattern: "/:locale/docs/:slug+",
+        rootParamNames: ["locale"],
+      },
+      { locale: "fr", slug: ["guides", "intro"] },
+    );
+
+    expect(shell).toEqual({
+      fallbackParamNames: ["slug"],
+      pathname: "/fr/docs/[...slug]",
+      params: { locale: "fr", slug: ["[...slug]"] },
+    });
+  });
+
+  it("preserves optional catch-all placeholder shape in the shell path and params", () => {
+    const shell = createAppPprFallbackShell(
+      {
+        params: ["locale", "slug"],
+        pattern: "/:locale/docs/:slug*",
+        rootParamNames: ["locale"],
+      },
+      { locale: "fr", slug: ["guides", "intro"] },
+    );
+
+    expect(shell).toEqual({
+      fallbackParamNames: ["slug"],
+      pathname: "/fr/docs/[[...slug]]",
+      params: { locale: "fr", slug: ["[[...slug]]"] },
+    });
+  });
+
+  it("orders nested fallback shells from most specific child prefix to root-only", () => {
+    const shells = createAppPprFallbackShells(
+      {
+        params: ["locale", "category", "slug"],
+        pattern: "/:locale/category/:category/post/:slug",
+        rootParamNames: ["locale"],
+      },
+      { locale: "en", category: "news", slug: "launch" },
+    );
+
+    expect(shells).toEqual([
+      {
+        fallbackParamNames: ["slug"],
+        pathname: "/en/category/news/post/[slug]",
+        params: { locale: "en", category: "news", slug: "[slug]" },
+      },
+      {
+        fallbackParamNames: ["category", "slug"],
+        pathname: "/en/category/[category]/post/[slug]",
+        params: { locale: "en", category: "[category]", slug: "[slug]" },
+      },
+    ]);
+  });
+
+  it("does not create a fallback shell without a known root-param boundary", () => {
+    expect(
+      createAppPprFallbackShell(
+        {
+          params: ["locale", "slug"],
+          pattern: "/:locale/blog/:slug",
+          rootParamNames: [],
+        },
+        { locale: "en", slug: "new-post" },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not create a fallback shell when the matched request lacks a root param", () => {
+    expect(
+      createAppPprFallbackShell(
+        {
+          params: ["locale", "slug"],
+          pattern: "/:locale/blog/:slug",
+          rootParamNames: ["locale"],
+        },
+        { slug: "new-post" },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("rewriteAppPprFallbackShellHtmlNavigation", () => {
+  it("patches cached fallback-shell HTML with the actual request navigation metadata", () => {
+    const html = rewriteAppPprFallbackShellHtmlNavigation({
+      html: "<html><head><title>x</title></head><body>shell</body></html>",
+      params: { locale: "en", slug: "new-post" },
+      pathname: "/en/blog/new-post",
+      searchParams: new URLSearchParams([["preview", "1"]]),
+    });
+
+    expect(html).toContain('params:{"locale":"en","slug":"new-post"}');
+    expect(html).toContain('"pathname":"/en/blog/new-post"');
+    expect(html).toContain('"searchParams":[["preview","1"]]');
+    const paramsIndex = html.indexOf('params:{"locale":"en","slug":"new-post"}');
+    const headCloseIndex = html.indexOf("</head>");
+    expect(paramsIndex).toBeGreaterThanOrEqual(0);
+    expect(headCloseIndex).toBeGreaterThanOrEqual(0);
+    expect(paramsIndex).toBeLessThan(headCloseIndex);
+  });
+});

--- a/tests/prerender-route-params.test.ts
+++ b/tests/prerender-route-params.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  encodePrerenderRouteParams,
   prerenderRouteParamsPayloadMatchesRoute,
   type PrerenderRouteParamsPayload,
 } from "../packages/vinext/src/server/prerender-route-params.js";
@@ -49,5 +50,76 @@ describe("prerenderRouteParamsPayloadMatchesRoute", () => {
         slug: "sticks & stones",
       }),
     ).toBe(false);
+  });
+
+  it("rejects a payload whose fallbackParamNames contain a param not present in the route pattern", () => {
+    const payload: PrerenderRouteParamsPayload = {
+      routePattern: "/product/:id",
+      params: { id: "abc" },
+      fallbackParamNames: ["id", "slug"],
+    };
+
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+        id: "abc",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a payload whose fallbackParamNames contain duplicates", () => {
+    const payload: PrerenderRouteParamsPayload = {
+      routePattern: "/product/:id",
+      params: { id: "abc" },
+      fallbackParamNames: ["id", "id"],
+    };
+
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+        id: "abc",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for a valid fallback-shell match because only exact matches are accepted", () => {
+    const payload: PrerenderRouteParamsPayload = {
+      routePattern: "/product/:id",
+      params: { id: "abc" },
+      fallbackParamNames: ["id"],
+    };
+
+    expect(
+      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+        id: "abc",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("encodePrerenderRouteParams", () => {
+  it("round-trips fallbackParamNames when provided", () => {
+    const payload = encodePrerenderRouteParams("/product/:id", { id: "abc" }, ["id"]);
+
+    expect(payload).toEqual({
+      routePattern: "/product/:id",
+      params: { id: "abc" },
+      fallbackParamNames: ["id"],
+    });
+  });
+
+  it("omits fallbackParamNames when the array is empty", () => {
+    const payload = encodePrerenderRouteParams("/product/:id", { id: "abc" }, []);
+
+    expect(payload).toEqual({
+      routePattern: "/product/:id",
+      params: { id: "abc" },
+    });
+  });
+
+  it("returns null when there are no dynamic params", () => {
+    expect(encodePrerenderRouteParams("/about", {})).toBe(null);
+  });
+
+  it("returns null when there are no dynamic params even with fallbackParamNames", () => {
+    expect(encodePrerenderRouteParams("/about", {}, ["id"])).toBe(null);
   });
 });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -1072,6 +1072,102 @@ describe("runPrerender — hybrid app+pages (app-basic)", () => {
   });
 });
 
+describe("prerenderApp — cacheComponents PPR fallback-shell artifacts", () => {
+  async function prerenderDynamicRootParamRoute(cacheComponents: boolean) {
+    const root = tmpDir("vinext-prerender-ppr-shell-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    const pageDir = path.join(appDir, "[locale]", "blog", "[slug]");
+    fs.mkdirSync(pageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "[locale]", "layout.tsx"),
+      "export default function Layout({ children }: { children: React.ReactNode }) { return children; }\n",
+    );
+    fs.writeFileSync(
+      path.join(pageDir, "page.tsx"),
+      "export default function Page() { return null; }\n",
+    );
+
+    const renderedPaths: string[] = [];
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/__vinext/prerender/static-params") {
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify([{ locale: "en", slug: "hello" }]));
+        return;
+      }
+      if (url.pathname === "/__vinext_nonexistent_for_404__") {
+        res.statusCode = 404;
+        res.end("<html><body>not found</body></html>");
+        return;
+      }
+
+      renderedPaths.push(url.pathname);
+      res.setHeader("content-type", "text/html");
+      res.end(
+        "<html><body>" +
+          runtimeRscChunkScript(
+            `0:["$","div",null,{"children":${JSON.stringify(url.pathname)}}]\n`,
+          ) +
+          runtimeRscDoneScript() +
+          "</body></html>",
+      );
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({ cacheComponents });
+
+      const result = await prerenderApp({
+        mode: "default",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      return { renderedPaths, routes: result.routes };
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  it("queues fallback-shell artifacts when cacheComponents is enabled", async () => {
+    const { renderedPaths, routes } = await prerenderDynamicRootParamRoute(true);
+
+    expect(findRoute(routes, "/en/blog/hello")).toMatchObject({
+      route: "/:locale/blog/:slug",
+      path: "/en/blog/hello",
+      status: "rendered",
+    });
+    expect(findRoute(routes, "/en/blog/[slug]")).toMatchObject({
+      route: "/:locale/blog/:slug",
+      path: "/en/blog/[slug]",
+      status: "rendered",
+    });
+    expect(renderedPaths).toEqual(expect.arrayContaining(["/en/blog/hello", "/en/blog/[slug]"]));
+  });
+
+  it("does not queue fallback-shell artifacts when cacheComponents is disabled", async () => {
+    const { renderedPaths, routes } = await prerenderDynamicRootParamRoute(false);
+
+    expect(findRoute(routes, "/en/blog/hello")).toMatchObject({
+      route: "/:locale/blog/:slug",
+      path: "/en/blog/hello",
+      status: "rendered",
+    });
+    expect(findRoute(routes, "/en/blog/[slug]")).toBeUndefined();
+    expect(renderedPaths).toContain("/en/blog/hello");
+    expect(renderedPaths).not.toContain("/en/blog/[slug]");
+  });
+});
+
 // ─── runPrerender — output: 'export' wiring ───────────────────────────────────
 
 describe("runPrerender — output: 'export' wiring", () => {


### PR DESCRIPTION
## Stack position

PR 1 of 4 for `cacheComponents` PPR root-param fallback shells.

This slice is intentionally limited to **model + generation**. It teaches vinext how to describe fallback-shell artifacts during prerender, but it does not add runtime cache serving or render lifecycle policy.

Stack:

1. #1702: model + prerender generation
2. #1714: payload identity + pregenerated concrete-path identity
3. #1715: fallback-shell render lifecycle
4. #1716: safe runtime serving

## Problem

Next.js can prerender a reusable shell for routes where root params are known but child params are still fallback params. Example: if `/en` is pregenerated and `[slug]` is unknown, the reusable shell path is `/en/blog/[slug]`.

Vinext did not have a first-class model for these fallback-shell artifacts, so later runtime code had no precise artifact to probe. A broad runtime wait policy can hide the symptom, but the correct base is to produce the intended shell artifacts during prerender.

## What changed

- Adds fallback-shell path generation for App Router PPR routes.
- Supports normal dynamic, catch-all, and optional catch-all fallback placeholders:
  - `/:locale/blog/:slug` with root `locale=en` -> `/en/blog/[slug]`
  - `/fr/docs/[...slug]`
  - `/fr/docs/[[...slug]]`
- Sorts nested shells most-specific first so runtime can probe the most precise reusable shell before broader candidates.
- Queues fallback-shell artifacts only when `cacheComponents` is enabled.
- Leaves non-root-param routes without fallback-shell artifacts.

## Contract covered

`createAppPprFallbackShells` should produce shell artifact descriptors only when there is a concrete root-param prefix and at least one fallback child param.

`runPrerender` should queue those artifacts only for `cacheComponents: true`; `cacheComponents: false` must keep the previous prerender artifact set.

## Deliberate non-goals

- No runtime cache lookup.
- No stale lifecycle.
- No SSR streaming or warmup policy.
- No request-time static-param validation.

Those are isolated in later PRs so this PR can be reviewed as pure artifact generation.

## Validation

- `vp test run tests/app-ppr-fallback-shell.test.ts tests/prerender.test.ts -t "fallback shell|cacheComponents PPR fallback-shell artifacts"`
- Commit hook: format, lint/typecheck, knip

## References

- [Next.js ppr-root-param-fallback test](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/ppr-root-param-fallback/ppr-root-param-fallback.test.ts)
- [Next.js static path fallback route params](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/static-paths/app.ts#L932-L1058)
- [Next.js root/prefix static param combinations](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/static-paths/app.ts#L134-L260)
