### PR TITLE
feat(ppr): add PPR fallback-shell render lifecycle tests

### DIFF
--- a/packages/vinext/src/shims/ppr-fallback-shell.ts
+++ b/packages/vinext/src/shims/ppr-fallback-shell.ts
@@ -1,0 +1,229 @@
+import { makeHangingPromise } from "./internal/make-hanging-promise.js";
+import { getOrCreateAls } from "./internal/als-registry.js";
+
+export type PprFallbackShellState = {
+  abortController: AbortController;
+  cacheReadyResolvers: Array<() => void>;
+  fallbackParamNames: ReadonlySet<string>;
+  hasDynamicBoundary: boolean;
+  isAbortScheduled: boolean;
+  pendingCacheReadyCleanup: (() => void) | null;
+  pendingCacheTasks: number;
+  phase: "warmup" | "final";
+  routePattern: string;
+};
+
+type CreatePprFallbackShellStateOptions = {
+  fallbackParamNames: readonly string[];
+  routePattern: string;
+};
+
+type PprFallbackShellCacheTask = {
+  isIgnored: boolean;
+  isPending: boolean;
+};
+
+const pprFallbackShellAls = getOrCreateAls<PprFallbackShellState>("vinext.pprFallbackShell.als");
+const pprFallbackShellCacheTaskStackAls = getOrCreateAls<PprFallbackShellCacheTask[]>(
+  "vinext.pprFallbackShell.cacheTaskStack.als",
+);
+
+function noop(): void {}
+
+function scheduleAfterTask(callback: () => void): () => void {
+  let firstTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+    firstTimer = null;
+    secondTimer = setTimeout(() => {
+      secondTimer = null;
+      callback();
+    }, 0);
+  }, 0);
+  let secondTimer: ReturnType<typeof setTimeout> | null = null;
+
+  return () => {
+    if (firstTimer !== null) {
+      clearTimeout(firstTimer);
+      firstTimer = null;
+    }
+    if (secondTimer !== null) {
+      clearTimeout(secondTimer);
+      secondTimer = null;
+    }
+  };
+}
+
+function resolveCacheReadyIfSettled(state: PprFallbackShellState): void {
+  if (state.pendingCacheTasks !== 0) return;
+
+  const resolvers = state.cacheReadyResolvers.splice(0);
+  for (const resolve of resolvers) {
+    resolve();
+  }
+}
+
+function cancelPendingCacheReady(state: PprFallbackShellState): void {
+  if (state.pendingCacheReadyCleanup === null) return;
+  state.pendingCacheReadyCleanup();
+  state.pendingCacheReadyCleanup = null;
+}
+
+function scheduleCacheReadyIfSettled(state: PprFallbackShellState): void {
+  if (state.pendingCacheTasks !== 0 || state.pendingCacheReadyCleanup !== null) {
+    return;
+  }
+
+  state.pendingCacheReadyCleanup = scheduleAfterTask(() => {
+    state.pendingCacheReadyCleanup = null;
+    resolveCacheReadyIfSettled(state);
+    if (state.phase === "final") {
+      scheduleAbortIfReady(state);
+    }
+  });
+}
+
+function scheduleAbortIfReady(state: PprFallbackShellState): void {
+  if (
+    state.phase !== "final" ||
+    !state.hasDynamicBoundary ||
+    state.pendingCacheTasks > 0 ||
+    state.pendingCacheReadyCleanup !== null ||
+    state.isAbortScheduled
+  ) {
+    return;
+  }
+
+  state.isAbortScheduled = true;
+  scheduleAfterTask(() => {
+    state.isAbortScheduled = false;
+    if (
+      state.phase === "final" &&
+      state.hasDynamicBoundary &&
+      state.pendingCacheTasks === 0 &&
+      state.pendingCacheReadyCleanup === null &&
+      !state.abortController.signal.aborted
+    ) {
+      state.abortController.abort();
+    }
+  });
+}
+
+function completeCacheTask(state: PprFallbackShellState, task: PprFallbackShellCacheTask): void {
+  if (!task.isPending) return;
+  task.isPending = false;
+  state.pendingCacheTasks--;
+  scheduleCacheReadyIfSettled(state);
+}
+
+function ignoreCacheTask(state: PprFallbackShellState, task: PprFallbackShellCacheTask): void {
+  if (!task.isPending || task.isIgnored) return;
+  task.isIgnored = true;
+  completeCacheTask(state, task);
+}
+
+export function createPprFallbackShellState(
+  options: CreatePprFallbackShellStateOptions,
+): PprFallbackShellState {
+  return {
+    abortController: new AbortController(),
+    cacheReadyResolvers: [],
+    fallbackParamNames: new Set(options.fallbackParamNames),
+    hasDynamicBoundary: false,
+    isAbortScheduled: false,
+    pendingCacheReadyCleanup: null,
+    pendingCacheTasks: 0,
+    phase: "warmup",
+    routePattern: options.routePattern,
+  };
+}
+
+export function runWithPprFallbackShellState<T>(state: PprFallbackShellState, fn: () => T): T {
+  return pprFallbackShellAls.run(state, fn);
+}
+
+export function getPprFallbackShellState(): PprFallbackShellState | null {
+  return pprFallbackShellAls.getStore() ?? null;
+}
+
+export function trackPprFallbackShellCacheTask<T>(
+  fn: () => Promise<T>,
+  cacheVariant: string,
+): Promise<T> {
+  const state = getPprFallbackShellState();
+  if (state === null || cacheVariant === "private") {
+    return fn();
+  }
+
+  cancelPendingCacheReady(state);
+  state.pendingCacheTasks++;
+  const task: PprFallbackShellCacheTask = {
+    isIgnored: false,
+    isPending: true,
+  };
+  const parentStack = pprFallbackShellCacheTaskStackAls.getStore() ?? [];
+  let promise: Promise<T>;
+  try {
+    promise = pprFallbackShellCacheTaskStackAls.run([...parentStack, task], fn);
+  } catch (error) {
+    completeCacheTask(state, task);
+    return Promise.reject(error);
+  }
+
+  return promise.finally(() => {
+    if (!task.isIgnored) {
+      completeCacheTask(state, task);
+    }
+  });
+}
+
+export function createPprFallbackShellSuspensePromise<T>(expression: string): Promise<T> | null {
+  const state = getPprFallbackShellState();
+  if (state === null) return null;
+
+  state.hasDynamicBoundary = true;
+  for (const task of pprFallbackShellCacheTaskStackAls.getStore() ?? []) {
+    ignoreCacheTask(state, task);
+  }
+  if (state.phase === "final") {
+    scheduleCacheReadyIfSettled(state);
+    scheduleAbortIfReady(state);
+  }
+  const promise = makeHangingPromise<T>(
+    state.abortController.signal,
+    state.routePattern,
+    expression,
+  );
+  promise.catch(noop);
+  return promise;
+}
+
+export function waitForPprFallbackShellCacheReady(state: PprFallbackShellState): Promise<void> {
+  if (state.phase !== "warmup") {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    state.cacheReadyResolvers.push(resolve);
+    scheduleCacheReadyIfSettled(state);
+  });
+}
+
+export function preparePprFallbackShellFinalRender(state: PprFallbackShellState): void {
+  cancelPendingCacheReady(state);
+  state.abortController = new AbortController();
+  state.cacheReadyResolvers.length = 0;
+  state.hasDynamicBoundary = false;
+  state.isAbortScheduled = false;
+  state.pendingCacheTasks = 0;
+  state.phase = "final";
+}
+
+export function isPprFallbackShellAbortError(error: unknown): boolean {
+  if (
+    typeof DOMException !== "undefined" &&
+    error instanceof DOMException &&
+    error.name === "AbortError"
+  ) {
+    return true;
+  }
+  return error instanceof Error && error.name === "HangingPromiseRejectionError";
+}

--- a/packages/vinext/src/shims/ppr-fallback-shell.ts
+++ b/packages/vinext/src/shims/ppr-fallback-shell.ts
@@ -3,6 +3,10 @@ import { getOrCreateAls } from "./internal/als-registry.js";
 
 export type PprFallbackShellState = {
   abortController: AbortController;
+  // Incremented on every warmup->final transition so that cache tasks tracked
+  // in an earlier phase no longer touch the (reset) `pendingCacheTasks` counter
+  // when they settle late.
+  cacheEpoch: number;
   cacheReadyResolvers: Array<() => void>;
   fallbackParamNames: ReadonlySet<string>;
   hasDynamicBoundary: boolean;
@@ -20,6 +24,9 @@ type CreatePprFallbackShellStateOptions = {
 };
 
 type PprFallbackShellCacheTask = {
+  // The `cacheEpoch` the task was created in. A task that settles in a later
+  // epoch (after a warmup->final transition) must not decrement the counter.
+  epoch: number;
   isIgnored: boolean;
   isPending: boolean;
 };
@@ -112,6 +119,11 @@ function scheduleAbortIfReady(state: PprFallbackShellState): void {
 function completeCacheTask(state: PprFallbackShellState, task: PprFallbackShellCacheTask): void {
   if (!task.isPending) return;
   task.isPending = false;
+  // A task created in an earlier epoch was already accounted for when
+  // `preparePprFallbackShellFinalRender` reset `pendingCacheTasks` to 0, so a
+  // late settle must not decrement the freshly-reset counter below zero (which
+  // would permanently block `resolveCacheReadyIfSettled`).
+  if (task.epoch !== state.cacheEpoch) return;
   state.pendingCacheTasks--;
   scheduleCacheReadyIfSettled(state);
 }
@@ -127,6 +139,7 @@ export function createPprFallbackShellState(
 ): PprFallbackShellState {
   return {
     abortController: new AbortController(),
+    cacheEpoch: 0,
     cacheReadyResolvers: [],
     fallbackParamNames: new Set(options.fallbackParamNames),
     hasDynamicBoundary: false,
@@ -159,6 +172,7 @@ export function trackPprFallbackShellCacheTask<T>(
   cancelPendingCacheReady(state);
   state.pendingCacheTasks++;
   const task: PprFallbackShellCacheTask = {
+    epoch: state.cacheEpoch,
     isIgnored: false,
     isPending: true,
   };
@@ -230,6 +244,9 @@ export function preparePprFallbackShellFinalRender(state: PprFallbackShellState)
     state.pendingAbortCleanup = null;
   }
   state.abortController = new AbortController();
+  // Bump the epoch so any warmup cache task still in flight no longer
+  // decrements the reset counter when it settles.
+  state.cacheEpoch++;
   state.cacheReadyResolvers.length = 0;
   state.hasDynamicBoundary = false;
   state.isAbortScheduled = false;

--- a/packages/vinext/src/shims/ppr-fallback-shell.ts
+++ b/packages/vinext/src/shims/ppr-fallback-shell.ts
@@ -178,16 +178,23 @@ export function trackPprFallbackShellCacheTask<T>(
   });
 }
 
-export function createPprFallbackShellSuspensePromise<T>(expression: string): Promise<T> | null {
-  const state = getPprFallbackShellState();
-  if (state === null) return null;
-
+export function createPprFallbackShellSuspensePromiseForState<T>(
+  state: PprFallbackShellState,
+  expression: string,
+): Promise<T> {
   state.hasDynamicBoundary = true;
   for (const task of pprFallbackShellCacheTaskStackAls.getStore() ?? []) {
     ignoreCacheTask(state, task);
   }
+  // Re-evaluate cache-ready settling even when there is no in-scope cache task
+  // to ignore (e.g. a bare `headers()`/`cookies()` access outside any tracked
+  // cache task). `ignoreCacheTask` only drives `scheduleCacheReadyIfSettled`
+  // when it actually completes a task, so without this call a dynamic boundary
+  // hit with an empty cache-task stack would never re-schedule the warmup
+  // `waitForPprFallbackShellCacheReady` settle. The call is a no-op while
+  // `pendingCacheTasks > 0`, so in-scope work still holds the shell open.
+  scheduleCacheReadyIfSettled(state);
   if (state.phase === "final") {
-    scheduleCacheReadyIfSettled(state);
     scheduleAbortIfReady(state);
   }
   const promise = makeHangingPromise<T>(
@@ -197,6 +204,12 @@ export function createPprFallbackShellSuspensePromise<T>(expression: string): Pr
   );
   promise.catch(noop);
   return promise;
+}
+
+export function createPprFallbackShellSuspensePromise<T>(expression: string): Promise<T> | null {
+  const state = getPprFallbackShellState();
+  if (state === null) return null;
+  return createPprFallbackShellSuspensePromiseForState<T>(state, expression);
 }
 
 export function waitForPprFallbackShellCacheReady(state: PprFallbackShellState): Promise<void> {

--- a/packages/vinext/src/shims/ppr-fallback-shell.ts
+++ b/packages/vinext/src/shims/ppr-fallback-shell.ts
@@ -7,6 +7,7 @@ export type PprFallbackShellState = {
   fallbackParamNames: ReadonlySet<string>;
   hasDynamicBoundary: boolean;
   isAbortScheduled: boolean;
+  pendingAbortCleanup: (() => void) | null;
   pendingCacheReadyCleanup: (() => void) | null;
   pendingCacheTasks: number;
   phase: "warmup" | "final";
@@ -93,7 +94,8 @@ function scheduleAbortIfReady(state: PprFallbackShellState): void {
   }
 
   state.isAbortScheduled = true;
-  scheduleAfterTask(() => {
+  state.pendingAbortCleanup = scheduleAfterTask(() => {
+    state.pendingAbortCleanup = null;
     state.isAbortScheduled = false;
     if (
       state.phase === "final" &&
@@ -129,6 +131,7 @@ export function createPprFallbackShellState(
     fallbackParamNames: new Set(options.fallbackParamNames),
     hasDynamicBoundary: false,
     isAbortScheduled: false,
+    pendingAbortCleanup: null,
     pendingCacheReadyCleanup: null,
     pendingCacheTasks: 0,
     phase: "warmup",
@@ -209,6 +212,10 @@ export function waitForPprFallbackShellCacheReady(state: PprFallbackShellState):
 
 export function preparePprFallbackShellFinalRender(state: PprFallbackShellState): void {
   cancelPendingCacheReady(state);
+  if (state.pendingAbortCleanup !== null) {
+    state.pendingAbortCleanup();
+    state.pendingAbortCleanup = null;
+  }
   state.abortController = new AbortController();
   state.cacheReadyResolvers.length = 0;
   state.hasDynamicBoundary = false;

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -1,3 +1,8 @@
+import {
+  createPprFallbackShellSuspensePromise,
+  getPprFallbackShellState,
+} from "./ppr-fallback-shell.js";
+
 function hasParamProperty<T extends Record<string, unknown>>(obj: T, prop: PropertyKey): boolean {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
@@ -99,7 +104,21 @@ export function makeThenableParams<T extends Record<string, unknown>>(
   observer?: ThenableParamsObserver,
 ): ThenableParams<T> {
   const plain = { ...obj };
-  const promise = Promise.resolve(plain);
+  const fallbackShellState = getPprFallbackShellState();
+  const fallbackParamNames =
+    fallbackShellState &&
+    Object.keys(plain).some((key) => fallbackShellState.fallbackParamNames.has(key))
+      ? fallbackShellState.fallbackParamNames
+      : null;
+  const fallbackShellPromise = fallbackParamNames
+    ? createPprFallbackShellSuspensePromise<T>("`params`")
+    : null;
+
+  function isFallbackParam(prop: PropertyKey): boolean {
+    return typeof prop === "string" && (fallbackParamNames?.has(prop) ?? false);
+  }
+
+  const promise = fallbackShellPromise ?? Promise.resolve(plain);
 
   // The Proxy implements both Promise and plain-object behaviour so that
   // `await params` and `params.id` both work. TypeScript's Proxy type
@@ -121,6 +140,9 @@ export function makeThenableParams<T extends Record<string, unknown>>(
       }
 
       if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
+        if (fallbackShellPromise && isFallbackParam(prop)) {
+          throw fallbackShellPromise;
+        }
         return Reflect.get(plain, prop);
       }
 
@@ -133,6 +155,16 @@ export function makeThenableParams<T extends Record<string, unknown>>(
       }
 
       if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
+        if (fallbackShellPromise && isFallbackParam(prop)) {
+          return {
+            configurable: true,
+            enumerable: true,
+            get() {
+              throw fallbackShellPromise;
+            },
+          };
+        }
+
         return {
           configurable: true,
           enumerable: true,

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -110,15 +110,20 @@ export function makeThenableParams<T extends Record<string, unknown>>(
     Object.keys(plain).some((key) => fallbackShellState.fallbackParamNames.has(key))
       ? fallbackShellState.fallbackParamNames
       : null;
-  const fallbackShellPromise = fallbackParamNames
-    ? createPprFallbackShellSuspensePromise<T>("`params`")
-    : null;
+  let fallbackShellPromise: Promise<T> | null = null;
+
+  function getFallbackShellPromise(): Promise<T> | null {
+    if (!fallbackShellPromise && fallbackParamNames) {
+      fallbackShellPromise = createPprFallbackShellSuspensePromise<T>("`params`");
+    }
+    return fallbackShellPromise;
+  }
 
   function isFallbackParam(prop: PropertyKey): boolean {
     return typeof prop === "string" && (fallbackParamNames?.has(prop) ?? false);
   }
 
-  const promise = fallbackShellPromise ?? Promise.resolve(plain);
+  const promise = Promise.resolve(plain);
 
   // The Proxy implements both Promise and plain-object behaviour so that
   // `await params` and `params.id` both work. TypeScript's Proxy type
@@ -140,8 +145,9 @@ export function makeThenableParams<T extends Record<string, unknown>>(
       }
 
       if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
-        if (fallbackShellPromise && isFallbackParam(prop)) {
-          throw fallbackShellPromise;
+        if (isFallbackParam(prop)) {
+          const p = getFallbackShellPromise();
+          if (p) throw p;
         }
         return Reflect.get(plain, prop);
       }
@@ -155,14 +161,17 @@ export function makeThenableParams<T extends Record<string, unknown>>(
       }
 
       if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
-        if (fallbackShellPromise && isFallbackParam(prop)) {
-          return {
-            configurable: true,
-            enumerable: true,
-            get() {
-              throw fallbackShellPromise;
-            },
-          };
+        if (isFallbackParam(prop)) {
+          const p = getFallbackShellPromise();
+          if (p) {
+            return {
+              configurable: true,
+              enumerable: true,
+              get() {
+                throw p;
+              },
+            };
+          }
         }
 
         return {

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -1,5 +1,5 @@
 import {
-  createPprFallbackShellSuspensePromise,
+  createPprFallbackShellSuspensePromiseForState,
   getPprFallbackShellState,
 } from "./ppr-fallback-shell.js";
 
@@ -209,8 +209,22 @@ export function makeThenableParams<T extends Record<string, unknown>>(
   let fallbackShellPromise: Promise<T> | null = null;
 
   function getFallbackShellPromise(): Promise<T> | null {
-    if (!fallbackShellPromise && fallbackParamNames) {
-      fallbackShellPromise = createPprFallbackShellSuspensePromise<T>("`params`");
+    // `fallbackParamNames` is non-null only when this params object was built
+    // inside a fallback-shell scope that owns one of these keys, so the
+    // originating `fallbackShellState` is captured here rather than re-read
+    // lazily from the ALS store. Capturing keeps fallback-key access suspending
+    // against the shell that produced this object even if the object escapes
+    // the ALS scope before the key is read — without it, an out-of-scope read
+    // would return `null` and silently leak the raw `[slug]` placeholder (and
+    // diverge between the `get` and `getOwnPropertyDescriptor` traps).
+    // Promise creation stays lazy so the dynamic-boundary side effects only
+    // fire on first actual fallback-key access.
+    if (!fallbackParamNames || !fallbackShellState) return null;
+    if (!fallbackShellPromise) {
+      fallbackShellPromise = createPprFallbackShellSuspensePromiseForState<T>(
+        fallbackShellState,
+        "`params`",
+      );
     }
     return fallbackShellPromise;
   }

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -207,6 +207,7 @@ export function makeThenableParams<T extends Record<string, unknown>>(
       ? fallbackShellState.fallbackParamNames
       : null;
   let fallbackShellPromise: Promise<T> | null = null;
+  let fallbackShellPromiseController: AbortController | null = null;
 
   function getFallbackShellPromise(): Promise<T> | null {
     // `fallbackParamNames` is non-null only when this params object was built
@@ -220,12 +221,23 @@ export function makeThenableParams<T extends Record<string, unknown>>(
     // Promise creation stays lazy so the dynamic-boundary side effects only
     // fire on first actual fallback-key access.
     if (!fallbackParamNames || !fallbackShellState) return null;
-    if (!fallbackShellPromise) {
-      fallbackShellPromise = createPprFallbackShellSuspensePromiseForState<T>(
-        fallbackShellState,
-        "`params`",
-      );
+    // `preparePprFallbackShellFinalRender` swaps in a fresh `AbortController`
+    // on the warmup->final transition. Re-derive the hanging promise whenever
+    // the live controller has changed so suspension always tracks the
+    // controller the lifecycle will actually abort, instead of a stale signal
+    // from a prior phase. This also re-applies the dynamic-boundary side
+    // effects against the current phase.
+    if (
+      fallbackShellPromise &&
+      fallbackShellPromiseController === fallbackShellState.abortController
+    ) {
+      return fallbackShellPromise;
     }
+    fallbackShellPromiseController = fallbackShellState.abortController;
+    fallbackShellPromise = createPprFallbackShellSuspensePromiseForState<T>(
+      fallbackShellState,
+      "`params`",
+    );
     return fallbackShellPromise;
   }
 

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -100,10 +100,13 @@ function isPromiseContinuation(prop: PropertyKey): boolean {
 }
 
 /**
- * Create a non-Promise params object that preserves fallback-key suspension.
+ * Build a proxy around `plain` that preserves fallback-key suspension.
  * This is the value `await params` resolves to during fallback-shell
  * prerendering. Known params are readable synchronously; fallback params
  * suspend (throw a hanging promise) only when actually accessed.
+ *
+ * The handler is typed as `ProxyHandler<T>` and no cast is needed because
+ * the target is already `plain: T`.
  */
 function createResolvedParamsProxy<T extends Record<string, unknown>>(
   plain: T,
@@ -119,7 +122,7 @@ function createResolvedParamsProxy<T extends Record<string, unknown>>(
     return typeof prop === "string" && fallbackParamNames !== null && fallbackParamNames.has(prop);
   }
 
-  return new Proxy(plain, {
+  const handler: ProxyHandler<T> = {
     get(_target, prop, _receiver) {
       if (typeof prop === "string" && !isWellKnownProperty(prop)) {
         observeParamKeys(observer, [prop]);
@@ -148,7 +151,6 @@ function createResolvedParamsProxy<T extends Record<string, unknown>>(
             get() {
               const p = getFallbackShellPromise();
               if (p) throw p;
-              return Reflect.get(plain, prop);
             },
           };
         }
@@ -176,7 +178,21 @@ function createResolvedParamsProxy<T extends Record<string, unknown>>(
       observeReadableParamKeys(observer, plain);
       return Reflect.ownKeys(plain).filter((prop) => !isWellKnownProperty(prop));
     },
-  }) as unknown as T;
+  };
+
+  return new Proxy(plain, handler);
+}
+
+/**
+ * Wrap a `Promise<T>` with a proxy that also exposes param properties for
+ * synchronous access. TypeScript cannot prove this hybrid shape statically,
+ * so the single `as ThenableParams<T>` cast is isolated here.
+ */
+function createThenableParamsProxy<T extends Record<string, unknown>>(
+  promise: Promise<T>,
+  handler: ProxyHandler<Promise<T>>,
+): ThenableParams<T> {
+  return new Proxy(promise, handler) as ThenableParams<T>;
 }
 
 export function makeThenableParams<T extends Record<string, unknown>>(
@@ -199,10 +215,6 @@ export function makeThenableParams<T extends Record<string, unknown>>(
     return fallbackShellPromise;
   }
 
-  function isFallbackParam(prop: PropertyKey): boolean {
-    return typeof prop === "string" && (fallbackParamNames?.has(prop) ?? false);
-  }
-
   const resolvedParams = createResolvedParamsProxy(
     plain,
     fallbackParamNames,
@@ -212,17 +224,22 @@ export function makeThenableParams<T extends Record<string, unknown>>(
 
   const promise = Promise.resolve(resolvedParams);
 
-  // The Proxy implements both Promise and plain-object behaviour so that
-  // `await params` and `params.id` both work. TypeScript's Proxy type
-  // cannot express this intersection precisely — the cast is isolated to
-  // the boundary so the handler above stays fully type-checked.
-  return new Proxy(promise, {
+  function isFallbackParam(prop: PropertyKey): boolean {
+    return typeof prop === "string" && (fallbackParamNames?.has(prop) ?? false);
+  }
+
+  const handler: ProxyHandler<Promise<T>> = {
     get(target, prop, receiver) {
       if (isPromiseContinuation(prop)) {
         const value = Reflect.get(target, prop, receiver);
         if (typeof value !== "function") return value;
         return (...args: unknown[]) => {
-          observeAllParamKeys(observer, plain);
+          // Only observe all keys when NOT in fallback-shell mode.
+          // In fallback-shell mode, let the resolved params proxy report
+          // actual property access lazily.
+          if (!fallbackParamNames) {
+            observeAllParamKeys(observer, plain);
+          }
           return Reflect.apply(value, target, args);
         };
       }
@@ -255,7 +272,6 @@ export function makeThenableParams<T extends Record<string, unknown>>(
             get() {
               const p = getFallbackShellPromise();
               if (p) throw p;
-              return Reflect.get(plain, prop);
             },
           };
         }
@@ -283,5 +299,7 @@ export function makeThenableParams<T extends Record<string, unknown>>(
       observeReadableParamKeys(observer, plain);
       return Reflect.ownKeys(plain).filter((prop) => !isWellKnownProperty(prop));
     },
-  }) as unknown as ThenableParams<T>;
+  };
+
+  return createThenableParamsProxy(promise, handler);
 }

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -99,6 +99,86 @@ function isPromiseContinuation(prop: PropertyKey): boolean {
   return prop === "then" || prop === "catch" || prop === "finally";
 }
 
+/**
+ * Create a non-Promise params object that preserves fallback-key suspension.
+ * This is the value `await params` resolves to during fallback-shell
+ * prerendering. Known params are readable synchronously; fallback params
+ * suspend (throw a hanging promise) only when actually accessed.
+ */
+function createResolvedParamsProxy<T extends Record<string, unknown>>(
+  plain: T,
+  fallbackParamNames: ReadonlySet<string> | null,
+  observer: ThenableParamsObserver | undefined,
+  getFallbackShellPromise: () => Promise<T> | null,
+): T {
+  if (!fallbackParamNames || fallbackParamNames.size === 0) {
+    return plain;
+  }
+
+  function isFallbackParam(prop: PropertyKey): boolean {
+    return typeof prop === "string" && fallbackParamNames !== null && fallbackParamNames.has(prop);
+  }
+
+  return new Proxy(plain, {
+    get(_target, prop, _receiver) {
+      if (typeof prop === "string" && !isWellKnownProperty(prop)) {
+        observeParamKeys(observer, [prop]);
+      }
+
+      if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
+        if (isFallbackParam(prop)) {
+          const p = getFallbackShellPromise();
+          if (p) throw p;
+        }
+        return Reflect.get(plain, prop);
+      }
+
+      return Reflect.get(plain, prop);
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      if (typeof prop === "string" && !isWellKnownProperty(prop)) {
+        observeParamKeys(observer, [prop]);
+      }
+
+      if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
+        if (isFallbackParam(prop)) {
+          return {
+            configurable: true,
+            enumerable: true,
+            get() {
+              const p = getFallbackShellPromise();
+              if (p) throw p;
+              return Reflect.get(plain, prop);
+            },
+          };
+        }
+
+        return {
+          configurable: true,
+          enumerable: true,
+          value: Reflect.get(plain, prop),
+          writable: true,
+        };
+      }
+
+      return Reflect.getOwnPropertyDescriptor(plain, prop);
+    },
+    has(_target, prop) {
+      if (typeof prop === "string" && !isWellKnownProperty(prop)) {
+        observeParamKeys(observer, [prop]);
+      }
+
+      return (
+        Reflect.has(plain, prop) || (!isWellKnownProperty(prop) && hasParamProperty(plain, prop))
+      );
+    },
+    ownKeys() {
+      observeReadableParamKeys(observer, plain);
+      return Reflect.ownKeys(plain).filter((prop) => !isWellKnownProperty(prop));
+    },
+  }) as unknown as T;
+}
+
 export function makeThenableParams<T extends Record<string, unknown>>(
   obj: T,
   observer?: ThenableParamsObserver,
@@ -123,7 +203,14 @@ export function makeThenableParams<T extends Record<string, unknown>>(
     return typeof prop === "string" && (fallbackParamNames?.has(prop) ?? false);
   }
 
-  const promise = Promise.resolve(plain);
+  const resolvedParams = createResolvedParamsProxy(
+    plain,
+    fallbackParamNames,
+    observer,
+    getFallbackShellPromise,
+  );
+
+  const promise = Promise.resolve(resolvedParams);
 
   // The Proxy implements both Promise and plain-object behaviour so that
   // `await params` and `params.id` both work. TypeScript's Proxy type
@@ -162,16 +249,15 @@ export function makeThenableParams<T extends Record<string, unknown>>(
 
       if (!isWellKnownProperty(prop) && hasParamProperty(plain, prop)) {
         if (isFallbackParam(prop)) {
-          const p = getFallbackShellPromise();
-          if (p) {
-            return {
-              configurable: true,
-              enumerable: true,
-              get() {
-                throw p;
-              },
-            };
-          }
+          return {
+            configurable: true,
+            enumerable: true,
+            get() {
+              const p = getFallbackShellPromise();
+              if (p) throw p;
+              return Reflect.get(plain, prop);
+            },
+          };
         }
 
         return {

--- a/tests/ppr-fallback-shell.test.ts
+++ b/tests/ppr-fallback-shell.test.ts
@@ -205,6 +205,28 @@ describe("ppr fallback shell render lifecycle", () => {
     expect(isPprFallbackShellAbortError(null)).toBe(false);
   });
 
+  it("re-schedules warmup cache-ready when a dynamic boundary has no in-scope cache task", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    expect(state.pendingCacheReadyCleanup).toBeNull();
+
+    // A bare `headers()`/`cookies()` access outside any tracked cache task has
+    // an empty cache-task stack, so `ignoreCacheTask` completes nothing and
+    // cannot drive the settle. The suspense creation itself must re-schedule
+    // the warmup cache-ready settle; previously this only happened in the
+    // final phase, leaving a warmup waiter un-settled.
+    runWithPprFallbackShellState(state, () => {
+      void createPprFallbackShellSuspensePromise("headers");
+    });
+
+    expect(state.pendingCacheReadyCleanup).not.toBeNull();
+
+    state.abortController.abort();
+  });
+
   it("multiple suspense promises in the same warmup phase track correctly", async () => {
     const state = createPprFallbackShellState({
       fallbackParamNames: ["slug"],

--- a/tests/ppr-fallback-shell.test.ts
+++ b/tests/ppr-fallback-shell.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createPprFallbackShellState,
+  createPprFallbackShellSuspensePromise,
+  isPprFallbackShellAbortError,
+  preparePprFallbackShellFinalRender,
+  runWithPprFallbackShellState,
+  trackPprFallbackShellCacheTask,
+  waitForPprFallbackShellCacheReady,
+} from "../packages/vinext/src/shims/ppr-fallback-shell.js";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("ppr fallback shell cache task tracking", () => {
+  it("waits for public cache work before marking warmup cache-ready", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+    let finishTask!: () => void;
+    let isReady = false;
+
+    const tracked = runWithPprFallbackShellState(state, () =>
+      trackPprFallbackShellCacheTask(
+        () => new Promise<void>((resolve) => (finishTask = resolve)),
+        "default",
+      ),
+    );
+    const ready = waitForPprFallbackShellCacheReady(state).then(() => {
+      isReady = true;
+    });
+
+    await delay(5);
+    expect(isReady).toBe(false);
+    finishTask();
+    await tracked;
+    await ready;
+    expect(state.pendingCacheTasks).toBe(0);
+  });
+
+  it("completes independent child public cache work before cache-ready when parent hits dynamic boundary", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+    let childWorkResolve!: () => void;
+    const childWork = new Promise<void>((resolve) => {
+      childWorkResolve = resolve;
+    });
+    let childCompleted = false;
+    let isReady = false;
+    const readyPromise = waitForPprFallbackShellCacheReady(state).then(() => {
+      isReady = true;
+    });
+
+    runWithPprFallbackShellState(state, () =>
+      trackPprFallbackShellCacheTask(async () => {
+        trackPprFallbackShellCacheTask(async () => {
+          await childWork;
+          childCompleted = true;
+        }, "default").catch(() => {});
+
+        const suspension = createPprFallbackShellSuspensePromise("headers");
+        if (suspension) throw suspension;
+      }, "default"),
+    ).catch(() => {});
+
+    await delay(5);
+    expect(isReady).toBe(false);
+
+    childWorkResolve();
+    await readyPromise;
+
+    expect(isReady).toBe(true);
+    expect(childCompleted).toBe(true);
+    expect(state.pendingCacheTasks).toBe(0);
+
+    state.abortController.abort();
+  });
+
+  it("stops waiting for cache tasks that suspend on fallback-shell dynamic work", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+    let reachedAfterSuspend = false;
+
+    const tracked = runWithPprFallbackShellState(state, () =>
+      trackPprFallbackShellCacheTask(
+        () =>
+          trackPprFallbackShellCacheTask(async () => {
+            const suspension = createPprFallbackShellSuspensePromise<void>("`params`");
+            if (suspension) {
+              await suspension;
+            }
+            reachedAfterSuspend = true;
+          }, "default"),
+        "default",
+      ),
+    );
+
+    await waitForPprFallbackShellCacheReady(state);
+    expect(state.pendingCacheTasks).toBe(0);
+    expect(reachedAfterSuspend).toBe(false);
+
+    state.abortController.abort();
+    await tracked.catch(() => undefined);
+  });
+});
+
+describe("ppr fallback shell render lifecycle", () => {
+  it("createPprFallbackShellSuspensePromise returns a promise for params expression", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    runWithPprFallbackShellState(state, () => {
+      const promise = createPprFallbackShellSuspensePromise("params");
+      expect(promise).not.toBeNull();
+      expect(typeof (promise as Promise<void>)?.then).toBe("function");
+      expect(state.hasDynamicBoundary).toBe(true);
+    });
+
+    state.abortController.abort();
+  });
+
+  it("createPprFallbackShellSuspensePromise returns a promise for headers expression", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    runWithPprFallbackShellState(state, () => {
+      const promise = createPprFallbackShellSuspensePromise("headers");
+      expect(promise).not.toBeNull();
+      expect(state.hasDynamicBoundary).toBe(true);
+    });
+
+    state.abortController.abort();
+  });
+
+  it("createPprFallbackShellSuspensePromise returns a promise for cookies expression", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    runWithPprFallbackShellState(state, () => {
+      const promise = createPprFallbackShellSuspensePromise("cookies");
+      expect(promise).not.toBeNull();
+      expect(state.hasDynamicBoundary).toBe(true);
+    });
+
+    state.abortController.abort();
+  });
+
+  it("createPprFallbackShellSuspensePromise returns null outside shell context", () => {
+    const promise = createPprFallbackShellSuspensePromise("params");
+    expect(promise).toBeNull();
+  });
+
+  it("waitForPprFallbackShellCacheReady resolves immediately in final phase", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    preparePprFallbackShellFinalRender(state);
+    expect(state.phase).toBe("final");
+
+    const result = await waitForPprFallbackShellCacheReady(state);
+    expect(result).toBeUndefined();
+  });
+
+  it("preparePprFallbackShellFinalRender resets state for final render", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    state.hasDynamicBoundary = true;
+    state.pendingCacheTasks = 3;
+
+    preparePprFallbackShellFinalRender(state);
+
+    expect(state.phase).toBe("final");
+    expect(state.hasDynamicBoundary).toBe(false);
+    expect(state.pendingCacheTasks).toBe(0);
+    expect(state.isAbortScheduled).toBe(false);
+    expect(state.cacheReadyResolvers.length).toBe(0);
+    expect(state.abortController.signal.aborted).toBe(false);
+  });
+
+  it("isPprFallbackShellAbortError returns true for DOMException AbortError", () => {
+    const error = new DOMException("aborted", "AbortError");
+    expect(isPprFallbackShellAbortError(error)).toBe(true);
+  });
+
+  it("isPprFallbackShellAbortError returns false for regular errors", () => {
+    expect(isPprFallbackShellAbortError(new Error("something else"))).toBe(false);
+    expect(isPprFallbackShellAbortError("string error")).toBe(false);
+    expect(isPprFallbackShellAbortError(null)).toBe(false);
+  });
+
+  it("multiple suspense promises in the same warmup phase track correctly", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+    let isReady = false;
+
+    const ready = waitForPprFallbackShellCacheReady(state).then(() => {
+      isReady = true;
+    });
+
+    runWithPprFallbackShellState(state, () => {
+      const p1 = createPprFallbackShellSuspensePromise("params");
+      expect(p1).not.toBeNull();
+      const p2 = createPprFallbackShellSuspensePromise("headers");
+      expect(p2).not.toBeNull();
+    });
+
+    await delay(5);
+    expect(isReady).toBe(true);
+    expect(state.pendingCacheTasks).toBe(0);
+
+    state.abortController.abort();
+    await ready.catch(() => {});
+  });
+});

--- a/tests/ppr-fallback-shell.test.ts
+++ b/tests/ppr-fallback-shell.test.ts
@@ -227,6 +227,38 @@ describe("ppr fallback shell render lifecycle", () => {
     state.abortController.abort();
   });
 
+  it("does not drive pendingCacheTasks negative when a warmup task settles after final transition", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    let finishWarmupTask!: () => void;
+    const tracked = runWithPprFallbackShellState(state, () =>
+      trackPprFallbackShellCacheTask(
+        () => new Promise<void>((resolve) => (finishWarmupTask = resolve)),
+        "default",
+      ),
+    );
+    expect(state.pendingCacheTasks).toBe(1);
+
+    // Transition to the final render while the warmup task is still in flight.
+    // This resets `pendingCacheTasks` to 0.
+    preparePprFallbackShellFinalRender(state);
+    expect(state.pendingCacheTasks).toBe(0);
+
+    // The stale warmup task settling must not decrement the reset counter
+    // below zero (which would permanently block `waitForPprFallbackShellCacheReady`).
+    finishWarmupTask();
+    await tracked;
+    expect(state.pendingCacheTasks).toBe(0);
+
+    // Final-phase cache-ready still resolves immediately.
+    await waitForPprFallbackShellCacheReady(state);
+
+    state.abortController.abort();
+  });
+
   it("multiple suspense promises in the same warmup phase track correctly", async () => {
     const state = createPprFallbackShellState({
       fallbackParamNames: ["slug"],

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
+import {
+  createPprFallbackShellState,
+  runWithPprFallbackShellState,
+} from "../packages/vinext/src/shims/ppr-fallback-shell.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 
 describe("makeThenableParams", () => {
@@ -149,5 +153,29 @@ describe("makeThenableParams", () => {
 
     expect(slug).toBe("post");
     expect(observedKeys).toEqual([["slug"]]);
+  });
+
+  it("suspends only fallback params during cacheComponents fallback-shell prerendering", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+    let thrown: unknown;
+
+    runWithPprFallbackShellState(state, () => {
+      const params = makeThenableParams({ locale: "en", slug: "[slug]" });
+
+      expect(params.locale).toBe("en");
+      expect(Object.keys(params)).toEqual(["locale", "slug"]);
+      try {
+        Reflect.get(params, "slug");
+      } catch (error) {
+        thrown = error;
+      }
+    });
+    state.abortController.abort();
+
+    expect(thrown).toBeDefined();
+    expect(typeof (thrown as Promise<unknown>).then).toBe("function");
   });
 });

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -184,29 +184,38 @@ describe("makeThenableParams", () => {
       fallbackParamNames: ["slug"],
       routePattern: "/:locale/blog/:slug",
     });
-    let thrown: unknown;
 
-    const params = runWithPprFallbackShellState(state, () =>
-      makeThenableParams({ locale: "en", slug: "[slug]" }),
-    );
+    await runWithPprFallbackShellState(state, async () => {
+      const params = makeThenableParams({ locale: "en", slug: "[slug]" });
 
-    const result = await params;
-    expect(result.locale).toBe("en");
+      const result = await params;
+      expect(result.locale).toBe("en");
 
-    // Access the resolved object inside the fallback-shell context so that
-    // getFallbackShellPromise can reach the ALS state for side-effects.
-    runWithPprFallbackShellState(state, () => {
-      try {
-        Reflect.get(result, "slug");
-      } catch (error) {
-        thrown = error;
-      }
+      expect(() => Reflect.get(result, "slug")).toThrow();
+      expect(state.hasDynamicBoundary).toBe(true);
     });
 
-    expect(thrown).toBeDefined();
-    expect(typeof (thrown as Promise<unknown>).then).toBe("function");
-    expect(state.hasDynamicBoundary).toBe(true);
+    state.abortController.abort();
+  });
 
+  it("awaiting params during fallback-shell prerender observes only accessed known params", async () => {
+    const observedKeys: string[][] = [];
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    await runWithPprFallbackShellState(state, async () => {
+      const params = makeThenableParams(
+        { locale: "en", slug: "[slug]" },
+        { observeParamAccess: (keys) => observedKeys.push([...keys]) },
+      );
+
+      const resolved = await params;
+      expect(resolved.locale).toBe("en");
+    });
+
+    expect(observedKeys).toEqual([["locale"]]);
     state.abortController.abort();
   });
 

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -179,11 +179,12 @@ describe("makeThenableParams", () => {
     expect(typeof (thrown as Promise<unknown>).then).toBe("function");
   });
 
-  it("awaiting params resolves known params without hanging during fallback-shell prerendering", async () => {
+  it("awaited params object suspends on fallback param access", async () => {
     const state = createPprFallbackShellState({
       fallbackParamNames: ["slug"],
       routePattern: "/:locale/blog/:slug",
     });
+    let thrown: unknown;
 
     const params = runWithPprFallbackShellState(state, () =>
       makeThenableParams({ locale: "en", slug: "[slug]" }),
@@ -191,7 +192,21 @@ describe("makeThenableParams", () => {
 
     const result = await params;
     expect(result.locale).toBe("en");
-    expect(result.slug).toBe("[slug]");
+
+    // Access the resolved object inside the fallback-shell context so that
+    // getFallbackShellPromise can reach the ALS state for side-effects.
+    runWithPprFallbackShellState(state, () => {
+      try {
+        Reflect.get(result, "slug");
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    expect(thrown).toBeDefined();
+    expect(typeof (thrown as Promise<unknown>).then).toBe("function");
+    expect(state.hasDynamicBoundary).toBe(true);
+
     state.abortController.abort();
   });
 
@@ -212,6 +227,21 @@ describe("makeThenableParams", () => {
         /* expected suspension */
       }
       expect(state.hasDynamicBoundary).toBe(true);
+    });
+
+    state.abortController.abort();
+  });
+
+  it("Object.keys(params) does not mark dynamic boundary before fallback param access", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    runWithPprFallbackShellState(state, () => {
+      const params = makeThenableParams({ locale: "en", slug: "[slug]" });
+      Object.keys(params);
+      expect(state.hasDynamicBoundary).toBe(false);
     });
 
     state.abortController.abort();

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -244,6 +244,48 @@ describe("makeThenableParams", () => {
     state.abortController.abort();
   });
 
+  it("suspends on fallback param access even after the params object escapes the shell scope", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    // Build the params object inside the shell scope, then read the fallback
+    // key after the scope has exited. The object must still suspend against the
+    // shell that produced it instead of silently leaking the `[slug]`
+    // placeholder.
+    const params = runWithPprFallbackShellState(state, () =>
+      makeThenableParams({ locale: "en", slug: "[slug]" }),
+    );
+
+    expect(params.locale).toBe("en");
+
+    let thrownFromGet: unknown;
+    try {
+      Reflect.get(params, "slug");
+    } catch (error) {
+      thrownFromGet = error;
+    }
+    expect(thrownFromGet).toBeDefined();
+    expect(typeof (thrownFromGet as Promise<unknown>).then).toBe("function");
+
+    // The `getOwnPropertyDescriptor` trap must suspend identically — its getter
+    // throws the same hanging promise instead of falling through to `undefined`
+    // — so both traps agree on the out-of-scope path.
+    const descriptor = Object.getOwnPropertyDescriptor(params, "slug");
+    expect(typeof descriptor?.get).toBe("function");
+    let thrownFromDescriptor: unknown;
+    try {
+      descriptor?.get?.();
+    } catch (error) {
+      thrownFromDescriptor = error;
+    }
+    expect(thrownFromDescriptor).toBeDefined();
+    expect(typeof (thrownFromDescriptor as Promise<unknown>).then).toBe("function");
+
+    state.abortController.abort();
+  });
+
   it("Object.keys(params) does not mark dynamic boundary before fallback param access", () => {
     const state = createPprFallbackShellState({
       fallbackParamNames: ["slug"],

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   createPprFallbackShellState,
+  preparePprFallbackShellFinalRender,
   runWithPprFallbackShellState,
 } from "../packages/vinext/src/shims/ppr-fallback-shell.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
@@ -284,6 +285,52 @@ describe("makeThenableParams", () => {
     expect(typeof (thrownFromDescriptor as Promise<unknown>).then).toBe("function");
 
     state.abortController.abort();
+  });
+
+  it("re-derives fallback suspension against the live controller after a phase transition", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    const params = runWithPprFallbackShellState(state, () =>
+      makeThenableParams({ locale: "en", slug: "[slug]" }),
+    );
+
+    // Warmup access throws a hanging promise wired to the warmup controller.
+    let warmupPromise: Promise<unknown> | undefined;
+    try {
+      Reflect.get(params, "slug");
+    } catch (error) {
+      warmupPromise = error as Promise<unknown>;
+    }
+    expect(warmupPromise).toBeDefined();
+    const warmupController = state.abortController;
+
+    // Transition to the final render — this swaps in a fresh AbortController.
+    preparePprFallbackShellFinalRender(state);
+    expect(state.abortController).not.toBe(warmupController);
+
+    // Final-phase access must throw a *new* hanging promise wired to the live
+    // (final) controller, not the memoized warmup promise bound to the dead
+    // signal the lifecycle will never abort again.
+    let finalPromise: Promise<unknown> | undefined;
+    try {
+      Reflect.get(params, "slug");
+    } catch (error) {
+      finalPromise = error as Promise<unknown>;
+    }
+    expect(finalPromise).toBeDefined();
+    expect(finalPromise).not.toBe(warmupPromise);
+
+    // Aborting the live controller rejects the final-phase suspension.
+    const rejectedAssertion = expect(finalPromise).rejects.toThrow();
+    state.abortController.abort();
+    await rejectedAssertion;
+
+    // Settle the warmup promise too so it does not leak as unhandled.
+    warmupController.abort();
+    await (warmupPromise as Promise<unknown>).catch(() => {});
   });
 
   it("Object.keys(params) does not mark dynamic boundary before fallback param access", () => {

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -178,4 +178,42 @@ describe("makeThenableParams", () => {
     expect(thrown).toBeDefined();
     expect(typeof (thrown as Promise<unknown>).then).toBe("function");
   });
+
+  it("awaiting params resolves known params without hanging during fallback-shell prerendering", async () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    const params = runWithPprFallbackShellState(state, () =>
+      makeThenableParams({ locale: "en", slug: "[slug]" }),
+    );
+
+    const result = await params;
+    expect(result.locale).toBe("en");
+    expect(result.slug).toBe("[slug]");
+    state.abortController.abort();
+  });
+
+  it("does not mark dynamic boundary until a fallback param is actually accessed", () => {
+    const state = createPprFallbackShellState({
+      fallbackParamNames: ["slug"],
+      routePattern: "/:locale/blog/:slug",
+    });
+
+    runWithPprFallbackShellState(state, () => {
+      const params = makeThenableParams({ locale: "en", slug: "[slug]" });
+      expect(params.locale).toBe("en");
+      expect(state.hasDynamicBoundary).toBe(false);
+
+      try {
+        Reflect.get(params, "slug");
+      } catch {
+        /* expected suspension */
+      }
+      expect(state.hasDynamicBoundary).toBe(true);
+    });
+
+    state.abortController.abort();
+  });
 });

--- a/tests/thenable-params.test.ts
+++ b/tests/thenable-params.test.ts
@@ -213,6 +213,9 @@ describe("makeThenableParams", () => {
 
       const resolved = await params;
       expect(resolved.locale).toBe("en");
+      // Known-param access must not convert the shell into a
+      // dynamic-boundary shell — only actual fallback-param access does.
+      expect(state.hasDynamicBoundary).toBe(false);
     });
 
     expect(observedKeys).toEqual([["locale"]]);


### PR DESCRIPTION
## Stack position

PR 3 of the original `cacheComponents` PPR root-param fallback-shell stack.

#1702 and #1714 are now merged, so this PR is rebased onto current `main` and should be reviewed as the next standalone delta: **fallback-shell render lifecycle**.

Remaining follow-ups in the stack:

1. #1715: fallback-shell render lifecycle
2. #1716: safe runtime serving

## Problem

The intended invariant is not “wait for the whole SSR tree.”

For a root-param fallback shell, vinext should wait for public `"use cache"` work that can complete for known params, but it should not block forever on work that depends on fallback params or request APIs such as `headers()` / `cookies()`.

Known scoped params must remain synchronously readable. Fallback params should suspend only when they are actually accessed.

## What changed

- Adds a fallback-shell prerender scope with explicit lifecycle state.
- Tracks public cache work that fallback-shell prerendering should wait for.
- Stops waiting for work that suspends on:
  - fallback params
  - request-bound dynamic APIs such as `headers()` / `cookies()`
- Keeps independent child public cache work able to complete.
- Teaches thenable params to suspend lazily for fallback params while keeping known params synchronously readable.

## Contract covered

During fallback-shell prerendering:

- public cache work can hold the shell open until it resolves
- request-bound dynamic work remains behind Suspense
- fallback params suspend only on access
- known params remain sync-readable for layout/root-param content

This keeps the root-param shell invariant narrow: cached known-param content can be ready in the shell without converting the whole document into an `allReady` wait.

## Deliberate non-goals

- No runtime shell cache lookup.
- No exact-cache/static-param dispatch policy.
- No stale shell regeneration.
- No HTML metadata rewrite.

Those remain isolated in #1716.

## Validation

After rebasing onto current `upstream/main`:

- `vp test run tests/ppr-fallback-shell.test.ts tests/thenable-params.test.ts`
- `vp check`

## References

- [Next.js CacheSignal](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/server/app-render/cache-signal.ts#L1-L180)
- [Next.js cacheComponents warmup/final render flow](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/server/app-render/app-render.tsx#L5538-L6205)
- [Next.js fallback params in request params](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/server/request/params.ts#L197-L367)


References #1359
