### PR TITLE
fix(app-router): restore scroll snapshots on back

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -103,6 +103,12 @@ export default {
     // probed via require.resolve
     "next-intl",
 
+    // Optional peer dependency probed by tests/scss.test.ts.
+    "sass",
+
+    // Vite+ reporter name used outside CI in vite.config.ts.
+    "agent",
+
     // internal module name, not an actual dependency
     "private-next-instrumentation-client",
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -70,8 +70,10 @@ import {
   getVinextBrowserGlobal,
 } from "./app-browser-stream.js";
 import {
-  createAppBrowserNavigationController,
   clearHardNavigationLoopGuard,
+  createAppBrowserNavigationController,
+  createBasePathStrippedPathAndSearch,
+  createSnapshotPathAndSearch,
   type HistoryUpdateMode,
   type NavigationPayloadOutcome,
   type PendingBrowserRouterState,
@@ -223,6 +225,7 @@ function getBrowserRouteManifest(): RouteManifest | null {
 }
 
 const browserNavigationController = createAppBrowserNavigationController({
+  basePath: __basePath,
   getRouteManifest: getBrowserRouteManifest,
   syncHistoryStatePreviousNextUrl: syncCurrentHistoryStatePreviousNextUrl,
 });
@@ -1317,12 +1320,10 @@ function isSameAppRoutePopstateTarget(href: string): boolean {
 
   const target = new URL(href, window.location.origin);
   const routerState = getBrowserRouterState();
-  const targetPathname = stripBasePath(target.pathname, __basePath);
-  const targetSearch = new URLSearchParams(target.search).toString();
-  const currentSearch = routerState.navigationSnapshot.searchParams.toString();
 
   return (
-    targetPathname === routerState.navigationSnapshot.pathname && targetSearch === currentSearch
+    createBasePathStrippedPathAndSearch(target, __basePath) ===
+    createSnapshotPathAndSearch(routerState.navigationSnapshot)
   );
 }
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -109,10 +109,8 @@ import {
   createBfcacheSegmentStateKeyMap,
   createHistoryStateWithNavigationMetadata,
   createInitialBfcacheIdMap,
-  isHistoryStateBfcacheVersionCurrent,
   isCacheRestorableAppPayloadMetadata,
   readHistoryStateBfcacheIds,
-  readHistoryStateBfcacheVersion,
   readHistoryStatePreviousNextUrl,
   readHistoryStateTraversalIndex,
   resolveHistoryTraversalIntent,
@@ -123,6 +121,7 @@ import {
   type HistoryTraversalIntent,
   type OperationLane,
 } from "./app-browser-state.js";
+import { RestorableClientStateController } from "./app-history-state.js";
 import {
   createVisitedResponseCacheEntry,
   isVisitedResponseCacheEntryFresh,
@@ -290,21 +289,15 @@ const mpaNavigationScheduler = new AppBrowserMpaNavigationScheduler();
 const unresolvedMpaNavigation = new Promise<never>(() => {});
 const RSC_HMR_SETTLE_DELAY_MS = 150;
 let latestRscHmrUpdateId = 0;
-const initialHistoryBfcacheVersion = readHistoryStateBfcacheVersion(window.history.state);
-// A new browser document does not retain Next's in-memory BFCache entries.
-// Treat bfcache ids persisted by an older document as stale so a hard reload
-// cannot restore/collide with pre-reload route identities.
-let currentBfcacheVersion =
-  initialHistoryBfcacheVersion === null ? 0 : initialHistoryBfcacheVersion + 1;
 let currentHistoryTraversalIndex: number | null =
   readHistoryStateTraversalIndex(window.history.state) ?? 0;
 let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
-const historyStateSnapshots = new Map<number, AppRouterState>();
+let synchronousPopstateScrollRestoreNavigationId: number | null = null;
 const MAX_HISTORY_STATE_SNAPSHOTS = 50;
-
-function isCurrentBfcacheVersion(state: unknown): boolean {
-  return isHistoryStateBfcacheVersionCurrent(state, currentBfcacheVersion);
-}
+const restorableClientState = new RestorableClientStateController<AppRouterState>({
+  initialHistoryState: window.history.state,
+  maxHistoryStateSnapshots: MAX_HISTORY_STATE_SNAPSHOTS,
+});
 
 // Vite can notify the browser about an RSC HMR update before the dev server's
 // request runner has swapped to the invalidated module graph. Give the
@@ -314,18 +307,6 @@ function waitForRscHmrSettle(delayMs = RSC_HMR_SETTLE_DELAY_MS): Promise<void> {
   return new Promise((resolve) => {
     window.setTimeout(resolve, delayMs);
   });
-}
-
-function readCurrentBfcacheVersionHistoryIds(
-  state: unknown,
-): Readonly<Record<string, string>> | null {
-  const ids = readHistoryStateBfcacheIds(state);
-  if (ids === null) return null;
-  return isCurrentBfcacheVersion(state) ? ids : null;
-}
-
-function invalidateRestorableBfcacheIds(): void {
-  currentBfcacheVersion += 1;
 }
 
 function allocateNavigationHistoryTraversalIndex(
@@ -366,12 +347,12 @@ function commitHashOnlyNavigation(
     : readHistoryStatePreviousNextUrl(window.history.state);
   const bfcacheIds = hasBrowserRouterState()
     ? getBrowserRouterState().bfcacheIds
-    : readCurrentBfcacheVersionHistoryIds(window.history.state);
+    : restorableClientState.readCurrentBfcacheVersionHistoryIds(window.history.state);
   const historyState = createHistoryStateWithNavigationMetadata(
     createHashOnlyNavigationBaseHistoryState(historyUpdateMode, scroll),
     {
       bfcacheIds,
-      bfcacheVersion: bfcacheIds === null ? undefined : currentBfcacheVersion,
+      bfcacheVersion: bfcacheIds === null ? undefined : restorableClientState.currentBfcacheVersion,
       previousNextUrl,
       traversalIndex: navigationHistoryIndex,
     },
@@ -415,32 +396,27 @@ function commitTraversalIndexFromHistoryState(historyState: unknown): void {
   commitHistoryTraversalIndex(readHistoryStateTraversalIndex(historyState));
 }
 
-function rememberHistoryStateSnapshot(state: AppRouterState): void {
-  const index = currentHistoryTraversalIndex;
-  if (index === null) return;
-
-  historyStateSnapshots.delete(index);
-  historyStateSnapshots.set(index, state);
-  if (historyStateSnapshots.size <= MAX_HISTORY_STATE_SNAPSHOTS) return;
-
-  const oldestIndex = historyStateSnapshots.keys().next().value;
-  if (typeof oldestIndex === "number") {
-    historyStateSnapshots.delete(oldestIndex);
-  }
-}
-
 function restoreHistoryStateSnapshot(historyState: unknown): boolean {
-  const targetIndex = readHistoryStateTraversalIndex(historyState);
-  if (targetIndex === null) return false;
+  const decision = restorableClientState.resolveHistoryStateSnapshotRestore(historyState);
+  if (decision.kind === "skip") {
+    return false;
+  }
 
-  const snapshot = historyStateSnapshots.get(targetIndex);
-  if (!snapshot) return false;
-
-  commitHistoryTraversalIndex(targetIndex);
-  stageClientParams(snapshot.navigationSnapshot.params);
+  const navId = browserNavigationController.getActiveNavigationId();
+  let restored = false;
   flushSync(() => {
-    browserNavigationController.restoreVisibleState(snapshot);
+    restored = browserNavigationController.restoreHistorySnapshotVisibleState({
+      beforeCommit: () => {
+        commitHistoryTraversalIndex(decision.targetHistoryIndex);
+        stageClientParams(decision.state.navigationSnapshot.params);
+      },
+      navId,
+      state: decision.state,
+      targetHref: window.location.href,
+    });
   });
+  if (!restored) return false;
+
   commitClientNavigationState();
   return true;
 }
@@ -489,7 +465,7 @@ function clearPrefetchState(): void {
 function clearClientNavigationCaches(): void {
   clearVisitedResponseCache();
   clearPrefetchState();
-  invalidateRestorableBfcacheIds();
+  restorableClientState.invalidateClientState();
 }
 
 function isSettledPrefetchCacheEntry(
@@ -615,7 +591,7 @@ function isHistoryStateNavigationMetadataInSync(
     readHistoryStatePreviousNextUrl(state) === previousNextUrl &&
     (bfcacheIds === undefined ||
       (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(state), bfcacheIds) &&
-        isCurrentBfcacheVersion(state)))
+        restorableClientState.isCurrentBfcacheVersion(state)))
   );
 }
 
@@ -629,7 +605,8 @@ function syncCurrentHistoryStatePreviousNextUrl(
 
   const nextHistoryState = createHistoryStateWithNavigationMetadata(window.history.state, {
     bfcacheIds,
-    bfcacheVersion: bfcacheIds === undefined ? undefined : currentBfcacheVersion,
+    bfcacheVersion:
+      bfcacheIds === undefined ? undefined : restorableClientState.currentBfcacheVersion,
     previousNextUrl,
   });
   // First attempt: use replaceHistoryStateWithoutNotify which fires no popstate
@@ -695,7 +672,7 @@ function createNavigationCommitEffect(options: {
       preserveExistingState ? window.history.state : null,
       {
         bfcacheIds,
-        bfcacheVersion: currentBfcacheVersion,
+        bfcacheVersion: restorableClientState.currentBfcacheVersion,
         previousNextUrl,
         traversalIndex: navigationHistoryIndex,
       },
@@ -745,6 +722,7 @@ async function renderNavigationPayload(
   traversalIntent: HistoryTraversalIntent | null = null,
   scrollIntent: AppRouterScrollIntent | null | undefined = null,
   restoredBfcacheIds: Readonly<Record<string, string>> | null = null,
+  reuseCurrentBfcacheIds: boolean = true,
 ): Promise<NavigationPayloadOutcome> {
   syncServerActionHttpFallbackHead(null);
   try {
@@ -764,6 +742,7 @@ async function renderNavigationPayload(
       previousNextUrl,
       scrollIntent,
       restoredBfcacheIds,
+      reuseCurrentBfcacheIds,
       targetHistoryIndex: traversalIntent === null ? undefined : traversalIntent.targetHistoryIndex,
       targetHref,
       navId,
@@ -1189,7 +1168,10 @@ function BrowserRoot({
   }, [setTreeStateValue]);
 
   useLayoutEffect(() => {
-    rememberHistoryStateSnapshot(treeState);
+    restorableClientState.rememberHistoryStateSnapshot({
+      historyIndex: currentHistoryTraversalIndex,
+      state: treeState,
+    });
   }, [treeState]);
 
   useLayoutEffect(() => {
@@ -1206,7 +1188,7 @@ function BrowserRoot({
     replaceHistoryStateWithoutNotify(
       createHistoryStateWithNavigationMetadata(window.history.state, {
         bfcacheIds: treeState.bfcacheIds,
-        bfcacheVersion: currentBfcacheVersion,
+        bfcacheVersion: restorableClientState.currentBfcacheVersion,
         previousNextUrl: treeState.previousNextUrl,
         traversalIndex: currentHistoryTraversalIndex,
       }),
@@ -1507,10 +1489,9 @@ function applyRuntimeRscBootstrap(rsc: NavigationRuntimeRscBootstrap): void {
 }
 
 function registerServerActionCallback(): void {
-  setServerCallback(async (id, args) => {
+  const serverActionCallback: Parameters<typeof setServerCallback>[0] = async (id, args) => {
     syncServerActionHttpFallbackHead(null);
     const temporaryReferences = createTemporaryReferenceSet();
-
     // Carry the interception context + mounted slots from the current router
     // state so the server-action re-render rebuilds the intercepted tree
     // instead of replacing it with the direct page. Parity with Next.js,
@@ -1578,6 +1559,9 @@ function registerServerActionCallback(): void {
     }
 
     const revalidation = parseServerActionRevalidationHeader(fetchResponse.headers);
+    if (revalidation !== "none") {
+      clearClientNavigationCaches();
+    }
     const invalidResponseError = await readInvalidServerActionResponseError(
       fetchResponse.clone(),
       actionRedirectTarget !== null,
@@ -1604,7 +1588,10 @@ function registerServerActionCallback(): void {
       Promise.resolve(flightResponse),
       { temporaryReferences },
     );
-    if (shouldClearClientNavigationCachesForServerActionResult(result, revalidation)) {
+    if (
+      revalidation === "none" &&
+      shouldClearClientNavigationCachesForServerActionResult(result, revalidation)
+    ) {
       clearClientNavigationCaches();
     }
 
@@ -1694,6 +1681,13 @@ function registerServerActionCallback(): void {
       undefined,
       revalidation,
     );
+  };
+
+  setServerCallback((id, args) => {
+    const releaseCacheInvalidationGuard = restorableClientState.beginCacheInvalidationGuard();
+    return Promise.resolve()
+      .then(() => serverActionCallback(id, args))
+      .finally(releaseCacheInvalidationGuard);
   });
 }
 
@@ -1800,10 +1794,16 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     // stale ids from the pre-redirect history entry cannot win.
     let restoredBfcacheIds =
       navigationKind === "traverse"
-        ? readCurrentBfcacheVersionHistoryIds(
+        ? restorableClientState.readCurrentBfcacheVersionHistoryIds(
             activeTraversalIntent?.historyState ?? window.history.state,
           )
         : null;
+    const reuseCurrentBfcacheIds =
+      navigationKind !== "traverse" ||
+      (!restorableClientState.isCacheInvalidationGuarded() &&
+        restorableClientState.isCurrentBfcacheVersion(
+          activeTraversalIntent?.historyState ?? window.history.state,
+        ));
     try {
       const shouldUsePendingRouterState = programmaticTransition;
       if (shouldUsePendingRouterState && hasBrowserRouterState()) {
@@ -1945,6 +1945,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             activeTraversalIntent,
             scrollIntent,
             restoredBfcacheIds,
+            reuseCurrentBfcacheIds,
           );
           if (cachedRenderOutcome === "no-commit") {
             deleteVisitedResponse(rscUrl, requestInterceptionContext);
@@ -2028,6 +2029,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
                 activeTraversalIntent,
                 scrollIntent,
                 restoredBfcacheIds,
+                reuseCurrentBfcacheIds,
               ).catch((error) => {
                 if (browserNavigationController.isCurrentNavigation(navId)) {
                   console.error("[vinext] Optimistic RSC navigation error:", error);
@@ -2235,6 +2237,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           activeTraversalIntent,
           scrollIntent,
           restoredBfcacheIds,
+          reuseCurrentBfcacheIds,
         );
         if (renderOutcome !== "committed") return;
         // Don't cache the response if this navigation was superseded during
@@ -2321,6 +2324,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     setPendingNavigation: (pendingNavigation) => {
       window.__VINEXT_RSC_PENDING__ = pendingNavigation;
     },
+    shouldSkipScrollRestore: (navId) => synchronousPopstateScrollRestoreNavigationId === navId,
   });
 
   window.addEventListener("popstate", (event) => {
@@ -2339,6 +2343,8 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     }
     handlePopstate(event);
     if (restoreHistoryStateSnapshot(event.state)) {
+      synchronousPopstateScrollRestoreNavigationId =
+        browserNavigationController.getActiveNavigationId();
       restorePopstateScrollPosition(event.state);
     }
   });

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1564,6 +1564,10 @@ function registerServerActionCallback(): void {
 
     const revalidation = parseServerActionRevalidationHeader(fetchResponse.headers);
     if (revalidation !== "none") {
+      // The revalidation header is the server's cache-invalidation signal. Clear
+      // restorable BFCache ids and snapshots before body decoding so no pending
+      // traversal can synchronously restore visible state from the old
+      // client-state epoch.
       clearClientNavigationCaches();
     }
     const invalidResponseError = await readInvalidServerActionResponseError(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -127,7 +127,10 @@ import {
   isVisitedResponseCacheEntryFresh,
   type VisitedResponseCacheEntry,
 } from "./app-visited-response-cache.js";
-import { createPopstateRestoreHandler } from "./app-browser-popstate.js";
+import {
+  createPopstateRestoreHandler,
+  restoreSynchronousPopstateScrollPosition,
+} from "./app-browser-popstate.js";
 import { DevRecoveryBoundary, RedirectBoundary } from "vinext/shims/error-boundary";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/slot";
@@ -1306,7 +1309,7 @@ function restorePopstateScrollPosition(
   const y = Number(state.__vinext_scrollY);
   const x = "__vinext_scrollX" in state ? Number(state.__vinext_scrollX) : 0;
 
-  retryScrollTo(x, y, { shouldContinue });
+  retryScrollTo(x, y, { minFrames: 1, shouldContinue });
 }
 
 function isSameAppRoutePopstateTarget(href: string): boolean {
@@ -2343,9 +2346,17 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     }
     handlePopstate(event);
     if (restoreHistoryStateSnapshot(event.state)) {
-      synchronousPopstateScrollRestoreNavigationId =
-        browserNavigationController.getActiveNavigationId();
-      restorePopstateScrollPosition(event.state);
+      restoreSynchronousPopstateScrollPosition(
+        {
+          getActiveNavigationId: () => browserNavigationController.getActiveNavigationId(),
+          isCurrentNavigation: (navId) => browserNavigationController.isCurrentNavigation(navId),
+          markScrollRestoreConsumed: (navId) => {
+            synchronousPopstateScrollRestoreNavigationId = navId;
+          },
+          restorePopstateScrollPosition,
+        },
+        event.state,
+      );
     }
   });
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2350,6 +2350,25 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       return;
     }
     handlePopstate(event);
+    // Synchronous snapshot restore supersedes the in-flight async RSC traverse.
+    //
+    // handlePopstate calls navigate() which starts an async RSC traversal:
+    // renderNavigationPayload captures startedState (visibleCommitVersion N)
+    // and awaits nextElements, yielding at least one microtask.
+    //
+    // restoreHistoryStateSnapshot runs synchronously (flushSync, no await) in
+    // the same task, commits the cached history snapshot, and bumps
+    // visibleCommitVersion to N+1.
+    //
+    // When the async traverse resolves,
+    // resolvePendingNavigationCommitDispositionDecision sees
+    // startedVisibleCommitVersion (N) !== currentState.visibleCommitVersion
+    // (N+1) and returns staleOperation → no-commit, discarding the fresh
+    // RSC payload in favor of the cached client snapshot.
+    //
+    // This matches Next's in-memory bfcache behaviour (no refetch on back).
+    // The ordering is deterministic only because restoreHistoryStateSnapshot
+    // is synchronous while the async traverse always yields.
     if (restoreHistoryStateSnapshot(event.state)) {
       restoreSynchronousPopstateScrollPosition(
         {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -298,6 +298,11 @@ let latestRscHmrUpdateId = 0;
 let currentHistoryTraversalIndex: number | null =
   readHistoryStateTraversalIndex(window.history.state) ?? 0;
 let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
+// Single-slot latch tracking the navId of the most recent synchronous
+// popstate snapshot restore. activeNavigationId is strictly monotonic, so
+// shouldSkipScrollRestore can only match the most-recently restored
+// navigation. This is intentionally not a per-navigation set — a future
+// asynchronous scroll restore for an older navId is already stale.
 let synchronousPopstateScrollRestoreNavigationId: number | null = null;
 const MAX_HISTORY_STATE_SNAPSHOTS = 50;
 const restorableClientState = new RestorableClientStateController<AppRouterState>({
@@ -1173,6 +1178,13 @@ function BrowserRoot({
     };
   }, [setTreeStateValue]);
 
+  // This effect keys the snapshot by currentHistoryTraversalIndex but only
+  // depends on [treeState]. The ordering works because
+  // commitHistoryTraversalIndex runs inside the navigation commit effect
+  // (before setTreeStateValue fires), so the index is already current when
+  // this layout effect runs for the new treeState. If the commit ordering
+  // ever changes, the snapshot index may not match the traversed history
+  // entry, causing resolveRestore to read the wrong index on back.
   useLayoutEffect(() => {
     restorableClientState.rememberHistoryStateSnapshot({
       historyIndex: currentHistoryTraversalIndex,
@@ -1800,6 +1812,11 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     // Traversal restores history-state ids before identity matching. Any
     // redirect hop that changes currentHref must null this before commit so
     // stale ids from the pre-redirect history entry cannot win.
+    // Both restoredBfcacheIds and reuseCurrentBfcacheIds are snapshotted at
+    // navigation-start. If the bfcache epoch changes or a server-action
+    // guard is released before the async traverse resolves, these captured
+    // values may be stale — consistent with the existing restoredBfcacheIds
+    // pattern, and not a regression.
     let restoredBfcacheIds =
       navigationKind === "traverse"
         ? restorableClientState.readCurrentBfcacheVersionHistoryIds(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -17,6 +17,7 @@ import {
   encodeReply,
   setServerCallback,
 } from "@vitejs/plugin-rsc/browser";
+import { flushSync } from "react-dom";
 import { hydrateRoot } from "react-dom/client";
 import "../client/instrumentation-client.js";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
@@ -298,6 +299,8 @@ let currentBfcacheVersion =
 let currentHistoryTraversalIndex: number | null =
   readHistoryStateTraversalIndex(window.history.state) ?? 0;
 let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
+const historyStateSnapshots = new Map<number, AppRouterState>();
+const MAX_HISTORY_STATE_SNAPSHOTS = 50;
 
 function isCurrentBfcacheVersion(state: unknown): boolean {
   return isHistoryStateBfcacheVersionCurrent(state, currentBfcacheVersion);
@@ -410,6 +413,36 @@ function stripVinextScrollState(state: unknown): unknown {
 
 function commitTraversalIndexFromHistoryState(historyState: unknown): void {
   commitHistoryTraversalIndex(readHistoryStateTraversalIndex(historyState));
+}
+
+function rememberHistoryStateSnapshot(state: AppRouterState): void {
+  const index = currentHistoryTraversalIndex;
+  if (index === null) return;
+
+  historyStateSnapshots.delete(index);
+  historyStateSnapshots.set(index, state);
+  if (historyStateSnapshots.size <= MAX_HISTORY_STATE_SNAPSHOTS) return;
+
+  const oldestIndex = historyStateSnapshots.keys().next().value;
+  if (typeof oldestIndex === "number") {
+    historyStateSnapshots.delete(oldestIndex);
+  }
+}
+
+function restoreHistoryStateSnapshot(historyState: unknown): boolean {
+  const targetIndex = readHistoryStateTraversalIndex(historyState);
+  if (targetIndex === null) return false;
+
+  const snapshot = historyStateSnapshots.get(targetIndex);
+  if (!snapshot) return false;
+
+  commitHistoryTraversalIndex(targetIndex);
+  stageClientParams(snapshot.navigationSnapshot.params);
+  flushSync(() => {
+    browserNavigationController.restoreVisibleState(snapshot);
+  });
+  commitClientNavigationState();
+  return true;
 }
 
 function getBrowserRouterState(): AppRouterState {
@@ -1154,6 +1187,10 @@ function BrowserRoot({
       setMountedSlotsHeader(null);
     };
   }, [setTreeStateValue]);
+
+  useLayoutEffect(() => {
+    rememberHistoryStateSnapshot(treeState);
+  }, [treeState]);
 
   useLayoutEffect(() => {
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
@@ -2263,10 +2300,6 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     navigate: navigateRsc,
   });
 
-  if ("scrollRestoration" in history) {
-    history.scrollRestoration = "manual";
-  }
-
   // Note: This popstate handler runs for App Router (RSC navigation available).
   // It coordinates scroll restoration with the pending RSC navigation.
   // Pages Router scroll restoration is handled in shims/navigation.ts:1289 with
@@ -2305,6 +2338,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       return;
     }
     handlePopstate(event);
+    if (restoreHistoryStateSnapshot(event.state)) {
+      restorePopstateScrollPosition(event.state);
+    }
   });
 
   if (import.meta.hot) {

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -86,6 +86,7 @@ type BrowserNavigationController = {
   ): () => void;
   beginPendingBrowserRouterState(): PendingBrowserRouterState;
   finalizeNavigation(navId: number, pending: PendingBrowserRouterState | null | undefined): void;
+  restoreVisibleState(state: AppRouterState): void;
   renderNavigationPayload(options: {
     actionType: "navigate" | "replace" | "traverse";
     createNavigationCommitEffect: BrowserNavigationCommitEffectFactory;
@@ -492,6 +493,15 @@ export function createAppBrowserNavigationController(
     setter(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
   }
 
+  function restoreVisibleState(state: AppRouterState): void {
+    const currentState = getBrowserRouterState();
+    getBrowserRouterStateSetter()({
+      ...state,
+      activeOperation: null,
+      visibleCommitVersion: currentState.visibleCommitVersion + 1,
+    });
+  }
+
   function notifyDiscardedServerActionRevalidation(
     lifecycleOptions: SameUrlServerActionLifecycleOptions | undefined,
   ): void {
@@ -717,6 +727,7 @@ export function createAppBrowserNavigationController(
     attachBrowserRouterState,
     beginPendingBrowserRouterState,
     finalizeNavigation,
+    restoreVisibleState,
     renderNavigationPayload,
     commitSameUrlNavigatePayload,
     hmrReplaceTree,

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -11,6 +11,7 @@ import {
   type AppRouterScrollIntent,
 } from "vinext/shims/app-router-scroll-state";
 import type { RouteManifest } from "../routing/app-route-graph.js";
+import { stripBasePath } from "../utils/base-path.js";
 import {
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createPendingNavigationCommit,
@@ -65,6 +66,7 @@ type SameUrlServerActionLifecycleOptions = {
 };
 
 type BrowserNavigationControllerDeps = {
+  basePath?: string;
   commitClientNavigationState?: typeof commitClientNavigationState;
   performHardNavigation?: (href: string, mode?: HardNavigationMode) => boolean;
   getRouteManifest?: () => RouteManifest | null;
@@ -213,19 +215,28 @@ function performHardNavigationWithLoopGuard(
   return true;
 }
 
-function createSnapshotPathAndSearch(snapshot: ClientNavigationRenderSnapshot): string {
+export function createSnapshotPathAndSearch(snapshot: ClientNavigationRenderSnapshot): string {
   const query = snapshot.searchParams.toString();
   return query === "" ? snapshot.pathname : `${snapshot.pathname}?${query}`;
 }
 
+export function createBasePathStrippedPathAndSearch(url: URL, basePath: string): string {
+  const pathname = stripBasePath(url.pathname, basePath);
+  return `${pathname}${url.search}`;
+}
+
 function isSnapshotTargetHref(
+  basePath: string,
   snapshot: ClientNavigationRenderSnapshot,
   targetHref: string,
 ): boolean {
   try {
     const baseHref = typeof window === "undefined" ? "http://localhost" : window.location.href;
     const targetUrl = new URL(targetHref, baseHref);
-    return `${targetUrl.pathname}${targetUrl.search}` === createSnapshotPathAndSearch(snapshot);
+    return (
+      createBasePathStrippedPathAndSearch(targetUrl, basePath) ===
+      createSnapshotPathAndSearch(snapshot)
+    );
   } catch {
     return false;
   }
@@ -234,6 +245,7 @@ function isSnapshotTargetHref(
 export function createAppBrowserNavigationController(
   deps: BrowserNavigationControllerDeps = {},
 ): BrowserNavigationController {
+  const basePath = deps.basePath ?? "";
   const commitClientNavigationStateImpl =
     deps.commitClientNavigationState ?? commitClientNavigationState;
   const performHardNavigation = deps.performHardNavigation ?? performHardNavigationWithLoopGuard;
@@ -565,7 +577,7 @@ export function createAppBrowserNavigationController(
     state: AppRouterState;
     targetHref: string;
   }): boolean {
-    if (!isSnapshotTargetHref(options.state.navigationSnapshot, options.targetHref)) {
+    if (!isSnapshotTargetHref(basePath, options.state.navigationSnapshot, options.targetHref)) {
       return false;
     }
 

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -222,7 +222,8 @@ export function createSnapshotPathAndSearch(snapshot: ClientNavigationRenderSnap
 
 export function createBasePathStrippedPathAndSearch(url: URL, basePath: string): string {
   const pathname = stripBasePath(url.pathname, basePath);
-  return `${pathname}${url.search}`;
+  const query = new URLSearchParams(url.search).toString();
+  return query === "" ? pathname : `${pathname}?${query}`;
 }
 
 function isSnapshotTargetHref(

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -17,6 +17,8 @@ import {
   type AppNavigationPayloadOrigin,
   type AppRouterState,
   type OperationLane,
+  type PendingNavigationCommit,
+  type PendingOperationRecord,
 } from "./app-browser-state.js";
 import {
   applyApprovedVisibleCommit,
@@ -86,7 +88,12 @@ type BrowserNavigationController = {
   ): () => void;
   beginPendingBrowserRouterState(): PendingBrowserRouterState;
   finalizeNavigation(navId: number, pending: PendingBrowserRouterState | null | undefined): void;
-  restoreVisibleState(state: AppRouterState): void;
+  restoreHistorySnapshotVisibleState(options: {
+    beforeCommit?: () => void;
+    navId: number;
+    state: AppRouterState;
+    targetHref: string;
+  }): boolean;
   renderNavigationPayload(options: {
     actionType: "navigate" | "replace" | "traverse";
     createNavigationCommitEffect: BrowserNavigationCommitEffectFactory;
@@ -100,6 +107,7 @@ type BrowserNavigationController = {
     previousNextUrl: string | null;
     scrollIntent?: AppRouterScrollIntent | null;
     restoredBfcacheIds?: Readonly<Record<string, string>> | null;
+    reuseCurrentBfcacheIds?: boolean;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -203,6 +211,24 @@ function performHardNavigationWithLoopGuard(
     window.location.assign(href);
   }
   return true;
+}
+
+function createSnapshotPathAndSearch(snapshot: ClientNavigationRenderSnapshot): string {
+  const query = snapshot.searchParams.toString();
+  return query === "" ? snapshot.pathname : `${snapshot.pathname}?${query}`;
+}
+
+function isSnapshotTargetHref(
+  snapshot: ClientNavigationRenderSnapshot,
+  targetHref: string,
+): boolean {
+  try {
+    const baseHref = typeof window === "undefined" ? "http://localhost" : window.location.href;
+    const targetUrl = new URL(targetHref, baseHref);
+    return `${targetUrl.pathname}${targetUrl.search}` === createSnapshotPathAndSearch(snapshot);
+  } catch {
+    return false;
+  }
 }
 
 export function createAppBrowserNavigationController(
@@ -493,13 +519,78 @@ export function createAppBrowserNavigationController(
     setter(applyApprovedVisibleCommit(getBrowserRouterState(), commit));
   }
 
-  function restoreVisibleState(state: AppRouterState): void {
+  function createRestoredHistorySnapshotCommit(options: {
+    currentState: AppRouterState;
+    renderId: number;
+    restoredState: AppRouterState;
+  }): PendingNavigationCommit {
+    const operation: PendingOperationRecord = {
+      id: options.renderId,
+      lane: "traverse",
+      startedVisibleCommitVersion: options.currentState.visibleCommitVersion,
+      state: "pending",
+    };
+
+    return {
+      action: {
+        bfcacheIds: options.restoredState.bfcacheIds,
+        elements: options.restoredState.elements,
+        interception: options.restoredState.interception,
+        interceptionContext: options.restoredState.interceptionContext,
+        layoutFlags: options.restoredState.layoutFlags,
+        layoutIds: options.restoredState.layoutIds,
+        navigationSnapshot: options.restoredState.navigationSnapshot,
+        operation,
+        previousNextUrl: options.restoredState.previousNextUrl,
+        renderId: options.renderId,
+        rootLayoutTreePath: options.restoredState.rootLayoutTreePath,
+        reuseCurrentBfcacheIds: false,
+        routeId: options.restoredState.routeId,
+        skippedLayoutIds: [],
+        slotBindings: options.restoredState.slotBindings,
+        type: "traverse",
+      },
+      interception: options.restoredState.interception,
+      interceptionContext: options.restoredState.interceptionContext,
+      previousNextUrl: options.restoredState.previousNextUrl,
+      rootLayoutTreePath: options.restoredState.rootLayoutTreePath,
+      routeId: options.restoredState.routeId,
+      skippedLayoutIds: [],
+    };
+  }
+
+  function restoreHistorySnapshotVisibleState(options: {
+    beforeCommit?: () => void;
+    navId: number;
+    state: AppRouterState;
+    targetHref: string;
+  }): boolean {
+    if (!isSnapshotTargetHref(options.state.navigationSnapshot, options.targetHref)) {
+      return false;
+    }
+
     const currentState = getBrowserRouterState();
-    getBrowserRouterStateSetter()({
-      ...state,
-      activeOperation: null,
-      visibleCommitVersion: currentState.visibleCommitVersion + 1,
+    const pending = createRestoredHistorySnapshotCommit({
+      currentState,
+      renderId: allocateRenderId(),
+      restoredState: options.state,
     });
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId,
+      currentState,
+      pending,
+      routeManifest: getRouteManifest(),
+      startedNavigationId: options.navId,
+      targetHref: options.targetHref,
+    });
+
+    if (approval.approvedCommit === null) {
+      return false;
+    }
+
+    options.beforeCommit?.();
+    dispatchSynchronousVisibleCommit(approval.approvedCommit);
+    return true;
   }
 
   function notifyDiscardedServerActionRevalidation(
@@ -524,6 +615,7 @@ export function createAppBrowserNavigationController(
     previousNextUrl: string | null;
     scrollIntent?: AppRouterScrollIntent | null;
     restoredBfcacheIds?: Readonly<Record<string, string>> | null;
+    reuseCurrentBfcacheIds?: boolean;
     targetHistoryIndex?: number | null;
     targetHref: string;
     navId: number;
@@ -547,6 +639,7 @@ export function createAppBrowserNavigationController(
         previousNextUrl: options.previousNextUrl,
         renderId,
         restoredBfcacheIds: options.restoredBfcacheIds,
+        reuseCurrentBfcacheIds: options.reuseCurrentBfcacheIds,
         type: options.actionType,
       });
 
@@ -727,7 +820,7 @@ export function createAppBrowserNavigationController(
     attachBrowserRouterState,
     beginPendingBrowserRouterState,
     finalizeNavigation,
-    restoreVisibleState,
+    restoreHistorySnapshotVisibleState,
     renderNavigationPayload,
     commitSameUrlNavigatePayload,
     hmrReplaceTree,

--- a/packages/vinext/src/server/app-browser-popstate.ts
+++ b/packages/vinext/src/server/app-browser-popstate.ts
@@ -1,23 +1,25 @@
+import {
+  readHistoryStateTraversalIndex,
+  type HistoryTraversalIntent,
+} from "./app-browser-state.js";
+import type { NavigationRuntimeNavigate } from "../client/navigation-runtime.js";
+
 type RestoreScrollPosition = (
   state: unknown,
   options?: {
     shouldContinue?: () => boolean;
   },
 ) => void;
-type NavigateRsc = (
-  href: string,
-  redirectDepth?: number,
-  navigationKind?: "navigate" | "traverse" | "refresh",
-) => Promise<void>;
 
 type BrowserPopstateRestoreDeps = {
   getActiveNavigationId: () => number;
   getPendingNavigation: () => Promise<void> | null | undefined;
-  getNavigate: () => NavigateRsc | undefined;
+  getNavigate: () => NavigationRuntimeNavigate | undefined;
   isCurrentNavigation: (navId: number) => boolean;
   notifyAppRouterTransitionStart: (href: string) => void;
   restorePopstateScrollPosition: RestoreScrollPosition;
   setPendingNavigation: (pendingNavigation: Promise<void> | null) => void;
+  shouldSkipScrollRestore: (navId: number) => boolean;
 };
 
 function hasSavedScrollPosition(state: unknown): boolean {
@@ -33,29 +35,49 @@ function scheduleAfterFrame(callback: () => void): void {
   queueMicrotask(callback);
 }
 
+function createPopstateTraversalIntent(historyState: unknown): HistoryTraversalIntent {
+  return {
+    direction: "unknown",
+    historyState,
+    targetHistoryIndex: readHistoryStateTraversalIndex(historyState),
+  };
+}
+
 export function createPopstateRestoreHandler(
   deps: BrowserPopstateRestoreDeps,
 ): (event: PopStateEvent) => void {
   return (event) => {
     deps.notifyAppRouterTransitionStart(window.location.href);
     const navigate = deps.getNavigate();
-    const pendingNavigation = navigate?.(window.location.href, 0, "traverse") ?? Promise.resolve();
+    const pendingNavigation =
+      navigate?.(
+        window.location.href,
+        0,
+        "traverse",
+        undefined,
+        undefined,
+        false,
+        createPopstateTraversalIntent(event.state),
+      ) ?? Promise.resolve();
     const popstateNavId = deps.getActiveNavigationId();
 
     deps.setPendingNavigation(pendingNavigation);
     const shouldRestoreSavedScroll = hasSavedScrollPosition(event.state);
+    const shouldRestoreScrollForNavigation = () =>
+      deps.isCurrentNavigation(popstateNavId) && !deps.shouldSkipScrollRestore(popstateNavId);
+
     if (shouldRestoreSavedScroll) {
       scheduleAfterFrame(() => {
-        if (deps.isCurrentNavigation(popstateNavId)) {
+        if (shouldRestoreScrollForNavigation()) {
           deps.restorePopstateScrollPosition(event.state, {
-            shouldContinue: () => deps.isCurrentNavigation(popstateNavId),
+            shouldContinue: shouldRestoreScrollForNavigation,
           });
         }
       });
     }
 
     void pendingNavigation.finally(() => {
-      if (deps.isCurrentNavigation(popstateNavId) && !shouldRestoreSavedScroll) {
+      if (shouldRestoreScrollForNavigation() && !shouldRestoreSavedScroll) {
         deps.restorePopstateScrollPosition(event.state);
       }
 

--- a/packages/vinext/src/server/app-browser-popstate.ts
+++ b/packages/vinext/src/server/app-browser-popstate.ts
@@ -22,8 +22,26 @@ type BrowserPopstateRestoreDeps = {
   shouldSkipScrollRestore: (navId: number) => boolean;
 };
 
+type SynchronousPopstateScrollRestoreDeps = {
+  getActiveNavigationId: () => number;
+  isCurrentNavigation: (navId: number) => boolean;
+  markScrollRestoreConsumed: (navId: number) => void;
+  restorePopstateScrollPosition: RestoreScrollPosition;
+};
+
 function hasSavedScrollPosition(state: unknown): boolean {
   return Boolean(state && typeof state === "object" && "__vinext_scrollY" in state);
+}
+
+export function restoreSynchronousPopstateScrollPosition(
+  deps: SynchronousPopstateScrollRestoreDeps,
+  state: unknown,
+): void {
+  const navId = deps.getActiveNavigationId();
+  deps.markScrollRestoreConsumed(navId);
+  deps.restorePopstateScrollPosition(state, {
+    shouldContinue: () => deps.isCurrentNavigation(navId),
+  });
 }
 
 function scheduleAfterFrame(callback: () => void): void {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -106,6 +106,7 @@ export type AppRouterAction = {
   previousNextUrl: string | null;
   renderId: number;
   rootLayoutTreePath: string | null;
+  reuseCurrentBfcacheIds: boolean;
   routeId: string;
   skippedLayoutIds: readonly string[];
   slotBindings: readonly AppElementsSlotBinding[];
@@ -326,8 +327,10 @@ export function createNextBfcacheIdMap(options: {
   elements: AppElements;
   nextPathname: string;
   restored?: BfcacheIdMap | null;
+  reuseCurrent?: boolean;
 }): BfcacheIdMap {
-  for (const value of Object.values(options.current)) {
+  const current = options.reuseCurrent === false ? {} : options.current;
+  for (const value of Object.values(current)) {
     rememberBfcacheId(value);
   }
   for (const value of Object.values(options.restored ?? {})) {
@@ -348,7 +351,7 @@ export function createNextBfcacheIdMap(options: {
       metadata: nextMetadata,
       pathname: nextPathname,
     });
-    const currentValue = currentIdentity === nextIdentity ? options.current[id] : undefined;
+    const currentValue = currentIdentity === nextIdentity ? current[id] : undefined;
     // History traversals restore persisted ids first, matching segments keep
     // their current id, and newly-created segments mint a fresh opaque id.
     // Restored ids intentionally win over identity-matching: the target entry's
@@ -805,6 +808,7 @@ export async function createPendingNavigationCommit(options: {
   previousNextUrl?: string | null;
   renderId: number;
   restoredBfcacheIds?: BfcacheIdMap | null;
+  reuseCurrentBfcacheIds?: boolean;
   type: "navigate" | "replace" | "traverse";
 }): Promise<PendingNavigationCommit> {
   const elements = await options.nextElements;
@@ -829,6 +833,7 @@ export async function createPendingNavigationCommit(options: {
         elements,
         nextPathname: options.navigationSnapshot.pathname,
         restored: options.restoredBfcacheIds,
+        reuseCurrent: options.reuseCurrentBfcacheIds,
       }),
       ...(cacheEntryReuseProof ? { cacheEntryReuseProof } : {}),
       elements,
@@ -846,6 +851,7 @@ export async function createPendingNavigationCommit(options: {
       previousNextUrl,
       renderId: options.renderId,
       rootLayoutTreePath: metadata.rootLayoutTreePath,
+      reuseCurrentBfcacheIds: options.reuseCurrentBfcacheIds ?? true,
       routeId: metadata.routeId,
       skippedLayoutIds: metadata.skippedLayoutIds,
       type: options.type,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -514,6 +514,12 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
     options.pending.action.operation.startedVisibleCommitVersion !==
       options.currentState.visibleCommitVersion
   ) {
+    // staleOperation — the navigation that created `pending` started from a
+    // different visibleCommitVersion than the current state. This happens when
+    // a synchronous history snapshot restore (restoreHistoryStateSnapshot, see
+    // app-browser-entry.ts popstate handler) bumps visibleCommitVersion before
+    // an in-flight async RSC traverse resolves. The snapshot restore is the
+    // authoritative commit; the stale async payload is intentionally discarded.
     return {
       disposition: "skip",
       preserveElementIds: [],

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -151,11 +151,17 @@ function reduceApprovedVisibleCommitState(
   switch (action.type) {
     case "traverse":
     case "navigate": {
+      const preserveElementIds = action.reuseCurrentBfcacheIds
+        ? commit.decision.preserveElementIds
+        : [];
+      const preservePreviousSlotIds = action.reuseCurrentBfcacheIds
+        ? commit.decision.preservePreviousSlotIds
+        : [];
       const mergedElements = mergeElements(state.elements, action.elements, {
-        clearAbsentSlots: action.type === "traverse",
-        preserveAbsentSlots: commit.decision.preserveAbsentSlots,
-        preserveElementIds: commit.decision.preserveElementIds,
-        preservePreviousSlotIds: commit.decision.preservePreviousSlotIds,
+        clearAbsentSlots: action.type === "traverse" || !action.reuseCurrentBfcacheIds,
+        preserveAbsentSlots: action.reuseCurrentBfcacheIds && commit.decision.preserveAbsentSlots,
+        preserveElementIds,
+        preservePreviousSlotIds,
       });
       return commitVisibleRouterState(
         state,
@@ -163,16 +169,12 @@ function reduceApprovedVisibleCommitState(
           bfcacheIds: preserveBfcacheIdsForMergedElements({
             elements: mergedElements,
             next: action.bfcacheIds,
-            previous: state.bfcacheIds,
+            previous: action.reuseCurrentBfcacheIds ? state.bfcacheIds : {},
           }),
           elements: mergedElements,
           interception: action.interception,
           interceptionContext: action.interceptionContext,
-          layoutFlags: mergeLayoutFlags(
-            state.layoutFlags,
-            action.layoutFlags,
-            commit.decision.preserveElementIds,
-          ),
+          layoutFlags: mergeLayoutFlags(state.layoutFlags, action.layoutFlags, preserveElementIds),
           layoutIds: action.layoutIds,
           navigationSnapshot: action.navigationSnapshot,
           previousNextUrl: action.previousNextUrl,
@@ -183,7 +185,7 @@ function reduceApprovedVisibleCommitState(
             state.slotBindings,
             action.slotBindings,
             action.layoutIds,
-            commit.decision.preservePreviousSlotIds,
+            preservePreviousSlotIds,
           ),
         },
         action.operation,

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -19,6 +19,154 @@ export type HistoryTraversalIntent = {
   targetHistoryIndex: number | null;
 };
 
+type HistoryStateSnapshot<TState> = {
+  bfcacheVersion: number;
+  state: TState;
+};
+
+type HistoryStateSnapshotRestoreDecision<TState> =
+  | {
+      kind: "restore";
+      state: TState;
+      targetHistoryIndex: number;
+    }
+  | {
+      kind: "skip";
+      reason: "guarded" | "missing-history-index" | "missing-snapshot" | "stale-bfcache-version";
+      targetHistoryIndex: number | null;
+    };
+
+export class HistoryStateSnapshotCache<TState> {
+  readonly #maxEntries: number;
+  readonly #snapshots = new Map<number, HistoryStateSnapshot<TState>>();
+
+  constructor(options: { maxEntries: number }) {
+    this.#maxEntries = options.maxEntries;
+  }
+
+  clear(): void {
+    this.#snapshots.clear();
+  }
+
+  remember(options: { bfcacheVersion: number; historyIndex: number | null; state: TState }): void {
+    if (options.historyIndex === null) return;
+
+    this.#snapshots.delete(options.historyIndex);
+    this.#snapshots.set(options.historyIndex, {
+      bfcacheVersion: options.bfcacheVersion,
+      state: options.state,
+    });
+
+    if (this.#snapshots.size <= this.#maxEntries) return;
+
+    const oldestIndex = this.#snapshots.keys().next().value;
+    if (typeof oldestIndex === "number") {
+      this.#snapshots.delete(oldestIndex);
+    }
+  }
+
+  resolveRestore(options: {
+    currentBfcacheVersion: number;
+    guarded: boolean;
+    historyState: unknown;
+  }): HistoryStateSnapshotRestoreDecision<TState> {
+    const targetHistoryIndex = readHistoryStateTraversalIndex(options.historyState);
+    if (targetHistoryIndex === null) {
+      return { kind: "skip", reason: "missing-history-index", targetHistoryIndex };
+    }
+
+    const snapshot = this.#snapshots.get(targetHistoryIndex);
+    if (!snapshot) {
+      return { kind: "skip", reason: "missing-snapshot", targetHistoryIndex };
+    }
+    if (options.guarded) {
+      return { kind: "skip", reason: "guarded", targetHistoryIndex };
+    }
+    if (snapshot.bfcacheVersion !== options.currentBfcacheVersion) {
+      this.#snapshots.delete(targetHistoryIndex);
+      return { kind: "skip", reason: "stale-bfcache-version", targetHistoryIndex };
+    }
+
+    return { kind: "restore", state: snapshot.state, targetHistoryIndex };
+  }
+}
+
+export class RestorableClientStateController<TState> {
+  #currentBfcacheVersion: number;
+  #pendingCacheInvalidationGuards = 0;
+  readonly #snapshots: HistoryStateSnapshotCache<TState>;
+
+  constructor(options: { initialHistoryState: unknown; maxHistoryStateSnapshots: number }) {
+    const initialHistoryBfcacheVersion = readHistoryStateBfcacheVersion(
+      options.initialHistoryState,
+    );
+    // A new browser document does not retain Next's in-memory BFCache entries.
+    // Treat bfcache ids persisted by an older document as stale so a hard
+    // reload cannot restore/collide with pre-reload route identities.
+    this.#currentBfcacheVersion =
+      initialHistoryBfcacheVersion === null ? 0 : initialHistoryBfcacheVersion + 1;
+    this.#snapshots = new HistoryStateSnapshotCache<TState>({
+      maxEntries: options.maxHistoryStateSnapshots,
+    });
+  }
+
+  get currentBfcacheVersion(): number {
+    return this.#currentBfcacheVersion;
+  }
+
+  beginCacheInvalidationGuard(): () => void {
+    this.#pendingCacheInvalidationGuards += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.#pendingCacheInvalidationGuards = Math.max(0, this.#pendingCacheInvalidationGuards - 1);
+    };
+  }
+
+  isCacheInvalidationGuarded(): boolean {
+    return this.#pendingCacheInvalidationGuards > 0;
+  }
+
+  isCurrentBfcacheVersion(historyState: unknown): boolean {
+    return isHistoryStateBfcacheVersionCurrent(historyState, this.#currentBfcacheVersion);
+  }
+
+  readCurrentBfcacheVersionHistoryIds(historyState: unknown): BfcacheIdMap | null {
+    if (this.isCacheInvalidationGuarded()) return null;
+    const ids = readHistoryStateBfcacheIds(historyState);
+    if (ids === null) return null;
+    return this.isCurrentBfcacheVersion(historyState) ? ids : null;
+  }
+
+  #invalidateBfcacheIds(): void {
+    this.#currentBfcacheVersion += 1;
+  }
+
+  invalidateClientState(): void {
+    this.#snapshots.clear();
+    this.#invalidateBfcacheIds();
+  }
+
+  rememberHistoryStateSnapshot(options: { historyIndex: number | null; state: TState }): void {
+    this.#snapshots.remember({
+      bfcacheVersion: this.#currentBfcacheVersion,
+      historyIndex: options.historyIndex,
+      state: options.state,
+    });
+  }
+
+  resolveHistoryStateSnapshotRestore(
+    historyState: unknown,
+  ): HistoryStateSnapshotRestoreDecision<TState> {
+    return this.#snapshots.resolveRestore({
+      currentBfcacheVersion: this.#currentBfcacheVersion,
+      guarded: this.isCacheInvalidationGuarded(),
+      historyState,
+    });
+  }
+}
+
 function cloneHistoryState(state: unknown): HistoryStateRecord {
   if (!state || typeof state !== "object") {
     return {};

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -50,7 +50,7 @@ export type NavigationTraceReasonCode =
 export type NavigationTraceTransactionCode =
   (typeof NavigationTraceTransactionCodes)[keyof typeof NavigationTraceTransactionCodes];
 
-export type NavigationTraceCode = NavigationTraceReasonCode | NavigationTraceTransactionCode;
+type NavigationTraceCode = NavigationTraceReasonCode | NavigationTraceTransactionCode;
 
 type NavigationTraceFieldName =
   | "activeNavigationId"

--- a/packages/vinext/src/shims/hash-scroll.ts
+++ b/packages/vinext/src/shims/hash-scroll.ts
@@ -34,14 +34,16 @@ export function scrollToHashTargetOnNextFrame(hash: string): void {
 export function retryScrollTo(
   x: number,
   y: number,
-  opts?: { shouldContinue?: () => boolean },
+  opts?: { minFrames?: number; shouldContinue?: () => boolean },
 ): void {
+  const minFrames = opts?.minFrames ?? 0;
   const shouldContinue = opts?.shouldContinue ?? (() => true);
   let attempts = 0;
   const restore = () => {
     if (!shouldContinue()) return;
     window.scrollTo(x, y);
-    if (!shouldContinue() || Math.abs(window.scrollY - y) <= 1 || attempts >= 60) {
+    const reachedTarget = Math.abs(window.scrollY - y) <= 1;
+    if (!shouldContinue() || (reachedTarget && attempts >= minFrames) || attempts >= 60) {
       return;
     }
     attempts += 1;

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -19,7 +19,10 @@ import {
   hydrateRootInTransition,
 } from "../packages/vinext/src/server/app-browser-hydration.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
-import { createPopstateRestoreHandler } from "../packages/vinext/src/server/app-browser-popstate.js";
+import {
+  createPopstateRestoreHandler,
+  restoreSynchronousPopstateScrollPosition,
+} from "../packages/vinext/src/server/app-browser-popstate.js";
 import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   resolveRscCompatibilityNavigationDecision,
@@ -5435,6 +5438,34 @@ describe("app browser entry bfcacheId helpers", () => {
 });
 
 describe("createPopstateRestoreHandler", () => {
+  it("guards synchronous popstate scroll retry to the active navigation", () => {
+    const scrollState = { __vinext_scrollY: 10 };
+    let activeNavigationId = 3;
+    let consumedNavigationId: number | null = null;
+    let shouldContinue: (() => boolean) | undefined;
+
+    restoreSynchronousPopstateScrollPosition(
+      {
+        getActiveNavigationId: () => activeNavigationId,
+        isCurrentNavigation: (navId) => navId === activeNavigationId,
+        markScrollRestoreConsumed: (navId) => {
+          consumedNavigationId = navId;
+        },
+        restorePopstateScrollPosition: (state, options) => {
+          expect(state).toBe(scrollState);
+          shouldContinue = options?.shouldContinue;
+        },
+      },
+      scrollState,
+    );
+
+    expect(consumedNavigationId).toBe(3);
+    expect(shouldContinue?.()).toBe(true);
+
+    activeNavigationId = 4;
+    expect(shouldContinue?.()).toBe(false);
+  });
+
   it("restores scroll only after the latest popstate navigation commits", async () => {
     const restoreCalls: unknown[] = [];
     const firstNavigation = createDeferred();

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -86,6 +86,10 @@ import {
   type AppRouterState,
   type OperationLane,
 } from "../packages/vinext/src/server/app-browser-state.js";
+import {
+  HistoryStateSnapshotCache,
+  RestorableClientStateController,
+} from "../packages/vinext/src/server/app-history-state.js";
 import { resolveRscRedirectLifecycleHop } from "../packages/vinext/src/server/app-browser-rsc-redirect.js";
 import {
   applyApprovedVisibleCommit,
@@ -1028,22 +1032,90 @@ describe("app browser entry navigation scheduling", () => {
     expect(assertNoTransitionOverride).toBeTypeOf("function");
   });
 
-  it("restores visible history snapshots without rewinding visible commit versions", () => {
+  it("restores visible history snapshots through an approved traversal commit", () => {
     const currentState = createState({
+      elements: createResolvedElements("route:/scroll-restoration/other", "/"),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/scroll-restoration/other",
+        {},
+      ),
       routeId: "route:/scroll-restoration/other",
       visibleCommitVersion: 7,
     });
     const snapshotState = createState({
+      elements: createResolvedElements("route:/scroll-restoration", "/"),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/scroll-restoration",
+        {},
+      ),
       routeId: "route:/scroll-restoration",
       visibleCommitVersion: 2,
     });
     const { controller, stateRef } = createControllerHarness(currentState);
+    const navId = controller.beginNavigation();
 
-    controller.restoreVisibleState(snapshotState);
+    const restored = controller.restoreHistorySnapshotVisibleState({
+      navId,
+      state: snapshotState,
+      targetHref: "https://example.com/scroll-restoration",
+    });
 
+    expect(restored).toBe(true);
     expect(stateRef.current.routeId).toBe("route:/scroll-restoration");
     expect(stateRef.current.visibleCommitVersion).toBe(8);
-    expect(stateRef.current.activeOperation).toBeNull();
+    expect(stateRef.current.activeOperation).toMatchObject({
+      lane: "traverse",
+      startedVisibleCommitVersion: 7,
+      state: "committed",
+      visibleCommitVersion: 8,
+    });
+  });
+
+  it("rejects visible history snapshots for stale navigation lifecycles", () => {
+    const currentState = createState({ visibleCommitVersion: 7 });
+    const snapshotState = createState({
+      elements: createResolvedElements("route:/scroll-restoration", "/"),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/scroll-restoration",
+        {},
+      ),
+      routeId: "route:/scroll-restoration",
+    });
+    const { controller, stateRef } = createControllerHarness(currentState);
+    const staleNavId = controller.beginNavigation();
+    controller.beginNavigation();
+
+    const restored = controller.restoreHistorySnapshotVisibleState({
+      navId: staleNavId,
+      state: snapshotState,
+      targetHref: "https://example.com/scroll-restoration",
+    });
+
+    expect(restored).toBe(false);
+    expect(stateRef.current).toBe(currentState);
+  });
+
+  it("rejects visible history snapshots when the active target does not match", () => {
+    const currentState = createState({ visibleCommitVersion: 7 });
+    const snapshotState = createState({
+      elements: createResolvedElements("route:/scroll-restoration", "/"),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/scroll-restoration",
+        {},
+      ),
+      routeId: "route:/scroll-restoration",
+    });
+    const { controller, stateRef } = createControllerHarness(currentState);
+    const navId = controller.beginNavigation();
+
+    const restored = controller.restoreHistorySnapshotVisibleState({
+      navId,
+      state: snapshotState,
+      targetHref: "https://example.com/scroll-restoration/other",
+    });
+
+    expect(restored).toBe(false);
+    expect(stateRef.current).toBe(currentState);
   });
 });
 
@@ -1191,6 +1263,38 @@ describe("app browser entry state helpers", () => {
     expect(pending.action.interception).toEqual(createInterceptionProof("/feed", "/photos/42"));
     expect(pending.action.interceptionContext).toBe("/feed");
     expect(pending.action.previousNextUrl).toBe("/feed");
+  });
+
+  it("mints fresh bfcache ids instead of reusing current ids when requested", async () => {
+    const currentRootLayout = React.createElement("div", null, "current root");
+    const nextRootLayout = React.createElement("div", null, "next root");
+    const currentState = createState({
+      bfcacheIds: {
+        "layout:/": "_b_4_",
+      },
+      elements: createResolvedElements("route:/dashboard", "/", null, {
+        "layout:/": currentRootLayout,
+      }),
+    });
+
+    const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      currentState,
+      nextElements: Promise.resolve(
+        createResolvedElements("route:/settings", "/", null, {
+          "layout:/": nextRootLayout,
+        }),
+      ),
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/settings", {}),
+      operationLane: "traverse",
+      renderId: 1,
+      reuseCurrentBfcacheIds: false,
+      type: "traverse",
+    });
+
+    expect(pending.action.reuseCurrentBfcacheIds).toBe(false);
+    expect(pending.action.bfcacheIds["layout:/"]).toMatch(/^_b_\d+_$/);
+    expect(pending.action.bfcacheIds["layout:/"]).not.toBe("_b_4_");
   });
 
   it("clears previousNextUrl when traversing to a non-intercepted entry", async () => {
@@ -3981,6 +4085,70 @@ describe("app browser entry previousNextUrl helpers", () => {
     });
   });
 
+  it("does not preserve skipped layouts when current bfcache ids are stale", async () => {
+    const rootLayout = React.createElement("div", null, "root layout");
+    const currentState = createState({
+      bfcacheIds: {
+        "layout:/": "_b_4_",
+      },
+      elements: createResolvedElements(
+        "route:/dashboard",
+        "/",
+        null,
+        {
+          "layout:/": rootLayout,
+        },
+        ["layout:/"],
+      ),
+      layoutFlags: {
+        "layout:/": "s",
+      },
+      layoutIds: ["layout:/"],
+    });
+    const pending = await createPendingNavigationCommit({
+      currentState,
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/settings", {}),
+      nextElements: Promise.resolve(
+        createResolvedElements(
+          "route:/settings",
+          "/",
+          null,
+          {
+            [APP_LAYOUT_FLAGS_KEY]: {},
+            [APP_SKIPPED_LAYOUT_IDS_KEY]: ["layout:/"],
+            "page:/settings": React.createElement("main", null, "settings"),
+          },
+          ["layout:/"],
+        ),
+      ),
+      operationLane: "traverse",
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      renderId: 1,
+      reuseCurrentBfcacheIds: false,
+      type: "traverse",
+    });
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 1,
+      currentState,
+      pending,
+      routeManifest: null,
+      startedNavigationId: 1,
+      targetHref: "https://example.com/settings",
+    });
+
+    expect(approval.approvedCommit).not.toBeNull();
+    if (approval.approvedCommit === null) return;
+    expect(approval.decision.preserveElementIds).toEqual(["layout:/"]);
+
+    const nextState = applyApprovedVisibleCommit(currentState, approval.approvedCommit);
+
+    expect(Object.hasOwn(nextState.elements, "layout:/")).toBe(false);
+    expect(nextState.elements["page:/settings"]).toBeDefined();
+    expect(nextState.layoutFlags).toEqual({});
+    expect(nextState.bfcacheIds["layout:/"]).toMatch(/^_b_\d+_$/);
+    expect(nextState.bfcacheIds["layout:/"]).not.toBe("_b_4_");
+  });
+
   it("preserves the default parallel slot owned by a skipped slot-owning layout", async () => {
     const rootLayout = React.createElement("div", null, "root layout");
     const dashboardLayout = React.createElement("div", null, "dashboard layout");
@@ -4947,6 +5115,246 @@ describe("app browser entry bfcacheId helpers", () => {
     expect(isHistoryStateBfcacheVersionCurrent(null, 0)).toBe(false);
   });
 
+  it("restores matching history snapshots and evicts the oldest entry", () => {
+    const cache = new HistoryStateSnapshotCache<string>({ maxEntries: 2 });
+    const entry1 = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 1,
+    });
+    const entry2 = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 2,
+    });
+    const entry3 = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 3,
+    });
+
+    cache.remember({ bfcacheVersion: 7, historyIndex: 1, state: "one" });
+    cache.remember({ bfcacheVersion: 7, historyIndex: 2, state: "two" });
+    cache.remember({ bfcacheVersion: 7, historyIndex: 3, state: "three" });
+
+    expect(
+      cache.resolveRestore({
+        currentBfcacheVersion: 7,
+        guarded: false,
+        historyState: entry1,
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason: "missing-snapshot",
+      targetHistoryIndex: 1,
+    });
+    expect(
+      cache.resolveRestore({
+        currentBfcacheVersion: 7,
+        guarded: false,
+        historyState: entry2,
+      }),
+    ).toEqual({
+      kind: "restore",
+      state: "two",
+      targetHistoryIndex: 2,
+    });
+    expect(
+      cache.resolveRestore({
+        currentBfcacheVersion: 7,
+        guarded: false,
+        historyState: entry3,
+      }),
+    ).toEqual({
+      kind: "restore",
+      state: "three",
+      targetHistoryIndex: 3,
+    });
+  });
+
+  it("suppresses history snapshot restore while cache invalidation is guarded", () => {
+    const cache = new HistoryStateSnapshotCache<string>({ maxEntries: 2 });
+    const entry = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 2,
+    });
+
+    cache.remember({ bfcacheVersion: 7, historyIndex: 2, state: "two" });
+
+    expect(
+      cache.resolveRestore({
+        currentBfcacheVersion: 7,
+        guarded: true,
+        historyState: entry,
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason: "guarded",
+      targetHistoryIndex: 2,
+    });
+    expect(
+      cache.resolveRestore({
+        currentBfcacheVersion: 7,
+        guarded: false,
+        historyState: entry,
+      }),
+    ).toEqual({
+      kind: "restore",
+      state: "two",
+      targetHistoryIndex: 2,
+    });
+  });
+
+  it("deletes stale history snapshots when the bfcache epoch changes", () => {
+    const cache = new HistoryStateSnapshotCache<string>({ maxEntries: 2 });
+    const entry = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 2,
+    });
+
+    cache.remember({ bfcacheVersion: 7, historyIndex: 2, state: "two" });
+
+    expect(
+      cache.resolveRestore({
+        currentBfcacheVersion: 8,
+        guarded: false,
+        historyState: entry,
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason: "stale-bfcache-version",
+      targetHistoryIndex: 2,
+    });
+    expect(
+      cache.resolveRestore({
+        currentBfcacheVersion: 7,
+        guarded: false,
+        historyState: entry,
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason: "missing-snapshot",
+      targetHistoryIndex: 2,
+    });
+  });
+
+  it("initializes restorable client state with a fresh document bfcache epoch", () => {
+    const initialState = createHistoryStateWithNavigationMetadata(null, {
+      bfcacheIds: { [pageX1Id]: "_b_9_" },
+      bfcacheVersion: 3,
+      previousNextUrl: null,
+    });
+    const controller = new RestorableClientStateController<string>({
+      initialHistoryState: initialState,
+      maxHistoryStateSnapshots: 2,
+    });
+
+    expect(controller.currentBfcacheVersion).toBe(4);
+    expect(controller.readCurrentBfcacheVersionHistoryIds(initialState)).toBeNull();
+
+    const currentState = createHistoryStateWithNavigationMetadata(null, {
+      bfcacheIds: { [pageX1Id]: "_b_10_" },
+      bfcacheVersion: controller.currentBfcacheVersion,
+      previousNextUrl: null,
+    });
+    expect(controller.readCurrentBfcacheVersionHistoryIds(currentState)).toEqual({
+      [pageX1Id]: "_b_10_",
+    });
+  });
+
+  it("keeps bfcache ids and history snapshots behind the same restorable client state guard", () => {
+    const controller = new RestorableClientStateController<string>({
+      initialHistoryState: null,
+      maxHistoryStateSnapshots: 2,
+    });
+    const entry = createHistoryStateWithNavigationMetadata(null, {
+      bfcacheIds: { [pageX1Id]: "_b_9_" },
+      bfcacheVersion: controller.currentBfcacheVersion,
+      previousNextUrl: null,
+      traversalIndex: 2,
+    });
+
+    controller.rememberHistoryStateSnapshot({ historyIndex: 2, state: "two" });
+    const release = controller.beginCacheInvalidationGuard();
+
+    expect(controller.readCurrentBfcacheVersionHistoryIds(entry)).toBeNull();
+    expect(controller.resolveHistoryStateSnapshotRestore(entry)).toEqual({
+      kind: "skip",
+      reason: "guarded",
+      targetHistoryIndex: 2,
+    });
+
+    release();
+
+    expect(controller.readCurrentBfcacheVersionHistoryIds(entry)).toEqual({
+      [pageX1Id]: "_b_9_",
+    });
+    expect(controller.resolveHistoryStateSnapshotRestore(entry)).toEqual({
+      kind: "restore",
+      state: "two",
+      targetHistoryIndex: 2,
+    });
+  });
+
+  it("keeps restorable client state guarded until nested guards are released", () => {
+    const controller = new RestorableClientStateController<string>({
+      initialHistoryState: null,
+      maxHistoryStateSnapshots: 2,
+    });
+    const entry = createHistoryStateWithNavigationMetadata(null, {
+      bfcacheIds: { [pageX1Id]: "_b_9_" },
+      bfcacheVersion: controller.currentBfcacheVersion,
+      previousNextUrl: null,
+      traversalIndex: 2,
+    });
+
+    controller.rememberHistoryStateSnapshot({ historyIndex: 2, state: "two" });
+    const releaseOuter = controller.beginCacheInvalidationGuard();
+    const releaseInner = controller.beginCacheInvalidationGuard();
+
+    releaseOuter();
+    releaseOuter();
+
+    expect(controller.readCurrentBfcacheVersionHistoryIds(entry)).toBeNull();
+    expect(controller.resolveHistoryStateSnapshotRestore(entry)).toEqual({
+      kind: "skip",
+      reason: "guarded",
+      targetHistoryIndex: 2,
+    });
+
+    releaseInner();
+    releaseInner();
+
+    expect(controller.readCurrentBfcacheVersionHistoryIds(entry)).toEqual({
+      [pageX1Id]: "_b_9_",
+    });
+    expect(controller.resolveHistoryStateSnapshotRestore(entry)).toEqual({
+      kind: "restore",
+      state: "two",
+      targetHistoryIndex: 2,
+    });
+  });
+
+  it("invalidates bfcache ids and history snapshots through one restorable client state epoch", () => {
+    const controller = new RestorableClientStateController<string>({
+      initialHistoryState: null,
+      maxHistoryStateSnapshots: 2,
+    });
+    const entry = createHistoryStateWithNavigationMetadata(null, {
+      bfcacheIds: { [pageX1Id]: "_b_9_" },
+      bfcacheVersion: controller.currentBfcacheVersion,
+      previousNextUrl: null,
+      traversalIndex: 2,
+    });
+
+    controller.rememberHistoryStateSnapshot({ historyIndex: 2, state: "two" });
+    controller.invalidateClientState();
+
+    expect(controller.readCurrentBfcacheVersionHistoryIds(entry)).toBeNull();
+    expect(controller.resolveHistoryStateSnapshotRestore(entry)).toEqual({
+      kind: "skip",
+      reason: "missing-snapshot",
+      targetHistoryIndex: 2,
+    });
+  });
+
   it("uses restored history bfcache ids for traversal commits", async () => {
     const currentState = createState({
       bfcacheIds: {
@@ -5059,6 +5467,7 @@ describe("createPopstateRestoreHandler", () => {
       setPendingNavigation: (pendingNavigation) => {
         window.__VINEXT_RSC_PENDING__ = pendingNavigation;
       },
+      shouldSkipScrollRestore: () => false,
     });
 
     handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
@@ -5104,6 +5513,7 @@ describe("createPopstateRestoreHandler", () => {
       setPendingNavigation: (pendingNavigation) => {
         window.__VINEXT_RSC_PENDING__ = pendingNavigation;
       },
+      shouldSkipScrollRestore: () => false,
     });
 
     handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
@@ -5115,6 +5525,46 @@ describe("createPopstateRestoreHandler", () => {
     await Promise.resolve();
 
     expect(restoreCalls).toEqual([]);
+    expect(window.__VINEXT_RSC_PENDING__).toBeNull();
+  });
+
+  it("does not reapply delayed scroll after synchronous popstate restore consumed it", async () => {
+    const restoreCalls: unknown[] = [];
+    const navigation = createDeferred();
+    let activeNavigationId = 0;
+    let synchronouslyRestoredNavigationId: number | null = null;
+
+    stubWindow("https://example.com/feed");
+    window.__VINEXT_RSC_PENDING__ = null;
+
+    const handler = createPopstateRestoreHandler({
+      getActiveNavigationId: () => activeNavigationId,
+      getNavigate: () => {
+        activeNavigationId += 1;
+        return () => navigation.promise;
+      },
+      getPendingNavigation: () => window.__VINEXT_RSC_PENDING__,
+      isCurrentNavigation: (navId) => navId === activeNavigationId,
+      notifyAppRouterTransitionStart: () => {},
+      restorePopstateScrollPosition: (scrollState) => {
+        restoreCalls.push(scrollState);
+      },
+      setPendingNavigation: (pendingNavigation) => {
+        window.__VINEXT_RSC_PENDING__ = pendingNavigation;
+      },
+      shouldSkipScrollRestore: (navId) => synchronouslyRestoredNavigationId === navId,
+    });
+
+    handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
+    synchronouslyRestoredNavigationId = activeNavigationId;
+    restoreCalls.push({ __vinext_scrollY: 10, source: "sync" });
+
+    await Promise.resolve();
+    navigation.resolve();
+    await navigation.promise;
+    await Promise.resolve();
+
+    expect(restoreCalls).toEqual([{ __vinext_scrollY: 10, source: "sync" }]);
     expect(window.__VINEXT_RSC_PENDING__).toBeNull();
   });
 });

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1074,7 +1074,7 @@ describe("app browser entry navigation scheduling", () => {
     });
   });
 
-  it("matches visible history snapshot targets after stripping basePath", () => {
+  it("matches visible history snapshot targets after stripping basePath and canonicalizing search", () => {
     const currentState = createState({
       elements: createResolvedElements("route:/scroll-restoration/other", "/"),
       navigationSnapshot: createClientNavigationRenderSnapshot(
@@ -1087,7 +1087,7 @@ describe("app browser entry navigation scheduling", () => {
     const snapshotState = createState({
       elements: createResolvedElements("route:/scroll-restoration", "/"),
       navigationSnapshot: createClientNavigationRenderSnapshot(
-        "https://example.com/scroll-restoration",
+        "https://example.com/scroll-restoration?q=a+b",
         {},
       ),
       routeId: "route:/scroll-restoration",
@@ -1101,7 +1101,7 @@ describe("app browser entry navigation scheduling", () => {
     const restored = controller.restoreHistorySnapshotVisibleState({
       navId,
       state: snapshotState,
-      targetHref: "https://example.com/docs/scroll-restoration",
+      targetHref: "https://example.com/docs/scroll-restoration?q=a%20b",
     });
 
     expect(restored).toBe(true);

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1074,6 +1074,41 @@ describe("app browser entry navigation scheduling", () => {
     });
   });
 
+  it("matches visible history snapshot targets after stripping basePath", () => {
+    const currentState = createState({
+      elements: createResolvedElements("route:/scroll-restoration/other", "/"),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/scroll-restoration/other",
+        {},
+      ),
+      routeId: "route:/scroll-restoration/other",
+      visibleCommitVersion: 7,
+    });
+    const snapshotState = createState({
+      elements: createResolvedElements("route:/scroll-restoration", "/"),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/scroll-restoration",
+        {},
+      ),
+      routeId: "route:/scroll-restoration",
+      visibleCommitVersion: 2,
+    });
+    const { controller, stateRef } = createControllerHarness(currentState, {
+      basePath: "/docs",
+    });
+    const navId = controller.beginNavigation();
+
+    const restored = controller.restoreHistorySnapshotVisibleState({
+      navId,
+      state: snapshotState,
+      targetHref: "https://example.com/docs/scroll-restoration",
+    });
+
+    expect(restored).toBe(true);
+    expect(stateRef.current.routeId).toBe("route:/scroll-restoration");
+    expect(stateRef.current.visibleCommitVersion).toBe(8);
+  });
+
   it("rejects visible history snapshots for stale navigation lifecycles", () => {
     const currentState = createState({ visibleCommitVersion: 7 });
     const snapshotState = createState({

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1027,6 +1027,24 @@ describe("app browser entry navigation scheduling", () => {
 
     expect(assertNoTransitionOverride).toBeTypeOf("function");
   });
+
+  it("restores visible history snapshots without rewinding visible commit versions", () => {
+    const currentState = createState({
+      routeId: "route:/scroll-restoration/other",
+      visibleCommitVersion: 7,
+    });
+    const snapshotState = createState({
+      routeId: "route:/scroll-restoration",
+      visibleCommitVersion: 2,
+    });
+    const { controller, stateRef } = createControllerHarness(currentState);
+
+    controller.restoreVisibleState(snapshotState);
+
+    expect(stateRef.current.routeId).toBe("route:/scroll-restoration");
+    expect(stateRef.current.visibleCommitVersion).toBe(8);
+    expect(stateRef.current.activeOperation).toBeNull();
+  });
 });
 
 describe("app browser entry state helpers", () => {

--- a/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-router-bfcache-id.spec.ts
@@ -268,4 +268,34 @@ test.describe("Next.js compat: useRouter().bfcacheId", () => {
     expect(restoredAfterInvalidation).not.toBe(staleX1BfcacheId);
     await expect(visibleTestId(page, "leaf-input")).toHaveValue("");
   });
+
+  test("preserves restorable client state after a return-value-only server action", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}${ROUTE}/x/1`);
+    await waitForAppRouterHydration(page);
+
+    const x1BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await visibleTestId(page, "layout-input").fill("return-value-layout-state");
+
+    await revealAndClick(page, `${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    const x2BfcacheId = await visibleTestId(page, "leaf-bfcache-id").textContent();
+    await expect(visibleTestId(page, "layout-input")).toHaveValue("return-value-layout-state");
+
+    const actionResponse = waitForServerActionResponse(page, `${ROUTE}/x/2`);
+    await visibleTestId(page, "server-action-return-value-only").click();
+    await actionResponse;
+    await expect(visibleTestId(page, "server-action-return-value")).toHaveText("return-value-only");
+
+    await page.goBack();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/1`);
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x1BfcacheId ?? "");
+    await expect(visibleTestId(page, "layout-input")).toHaveValue("return-value-layout-state");
+
+    await page.goForward();
+    await expect(visibleTestId(page, "pathname")).toHaveText(`${ROUTE}/x/2`);
+    await expect(visibleTestId(page, "leaf-bfcache-id")).toHaveText(x2BfcacheId ?? "");
+    await expect(visibleTestId(page, "layout-input")).toHaveValue("return-value-layout-state");
+  });
 });

--- a/tests/e2e/app-router/scroll-restoration.spec.ts
+++ b/tests/e2e/app-router/scroll-restoration.spec.ts
@@ -26,10 +26,12 @@ test.describe("App Router scroll restoration", () => {
     expect(scrollPosition).toBeGreaterThan(0);
 
     await page.locator('a[href="/scroll-restoration/other"]').click();
+    await expect(page).toHaveURL(`${BASE}/scroll-restoration/other`);
     await expect(page.locator("#back-button")).toBeVisible();
     await page.locator("#back-button").click();
+    await expect(page).toHaveURL(`${BASE}/scroll-restoration`);
+    await expect(body).toContainText("Item 200");
 
-    const newScrollPosition = await page.evaluate(() => window.pageYOffset);
-    expect(newScrollPosition).toEqual(scrollPosition);
+    await expect.poll(() => page.evaluate(() => window.pageYOffset)).toEqual(scrollPosition);
   });
 });

--- a/tests/e2e/app-router/scroll-restoration.spec.ts
+++ b/tests/e2e/app-router/scroll-restoration.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+const BASE = "http://localhost:4174";
+
+test.describe("App Router scroll restoration", () => {
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation/navigation.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/navigation.test.ts#L706-L735
+  test("restores the original scroll position when navigating back", async ({ page }) => {
+    await page.goto(`${BASE}/scroll-restoration`);
+    await waitForAppRouterHydration(page);
+
+    const body = page.locator("body");
+    await expect(body).toContainText("Item 50");
+    await page.locator("#load-more").click();
+    await page.locator("#load-more").click();
+    await page.locator("#load-more").click();
+    await expect(body).toContainText("Item 200");
+
+    await page.evaluate(() => {
+      window.scrollTo(0, document.body.scrollHeight);
+    });
+
+    const scrollPosition = await page.evaluate(() => window.pageYOffset);
+    expect(scrollPosition).toBeGreaterThan(0);
+
+    await page.locator('a[href="/scroll-restoration/other"]').click();
+    await expect(page.locator("#back-button")).toBeVisible();
+    await page.locator("#back-button").click();
+
+    const newScrollPosition = await page.evaluate(() => window.pageYOffset);
+    expect(newScrollPosition).toEqual(scrollPosition);
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/[group]/[page]/leaf-content.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 import { LinkAccordion } from "../../components/link-accordion";
-import { refreshAction } from "../../actions";
+import { refreshAction, returnValueOnlyAction } from "../../actions";
 
 const base = "/nextjs-compat/use-router-bfcache-id";
 
@@ -11,6 +12,7 @@ export function LeafContent() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const search = searchParams.toString();
+  const [returnValue, setReturnValue] = useState("");
 
   return (
     <>
@@ -32,6 +34,16 @@ export function LeafContent() {
           server action refresh
         </button>
       </form>
+      <button
+        data-testid="server-action-return-value-only"
+        onClick={async () => {
+          setReturnValue(await returnValueOnlyAction());
+        }}
+        type="button"
+      >
+        server action return value only
+      </button>
+      <p data-testid="server-action-return-value">{returnValue}</p>
       <button
         data-testid="router-push-x-2"
         onClick={() => router.push(`${base}/x/2`)}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-router-bfcache-id/actions.ts
@@ -5,3 +5,7 @@ import { refresh } from "next/cache";
 export async function refreshAction() {
   refresh();
 }
+
+export async function returnValueOnlyAction() {
+  return "return-value-only";
+}

--- a/tests/fixtures/app-basic/app/scroll-restoration/context.ts
+++ b/tests/fixtures/app-basic/app/scroll-restoration/context.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+export type Item = {
+  id: number;
+};
+
+export const ItemsContext = createContext<{
+  items: Item[];
+  loadMoreItems: () => void;
+}>({ items: [], loadMoreItems: () => {} });

--- a/tests/fixtures/app-basic/app/scroll-restoration/layout.tsx
+++ b/tests/fixtures/app-basic/app/scroll-restoration/layout.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { ItemsContext, type Item } from "./context";
+
+function createItems(start: number, end: number): Item[] {
+  const items: Item[] = [];
+  for (let id = start; id <= end; id += 1) {
+    items.push({ id });
+  }
+  return items;
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<Item[]>(createItems(1, 50));
+
+  const loadMoreItems = () => {
+    setItems((prevItems) => {
+      const start = prevItems.length + 1;
+      const end = start + 50 - 1;
+      return [...prevItems, ...createItems(start, end)];
+    });
+  };
+
+  return <ItemsContext.Provider value={{ items, loadMoreItems }}>{children}</ItemsContext.Provider>;
+}

--- a/tests/fixtures/app-basic/app/scroll-restoration/other/page.tsx
+++ b/tests/fixtures/app-basic/app/scroll-restoration/other/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function Page() {
+  const router = useRouter();
+
+  return (
+    <div>
+      <button id="back-button" onClick={() => router.back()}>
+        Go Back
+      </button>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/scroll-restoration/page.tsx
+++ b/tests/fixtures/app-basic/app/scroll-restoration/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { useContext } from "react";
+import { ItemsContext } from "./context";
+
+export default function Page() {
+  const { items, loadMoreItems } = useContext(ItemsContext);
+
+  return (
+    <div>
+      <h1>Page</h1>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>Item {item.id}</li>
+        ))}
+      </ul>
+      <button id="load-more" onClick={loadMoreItems}>
+        Load More
+      </button>
+      <Link href="/scroll-restoration/other">Go to Other</Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Port the Next.js App Router scroll restoration regression from `navigation.test.ts` into the app-router Playwright suite.
- Stop forcing App Router documents into manual `history.scrollRestoration`; Next's App Router does not do that by default.
- Cache visible App Router state by vinext history traversal index and synchronously restore the cached source snapshot on `popstate` before the async RSC traverse finishes.

## Root Cause

The failing upstream case navigates from `/scroll-restoration` to `/scroll-restoration/other`, calls `router.back()`, and immediately reads `window.pageYOffset`. Vinext already persisted scroll coordinates in history state, but the App Router back path waited for an async RSC traverse before the source route was visible again. At the immediate assertion point the document was still rendering the short `/other` page, so the browser reported `0` instead of the original scroll offset.

Next.js stores App Router tree state in the browser history entry and restores from that state during traversal. Vinext has a different router-state representation, so this PR keeps a bounded document-local snapshot cache keyed by the existing traversal index and restores the visible snapshot synchronously while still letting the normal RSC traverse reconcile afterward.

## Next.js References

- Regression contract: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/navigation.test.ts#L706-L735
- Upstream fixture page: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/app/scroll-restoration/page.tsx
- Upstream fixture layout: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/app/scroll-restoration/layout.tsx
- History state updater: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/app-router.tsx#L56-L94
- App Router `popstate` handling: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/app-router.tsx#L350-L371
- Restore reducer: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts#L17-L94

## Verification

Red before fix:

- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/scroll-restoration.spec.ts` failed with expected saved scroll offset and received `0`.

Green after fix:

- `vp test run tests/app-browser-entry.test.ts`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/scroll-restoration.spec.ts tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/scroll-restoration.spec.ts`
- `vp check`

Closes #1367
