### PR TITLE
fix(app-router): honor per-response dynamic stale times on the client

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -840,10 +840,9 @@ function getVisitedResponse(
     return null;
   }
 
-  if (navigationKind === "refresh") {
-    return null;
-  }
-
+  // `isVisitedResponseCacheEntryFresh` already bypasses the cache for
+  // `navigationKind === "refresh"`, so the refresh case falls through to the
+  // miss path below (which also evicts the stale entry).
   if (
     isVisitedResponseCacheEntryFresh(cached, {
       navigationKind,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -35,6 +35,7 @@ import {
   pushHistoryStateWithoutNotify,
   replaceClientParamsWithoutNotify,
   replaceHistoryStateWithoutNotify,
+  resolvePrefetchCacheEntryMountedSlotsHeader,
   restoreRscResponse,
   saveScrollPosition,
   setClientParams,
@@ -106,11 +107,11 @@ import {
   createHistoryStateWithNavigationMetadata,
   createInitialBfcacheIdMap,
   isHistoryStateBfcacheVersionCurrent,
+  isCacheRestorableAppPayloadMetadata,
   readHistoryStateBfcacheIds,
   readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
-  isCacheRestorableAppPayloadMetadata,
   resolveHistoryTraversalIntent,
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
@@ -119,6 +120,11 @@ import {
   type HistoryTraversalIntent,
   type OperationLane,
 } from "./app-browser-state.js";
+import {
+  createVisitedResponseCacheEntry,
+  isVisitedResponseCacheEntryFresh,
+  type VisitedResponseCacheEntry,
+} from "./app-visited-response-cache.js";
 import { createPopstateRestoreHandler } from "./app-browser-popstate.js";
 import { DevRecoveryBoundary, RedirectBoundary } from "vinext/shims/error-boundary";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
@@ -200,15 +206,7 @@ function toOperationLane(kind: NavigationKind): OperationLane {
   }
 }
 
-type VisitedResponseCacheEntry = {
-  params: Record<string, string | string[]>;
-  expiresAt: number;
-  response: CachedRscResponse;
-};
-
 const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
-const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
-const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
 const CLIENT_RSC_COMPATIBILITY_ID = getVinextRscCompatibilityId();
 const optimisticRouteTemplates = new Map<string, OptimisticRouteTemplate>();
 const optimisticRouteTemplateSources = new Set<string>();
@@ -476,8 +474,9 @@ async function learnOptimisticRouteTemplateFromPrefetch(options: {
 }): Promise<boolean> {
   const source = parsePrefetchCacheKey(options.cacheKey);
   if (source.interceptionContext !== options.interceptionContext) return false;
-  if ((options.entry.snapshot.mountedSlotsHeader ?? null) !== options.mountedSlotsHeader)
+  if (resolvePrefetchCacheEntryMountedSlotsHeader(options.entry) !== options.mountedSlotsHeader) {
     return false;
+  }
   if (options.interceptionContext !== null) return false;
 
   const elements = await decodeAppElementsPromise(
@@ -845,19 +844,12 @@ function getVisitedResponse(
     return null;
   }
 
-  if (navigationKind === "traverse") {
-    const createdAt = cached.expiresAt - VISITED_RESPONSE_CACHE_TTL;
-    if (Date.now() - createdAt >= MAX_TRAVERSAL_CACHE_TTL) {
-      visitedResponseCache.delete(cacheKey);
-      return null;
-    }
-    // LRU: promote to most-recently-used (delete + re-insert moves to end of Map)
-    visitedResponseCache.delete(cacheKey);
-    visitedResponseCache.set(cacheKey, cached);
-    return cached;
-  }
-
-  if (cached.expiresAt > Date.now()) {
+  if (
+    isVisitedResponseCacheEntryFresh(cached, {
+      navigationKind,
+      now: Date.now(),
+    })
+  ) {
     // LRU: promote to most-recently-used
     visitedResponseCache.delete(cacheKey);
     visitedResponseCache.set(cacheKey, cached);
@@ -866,6 +858,10 @@ function getVisitedResponse(
 
   visitedResponseCache.delete(cacheKey);
   return null;
+}
+
+function deleteVisitedResponse(rscUrl: string, interceptionContext: string | null): void {
+  visitedResponseCache.delete(AppElementsWire.encodeCacheKey(rscUrl, interceptionContext));
 }
 
 function storeVisitedResponseSnapshot(
@@ -878,11 +874,14 @@ function storeVisitedResponseSnapshot(
   visitedResponseCache.delete(cacheKey);
   evictVisitedResponseCacheIfNeeded();
   const now = Date.now();
-  visitedResponseCache.set(cacheKey, {
-    params,
-    expiresAt: now + VISITED_RESPONSE_CACHE_TTL,
-    response: snapshot,
-  });
+  visitedResponseCache.set(
+    cacheKey,
+    createVisitedResponseCacheEntry({
+      now,
+      params,
+      response: snapshot,
+    }),
+  );
 }
 
 type NavigationRequestState = {
@@ -1055,7 +1054,7 @@ function BrowserRoot({
   >(() => ({
     activeOperation: null,
     // Intentional Next.js parity: a hard reload starts a new browser
-    // document without the prior in-memory CacheNode/Activity tree. Hydrate
+    // document without the prior in-memory router state. Hydrate
     // the new document on the zero sentinel and rely on the document-scoped
     // bfcache version gate to reject stale ids persisted by previous
     // documents.
@@ -1078,7 +1077,6 @@ function BrowserRoot({
     throw unresolvedMpaNavigation;
   }
   const treeState = isRouterStatePromise(treeStateValue) ? use(treeStateValue) : treeStateValue;
-
   // Keep the latest router state in a ref so external callers (navigate(),
   // server actions, HMR) always read the current state. Safe: those readers
   // run from events/effects, never from React render itself.
@@ -1725,7 +1723,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             activeTraversalIntent?.historyState ?? window.history.state,
           )
         : null;
-
     try {
       const shouldUsePendingRouterState = programmaticTransition;
       if (shouldUsePendingRouterState && hasBrowserRouterState()) {
@@ -1843,7 +1840,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             ),
           );
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
-          await renderNavigationPayload(
+          const cachedRenderOutcome = await renderNavigationPayload(
             cachedPayload,
             cachedNavigationSnapshot,
             currentHref,
@@ -1859,6 +1856,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             scrollIntent,
             restoredBfcacheIds,
           );
+          if (cachedRenderOutcome === "no-commit") {
+            deleteVisitedResponse(rscUrl, requestInterceptionContext);
+            continue;
+          }
           return;
         }
 
@@ -1866,6 +1867,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // and prefetch compatibility decisions.
 
         let navResponse: Response | undefined;
+        let navResponseExpiresAt: number | undefined;
         let navResponseUrl: string | null = null;
         if (navigationKind !== "refresh") {
           const prefetchedResponse = await consumePrefetchResponseForNavigation(
@@ -1879,6 +1881,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
             navResponse = restoreRscResponse(prefetchedResponse, false);
+            navResponseExpiresAt = prefetchedResponse.expiresAt;
             navResponseUrl = prefetchedResponse.url;
           }
         }
@@ -2095,9 +2098,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // here would block the commit until the page's slowest server
         // promise resolved, hiding the loading state entirely.
         //
-        // The cache branch is read in the background so the visited-
-        // response snapshot lands as soon as the full stream completes,
-        // without holding up React's commit.
+        // The cache branch is read alongside React's branch, but persistence is
+        // best-effort after a successful visible commit. A failed snapshot must
+        // degrade future back/forward reuse, not recover by reloading the page
+        // the user already reached.
         const navBody = navResponse.body;
         if (!navBody) {
           // Already validated above (`!navResponse.body` triggers a hard
@@ -2144,25 +2148,31 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // If we stored it before and renderNavigationPayload threw, a future
         // back/forward navigation could replay a snapshot from a navigation that
         // never actually rendered successfully.
-        const resolvedElements = await rscPayload;
-        const metadata = AppElementsWire.readMetadata(resolvedElements);
-        if (!isCacheRestorableAppPayloadMetadata(metadata)) {
-          void cacheBufferPromise.catch(() => {});
-          return;
+        try {
+          const renderedElements = await rscPayload;
+          const metadata = AppElementsWire.readMetadata(renderedElements);
+          if (!isCacheRestorableAppPayloadMetadata(metadata)) {
+            void cacheBufferPromise.catch(() => {});
+            return;
+          }
+          const cacheBuffer = await cacheBufferPromise;
+          storeVisitedResponseSnapshot(
+            rscUrl,
+            resolveVisitedResponseInterceptionContext(
+              requestInterceptionContext,
+              metadata.interceptionContext,
+            ),
+            {
+              ...createCachedRscResponseSnapshot(navResponse, cacheBuffer, navResponseUrl),
+              ...(navResponseExpiresAt !== undefined ? { expiresAt: navResponseExpiresAt } : {}),
+              mountedSlotsHeader: getMountedSlotIdsHeader(renderedElements),
+            },
+            navParams,
+          );
+        } catch {
+          // The visible navigation already committed. A cache snapshot failure
+          // only affects future reuse; it must not reload the page.
         }
-        void cacheBufferPromise
-          .then((cacheBuffer) => {
-            storeVisitedResponseSnapshot(
-              rscUrl,
-              resolveVisitedResponseInterceptionContext(
-                requestInterceptionContext,
-                metadata.interceptionContext,
-              ),
-              createCachedRscResponseSnapshot(navResponse, cacheBuffer, navResponseUrl),
-              navParams,
-            );
-          })
-          .catch(() => {});
         return;
       }
     } catch (error) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -840,9 +840,9 @@ function getVisitedResponse(
     return null;
   }
 
-  // `isVisitedResponseCacheEntryFresh` already bypasses the cache for
-  // `navigationKind === "refresh"`, so the refresh case falls through to the
-  // miss path below (which also evicts the stale entry).
+  // `isVisitedResponseCacheEntryFresh` is the single source of truth for
+  // freshness and returns `false` for `navigationKind === "refresh"`, so a
+  // refresh falls through to the miss path below.
   if (
     isVisitedResponseCacheEntryFresh(cached, {
       navigationKind,
@@ -855,6 +855,10 @@ function getVisitedResponse(
     return cached;
   }
 
+  // Stale (or refresh) entries are evicted on read. A refresh intentionally
+  // drops any prior snapshot here — the navigation re-fetches and re-stores a
+  // fresh one, so leaving the old entry around would only risk a later
+  // non-refresh navigation reusing a snapshot the user explicitly refreshed.
   visitedResponseCache.delete(cacheKey);
   return null;
 }

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -651,26 +651,20 @@ export async function renderAppPageLifecycle(
     if (shouldBypassRscCacheForSkipTransport) {
       options.isrDebug?.("RSC cache write skipped (skip transport payload)", options.cleanPathname);
     }
+    const shouldEmitDynamicStaleTime =
+      options.dynamicStaleTimeSeconds !== undefined &&
+      options.isPrerender !== true &&
+      !options.isForceStatic &&
+      (dynamicUsedDuringBuild || !shouldCaptureRscForCacheMetadata);
     const rscResponse = buildAppPageRscResponse(rscForResponse, {
       // Only emit on dynamic renders — Next.js gates on !workStore.isStaticGeneration (line 2223).
       // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx#L2223-L2229
       // shouldCaptureRscForCacheMetadata is the runtime analog of isStaticGeneration: a render
       // written to the ISR cache (incl. production ISR, where isPrerender is false at runtime)
       // must not emit the authoritative per-page stale time.
-      //
-      // Known over-gating: shouldCaptureRscForCacheMetadata is computed from config
-      // alone (line 387), before the RSC stream is consumed, so it cannot see late
-      // dynamic-API usage (cookies()/headers()). A production default-config route
-      // (revalidateSeconds === null, not force-dynamic) that becomes dynamic at
-      // render time is !isStaticGeneration in Next.js (header emitted), but here the
-      // header is omitted even though the cache write is later skipped via two-phase
-      // dynamic detection (consumeDynamicUsage in scheduleAppPageRscCacheWrite). The
-      // exact value is unknowable at this point since the stream has not yet run, so
-      // we accept dropping the (advisory) stale-time hint on those NO_STORE responses.
-      dynamicStaleTimeSeconds:
-        options.isPrerender === true || options.isForceStatic || shouldCaptureRscForCacheMetadata
-          ? undefined
-          : options.dynamicStaleTimeSeconds,
+      dynamicStaleTimeSeconds: shouldEmitDynamicStaleTime
+        ? options.dynamicStaleTimeSeconds
+        : undefined,
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       mountedSlotsHeader: options.mountedSlotsHeader,

--- a/packages/vinext/src/server/app-visited-response-cache.ts
+++ b/packages/vinext/src/server/app-visited-response-cache.ts
@@ -1,0 +1,48 @@
+import { resolveCachedRscResponseExpiresAt, type CachedRscResponse } from "vinext/shims/navigation";
+
+type VisitedResponseCacheNavigationKind = "navigate" | "refresh" | "traverse";
+
+export type VisitedResponseCacheEntry = {
+  createdAt: number;
+  expiresAt: number;
+  params: Record<string, string | string[]>;
+  response: CachedRscResponse;
+};
+
+export const VISITED_RESPONSE_CACHE_TTL = 5 * 60_000;
+export const MAX_TRAVERSAL_CACHE_TTL = 30 * 60_000;
+
+export function createVisitedResponseCacheEntry(options: {
+  now: number;
+  params: Record<string, string | string[]>;
+  response: CachedRscResponse;
+}): VisitedResponseCacheEntry {
+  return {
+    createdAt: options.now,
+    expiresAt: resolveCachedRscResponseExpiresAt(
+      options.now,
+      options.response,
+      VISITED_RESPONSE_CACHE_TTL,
+    ),
+    params: options.params,
+    response: options.response,
+  };
+}
+
+export function isVisitedResponseCacheEntryFresh(
+  entry: VisitedResponseCacheEntry,
+  options: {
+    navigationKind: VisitedResponseCacheNavigationKind;
+    now: number;
+  },
+): boolean {
+  if (options.navigationKind === "refresh") {
+    return false;
+  }
+
+  if (options.navigationKind === "traverse") {
+    return options.now - entry.createdAt < MAX_TRAVERSAL_CACHE_TTL;
+  }
+
+  return entry.expiresAt > options.now;
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -31,6 +31,7 @@ import {
   getPrefetchCache,
   getPrefetchedUrls,
   getMountedSlotsHeader,
+  hasPrefetchCacheEntryForNavigation,
   navigateClientSide,
   prefetchRscResponse,
 } from "./navigation.js";
@@ -379,6 +380,12 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
               existing.cacheForNavigation = true;
             }
           }
+          return;
+        }
+        if (
+          autoPrefetch.cacheForNavigation &&
+          hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)
+        ) {
           return;
         }
         prefetched.add(cacheKey);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -382,14 +382,10 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           if (existing?.cacheForNavigation === false) {
             existing.cacheForNavigation = true;
           }
-
-          if (hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)) {
-            return;
-          }
-
-          // stale/orphaned exact entry was deleted by helper, or set was stale
-          prefetched.delete(cacheKey);
         }
+        // A single freshness-aware gate covers both an exact prior prefetch and
+        // an equivalent `_rsc` variant; the helper also deletes any stale exact
+        // entry, so a stale `prefetched` member is harmlessly re-added below.
         if (
           autoPrefetch.cacheForNavigation &&
           hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -374,13 +374,21 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
         const prefetched = getPrefetchedUrls();
         if (prefetched.has(cacheKey)) {
-          if (autoPrefetch.cacheForNavigation) {
-            const existing = getPrefetchCache().get(cacheKey);
-            if (existing?.cacheForNavigation === false) {
-              existing.cacheForNavigation = true;
-            }
+          if (!autoPrefetch.cacheForNavigation) {
+            return;
           }
-          return;
+
+          const existing = getPrefetchCache().get(cacheKey);
+          if (existing?.cacheForNavigation === false) {
+            existing.cacheForNavigation = true;
+          }
+
+          if (hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)) {
+            return;
+          }
+
+          // stale/orphaned exact entry was deleted by helper, or set was stale
+          prefetched.delete(cacheKey);
         }
         if (
           autoPrefetch.cacheForNavigation &&

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -570,6 +570,13 @@ function isPrefetchCacheEntryCompatibleWithMountedSlots(
   entry: PrefetchCacheEntry,
   mountedSlotsHeader: string | null,
 ): boolean {
+  // The two clauses are load-bearing, not redundant. `resolvePrefetch...Header`
+  // prefers the entry's pinned request-time slot context (falling back to the
+  // snapshot header only when unset), while the second clause matches the
+  // server-declared snapshot header. They diverge only when the entry pins a
+  // request-time context that disagrees with the response (the
+  // `prefetchRscResponse` case); accepting either preserves the "request-time OR
+  // server-declared slot context" reuse semantics.
   if (resolvePrefetchCacheEntryMountedSlotsHeader(entry) === mountedSlotsHeader) {
     return true;
   }
@@ -985,6 +992,10 @@ export function consumePrefetchResponse(
     if (resolvePrefetchCacheEntryExpiresAt(entry) <= Date.now()) {
       return null;
     }
+    // Only synthesize `expiresAt` onto the returned snapshot when the entry (or
+    // its snapshot) already carried one. Entries that never had an explicit
+    // expiry must round-trip unchanged so callers/tests can assert the raw
+    // snapshot — don't collapse this into an unconditional spread.
     if (entry.expiresAt !== undefined || entry.snapshot.expiresAt !== undefined) {
       return {
         ...entry.snapshot,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -23,10 +23,15 @@ import {
 import {
   createRscRequestHeaders,
   createRscRequestUrl,
+  stripRscCacheBustingSearchParam,
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "../server/app-rsc-cache-busting.js";
-import { VINEXT_MOUNTED_SLOTS_HEADER, VINEXT_PARAMS_HEADER } from "../server/headers.js";
+import {
+  VINEXT_DYNAMIC_STALE_TIME_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_PARAMS_HEADER,
+} from "../server/headers.js";
 import {
   isAbsoluteOrProtocolRelativeUrl,
   isHashOnlyBrowserUrlChange,
@@ -402,6 +407,8 @@ export type CachedRscResponse = {
   compatibilityIdHeader?: string | null;
   buffer: ArrayBuffer;
   contentType: string;
+  dynamicStaleTimeSeconds?: number;
+  expiresAt?: number;
   mountedSlotsHeader?: string | null;
   paramsHeader: string | null;
   url: string;
@@ -414,7 +421,9 @@ export type PrefetchOptions = {
 
 export type PrefetchCacheEntry = {
   cacheForNavigation?: boolean;
+  expiresAt?: number;
   invalidationTimer?: ReturnType<typeof setTimeout>;
+  mountedSlotsHeader?: string | null;
   onInvalidateCallbacks?: Set<() => void>;
   optimisticRouteShell?: boolean;
   outcome: "pending" | "cache-seeded";
@@ -480,6 +489,152 @@ export function getPrefetchedUrls(): Set<string> {
   return window.__VINEXT_RSC_PREFETCHED_URLS__;
 }
 
+function isDynamicStaleTimeSeconds(value: unknown): value is number {
+  return (
+    typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0
+  );
+}
+
+function isCacheExpiresAt(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function parseDynamicStaleTimeSeconds(value: string | null): number | undefined {
+  if (value === null || value === "") return undefined;
+  const seconds = Number(value);
+  return isDynamicStaleTimeSeconds(seconds) ? seconds : undefined;
+}
+
+export function resolveCachedRscResponseTtlMs(
+  cached: Pick<CachedRscResponse, "dynamicStaleTimeSeconds">,
+  fallbackTtlMs: number,
+): number {
+  const seconds = cached.dynamicStaleTimeSeconds;
+  if (!isDynamicStaleTimeSeconds(seconds)) {
+    return fallbackTtlMs;
+  }
+  return seconds * 1000;
+}
+
+export function resolveCachedRscResponseExpiresAt(
+  timestamp: number,
+  cached: Pick<CachedRscResponse, "dynamicStaleTimeSeconds" | "expiresAt">,
+  fallbackTtlMs: number,
+): number {
+  if (isCacheExpiresAt(cached.expiresAt)) {
+    return cached.expiresAt;
+  }
+  return timestamp + resolveCachedRscResponseTtlMs(cached, fallbackTtlMs);
+}
+
+function resolvePrefetchCacheEntryExpiresAt(entry: PrefetchCacheEntry): number {
+  if (entry.expiresAt !== undefined) return entry.expiresAt;
+  if (entry.snapshot) {
+    return resolveCachedRscResponseExpiresAt(entry.timestamp, entry.snapshot, PREFETCH_CACHE_TTL);
+  }
+  return entry.timestamp + PREFETCH_CACHE_TTL;
+}
+
+export function resolvePrefetchCacheEntryMountedSlotsHeader(
+  entry: PrefetchCacheEntry,
+): string | null {
+  if (entry.mountedSlotsHeader !== undefined) return entry.mountedSlotsHeader;
+  return entry.snapshot?.mountedSlotsHeader ?? null;
+}
+
+function normalizeRscCacheLookupUrl(rscUrl: string): string | null {
+  try {
+    const url = new URL(rscUrl, "http://vinext.local");
+    stripRscCacheBustingSearchParam(url);
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
+function parsePrefetchCacheKey(cacheKey: string): {
+  interceptionContext: string | null;
+  rscUrl: string;
+} {
+  const separatorIndex = cacheKey.indexOf("\0");
+  if (separatorIndex === -1) {
+    return { interceptionContext: null, rscUrl: cacheKey };
+  }
+  return {
+    interceptionContext: cacheKey.slice(separatorIndex + 1),
+    rscUrl: cacheKey.slice(0, separatorIndex),
+  };
+}
+
+function isPrefetchCacheEntryCompatibleWithMountedSlots(
+  entry: PrefetchCacheEntry,
+  mountedSlotsHeader: string | null,
+): boolean {
+  if (resolvePrefetchCacheEntryMountedSlotsHeader(entry) === mountedSlotsHeader) {
+    return true;
+  }
+  return (entry.snapshot?.mountedSlotsHeader ?? null) === mountedSlotsHeader;
+}
+
+function findPrefetchCacheEntryForNavigation(
+  rscUrl: string,
+  interceptionContext: string | null,
+  mountedSlotsHeader: string | null,
+): { cacheKey: string; entry: PrefetchCacheEntry } | null {
+  const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+  const cache = getPrefetchCache();
+  const exactEntry = cache.get(exactCacheKey);
+  if (
+    exactEntry &&
+    exactEntry.cacheForNavigation !== false &&
+    isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
+  ) {
+    return { cacheKey: exactCacheKey, entry: exactEntry };
+  }
+
+  const normalizedTarget = normalizeRscCacheLookupUrl(rscUrl);
+  if (normalizedTarget === null) return null;
+
+  for (const [cacheKey, entry] of cache) {
+    if (cacheKey === exactCacheKey) continue;
+    if (entry.cacheForNavigation === false) continue;
+
+    const source = parsePrefetchCacheKey(cacheKey);
+    if (source.interceptionContext !== interceptionContext) continue;
+    if (normalizeRscCacheLookupUrl(source.rscUrl) !== normalizedTarget) continue;
+    if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) continue;
+
+    return { cacheKey, entry };
+  }
+
+  return null;
+}
+
+export function hasPrefetchCacheEntryForNavigation(
+  rscUrl: string,
+  interceptionContext: string | null = null,
+  mountedSlotsHeader: string | null = null,
+): boolean {
+  const match = findPrefetchCacheEntryForNavigation(
+    rscUrl,
+    interceptionContext,
+    mountedSlotsHeader,
+  );
+  if (match === null) return false;
+
+  if (match.entry.pending !== undefined) return true;
+  if (resolvePrefetchCacheEntryExpiresAt(match.entry) > Date.now()) return true;
+
+  deletePrefetchCacheEntry(
+    getPrefetchCache(),
+    getPrefetchedUrls(),
+    match.cacheKey,
+    match.entry,
+    true,
+  );
+  return false;
+}
+
 /**
  * Evict prefetch cache entries if at capacity.
  * First sweeps expired entries, then falls back to FIFO eviction.
@@ -492,7 +647,7 @@ function evictPrefetchCacheIfNeeded(): void {
   const prefetched = getPrefetchedUrls();
 
   for (const [key, entry] of cache) {
-    if (now - entry.timestamp >= PREFETCH_CACHE_TTL) {
+    if (resolvePrefetchCacheEntryExpiresAt(entry) <= now) {
       deletePrefetchCacheEntry(cache, prefetched, key, entry, true);
     }
   }
@@ -567,8 +722,7 @@ function schedulePrefetchInvalidation(cacheKey: string, entry: PrefetchCacheEntr
   if (entry.onInvalidateCallbacks === undefined || entry.onInvalidateCallbacks.size === 0) return;
 
   clearPrefetchInvalidation(entry);
-  const elapsed = Date.now() - entry.timestamp;
-  const delay = Math.max(0, PREFETCH_CACHE_TTL - elapsed);
+  const delay = Math.max(0, resolvePrefetchCacheEntryExpiresAt(entry) - Date.now());
   entry.invalidationTimer = setTimeout(() => {
     invalidatePrefetchCacheEntry(cacheKey);
   }, delay);
@@ -635,13 +789,20 @@ export function storePrefetchResponse(
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   evictPrefetchCacheIfNeeded();
   const entry: PrefetchCacheEntry = {
+    mountedSlotsHeader: null,
     outcome: "pending",
     timestamp: Date.now(),
   };
   addPrefetchInvalidationCallback(entry, options?.onInvalidate);
   entry.pending = snapshotRscResponse(response)
     .then((snapshot) => {
+      entry.mountedSlotsHeader = snapshot.mountedSlotsHeader ?? null;
       entry.snapshot = snapshot;
+      entry.expiresAt = resolveCachedRscResponseExpiresAt(
+        entry.timestamp,
+        snapshot,
+        PREFETCH_CACHE_TTL,
+      );
     })
     .catch(() => {
       deletePrefetchCacheEntry(getPrefetchCache(), getPrefetchedUrls(), cacheKey, entry, false);
@@ -661,10 +822,14 @@ export function createCachedRscResponseSnapshot(
   buffer: ArrayBuffer,
   responseUrl: string | null = null,
 ): CachedRscResponse {
+  const dynamicStaleTimeSeconds = parseDynamicStaleTimeSeconds(
+    response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER),
+  );
   return {
     compatibilityIdHeader: response.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
     buffer,
     contentType: response.headers.get("content-type") ?? VINEXT_RSC_CONTENT_TYPE,
+    ...(dynamicStaleTimeSeconds !== undefined ? { dynamicStaleTimeSeconds } : {}),
     mountedSlotsHeader: response.headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
     paramsHeader: response.headers.get(VINEXT_PARAMS_HEADER),
     url: responseUrl ?? response.url,
@@ -702,6 +867,9 @@ export function restoreRscResponse(cached: CachedRscResponse, copy = true): Resp
   if (cached.compatibilityIdHeader != null) {
     headers.set(VINEXT_RSC_COMPATIBILITY_ID_HEADER, cached.compatibilityIdHeader);
   }
+  if (isDynamicStaleTimeSeconds(cached.dynamicStaleTimeSeconds)) {
+    headers.set(VINEXT_DYNAMIC_STALE_TIME_HEADER, String(cached.dynamicStaleTimeSeconds));
+  }
   if (cached.paramsHeader != null) {
     headers.set(VINEXT_PARAMS_HEADER, cached.paramsHeader);
   }
@@ -734,6 +902,7 @@ export function prefetchRscResponse(
 
   const entry: PrefetchCacheEntry = {
     cacheForNavigation: behavior.cacheForNavigation ?? true,
+    mountedSlotsHeader,
     optimisticRouteShell: behavior.optimisticRouteShell === true,
     outcome: "pending",
     timestamp: now,
@@ -743,12 +912,12 @@ export function prefetchRscResponse(
   entry.pending = fetchPromise
     .then(async (response) => {
       if (response.ok) {
-        entry.snapshot = {
-          ...(await snapshotRscResponse(response)),
-          // Prefetch compatibility is defined by the slot context at fetch
-          // time, not by whatever header a reused response happens to carry.
-          mountedSlotsHeader,
-        };
+        entry.snapshot = await snapshotRscResponse(response);
+        entry.expiresAt = resolveCachedRscResponseExpiresAt(
+          entry.timestamp,
+          entry.snapshot,
+          PREFETCH_CACHE_TTL,
+        );
       } else {
         deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);
       }
@@ -781,10 +950,24 @@ export function consumePrefetchResponse(
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
 ): CachedRscResponse | null {
-  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
-  const entry = cache.get(cacheKey);
-  if (!entry) return null;
+  const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+  const exactEntry = cache.get(exactCacheKey);
+  if (
+    exactEntry &&
+    exactEntry.cacheForNavigation !== false &&
+    !isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
+  ) {
+    deletePrefetchCacheEntry(cache, getPrefetchedUrls(), exactCacheKey, exactEntry, false);
+  }
+
+  const match = findPrefetchCacheEntryForNavigation(
+    rscUrl,
+    interceptionContext,
+    mountedSlotsHeader,
+  );
+  if (!match) return null;
+  const { cacheKey, entry } = match;
 
   // Skip in-flight snapshots and error-path residue where pending cleared
   // without a successful transition to a cache-seeded entry.
@@ -794,13 +977,19 @@ export function consumePrefetchResponse(
   deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, false);
 
   if (entry.snapshot) {
-    if ((entry.snapshot.mountedSlotsHeader ?? null) !== mountedSlotsHeader) {
+    if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) {
       // Entry was already removed above. Slot mismatch means the prefetch
       // used stale slot context and cannot be safely reused.
       return null;
     }
-    if (Date.now() - entry.timestamp >= PREFETCH_CACHE_TTL) {
+    if (resolvePrefetchCacheEntryExpiresAt(entry) <= Date.now()) {
       return null;
+    }
+    if (entry.expiresAt !== undefined || entry.snapshot.expiresAt !== undefined) {
+      return {
+        ...entry.snapshot,
+        expiresAt: resolvePrefetchCacheEntryExpiresAt(entry),
+      };
     }
     return entry.snapshot;
   }
@@ -825,11 +1014,14 @@ export async function consumePrefetchResponseForNavigation(
   mountedSlotsHeader: string | null = null,
   options?: ConsumePrefetchResponseForNavigationOptions,
 ): Promise<CachedRscResponse | null> {
-  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
-  const entry = cache.get(cacheKey);
-  if (!entry) return null;
-  if (entry.cacheForNavigation === false) return null;
+  const match = findPrefetchCacheEntryForNavigation(
+    rscUrl,
+    interceptionContext,
+    mountedSlotsHeader,
+  );
+  if (!match) return null;
+  const { cacheKey, entry } = match;
 
   if (entry.pending !== undefined) {
     await entry.pending.catch(() => {});
@@ -1361,7 +1553,6 @@ export function commitClientNavigationState(
 
   if (shouldNotify) {
     notifyNavigationListeners();
-    getNavigationRuntime()?.functions.pingVisibleLinks?.();
   }
 }
 

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -228,13 +228,17 @@ declare module "next/navigation" {
     compatibilityIdHeader?: string | null;
     buffer: ArrayBuffer;
     contentType: string;
+    dynamicStaleTimeSeconds?: number;
+    expiresAt?: number;
     mountedSlotsHeader?: string | null;
     paramsHeader: string | null;
     url: string;
   };
   export type PrefetchCacheEntry = {
     cacheForNavigation?: boolean;
+    expiresAt?: number;
     invalidationTimer?: ReturnType<typeof setTimeout>;
+    mountedSlotsHeader?: string | null;
     onInvalidateCallbacks?: Set<() => void>;
     optimisticRouteShell?: boolean;
     outcome: "pending" | "cache-seeded";
@@ -248,6 +252,14 @@ declare module "next/navigation" {
   export function getPrefetchCache(): Map<string, PrefetchCacheEntry>;
   export function getPrefetchedUrls(): Set<string>;
   export function invalidatePrefetchCache(): void;
+  export function resolvePrefetchCacheEntryMountedSlotsHeader(
+    entry: PrefetchCacheEntry,
+  ): string | null;
+  export function hasPrefetchCacheEntryForNavigation(
+    rscUrl: string,
+    interceptionContext?: string | null,
+    mountedSlotsHeader?: string | null,
+  ): boolean;
   export function storePrefetchResponse(
     rscUrl: string,
     response: Response,

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -831,18 +831,29 @@ describe("app page render lifecycle", () => {
     await expect(response.text()).resolves.toBe("flight-data");
   });
 
-  it("omits the dynamic stale time header on production default-config renders that turn dynamic", async () => {
-    // Documents the known over-gating at the cache-capture boundary: a production
-    // default-config route (revalidateSeconds === null, not force-dynamic) that
-    // uses a late dynamic API is genuinely dynamic, but shouldCaptureRscForCacheMetadata
-    // is true (computed from config before the stream runs), so the header is omitted.
-    // Next.js would emit it here (!isStaticGeneration); the value is unknowable until
-    // after the headers are built, so the advisory hint is dropped on this NO_STORE
-    // response. See app-page-render.ts gating comment.
+  it("emits the dynamic stale time header on dynamic production default-config RSC responses", async () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+    // The upstream fixture pages export unstable_dynamicStaleTime and call
+    // connection(), so the per-page value is authoritative only once the render
+    // is known to be dynamic.
     const common = createCommonOptions();
     const response = await renderAppPageLifecycle({
       ...common.options,
       consumeDynamicUsage: vi.fn(() => true),
+      dynamicStaleTimeSeconds: 60,
+      isProduction: true,
+      isRscRequest: true,
+      revalidateSeconds: null,
+    });
+    expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBe("60");
+    await expect(response.text()).resolves.toBe("flight-data");
+  });
+
+  it("omits the dynamic stale time header on static production default-config RSC responses", async () => {
+    const common = createCommonOptions();
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeDynamicUsage: vi.fn(() => false),
       dynamicStaleTimeSeconds: 60,
       isProduction: true,
       isRscRequest: true,

--- a/tests/app-visited-response-cache.test.ts
+++ b/tests/app-visited-response-cache.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  MAX_TRAVERSAL_CACHE_TTL,
+  VISITED_RESPONSE_CACHE_TTL,
+  createVisitedResponseCacheEntry,
+  isVisitedResponseCacheEntryFresh,
+} from "../packages/vinext/src/server/app-visited-response-cache.js";
+import type { CachedRscResponse } from "../packages/vinext/src/shims/navigation.js";
+
+function createCachedResponse(overrides: Partial<CachedRscResponse> = {}): CachedRscResponse {
+  return {
+    buffer: new TextEncoder().encode("flight").buffer,
+    contentType: "text/x-component",
+    paramsHeader: null,
+    url: "/dynamic.rsc",
+    ...overrides,
+  };
+}
+
+describe("visited response cache freshness", () => {
+  it("uses per-response dynamic stale time for regular navigations", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+    const now = 1_000_000;
+    const entry = createVisitedResponseCacheEntry({
+      now,
+      params: {},
+      response: createCachedResponse({ dynamicStaleTimeSeconds: 10 }),
+    });
+
+    expect(entry.expiresAt).toBe(now + 10_000);
+    expect(
+      isVisitedResponseCacheEntryFresh(entry, {
+        navigationKind: "navigate",
+        now: now + 9_999,
+      }),
+    ).toBe(true);
+    expect(
+      isVisitedResponseCacheEntryFresh(entry, {
+        navigationKind: "navigate",
+        now: now + 10_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the default visited response TTL without server metadata", () => {
+    const now = 1_000_000;
+    const entry = createVisitedResponseCacheEntry({
+      now,
+      params: {},
+      response: createCachedResponse(),
+    });
+
+    expect(entry.expiresAt).toBe(now + VISITED_RESPONSE_CACHE_TTL);
+  });
+
+  it("keeps traversal restores independent from dynamic stale expiry", () => {
+    const now = 1_000_000;
+    const entry = createVisitedResponseCacheEntry({
+      now,
+      params: {},
+      response: createCachedResponse({ dynamicStaleTimeSeconds: 10 }),
+    });
+
+    expect(
+      isVisitedResponseCacheEntryFresh(entry, {
+        navigationKind: "traverse",
+        now: now + 20_000,
+      }),
+    ).toBe(true);
+    expect(
+      isVisitedResponseCacheEntryFresh(entry, {
+        navigationKind: "traverse",
+        now: now + MAX_TRAVERSAL_CACHE_TTL,
+      }),
+    ).toBe(false);
+  });
+
+  it("never reuses visited responses for refresh navigations", () => {
+    const now = 1_000_000;
+    const entry = createVisitedResponseCacheEntry({
+      now,
+      params: {},
+      response: createCachedResponse({ dynamicStaleTimeSeconds: 60 }),
+    });
+
+    expect(
+      isVisitedResponseCacheEntryFresh(entry, {
+        navigationKind: "refresh",
+        now,
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1232,6 +1232,48 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("re-prefetches a visible Link when the exact cache entry has gone stale", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    try {
+      // First visibility → initial prefetch
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      // Manually expire the cached entry
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const cache = getPrefetchCache();
+      const now = 1_000_000;
+      for (const [, entry] of cache) {
+        entry.expiresAt = now - 1;
+      }
+
+      vi.spyOn(Date, "now").mockReturnValue(now);
+
+      // Ping visible links again; the stale exact entry should be deleted and re-fetched
+      pingVisibleLinksFromRuntime();
+      await waitForFetchCalls(result.fetch, 2);
+
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[1],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("prefetches visible dynamic links in automatic production mode without seeding navigation cache", async () => {
     const observer = stubIntersectionObserver();
 

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -12,6 +12,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
 import { AppElementsWire } from "../packages/vinext/src/server/app-elements.js";
 import { VINEXT_RSC_COMPATIBILITY_ID_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import {
+  VINEXT_DYNAMIC_STALE_TIME_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 
 type Navigation = typeof import("../packages/vinext/src/shims/navigation.js");
 let storePrefetchResponse: Navigation["storePrefetchResponse"];
@@ -25,6 +29,7 @@ let snapshotRscResponse: Navigation["snapshotRscResponse"];
 let restoreRscResponse: Navigation["restoreRscResponse"];
 let prefetchRscResponse: Navigation["prefetchRscResponse"];
 let invalidatePrefetchCache: Navigation["invalidatePrefetchCache"];
+let hasPrefetchCacheEntryForNavigation: Navigation["hasPrefetchCacheEntryForNavigation"];
 let appRouterInstance: Navigation["appRouterInstance"];
 let consumePrefetchResponseForNavigation: Navigation["consumePrefetchResponseForNavigation"];
 
@@ -57,6 +62,7 @@ beforeEach(async () => {
   restoreRscResponse = nav.restoreRscResponse;
   prefetchRscResponse = nav.prefetchRscResponse;
   invalidatePrefetchCache = nav.invalidatePrefetchCache;
+  hasPrefetchCacheEntryForNavigation = nav.hasPrefetchCacheEntryForNavigation;
   appRouterInstance = nav.appRouterInstance;
   consumePrefetchResponseForNavigation = nav.consumePrefetchResponseForNavigation;
 });
@@ -234,6 +240,65 @@ describe("prefetch cache eviction", () => {
     expect(prefetched.has(rscUrl)).toBe(false);
   });
 
+  it("preserves server mounted-slot metadata separately from prefetch request context", async () => {
+    const rscUrl = "/parallel-slots.rsc";
+    const responseMountedSlotsHeader = "slot:slotA:/parallel-slots slot:slotB:/parallel-slots";
+
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("flight", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_MOUNTED_SLOTS_HEADER]: responseMountedSlotsHeader,
+          },
+        }),
+      ),
+      null,
+      null,
+    );
+
+    await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
+
+    const entry = getPrefetchCache().get(rscUrl);
+    expect(entry?.mountedSlotsHeader).toBeNull();
+
+    const consumed = consumePrefetchResponse(rscUrl, null, null);
+    expect(consumed?.mountedSlotsHeader).toBe(responseMountedSlotsHeader);
+  });
+
+  it("matches equivalent RSC cache variants by server-declared mounted slots", () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const originalRscUrl = "/parallel-slots.rsc?_rsc";
+    const mountedVariantRscUrl = "/parallel-slots.rsc?_rsc=mounted-slot-hash";
+    const mountedSlotsHeader = "slot:slotA:/parallel-slots slot:slotB:/parallel-slots";
+    const snapshot = {
+      buffer: new TextEncoder().encode("parallel-flight").buffer,
+      contentType: "text/x-component",
+      mountedSlotsHeader,
+      paramsHeader: null,
+      url: originalRscUrl,
+    };
+
+    cache.set(originalRscUrl, {
+      mountedSlotsHeader: null,
+      outcome: "cache-seeded",
+      snapshot,
+      timestamp: Date.now(),
+    });
+    prefetched.add(originalRscUrl);
+
+    expect(hasPrefetchCacheEntryForNavigation(mountedVariantRscUrl, null, mountedSlotsHeader)).toBe(
+      true,
+    );
+    expect(consumePrefetchResponse(mountedVariantRscUrl, null, mountedSlotsHeader)).toEqual(
+      snapshot,
+    );
+    expect(cache.has(originalRscUrl)).toBe(false);
+    expect(prefetched.has(originalRscUrl)).toBe(false);
+  });
+
   it("keeps learning-only prefetch responses out of navigation consumption", () => {
     const cache = getPrefetchCache();
     const prefetched = getPrefetchedUrls();
@@ -280,6 +345,7 @@ describe("prefetch cache eviction", () => {
       headers: {
         "content-type": "text/x-component",
         [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "compat-a",
+        [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "60",
         "x-vinext-params": encodeURIComponent('{"id":"2"}'),
       },
     });
@@ -287,8 +353,10 @@ describe("prefetch cache eviction", () => {
     const snapshot = await snapshotRscResponse(response);
     const restored = restoreRscResponse(snapshot);
 
+    expect(snapshot.dynamicStaleTimeSeconds).toBe(60);
     expect(restored.headers.get("content-type")).toBe("text/x-component");
     expect(restored.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
+    expect(restored.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBe("60");
     expect(restored.headers.get("x-vinext-params")).toBe(encodeURIComponent('{"id":"2"}'));
     await expect(restored.text()).resolves.toBe("flight");
   });
@@ -559,6 +627,101 @@ describe("prefetch cache eviction", () => {
       vi.spyOn(Date, "now").mockReturnValue(now + 200_000);
       expect(nav.consumePrefetchResponse(rscUrl, null, null)).toBeNull();
     });
+  });
+
+  it("uses per-response dynamic stale windows when consuming prefetched responses", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const now = 1_000_000;
+    const snapshot60 = {
+      buffer: new TextEncoder().encode("dynamic-60").buffer,
+      contentType: "text/x-component",
+      dynamicStaleTimeSeconds: 60,
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: "/dynamic-stale-60.rsc",
+    };
+    const snapshot10 = {
+      buffer: new TextEncoder().encode("dynamic-10").buffer,
+      contentType: "text/x-component",
+      dynamicStaleTimeSeconds: 10,
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: "/dynamic-stale-10.rsc",
+    };
+
+    cache.set(snapshot60.url, { outcome: "cache-seeded", snapshot: snapshot60, timestamp: now });
+    cache.set(snapshot10.url, { outcome: "cache-seeded", snapshot: snapshot10, timestamp: now });
+    prefetched.add(snapshot60.url);
+    prefetched.add(snapshot10.url);
+
+    vi.spyOn(Date, "now").mockReturnValue(now + 15_000);
+
+    expect(consumePrefetchResponse(snapshot60.url, null, null)).toEqual(snapshot60);
+    expect(consumePrefetchResponse(snapshot10.url, null, null)).toBeNull();
+  });
+
+  it("does not report stale entries as available for Link prefetch dedupe", () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const now = 1_000_000;
+    const rscUrl = "/dynamic-stale-10.rsc";
+    cache.set(rscUrl, {
+      outcome: "cache-seeded",
+      snapshot: {
+        buffer: new TextEncoder().encode("dynamic-10").buffer,
+        contentType: "text/x-component",
+        dynamicStaleTimeSeconds: 10,
+        mountedSlotsHeader: null,
+        paramsHeader: null,
+        url: rscUrl,
+      },
+      timestamp: now,
+    });
+    prefetched.add(rscUrl);
+
+    vi.spyOn(Date, "now").mockReturnValue(now + 10_000);
+
+    expect(hasPrefetchCacheEntryForNavigation(rscUrl, null, null)).toBe(false);
+    expect(getPrefetchCache().has(rscUrl)).toBe(false);
+    expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
+  });
+
+  it("preserves the original expiry when consuming a prefetched response", () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const rscUrl = "/parallel-slots.rsc";
+    const now = 1_000_000;
+    const expiresAt = now + 15_000;
+    const snapshot = {
+      buffer: new TextEncoder().encode("parallel-flight").buffer,
+      contentType: "text/x-component",
+      dynamicStaleTimeSeconds: 15,
+      mountedSlotsHeader: "slot:slotA:/parallel-slots slot:slotB:/parallel-slots",
+      paramsHeader: null,
+      url: rscUrl,
+    };
+
+    cache.set(rscUrl, {
+      expiresAt,
+      mountedSlotsHeader: snapshot.mountedSlotsHeader,
+      outcome: "cache-seeded",
+      snapshot,
+      timestamp: now,
+    });
+    prefetched.add(rscUrl);
+
+    vi.spyOn(Date, "now").mockReturnValue(now + 14_000);
+    const consumed = consumePrefetchResponse(rscUrl, null, snapshot.mountedSlotsHeader);
+    expect(consumed).not.toBeNull();
+    if (consumed === null) {
+      throw new Error("Expected prefetched response to be reusable before its expiry");
+    }
+    expect(consumed?.expiresAt).toBe(expiresAt);
+
+    vi.spyOn(Date, "now").mockReturnValue(now + 16_000);
+    expect(consumePrefetchResponse(rscUrl, null, snapshot.mountedSlotsHeader)).toBeNull();
   });
 
   it("does not sweep when cache is below capacity", () => {


### PR DESCRIPTION
## Overview

| | |
|---|---|
| **Goal** | Make the App Router client cache honor per-response stale-time metadata instead of a single global TTL. |
| **Core change** | RSC snapshots now carry `dynamicStaleTimeSeconds`; prefetch and visited caches compute `expiresAt` per entry; duplicate-prefetch suppression is freshness-aware. |
| **Primary files** | `packages/vinext/src/shims/navigation.ts`, `packages/vinext/src/shims/link.tsx`, `packages/vinext/src/entries/app-browser-entry.ts` |
| **Tests** | `tests/prefetch-cache.test.ts`, `tests/link-navigation.test.ts`, `tests/app-visited-response-cache.test.ts`, `tests/app-page-render.test.ts` |
| **Risk** | Low — scoped to client-side cache expiry; no server contract changes. |

## Why

Next.js treats stale time as response metadata, not a global client TTL. The upstream segment cache computes `staleAt` per entry, and back/forward traversal uses a separate freshness window from normal navigation. Vinext previously used one global `PREFETCH_CACHE_TTL`, so pages with `unstable_dynamicStaleTime = 60` and `unstable_dynamicStaleTime = 10` could not expire independently.

## What changed

| Scenario | Before | After |
|---|---|---|
| Prefetch cache expiry | One global `PREFETCH_CACHE_TTL` for all entries | Per-entry `expiresAt` derived from the response's `dynamicStaleTimeSeconds` or the global fallback |
| Visited RSC response cache | Same global TTL | Preserves `createdAt` and computes per-entry expiry; refresh never reuses visited responses; traversal restore uses traversal window |
| Duplicate prefetch suppression | `prefetched.has(cacheKey)` returned early for any exact match, including stale entries | Freshness-aware: stale exact entries are deleted and re-fetched; equivalent `_rsc` variants are still checked |
| Dynamic stale-time header | Emitted for all responses | Only emitted when the page explicitly exported `unstable_dynamicStaleTime` and the response is known to be dynamic/non-cache-captured; static/default-config responses omit it |
| Visible Link re-prefetch | Lost after the PR removed the old ping | Restored in `BrowserRoot`'s `treeState.elements` effect so persistent visible links re-prefetch when mounted-slot context changes |

## Reviewer path

1. `packages/vinext/src/shims/navigation.ts` — `resolvePrefetchCacheEntryExpiresAt`, `hasPrefetchCacheEntryForNavigation`, `consumePrefetchResponse`, `snapshotRscResponse`/`restoreRscResponse`
2. `packages/vinext/src/shims/link.tsx` — `prefetchUrl` freshness-aware dedupe gate
3. `packages/vinext/src/entries/app-browser-entry.ts` — visited-cache snapshot/restore and traversal window handling

## Tests

- `tests/prefetch-cache.test.ts` — per-response stale window consumption, stale entry deletion by `hasPrefetchCacheEntryForNavigation`, expiry preservation on consumed prefetches
- `tests/link-navigation.test.ts` — visible Link re-prefetch after exact cache entry goes stale
- `tests/app-visited-response-cache.test.ts` — visited-cache replay, refresh bypass, traversal window
- `tests/app-page-render.test.ts` — dynamic stale-time header gating for static vs dynamic responses
- E2E: `tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts`

## Risk / compatibility

- Public API: no changes
- Config: no changes
- Existing apps: safe — static responses still use the existing global TTL as fallback; only dynamic responses with explicit `unstable_dynamicStaleTime` gain per-entry expiry
- Framework parity: closer to Next.js 16 segment-cache staleness behavior

## Non-goals

- Full Segment Cache / route-state parity (the upstream file is broader than this PR's scope)
- Route-instance key plumbing
- DOM form-control snapshotting/restoration
- React `Activity` route boundary
- Viewport-prefetch suppression
- Exact visited-cache proof bypass

## References

- Next.js upstream behavior: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
