### PR TITLE
fix(app-router): refetch same-page search navigations

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1908,6 +1908,12 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           }
         }
 
+        // The optimistic shell is intentionally not gated by
+        // `shouldBypassNavigationCache`. A same-page search change can still
+        // render an optimistic shell from cached route templates before the
+        // real fetch commits, but that shell is a detached commit (see below)
+        // that is always superseded by the authoritative fetch — the same as
+        // cross-route navigations — so it never persists stale page content.
         if (!navResponse && navigationKind === "navigate") {
           const routeManifest = getBrowserRouteManifest();
           await learnOptimisticRouteTemplatesFromPrefetchCache({

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -887,6 +887,16 @@ function storeVisitedResponseSnapshot(
   );
 }
 
+function isSamePageSearchNavigation(
+  currentSnapshot: ClientNavigationRenderSnapshot,
+  targetUrl: URL,
+): boolean {
+  const targetPathname = stripBasePath(targetUrl.pathname, __basePath);
+  if (targetPathname !== currentSnapshot.pathname) return false;
+
+  return targetUrl.searchParams.toString() !== currentSnapshot.searchParams.toString();
+}
+
 type NavigationRequestState = {
   interceptionContext: string | null;
   previousNextUrl: string | null;
@@ -1763,6 +1773,13 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const routerStateAtNavStart = getBrowserRouterState();
         const elementsAtNavStart = routerStateAtNavStart.elements;
         const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
+        // Next.js refetches page segments for same-page search changes even
+        // when a visible Link prefetched the target. Search params are a page
+        // input, so a cached full-route payload is not authoritative here.
+        // Ref: packages/next/src/client/components/router-reducer/ppr-navigations.ts
+        const shouldBypassNavigationCache =
+          navigationKind === "navigate" &&
+          isSamePageSearchNavigation(routerStateAtNavStart.navigationSnapshot, url);
         // The client reuse manifest is excluded from VINEXT_RSC_VARY_HEADER, so
         // it never affects the cache-busting URL. Defer producing it until the
         // visited-response cache miss is confirmed below — its producer iterates
@@ -1775,12 +1792,14 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
         });
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
-        const cachedRoute = getVisitedResponse(
-          rscUrl,
-          requestInterceptionContext,
-          mountedSlotsHeader,
-          navigationKind,
-        );
+        const cachedRoute = shouldBypassNavigationCache
+          ? null
+          : getVisitedResponse(
+              rscUrl,
+              requestInterceptionContext,
+              mountedSlotsHeader,
+              navigationKind,
+            );
         if (cachedRoute) {
           const compatibilityDecision = resolveRscCompatibilityNavigationDecision({
             clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
@@ -1872,7 +1891,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         let navResponse: Response | undefined;
         let navResponseExpiresAt: number | undefined;
         let navResponseUrl: string | null = null;
-        if (navigationKind !== "refresh") {
+        if (navigationKind !== "refresh" && !shouldBypassNavigationCache) {
           const prefetchedResponse = await consumePrefetchResponseForNavigation(
             rscUrl,
             requestInterceptionContext,

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -229,6 +229,18 @@ function isRscCacheBustingSearchPair(pair: string): boolean {
   }
 }
 
+/**
+ * Detect the internal RSC cache-busting search param using the same
+ * encoding-aware matching as `stripRscCacheBustingSearchParam`
+ * (`isRscCacheBustingSearchPair`). The two share a single matcher so a guard
+ * built on this helper and the stripper can never disagree on which pairs
+ * count as `_rsc`, including encoded-key edge cases like `%5Frsc`.
+ */
+export function hasRscCacheBustingSearchParam(url: URL): boolean {
+  const rawQuery = url.search.startsWith("?") ? url.search.slice(1) : url.search;
+  return rawQuery.split("&").some((pair) => pair.length > 0 && isRscCacheBustingSearchPair(pair));
+}
+
 export async function computeRscCacheBustingSearchParam(headers: Headers): Promise<string> {
   const input = createCacheBustingInput(headers);
   if (input === null) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -57,6 +57,7 @@ import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
 import {
   cloneRequestWithHeaders,
+  cloneRequestWithUrl,
   filterInternalHeaders,
   applyConfigHeadersToResponse,
   normalizeTrailingSlash,
@@ -353,8 +354,12 @@ function requestWithoutRscCacheBustingSearchParam(request: Request): Request {
   if (!hasRscCacheBustingSearchParam(url)) return request;
 
   stripRscCacheBustingSearchParam(url);
+  // Clone when a body is present so the original request stays usable, then
+  // reconstruct via `cloneRequestWithUrl` rather than a bare `new Request` so
+  // the Workers `cf` metadata is preserved (user middleware reads it directly)
+  // and `duplex: "half"` is set for streaming bodies.
   const source = request.body ? request.clone() : request;
-  return new Request(url.toString(), source);
+  return cloneRequestWithUrl(source, url.toString());
 }
 
 async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -40,7 +40,6 @@ import {
   resolveInvalidRscCacheBustingRequest,
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
-  VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
 } from "./app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
@@ -343,9 +342,15 @@ function applyConfigHeadersToMiddlewareRedirect(
 
 function requestWithoutRscCacheBustingSearchParam(request: Request): Request {
   const url = new URL(request.url);
-  if (!url.searchParams.has(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM)) return request;
-
+  // Use `stripRscCacheBustingSearchParam` as the single source of truth for
+  // detecting the param too: comparing the search string before/after the
+  // strip keeps the guard and the stripper using identical, encoding-aware
+  // matching (`URLSearchParams.has` decodes keys differently for encoded edge
+  // cases like `%5Frsc`), so they can never diverge.
+  const originalSearch = url.search;
   stripRscCacheBustingSearchParam(url);
+  if (url.search === originalSearch) return request;
+
   const source = request.body ? request.clone() : request;
   return new Request(url.toString(), source);
 }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -37,6 +37,7 @@ import { mergeMiddlewareResponseHeaders } from "./app-page-response.js";
 import { handleAppPrerenderEndpoint } from "./app-prerender-endpoints.js";
 import {
   createRscRedirectLocation,
+  hasRscCacheBustingSearchParam,
   resolveInvalidRscCacheBustingRequest,
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
@@ -342,15 +343,16 @@ function applyConfigHeadersToMiddlewareRedirect(
 
 function requestWithoutRscCacheBustingSearchParam(request: Request): Request {
   const url = new URL(request.url);
-  // Use `stripRscCacheBustingSearchParam` as the single source of truth for
-  // detecting the param too: comparing the search string before/after the
-  // strip keeps the guard and the stripper using identical, encoding-aware
-  // matching (`URLSearchParams.has` decodes keys differently for encoded edge
-  // cases like `%5Frsc`), so they can never diverge.
-  const originalSearch = url.search;
-  stripRscCacheBustingSearchParam(url);
-  if (url.search === originalSearch) return request;
+  // `hasRscCacheBustingSearchParam` and `stripRscCacheBustingSearchParam` share
+  // the same encoding-aware matcher (`isRscCacheBustingSearchPair`), so the
+  // guard and the strip can never disagree on which pairs count as `_rsc`
+  // (including encoded-key edge cases like `%5Frsc`). Gating on the matcher
+  // rather than a before/after search comparison also avoids spuriously
+  // rebuilding/normalizing requests whose only difference is degenerate empty
+  // query pairs (e.g. `?a=1&&b=2`).
+  if (!hasRscCacheBustingSearchParam(url)) return request;
 
+  stripRscCacheBustingSearchParam(url);
   const source = request.body ? request.clone() : request;
   return new Request(url.toString(), source);
 }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -512,7 +512,9 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     {
       basePathState,
       clearRequestContext: options.clearRequestContext,
-      request,
+      // Forward the `_rsc`-stripped request so external rewrite proxies never
+      // receive the internal RSC transport query (same invariant as middleware).
+      request: userlandRequest,
       requestContext: postMiddlewareRequestContext,
       rewrites: options.configRewrites.beforeFiles,
     },
@@ -617,7 +619,9 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       {
         basePathState,
         clearRequestContext: options.clearRequestContext,
-        request,
+        // Forward the `_rsc`-stripped request so external rewrite proxies never
+        // receive the internal RSC transport query (same invariant as middleware).
+        request: userlandRequest,
         requestContext: postMiddlewareRequestContext,
         rewrites: options.configRewrites.afterFiles,
       },
@@ -635,7 +639,9 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       {
         basePathState,
         clearRequestContext: options.clearRequestContext,
-        request,
+        // Forward the `_rsc`-stripped request so external rewrite proxies never
+        // receive the internal RSC transport query (same invariant as middleware).
+        request: userlandRequest,
         requestContext: postMiddlewareRequestContext,
         rewrites: options.configRewrites.fallback,
       },

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -40,6 +40,7 @@ import {
   resolveInvalidRscCacheBustingRequest,
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
+  VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
 } from "./app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
@@ -340,6 +341,15 @@ function applyConfigHeadersToMiddlewareRedirect(
   return response;
 }
 
+function requestWithoutRscCacheBustingSearchParam(request: Request): Request {
+  const url = new URL(request.url);
+  if (!url.searchParams.has(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM)) return request;
+
+  stripRscCacheBustingSearchParam(url);
+  const source = request.body ? request.clone() : request;
+  return new Request(url.toString(), source);
+}
+
 async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   options: CreateAppRscHandlerOptions<TRoute>,
   request: Request,
@@ -439,6 +449,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   });
   if (rscCacheBustingRedirect) return rscCacheBustingRedirect;
 
+  // Keep cache-busting validation on the real request above, then hide the
+  // internal `_rsc` transport query from userland middleware and post-middleware
+  // has/missing matching. This mirrors Next.js' navigation middleware fixture.
+  const userlandRequest = isRscRequest
+    ? requestWithoutRscCacheBustingSearchParam(request)
+    : request;
   const middlewareContext: AppRscMiddlewareContext = {
     headers: null,
     requestHeaders: null,
@@ -454,7 +470,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       isDataRequest,
       isProxy: options.isMiddlewareProxy,
       module: options.middlewareModule,
-      request,
+      request: userlandRequest,
       trailingSlash: options.trailingSlash,
     });
     if (middlewareResult.kind === "response") {
@@ -473,7 +489,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   }
 
   const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareContext.headers);
-  const postMiddlewareRequestContext = buildPostMwRequestContext(request);
+  const postMiddlewareRequestContext = buildPostMwRequestContext(userlandRequest);
 
   // Rewrites (beforeFiles, afterFiles, fallback) use `matchPathname` from
   // above to splice in the default locale before matching. Route matching

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -683,3 +683,51 @@ export function cloneRequestWithHeaders(request: Request, headers: Headers): Req
   }
   return cloned;
 }
+
+/**
+ * Clone a Request while overriding the URL, preserving headers and metadata
+ * when possible.
+ *
+ * Mirrors `cloneRequestWithHeaders`, but rewrites the URL instead of the
+ * headers. Workers support `new Request(url, request)` to copy method/headers/
+ * body onto a new URL; Node/undici can throw on a foreign Request instance, so
+ * we fall back to a manual RequestInit. `new Request()` does not copy the
+ * Workers-specific `cf` property and omits `duplex` for streaming bodies, so
+ * both are handled explicitly — the same reasons `cloneRequestWithHeaders`
+ * exists.
+ */
+export function cloneRequestWithUrl(request: Request, url: string): Request {
+  let cloned: Request;
+  try {
+    cloned = new Request(url, request);
+  } catch {
+    const init: RequestInitWithCf = {
+      method: request.method,
+      headers: request.headers,
+      body: request.body ?? undefined,
+      redirect: request.redirect,
+      signal: request.signal,
+      integrity: request.integrity,
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+    };
+    if (request.body) {
+      // @ts-expect-error — duplex needed for streaming request bodies
+      init.duplex = "half";
+    }
+    cloned = new Request(url, init);
+  }
+  const cf = getRequestCf(request);
+  if (cf !== undefined) {
+    // new Request() does not copy Workers-specific cf, so re-attach it.
+    Object.defineProperty(cloned, "cf", {
+      value: cf,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return cloned;
+}

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   computeRscCacheBustingSearchParam,
@@ -628,6 +630,51 @@ describe("createAppRscHandler", () => {
     );
     expect(middlewareRequest?.nextUrl.search).toBe("?tab=latest");
     expect(dispatchMatchedPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides internal RSC cache-busting params from external rewrite proxies", async () => {
+    // The fetch-cache instrumentation captures the real `fetch` at module load
+    // and reinstalls a patched copy during request handling, so a global
+    // `fetch` mock can't intercept the proxied request. Use a real loopback
+    // server as the external rewrite destination and record the URL it
+    // receives — that exercises the full handler -> applyRewrite ->
+    // proxyExternalRequest path without fighting the instrumentation.
+    const receivedUrls: string[] = [];
+    const server = createServer((req, res) => {
+      receivedUrls.push(req.url ?? "");
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("upstream");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as AddressInfo;
+    const upstreamBase = `http://127.0.0.1:${address.port}`;
+
+    try {
+      const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+      const rscUrl = await createRscRequestUrl("/docs/proxy?tab=latest", headers);
+      const handler = createHandler({
+        configHeaders: [],
+        configRewrites: {
+          beforeFiles: [{ source: "/proxy", destination: `${upstreamBase}/proxy` }],
+          afterFiles: [],
+          fallback: [],
+        },
+        matchRoute: () => null,
+      });
+
+      const response = await handler(
+        new Request(`https://example.test${rscUrl}`, { headers }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(receivedUrls).toHaveLength(1);
+      const forwardedUrl = new URL(`${upstreamBase}${receivedUrls[0]}`);
+      expect(forwardedUrl.searchParams.has(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM)).toBe(false);
+      expect(forwardedUrl.searchParams.get("tab")).toBe("latest");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("does not render RSC payloads at HTML URLs marked only by RSC headers", async () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -3,6 +3,7 @@ import {
   computeRscCacheBustingSearchParam,
   createRscRequestHeaders,
   createRscRequestUrl,
+  VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { createAppRscHandler } from "../packages/vinext/src/server/app-rsc-handler.js";
@@ -599,6 +600,34 @@ describe("createAppRscHandler", () => {
     );
     expect(middleware).not.toHaveBeenCalled();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("hides internal RSC cache-busting params from middleware nextUrl", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/navigation/middleware.js
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/middleware.js
+    const middleware = vi.fn(
+      (_: { nextUrl: URL }) => new Response(null, { headers: { "x-middleware-next": "1" } }),
+    );
+    const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
+    const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+    const rscUrl = await createRscRequestUrl("/docs/about?tab=latest", headers);
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      middlewareModule: { default: middleware },
+    });
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(middleware).toHaveBeenCalledTimes(1);
+    const middlewareRequest = middleware.mock.calls[0]?.[0];
+    expect(middlewareRequest?.nextUrl.searchParams.has(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM)).toBe(
+      false,
+    );
+    expect(middlewareRequest?.nextUrl.search).toBe("?tab=latest");
+    expect(dispatchMatchedPage).toHaveBeenCalledTimes(1);
   });
 
   it("does not render RSC payloads at HTML URLs marked only by RSC headers", async () => {

--- a/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
@@ -19,15 +19,28 @@ async function closeServer(server: Server): Promise<void> {
   await closed;
 }
 
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+
+  await fs.mkdir(targetNodeModules, { recursive: true });
+
+  for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+    if (entry.name === ".vite-temp") continue;
+
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
 async function writeHashRscFixture(fixtureRoot: string): Promise<void> {
   const appDir = path.join(fixtureRoot, "app");
   const routeDir = path.join(appDir, "nextjs-compat", "hash-rsc-requests");
   await fs.mkdir(routeDir, { recursive: true });
-  await fs.symlink(
-    path.resolve(process.cwd(), "node_modules"),
-    path.join(fixtureRoot, "node_modules"),
-    "junction",
-  );
+  await linkFixtureNodeModules(fixtureRoot);
 
   await fs.writeFile(
     path.join(fixtureRoot, "package.json"),
@@ -190,6 +203,17 @@ test.describe("Next.js compat: hash RSC requests in production", () => {
           rscRequestUrls.add(request.url());
         }
       });
+      // The fixture middleware returns HTTP 599 if the internal `_rsc`
+      // cache-busting query ever leaks into request.nextUrl. Track every
+      // response so a regression in the `_rsc`-hiding logic fails with a clear
+      // status assertion instead of an indirect scroll-offset mismatch (a 599
+      // on the RSC fetch would hard-navigate rather than soft-navigate).
+      const middlewareLeakResponses: string[] = [];
+      page.on("response", (response) => {
+        if (response.status() === 599) {
+          middlewareLeakResponses.push(response.url());
+        }
+      });
       const checkLink = async (id: number | string, expectedScroll: number) => {
         await page.locator(`#link-to-${id.toString()}`).click();
         await expect.poll(() => page.evaluate(() => window.pageYOffset)).toBe(expectedScroll);
@@ -221,6 +245,10 @@ test.describe("Next.js compat: hash RSC requests in production", () => {
       await expect
         .poll(() => Array.from(rscRequestUrls).some((url) => url.includes("with-query-param")))
         .toBe(true);
+
+      // No request (RSC fetch included) should have leaked `_rsc` to the
+      // fixture middleware, which would have responded with HTTP 599.
+      expect(middlewareLeakResponses).toEqual([]);
     } finally {
       await closeServer(app.server);
       await fs.rm(app.fixtureRoot, { recursive: true, force: true });

--- a/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+type ProductionApp = {
+  baseUrl: string;
+  fixtureRoot: string;
+  server: Server;
+};
+
+async function closeServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await closed;
+}
+
+async function writeHashRscFixture(fixtureRoot: string): Promise<void> {
+  const appDir = path.join(fixtureRoot, "app");
+  const routeDir = path.join(appDir, "nextjs-compat", "hash-rsc-requests");
+  await fs.mkdir(routeDir, { recursive: true });
+  await fs.symlink(
+    path.resolve(process.cwd(), "node_modules"),
+    path.join(fixtureRoot, "node_modules"),
+    "junction",
+  );
+
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "layout.tsx"),
+    `import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(routeDir, "page.tsx"),
+    `import Link from "next/link";
+
+import "./global.css";
+
+const items = Array.from({ length: 5000 }, (_, id) => ({ id }));
+
+export default function HashRscRequestsPage() {
+  return (
+    <main style={{ fontFamily: "sans-serif", fontSize: "16px" }}>
+      <h1>Hash RSC Requests</h1>
+      <nav>
+        <Link href="/nextjs-compat/hash-rsc-requests#hash-6" id="link-to-6">
+          To 6
+        </Link>
+        <Link href="/nextjs-compat/hash-rsc-requests#hash-50" id="link-to-50">
+          To 50
+        </Link>
+        <Link href="/nextjs-compat/hash-rsc-requests#hash-160" id="link-to-160">
+          To 160
+        </Link>
+        <Link href="/nextjs-compat/hash-rsc-requests#hash-300" id="link-to-300">
+          To 300
+        </Link>
+        <Link href="#hash-500" id="link-to-500">
+          To 500
+        </Link>
+        <Link href="/nextjs-compat/hash-rsc-requests#top" id="link-to-top">
+          To Top
+        </Link>
+        <Link href="/nextjs-compat/hash-rsc-requests#non-existent" id="link-to-non-existent">
+          To non-existent
+        </Link>
+      </nav>
+      <div>
+        <Link href="?with-query-param#hash-160" id="link-to-query-param">
+          To 160 with query param
+        </Link>
+      </div>
+      <div>
+        {items.map((item) => (
+          <div id={\`hash-\${item.id}\`} key={item.id}>
+            {item.id}
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(routeDir, "global.css"),
+    `* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-size: 14px;
+  line-height: 1;
+}
+`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});
+`,
+  );
+}
+
+async function buildAndServeHashRscFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-hash-rsc-"));
+  await writeHashRscFixture(fixtureRoot);
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const { startProdServer } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/server/prod-server.js")).href
+  );
+  const started = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir: path.join(fixtureRoot, "dist"),
+    noCompression: true,
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${started.port}`,
+    fixtureRoot,
+    server: started.server,
+  };
+}
+
+test.setTimeout(90_000);
+
+test.describe("Next.js compat: hash RSC requests in production", () => {
+  // Ported from Next.js:
+  // test/e2e/app-dir/navigation/navigation.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/navigation.test.ts#L143-L198
+  test("hash-only navigations do not request the query-param RSC payload", async ({ page }) => {
+    const app = await buildAndServeHashRscFixture();
+
+    try {
+      const rscRequestUrls = new Set<string>();
+      page.on("request", (request) => {
+        const headers = request.headers();
+        if (headers.rsc) {
+          rscRequestUrls.add(request.url());
+        }
+      });
+
+      await page.goto(`${app.baseUrl}/nextjs-compat/hash-rsc-requests`);
+      await waitForAppRouterHydration(page);
+      await expect(page.locator("h1")).toHaveText("Hash RSC Requests");
+      rscRequestUrls.clear();
+
+      await page.locator("#link-to-6").click();
+      await expect(page.locator("#hash-6")).toBeInViewport();
+
+      await page.locator("#link-to-50").click();
+      await expect(page.locator("#hash-50")).toBeInViewport();
+
+      await page.locator("#link-to-160").click();
+      await expect(page.locator("#hash-160")).toBeInViewport();
+
+      await page.locator("#link-to-300").click();
+      await expect(page.locator("#hash-300")).toBeInViewport();
+
+      await page.locator("#link-to-500").click();
+      await expect(page.locator("#hash-500")).toBeInViewport();
+
+      await page.locator("#link-to-top").click();
+      await expect.poll(() => page.evaluate(() => window.pageYOffset)).toBe(0);
+
+      await page.locator("#link-to-non-existent").click();
+      await expect.poll(() => page.evaluate(() => window.pageYOffset)).toBe(0);
+
+      const hasQueryParamRscRequestBeforeQueryChange = Array.from(rscRequestUrls).some((url) =>
+        url.includes("with-query-param"),
+      );
+      expect(hasQueryParamRscRequestBeforeQueryChange).toBe(false);
+
+      await page.locator("#link-to-query-param").click();
+      await expect(page.locator("#hash-160")).toBeInViewport();
+      await expect(page).toHaveURL(
+        `${app.baseUrl}/nextjs-compat/hash-rsc-requests?with-query-param#hash-160`,
+      );
+
+      await expect
+        .poll(() => Array.from(rscRequestUrls).some((url) => url.includes("with-query-param")))
+        .toBe(true);
+    } finally {
+      await closeServer(app.server);
+      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
@@ -56,44 +56,42 @@ const items = Array.from({ length: 5000 }, (_, id) => ({ id }));
 
 export default function HashRscRequestsPage() {
   return (
-    <main style={{ fontFamily: "sans-serif", fontSize: "16px" }}>
-      <h1>Hash RSC Requests</h1>
-      <nav>
-        <Link href="/nextjs-compat/hash-rsc-requests#hash-6" id="link-to-6">
-          To 6
-        </Link>
-        <Link href="/nextjs-compat/hash-rsc-requests#hash-50" id="link-to-50">
-          To 50
-        </Link>
-        <Link href="/nextjs-compat/hash-rsc-requests#hash-160" id="link-to-160">
-          To 160
-        </Link>
-        <Link href="/nextjs-compat/hash-rsc-requests#hash-300" id="link-to-300">
-          To 300
-        </Link>
-        <Link href="#hash-500" id="link-to-500">
-          To 500
-        </Link>
-        <Link href="/nextjs-compat/hash-rsc-requests#top" id="link-to-top">
-          To Top
-        </Link>
-        <Link href="/nextjs-compat/hash-rsc-requests#non-existent" id="link-to-non-existent">
-          To non-existent
-        </Link>
-      </nav>
+    <div style={{ fontFamily: "sans-serif", fontSize: "16px" }}>
+      <p>Hash Page</p>
+      <Link href="/nextjs-compat/hash-rsc-requests#hash-6" id="link-to-6">
+        To 6
+      </Link>
+      <Link href="/nextjs-compat/hash-rsc-requests#hash-50" id="link-to-50">
+        To 50
+      </Link>
+      <Link href="/nextjs-compat/hash-rsc-requests#hash-160" id="link-to-160">
+        To 160
+      </Link>
+      <Link href="/nextjs-compat/hash-rsc-requests#hash-300" id="link-to-300">
+        To 300
+      </Link>
+      <Link href="#hash-500" id="link-to-500">
+        To 500 (hash only)
+      </Link>
+      <Link href="/nextjs-compat/hash-rsc-requests#top" id="link-to-top">
+        To Top
+      </Link>
+      <Link href="/nextjs-compat/hash-rsc-requests#non-existent" id="link-to-non-existent">
+        To non-existent
+      </Link>
       <div>
         <Link href="?with-query-param#hash-160" id="link-to-query-param">
-          To 160 with query param
+          To 160 (with query param)
         </Link>
       </div>
       <div>
         {items.map((item) => (
-          <div id={\`hash-\${item.id}\`} key={item.id}>
-            {item.id}
+          <div key={item.id}>
+            <div id={\`hash-\${item.id}\`}>{item.id}</div>
           </div>
         ))}
       </div>
-    </main>
+    </div>
   );
 }
 `,
@@ -192,40 +190,30 @@ test.describe("Next.js compat: hash RSC requests in production", () => {
           rscRequestUrls.add(request.url());
         }
       });
+      const checkLink = async (id: number | string, expectedScroll: number) => {
+        await page.locator(`#link-to-${id.toString()}`).click();
+        await expect.poll(() => page.evaluate(() => window.pageYOffset)).toBe(expectedScroll);
+      };
 
       await page.goto(`${app.baseUrl}/nextjs-compat/hash-rsc-requests`);
       await waitForAppRouterHydration(page);
-      await expect(page.locator("h1")).toHaveText("Hash RSC Requests");
+      await expect(page.locator("p")).toHaveText("Hash Page");
       rscRequestUrls.clear();
 
-      await page.locator("#link-to-6").click();
-      await expect(page.locator("#hash-6")).toBeInViewport();
-
-      await page.locator("#link-to-50").click();
-      await expect(page.locator("#hash-50")).toBeInViewport();
-
-      await page.locator("#link-to-160").click();
-      await expect(page.locator("#hash-160")).toBeInViewport();
-
-      await page.locator("#link-to-300").click();
-      await expect(page.locator("#hash-300")).toBeInViewport();
-
-      await page.locator("#link-to-500").click();
-      await expect(page.locator("#hash-500")).toBeInViewport();
-
-      await page.locator("#link-to-top").click();
-      await expect.poll(() => page.evaluate(() => window.pageYOffset)).toBe(0);
-
-      await page.locator("#link-to-non-existent").click();
-      await expect.poll(() => page.evaluate(() => window.pageYOffset)).toBe(0);
+      await checkLink(6, 128);
+      await checkLink(50, 744);
+      await checkLink(160, 2284);
+      await checkLink(300, 4244);
+      await checkLink(500, 7044);
+      await checkLink("top", 0);
+      await checkLink("non-existent", 0);
 
       const hasQueryParamRscRequestBeforeQueryChange = Array.from(rscRequestUrls).some((url) =>
         url.includes("with-query-param"),
       );
       expect(hasQueryParamRscRequestBeforeQueryChange).toBe(false);
 
-      await page.locator("#link-to-query-param").click();
-      await expect(page.locator("#hash-160")).toBeInViewport();
+      await checkLink("query-param", 2284);
       await expect(page).toHaveURL(
         `${app.baseUrl}/nextjs-compat/hash-rsc-requests?with-query-param#hash-160`,
       );

--- a/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
@@ -109,6 +109,24 @@ export default function HashRscRequestsPage() {
 }
 `,
   );
+  await fs.writeFile(
+    path.join(fixtureRoot, "middleware.ts"),
+    `import { NextResponse, type NextRequest } from "next/server";
+
+const NEXT_RSC_UNION_QUERY = "_rsc";
+
+export function middleware(request: NextRequest) {
+  // Mirrors Next.js' navigation fixture: middleware should never observe the
+  // internal RSC cache-busting query in request.nextUrl.
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/middleware.js
+  if (request.nextUrl.searchParams.has(NEXT_RSC_UNION_QUERY)) {
+    return new Response("RSC query leaked to middleware", { status: 599 });
+  }
+
+  return NextResponse.next();
+}
+`,
+  );
 
   const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
   await fs.writeFile(

--- a/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
@@ -222,6 +222,12 @@ test.describe("Next.js compat: hash RSC requests in production", () => {
       await page.goto(`${app.baseUrl}/nextjs-compat/hash-rsc-requests`);
       await waitForAppRouterHydration(page);
       await expect(page.locator("p")).toHaveText("Hash Page");
+      // Wait for all initial network activity (including the query-param link's
+      // viewport prefetch) to settle *before* clearing the tracked RSC requests.
+      // Otherwise the prefetch can land after the clear on slower runtimes
+      // (e.g. WebKit) and be misattributed to the hash-only navigations below.
+      // Mirrors upstream's `waitForIdleNetwork()` in the ported Next.js test.
+      await page.waitForLoadState("networkidle");
       rscRequestUrls.clear();
 
       await checkLink(6, 128);

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -3,6 +3,7 @@ import {
   applyConfigHeadersToHeaderRecord,
   applyConfigHeadersToResponse,
   cloneRequestWithHeaders,
+  cloneRequestWithUrl,
   createStaticFileSignal,
   filterInternalHeaders,
   guardProtocolRelativeUrl,
@@ -926,5 +927,59 @@ describe("cloneRequestWithHeaders", () => {
     expect(cloned.method).toBe("GET");
     expect(cloned.body).toBeNull();
     expect(cloned.headers.get("accept")).toBe("text/html");
+  });
+});
+
+// ── cloneRequestWithUrl ──────────────────────────────────────────────────
+//
+// Used to hide the internal `_rsc` cache-busting query from userland middleware
+// without dropping Workers `cf` metadata or throwing on bodied requests (which a
+// bare `new Request(url, request)` would do on Node/undici without `duplex`).
+
+describe("cloneRequestWithUrl", () => {
+  it("overrides the URL", () => {
+    const original = new Request("http://localhost/path?_rsc=abc&keep=1");
+    const cloned = cloneRequestWithUrl(original, "http://localhost/path?keep=1");
+    expect(cloned.url).toBe("http://localhost/path?keep=1");
+  });
+
+  it("preserves method and headers", () => {
+    const original = new Request("http://localhost/path?_rsc=abc", {
+      method: "GET",
+      headers: new Headers({ "x-keep": "yes" }),
+    });
+    const cloned = cloneRequestWithUrl(original, "http://localhost/path");
+    expect(cloned.method).toBe("GET");
+    expect(cloned.headers.get("x-keep")).toBe("yes");
+  });
+
+  it("preserves cf property when defined via Object.defineProperty", () => {
+    const original = new Request("http://localhost/path?_rsc=abc");
+    Object.defineProperty(original, "cf", {
+      value: { country: "US" },
+      enumerable: true,
+      configurable: true,
+    });
+    const cloned = cloneRequestWithUrl(original, "http://localhost/path");
+    expect(Reflect.get(cloned, "cf")).toEqual({ country: "US" });
+  });
+
+  it("preserves body readability for streaming requests", async () => {
+    const bodyText = "hello world";
+    const original = new Request("http://localhost/path?_rsc=abc", {
+      method: "POST",
+      body: bodyText,
+    });
+    const cloned = cloneRequestWithUrl(original, "http://localhost/path");
+    expect(cloned.method).toBe("POST");
+    expect(cloned.url).toBe("http://localhost/path");
+    const text = await cloned.text();
+    expect(text).toBe(bodyText);
+  });
+
+  it("preserves redirect mode", () => {
+    const original = new Request("http://localhost/path?_rsc=abc", { redirect: "manual" });
+    const cloned = cloneRequestWithUrl(original, "http://localhost/path");
+    expect(cloned.redirect).toBe("manual");
   });
 });


### PR DESCRIPTION
## Overview

| Area | Detail |
| --- | --- |
| Goal | Match Next.js App Router behavior for same-page search/hash navigations from the navigation deploy suite. |
| Core changes | Bypass stale client RSC payload caches when `navigate` keeps the pathname but changes search params, and hide the internal `_rsc` cache-busting query from middleware-facing `request.nextUrl`. |
| Main boundary | Hash-only changes stay local; search changes are page inputs and request the target RSC payload; internal RSC transport params remain framework-only. |
| Primary files | `packages/vinext/src/server/app-browser-entry.ts`, `packages/vinext/src/server/app-rsc-handler.ts`, `tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts`, `tests/app-rsc-handler.test.ts` |
| Expected impact | Query+hash navigations no longer reuse stale prefetched route payloads or fail middleware that rejects visible `_rsc`; cross-route prefetch reuse remains unchanged. |

## Why

For App Router, search params are part of the page input. Next.js treats same-page navigations specially: hash-only changes are local, but same-page search changes refetch page segments rather than relying on a cached payload that may have been prefetched before the navigation.

The upstream navigation fixture also asserts that middleware must not observe Next's internal RSC union query. Vinext already uses `_rsc` to validate RSC cache-busting, but the same raw URL was passed into middleware. That made the query+hash RSC request fail before it could commit and scroll.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Hash navigation | A hash-only URL change should not request unrelated query payloads. | The regression keeps asserting no `with-query-param` RSC request occurs during hash-only clicks and now mirrors the upstream fixture's exact scroll offsets. |
| Same-page search navigation | Changed search params require server work for the page segment. | The browser entry bypasses visited and prefetched RSC caches for `navigate` operations with unchanged pathname and changed search params. |
| Middleware URL surface | Internal RSC cache-busting is framework transport state, not userland request state. | The RSC handler validates `_rsc` first, then strips it from the request clone passed to middleware and post-middleware has/missing matching. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `/hash#non-existent` to `/hash?with-query-param#hash-160` after visible Link prefetch | vinext replayed the prefetched query RSC payload, so no request was visible during the click. | vinext bypasses the client cache and requests the query-param RSC payload during navigation. |
| Query+hash RSC request through middleware | middleware saw `_rsc` in `request.nextUrl.searchParams`, matching the remaining deploy-suite failure. | middleware sees only userland query params while RSC cache-busting validation still runs on the real request first. |
| Hash-only clicks on `/hash#...` | Stayed local. | Still local, with exact scroll-position assertions ported from upstream. |
| Cross-route App Router prefetch reuse | Could reuse prefetched payloads. | Unchanged. |

<details>
<summary>Validation</summary>

- `vp test run tests/app-rsc-handler.test.ts`
- `vp run vinext#build`
- `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific pnpm run test:e2e tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts`
- `vp test run tests/app-browser-entry.test.ts tests/prefetch-cache.test.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/nextjs-compat/hash-popstate-scroll.spec.ts tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`
- `vp check`

The new handler regression was red before the source change: middleware received a `NextRequest.nextUrl` whose `searchParams` still contained `_rsc`.

</details>

<details>
<summary>References</summary>

| Reference | Why it matters |
| --- | --- |
| [Next.js navigation hash test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/navigation.test.ts#L143-L198) | Upstream observable behavior and assertion ported here. |
| [Next.js navigation middleware guard](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/middleware.js#L13-L18) | Upstream fixture throws when middleware can see the internal RSC query. |
| [Next.js hash fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/navigation/app/hash/page.js) | Fixture shape that makes the query link visible and prefetched before the assertion window. |
| [Next.js only-hash check](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/segment-cache/navigation.ts#L582-L587) | Search must match for a navigation to be hash-only. |
| [Next.js same-page segment refetch rule](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/router-reducer/ppr-navigations.ts#L338-L340) | Same-page navigations refetch page segments instead of reusing existing cached page data. |
| [Next.js `createHrefFromUrl`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/router-reducer/create-href-from-url.ts) | Canonical href construction includes pathname, search, and hash. |

</details>

## Non-goals

This PR does not replace vinext's route-level prefetch cache with Next.js's segment cache. It only closes the observed parity gap for same-page search navigations while preserving the existing cache model.
