### PR TITLE
fix(css): preserve static media filenames for CSS url assets

### DIFF
--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -24,11 +24,18 @@ function joinAssetFileNamePattern(assetsDir: string, pattern: string): string {
 
 function getAssetSourceNames(assetInfo: ClientAssetFileNameInfo): string[] {
   const names: string[] = [];
+  const seen = new Set<string>();
 
-  for (const name of assetInfo.names ?? []) names.push(name);
-  if (assetInfo.name) names.push(assetInfo.name);
-  for (const originalFileName of assetInfo.originalFileNames ?? []) names.push(originalFileName);
-  if (assetInfo.originalFileName) names.push(assetInfo.originalFileName);
+  function addName(name: string | undefined): void {
+    if (!name || seen.has(name)) return;
+    seen.add(name);
+    names.push(name);
+  }
+
+  for (const name of assetInfo.names ?? []) addName(name);
+  addName(assetInfo.name);
+  for (const originalFileName of assetInfo.originalFileNames ?? []) addName(originalFileName);
+  addName(assetInfo.originalFileName);
 
   return names;
 }

--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -22,6 +22,12 @@ function joinAssetFileNamePattern(assetsDir: string, pattern: string): string {
   return `${normalizedAssetsDir}/${pattern}`;
 }
 
+// Collects the source name/path candidates Rolldown exposes for an asset,
+// deduping on the full string. This differs from the same-named helper in
+// `css-url-assets.ts`, which dedupes on `basename()`: there we derive an output
+// filename and want one entry per basename, whereas here we only need the
+// candidates to test their extension (e.g. `.css`), so the full path is the
+// correct dedup key.
 function getAssetSourceNames(assetInfo: ClientAssetFileNameInfo): string[] {
   const names: string[] = [];
   const seen = new Set<string>();

--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -1,5 +1,52 @@
 import type { UserConfig } from "vite";
 
+type ClientAssetFileNameInfo = {
+  readonly name?: string;
+  readonly names?: readonly string[];
+  readonly originalFileName?: string;
+  readonly originalFileNames?: readonly string[];
+};
+
+const NEXT_CLIENT_CSS_ASSET_FILE_NAMES = "css/[name].[hash:8][extname]";
+const NEXT_CLIENT_STATIC_MEDIA_FILE_NAMES = "media/[name].[hash:8][extname]";
+
+function withoutTrailingSlash(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+}
+
+function joinAssetFileNamePattern(assetsDir: string, pattern: string): string {
+  const normalizedAssetsDir = withoutTrailingSlash(assetsDir);
+  if (!normalizedAssetsDir) return pattern;
+  return `${normalizedAssetsDir}/${pattern}`;
+}
+
+function getAssetSourceNames(assetInfo: ClientAssetFileNameInfo): string[] {
+  const names: string[] = [];
+
+  for (const name of assetInfo.names ?? []) names.push(name);
+  if (assetInfo.name) names.push(assetInfo.name);
+  for (const originalFileName of assetInfo.originalFileNames ?? []) names.push(originalFileName);
+  if (assetInfo.originalFileName) names.push(assetInfo.originalFileName);
+
+  return names;
+}
+
+export function createClientAssetFileNames(assetsDir: string) {
+  const cssAssetFileNames = joinAssetFileNamePattern(assetsDir, NEXT_CLIENT_CSS_ASSET_FILE_NAMES);
+  const staticMediaFileNames = joinAssetFileNamePattern(
+    assetsDir,
+    NEXT_CLIENT_STATIC_MEDIA_FILE_NAMES,
+  );
+
+  return function getClientAssetFileNames(assetInfo: ClientAssetFileNameInfo): string {
+    const sourceNames = getAssetSourceNames(assetInfo);
+    const isCssAsset = sourceNames.some((name) => name.toLowerCase().endsWith(".css"));
+    return isCssAsset ? cssAssetFileNames : staticMediaFileNames;
+  };
+}
+
 /**
  * Extract the npm package name from a module ID (file path).
  * Returns null if not in node_modules.
@@ -85,8 +132,12 @@ export function createClientManualChunks(shimsDir: string) {
  * compression efficiency — small files restart the compression dictionary,
  * adding ~5-15% wire overhead vs fewer larger chunks.
  */
-export function createClientOutputConfig(clientManualChunks: (id: string) => string | undefined) {
+export function createClientOutputConfig(
+  clientManualChunks: (id: string) => string | undefined,
+  assetsDir: string,
+) {
   return {
+    assetFileNames: createClientAssetFileNames(assetsDir),
     manualChunks: clientManualChunks,
     experimentalMinChunkSize: 10_000,
   };

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -166,6 +166,15 @@ function getCssUrlReplacement(match: RegExpExecArray, nextUrl: string): string {
   return `url(${nextUrl})`;
 }
 
+// Intentionally runs on every client-environment CSS request, including
+// `node_modules` stylesheets. The scope is wider than the upstream Next.js
+// fixture exercises, but it is deliberate and safe: marking only appends the
+// private provenance query carrying the source basename, it is idempotent (the
+// marker check in `shouldMarkCssUrlAsset` bails on already-marked URLs), and the
+// restore phase strips the marker before emit — so vendored CSS gets the same
+// correct per-source provenance with no behavioral difference. Narrowing this to
+// exclude `node_modules` would risk dropping provenance for legitimate vendored
+// `url()` assets, so we keep the scope broad.
 export function markCssUrlAssetReferences(code: string, id: string): string | null {
   if (!isCssRequest(id) || !code.includes("url(")) return null;
 

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -451,39 +451,35 @@ function restoreMarkedCssUrls(
   return restoredSource + source.slice(lastIndex);
 }
 
-// Strips the private provenance marker from a url() without restoration. Used
-// for CSS that Vite inlined into a JS chunk (`cssCodeSplit: false` or the
-// `?inline` query) instead of emitting as a standalone `.css` asset: there the
-// asset URL is already final (Vite inlined or rewrote it), so we only need to
-// remove the leaked marker query and never emit sibling media files.
-function stripMarkedCssUrl(rawUrl: string): string | null {
-  const parts = splitUrl(rawUrl);
-  if (getQueryParam(parts.query, CSS_URL_ASSET_MARKER) === null) return null;
-  return joinUrl({ ...parts, query: removeQueryParam(parts.query, CSS_URL_ASSET_MARKER) });
-}
+// Matches the private provenance marker query param embedded in a URL string,
+// in either leading (`?marker=value`) or subsequent (`&marker=value`) position.
+// The value is the URL-encoded source basename, which never contains a query
+// separator (`&`), URL terminator (`#`), or string/CSS delimiter — so the value
+// run stops at any of those. This deliberately does NOT parse `url()` syntax:
+// chunk code is JS where Vite JSON-stringifies inlined CSS, so quoted
+// `url("...")` appears as `url(\"...\")` with escaped quotes that a CSS-quote
+// regex would miss. Stripping the marker param directly is quoting-agnostic.
+const CSS_URL_MARKER_PARAM_RE = new RegExp(
+  // Either: leading `?marker=v` followed by `&` (promote next param to leading),
+  // captured so we can keep the `?` and drop the consumed `&`.
+  `(\\?)${CSS_URL_ASSET_MARKER}=[^&#'")\\\\\\s]*&` +
+    // Or: `?marker=v` / `&marker=v` with nothing chained after the value.
+    `|[?&]${CSS_URL_ASSET_MARKER}=[^&#'")\\\\\\s]*`,
+  "g",
+);
 
+// Strips the private provenance marker from CSS that Vite inlined into a JS
+// chunk (`cssCodeSplit: false` or the `?inline` query) instead of emitting as a
+// standalone `.css` asset. The asset URL is already final there (Vite inlined or
+// rewrote it), so we only remove the leaked marker query and never emit sibling
+// media files. Operates on the raw chunk string to stay agnostic to JS escaping.
 function stripMarkedCssUrls(source: string): string {
-  let strippedSource = "";
-  let lastIndex = 0;
-  let didStrip = false;
-
-  CSS_URL_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = CSS_URL_RE.exec(source)) !== null) {
-    const rawUrl = match[1] ?? match[2] ?? match[3]?.trim();
-    if (!rawUrl || !rawUrl.includes(CSS_URL_ASSET_MARKER)) continue;
-
-    const strippedUrl = stripMarkedCssUrl(rawUrl);
-    if (!strippedUrl) continue;
-
-    strippedSource += source.slice(lastIndex, match.index);
-    strippedSource += getCssUrlReplacement(match, strippedUrl);
-    lastIndex = match.index + match[0].length;
-    didStrip = true;
-  }
-
-  if (!didStrip) return source;
-  return strippedSource + source.slice(lastIndex);
+  return source.replace(CSS_URL_MARKER_PARAM_RE, (_match, leadingQuestion?: string) =>
+    // The first alternative captured a leading `?`; preserve it (the trailing
+    // `&` it consumed promotes the next param to leading position). The second
+    // alternative matched the whole param including its separator — drop it all.
+    leadingQuestion ? leadingQuestion : "",
+  );
 }
 
 /**

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -125,6 +125,8 @@ function isExternalOrRuntimeUrl(pathname: string): boolean {
     pathname.startsWith("#") ||
     pathname.startsWith("//") ||
     /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(pathname) ||
+    // Avoid treating CSS function syntax as an asset path in values such as
+    // gradient fallbacks. Filenames with parentheses stay on Vite's default path.
     pathname.includes("(")
   );
 }
@@ -287,6 +289,9 @@ function findAssetForUrlPath(urlPath: string, indexes: AssetIndexes): BundleAsse
   const directAsset = indexes.assetsByFileName.get(normalizedPath);
   if (directAsset) return directAsset;
 
+  // Vite normally rewrites marked CSS URLs to absolute emitted paths that hit
+  // the direct lookup above. These fallbacks keep the marker repair resilient to
+  // relative or rebased CSS URL output from future Vite/Rolldown changes.
   for (const [fileName, asset] of indexes.assetsByFileName) {
     if (normalizedPath.endsWith(fileName)) return asset;
   }
@@ -335,6 +340,9 @@ function ensureAssetFileNameForSource(
   emitRestoredAsset: EmitRestoredCssUrlAsset,
 ): string {
   const sourceBaseName = basename(sourceName);
+  // Rolldown's deduped asset record does not preserve enough URL provenance to
+  // disambiguate same-basename files from different directories. In that case
+  // both references intentionally share one restored filename for the same bytes.
   const restoreKey = `${asset.fileName}\0${sourceBaseName}`;
   const cachedFileName = indexes.restoredFileNames.get(restoreKey);
   if (cachedFileName) return cachedFileName;
@@ -426,6 +434,15 @@ function restoreMarkedCssUrls(
   return restoredSource + source.slice(lastIndex);
 }
 
+/**
+ * Mutates emitted CSS assets so byte-identical CSS url() dependencies keep
+ * Next-compatible source basenames, emitting sibling media files through the
+ * callback when Rolldown collapsed multiple source files to one asset.
+ *
+ * This expects CSS sources to have been passed through
+ * `markCssUrlAssetReferences()` before Vite resolves relative asset URLs.
+ * The private marker is stripped from final CSS here.
+ */
 export function restoreDedupedCssAssetReferences(
   bundle: CssUrlAssetBundle,
   emitRestoredAsset: EmitRestoredCssUrlAsset,

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -451,6 +451,41 @@ function restoreMarkedCssUrls(
   return restoredSource + source.slice(lastIndex);
 }
 
+// Strips the private provenance marker from a url() without restoration. Used
+// for CSS that Vite inlined into a JS chunk (`cssCodeSplit: false` or the
+// `?inline` query) instead of emitting as a standalone `.css` asset: there the
+// asset URL is already final (Vite inlined or rewrote it), so we only need to
+// remove the leaked marker query and never emit sibling media files.
+function stripMarkedCssUrl(rawUrl: string): string | null {
+  const parts = splitUrl(rawUrl);
+  if (getQueryParam(parts.query, CSS_URL_ASSET_MARKER) === null) return null;
+  return joinUrl({ ...parts, query: removeQueryParam(parts.query, CSS_URL_ASSET_MARKER) });
+}
+
+function stripMarkedCssUrls(source: string): string {
+  let strippedSource = "";
+  let lastIndex = 0;
+  let didStrip = false;
+
+  CSS_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CSS_URL_RE.exec(source)) !== null) {
+    const rawUrl = match[1] ?? match[2] ?? match[3]?.trim();
+    if (!rawUrl || !rawUrl.includes(CSS_URL_ASSET_MARKER)) continue;
+
+    const strippedUrl = stripMarkedCssUrl(rawUrl);
+    if (!strippedUrl) continue;
+
+    strippedSource += source.slice(lastIndex, match.index);
+    strippedSource += getCssUrlReplacement(match, strippedUrl);
+    lastIndex = match.index + match[0].length;
+    didStrip = true;
+  }
+
+  if (!didStrip) return source;
+  return strippedSource + source.slice(lastIndex);
+}
+
 /**
  * Mutates emitted CSS assets so byte-identical CSS url() dependencies keep
  * Next-compatible source basenames, emitting sibling media files through the
@@ -459,6 +494,12 @@ function restoreMarkedCssUrls(
  * This expects CSS sources to have been passed through
  * `markCssUrlAssetReferences()` before Vite resolves relative asset URLs.
  * The private marker is stripped from final CSS here.
+ *
+ * CSS that Vite inlined into a JS chunk (`cssCodeSplit: false` or `?inline`)
+ * never becomes a standalone `.css` asset, so the restore pass would otherwise
+ * leak the private marker into the served CSS string. We defensively strip the
+ * marker from chunk code as well (without sibling-emit, since inlined asset URLs
+ * are already final).
  */
 export function restoreDedupedCssAssetReferences(
   bundle: CssUrlAssetBundle,
@@ -467,10 +508,17 @@ export function restoreDedupedCssAssetReferences(
   const indexes = createAssetIndexes(bundle);
 
   for (const entry of Object.values(bundle)) {
-    if (entry.type !== "asset") continue;
-    if (!isCssFileName(entry.fileName)) continue;
-    if (typeof entry.source !== "string") continue;
+    if (entry.type === "asset") {
+      if (!isCssFileName(entry.fileName)) continue;
+      if (typeof entry.source !== "string") continue;
+      entry.source = restoreMarkedCssUrls(entry.source, indexes, emitRestoredAsset);
+      continue;
+    }
 
-    entry.source = restoreMarkedCssUrls(entry.source, indexes, emitRestoredAsset);
+    // type === "chunk": CSS inlined into JS. Only strip the leaked marker.
+    if (typeof entry.code !== "string" || !entry.code.includes(CSS_URL_ASSET_MARKER)) {
+      continue;
+    }
+    entry.code = stripMarkedCssUrls(entry.code);
   }
 }

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -1,5 +1,13 @@
 import type { Rolldown } from "vite";
 
+// Carried through Vite's CSS asset transform and stripped from final CSS.
+// Avoid double underscores here because unresolved asset placeholders use them.
+const CSS_URL_ASSET_MARKER = "vinext_css_url_asset";
+const CSS_URL_RE = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^'")]*?))\s*\)/g;
+const CSS_ASSET_EXT_RE =
+  /\.(?:avif|bmp|gif|ico|jpe?g|png|svg|webp|woff2?|eot|ttf|otf|mp4|webm|ogg|mp3|wav|flac|aac|wasm)$/i;
+const CSS_REQUEST_RE = /\.(?:css|scss|sass|less|styl|stylus)$/i;
+
 // Vite/Rolldown dedupes assets by source content. Next.js webpack emits CSS
 // url() dependencies as asset/resource modules, so distinct source files keep
 // distinct output names even when their bytes are identical.
@@ -15,10 +23,17 @@ type RestoredCssUrlAsset = {
 
 type EmitRestoredCssUrlAsset = (asset: RestoredCssUrlAsset) => void;
 
-type DedupedAssetRestoration = {
-  readonly sourceFileName: string;
-  readonly outputFileNames: readonly string[];
-  nextOutputIndex: number;
+type UrlParts = {
+  readonly path: string;
+  readonly query: string;
+  readonly hash: string;
+};
+
+type AssetIndexes = {
+  readonly assetsByFileName: Map<string, BundleAsset>;
+  readonly assetsByBaseName: Map<string, BundleAsset[]>;
+  readonly restoredFileNames: Map<string, string>;
+  readonly usedFileNames: Set<string>;
 };
 
 function toPosixPath(value: string): string {
@@ -37,36 +52,190 @@ function fileStem(fileName: string): string {
   return dotIndex <= 0 ? base : base.slice(0, dotIndex);
 }
 
-function getSourceName(asset: BundleAsset, index: number): string | null {
-  const name = asset.names?.[index];
-  if (name) return basename(name);
+function fileDir(fileName: string): string {
+  const normalized = toPosixPath(fileName);
+  const slashIndex = normalized.lastIndexOf("/");
+  return slashIndex === -1 ? "" : normalized.slice(0, slashIndex + 1);
+}
 
-  const originalFileName = asset.originalFileNames?.[index];
-  return originalFileName ? basename(originalFileName) : null;
+function splitUrl(url: string): UrlParts {
+  const hashIndex = url.indexOf("#");
+  const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? "" : url.slice(hashIndex);
+  const queryIndex = beforeHash.indexOf("?");
+
+  if (queryIndex === -1) {
+    return { path: beforeHash, query: "", hash };
+  }
+
+  return {
+    path: beforeHash.slice(0, queryIndex),
+    query: beforeHash.slice(queryIndex + 1),
+    hash,
+  };
+}
+
+function joinUrl({ path, query, hash }: UrlParts): string {
+  return `${path}${query ? `?${query}` : ""}${hash}`;
+}
+
+function decodeURIComponentSafe(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function queryPartKey(part: string): string {
+  const equalsIndex = part.indexOf("=");
+  return equalsIndex === -1 ? part : part.slice(0, equalsIndex);
+}
+
+function getQueryParam(query: string, name: string): string | null {
+  if (!query) return null;
+
+  for (const part of query.split("&")) {
+    if (decodeURIComponentSafe(queryPartKey(part)) !== name) continue;
+    const equalsIndex = part.indexOf("=");
+    return equalsIndex === -1 ? "" : decodeURIComponentSafe(part.slice(equalsIndex + 1));
+  }
+
+  return null;
+}
+
+function removeQueryParam(query: string, name: string): string {
+  if (!query) return "";
+
+  return query
+    .split("&")
+    .filter((part) => decodeURIComponentSafe(queryPartKey(part)) !== name)
+    .join("&");
+}
+
+function appendQueryParam(query: string, name: string, value: string): string {
+  const param = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+  return query ? `${query}&${param}` : param;
+}
+
+function isExternalOrRuntimeUrl(pathname: string): boolean {
+  return (
+    pathname === "" ||
+    pathname.startsWith("/") ||
+    pathname.startsWith("#") ||
+    pathname.startsWith("//") ||
+    /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(pathname) ||
+    pathname.includes("(")
+  );
+}
+
+function shouldMarkCssUrlAsset(rawUrl: string): boolean {
+  const { path: urlPath, query } = splitUrl(rawUrl.trim());
+  if (isExternalOrRuntimeUrl(urlPath)) return false;
+  if (getQueryParam(query, CSS_URL_ASSET_MARKER) !== null) return false;
+
+  const lowerPath = urlPath.toLowerCase();
+  return CSS_ASSET_EXT_RE.test(lowerPath) && !lowerPath.endsWith(".css");
+}
+
+function markCssUrl(rawUrl: string): string | null {
+  const trimmedUrl = rawUrl.trim();
+  if (!shouldMarkCssUrlAsset(trimmedUrl)) return null;
+
+  const parts = splitUrl(trimmedUrl);
+  return joinUrl({
+    ...parts,
+    query: appendQueryParam(parts.query, CSS_URL_ASSET_MARKER, basename(parts.path)),
+  });
+}
+
+function isCssRequest(id: string): boolean {
+  const queryIndex = id.indexOf("?");
+  const cleanId = queryIndex === -1 ? id : id.slice(0, queryIndex);
+  return CSS_REQUEST_RE.test(cleanId);
+}
+
+function getCssUrlReplacement(match: RegExpExecArray, nextUrl: string): string {
+  if (match[1] !== undefined) return `url("${nextUrl}")`;
+  if (match[2] !== undefined) return `url('${nextUrl}')`;
+  return `url(${nextUrl})`;
+}
+
+export function markCssUrlAssetReferences(code: string, id: string): string | null {
+  if (!isCssRequest(id) || !code.includes("url(")) return null;
+
+  let markedCode = "";
+  let lastIndex = 0;
+  let didMark = false;
+
+  CSS_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CSS_URL_RE.exec(code)) !== null) {
+    const rawUrl = match[1] ?? match[2] ?? match[3]?.trim();
+    if (!rawUrl) continue;
+
+    const markedUrl = markCssUrl(rawUrl);
+    if (!markedUrl) continue;
+
+    markedCode += code.slice(lastIndex, match.index);
+    markedCode += getCssUrlReplacement(match, markedUrl);
+    lastIndex = match.index + match[0].length;
+    didMark = true;
+  }
+
+  if (!didMark) return null;
+  return markedCode + code.slice(lastIndex);
+}
+
+function getAssetSourceNames(asset: BundleAsset): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  function addName(name: string | undefined): void {
+    if (!name) return;
+    const sourceName = basename(name);
+    if (seen.has(sourceName)) return;
+    seen.add(sourceName);
+    names.push(sourceName);
+  }
+
+  for (const name of asset.names ?? []) addName(name);
+  if (asset.name) addName(asset.name);
+  for (const originalFileName of asset.originalFileNames ?? []) addName(originalFileName);
+  if (asset.originalFileName) addName(asset.originalFileName);
+
+  return names;
 }
 
 function isCssFileName(fileName: string): boolean {
   return fileName.toLowerCase().endsWith(".css");
 }
 
-function deriveSiblingAssetFileName(
-  existingFileName: string,
-  existingSourceName: string,
-  siblingSourceName: string,
-): string | null {
-  const existingStem = fileStem(existingSourceName);
-  const siblingStem = fileStem(siblingSourceName);
-  if (!existingStem || !siblingStem) return null;
+function outputBaseStartsWithStem(outputBase: string, stem: string): boolean {
+  if (!outputBase.startsWith(stem)) return false;
+  const nextChar = outputBase[stem.length];
+  return nextChar === undefined || nextChar === "." || nextChar === "-";
+}
 
-  const normalizedOutputName = toPosixPath(existingFileName);
-  const slashIndex = normalizedOutputName.lastIndexOf("/");
-  const outputDir = slashIndex === -1 ? "" : normalizedOutputName.slice(0, slashIndex + 1);
-  const outputBase =
-    slashIndex === -1 ? normalizedOutputName : normalizedOutputName.slice(slashIndex + 1);
+function deriveAssetFileNameForSource(asset: BundleAsset, sourceName: string): string | null {
+  const desiredStem = fileStem(sourceName);
+  if (!desiredStem) return null;
 
-  if (!outputBase.startsWith(existingStem)) return null;
+  const outputDir = fileDir(asset.fileName);
+  const outputBase = basename(asset.fileName);
+  const sourceNames = getAssetSourceNames(asset).sort(
+    (a, b) => fileStem(b).length - fileStem(a).length,
+  );
 
-  return `${outputDir}${siblingStem}${outputBase.slice(existingStem.length)}`;
+  for (const candidateSourceName of sourceNames) {
+    const candidateStem = fileStem(candidateSourceName);
+    if (!candidateStem || !outputBaseStartsWithStem(outputBase, candidateStem)) continue;
+    return `${outputDir}${desiredStem}${outputBase.slice(candidateStem.length)}`;
+  }
+
+  const dotIndex = outputBase.indexOf(".");
+  const suffix = dotIndex === -1 ? "" : outputBase.slice(dotIndex);
+  return `${outputDir}${desiredStem}${suffix}`;
 }
 
 function reserveBundleFileName(fileName: string, usedFileNames: Set<string>): string {
@@ -90,134 +259,184 @@ function reserveBundleFileName(fileName: string, usedFileNames: Set<string>): st
   }
 }
 
-function addSiblingAsset(
-  usedFileNames: Set<string>,
-  mergedAsset: BundleAsset,
-  fileName: string,
-  emitRestoredAsset: EmitRestoredCssUrlAsset,
-): string {
-  const reservedFileName = reserveBundleFileName(fileName, usedFileNames);
-  emitRestoredAsset({ fileName: reservedFileName, source: mergedAsset.source });
-  return reservedFileName;
-}
-
-function buildDedupedAssetRestorations(
-  bundle: CssUrlAssetBundle,
-  emitRestoredAsset: EmitRestoredCssUrlAsset,
-): DedupedAssetRestoration[] {
-  const usedFileNames = new Set(Object.keys(bundle));
-  const restorations: DedupedAssetRestoration[] = [];
+function createAssetIndexes(bundle: CssUrlAssetBundle): AssetIndexes {
+  const assetsByFileName = new Map<string, BundleAsset>();
+  const assetsByBaseName = new Map<string, BundleAsset[]>();
 
   for (const entry of Object.values(bundle)) {
-    if (entry.type !== "asset") continue;
-    if (isCssFileName(entry.fileName)) continue;
+    if (entry.type !== "asset" || isCssFileName(entry.fileName)) continue;
 
-    const sourceCount = Math.max(entry.originalFileNames?.length ?? 0, entry.names?.length ?? 0);
-    if (sourceCount < 2) continue;
+    assetsByFileName.set(entry.fileName, entry);
 
-    const firstSourceName = getSourceName(entry, 0);
-    if (!firstSourceName) continue;
-
-    const outputFileNames = [entry.fileName];
-    let hasSiblingOutput = false;
-
-    for (let index = 1; index < sourceCount; index += 1) {
-      const sourceName = getSourceName(entry, index);
-      if (!sourceName || sourceName === firstSourceName) {
-        outputFileNames.push(entry.fileName);
-        continue;
-      }
-
-      const siblingFileName = deriveSiblingAssetFileName(
-        entry.fileName,
-        firstSourceName,
-        sourceName,
-      );
-      if (!siblingFileName) {
-        outputFileNames.push(entry.fileName);
-        continue;
-      }
-
-      const restoredFileName = addSiblingAsset(
-        usedFileNames,
-        entry,
-        siblingFileName,
-        emitRestoredAsset,
-      );
-      outputFileNames.push(restoredFileName);
-      hasSiblingOutput = true;
-    }
-
-    if (hasSiblingOutput) {
-      restorations.push({
-        sourceFileName: entry.fileName,
-        outputFileNames,
-        nextOutputIndex: 0,
-      });
-    }
-  }
-
-  return restorations;
-}
-
-function replaceNextOccurrence(
-  source: string,
-  search: string,
-  replacement: string,
-  fromIndex: number,
-): { source: string; nextIndex: number; replaced: boolean } {
-  const index = source.indexOf(search, fromIndex);
-  if (index === -1) {
-    return { source, nextIndex: fromIndex, replaced: false };
+    const base = basename(entry.fileName);
+    const assets = assetsByBaseName.get(base) ?? [];
+    assets.push(entry);
+    assetsByBaseName.set(base, assets);
   }
 
   return {
-    source: source.slice(0, index) + replacement + source.slice(index + search.length),
-    nextIndex: index + replacement.length,
-    replaced: true,
+    assetsByFileName,
+    assetsByBaseName,
+    restoredFileNames: new Map(),
+    usedFileNames: new Set(Object.keys(bundle)),
   };
 }
 
-function restoreCssSourceReferences(
-  source: string,
-  restorations: DedupedAssetRestoration[],
-): string {
-  let nextSource = source;
+function findAssetForUrlPath(urlPath: string, indexes: AssetIndexes): BundleAsset | null {
+  const normalizedPath = toPosixPath(urlPath).replace(/^\/+/, "");
+  const directAsset = indexes.assetsByFileName.get(normalizedPath);
+  if (directAsset) return directAsset;
 
-  for (const restoration of restorations) {
-    let nextIndex = 0;
-    while (true) {
-      const replacement =
-        restoration.outputFileNames[restoration.nextOutputIndex] ?? restoration.sourceFileName;
-      const result = replaceNextOccurrence(
-        nextSource,
-        restoration.sourceFileName,
-        replacement,
-        nextIndex,
-      );
-      if (!result.replaced) break;
-
-      nextSource = result.source;
-      nextIndex = result.nextIndex;
-      restoration.nextOutputIndex += 1;
-    }
+  for (const [fileName, asset] of indexes.assetsByFileName) {
+    if (normalizedPath.endsWith(fileName)) return asset;
   }
 
-  return nextSource;
+  const baseNameMatches = indexes.assetsByBaseName.get(basename(normalizedPath)) ?? [];
+  return baseNameMatches.length === 1 ? baseNameMatches[0] : null;
+}
+
+function replaceUrlPathAssetFileName(
+  urlPath: string,
+  currentFileName: string,
+  restoredFileName: string,
+): string {
+  const normalizedPath = toPosixPath(urlPath);
+  const pathWithoutLeadingSlash = normalizedPath.replace(/^\/+/, "");
+
+  if (pathWithoutLeadingSlash === currentFileName) {
+    return `${normalizedPath.startsWith("/") ? "/" : ""}${restoredFileName}`;
+  }
+
+  if (normalizedPath.endsWith(currentFileName)) {
+    return (
+      normalizedPath.slice(0, normalizedPath.length - currentFileName.length) + restoredFileName
+    );
+  }
+
+  const currentBaseName = basename(currentFileName);
+  if (normalizedPath.endsWith(currentBaseName)) {
+    return (
+      normalizedPath.slice(0, normalizedPath.length - currentBaseName.length) +
+      basename(restoredFileName)
+    );
+  }
+
+  return urlPath;
+}
+
+function assetFileNameMatchesSourceName(fileName: string, sourceName: string): boolean {
+  return outputBaseStartsWithStem(basename(fileName), fileStem(sourceName));
+}
+
+function ensureAssetFileNameForSource(
+  asset: BundleAsset,
+  sourceName: string,
+  indexes: AssetIndexes,
+  emitRestoredAsset: EmitRestoredCssUrlAsset,
+): string {
+  const sourceBaseName = basename(sourceName);
+  const restoreKey = `${asset.fileName}\0${sourceBaseName}`;
+  const cachedFileName = indexes.restoredFileNames.get(restoreKey);
+  if (cachedFileName) return cachedFileName;
+
+  if (assetFileNameMatchesSourceName(asset.fileName, sourceBaseName)) {
+    indexes.restoredFileNames.set(restoreKey, asset.fileName);
+    return asset.fileName;
+  }
+
+  const derivedFileName = deriveAssetFileNameForSource(asset, sourceBaseName);
+  if (!derivedFileName || derivedFileName === asset.fileName) {
+    indexes.restoredFileNames.set(restoreKey, asset.fileName);
+    return asset.fileName;
+  }
+
+  const existingAsset = indexes.assetsByFileName.get(derivedFileName);
+  if (existingAsset?.source === asset.source) {
+    indexes.restoredFileNames.set(restoreKey, derivedFileName);
+    return derivedFileName;
+  }
+
+  const restoredFileName = reserveBundleFileName(derivedFileName, indexes.usedFileNames);
+  emitRestoredAsset({ fileName: restoredFileName, source: asset.source });
+  indexes.restoredFileNames.set(restoreKey, restoredFileName);
+  indexes.assetsByFileName.set(restoredFileName, asset);
+
+  const base = basename(restoredFileName);
+  const assets = indexes.assetsByBaseName.get(base) ?? [];
+  assets.push(asset);
+  indexes.assetsByBaseName.set(base, assets);
+
+  return restoredFileName;
+}
+
+function restoreMarkedCssUrl(
+  rawUrl: string,
+  indexes: AssetIndexes,
+  emitRestoredAsset: EmitRestoredCssUrlAsset,
+): string | null {
+  const parts = splitUrl(rawUrl);
+  const sourceName = getQueryParam(parts.query, CSS_URL_ASSET_MARKER);
+  if (sourceName === null) return null;
+
+  const queryWithoutMarker = removeQueryParam(parts.query, CSS_URL_ASSET_MARKER);
+  const asset = findAssetForUrlPath(parts.path, indexes);
+  if (!asset) {
+    return joinUrl({ ...parts, query: queryWithoutMarker });
+  }
+
+  const restoredFileName = ensureAssetFileNameForSource(
+    asset,
+    sourceName,
+    indexes,
+    emitRestoredAsset,
+  );
+
+  return joinUrl({
+    path: replaceUrlPathAssetFileName(parts.path, asset.fileName, restoredFileName),
+    query: queryWithoutMarker,
+    hash: parts.hash,
+  });
+}
+
+function restoreMarkedCssUrls(
+  source: string,
+  indexes: AssetIndexes,
+  emitRestoredAsset: EmitRestoredCssUrlAsset,
+): string {
+  let restoredSource = "";
+  let lastIndex = 0;
+  let didRestore = false;
+
+  CSS_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CSS_URL_RE.exec(source)) !== null) {
+    const rawUrl = match[1] ?? match[2] ?? match[3]?.trim();
+    if (!rawUrl || !rawUrl.includes(CSS_URL_ASSET_MARKER)) continue;
+
+    const restoredUrl = restoreMarkedCssUrl(rawUrl, indexes, emitRestoredAsset);
+    if (!restoredUrl) continue;
+
+    restoredSource += source.slice(lastIndex, match.index);
+    restoredSource += getCssUrlReplacement(match, restoredUrl);
+    lastIndex = match.index + match[0].length;
+    didRestore = true;
+  }
+
+  if (!didRestore) return source;
+  return restoredSource + source.slice(lastIndex);
 }
 
 export function restoreDedupedCssAssetReferences(
   bundle: CssUrlAssetBundle,
   emitRestoredAsset: EmitRestoredCssUrlAsset,
 ): void {
-  const restorations = buildDedupedAssetRestorations(bundle, emitRestoredAsset);
-  if (restorations.length === 0) return;
+  const indexes = createAssetIndexes(bundle);
 
   for (const entry of Object.values(bundle)) {
     if (entry.type !== "asset") continue;
     if (!isCssFileName(entry.fileName)) continue;
     if (typeof entry.source !== "string") continue;
 
-    entry.source = restoreCssSourceReferences(entry.source, restorations);
+    entry.source = restoreMarkedCssUrls(entry.source, indexes, emitRestoredAsset);
   }
 }

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -1,0 +1,223 @@
+import type { Rolldown } from "vite";
+
+// Vite/Rolldown dedupes assets by source content. Next.js webpack emits CSS
+// url() dependencies as asset/resource modules, so distinct source files keep
+// distinct output names even when their bytes are identical.
+type BundleAsset = Rolldown.OutputAsset;
+type BundleAssetSource = BundleAsset["source"];
+
+type CssUrlAssetBundle = Rolldown.OutputBundle;
+
+type RestoredCssUrlAsset = {
+  readonly fileName: string;
+  readonly source: BundleAssetSource;
+};
+
+type EmitRestoredCssUrlAsset = (asset: RestoredCssUrlAsset) => void;
+
+type DedupedAssetRestoration = {
+  readonly sourceFileName: string;
+  readonly outputFileNames: readonly string[];
+  nextOutputIndex: number;
+};
+
+function toPosixPath(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+function basename(value: string): string {
+  const normalized = toPosixPath(value);
+  const slashIndex = normalized.lastIndexOf("/");
+  return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
+}
+
+function fileStem(fileName: string): string {
+  const base = basename(fileName);
+  const dotIndex = base.lastIndexOf(".");
+  return dotIndex <= 0 ? base : base.slice(0, dotIndex);
+}
+
+function getSourceName(asset: BundleAsset, index: number): string | null {
+  const name = asset.names?.[index];
+  if (name) return basename(name);
+
+  const originalFileName = asset.originalFileNames?.[index];
+  return originalFileName ? basename(originalFileName) : null;
+}
+
+function isCssFileName(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(".css");
+}
+
+function deriveSiblingAssetFileName(
+  existingFileName: string,
+  existingSourceName: string,
+  siblingSourceName: string,
+): string | null {
+  const existingStem = fileStem(existingSourceName);
+  const siblingStem = fileStem(siblingSourceName);
+  if (!existingStem || !siblingStem) return null;
+
+  const normalizedOutputName = toPosixPath(existingFileName);
+  const slashIndex = normalizedOutputName.lastIndexOf("/");
+  const outputDir = slashIndex === -1 ? "" : normalizedOutputName.slice(0, slashIndex + 1);
+  const outputBase =
+    slashIndex === -1 ? normalizedOutputName : normalizedOutputName.slice(slashIndex + 1);
+
+  if (!outputBase.startsWith(existingStem)) return null;
+
+  return `${outputDir}${siblingStem}${outputBase.slice(existingStem.length)}`;
+}
+
+function reserveBundleFileName(fileName: string, usedFileNames: Set<string>): string {
+  if (!usedFileNames.has(fileName)) {
+    usedFileNames.add(fileName);
+    return fileName;
+  }
+
+  const dotIndex = fileName.lastIndexOf(".");
+  const prefix = dotIndex === -1 ? fileName : fileName.slice(0, dotIndex);
+  const suffix = dotIndex === -1 ? "" : fileName.slice(dotIndex);
+
+  let index = 1;
+  while (true) {
+    const candidate = `${prefix}-${index}${suffix}`;
+    if (!usedFileNames.has(candidate)) {
+      usedFileNames.add(candidate);
+      return candidate;
+    }
+    index += 1;
+  }
+}
+
+function addSiblingAsset(
+  usedFileNames: Set<string>,
+  mergedAsset: BundleAsset,
+  fileName: string,
+  emitRestoredAsset: EmitRestoredCssUrlAsset,
+): string {
+  const reservedFileName = reserveBundleFileName(fileName, usedFileNames);
+  emitRestoredAsset({ fileName: reservedFileName, source: mergedAsset.source });
+  return reservedFileName;
+}
+
+function buildDedupedAssetRestorations(
+  bundle: CssUrlAssetBundle,
+  emitRestoredAsset: EmitRestoredCssUrlAsset,
+): DedupedAssetRestoration[] {
+  const usedFileNames = new Set(Object.keys(bundle));
+  const restorations: DedupedAssetRestoration[] = [];
+
+  for (const entry of Object.values(bundle)) {
+    if (entry.type !== "asset") continue;
+    if (isCssFileName(entry.fileName)) continue;
+
+    const sourceCount = Math.max(entry.originalFileNames?.length ?? 0, entry.names?.length ?? 0);
+    if (sourceCount < 2) continue;
+
+    const firstSourceName = getSourceName(entry, 0);
+    if (!firstSourceName) continue;
+
+    const outputFileNames = [entry.fileName];
+    let hasSiblingOutput = false;
+
+    for (let index = 1; index < sourceCount; index += 1) {
+      const sourceName = getSourceName(entry, index);
+      if (!sourceName || sourceName === firstSourceName) {
+        outputFileNames.push(entry.fileName);
+        continue;
+      }
+
+      const siblingFileName = deriveSiblingAssetFileName(
+        entry.fileName,
+        firstSourceName,
+        sourceName,
+      );
+      if (!siblingFileName) {
+        outputFileNames.push(entry.fileName);
+        continue;
+      }
+
+      const restoredFileName = addSiblingAsset(
+        usedFileNames,
+        entry,
+        siblingFileName,
+        emitRestoredAsset,
+      );
+      outputFileNames.push(restoredFileName);
+      hasSiblingOutput = true;
+    }
+
+    if (hasSiblingOutput) {
+      restorations.push({
+        sourceFileName: entry.fileName,
+        outputFileNames,
+        nextOutputIndex: 0,
+      });
+    }
+  }
+
+  return restorations;
+}
+
+function replaceNextOccurrence(
+  source: string,
+  search: string,
+  replacement: string,
+  fromIndex: number,
+): { source: string; nextIndex: number; replaced: boolean } {
+  const index = source.indexOf(search, fromIndex);
+  if (index === -1) {
+    return { source, nextIndex: fromIndex, replaced: false };
+  }
+
+  return {
+    source: source.slice(0, index) + replacement + source.slice(index + search.length),
+    nextIndex: index + replacement.length,
+    replaced: true,
+  };
+}
+
+function restoreCssSourceReferences(
+  source: string,
+  restorations: DedupedAssetRestoration[],
+): string {
+  let nextSource = source;
+
+  for (const restoration of restorations) {
+    let nextIndex = 0;
+    while (true) {
+      const replacement =
+        restoration.outputFileNames[restoration.nextOutputIndex] ?? restoration.sourceFileName;
+      const result = replaceNextOccurrence(
+        nextSource,
+        restoration.sourceFileName,
+        replacement,
+        nextIndex,
+      );
+      if (!result.replaced) break;
+
+      nextSource = result.source;
+      nextIndex = result.nextIndex;
+      restoration.nextOutputIndex += 1;
+    }
+  }
+
+  return nextSource;
+}
+
+export function restoreDedupedCssAssetReferences(
+  bundle: CssUrlAssetBundle,
+  emitRestoredAsset: EmitRestoredCssUrlAsset,
+): void {
+  const restorations = buildDedupedAssetRestorations(bundle, emitRestoredAsset);
+  if (restorations.length === 0) return;
+
+  for (const entry of Object.values(bundle)) {
+    if (entry.type !== "asset") continue;
+    if (!isCssFileName(entry.fileName)) continue;
+    if (typeof entry.source !== "string") continue;
+
+    entry.source = restoreCssSourceReferences(entry.source, restorations);
+  }
+}

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -3,6 +3,9 @@ import type { Rolldown } from "vite";
 // Carried through Vite's CSS asset transform and stripped from final CSS.
 // Avoid double underscores here because unresolved asset placeholders use them.
 const CSS_URL_ASSET_MARKER = "vinext_css_url_asset";
+// Module-level and stateful because of the `g` flag: callers MUST reset
+// `CSS_URL_RE.lastIndex = 0` before each new scan, otherwise the regex resumes
+// from the previous match position and silently skips url() references.
 const CSS_URL_RE = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^'")]*?))\s*\)/g;
 const CSS_ASSET_EXT_RE =
   /\.(?:avif|bmp|gif|ico|jpe?g|png|svg|webp|woff2?|eot|ttf|otf|mp4|webm|ogg|mp3|wav|flac|aac|wasm)$/i;
@@ -367,6 +370,11 @@ function ensureAssetFileNameForSource(
   const restoredFileName = reserveBundleFileName(derivedFileName, indexes.usedFileNames);
   emitRestoredAsset({ fileName: restoredFileName, source: asset.source });
   indexes.restoredFileNames.set(restoreKey, restoredFileName);
+  // Index by the sibling's name but keep the original deduped asset object: we
+  // only need its `source` for the byte-identity check above, and the restore
+  // cache (`restoredFileNames`) short-circuits before this index is consulted
+  // for the sibling. Callers must not assume the indexed asset's `.fileName`
+  // matches the key — for this entry it still points at the original.
   indexes.assetsByFileName.set(restoredFileName, asset);
 
   const base = basename(restoredFileName);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -130,10 +130,12 @@ import {
   createClientManualChunks,
   createClientOutputConfig,
   createClientCodeSplittingConfig,
+  createClientAssetFileNames,
   getClientTreeshakeConfigForVite,
   getBuildBundlerOptions,
   withBuildBundlerOptions,
 } from "./build/client-build-config.js";
+import { restoreDedupedCssAssetReferences } from "./build/css-url-assets.js";
 import {
   augmentSsrManifestFromBundle,
   tryRealpathSync,
@@ -607,11 +609,15 @@ const _reactServerShims = new Map<string, string>([
 ]);
 
 const clientManualChunks = createClientManualChunks(_shimsDir);
-const clientOutputConfig = createClientOutputConfig(clientManualChunks);
 const clientCodeSplittingConfig = createClientCodeSplittingConfig(clientManualChunks);
 
-function getClientOutputConfigForVite(viteMajorVersion: number) {
-  return viteMajorVersion >= 8 ? { codeSplitting: clientCodeSplittingConfig } : clientOutputConfig;
+function getClientOutputConfigForVite(viteMajorVersion: number, assetsDir: string) {
+  return viteMajorVersion >= 8
+    ? {
+        assetFileNames: createClientAssetFileNames(assetsDir),
+        codeSplitting: clientCodeSplittingConfig,
+      }
+    : createClientOutputConfig(clientManualChunks, assetsDir);
 }
 
 export type VinextOptions = {
@@ -1509,6 +1515,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // (on the client env), not globally — otherwise it leaks into RSC/SSR
         // environments where it can cause asset resolution issues.
         const isMultiEnv = hasAppDir || hasCloudflarePlugin || hasNitroPlugin;
+        const clientAssetsDir = resolveAssetsDir(nextConfig.assetPrefix ?? "");
 
         const viteConfig: UserConfig = {
           // Disable Vite's default HTML serving - we handle all routing
@@ -1589,7 +1596,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // and any static file server can resolve
             // `<assetPrefix?>/_next/static/...` requests directly, and
             // misses naturally fall through as plain-text 404s.
-            assetsDir: resolveAssetsDir(nextConfig.assetPrefix ?? ""),
+            assetsDir: clientAssetsDir,
+            // Next.js emits CSS url() dependencies as separate files
+            // (`asset/resource`) instead of inlining small files as data URLs.
+            // Keep an explicit user-provided Vite override, but default vinext
+            // builds to the Next.js asset graph.
+            assetsInlineLimit: config.build?.assetsInlineLimit ?? 0,
             ...withBuildBundlerOptions(viteMajorVersion, {
               // Suppress "Module level directives cause errors when bundled"
               // warnings for "use client" / "use server" directives. Our shims
@@ -1663,7 +1675,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // manualChunks is set per-environment on the client env below
               // to avoid leaking into RSC/SSR environments.
               ...(!isSSR && !isMultiEnv
-                ? { output: getClientOutputConfigForVite(viteMajorVersion) }
+                ? { output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir) }
                 : {}),
             }),
           },
@@ -2043,7 +2055,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ...(hasCloudflarePlugin ? { manifest: true } : {}),
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_APP_BROWSER_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
                   treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
                 }),
               },
@@ -2064,7 +2076,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ssrManifest: true,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_CLIENT_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
                   treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
                 }),
               },
@@ -2090,7 +2102,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ssrManifest: true,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_CLIENT_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
                   treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
                 }),
               },
@@ -2482,6 +2494,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // prevents a stale manifest from leaking into a subsequent generateBundle
         // call if the load hook is not re-triggered (e.g., in non-standard rebuild paths).
         rscClassificationManifest = null;
+      },
+    },
+    {
+      name: "vinext:css-url-assets",
+      enforce: "post",
+
+      generateBundle(_options, bundle) {
+        restoreDedupedCssAssetReferences(bundle, (asset) => {
+          this.emitFile({
+            type: "asset",
+            fileName: asset.fileName,
+            source: asset.source,
+          });
+        });
       },
     },
     // Stub node:async_hooks in client builds — see src/plugins/async-hooks-stub.ts

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2519,6 +2519,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     {
       name: "vinext:css-url-assets-mark",
       enforce: "pre",
+      apply: "build",
 
       transform(code, id) {
         if (this.environment?.name !== "client") return null;
@@ -2536,6 +2537,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     {
       name: "vinext:css-url-assets-restore",
       enforce: "post",
+      apply: "build",
 
       generateBundle(_options, bundle) {
         if (this.environment?.name !== "client") return;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2528,6 +2528,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     },
     {
       name: "vinext:client-css-url-assets-defaults",
+      apply: "build",
 
       configEnvironment(name) {
         if (name !== "client") return null;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -135,7 +135,10 @@ import {
   getBuildBundlerOptions,
   withBuildBundlerOptions,
 } from "./build/client-build-config.js";
-import { restoreDedupedCssAssetReferences } from "./build/css-url-assets.js";
+import {
+  markCssUrlAssetReferences,
+  restoreDedupedCssAssetReferences,
+} from "./build/css-url-assets.js";
 import {
   augmentSsrManifestFromBundle,
   tryRealpathSync,
@@ -2497,10 +2500,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
     },
     {
-      name: "vinext:css-url-assets",
+      name: "vinext:css-url-assets-mark",
+      enforce: "pre",
+
+      transform(code, id) {
+        if (this.environment?.name !== "client") return null;
+        return markCssUrlAssetReferences(code, id);
+      },
+    },
+    {
+      name: "vinext:css-url-assets-restore",
       enforce: "post",
 
       generateBundle(_options, bundle) {
+        if (this.environment?.name !== "client") return;
         restoreDedupedCssAssetReferences(bundle, (asset) => {
           this.emitFile({
             type: "asset",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -734,6 +734,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let instrumentationPath: string | null = null;
   let instrumentationClientPath: string | null = null;
   let clientInjectModule: string | null = null;
+  let clientAssetsInlineLimit: NonNullable<UserConfig["build"]>["assetsInlineLimit"] = 0;
   let hasCloudflarePlugin = false;
   let warnedInlineNextConfigOverride = false;
   let hasNitroPlugin = false;
@@ -1513,12 +1514,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // or `build.ssr` in config). SSR builds must NOT use manualChunks
         // because they use inlineDynamicImports which is incompatible.
         const isSSR = !!config.build?.ssr;
+        const hasBuildInput = getBuildBundlerOptions(config.build)?.input !== undefined;
         // Detect if this is a multi-environment build (App Router or Cloudflare).
         // In multi-env builds, manualChunks must only be set per-environment
         // (on the client env), not globally — otherwise it leaks into RSC/SSR
         // environments where it can cause asset resolution issues.
         const isMultiEnv = hasAppDir || hasCloudflarePlugin || hasNitroPlugin;
+        const shouldInjectPlainPagesEnvironments =
+          !hasAppDir && !hasCloudflarePlugin && !isSSR && !hasBuildInput;
+        const hasClientBuildEnvironment =
+          hasAppDir || hasCloudflarePlugin || hasNitroPlugin || shouldInjectPlainPagesEnvironments;
         const clientAssetsDir = resolveAssetsDir(nextConfig.assetPrefix ?? "");
+        clientAssetsInlineLimit = config.build?.assetsInlineLimit ?? 0;
 
         const viteConfig: UserConfig = {
           // Disable Vite's default HTML serving - we handle all routing
@@ -1600,11 +1607,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // `<assetPrefix?>/_next/static/...` requests directly, and
             // misses naturally fall through as plain-text 404s.
             assetsDir: clientAssetsDir,
-            // Next.js emits CSS url() dependencies as separate files
-            // (`asset/resource`) instead of inlining small files as data URLs.
-            // Keep an explicit user-provided Vite override, but default vinext
-            // builds to the Next.js asset graph.
-            assetsInlineLimit: config.build?.assetsInlineLimit ?? 0,
+            // For single-build client output there is no client environment to
+            // carry this default, so apply it at the top level. Multi-env builds
+            // set it on `environments.client.build` below to avoid changing RSC
+            // or SSR asset handling.
+            ...(!isSSR && !hasClientBuildEnvironment
+              ? { assetsInlineLimit: clientAssetsInlineLimit }
+              : {}),
             ...withBuildBundlerOptions(viteMajorVersion, {
               // Suppress "Module level directives cause errors when bundled"
               // warnings for "use client" / "use server" directives. Our shims
@@ -2056,6 +2065,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 // on every page — defeating code-splitting for React.lazy() and
                 // next/dynamic boundaries.
                 ...(hasCloudflarePlugin ? { manifest: true } : {}),
+                // Next.js emits CSS url() dependencies as separate files
+                // (`asset/resource`) instead of inlining small files as data URLs.
+                // Scope vinext's default to the client build so RSC/SSR keep
+                // their normal asset handling unless the user configured Vite
+                // globally.
+                assetsInlineLimit: clientAssetsInlineLimit,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_APP_BROWSER_ENTRY },
                   output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
@@ -2077,6 +2092,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               build: {
                 manifest: true,
                 ssrManifest: true,
+                assetsInlineLimit: clientAssetsInlineLimit,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_CLIENT_ENTRY },
                   output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
@@ -2085,7 +2101,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               },
             },
           };
-        } else if (!isSSR && !getBuildBundlerOptions(config.build)?.input) {
+        } else if (shouldInjectPlainPagesEnvironments) {
           // Plain Pages Router (Node): define client + ssr environments so
           // createBuilder + buildApp() produces both dist/client and
           // dist/server/entry.js. Without this, buildApp() only sees the
@@ -2103,6 +2119,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 outDir: "dist/client",
                 manifest: true,
                 ssrManifest: true,
+                assetsInlineLimit: clientAssetsInlineLimit,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: { index: VIRTUAL_CLIENT_ENTRY },
                   output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
@@ -2506,6 +2523,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       transform(code, id) {
         if (this.environment?.name !== "client") return null;
         return markCssUrlAssetReferences(code, id);
+      },
+    },
+    {
+      name: "vinext:client-css-url-assets-defaults",
+
+      configEnvironment(name) {
+        if (name !== "client") return null;
+        return { build: { assetsInlineLimit: clientAssetsInlineLimit } };
       },
     },
     {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -734,6 +734,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let instrumentationPath: string | null = null;
   let instrumentationClientPath: string | null = null;
   let clientInjectModule: string | null = null;
+  // Populated by the `config` hook from the user's `build.assetsInlineLimit`,
+  // then read by `configEnvironment` (the client-css-url-assets-defaults plugin)
+  // and the per-environment build config. The `config` hook always runs before
+  // `configEnvironment`/build for a single `vinext()` instance, and the `= 0`
+  // initializer guards any unexpected ordering.
   let clientAssetsInlineLimit: NonNullable<UserConfig["build"]>["assetsInlineLimit"] = 0;
   let hasCloudflarePlugin = false;
   let warnedInlineNextConfigOverride = false;
@@ -2523,7 +2528,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
       transform(code, id) {
         if (this.environment?.name !== "client") return null;
-        return markCssUrlAssetReferences(code, id);
+        const marked = markCssUrlAssetReferences(code, id);
+        if (marked === null) return null;
+        // No source map: marking only edits text within a single `url(...)`
+        // token and never shifts line/column positions, so a passthrough map
+        // carries no information. Matches the css-data-url plugin's contract.
+        return { code: marked, map: null };
       },
     },
     {

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -752,7 +752,13 @@ describe("treeshake config integration", () => {
     const mainPlugin = plugins.find(
       (p: any) => p.name === "vinext:config" && typeof p.config === "function",
     );
+    const clientAssetsDefaultsPlugin = plugins.find(
+      (p: any) =>
+        p.name === "vinext:client-css-url-assets-defaults" &&
+        typeof p.configEnvironment === "function",
+    );
     expect(mainPlugin).toBeDefined();
+    expect(clientAssetsDefaultsPlugin).toBeDefined();
 
     const os = await import("node:os");
     const fsp = await import("node:fs/promises");
@@ -786,15 +792,28 @@ describe("treeshake config integration", () => {
 
       // Global bundler options should NOT have treeshake (would leak into RSC/SSR)
       expect(getBuildBundlerOptions(result).treeshake).toBeUndefined();
+      expect(result.build.assetsInlineLimit).toBeUndefined();
 
       // Client environment should have treeshake
       expect(getEnvBuildBundlerOptions(result.environments.client).treeshake).toEqual({
         moduleSideEffects: "no-external",
       });
+      expect(result.environments.client.build.assetsInlineLimit).toBe(0);
 
       // RSC and SSR environments should NOT have treeshake
       expect(getEnvBuildBundlerOptions(result.environments.rsc)?.treeshake).toBeUndefined();
       expect(getEnvBuildBundlerOptions(result.environments.ssr)?.treeshake).toBeUndefined();
+      expect(result.environments.rsc.build.assetsInlineLimit).toBeUndefined();
+      expect(result.environments.ssr.build.assetsInlineLimit).toBeUndefined();
+
+      expect(
+        (clientAssetsDefaultsPlugin as any).configEnvironment("client", {}, { command: "build" }),
+      ).toEqual({
+        build: { assetsInlineLimit: 0 },
+      });
+      expect(
+        (clientAssetsDefaultsPlugin as any).configEnvironment("ssr", {}, { command: "build" }),
+      ).toBeNull();
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -9,7 +9,7 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
-import { parseAst } from "vite";
+import { createBuilder, parseAst } from "vite";
 import { augmentSsrManifestFromBundle as _augmentSsrManifestFromBundle } from "../packages/vinext/src/build/ssr-manifest.js";
 import { stripServerExports as _stripServerExports } from "../packages/vinext/src/plugins/strip-server-exports.js";
 import {
@@ -818,6 +818,59 @@ describe("treeshake config integration", () => {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);
+
+  it("resolves CSS URL asset inline defaults through Vite's builder lifecycle", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-css-assets-env-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "page.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+
+    try {
+      const defaultBuilder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+
+      expect(defaultBuilder.environments.client.config.build.assetsInlineLimit).toBe(0);
+      expect(defaultBuilder.environments.rsc.config.build.assetsInlineLimit).not.toBe(0);
+      expect(defaultBuilder.environments.ssr.config.build.assetsInlineLimit).not.toBe(0);
+
+      const userAssetsInlineLimit = 1234;
+      const userBuilder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+        build: {
+          assetsInlineLimit: userAssetsInlineLimit,
+        },
+      });
+
+      expect(userBuilder.environments.client.config.build.assetsInlineLimit).toBe(
+        userAssetsInlineLimit,
+      );
+      expect(userBuilder.environments.rsc.config.build.assetsInlineLimit).toBe(
+        userAssetsInlineLimit,
+      );
+      expect(userBuilder.environments.ssr.config.build.assetsInlineLimit).toBe(
+        userAssetsInlineLimit,
+      );
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 30_000);
 
   it("client output config includes minimum chunk sizing", async () => {
     const vinext = (await import("../packages/vinext/src/index.js")).default;

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -17,6 +17,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import vinext from "../packages/vinext/src/index.js";
+import { restoreDedupedCssAssetReferences } from "../packages/vinext/src/build/css-url-assets.js";
 
 const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
 const DARK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><path fill="black" d="M0 0h2v2H0z"/></svg>\n`;
@@ -411,4 +412,38 @@ describe("App Router CSS url() asset emission", () => {
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 180_000);
+});
+
+describe("restoreDedupedCssAssetReferences chunk handling", () => {
+  it("strips the private marker from CSS inlined into a JS chunk", () => {
+    // Simulates `cssCodeSplit: false` / `?inline`: the marked CSS ends up in a
+    // JS chunk's `code` rather than a standalone `.css` asset, so the restore
+    // pass must still strip the leaked provenance marker.
+    const bundle = {
+      "main.js": {
+        type: "chunk" as const,
+        fileName: "main.js",
+        code: 'const css = ".x{background:url(/_next/static/media/dark.abc123.svg?vinext_css_url_asset=dark.svg)}";',
+      },
+    } as unknown as Parameters<typeof restoreDedupedCssAssetReferences>[0];
+
+    const emitted: unknown[] = [];
+    restoreDedupedCssAssetReferences(bundle, (asset) => emitted.push(asset));
+
+    const code = (bundle["main.js"] as { code: string }).code;
+    expect(code).not.toContain("vinext_css_url_asset");
+    expect(code).toContain("/_next/static/media/dark.abc123.svg");
+    // Inlined CSS URLs are already final; no sibling media files are emitted.
+    expect(emitted).toHaveLength(0);
+  });
+
+  it("leaves chunks without the marker untouched", () => {
+    const original = 'const css = ".x{background:url(/_next/static/media/dark.abc123.svg)}";';
+    const bundle = {
+      "main.js": { type: "chunk" as const, fileName: "main.js", code: original },
+    } as unknown as Parameters<typeof restoreDedupedCssAssetReferences>[0];
+
+    restoreDedupedCssAssetReferences(bundle, () => {});
+    expect((bundle["main.js"] as { code: string }).code).toBe(original);
+  });
 });

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -216,6 +216,7 @@ describe("Pages Router CSS url() asset emission", () => {
           expect.stringMatching(/^\/_next\/static\/media\/dark\.[A-Za-z0-9_-]+\.svg$/),
           expect.stringMatching(/^\/_next\/static\/media\/dark2\.[A-Za-z0-9_-]+\.svg$/),
         ]);
+        expect(new Set(assetUrls).size, "asset URLs should be unique").toBe(assetUrls.length);
 
         for (const assetUrl of assetUrls) {
           const assetRes = await fetch(new URL(assetUrl, baseUrl));
@@ -274,6 +275,10 @@ describe("Pages Router CSS url() asset emission", () => {
       expect(aboutAssetUrls).toEqual([
         expect.stringMatching(/^\/_next\/static\/media\/dark2\.[A-Za-z0-9_-]+\.svg$/),
       ]);
+      expect(
+        new Set([...homeAssetUrls, ...aboutAssetUrls]).size,
+        "split CSS asset URLs should be unique",
+      ).toBe(homeAssetUrls.length + aboutAssetUrls.length);
 
       const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
       const { server, port } = await startProdServer({

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -69,6 +69,76 @@ async function makePagesCssUrlFixture(): Promise<string> {
   return tmpDir;
 }
 
+async function makePagesSplitCssUrlFixture(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-split-css-url-assets-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const stylesDir = path.join(tmpDir, "styles");
+  await fs.mkdir(stylesDir, { recursive: true });
+  await fs.writeFile(path.join(stylesDir, "dark.svg"), DARK_SVG);
+  await fs.writeFile(path.join(stylesDir, "dark2.svg"), DARK_2_SVG);
+  await fs.writeFile(
+    path.join(stylesDir, "home.module.css"),
+    '.home { background-image: url("./dark.svg"); }\n',
+  );
+  await fs.writeFile(
+    path.join(stylesDir, "about.module.css"),
+    '.about { background-image: url("./dark2.svg"); }\n',
+  );
+
+  const pagesDir = path.join(tmpDir, "pages");
+  await fs.mkdir(pagesDir, { recursive: true });
+  await fs.writeFile(
+    path.join(pagesDir, "_app.jsx"),
+    [
+      "export default function App({ Component, pageProps }) {",
+      "  return <Component {...pageProps} />;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.jsx"),
+    [
+      'import styles from "../styles/home.module.css";',
+      "",
+      "export default function Home() {",
+      "  return <div className={styles.home}>Home</div>;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "about.jsx"),
+    [
+      'import styles from "../styles/about.module.css";',
+      "",
+      "export default function About() {",
+      "  return <div className={styles.about}>About</div>;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  return tmpDir;
+}
+
+async function listFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
 function extractStylesheetHrefs(html: string): string[] {
   const hrefs: string[] = [];
   const hrefRe = /<link\s+rel="stylesheet"[^>]*\shref="([^"]+\.css)"/g;
@@ -152,6 +222,73 @@ describe("Pages Router CSS url() asset emission", () => {
           expect(assetRes.status, `expected ${assetUrl} to be served`).toBe(200);
           expect(assetRes.headers.get("content-type")).toMatch(/^image\/svg\+xml/);
           expect(await assetRes.text()).toContain("<svg");
+        }
+      } finally {
+        await closeServer(server);
+      }
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 180_000);
+
+  it("preserves url() asset provenance across separate emitted CSS chunks", async () => {
+    const tmpDir = await makePagesSplitCssUrlFixture();
+    try {
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ disableAppRouter: true })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const emittedCssFiles = (await listFiles(path.join(tmpDir, "dist", "client"))).filter(
+        (file) => file.endsWith(".css"),
+      );
+      const emittedCss = await Promise.all(
+        emittedCssFiles.map(async (file) => ({
+          file,
+          text: await fs.readFile(file, "utf-8"),
+        })),
+      );
+      const cssWithSvgUrls = emittedCss.filter(({ text }) =>
+        extractCssUrls(text).some((url) => url.includes(".svg")),
+      );
+      expect(cssWithSvgUrls.length).toBeGreaterThanOrEqual(2);
+
+      const homeCss = cssWithSvgUrls.find(({ text }) => text.includes("_home_"));
+      const aboutCss = cssWithSvgUrls.find(({ text }) => text.includes("_about_"));
+      expect(homeCss, `emitted CSS with .home module class not found`).toBeDefined();
+      expect(aboutCss, `emitted CSS with .about module class not found`).toBeDefined();
+
+      const homeAssetUrls = extractCssUrls(homeCss?.text ?? "").filter((url) =>
+        url.includes(".svg"),
+      );
+      const aboutAssetUrls = extractCssUrls(aboutCss?.text ?? "").filter((url) =>
+        url.includes(".svg"),
+      );
+
+      expect(homeAssetUrls).toEqual([
+        expect.stringMatching(/^\/_next\/static\/media\/dark\.[A-Za-z0-9_-]+\.svg$/),
+      ]);
+      expect(aboutAssetUrls).toEqual([
+        expect.stringMatching(/^\/_next\/static\/media\/dark2\.[A-Za-z0-9_-]+\.svg$/),
+      ]);
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      const { server, port } = await startProdServer({
+        port: 0,
+        host: "127.0.0.1",
+        outDir: path.join(tmpDir, "dist"),
+        noCompression: true,
+      });
+
+      try {
+        const baseUrl = `http://127.0.0.1:${port}`;
+        for (const assetUrl of [...homeAssetUrls, ...aboutAssetUrls]) {
+          const assetRes = await fetch(new URL(assetUrl, baseUrl));
+          expect(assetRes.status, `expected ${assetUrl} to be served`).toBe(200);
+          expect(assetRes.headers.get("content-type")).toMatch(/^image\/svg\+xml/);
         }
       } finally {
         await closeServer(server);

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Pages Router global CSS url() assets must be emitted as static files.
+ *
+ * Ported from Next.js:
+ * test/e2e/app-dir/scss/url-global/url-global.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/scss/url-global/url-global.test.ts
+ *
+ * The upstream fixture uses SCSS, but the parity contract lives one layer
+ * lower than Sass preprocessing: once CSS reaches the bundler, url() asset
+ * dependencies are webpack `asset/resource` files under `/_next/static/media/`.
+ */
+
+import { describe, it, expect } from "vite-plus/test";
+import { createBuilder } from "vite";
+import type { Server } from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vinext from "../packages/vinext/src/index.js";
+
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+const DARK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><path fill="black" d="M0 0h2v2H0z"/></svg>\n`;
+// The upstream fixture's two SVG files have identical bytes; that is what
+// exposes content-based asset dedupe collapsing the second filename.
+const DARK_2_SVG = DARK_SVG;
+
+async function makePagesCssUrlFixture(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-css-url-assets-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const stylesDir = path.join(tmpDir, "styles");
+  await fs.mkdir(stylesDir, { recursive: true });
+  await fs.writeFile(path.join(stylesDir, "dark.svg"), DARK_SVG);
+  await fs.writeFile(path.join(stylesDir, "dark2.svg"), DARK_2_SVG);
+  await fs.writeFile(
+    path.join(stylesDir, "global.css"),
+    [
+      ".red-text {",
+      "  color: red;",
+      '  background-image: url("./dark.svg"), url(dark2.svg);',
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const pagesDir = path.join(tmpDir, "pages");
+  await fs.mkdir(pagesDir, { recursive: true });
+  await fs.writeFile(
+    path.join(pagesDir, "_app.jsx"),
+    [
+      'import "../styles/global.css";',
+      "",
+      "export default function App({ Component, pageProps }) {",
+      "  return <Component {...pageProps} />;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    path.join(pagesDir, "index.jsx"),
+    [
+      "export default function Home() {",
+      '  return <div className="red-text">This text should be red.</div>;',
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  return tmpDir;
+}
+
+function extractStylesheetHrefs(html: string): string[] {
+  const hrefs: string[] = [];
+  const hrefRe = /<link\s+rel="stylesheet"[^>]*\shref="([^"]+\.css)"/g;
+  for (const match of html.matchAll(hrefRe)) {
+    const href = match[1];
+    if (href) hrefs.push(href);
+  }
+  return hrefs;
+}
+
+function extractCssUrls(css: string): string[] {
+  const urls: string[] = [];
+  const urlRe = /url\((?:"([^"]+)"|'([^']+)'|([^)]*))\)/g;
+  for (const match of css.matchAll(urlRe)) {
+    const url = match[1] ?? match[2] ?? match[3];
+    if (url) urls.push(url.trim());
+  }
+  return urls;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+describe("Pages Router CSS url() asset emission", () => {
+  it("emits global CSS svg url() dependencies under /_next/static/media/", async () => {
+    const tmpDir = await makePagesCssUrlFixture();
+    try {
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ disableAppRouter: true })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      const { server, port } = await startProdServer({
+        port: 0,
+        host: "127.0.0.1",
+        outDir: path.join(tmpDir, "dist"),
+        noCompression: true,
+      });
+
+      try {
+        const baseUrl = `http://127.0.0.1:${port}`;
+        const pageRes = await fetch(`${baseUrl}/`);
+        expect(pageRes.status).toBe(200);
+        const html = await pageRes.text();
+
+        const stylesheetHrefs = extractStylesheetHrefs(html);
+        expect(
+          stylesheetHrefs.length,
+          `expected a linked stylesheet in HTML:\n${html}`,
+        ).toBeGreaterThan(0);
+
+        const cssTexts: string[] = [];
+        for (const href of stylesheetHrefs) {
+          const cssRes = await fetch(new URL(href, baseUrl));
+          expect(cssRes.status, `expected stylesheet ${href} to be served`).toBe(200);
+          cssTexts.push(await cssRes.text());
+        }
+
+        const css = cssTexts.join("\n");
+        expect(css).toContain("red-text");
+
+        const assetUrls = extractCssUrls(css).filter((url) => url.includes(".svg"));
+        expect(assetUrls).toHaveLength(2);
+        expect(assetUrls).toEqual([
+          expect.stringMatching(/^\/_next\/static\/media\/dark\.[A-Za-z0-9_-]+\.svg$/),
+          expect.stringMatching(/^\/_next\/static\/media\/dark2\.[A-Za-z0-9_-]+\.svg$/),
+        ]);
+
+        for (const assetUrl of assetUrls) {
+          const assetRes = await fetch(new URL(assetUrl, baseUrl));
+          expect(assetRes.status, `expected ${assetUrl} to be served`).toBe(200);
+          expect(assetRes.headers.get("content-type")).toMatch(/^image\/svg\+xml/);
+          expect(await assetRes.text()).toContain("<svg");
+        }
+      } finally {
+        await closeServer(server);
+      }
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 180_000);
+});

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -123,6 +123,49 @@ async function makePagesSplitCssUrlFixture(): Promise<string> {
   return tmpDir;
 }
 
+async function makeAppCssUrlFixture(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-app-css-url-assets-"));
+  await fs.symlink(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+
+  const appDir = path.join(tmpDir, "app");
+  await fs.mkdir(appDir, { recursive: true });
+  await fs.writeFile(path.join(appDir, "dark.svg"), DARK_SVG);
+  await fs.writeFile(path.join(appDir, "dark2.svg"), DARK_2_SVG);
+  await fs.writeFile(
+    path.join(appDir, "page.module.css"),
+    [
+      ".redText {",
+      "  color: red;",
+      '  background-image: url("./dark.svg"), url(dark2.svg);',
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    path.join(appDir, "layout.tsx"),
+    [
+      "export default function RootLayout({ children }: { children: React.ReactNode }) {",
+      "  return <html><body>{children}</body></html>;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    path.join(appDir, "page.tsx"),
+    [
+      '"use client";',
+      'import styles from "./page.module.css";',
+      "",
+      "export default function Home() {",
+      "  return <main className={styles.redText}>App CSS URL asset test</main>;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  return tmpDir;
+}
+
 async function listFiles(dir: string): Promise<string[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const files: string[] = [];
@@ -168,7 +211,30 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
+function isPluginNamed(plugin: unknown, name: string): plugin is { name: string; apply?: unknown } {
+  return (
+    typeof plugin === "object" &&
+    plugin !== null &&
+    !Array.isArray(plugin) &&
+    "name" in plugin &&
+    plugin.name === name
+  );
+}
+
 describe("Pages Router CSS url() asset emission", () => {
+  it("marks and restores CSS URL assets only during build", async () => {
+    const plugins = vinext({ disableAppRouter: true });
+    const markPlugin = plugins.find((plugin) =>
+      isPluginNamed(plugin, "vinext:css-url-assets-mark"),
+    );
+    const restorePlugin = plugins.find((plugin) =>
+      isPluginNamed(plugin, "vinext:css-url-assets-restore"),
+    );
+
+    expect(markPlugin).toMatchObject({ apply: "build" });
+    expect(restorePlugin).toMatchObject({ apply: "build" });
+  });
+
   it("emits global CSS svg url() dependencies under /_next/static/media/", async () => {
     const tmpDir = await makePagesCssUrlFixture();
     try {
@@ -297,6 +363,49 @@ describe("Pages Router CSS url() asset emission", () => {
         }
       } finally {
         await closeServer(server);
+      }
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 180_000);
+});
+
+describe("App Router CSS url() asset emission", () => {
+  it("emits App page CSS svg url() dependencies from the client environment", async () => {
+    const tmpDir = await makeAppCssUrlFixture();
+    try {
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const emittedCssFiles = (await listFiles(path.join(tmpDir, "dist", "client"))).filter(
+        (file) => file.endsWith(".css"),
+      );
+      const css = (
+        await Promise.all(emittedCssFiles.map((file) => fs.readFile(file, "utf-8")))
+      ).join("\n");
+
+      expect(css, `expected emitted app CSS under dist/client`).toContain("redText");
+      expect(css).not.toContain("vinext_css_url_asset");
+
+      const assetUrls = extractCssUrls(css).filter((url) => url.includes(".svg"));
+      expect(assetUrls, `expected SVG URLs in emitted CSS:\n${css}`).toHaveLength(2);
+      expect(assetUrls).toEqual([
+        expect.stringMatching(/^\/_next\/static\/media\/dark\.[A-Za-z0-9_-]+\.svg$/),
+        expect.stringMatching(/^\/_next\/static\/media\/dark2\.[A-Za-z0-9_-]+\.svg$/),
+      ]);
+      expect(new Set(assetUrls).size, "App Router asset URLs should be unique").toBe(
+        assetUrls.length,
+      );
+
+      for (const assetUrl of assetUrls) {
+        const assetPath = path.join(tmpDir, "dist", "client", assetUrl);
+        const assetStat = await fs.stat(assetPath);
+        expect(assetStat.isFile(), `expected emitted asset ${assetUrl}`).toBe(true);
       }
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -414,36 +414,69 @@ describe("App Router CSS url() asset emission", () => {
   }, 180_000);
 });
 
-describe("restoreDedupedCssAssetReferences chunk handling", () => {
-  it("strips the private marker from CSS inlined into a JS chunk", () => {
-    // Simulates `cssCodeSplit: false` / `?inline`: the marked CSS ends up in a
-    // JS chunk's `code` rather than a standalone `.css` asset, so the restore
-    // pass must still strip the leaked provenance marker.
-    const bundle = {
-      "main.js": {
-        type: "chunk" as const,
-        fileName: "main.js",
-        code: 'const css = ".x{background:url(/_next/static/media/dark.abc123.svg?vinext_css_url_asset=dark.svg)}";',
-      },
-    } as unknown as Parameters<typeof restoreDedupedCssAssetReferences>[0];
+function makeChunkBundle(code: string) {
+  return {
+    "main.js": { type: "chunk" as const, fileName: "main.js", code },
+  } as unknown as Parameters<typeof restoreDedupedCssAssetReferences>[0];
+}
 
+function stripChunk(code: string): string {
+  const bundle = makeChunkBundle(code);
+  restoreDedupedCssAssetReferences(bundle, () => {});
+  return (bundle["main.js"] as { code: string }).code;
+}
+
+describe("restoreDedupedCssAssetReferences chunk handling", () => {
+  it("strips the marker from CSS inlined into a JS chunk (Vite's escaped-quote layout)", () => {
+    // `cssCodeSplit: false` / `?inline`: Vite JSON-stringifies the CSS into a JS
+    // string, so a quoted `url("...")` becomes `url(\"...\")` with escaped
+    // double quotes. The strip must be agnostic to that escaping.
+    const css =
+      '.x{background:url("/_next/static/media/dark.abc123.svg?vinext_css_url_asset=dark.svg")}';
+    const code = `const css = ${JSON.stringify(css)};`;
+    expect(code).toContain('\\"'); // sanity: realistic escaped-quote layout
+
+    const bundle = makeChunkBundle(code);
     const emitted: unknown[] = [];
     restoreDedupedCssAssetReferences(bundle, (asset) => emitted.push(asset));
 
-    const code = (bundle["main.js"] as { code: string }).code;
-    expect(code).not.toContain("vinext_css_url_asset");
-    expect(code).toContain("/_next/static/media/dark.abc123.svg");
+    const out = (bundle["main.js"] as { code: string }).code;
+    expect(out).not.toContain("vinext_css_url_asset");
+    expect(out).toContain("/_next/static/media/dark.abc123.svg");
+    // The escaped quotes and surrounding URL are preserved.
+    expect(out).toContain('url(\\"/_next/static/media/dark.abc123.svg\\")');
     // Inlined CSS URLs are already final; no sibling media files are emitted.
     expect(emitted).toHaveLength(0);
   });
 
+  it("strips the marker from unquoted and single-quoted inlined url()", () => {
+    expect(stripChunk("url(/m/dark.svg?vinext_css_url_asset=dark.svg)")).toBe("url(/m/dark.svg)");
+    expect(stripChunk("url('/m/dark.svg?vinext_css_url_asset=dark.svg')")).toBe(
+      "url('/m/dark.svg')",
+    );
+  });
+
+  it("preserves other query params and fragments when stripping the marker", () => {
+    // Marker is the leading param, another param follows.
+    expect(stripChunk("url(/m/dark.svg?vinext_css_url_asset=dark.svg&v=2)")).toBe(
+      "url(/m/dark.svg?v=2)",
+    );
+    // Marker is a trailing param.
+    expect(stripChunk("url(/m/dark.svg?v=2&vinext_css_url_asset=dark.svg)")).toBe(
+      "url(/m/dark.svg?v=2)",
+    );
+    // Marker is a middle param.
+    expect(stripChunk("url(/m/dark.svg?v=2&vinext_css_url_asset=dark.svg&w=3)")).toBe(
+      "url(/m/dark.svg?v=2&w=3)",
+    );
+    // Marker followed by a fragment.
+    expect(stripChunk("url(/m/dark.svg?vinext_css_url_asset=dark.svg#f)")).toBe(
+      "url(/m/dark.svg#f)",
+    );
+  });
+
   it("leaves chunks without the marker untouched", () => {
     const original = 'const css = ".x{background:url(/_next/static/media/dark.abc123.svg)}";';
-    const bundle = {
-      "main.js": { type: "chunk" as const, fileName: "main.js", code: original },
-    } as unknown as Parameters<typeof restoreDedupedCssAssetReferences>[0];
-
-    restoreDedupedCssAssetReferences(bundle, () => {});
-    expect((bundle["main.js"] as { code: string }).code).toBe(original);
+    expect(stripChunk(original)).toBe(original);
   });
 });


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js CSS `url()` asset/resource output for global SCSS and CSS. |
| Core change | Emit CSS `url()` assets as files under `/_next/static/media/`, preserve distinct source filenames after content dedupe, and restore each CSS reference from its own provenance instead of a shared cursor. |
| Main boundary | Build-time client CSS output only. Runtime dev-server handling and SSR/RSC sibling media emission are not changed. |
| Primary files | `client-build-config.ts`, `css-url-assets.ts`, `index.ts`, `css-url-assets.test.ts`, `build-optimization.test.ts` |
| Expected impact | Migrated Next.js apps keep observable CSS asset URLs such as `dark.*.svg` and `dark2.*.svg` even when the files have identical bytes and are referenced from different CSS chunks. |

## Why

Next.js treats CSS `url()` dependencies as emitted resources. That means two different source files are two observable URL resources, even when their contents are byte-identical. Vinext was inheriting Vite defaults, which could inline small assets and let Rolldown collapse identical SVG contents to the first emitted filename.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| CSS asset graph | CSS `url()` dependencies should behave like Next.js `asset/resource`. | Defaults vinext client builds to `assetsInlineLimit: 0` unless the user explicitly configured Vite otherwise. |
| Output layout | Client assets should live under the Next-compatible static tree. | Sets client asset names to `css/[name].[hash:8][extname]` or `media/[name].[hash:8][extname]` under the resolved assets dir. |
| Reference provenance | A CSS output reference must be restored from the source URL that produced it, not from global bundle iteration order. | Carries the source basename through Vite's CSS transform as a private query marker, then strips that marker while restoring final CSS URLs. |
| Phase ownership | The provenance repair is a build-time client CSS concern. | Marks both CSS URL repair plugins as `apply: "build"` and keeps restoration gated to `this.environment.name === "client"`. |
| Environment ownership | Vinext's default asset inlining policy should not be injected into server environments. | Applies the default through client build environment config and verifies the resolved builder lifecycle. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| Small SVG in CSS | Could become a `data:image/svg+xml` URL. | Emits a static SVG file under `/_next/static/media/`. |
| `dark.svg` and `dark2.svg` with identical bytes in one CSS file | Both CSS references could point to `dark.*.svg`. | CSS references point to `dark.*.svg` and `dark2.*.svg`, and both files are served. |
| Byte-identical URL assets referenced from separate CSS chunks | A shared mutable repair cursor made the result depend on CSS bundle iteration order. | Each marked URL restores from its own source basename, so split CSS chunks keep their own media filename. |
| Dev server CSS transforms | The marker transform could run in dev without a matching restore phase. | Marker and restore plugins are build-only, so dev CSS is untouched by this repair. |
| SSR/RSC bundle generation | Vinext's client asset default could be injected through top-level build config in multi-environment builds. | The default is applied to client build environments, with RSC/SSR left untouched unless the user configured Vite globally. |

<details>
<summary>Maintainer review path</summary>

1. `tests/css-url-assets.test.ts` checks the observable contract copied from the upstream Next.js fixture, including byte-identical SVG files in one CSS file, separate CSS chunks, build-only plugin phase metadata, and App Router client CSS output.
2. `packages/vinext/src/index.ts` wires marker injection, client-scoped asset defaults, and final CSS URL restoration at the build/client boundary.
3. `packages/vinext/src/build/client-build-config.ts` owns the client asset filename policy and dedupes source-name candidates from Rolldown metadata.
4. `packages/vinext/src/build/css-url-assets.ts` owns the narrow client-bundle repair for content-deduped CSS asset references.
5. `tests/build-optimization.test.ts` checks both the config object boundary and Vite's resolved `createBuilder` lifecycle for `assetsInlineLimit`.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/build-optimization.test.ts tests/css-url-assets.test.ts tests/pages-css-url-encoding.test.ts tests/ssr-css-assets.test.ts tests/scss.test.ts`
  - 88 passed, 2 skipped. `tests/scss.test.ts` remains skipped in this root test environment because `sass` is not installed there.
- `vp check`
- Commit hook: formatting, type/lint, `knip --no-progress`
- Upstream deploy-suite verification:

```bash
vp env exec --node 24 \
  ./scripts/run-nextjs-deploy-suite.sh \
  /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 \
  --retries 0 -c 1 --debug \
  test/e2e/app-dir/scss/url-global/url-global.test.ts
```

Result: both upstream cases passed, `sass` and `sass-embedded`.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public runtime API.
- Dev server: the CSS URL marker and restore plugins are build-only, so dev-served CSS URLs are not modified by this repair.
- Config: vinext's Next-compatible default is scoped to client output. A user-supplied top-level `build.assetsInlineLimit` remains user-owned Vite config.
- Build output: CSS assets now use `_next/static/css/` and non-CSS assets use `_next/static/media/` through the existing resolved assets dir.
- Runtime: static serving path is unchanged. The new sibling files are emitted into the same client output tree that CSS already references.
- Marker handling: the private query marker is inserted only for relative CSS asset URLs and is stripped from emitted CSS. Existing user query strings and hashes are preserved.
- Provenance limit: when Rolldown dedupes byte-identical assets with the same basename from different directories, the emitted asset metadata does not preserve enough URL provenance to recover distinct directory origins. Those references intentionally share one restored filename for the same bytes.
- Existing-app risk: apps that relied on Vite's default CSS asset inlining will now see Next-compatible emitted files unless they explicitly configure `build.assetsInlineLimit`.

</details>

<details>
<summary>Non-goals</summary>

- Does not change dev-server asset handling.
- Does not attempt to make JavaScript asset imports preserve duplicate filenames. This PR is scoped to CSS `url()` dependencies, matching the failing upstream fixture.
- Does not change user overrides for Vite asset inlining.
- Does not make App Router server-layout CSS go through the client CSS repair path. The new App Router regression exercises client-environment CSS with a page CSS module.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js scss/url-global test](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/scss/url-global/url-global.test.ts#L24-L40) | Defines the observable behavior: CSS background URLs should include separate `dark.*.svg` and `dark2.*.svg` files and both should fetch successfully. |
| [Next.js CSS url asset rule](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/webpack/config/blocks/css/index.ts#L523-L540) | Next applies webpack `asset/resource` to CSS issuers so CSS file references emit URLs instead of inlining. |
| [Next.js asset filename generator](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/webpack-config.ts#L2095-L2103) | Shows the `static/media/[name].[hash:8][ext]` naming convention this PR mirrors. |
| [Vite plugin conditional application](https://vite.dev/guide/using-plugins.html#conditional-application) | Documents `apply: "build"`, which keeps the marker transform out of dev. |
| [Vite Environment API for plugins](https://vite.dev/guide/api-environment-plugins.html) | Documents per-environment build hooks and `configEnvironment`, which this PR uses for client-scoped build config. |
| [Vite `build.assetsInlineLimit`](https://github.com/vitejs/vite/blob/v8.0.10/docs/config/build-options.md#build-assetsinlinelimit) | Documents Vite's default inlining behavior that vinext now overrides by default for Next parity on client output. |
