### PR TITLE
feat(skip): plumb client reuse manifests through the app request path

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -57,7 +57,6 @@ const appPageRouteWiringPath = resolveEntryPath(
   import.meta.url,
 );
 const appPageProbePath = resolveEntryPath("../server/app-page-probe.js", import.meta.url);
-const appPageParamsPath = resolveEntryPath("../server/app-page-params.js", import.meta.url);
 const appPageDispatchPath = resolveEntryPath("../server/app-page-dispatch.js", import.meta.url);
 const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
 const appSegmentConfigPath = resolveEntryPath("../server/app-segment-config.js", import.meta.url);
@@ -277,12 +276,10 @@ import {
   AppElementsWire as __AppElementsWire,
 } from ${JSON.stringify(appElementsPath)};
 import {
+  probeAppPageLayoutWithTracking as __probeAppPageLayoutWithTracking,
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from ${JSON.stringify(appPageRouteWiringPath)};
 import { buildPageElements as __buildPageElements } from ${JSON.stringify(appPageElementBuilderPath)};
-import {
-  resolveAppPageSegmentParams as __resolveAppPageSegmentParams,
-} from ${JSON.stringify(appPageParamsPath)};
 import { probeAppPage as __probeAppPage } from ${JSON.stringify(appPageProbePath)};
 import {
   dispatchAppPage as __dispatchAppPage,
@@ -483,7 +480,7 @@ function findIntercept(pathname, sourcePathname = null) {
   return __routeMatcher.findIntercept(pathname, sourcePathname);
 }
 
-async function buildPageElements(route, params, routePath, pageRequest) {
+async function buildPageElements(route, params, routePath, pageRequest, layoutParamAccess) {
   return __buildPageElements({
     route,
     params,
@@ -494,6 +491,7 @@ async function buildPageElements(route, params, routePath, pageRequest) {
     rootForbiddenModule: ${rootForbiddenVar ? rootForbiddenVar : "null"},
     rootUnauthorizedModule: ${rootUnauthorizedVar ? rootUnauthorizedVar : "null"},
     metadataRoutes,
+    layoutParamAccess,
     basePath: __basePath,
     htmlLimitedBots: __htmlLimitedBots,
   });
@@ -560,6 +558,7 @@ export default __createAppRscHandler({
   configRewrites: __configRewrites,
   draftModeSecret: __draftModeSecret,
   dispatchMatchedPage({
+    clientReuseManifest,
     cleanPathname,
     formState,
     actionError,
@@ -594,7 +593,7 @@ export default __createAppRscHandler({
     return __dispatchAppPage({
       basePath: __basePath,
       clientTraceMetadata: __clientTraceMetadata,
-      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams) {
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams, layoutParamAccess) {
         return buildPageElements(targetRoute, targetParams, cleanPathname, {
           opts: targetOpts,
           searchParams: targetSearchParams,
@@ -602,8 +601,9 @@ export default __createAppRscHandler({
           request,
           mountedSlotsHeader,
           renderMode,
-        });
+        }, layoutParamAccess);
       },
+      clientReuseManifest,
       cleanPathname,
       clearRequestContext() {
         __clearRequestContext();
@@ -653,16 +653,13 @@ export default __createAppRscHandler({
       params,
       staticParamsValidationParams,
       rootParams,
-      probeLayoutAt(li) {
-        const LayoutComp = route.layouts[li]?.default;
-        if (!LayoutComp) return null;
-        return LayoutComp({
-          params: makeThenableParams(__resolveAppPageSegmentParams(
-            route.routeSegments,
-            route.layoutTreePositions?.[li] ?? 0,
-            params,
-          )),
-          children: null,
+      probeLayoutAt(li, layoutParamAccess) {
+        return __probeAppPageLayoutWithTracking({
+          layoutIndex: li,
+          layoutParamAccess,
+          makeThenableParams,
+          matchedParams: params,
+          route,
         });
       },
       probePage() {

--- a/packages/vinext/src/server/app-browser-client-reuse-manifest.ts
+++ b/packages/vinext/src/server/app-browser-client-reuse-manifest.ts
@@ -1,0 +1,170 @@
+import type { ArtifactCompatibilityEnvelope } from "./artifact-compatibility.js";
+import {
+  buildCacheVariantWithRouteBudget,
+  DEFAULT_CACHE_VARIANT_BUDGET,
+  type StaticLayoutCacheProofOutputScope,
+} from "./cache-proof.js";
+import {
+  CLIENT_REUSE_MANIFEST_SKIP_VERIFICATION_ENTRY_BUDGET,
+  countUtf8Bytes,
+  DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+  serializeClientReuseManifest,
+} from "./client-reuse-manifest.js";
+import { AppElementsWire, type AppElements } from "./app-elements.js";
+import {
+  createStaticLayoutClientReuseArtifactCompatibility,
+  createStaticLayoutClientReusePayloadHash,
+  createStaticLayoutClientReuseRouteId,
+} from "./static-layout-client-reuse-proof.js";
+import type { AppRouterState } from "./app-browser-state.js";
+
+type ClientReuseManifestLimits = typeof DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS;
+
+type VisibleAppState = Pick<AppRouterState, "elements" | "visibleCommitVersion">;
+
+type BrowserClientReuseManifestEntry = Readonly<{
+  artifactCompatibility: ArtifactCompatibilityEnvelope;
+  id: string;
+  payloadHash: string;
+  privacy: "public";
+  variantCacheKey: string;
+}>;
+
+type CreateClientReuseManifestHeaderOptions = Readonly<{
+  limits?: ClientReuseManifestLimits;
+}>;
+
+function capClientReuseManifestProducerLimits(
+  limits: ClientReuseManifestLimits,
+): ClientReuseManifestLimits {
+  return {
+    ...limits,
+    maxEntryCount: Math.min(
+      limits.maxEntryCount,
+      CLIENT_REUSE_MANIFEST_SKIP_VERIFICATION_ENTRY_BUDGET,
+    ),
+  };
+}
+
+function serializeBoundedClientReuseManifest(input: {
+  entries: readonly BrowserClientReuseManifestEntry[];
+  limits: ClientReuseManifestLimits;
+  visibleCommitVersion: number;
+}): string | null {
+  const entries = input.entries.slice(0, input.limits.maxEntryCount);
+  // Binary search for the largest prefix that fits. JSON array serialization
+  // is monotonic here: adding an entry cannot reduce the byte count.
+  let low = 1;
+  let high = entries.length;
+  let best: string | null = null;
+
+  while (low <= high) {
+    const size = Math.floor((low + high) / 2);
+    const serialized = serializeClientReuseManifest({
+      entries: entries.slice(0, size),
+      replayWindow: {
+        validFromVisibleCommitVersion: input.visibleCommitVersion,
+        validUntilVisibleCommitVersion: input.visibleCommitVersion,
+      },
+      visibleCommitVersion: input.visibleCommitVersion,
+    });
+    if (countUtf8Bytes(serialized) <= input.limits.maxManifestBytes) {
+      best = serialized;
+      low = size + 1;
+    } else {
+      high = size - 1;
+    }
+  }
+
+  return best;
+}
+
+function hasRetainedElement(elements: AppElements, elementId: string): boolean {
+  return Object.hasOwn(elements, elementId);
+}
+
+function createStaticLayoutEntry(input: {
+  artifactCompatibility: ArtifactCompatibilityEnvelope;
+  layoutId: string;
+}): BrowserClientReuseManifestEntry | null {
+  const routeId = createStaticLayoutClientReuseRouteId(input.layoutId);
+  const output: StaticLayoutCacheProofOutputScope = {
+    kind: "layout",
+    layoutId: input.layoutId,
+    rootBoundaryId: input.artifactCompatibility.rootBoundaryId,
+    routeId,
+  };
+  const candidateVariant = buildCacheVariantWithRouteBudget({
+    budget: DEFAULT_CACHE_VARIANT_BUDGET,
+    dimensions: [],
+    output,
+    routeBudget: {
+      routeId: output.routeId,
+      variantCacheKeys: [],
+    },
+  });
+  if (candidateVariant.kind !== "variant") {
+    return null;
+  }
+
+  const artifactCompatibility = createStaticLayoutClientReuseArtifactCompatibility({
+    artifactCompatibility: input.artifactCompatibility,
+    layoutId: input.layoutId,
+    rootBoundaryId: output.rootBoundaryId,
+    routeId: output.routeId,
+    variantCacheKey: candidateVariant.variant.cacheKey,
+  });
+
+  return {
+    artifactCompatibility,
+    id: input.layoutId,
+    payloadHash: createStaticLayoutClientReusePayloadHash({
+      artifactCompatibility,
+      layoutId: input.layoutId,
+      rootBoundaryId: output.rootBoundaryId,
+      routeId: output.routeId,
+      variantCacheKey: candidateVariant.variant.cacheKey,
+    }),
+    privacy: "public",
+    variantCacheKey: candidateVariant.variant.cacheKey,
+  };
+}
+
+export function createClientReuseManifestHeaderFromVisibleAppState(
+  state: VisibleAppState,
+  options: CreateClientReuseManifestHeaderOptions = {},
+): string | null {
+  const limits = capClientReuseManifestProducerLimits(
+    options.limits ?? DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+  );
+  const metadata = AppElementsWire.readMetadata(state.elements);
+  const entries: BrowserClientReuseManifestEntry[] = [];
+
+  for (const layoutId of metadata.layoutIds) {
+    if (entries.length >= limits.maxEntryCount) break;
+    if (layoutId.length > limits.maxEntryIdLength) continue;
+    if (metadata.layoutFlags[layoutId] !== "s") continue;
+    if (!hasRetainedElement(state.elements, layoutId)) continue;
+
+    const parsedKey = AppElementsWire.parseElementKey(layoutId);
+    if (parsedKey?.kind !== "layout") continue;
+
+    const entry = createStaticLayoutEntry({
+      artifactCompatibility: metadata.artifactCompatibility,
+      layoutId,
+    });
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return serializeBoundedClientReuseManifest({
+    entries,
+    limits,
+    visibleCommitVersion: state.visibleCommitVersion,
+  });
+}

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -157,6 +157,7 @@ import {
   ACTION_REDIRECT_HEADER,
   ACTION_REDIRECT_STATUS_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
+  VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_RSC_REDIRECT_HEADER,
 } from "./headers.js";
@@ -1660,12 +1661,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const routerStateAtNavStart = getBrowserRouterState();
         const elementsAtNavStart = routerStateAtNavStart.elements;
         const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
-        const clientReuseManifestHeader =
-          navigationKind === "navigate"
-            ? createClientReuseManifestHeaderFromVisibleAppState(routerStateAtNavStart)
-            : null;
+        // The client reuse manifest is excluded from VINEXT_RSC_VARY_HEADER, so
+        // it never affects the cache-busting URL. Defer producing it until the
+        // visited-response cache miss is confirmed below — its producer iterates
+        // the visible layout ids and binary-searches a byte budget, which is
+        // pure waste on the cache-hit soft-nav path.
         const requestHeaders = createRscRequestHeaders({
-          clientReuseManifestHeader,
           interceptionContext: requestInterceptionContext,
           mountedSlotsHeader,
           renderMode:
@@ -1807,6 +1808,17 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         }
 
         if (!navResponse) {
+          // Produce the client reuse manifest only now that prefetch/optimistic
+          // paths did not satisfy the navigation and a real request is required.
+          // Computed from the nav-start router state so it matches the snapshot
+          // the request would have carried if produced earlier.
+          if (navigationKind === "navigate") {
+            const clientReuseManifestHeader =
+              createClientReuseManifestHeaderFromVisibleAppState(routerStateAtNavStart);
+            if (clientReuseManifestHeader !== null) {
+              requestHeaders.set(VINEXT_CLIENT_REUSE_MANIFEST_HEADER, clientReuseManifestHeader);
+            }
+          }
           navResponse = await fetch(rscUrl, {
             headers: requestHeaders,
             credentials: "include",

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -122,6 +122,7 @@ import { ElementsContext, Slot } from "vinext/shims/slot";
 import type { RouteManifest } from "../routing/app-route-graph.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { createOnUncaughtError } from "./app-browser-error.js";
+import { createClientReuseManifestHeaderFromVisibleAppState } from "./app-browser-client-reuse-manifest.js";
 import {
   devOnCaughtError,
   devOnUncaughtError,
@@ -156,7 +157,6 @@ import {
   ACTION_REDIRECT_HEADER,
   ACTION_REDIRECT_STATUS_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
-  VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_RSC_REDIRECT_HEADER,
 } from "./headers.js";
@@ -1657,16 +1657,20 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // Pass navId so only this navigation (or a newer one) can clear it later.
         setPendingPathname(url.pathname, navId);
 
-        const elementsAtNavStart = getBrowserRouterState().elements;
+        const routerStateAtNavStart = getBrowserRouterState();
+        const elementsAtNavStart = routerStateAtNavStart.elements;
         const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
+        const clientReuseManifestHeader =
+          navigationKind === "navigate"
+            ? createClientReuseManifestHeaderFromVisibleAppState(routerStateAtNavStart)
+            : null;
         const requestHeaders = createRscRequestHeaders({
+          clientReuseManifestHeader,
           interceptionContext: requestInterceptionContext,
+          mountedSlotsHeader,
           renderMode:
             navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
         });
-        if (mountedSlotsHeader) {
-          requestHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
-        }
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
         const cachedRoute = getVisitedResponse(
           rscUrl,

--- a/packages/vinext/src/server/app-layout-param-observation.ts
+++ b/packages/vinext/src/server/app-layout-param-observation.ts
@@ -9,7 +9,7 @@ import {
   peekCacheableFetchObservations,
   peekDynamicFetchObservations,
 } from "vinext/shims/fetch-cache";
-import { peekRenderRequestApiUsage } from "vinext/shims/headers";
+import { peekDynamicUsage, peekRenderRequestApiUsage } from "vinext/shims/headers";
 import {
   isInsideUnifiedScope,
   runWithUnifiedStateMutation,
@@ -22,6 +22,13 @@ export type AppLayoutParamAccessObservation = Readonly<{
   cacheableFetchCount: number;
   completeness: "complete" | "unknown";
   dynamicFetchCount: number;
+  /**
+   * `markDynamicUsage()` fired during the probe (e.g. `"use cache: private"`,
+   * `connection()`) with no other observable trace. Folded in from the
+   * isolated probe scope so this signal can't diverge from the Layer-3
+   * `dynamicDetected` path it replaced.
+   */
+  dynamicUsageObserved: boolean;
   finiteRevalidateSeconds: number | null;
   keys: readonly string[];
   observed: boolean;
@@ -45,6 +52,7 @@ export function isAppLayoutObservationUnsafeForStaticReuse(
     observation.completeness !== "complete" ||
     observation.paramScopeKeys.length > 0 ||
     observation.observed ||
+    observation.dynamicUsageObserved ||
     observation.requestApis.length > 0 ||
     observation.finiteRevalidateSeconds !== null ||
     observation.cacheLifeObserved ||
@@ -60,6 +68,7 @@ type MutableLayoutParamAccessObservation = {
   cacheTags: Set<string>;
   cacheableFetches: Set<string>;
   dynamicFetches: Set<string>;
+  dynamicUsageObserved: boolean;
   finiteRevalidateSeconds: number | null;
   keys: Set<string>;
   observed: boolean;
@@ -90,6 +99,7 @@ export function createAppLayoutParamAccessTracker(): AppLayoutParamAccessTracker
       cacheTags: new Set(),
       cacheableFetches: new Set(),
       dynamicFetches: new Set(),
+      dynamicUsageObserved: false,
       finiteRevalidateSeconds: null,
       keys: new Set(),
       observed: false,
@@ -132,6 +142,14 @@ export function createAppLayoutParamAccessTracker(): AppLayoutParamAccessTracker
 
   const recordProbeDependencies = (layoutId: string) => {
     const observation = ensureObservation(layoutId);
+    // Capture the probe's child-scope dynamic-usage flag before the isolated
+    // scope is discarded. `markDynamicUsage()` calls that leave no other
+    // observable trace (e.g. `"use cache: private"`) would otherwise be lost
+    // when the child scope resets `dynamicUsageDetected`, masking the Layer-3
+    // `dynamicDetected` signal this probe wiring replaced.
+    if (peekDynamicUsage()) {
+      observation.dynamicUsageObserved = true;
+    }
     if (_peekRequestScopedCacheLife() !== null) {
       observation.cacheLifeObserved = true;
     }
@@ -169,6 +187,7 @@ export function createAppLayoutParamAccessTracker(): AppLayoutParamAccessTracker
           cacheableFetchCount: 0,
           completeness: "unknown",
           dynamicFetchCount: 0,
+          dynamicUsageObserved: false,
           finiteRevalidateSeconds: null,
           keys: [],
           observed: false,
@@ -184,6 +203,7 @@ export function createAppLayoutParamAccessTracker(): AppLayoutParamAccessTracker
         cacheableFetchCount: observation.cacheableFetches.size,
         completeness: observation.probeComplete ? "complete" : "unknown",
         dynamicFetchCount: observation.dynamicFetches.size,
+        dynamicUsageObserved: observation.dynamicUsageObserved,
         finiteRevalidateSeconds: observation.finiteRevalidateSeconds,
         keys: [...observation.keys].sort(),
         observed: observation.observed,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -277,16 +277,15 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
 /**
  * Request-time counterpart to the build-time `classifyLayoutSegmentConfig`
  * (`build/report.ts`). Both classify a layout by its `dynamic`/`revalidate`
- * segment config and must stay in sync on the shared cases; keep them aligned
- * when either changes.
+ * segment config and agree on the shared cases (the build-time version
+ * normalizes `revalidate = false` to `Infinity` upstream, so both treat it as
+ * static); keep them aligned when either changes.
  *
- * Intentional divergence: this request-time pass reads the resolved module
- * value, so it can treat `revalidate === false` (alongside `Infinity`) as
- * static, whereas the build-time version only sees the numeric literal and so
- * normalizes `false` to `Infinity` upstream. The runtime override is merged on
- * top of the build-time classification map in
- * `createEffectiveLayoutClassifications`, so layouts not captured at build time
- * (e.g. dev mode) are classified here where they previously were not.
+ * The meaningful difference is scope, not logic: this request-time pass reads
+ * the resolved module value, so it classifies layouts that were never captured
+ * at build time (e.g. dev mode). Its result is merged on top of the build-time
+ * classification map in `createEffectiveLayoutClassifications`, so such layouts
+ * are classified here where they previously were not.
  */
 function classifyLayoutSegmentConfigFromModule(
   layout: AppPageModule | null | undefined,
@@ -334,6 +333,11 @@ function createEffectiveLayoutClassifications(
     const classification = classifyLayoutSegmentConfigFromModule(route.layouts[index]);
     if (classification === null) continue;
 
+    // Precedence: when a layout's module segment config classifies, it is
+    // authoritative and overrides the build-time map for that layout — even if
+    // a Layer 1/2 build-time classifier marked it differently for a
+    // non-segment-config reason. Downstream consumers should treat this merged
+    // result, not `__buildTimeClassifications`, as the source of truth.
     classifications.set(index, classification.kind);
     reasons?.set(index, classification.reason);
   }

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -75,9 +75,15 @@ import {
 } from "./app-rsc-render-mode.js";
 import { createAppPageTreePath } from "./app-page-route-wiring.js";
 import type { AppPageSsrHandler } from "./app-page-stream.js";
+import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
 import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
 import type { ISRCacheEntry } from "./isr-cache.js";
+import {
+  createAppLayoutParamAccessTracker,
+  isAppLayoutObservationUnsafeForStaticReuse,
+  type AppLayoutParamAccessTracker,
+} from "./app-layout-param-observation.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type AppPageElement = ReactNode | Readonly<Record<string, ReactNode>>;
@@ -128,7 +134,19 @@ type AppPageDispatchInterceptOptions<TPage = unknown> = {
 
 type AppPageModule = {
   default?: unknown;
+  dynamic?: unknown;
+  revalidate?: unknown;
 };
+
+type LayoutSegmentConfigClassification = Readonly<{
+  kind: "dynamic" | "static";
+  reason: ClassificationReason;
+}>;
+
+type EffectiveLayoutClassifications = Readonly<{
+  buildTimeClassifications: ReadonlyMap<number, "static" | "dynamic"> | null;
+  buildTimeReasons: ReadonlyMap<number, ClassificationReason> | null | undefined;
+}>;
 
 type AppPageDispatchRoute = {
   __buildTimeClassifications?: LayoutClassificationOptions["buildTimeClassifications"];
@@ -174,7 +192,9 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
     params: AppPageParams,
     opts: AppPageDispatchInterceptOptions | undefined,
     searchParams: URLSearchParams,
+    layoutParamAccess?: AppLayoutParamAccessTracker,
   ) => Promise<AppPageElement>;
+  clientReuseManifest?: ClientReuseManifestParseResult;
   cleanPathname: string;
   clearRequestContext: () => void;
   createRscOnErrorHandler: (pathname: string, routePath: string) => AppPageBoundaryOnError;
@@ -218,7 +238,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   params: AppPageParams;
   staticParamsValidationParams?: AppPageParams;
   rootParams?: RootParams;
-  probeLayoutAt: (layoutIndex: number) => unknown;
+  probeLayoutAt: (layoutIndex: number, layoutParamAccess?: AppLayoutParamAccessTracker) => unknown;
   probePage: () => unknown;
   expireSeconds?: number;
   renderErrorBoundaryPage: (error: unknown) => Promise<Response | null>;
@@ -253,6 +273,69 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   }) => void;
   renderMode?: AppRscRenderMode;
 };
+
+function classifyLayoutSegmentConfigFromModule(
+  layout: AppPageModule | null | undefined,
+): LayoutSegmentConfigClassification | null {
+  if (!layout) return null;
+
+  switch (layout.dynamic) {
+    case "force-dynamic":
+      return {
+        kind: "dynamic",
+        reason: { layer: "segment-config", key: "dynamic", value: "force-dynamic" },
+      };
+    case "force-static":
+    case "error":
+      return {
+        kind: "static",
+        reason: { layer: "segment-config", key: "dynamic", value: layout.dynamic },
+      };
+  }
+
+  if (layout.revalidate === false || layout.revalidate === Infinity) {
+    return {
+      kind: "static",
+      reason: { layer: "segment-config", key: "revalidate", value: Infinity },
+    };
+  }
+  if (layout.revalidate === 0) {
+    return {
+      kind: "dynamic",
+      reason: { layer: "segment-config", key: "revalidate", value: 0 },
+    };
+  }
+
+  return null;
+}
+
+function createEffectiveLayoutClassifications(
+  route: AppPageDispatchRoute,
+  includeReasons: boolean,
+): EffectiveLayoutClassifications {
+  const classifications = new Map(route.__buildTimeClassifications ?? []);
+  const reasons = includeReasons ? new Map(route.__buildTimeReasons ?? []) : null;
+
+  for (let index = 0; index < route.layouts.length; index++) {
+    const classification = classifyLayoutSegmentConfigFromModule(route.layouts[index]);
+    if (classification === null) continue;
+
+    classifications.set(index, classification.kind);
+    reasons?.set(index, classification.reason);
+  }
+
+  return {
+    buildTimeClassifications: classifications.size > 0 ? classifications : null,
+    buildTimeReasons: reasons && reasons.size > 0 ? reasons : null,
+  };
+}
+
+function getEffectiveLayoutClassifications(
+  route: AppPageDispatchRoute,
+  debugClassification: DispatchAppPageOptions<AppPageDispatchRoute>["debugClassification"],
+): EffectiveLayoutClassifications {
+  return createEffectiveLayoutClassifications(route, debugClassification !== undefined);
+}
 
 function shouldReadAppPageCache(options: {
   isProgressiveActionRender: boolean;
@@ -368,6 +451,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const isDynamicError = dynamicConfig === "error";
   const isForceDynamic = dynamicConfig === "force-dynamic";
   const isDraftMode = isDraftModeRequest(options.request, options.draftModeSecret);
+  const layoutParamAccess = createAppLayoutParamAccessTracker();
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
   setCurrentFetchCacheMode(options.fetchCache ?? null);
@@ -596,13 +680,20 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     AppPageDispatchInterceptOptions,
     AppPageElement
   >({
-    buildPageElement(interceptRoute, interceptParams, interceptOpts, interceptSearchParams) {
+    buildPageElement(
+      interceptRoute,
+      interceptParams,
+      interceptOpts,
+      interceptSearchParams,
+      interceptLayoutParamAccess,
+    ) {
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(interceptRoute) ?? null);
       return options.buildPageElement(
         interceptRoute,
         interceptParams,
         interceptOpts,
         interceptSearchParams,
+        interceptLayoutParamAccess,
       );
     },
     cleanPathname: options.cleanPathname,
@@ -617,6 +708,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       return options.getSourceRoute(sourceRouteIndex);
     },
     isRscRequest: options.isRscRequest,
+    layoutParamAccess,
     renderInterceptResponse(sourceRoute, interceptElement) {
       const interceptOnError = options.createRscOnErrorHandler(
         options.cleanPathname,
@@ -658,6 +750,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         options.params,
         interceptResult.interceptOpts,
         options.searchParams,
+        layoutParamAccess,
       );
     },
     renderErrorBoundaryPage(buildError) {
@@ -671,6 +764,11 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   if (pageBuildResult.response) {
     return pageBuildResult.response;
   }
+
+  const layoutClassifications = getEffectiveLayoutClassifications(
+    route,
+    options.debugClassification,
+  );
 
   return renderAppPageLifecycle({
     basePath: options.basePath,
@@ -689,6 +787,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       return options.createRscOnErrorHandler(pathname, routePath);
     },
     element: pageBuildResult.element,
+    clientReuseManifest: options.clientReuseManifest,
     getDraftModeCookieHeader,
     getFontLinks: options.getFontLinks,
     getFontPreloads: options.getFontPreloads,
@@ -729,6 +828,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     loadSsrHandler: options.loadSsrHandler,
     middlewareContext: options.middlewareContext,
     params: options.params,
+    layoutParamAccess,
     rootParams: options.rootParams,
     peekRenderObservationState() {
       return {
@@ -737,7 +837,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       };
     },
     probeLayoutAt(layoutIndex) {
-      return options.probeLayoutAt(layoutIndex);
+      return options.probeLayoutAt(layoutIndex, layoutParamAccess);
     },
     probePage() {
       return options.probePage();
@@ -749,9 +849,14 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
           createAppPageTreePath([...route.routeSegments], treePosition),
         );
       },
-      buildTimeClassifications: route.__buildTimeClassifications,
-      buildTimeReasons: route.__buildTimeReasons,
+      buildTimeClassifications: layoutClassifications.buildTimeClassifications,
+      buildTimeReasons: layoutClassifications.buildTimeReasons,
       debugClassification: options.debugClassification,
+      isLayoutObservationDynamic(layoutId) {
+        return isAppLayoutObservationUnsafeForStaticReuse(
+          layoutParamAccess.getLayoutObservation(layoutId),
+        );
+      },
       async runWithIsolatedDynamicScope(fn) {
         const priorDynamic = consumeDynamicUsage();
         try {

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -274,6 +274,20 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   renderMode?: AppRscRenderMode;
 };
 
+/**
+ * Request-time counterpart to the build-time `classifyLayoutSegmentConfig`
+ * (`build/report.ts`). Both classify a layout by its `dynamic`/`revalidate`
+ * segment config and must stay in sync on the shared cases; keep them aligned
+ * when either changes.
+ *
+ * Intentional divergence: this request-time pass reads the resolved module
+ * value, so it can treat `revalidate === false` (alongside `Infinity`) as
+ * static, whereas the build-time version only sees the numeric literal and so
+ * normalizes `false` to `Infinity` upstream. The runtime override is merged on
+ * top of the build-time classification map in
+ * `createEffectiveLayoutClassifications`, so layouts not captured at build time
+ * (e.g. dev mode) are classified here where they previously were not.
+ */
 function classifyLayoutSegmentConfigFromModule(
   layout: AppPageModule | null | undefined,
 ): LayoutSegmentConfigClassification | null {

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -16,6 +16,7 @@ import { DEFAULT_GLOBAL_ERROR_MODULE } from "./default-global-error-module.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
 import { APP_RSC_RENDER_MODE_NAVIGATION, type AppRscRenderMode } from "./app-rsc-render-mode.js";
+import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
 import { createAppPageRenderIdentity } from "./app-page-render-identity.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 
@@ -79,6 +80,7 @@ export type BuildPageElementsOptions<
   rootUnauthorizedModule?: TModule | null;
   /** File-based metadata routes (favicon, manifest, sitemap, etc.). */
   metadataRoutes: readonly MetadataFileRoute[];
+  layoutParamAccess?: AppLayoutParamAccessTracker;
   /**
    * Configured next.config `basePath`. Threaded through `resolveAppPageHead`
    * so file-based metadata route URLs emitted in <head> are prefixed.
@@ -219,6 +221,7 @@ export async function buildPageElements<
     globalErrorModule:
       globalErrorModule ?? (DEFAULT_GLOBAL_ERROR_MODULE as unknown as TErrorModule),
     isRscRequest,
+    layoutParamAccess: options.layoutParamAccess,
     mountedSlotIds,
     makeThenableParams,
     matchedParams: params,

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -161,6 +161,11 @@ export type LayoutClassificationOptions = {
   debugClassification?: (layoutId: string, reason: ClassificationReason) => void;
   /** Maps layout index to its layout ID (e.g. "layout:/blog"). */
   getLayoutId: (layoutIndex: number) => string;
+  /**
+   * Returns whether the completed per-layout observation makes static reuse
+   * unsafe even if the older dynamic scope did not report dynamic usage.
+   */
+  isLayoutObservationDynamic?: (layoutId: string) => boolean;
   /** Runs a function with isolated dynamic usage tracking per layout. */
   runWithIsolatedDynamicScope: <T>(fn: () => T) => Promise<{ result: T; dynamicDetected: boolean }>;
 };
@@ -402,9 +407,10 @@ export async function probeAppPageLayouts(
       const buildTimeResult = cls?.buildTimeClassifications?.get(layoutIndex);
 
       if (cls && buildTimeResult) {
+        const layoutId = cls.getLayoutId(layoutIndex);
         // Build-time classified (Layer 1 or Layer 2): skip dynamic isolation,
         // but still probe for special errors (redirects, not-found).
-        layoutFlags[cls.getLayoutId(layoutIndex)] = buildTimeResult === "static" ? "s" : "d";
+        layoutFlags[layoutId] = buildTimeResult === "static" ? "s" : "d";
         if (cls.debugClassification) {
           // `no-classifier` is the documented fallback for a layout that was
           // build-time classified but whose reason payload is absent — either
@@ -412,34 +418,39 @@ export async function probeAppPageLayouts(
           // because no Layer 1/2 classifier attached a reason. This is the sole
           // producer of the variant; see `layout-classification-types.ts`.
           cls.debugClassification(
-            cls.getLayoutId(layoutIndex),
+            layoutId,
             cls.buildTimeReasons?.get(layoutIndex) ?? { layer: "no-classifier" },
           );
         }
         const errorResponse = await probeLayoutForErrors(options, layoutIndex);
         if (errorResponse) return errorResponse;
+        const observationDynamic = cls.isLayoutObservationDynamic?.(layoutId) === true;
+        layoutFlags[layoutId] = buildTimeResult === "dynamic" || observationDynamic ? "d" : "s";
         continue;
       }
 
       if (cls) {
+        const layoutId = cls.getLayoutId(layoutIndex);
         // Layer 3: probe with isolated dynamic scope to detect per-layout
         // dynamic API usage (headers(), cookies(), connection(), etc.)
         try {
           const { dynamicDetected } = await cls.runWithIsolatedDynamicScope(() =>
             options.probeLayoutAt(layoutIndex),
           );
-          layoutFlags[cls.getLayoutId(layoutIndex)] = dynamicDetected ? "d" : "s";
+          const observationDynamic = cls.isLayoutObservationDynamic?.(layoutId) === true;
+          const layoutDynamic = dynamicDetected || observationDynamic;
+          layoutFlags[layoutId] = layoutDynamic ? "d" : "s";
           if (cls.debugClassification) {
-            cls.debugClassification(cls.getLayoutId(layoutIndex), {
+            cls.debugClassification(layoutId, {
               layer: "runtime-probe",
-              outcome: dynamicDetected ? "dynamic" : "static",
+              outcome: layoutDynamic ? "dynamic" : "static",
             });
           }
         } catch (error) {
           // Probe failed — conservatively treat as dynamic.
-          layoutFlags[cls.getLayoutId(layoutIndex)] = "d";
+          layoutFlags[layoutId] = "d";
           if (cls.debugClassification) {
-            cls.debugClassification(cls.getLayoutId(layoutIndex), {
+            cls.debugClassification(layoutId, {
               layer: "runtime-probe",
               outcome: "dynamic",
               error: error instanceof Error ? error.message : String(error),

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -409,23 +409,37 @@ export async function probeAppPageLayouts(
       if (cls && buildTimeResult) {
         const layoutId = cls.getLayoutId(layoutIndex);
         // Build-time classified (Layer 1 or Layer 2): skip dynamic isolation,
-        // but still probe for special errors (redirects, not-found).
+        // but still probe for special errors (redirects, not-found). Record the
+        // build-time flag up front so it survives a short-circuit if the error
+        // probe returns a special-error response below.
         layoutFlags[layoutId] = buildTimeResult === "static" ? "s" : "d";
-        if (cls.debugClassification) {
-          // `no-classifier` is the documented fallback for a layout that was
-          // build-time classified but whose reason payload is absent — either
-          // because the build was run without `VINEXT_DEBUG_CLASSIFICATION` or
-          // because no Layer 1/2 classifier attached a reason. This is the sole
-          // producer of the variant; see `layout-classification-types.ts`.
-          cls.debugClassification(
-            layoutId,
-            cls.buildTimeReasons?.get(layoutIndex) ?? { layer: "no-classifier" },
-          );
-        }
         const errorResponse = await probeLayoutForErrors(options, layoutIndex);
         if (errorResponse) return errorResponse;
+        // Compute the final flag before reporting so the emitted debug reason
+        // always agrees with `layoutFlags[layoutId]`. A runtime observation can
+        // override a build-time `static` decision to dynamic; in that case we
+        // report a `runtime-probe` reason rather than the stale build-time one.
         const observationDynamic = cls.isLayoutObservationDynamic?.(layoutId) === true;
-        layoutFlags[layoutId] = buildTimeResult === "dynamic" || observationDynamic ? "d" : "s";
+        const layoutDynamic = buildTimeResult === "dynamic" || observationDynamic;
+        layoutFlags[layoutId] = layoutDynamic ? "d" : "s";
+        if (cls.debugClassification) {
+          if (observationDynamic && buildTimeResult === "static") {
+            cls.debugClassification(layoutId, {
+              layer: "runtime-probe",
+              outcome: "dynamic",
+            });
+          } else {
+            // `no-classifier` is the documented fallback for a layout that was
+            // build-time classified but whose reason payload is absent — either
+            // because the build was run without `VINEXT_DEBUG_CLASSIFICATION` or
+            // because no Layer 1/2 classifier attached a reason. This is the sole
+            // producer of the variant; see `layout-classification-types.ts`.
+            cls.debugClassification(
+              layoutId,
+              cls.buildTimeReasons?.get(layoutIndex) ?? { layer: "no-classifier" },
+            );
+          }
+        }
         continue;
       }
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -49,6 +49,8 @@ import {
   createEmptyAppPageRenderObservationState,
   type AppPageRenderObservationState,
 } from "./app-page-render-observation.js";
+import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
+import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
 
 type AppPageBoundaryOnError = (
   error: unknown,
@@ -141,6 +143,12 @@ type RenderAppPageLifecycleOptions = {
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
   waitUntil?: (promise: Promise<void>) => void;
+  // Parsed manifest threaded through dispatch for future skip planner use.
+  // PR3 does not consume it; the planner call lives in the enable-transport slice.
+  clientReuseManifest?: ClientReuseManifestParseResult;
+  // Per-layout observation tracker. Constructed in dispatch, consumed by the
+  // planner in the enable-transport slice.
+  layoutParamAccess?: AppLayoutParamAccessTracker;
   element: ReactNode | Readonly<Record<string, ReactNode>>;
   classification?: LayoutClassificationOptions | null;
 };

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -2,6 +2,7 @@ import type { AppPageSpecialError } from "./app-page-execution.js";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { getAppPageSegmentParamName } from "./app-page-params.js";
 import { notFoundResponse } from "./http-error-responses.js";
+import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type GenerateStaticParams = (args: { params: AppPageParams }) => unknown;
@@ -106,6 +107,7 @@ type ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts, TElement> = {
     params: AppPageParams,
     interceptOpts: TInterceptOpts | undefined,
     searchParams: URLSearchParams,
+    layoutParamAccess?: AppLayoutParamAccessTracker,
   ) => Promise<TElement>;
   cleanPathname: string;
   currentRoute: TRoute;
@@ -113,6 +115,7 @@ type ResolveAppPageInterceptOptions<TRoute, TPage, TInterceptOpts, TElement> = {
   getRouteParamNames: (route: TRoute) => readonly string[];
   getSourceRoute: (sourceRouteIndex: number) => TRoute | undefined;
   isRscRequest: boolean;
+  layoutParamAccess?: AppLayoutParamAccessTracker;
   renderInterceptResponse: (route: TRoute, element: TElement) => Promise<Response> | Response;
   searchParams: URLSearchParams;
   setNavigationContext: (context: {
@@ -408,6 +411,7 @@ export async function resolveAppPageIntercept<TRoute, TPage, TInterceptOpts, TEl
       ),
       options.toInterceptOpts(interceptState.intercept),
       options.searchParams,
+      options.layoutParamAccess,
     );
 
     return {

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1,4 +1,4 @@
-import { Suspense, type ComponentType, type ReactNode } from "react";
+import { Fragment, Suspense, type ComponentType, type ReactNode } from "react";
 import {
   AppElementsWire,
   APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
@@ -27,13 +27,20 @@ import {
 } from "vinext/shims/metadata";
 import { Children, ParallelSlot, Slot } from "vinext/shims/slot";
 import type { AppPageParams } from "./app-page-boundary.js";
+import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
+import type { ThenableParamsObserver } from "vinext/shims/thenable-params";
 import {
   createAppRenderDependency,
+  registerAppElementRenderDependencies,
   renderAfterAppDependencies,
   renderWithAppDependencyBarrier,
   type AppRenderDependency,
 } from "./app-render-dependency.js";
-import { resolveAppPageSegmentParams } from "./app-page-params.js";
+import {
+  resolveAppPageSegmentParamScopeKeys,
+  resolveAppPageSegmentParams,
+} from "./app-page-params.js";
+import { probeReactServerSubtree } from "./app-page-probe.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
@@ -58,6 +65,7 @@ type AppPageComponentProps = {
 
 type AppPageComponent = ComponentType<AppPageComponentProps>;
 type AppPageErrorComponent = ComponentType<{ error: unknown; reset: () => void }>;
+const APP_PAGE_LAYOUT_PROBE_CHILD = <Fragment />;
 
 export type AppPageModule = Record<string, unknown> & {
   default?: AppPageComponent | null | undefined;
@@ -165,7 +173,8 @@ type BuildAppPageRouteElementOptions<
 > = {
   element: ReactNode;
   globalErrorModule?: TErrorModule | null;
-  makeThenableParams: (params: AppPageParams) => unknown;
+  layoutParamAccess?: AppLayoutParamAccessTracker;
+  makeThenableParams: MakeThenableParams;
   matchedParams: AppPageParams;
   metadataPlacement?: "body" | "head";
   resolvedMetadata: Metadata | null;
@@ -177,6 +186,8 @@ type BuildAppPageRouteElementOptions<
   route: AppPageRouteWiringRoute<TModule, TErrorModule>;
   slotOverrides?: Readonly<Record<string, AppPageSlotOverride<TModule>>> | null;
 };
+
+type MakeThenableParams = (params: AppPageParams, observer?: ThenableParamsObserver) => unknown;
 
 type BuildAppPageElementsOptions<
   TModule extends AppPageModule = AppPageModule,
@@ -224,6 +235,76 @@ export function createAppPageTreePath(
     return "/";
   }
   return `/${treePathSegments.join("/")}`;
+}
+
+function readFiniteRevalidateSeconds(module: AppPageModule | null | undefined): number | null {
+  const revalidate = module?.revalidate;
+  return typeof revalidate === "number" && Number.isFinite(revalidate) && revalidate > 0
+    ? revalidate
+    : null;
+}
+
+function recordLayoutSkipObservationScope(options: {
+  layoutId: string;
+  layoutModule: AppPageModule | null | undefined;
+  layoutParamAccess: AppLayoutParamAccessTracker | undefined;
+  routeSegments: readonly string[] | null | undefined;
+  treePosition: number;
+}): void {
+  options.layoutParamAccess?.recordLayoutParamScope(
+    options.layoutId,
+    resolveAppPageSegmentParamScopeKeys(options.routeSegments, options.treePosition),
+  );
+  const revalidateSeconds = readFiniteRevalidateSeconds(options.layoutModule);
+  if (revalidateSeconds !== null) {
+    options.layoutParamAccess?.recordLayoutFiniteRevalidate(options.layoutId, revalidateSeconds);
+  }
+}
+
+export function probeAppPageLayoutWithTracking<TModule extends AppPageModule>(options: {
+  layoutIndex: number;
+  layoutParamAccess: AppLayoutParamAccessTracker | undefined;
+  makeThenableParams: MakeThenableParams;
+  matchedParams: AppPageParams;
+  route: Pick<
+    AppPageRouteWiringRoute<TModule>,
+    "layoutTreePositions" | "layouts" | "routeSegments"
+  >;
+}): unknown {
+  const treePosition = options.route.layoutTreePositions?.[options.layoutIndex] ?? 0;
+  const treePath = createAppPageTreePath(options.route.routeSegments, treePosition);
+  const layoutId = AppElementsWire.encodeLayoutId(treePath);
+  const probe = () => {
+    const layoutModule = options.route.layouts[options.layoutIndex];
+    const LayoutComponent = getDefaultExport(layoutModule);
+    if (!LayoutComponent) return null;
+    recordLayoutSkipObservationScope({
+      layoutId,
+      layoutModule,
+      layoutParamAccess: options.layoutParamAccess,
+      routeSegments: options.route.routeSegments,
+      treePosition,
+    });
+    const layoutParams = resolveAppPageSegmentParams(
+      options.route.routeSegments,
+      treePosition,
+      options.matchedParams,
+    );
+    return probeReactServerSubtree(
+      <LayoutComponent
+        params={options.makeThenableParams(
+          layoutParams,
+          options.layoutParamAccess?.createThenableParamsObserver(layoutId),
+        )}
+      >
+        {APP_PAGE_LAYOUT_PROBE_CHILD}
+      </LayoutComponent>,
+    );
+  };
+
+  return options.layoutParamAccess
+    ? options.layoutParamAccess.runLayoutProbe(layoutId, probe)
+    : probe();
 }
 
 export function createAppPageLayoutEntries<
@@ -438,6 +519,7 @@ export function buildAppPageElements<
     layoutIndicesByTreePosition.set(layoutEntries[index].treePosition, index);
   }
   const layoutDependenciesByIndex = new Map<number, AppRenderDependency>();
+  const renderDependenciesByElementId = new Map<string, AppRenderDependency>();
   const layoutDependenciesBefore: AppRenderDependency[][] = [];
   const slotDependenciesByLayoutIndex: AppRenderDependency[][] = [];
   const templateDependenciesById = new Map<string, AppRenderDependency>();
@@ -508,6 +590,7 @@ export function buildAppPageElements<
       if (getDefaultExport(layoutEntry.layoutModule)) {
         const layoutDependency = createAppRenderDependency();
         layoutDependenciesByIndex.set(layoutIndex, layoutDependency);
+        renderDependenciesByElementId.set(layoutEntry.id, layoutDependency);
         pageDependencies.push(layoutDependency);
       }
       slotDependenciesByLayoutIndex[layoutIndex] = [...pageDependencies];
@@ -570,14 +653,23 @@ export function buildAppPageElements<
     if (!layoutComponent) {
       continue;
     }
+    const layoutParams = resolveAppPageSegmentParams(
+      options.route.routeSegments,
+      layoutEntry.treePosition,
+      options.matchedParams,
+    );
+    recordLayoutSkipObservationScope({
+      layoutId: layoutEntry.id,
+      layoutModule: layoutEntry.layoutModule,
+      layoutParamAccess: options.layoutParamAccess,
+      routeSegments: options.route.routeSegments,
+      treePosition: layoutEntry.treePosition,
+    });
 
     const layoutProps: Record<string, unknown> = {
       params: options.makeThenableParams(
-        resolveAppPageSegmentParams(
-          options.route.routeSegments,
-          layoutEntry.treePosition,
-          options.matchedParams,
-        ),
+        layoutParams,
+        options.layoutParamAccess?.createThenableParamsObserver(layoutEntry.id),
       ),
     };
 
@@ -935,5 +1027,6 @@ export function buildAppPageElements<
     </>
   );
 
+  registerAppElementRenderDependencies(elements, renderDependenciesByElementId);
   return elements;
 }

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -10,6 +10,10 @@ const appElementRenderDependencies = new WeakMap<
   ReadonlyMap<string, AppRenderDependency>
 >();
 
+// Write-only until the enable slice: this map is populated here so the
+// per-element render dependencies are registered ahead of the consumer
+// (`releaseAppElementRenderDependency`) that lands with enable-transport. It is
+// keyed by the elements object and GCs with it, so it is harmless while unread.
 export function registerAppElementRenderDependencies(
   elements: Readonly<Record<string, unknown>>,
   dependenciesByElementId: ReadonlyMap<string, AppRenderDependency>,

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -5,6 +5,19 @@ export type AppRenderDependency = {
   release: () => void;
 };
 
+const appElementRenderDependencies = new WeakMap<
+  Readonly<Record<string, unknown>>,
+  ReadonlyMap<string, AppRenderDependency>
+>();
+
+export function registerAppElementRenderDependencies(
+  elements: Readonly<Record<string, unknown>>,
+  dependenciesByElementId: ReadonlyMap<string, AppRenderDependency>,
+): void {
+  if (dependenciesByElementId.size === 0) return;
+  appElementRenderDependencies.set(elements, dependenciesByElementId);
+}
+
 export function createAppRenderDependency(): AppRenderDependency {
   let released = false;
   let resolve!: () => void;

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -10,6 +10,7 @@ import {
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_URL_HEADER,
   RSC_HEADER,
+  VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
@@ -44,6 +45,7 @@ const CACHE_BUSTING_DIGEST_BYTES = 12;
 const textEncoder = new TextEncoder();
 
 type CreateRscRequestHeadersOptions = {
+  clientReuseManifestHeader?: string | null;
   interceptionContext?: string | null;
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
@@ -272,6 +274,13 @@ export function createRscRequestHeaders(options: CreateRscRequestHeadersOptions 
 
   if (options.mountedSlotsHeader !== undefined && options.mountedSlotsHeader !== null) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
+  }
+
+  if (
+    options.clientReuseManifestHeader !== undefined &&
+    options.clientReuseManifestHeader !== null
+  ) {
+    headers.set(VINEXT_CLIENT_REUSE_MANIFEST_HEADER, options.clientReuseManifestHeader);
   }
 
   const renderMode = options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -53,6 +53,7 @@ import type { MiddlewareModule } from "./middleware-runtime.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
+import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
 import {
   cloneRequestWithHeaders,
   filterInternalHeaders,
@@ -111,6 +112,7 @@ function applyMiddlewareContextToResponse(
 }
 
 type DispatchMatchedPageOptions<TRoute> = {
+  clientReuseManifest: ClientReuseManifestParseResult;
   cleanPathname: string;
   formState: ReactFormState | null;
   actionError?: unknown;
@@ -354,8 +356,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   const normalized = normalizeRscRequest(request, options.basePath);
   if (normalized instanceof Response) return normalized;
 
-  const { url, isRscRequest, interceptionContextHeader, mountedSlotsHeader, renderMode } =
-    normalized;
+  const {
+    url,
+    isRscRequest,
+    interceptionContextHeader,
+    mountedSlotsHeader,
+    renderMode,
+    clientReuseManifest,
+  } = normalized;
   let { pathname, cleanPathname } = normalized;
   // Canonical (external) pathname the user requested. Middleware rewrites and
   // next.config.js rewrites mutate `cleanPathname` so internal route matching
@@ -688,6 +696,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   }
 
   const pageResponse = await options.dispatchMatchedPage({
+    clientReuseManifest,
     cleanPathname,
     formState,
     actionError,

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -40,7 +40,7 @@ export type NormalizedRscRequest = {
   mountedSlotsHeader: string | null;
   /** Semantic RSC payload mode. HTML requests always normalize to "navigation". */
   renderMode: AppRscRenderMode;
-  /** Disabled ClientReuseManifest hint. Never authorizes skip transport in this stage. */
+  /** Parsed ClientReuseManifest hint. Verification and skip authorization happen later. */
   clientReuseManifest: ClientReuseManifestParseResult;
 };
 
@@ -69,7 +69,7 @@ export type NormalizedRscRequest = {
  *   8. Sanitize X-Vinext-Interception-Context — strip null bytes (header injection)
  *   9. Normalize x-vinext-mounted-slots — dedup and sort for canonical cache keys
  *   10. Read semantic render mode for refresh/action payload rendering
- *   11. Parse disabled ClientReuseManifest hints on canonical RSC payload requests
+ *   11. Parse ClientReuseManifest hints on canonical RSC payload requests
  *
  * @returns A 400 or 404 Response for invalid or out-of-scope inputs,
  *          or a NormalizedRscRequest for valid requests.

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -230,7 +230,7 @@ function createCanonicalWireEntries(
 }
 
 // Manifest byte budgets are enforced over UTF-8 encoded header values.
-function countUtf8Bytes(input: string): number {
+export function countUtf8Bytes(input: string): number {
   return textEncoder.encode(input).length;
 }
 

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -320,6 +320,17 @@ export function consumeDynamicUsage(): boolean {
   return used;
 }
 
+/**
+ * Read the dynamic usage flag without resetting it.
+ * Used by the layout probe to fold a probe-scoped `markDynamicUsage()` into the
+ * per-layout observation before the isolated probe scope is discarded, so the
+ * observation captures `markDynamicUsage()` paths (e.g. `"use cache: private"`)
+ * that leave no other observable trace.
+ */
+export function peekDynamicUsage(): boolean {
+  return _getState().dynamicUsageDetected;
+}
+
 function _setStatePhase(
   state: VinextHeadersShimState,
   phase: HeadersAccessPhase,

--- a/tests/app-browser-client-reuse-manifest.test.ts
+++ b/tests/app-browser-client-reuse-manifest.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createArtifactCompatibilityEnvelope } from "../packages/vinext/src/server/artifact-compatibility.js";
+import { createClientReuseManifestHeaderFromVisibleAppState } from "../packages/vinext/src/server/app-browser-client-reuse-manifest.js";
+import { AppElementsWire } from "../packages/vinext/src/server/app-elements.js";
+import {
+  CLIENT_REUSE_MANIFEST_SKIP_VERIFICATION_ENTRY_BUDGET,
+  DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+  parseClientReuseManifestHeader,
+} from "../packages/vinext/src/server/client-reuse-manifest.js";
+
+function createVisibleState(input: {
+  extraEntries?: Record<string, unknown>;
+  graphVersion?: string;
+  layoutFlags: Record<string, "s" | "d">;
+  layoutIds: readonly string[];
+  routeId?: string;
+  visibleCommitVersion?: number;
+}) {
+  const artifactCompatibility = createArtifactCompatibilityEnvelope({
+    deploymentVersion: "deploy:test",
+    graphVersion: input.graphVersion ?? "graph:test",
+    rootBoundaryId: "/",
+  });
+  return {
+    elements: {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: input.layoutIds,
+        rootLayoutTreePath: "/",
+        routeId: input.routeId ?? "route:/current",
+      }),
+      [AppElementsWire.keys.artifactCompatibility]: artifactCompatibility,
+      [AppElementsWire.keys.layoutFlags]: input.layoutFlags,
+      ...input.extraEntries,
+    },
+    visibleCommitVersion: input.visibleCommitVersion ?? 4,
+  };
+}
+
+describe("app browser client reuse manifest", () => {
+  it("builds a public manifest only for retained static layout entries", () => {
+    const header = createClientReuseManifestHeaderFromVisibleAppState(
+      createVisibleState({
+        extraEntries: {
+          "layout:/": "root layout",
+          "layout:/dynamic": "dynamic layout",
+          "page:/current": "page",
+        },
+        layoutFlags: {
+          "layout:/": "s",
+          "layout:/dynamic": "d",
+          "layout:/missing": "s",
+        },
+        layoutIds: ["layout:/", "layout:/dynamic", "layout:/missing"],
+      }),
+    );
+
+    const parsed = parseClientReuseManifestHeader(header);
+
+    expect(parsed.kind).toBe("parsed");
+    if (parsed.kind !== "parsed") {
+      throw new Error("Expected client reuse manifest to parse");
+    }
+    expect(parsed.manifest.visibleCommitVersion).toBe(4);
+    expect(parsed.manifest.replayWindow).toEqual({
+      validFromVisibleCommitVersion: 4,
+      validUntilVisibleCommitVersion: 4,
+    });
+    expect(parsed.manifest.entries.map((entry) => entry.id)).toEqual(["layout:/"]);
+    expect(parsed.manifest.entries[0]).toMatchObject({
+      kind: "layout",
+      privacy: "public",
+    });
+  });
+
+  it("keeps retained static layout proofs stable across source routes", () => {
+    function readLayoutEntry(routeId: string, graphVersion: string) {
+      const header = createClientReuseManifestHeaderFromVisibleAppState(
+        createVisibleState({
+          extraEntries: { "layout:/dashboard": "dashboard layout" },
+          graphVersion,
+          layoutFlags: { "layout:/dashboard": "s" },
+          layoutIds: ["layout:/dashboard"],
+          routeId,
+        }),
+      );
+      const parsed = parseClientReuseManifestHeader(header);
+      expect(parsed.kind).toBe("parsed");
+      if (parsed.kind !== "parsed") {
+        throw new Error("Expected client reuse manifest to parse");
+      }
+      return parsed.manifest.entries[0];
+    }
+
+    const settingsEntry = readLayoutEntry("route:/dashboard/settings", "graph:settings");
+    const profileEntry = readLayoutEntry("route:/dashboard/profile", "graph:profile");
+
+    expect(settingsEntry).toEqual(profileEntry);
+  });
+
+  it("trims entries rather than emitting an oversized manifest header", () => {
+    const layoutIds = Array.from({ length: 12 }, (_, index) => `layout:/section-${index}`);
+    const header = createClientReuseManifestHeaderFromVisibleAppState(
+      createVisibleState({
+        extraEntries: Object.fromEntries(layoutIds.map((layoutId) => [layoutId, layoutId])),
+        layoutFlags: Object.fromEntries(layoutIds.map((layoutId) => [layoutId, "s"])),
+        layoutIds,
+      }),
+      {
+        limits: {
+          ...DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+          maxManifestBytes: 900,
+        },
+      },
+    );
+
+    expect(header).not.toBeNull();
+    expect(new TextEncoder().encode(header!).length).toBeLessThanOrEqual(900);
+
+    const parsed = parseClientReuseManifestHeader(header, {
+      limits: {
+        ...DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+        maxManifestBytes: 900,
+      },
+    });
+    expect(parsed.kind).toBe("parsed");
+    if (parsed.kind !== "parsed") {
+      throw new Error("Expected trimmed client reuse manifest to parse");
+    }
+    expect(parsed.manifest.entries.length).toBeGreaterThan(0);
+    expect(parsed.manifest.entries.length).toBeLessThan(layoutIds.length);
+  });
+
+  it("caps default browser manifests to the server skip verification budget", () => {
+    const layoutIds = Array.from(
+      { length: CLIENT_REUSE_MANIFEST_SKIP_VERIFICATION_ENTRY_BUDGET + 4 },
+      (_, index) => `layout:/section-${index}`,
+    );
+    const header = createClientReuseManifestHeaderFromVisibleAppState(
+      createVisibleState({
+        extraEntries: Object.fromEntries(layoutIds.map((layoutId) => [layoutId, layoutId])),
+        layoutFlags: Object.fromEntries(layoutIds.map((layoutId) => [layoutId, "s"])),
+        layoutIds,
+      }),
+      {
+        limits: {
+          ...DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+          maxManifestBytes: 16_000,
+        },
+      },
+    );
+
+    const parsed = parseClientReuseManifestHeader(header, {
+      limits: {
+        ...DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
+        maxManifestBytes: 16_000,
+      },
+    });
+
+    expect(parsed.kind).toBe("parsed");
+    if (parsed.kind !== "parsed") {
+      throw new Error("Expected capped client reuse manifest to parse");
+    }
+    expect(parsed.manifest.entries.map((entry) => entry.id)).toEqual(
+      layoutIds.slice(0, CLIENT_REUSE_MANIFEST_SKIP_VERIFICATION_ENTRY_BUDGET),
+    );
+  });
+});

--- a/tests/app-layout-param-observation.test.ts
+++ b/tests/app-layout-param-observation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createAppLayoutParamAccessTracker } from "../packages/vinext/src/server/app-layout-param-observation.js";
+import {
+  createAppLayoutParamAccessTracker,
+  isAppLayoutObservationUnsafeForStaticReuse,
+} from "../packages/vinext/src/server/app-layout-param-observation.js";
 import {
   cacheLife,
   MemoryCacheHandler,
@@ -12,9 +15,39 @@ import {
   getRequestContext,
   runWithRequestContext,
 } from "../packages/vinext/src/shims/unified-request-context.js";
-import { markRenderRequestApiUsage } from "../packages/vinext/src/shims/headers.js";
+import {
+  markDynamicUsage,
+  markRenderRequestApiUsage,
+} from "../packages/vinext/src/shims/headers.js";
 
 describe("app layout param observation", () => {
+  it("folds a probe-scoped markDynamicUsage() into the observation as unsafe for static reuse", () => {
+    // Regression guard: the probe runs inside an isolated child scope that
+    // resets `dynamicUsageDetected`, so a `markDynamicUsage()` with no other
+    // observable trace (e.g. `"use cache: private"`) would be discarded when
+    // the scope exits — masking the Layer-3 `dynamicDetected` signal. The
+    // tracker must capture it so the two signals can't diverge.
+    const tracker = createAppLayoutParamAccessTracker();
+
+    void runWithRequestContext(createRequestContext(), () => {
+      tracker.runLayoutProbe("layout:/dynamic", () => {
+        // No request API, cache tag, fetch, or param access — only the raw
+        // dynamic-usage flag, which is the path the old code caught via
+        // `consumeDynamicUsage()`.
+        markDynamicUsage();
+      });
+      tracker.runLayoutProbe("layout:/static", () => null);
+    });
+
+    const dynamicObservation = tracker.getLayoutObservation("layout:/dynamic");
+    expect(dynamicObservation.dynamicUsageObserved).toBe(true);
+    expect(isAppLayoutObservationUnsafeForStaticReuse(dynamicObservation)).toBe(true);
+
+    const staticObservation = tracker.getLayoutObservation("layout:/static");
+    expect(staticObservation.dynamicUsageObserved).toBe(false);
+    expect(isAppLayoutObservationUnsafeForStaticReuse(staticObservation)).toBe(false);
+  });
+
   it("isolates fetch and cacheLife observations to the current layout probe", async () => {
     const tracker = createAppLayoutParamAccessTracker();
 

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { dispatchAppPage } from "../packages/vinext/src/server/app-page-dispatch.js";
 import type { AppPageMiddlewareContext } from "../packages/vinext/src/server/app-page-response.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
+import type { ClientReuseManifestParseResult } from "../packages/vinext/src/server/client-reuse-manifest.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
 
 type TestRoute = {
@@ -85,6 +86,7 @@ function createDispatchOptions(
     isRscRequest?: boolean;
     isrRscKey?: DispatchOptions["isrRscKey"];
     isrGet?: DispatchOptions["isrGet"];
+    clientReuseManifest?: ClientReuseManifestParseResult;
     loadSsrHandler?: DispatchOptions["loadSsrHandler"];
     middlewareContext?: AppPageMiddlewareContext;
     mountedSlotsHeader?: string | null;
@@ -157,6 +159,7 @@ function createDispatchOptions(
         mountedSlotsHeader ? `rsc:${pathname}:${mountedSlotsHeader}` : `rsc:${pathname}`),
     isrSet: vi.fn(async () => {}),
     loadSsrHandler,
+    clientReuseManifest: overrides.clientReuseManifest ?? { kind: "absent" },
     middlewareContext: overrides.middlewareContext ?? {
       headers: null,
       status: null,

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -905,6 +905,72 @@ describe("app page execution helpers", () => {
     });
   });
 
+  it("flips a build-time static layout to dynamic when a runtime observation is unsafe for static reuse", async () => {
+    // Parity guard for the observation override: a layout the build classified
+    // `static` is downgraded to `"d"` at request time when
+    // `isLayoutObservationDynamic` reports the observed render is unsafe for
+    // static reuse (finite revalidate, cache tags, request APIs, param scope,
+    // etc.). The emitted debug reason switches from the stale build-time reason
+    // to `runtime-probe`/`dynamic` so the flag and reason stay in agreement.
+    const calls: Array<{ layoutId: string; reason: unknown }> = [];
+
+    const result = await probeAppPageLayouts({
+      layoutCount: 2,
+      onLayoutError() {
+        return Promise.resolve(null);
+      },
+      probeLayoutAt() {
+        return null;
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+      classification: {
+        buildTimeClassifications: new Map([
+          [0, "static"],
+          [1, "static"],
+        ]),
+        buildTimeReasons: new Map([
+          [0, { layer: "segment-config", key: "dynamic", value: "force-static" }],
+          [1, { layer: "segment-config", key: "dynamic", value: "force-static" }],
+        ]),
+        debugClassification(layoutId, reason) {
+          calls.push({ layoutId, reason });
+        },
+        getLayoutId(layoutIndex) {
+          return ["layout:/", "layout:/dashboard"][layoutIndex];
+        },
+        // Only the dashboard layout's observation is unsafe for static reuse.
+        isLayoutObservationDynamic(layoutId) {
+          return layoutId === "layout:/dashboard";
+        },
+        runWithIsolatedDynamicScope() {
+          throw new Error("isolated scope must not run for build-time classified layouts");
+        },
+      },
+    });
+
+    expect(result.response).toBeNull();
+    // dashboard: build-time static, but the observation flips it to dynamic.
+    // root: build-time static with a safe observation stays static.
+    expect(result.layoutFlags).toEqual({
+      "layout:/": "s",
+      "layout:/dashboard": "d",
+    });
+
+    const byId = Object.fromEntries(calls.map((c) => [c.layoutId, c.reason]));
+    expect(byId["layout:/dashboard"]).toEqual({
+      layer: "runtime-probe",
+      outcome: "dynamic",
+    });
+    // The unflipped layout keeps reporting its build-time reason.
+    expect(byId["layout:/"]).toEqual({
+      layer: "segment-config",
+      key: "dynamic",
+      value: "force-static",
+    });
+  });
+
   it("emits runtime-probe reason with the error message when the probe throws", async () => {
     const calls: Array<{ layoutId: string; reason: unknown }> = [];
 

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -238,6 +238,7 @@ describe("app page request helpers", () => {
         interceptSlotKey: "modal@app/feed/@modal",
       },
       new URLSearchParams("from=feed"),
+      undefined,
     );
     expect(renderInterceptResponse).toHaveBeenCalledTimes(1);
   });

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -13,12 +13,20 @@ import {
   type AppPageSlotOverride,
   buildAppPageElements,
   createAppPageLayoutEntries,
+  probeAppPageLayoutWithTracking,
   resolveAppPageChildSegments,
 } from "../packages/vinext/src/server/app-page-route-wiring.js";
+import { createAppLayoutParamAccessTracker } from "../packages/vinext/src/server/app-layout-param-observation.js";
 import {
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
 } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
+import {
+  createRequestContext,
+  getRequestContext,
+  runWithRequestContext,
+} from "../packages/vinext/src/shims/unified-request-context.js";
 import { buildPageElements as buildResolvedPageElements } from "../packages/vinext/src/server/app-page-element-builder.js";
 
 function readNode(value: unknown): string {
@@ -327,6 +335,81 @@ function LayoutWithoutChildren() {
 }
 
 describe("app page route wiring helpers", () => {
+  it("probes returned layout children with param and revalidate tracking", async () => {
+    const calls: string[] = [];
+    const layoutParamAccess = createAppLayoutParamAccessTracker();
+
+    function Child() {
+      calls.push("child");
+      return null;
+    }
+
+    function Layout() {
+      calls.push("layout");
+      return createElement("section", null, createElement(Child));
+    }
+
+    await probeAppPageLayoutWithTracking({
+      layoutIndex: 0,
+      layoutParamAccess,
+      makeThenableParams,
+      matchedParams: {},
+      route: {
+        layoutTreePositions: [0],
+        layouts: [{ default: Layout, revalidate: 60 }],
+        routeSegments: ["dashboard"],
+      },
+    });
+
+    expect(calls).toEqual(["layout", "child"]);
+    expect(layoutParamAccess.getLayoutObservation("layout:/")).toMatchObject({
+      completeness: "complete",
+      finiteRevalidateSeconds: 60,
+    });
+  });
+
+  it("probes layout branches that render only when children are present", async () => {
+    const calls: string[] = [];
+    const layoutParamAccess = createAppLayoutParamAccessTracker();
+
+    function ChromeThatUsesTaggedData() {
+      calls.push("chrome");
+      getRequestContext().currentRequestTags.push("tag:dashboard-chrome");
+      return null;
+    }
+
+    function Layout(props: { children?: ReactNode }) {
+      calls.push("layout");
+      if (!props.children) return null;
+      return createElement(
+        "section",
+        null,
+        createElement(ChromeThatUsesTaggedData),
+        props.children,
+      );
+    }
+
+    await runWithRequestContext(createRequestContext(), () =>
+      probeAppPageLayoutWithTracking({
+        layoutIndex: 0,
+        layoutParamAccess,
+        makeThenableParams,
+        matchedParams: {},
+        route: {
+          layoutTreePositions: [0],
+          layouts: [{ default: Layout }],
+          routeSegments: ["dashboard"],
+        },
+      }),
+    );
+
+    expect(calls).toEqual(["layout", "chrome"]);
+    expect(layoutParamAccess.getLayoutObservation("layout:/")).toMatchObject({
+      cacheTags: ["tag:dashboard-chrome"],
+      completeness: "complete",
+    });
+  });
+
   it("renders generated metadata in a hidden body outlet for streaming-capable requests", async () => {
     // Ported from Next.js: test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -18,6 +18,7 @@ import {
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
 } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import { VINEXT_CLIENT_REUSE_MANIFEST_HEADER } from "../packages/vinext/src/server/headers.js";
 import { fnv1a64 } from "../packages/vinext/src/utils/hash.js";
 import { withEnvVar } from "./env-test-helpers.js";
 
@@ -80,6 +81,14 @@ describe("App Router RSC cache-busting", () => {
     // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
     expect(createServerActionRequestUrl("/server?name=alice#section")).toBe("/server?name=alice");
+  });
+
+  it("attaches client reuse manifests without making them shared cache variants", async () => {
+    const manifestHeader = '{"entries":[]}';
+    const headers = createRscRequestHeaders({ clientReuseManifestHeader: manifestHeader });
+
+    expect(headers.get(VINEXT_CLIENT_REUSE_MANIFEST_HEADER)).toBe(manifestHeader);
+    await expect(createRscRequestUrl("/dashboard", headers)).resolves.toBe("/dashboard?_rsc");
   });
 
   it("changes the hash when a varying header changes", async () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -6,6 +6,12 @@ import {
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { createAppRscHandler } from "../packages/vinext/src/server/app-rsc-handler.js";
+import { createArtifactCompatibilityEnvelope } from "../packages/vinext/src/server/artifact-compatibility.js";
+import {
+  createClientReuseManifest,
+  createClientReusePayloadHash,
+} from "../packages/vinext/src/server/client-reuse-manifest.js";
+import { VINEXT_CLIENT_REUSE_MANIFEST_HEADER } from "../packages/vinext/src/server/headers.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 
 type TestRoute = {
@@ -614,6 +620,45 @@ describe("createAppRscHandler", () => {
       expect.objectContaining({
         cleanPathname: "/about",
         isRscRequest: false,
+      }),
+    );
+  });
+
+  it("passes parsed ClientReuseManifest hints from canonical RSC requests to page dispatch", async () => {
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const manifest = createClientReuseManifest({
+      entries: [
+        {
+          artifactCompatibility: createArtifactCompatibilityEnvelope(),
+          id: "layout:/",
+          payloadHash: createClientReusePayloadHash("root-layout"),
+          privacy: "public",
+          variantCacheKey: "cp1:root",
+        },
+      ],
+      visibleCommitVersion: 1,
+    });
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about.rsc", {
+        headers: {
+          [VINEXT_CLIENT_REUSE_MANIFEST_HEADER]: JSON.stringify(manifest),
+        },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientReuseManifest: expect.objectContaining({
+          kind: "parsed",
+        }),
+        isRscRequest: true,
       }),
     );
   });


### PR DESCRIPTION
## What this changes
Adds the transport wiring that carries a client reuse manifest from the browser to the server. The browser now derives a bounded manifest from the visible AppElements state and attaches it on soft navigations; the server parses it and threads the parsed result through the RSC handler, the generated app entry, page dispatch, and the render lifecycle. Nothing reads the manifest to authorize a skip yet — no skip decision, no RSC payload omission, no cache-control change.

Note: this is not a pure no-op plumbing slice. Two observable, intentional (more Next-accurate) behavioral changes ride along with the wiring so the enable slice has correct inputs to consume; both are called out under "Behavioral changes" below and pinned by parity assertions.

Bonk: Pls read #1437 to see the context. Tests will come in the next PR. Please do not block on missing tests since churning is time wasting. Focus on the logic/implementation please.

## Why
The static-layout skip planner (#1674) and observation foundations (#1672) have no input to act on until a manifest actually reaches the server. Landing the plumbing on its own keeps it reviewable in isolation and lets the enable-transport slice focus purely on the skip decision and payload omission.

## Approach
- `app-browser-client-reuse-manifest`: bounded producer that builds the manifest from visible AppElements state and caps entries to the skip planner's verification budget. Attached as `X-Vinext-Client-Reuse-Manifest` only for normal `navigate` transitions (not refresh).
- `client-reuse-manifest`: parse the header into a render/send-by-default disposition.
- Thread the parsed result through `app-rsc-handler` -> generated `app-rsc-entry` -> `app-page-dispatch` -> `app-page-render`.
- Wire the per-layout observation tracker (`app-layout-param-observation`) and segment-config classification into dispatch, and register per-element render dependencies via `app-page-route-wiring`, so the enable slice can read them.
- Non-goals: no skip decision, no RSC payload omission, no cache-control change, no `releaseAppElementRenderDependency` consumer (that lands with enable).

## Behavioral changes (intentional, not no-op)
1. **Layout error-probe now renders the full layout subtree, not just the layout function with `children: null`.** `probeLayoutAt` was rewritten to go through `probeAppPageLayoutWithTracking` -> `probeReactServerSubtree`, which (a) passes `<Fragment />` (truthy) as `children` instead of `null` and (b) recursively invokes child server components. Because `probeLayoutForErrors` runs on the build-time-classified path too, a layout whose chrome only renders when `children` is truthy (`if (!children) return null`), or a child component deep in the subtree, can now throw `notFound()`/`redirect()` (or run `fetch`/side effects) during the probe where it previously did not — which can change the emitted HTTP response on an App Router request. This matches Next's render order (layouts render with their children present) and is required so observation tracking sees the dependencies created below a layout's immediate body. Pinned by `tests/app-page-route-wiring.test.ts` ("probes layout branches that render only when children are present").
2. **`__layoutFlags` output can change.** `isLayoutObservationDynamic` is now live in classification and flips a build-time `static` layout to `d` whenever `isAppLayoutObservationUnsafeForStaticReuse` is true (finite revalidate, cache tags, request APIs, param scope, etc.). Additionally, `classifyLayoutSegmentConfigFromModule` runs at request time and is merged on top of the build-time map (module segment config is authoritative), so layouts not captured at build time (e.g. dev mode) are now classified. `__layoutFlags` is serialized to the wire (`app-elements-wire.ts`) and stored in client router state (`app-browser-state.ts`), so the flags a client receives — and which entries enter the manifest — can differ from before this PR. Pinned by `tests/app-page-execution.test.ts` ("flips a build-time static layout to dynamic when a runtime observation is unsafe for static reuse") plus the existing classification suite.

## Validation
- `vp check`: format, lint, type check passed.
- `vp test run` (full suite): 243 files, 6827 tests passed.
- Manifest threading covered by `tests/app-rsc-handler.test.ts` ("passes parsed ClientReuseManifest hints..."), `tests/app-browser-client-reuse-manifest.test.ts`, and `tests/app-rsc-cache-busting.test.ts` (manifest attached without becoming a shared cache variant).

## Risks / follow-ups
- The parsed manifest is carried but never authorizes a skip; absent and unproven manifests render and send exactly as before.
- The two behavioral changes above are observable today (with no manifest consumer yet); they are pinned by the parity assertions noted in each item.
- The producer's per-entry guards (`maxEntryIdLength`, `maxEntryCount`) and the byte budget (`maxManifestBytes`, enforced in `serializeBoundedClientReuseManifest`) are not independently observable: an entry can pass the per-entry guards yet still be trimmed by the byte budget. The enable slice must not assume `layoutFlags[id] === "s" && id in elements` implies the entry made it into the emitted header.
- Slice 3 of 4 from #1437. Enable-transport (the big PR) and SKIP-05 safety hardening follow as stacked PRs.

Refs #726
