### PR TITLE
fix(pages-router): collapse doubled basePath in client asset URLs

### DIFF
--- a/packages/vinext/src/build/ssr-manifest.ts
+++ b/packages/vinext/src/build/ssr-manifest.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { normalizeManifestFile, manifestFileWithBase } from "../utils/manifest-paths.js";
+import { collapseDuplicateBase, manifestFileWithBase } from "../utils/manifest-paths.js";
 
 export type BundleBackfillChunk = {
   type: "chunk";
@@ -92,7 +92,7 @@ export function augmentSsrManifestFromBundle(
     const normalizedKey = normalizeManifestModuleId(key, root);
     if (!nextManifest[normalizedKey]) nextManifest[normalizedKey] = new Set<string>();
     for (const file of files) {
-      nextManifest[normalizedKey].add(normalizeManifestFile(file));
+      nextManifest[normalizedKey].add(collapseDuplicateBase(file, base));
     }
   }
 

--- a/packages/vinext/src/utils/manifest-paths.ts
+++ b/packages/vinext/src/utils/manifest-paths.ts
@@ -1,4 +1,4 @@
-export function normalizeManifestFile(file: string): string {
+function normalizeManifestFile(file: string): string {
   return file.startsWith("/") ? file.slice(1) : file;
 }
 
@@ -16,4 +16,23 @@ export function manifestFileWithBase(file: string, base: string): string {
 
 export function manifestFilesWithBase(files: string[], base: string): string[] {
   return files.map((file) => manifestFileWithBase(file, base));
+}
+
+/**
+ * Strip a `base` prefix that Vite applied twice: it bakes `base` into the
+ * on-disk chunk fileName and then prepends it again in `ssr-manifest.json`,
+ * yielding `docs/docs/_next/static/...` which 404s. Only an exact
+ * `<base>/<base>/` prefix is collapsed; a single prefix is left untouched.
+ */
+export function collapseDuplicateBase(file: string, base: string): string {
+  const normalizedFile = normalizeManifestFile(file);
+  if (!base || base === "/") return normalizedFile;
+
+  const normalizedBase = normalizeManifestFile(base).replace(/\/+$/, "");
+  if (!normalizedBase) return normalizedFile;
+
+  const doubledPrefix = `${normalizedBase}/${normalizedBase}/`;
+  return normalizedFile.startsWith(doubledPrefix)
+    ? normalizedFile.slice(normalizedBase.length + 1)
+    : normalizedFile;
 }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -1356,6 +1356,41 @@ describe("augmentSsrManifestFromBundle", () => {
     expect(augmented["pages/about.tsx"]).toEqual(["assets/about.js", "assets/about.css"]);
   });
 
+  it("collapses a basePath that Vite duplicated in the SSR manifest", () => {
+    // basePath baked into fileNames + reapplied by Vite yields a doubled URL
+    // that 404s; both sources must dedupe to one single-base path here.
+    const bundle = {
+      "docs/_next/static/_slug_.js": {
+        type: "chunk" as const,
+        fileName: "docs/_next/static/_slug_.js",
+        imports: [],
+        modules: {
+          "/proj/pages/[slug].tsx": {},
+        },
+      },
+    };
+
+    const ssrManifest = {
+      "pages/[slug].tsx": ["docs/docs/_next/static/_slug_.js"],
+    };
+
+    const augmented = _augmentSsrManifestFromBundle(ssrManifest, bundle, "/proj", "/docs/");
+
+    expect(augmented["pages/[slug].tsx"]).toEqual(["docs/_next/static/_slug_.js"]);
+  });
+
+  it("leaves a single basePath prefix untouched (no over-collapse)", () => {
+    // Guards the collapse logic against rewriting a correctly single-prefixed
+    // entry (e.g. when the bundler does not bake base into fileNames).
+    const ssrManifest = {
+      "pages/index.tsx": ["docs/_next/static/index.js"],
+    };
+
+    const augmented = _augmentSsrManifestFromBundle(ssrManifest, {}, "/proj", "/docs/");
+
+    expect(augmented["pages/index.tsx"]).toEqual(["docs/_next/static/index.js"]);
+  });
+
   it("normalizes existing absolute manifest keys before merging bundle metadata", () => {
     const bundle = {
       "assets/counter.js": {


### PR DESCRIPTION
## What this changes

Pages Router apps built with a `basePath` now emit their page and `_app`
client chunk URLs with the basePath applied exactly once
(`/docs/_next/static/_slug_.js`) instead of twice
(`/docs/docs/_next/static/_slug_.js`).

## Why

With a `basePath` (e.g. `/docs`), the rendered HTML pointed every page and
`_app` chunk at a doubled path:

```html
<link rel="modulepreload" href="/docs/docs/_next/static/_slug_-….js">
<script type="module" src="/docs/docs/_next/static/_slug_-….js"></script>
```

```json
"__vinext":{"pageModuleUrl":"/docs/docs/_next/static/_slug_-….js", ...}
```

Those URLs 404, so the client bundle never loads, the page never hydrates,
`next.router` never initializes, and any client-side navigation silently does
nothing. `<div id="__next">` stays empty.

This surfaced as two failing cases in the upstream Next.js suite
[`test/e2e/basepath/error-pages.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/error-pages.test.ts):

- `basePath › client-side navigation › should navigate to /404 correctly client-side`
- `basePath › client-side navigation › should navigate to /_error correctly client-side`

Both call `next.router.push("/404", "/slug-2")` and time out waiting for the
404 page, because the router that would handle the push never came online.

## Approach

Root cause is a base-applied-twice interaction in the build:

1. Vite+ bakes the configured `base` into emitted chunk fileNames on disk
   (`dist/client/docs/_next/static/...`). vinext relies on that layout so the
   Cloudflare ASSETS binding serves `/docs/_next/static/...` directly.
2. Vite then prepends `base` **again** when it writes `ssr-manifest.json`,
   producing `docs/docs/_next/static/...` entries.
3. [`augmentSsrManifestFromBundle`](../blob/main/packages/vinext/src/build/ssr-manifest.ts)
   preserved those doubled entries verbatim (it only stripped a leading slash),
   while its own bundle backfill keyed off `chunk.fileName` and produced the
   correct single-prefix path. The merged manifest held both, and
   `resolveClientModuleUrl` returned the first (doubled) entry.

The on-disk chunk fileName carries the basePath exactly once, so the public URL
must too. New `collapseDuplicateBase` helper collapses an exact
`<base>/<base>/` prefix when normalizing the Vite-sourced manifest entries, so
they line up with the single-base paths the backfill already produces. A
correctly single-prefixed entry is left untouched (no over-collapse).

The fix lives at the single boundary that owns the manifest shape, so every
downstream reader (modulepreload tags, `__vinext.pageModuleUrl`, CSS links) is
corrected at once.

### Non-goals

- App Router is unaffected: its bootstrap script URLs come from the RSC
  plugin's Vite runtime base resolution, which already emitted single-base URLs
  even in the broken output.

## Validation

- New unit tests on `augmentSsrManifestFromBundle`:
  - collapses a basePath that Vite duplicated in the SSR manifest (fails on the
    old implementation, passes with the fix)
  - leaves a single basePath prefix untouched (guards against over-collapse)
- Rebuilt the `pages-i18n-domains-basepath` fixture and confirmed the emitted
  `ssr-manifest.json` no longer contains any `app/app/...` entries.
- Ran the upstream deploy suite end to end:
  `test/e2e/basepath/error-pages.test.ts` went from 2 failed / 6 passed to
  8 passed / 1 skipped.
- `vp check` and the full `tests/build-optimization.test.ts` +
  `tests/deploy.test.ts` suites pass.

## Risks / follow-ups

- The collapse only triggers on an exact `<base>/<base>/` prefix, so it is a
  no-op for builds where the bundler does not bake `base` into fileNames (the
  paths are already single-prefixed). No behavior change for apps without a
  `basePath`.
