### PR TITLE
fix: allow server-only imports from 'use server' modules

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -171,6 +171,29 @@ function createRscCompatibilityId(nextConfig: ResolvedNextConfig): string {
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
 
+// Detect a module-level `"use server"` directive (a Server Actions module).
+// Directives form the leading prologue of string-literal ExpressionStatements,
+// so we only scan until the first non-directive statement.
+function hasModuleLevelUseServerDirective(body: ReturnType<typeof parseAst>["body"]): boolean {
+  for (const node of body) {
+    if (node.type !== "ExpressionStatement") break;
+    const directive = (node as ASTNode & { directive?: unknown }).directive;
+    const expression = (node as ASTNode & { expression?: { type?: string; value?: unknown } })
+      .expression;
+    const value =
+      typeof directive === "string"
+        ? directive
+        : expression?.type === "Literal"
+          ? expression.value
+          : undefined;
+    if (value === "use server") return true;
+    // Keep scanning through other directives (e.g. "use strict"); a
+    // non-string-literal statement ends the directive prologue.
+    if (typeof value !== "string") break;
+  }
+  return false;
+}
+
 function hasServerOnlyMarkerImport(code: string): boolean {
   if (!code.includes("server-only")) return false;
 
@@ -180,6 +203,15 @@ function hasServerOnlyMarkerImport(code: string): boolean {
   } catch {
     return false;
   }
+
+  // Server Actions modules (`"use server"`) live in the server/action layer,
+  // not the client layer. Next.js allows them to `import "server-only"` even
+  // though the client bundle holds references used to invoke the actions
+  // (see test/e2e/app-dir/actions/app/client/actions.js, which does exactly
+  // this). Treating them as client-reachable here is a false positive that
+  // breaks the entire client build, so exempt them while still rejecting
+  // genuine client modules below.
+  if (hasModuleLevelUseServerDirective(ast.body)) return false;
 
   function walk(node: ASTNode | ASTNode[] | null | undefined): boolean {
     if (!node) return false;

--- a/tests/middleware-server-only.test.ts
+++ b/tests/middleware-server-only.test.ts
@@ -189,6 +189,78 @@ export default function Comp() {
   await builder.buildApp();
 }
 
+async function buildAppServerActionServerOnlyFixture(): Promise<void> {
+  const workspaceRoot = path.resolve(import.meta.dirname, "..");
+  const workspaceNodeModules = path.join(workspaceRoot, "node_modules");
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-action-server-only-"));
+
+  await writeFile(
+    path.join(tmpDir, "app", "layout.tsx"),
+    `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html lang="en"><body>{children}</body></html>;
+}
+`,
+  );
+  // A Server Actions module ("use server") that imports server-only. This
+  // mirrors Next.js's own fixture, which is valid because server actions run
+  // in the server/action layer — not the client layer that server-only guards.
+  await writeFile(
+    path.join(tmpDir, "app", "actions.ts"),
+    `'use server'
+
+import 'server-only'
+
+export async function inc(value: number) {
+  return value + 1;
+}
+`,
+  );
+  // A client component that references the action. This is what pulls the
+  // action module into the client environment graph, where the
+  // vinext:validate-server-only-client-imports guard runs.
+  await writeFile(
+    path.join(tmpDir, "app", "counter.tsx"),
+    `'use client'
+
+import { useState } from "react";
+import { inc } from "./actions";
+
+export default function Counter() {
+  const [value, setValue] = useState(0);
+  return <button onClick={async () => setValue(await inc(value))}>{value}</button>;
+}
+`,
+  );
+  await writeFile(
+    path.join(tmpDir, "app", "page.tsx"),
+    `import Counter from "./counter";
+
+export default function Home() {
+  return <Counter />;
+}
+`,
+  );
+
+  await fsp.symlink(workspaceNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+  const { default: vinext } = await import(
+    pathToFileURL(path.join(workspaceRoot, "packages/vinext/src/index.ts")).href
+  );
+  const { createBuilder } = await import("vite");
+  const rscOutDir = path.join(tmpDir, "dist", "server");
+  const ssrOutDir = path.join(tmpDir, "dist", "server", "ssr");
+  const clientOutDir = path.join(tmpDir, "dist", "client");
+
+  const builder = await createBuilder({
+    root: tmpDir,
+    configFile: false,
+    plugins: [vinext({ appDir: tmpDir, rscOutDir, ssrOutDir, clientOutDir })],
+    logLevel: "error",
+  });
+
+  await builder.buildApp();
+}
+
 describe("middleware can import server-only", () => {
   let tmpDir: string;
 
@@ -270,4 +342,17 @@ describe("Pages Router client builds reject server-only", () => {
       /server-only.*Server Components in the App Router/s,
     );
   });
+});
+
+describe("App Router Server Actions can import server-only", () => {
+  it("builds when a 'use server' module imports server-only", async () => {
+    // Mirrors Next.js's test/e2e/app-dir/actions fixture, whose
+    // app/client/actions.js is a `'use server'` module with `import 'server-only'`.
+    // Server Actions run in the server/action layer, so server-only is allowed
+    // even though the client bundle references the actions to invoke them.
+    // The validate-server-only-client-imports guard (added in #1697) must not
+    // false-positive on these or it breaks the whole client build — regression
+    // test for the actions/app-basepath deploy-suite failures.
+    await expect(buildAppServerActionServerOnlyFixture()).resolves.toBeUndefined();
+  }, 120_000);
 });


### PR DESCRIPTION
## Problem

The nightly Next.js deploy suite jumped from **797 → 933 failures** in [run 26701715604](https://github.com/cloudflare/vinext/actions/runs/26701715604) (commit `87479df1`). Diffing the per-test reports against the prior run found **136 newly-failing tests, 0 newly-passing**, concentrated in the Server Actions suites:

| Count | Suite |
|------|-------|
| 58 | `app-dir/actions/app-action.test.ts` |
| 58 | `app-dir/actions/app-action-node-middleware.test.ts` |
| 8 | `app-dir/app-basepath/index.test.ts` |
| 4 | `app-dir/actions/app-action-progressive-enhancement.test.ts` |
| 4 | `app-dir/actions/app-action-form-state.test.ts` |
| 4 | `app-dir/actions/app-action-form-state-node-middleware.test.ts` |

The regression bisects to **#1697** ("reject server-only imports from client-reachable modules").

## Root cause

#1697 added the `vinext:validate-server-only-client-imports` transform, which throws at **build time** in the client environment for any module importing `server-only`. But Next.js's failing fixtures (`actions/app/client/actions.js`, `app-basepath/app/client/action.js`) are **`'use server'` Server Action modules** that legitimately `import 'server-only'`.

Because the client bundle holds references used to invoke the actions, the action module enters the client graph and the guard throws — failing the *entire* app build, which is why all ~58 tests in a suite fail at once.

This is a false positive: Next.js places `'use server'` modules in the server/action layer, so the server-only **client-layer** check never applies to them.

## Fix

Exempt modules with a top-level `"use server"` directive from the guard. Genuine client modules (no directive, or `'use client'`) importing `server-only` are still rejected — preserving #1697's intent.

## Testing

- Reproduced the build failure locally via `createBuilder` (App Router `'use server'` action importing `server-only`, referenced from a client component), then confirmed it builds after the fix.
- Added a regression test in `tests/middleware-server-only.test.ts`.
- The existing negative test ("Pages Router client builds reject server-only") still passes — genuine client modules are still rejected.
- `vp check` (format/lint/types) clean.