### PR TITLE
fix(app-router): emit per-page dynamic stale time metadata

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -583,6 +583,7 @@ export default __createAppRscHandler({
     const __segmentConfig = __resolveAppPageSegmentConfig({
       layouts: route.layouts,
       page: route.page,
+      parallelPages: Object.values(route.slots ?? {}).map((slot) => slot.page),
     });
     const __generateStaticParams = __resolveAppPageGenerateStaticParamsSources({
       layouts: route.layouts,
@@ -614,6 +615,7 @@ export default __createAppRscHandler({
       debugClassification: __classDebug,
       draftModeSecret: __draftModeSecret,
       dynamicConfig: __segmentConfig.dynamicConfig,
+      dynamicStaleTimeSeconds: __segmentConfig.dynamicStaleTimeSeconds,
       dynamicParamsConfig: __segmentConfig.dynamicParamsConfig,
       fetchCache: __segmentConfig.fetchCache ?? null,
       isEdgeRuntime: __isEdgeRuntime(__segmentConfig.runtime),

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -181,6 +181,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   debugClassification?: (layoutId: string, reason: ClassificationReason) => void;
   draftModeSecret: string;
   dynamicConfig?: string;
+  dynamicStaleTimeSeconds?: number;
   dynamicParamsConfig?: boolean;
   fetchCache?: FetchCacheMode | null;
   findIntercept: (pathname: string) => AppPageDispatchIntercept | null;
@@ -764,6 +765,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         }
       },
     },
+    dynamicStaleTimeSeconds: options.dynamicStaleTimeSeconds,
     revalidateSeconds: currentRevalidateSeconds,
     mountedSlotsHeader: options.mountedSlotsHeader,
     renderMode: options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -425,7 +425,17 @@ export async function renderAppPageLifecycle(
       revalidateSeconds,
     });
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
-      dynamicStaleTimeSeconds: options.dynamicStaleTimeSeconds,
+      // Only emit the dynamic stale time on dynamic renders — not prerenders or
+      // force-static. Next.js gates this on !workStore.isStaticGeneration because
+      // the client treats the header's presence as authoritative; leaking it onto
+      // static/prerendered responses would cause the client cache to apply dynamic
+      // stale time semantics to a statically-cached entry.
+      // Ported from Next.js: packages/next/src/server/app-render/app-render.tsx
+      //   generateDynamicRSCPayload
+      dynamicStaleTimeSeconds:
+        options.isPrerender === true || options.isForceStatic
+          ? undefined
+          : options.dynamicStaleTimeSeconds,
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       mountedSlotsHeader: options.mountedSlotsHeader,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -430,6 +430,16 @@ export async function renderAppPageLifecycle(
       // shouldCaptureRscForCacheMetadata is the runtime analog of isStaticGeneration: a render
       // written to the ISR cache (incl. production ISR, where isPrerender is false at runtime)
       // must not emit the authoritative per-page stale time.
+      //
+      // Known over-gating: shouldCaptureRscForCacheMetadata is computed from config
+      // alone (line 387), before the RSC stream is consumed, so it cannot see late
+      // dynamic-API usage (cookies()/headers()). A production default-config route
+      // (revalidateSeconds === null, not force-dynamic) that becomes dynamic at
+      // render time is !isStaticGeneration in Next.js (header emitted), but here the
+      // header is omitted even though the cache write is later skipped via two-phase
+      // dynamic detection (consumeDynamicUsage in scheduleAppPageRscCacheWrite). The
+      // exact value is unknowable at this point since the stream has not yet run, so
+      // we accept dropping the (advisory) stale-time hint on those NO_STORE responses.
       dynamicStaleTimeSeconds:
         options.isPrerender === true || options.isForceStatic || shouldCaptureRscForCacheMetadata
           ? undefined

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -425,13 +425,8 @@ export async function renderAppPageLifecycle(
       revalidateSeconds,
     });
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
-      // Only emit the dynamic stale time on dynamic renders — not prerenders or
-      // force-static. Next.js gates this on !workStore.isStaticGeneration because
-      // the client treats the header's presence as authoritative; leaking it onto
-      // static/prerendered responses would cause the client cache to apply dynamic
-      // stale time semantics to a statically-cached entry.
-      // Ported from Next.js: packages/next/src/server/app-render/app-render.tsx
-      //   generateDynamicRSCPayload
+      // Only emit on dynamic renders — Next.js gates on !workStore.isStaticGeneration (line 2223).
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L2223-L2229
       dynamicStaleTimeSeconds:
         options.isPrerender === true || options.isForceStatic
           ? undefined

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -94,6 +94,7 @@ type RenderAppPageLifecycleOptions = {
   getDraftModeCookieHeader: () => string | null | undefined;
   handlerStart: number;
   hasLoadingBoundary: boolean;
+  dynamicStaleTimeSeconds?: number;
   isDynamicError: boolean;
   isDraftMode: boolean;
   isEdgeRuntime?: boolean;
@@ -424,6 +425,7 @@ export async function renderAppPageLifecycle(
       revalidateSeconds,
     });
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
+      dynamicStaleTimeSeconds: options.dynamicStaleTimeSeconds,
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       mountedSlotsHeader: options.mountedSlotsHeader,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -427,8 +427,11 @@ export async function renderAppPageLifecycle(
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
       // Only emit on dynamic renders — Next.js gates on !workStore.isStaticGeneration (line 2223).
       // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L2223-L2229
+      // shouldCaptureRscForCacheMetadata is the runtime analog of isStaticGeneration: a render
+      // written to the ISR cache (incl. production ISR, where isPrerender is false at runtime)
+      // must not emit the authoritative per-page stale time.
       dynamicStaleTimeSeconds:
-        options.isPrerender === true || options.isForceStatic
+        options.isPrerender === true || options.isForceStatic || shouldCaptureRscForCacheMetadata
           ? undefined
           : options.dynamicStaleTimeSeconds,
       isEdgeRuntime: options.isEdgeRuntime,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -4,6 +4,7 @@ import {
   STATIC_CACHE_CONTROL,
 } from "./cache-control.js";
 import {
+  VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_TIMING_HEADER,
@@ -58,6 +59,7 @@ type AppPageHtmlResponsePolicy = {
 } & AppPageResponsePolicy;
 
 type BuildAppPageRscResponseOptions = {
+  dynamicStaleTimeSeconds?: number;
   isEdgeRuntime?: boolean;
   middlewareContext: AppPageMiddlewareContext;
   mountedSlotsHeader?: string | null;
@@ -91,6 +93,17 @@ function applyTimingHeader(headers: Headers, timing?: AppPageResponseTiming): vo
       : -1;
 
   headers.set(VINEXT_TIMING_HEADER, `${handlerStart},${compileMs},${renderMs}`);
+}
+
+function applyDynamicStaleTimeHeader(headers: Headers, dynamicStaleTimeSeconds?: number): void {
+  if (
+    dynamicStaleTimeSeconds !== undefined &&
+    Number.isFinite(dynamicStaleTimeSeconds) &&
+    Number.isInteger(dynamicStaleTimeSeconds) &&
+    dynamicStaleTimeSeconds >= 0
+  ) {
+    headers.set(VINEXT_DYNAMIC_STALE_TIME_HEADER, String(dynamicStaleTimeSeconds));
+  }
 }
 
 export function resolveAppPageRscResponsePolicy(
@@ -256,6 +269,7 @@ export function buildAppPageRscResponse(
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
   }
+  applyDynamicStaleTimeHeader(headers, options.dynamicStaleTimeSeconds);
   if (options.policy.cacheControl) {
     headers.set("Cache-Control", options.policy.cacheControl);
   }

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -98,7 +98,6 @@ function applyTimingHeader(headers: Headers, timing?: AppPageResponseTiming): vo
 function applyDynamicStaleTimeHeader(headers: Headers, dynamicStaleTimeSeconds?: number): void {
   if (
     dynamicStaleTimeSeconds !== undefined &&
-    Number.isFinite(dynamicStaleTimeSeconds) &&
     Number.isInteger(dynamicStaleTimeSeconds) &&
     dynamicStaleTimeSeconds >= 0
   ) {

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -75,12 +75,7 @@ function resolveDynamicStaleTimeSeconds(
   current: number | undefined,
   value: unknown,
 ): number | undefined {
-  if (
-    typeof value !== "number" ||
-    !Number.isFinite(value) ||
-    !Number.isInteger(value) ||
-    value < 0
-  ) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
     return current;
   }
 

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -9,11 +9,13 @@ type AppRouteSegmentConfigModule = {
   fetchCache?: unknown;
   revalidate?: unknown;
   runtime?: unknown;
+  unstable_dynamicStaleTime?: unknown;
 };
 
 type EffectiveAppPageSegmentConfig = {
   dynamicConfig?: AppRouteSegmentDynamic;
   dynamicParamsConfig?: boolean;
+  dynamicStaleTimeSeconds?: number;
   fetchCache?: FetchCacheMode;
   revalidateSeconds: number | null;
   runtime?: "edge" | "experimental-edge" | "nodejs";
@@ -22,6 +24,7 @@ type EffectiveAppPageSegmentConfig = {
 type ResolveAppPageSegmentConfigOptions = {
   layouts?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
   page?: AppRouteSegmentConfigModule | null;
+  parallelPages?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
 };
 
 const DYNAMIC_VALUES = new Set<unknown>(["auto", "error", "force-dynamic", "force-static"]);
@@ -66,6 +69,22 @@ function resolveRevalidateSeconds(current: number | null, value: unknown): numbe
   }
 
   return value < current ? value : current;
+}
+
+function resolveDynamicStaleTimeSeconds(
+  current: number | undefined,
+  value: unknown,
+): number | undefined {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
+    return current;
+  }
+
+  return current === undefined ? value : Math.min(current, value);
 }
 
 function isCacheFetchCacheMode(value: FetchCacheMode): boolean {
@@ -157,6 +176,14 @@ export function resolveAppPageSegmentConfig(
     config.revalidateSeconds = resolveRevalidateSeconds(
       config.revalidateSeconds,
       segment.revalidate,
+    );
+  }
+
+  for (const segment of [options.page, ...(options.parallelPages ?? [])]) {
+    if (!segment) continue;
+    config.dynamicStaleTimeSeconds = resolveDynamicStaleTimeSeconds(
+      config.dynamicStaleTimeSeconds,
+      segment.unstable_dynamicStaleTime,
     );
   }
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -46,6 +46,9 @@ export const VINEXT_PARAMS_HEADER = "X-Vinext-Params";
 /** Deduplicated, sorted list of mounted layout slots for cache keying. */
 export const VINEXT_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
 
+/** Per-page dynamic stale time in seconds for App Router RSC responses. */
+export const VINEXT_DYNAMIC_STALE_TIME_HEADER = "X-Vinext-Dynamic-Stale-Time";
+
 /** Route interception context for parallel/intercepting routes. */
 export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context";
 

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -783,6 +783,27 @@ describe("app page render lifecycle", () => {
     expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
     await expect(response.text()).resolves.toBe("flight-data");
   });
+
+  it("omits the dynamic stale time header on production default-config renders that turn dynamic", async () => {
+    // Documents the known over-gating at the cache-capture boundary: a production
+    // default-config route (revalidateSeconds === null, not force-dynamic) that
+    // uses a late dynamic API is genuinely dynamic, but shouldCaptureRscForCacheMetadata
+    // is true (computed from config before the stream runs), so the header is omitted.
+    // Next.js would emit it here (!isStaticGeneration); the value is unknowable until
+    // after the headers are built, so the advisory hint is dropped on this NO_STORE
+    // response. See app-page-render.ts gating comment.
+    const common = createCommonOptions();
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeDynamicUsage: vi.fn(() => true),
+      dynamicStaleTimeSeconds: 60,
+      isProduction: true,
+      isRscRequest: true,
+      revalidateSeconds: null,
+    });
+    expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
+    await expect(response.text()).resolves.toBe("flight-data");
+  });
 });
 
 describe("layoutFlags injection into RSC payload", () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -766,6 +766,23 @@ describe("app page render lifecycle", () => {
     expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
     await expect(response.text()).resolves.toBe("flight-data");
   });
+
+  it("omits the dynamic stale time header on production ISR renders captured into the cache", async () => {
+    // Production ISR (revalidate > 0, not force-static, not a build prerender)
+    // satisfies shouldCaptureRscForCacheMetadata, so the render feeds the ISR
+    // cache. Like Next.js's !workStore.isStaticGeneration guard, the
+    // authoritative per-page stale time must not be emitted on such responses.
+    const common = createCommonOptions();
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      dynamicStaleTimeSeconds: 60,
+      isProduction: true,
+      isRscRequest: true,
+      revalidateSeconds: 60,
+    });
+    expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
+    await expect(response.text()).resolves.toBe("flight-data");
+  });
 });
 
 describe("layoutFlags injection into RSC payload", () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../packages/vinext/src/server/artifact-compatibility.js";
 import type { LayoutClassificationOptions } from "../packages/vinext/src/server/app-page-execution.js";
 import { renderAppPageLifecycle } from "../packages/vinext/src/server/app-page-render.js";
+import { VINEXT_DYNAMIC_STALE_TIME_HEADER } from "../packages/vinext/src/server/headers.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
 
 function captureRecord(value: ReactNode | AppOutgoingElements): Record<string, unknown> {
@@ -729,6 +730,41 @@ describe("app page render lifecycle", () => {
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(common.waitUntilPromises).toHaveLength(0);
     expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
+  it("emits the dynamic stale time header on RSC responses during dynamic renders", async () => {
+    const common = createCommonOptions();
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      dynamicStaleTimeSeconds: 60,
+      isRscRequest: true,
+    });
+    expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBe("60");
+    await expect(response.text()).resolves.toBe("flight-data");
+  });
+
+  it("omits the dynamic stale time header during prerender (isPrerender=true)", async () => {
+    const common = createCommonOptions();
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      dynamicStaleTimeSeconds: 60,
+      isRscRequest: true,
+      isPrerender: true,
+    });
+    expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
+    await expect(response.text()).resolves.toBe("flight-data");
+  });
+
+  it("omits the dynamic stale time header during force-static renders", async () => {
+    const common = createCommonOptions();
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      dynamicStaleTimeSeconds: 60,
+      isRscRequest: true,
+      isForceStatic: true,
+    });
+    expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
+    await expect(response.text()).resolves.toBe("flight-data");
   });
 });
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -10,6 +10,7 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { VINEXT_DYNAMIC_STALE_TIME_HEADER } from "../packages/vinext/src/server/headers.js";
 import { withEnvVar } from "./env-test-helpers.js";
 
 function createBody(text: string): ReadableStream {
@@ -436,6 +437,19 @@ describe("app page response helpers", () => {
     );
 
     expect(response.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
+  });
+
+  it("emits per-page dynamic stale time metadata on RSC responses", () => {
+    // Next.js sends the per-page dynamic stale time in the Flight response `d`
+    // field; vinext carries the same response-level contract through an RSC
+    // response header that the client cache can snapshot.
+    const response = buildAppPageRscResponse(createBody("flight"), {
+      dynamicStaleTimeSeconds: 60,
+      middlewareContext: { headers: null, status: null },
+      policy: {},
+    });
+
+    expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBe("60");
   });
 
   it("keeps the framework compatibility ID when middleware sets the internal header", () => {

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -221,6 +221,37 @@ describe("resolveAppPageSegmentConfig", () => {
     ).toBe(60);
   });
 
+  it("reads unstable_dynamicStaleTime only from page modules", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+    // See also: packages/next/src/server/app-render/app-render.tsx#getDynamicStaleTime
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ unstable_dynamicStaleTime: 5 }],
+        page: { unstable_dynamicStaleTime: 60 },
+      }),
+    ).toEqual({
+      dynamicStaleTimeSeconds: 60,
+      revalidateSeconds: null,
+    });
+  });
+
+  it("uses the shortest unstable_dynamicStaleTime across active page slots", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+    expect(
+      resolveAppPageSegmentConfig({
+        page: { unstable_dynamicStaleTime: 60 },
+        parallelPages: [
+          { unstable_dynamicStaleTime: 15 },
+          { unstable_dynamicStaleTime: 30 },
+          { unstable_dynamicStaleTime: "not-a-number" },
+        ],
+      }),
+    ).toEqual({
+      dynamicStaleTimeSeconds: 15,
+      revalidateSeconds: null,
+    });
+  });
+
   it("resolves just the fetchCache mode for route-specific render scopes", () => {
     expect(
       resolveAppPageFetchCacheMode({

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -761,6 +761,16 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("computeRscCacheBustingSearchParam(");
   });
 
+  it("generateRscEntry passes page-slot dynamic stale time config into App page dispatch", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+
+    expect(code).toContain(
+      "parallelPages: Object.values(route.slots ?? {}).map((slot) => slot.page)",
+    );
+    expect(code).toContain("dynamicStaleTimeSeconds: __segmentConfig.dynamicStaleTimeSeconds");
+  });
+
   it("generateRscEntry threads globalNotFoundPath from config into the fallback renderer", () => {
     // The generated entry's createAppFallbackRenderer call must receive a
     // loader so route-miss 404s can render app/global-not-found.tsx standalone.


### PR DESCRIPTION
## Summary

This is PR 1 of 2 for per-page `unstable_dynamicStaleTime` support.

It fixes the server side of the contract: App Router page segment config now resolves page-only `unstable_dynamicStaleTime`, includes parallel route pages in the minimum stale-time calculation, and emits the resolved value on RSC responses so the client can make per-response cache decisions.

## Why

Next.js treats `unstable_dynamicStaleTime` as page-only stale-time metadata:

- Build-time validation reads the export and rejects layout usage / `unstable_instant` combinations: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/analysis/get-page-static-info.ts
- Runtime reads page module stale time while building the component tree: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/app-render/create-component-tree.tsx
- Runtime computes the effective value across the loader tree and writes it into the app render response metadata: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/app-render/app-render.tsx
- Covered upstream behavior: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts

Vinext previously ignored this export in `resolveAppPageSegmentConfig`, so page-level stale time never reached the RSC response.

## Changes

- Adds `dynamicStaleTimeSeconds` to effective App Router segment config.
- Reads `unstable_dynamicStaleTime` from pages, not layouts.
- Includes parallel route pages and uses the minimum valid stale time, matching the upstream parallel-route behavior.
- Emits `X-Vinext-Dynamic-Stale-Time` on app-page RSC responses when a finite non-negative integer stale time is resolved.
- Ports focused server-side regression coverage for segment config resolution, response headers, and generated RSC-entry wiring.

## Verification

- `vp test run tests/app-segment-config.test.ts tests/app-page-response.test.ts tests/entry-templates.test.ts tests/prefetch-cache.test.ts tests/app-browser-entry.test.ts tests/app-visited-response-cache.test.ts tests/link-navigation.test.ts`
- `PLAYWRIGHT_PROJECT=app-router vp run test:e2e tests/e2e/app-router/build-id-navigation.spec.ts`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts`
