### PR TITLE
test(app-router): remove live network from ISR revalidation fixtures

### DIFF
--- a/tests/app-layout-param-observation.test.ts
+++ b/tests/app-layout-param-observation.test.ts
@@ -256,9 +256,9 @@ describe("app layout param observation", () => {
         // Catch the background promise so it cannot produce an
         // unhandled rejection after the synchronous assertions
         // complete. The patched fetch continues past observation
-        // into cache lookup and network fetch, which may fail in
-        // this test environment.
-        fetch("https://example.com/data", {
+        // into cache lookup and fetch completion. Use a deterministic data URL
+        // because the test only needs the synchronous observation side effect.
+        fetch("data:application/json,%7B%22ok%22%3Atrue%7D", {
           next: { revalidate: 60, tags: ["banner"] },
         }).catch(() => {});
       });

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-fetch/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-fetch/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = "error";
 
 export default async function Page() {
-  await fetch("https://example.com/not-cacheable", { cache: "no-store" });
+  await fetch("data:text/plain,not-cacheable", { cache: "no-store" });
   return <p data-testid="layout-segment-config-dynamic-error-fetch">Should not render</p>;
 }

--- a/tests/fixtures/app-basic/app/revalidate-tag-test/nested/page.tsx
+++ b/tests/fixtures/app-basic/app/revalidate-tag-test/nested/page.tsx
@@ -7,7 +7,9 @@
 export const revalidate = 3600;
 
 async function getTaggedData() {
-  await fetch("https://httpbin.org/uuid", {
+  // Use a tagged fetch to demonstrate revalidateTag behavior without depending
+  // on external network availability in CI.
+  await fetch("data:application/json,%7B%22ok%22%3Atrue%7D", {
     next: { tags: ["test-data"] },
   });
   const timestamp = Date.now();

--- a/tests/fixtures/app-basic/app/revalidate-tag-test/page.tsx
+++ b/tests/fixtures/app-basic/app/revalidate-tag-test/page.tsx
@@ -8,11 +8,11 @@
 export const revalidate = 3600; // Long TTL — only invalidated by revalidateTag
 
 async function getTaggedData() {
-  // Use a tagged fetch to demonstrate revalidateTag behavior
-  await fetch("https://httpbin.org/uuid", {
+  // Use a tagged fetch to demonstrate revalidateTag behavior without depending
+  // on external network availability in CI.
+  await fetch("data:application/json,%7B%22ok%22%3Atrue%7D", {
     next: { tags: ["test-data"] },
   });
-  // If fetch fails or is unavailable, use local timestamp
   const timestamp = Date.now();
   return { timestamp };
 }


### PR DESCRIPTION
## Overview

| Area | Detail |
| --- | --- |
| Goal | Fix flaky App Router ISR revalidation tests from issue #1755. |
| Core change | Replace live `httpbin.org` fixture fetches with deterministic `data:` URL fetches. |
| Expected impact | Tests still collect `next.tags` for ISR invalidation, without depending on external network latency. |
| Primary files | `tests/fixtures/app-basic/app/revalidate-tag-test/page.tsx`, `tests/fixtures/app-basic/app/revalidate-tag-test/nested/page.tsx` |

## Why

The revalidation tests only need the tagged fetch side effect so App Router ISR entries receive the `test-data` tag. The fixture previously waited on `https://httpbin.org/uuid`, making CI sensitive to an external service even though the response body was not part of the contract.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Tagged ISR fixture fetch | Calls `https://httpbin.org/uuid` during render | Calls a deterministic `data:` URL during render |
| Tag collection | Uses `next: { tags: ["test-data"] }` | Preserved |
| External network dependency | Present | Removed |

## Validation

- `vp test run tests/app-router.test.ts -t "revalidateTag invalidates App Router ISR page entries by fetch tag|revalidatePath invalidates App Router ISR page entries by path tag"`
- `vp test run tests/nextjs-compat/revalidate.test.ts`
- staged-file hook: `vp check --fix`

Fixes #1755
