### PR TITLE
chore(vinext): bundle zero-dep leaf utilities into dist

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -74,12 +74,9 @@
   "dependencies": {
     "@unpic/react": "catalog:",
     "@vercel/og": "catalog:",
-    "image-size": "catalog:",
-    "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
     "vite-plugin-commonjs": "catalog:",
-    "vite-tsconfig-paths": "catalog:",
-    "web-vitals": "catalog:"
+    "vite-tsconfig-paths": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",
@@ -87,9 +84,12 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@vitejs/plugin-rsc": "catalog:",
+    "image-size": "catalog:",
+    "ipaddr.js": "catalog:",
     "react-server-dom-webpack": "catalog:",
     "vite": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "web-vitals": "catalog:"
   },
   "peerDependencies": {
     "@mdx-js/rollup": "^3.0.0",

--- a/packages/vinext/vite.config.ts
+++ b/packages/vinext/vite.config.ts
@@ -5,7 +5,23 @@ export default defineConfig({
     entry: ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"],
     clean: true,
     deps: {
-      skipNodeModulesBundle: true,
+      // vinext requires *all* node_modules imports to stay external by default:
+      // many `next/*` and other bare imports are re-resolved/aliased inside the
+      // user's build, so bundling the real packages here would break that.
+      // `skipNodeModulesBundle` would do that, but it is mutually exclusive with
+      // `alwaysBundle`. So we replicate it with `neverBundle` (externalize every
+      // bare specifier) and carve out the leaves we want to inline.
+      //
+      // We inline only zero-dependency leaf utilities that vinext uses
+      // internally: they have no transitive deps and are never imported directly
+      // by user code, so there is no benefit to resolving them separately.
+      // Bundling shrinks the install footprint and supply-chain surface.
+      alwaysBundle: ["ipaddr.js", "web-vitals", "image-size"],
+      neverBundle: (id: string) =>
+        /^[^./]/.test(id) && !["ipaddr.js", "web-vitals", "image-size"].includes(id),
+      // Guard: fail the build if anything other than these three ever gets
+      // inlined, so a future stray import can't silently bundle a large package.
+      onlyBundle: ["ipaddr.js", "web-vitals", "image-size"],
     },
     dts: true,
     fixedExtension: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -905,12 +905,6 @@ importers:
       '@vercel/og':
         specifier: 'catalog:'
         version: 0.8.6
-      image-size:
-        specifier: 'catalog:'
-        version: 2.0.2
-      ipaddr.js:
-        specifier: 'catalog:'
-        version: 2.4.0
       magic-string:
         specifier: 'catalog:'
         version: 0.30.21
@@ -923,9 +917,6 @@ importers:
       vite-tsconfig-paths:
         specifier: 'catalog:'
         version: 6.1.1(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(typescript@5.9.3)
-      web-vitals:
-        specifier: 'catalog:'
-        version: 4.2.4
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -942,12 +933,21 @@ importers:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.27(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      image-size:
+        specifier: 'catalog:'
+        version: 2.0.2
+      ipaddr.js:
+        specifier: 'catalog:'
+        version: 2.4.0
       react-server-dom-webpack:
         specifier: 'catalog:'
         version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.22(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.6)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
+      web-vitals:
+        specifier: 'catalog:'
+        version: 4.2.4
 
   tests/fixtures/app-basic:
     dependencies:


### PR DESCRIPTION
## Summary

Inline three zero-dependency leaf utilities into vinext's published `dist/` so downstream users no longer download them (or resolve them through their own lockfile) from the registry:

- `ipaddr.js` — used internally by the `next/image` private-IP validation shim
- `web-vitals` — used internally by the `next/web-vitals` shim
- `image-size` — used internally for metadata route image dimensions

These are never imported directly by user code and have no transitive deps, so there's no dedup/pinning benefit to resolving them separately. Bundling shrinks the install footprint and reduces the supply-chain surface (fewer packages auto-pulled into consumer installs; versions pinned at vinext build time).

## Implementation

- `vite.config.ts`: replace `deps.skipNodeModulesBundle: true` with:
  - `alwaysBundle` — inline the three leaves
  - `neverBundle` — externalize every *other* bare specifier (replicates the old "all node_modules external" behavior, which vinext requires so `next/*` and peer imports still resolve/alias in the user's build)
  - `onlyBundle` — guard that **fails the build** if anything other than these three ever gets inlined
- `package.json`: move the three from `dependencies` → `devDependencies` (still needed at build time to inline; no longer installed by consumers). Lockfile updated.

## Left external on purpose

- **Peer deps** (`react`, `react-dom`, `vite`, `@vitejs/*`, `react-server-dom-webpack`) — users import/dedupe these directly.
- **`@vercel/og`** — its shim is transformed inside the *user's* build and its WASM (`resvg.wasm`) is copied via `require.resolve` from node_modules; bundling would break both.
- **`magic-string`, `vite-plugin-commonjs`, `vite-tsconfig-paths`** — build-time-only, but they have transitive deps, so deferred for now.

## Verification

- Real `npm pack` tarball confirmed to ship `package/dist/node_modules/.pnpm/{ipaddr.js,web-vitals,image-size}/...` (npm does not strip these nested paths). `next`/`@vercel/og`/`@unpic/react`/`magic-string` etc. remain external.
- Emitted `.d.ts` reference bundled types via relative path, so types resolve without consumers installing the packages.
- Tests pass: `image-config`, `image-component`, `image-imports`, `metadata-route-build-data`, `metadata-routes`, `og-inline`, `shims` (1237 passed). `vp check` clean.

## Follow-ups (not in this PR)

- The `external`/`exclude: ["ipaddr.js"]` entries in `src/index.ts` are now inert (the shim imports a relative path, not the bare specifier) — harmless but could be cleaned up.
- Build-time-only deps with transitive trees (`vite-plugin-commonjs`, `vite-tsconfig-paths`) are larger footprint-reduction candidates if we decide to inline their transitive deps too.