### PR TITLE
fix: align app router navigation parity

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -44,6 +44,10 @@ export type NavigationRuntimeFunctions = {
     historyUpdateMode: NavigationRuntimeHistoryUpdateMode,
     scroll: boolean,
   ) => void;
+  navigateExternal?: (
+    href: string,
+    historyUpdateMode: NavigationRuntimeHistoryUpdateMode,
+  ) => Promise<void>;
   navigate?: NavigationRuntimeNavigate;
   pingVisibleLinks?: () => void;
 };
@@ -96,6 +100,7 @@ function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntim
   return (
     isOptionalRuntimeFunction(Reflect.get(value, "clearNavigationCaches")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "navigateExternal")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigate")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "pingVisibleLinks"))
   );

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -52,7 +52,7 @@ import {
   type NavigationRuntimeNavigate,
   type NavigationRuntimeRscBootstrap,
 } from "../client/navigation-runtime.js";
-import { scrollToHashTargetOnNextFrame } from "vinext/shims/hash-scroll";
+import { retryScrollTo, scrollToHashTargetOnNextFrame } from "vinext/shims/hash-scroll";
 import { AppRouterScrollCommitProvider } from "vinext/shims/app-router-scroll";
 import {
   beginAppRouterScrollIntent,
@@ -1159,18 +1159,7 @@ function restorePopstateScrollPosition(
   const y = Number(state.__vinext_scrollY);
   const x = "__vinext_scrollX" in state ? Number(state.__vinext_scrollX) : 0;
 
-  let attempts = 0;
-  const restore = () => {
-    if (!shouldContinue()) return;
-
-    window.scrollTo(x, y);
-    if (!shouldContinue() || Math.abs(window.scrollY - y) <= 1 || attempts >= 60) {
-      return;
-    }
-    attempts += 1;
-    requestAnimationFrame(restore);
-  };
-  restore();
+  retryScrollTo(x, y, { shouldContinue });
 }
 
 function isSameAppRoutePopstateTarget(href: string): boolean {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1399,7 +1399,6 @@ function registerServerActionCallback(): void {
       Promise.resolve(flightResponse),
       { temporaryReferences },
     );
-    syncServerActionHttpFallbackHead(fetchResponse.status);
     if (shouldClearClientNavigationCachesForServerActionResult(result, revalidation)) {
       clearClientNavigationCaches();
     }
@@ -1444,6 +1443,9 @@ function registerServerActionCallback(): void {
       browserNavigationController.performHardNavigation(actionRedirectTarget.href);
       return undefined;
     }
+
+    const hasSameUrlRerenderPayload = isServerActionResult(result) && result.root !== undefined;
+    syncServerActionHttpFallbackHead(hasSameUrlRerenderPayload ? null : fetchResponse.status);
 
     // Server actions stay on the same URL and use commitSameUrlNavigatePayload()
     // for merge-based dispatch. This path does not call

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -60,6 +60,7 @@ import {
   type NavigationPayloadOutcome,
   type PendingBrowserRouterState,
 } from "./app-browser-navigation-controller.js";
+import { AppBrowserMpaNavigationScheduler } from "./app-browser-mpa-navigation.js";
 import { resolveManifestNavigationInterceptionContext } from "./app-browser-interception-context.js";
 import {
   createDiscardedServerActionRefreshScheduler,
@@ -244,8 +245,7 @@ let browserRouterStateHasEverCommitted = false;
 // of stranding them on the previous URL with a blank page. Cleared once the
 // commit effect runs (URL update succeeded) or the navigation is superseded.
 let pendingNavigationRecoveryHref: string | null = null;
-let pendingMpaNavigationHref: string | null = null;
-let pendingMpaNavigationToken = 0;
+const mpaNavigationScheduler = new AppBrowserMpaNavigationScheduler();
 const unresolvedMpaNavigation = new Promise<never>(() => {});
 let currentHistoryTraversalIndex: number | null =
   readHistoryStateTraversalIndex(window.history.state) ?? 0;
@@ -820,37 +820,10 @@ function isMpaNavigationState(
 }
 
 function performMpaNavigation(href: string, historyUpdateMode: HistoryUpdateMode): void {
-  if (pendingMpaNavigationHref === href) {
-    return;
-  }
-
-  pendingMpaNavigationHref = href;
-  pendingMpaNavigationToken += 1;
-  const token = pendingMpaNavigationToken;
-  const navigate = () => {
-    if (pendingMpaNavigationHref !== href || pendingMpaNavigationToken !== token) {
-      return;
-    }
-
-    if (historyUpdateMode === "replace") {
-      window.location.replace(href);
-    } else {
-      window.location.assign(href);
-    }
-  };
-
   // Match Next's MPA path by suspending forever, but delay the actual location
   // mutation just enough for the old tree to commit the pending transition
-  // signal before unload. The token prevents retry renders from firing stale
-  // targets if a newer MPA navigation supersedes this one.
-  if (typeof window.requestAnimationFrame === "function") {
-    window.requestAnimationFrame(() => {
-      window.setTimeout(navigate, 0);
-    });
-    return;
-  }
-
-  window.setTimeout(navigate, 0);
+  // signal before unload.
+  mpaNavigationScheduler.navigate(window, href, historyUpdateMode);
 }
 
 function decodeAppElementsPromise(payload: Promise<AppWireElements>): Promise<AppElements> {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1,6 +1,14 @@
 /// <reference types="vite/client" />
 
-import { createElement, startTransition, use, useLayoutEffect, useRef, useState } from "react";
+import {
+  createElement,
+  startTransition,
+  use,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   createFromFetch,
   createFromReadableStream,
@@ -21,6 +29,7 @@ import {
   getClientNavigationRenderContext,
   getPrefetchCache,
   invalidatePrefetchCache,
+  isRedirectError,
   pushHistoryStateWithoutNotify,
   replaceClientParamsWithoutNotify,
   replaceHistoryStateWithoutNotify,
@@ -30,6 +39,7 @@ import {
   setPendingPathname,
   setMountedSlotsHeader,
   setNavigationContext,
+  useRouter,
   type CachedRscResponse,
   type ClientNavigationRenderSnapshot,
   type PrefetchCacheEntry,
@@ -910,6 +920,41 @@ function performMpaNavigation(href: string, historyUpdateMode: HistoryUpdateMode
   mpaNavigationScheduler.navigate(window, href, historyUpdateMode);
 }
 
+function AppRouterRedirectBridge({ children }: { children?: React.ReactNode }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleUnhandledRedirect = (event: ErrorEvent | PromiseRejectionEvent): void => {
+      const error = "reason" in event ? event.reason : event.error;
+      if (!isRedirectError(error)) return;
+
+      const redirectError = error as Error & { digest: string };
+      const parts = redirectError.digest.split(";");
+      const url = parts.length >= 5 ? parts.slice(2, -2).join(";") : parts[2];
+      if (!url) return;
+
+      event.preventDefault();
+      startTransition(() => {
+        if (parts[1] === "push") {
+          router.push(decodeURIComponent(url));
+        } else {
+          router.replace(decodeURIComponent(url));
+        }
+      });
+    };
+
+    window.addEventListener("error", handleUnhandledRedirect);
+    window.addEventListener("unhandledrejection", handleUnhandledRedirect);
+
+    return () => {
+      window.removeEventListener("error", handleUnhandledRedirect);
+      window.removeEventListener("unhandledrejection", handleUnhandledRedirect);
+    };
+  }, [router]);
+
+  return children ?? null;
+}
+
 function decodeAppElementsPromise(payload: Promise<AppWireElements>): Promise<AppElements> {
   // Wrap in Promise.resolve() because createFromReadableStream() returns a
   // React Flight thenable whose .then() returns undefined (not a new Promise).
@@ -1033,7 +1078,11 @@ function BrowserRoot({
     ),
   );
   const innerTree = AppRouterContext
-    ? createElement(AppRouterContext.Provider, { value: appRouterInstance }, routeTree)
+    ? createElement(
+        AppRouterContext.Provider,
+        { value: appRouterInstance },
+        createElement(AppRouterRedirectBridge, null, routeTree),
+      )
     : routeTree;
 
   // In dev, wrap the route tree in a top-level recovery boundary. A render

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -29,6 +29,7 @@ import {
   getClientNavigationRenderContext,
   getPrefetchCache,
   invalidatePrefetchCache,
+  decodeRedirectError,
   isRedirectError,
   pushHistoryStateWithoutNotify,
   replaceClientParamsWithoutNotify,
@@ -928,17 +929,15 @@ function AppRouterRedirectBridge({ children }: { children?: React.ReactNode }) {
       const error = "reason" in event ? event.reason : event.error;
       if (!isRedirectError(error)) return;
 
-      const redirectError = error as Error & { digest: string };
-      const parts = redirectError.digest.split(";");
-      const url = parts.length >= 5 ? parts.slice(2, -2).join(";") : parts[2];
-      if (!url) return;
+      const result = decodeRedirectError((error as Error & { digest: string }).digest);
+      if (!result) return;
 
       event.preventDefault();
       startTransition(() => {
-        if (parts[1] === "push") {
-          router.push(decodeURIComponent(url));
+        if (result.type === "push") {
+          router.push(result.url);
         } else {
-          router.replace(decodeURIComponent(url));
+          router.replace(result.url);
         }
       });
     };

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -149,6 +149,11 @@ type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 type ServerActionResult = AppBrowserServerActionResult<AppWireElements>;
 
 type NavigationKind = "navigate" | "traverse" | "refresh";
+type MpaNavigationState = {
+  href: string;
+  historyUpdateMode: HistoryUpdateMode;
+  kind: "mpa-navigation";
+};
 
 // Maps NavigationKind to the AppRouterAction type used by the reducer.
 // "refresh" is intentionally treated as "navigate" (merge, preserve absent slots).
@@ -222,7 +227,7 @@ function parseEncodedJsonHeader<T>(value: string | null): T | null {
 }
 
 function isRouterStatePromise(
-  value: AppRouterState | Promise<AppRouterState>,
+  value: AppRouterState | Promise<AppRouterState> | MpaNavigationState,
 ): value is Promise<AppRouterState> {
   return value instanceof Promise;
 }
@@ -239,6 +244,9 @@ let browserRouterStateHasEverCommitted = false;
 // of stranding them on the previous URL with a blank page. Cleared once the
 // commit effect runs (URL update succeeded) or the navigation is superseded.
 let pendingNavigationRecoveryHref: string | null = null;
+let pendingMpaNavigationHref: string | null = null;
+let pendingMpaNavigationToken = 0;
+const unresolvedMpaNavigation = new Promise<never>(() => {});
 let currentHistoryTraversalIndex: number | null =
   readHistoryStateTraversalIndex(window.history.state) ?? 0;
 let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
@@ -800,6 +808,51 @@ function handleDevRecoveryBoundaryCatch(resetKey: number): void {
   browserNavigationController.drainPrePaintEffects(resetKey);
 }
 
+function isMpaNavigationState(
+  value: AppRouterState | Promise<AppRouterState> | MpaNavigationState,
+): value is MpaNavigationState {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "kind" in value &&
+    value.kind === "mpa-navigation"
+  );
+}
+
+function performMpaNavigation(href: string, historyUpdateMode: HistoryUpdateMode): void {
+  if (pendingMpaNavigationHref === href) {
+    return;
+  }
+
+  pendingMpaNavigationHref = href;
+  pendingMpaNavigationToken += 1;
+  const token = pendingMpaNavigationToken;
+  const navigate = () => {
+    if (pendingMpaNavigationHref !== href || pendingMpaNavigationToken !== token) {
+      return;
+    }
+
+    if (historyUpdateMode === "replace") {
+      window.location.replace(href);
+    } else {
+      window.location.assign(href);
+    }
+  };
+
+  // Match Next's MPA path by suspending forever, but delay the actual location
+  // mutation just enough for the old tree to commit the pending transition
+  // signal before unload. The token prevents retry renders from firing stale
+  // targets if a newer MPA navigation supersedes this one.
+  if (typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(() => {
+      window.setTimeout(navigate, 0);
+    });
+    return;
+  }
+
+  window.setTimeout(navigate, 0);
+}
+
 function decodeAppElementsPromise(payload: Promise<AppWireElements>): Promise<AppElements> {
   // Wrap in Promise.resolve() because createFromReadableStream() returns a
   // React Flight thenable whose .then() returns undefined (not a new Promise).
@@ -816,7 +869,9 @@ function BrowserRoot({
 }) {
   const resolvedElements = use(initialElements);
   const initialMetadata = AppElementsWire.readMetadata(resolvedElements);
-  const [treeStateValue, setTreeStateValue] = useState<AppRouterState | Promise<AppRouterState>>({
+  const [treeStateValue, setTreeStateValue] = useState<
+    AppRouterState | Promise<AppRouterState> | MpaNavigationState
+  >({
     activeOperation: null,
     elements: resolvedElements,
     interception: initialMetadata.interception,
@@ -831,6 +886,10 @@ function BrowserRoot({
     slotBindings: initialMetadata.slotBindings,
     visibleCommitVersion: 0,
   });
+  if (isMpaNavigationState(treeStateValue)) {
+    performMpaNavigation(treeStateValue.href, treeStateValue.historyUpdateMode);
+    throw unresolvedMpaNavigation;
+  }
   const treeState = isRouterStatePromise(treeStateValue) ? use(treeStateValue) : treeStateValue;
 
   // Keep the latest router state in a ref so external callers (navigate(),
@@ -848,10 +907,23 @@ function BrowserRoot({
   // after hydrateRoot() returns; by then this layout effect has already run for
   // the hydration commit, so getBrowserRouterState() never observes a null ref.
   useLayoutEffect(() => {
+    const setAppRouterStateValue = (value: AppRouterState | Promise<AppRouterState>) => {
+      setTreeStateValue(value);
+    };
     const detach = browserNavigationController.attachBrowserRouterState(
-      setTreeStateValue,
+      setAppRouterStateValue,
       stateRef,
     );
+    registerNavigationRuntimeFunctions({
+      navigateExternal: (href, historyUpdateMode) => {
+        setTreeStateValue({
+          href,
+          historyUpdateMode,
+          kind: "mpa-navigation",
+        });
+        return new Promise<void>(() => {});
+      },
+    });
     browserRouterStateHasEverCommitted = true;
     // App Router uses this timestamp as first committed tree readiness: the
     // browser router state is attached and link/router interactions can safely
@@ -863,6 +935,7 @@ function BrowserRoot({
     window.__NEXT_HYDRATED_AT = hydratedAt;
     window.__NEXT_HYDRATED_CB?.();
     return () => {
+      registerNavigationRuntimeFunctions({ navigateExternal: undefined });
       detach();
       setMountedSlotsHeader(null);
     };
@@ -962,7 +1035,15 @@ function restoreHydrationNavigationContext(
   });
 }
 
-function restorePopstateScrollPosition(state: unknown): void {
+function restorePopstateScrollPosition(
+  state: unknown,
+  options?: {
+    shouldContinue?: () => boolean;
+  },
+): void {
+  const shouldContinue = options?.shouldContinue ?? (() => true);
+  if (!shouldContinue()) return;
+
   if (!(state && typeof state === "object" && "__vinext_scrollY" in state)) {
     if (window.location.hash) {
       scrollToHashTargetOnNextFrame(window.location.hash);
@@ -973,9 +1054,18 @@ function restorePopstateScrollPosition(state: unknown): void {
   const y = Number(state.__vinext_scrollY);
   const x = "__vinext_scrollX" in state ? Number(state.__vinext_scrollX) : 0;
 
-  requestAnimationFrame(() => {
+  let attempts = 0;
+  const restore = () => {
+    if (!shouldContinue()) return;
+
     window.scrollTo(x, y);
-  });
+    if (!shouldContinue() || Math.abs(window.scrollY - y) <= 1 || attempts >= 60) {
+      return;
+    }
+    attempts += 1;
+    requestAnimationFrame(restore);
+  };
+  restore();
 }
 
 function isSameAppRoutePopstateTarget(href: string): boolean {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2125,8 +2125,11 @@ if (typeof document !== "undefined") {
   // the flag stuck at true, which would silently swallow every subsequent
   // RSC navigation error for the lifetime of that tab. Matches Next.js'
   // fetch-server-response.ts handler pair.
-  window.addEventListener("pageshow", () => {
+  window.addEventListener("pageshow", (event) => {
     isPageUnloading = false;
+    if (event.persisted) {
+      mpaNavigationScheduler.reset();
+    }
   });
   void main();
 }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -929,7 +929,7 @@ function AppRouterRedirectBridge({ children }: { children?: React.ReactNode }) {
       const error = "reason" in event ? event.reason : event.error;
       if (!isRedirectError(error)) return;
 
-      const result = decodeRedirectError((error as Error & { digest: string }).digest);
+      const result = decodeRedirectError(error.digest);
       if (!result) return;
 
       event.preventDefault();

--- a/packages/vinext/src/server/app-browser-mpa-navigation.ts
+++ b/packages/vinext/src/server/app-browser-mpa-navigation.ts
@@ -16,6 +16,10 @@ export class AppBrowserMpaNavigationScheduler {
   #pendingNavigation: PendingMpaNavigation | null = null;
   #nextToken = 0;
 
+  reset(): void {
+    this.#pendingNavigation = null;
+  }
+
   navigate(
     targetWindow: AppBrowserMpaNavigationWindow,
     href: string,

--- a/packages/vinext/src/server/app-browser-mpa-navigation.ts
+++ b/packages/vinext/src/server/app-browser-mpa-navigation.ts
@@ -1,0 +1,62 @@
+import type { HistoryUpdateMode } from "./app-browser-navigation-controller.js";
+
+export type AppBrowserMpaNavigationWindow = {
+  location: Pick<Location, "assign" | "replace">;
+  requestAnimationFrame?: (callback: FrameRequestCallback) => unknown;
+  setTimeout(callback: () => void, timeout: number): unknown;
+};
+
+type PendingMpaNavigation = {
+  href: string;
+  historyUpdateMode: HistoryUpdateMode;
+  token: number;
+};
+
+export class AppBrowserMpaNavigationScheduler {
+  #pendingNavigation: PendingMpaNavigation | null = null;
+  #nextToken = 0;
+
+  navigate(
+    targetWindow: AppBrowserMpaNavigationWindow,
+    href: string,
+    historyUpdateMode: HistoryUpdateMode,
+  ): void {
+    const pendingNavigation = this.#pendingNavigation;
+    if (
+      pendingNavigation?.href === href &&
+      pendingNavigation.historyUpdateMode === historyUpdateMode
+    ) {
+      return;
+    }
+
+    const token = this.#nextToken + 1;
+    this.#nextToken = token;
+    this.#pendingNavigation = { href, historyUpdateMode, token };
+
+    const navigate = () => {
+      const currentNavigation = this.#pendingNavigation;
+      if (
+        currentNavigation?.href !== href ||
+        currentNavigation.historyUpdateMode !== historyUpdateMode ||
+        currentNavigation.token !== token
+      ) {
+        return;
+      }
+
+      if (historyUpdateMode === "replace") {
+        targetWindow.location.replace(href);
+      } else {
+        targetWindow.location.assign(href);
+      }
+    };
+
+    if (typeof targetWindow.requestAnimationFrame === "function") {
+      targetWindow.requestAnimationFrame(() => {
+        targetWindow.setTimeout(navigate, 0);
+      });
+      return;
+    }
+
+    targetWindow.setTimeout(navigate, 0);
+  }
+}

--- a/packages/vinext/src/server/app-browser-popstate.ts
+++ b/packages/vinext/src/server/app-browser-popstate.ts
@@ -1,4 +1,9 @@
-type RestoreScrollPosition = (state: unknown) => void;
+type RestoreScrollPosition = (
+  state: unknown,
+  options?: {
+    shouldContinue?: () => boolean;
+  },
+) => void;
 type NavigateRsc = (
   href: string,
   redirectDepth?: number,
@@ -15,6 +20,19 @@ type BrowserPopstateRestoreDeps = {
   setPendingNavigation: (pendingNavigation: Promise<void> | null) => void;
 };
 
+function hasSavedScrollPosition(state: unknown): boolean {
+  return Boolean(state && typeof state === "object" && "__vinext_scrollY" in state);
+}
+
+function scheduleAfterFrame(callback: () => void): void {
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(callback);
+    return;
+  }
+
+  queueMicrotask(callback);
+}
+
 export function createPopstateRestoreHandler(
   deps: BrowserPopstateRestoreDeps,
 ): (event: PopStateEvent) => void {
@@ -25,9 +43,19 @@ export function createPopstateRestoreHandler(
     const popstateNavId = deps.getActiveNavigationId();
 
     deps.setPendingNavigation(pendingNavigation);
+    const shouldRestoreSavedScroll = hasSavedScrollPosition(event.state);
+    if (shouldRestoreSavedScroll) {
+      scheduleAfterFrame(() => {
+        if (deps.isCurrentNavigation(popstateNavId)) {
+          deps.restorePopstateScrollPosition(event.state, {
+            shouldContinue: () => deps.isCurrentNavigation(popstateNavId),
+          });
+        }
+      });
+    }
 
     void pendingNavigation.finally(() => {
-      if (deps.isCurrentNavigation(popstateNavId)) {
+      if (deps.isCurrentNavigation(popstateNavId) && !shouldRestoreSavedScroll) {
         deps.restorePopstateScrollPosition(event.state);
       }
 

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -325,7 +325,7 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
 
   const headElements: ReactNode[] = [
     createElement("meta", { charSet: "utf-8", key: "charset" }),
-    createElement("meta", { content: "noindex", key: "robots", name: "robots" }),
+    createElement("meta", { key: "robots", name: "robots", content: "noindex" }),
   ];
   if (metadata) {
     headElements.push(createElement(MetadataHead, { key: "metadata", metadata, pathname }));

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -16,7 +16,7 @@ import {
 } from "./headers.js";
 
 /**
- * RSC cache-busting hashes cover the headers that make a `.rsc` payload vary.
+ * RSC cache-busting hashes cover the headers that make an RSC payload vary.
  * Client-side variant headers must survive transit through CDNs and reverse
  * proxies; stripping them changes the server hash and turns stale URLs into
  * repeated canonicalization redirects.
@@ -290,7 +290,7 @@ function toRscRequestPath(href: string): string {
   const query = queryIndex === -1 ? "" : beforeHash.slice(queryIndex);
   const normalizedPath =
     pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
-  return `${normalizedPath}.rsc${query}`;
+  return `${normalizedPath}${query}`;
 }
 
 export async function createRscRequestUrl(href: string, headers: Headers): Promise<string> {

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -285,12 +285,7 @@ export function createRscRequestHeaders(options: CreateRscRequestHeadersOptions 
 function toRscRequestPath(href: string): string {
   const hashIndex = href.indexOf("#");
   const beforeHash = hashIndex === -1 ? href : href.slice(0, hashIndex);
-  const queryIndex = beforeHash.indexOf("?");
-  const pathname = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
-  const query = queryIndex === -1 ? "" : beforeHash.slice(queryIndex);
-  const normalizedPath =
-    pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
-  return `${normalizedPath}${query}`;
+  return beforeHash;
 }
 
 export async function createRscRequestUrl(href: string, headers: Headers): Promise<string> {

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -98,9 +98,11 @@ function getRedirectTypeFromError(error: RedirectError): "push" | "replace" {
 function HandleRedirect({
   redirect,
   redirectType,
+  reset,
 }: {
   redirect: string;
   redirectType: "push" | "replace";
+  reset: () => void;
 }) {
   const router = useRouter();
 
@@ -111,17 +113,9 @@ function HandleRedirect({
       } else {
         router.replace(redirect);
       }
-      // Intentionally no reset() here. The boundary stays in its "redirect
-      // caught" state (rendering this component, which returns null) until
-      // router.push()/replace() triggers a new render at the destination
-      // route. That naturally unmounts this boundary and mounts a fresh one.
-      // Calling reset() would clear the boundary state, causing React to
-      // re-render children — which re-mounts the page component that threw
-      // redirect() in the first place. For deterministic redirects (e.g.
-      // auth guards), that creates an infinite redirect loop.
-      // Matches Next.js's HandleRedirect in redirect-boundary.tsx.
+      reset();
     });
-  }, [redirect, redirectType, router]);
+  }, [redirect, redirectType, reset, router]);
 
   return null;
 }
@@ -140,13 +134,7 @@ export class RedirectErrorBoundary extends React.Component<
 
   static getDerivedStateFromError(error: unknown): RedirectBoundaryState {
     if (isRedirectError(error)) {
-      // The public `isRedirectError` narrows to `Error & { digest: string }`.
-      // Cast to the local `RedirectError` (which also carries the optional
-      // `handled` field) so the parity logic below compiles. The cast is
-      // safe because every error that matches the prefix predicate is — by
-      // construction — produced by vinext's `redirect()` /
-      // `permanentRedirect()` helpers, which yield `Error` instances.
-      const redirectError = error as RedirectError;
+      const redirectError: RedirectError = error;
       // Next.js parity: an outer RedirectBoundary that has already started
       // handling a redirect marks the error as `handled` so that, if React
       // re-throws the same error during a retry render, an inner boundary
@@ -179,10 +167,23 @@ export class RedirectErrorBoundary extends React.Component<
     throw error;
   }
 
+  resetRedirect = () => {
+    this.setState({
+      redirect: null,
+      redirectType: null,
+    });
+  };
+
   render() {
     const { redirect, redirectType } = this.state;
     if (redirect !== null && redirectType !== null) {
-      return <HandleRedirect redirect={redirect} redirectType={redirectType} />;
+      return (
+        <HandleRedirect
+          redirect={redirect}
+          redirectType={redirectType}
+          reset={this.resetRedirect}
+        />
+      );
     }
 
     return this.props.children;
@@ -190,6 +191,36 @@ export class RedirectErrorBoundary extends React.Component<
 }
 
 export function RedirectBoundary({ children }: { children?: React.ReactNode }) {
+  const router = useRouter();
+
+  React.useEffect(() => {
+    function handleUnhandledRedirect(event: ErrorEvent | PromiseRejectionEvent): void {
+      const error = "reason" in event ? event.reason : event.error;
+      if (!isRedirectError(error)) return;
+
+      const redirectError: RedirectError = error;
+      const url = getURLFromRedirectError(redirectError);
+      if (url === null) return;
+
+      event.preventDefault();
+      React.startTransition(() => {
+        if (getRedirectTypeFromError(redirectError) === "push") {
+          router.push(url);
+        } else {
+          router.replace(url);
+        }
+      });
+    }
+
+    window.addEventListener("error", handleUnhandledRedirect);
+    window.addEventListener("unhandledrejection", handleUnhandledRedirect);
+
+    return () => {
+      window.removeEventListener("error", handleUnhandledRedirect);
+      window.removeEventListener("unhandledrejection", handleUnhandledRedirect);
+    };
+  }, [router]);
+
   return <RedirectErrorBoundary>{children}</RedirectErrorBoundary>;
 }
 
@@ -311,7 +342,12 @@ class NotFoundBoundaryInner extends React.Component<
 
   render() {
     if (this.state.notFound) {
-      return this.props.fallback;
+      return (
+        <>
+          <meta name="robots" content="noindex" />
+          {this.props.fallback}
+        </>
+      );
     }
     return this.props.children;
   }

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 // Import the local shim, not the public next/navigation alias. The built
 // package may execute this file before the plugin's resolveId hook is active.
-import { isRedirectError, usePathname, useRouter } from "./navigation.js";
+import { decodeRedirectError, isRedirectError, usePathname, useRouter } from "./navigation.js";
 import { isNavigationSignalError } from "../utils/navigation-signal.js";
 
 export type ErrorBoundaryProps = {
@@ -71,30 +71,6 @@ function shouldResetBoundary(
   return nextResetState.previousPathname !== previousResetState.previousPathname;
 }
 
-function decodeRedirectTarget(target: string): string {
-  try {
-    return decodeURIComponent(target);
-  } catch {
-    return target;
-  }
-}
-
-function getURLFromRedirectError(error: RedirectError): string | null {
-  const parts = error.digest.split(";");
-  // vinext emits 3-part (redirect: `NEXT_REDIRECT;;<encoded>`) or 4-part
-  // (permanentRedirect: `NEXT_REDIRECT;<type>;<encoded>;308`) digests;
-  // Next.js emits 5-part digests (`NEXT_REDIRECT;<type>;<url>;<status>;<isClient>`).
-  // vinext's `isRedirectError` is more permissive (just `startsWith("NEXT_REDIRECT;")`)
-  // so we branch on length rather than always using `slice(2, -2)`.
-  const encodedTarget = parts.length >= 5 ? parts.slice(2, -2).join(";") : parts[2];
-  return encodedTarget ? decodeRedirectTarget(encodedTarget) : null;
-}
-
-function getRedirectTypeFromError(error: RedirectError): "push" | "replace" {
-  const type = error.digest.split(";", 2)[1];
-  return type === "push" ? "push" : "replace";
-}
-
 function HandleRedirect({
   redirect,
   redirectType,
@@ -149,8 +125,8 @@ export class RedirectErrorBoundary extends React.Component<
         };
       }
 
-      const url = getURLFromRedirectError(redirectError);
-      if (url === null) {
+      const result = decodeRedirectError(redirectError.digest);
+      if (!result) {
         // Malformed digest (e.g. `NEXT_REDIRECT;push;` with an empty URL
         // segment). The server-side parser at next-error-digest.ts:51 also
         // rejects this. Re-throw so the error reaches a regular error
@@ -159,8 +135,8 @@ export class RedirectErrorBoundary extends React.Component<
       }
 
       return {
-        redirect: url,
-        redirectType: getRedirectTypeFromError(redirectError),
+        redirect: result.url,
+        redirectType: result.type,
       };
     }
 

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -357,7 +357,12 @@ export class ForbiddenBoundaryInner extends React.Component<
 
   render() {
     if (this.state.forbidden) {
-      return this.props.fallback;
+      return (
+        <>
+          <meta name="robots" content="noindex" />
+          {this.props.fallback}
+        </>
+      );
     }
     return this.props.children;
   }
@@ -424,7 +429,12 @@ export class UnauthorizedBoundaryInner extends React.Component<
 
   render() {
     if (this.state.unauthorized) {
-      return this.props.fallback;
+      return (
+        <>
+          <meta name="robots" content="noindex" />
+          {this.props.fallback}
+        </>
+      );
     }
     return this.props.children;
   }

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -167,13 +167,6 @@ export class RedirectErrorBoundary extends React.Component<
     throw error;
   }
 
-  resetRedirect = () => {
-    this.setState({
-      redirect: null,
-      redirectType: null,
-    });
-  };
-
   render() {
     const { redirect, redirectType } = this.state;
     if (redirect !== null && redirectType !== null) {
@@ -181,7 +174,7 @@ export class RedirectErrorBoundary extends React.Component<
         <HandleRedirect
           redirect={redirect}
           redirectType={redirectType}
-          reset={this.resetRedirect}
+          reset={() => this.setState({ redirect: null, redirectType: null })}
         />
       );
     }
@@ -191,52 +184,7 @@ export class RedirectErrorBoundary extends React.Component<
 }
 
 export function RedirectBoundary({ children }: { children?: React.ReactNode }) {
-  // This wrapper is rendered in both the browser entry and server-side route
-  // element tests. The global unhandled-redirect bridge is browser-only; eager
-  // `useRouter()` during SSR would require an AppRouterContext for routes that
-  // never redirect and would make a passive boundary observable.
-  const globalRedirectHandler = typeof window === "undefined" ? null : <UnhandledRedirectHandler />;
-
-  return (
-    <>
-      {globalRedirectHandler}
-      <RedirectErrorBoundary>{children}</RedirectErrorBoundary>
-    </>
-  );
-}
-
-function UnhandledRedirectHandler() {
-  const router = useRouter();
-
-  React.useEffect(() => {
-    function handleUnhandledRedirect(event: ErrorEvent | PromiseRejectionEvent): void {
-      const error = "reason" in event ? event.reason : event.error;
-      if (!isRedirectError(error)) return;
-
-      const redirectError: RedirectError = error;
-      const url = getURLFromRedirectError(redirectError);
-      if (url === null) return;
-
-      event.preventDefault();
-      React.startTransition(() => {
-        if (getRedirectTypeFromError(redirectError) === "push") {
-          router.push(url);
-        } else {
-          router.replace(url);
-        }
-      });
-    }
-
-    window.addEventListener("error", handleUnhandledRedirect);
-    window.addEventListener("unhandledrejection", handleUnhandledRedirect);
-
-    return () => {
-      window.removeEventListener("error", handleUnhandledRedirect);
-      window.removeEventListener("unhandledrejection", handleUnhandledRedirect);
-    };
-  }, [router]);
-
-  return null;
+  return <RedirectErrorBoundary>{children}</RedirectErrorBoundary>;
 }
 
 /**

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -21,11 +21,6 @@ type RedirectBoundaryState = {
   redirectType: "push" | "replace" | null;
 };
 
-type RedirectError = Error & {
-  digest: string;
-  handled?: boolean;
-};
-
 type ErrorBoundaryInnerProps = {
   pathname: string;
 } & ErrorBoundaryProps;
@@ -110,7 +105,6 @@ export class RedirectErrorBoundary extends React.Component<
 
   static getDerivedStateFromError(error: unknown): RedirectBoundaryState {
     if (isRedirectError(error)) {
-      const redirectError: RedirectError = error;
       // Next.js parity: an outer RedirectBoundary that has already started
       // handling a redirect marks the error as `handled` so that, if React
       // re-throws the same error during a retry render, an inner boundary
@@ -118,14 +112,14 @@ export class RedirectErrorBoundary extends React.Component<
       // currently emit `handled` itself (we never assign it on the error
       // object), but we keep the branch so behavior matches Next.js if a
       // host or future change ever does.
-      if (redirectError.handled) {
+      if ("handled" in error && error.handled) {
         return {
           redirect: null,
           redirectType: null,
         };
       }
 
-      const result = decodeRedirectError(redirectError.digest);
+      const result = decodeRedirectError(error.digest);
       if (!result) {
         // Malformed digest (e.g. `NEXT_REDIRECT;push;` with an empty URL
         // segment). The server-side parser at next-error-digest.ts:51 also

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -191,6 +191,21 @@ export class RedirectErrorBoundary extends React.Component<
 }
 
 export function RedirectBoundary({ children }: { children?: React.ReactNode }) {
+  // This wrapper is rendered in both the browser entry and server-side route
+  // element tests. The global unhandled-redirect bridge is browser-only; eager
+  // `useRouter()` during SSR would require an AppRouterContext for routes that
+  // never redirect and would make a passive boundary observable.
+  const globalRedirectHandler = typeof window === "undefined" ? null : <UnhandledRedirectHandler />;
+
+  return (
+    <>
+      {globalRedirectHandler}
+      <RedirectErrorBoundary>{children}</RedirectErrorBoundary>
+    </>
+  );
+}
+
+function UnhandledRedirectHandler() {
   const router = useRouter();
 
   React.useEffect(() => {
@@ -221,7 +236,7 @@ export function RedirectBoundary({ children }: { children?: React.ReactNode }) {
     };
   }, [router]);
 
-  return <RedirectErrorBoundary>{children}</RedirectErrorBoundary>;
+  return null;
 }
 
 /**

--- a/packages/vinext/src/shims/hash-scroll.ts
+++ b/packages/vinext/src/shims/hash-scroll.ts
@@ -30,3 +30,22 @@ export function scrollToHashTargetOnNextFrame(hash: string): void {
     scrollToHashTarget(hash);
   });
 }
+
+export function retryScrollTo(
+  x: number,
+  y: number,
+  opts?: { shouldContinue?: () => boolean },
+): void {
+  const shouldContinue = opts?.shouldContinue ?? (() => true);
+  let attempts = 0;
+  const restore = () => {
+    if (!shouldContinue()) return;
+    window.scrollTo(x, y);
+    if (!shouldContinue() || Math.abs(window.scrollY - y) <= 1 || attempts >= 60) {
+      return;
+    }
+    attempts += 1;
+    requestAnimationFrame(restore);
+  };
+  restore();
+}

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2042,13 +2042,17 @@ export function isRedirectError(error: unknown): error is _RedirectErrorShape {
 /**
  * Parse a redirect error digest into its URL and type components.
  *
- * Handles both vinext's 3-part format
- * (`NEXT_REDIRECT;{type};{encoded-url}`) and Next.js's 5-part format
- * (`NEXT_REDIRECT;{type};{url};{status};{isClient}`). Returns null for
- * malformed digests that have an empty URL segment.
+ * Supports two formats:
+ *   - vinext's 3-part: `NEXT_REDIRECT;{type};{encoded-url}`
+ *   - Next.js's 5-part: `NEXT_REDIRECT;{type};{url};{status};{isClient}`
  *
- * The returned URL is safely decoded — a malformed percent-encoding
- * returns null rather than throwing.
+ * The URL segment is always percent-encoded on the write side
+ * (encodeURIComponent is used), so re-joining with ";" for the 5-part
+ * format is defensive — it correctly handles any unencoded ";" that
+ * might appear in an externally-sourced digest.
+ *
+ * Returns null for malformed digests that have an empty URL segment, or
+ * when the URL contains invalid percent-encoding.
  */
 export function decodeRedirectError(
   digest: string,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1395,15 +1395,25 @@ function restoreScrollPosition(state: unknown): void {
       if (pending) {
         // Wait for the RSC navigation to finish rendering, then scroll.
         void pending.then(() => {
-          requestAnimationFrame(() => {
+          let attempts = 0;
+          const restore = () => {
             window.scrollTo(x, y);
-          });
+            if (Math.abs(window.scrollY - y) <= 1 || attempts >= 60) return;
+            attempts += 1;
+            requestAnimationFrame(restore);
+          };
+          restore();
         });
       } else {
         // No RSC navigation in flight (Pages Router or already settled).
-        requestAnimationFrame(() => {
+        let attempts = 0;
+        const restore = () => {
           window.scrollTo(x, y);
-        });
+          if (Math.abs(window.scrollY - y) <= 1 || attempts >= 60) return;
+          attempts += 1;
+          requestAnimationFrame(restore);
+        };
+        restore();
       }
     });
   }
@@ -1423,12 +1433,20 @@ export async function navigateClientSide(
   if (isExternalUrl(href)) {
     const localPath = toSameOriginAppPath(href, __basePath);
     if (localPath == null) {
-      // Truly external: use full page navigation
+      notifyAppRouterTransitionStart(href, mode);
+
+      const externalNavigate = getNavigationRuntime()?.functions.navigateExternal;
+      if (externalNavigate) {
+        await externalNavigate(href, mode);
+        return;
+      }
+
       if (mode === "replace") {
         window.location.replace(href);
       } else {
         window.location.assign(href);
       }
+      await new Promise<void>(() => {});
       return;
     }
     normalizedHref = localPath;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2063,6 +2063,37 @@ export function isRedirectError(error: unknown): error is _RedirectErrorShape {
 }
 
 /**
+ * Parse a redirect error digest into its URL and type components.
+ *
+ * Handles both vinext's 3-part format
+ * (`NEXT_REDIRECT;{type};{encoded-url}`) and Next.js's 5-part format
+ * (`NEXT_REDIRECT;{type};{url};{status};{isClient}`). Returns null for
+ * malformed digests that have an empty URL segment.
+ *
+ * The returned URL is safely decoded — a malformed percent-encoding
+ * returns null rather than throwing.
+ */
+export function decodeRedirectError(
+  digest: string,
+): { url: string; type: "push" | "replace" } | null {
+  if (!digest.startsWith("NEXT_REDIRECT;")) return null;
+
+  const parts = digest.split(";");
+  const encodedTarget = parts.length >= 5 ? parts.slice(2, -2).join(";") : parts[2];
+  if (!encodedTarget) return null;
+
+  let url: string;
+  try {
+    url = decodeURIComponent(encodedTarget);
+  } catch {
+    return null;
+  }
+
+  const type: "push" | "replace" = parts[1] === "push" ? "push" : "replace";
+  return { url, type };
+}
+
+/**
  * Returns true if the error is a Next.js navigation signal — either a redirect
  * or an HTTP access fallback (notFound / forbidden / unauthorized).
  *

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1137,13 +1137,11 @@ export function clearPendingPathname(navId: number): void {
 
 function getClientParamsSnapshot(): Record<string, string | string[]> {
   const state = getClientNavigationState();
+  const pagesCtx = _getPagesNavigationContext();
+  if (pagesCtx) return pagesCtx.params;
   if (state && Object.keys(state.clientParams).length > 0) {
     return state.clientParams;
   }
-  // Fall back to the Pages Router compat shim if nothing has populated the
-  // App Router client params (Pages Router pages never call setClientParams).
-  const pagesCtx = _getPagesNavigationContext();
-  if (pagesCtx) return pagesCtx.params;
   return state?.clientParams ?? _EMPTY_PARAMS;
 }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2051,15 +2051,10 @@ type _RedirectErrorShape = Error & { digest: string };
  * `shims/error-boundary.tsx`.
  */
 export function isRedirectError(error: unknown): error is _RedirectErrorShape {
-  if (
-    !error ||
-    typeof error !== "object" ||
-    !("digest" in error) ||
-    typeof (error as { digest: unknown }).digest !== "string"
-  ) {
-    return false;
-  }
-  return (error as { digest: string }).digest.startsWith("NEXT_REDIRECT;");
+  if (!error || typeof error !== "object") return false;
+  if (!("digest" in error)) return false;
+  if (typeof error.digest !== "string") return false;
+  return error.digest.startsWith("NEXT_REDIRECT;");
 }
 
 /**

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -34,7 +34,7 @@ import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
 import { AppRouterContext } from "./internal/app-router-context.js";
-import { scrollToHashTarget } from "./hash-scroll.js";
+import { retryScrollTo, scrollToHashTarget } from "./hash-scroll.js";
 import {
   beginAppRouterScrollIntent,
   clearAppRouterScrollIntent,
@@ -1424,27 +1424,9 @@ function restoreScrollPosition(state: unknown): void {
       const pending: Promise<void> | null = window.__VINEXT_RSC_PENDING__ ?? null;
 
       if (pending) {
-        // Wait for the RSC navigation to finish rendering, then scroll.
-        void pending.then(() => {
-          let attempts = 0;
-          const restore = () => {
-            window.scrollTo(x, y);
-            if (Math.abs(window.scrollY - y) <= 1 || attempts >= 60) return;
-            attempts += 1;
-            requestAnimationFrame(restore);
-          };
-          restore();
-        });
+        void pending.then(() => retryScrollTo(x, y));
       } else {
-        // No RSC navigation in flight (Pages Router or already settled).
-        let attempts = 0;
-        const restore = () => {
-          window.scrollTo(x, y);
-          if (Math.abs(window.scrollY - y) <= 1 || attempts >= 60) return;
-          attempts += 1;
-          requestAnimationFrame(restore);
-        };
-        restore();
+        retryScrollTo(x, y);
       }
     });
   }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -15,6 +15,7 @@ import {
   type ReactNode,
   type ComponentType,
 } from "react";
+import { AppRouterContext, type AppRouterInstance } from "./internal/app-router-context.js";
 import { RouterContext } from "./internal/router-context.js";
 import {
   applyVinextLocaleGlobals,
@@ -1542,7 +1543,36 @@ function PagesRouterProvider({ children }: { children: ReactNode }): ReactElemen
     [pathname, query, asPath],
   );
 
-  return createElement(RouterContext.Provider, { value: router }, children);
+  const appRouter = useMemo(
+    (): AppRouterInstance => ({
+      bfcacheId: "0",
+      back() {
+        Router.back();
+      },
+      forward() {
+        if (typeof window === "undefined") throwNoRouterInstance();
+        window.history.forward();
+      },
+      refresh() {
+        Router.reload();
+      },
+      push(href, options) {
+        void Router.push(href, undefined, { scroll: options?.scroll });
+      },
+      replace(href, options) {
+        void Router.replace(href, undefined, { scroll: options?.scroll });
+      },
+      prefetch(href) {
+        void Router.prefetch(href);
+      },
+    }),
+    [],
+  );
+
+  const content = createElement(RouterContext.Provider, { value: router }, children);
+  return AppRouterContext
+    ? createElement(AppRouterContext.Provider, { value: appRouter }, content)
+    : content;
 }
 
 // beforePopState callback: called before handling browser back/forward.

--- a/tests/app-browser-mpa-navigation.test.ts
+++ b/tests/app-browser-mpa-navigation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  AppBrowserMpaNavigationScheduler,
+  type AppBrowserMpaNavigationWindow,
+} from "../packages/vinext/src/server/app-browser-mpa-navigation.js";
+
+function createNavigationWindow(): {
+  assign: ReturnType<typeof vi.fn>;
+  flushNextTimeout: () => void;
+  replace: ReturnType<typeof vi.fn>;
+  targetWindow: AppBrowserMpaNavigationWindow;
+  timeoutCount: () => number;
+} {
+  const assign = vi.fn();
+  const replace = vi.fn();
+  const timeouts: Array<() => void> = [];
+  const targetWindow = {
+    location: { assign, replace },
+    setTimeout(callback: () => void) {
+      timeouts.push(callback);
+      return timeouts.length;
+    },
+  } satisfies AppBrowserMpaNavigationWindow;
+
+  return {
+    assign,
+    flushNextTimeout() {
+      const callback = timeouts.shift();
+      if (!callback) throw new Error("Expected a pending navigation timeout");
+      callback();
+    },
+    replace,
+    targetWindow,
+    timeoutCount() {
+      return timeouts.length;
+    },
+  };
+}
+
+describe("AppBrowserMpaNavigationScheduler", () => {
+  it("supersedes a pending same-href push with a replace before the delayed navigation fires", () => {
+    const scheduler = new AppBrowserMpaNavigationScheduler();
+    const { assign, flushNextTimeout, replace, targetWindow, timeoutCount } =
+      createNavigationWindow();
+
+    scheduler.navigate(targetWindow, "https://external.test/login", "push");
+    scheduler.navigate(targetWindow, "https://external.test/login", "replace");
+
+    expect(timeoutCount()).toBe(2);
+
+    flushNextTimeout();
+    expect(assign).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+
+    flushNextTimeout();
+    expect(assign).not.toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenCalledWith("https://external.test/login");
+  });
+
+  it("dedupes an identical pending external navigation", () => {
+    const scheduler = new AppBrowserMpaNavigationScheduler();
+    const { flushNextTimeout, replace, targetWindow, timeoutCount } = createNavigationWindow();
+
+    scheduler.navigate(targetWindow, "https://external.test/login", "replace");
+    scheduler.navigate(targetWindow, "https://external.test/login", "replace");
+
+    expect(timeoutCount()).toBe(1);
+
+    flushNextTimeout();
+    expect(replace).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/app-browser-mpa-navigation.test.ts
+++ b/tests/app-browser-mpa-navigation.test.ts
@@ -70,4 +70,19 @@ describe("AppBrowserMpaNavigationScheduler", () => {
     flushNextTimeout();
     expect(replace).toHaveBeenCalledTimes(1);
   });
+
+  it("allows the same external navigation again after reset", () => {
+    const scheduler = new AppBrowserMpaNavigationScheduler();
+    const { assign, flushNextTimeout, targetWindow } = createNavigationWindow();
+
+    scheduler.navigate(targetWindow, "https://external.test/login", "push");
+    flushNextTimeout();
+    expect(assign).toHaveBeenCalledTimes(1);
+
+    scheduler.reset();
+
+    scheduler.navigate(targetWindow, "https://external.test/login", "push");
+    flushNextTimeout();
+    expect(assign).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -436,10 +436,10 @@ describe("app page execution helpers", () => {
     });
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toMatch(/redirected\.rsc/);
+    expect(response.headers.get("location")).toMatch(/redirected\?_rsc/);
   });
 
-  it("canonicalizes same-origin RSC redirect locations to .rsc URLs", async () => {
+  it("canonicalizes same-origin RSC redirect locations to Next-style RSC URLs", async () => {
     const response = await buildAppPageSpecialErrorResponse({
       clearRequestContext: vi.fn(),
       isRscRequest: true,
@@ -459,7 +459,7 @@ describe("app page execution helpers", () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toMatch(
-      /^https:\/\/example\.com\/redirected\.rsc\?tab=1&_rsc=/,
+      /^https:\/\/example\.com\/redirected\?tab=1&_rsc=/,
     );
   });
 

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -41,8 +41,18 @@ describe("App Router RSC cache-busting", () => {
     const headers = createRscRequestHeaders();
 
     await expect(createRscRequestUrl("/dashboard?tab=activity", headers)).resolves.toBe(
-      "/dashboard.rsc?tab=activity&_rsc",
+      "/dashboard?tab=activity&_rsc",
     );
+  });
+
+  it("uses the canonical route URL for root RSC navigations", async () => {
+    // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+    // Client-side App Router navigations fetch the route URL with RSC: 1 and
+    // _rsc cache busting, not Vinext's legacy /.rsc transport path.
+    const headers = createRscRequestHeaders();
+
+    await expect(createRscRequestUrl("/", headers)).resolves.toBe("/?_rsc");
   });
 
   it("hashes Vinext RSC variant headers into the request URL", async () => {
@@ -55,7 +65,7 @@ describe("App Router RSC cache-busting", () => {
 
     expect(hash).not.toBe("");
     await expect(createRscRequestUrl("/photos/42", headers)).resolves.toBe(
-      `/photos/42.rsc?${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=${hash}`,
+      `/photos/42?${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=${hash}`,
     );
   });
 

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -55,6 +55,12 @@ describe("App Router RSC cache-busting", () => {
     await expect(createRscRequestUrl("/", headers)).resolves.toBe("/?_rsc");
   });
 
+  it("preserves the route pathname trailing slash when building canonical RSC URLs", async () => {
+    const headers = createRscRequestHeaders();
+
+    await expect(createRscRequestUrl("/docs/", headers)).resolves.toBe("/docs/?_rsc");
+  });
+
   it("hashes Vinext RSC variant headers into the request URL", async () => {
     const headers = createRscRequestHeaders({
       interceptionContext: "/feed",

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -98,6 +98,30 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
   });
 
+  it("does not trailing-slash redirect RSC requests built from already-canonical trailingSlash paths", async () => {
+    const headers = createRscRequestHeaders();
+    const requestPath = await createRscRequestUrl("/about/", headers);
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const route = createPageRoute({ pattern: "/about/", routeSegments: ["about"] });
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchRoute(pathname: string) {
+        return pathname === "/about/" ? { params: {}, route } : null;
+      },
+      trailingSlash: true,
+    });
+
+    const response = await handler(
+      new Request(`https://example.test/docs${requestPath}`, { headers }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.has("location")).toBe(false);
+    expect(dispatchMatchedPage).toHaveBeenCalledTimes(1);
+  });
+
   it("marks progressive action page renders even when decoded form state is null", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
     const handler = createHandler({

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -543,7 +543,7 @@ describe("createAppRscHandler", () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe(
-      `https://example.test/docs/about.rsc?from=old&_rsc=${expectedHash}`,
+      `https://example.test/docs/about?from=old&_rsc=${expectedHash}`,
     );
   });
 

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { waitForAppRouterHydration } from "../helpers";
+import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 const FEED_DRAFT_VALUE = "source draft survives";
@@ -209,8 +209,7 @@ test.describe("Intercepting Routes", () => {
   test("refresh on direct target clears stale intercepted history context", async ({ page }) => {
     const refreshInterceptionHeaders: Array<string | null> = [];
     page.on("request", (request) => {
-      const url = new URL(request.url());
-      if (url.pathname === "/photos/42.rsc") {
+      if (isAppRouterRscRequestForPath(request, "/photos/42")) {
         refreshInterceptionHeaders.push(request.headers()["x-vinext-interception-context"] ?? null);
       }
     });

--- a/tests/e2e/app-router/build-id-navigation.spec.ts
+++ b/tests/e2e/app-router/build-id-navigation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { waitForAppRouterHydration } from "../helpers";
+import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 const VISITED_CACHE_MARKER = "__VINEXT_VISITED_CACHE_MARKER__";
@@ -79,8 +79,7 @@ test.describe("App Router RSC compatibility navigation", () => {
   }) => {
     const aboutRscRequests: string[] = [];
     page.on("request", (request) => {
-      const url = new URL(request.url());
-      if (url.pathname === "/about.rsc" && url.searchParams.has("_rsc")) {
+      if (isAppRouterRscRequestForPath(request, "/about")) {
         aboutRscRequests.push(request.url());
       }
     });

--- a/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
@@ -10,16 +10,14 @@
  */
 
 import { test, expect, type Page } from "@playwright/test";
-import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../../helpers";
+import { isAppRouterServerActionRequestForPath, waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
 
 test.describe("Next.js compat: actions-revalidate (browser)", () => {
   function waitForActionDiscardingResponse(page: Page) {
-    return page.waitForResponse(
-      (response) =>
-        response.request().method() === "POST" &&
-        isAppRouterRscRequestForPath(response.request(), "/nextjs-compat/action-discarding"),
+    return page.waitForResponse((response) =>
+      isAppRouterServerActionRequestForPath(response.request(), "/nextjs-compat/action-discarding"),
     );
   }
 

--- a/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
@@ -10,7 +10,7 @@
  */
 
 import { test, expect, type Page } from "@playwright/test";
-import { waitForAppRouterHydration } from "../../helpers";
+import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
 
@@ -19,7 +19,7 @@ test.describe("Next.js compat: actions-revalidate (browser)", () => {
     return page.waitForResponse(
       (response) =>
         response.request().method() === "POST" &&
-        response.url().includes("/nextjs-compat/action-discarding.rsc"),
+        isAppRouterRscRequestForPath(response.request(), "/nextjs-compat/action-discarding"),
     );
   }
 

--- a/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts
@@ -195,6 +195,24 @@ test.describe("Next.js compat: hash popstate scroll", () => {
       .toBe(0);
   });
 
+  // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+  test("back navigation restores the saved scroll position before the next assertion frame", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => window.scrollTo(0, 1200));
+    await expectScrollY(page, 1200);
+
+    await page.click("#plain-link");
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll/plain`);
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/hash-popstate-scroll`);
+    await expectScrollY(page, 1200);
+  });
+
   test("forward traversal decodes non-latin hash fragments", async ({ page }) => {
     await expectHashForwardTraversal(page, "#encoded-link", "#caf%C3%A9", '[id="café"]');
   });

--- a/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
@@ -12,7 +12,7 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { waitForAppRouterHydration } from "../../helpers";
+import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../../helpers";
 
 const BASE = "http://localhost:4174";
 
@@ -50,6 +50,33 @@ test.describe("Next.js compat: navigation (browser)", () => {
       timeout: 10_000,
     });
     expect(page.url()).toContain("/nextjs-compat/nav-redirect-result");
+  });
+
+  test("client-side redirect() guard navigates once and does not loop", async ({ page }) => {
+    const loginRscRequests: string[] = [];
+    page.on("request", (request) => {
+      if (isAppRouterRscRequestForPath(request, "/nextjs-compat/nav-redirect-guard/login")) {
+        loginRscRequests.push(request.url());
+      }
+    });
+
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+
+    await page.evaluate(() => {
+      const router = window.next?.router;
+      if (!router) {
+        throw new Error("window.next.router is not installed");
+      }
+      void router.push("/nextjs-compat/nav-redirect-guard");
+    });
+
+    await expect(page.locator("#redirect-guard-login")).toHaveText("Login Page", {
+      timeout: 10_000,
+    });
+    expect(new URL(page.url()).pathname).toBe("/nextjs-compat/nav-redirect-guard/login");
+    await page.waitForLoadState("networkidle");
+    expect(loginRscRequests).toHaveLength(1);
   });
 
   // Next.js: 'should trigger not-found in a server component'

--- a/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
@@ -12,7 +12,11 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../../helpers";
+import {
+  isAppRouterRscRequestForPath,
+  waitForAppRouterHydration,
+  waitForHydration,
+} from "../../helpers";
 
 const BASE = "http://localhost:4174";
 
@@ -77,6 +81,21 @@ test.describe("Next.js compat: navigation (browser)", () => {
     expect(new URL(page.url()).pathname).toBe("/nextjs-compat/nav-redirect-guard/login");
     await page.waitForLoadState("networkidle");
     expect(loginRscRequests).toHaveLength(1);
+  });
+
+  test("client-side redirect() from App Router does not leak stale params into Pages Router", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/app-to-pages-params/alpha`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#go-to-pages-params");
+    await waitForHydration(page);
+
+    await expect(page.locator("#params")).toHaveText('{"foo":"foo"}', {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#params-change-count")).toHaveText("1");
   });
 
   // Next.js: 'should trigger not-found in a server component'

--- a/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
@@ -83,7 +83,7 @@ test.describe("Next.js compat: navigation (browser)", () => {
     expect(loginRscRequests).toHaveLength(1);
   });
 
-  test("client-side redirect() from App Router does not leak stale params into Pages Router", async ({
+  test("client-side navigation from App Router does not leak stale params into Pages Router", async ({
     page,
   }) => {
     await page.goto(`${BASE}/nextjs-compat/app-to-pages-params/alpha`);

--- a/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
@@ -39,6 +39,19 @@ test.describe("Next.js compat: navigation (browser)", () => {
     expect(page.url()).toContain("/nextjs-compat/nav-redirect-result");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+  test("client-side redirect() sentinel navigates and resets the boundary", async ({ page }) => {
+    await page.goto(`${BASE}/nextjs-compat/nav-client-redirect-sentinel`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#trigger-redirect");
+    await expect(page.locator("#result-page")).toHaveText("Result Page", {
+      timeout: 10_000,
+    });
+    expect(page.url()).toContain("/nextjs-compat/nav-redirect-result");
+  });
+
   // Next.js: 'should trigger not-found in a server component'
   // Source: navigation.test.ts#L136-L146
   test("server component notFound() renders not-found component", async ({ page }) => {
@@ -65,6 +78,8 @@ test.describe("Next.js compat: navigation (browser)", () => {
       const text = await page.locator("body").textContent();
       expect(text).toContain("404");
     }).toPass({ timeout: 10_000 });
+
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", "noindex");
   });
 
   // Next.js: Link-based client-side navigation
@@ -166,5 +181,33 @@ test.describe("Next.js compat: navigation (browser)", () => {
       () => (window as any).__APP_RELATIVE_ONNAV_URL__ ?? null,
     );
     expect(reportedUrl).toBe("/nextjs-compat/nav-link-test?page=2");
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+  test("router.push to an external URL keeps useTransition pending until unload", async ({
+    page,
+  }) => {
+    const storageKey = `external-${Date.now()}`;
+    await page.goto(`${BASE}/nextjs-compat/router-push-external-pending/${storageKey}`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#go");
+    await page.waitForURL("https://example.vercel.sh/stuff?abc=123", { timeout: 10_000 });
+
+    await page.goto(`${BASE}/nextjs-compat/router-push-external-pending/${storageKey}`);
+    await expect(page.locator("#storage")).toContainText(
+      `path-/nextjs-compat/router-push-external-pending/${storageKey}`,
+    );
+    const stored = JSON.parse((await page.locator("#storage").textContent()) ?? "{}");
+
+    expect(stored).toMatchObject({
+      [`path-/nextjs-compat/router-push-external-pending/${storageKey}`]: "true",
+      lastIsPending: "true",
+    });
+
+    if (stored["navigation-supported"] === "true") {
+      expect(stored["navigate-https://example.vercel.sh/stuff?abc=123"]).toBe("1");
+    }
   });
 });

--- a/tests/e2e/app-router/nextjs-compat/prefetch.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/prefetch.spec.ts
@@ -95,10 +95,21 @@ test.describe("Next.js compat: prefetch (browser)", () => {
       testWindow.__VINEXT_PENDING_PREFETCH_REUSE_TEST__ = state;
 
       window.fetch = async (input, init) => {
-        const url =
+        const rawUrl =
           typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        const url = new URL(rawUrl, window.location.href);
+        const headers = new Headers(input instanceof Request ? input.headers : undefined);
+        if (init?.headers) {
+          new Headers(init.headers).forEach((value, key) => {
+            headers.set(key, value);
+          });
+        }
 
-        if (url.includes("/nextjs-compat/prefetch-test/target.rsc")) {
+        if (
+          url.pathname === "/nextjs-compat/prefetch-test/target" &&
+          url.searchParams.has("_rsc") &&
+          headers.get("rsc") === "1"
+        ) {
           if (state.targetPrefetchRequests === 0) {
             state.targetPrefetchRequests += 1;
             await new Promise<void>((resolve) => {
@@ -174,10 +185,18 @@ test.describe("Next.js compat: prefetch (browser)", () => {
       };
       testWindow.__VINEXT_PREFETCH_TEST__ = state;
       window.fetch = (input, init) => {
-        const url =
+        const rawUrl =
           typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-        if (url.includes(".rsc")) {
-          state.fetchUrls.push(url);
+        const url = new URL(rawUrl, window.location.href);
+        const headers = new Headers(input instanceof Request ? input.headers : undefined);
+        if (init?.headers) {
+          new Headers(init.headers).forEach((value, key) => {
+            headers.set(key, value);
+          });
+        }
+
+        if (url.searchParams.has("_rsc") && headers.get("rsc") === "1") {
+          state.fetchUrls.push(url.href);
         }
         return originalFetch(input, init);
       };
@@ -198,10 +217,12 @@ test.describe("Next.js compat: prefetch (browser)", () => {
     await page.goto(`${BASE}/nextjs-compat/prefetch-test`);
     await waitForAppRouterHydration(page);
 
-    // Verify the fetch instrumentation sees .rsc URLs before relying on it
+    // Verify the fetch instrumentation sees canonical RSC URLs before relying on it
     // to assert that Link prefetch does not issue a no-prefetch request.
     await page.evaluate(async () => {
-      await window.fetch("/nextjs-compat/prefetch-test/target.rsc");
+      await window.fetch("/nextjs-compat/prefetch-test/target?_rsc", {
+        headers: { Accept: "text/x-component", RSC: "1" },
+      });
     });
     await expect
       .poll(async () =>
@@ -209,7 +230,13 @@ test.describe("Next.js compat: prefetch (browser)", () => {
           const testWindow: PrefetchTestWindow = window;
           const state = testWindow.__VINEXT_PREFETCH_TEST__;
           if (state === undefined) throw new Error("Missing prefetch test instrumentation");
-          return state.fetchUrls.some((url) => url.includes("target.rsc"));
+          return state.fetchUrls.some((url) => {
+            const parsed = new URL(url);
+            return (
+              parsed.pathname === "/nextjs-compat/prefetch-test/target" &&
+              parsed.searchParams.has("_rsc")
+            );
+          });
         }),
       )
       .toBe(true);
@@ -239,7 +266,15 @@ test.describe("Next.js compat: prefetch (browser)", () => {
         requestIdleCallbackCalls: state.requestIdleCallbackCalls,
       };
     });
-    expect(diagnostics.fetchUrls.some((url) => url.includes("no-prefetch.rsc"))).toBe(false);
+    expect(
+      diagnostics.fetchUrls.some((url) => {
+        const parsed = new URL(url);
+        return (
+          parsed.pathname === "/nextjs-compat/prefetch-test/no-prefetch" &&
+          parsed.searchParams.has("_rsc")
+        );
+      }),
+    ).toBe(false);
     expect(diagnostics.requestIdleCallbackCalls).toBe(0);
   });
 });

--- a/tests/e2e/app-router/pages-router-use-params.spec.ts
+++ b/tests/e2e/app-router/pages-router-use-params.spec.ts
@@ -27,4 +27,25 @@ test.describe("issue #1466: Pages Router useParams under app+pages project", () 
     await expect(page.locator("#params")).toBeVisible();
     await expect(page.locator("#params")).toHaveText('"foobar"');
   });
+
+  // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+  test("keeps the pages-router params object stable across rerenders", async ({ page }) => {
+    await page.goto(`${BASE}/search-params-pages/foo`);
+    await waitForHydration(page);
+
+    await expect(page.locator("#params")).toHaveText('{"foo":"foo"}');
+    const initialChangeCount = await page.locator("#params-change-count").textContent();
+
+    await page.click("#rerender-button");
+    await page.click("#rerender-button");
+    await page.click("#rerender-button");
+
+    await expect(page.locator("#rerender-button")).toHaveText("Re-Render 3");
+    await expect(page.locator("#params-change-count")).toHaveText(initialChangeCount ?? "");
+
+    await page.click("#change-params-button");
+    await expect(page).toHaveURL(`${BASE}/search-params-pages/bar`);
+    await expect(page.locator("#params")).toHaveText('{"foo":"bar"}');
+  });
 });

--- a/tests/e2e/app-router/rsc-fetch-errors.spec.ts
+++ b/tests/e2e/app-router/rsc-fetch-errors.spec.ts
@@ -6,14 +6,14 @@
  * rather than trying to parse the HTML error body as an RSC stream.
  *
  * Without the fix:
- *   - fetch(url.rsc) returns 404 HTML
+ *   - fetch(RSC payload URL) returns 404 HTML
  *   - createFromFetch throws a cryptic stream-parse error
  *   - The catch block logs "[vinext] RSC navigation error: ..." and hard-navs
  *     to the same URL again, which can loop
  *
  * With the fix:
  *   - !response.ok is detected immediately after fetch
- *   - Client hard-navigates directly to the destination URL (no .rsc suffix)
+ *   - Client hard-navigates directly to the destination URL (no internal RSC suffix)
  *   - No stream-parse error is logged
  *
  * Ported behavior from Next.js fetch-server-response.ts:211:
@@ -22,7 +22,7 @@
  *   }
  */
 import { test, expect } from "@playwright/test";
-import { waitForAppRouterHydration } from "../helpers";
+import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
@@ -46,9 +46,7 @@ function isRscStreamParseError(msg: string): boolean {
 }
 
 test.describe("RSC fetch non-ok response handling", () => {
-  test("client navigation to a non-existent route hard-navs to the non-.rsc URL", async ({
-    page,
-  }) => {
+  test("client navigation to a non-existent route hard-navs to the route URL", async ({ page }) => {
     const consoleErrors: string[] = [];
     page.on("console", (msg) => {
       if (msg.type() === "error") {
@@ -66,7 +64,7 @@ test.describe("RSC fetch non-ok response handling", () => {
     });
     await Promise.all([navigationPromise, page.getByTestId("missing-route-link").click()]);
 
-    // The browser must land on the non-.rsc URL — never on the .rsc variant.
+    // The browser must land on the route URL, never on an internal RSC URL.
     expect(page.url()).toBe(`${BASE}/this-route-does-not-exist`);
 
     // The bug this PR fixes surfaces as one of a small set of RSC-stream
@@ -82,14 +80,18 @@ test.describe("RSC fetch non-ok response handling", () => {
   }) => {
     const targetPath = "/rsc-fetch-error-target";
 
-    // Intercept the .rsc request for a dedicated unlinked fixture page and
+    // Intercept the RSC request for a dedicated unlinked fixture page and
     // return a 500 error. Using an unlinked target keeps the hit count tied to
     // the explicit navigation below instead of racing home-page Link prefetch.
-    // intercept persists across navigations and reloads on this page, so if
+    // The intercept persists across navigations and reloads on this page, so if
     // the fix is incomplete and a reload loop develops, the intercept hit
     // count will grow without bound.
     let targetRscHits = 0;
-    await page.route(/\/rsc-fetch-error-target\.rsc(\?|$)/, (route) => {
+    await page.route(/\/rsc-fetch-error-target(\.rsc)?(\?|$)/, (route) => {
+      if (!isAppRouterRscRequestForPath(route.request(), targetPath)) {
+        return route.continue();
+      }
+
       targetRscHits += 1;
       return route.fulfill({
         status: 500,
@@ -142,7 +144,7 @@ test.describe("RSC fetch non-ok response handling", () => {
     expect(page.url()).toBe(`${BASE}${targetPath}`);
     // Pin the embedded-RSC assumption: after the hard-nav lands on the target,
     // hydration must come from the HTML-embedded RSC branch and issue no
-    // further .rsc fetches. If a future change makes the embed path
+    // further RSC fetches. If a future change makes the embed path
     // conditional and falls back to a fetch, this count would grow and the
     // test would flag it rather than silently relying on networkidle timing.
     expect(targetRscHits).toBe(hitsBeforeNetworkIdle);
@@ -165,7 +167,7 @@ test.describe("RSC fetch non-ok response handling", () => {
     const targetPath = "/rsc-fetch-error-target";
 
     // Chain: client nav to /rsc-fetch-redirect-src → fetch
-    // /rsc-fetch-redirect-src.rsc → real server redirect to
+    // /rsc-fetch-redirect-src?_rsc → real server redirect to
     // /rsc-fetch-error-target.rsc → 500. The hard-nav target must be
     // /rsc-fetch-error-target (the post-redirect URL), not
     // /rsc-fetch-redirect-src (the original request).
@@ -194,12 +196,14 @@ test.describe("RSC fetch non-ok response handling", () => {
 
     const sourceRedirectPromise = page.waitForResponse(
       (response) =>
-        new URL(response.url()).pathname === `${sourcePath}.rsc` && response.status() === 307,
+        isAppRouterRscRequestForPath(response.request(), sourcePath) && response.status() === 307,
       { timeout: 10_000 },
     );
     const targetErrorPromise = page.waitForResponse(
       (response) =>
-        new URL(response.url()).pathname === `${targetPath}.rsc` && response.status() === 500,
+        (isAppRouterRscRequestForPath(response.request(), targetPath) ||
+          new URL(response.url()).pathname === `${targetPath}.rsc`) &&
+        response.status() === 500,
       { timeout: 10_000 },
     );
     const navigationPromise = page.waitForURL(`${BASE}${targetPath}`, { timeout: 10_000 });

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -160,6 +160,7 @@ test.describe("Server Actions", () => {
     await page.click("#missing-action");
 
     await expect(page.locator("#action-not-found")).toHaveText("Action not found boundary");
+    await expect(page.locator('meta[name="robots"]')).toHaveCount(1);
     await expect(page.locator('meta[name="robots"]')).toHaveAttribute("content", "noindex");
   });
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -8,6 +8,15 @@ export function isAppRouterRscRequestForPath(request: Request, pathname: string)
   );
 }
 
+export function isAppRouterServerActionRequestForPath(request: Request, pathname: string): boolean {
+  const url = new URL(request.url());
+  return (
+    request.method() === "POST" &&
+    url.pathname === pathname &&
+    request.headers()["next-action"] !== undefined
+  );
+}
+
 /**
  * Wait for Pages Router hydration to complete.
  * Checks for window.__VINEXT_ROOT__.

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,5 +1,12 @@
-import type { Page } from "@playwright/test";
+import type { Page, Request } from "@playwright/test";
 import { expect } from "@playwright/test";
+
+export function isAppRouterRscRequestForPath(request: Request, pathname: string): boolean {
+  const url = new URL(request.url());
+  return (
+    url.pathname === pathname && url.searchParams.has("_rsc") && request.headers()["rsc"] === "1"
+  );
+}
 
 /**
  * Wait for Pages Router hydration to complete.

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-to-pages-params/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-to-pages-params/[id]/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  return (
+    <div>
+      <h1 id="app-to-pages-params-page">App Params Source</h1>
+      <p id="app-param-id">{id}</p>
+      <Link href="/search-params-pages/foo" id="go-to-pages-params">
+        Go to Pages Params
+      </Link>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/page.tsx
@@ -18,6 +18,20 @@ export default function HashPopstateScrollPage() {
         <Link href="#top" id="top-link">
           Go to top
         </Link>
+        <Link
+          href="/nextjs-compat/hash-popstate-scroll/plain"
+          id="plain-link"
+          style={{
+            background: "white",
+            border: "1px solid black",
+            padding: 4,
+            position: "fixed",
+            right: 8,
+            top: 8,
+          }}
+        >
+          Go to plain page
+        </Link>
         <HashActions />
       </nav>
       <div style={{ height: 1200 }} />

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/plain/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-popstate-scroll/plain/page.tsx
@@ -1,0 +1,7 @@
+export default function PlainHashPopstateScrollPage() {
+  return (
+    <main style={{ minHeight: "3200px", padding: 24 }}>
+      <h1>Plain Hash Popstate Scroll Destination</h1>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/nav-client-redirect-sentinel/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/nav-client-redirect-sentinel/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { redirect } from "next/navigation";
+import { startTransition, useState } from "react";
+
+export default function Page() {
+  const [triggered, setTriggered] = useState(false);
+
+  if (triggered) {
+    redirect("/nextjs-compat/nav-redirect-result");
+  }
+
+  return (
+    <div>
+      <h1 id="redirect-sentinel-page">Redirect Sentinel Page</h1>
+      <button
+        id="trigger-redirect"
+        onClick={() => {
+          startTransition(() => {
+            setTriggered(true);
+          });
+        }}
+        type="button"
+      >
+        Redirect
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/nav-redirect-guard/login/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/nav-redirect-guard/login/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="redirect-guard-login">Login Page</h1>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/nav-redirect-guard/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/nav-redirect-guard/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { redirect, usePathname } from "next/navigation";
+
+export default function Page() {
+  const pathname = usePathname();
+  const authed = false;
+
+  if (!authed && pathname !== "/nextjs-compat/nav-redirect-guard/login") {
+    redirect("/nextjs-compat/nav-redirect-guard/login");
+  }
+
+  return <h1 id="redirect-guard-page">Protected Page</h1>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/router-push-external-pending/[storageKey]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/router-push-external-pending/[storageKey]/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { use, useEffect, useRef, useState, useTransition } from "react";
+
+let listening = false;
+
+type BrowserNavigationEvent = Event & {
+  destination?: {
+    url?: string;
+  };
+};
+
+type BrowserNavigation = EventTarget & {
+  addEventListener(type: "navigate", listener: (event: BrowserNavigationEvent) => void): void;
+};
+
+function readBrowserNavigation(): BrowserNavigation | null {
+  const maybeNavigation = Reflect.get(window, "navigation");
+  if (
+    maybeNavigation instanceof EventTarget &&
+    typeof Reflect.get(maybeNavigation, "addEventListener") === "function"
+  ) {
+    return maybeNavigation;
+  }
+  return null;
+}
+
+function getPersistentStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  // Playwright/Chromium can lose sessionStorage when the test hops through the
+  // external origin; localStorage keeps the upstream signal observable.
+  return window.localStorage;
+}
+
+function readStorage(storageKey: string): Record<string, string> {
+  const storage = getPersistentStorage();
+  if (storage === null) return {};
+
+  return Object.fromEntries(
+    Object.entries(storage).flatMap(([key, value]) =>
+      key.startsWith(`${storageKey}/`) ? [[key.slice(storageKey.length + 1), value]] : [],
+    ),
+  );
+}
+
+export default function Page({ params }: { params: Promise<{ storageKey: string }> }) {
+  const storageKey = use(params).storageKey;
+  const router = useRouter();
+  const searchParams = useSearchParams().toString();
+  const pathname = usePathname();
+  const path = searchParams ? `${pathname}?${searchParams}` : pathname;
+  const [isPending, startTransition] = useTransition();
+  const [storage, setStorage] = useState<Record<string, string>>({});
+  const startedNavigating = useRef(false);
+
+  useEffect(() => {
+    getPersistentStorage()?.setItem(`${storageKey}/path-${path}`, "true");
+    if (startedNavigating.current) {
+      getPersistentStorage()?.setItem(`${storageKey}/lastIsPending`, String(isPending));
+    }
+    setStorage(readStorage(storageKey));
+  }, [isPending, path, storageKey]);
+
+  return (
+    <>
+      <button
+        id="go"
+        onClick={() => {
+          const browserNavigation = readBrowserNavigation();
+          getPersistentStorage()?.setItem(
+            `${storageKey}/navigation-supported`,
+            String(browserNavigation !== null),
+          );
+          if (!listening && browserNavigation !== null) {
+            listening = true;
+            browserNavigation.addEventListener("navigate", (event) => {
+              const destinationUrl = event.destination?.url;
+              if (!destinationUrl) return;
+              const key = `${storageKey}/navigate-${destinationUrl}`;
+              const storage = getPersistentStorage();
+              if (storage === null) return;
+              const current = Number(storage.getItem(key) ?? "0");
+              storage.setItem(key, String(current + 1));
+            });
+          }
+
+          startedNavigating.current = true;
+          startTransition(() => {
+            router.push("https://example.vercel.sh/stuff?abc=123");
+          });
+        }}
+        type="button"
+      >
+        go
+      </button>
+      <pre id="storage">{JSON.stringify(storage, null, 2)}</pre>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/pages/search-params-pages/[foo]/index.tsx
+++ b/tests/fixtures/app-basic/pages/search-params-pages/[foo]/index.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+export default function Page() {
+  const params = useParams();
+  const router = useRouter();
+  const [count, setCount] = useState(0);
+  const [paramsChangeCount, setParamsChangeCount] = useState(0);
+
+  useEffect(() => {
+    setParamsChangeCount((value) => value + 1);
+  }, [params]);
+
+  return (
+    <div>
+      <button id="rerender-button" onClick={() => setCount((value) => value + 1)}>
+        Re-Render {count}
+      </button>
+      <button id="change-params-button" onClick={() => router.push("/search-params-pages/bar")}>
+        Change Params
+      </button>
+      <output id="params">{JSON.stringify(params)}</output>
+      <output id="params-change-count">{paramsChangeCount}</output>
+    </div>
+  );
+}

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -192,6 +192,21 @@ async function waitForFetchCalls(
   }
 }
 
+function expectCanonicalRscFetchCall(
+  call: unknown[] | undefined,
+  pathname: string,
+  initMatcher: unknown,
+): void {
+  expect(call).toBeDefined();
+  const input = call?.[0];
+  expect(typeof input).toBe("string");
+  if (typeof input !== "string") return;
+  const url = new URL(input, "https://example.com");
+  expect(url.pathname).toBe(pathname);
+  expect(url.searchParams.has("_rsc")).toBe(true);
+  expect(call?.[1]).toEqual(initMatcher);
+}
+
 describe("Link prefetch pure decisions", () => {
   it("decides whether Link should prefetch and with which priority", () => {
     const cases = [
@@ -1166,8 +1181,9 @@ describe("Link prefetch scheduling", () => {
       await waitForFetchCalls(result.fetch, 1);
 
       expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
-      expect(result.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/viewport-prefetch-target.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
         expect.objectContaining({
           credentials: "include",
           priority: "low",
@@ -1196,8 +1212,9 @@ describe("Link prefetch scheduling", () => {
       await flushPrefetchTasks();
 
       expect(result.fetch).toHaveBeenCalledTimes(2);
-      expect(result.fetch).toHaveBeenLastCalledWith(
-        expect.stringContaining("/viewport-prefetch-target.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[1],
+        "/viewport-prefetch-target",
         expect.objectContaining({
           credentials: "include",
           priority: "low",
@@ -1222,8 +1239,9 @@ describe("Link prefetch scheduling", () => {
       await waitForFetchCalls(result.fetch, 1);
 
       expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
-      expect(result.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/blog/hello.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/blog/hello",
         expect.objectContaining({
           credentials: "include",
           priority: "low",
@@ -1276,8 +1294,9 @@ describe("Link prefetch scheduling", () => {
       await flushPrefetchTasks();
 
       expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
-      expect(result.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/blog/hello.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/blog/hello",
         expect.objectContaining({
           credentials: "include",
           priority: "low",
@@ -1370,8 +1389,9 @@ describe("Link prefetch scheduling", () => {
       await flushPrefetchTasks();
 
       expect(userOnMouseEnter).toHaveBeenCalledTimes(1);
-      expect(result.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/intent-prefetch-target.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/intent-prefetch-target",
         expect.objectContaining({
           credentials: "include",
           priority: "high",
@@ -1394,8 +1414,9 @@ describe("Link prefetch scheduling", () => {
     try {
       observer.dispatchIntersectingEntry(result.anchor);
       await waitForFetchCalls(result.fetch, 1);
-      expect(result.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/blog/hello.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/blog/hello",
         expect.objectContaining({
           credentials: "include",
           priority: "low",
@@ -1423,8 +1444,9 @@ describe("Link prefetch scheduling", () => {
       await waitForFetchCalls(result.fetch, 3);
 
       expect(result.fetch).toHaveBeenCalledTimes(3);
-      expect(result.fetch).toHaveBeenLastCalledWith(
-        expect.stringContaining("/blog/hello.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[2],
+        "/blog/hello",
         expect.objectContaining({
           credentials: "include",
           priority: "low",
@@ -1449,8 +1471,9 @@ describe("Link prefetch scheduling", () => {
       await flushPrefetchTasks();
 
       expect(userOnTouchStart).toHaveBeenCalledTimes(1);
-      expect(result.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/touch-prefetch-target.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/touch-prefetch-target",
         expect.objectContaining({
           credentials: "include",
           priority: "high",
@@ -1506,17 +1529,23 @@ describe("Link prefetch scheduling", () => {
       result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
       await flushPrefetchTasks();
 
-      expect(result.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/same-origin-intent-prefetch-target.rsc"),
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/same-origin-intent-prefetch-target",
         expect.objectContaining({
           credentials: "include",
           priority: "high",
         }),
       );
-      expect(result.fetch).not.toHaveBeenCalledWith(
-        expect.stringContaining("https://example.com/same-origin-intent-prefetch-target.rsc"),
-        expect.anything(),
-      );
+      expect(
+        result.fetch.mock.calls.some((call) => {
+          const input = call[0];
+          return (
+            typeof input === "string" &&
+            input.startsWith("https://example.com/same-origin-intent-prefetch-target")
+          );
+        }),
+      ).toBe(false);
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -119,7 +119,7 @@ describe("prefetch cache eviction", () => {
     await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);
 
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetchedUrl).toMatch(/^\/dashboard\.rsc\?tab=1&_rsc(?:=.+)?$/);
+    expect(fetchedUrl).toMatch(/^\/dashboard\?tab=1&_rsc(?:=.+)?$/);
     expect(getPrefetchedUrls().has(AppElementsWire.encodeCacheKey(String(fetchedUrl), null))).toBe(
       true,
     );


### PR DESCRIPTION
## Summary
- Switch App Router client RSC requests to the canonical route URL plus `_rsc`, matching the route URL shape asserted by the Next.js navigation deploy suite.
- Preserve trailing-slash route path shape when generating canonical RSC URLs so `trailingSlash: true` navigations do not fetch a URL that the server has to redirect.
- Key delayed MPA hard navigations by both href and history mode, so a later same-href `replace()` cannot be superseded by an earlier pending `push()` closure.
- Align client `notFound()` and `redirect()` boundaries with Next.js: client fallbacks emit `noindex`, redirect boundaries reset after navigation, and unhandled redirect errors are recovered globally without requiring an App Router context during passive SSR route renders.
- Provide the Pages Router to App Router adapter context so `useRouter()` from `next/navigation` works inside Pages Router pages, while preserving stable `useParams()` snapshots.
- Retry saved popstate scroll restoration while the traversal remains current so delayed route content can still restore the intended position.

## Review follow-up
- Added focused trailing-slash coverage for `createRscRequestUrl("/docs/") -> "/docs/?_rsc"` and a server RSC request test proving the generated URL is not redirected under `trailingSlash: true`.
- Added unit coverage for external hard navigation ordering: pending `push(external)` followed by `replace(same external)` now executes the replace path.
- Added a deterministic client redirect guard fixture and E2E assertion that the guard navigates once to login and does not loop.
- Updated stale E2E and unit observers from legacy `.rsc` transport URLs to canonical route URLs carrying `_rsc` plus the `rsc: 1` request header.

## Upstream references
- Next.js navigation deploy suite candidate: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/navigation/navigation.test.ts#L31-L63
- Pages Router params identity case: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/navigation/navigation.test.ts#L80-L105
- Client not-found noindex assertions: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/navigation/navigation.test.ts#L319-L350
- Redirect and external navigation cases: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/navigation/navigation.test.ts#L353-L520
- SEO noindex exact string assertion: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/navigation/navigation.test.ts#L654-L660
- Scroll restoration case: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/navigation/navigation.test.ts#L706-L735
- Next.js redirect boundary reset behavior: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/components/redirect-boundary.tsx#L13-L80
- Next.js global unhandled redirect and MPA suspension behavior: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/components/app-router.tsx#L224-L280
- Next.js access fallback meta behavior: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/components/http-access-fallback/error-boundary.tsx#L121-L141
- Next.js Pages Router adapter: https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/shared/lib/router/adapters.tsx#L12-L28

## Verification
- Initial upstream deploy-suite run for `test/e2e/app-dir/navigation/navigation.test.ts`: 39 passed / 11 failed.
- End upstream deploy-suite run after the main navigation fixes: 45 passed / 5 failed. The remaining file-scope failures were exact hash offset scrolling, `redirect-with-loading` repeat rendering, upstream immediate scroll restoration, and earlier Pages Router params identity coverage before the adapter fix. Pages Router adapter behaviour is covered locally below.
- `vp run vinext#build`
- `vp test run tests/app-rsc-cache-busting.test.ts tests/error-boundary.test.ts tests/app-rsc-handler.test.ts tests/app-page-execution.test.ts tests/prefetch-cache.test.ts tests/app-page-boundary-render.test.ts tests/app-ssr-error-meta.test.ts tests/navigation-runtime.test.ts tests/app-browser-entry.test.ts`
- `vp test run tests/app-rsc-cache-busting.test.ts tests/app-rsc-handler.test.ts tests/app-browser-mpa-navigation.test.ts tests/app-browser-entry.test.ts`
- `vp test run tests/link-navigation.test.ts tests/app-page-route-wiring.test.ts`
- `vp test run tests/link-navigation.test.ts`
- `vp test run --project unit`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/nextjs-compat/navigation.spec.ts tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts tests/e2e/app-router/pages-router-use-params.spec.ts --retries=0`
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/build-id-navigation.spec.ts tests/e2e/app-router/advanced.spec.ts tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts tests/e2e/app-router/rsc-fetch-errors.spec.ts tests/e2e/app-router/nextjs-compat/navigation.spec.ts --retries=0`
- `vp check`
- Commit hook also ran formatting, type/lint checks, and `knip`.