### PR TITLE
fix(pages): render custom errors for notFound results

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -374,6 +374,15 @@ const _errorPageRoute = ErrorPageModule
     }
   : null;
 
+function __findPagesNotFoundRoute() {
+  for (var __i = 0; __i < pageRoutes.length; __i++) {
+    if (pageRoutes[__i].pattern === "/404") {
+      return pageRoutes[__i];
+    }
+  }
+  return _errorPageRoute;
+}
+
 const apiRoutes = [
 ${apiRouteEntries.join(",\n")}
 ];
@@ -649,14 +658,9 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
     if (!renderErrorPageOnMiss) {
       return __buildDefaultPagesNotFoundResponse();
     }
-    const notFoundMatch = matchRoute("/404", pageRoutes);
-    // matchRoute may match a catch-all (e.g. [...slug]); only use the explicit pages/404 route.
-    if (notFoundMatch && notFoundMatch.route.pattern === "/404") {
-      match = notFoundMatch;
-      renderStatusCodeOverride = 404;
-      renderAsPath = routeUrl;
-    } else if (_errorPageRoute) {
-      match = { route: _errorPageRoute, params: {} };
+    const notFoundRoute = __findPagesNotFoundRoute();
+    if (notFoundRoute) {
+      match = { route: notFoundRoute, params: {} };
       renderStatusCodeOverride = 404;
       renderAsPath = routeUrl;
     } else {
@@ -794,6 +798,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
         pageModule,
         params,
         query,
+        asPath: renderAsPath || routeUrl,
         renderIsrPassToStringAsync,
         route: {
           isDynamic: route.isDynamic,
@@ -820,6 +825,18 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
           hasMiddleware: __hasMiddleware,
         },
       });
+      if (pageDataResult.kind === "notFound") {
+        const notFoundRoute = __findPagesNotFoundRoute();
+        if (notFoundRoute && routePattern !== "/404" && routePattern !== "/_error") {
+          return await _renderPage(request, url, manifest, middlewareHeaders, {
+            statusCode: 404,
+            asPath: renderAsPath || routeUrl,
+            renderErrorPageOnMiss: false,
+            __forcedRoute: notFoundRoute,
+          });
+        }
+        return __buildDefaultPagesNotFoundResponse();
+      }
       if (pageDataResult.kind === "response") {
         return pageDataResult.response;
       }

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -613,6 +613,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
   // returns the plain "Internal Server Error" text response instead of trying
   // to render an error page again. Fixes #1458.
   const isInternalErrorRender = !!(options && options.__isInternalErrorRender);
+  const err = options && options.err;
   const localeInfo = i18nConfig
     ? resolvePagesI18nRequest(
         url,
@@ -745,6 +746,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
       } catch (e) { /* font preloads not available */ }
       const pageDataResult = await __resolvePagesPageData({
         isDataReq,
+        err,
         applyRequestContexts() {
           if (typeof setSSRContext === "function") {
             setSSRContext({
@@ -1043,6 +1045,7 @@ async function _renderPage(request, url, manifest, middlewareHeaders, options) {
               renderErrorPageOnMiss: false,
               __isInternalErrorRender: true,
               __forcedRoute: errorRoute,
+              err: e instanceof Error ? e : new Error(String(e)),
             });
           } catch (errorPageErr) {
             console.error("[vinext] Error page render failed:", errorPageErr);

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -55,6 +55,7 @@ import {
   runDocumentRenderPage,
 } from "./pages-document-initial-props.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
+import { loadPagesGetInitialProps } from "./pages-get-initial-props.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -1053,6 +1054,30 @@ export function createSSRHandler(
           }
         }
 
+        if (
+          typeof pageModule.getServerSideProps !== "function" &&
+          typeof pageModule.getStaticProps !== "function"
+        ) {
+          const initialProps = await loadPagesGetInitialProps(PageComponent, {
+            req,
+            res,
+            pathname: patternToNextFormat(route.pattern),
+            query,
+            asPath: url,
+            locale: locale ?? currentDefaultLocale,
+            locales: i18nConfig?.locales,
+            defaultLocale: currentDefaultLocale,
+          });
+
+          if (res.writableEnded) {
+            return;
+          }
+
+          if (initialProps) {
+            pageProps = { ...pageProps, ...initialProps };
+          }
+        }
+
         // ── _next/data JSON envelope short-circuit (dev) ──────────────
         // Client-side navigations fetch /_next/data/<buildId>/<page>.json and
         // expect { pageProps } as JSON. We have pageProps; skip the React
@@ -1434,7 +1459,7 @@ hydrate();
 async function renderErrorPage(
   server: ViteDevServer,
   runner: ModuleImporter,
-  _req: IncomingMessage,
+  req: IncomingMessage,
   res: ServerResponse,
   url: string,
   pagesDir: string,
@@ -1470,7 +1495,15 @@ async function renderErrorPage(
       }
 
       const createElement = React.createElement;
-      const errorProps = { statusCode };
+      const initialErrorProps = await loadPagesGetInitialProps(ErrorComponent, {
+        req,
+        res,
+        pathname: candidate === "_error" ? "/_error" : `/${candidate}`,
+        query: parseQuery(url),
+        asPath: url,
+      });
+      if (res.writableEnded) return;
+      const errorProps = { ...initialErrorProps, statusCode };
 
       // If the caller didn't supply wrapWithRouterContext, load it now.
       // runner.import() caches internally so the cost is negligible.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1069,7 +1069,7 @@ export function createSSRHandler(
             defaultLocale: currentDefaultLocale,
           });
 
-          if (res.writableEnded) {
+          if (res.headersSent || res.writableEnded) {
             return;
           }
 
@@ -1433,7 +1433,18 @@ hydrate();
         });
         // Try to render custom 500 error page
         try {
-          await renderErrorPage(server, runner, req, res, url, pagesDir, 500, undefined, matcher);
+          await renderErrorPage(
+            server,
+            runner,
+            req,
+            res,
+            url,
+            pagesDir,
+            500,
+            undefined,
+            matcher,
+            e instanceof Error ? e : new Error(String(e)),
+          );
         } catch (fallbackErr) {
           // If error page itself fails, fall back to plain text.
           // This is a dev-only code path (prod uses prod-server.ts), so
@@ -1466,6 +1477,7 @@ async function renderErrorPage(
   statusCode: number,
   wrapWithRouterContext?: ((el: React.ReactElement) => React.ReactElement) | null,
   fileMatcher?: ValidFileMatcher,
+  err?: Error,
 ): Promise<void> {
   const matcher = fileMatcher ?? createValidFileMatcher();
   // Try specific status page first, then _error, then fallback
@@ -1498,11 +1510,12 @@ async function renderErrorPage(
       const initialErrorProps = await loadPagesGetInitialProps(ErrorComponent, {
         req,
         res,
+        err,
         pathname: candidate === "_error" ? "/_error" : `/${candidate}`,
         query: parseQuery(url),
         asPath: url,
       });
-      if (res.writableEnded) return;
+      if (res.headersSent || res.writableEnded) return;
       const errorProps = { ...initialErrorProps, statusCode };
 
       // If the caller didn't supply wrapWithRouterContext, load it now.

--- a/packages/vinext/src/server/pages-get-initial-props.ts
+++ b/packages/vinext/src/server/pages-get-initial-props.ts
@@ -40,7 +40,7 @@ function getInitialPropsFn(component: unknown): PagesGetInitialProps | null {
   return isPagesGetInitialProps(getInitialProps) ? getInitialProps : null;
 }
 
-function isResponseSent(res: unknown): boolean {
+export function isResponseSent(res: unknown): boolean {
   return (
     getObjectProperty(res, "headersSent") === true ||
     getObjectProperty(res, "writableEnded") === true

--- a/packages/vinext/src/server/pages-get-initial-props.ts
+++ b/packages/vinext/src/server/pages-get-initial-props.ts
@@ -1,0 +1,90 @@
+type PagesGetInitialPropsContext = {
+  req?: unknown;
+  res?: unknown;
+  err?: unknown;
+  pathname: string;
+  query: Record<string, unknown>;
+  asPath: string;
+  locale?: string;
+  locales?: string[];
+  defaultLocale?: string;
+};
+
+type PagesGetInitialProps = (context: PagesGetInitialPropsContext) => unknown;
+
+function isObjectLike(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+function isPagesGetInitialProps(value: unknown): value is PagesGetInitialProps {
+  return typeof value === "function";
+}
+
+function getObjectProperty(target: unknown, property: string): unknown {
+  if (!isObjectLike(target)) return undefined;
+  return Reflect.get(target, property);
+}
+
+function getDisplayName(component: unknown): string {
+  const displayName = getObjectProperty(component, "displayName");
+  if (typeof displayName === "string" && displayName.length > 0) return displayName;
+
+  const name = getObjectProperty(component, "name");
+  if (typeof name === "string" && name.length > 0) return name;
+
+  return "Component";
+}
+
+function getInitialPropsFn(component: unknown): PagesGetInitialProps | null {
+  const getInitialProps = getObjectProperty(component, "getInitialProps");
+  return isPagesGetInitialProps(getInitialProps) ? getInitialProps : null;
+}
+
+function isResponseSent(res: unknown): boolean {
+  return (
+    getObjectProperty(res, "headersSent") === true ||
+    getObjectProperty(res, "writableEnded") === true
+  );
+}
+
+function isPropsObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeInitialPropsValue(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return `${value}`;
+  }
+  if (typeof value === "symbol")
+    return value.description ? `Symbol(${value.description})` : "Symbol()";
+  if (typeof value === "function") return `[function ${getDisplayName(value)}]`;
+  return Object.prototype.toString.call(value);
+}
+
+export async function loadPagesGetInitialProps(
+  component: unknown,
+  context: PagesGetInitialPropsContext,
+): Promise<Record<string, unknown> | null> {
+  const getInitialProps = getInitialPropsFn(component);
+  if (!getInitialProps) return null;
+
+  const result = await Promise.resolve(getInitialProps(context));
+  if (isResponseSent(context.res)) {
+    return isPropsObject(result) ? result : {};
+  }
+
+  if (!isPropsObject(result)) {
+    throw new Error(
+      `"${getDisplayName(
+        component,
+      )}.getInitialProps()" should resolve to an object. But found "${describeInitialPropsValue(
+        result,
+      )}" instead.`,
+    );
+  }
+
+  return result;
+}

--- a/packages/vinext/src/server/pages-get-initial-props.ts
+++ b/packages/vinext/src/server/pages-get-initial-props.ts
@@ -40,6 +40,10 @@ function getInitialPropsFn(component: unknown): PagesGetInitialProps | null {
   return isPagesGetInitialProps(getInitialProps) ? getInitialProps : null;
 }
 
+export function hasPagesGetInitialProps(component: unknown): boolean {
+  return getInitialPropsFn(component) !== null;
+}
+
 export function isResponseSent(res: unknown): boolean {
   return (
     getObjectProperty(res, "headersSent") === true ||

--- a/packages/vinext/src/server/pages-get-initial-props.ts
+++ b/packages/vinext/src/server/pages-get-initial-props.ts
@@ -71,7 +71,7 @@ export async function loadPagesGetInitialProps(
   const getInitialProps = getInitialPropsFn(component);
   if (!getInitialProps) return null;
 
-  const result = await Promise.resolve(getInitialProps(context));
+  const result = await Promise.resolve(getInitialProps.call(component, context));
   if (isResponseSent(context.res)) {
     return isPropsObject(result) ? result : {};
   }

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -124,6 +124,7 @@ export type ResolvePagesPageDataOptions = {
    * `isNextDataRequest` checks in `packages/next/src/server/base-server.ts`.
    */
   isDataReq?: boolean;
+  err?: unknown;
   createGsspReqRes: () => PagesGsspContextResponse;
   createPageElement: (pageProps: Record<string, unknown>) => ReactNode;
   fontLinkHeader: string;
@@ -684,6 +685,7 @@ export async function resolvePagesPageData(
     const initialProps = await loadPagesGetInitialProps(options.pageModule.default, {
       req,
       res,
+      err: options.err,
       pathname: options.routePattern,
       query: options.query,
       asPath: options.asPath ?? options.routeUrl,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -11,7 +11,7 @@ import {
   type PagesGsspResponse,
   type PagesI18nRenderContext,
 } from "./pages-page-response.js";
-import { loadPagesGetInitialProps } from "./pages-get-initial-props.js";
+import { isResponseSent, loadPagesGetInitialProps } from "./pages-get-initial-props.js";
 import { buildNextDataJsonResponse } from "./pages-data-route.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 
@@ -484,7 +484,7 @@ export async function resolvePagesPageData(
       defaultLocale: options.i18n.defaultLocale,
     });
 
-    if (res.headersSent) {
+    if (isResponseSent(res)) {
       return {
         kind: "response",
         response: await responsePromise,
@@ -694,7 +694,7 @@ export async function resolvePagesPageData(
       defaultLocale: options.i18n.defaultLocale,
     });
 
-    if (res.headersSent) {
+    if (isResponseSent(res)) {
       return {
         kind: "response",
         response: await responsePromise,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -11,7 +11,7 @@ import {
   type PagesGsspResponse,
   type PagesI18nRenderContext,
 } from "./pages-page-response.js";
-import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
+import { loadPagesGetInitialProps } from "./pages-get-initial-props.js";
 import { buildNextDataJsonResponse } from "./pages-data-route.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 
@@ -165,6 +165,7 @@ export type ResolvePagesPageDataOptions = {
   pageModule: PagesPageModule;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
+  asPath?: string;
   route: Pick<Route, "isDynamic">;
   routePattern: string;
   routeUrl: string;
@@ -201,13 +202,14 @@ type ResolvePagesPageDataResponseResult = {
   response: Response;
 };
 
+type ResolvePagesPageDataNotFoundResult = {
+  kind: "notFound";
+};
+
 type ResolvePagesPageDataResult =
   | ResolvePagesPageDataRenderResult
-  | ResolvePagesPageDataResponseResult;
-
-function buildPagesNotFoundResponse(): Response {
-  return buildDefaultPagesNotFoundResponse();
-}
+  | ResolvePagesPageDataResponseResult
+  | ResolvePagesPageDataNotFoundResult;
 
 function buildPagesDataNotFoundResponse(): Response {
   // Matches Next.js: `/_next/data/<buildId>/<page>.json` 404 responses use
@@ -217,6 +219,19 @@ function buildPagesDataNotFoundResponse(): Response {
     status: 404,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+function buildPagesNotFoundResult(
+  options: Pick<ResolvePagesPageDataOptions, "isDataReq">,
+): ResolvePagesPageDataResponseResult | ResolvePagesPageDataNotFoundResult {
+  if (options.isDataReq) {
+    return {
+      kind: "response",
+      response: buildPagesDataNotFoundResponse(),
+    };
+  }
+
+  return { kind: "notFound" };
 }
 
 function resolvePagesRedirectStatus(redirect: PagesRedirectResult): number {
@@ -430,13 +445,8 @@ export async function resolvePagesPageData(
     if (fallback === false && !isValidPath) {
       // For data requests (`/_next/data/...json`), return a JSON-shaped 404
       // so the client router can `res.json()` without blowing up — matches
-      // Next.js' behavior. HTML navigations still get the HTML 404 page.
-      return {
-        kind: "response",
-        response: options.isDataReq
-          ? buildPagesDataNotFoundResponse()
-          : buildPagesNotFoundResponse(),
-      };
+      // Next.js' behavior. HTML navigations still get the configured 404 page.
+      return buildPagesNotFoundResult(options);
     }
 
     // Render the fallback shell for unlisted paths under `fallback: true`.
@@ -496,12 +506,7 @@ export async function resolvePagesPageData(
     }
 
     if (result?.notFound) {
-      return {
-        kind: "response",
-        response: options.isDataReq
-          ? buildPagesDataNotFoundResponse()
-          : buildPagesNotFoundResponse(),
-      };
+      return buildPagesNotFoundResult(options);
     }
 
     // Mirrors Next.js render.tsx's `isSerializableProps(pathname, "getServerSideProps", data.props)`
@@ -651,12 +656,7 @@ export async function resolvePagesPageData(
     }
 
     if (result?.notFound) {
-      return {
-        kind: "response",
-        response: options.isDataReq
-          ? buildPagesDataNotFoundResponse()
-          : buildPagesNotFoundResponse(),
-      };
+      return buildPagesNotFoundResult(options);
     }
 
     // Mirrors Next.js render.tsx's `isSerializableProps(pathname, "getStaticProps", data.props)`
@@ -673,6 +673,34 @@ export async function resolvePagesPageData(
 
     if (typeof result?.revalidate === "number" && result.revalidate > 0) {
       isrRevalidateSeconds = result.revalidate;
+    }
+  }
+
+  if (
+    typeof options.pageModule.getServerSideProps !== "function" &&
+    typeof options.pageModule.getStaticProps !== "function"
+  ) {
+    const { req, res, responsePromise } = options.createGsspReqRes();
+    const initialProps = await loadPagesGetInitialProps(options.pageModule.default, {
+      req,
+      res,
+      pathname: options.routePattern,
+      query: options.query,
+      asPath: options.asPath ?? options.routeUrl,
+      locale: options.i18n.locale,
+      locales: options.i18n.locales,
+      defaultLocale: options.i18n.defaultLocale,
+    });
+
+    if (res.headersSent) {
+      return {
+        kind: "response",
+        response: await responsePromise,
+      };
+    }
+
+    if (initialProps) {
+      pageProps = { ...pageProps, ...initialProps };
     }
   }
 

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -11,7 +11,11 @@ import {
   type PagesGsspResponse,
   type PagesI18nRenderContext,
 } from "./pages-page-response.js";
-import { isResponseSent, loadPagesGetInitialProps } from "./pages-get-initial-props.js";
+import {
+  hasPagesGetInitialProps,
+  isResponseSent,
+  loadPagesGetInitialProps,
+} from "./pages-get-initial-props.js";
 import { buildNextDataJsonResponse } from "./pages-data-route.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 
@@ -679,7 +683,8 @@ export async function resolvePagesPageData(
 
   if (
     typeof options.pageModule.getServerSideProps !== "function" &&
-    typeof options.pageModule.getStaticProps !== "function"
+    typeof options.pageModule.getStaticProps !== "function" &&
+    hasPagesGetInitialProps(options.pageModule.default)
   ) {
     const { req, res, responsePromise } = options.createGsspReqRes();
     const initialProps = await loadPagesGetInitialProps(options.pageModule.default, {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -158,6 +158,130 @@ describe("pages page data", () => {
     });
   });
 
+  it("preserves getInitialProps this binding via component receiver", async () => {
+    const Page = Object.assign(
+      function Page() {
+        return null;
+      },
+      {
+        value: "ok",
+        getInitialProps(this: { value: string }) {
+          return { value: this.value };
+        },
+      },
+    );
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        createGsspReqRes() {
+          return {
+            req: {},
+            res: {
+              headersSent: false,
+              statusCode: 200,
+              getHeaders() {
+                return {};
+              },
+            },
+            responsePromise: Promise.resolve(new Response("short-circuit", { status: 202 })),
+          };
+        },
+        pageModule: {
+          default: Page,
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { value: "ok" },
+    });
+  });
+
+  it("returns a notFound signal when getServerSideProps returns notFound", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getServerSideProps() {
+            return { notFound: true };
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "notFound" });
+  });
+
+  it("returns JSON 404 envelope for data requests when getStaticPaths excludes a path", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        isDataReq: true,
+        pageModule: {
+          async getStaticPaths() {
+            return {
+              fallback: false,
+              paths: [{ params: { slug: "hello-world" } }],
+            };
+          },
+        },
+        params: { slug: "missing" },
+        query: { slug: "missing" },
+        route: { isDynamic: true },
+        routeUrl: "/posts/missing",
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.status).toBe(404);
+    expect(result.response.headers.get("content-type")).toBe("application/json");
+    await expect(result.response.text()).resolves.toBe("{}");
+  });
+
+  it("returns JSON 404 envelope for data requests when getStaticProps returns notFound", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        isDataReq: true,
+        pageModule: {
+          async getStaticProps() {
+            return { notFound: true };
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.status).toBe(404);
+    expect(result.response.headers.get("content-type")).toBe("application/json");
+    await expect(result.response.text()).resolves.toBe("{}");
+  });
+
+  it("returns JSON 404 envelope for data requests when getServerSideProps returns notFound", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        isDataReq: true,
+        pageModule: {
+          async getServerSideProps() {
+            return { notFound: true };
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.status).toBe(404);
+    expect(result.response.headers.get("content-type")).toBe("application/json");
+    await expect(result.response.text()).resolves.toBe("{}");
+  });
+
   it("short-circuits getServerSideProps responses after res.end()", async () => {
     const responsePromise = Promise.resolve(
       new Response('{"ok":true}', {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -94,7 +94,7 @@ describe("pages page data", () => {
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
   });
 
-  it("returns an HTML 404 when getStaticPaths excludes a dynamic path", async () => {
+  it("returns a notFound signal when getStaticPaths excludes a dynamic HTML path", async () => {
     const result = await resolvePagesPageData(
       createOptions({
         pageModule: {
@@ -112,12 +112,50 @@ describe("pages page data", () => {
       }),
     );
 
-    expect(result.kind).toBe("response");
-    if (result.kind !== "response") {
-      throw new Error("expected response result");
-    }
-    expect(result.response.status).toBe(404);
-    await expect(result.response.text()).resolves.toContain("This page could not be found.");
+    expect(result).toEqual({ kind: "notFound" });
+  });
+
+  it("runs page getInitialProps with the original request URL and asPath", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        asPath: "/3",
+        createGsspReqRes() {
+          return {
+            req: { url: "/3" },
+            res: {
+              headersSent: false,
+              statusCode: 200,
+              getHeaders() {
+                return {};
+              },
+            },
+            responsePromise: Promise.resolve(new Response("short-circuit", { status: 202 })),
+          };
+        },
+        pageModule: {
+          default: Object.assign(
+            function Page() {
+              return null;
+            },
+            {
+              getInitialProps(context: { req?: { url?: string }; asPath?: string }) {
+                return {
+                  reqUrl: context.req?.url,
+                  asPath: context.asPath,
+                };
+              },
+            },
+          ),
+        },
+        routePattern: "/_error",
+        routeUrl: "/3",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { reqUrl: "/3", asPath: "/3" },
+    });
   });
 
   it("short-circuits getServerSideProps responses after res.end()", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -323,6 +323,95 @@ describe("pages page data", () => {
     await expect(result.response.text()).resolves.toBe('{"ok":true}');
   });
 
+  it("short-circuits getServerSideProps responses when only writableEnded is set", async () => {
+    const responsePromise = Promise.resolve(
+      new Response('{"ok":true}', {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        createGsspReqRes() {
+          const res = {
+            headersSent: false,
+            writableEnded: true,
+            statusCode: 202,
+            getHeaders() {
+              return { "content-type": "application/json" };
+            },
+          };
+          return {
+            req: { method: "GET" },
+            res,
+            responsePromise,
+          };
+        },
+        pageModule: {
+          async getServerSideProps() {
+            return {};
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.status).toBe(202);
+    await expect(result.response.text()).resolves.toBe('{"ok":true}');
+  });
+
+  it("short-circuits getInitialProps responses when only writableEnded is set", async () => {
+    const responsePromise = Promise.resolve(
+      new Response('{"ok":true}', {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        createGsspReqRes() {
+          const res = {
+            headersSent: false,
+            writableEnded: true,
+            statusCode: 202,
+            getHeaders() {
+              return { "content-type": "application/json" };
+            },
+          };
+          return {
+            req: {},
+            res,
+            responsePromise,
+          };
+        },
+        pageModule: {
+          default: Object.assign(
+            function Page() {
+              return null;
+            },
+            {
+              getInitialProps() {
+                return {};
+              },
+            },
+          ),
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") {
+      throw new Error("expected response result");
+    }
+    expect(result.response.status).toBe(202);
+    await expect(result.response.text()).resolves.toBe('{"ok":true}');
+  });
+
   it("serves stale ISR entries immediately and regenerates them through typed helpers", async () => {
     let regenPromise: Promise<void> | null = null;
     const applyRequestContexts = vi.fn();
@@ -773,5 +862,25 @@ describe("pages page data", () => {
     );
 
     expect(received).toBeNull();
+  });
+
+  it("isResponseSent detects both headersSent and writableEnded", async () => {
+    const { isResponseSent } =
+      await import("../packages/vinext/src/server/pages-get-initial-props.js");
+
+    expect(isResponseSent({ headersSent: true })).toBe(true);
+    expect(isResponseSent({ writableEnded: true })).toBe(true);
+    expect(isResponseSent({ headersSent: true, writableEnded: true })).toBe(true);
+    expect(isResponseSent({ headersSent: false })).toBe(false);
+    expect(isResponseSent({ writableEnded: false })).toBe(false);
+    expect(isResponseSent({})).toBe(false);
+    expect(isResponseSent(undefined)).toBe(false);
+    expect(isResponseSent(null)).toBe(false);
+    // The prod PagesReqResResponse type only declares headersSent; the helper
+    // must not throw or treat the absent writableEnded as truthy.
+    const prodShaped: { headersSent: boolean } = { headersSent: false };
+    expect(isResponseSent(prodShaped)).toBe(false);
+    prodShaped.headersSent = true;
+    expect(isResponseSent(prodShaped)).toBe(true);
   });
 });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3032,6 +3032,92 @@ export default function CounterPage() {
     }
   });
 
+  // Ported from Next.js: test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
+  it("passes the original request URL and asPath to _error.getInitialProps for getStaticProps notFound", async () => {
+    const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-gsp-notfound-error-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    const fixtureOutDir = path.join(tmpRoot, "dist");
+
+    try {
+      await fsp.symlink(rootNodeModules, path.join(tmpRoot, "node_modules"), "junction");
+      await fsp.mkdir(path.join(tmpRoot, "pages"), { recursive: true });
+      await fsp.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ type: "module" }));
+      await fsp.writeFile(path.join(tmpRoot, "next.config.mjs"), `export default {};\n`);
+      await fsp.writeFile(path.join(tmpRoot, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "_error.tsx"),
+        `import type { NextPageContext } from "next";
+
+type ErrorProps = { reqUrl?: string; asPath?: string };
+
+ErrorPage.getInitialProps = (ctx: NextPageContext): ErrorProps => {
+  return {
+    reqUrl: ctx.req?.url,
+    asPath: ctx.asPath,
+  };
+};
+
+export default function ErrorPage({ reqUrl, asPath }: ErrorProps) {
+  return <p>reqUrl: {reqUrl}, asPath: {asPath}</p>;
+}
+`,
+      );
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "[slug].tsx"),
+        `export default function Page() {
+  return <p>hello world</p>;
+}
+
+export async function getStaticProps() {
+  return {
+    notFound: true,
+  };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+}
+`,
+      );
+
+      await buildPagesFixtureToOutDir(tmpRoot, fixtureOutDir);
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      const prodServer = unwrapStartedProdServer(
+        await startProdServer({
+          port: 0,
+          host: "127.0.0.1",
+          outDir: fixtureOutDir,
+        }),
+      );
+
+      try {
+        const addr = prodServer.address() as { port: number };
+        const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+        const res = await fetch(`${baseUrl}/3`);
+        expect(res.status).toBe(404);
+        const html = await res.text();
+        const visibleText = html
+          .replace(/<!--[\s\S]*?-->/g, "")
+          .replace(/<[^>]*>/g, "")
+          .replace(/\s+/g, " ")
+          .trim();
+
+        expect(visibleText).toContain("reqUrl: /3, asPath: /3");
+        expect(html).toContain('"page":"/_error"');
+      } finally {
+        await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+      }
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("preserves 404 status for cached ISR custom 404 route misses", async () => {
     const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-isr-404-"));
     const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3118,6 +3118,155 @@ export async function getStaticPaths() {
     }
   });
 
+  it("renders explicit pages/404 over pages/_error when getStaticProps returns notFound", async () => {
+    const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-gsp-notfound-404-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    const fixtureOutDir = path.join(tmpRoot, "dist");
+
+    try {
+      await fsp.symlink(rootNodeModules, path.join(tmpRoot, "node_modules"), "junction");
+      await fsp.mkdir(path.join(tmpRoot, "pages"), { recursive: true });
+      await fsp.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ type: "module" }));
+      await fsp.writeFile(path.join(tmpRoot, "next.config.mjs"), `export default {};\n`);
+      await fsp.writeFile(path.join(tmpRoot, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "_error.tsx"),
+        `export default function ErrorPage() {
+  return <p id="error">_error page</p>;
+}
+`,
+      );
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "404.tsx"),
+        `export default function Custom404() {
+  return <p id="custom-404">custom 404</p>;
+}
+`,
+      );
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "[slug].tsx"),
+        `export default function Page() {
+  return <p>hello world</p>;
+}
+
+export async function getStaticProps() {
+  return {
+    notFound: true,
+  };
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+}
+`,
+      );
+
+      await buildPagesFixtureToOutDir(tmpRoot, fixtureOutDir);
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      const prodServer = unwrapStartedProdServer(
+        await startProdServer({
+          port: 0,
+          host: "127.0.0.1",
+          outDir: fixtureOutDir,
+        }),
+      );
+
+      try {
+        const addr = prodServer.address() as { port: number };
+        const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+        const res = await fetch(`${baseUrl}/3`);
+        expect(res.status).toBe(404);
+        const html = await res.text();
+        expect(html).toContain('id="custom-404"');
+        expect(html).toContain("custom 404");
+        expect(html).not.toContain('id="error"');
+        expect(html).toContain('"page":"/404"');
+      } finally {
+        await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+      }
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("passes the original error to _error.getInitialProps when getServerSideProps throws", async () => {
+    const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-gssp-throw-error-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    const fixtureOutDir = path.join(tmpRoot, "dist");
+
+    try {
+      await fsp.symlink(rootNodeModules, path.join(tmpRoot, "node_modules"), "junction");
+      await fsp.mkdir(path.join(tmpRoot, "pages"), { recursive: true });
+      await fsp.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ type: "module" }));
+      await fsp.writeFile(path.join(tmpRoot, "next.config.mjs"), `export default {};\n`);
+      await fsp.writeFile(path.join(tmpRoot, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "_error.tsx"),
+        `import type { NextPageContext } from "next";
+
+type ErrorProps = { errMessage?: string };
+
+ErrorPage.getInitialProps = (ctx: NextPageContext): ErrorProps => {
+  return {
+    errMessage: ctx.err instanceof Error ? ctx.err.message : String(ctx.err),
+  };
+};
+
+export default function ErrorPage({ errMessage }: ErrorProps) {
+  return <p>errMessage: {errMessage}</p>;
+}
+`,
+      );
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "index.tsx"),
+        `export default function Page() {
+  return <p>hello world</p>;
+}
+
+export async function getServerSideProps() {
+  throw new Error("intentional gssp throw");
+}
+`,
+      );
+
+      await buildPagesFixtureToOutDir(tmpRoot, fixtureOutDir);
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      const prodServer = unwrapStartedProdServer(
+        await startProdServer({
+          port: 0,
+          host: "127.0.0.1",
+          outDir: fixtureOutDir,
+        }),
+      );
+
+      try {
+        const addr = prodServer.address() as { port: number };
+        const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+        const res = await fetch(`${baseUrl}/`);
+        expect(res.status).toBe(500);
+        const html = await res.text();
+        const visibleText = html
+          .replace(/<!--[\s\S]*?-->/g, "")
+          .replace(/<[^>]*>/g, "")
+          .replace(/\s+/g, " ")
+          .trim();
+
+        expect(visibleText).toContain("errMessage: intentional gssp throw");
+      } finally {
+        await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+      }
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("preserves 404 status for cached ISR custom 404 route misses", async () => {
     const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-isr-404-"));
     const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");


### PR DESCRIPTION
## Overview

| Area | Details |
| --- | --- |
| Goal | Match Next.js when a Pages Router data method returns `notFound` and the HTML request must render the configured 404/error page. |
| Core change | `resolvePagesPageData()` now returns an HTML `notFound` signal instead of constructing the built-in 404 response directly. |
| Main boundary | The generated Pages entry owns rerouting to `pages/404` or `pages/_error`, while data requests still return the JSON-shaped 404 envelope. |
| Primary files | `pages-page-data.ts`, `pages-server-entry.ts`, `pages-get-initial-props.ts`, `dev-server.ts`, `tests/pages-router.test.ts`. |
| Expected impact | `_error.getInitialProps(ctx)` receives the original request URL and `asPath` for `getStaticProps` or `getServerSideProps` `notFound` results. |

## Why

A Pages Router `notFound` result is not the final HTML response. In Next.js, `getStaticProps` marks render metadata as not found, the Pages route handler delegates to `render404()`, and the server then resolves `pages/404` before falling back to `pages/_error`. That fallback render still builds the normal `NextPageContext`, including `ctx.req`, `ctx.res`, and `ctx.asPath`.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| HTML `notFound` | Data resolution should describe the route outcome, not preempt the configured error-page renderer. | HTML `notFound` returns `{ kind: "notFound" }`; only `/_next/data` requests keep returning `{}` with status 404. |
| Error route rendering | `pages/404` and `pages/_error` should be resolved by the Pages entry with the original visible URL. | The generated entry rerenders the configured not-found route with `statusCode: 404` and the original `asPath`. |
| `getInitialProps` context | Pages `getInitialProps` belongs at the page render boundary and should observe sent-response short-circuits. | A typed helper invokes page `getInitialProps` in prod and dev without widening production code through `any` or broad assertions. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `getStaticProps` returns `{ notFound: true }` for an HTML request | vinext returned the built-in default 404, skipping custom `pages/_error`. | vinext rerenders `pages/404` or `pages/_error` and preserves 404 status. |
| `_error.getInitialProps(ctx)` on that rerender | Not called, so `ctx.req?.url` and `ctx.asPath` never reached the page. | Called with `req.url` and `asPath` from the original request, matching the upstream fixture. |
| `/_next/data/...json` not found | Returned JSON-shaped 404. | Preserved. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/pages-page-data.ts` - the resolver now emits a typed `notFound` signal for HTML while preserving JSON data-request behavior.
2. `packages/vinext/src/entries/pages-server-entry.ts` - the generated Pages runtime reroutes that signal to explicit `/404` or `/_error`, avoiding catch-all matches and recursion.
3. `packages/vinext/src/server/pages-get-initial-props.ts` - shared typed loader for Pages component `getInitialProps`, including the sent-response exception from Next.js `loadGetInitialProps`.
4. `packages/vinext/src/server/dev-server.ts` - dev parity for page and error-page `getInitialProps` context.
5. `tests/pages-router.test.ts` and `tests/pages-page-data.test.ts` - upstream fixture port plus lower-boundary contract coverage.

</details>

<details>
<summary>Validation</summary>

- `vp check`
- `vp test run tests/pages-page-data.test.ts`
- `vp test run tests/pages-router.test.ts`
- Commit hook: `vp test run tests/entry-templates.test.ts`
- Commit hook: checked formatting, lint, types, and `knip`
- Upstream deploy suite: `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no new public API. The new helper is internal.
- Runtime: affects Pages Router HTML `notFound` handling and Pages component `getInitialProps` invocation when no gSP/gSSP owns props.
- Data requests: preserved as JSON 404 envelopes so client-router data fetches can still parse the response.
- Compatibility: intentionally follows Next.js routing order for `notFound` fallback to `pages/404` and `pages/_error`.
- Existing-app risk: apps that relied on vinext's built-in 404 shortcut for gSP/gSSP `notFound` will now see their configured error page, which is the Next.js-compatible behavior.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream test: error-handler-not-found-req-url](https://github.com/vercel/next.js/blob/ee6e79b1792a/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts) | The fixture this PR ports and passes through the vinext deploy harness. |
| [Next.js `getStaticProps` `notFound` metadata](https://github.com/vercel/next.js/blob/ee6e79b1792a/packages/next/src/server/render.tsx#L873-L880) | Shows `notFound` becoming render metadata instead of an immediate built-in response. |
| [Next.js render returns null for `metadata.isNotFound`](https://github.com/vercel/next.js/blob/ee6e79b1792a/packages/next/src/server/render.tsx#L971-L975) | Explains why the Pages handler owns the final 404 render decision. |
| [Next.js Pages handler delegates `isNotFound` to `render404()`](https://github.com/vercel/next.js/blob/ee6e79b1792a/packages/next/src/server/route-modules/pages/pages-handler.ts#L585-L591) | The production behavior vinext now mirrors. |
| [Next.js `render404` and error fallback](https://github.com/vercel/next.js/blob/ee6e79b1792a/packages/next/src/server/base-server.ts#L2574-L2658) | Shows the `/404` then `/_error` fallback sequence. |
| [Next.js context passed to `loadGetInitialProps`](https://github.com/vercel/next.js/blob/ee6e79b1792a/packages/next/src/server/render.tsx#L746-L797) | Confirms `ctx.req`, `ctx.res`, and `ctx.asPath` are part of the error render context. |
| [Next.js `loadGetInitialProps`](https://github.com/vercel/next.js/blob/ee6e79b1792a/packages/next/src/shared/lib/utils.ts#L345-L393) | The sent-response and invalid-return semantics used by the vinext helper. |
| [Next.js docs for `getStaticProps.notFound`](https://github.com/vercel/next.js/blob/ee6e79b1792a/docs/02-pages/04-api-reference/03-functions/get-static-props.mdx#L106-L108) | Documents that `notFound` should render a 404 page. |
