### PR TITLE
fix(config): keep packages externalized when loading TypeScript next.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ These are gaps we'd like to close — distinct from the [intentional exclusions]
 - **Route segment config** — `runtime` and `preferredRegion` are ignored (everything runs in the same environment).
 - **Node.js production server (`vinext start`)** works for testing but is less complete than Workers deployment. Cloudflare Workers is the primary target.
 - **Native Node modules (sharp, resvg, satori, lightningcss, @napi-rs/canvas)** crash Vite's RSC dev environment. Dynamic OG image/icon routes using these work in production builds but not in dev mode. These are auto-stubbed during `vinext deploy`.
-- **`next.config.ts` `baseUrl` bare imports require Vite 8.** A `next.config.ts` that imports a bare specifier resolved through `tsconfig.json`'s `compilerOptions.baseUrl` (e.g. `import { bar } from "bar"` resolving to a local `bar.ts`) relies on Vite 8's native `resolve.tsconfigPaths` (Rolldown/oxc-resolver). On Vite 7 there is no native equivalent, so these imports are not resolved. `compilerOptions.paths` aliases (e.g. `@/foo`) work on both Vite 7 and 8.
+- **`next.config.ts` `baseUrl` bare imports require Vite 8.** A `next.config.ts` that imports a bare specifier resolved through `tsconfig.json`'s `compilerOptions.baseUrl` (e.g. `import { bar } from "bar"` resolving to a local `bar.ts`) relies on Vite 8's native `resolve.tsconfigPaths` (Rolldown/oxc-resolver). On Vite 7 there is no native equivalent, so these imports are not resolved. `compilerOptions.paths` aliases (e.g. `@/foo`) work on both Vite 7 and 8. Note that if a bare import matches both a `baseUrl`-local file and an installed package of the same name, the installed package wins (vinext keeps packages externalized so CJS config plugins like `@next/mdx` keep working).
 
 ## Benchmarks
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -828,6 +828,11 @@ export async function loadNextConfig(
   // so baseUrl-based imports in `next.config.ts` are a documented Vite 7/8
   // capability gap (see docs). `paths` aliases still work on both via
   // `resolve.alias`. Mirrors the Vite-major gate used in index.ts.
+  //
+  // Note: installed packages stay externalized (so CJS config plugins like
+  // `@next/mdx` that call `require`/`require.resolve` at runtime keep working).
+  // baseUrl resolves bare imports that have no installed package of the same
+  // name; it does not shadow an installed package with a baseUrl-local file.
   const useNativeTsconfigPaths = !!tsconfigBaseUrl && getViteMajorVersion() >= 8;
 
   // Symlink-resolved config path, used by the `commonjs()` filter below to
@@ -842,31 +847,16 @@ export async function loadNextConfig(
       root,
       logLevel: "error",
       clearScreen: false,
-      ...(useNativeTsconfigPaths
-        ? {
-            environments: {
-              inline: {
-                resolve: {
-                  // Vite's module runner externalizes installed bare packages
-                  // before calling resolveId, which would let a package win over
-                  // a baseUrl-local file of the same name. Keep those config
-                  // imports inside the resolver pipeline so the native tsconfig
-                  // resolver gets first lookup, then fall through to packages.
-                  noExternal: true,
-                },
-              },
-            },
-          }
-        : {}),
       resolve: {
         alias: tsconfigResolution.aliases,
         // On Vite 8, use native tsconfig resolution (oxc-resolver
         // `tsconfig: 'auto'`), which mirrors Next.js's SWC `paths` + `baseUrl`
-        // handling: it follows `extends`, resolves baseUrl-local bare imports
-        // before package fallback, and scopes the app baseUrl to project-owned
-        // importers via per-importer tsconfig discovery. Vite 7 has no native
-        // equivalent, so baseUrl bare imports in next.config.ts are unsupported
-        // there (documented gap); `resolve.alias` still covers `paths` aliases.
+        // handling: it follows `extends` and resolves baseUrl-local bare imports
+        // via per-importer tsconfig discovery. Installed packages stay
+        // externalized, so a baseUrl-local file does not shadow a package of the
+        // same name. Vite 7 has no native equivalent, so baseUrl bare imports in
+        // next.config.ts are unsupported there (documented gap); `resolve.alias`
+        // still covers `paths` aliases on both.
         ...(useNativeTsconfigPaths ? { tsconfigPaths: true } : {}),
         // Include `.cjs` and `.cts` so `vite-plugin-commonjs` recognises
         // those extensions (the plugin keys off `config.resolve.extensions`,

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -528,7 +528,14 @@ describe("loadNextConfig with tsconfig path aliases", () => {
     expect(config?.env?.VALUE).toBe("foobar");
   });
 
-  it("resolves baseUrl local imports before packages with the same bare name", async () => {
+  it("prefers an installed package over a baseUrl-local file of the same name", async () => {
+    // When a bare import matches both an installed package and a baseUrl-local
+    // file, the installed package wins. vinext keeps installed packages
+    // externalized so that CJS config plugins (e.g. @next/mdx) that call
+    // `require`/`require.resolve` at runtime keep working; the trade-off is
+    // that a baseUrl-local file does not shadow a package of the same name.
+    // (Pure TypeScript baseUrl semantics would prefer the local file, but that
+    // requires de-externalizing every package, which breaks CJS plugins.)
     tmpDir = makeTempDir();
 
     fs.writeFileSync(path.join(tmpDir, "bar.ts"), `export const bar = "local";\n`);
@@ -547,7 +554,41 @@ describe("loadNextConfig with tsconfig path aliases", () => {
     );
 
     const config = await loadNextConfig(tmpDir);
-    expect(config?.env?.BAR).toBe("local");
+    expect(config?.env?.BAR).toBe("package");
+  });
+
+  it("loads a CJS config plugin that calls require.resolve at runtime", async () => {
+    // Regression for @next/mdx-style plugins: next.config.ts imports a CJS
+    // package whose factory calls `require.resolve(...)` when invoked. Keeping
+    // installed packages externalized (rather than forcing them through the
+    // module runner) ensures `require` is defined. Reproduces the
+    // app-router-playground deploy failure: "require is not defined".
+    tmpDir = makeTempDir();
+
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ type: "module" }));
+    writePackage(
+      "fake-mdx",
+      { type: "commonjs", main: "index.js" },
+      {
+        "index.js":
+          `module.exports = (opts = {}) => (config = {}) => ({\n` +
+          `  ...config,\n` +
+          `  loaderPath: require.resolve("./loader.js"),\n` +
+          `});\n`,
+        "loader.js": `module.exports = "loader";\n`,
+      },
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { baseUrl: "." } }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import withMDX from "fake-mdx";\n` + `export default withMDX({})({ env: { OK: "yes" } });\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.OK).toBe("yes");
   });
 
   it("falls through to packages when baseUrl has no local match", async () => {


### PR DESCRIPTION
## Summary

Fixes a production-build regression introduced by #1701. The `app-router-playground` example (and any app whose `next.config.ts` imports a CJS config plugin) fails to build with:

```
[vinext] Failed to load next.config.ts: require is not defined
  at @next/mdx/index.js:22  (require.resolve('./mdx-js-loader'))
```

See the failing deploy: https://github.com/cloudflare/vinext/actions/runs/26746903446/job/78825508039

## Root cause

#1701 added `resolve.noExternal: true` while loading a TypeScript `next.config` so that a `baseUrl`-local file could shadow an installed package of the same name. `noExternal: true` de-externalizes **every** installed package and forces it through Vite's module runner. CJS config plugins like `@next/mdx` call `require` / `require.resolve` at runtime (inside the returned config factory), and the runner doesn't provide `require` for those de-externalized modules — so they throw `require is not defined`.

This wasn't caught before merge because `deploy-examples` is skipped for fork PRs, and the added "imports ESM and CommonJS packages" test only used trivial `module.exports = "..."` packages that never call `require` at runtime.

## Fix

Drop the blanket `noExternal: true`. Installed packages stay externalized (so CJS config plugins keep working), and the native Vite 8 `resolve.tsconfigPaths` resolver still resolves `baseUrl`-local bare imports that have **no** installed package of the same name — which is the actual [Next.js `tsconfig-extends` fixture](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-config-ts/tsconfig-extends/) behavior.

The only behavior we give up is shadowing an *installed package* with a `baseUrl`-local file of the same name. No Next.js fixture exercises that case; it was an extra invariant added in #1701.

## Behavior matrix

| Scenario | Before (#1701) | After |
| --- | --- | --- |
| `next.config.ts` imports `bar`, only local `bar.ts` exists | local | local |
| `next.config.ts` imports `bar`, only package `bar` exists | package | package |
| `next.config.ts` imports `bar`, both local `bar.ts` and package `bar` exist | local | **package** |
| `next.config.ts` imports a CJS plugin that calls `require.resolve` at runtime (`@next/mdx`) | **throws** | works |

## Tests

- Updated the shadowing test to assert the installed package wins.
- Added a regression test for an `@next/mdx`-style CJS plugin that calls `require.resolve` at runtime (verified red before this change, green after).
- Documented the package-precedence behavior in the README limitations entry.

## Validation

- `vp test run tests/next-config.test.ts` — 167 pass
- `vp build` in `examples/app-router-playground` — builds successfully (was failing on `main`)