### PR TITLE
fix(app-router): reuse pending prefetched RSC payloads

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -206,7 +206,7 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   "experimental.prefetchInlining": {
     status: "partial",
     detail:
-      "config recognized; vinext uses unified RSC navigation payloads so per-segment prefetch inlining is a no-op",
+      "config recognized; Link prefetch preserves pending/dedup semantics, but vinext does not implement per-segment cache storage",
   },
   "experimental.outputHashSalt": {
     status: "supported",

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -321,6 +321,12 @@ export type ResolvedNextConfig = {
   pageExtensions: string[];
   instrumentationClientInject: string[];
   cacheComponents: boolean;
+  /**
+   * Whether `experimental.prefetchInlining` is configured. Next.js uses this
+   * with the Segment Cache to fetch the route tree before the bundled inlined
+   * segment payload.
+   */
+  prefetchInlining: boolean;
   redirects: NextRedirect[];
   rewrites: {
     beforeFiles: NextRewrite[];
@@ -1108,6 +1114,7 @@ export async function resolveNextConfig(
       output: "",
       pageExtensions: normalizePageExtensions(),
       cacheComponents: false,
+      prefetchInlining: false,
       redirects: [],
       rewrites: { beforeFiles: [], afterFiles: [], fallback: [] },
       headers: [],
@@ -1229,6 +1236,8 @@ export async function resolveNextConfig(
     ? rawOptimize.filter((x): x is string => typeof x === "string")
     : [];
   const inlineCss = experimental?.inlineCss === true;
+  const prefetchInlining =
+    experimental?.prefetchInlining === true || isUnknownRecord(experimental?.prefetchInlining);
 
   // Resolve serverExternalPackages — support the current top-level key and the
   // legacy experimental.serverComponentsExternalPackages name that Next.js still
@@ -1342,6 +1351,7 @@ export async function resolveNextConfig(
         )
       : [],
     cacheComponents: config.cacheComponents ?? false,
+    prefetchInlining,
     redirects,
     rewrites,
     headers,

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -365,6 +365,12 @@ declare global {
       __VINEXT_DEPLOYMENT_ID?: string;
 
       /**
+       * `"true"` when `next.config.js` enables
+       * `experimental.prefetchInlining`.
+       */
+      __VINEXT_PREFETCH_INLINING?: string;
+
+      /**
        * JSON-encoded array of `RemotePattern` objects from
        * `next.config.js` → `images.remotePatterns`.
        */

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1197,6 +1197,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME"] = JSON.stringify(
           String(nextConfig.staleTimes.static),
         );
+        defines["process.env.__VINEXT_PREFETCH_INLINING"] = JSON.stringify(
+          nextConfig.prefetchInlining ? "true" : "false",
+        );
         // Expose trailingSlash to client-side code so <Link> can render hrefs
         // in the canonical form and avoid an unnecessary 308 redirect bounce.
         defines["process.env.__VINEXT_TRAILING_SLASH"] = JSON.stringify(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -15,7 +15,7 @@ import {
   __basePath,
   appRouterInstance,
   commitClientNavigationState,
-  consumePrefetchResponse,
+  consumePrefetchResponseForNavigation,
   createCachedRscResponseSnapshot,
   createClientNavigationRenderSnapshot,
   getClientNavigationRenderContext,
@@ -1479,11 +1479,15 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         let navResponse: Response | undefined;
         let navResponseUrl: string | null = null;
         if (navigationKind !== "refresh") {
-          const prefetchedResponse = consumePrefetchResponse(
+          const prefetchedResponse = await consumePrefetchResponseForNavigation(
             rscUrl,
             requestInterceptionContext,
             mountedSlotsHeader,
+            {
+              shouldConsume: () => browserNavigationController.isCurrentNavigation(navId),
+            },
           );
+          if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
             navResponse = restoreRscResponse(prefetchedResponse, false);
             navResponseUrl = prefetchedResponse.url;

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -407,7 +407,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
                 if (!shellResponse.ok) {
                   return shellResponse;
                 }
-                void shellResponse.arrayBuffer().catch(() => {});
+                await shellResponse.arrayBuffer().catch(() => {});
                 return fetch(rscUrl, {
                   headers,
                   credentials: "include",

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -153,6 +153,7 @@ export function useLinkStatus(): LinkStatusContextValue {
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 /** trailingSlash from next.config.js, injected by the plugin at build time */
 const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
+const __prefetchInlining: boolean = process.env.__VINEXT_PREFETCH_INLINING === "true";
 const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
 function resolveHref(href: LinkProps["href"]): string {
@@ -328,8 +329,21 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
   if (prefetchHref == null) return;
 
   const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
+  const target = new URL(fullHref, window.location.href);
+  if (
+    target.origin === window.location.origin &&
+    target.pathname === window.location.pathname &&
+    target.search === window.location.search
+  ) {
+    return;
+  }
 
-  const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
+  const schedule =
+    priority === "high"
+      ? (fn: () => void) => {
+          fn();
+        }
+      : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
 
   schedule(() => {
     void (async () => {
@@ -368,15 +382,50 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           return;
         }
         prefetched.add(cacheKey);
+        // Next's `prefetchInlining` Segment Cache path reserves the final
+        // payload while a route-tree request is still pending. Vinext keeps a
+        // unified route payload, so gate that payload behind a loading-shell
+        // request to preserve the same pending/dedup observable contract.
+        const fetchPromise =
+          __prefetchInlining && autoPrefetch.cacheForNavigation
+            ? (async () => {
+                const shellHeaders = createRscRequestHeaders({
+                  interceptionContext,
+                  renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+                });
+                if (mountedSlotsHeader) {
+                  shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+                }
+                const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
+                const shellResponse = await fetch(shellRscUrl, {
+                  headers: shellHeaders,
+                  credentials: "include",
+                  priority,
+                  // @ts-expect-error — purpose is a valid fetch option in some browsers
+                  purpose: "prefetch",
+                });
+                if (!shellResponse.ok) {
+                  return shellResponse;
+                }
+                void shellResponse.arrayBuffer().catch(() => {});
+                return fetch(rscUrl, {
+                  headers,
+                  credentials: "include",
+                  priority,
+                  // @ts-expect-error — purpose is a valid fetch option in some browsers
+                  purpose: "prefetch",
+                });
+              })()
+            : fetch(rscUrl, {
+                headers,
+                credentials: "include",
+                priority,
+                // @ts-expect-error — purpose is a valid fetch option in some browsers
+                purpose: "prefetch",
+              });
         prefetchRscResponse(
           rscUrl,
-          fetch(rscUrl, {
-            headers,
-            credentials: "include",
-            priority,
-            // @ts-expect-error — purpose is a valid fetch option in some browsers
-            purpose: "prefetch",
-          }),
+          fetchPromise,
           interceptionContext,
           mountedSlotsHeader,
           undefined,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -774,6 +774,39 @@ export function consumePrefetchResponse(
   return null;
 }
 
+/**
+ * Consume a prefetched response for navigation. Unlike the synchronous cache
+ * read above, this waits for an already-started prefetch snapshot before
+ * deciding whether to fetch again. That preserves the ownership invariant set
+ * up by prefetchRscResponse(): a pending cache entry means this URL already has
+ * one in-flight network request that navigation should share.
+ */
+type ConsumePrefetchResponseForNavigationOptions = {
+  shouldConsume?: () => boolean;
+};
+
+export async function consumePrefetchResponseForNavigation(
+  rscUrl: string,
+  interceptionContext: string | null = null,
+  mountedSlotsHeader: string | null = null,
+  options?: ConsumePrefetchResponseForNavigationOptions,
+): Promise<CachedRscResponse | null> {
+  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+  const cache = getPrefetchCache();
+  const entry = cache.get(cacheKey);
+  if (!entry) return null;
+  if (entry.cacheForNavigation === false) return null;
+
+  if (entry.pending !== undefined) {
+    await entry.pending.catch(() => {});
+    if (cache.get(cacheKey) !== entry) return null;
+  }
+
+  if (options?.shouldConsume?.() === false) return null;
+
+  return consumePrefetchResponse(rscUrl, interceptionContext, mountedSlotsHeader);
+}
+
 // ---------------------------------------------------------------------------
 // Client navigation state — stored on a Symbol.for global to survive
 // multiple Vite module instances loading this file through different IDs.

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -269,6 +269,12 @@ declare module "next/navigation" {
     interceptionContext?: string | null,
     mountedSlotsHeader?: string | null,
   ): CachedRscResponse | null;
+  export function consumePrefetchResponseForNavigation(
+    rscUrl: string,
+    interceptionContext?: string | null,
+    mountedSlotsHeader?: string | null,
+    options?: { shouldConsume?: () => boolean },
+  ): Promise<CachedRscResponse | null>;
 }
 
 declare module "next/image" {

--- a/tests/e2e/app-router/nextjs-compat/prefetch.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/prefetch.spec.ts
@@ -16,7 +16,21 @@ type PrefetchTestState = {
   requestIdleCallbackCalls: number;
 };
 
-type PrefetchTestWindow = Window & Partial<Record<"__VINEXT_PREFETCH_TEST__", PrefetchTestState>>;
+type PendingPrefetchReuseState = {
+  releasePrefetch: (() => void) | null;
+  targetNavigationRequests: number;
+  targetPrefetchRequests: number;
+};
+
+type PrefetchTestWindow = Window & {
+  __VINEXT_PREFETCH_TEST__?: PrefetchTestState;
+  __VINEXT_PENDING_PREFETCH_REUSE_TEST__?: PendingPrefetchReuseState;
+  next?: {
+    router?: {
+      prefetch(href: string): void;
+    };
+  };
+};
 
 test.describe("Next.js compat: prefetch (browser)", () => {
   // Next.js: 'should navigate when prefetch is false'
@@ -62,6 +76,91 @@ test.describe("Next.js compat: prefetch (browser)", () => {
     // Marker should survive (no full reload)
     const marker = await page.evaluate(() => (window as any).__PREFETCH_MARKER__);
     expect(marker).toBe(true);
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts
+  test("navigation reuses an in-flight RSC prefetch without a duplicate request", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      const testWindow: PrefetchTestWindow = window;
+      const originalFetch = window.fetch.bind(window);
+      const state: PendingPrefetchReuseState = {
+        releasePrefetch: null,
+        targetNavigationRequests: 0,
+        targetPrefetchRequests: 0,
+      };
+      testWindow.__VINEXT_PENDING_PREFETCH_REUSE_TEST__ = state;
+
+      window.fetch = async (input, init) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+        if (url.includes("/nextjs-compat/prefetch-test/target.rsc")) {
+          if (state.targetPrefetchRequests === 0) {
+            state.targetPrefetchRequests += 1;
+            await new Promise<void>((resolve) => {
+              state.releasePrefetch = resolve;
+            });
+          } else {
+            state.targetNavigationRequests += 1;
+          }
+        }
+
+        return originalFetch(input, init);
+      };
+    });
+
+    await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
+    await waitForAppRouterHydration(page);
+
+    await page.evaluate(() => {
+      const router = (window as PrefetchTestWindow).next?.router;
+      if (router === undefined) throw new Error("Missing app router instance");
+      router.prefetch("/nextjs-compat/prefetch-test/target");
+    });
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const state = (window as PrefetchTestWindow).__VINEXT_PENDING_PREFETCH_REUSE_TEST__;
+          if (state === undefined) throw new Error("Missing pending prefetch test state");
+          return state.targetPrefetchRequests;
+        }),
+      )
+      .toBe(1);
+
+    await page.click("#prefetch-link");
+
+    await page.evaluate(() => new Promise<void>((resolve) => setTimeout(resolve, 100)));
+    expect(
+      await page.evaluate(() => {
+        const state = (window as PrefetchTestWindow).__VINEXT_PENDING_PREFETCH_REUSE_TEST__;
+        if (state === undefined) throw new Error("Missing pending prefetch test state");
+        return state.targetNavigationRequests;
+      }),
+    ).toBe(0);
+
+    await page.evaluate(() => {
+      const state = (window as PrefetchTestWindow).__VINEXT_PENDING_PREFETCH_REUSE_TEST__;
+      if (state?.releasePrefetch === null || state?.releasePrefetch === undefined) {
+        throw new Error("Target prefetch was not blocked");
+      }
+      state.releasePrefetch();
+    });
+
+    await expect(page.locator("#prefetch-target")).toHaveText("Prefetch Target Page", {
+      timeout: 10_000,
+    });
+    expect(
+      await page.evaluate(() => {
+        const state = (window as PrefetchTestWindow).__VINEXT_PENDING_PREFETCH_REUSE_TEST__;
+        if (state === undefined) throw new Error("Missing pending prefetch test state");
+        return state.targetNavigationRequests;
+      }),
+    ).toBe(0);
   });
 
   test("Link with prefetch={false} does not prefetch RSC payload in dev", async ({ page }) => {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1475,8 +1475,16 @@ describe("Link prefetch scheduling", () => {
     vi.stubEnv("__VINEXT_PREFETCH_INLINING", "true");
     const observer = stubIntersectionObserver();
     let resolveShell: ((response: Response) => void) | undefined;
+    let releaseShellBody: (() => void) | undefined;
     const shellPromise = new Promise<Response>((resolve) => {
       resolveShell = resolve;
+    });
+    const shellBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseShellBody = () => {
+          controller.close();
+        };
+      },
     });
     const result = await renderIsolatedLink({
       href: "/intent-prefetch-target",
@@ -1507,7 +1515,14 @@ describe("Link prefetch scheduling", () => {
       if (resolveShell === undefined) {
         throw new Error("Expected shell prefetch resolver");
       }
-      resolveShell(new Response("shell"));
+      resolveShell(new Response(shellBody));
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      if (releaseShellBody === undefined) {
+        throw new Error("Expected shell body release");
+      }
+      releaseShellBody();
       await waitForFetchCalls(result.fetch, 2);
 
       const secondInit = result.fetch.mock.calls[1]?.[1];

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -151,6 +151,8 @@ function mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE(
   vi.doMock("react/jsx-dev-runtime", async () => {
     const actual =
       await vi.importActual<typeof import("react/jsx-dev-runtime")>("react/jsx-dev-runtime");
+    const jsxRuntime =
+      await vi.importActual<typeof import("react/jsx-runtime")>("react/jsx-runtime");
     return {
       ...actual,
       jsxDEV(
@@ -162,7 +164,10 @@ function mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE(
         self?: Parameters<typeof actual.jsxDEV>[5],
       ) {
         options.captureAnchor(type, props);
-        return actual.jsxDEV(type, props, key, isStaticChildren ?? false, source, self);
+        if (typeof actual.jsxDEV === "function") {
+          return actual.jsxDEV(type, props, key, isStaticChildren ?? false, source, self);
+        }
+        return jsxRuntime.jsx(type, props, key);
       },
     };
   });
@@ -1028,6 +1033,8 @@ async function renderIsolatedLink(options: {
   const location = {
     href: "https://example.com/current",
     origin: "https://example.com",
+    pathname: "/current",
+    search: "",
   };
   const navigationRuntime =
     options.appNavigation === false ? undefined : createTestNavigationRuntime(navigate);
@@ -1377,6 +1384,138 @@ describe("Link prefetch scheduling", () => {
           priority: "high",
         }),
       );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("checks high-priority intent prefetch before queued click navigation can consume the cache", async () => {
+    const idleCallbacks: Array<() => void> = [];
+    const requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+    const result = await renderIsolatedLink({
+      href: "/intent-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+    const { createRscRequestHeaders, createRscRequestUrl } =
+      await import("../packages/vinext/src/server/app-rsc-cache-busting.js");
+    const { consumePrefetchResponse, getPrefetchCache, getPrefetchedUrls } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const rscUrl = await createRscRequestUrl("/intent-prefetch-target", createRscRequestHeaders());
+    const snapshot = {
+      buffer: new TextEncoder().encode("flight").buffer,
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: rscUrl,
+    };
+
+    try {
+      getPrefetchCache().set(rscUrl, {
+        cacheForNavigation: true,
+        outcome: "cache-seeded",
+        snapshot,
+        timestamp: Date.now(),
+      });
+      getPrefetchedUrls().add(rscUrl);
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expect(idleCallbacks).toEqual([]);
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      // Simulate the click navigation consuming the existing viewport prefetch.
+      expect(consumePrefetchResponse(rscUrl, null, null)).toEqual(snapshot);
+      for (const callback of idleCallbacks) {
+        callback();
+      }
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not reprefetch a visible link after navigation makes it the current URL", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/intent-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { getPrefetchCache, getPrefetchedUrls } =
+      await import("../packages/vinext/src/shims/navigation.js");
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      getPrefetchCache().clear();
+      getPrefetchedUrls().clear();
+      result.fetch.mockClear();
+      window.location.href = "https://example.com/intent-prefetch-target";
+      window.location.pathname = "/intent-prefetch-target";
+      window.location.search = "";
+
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("gates prefetchInlining full payload behind a loading-shell request", async () => {
+    vi.stubEnv("__VINEXT_PREFETCH_INLINING", "true");
+    const observer = stubIntersectionObserver();
+    let resolveShell: ((response: Response) => void) | undefined;
+    const shellPromise = new Promise<Response>((resolve) => {
+      resolveShell = resolve;
+    });
+    const result = await renderIsolatedLink({
+      href: "/intent-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    result.fetch
+      .mockImplementationOnce(() => shellPromise)
+      .mockImplementationOnce(() => Promise.resolve(new Response("full")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const firstInit = result.fetch.mock.calls[0]?.[1];
+      expect(firstInit?.headers).toBeInstanceOf(Headers);
+      if (!(firstInit?.headers instanceof Headers)) {
+        throw new Error("Expected prefetch request headers");
+      }
+      expect(firstInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      if (resolveShell === undefined) {
+        throw new Error("Expected shell prefetch resolver");
+      }
+      resolveShell(new Response("shell"));
+      await waitForFetchCalls(result.fetch, 2);
+
+      const secondInit = result.fetch.mock.calls[1]?.[1];
+      expect(secondInit?.headers).toBeInstanceOf(Headers);
+      if (!(secondInit?.headers instanceof Headers)) {
+        throw new Error("Expected full prefetch request headers");
+      }
+      expect(secondInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -822,7 +822,9 @@ describe("resolveNextConfig serverActionsBodySizeLimit", () => {
     });
     expect(resolved.serverActionsBodySizeLimit).toBe(5242880);
   });
+});
 
+describe("resolveNextConfig disableOptimizedLoading", () => {
   // Regression for #1519: `experimental.disableOptimizedLoading` defaults to
   // `false` and is read into the resolved config. The default drives the
   // `defer`-in-head behaviour for Pages Router scripts in production.
@@ -837,7 +839,9 @@ describe("resolveNextConfig serverActionsBodySizeLimit", () => {
     });
     expect(resolved.disableOptimizedLoading).toBe(true);
   });
+});
 
+describe("resolveNextConfig prefetchInlining", () => {
   it("reads experimental.prefetchInlining from next.config", async () => {
     const disabled = await resolveNextConfig({});
     expect(disabled.prefetchInlining).toBe(false);

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -837,6 +837,21 @@ describe("resolveNextConfig serverActionsBodySizeLimit", () => {
     });
     expect(resolved.disableOptimizedLoading).toBe(true);
   });
+
+  it("reads experimental.prefetchInlining from next.config", async () => {
+    const disabled = await resolveNextConfig({});
+    expect(disabled.prefetchInlining).toBe(false);
+
+    const enabledByBoolean = await resolveNextConfig({
+      experimental: { prefetchInlining: true },
+    });
+    expect(enabledByBoolean.prefetchInlining).toBe(true);
+
+    const enabledByThresholds = await resolveNextConfig({
+      experimental: { prefetchInlining: { maxSize: Infinity, maxBundleSize: Infinity } },
+    });
+    expect(enabledByThresholds.prefetchInlining).toBe(true);
+  });
 });
 
 describe("resolveNextConfig hashSalt", () => {
@@ -1165,6 +1180,7 @@ describe("detectNextIntlConfig", () => {
       output: "",
       pageExtensions: ["tsx", "ts", "jsx", "js"],
       cacheComponents: false,
+      prefetchInlining: false,
       redirects: [],
       rewrites: { beforeFiles: [], afterFiles: [], fallback: [] },
       headers: [],

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -23,8 +23,10 @@ let MAX_PREFETCH_CACHE_SIZE: Navigation["MAX_PREFETCH_CACHE_SIZE"];
 let PREFETCH_CACHE_TTL: Navigation["PREFETCH_CACHE_TTL"];
 let snapshotRscResponse: Navigation["snapshotRscResponse"];
 let restoreRscResponse: Navigation["restoreRscResponse"];
+let prefetchRscResponse: Navigation["prefetchRscResponse"];
 let invalidatePrefetchCache: Navigation["invalidatePrefetchCache"];
 let appRouterInstance: Navigation["appRouterInstance"];
+let consumePrefetchResponseForNavigation: Navigation["consumePrefetchResponseForNavigation"];
 
 beforeEach(async () => {
   // Set window BEFORE importing so isServer evaluates to false
@@ -53,8 +55,10 @@ beforeEach(async () => {
   PREFETCH_CACHE_TTL = nav.PREFETCH_CACHE_TTL;
   snapshotRscResponse = nav.snapshotRscResponse;
   restoreRscResponse = nav.restoreRscResponse;
+  prefetchRscResponse = nav.prefetchRscResponse;
   invalidatePrefetchCache = nav.invalidatePrefetchCache;
   appRouterInstance = nav.appRouterInstance;
+  consumePrefetchResponseForNavigation = nav.consumePrefetchResponseForNavigation;
 });
 
 afterEach(() => {
@@ -83,6 +87,19 @@ function fillCache(count: number, timestamp: number, keyPrefix = "/page-"): void
     });
     prefetched.add(key);
   }
+}
+
+function createDeferredResponse(): {
+  promise: Promise<Response>;
+  resolve: (response: Response) => void;
+} {
+  let resolve: (response: Response) => void = () => {
+    throw new Error("Deferred response was not initialized");
+  };
+  const promise = new Promise<Response>((resolveInner) => {
+    resolve = resolveInner;
+  });
+  return { promise, resolve };
 }
 
 async function waitForPrefetchSetup(isReady: () => boolean = () => true): Promise<void> {
@@ -331,6 +348,61 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchCache().has(cacheKey)).toBe(false);
     expect(getPrefetchedUrls().has(cacheKey)).toBe(false);
     expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("awaits an in-flight prefetch instead of missing the navigation cache", async () => {
+    const rscUrl = "/dashboard.rsc";
+    const deferred = createDeferredResponse();
+    let settled = false;
+
+    prefetchRscResponse(rscUrl, deferred.promise, null, null);
+
+    const consumedPromise = consumePrefetchResponseForNavigation(rscUrl, null, null).then(
+      (snapshot) => {
+        settled = true;
+        return snapshot;
+      },
+    );
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(getPrefetchCache().get(rscUrl)?.outcome).toBe("pending");
+
+    deferred.resolve(new Response("flight", { headers: { "content-type": "text/x-component" } }));
+
+    const consumed = await consumedPromise;
+    expect(settled).toBe(true);
+    expect(consumed).not.toBeNull();
+    if (consumed === null) return;
+    await expect(restoreRscResponse(consumed).text()).resolves.toBe("flight");
+    expect(getPrefetchCache().has(rscUrl)).toBe(false);
+    expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
+  });
+
+  it("leaves a resolved in-flight prefetch for a newer navigation when the old navigation is stale", async () => {
+    const rscUrl = "/dashboard.rsc";
+    const deferred = createDeferredResponse();
+    let currentNavigation = true;
+
+    prefetchRscResponse(rscUrl, deferred.promise, null, null);
+
+    const staleNavigationConsume = consumePrefetchResponseForNavigation(rscUrl, null, null, {
+      shouldConsume: () => currentNavigation,
+    });
+
+    await Promise.resolve();
+    currentNavigation = false;
+    deferred.resolve(new Response("flight", { headers: { "content-type": "text/x-component" } }));
+
+    await expect(staleNavigationConsume).resolves.toBeNull();
+    expect(getPrefetchCache().get(rscUrl)?.outcome).toBe("cache-seeded");
+
+    const consumed = await consumePrefetchResponseForNavigation(rscUrl, null, null);
+    expect(consumed).not.toBeNull();
+    if (consumed === null) return;
+    await expect(restoreRscResponse(consumed).text()).resolves.toBe("flight");
+    expect(getPrefetchCache().has(rscUrl)).toBe(false);
+    expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
   });
 
   it("sweeps all expired entries before FIFO", () => {


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js App Router prefetch reuse semantics for pending and fully-prefetched routes. |
| Core change | Navigation now awaits an in-flight prefetch owner before issuing a fresh RSC request. Link prefetch repings skip the route that is already current. |
| Design concern | Vinext keeps unified route RSC payloads, while Next.js Segment Cache can split route tree and inlined segment payload requests. |
| Primary files | `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/shims/link.tsx`, `packages/vinext/src/server/app-browser-entry.ts` |
| Expected impact | Prevents duplicate `.rsc` requests during immediate click-after-prefetch and preserves `experimental.prefetchInlining` pending dedup ordering. |

## Why

A pending RSC prefetch cache entry must own the network request for its cache key until it resolves or fails. Navigation should share that owner instead of deciding from a synchronous cache miss, and Link visibility repings should not recreate work for the route that just became current.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Navigation | Pending prefetch means one request is already in flight for the URL. | Adds an async navigation consume path that awaits the pending entry and rechecks stale navigation ownership before consuming it. |
| Link reping | Visible-link pings must not create work for the current URL after a committed navigation. | Skips RSC prefetch setup when the target path and search already match `window.location`. |
| Prefetch inlining | Next.js reserves the final payload while the route-tree request is pending. | For `experimental.prefetchInlining`, Link prefetch reserves the final unified payload behind a loading-shell request so duplicate reveals see pending work. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Click while a route prefetch is in flight | Navigation saw the pending cache entry as unusable and fetched the same `.rsc` URL again. | Navigation awaits the pending owner and consumes the seeded snapshot when it resolves. |
| Stale navigation waiting on a prefetch | A superseded navigation could consume or delete the entry after it resolved. | The stale navigation returns null and leaves the seeded entry for the current navigation. |
| Link reping after navigation commit | The old visible Link could prefetch the route that had just become current. | Current-route repings are ignored. |
| `experimental.prefetchInlining` duplicate reveal | The single unified request did not match Next.js blocked route-tree then inlined-payload ordering. | The final unified payload is reserved pending while a loading-shell request gates the full fetch. |

<details>
<summary>Maintainer Review Path</summary>

1. `packages/vinext/src/shims/navigation.ts` - new async consume path and stale-navigation guard.
2. `packages/vinext/src/server/app-browser-entry.ts` - navigation call site now awaits pending prefetch ownership before falling back to fetch.
3. `packages/vinext/src/shims/link.tsx` - current-route skip, high-priority intent scheduling, and config-gated prefetchInlining ordering.
4. `packages/vinext/src/config/next-config.ts` and `packages/vinext/src/index.ts` - `experimental.prefetchInlining` is resolved and exposed to the client bundle.
5. Tests in `tests/prefetch-cache.test.ts`, `tests/link-navigation.test.ts`, and `tests/e2e/app-router/nextjs-compat/prefetch.spec.ts` cover the regression surfaces.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/prefetch-cache.test.ts`
- `vp test run tests/link-navigation.test.ts`
- `vp test run tests/next-config.test.ts -t "prefetchInlining|disableOptimizedLoading|staleTimes"`
- `vp test run tests/check.test.ts -t "prefetchInlining"`
- `pnpm exec playwright test tests/e2e/app-router/nextjs-compat/prefetch.spec.ts -c tests/e2e/app-router/nextjs-compat/playwright.nextjs-compat.config.ts --project=chromium`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts`

</details>

<details>
<summary>Risk / Compatibility</summary>

- Public API: no user-facing API changes.
- Config: `experimental.prefetchInlining` is now resolved into `ResolvedNextConfig` and exposed as an internal client define.
- Runtime: normal Link prefetch keeps the existing single full-route request unless `experimental.prefetchInlining` is configured.
- App Router cache: pending entries are awaited only on navigation consumption. Existing synchronous cache consumers keep the old behavior.
- Compatibility: this preserves Next.js pending/dedup observable behavior without implementing full per-segment Segment Cache storage.

</details>

<details>
<summary>Non-goals</summary>

- This does not implement Next.js per-segment Segment Cache storage.
- This does not add `/_tree` or `/_inlined` wire endpoints. Vinext still serves unified route RSC payloads.
- This does not change Pages Router prefetching.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js max prefetch inlining test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts) | Upstream behavior candidate reproduced by this PR. |
| [Next.js collect segment data prefetch inlining](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/collect-segment-data.tsx#L626-L642) | Shows the inlined prefetch task selection. |
| [Next.js inlined prefetch response shape](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/collect-segment-data.tsx#L836-L879) | Shows the bundled inlined segment response format. |
| [Next.js Segment Cache scheduler](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/scheduler.ts#L1376-L1390) | Shows how pending inlined requests are spawned and deduped. |
| [Next.js Segment Cache inlined fill](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/cache.ts#L1885-L2019) | Shows how inlined responses fill pending cache entries. |
