### PR TITLE
fix(link): full-prefetch dynamic routes without loading shells

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -260,6 +260,23 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
+function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
+  cacheForNavigation: boolean;
+  prefetchShellFirst: boolean;
+  shouldPrefetch: boolean;
+} {
+  const hasLoadingShell = route.isDynamic && route.canPrefetchLoadingShell;
+  return {
+    // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
+    // Until that route fact exists, dynamic routes without loading-shell
+    // fallbacks are treated as exact-URL full prefetches. The prefetch cache is
+    // keyed by the concrete RSC URL, so this cannot reuse data across params.
+    cacheForNavigation: !hasLoadingShell,
+    prefetchShellFirst: !route.isDynamic,
+    shouldPrefetch: true,
+  };
+}
+
 export function canAutoPrefetchFullAppRoute(href: string): boolean {
   if (typeof window === "undefined") return false;
 
@@ -272,36 +289,34 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) return false;
 
-  return !match.route.isDynamic || !match.route.canPrefetchLoadingShell;
+  return resolveMatchedAutoAppRoutePrefetch(match.route).cacheForNavigation;
 }
 
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
+  prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
   }
 
-  return {
-    cacheForNavigation: !match.route.isDynamic || !match.route.canPrefetchLoadingShell,
-    shouldPrefetch: true,
-  };
+  return resolveMatchedAutoAppRoutePrefetch(match.route);
 }
 
 // ---------------------------------------------------------------------------
@@ -351,7 +366,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         const autoPrefetch =
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchHref)
-            : { cacheForNavigation: true, shouldPrefetch: true };
+            : { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true };
         if (!autoPrefetch.shouldPrefetch) return;
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
@@ -387,7 +402,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         // unified route payload, so gate that payload behind a loading-shell
         // request to preserve the same pending/dedup observable contract.
         const fetchPromise =
-          __prefetchInlining && autoPrefetch.cacheForNavigation
+          __prefetchInlining && autoPrefetch.cacheForNavigation && autoPrefetch.prefetchShellFirst
             ? (async () => {
                 const shellHeaders = createRscRequestHeaders({
                   interceptionContext,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -272,7 +272,7 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) return false;
 
-  return !match.route.isDynamic;
+  return !match.route.isDynamic || !match.route.canPrefetchLoadingShell;
 }
 
 export function resolveAutoAppRoutePrefetch(href: string): {
@@ -299,8 +299,8 @@ export function resolveAutoAppRoutePrefetch(href: string): {
   }
 
   return {
-    cacheForNavigation: !match.route.isDynamic,
-    shouldPrefetch: !match.route.isDynamic || match.route.canPrefetchLoadingShell,
+    cacheForNavigation: !match.route.isDynamic || !match.route.canPrefetchLoadingShell,
+    shouldPrefetch: true,
   };
 }
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -51,6 +51,7 @@ const linkPrefetchRoutes = [
   },
   { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
+  { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
 ] satisfies VinextLinkPrefetchRoute[];
 
 function createTestNavigationRuntime(navigate: unknown) {
@@ -1267,20 +1268,38 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("does not auto-prefetch dynamic links without a loading shell boundary", async () => {
+  it("full-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
     const observer = stubIntersectionObserver();
 
     const result = await renderIsolatedLink({
-      href: "/products/1",
+      href: "/clothing/1",
       nodeEnv: "production",
     });
 
     try {
       expect(observer.observe).toHaveBeenCalledWith(result.anchor);
       observer.dispatchIntersectingEntry(result.anchor);
-      await flushPrefetchTasks();
+      await waitForFetchCalls(result.fetch, 1);
 
-      expect(result.fetch).not.toHaveBeenCalled();
+      // Ported from Next.js:
+      // test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
+      // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/clothing/1",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(true);
+      expect(entry?.optimisticRouteShell).toBe(false);
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1575,6 +1575,37 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("does not issue a prefetchInlining shell request for dynamic routes without loading shells", async () => {
+    vi.stubEnv("__VINEXT_PREFETCH_INLINING", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/clothing/1",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/clothing/1",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("upgrades automatic dynamic links to full prefetch on unstable_dynamicOnHover intent", async () => {
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -263,7 +263,7 @@ describe("Link App Router prefetch mode", () => {
     expect(resolveLinkPrefetchMode(true, true)).toBe("disabled");
   });
 
-  it("allows automatic full RSC prefetch only for known static App Router routes", () => {
+  it("allows automatic full RSC prefetch only for routes without loading-shell prefetches", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -274,6 +274,8 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
         { canPrefetchLoadingShell: true, patternParts: ["docs", ":slug+"], isDynamic: true },
+        { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
+        { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
       ],
     };
 
@@ -281,6 +283,8 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/about")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
+      expect(canAutoPrefetchFullAppRoute("/settings")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
     } finally {
       if (originalWindow === undefined) {
@@ -291,7 +295,7 @@ describe("Link App Router prefetch mode", () => {
     }
   });
 
-  it("allows automatic dynamic App Router prefetches only as loading-boundary learning requests", () => {
+  it("allows automatic dynamic App Router routes without loading shells to seed navigation cache", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -302,6 +306,8 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
+        { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
+        { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
       ],
     };
 
@@ -314,9 +320,20 @@ describe("Link App Router prefetch mode", () => {
         cacheForNavigation: false,
         shouldPrefetch: true,
       });
+      expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
+        cacheForNavigation: true,
+        shouldPrefetch: true,
+      });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
-        cacheForNavigation: false,
-        shouldPrefetch: false,
+        cacheForNavigation: true,
+        shouldPrefetch: true,
+      });
+      // Ported from Next.js:
+      // test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
+      // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
+      expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
+        cacheForNavigation: true,
+        shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -314,18 +314,22 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: true,
+        prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       // Ported from Next.js:
@@ -333,10 +337,12 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
+        prefetchShellFirst: false,
         shouldPrefetch: false,
       });
     } finally {


### PR DESCRIPTION
## Overview

| Item | Details |
| --- | --- |
| Goal | Match the Next.js segment-cache behavior for client-param dynamic routes. |
| Core change | Automatic App Router prefetch now full-prefetches exact dynamic URLs when the matched route has no loading-shell fallback. |
| Main boundary | Dynamic routes with `loading.tsx` keep the existing shell-only learning request and stay out of navigation cache. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `tests/link.test.ts`, `tests/link-navigation.test.ts` |
| Expected impact | A visible `<Link href="/clothing/1">` can prefetch and satisfy the immediate click without a second request. |

## Why

Automatic prefetch should be gated by what the route can return for the target URL, not by dynamic URL shape alone. Next.js segment cache can statically prefetch client-param routes because the params are reified on the client, while routes with loading boundaries still use a shell-oriented path.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Link prefetch decision | Static routes and exact dynamic URLs without loading-shell fallback can seed navigation cache. | `resolveAutoAppRoutePrefetch()` now returns `{ shouldPrefetch: true, cacheForNavigation: true }` for dynamic no-loading routes. |
| Loading-shell routes | Shell prefetches are useful for learning and pending state, but are not navigation-complete payloads. | Dynamic routes with `canPrefetchLoadingShell` still set `cacheForNavigation: false`. |
| Regression coverage | The upstream behavior is viewport prefetch followed by click navigation with no additional request. | Ported focused expectations into the pure decision test and Link scheduling test. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| Static route | Full auto-prefetch | Full auto-prefetch |
| Dynamic route with `loading.tsx` | Shell-only auto-prefetch | Shell-only auto-prefetch |
| Dynamic route without `loading.tsx` | No auto-prefetch | Full exact-URL auto-prefetch, cached for navigation |

<details>
<summary>Maintainer Review Path</summary>

1. `packages/vinext/src/shims/link.tsx`
   - Review the predicate change in `canAutoPrefetchFullAppRoute()` and `resolveAutoAppRoutePrefetch()`.
   - Confirm the dynamic loading-shell path still produces a non-navigation cache entry.
2. `tests/link.test.ts`
   - Review the decision matrix for static, dynamic loading-shell, dynamic no-loading, missing routes.
3. `tests/link-navigation.test.ts`
   - Review the ported client-param scheduling regression that verifies a visible dynamic no-loading link starts a full RSC prefetch and seeds navigation cache.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/link.test.ts tests/link-navigation.test.ts tests/prefetch-cache.test.ts`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/segment-cache/client-params/client-params.test.ts`
- Commit hook also ran formatting, lint/type, and `knip` successfully.

</details>

<details>
<summary>Risk / Compatibility</summary>

- Public API: no API shape change.
- Runtime: dynamic no-loading App Router links can now issue a production viewport prefetch.
- Cache/router: prefetched payloads remain keyed by the exact RSC URL, so this does not introduce cross-param reuse.
- Existing behavior preserved: dynamic routes with loading boundaries continue to use shell-only prefetches and do not seed navigation cache.

</details>

<details>
<summary>Non-goals</summary>

- This does not implement Next.js's full segment cache or fallback-param tracking.
- This does not change explicit `prefetch={true}` behavior.
- This does not alter Pages Router prefetching.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js client-params deploy test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts#L14-L43) | Defines the failing observable behavior: visible link prefetch, then click with `no-requests`, then client-rendered dynamic params. |
| [Next.js Link prefetch contract](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/app-dir/link.tsx#L135-L140) | Documents static full prefetch and dynamic loading-boundary prefetch behavior. |
| [Next.js cache-components fetch strategy](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/app-dir/link.tsx#L728-L740) | Shows auto prefetch maps to the PPR strategy under cache components. |
| [Next.js segment-cache static segment traversal](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/segment-cache/scheduler.ts#L919-L955) | Shows new route-tree segments default to static prefetch unless the server hints runtime prefetch. |
| [Next.js loading-boundary fallback path](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/segment-cache/scheduler.ts#L1019-L1050) | Shows loading-boundary prefetch is the conservative fallback when the tree has a loading boundary. |