### PR TITLE
fix: dev overlay browser sourcemap stacks

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -74,6 +74,7 @@ import { PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER } from "vinext/shims/c
 import { precompressAssets } from "./build/precompress.js";
 import { collectInlineCssManifest, injectInlineCssManifestGlobal } from "./build/inline-css.js";
 import { validateDevRequest } from "./server/dev-origin-check.js";
+import { installDevStackSourcemapMiddleware } from "./server/dev-stack-sourcemap.js";
 import {
   isExternalUrl,
   proxyExternalRequest,
@@ -2856,6 +2857,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
           next();
         });
+
+        installDevStackSourcemapMiddleware(server);
 
         // Return a function to register middleware AFTER Vite's built-in middleware
         return () => {

--- a/packages/vinext/src/server/dev-error-overlay-store.ts
+++ b/packages/vinext/src/server/dev-error-overlay-store.ts
@@ -5,6 +5,7 @@
 export type Source = "uncaught" | "caught" | "window-error" | "unhandledrejection";
 
 export type ReportedError = {
+  id: number;
   source: Source;
   message: string;
   stack: string | undefined;
@@ -24,6 +25,7 @@ const MAX_DEV_OVERLAY_ERRORS = 50;
 
 let snapshot: OverlayState = { errors: [], index: 0, minimized: false };
 const listeners = new Set<() => void>();
+let nextErrorId = 1;
 
 function emit(): void {
   for (const fn of listeners) fn();
@@ -40,17 +42,28 @@ export function getOverlaySnapshot(): OverlayState {
   return snapshot;
 }
 
-export function reportToOverlay(error: ReportedError): void {
+export function reportToOverlay(error: Omit<ReportedError, "id">): number {
   // Any new error pops the dialog open, regardless of source or current
   // state. The developer can minimize once they've taken stock; subsequent
   // failures will re-expand.
-  const next = [...snapshot.errors, error];
+  const id = nextErrorId++;
+  const next = [...snapshot.errors, { ...error, id }];
   const dropped = next.length > MAX_DEV_OVERLAY_ERRORS ? next.length - MAX_DEV_OVERLAY_ERRORS : 0;
   const errors = dropped > 0 ? next.slice(dropped) : next;
   snapshot = {
     errors,
     index: errors.length - 1,
     minimized: false,
+  };
+  emit();
+  return id;
+}
+
+export function updateOverlayErrorStack(id: number, stack: string | undefined): void {
+  if (!snapshot.errors.some((error) => error.id === id)) return;
+  snapshot = {
+    ...snapshot,
+    errors: snapshot.errors.map((error) => (error.id === id ? { ...error, stack } : error)),
   };
   emit();
 }

--- a/packages/vinext/src/server/dev-error-overlay.tsx
+++ b/packages/vinext/src/server/dev-error-overlay.tsx
@@ -24,6 +24,7 @@ import {
   reportToOverlay,
   setOverlayIndex,
   subscribeOverlay,
+  updateOverlayErrorStack,
 } from "./dev-error-overlay-store.js";
 
 // Re-export so callers (e.g. the HMR rsc:update handler) can clear the
@@ -93,11 +94,17 @@ function reportDevError(
   const stack = error instanceof Error ? error.stack : undefined;
 
   ensureMounted();
-  reportToOverlay({
+  const id = reportToOverlay({
     source: options.source,
     message,
     stack,
     componentStack: options.componentStack,
+  });
+
+  void resolveBrowserStackTrace(stack).then((mappedStack) => {
+    if (mappedStack !== stack) {
+      updateOverlayErrorStack(id, mappedStack);
+    }
   });
 }
 
@@ -387,6 +394,30 @@ type Frame = { key: string; fn: string; file?: string; line?: string; col?: stri
 const V8_PAREN_FRAME = /^(.*?)\s*\((.+):(\d+):(\d+)\)$/;
 const V8_BARE_FRAME = /^(.+):(\d+):(\d+)$/;
 const MOZ_FRAME = /^(.*?)@(.+):(\d+):(\d+)$/;
+const V8_PAREN_STACK_LINE = /^(\s*at\s+.*?\()(.+):(\d+):(\d+)(\)\s*)$/;
+const V8_BARE_STACK_LINE = /^(\s*at\s+)(.+):(\d+):(\d+)(\s*)$/;
+const MOZ_STACK_LINE = /^([^@\n]*@)(.+):(\d+):(\d+)(\s*)$/;
+const SOURCE_MAPPING_URL_RE = /(?:\/\/|\/\*)# sourceMappingURL=([^\s*]+)(?:\s*\*\/)?/g;
+
+type SourceMapPayload = {
+  version?: number;
+  sources: string[];
+  sourceRoot?: string;
+  mappings: string;
+};
+
+type SourceMapPosition = {
+  source: string;
+  line: number;
+  column: number;
+};
+
+const BASE64_VLQ_VALUES: Record<string, number> = Object.create(null) as Record<string, number>;
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  .split("")
+  .forEach((char, index) => {
+    BASE64_VLQ_VALUES[char] = index;
+  });
 
 function parseStack(stack: string): Frame[] {
   const frames: Frame[] = [];
@@ -435,6 +466,241 @@ function parseStack(stack: string): Frame[] {
     pushFrame(line);
   }
   return frames;
+}
+
+async function resolveBrowserStackTrace(stack: string | undefined): Promise<string | undefined> {
+  if (!stack || typeof window === "undefined" || typeof fetch !== "function") {
+    return stack;
+  }
+
+  // Browsers expose raw generated locations in Error.stack. Vite dev modules
+  // carry inline source maps, so map same-origin frames before rendering.
+  const sourceMapCache = new Map<string, Promise<SourceMapPayload | null>>();
+  const mapped = await Promise.all(
+    stack.split("\n").map((line) => mapStackLine(line, sourceMapCache)),
+  );
+  return mapped.join("\n");
+}
+
+async function mapStackLine(
+  line: string,
+  sourceMapCache: Map<string, Promise<SourceMapPayload | null>>,
+): Promise<string> {
+  const v8Paren = line.match(V8_PAREN_STACK_LINE);
+  if (v8Paren) {
+    const mapped = await mapGeneratedFrame(v8Paren[2], v8Paren[3], v8Paren[4], sourceMapCache);
+    return mapped
+      ? `${v8Paren[1]}${mapped.file}:${mapped.line}:${mapped.column}${v8Paren[5]}`
+      : line;
+  }
+
+  const v8Bare = line.match(V8_BARE_STACK_LINE);
+  if (v8Bare) {
+    const mapped = await mapGeneratedFrame(v8Bare[2], v8Bare[3], v8Bare[4], sourceMapCache);
+    return mapped ? `${v8Bare[1]}${mapped.file}:${mapped.line}:${mapped.column}${v8Bare[5]}` : line;
+  }
+
+  const moz = line.match(MOZ_STACK_LINE);
+  if (moz) {
+    const mapped = await mapGeneratedFrame(moz[2], moz[3], moz[4], sourceMapCache);
+    return mapped ? `${moz[1]}${mapped.file}:${mapped.line}:${mapped.column}${moz[5]}` : line;
+  }
+
+  return line;
+}
+
+async function mapGeneratedFrame(
+  file: string,
+  line: string,
+  column: string,
+  sourceMapCache: Map<string, Promise<SourceMapPayload | null>>,
+): Promise<{ file: string; line: number; column: number } | null> {
+  const generatedUrl = getMappableGeneratedUrl(file);
+  if (!generatedUrl) return null;
+
+  const generatedLine = Number(line);
+  const generatedColumn = Number(column);
+  if (!Number.isFinite(generatedLine) || !Number.isFinite(generatedColumn)) return null;
+
+  const sourceMap = await getSourceMapForGeneratedUrl(generatedUrl, sourceMapCache);
+  if (!sourceMap) return null;
+
+  const original = originalPositionFor(sourceMap, generatedLine, generatedColumn);
+  if (!original) return null;
+
+  const originalFile = resolveSourceFile(original.source, sourceMap, generatedUrl);
+  return {
+    file: originalFile,
+    line: original.line,
+    column: original.column,
+  };
+}
+
+function getMappableGeneratedUrl(file: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(file, window.location.href);
+  } catch {
+    return null;
+  }
+
+  if (url.origin !== window.location.origin) return null;
+  if (url.pathname.includes("/node_modules/")) return null;
+  return url;
+}
+
+async function getSourceMapForGeneratedUrl(
+  generatedUrl: URL,
+  cache: Map<string, Promise<SourceMapPayload | null>>,
+): Promise<SourceMapPayload | null> {
+  const cacheKey = generatedUrl.href;
+  let sourceMap = cache.get(cacheKey);
+  if (!sourceMap) {
+    sourceMap = loadSourceMapForGeneratedUrl(generatedUrl);
+    cache.set(cacheKey, sourceMap);
+  }
+  return sourceMap;
+}
+
+async function loadSourceMapForGeneratedUrl(generatedUrl: URL): Promise<SourceMapPayload | null> {
+  try {
+    const response = await fetch(generatedUrl.href);
+    if (!response.ok) return null;
+
+    const code = await response.text();
+    const sourceMapUrl = findLastSourceMappingUrl(code);
+    if (!sourceMapUrl) return null;
+
+    const resolvedSourceMapUrl = new URL(sourceMapUrl, generatedUrl.href);
+    if (
+      resolvedSourceMapUrl.protocol !== "data:" &&
+      resolvedSourceMapUrl.origin !== window.location.origin
+    ) {
+      return null;
+    }
+
+    const sourceMapResponse = await fetch(resolvedSourceMapUrl.href);
+    if (!sourceMapResponse.ok) return null;
+
+    return normalizeSourceMapPayload(await sourceMapResponse.json());
+  } catch {
+    return null;
+  }
+}
+
+function findLastSourceMappingUrl(code: string): string | null {
+  let match: RegExpExecArray | null;
+  let last: string | null = null;
+  SOURCE_MAPPING_URL_RE.lastIndex = 0;
+  while ((match = SOURCE_MAPPING_URL_RE.exec(code))) {
+    last = match[1] ?? null;
+  }
+  return last;
+}
+
+function normalizeSourceMapPayload(payload: unknown): SourceMapPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const map = payload as {
+    version?: unknown;
+    sources?: unknown;
+    sourceRoot?: unknown;
+    mappings?: unknown;
+  };
+  if (!Array.isArray(map.sources) || typeof map.mappings !== "string") return null;
+  if (!map.sources.every((source): source is string => typeof source === "string")) return null;
+  return {
+    version: typeof map.version === "number" ? map.version : undefined,
+    sources: map.sources,
+    sourceRoot: typeof map.sourceRoot === "string" ? map.sourceRoot : undefined,
+    mappings: map.mappings,
+  };
+}
+
+function originalPositionFor(
+  sourceMap: SourceMapPayload,
+  generatedLine: number,
+  generatedColumn: number,
+): SourceMapPosition | null {
+  const targetLineIndex = generatedLine - 1;
+  const targetColumn = Math.max(0, generatedColumn - 1);
+  if (targetLineIndex < 0) return null;
+
+  let sourceIndex = 0;
+  let originalLine = 0;
+  let originalColumn = 0;
+  const generatedLines = sourceMap.mappings.split(";");
+
+  for (let generatedLineIndex = 0; generatedLineIndex <= targetLineIndex; generatedLineIndex++) {
+    const generatedSegments = generatedLines[generatedLineIndex];
+    if (generatedSegments === undefined) return null;
+
+    let generatedSegmentColumn = 0;
+    let bestMatch: SourceMapPosition | null = null;
+
+    for (const segment of generatedSegments.split(",")) {
+      if (!segment) continue;
+
+      const decoded = decodeVlqSegment(segment);
+      if (decoded.length === 0) continue;
+
+      generatedSegmentColumn += decoded[0] ?? 0;
+      if (decoded.length >= 4) {
+        sourceIndex += decoded[1] ?? 0;
+        originalLine += decoded[2] ?? 0;
+        originalColumn += decoded[3] ?? 0;
+      }
+
+      if (generatedLineIndex !== targetLineIndex) continue;
+      if (generatedSegmentColumn > targetColumn) break;
+
+      bestMatch =
+        decoded.length >= 4 && sourceMap.sources[sourceIndex]
+          ? {
+              source: sourceMap.sources[sourceIndex]!,
+              line: originalLine + 1,
+              column: originalColumn + 1,
+            }
+          : null;
+    }
+
+    if (generatedLineIndex === targetLineIndex) return bestMatch;
+  }
+
+  return null;
+}
+
+function decodeVlqSegment(segment: string): number[] {
+  const values: number[] = [];
+  let value = 0;
+  let shift = 0;
+
+  for (const char of segment) {
+    const integer = BASE64_VLQ_VALUES[char];
+    if (integer === undefined) return [];
+
+    value += (integer & 31) << shift;
+    if (integer & 32) {
+      shift += 5;
+      continue;
+    }
+
+    values.push(value & 1 ? -(value >> 1) : value >> 1);
+    value = 0;
+    shift = 0;
+  }
+
+  return values;
+}
+
+function resolveSourceFile(source: string, sourceMap: SourceMapPayload, generatedUrl: URL): string {
+  const rootedSource = sourceMap.sourceRoot
+    ? `${sourceMap.sourceRoot.replace(/\/?$/, "/")}${source}`
+    : source;
+  try {
+    return new URL(rootedSource, generatedUrl.href).href;
+  } catch {
+    return source;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/server/dev-error-overlay.tsx
+++ b/packages/vinext/src/server/dev-error-overlay.tsx
@@ -32,6 +32,7 @@ import {
 export { dismissOverlay } from "./dev-error-overlay-store.js";
 
 const MOUNT_NODE_ID = "__vinext_dev_error_overlay_root";
+const ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
 
 let reactRoot: Root | null = null;
 let installed = false;
@@ -394,30 +395,6 @@ type Frame = { key: string; fn: string; file?: string; line?: string; col?: stri
 const V8_PAREN_FRAME = /^(.*?)\s*\((.+):(\d+):(\d+)\)$/;
 const V8_BARE_FRAME = /^(.+):(\d+):(\d+)$/;
 const MOZ_FRAME = /^(.*?)@(.+):(\d+):(\d+)$/;
-const V8_PAREN_STACK_LINE = /^(\s*at\s+.*?\()(.+):(\d+):(\d+)(\)\s*)$/;
-const V8_BARE_STACK_LINE = /^(\s*at\s+)(.+):(\d+):(\d+)(\s*)$/;
-const MOZ_STACK_LINE = /^([^@\n]*@)(.+):(\d+):(\d+)(\s*)$/;
-const SOURCE_MAPPING_URL_RE = /(?:\/\/|\/\*)# sourceMappingURL=([^\s*]+)(?:\s*\*\/)?/g;
-
-type SourceMapPayload = {
-  version?: number;
-  sources: string[];
-  sourceRoot?: string;
-  mappings: string;
-};
-
-type SourceMapPosition = {
-  source: string;
-  line: number;
-  column: number;
-};
-
-const BASE64_VLQ_VALUES: Record<string, number> = Object.create(null) as Record<string, number>;
-"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-  .split("")
-  .forEach((char, index) => {
-    BASE64_VLQ_VALUES[char] = index;
-  });
 
 function parseStack(stack: string): Frame[] {
   const frames: Frame[] = [];
@@ -473,233 +450,17 @@ async function resolveBrowserStackTrace(stack: string | undefined): Promise<stri
     return stack;
   }
 
-  // Browsers expose raw generated locations in Error.stack. Vite dev modules
-  // carry inline source maps, so map same-origin frames before rendering.
-  const sourceMapCache = new Map<string, Promise<SourceMapPayload | null>>();
-  const mapped = await Promise.all(
-    stack.split("\n").map((line) => mapStackLine(line, sourceMapCache)),
-  );
-  return mapped.join("\n");
-}
-
-async function mapStackLine(
-  line: string,
-  sourceMapCache: Map<string, Promise<SourceMapPayload | null>>,
-): Promise<string> {
-  const v8Paren = line.match(V8_PAREN_STACK_LINE);
-  if (v8Paren) {
-    const mapped = await mapGeneratedFrame(v8Paren[2], v8Paren[3], v8Paren[4], sourceMapCache);
-    return mapped
-      ? `${v8Paren[1]}${mapped.file}:${mapped.line}:${mapped.column}${v8Paren[5]}`
-      : line;
-  }
-
-  const v8Bare = line.match(V8_BARE_STACK_LINE);
-  if (v8Bare) {
-    const mapped = await mapGeneratedFrame(v8Bare[2], v8Bare[3], v8Bare[4], sourceMapCache);
-    return mapped ? `${v8Bare[1]}${mapped.file}:${mapped.line}:${mapped.column}${v8Bare[5]}` : line;
-  }
-
-  const moz = line.match(MOZ_STACK_LINE);
-  if (moz) {
-    const mapped = await mapGeneratedFrame(moz[2], moz[3], moz[4], sourceMapCache);
-    return mapped ? `${moz[1]}${mapped.file}:${mapped.line}:${mapped.column}${moz[5]}` : line;
-  }
-
-  return line;
-}
-
-async function mapGeneratedFrame(
-  file: string,
-  line: string,
-  column: string,
-  sourceMapCache: Map<string, Promise<SourceMapPayload | null>>,
-): Promise<{ file: string; line: number; column: number } | null> {
-  const generatedUrl = getMappableGeneratedUrl(file);
-  if (!generatedUrl) return null;
-
-  const generatedLine = Number(line);
-  const generatedColumn = Number(column);
-  if (!Number.isFinite(generatedLine) || !Number.isFinite(generatedColumn)) return null;
-
-  const sourceMap = await getSourceMapForGeneratedUrl(generatedUrl, sourceMapCache);
-  if (!sourceMap) return null;
-
-  const original = originalPositionFor(sourceMap, generatedLine, generatedColumn);
-  if (!original) return null;
-
-  const originalFile = resolveSourceFile(original.source, sourceMap, generatedUrl);
-  return {
-    file: originalFile,
-    line: original.line,
-    column: original.column,
-  };
-}
-
-function getMappableGeneratedUrl(file: string): URL | null {
-  let url: URL;
   try {
-    url = new URL(file, window.location.href);
+    const response = await fetch(ORIGINAL_STACK_TRACE_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ stack }),
+    });
+    if (!response.ok) return stack;
+    const payload = (await response.json()) as { stack?: unknown };
+    return typeof payload.stack === "string" ? payload.stack : stack;
   } catch {
-    return null;
-  }
-
-  if (url.origin !== window.location.origin) return null;
-  if (url.pathname.includes("/node_modules/")) return null;
-  return url;
-}
-
-async function getSourceMapForGeneratedUrl(
-  generatedUrl: URL,
-  cache: Map<string, Promise<SourceMapPayload | null>>,
-): Promise<SourceMapPayload | null> {
-  const cacheKey = generatedUrl.href;
-  let sourceMap = cache.get(cacheKey);
-  if (!sourceMap) {
-    sourceMap = loadSourceMapForGeneratedUrl(generatedUrl);
-    cache.set(cacheKey, sourceMap);
-  }
-  return sourceMap;
-}
-
-async function loadSourceMapForGeneratedUrl(generatedUrl: URL): Promise<SourceMapPayload | null> {
-  try {
-    const response = await fetch(generatedUrl.href);
-    if (!response.ok) return null;
-
-    const code = await response.text();
-    const sourceMapUrl = findLastSourceMappingUrl(code);
-    if (!sourceMapUrl) return null;
-
-    const resolvedSourceMapUrl = new URL(sourceMapUrl, generatedUrl.href);
-    if (
-      resolvedSourceMapUrl.protocol !== "data:" &&
-      resolvedSourceMapUrl.origin !== window.location.origin
-    ) {
-      return null;
-    }
-
-    const sourceMapResponse = await fetch(resolvedSourceMapUrl.href);
-    if (!sourceMapResponse.ok) return null;
-
-    return normalizeSourceMapPayload(await sourceMapResponse.json());
-  } catch {
-    return null;
-  }
-}
-
-function findLastSourceMappingUrl(code: string): string | null {
-  let match: RegExpExecArray | null;
-  let last: string | null = null;
-  SOURCE_MAPPING_URL_RE.lastIndex = 0;
-  while ((match = SOURCE_MAPPING_URL_RE.exec(code))) {
-    last = match[1] ?? null;
-  }
-  return last;
-}
-
-function normalizeSourceMapPayload(payload: unknown): SourceMapPayload | null {
-  if (!payload || typeof payload !== "object") return null;
-  const map = payload as {
-    version?: unknown;
-    sources?: unknown;
-    sourceRoot?: unknown;
-    mappings?: unknown;
-  };
-  if (!Array.isArray(map.sources) || typeof map.mappings !== "string") return null;
-  if (!map.sources.every((source): source is string => typeof source === "string")) return null;
-  return {
-    version: typeof map.version === "number" ? map.version : undefined,
-    sources: map.sources,
-    sourceRoot: typeof map.sourceRoot === "string" ? map.sourceRoot : undefined,
-    mappings: map.mappings,
-  };
-}
-
-function originalPositionFor(
-  sourceMap: SourceMapPayload,
-  generatedLine: number,
-  generatedColumn: number,
-): SourceMapPosition | null {
-  const targetLineIndex = generatedLine - 1;
-  const targetColumn = Math.max(0, generatedColumn - 1);
-  if (targetLineIndex < 0) return null;
-
-  let sourceIndex = 0;
-  let originalLine = 0;
-  let originalColumn = 0;
-  const generatedLines = sourceMap.mappings.split(";");
-
-  for (let generatedLineIndex = 0; generatedLineIndex <= targetLineIndex; generatedLineIndex++) {
-    const generatedSegments = generatedLines[generatedLineIndex];
-    if (generatedSegments === undefined) return null;
-
-    let generatedSegmentColumn = 0;
-    let bestMatch: SourceMapPosition | null = null;
-
-    for (const segment of generatedSegments.split(",")) {
-      if (!segment) continue;
-
-      const decoded = decodeVlqSegment(segment);
-      if (decoded.length === 0) continue;
-
-      generatedSegmentColumn += decoded[0] ?? 0;
-      if (decoded.length >= 4) {
-        sourceIndex += decoded[1] ?? 0;
-        originalLine += decoded[2] ?? 0;
-        originalColumn += decoded[3] ?? 0;
-      }
-
-      if (generatedLineIndex !== targetLineIndex) continue;
-      if (generatedSegmentColumn > targetColumn) break;
-
-      bestMatch =
-        decoded.length >= 4 && sourceMap.sources[sourceIndex]
-          ? {
-              source: sourceMap.sources[sourceIndex]!,
-              line: originalLine + 1,
-              column: originalColumn + 1,
-            }
-          : null;
-    }
-
-    if (generatedLineIndex === targetLineIndex) return bestMatch;
-  }
-
-  return null;
-}
-
-function decodeVlqSegment(segment: string): number[] {
-  const values: number[] = [];
-  let value = 0;
-  let shift = 0;
-
-  for (const char of segment) {
-    const integer = BASE64_VLQ_VALUES[char];
-    if (integer === undefined) return [];
-
-    value += (integer & 31) << shift;
-    if (integer & 32) {
-      shift += 5;
-      continue;
-    }
-
-    values.push(value & 1 ? -(value >> 1) : value >> 1);
-    value = 0;
-    shift = 0;
-  }
-
-  return values;
-}
-
-function resolveSourceFile(source: string, sourceMap: SourceMapPayload, generatedUrl: URL): string {
-  const rootedSource = sourceMap.sourceRoot
-    ? `${sourceMap.sourceRoot.replace(/\/?$/, "/")}${source}`
-    : source;
-  try {
-    return new URL(rootedSource, generatedUrl.href).href;
-  } catch {
-    return source;
+    return stack;
   }
 }
 

--- a/packages/vinext/src/server/dev-error-overlay.tsx
+++ b/packages/vinext/src/server/dev-error-overlay.tsx
@@ -26,13 +26,13 @@ import {
   subscribeOverlay,
   updateOverlayErrorStack,
 } from "./dev-error-overlay-store.js";
+import { VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT } from "./dev-stack-sourcemap.js";
 
 // Re-export so callers (e.g. the HMR rsc:update handler) can clear the
 // overlay when a new payload lands.
 export { dismissOverlay } from "./dev-error-overlay-store.js";
 
 const MOUNT_NODE_ID = "__vinext_dev_error_overlay_root";
-const ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
 
 let reactRoot: Root | null = null;
 let installed = false;
@@ -451,7 +451,7 @@ async function resolveBrowserStackTrace(stack: string | undefined): Promise<stri
   }
 
   try {
-    const response = await fetch(ORIGINAL_STACK_TRACE_ENDPOINT, {
+    const response = await fetch(VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ stack }),

--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -1,7 +1,7 @@
 import type { ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-export const VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
+const VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
 
 type SourceMapPayload = {
   version?: number;

--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -1,7 +1,7 @@
 import type { ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-const VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
+export const VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
 
 export type SourceMapPayload = {
   version?: number;

--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -1,0 +1,335 @@
+import type { ViteDevServer } from "vite";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export const VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
+
+type SourceMapPayload = {
+  version?: number;
+  sources: string[];
+  sourceRoot?: string;
+  mappings: string;
+};
+
+type SourceMapPosition = {
+  source: string;
+  line: number;
+  column: number;
+};
+
+const V8_PAREN_STACK_LINE = /^(\s*at\s+.*?\()(.+):(\d+):(\d+)(\)\s*)$/;
+const V8_BARE_STACK_LINE = /^(\s*at\s+)(.+):(\d+):(\d+)(\s*)$/;
+const MOZ_STACK_LINE = /^([^@\n]*@)(.+):(\d+):(\d+)(\s*)$/;
+
+const BASE64_VLQ_VALUES: Record<string, number> = Object.create(null) as Record<string, number>;
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  .split("")
+  .forEach((char, index) => {
+    BASE64_VLQ_VALUES[char] = index;
+  });
+
+export function installDevStackSourcemapMiddleware(server: ViteDevServer): void {
+  server.middlewares.use((req, res, next) => {
+    if (!isOriginalStackTraceRequest(req)) {
+      next();
+      return;
+    }
+
+    void handleOriginalStackTraceRequest(server, req, res);
+  });
+}
+
+function isOriginalStackTraceRequest(req: IncomingMessage): boolean {
+  const url = new URL(req.url ?? "/", "http://vinext.local");
+  return url.pathname === VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT;
+}
+
+async function handleOriginalStackTraceRequest(
+  server: ViteDevServer,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    writeJson(res, 405, { error: "Method Not Allowed" });
+    return;
+  }
+
+  try {
+    const payload = parseStackTraceRequestBody(await readRequestBody(req));
+    if (!payload) {
+      writeJson(res, 400, { error: "Bad Request" });
+      return;
+    }
+
+    const stack = await resolveDevServerStackTrace(server, payload.stack, req.headers.host);
+    writeJson(res, 200, { stack });
+  } catch {
+    writeJson(res, 500, { error: "Internal Server Error" });
+  }
+}
+
+function parseStackTraceRequestBody(body: string): { stack: string } | null {
+  try {
+    const payload = JSON.parse(body) as { stack?: unknown };
+    return typeof payload.stack === "string" ? { stack: payload.stack } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+function writeJson(res: ServerResponse, statusCode: number, payload: unknown): void {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+async function resolveDevServerStackTrace(
+  server: ViteDevServer,
+  stack: string,
+  requestHost: string | undefined,
+): Promise<string> {
+  const sourceMapCache = new Map<string, Promise<SourceMapPayload | null>>();
+  const mapped = await Promise.all(
+    stack.split("\n").map((line) => mapStackLine(server, line, requestHost, sourceMapCache)),
+  );
+  return mapped.join("\n");
+}
+
+async function mapStackLine(
+  server: ViteDevServer,
+  line: string,
+  requestHost: string | undefined,
+  sourceMapCache: Map<string, Promise<SourceMapPayload | null>>,
+): Promise<string> {
+  const v8Paren = line.match(V8_PAREN_STACK_LINE);
+  if (v8Paren) {
+    const mapped = await mapGeneratedFrame(
+      server,
+      v8Paren[2],
+      v8Paren[3],
+      v8Paren[4],
+      requestHost,
+      sourceMapCache,
+    );
+    return mapped
+      ? `${v8Paren[1]}${mapped.file}:${mapped.line}:${mapped.column}${v8Paren[5]}`
+      : line;
+  }
+
+  const v8Bare = line.match(V8_BARE_STACK_LINE);
+  if (v8Bare) {
+    const mapped = await mapGeneratedFrame(
+      server,
+      v8Bare[2],
+      v8Bare[3],
+      v8Bare[4],
+      requestHost,
+      sourceMapCache,
+    );
+    return mapped ? `${v8Bare[1]}${mapped.file}:${mapped.line}:${mapped.column}${v8Bare[5]}` : line;
+  }
+
+  const moz = line.match(MOZ_STACK_LINE);
+  if (moz) {
+    const mapped = await mapGeneratedFrame(
+      server,
+      moz[2],
+      moz[3],
+      moz[4],
+      requestHost,
+      sourceMapCache,
+    );
+    return mapped ? `${moz[1]}${mapped.file}:${mapped.line}:${mapped.column}${moz[5]}` : line;
+  }
+
+  return line;
+}
+
+async function mapGeneratedFrame(
+  server: ViteDevServer,
+  file: string,
+  line: string,
+  column: string,
+  requestHost: string | undefined,
+  sourceMapCache: Map<string, Promise<SourceMapPayload | null>>,
+): Promise<{ file: string; line: number; column: number } | null> {
+  const generatedUrl = getMappableGeneratedUrl(file, requestHost);
+  if (!generatedUrl) return null;
+
+  const generatedLine = Number(line);
+  const generatedColumn = Number(column);
+  if (!Number.isFinite(generatedLine) || !Number.isFinite(generatedColumn)) return null;
+
+  const sourceMap = await getSourceMapForGeneratedUrl(server, generatedUrl, sourceMapCache);
+  if (!sourceMap) return null;
+
+  const original = originalPositionFor(sourceMap, generatedLine, generatedColumn);
+  if (!original) return null;
+
+  const originalFile = resolveSourceFile(original.source, sourceMap, generatedUrl);
+  return {
+    file: originalFile,
+    line: original.line,
+    column: original.column,
+  };
+}
+
+function getMappableGeneratedUrl(file: string, requestHost: string | undefined): URL | null {
+  const isAbsoluteHttpUrl = /^https?:\/\//i.test(file);
+  let url: URL;
+  try {
+    url = new URL(file, "http://vinext.local");
+  } catch {
+    return null;
+  }
+
+  if (isAbsoluteHttpUrl && requestHost && url.host !== requestHost) {
+    return null;
+  }
+  if (url.pathname.includes("/node_modules/")) return null;
+  return url;
+}
+
+async function getSourceMapForGeneratedUrl(
+  server: ViteDevServer,
+  generatedUrl: URL,
+  cache: Map<string, Promise<SourceMapPayload | null>>,
+): Promise<SourceMapPayload | null> {
+  const cacheKey = generatedUrl.pathname + generatedUrl.search;
+  let sourceMap = cache.get(cacheKey);
+  if (!sourceMap) {
+    sourceMap = loadSourceMapForGeneratedUrl(server, generatedUrl);
+    cache.set(cacheKey, sourceMap);
+  }
+  return sourceMap;
+}
+
+async function loadSourceMapForGeneratedUrl(
+  server: ViteDevServer,
+  generatedUrl: URL,
+): Promise<SourceMapPayload | null> {
+  try {
+    const viteUrl = generatedUrl.pathname + generatedUrl.search;
+    const result = await server.environments.client.transformRequest(viteUrl);
+    return normalizeSourceMapPayload(result?.map);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeSourceMapPayload(payload: unknown): SourceMapPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const map = payload as {
+    version?: unknown;
+    sources?: unknown;
+    sourceRoot?: unknown;
+    mappings?: unknown;
+  };
+  if (!Array.isArray(map.sources) || typeof map.mappings !== "string" || map.mappings === "") {
+    return null;
+  }
+  if (!map.sources.every((source): source is string => typeof source === "string")) return null;
+  return {
+    version: typeof map.version === "number" ? map.version : undefined,
+    sources: map.sources,
+    sourceRoot: typeof map.sourceRoot === "string" ? map.sourceRoot : undefined,
+    mappings: map.mappings,
+  };
+}
+
+function originalPositionFor(
+  sourceMap: SourceMapPayload,
+  generatedLine: number,
+  generatedColumn: number,
+): SourceMapPosition | null {
+  const targetLineIndex = generatedLine - 1;
+  const targetColumn = Math.max(0, generatedColumn - 1);
+  if (targetLineIndex < 0) return null;
+
+  let sourceIndex = 0;
+  let originalLine = 0;
+  let originalColumn = 0;
+  const generatedLines = sourceMap.mappings.split(";");
+
+  for (let generatedLineIndex = 0; generatedLineIndex <= targetLineIndex; generatedLineIndex++) {
+    const generatedSegments = generatedLines[generatedLineIndex];
+    if (generatedSegments === undefined) return null;
+
+    let generatedSegmentColumn = 0;
+    let bestMatch: SourceMapPosition | null = null;
+
+    for (const segment of generatedSegments.split(",")) {
+      if (!segment) continue;
+
+      const decoded = decodeVlqSegment(segment);
+      if (decoded.length === 0) continue;
+
+      generatedSegmentColumn += decoded[0] ?? 0;
+      if (decoded.length >= 4) {
+        sourceIndex += decoded[1] ?? 0;
+        originalLine += decoded[2] ?? 0;
+        originalColumn += decoded[3] ?? 0;
+      }
+
+      if (generatedLineIndex !== targetLineIndex) continue;
+      if (generatedSegmentColumn > targetColumn) break;
+
+      bestMatch =
+        decoded.length >= 4 && sourceMap.sources[sourceIndex]
+          ? {
+              source: sourceMap.sources[sourceIndex]!,
+              line: originalLine + 1,
+              column: originalColumn + 1,
+            }
+          : null;
+    }
+
+    if (generatedLineIndex === targetLineIndex) return bestMatch;
+  }
+
+  return null;
+}
+
+function decodeVlqSegment(segment: string): number[] {
+  const values: number[] = [];
+  let value = 0;
+  let shift = 0;
+
+  for (const char of segment) {
+    const integer = BASE64_VLQ_VALUES[char];
+    if (integer === undefined) return [];
+
+    value += (integer & 31) << shift;
+    if (integer & 32) {
+      shift += 5;
+      continue;
+    }
+
+    values.push(value & 1 ? -(value >> 1) : value >> 1);
+    value = 0;
+    shift = 0;
+  }
+
+  return values;
+}
+
+function resolveSourceFile(source: string, sourceMap: SourceMapPayload, generatedUrl: URL): string {
+  const rootedSource = sourceMap.sourceRoot
+    ? `${sourceMap.sourceRoot.replace(/\/?$/, "/")}${source}`
+    : source;
+  try {
+    return new URL(rootedSource, generatedUrl.href).href;
+  } catch {
+    return source;
+  }
+}

--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -3,6 +3,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 export const VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
 
+const MAX_ORIGINAL_STACK_TRACE_BODY_BYTES = 1024 * 1024;
+
 export type SourceMapPayload = {
   version?: number;
   sources: string[];
@@ -19,6 +21,8 @@ type SourceMapPosition = {
 const V8_PAREN_STACK_LINE = /^(\s*at\s+.*?\()(.+):(\d+):(\d+)(\)\s*)$/;
 const V8_BARE_STACK_LINE = /^(\s*at\s+)(.+):(\d+):(\d+)(\s*)$/;
 const MOZ_STACK_LINE = /^([^@\n]*@)(.+):(\d+):(\d+)(\s*)$/;
+
+class RequestBodyTooLargeError extends Error {}
 
 const BASE64_VLQ_VALUES: Record<string, number> = Object.create(null) as Record<string, number>;
 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
@@ -68,7 +72,11 @@ async function handleOriginalStackTraceRequest(
       getDevStackSourcemapRequestHost(req.headers),
     );
     writeJson(res, 200, { stack });
-  } catch {
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      writeJson(res, 413, { error: "Payload Too Large" });
+      return;
+    }
     writeJson(res, 500, { error: "Internal Server Error" });
   }
 }
@@ -85,12 +93,29 @@ function parseStackTraceRequestBody(body: string): { stack: string } | null {
 async function readRequestBody(req: IncomingMessage): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     let body = "";
+    let bytes = 0;
+    let settled = false;
     req.setEncoding("utf8");
     req.on("data", (chunk: string) => {
+      bytes += Buffer.byteLength(chunk, "utf8");
+      if (bytes > MAX_ORIGINAL_STACK_TRACE_BODY_BYTES) {
+        settled = true;
+        reject(new RequestBodyTooLargeError());
+        req.destroy();
+        return;
+      }
       body += chunk;
     });
-    req.on("end", () => resolve(body));
-    req.on("error", reject);
+    req.on("end", () => {
+      if (settled) return;
+      settled = true;
+      resolve(body);
+    });
+    req.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
   });
 }
 

--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -3,14 +3,14 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 const VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT = "/__vinext_original-stack-trace";
 
-type SourceMapPayload = {
+export type SourceMapPayload = {
   version?: number;
   sources: string[];
   sourceRoot?: string;
   mappings: string;
 };
 
-type SourceMapPosition = {
+export type SourceMapPosition = {
   source: string;
   line: number;
   column: number;
@@ -34,7 +34,9 @@ export function installDevStackSourcemapMiddleware(server: ViteDevServer): void 
       return;
     }
 
-    void handleOriginalStackTraceRequest(server, req, res);
+    handleOriginalStackTraceRequest(server, req, res).catch(() => {
+      if (!res.headersSent) writeJson(res, 500, { error: "Internal Server Error" });
+    });
   });
 }
 
@@ -118,7 +120,7 @@ async function resolveDevServerStackTrace(
   return mapped.join("\n");
 }
 
-async function mapStackLine(
+export async function mapStackLine(
   server: ViteDevServer,
   line: string,
   requestHost: string | undefined,
@@ -260,7 +262,7 @@ function normalizeSourceMapPayload(payload: unknown): SourceMapPayload | null {
   };
 }
 
-function originalPositionFor(
+export function originalPositionFor(
   sourceMap: SourceMapPayload,
   generatedLine: number,
   generatedColumn: number,
@@ -313,7 +315,7 @@ function originalPositionFor(
   return null;
 }
 
-function decodeVlqSegment(segment: string): number[] {
+export function decodeVlqSegment(segment: string): number[] {
   const values: number[] = [];
   let value = 0;
   let shift = 0;
@@ -336,7 +338,11 @@ function decodeVlqSegment(segment: string): number[] {
   return values;
 }
 
-function resolveSourceFile(source: string, sourceMap: SourceMapPayload, generatedUrl: URL): string {
+export function resolveSourceFile(
+  source: string,
+  sourceMap: SourceMapPayload,
+  generatedUrl: URL,
+): string {
   const rootedSource = sourceMap.sourceRoot
     ? `${sourceMap.sourceRoot.replace(/\/?$/, "/")}${source}`
     : source;

--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -60,7 +60,11 @@ async function handleOriginalStackTraceRequest(
       return;
     }
 
-    const stack = await resolveDevServerStackTrace(server, payload.stack, req.headers.host);
+    const stack = await resolveDevServerStackTrace(
+      server,
+      payload.stack,
+      getDevStackSourcemapRequestHost(req.headers),
+    );
     writeJson(res, 200, { stack });
   } catch {
     writeJson(res, 500, { error: "Internal Server Error" });
@@ -91,6 +95,15 @@ async function readRequestBody(req: IncomingMessage): Promise<string> {
 function writeJson(res: ServerResponse, statusCode: number, payload: unknown): void {
   res.writeHead(statusCode, { "Content-Type": "application/json" });
   res.end(JSON.stringify(payload));
+}
+
+function getDevStackSourcemapRequestHost(headers: IncomingMessage["headers"]): string | undefined {
+  return normalizeRequestHost(headers["x-forwarded-host"]) ?? normalizeRequestHost(headers.host);
+}
+
+function normalizeRequestHost(value: string | string[] | undefined): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw?.split(",")[0]?.trim().toLowerCase() || undefined;
 }
 
 async function resolveDevServerStackTrace(

--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -10,7 +10,7 @@ export type SourceMapPayload = {
   mappings: string;
 };
 
-export type SourceMapPosition = {
+type SourceMapPosition = {
   source: string;
   line: number;
   column: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1067,6 +1067,10 @@ importers:
         specifier: 'catalog:'
         version: 0.1.22(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.6)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
 
+  tests/fixtures/css-url-assets-app: {}
+
+  tests/fixtures/css-url-assets-pages: {}
+
   tests/fixtures/ecosystem/better-auth:
     dependencies:
       '@opentelemetry/api':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1067,10 +1067,6 @@ importers:
         specifier: 'catalog:'
         version: 0.1.22(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/coverage-istanbul@4.1.6)(@voidzero-dev/vite-plus-core@0.1.22(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3)
 
-  tests/fixtures/css-url-assets-app: {}
-
-  tests/fixtures/css-url-assets-pages: {}
-
   tests/fixtures/ecosystem/better-auth:
     dependencies:
       '@opentelemetry/api':

--- a/tests/dev-stack-sourcemap.test.ts
+++ b/tests/dev-stack-sourcemap.test.ts
@@ -1,10 +1,14 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { PassThrough } from "node:stream";
 import type { ViteDevServer } from "vite";
 import { describe, expect, it } from "vite-plus/test";
 import {
   decodeVlqSegment,
+  installDevStackSourcemapMiddleware,
   mapStackLine,
   originalPositionFor,
   resolveSourceFile,
+  VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT,
   type SourceMapPayload,
 } from "../packages/vinext/src/server/dev-stack-sourcemap.js";
 
@@ -13,11 +17,15 @@ const SOURCE_MAP = {
   mappings: "AAAA,KASE",
 } satisfies SourceMapPayload;
 
+type DevStackMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+
 function createServer(sourceMap: SourceMapPayload | null = SOURCE_MAP): {
   server: ViteDevServer;
   transformRequests: string[];
+  middlewareHandlers: DevStackMiddleware[];
 } {
   const transformRequests: string[] = [];
+  const middlewareHandlers: DevStackMiddleware[] = [];
   const server = {
     environments: {
       client: {
@@ -27,10 +35,103 @@ function createServer(sourceMap: SourceMapPayload | null = SOURCE_MAP): {
         },
       },
     },
+    middlewares: {
+      use(handler: DevStackMiddleware) {
+        middlewareHandlers.push(handler);
+      },
+    },
   } as unknown as ViteDevServer;
 
-  return { server, transformRequests };
+  return { server, transformRequests, middlewareHandlers };
 }
+
+function mockStackTraceRequest(body: string): IncomingMessage {
+  const stream = new PassThrough();
+  const req = Object.assign(stream, {
+    method: "POST",
+    url: VINEXT_ORIGINAL_STACK_TRACE_ENDPOINT,
+    headers: { host: "localhost:5173" },
+  }) as unknown as IncomingMessage;
+
+  queueMicrotask(() => {
+    stream.end(body);
+  });
+
+  return req;
+}
+
+function mockResponse(): ServerResponse & {
+  _body: string;
+  _headers: Record<string, string>;
+  _statusCode: number;
+  done: Promise<void>;
+} {
+  let resolveDone!: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  const headers: Record<string, string> = {};
+  let headersSent = false;
+  const res = {
+    statusCode: 200,
+    get headersSent() {
+      return headersSent;
+    },
+    _body: "",
+    _headers: headers,
+    _statusCode: 200,
+    done,
+    writeHead(status: number, hdrs?: Record<string, string>) {
+      res.statusCode = status;
+      res._statusCode = status;
+      headersSent = true;
+      if (hdrs) {
+        for (const [key, value] of Object.entries(hdrs)) {
+          headers[key.toLowerCase()] = value;
+        }
+      }
+      return res;
+    },
+    end(data?: string | Buffer) {
+      if (data !== undefined) {
+        res._body = Buffer.isBuffer(data) ? data.toString("utf8") : data;
+      }
+      resolveDone();
+      return res;
+    },
+  } as unknown as ServerResponse & {
+    _body: string;
+    _headers: Record<string, string>;
+    _statusCode: number;
+    done: Promise<void>;
+  };
+
+  return res;
+}
+
+describe("installDevStackSourcemapMiddleware", () => {
+  it("returns 413 when the stack trace request body exceeds 1 MB", async () => {
+    const { server, middlewareHandlers, transformRequests } = createServer();
+    installDevStackSourcemapMiddleware(server);
+    const middleware = middlewareHandlers[0];
+    expect(middleware).toBeDefined();
+
+    const req = mockStackTraceRequest(JSON.stringify({ stack: "x".repeat(1024 * 1024) }));
+    const res = mockResponse();
+    let nextCalled = false;
+
+    middleware!(req, res, () => {
+      nextCalled = true;
+    });
+
+    await res.done;
+
+    expect(nextCalled).toBe(false);
+    expect(res._statusCode).toBe(413);
+    expect(JSON.parse(res._body)).toEqual({ error: "Payload Too Large" });
+    expect(transformRequests).toEqual([]);
+  });
+});
 
 describe("decodeVlqSegment", () => {
   it("decodes base64 VLQ source-map segments", () => {

--- a/tests/dev-stack-sourcemap.test.ts
+++ b/tests/dev-stack-sourcemap.test.ts
@@ -1,0 +1,170 @@
+import type { ViteDevServer } from "vite";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  decodeVlqSegment,
+  mapStackLine,
+  originalPositionFor,
+  resolveSourceFile,
+  type SourceMapPayload,
+} from "../packages/vinext/src/server/dev-stack-sourcemap.js";
+
+const SOURCE_MAP = {
+  sources: ["./original.tsx"],
+  mappings: "AAAA,KASE",
+} satisfies SourceMapPayload;
+
+function createServer(sourceMap: SourceMapPayload | null = SOURCE_MAP): {
+  server: ViteDevServer;
+  transformRequests: string[];
+} {
+  const transformRequests: string[] = [];
+  const server = {
+    environments: {
+      client: {
+        async transformRequest(viteUrl: string) {
+          transformRequests.push(viteUrl);
+          return { map: sourceMap };
+        },
+      },
+    },
+  } as unknown as ViteDevServer;
+
+  return { server, transformRequests };
+}
+
+describe("decodeVlqSegment", () => {
+  it("decodes base64 VLQ source-map segments", () => {
+    expect(decodeVlqSegment("AAAA")).toEqual([0, 0, 0, 0]);
+    expect(decodeVlqSegment("KACE")).toEqual([5, 0, 1, 2]);
+    expect(decodeVlqSegment("GACD")).toEqual([3, 0, 1, -1]);
+  });
+
+  it("returns an empty segment for invalid VLQ characters", () => {
+    expect(decodeVlqSegment("$")).toEqual([]);
+  });
+});
+
+describe("originalPositionFor", () => {
+  it("uses the nearest mapped segment at or before the generated column", () => {
+    const sourceMap = {
+      sources: ["source.tsx"],
+      mappings: "AAAA,KACE,GACD",
+    } satisfies SourceMapPayload;
+
+    expect(originalPositionFor(sourceMap, 1, 1)).toEqual({
+      source: "source.tsx",
+      line: 1,
+      column: 1,
+    });
+    expect(originalPositionFor(sourceMap, 1, 7)).toEqual({
+      source: "source.tsx",
+      line: 2,
+      column: 3,
+    });
+    expect(originalPositionFor(sourceMap, 1, 9)).toEqual({
+      source: "source.tsx",
+      line: 3,
+      column: 2,
+    });
+  });
+
+  it("treats single-field generated-only segments as unmapped ranges", () => {
+    const sourceMap = {
+      sources: ["source.tsx"],
+      mappings: "AAAA,KACE,C,GACD",
+    } satisfies SourceMapPayload;
+
+    expect(originalPositionFor(sourceMap, 1, 7)).toBeNull();
+    expect(originalPositionFor(sourceMap, 1, 10)).toEqual({
+      source: "source.tsx",
+      line: 3,
+      column: 2,
+    });
+  });
+
+  it("resets generated columns per line while carrying original fields across lines", () => {
+    const sourceMap = {
+      sources: ["source.tsx"],
+      mappings: "AAAA,KACE;AACA",
+    } satisfies SourceMapPayload;
+
+    expect(originalPositionFor(sourceMap, 2, 1)).toEqual({
+      source: "source.tsx",
+      line: 3,
+      column: 3,
+    });
+  });
+});
+
+describe("mapStackLine", () => {
+  const cases = [
+    {
+      name: "V8 paren frames",
+      input: "    at onClick (http://localhost:5173/src/App.tsx?t=1:1:6)",
+      expected: "    at onClick (http://localhost:5173/src/original.tsx:10:3)",
+    },
+    {
+      name: "V8 bare frames",
+      input: "    at http://localhost:5173/src/App.tsx?t=1:1:6",
+      expected: "    at http://localhost:5173/src/original.tsx:10:3",
+    },
+    {
+      name: "Moz frames",
+      input: "onClick@http://localhost:5173/src/App.tsx?t=1:1:6",
+      expected: "onClick@http://localhost:5173/src/original.tsx:10:3",
+    },
+  ];
+
+  for (const { name, input, expected } of cases) {
+    it(`maps ${name}`, async () => {
+      const { server, transformRequests } = createServer();
+
+      await expect(
+        mapStackLine(
+          server,
+          input,
+          "localhost:5173",
+          new Map<string, Promise<SourceMapPayload | null>>(),
+        ),
+      ).resolves.toBe(expected);
+      expect(transformRequests).toEqual(["/src/App.tsx?t=1"]);
+    });
+  }
+
+  it("leaves frames unchanged when the generated URL host does not match the request host", async () => {
+    const { server, transformRequests } = createServer();
+    const line = "    at onClick (http://evil.test/src/App.tsx?t=1:1:6)";
+
+    await expect(
+      mapStackLine(
+        server,
+        line,
+        "localhost:5173",
+        new Map<string, Promise<SourceMapPayload | null>>(),
+      ),
+    ).resolves.toBe(line);
+    expect(transformRequests).toEqual([]);
+  });
+});
+
+describe("resolveSourceFile", () => {
+  it("resolves relative sources against the generated URL", () => {
+    expect(
+      resolveSourceFile(
+        "./original.tsx",
+        { sources: [], mappings: "AAAA" },
+        new URL("http://localhost:5173/src/App.tsx?t=1"),
+      ),
+    ).toBe("http://localhost:5173/src/original.tsx");
+  });
+
+  it("resolves sourceRoot before source paths", () => {
+    expect(
+      resolveSourceFile(
+        "src/page.tsx",
+        { sources: [], sourceRoot: "file:///repo/app", mappings: "AAAA" },
+        new URL("http://localhost:5173/generated/chunk.js"),
+      ),
+    ).toBe("file:///repo/app/src/page.tsx");
+  });
+});

--- a/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
+++ b/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
@@ -5,9 +5,9 @@ const EXPECTED_THROW_LINE = 33;
 
 // Regression for https://github.com/langgenius/dify/issues/37031.
 // Next.js reference: dev client bundles remain source-map aware, and App Router
-// dev errors can request source maps through the dev server.
-// https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/config/blocks/base.ts
-// https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-find-source-map-url.ts
+// dev errors request original stack frames through the dev server.
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/next-devtools/shared/stack-frame.ts
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dev/middleware-webpack.ts
 test("maps browser runtime error stack frames back to original TSX source lines", async ({
   page,
 }) => {
@@ -15,7 +15,14 @@ test("maps browser runtime error stack frames back to original TSX source lines"
   await page.waitForFunction(
     () => (window as Window & { __VINEXT_HYDRATED_AT?: number }).__VINEXT_HYDRATED_AT !== undefined,
   );
+
+  const originalStackTraceRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === "/__vinext_original-stack-trace" && request.method() === "POST";
+  });
+
   await page.getByTestId("trigger-client-runtime-sourcemap-error").click();
+  await originalStackTraceRequest;
 
   await expect(page.getByTestId("vinext-dev-error-message")).toContainText(
     "client-runtime-sourcemap: original TSX throw line",

--- a/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
+++ b/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 const BASE = "http://localhost:4181";
+// Keep in sync with the throw in source-mapped-runtime-error.tsx.
 const EXPECTED_THROW_LINE = 33;
 
 // Regression for https://github.com/langgenius/dify/issues/37031.

--- a/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
+++ b/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = "http://localhost:4181";
+const EXPECTED_THROW_LINE = 33;
+
+// Regression for https://github.com/langgenius/dify/issues/37031.
+// Next.js reference: dev client bundles remain source-map aware, and App Router
+// dev errors can request source maps through the dev server.
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/config/blocks/base.ts
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/client/app-find-source-map-url.ts
+test("maps browser runtime error stack frames back to original TSX source lines", async ({
+  page,
+}) => {
+  await page.goto(`${BASE}/client-runtime-sourcemap`);
+  await page.waitForFunction(
+    () => (window as Window & { __VINEXT_HYDRATED_AT?: number }).__VINEXT_HYDRATED_AT !== undefined,
+  );
+  await page.getByTestId("trigger-client-runtime-sourcemap-error").click();
+
+  await expect(page.getByTestId("vinext-dev-error-message")).toContainText(
+    "client-runtime-sourcemap: original TSX throw line",
+  );
+
+  const frames = await page
+    .getByTestId("vinext-dev-error-stack")
+    .locator("li")
+    .evaluateAll((nodes) => nodes.map((node) => node.textContent ?? ""));
+  const sourceFrame = frames.find((frame) =>
+    frame.includes("client-runtime-sourcemap/source-mapped-runtime-error.tsx"),
+  );
+
+  expect(sourceFrame ?? "").toContain(
+    `client-runtime-sourcemap/source-mapped-runtime-error.tsx:${EXPECTED_THROW_LINE}:`,
+  );
+});

--- a/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
+++ b/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
@@ -21,15 +21,7 @@ test("maps browser runtime error stack frames back to original TSX source lines"
     "client-runtime-sourcemap: original TSX throw line",
   );
 
-  const frames = await page
-    .getByTestId("vinext-dev-error-stack")
-    .locator("li")
-    .evaluateAll((nodes) => nodes.map((node) => node.textContent ?? ""));
-  const sourceFrame = frames.find((frame) =>
-    frame.includes("client-runtime-sourcemap/source-mapped-runtime-error.tsx"),
-  );
-
-  expect(sourceFrame ?? "").toContain(
+  await expect(page.getByTestId("vinext-dev-error-stack")).toContainText(
     `client-runtime-sourcemap/source-mapped-runtime-error.tsx:${EXPECTED_THROW_LINE}:`,
   );
 });

--- a/tests/fixtures/app-with-src/src/app/client-runtime-sourcemap/page.tsx
+++ b/tests/fixtures/app-with-src/src/app/client-runtime-sourcemap/page.tsx
@@ -1,0 +1,10 @@
+import { SourceMappedRuntimeErrorButton } from "./source-mapped-runtime-error";
+
+export default function ClientRuntimeSourcemapPage() {
+  return (
+    <main>
+      <h1>Client runtime sourcemap</h1>
+      <SourceMappedRuntimeErrorButton />
+    </main>
+  );
+}

--- a/tests/fixtures/app-with-src/src/app/client-runtime-sourcemap/source-mapped-runtime-error.tsx
+++ b/tests/fixtures/app-with-src/src/app/client-runtime-sourcemap/source-mapped-runtime-error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+type RuntimeSourcemapPayload = {
+  alpha: string;
+  beta: string;
+  gamma: string;
+  delta: string;
+  epsilon: string;
+  zeta: string;
+  eta: string;
+  theta: string;
+};
+
+const CLIENT_RUNTIME_SOURCEMAP_ERROR = "client-runtime-sourcemap: original TSX throw line";
+
+function createPayload(): RuntimeSourcemapPayload {
+  return {
+    alpha: "alpha",
+    beta: "beta",
+    gamma: "gamma",
+    delta: "delta",
+    epsilon: "epsilon",
+    zeta: "zeta",
+    eta: "eta",
+    theta: "theta",
+  };
+}
+
+function raiseSourceMappedRuntimeError() {
+  const payload = createPayload();
+
+  if (payload.alpha === "alpha") {
+    throw new Error(CLIENT_RUNTIME_SOURCEMAP_ERROR);
+  }
+}
+
+export function SourceMappedRuntimeErrorButton() {
+  return (
+    <button
+      type="button"
+      data-testid="trigger-client-runtime-sourcemap-error"
+      onClick={raiseSourceMappedRuntimeError}
+    >
+      Trigger runtime error
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add an app-with-src E2E regression test for browser runtime errors emitted from TSX source.
- Move browser stack source-map resolution behind the dev server endpoint `/__vinext_original-stack-trace`.
- Have the dev overlay POST the raw browser `Error.stack` and let the server resolve original locations from Vite client transform source maps, avoiding browser-side dev module/source-map fetches.

## Tests
- `npx vp fmt --check packages/vinext/src/server/dev-error-overlay.tsx packages/vinext/src/server/dev-stack-sourcemap.ts packages/vinext/src/index.ts tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts`
- `npx tsc -p packages/vinext/tsconfig.json --noEmit`
- `npx vp run knip`
- `PLAYWRIGHT_PROJECT=app-with-src npx playwright test tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts --reporter=list --retries=0`
- `npx vp run vinext#build`

close https://github.com/langgenius/dify/issues/37031