### PR TITLE
ci(bonk): bump models to Opus 4.8 high and GPT-5.5 high, opencode 1.15.13

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -42,10 +42,10 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          model: "cloudflare-ai-gateway/openai/gpt-5.5"
           mentions: "/bigbonk"
-          variant: "max"
+          variant: "xhigh"
           permissions: write
           opencode_dev: false
-          opencode_version: 1.3.9
+          opencode_version: 1.14.40
           agent: viguy

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -42,9 +42,9 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/openai/gpt-5.5"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
           mentions: "/bigbonk"
-          variant: "xhigh"
+          variant: "max"
           permissions: write
           opencode_dev: false
           opencode_version: 1.14.40

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -42,10 +42,10 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           mentions: "/bigbonk"
-          variant: "max"
+          variant: "high"
           permissions: write
           opencode_dev: false
-          opencode_version: 1.14.40
+          opencode_version: 1.15.13
           agent: viguy

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -48,4 +48,4 @@ jobs:
           permissions: write
           opencode_dev: false
           opencode_version: 1.14.40
-          agent: viguy
+          agent: reviewer

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -42,9 +42,9 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
+          model: "cloudflare-ai-gateway/openai/gpt-5.5"
           mentions: "/bonk,@ask-bonk"
-          variant: "max"
+          variant: "xhigh"
           permissions: write
           opencode_dev: false
           opencode_version: 1.14.40

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -42,10 +42,10 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          model: "cloudflare-ai-gateway/openai/gpt-5.5"
           mentions: "/bonk,@ask-bonk"
-          variant: "max"
+          variant: "xhigh"
           permissions: write
           opencode_dev: false
-          opencode_version: 1.3.9
+          opencode_version: 1.14.40
           agent: viguy

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -42,9 +42,9 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/openai/gpt-5.5"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
           mentions: "/bonk,@ask-bonk"
-          variant: "xhigh"
+          variant: "max"
           permissions: write
           opencode_dev: false
           opencode_version: 1.14.40

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           model: "cloudflare-ai-gateway/openai/gpt-5.5"
           mentions: "/bonk,@ask-bonk"
-          variant: "xhigh"
+          variant: "high"
           permissions: write
           opencode_dev: false
-          opencode_version: 1.14.40
-          agent: reviewer
+          opencode_version: 1.15.13
+          agent: viguy

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Thorough code reviewer focused on correctness, edge cases, and dev/prod parity. Posts reviews directly on GitHub PRs.
 mode: subagent
-model: cloudflare-ai-gateway/openai/gpt-5.5
+model: openai/gpt-5.5
 temperature: 0.2
 tools:
   write: false

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -2,7 +2,7 @@
 description: Thorough code reviewer focused on correctness, edge cases, and dev/prod parity. Posts reviews directly on GitHub PRs.
 mode: subagent
 model: cloudflare-ai-gateway/openai/gpt-5.5
-temperature: 0.1
+temperature: 0.2
 tools:
   write: false
   edit: false

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Thorough code reviewer focused on correctness, edge cases, and dev/prod parity. Posts reviews directly on GitHub PRs.
 mode: subagent
-model: anthropic/claude-opus-4-6
+model: cloudflare-ai-gateway/openai/gpt-5.5
 temperature: 0.1
 tools:
   write: false

--- a/.opencode/agents/viguy.md
+++ b/.opencode/agents/viguy.md
@@ -1,7 +1,7 @@
 ---
 description: Vite, Next.js, TypeScript and JS build systems expert for vinext
 mode: primary
-model: anthropic/claude-opus-4-6
+model: anthropic/claude-opus-4-8
 temperature: 0.2
 ---
 

--- a/.opencode/agents/viguy.md
+++ b/.opencode/agents/viguy.md
@@ -1,7 +1,7 @@
 ---
 description: Vite, Next.js, TypeScript and JS build systems expert for vinext
 mode: primary
-model: cloudflare-ai-gateway/openai/gpt-5.5
+model: cloudflare-ai-gateway/anthropic/claude-opus-4-6
 temperature: 0.2
 ---
 

--- a/.opencode/agents/viguy.md
+++ b/.opencode/agents/viguy.md
@@ -1,7 +1,7 @@
 ---
 description: Vite, Next.js, TypeScript and JS build systems expert for vinext
 mode: primary
-model: anthropic/claude-opus-4-6
+model: cloudflare-ai-gateway/openai/gpt-5.5
 temperature: 0.2
 ---
 

--- a/.opencode/agents/viguy.md
+++ b/.opencode/agents/viguy.md
@@ -1,7 +1,7 @@
 ---
 description: Vite, Next.js, TypeScript and JS build systems expert for vinext
 mode: primary
-model: cloudflare-ai-gateway/anthropic/claude-opus-4-6
+model: anthropic/claude-opus-4-6
 temperature: 0.2
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ vinext was born from an experiment in pushing AI to its limits. Almost every lin
 
 ## Recommended setup
 
-We use [OpenCode](https://opencode.ai) with GPT-5.5 set to xhigh reasoning effort for BigBonk reviews, and Claude Opus 4.7 for regular Bonk review passes. This is the same setup that built the project.
+We use [OpenCode](https://opencode.ai) with Claude Opus 4.6 set to max reasoning effort for BigBonk reviews, and GPT-5.5 at xhigh for regular Bonk review passes. This is the same setup that built the project.
 
 ## Before you open a PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We use [OpenCode](https://opencode.ai) with Claude Opus 4.6 set to max reasoning
 
 ## AI code review
 
-Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (GPT-5.5, xhigh reasoning effort). For lighter review passes, maintainers can use **Bonk** (Claude Opus 4.7). External contributors can't trigger this directly.
+Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (Claude Opus 4.6, max reasoning effort). For lighter review passes, maintainers can use **Bonk** (GPT-5.5, xhigh reasoning effort). External contributors can't trigger this directly.
 
 Our process is to iterate on BigBonk's feedback until there are no unresolved comments. That doesn't mean you have to accept every suggestion verbatim, but we've found it to be very good at finding real problems and very useful for debugging this codebase. Expect multiple review rounds on larger PRs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ vinext was born from an experiment in pushing AI to its limits. Almost every lin
 
 ## Recommended setup
 
-We use [OpenCode](https://opencode.ai) with GPT-5.5, set to xhigh reasoning effort. This is the same setup that built the project.
+We use [OpenCode](https://opencode.ai) with GPT-5.5 set to xhigh reasoning effort for BigBonk reviews, and Claude Opus 4.7 for regular Bonk review passes. This is the same setup that built the project.
 
 ## Before you open a PR
 
@@ -15,7 +15,7 @@ We use [OpenCode](https://opencode.ai) with GPT-5.5, set to xhigh reasoning effo
 
 ## AI code review
 
-Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (GPT-5.5, xhigh reasoning effort). External contributors can't trigger this directly.
+Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (GPT-5.5, xhigh reasoning effort). For lighter review passes, maintainers can use **Bonk** (Claude Opus 4.7). External contributors can't trigger this directly.
 
 Our process is to iterate on BigBonk's feedback until there are no unresolved comments. That doesn't mean you have to accept every suggestion verbatim, but we've found it to be very good at finding real problems and very useful for debugging this codebase. Expect multiple review rounds on larger PRs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ vinext was born from an experiment in pushing AI to its limits. Almost every lin
 
 ## Recommended setup
 
-We use [OpenCode](https://opencode.ai) with GPT-5.4, set to xhigh reasoning effort. This is the same setup that built the project.
+We use [OpenCode](https://opencode.ai) with GPT-5.5, set to xhigh reasoning effort. This is the same setup that built the project.
 
 ## Before you open a PR
 
@@ -15,7 +15,7 @@ We use [OpenCode](https://opencode.ai) with GPT-5.4, set to xhigh reasoning effo
 
 ## AI code review
 
-Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (GPT-5.4, xhigh reasoning effort). External contributors can't trigger this directly.
+Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (GPT-5.5, xhigh reasoning effort). External contributors can't trigger this directly.
 
 Our process is to iterate on BigBonk's feedback until there are no unresolved comments. That doesn't mean you have to accept every suggestion verbatim, but we've found it to be very good at finding real problems and very useful for debugging this codebase. Expect multiple review rounds on larger PRs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,6 @@ We use [OpenCode](https://opencode.ai) with Opus 4.8 at high reasoning effort fo
 ## AI code review
 
 Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (Opus 4.8, high reasoning effort). For lighter review passes, maintainers can use **Bonk** (GPT-5.5, high reasoning effort). External contributors can't trigger this directly.
->>>>>>> Stashed changes
 
 Our process is to iterate on BigBonk's feedback until there are no unresolved comments. That doesn't mean you have to accept every suggestion verbatim, but we've found it to be very good at finding real problems and very useful for debugging this codebase. Expect multiple review rounds on larger PRs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ vinext was born from an experiment in pushing AI to its limits. Almost every lin
 
 ## Recommended setup
 
-We use [OpenCode](https://opencode.ai) with Claude Opus 4.6 set to max reasoning effort for BigBonk reviews, and GPT-5.5 at xhigh for regular Bonk review passes. This is the same setup that built the project.
+We use [OpenCode](https://opencode.ai) with Opus 4.8 at high reasoning effort for BigBonk reviews, and GPT-5.5 at high reasoning effort for regular Bonk review passes. This is the same setup that built the project.
 
 ## Before you open a PR
 
@@ -15,7 +15,8 @@ We use [OpenCode](https://opencode.ai) with Claude Opus 4.6 set to max reasoning
 
 ## AI code review
 
-Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (Claude Opus 4.6, max reasoning effort). For lighter review passes, maintainers can use **Bonk** (GPT-5.5, xhigh reasoning effort). External contributors can't trigger this directly.
+Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (Opus 4.8, high reasoning effort). For lighter review passes, maintainers can use **Bonk** (GPT-5.5, high reasoning effort). External contributors can't trigger this directly.
+>>>>>>> Stashed changes
 
 Our process is to iterate on BigBonk's feedback until there are no unresolved comments. That doesn't mean you have to accept every suggestion verbatim, but we've found it to be very good at finding real problems and very useful for debugging this codebase. Expect multiple review rounds on larger PRs.
 


### PR DESCRIPTION
@james-elicx  this is basically same settings, /bonk is gpt 5.5 high and /bigbonk is still opus but 4.8 high