### PR TITLE
test(i18n): fix unit suite broken by sticky-locale history state

### DIFF
--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1904,8 +1904,13 @@ describe("window.next debug global", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       // The visible URL is `as` (/redirect-1), even though the underlying
       // route is `url` (/). The server's redirect rule for /redirect-1
-      // must not fire on a shallow update.
-      expect(pushState).toHaveBeenCalledWith({}, "", "/redirect-1");
+      // must not fire on a shallow update. History state now follows the
+      // Next.js shape (`{ url, as, options, __N, key }`) instead of `{}`.
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({ __N: true }),
+        "",
+        "/redirect-1",
+      );
     } finally {
       (globalThis as any).window = previousWindow;
       globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Problem

The unit test suite is red on `main` ([failing run](https://github.com/cloudflare/vinext/actions/runs/26916276780/job/79406619397)):

```
FAIL  |unit| tests/shims.test.ts > window.next debug global >
  Router.push with shallow=true updates URL to `as` and skips fetch for redirect-matching paths
AssertionError: expected "vi.fn()" to be called with arguments: [ {}, '', '/redirect-1' ]
```

## Root cause

[f4d13e25](https://github.com/cloudflare/vinext/commit/f4d13e25) ("fix(i18n): make locale sticky across client navigations") changed the Pages Router `pushState`/`replaceState` calls to write a Next.js-compatible history state shape (`{ url, as, options, __N, key }`) instead of `{}`. That commit updated **6** of the matching `expect(pushState).toHaveBeenCalledWith({}, …)` assertions to use `expect.objectContaining({ __N: true })` — but the shallow `Router.push` redirect-skip test (issue #1522) carried the same `{}` assertion and was missed, so it now fails on the new state shape.

## Fix

Align the missed assertion with the other six: match the first `pushState` argument via `expect.objectContaining({ __N: true })`, while still verifying the visible URL committed to history is `/redirect-1`. No production code changes — the new state shape is the intended behavior.

## Verification

`pnpm test:unit` locally: **5406 passed | 2 skipped, 0 failed** (was 1 failed).