### PR TITLE
fix(metadata): omit unused parent arg for cached generateMetadata

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -578,14 +578,8 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
   // which omits the `parent` argument when a cached `generateMetadata` does not
   // declare/use it, so non-serializable parent values (like a `URL`
   // `metadataBase`) never reach the cache-key encoder.
-  try {
-    Object.defineProperty(cachedFn, "length", {
-      value: fn.length,
-      configurable: true,
-    });
-  } catch {
-    // Some environments may make `length` non-configurable; ignore.
-  }
+  // Function `length` is always `configurable: true` per spec, so this is safe.
+  Object.defineProperty(cachedFn, "length", { value: fn.length, configurable: true });
 
   return cachedFn;
 }

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -571,6 +571,22 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
     return result;
   };
 
+  // Preserve the original function's arity on the wrapper. The wrapper is
+  // declared as `(...args)` (arity 0), which hides the original signature.
+  // Callers like `resolveModuleMetadata` rely on `fn.length` to decide whether
+  // to pass optional arguments (e.g. the `parent` metadata) — matching Next.js,
+  // which omits the `parent` argument when a cached `generateMetadata` does not
+  // declare/use it, so non-serializable parent values (like a `URL`
+  // `metadataBase`) never reach the cache-key encoder.
+  try {
+    Object.defineProperty(cachedFn, "length", {
+      value: fn.length,
+      configurable: true,
+    });
+  } catch {
+    // Some environments may make `length` non-configurable; ignore.
+  }
+
   return cachedFn;
 }
 

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -552,6 +552,11 @@ export async function resolveModuleMetadata(
     // resolved parent metadata, which can contain a non-serializable `URL`
     // `metadataBase` and throws "URL objects are not supported".
     // See Next.js resolve-metadata.ts (getResult / useCacheFunctionInfo.usedArgs[1]).
+    //
+    // Note: `fn.length` approximates Next.js's static usage analysis. It can
+    // diverge on default-parameter signatures — e.g. `(props, parent = x)`
+    // reports length 1, and `(props = {}, parent)` reports length 0 — but a
+    // default value on `generateMetadata`'s `parent` is unusual in practice.
     const usesParent = mod.generateMetadata.length >= 2;
     return await (usesParent ? mod.generateMetadata(props, parent) : mod.generateMetadata(props));
   }

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -545,7 +545,15 @@ export async function resolveModuleMetadata(
       searchParams === undefined
         ? { params: asyncParams }
         : { params: asyncParams, searchParams: makeThenableParams(searchParams) };
-    return await mod.generateMetadata(props, parent);
+    // Only pass the `parent` metadata when `generateMetadata` actually declares
+    // it (arity >= 2). Next.js omits the parent argument for `generateMetadata`
+    // functions that don't use it, which matters for `'use cache'` functions:
+    // the cache-key encoder (encodeReply) would otherwise try to serialize the
+    // resolved parent metadata, which can contain a non-serializable `URL`
+    // `metadataBase` and throws "URL objects are not supported".
+    // See Next.js resolve-metadata.ts (getResult / useCacheFunctionInfo.usedArgs[1]).
+    const usesParent = mod.generateMetadata.length >= 2;
+    return await (usesParent ? mod.generateMetadata(props, parent) : mod.generateMetadata(props));
   }
   if (mod.metadata && typeof mod.metadata === "object") {
     return mod.metadata as Metadata;

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -361,6 +361,78 @@ describe("app page head resolution", () => {
     });
   });
 
+  // Regression: a `generateMetadata` that does not declare the `parent`
+  // argument must NOT receive it. Matches Next.js, which omits the parent
+  // argument for cached `generateMetadata` functions that don't use it
+  // (resolve-metadata.ts `getResult` / `useCacheFunctionInfo.usedArgs[1]`).
+  // Passing the parent into a `'use cache'` function feeds it to the cache-key
+  // encoder (encodeReply), which throws on non-serializable values such as a
+  // `URL` `metadataBase` ("URL objects are not supported").
+  it("omits the parent argument for generateMetadata that does not declare it", async () => {
+    const receivedArgCounts: number[] = [];
+    const rootLayout = {
+      metadata: {
+        metadataBase: new URL("https://example.com"),
+        title: "Root",
+      },
+    };
+    const page = {
+      // Arity 0 — declares no `parent` parameter.
+      generateMetadata: async function () {
+        receivedArgCounts.push(arguments.length);
+        return { title: "Page" };
+      },
+    };
+
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [rootLayout],
+      layoutTreePositions: [0],
+      metadataRoutes: [],
+      pageModule: page,
+      params: {},
+      routePath: "/",
+      routeSegments: [],
+    });
+
+    // Only `props` was passed (no parent).
+    expect(receivedArgCounts).toEqual([1]);
+    // metadataBase from the root layout still flows into the resolved metadata.
+    expect(result.metadata?.metadataBase).toBeInstanceOf(URL);
+    expect(String(result.metadata?.metadataBase)).toBe("https://example.com/");
+    expect(result.metadata?.title).toBe("Page");
+  });
+
+  it("still passes the parent argument to generateMetadata that declares it", async () => {
+    const receivedArgCounts: number[] = [];
+    const rootLayout = {
+      metadata: {
+        metadataBase: new URL("https://example.com"),
+        description: "Root description",
+      },
+    };
+    const page = {
+      // Arity 2 — declares `parent`, so it must receive it.
+      generateMetadata: async function (_props: unknown, parent: Promise<Record<string, unknown>>) {
+        receivedArgCounts.push(arguments.length);
+        const parentMetadata = await parent;
+        return { title: String(parentMetadata.description) };
+      },
+    };
+
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [rootLayout],
+      layoutTreePositions: [0],
+      metadataRoutes: [],
+      pageModule: page,
+      params: {},
+      routePath: "/",
+      routeSegments: [],
+    });
+
+    expect(receivedArgCounts).toEqual([2]);
+    expect(result.metadata?.title).toBe("Root description");
+  });
+
   it("keeps primary page title handling independent from active parallel route metadata", async () => {
     const rootLayout = {
       metadata: {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4522,6 +4522,26 @@ describe('"use cache" runtime', () => {
     expect(callCount).toBe(1);
   });
 
+  it("preserves the original function arity on the cached wrapper", async () => {
+    // The wrapper is declared as `(...args)` (arity 0). Callers like
+    // `resolveModuleMetadata` rely on `fn.length` to decide whether to pass
+    // optional arguments (e.g. the metadata `parent`), so the wrapper must
+    // expose the original arity rather than 0.
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    setCacheHandler(new MemoryCacheHandler());
+
+    const zero = registerCachedFunction(async () => ({}), "test:arity-0");
+    const one = registerCachedFunction(async (_a: unknown) => ({}), "test:arity-1");
+    const two = registerCachedFunction(async (_a: unknown, _b: unknown) => ({}), "test:arity-2");
+
+    expect(zero.length).toBe(0);
+    expect(one.length).toBe(1);
+    expect(two.length).toBe(2);
+  });
+
   it("falls back to JSON when RSC module is unavailable (test environment)", async () => {
     // In vitest, @vitejs/plugin-rsc/react/rsc is not available (no Vite RSC
     // environment). The runtime should gracefully fall back to JSON.stringify


### PR DESCRIPTION
## Problem

On routes where a parent layout uses a module-level `'use cache'` directive and exports a `generateMetadata()` that takes **no arguments**, vinext logged:

```
Only plain objects can be passed to Server Functions from the Client. URL objects are not supported.
  {metadataBase: URL, description: ..., openGraph: ..., twitter: ..., title: ...}
                 ^^^
```

(Reproduced on `app-router-playground` at `GET /layouts/clothing`.)

## Root cause

`'use cache'` wraps `generateMetadata` in the cache runtime. vinext always invoked it as `generateMetadata(props, parent)`, where `parent` resolves to the merged ancestor metadata. When an ancestor sets `metadataBase: new URL(...)`, the cache-key encoder (`encodeReply`) awaited the `parent` promise and tried to serialize the `URL` instance — which React rejects.

## Fix (matches Next.js)

Next.js omits the `parent` argument for `generateMetadata` functions that don't use it (`resolve-metadata.ts` `getResult` / `useCacheFunctionInfo.usedArgs[1]`), precisely so non-serializable parent values never reach the cache encoder.

- `resolveModuleMetadata` now only passes `parent` when `generateMetadata` declares it (`fn.length >= 2`).
- `registerCachedFunction` preserves the original function's arity on the wrapper (the wrapper is `(...args)` / arity 0, which otherwise hides the signature) so the arity check works for cached functions too.

## Verification

- Reproduced the warning, then confirmed it is gone after the fix; `metadataBase` URL resolution still works (`og:image` → absolute URL).
- Added regression tests in `tests/app-page-head.test.ts` (parent omitted for arity-0, still passed for arity-2, `metadataBase` URL preserved) and `tests/shims.test.ts` (arity-preserving wrapper).
- `features`, `file-based-metadata`, `nextjs-compat/metadata`, and `shims` suites pass (1395 tests); `vp check` is clean.