### PR TITLE
fix: make fnv1a64 output fixed-width

### DIFF
--- a/packages/vinext/src/utils/hash.ts
+++ b/packages/vinext/src/utils/hash.ts
@@ -15,5 +15,5 @@ export function fnv1a64(input: string): string {
     h2 ^= input.charCodeAt(i);
     h2 = (h2 * 0x01000193) >>> 0;
   }
-  return h1.toString(36) + h2.toString(36);
+  return h1.toString(16).padStart(8, "0") + h2.toString(16).padStart(8, "0");
 }

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -27,6 +27,7 @@ import {
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
 } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import { fnv1a64 } from "../packages/vinext/src/utils/hash.js";
 import { buildPageCacheTags } from "../packages/vinext/src/server/implicit-tags.js";
 import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
 import {
@@ -45,6 +46,11 @@ import {
 // ─── isrCacheKey ────────────────────────────────────────────────────────
 
 describe("isrCacheKey", () => {
+  it("fnv1a64 uses fixed-width unambiguous output", () => {
+    const hash = fnv1a64("/" + "a".repeat(250));
+    expect(hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
   it("generates pages: prefix for Pages Router", () => {
     expect(isrCacheKey("pages", "/about")).toBe("pages:/about");
   });


### PR DESCRIPTION
## Summary

Make `fnv1a64()` return fixed-width hexadecimal output instead of concatenating two variable-length base36 strings.

## Details

The previous output format concatenated two base36-encoded 32-bit values. Base36 output is variable length, so the boundary between the two halves was ambiguous.

This change switches to two fixed-width 8-character hex halves:

```ts
h1.toString(16).padStart(8, "0") + h2.toString(16).padStart(8, "0")
```

Call sites continue to treat the result as an opaque deterministic string.

## Tests

Adds a focused unit test asserting `fnv1a64()` returns exactly 16 lowercase hex characters, and re-runs the existing long-path ISR cache key tests.