### PR TITLE
fix(shims/head): keep charset/viewport defaults on client hydration

### DIFF
--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -417,25 +417,69 @@ export function _applyHeadPropsToElement(
   }
 }
 
-/** @internal — exported for unit tests; called from the Head client effect. */
+/**
+ * Reconcile the document <head> against the desired projection.
+ *
+ * Mirrors Next.js's client `head-manager.ts` `updateElements()`: rather than
+ * wiping every [data-next-head] node and re-appending (which reorders the
+ * SSR-emitted tags to the end of <head> and causes flicker on each update),
+ * we diff the desired tags against the existing ones with isEqualNode(). Tags
+ * that already match are left untouched in their original DOM position, only
+ * genuinely new tags are inserted, and stale tags are removed.
+ *
+ * The desired list seeds defaultHead() (charset + viewport) ahead of user
+ * tags — matching the SSR path in getSSRHeadHTML() and Next.js's
+ * reduceComponents(), which always concatenates defaultHead() on both server
+ * and client. Without it the first <Head> mount after hydration would drop the
+ * server-rendered defaults. Users can still override via key="charset" /
+ * key="viewport" through the dedupe pipeline.
+ *
+ * @internal — exported for unit tests; called from the Head client effect.
+ */
 export function _syncClientHead(): void {
-  document.querySelectorAll("[data-next-head]").forEach((el) => el.remove());
+  const headEl = document.head;
+  if (!headEl) return;
 
-  // Seed defaultHead() (charset + viewport) ahead of user tags, mirroring the
-  // SSR path in getSSRHeadHTML() and Next.js's reduceComponents() (which always
-  // concatenates defaultHead()). Without this, the first <Head> mount after
-  // hydration would strip the server-rendered defaults — which carry
-  // data-next-head="" — and never re-add them. Users can still override via
-  // key="charset" / key="viewport" because they win in the dedupe pipeline.
+  // Existing vinext-managed tags. Also fold in any <meta charset> even if it
+  // somehow lost the marker, so we never end up with a duplicate charset.
+  const oldTags = new Set<Element>(headEl.querySelectorAll("[data-next-head]"));
+  const charsetEl = headEl.querySelector("meta[charset]");
+  if (charsetEl) oldTags.add(charsetEl);
+
+  const newTags: Element[] = [];
   for (const child of reduceHeadChildren([...defaultHead(), ..._clientHeadChildren.values()])) {
     if (typeof child.type !== "string") continue;
 
     const domEl = document.createElement(child.type);
-    const props = child.props as Record<string, unknown>;
-    _applyHeadPropsToElement(domEl, props);
-
+    _applyHeadPropsToElement(domEl, child.props as Record<string, unknown>);
     domEl.setAttribute("data-next-head", "");
-    document.head.appendChild(domEl);
+
+    // Reuse an identical node already in <head> so its DOM position (and thus
+    // the head ordering produced by SSR) is preserved.
+    let isNew = true;
+    for (const oldTag of oldTags) {
+      if (oldTag.isEqualNode(domEl)) {
+        oldTags.delete(oldTag);
+        isNew = false;
+        break;
+      }
+    }
+    if (isNew) newTags.push(domEl);
+  }
+
+  // Remove tags that are no longer desired.
+  for (const oldTag of oldTags) {
+    oldTag.parentNode?.removeChild(oldTag);
+  }
+
+  // Insert genuinely new tags. Keep <meta charset> first in <head> so the
+  // declared encoding stays at the top, matching Next.js.
+  for (const newTag of newTags) {
+    if (newTag.tagName.toLowerCase() === "meta" && newTag.getAttribute("charset") !== null) {
+      headEl.prepend(newTag);
+    } else {
+      headEl.appendChild(newTag);
+    }
   }
 }
 

--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -456,6 +456,13 @@ export function _syncClientHead(): void {
 
     // Reuse an identical node already in <head> so its DOM position (and thus
     // the head ordering produced by SSR) is preserved.
+    //
+    // Note: Next.js routes <title> through document.title rather than
+    // updateElements(), so a title node never moves. We reconcile <title> like
+    // any other tag — on hydration with an unchanged title it is reused in
+    // place via isEqualNode (the common case), and only on a client-side title
+    // *change* does the old node get removed and the new one appended. The
+    // position of <title> in <head> is not observable, so this is cosmetic.
     let isNew = true;
     for (const oldTag of oldTags) {
       if (oldTag.isEqualNode(domEl)) {
@@ -473,7 +480,15 @@ export function _syncClientHead(): void {
   }
 
   // Insert genuinely new tags. Keep <meta charset> first in <head> so the
-  // declared encoding stays at the top, matching Next.js.
+  // declared encoding stays at the top.
+  //
+  // This deliberately diverges from Next.js's literal head-manager.ts, which
+  // does `if (charset) headEl.prepend(newTag)` with NO `else` and then
+  // unconditionally `headEl.appendChild(newTag)` — moving a newly-created
+  // charset node twice and landing it last. We use a proper if/else so a new
+  // charset is prepended and only prepended. Don't "fix" this back to match
+  // Next.js's sequence. (This branch only runs on client-only navigation; on
+  // SSR hydration the charset is reused in place via isEqualNode above.)
   for (const newTag of newTags) {
     if (newTag.tagName.toLowerCase() === "meta" && newTag.getAttribute("charset") !== null) {
       headEl.prepend(newTag);

--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -19,7 +19,8 @@ type HeadProps = {
 
 let _ssrHeadChildren: React.ReactNode[] = [];
 let _documentInitialHead: React.ReactNode[] = [];
-const _clientHeadChildren = new Map<symbol, React.ReactNode>();
+/** @internal — exposed for unit tests of the client head projection. */
+export const _clientHeadChildren = new Map<symbol, React.ReactNode>();
 
 let _getSSRHeadChildren = (): React.ReactNode[] => _ssrHeadChildren;
 let _resetSSRHeadImpl = (): void => {
@@ -416,10 +417,17 @@ export function _applyHeadPropsToElement(
   }
 }
 
-function syncClientHead(): void {
+/** @internal — exported for unit tests; called from the Head client effect. */
+export function _syncClientHead(): void {
   document.querySelectorAll("[data-next-head]").forEach((el) => el.remove());
 
-  for (const child of reduceHeadChildren([..._clientHeadChildren.values()])) {
+  // Seed defaultHead() (charset + viewport) ahead of user tags, mirroring the
+  // SSR path in getSSRHeadHTML() and Next.js's reduceComponents() (which always
+  // concatenates defaultHead()). Without this, the first <Head> mount after
+  // hydration would strip the server-rendered defaults — which carry
+  // data-next-head="" — and never re-add them. Users can still override via
+  // key="charset" / key="viewport" because they win in the dedupe pipeline.
+  for (const child of reduceHeadChildren([...defaultHead(), ..._clientHeadChildren.values()])) {
     if (typeof child.type !== "string") continue;
 
     const domEl = document.createElement(child.type);
@@ -450,11 +458,11 @@ function Head({ children }: HeadProps): null {
   useEffect(() => {
     const instanceId = headInstanceIdRef.current!;
     _clientHeadChildren.set(instanceId, children);
-    syncClientHead();
+    _syncClientHead();
 
     return () => {
       _clientHeadChildren.delete(instanceId);
-      syncClientHead();
+      _syncClientHead();
     };
   }, [children]);
 

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -717,65 +717,88 @@ describe("Head _document.getInitialProps() merge (issue #1569)", () => {
   });
 });
 
-// ─── client hydration sync keeps defaults (issue #1569 regression) ─────────
+// ─── client hydration sync keeps defaults & order (issue #1569 regression) ──
 //
-// On the client, the first <Head> mount runs _syncClientHead(), which removes
-// every [data-next-head] element (including the server-rendered charset /
-// viewport defaults) and rebuilds the projection. If the client reduce does
-// not seed defaultHead() — like the SSR path does — the charset and viewport
-// meta tags vanish after hydration. This mirrors Next.js's reduceComponents(),
-// which always concatenates defaultHead() on both server and client.
+// On the client, the first <Head> mount runs _syncClientHead(). It must:
+//   1. keep the server-rendered charset / viewport defaults (which carry
+//      data-next-head="") — they must not vanish after hydration, and
+//   2. reconcile in place (diff via isEqualNode) rather than wipe-and-rebuild,
+//      so SSR head ordering is preserved and <meta charset> stays first.
+// This mirrors Next.js's reduceComponents() (always seeds defaultHead()) and
+// head-manager.ts updateElements() (in-place reconciliation).
 
-describe("Head client sync keeps defaults after hydration (issue #1569)", () => {
+describe("Head client sync (defaults + order, issue #1569)", () => {
   // Minimal DOM double — the repo has no jsdom/happy-dom. Only the surface
   // _syncClientHead() touches is implemented.
   class FakeElement {
     attributes = new Map<string, string>();
     innerHTML = "";
     textContent = "";
-    constructor(
-      public tagName: string,
-      private readonly onRemove: (el: FakeElement) => void,
-    ) {}
+    parentNode: FakeHead | null = null;
+    constructor(public readonly tagName: string) {}
     setAttribute(name: string, value: string): void {
       this.attributes.set(name, value);
+    }
+    getAttribute(name: string): string | null {
+      return this.attributes.has(name) ? this.attributes.get(name)! : null;
     }
     hasAttribute(name: string): boolean {
       return this.attributes.has(name);
     }
-    remove(): void {
-      this.onRemove(this);
+    isEqualNode(other: unknown): boolean {
+      if (!(other instanceof FakeElement)) return false;
+      if (this.tagName.toLowerCase() !== other.tagName.toLowerCase()) return false;
+      if (this.attributes.size !== other.attributes.size) return false;
+      for (const [k, v] of this.attributes) {
+        if (other.attributes.get(k) !== v) return false;
+      }
+      return this.textContent === other.textContent && this.innerHTML === other.innerHTML;
+    }
+  }
+
+  class FakeHead {
+    children: FakeElement[] = [];
+    appendChild(el: FakeElement): void {
+      el.parentNode?.removeChild(el);
+      el.parentNode = this;
+      this.children.push(el);
+    }
+    prepend(el: FakeElement): void {
+      el.parentNode?.removeChild(el);
+      el.parentNode = this;
+      this.children.unshift(el);
+    }
+    removeChild(el: FakeElement): void {
+      const idx = this.children.indexOf(el);
+      if (idx >= 0) this.children.splice(idx, 1);
+      el.parentNode = null;
+    }
+    querySelectorAll(selector: string): FakeElement[] {
+      if (selector !== "[data-next-head]") return [];
+      return this.children.filter((el) => el.hasAttribute("data-next-head"));
+    }
+    querySelector(selector: string): FakeElement | null {
+      if (selector !== "meta[charset]") return null;
+      return (
+        this.children.find(
+          (el) => el.tagName.toLowerCase() === "meta" && el.hasAttribute("charset"),
+        ) ?? null
+      );
     }
   }
 
   function installFakeDocument(): {
     restore: () => void;
-    headChildren: FakeElement[];
+    head: FakeHead;
     createElement: (tag: string) => FakeElement;
   } {
-    const headChildren: FakeElement[] = [];
-    const removeChild = (el: FakeElement) => {
-      const idx = headChildren.indexOf(el);
-      if (idx >= 0) headChildren.splice(idx, 1);
-    };
-    const createElement = (tag: string) => new FakeElement(tag, removeChild);
-    const fakeDocument = {
-      createElement,
-      querySelectorAll: (selector: string) => {
-        if (selector !== "[data-next-head]") return [];
-        // Return a snapshot so .remove() during iteration is safe.
-        return headChildren.filter((el) => el.hasAttribute("data-next-head"));
-      },
-      head: {
-        appendChild: (el: FakeElement) => {
-          headChildren.push(el);
-        },
-      },
-    };
+    const head = new FakeHead();
+    const createElement = (tag: string) => new FakeElement(tag);
+    const fakeDocument = { createElement, head };
     const prevDocument = (globalThis as Record<string, unknown>).document;
     (globalThis as Record<string, unknown>).document = fakeDocument;
     return {
-      headChildren,
+      head,
       createElement,
       restore: () => {
         (globalThis as Record<string, unknown>).document = prevDocument;
@@ -783,58 +806,145 @@ describe("Head client sync keeps defaults after hydration (issue #1569)", () => 
     };
   }
 
+  // Build a server-rendered <head> matching what SSR emits for the example:
+  // charset, viewport, title (all data-next-head), followed by a modulepreload
+  // link that is NOT vinext-managed.
+  function seedServerHead(head: FakeHead, createElement: (tag: string) => FakeElement) {
+    const charset = createElement("meta");
+    charset.setAttribute("charset", "utf-8");
+    charset.setAttribute("data-next-head", "");
+    const viewport = createElement("meta");
+    viewport.setAttribute("name", "viewport");
+    viewport.setAttribute("content", "width=device-width");
+    viewport.setAttribute("data-next-head", "");
+    const title = createElement("title");
+    title.textContent = "Cloudflare Pages Router";
+    title.setAttribute("data-next-head", "");
+    const modulepreload = createElement("link");
+    modulepreload.setAttribute("rel", "modulepreload");
+    modulepreload.setAttribute("href", "/_next/static/index.js");
+    head.children.push(charset, viewport, title, modulepreload);
+    for (const el of head.children) el.parentNode = head;
+    return { charset, viewport, title, modulepreload };
+  }
+
   beforeEach(() => {
     _clientHeadChildren.clear();
   });
 
-  it("re-adds charset + viewport defaults alongside user tags on sync", () => {
-    const { headChildren, createElement, restore } = installFakeDocument();
+  it("preserves SSR order and reuses matching nodes (no reorder, no churn)", () => {
+    const { head, createElement, restore } = installFakeDocument();
     try {
-      // Simulate the server-rendered defaults already present in <head>.
-      const serverCharset = createElement("meta");
-      serverCharset.setAttribute("charset", "utf-8");
-      serverCharset.setAttribute("data-next-head", "");
-      const serverViewport = createElement("meta");
-      serverViewport.setAttribute("name", "viewport");
-      serverViewport.setAttribute("data-next-head", "");
-      headChildren.push(serverCharset, serverViewport);
+      const server = seedServerHead(head, createElement);
 
-      // A user <Head> with just a <title> mounts on the client.
-      _clientHeadChildren.set(Symbol("test"), React.createElement("title", null, "Hi"));
+      // The page's <Head> re-declares the same title on the client.
+      _clientHeadChildren.set(
+        Symbol("test"),
+        React.createElement("title", null, "Cloudflare Pages Router"),
+      );
       _syncClientHead();
 
-      // The server-rendered defaults were removed and rebuilt — not duplicated.
-      const byTag = (tag: string) => headChildren.filter((el) => el.tagName === tag);
-      const metas = byTag("meta");
-      expect(metas.filter((el) => el.attributes.get("charset") === "utf-8")).toHaveLength(1);
-      expect(metas.filter((el) => el.attributes.get("name") === "viewport")).toHaveLength(1);
+      // Order is unchanged and the exact same node instances are reused.
+      expect(head.children).toEqual([
+        server.charset,
+        server.viewport,
+        server.title,
+        server.modulepreload,
+      ]);
+      // No duplicate charset/viewport.
+      const metas = head.children.filter((el) => el.tagName === "meta");
+      expect(metas.filter((el) => el.getAttribute("charset") === "utf-8")).toHaveLength(1);
+      expect(metas.filter((el) => el.getAttribute("name") === "viewport")).toHaveLength(1);
+    } finally {
+      restore();
+    }
+  });
 
-      const charset = metas.find((el) => el.attributes.get("charset") === "utf-8");
-      const viewport = metas.find((el) => el.attributes.get("name") === "viewport");
-      const title = byTag("title")[0];
+  it("appends genuinely new tags without disturbing existing order", () => {
+    const { head, createElement, restore } = installFakeDocument();
+    try {
+      const server = seedServerHead(head, createElement);
 
-      // Defaults survive the sync and still carry data-next-head.
-      expect(charset).toBeDefined();
-      expect(charset?.attributes.get("data-next-head")).toBe("");
-      expect(viewport).toBeDefined();
-      expect(viewport?.attributes.get("content")).toBe("width=device-width");
-      expect(viewport?.attributes.get("data-next-head")).toBe("");
-      // User tag is present too.
-      expect(title?.textContent).toBe("Hi");
+      _clientHeadChildren.set(
+        Symbol("test"),
+        React.createElement(
+          React.Fragment,
+          null,
+          React.createElement("title", null, "Cloudflare Pages Router"),
+          React.createElement("meta", { name: "description", content: "hi" }),
+        ),
+      );
+      _syncClientHead();
+
+      // Defaults + title kept in place; the new description meta is appended.
+      const description = head.children.find((el) => el.getAttribute("name") === "description");
+      expect(description).toBeDefined();
+      expect(head.children.indexOf(server.charset)).toBe(0);
+      expect(head.children.indexOf(server.viewport)).toBe(1);
+      expect(head.children.indexOf(server.title)).toBe(2);
+      // The new tag lands after the previously-existing children.
+      expect(head.children.indexOf(description!)).toBeGreaterThan(
+        head.children.indexOf(server.modulepreload),
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("removes stale vinext-managed tags that are no longer desired", () => {
+    const { head, createElement, restore } = installFakeDocument();
+    try {
+      seedServerHead(head, createElement);
+      const stale = createElement("meta");
+      stale.setAttribute("name", "stale");
+      stale.setAttribute("data-next-head", "");
+      head.appendChild(stale);
+
+      // Client <Head> declares only the title (defaults come from defaultHead()).
+      _clientHeadChildren.set(
+        Symbol("test"),
+        React.createElement("title", null, "Cloudflare Pages Router"),
+      );
+      _syncClientHead();
+
+      expect(head.children.includes(stale)).toBe(false);
+      // Defaults remain.
+      const metas = head.children.filter((el) => el.tagName === "meta");
+      expect(metas.some((el) => el.getAttribute("charset") === "utf-8")).toBe(true);
+      expect(metas.some((el) => el.getAttribute("name") === "viewport")).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("prepends a newly-created <meta charset> so it stays first", () => {
+    const { head, createElement, restore } = installFakeDocument();
+    try {
+      // <head> has a non-managed script first and no charset yet.
+      const script = createElement("script");
+      script.setAttribute("src", "/a.js");
+      head.appendChild(script);
+
+      _clientHeadChildren.set(Symbol("test"), null);
+      _syncClientHead();
+
+      // defaultHead()'s charset must be prepended ahead of the script.
+      expect(head.children[0]?.tagName).toBe("meta");
+      expect(head.children[0]?.getAttribute("charset")).toBe("utf-8");
     } finally {
       restore();
     }
   });
 
   it("emits defaults even when the client <Head> has no children", () => {
-    const { headChildren, restore } = installFakeDocument();
+    const { head, restore } = installFakeDocument();
     try {
       _clientHeadChildren.set(Symbol("test"), null);
       _syncClientHead();
 
-      const metas = headChildren.filter((el) => el.tagName === "meta");
-      expect(metas.some((el) => el.attributes.get("charset") === "utf-8")).toBe(true);
-      expect(metas.some((el) => el.attributes.get("name") === "viewport")).toBe(true);
+      const metas = head.children.filter((el) => el.tagName === "meta");
+      expect(metas.some((el) => el.getAttribute("charset") === "utf-8")).toBe(true);
+      expect(metas.some((el) => el.getAttribute("name") === "viewport")).toBe(true);
     } finally {
       restore();
     }

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -717,9 +717,11 @@ describe("Head _document.getInitialProps() merge (issue #1569)", () => {
   });
 });
 
-// ─── client hydration sync keeps defaults & order (issue #1569 regression) ──
+// ─── client hydration sync keeps defaults & order (issue #1569 / #1677) ─────
 //
-// On the client, the first <Head> mount runs _syncClientHead(). It must:
+// Underlying issue #1569 was fixed for SSR by #1677; this exercises the client
+// path, which regressed: on the client, the first <Head> mount runs
+// _syncClientHead(). It must:
 //   1. keep the server-rendered charset / viewport defaults (which carry
 //      data-next-head="") — they must not vanish after hydration, and
 //   2. reconcile in place (diff via isEqualNode) rather than wipe-and-rebuild,
@@ -727,7 +729,7 @@ describe("Head _document.getInitialProps() merge (issue #1569)", () => {
 // This mirrors Next.js's reduceComponents() (always seeds defaultHead()) and
 // head-manager.ts updateElements() (in-place reconciliation).
 
-describe("Head client sync (defaults + order, issue #1569)", () => {
+describe("Head client sync (defaults + order, issue #1569 / #1677)", () => {
   // Minimal DOM double — the repo has no jsdom/happy-dom. Only the surface
   // _syncClientHead() touches is implemented.
   class FakeElement {
@@ -931,6 +933,37 @@ describe("Head client sync (defaults + order, issue #1569)", () => {
       // defaultHead()'s charset must be prepended ahead of the script.
       expect(head.children[0]?.tagName).toBe("meta");
       expect(head.children[0]?.getAttribute("charset")).toBe("utf-8");
+    } finally {
+      restore();
+    }
+  });
+
+  it("lets a user key='viewport' override the default viewport on the client", () => {
+    // Mirrors the SSR override test (head.test.ts) on the client path: the
+    // default viewport carries key="viewport", so a user tag with the same key
+    // wins the dedupe in reduceHeadChildren — same precedence as Next.js.
+    const { head, restore } = installFakeDocument();
+    try {
+      _clientHeadChildren.set(
+        Symbol("test"),
+        React.createElement("meta", {
+          name: "viewport",
+          content: "width=500",
+          key: "viewport",
+        }),
+      );
+      _syncClientHead();
+
+      const viewports = head.children.filter(
+        (el) => el.tagName === "meta" && el.getAttribute("name") === "viewport",
+      );
+      // Exactly one viewport, and it is the user's override.
+      expect(viewports).toHaveLength(1);
+      expect(viewports[0]?.getAttribute("content")).toBe("width=500");
+      // The default charset is still emitted alongside the override.
+      expect(
+        head.children.some((el) => el.tagName === "meta" && el.getAttribute("charset") === "utf-8"),
+      ).toBe(true);
     } finally {
       restore();
     }

--- a/tests/head.test.ts
+++ b/tests/head.test.ts
@@ -15,6 +15,8 @@ import Head, {
   reduceHeadChildren,
   setDocumentInitialHead,
   _applyHeadPropsToElement,
+  _syncClientHead,
+  _clientHeadChildren,
 } from "../packages/vinext/src/shims/head.js";
 
 // ─── SSR rendering (mirrors Next.js test/unit/next-head-rendering.test.ts) ──
@@ -712,5 +714,129 @@ describe("Head _document.getInitialProps() merge (issue #1569)", () => {
     resetSSRHead();
 
     expect(getSSRHeadHTML()).not.toContain('name="leaked"');
+  });
+});
+
+// ─── client hydration sync keeps defaults (issue #1569 regression) ─────────
+//
+// On the client, the first <Head> mount runs _syncClientHead(), which removes
+// every [data-next-head] element (including the server-rendered charset /
+// viewport defaults) and rebuilds the projection. If the client reduce does
+// not seed defaultHead() — like the SSR path does — the charset and viewport
+// meta tags vanish after hydration. This mirrors Next.js's reduceComponents(),
+// which always concatenates defaultHead() on both server and client.
+
+describe("Head client sync keeps defaults after hydration (issue #1569)", () => {
+  // Minimal DOM double — the repo has no jsdom/happy-dom. Only the surface
+  // _syncClientHead() touches is implemented.
+  class FakeElement {
+    attributes = new Map<string, string>();
+    innerHTML = "";
+    textContent = "";
+    constructor(
+      public tagName: string,
+      private readonly onRemove: (el: FakeElement) => void,
+    ) {}
+    setAttribute(name: string, value: string): void {
+      this.attributes.set(name, value);
+    }
+    hasAttribute(name: string): boolean {
+      return this.attributes.has(name);
+    }
+    remove(): void {
+      this.onRemove(this);
+    }
+  }
+
+  function installFakeDocument(): {
+    restore: () => void;
+    headChildren: FakeElement[];
+    createElement: (tag: string) => FakeElement;
+  } {
+    const headChildren: FakeElement[] = [];
+    const removeChild = (el: FakeElement) => {
+      const idx = headChildren.indexOf(el);
+      if (idx >= 0) headChildren.splice(idx, 1);
+    };
+    const createElement = (tag: string) => new FakeElement(tag, removeChild);
+    const fakeDocument = {
+      createElement,
+      querySelectorAll: (selector: string) => {
+        if (selector !== "[data-next-head]") return [];
+        // Return a snapshot so .remove() during iteration is safe.
+        return headChildren.filter((el) => el.hasAttribute("data-next-head"));
+      },
+      head: {
+        appendChild: (el: FakeElement) => {
+          headChildren.push(el);
+        },
+      },
+    };
+    const prevDocument = (globalThis as Record<string, unknown>).document;
+    (globalThis as Record<string, unknown>).document = fakeDocument;
+    return {
+      headChildren,
+      createElement,
+      restore: () => {
+        (globalThis as Record<string, unknown>).document = prevDocument;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    _clientHeadChildren.clear();
+  });
+
+  it("re-adds charset + viewport defaults alongside user tags on sync", () => {
+    const { headChildren, createElement, restore } = installFakeDocument();
+    try {
+      // Simulate the server-rendered defaults already present in <head>.
+      const serverCharset = createElement("meta");
+      serverCharset.setAttribute("charset", "utf-8");
+      serverCharset.setAttribute("data-next-head", "");
+      const serverViewport = createElement("meta");
+      serverViewport.setAttribute("name", "viewport");
+      serverViewport.setAttribute("data-next-head", "");
+      headChildren.push(serverCharset, serverViewport);
+
+      // A user <Head> with just a <title> mounts on the client.
+      _clientHeadChildren.set(Symbol("test"), React.createElement("title", null, "Hi"));
+      _syncClientHead();
+
+      // The server-rendered defaults were removed and rebuilt — not duplicated.
+      const byTag = (tag: string) => headChildren.filter((el) => el.tagName === tag);
+      const metas = byTag("meta");
+      expect(metas.filter((el) => el.attributes.get("charset") === "utf-8")).toHaveLength(1);
+      expect(metas.filter((el) => el.attributes.get("name") === "viewport")).toHaveLength(1);
+
+      const charset = metas.find((el) => el.attributes.get("charset") === "utf-8");
+      const viewport = metas.find((el) => el.attributes.get("name") === "viewport");
+      const title = byTag("title")[0];
+
+      // Defaults survive the sync and still carry data-next-head.
+      expect(charset).toBeDefined();
+      expect(charset?.attributes.get("data-next-head")).toBe("");
+      expect(viewport).toBeDefined();
+      expect(viewport?.attributes.get("content")).toBe("width=device-width");
+      expect(viewport?.attributes.get("data-next-head")).toBe("");
+      // User tag is present too.
+      expect(title?.textContent).toBe("Hi");
+    } finally {
+      restore();
+    }
+  });
+
+  it("emits defaults even when the client <Head> has no children", () => {
+    const { headChildren, restore } = installFakeDocument();
+    try {
+      _clientHeadChildren.set(Symbol("test"), null);
+      _syncClientHead();
+
+      const metas = headChildren.filter((el) => el.tagName === "meta");
+      expect(metas.some((el) => el.attributes.get("charset") === "utf-8")).toBe(true);
+      expect(metas.some((el) => el.attributes.get("name") === "viewport")).toBe(true);
+    } finally {
+      restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1677. The Pages Router charset/viewport `<meta>` tags render correctly on the server but behave incorrectly after client hydration on the live deployment (https://pages-router-cloudflare.vinext.workers.dev/). Two related problems in `next/head`'s client sync (`syncClientHead`):

1. **Defaults disappeared after hydration.** PR #1677 seeded `defaultHead()` (charset + viewport) into the **SSR** collector (`getSSRHeadHTML`) but not the client path. The client did `document.querySelectorAll("[data-next-head]").forEach(el => el.remove())` then re-added only the user `<Head>` children — so the server-rendered charset + viewport (which carry `data-next-head=""`) got stripped and never re-added.

2. **Tag order changed + DOM churn.** Even with the defaults re-added, the destructive remove-all + append-all approach moved the surviving tags to the *end* of `<head>` (after the modulepreload/script links the server placed after them) and rebuilt every node on each `<Head>` update, causing flicker.

Next.js handles both correctly:
- [`reduceComponents()`](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/head.tsx) **always** concatenates `defaultHead()` on both server and client.
- [`head-manager.ts` `updateElements()`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/head-manager.ts) **reconciles in place**: diffs desired tags against existing `[data-next-head]` nodes via `isEqualNode()`, leaves matches untouched in their original position, appends only new tags, removes stale ones, and prepends `<meta charset>` to keep it first.

## Fix

`_syncClientHead` now:
- Seeds `defaultHead()` into the client reduce, mirroring the SSR path (charset + viewport survive hydration; users can still override via `key="charset"` / `key="viewport"` through the dedupe pipeline).
- Reconciles in place via `isEqualNode()` instead of wipe-and-rebuild — preserving SSR head ordering, avoiding flicker, and keeping `<meta charset>` first.

## Test plan

- [x] New regression tests in `tests/head.test.ts` exercise the client projection with a minimal DOM double (the repo has no jsdom). They cover: defaults surviving hydration, SSR order preservation + node reuse, appending new tags, removing stale tags, and charset-first prepend.
- [x] `vp test run tests/head.test.ts` (52 passed)
- [x] `vp test run tests/shims.test.ts tests/pages-page-response.test.ts tests/document.test.ts` (1042 passed)
- [x] `vp check` (format, lint, types)

## Out of scope

The duplicate charset/viewport meta tags on the App Router example (https://app-router-cloudflare.vinext.workers.dev/) are a **separate, pre-existing** issue — the example's `layout.tsx` manually adds `<meta charSet>`/viewport that vinext auto-injects via the metadata system (since #1317, May 19), not a regression from #1677. Being handled separately.