### PR TITLE
fix(build): emit Next client runtime manifests

### DIFF
--- a/packages/vinext/src/build/next-client-runtime-manifests.ts
+++ b/packages/vinext/src/build/next-client-runtime-manifests.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { NextRewrite, ResolvedNextConfig } from "../config/next-config.js";
+
+type ClientRuntimeRewrite = {
+  source: string;
+  destination?: string;
+  has?: NextRewrite["has"];
+};
+
+type ClientRuntimeRewrites = {
+  beforeFiles: ClientRuntimeRewrite[];
+  afterFiles: ClientRuntimeRewrite[];
+  fallback: ClientRuntimeRewrite[];
+};
+
+type ClientRuntimeBuildManifest = {
+  __rewrites: ClientRuntimeRewrites;
+  sortedPages: string[];
+};
+
+type EmitNextClientRuntimeManifestsOptions = {
+  clientDir: string;
+  assetsSubdir: string;
+  buildId: string;
+  rewrites: ResolvedNextConfig["rewrites"];
+};
+
+function normalizeRewriteForClientManifest(rewrite: NextRewrite): ClientRuntimeRewrite {
+  const result: ClientRuntimeRewrite = { source: rewrite.source };
+  if (rewrite.destination.startsWith("/")) {
+    result.destination = rewrite.destination;
+  }
+  if (rewrite.has) {
+    result.has = rewrite.has;
+  }
+  return result;
+}
+
+function normalizeRewritesForClientManifest(
+  rewrites: ResolvedNextConfig["rewrites"],
+): ClientRuntimeRewrites {
+  return {
+    beforeFiles: rewrites.beforeFiles.map(normalizeRewriteForClientManifest),
+    afterFiles: rewrites.afterFiles.map(normalizeRewriteForClientManifest),
+    fallback: rewrites.fallback.map(normalizeRewriteForClientManifest),
+  };
+}
+
+export function buildNextClientBuildManifestContent(
+  rewrites: ResolvedNextConfig["rewrites"],
+): string {
+  const manifest: ClientRuntimeBuildManifest = {
+    __rewrites: normalizeRewritesForClientManifest(rewrites),
+    sortedPages: [],
+  };
+  return `self.__BUILD_MANIFEST = ${JSON.stringify(manifest)};self.__BUILD_MANIFEST_CB && self.__BUILD_MANIFEST_CB()`;
+}
+
+export function buildNextClientSsgManifestContent(): string {
+  return "self.__SSG_MANIFEST=new Set;self.__SSG_MANIFEST_CB&&self.__SSG_MANIFEST_CB()";
+}
+
+export function emitNextClientRuntimeManifests(
+  options: EmitNextClientRuntimeManifestsOptions,
+): void {
+  const manifestDir = path.join(options.clientDir, options.assetsSubdir, options.buildId);
+  fs.mkdirSync(manifestDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(manifestDir, "_buildManifest.js"),
+    buildNextClientBuildManifestContent(options.rewrites),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(manifestDir, "_ssgManifest.js"),
+    buildNextClientSsgManifestContent(),
+    "utf-8",
+  );
+}

--- a/packages/vinext/src/build/next-client-runtime-manifests.ts
+++ b/packages/vinext/src/build/next-client-runtime-manifests.ts
@@ -2,10 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import type { NextRewrite, ResolvedNextConfig } from "../config/next-config.js";
 
-type ClientRuntimeRewrite = {
-  source: string;
+type ClientRuntimeRewrite = Omit<NextRewrite, "destination"> & {
   destination?: string;
-  has?: NextRewrite["has"];
 };
 
 type ClientRuntimeRewrites = {
@@ -27,14 +25,13 @@ type EmitNextClientRuntimeManifestsOptions = {
 };
 
 function normalizeRewriteForClientManifest(rewrite: NextRewrite): ClientRuntimeRewrite {
-  const result: ClientRuntimeRewrite = { source: rewrite.source };
-  if (rewrite.destination.startsWith("/")) {
-    result.destination = rewrite.destination;
+  const { destination, ...rest } = rewrite;
+
+  if (destination.startsWith("/")) {
+    return { ...rest, destination };
   }
-  if (rewrite.has) {
-    result.has = rewrite.has;
-  }
-  return result;
+
+  return rest;
 }
 
 function normalizeRewritesForClientManifest(

--- a/packages/vinext/src/build/next-client-runtime-manifests.ts
+++ b/packages/vinext/src/build/next-client-runtime-manifests.ts
@@ -2,8 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import type { NextRewrite, ResolvedNextConfig } from "../config/next-config.js";
 
-type ClientRuntimeRewrite = Omit<NextRewrite, "destination"> & {
+type ClientRuntimeRewrite = {
+  source: string;
   destination?: string;
+  has?: NextRewrite["has"];
 };
 
 type ClientRuntimeRewrites = {
@@ -25,13 +27,11 @@ type EmitNextClientRuntimeManifestsOptions = {
 };
 
 function normalizeRewriteForClientManifest(rewrite: NextRewrite): ClientRuntimeRewrite {
-  const { destination, ...rest } = rewrite;
-
-  if (destination.startsWith("/")) {
-    return { ...rest, destination };
+  if (rewrite.destination.startsWith("/")) {
+    return { has: rewrite.has, source: rewrite.source, destination: rewrite.destination };
   }
 
-  return rest;
+  return { has: rewrite.has, source: rewrite.source };
 }
 
 function normalizeRewritesForClientManifest(

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -72,6 +72,7 @@ import {
 } from "./server/instrumentation.js";
 import { PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { precompressAssets } from "./build/precompress.js";
+import { emitNextClientRuntimeManifests } from "./build/next-client-runtime-manifests.js";
 import { collectInlineCssManifest, injectInlineCssManifestGlobal } from "./build/inline-css.js";
 import { validateDevRequest } from "./server/dev-origin-check.js";
 import {
@@ -4286,6 +4287,30 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // Leave Vite's manifest untouched if parsing fails.
             console.warn("[vinext] Failed to augment SSR manifest:", err);
           }
+        },
+      },
+    },
+    {
+      name: "vinext:next-client-runtime-manifests",
+      apply: "build",
+      enforce: "post",
+      writeBundle: {
+        sequential: true,
+        order: "post",
+        handler(outputOptions: { dir?: string }) {
+          const clientDir = outputOptions.dir;
+          if (!clientDir) return;
+
+          const isClientBuild =
+            this.environment?.name === "client" || path.basename(clientDir) === "client";
+          if (!isClientBuild) return;
+
+          emitNextClientRuntimeManifests({
+            clientDir,
+            assetsSubdir: resolveAssetsDir(nextConfig.assetPrefix),
+            buildId: nextConfig.buildId,
+            rewrites: nextConfig.rewrites,
+          });
         },
       },
     },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4301,8 +4301,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           const clientDir = outputOptions.dir;
           if (!clientDir) return;
 
-          const isClientBuild =
-            this.environment?.name === "client" || path.basename(clientDir) === "client";
+          const isClientBuild = this.environment?.name === "client";
           if (!isClientBuild) return;
 
           emitNextClientRuntimeManifests({

--- a/tests/client-build-manifest.test.ts
+++ b/tests/client-build-manifest.test.ts
@@ -156,7 +156,13 @@ describe("client build manifest helpers", () => {
           destination: "https://example.com/external",
         },
       ],
-      fallback: [],
+      fallback: [
+        {
+          source: "/only-without-cookie",
+          destination: "/target",
+          missing: [{ type: "cookie", key: "seen" }],
+        },
+      ],
     });
 
     expect(content).toContain('"source":"/internal/:path*"');
@@ -164,5 +170,6 @@ describe("client build manifest helpers", () => {
     expect(content).toContain('"source":"/external"');
     expect(content).not.toContain("https://example.com/external");
     expect(content).toContain('"sortedPages":[]');
+    expect(content).toContain('"missing":[{"type":"cookie","key":"seen"}]');
   });
 });

--- a/tests/client-build-manifest.test.ts
+++ b/tests/client-build-manifest.test.ts
@@ -170,6 +170,6 @@ describe("client build manifest helpers", () => {
     expect(content).toContain('"source":"/external"');
     expect(content).not.toContain("https://example.com/external");
     expect(content).toContain('"sortedPages":[]');
-    expect(content).toContain('"missing":[{"type":"cookie","key":"seen"}]');
+    expect(content).not.toContain('"missing"');
   });
 });

--- a/tests/client-build-manifest.test.ts
+++ b/tests/client-build-manifest.test.ts
@@ -7,6 +7,11 @@ import {
   findClientEntryFileFromManifest,
   readClientBuildManifest,
 } from "../packages/vinext/src/utils/client-build-manifest.js";
+import {
+  buildNextClientBuildManifestContent,
+  buildNextClientSsgManifestContent,
+  emitNextClientRuntimeManifests,
+} from "../packages/vinext/src/build/next-client-runtime-manifests.js";
 
 describe("client build manifest helpers", () => {
   let tmpDir: string;
@@ -112,5 +117,52 @@ describe("client build manifest helpers", () => {
     });
 
     expect(entry).toBe("cdn/_next/static/vinext-client-entry-5678.js");
+  });
+
+  it("emits Next.js runtime manifests under the configured assets directory and build ID", async () => {
+    emitNextClientRuntimeManifests({
+      clientDir,
+      assetsSubdir: "base/_next/static",
+      buildId: "build-123",
+      rewrites: { beforeFiles: [], afterFiles: [], fallback: [] },
+    });
+
+    const buildManifest = await fsp.readFile(
+      path.join(clientDir, "base", "_next", "static", "build-123", "_buildManifest.js"),
+      "utf-8",
+    );
+    expect(buildManifest).toContain("self.__BUILD_MANIFEST = ");
+    expect(buildManifest).toContain("__BUILD_MANIFEST_CB");
+
+    const ssgManifest = await fsp.readFile(
+      path.join(clientDir, "base", "_next", "static", "build-123", "_ssgManifest.js"),
+      "utf-8",
+    );
+    expect(ssgManifest).toBe(buildNextClientSsgManifestContent());
+  });
+
+  it("normalizes rewrites in the Next.js runtime build manifest", () => {
+    const content = buildNextClientBuildManifestContent({
+      beforeFiles: [
+        {
+          source: "/internal/:path*",
+          destination: "/rewritten/:path*",
+          has: [{ type: "header", key: "x-test", value: "1" }],
+        },
+      ],
+      afterFiles: [
+        {
+          source: "/external",
+          destination: "https://example.com/external",
+        },
+      ],
+      fallback: [],
+    });
+
+    expect(content).toContain('"source":"/internal/:path*"');
+    expect(content).toContain('"destination":"/rewritten/:path*"');
+    expect(content).toContain('"source":"/external"');
+    expect(content).not.toContain("https://example.com/external");
+    expect(content).toContain('"sortedPages":[]');
   });
 });

--- a/tests/invalid-static-asset-404.test.ts
+++ b/tests/invalid-static-asset-404.test.ts
@@ -20,6 +20,7 @@
  * Ported from Next.js:
  *   - test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
  *   - test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app.test.ts
+ *   - test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
  *   - test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-base-path.test.ts
  *   - test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-asset-prefix.test.ts
  *
@@ -73,6 +74,21 @@ async function buildAppFixtureWithConfig(
   return { outDir };
 }
 
+function findClientRuntimeManifestBuildId(outDir: string, pathPrefix: string): string | undefined {
+  const prefixSegments = pathPrefix.split("/").filter(Boolean);
+  const staticDir = path.join(outDir, "client", ...prefixSegments, "_next", "static");
+  if (!fs.existsSync(staticDir)) return undefined;
+
+  for (const entry of fs.readdirSync(staticDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (fs.existsSync(path.join(staticDir, entry.name, "_buildManifest.js"))) {
+      return entry.name;
+    }
+  }
+
+  return undefined;
+}
+
 describe("App Router invalid `_next/static/*` 404", () => {
   const cleanups: Array<() => void> = [];
   afterAll(() => {
@@ -105,6 +121,34 @@ describe("App Router invalid `_next/static/*` 404", () => {
       expect(htmlRes.status).toBe(404);
       const htmlBody = await htmlRes.text();
       expect(htmlBody).toContain("<");
+    } finally {
+      server.close();
+    }
+  }, 180_000);
+
+  it("serves generated build manifest asset under basePath", async () => {
+    // Ported from Next.js: test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
+    const built = await buildAppFixtureWithConfig(`basePath: "/base",`, register);
+    const buildId = findClientRuntimeManifestBuildId(built.outDir, "/base");
+    if (!buildId) {
+      throw new Error("Expected _buildManifest.js under /base/_next/static/<buildId>/");
+    }
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      outDir: built.outDir,
+      noCompression: true,
+    });
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://localhost:${port}`;
+
+      const res = await fetch(`${baseUrl}/base/_next/static/${buildId}/_buildManifest.js`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain("__BUILD_MANIFEST");
     } finally {
       server.close();
     }

--- a/tests/invalid-static-asset-404.test.ts
+++ b/tests/invalid-static-asset-404.test.ts
@@ -149,6 +149,10 @@ describe("App Router invalid `_next/static/*` 404", () => {
       const res = await fetch(`${baseUrl}/base/_next/static/${buildId}/_buildManifest.js`);
       expect(res.status).toBe(200);
       expect(await res.text()).toContain("__BUILD_MANIFEST");
+
+      const ssgRes = await fetch(`${baseUrl}/base/_next/static/${buildId}/_ssgManifest.js`);
+      expect(ssgRes.status).toBe(200);
+      expect(await ssgRes.text()).toContain("__SSG_MANIFEST");
     } finally {
       server.close();
     }


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js for valid `/_next/static/<buildId>/_buildManifest.js` assets under `basePath`. |
| Core change | Emit Next-compatible `_buildManifest.js` and `_ssgManifest.js` during the client build under the resolved asset directory and build ID. |
| Main boundary | This is a build output compatibility fix, not a static-file routing change. |
| Primary files | `packages/vinext/src/build/next-client-runtime-manifests.ts`, `packages/vinext/src/index.ts`, `tests/invalid-static-asset-404.test.ts` |
| Expected impact | Valid manifest asset probes stop returning 404 when `basePath` becomes the effective asset prefix. |

## Why

A URL that Next.js treats as an emitted client asset must exist in vinext's client output at the same logical `_next/static/<buildId>` location. The upstream deploy test showed the prefix routing was not the failing boundary: invalid static assets already returned the plain-text static 404, but the valid `_buildManifest.js` asset did not exist in vinext's build output.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Build output | Next.js emits low-priority runtime manifest assets under `/_next/static/<buildId>/`. | vinext now writes `_buildManifest.js` and `_ssgManifest.js` after the client bundle is written. |
| Prefix handling | Next.js folds `basePath` into `assetPrefix` when no explicit `assetPrefix` is configured. | The emit path uses vinext's resolved assets directory, so `basePath` and path-style `assetPrefix` share the same on-disk layout as other client assets. |
| Client manifest shape | External rewrites are not represented as client-side destinations in Next's build manifest. | The emitted manifest normalizes rewrites to the client-visible shape and omits external destinations. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `/base/_next/static/<buildId>/_buildManifest.js` | 404 because no file was emitted. | 200 with a `self.__BUILD_MANIFEST` runtime manifest asset. |
| `/base/_next/static/invalid-path` | Plain text `Not Found`. | Unchanged. |
| `/base/invalid-path` | Custom 404 page. | Unchanged. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/build/next-client-runtime-manifests.ts` defines the small build-output helper and the Next-compatible runtime strings.
2. `packages/vinext/src/index.ts` wires the helper into the client build as a post `writeBundle` hook before precompression.
3. `tests/client-build-manifest.test.ts` covers the helper output and rewrite normalization at the lowest boundary.
4. `tests/invalid-static-asset-404.test.ts` ports the upstream basePath valid-asset assertion and keeps it alongside the existing static 404 parity checks.

</details>

<details>
<summary>Validation</summary>

Initial upstream run before the fix reproduced the bug: the valid asset path expected 200 and returned 404.

Commands run after the fix:

```bash
vp env exec --node 24 vp test run tests/client-build-manifest.test.ts tests/invalid-static-asset-404.test.ts
vp env exec --node 24 vp check
vp env exec --node 24 vp run knip --no-progress
vp env exec --node 24 \
  ./scripts/run-nextjs-deploy-suite.sh \
  /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 \
  --retries 0 -c 1 --debug \
  test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
```

Final upstream deploy-suite result: 1 test suite passed, 3 tests passed.

The commit hook also reran formatting, lint/type checks, and `knip --no-progress` successfully.

</details>

<details>
<summary>Risk and compatibility</summary>

- Public API: no new public vinext API.
- Build output: adds two Next-compatible runtime files under the existing client asset directory.
- Runtime routing: unchanged. The fix makes the asset exist instead of changing static miss classification.
- Existing apps: low risk because the new files are deterministic static assets under the build ID directory.
- Intentional scope: this does not replace vinext's existing client entry and page loader machinery with Next's full page dependency build manifest. vinext's own navigation already uses its own loader map.

</details>

<details>
<summary>Non-goals</summary>

- Implementing a complete Next.js page-loader dependency manifest for Pages Router navigation.
- Changing static asset 404 semantics.
- Changing config header, redirect, middleware, or rewrite ordering.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream basePath invalid static asset test](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts#L11-L18) | Confirms `/base/_next/static/<buildId>/_buildManifest.js` must return 200 and contain `__BUILD_MANIFEST`. |
| [Next.js config folds `basePath` into `assetPrefix`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/server/config.ts#L481-L482) | Explains why the basePath fixture expects assets under `/base/_next/static/`. |
| [Next.js Webpack manifest emission](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts#L191-L238) | Shows `_buildManifest.js` and `_ssgManifest.js` are emitted as low-priority runtime assets. |
| [Next.js Turbopack manifest emission](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/shared/lib/turbopack/manifest-loader.ts#L481-L502) | Confirms the same runtime manifest files are written in the Turbopack path. |
| [Next.js rewrite normalization for build manifest](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/build/webpack/plugins/build-manifest-plugin-utils.ts#L25-L43) | Supports omitting external rewrite destinations from the client manifest. |
| [Next.js static miss classification](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/server/lib/router-server.ts#L575-L596) | Confirms prefix-stripped `_next/static` misses return plain text `Not Found`, which was already working in vinext. |
| [Next.js `assetPrefix` docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix) | Documents that only `/_next/static/` assets are uploaded or served from the asset prefix. |
| [Next.js `basePath` docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath) | Documents the configured route prefix that applies to the test fixture. |