### PR TITLE
test(e2e): de-flake dev-overlay build-error recovery + middleware invocation count

### DIFF
--- a/tests/e2e/app-router/dev-error-overlay.spec.ts
+++ b/tests/e2e/app-router/dev-error-overlay.spec.ts
@@ -348,13 +348,16 @@ test.describe("Dev error overlay", () => {
       await expect(page.getByTestId("vinext-dev-error-stack-container")).toBeHidden();
       await expect(page.locator("vite-error-overlay")).toHaveCount(0);
 
-      const waitForCleanRsc = page.waitForResponse(
-        (response) => isAppRouterRscRequestForPath(response.request(), "/dev-overlay-hmr-toggle"),
-        { timeout: 10_000 },
-      );
+      // A build error tears down the RSC tree, so recovery lands via a full
+      // document reload (app-browser-entry's applyRscHmrUpdate reloads the
+      // route) rather than an in-place RSC refetch. Waiting for an RSC response
+      // races that reload and flakes — assert the user-visible recovered state
+      // instead, which holds whether recovery reloads or refetches.
       await writeFile(SERVER_HMR_TOGGLE_FILE, SERVER_HMR_TOGGLE_CLEAN);
-      await waitForCleanRsc;
       await expect(page.getByTestId("vinext-dev-error-overlay")).toBeHidden({ timeout: 10_000 });
+      await expect(page.getByTestId("server-hmr-toggle")).toHaveText("server hmr clean", {
+        timeout: 10_000,
+      });
     });
 
     test("layout server component HMR updates the overlay when a throw is toggled", async ({

--- a/tests/e2e/app-router/middleware.spec.ts
+++ b/tests/e2e/app-router/middleware.spec.ts
@@ -7,6 +7,7 @@
  * Tests: ON-11 in TRACKING.md
  */
 import { test, expect } from "@playwright/test";
+import { randomUUID } from "node:crypto";
 
 const BASE = "http://localhost:4174";
 
@@ -85,12 +86,6 @@ test.describe("Middleware Block (OpenNext compat)", () => {
 });
 
 test.describe("Middleware execution count", () => {
-  test.beforeEach(async ({ request }) => {
-    // Reset the invocation counter before each test.
-    const res = await request.delete(`${BASE}/api/instrumentation-test`);
-    expect(res.status()).toBe(200);
-  });
-
   // Regression test: in a hybrid app+pages fixture the connect handler
   // forwards middleware results to the RSC entry via x-vinext-mw-ctx so that
   // middleware only executes once per request. Without this, middleware runs
@@ -98,12 +93,22 @@ test.describe("Middleware execution count", () => {
   test("middleware runs exactly once per App Router request in hybrid app+pages fixture", async ({
     request,
   }) => {
+    // Scope counting to a unique id so concurrent workers hitting other
+    // middleware-matched routes (/, /about, …) can't inflate the shared
+    // global counter. A double-run would still be observed under this id
+    // because both the SSR and RSC invocations see the same request header.
+    const testId = randomUUID();
+
     // /about is an App Router route that is in the middleware matcher.
-    const res = await request.get(`${BASE}/about`);
+    const res = await request.get(`${BASE}/about`, {
+      headers: { "x-mw-test-id": testId },
+    });
     expect(res.status()).toBe(200);
     expect(res.headers()["x-mw-ran"]).toBe("true");
 
-    const stateRes = await request.get(`${BASE}/api/instrumentation-test`);
+    const stateRes = await request.get(
+      `${BASE}/api/instrumentation-test?id=${encodeURIComponent(testId)}`,
+    );
     const data = await stateRes.json();
 
     expect(data.middlewareInvocationCount).toBe(1);

--- a/tests/fixtures/app-basic/app/api/instrumentation-test/route.ts
+++ b/tests/fixtures/app-basic/app/api/instrumentation-test/route.ts
@@ -10,21 +10,29 @@
  *   Resets the captured state so tests can start from a clean slate.
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import {
   getRegisterCalled,
   getCapturedErrors,
   resetInstrumentationState,
   getMiddlewareInvocationCount,
   getMiddlewareInvokedPaths,
+  getMiddlewareInvocationCountById,
+  getMiddlewareInvokedPathsById,
 } from "../../../instrumentation-state";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // When an `id` is supplied, report only the invocations recorded under that
+  // unique test id — isolating the assertion from concurrent e2e traffic that
+  // shares the global counter.
+  const id = request.nextUrl.searchParams.get("id");
   return NextResponse.json({
     registerCalled: getRegisterCalled(),
     errors: getCapturedErrors(),
-    middlewareInvocationCount: getMiddlewareInvocationCount(),
-    middlewareInvokedPaths: getMiddlewareInvokedPaths(),
+    middlewareInvocationCount: id
+      ? getMiddlewareInvocationCountById(id)
+      : getMiddlewareInvocationCount(),
+    middlewareInvokedPaths: id ? getMiddlewareInvokedPathsById(id) : getMiddlewareInvokedPaths(),
   });
 }
 

--- a/tests/fixtures/app-basic/instrumentation-state.ts
+++ b/tests/fixtures/app-basic/instrumentation-state.ts
@@ -86,6 +86,7 @@ export function resetInstrumentationState(): void {
  */
 const MW_COUNT_KEY = "__vinext_mw_count__";
 const MW_PATHS_KEY = "__vinext_mw_paths__";
+const MW_BY_ID_KEY = "__vinext_mw_by_id__";
 
 function _mwCount(): number {
   return (globalThis as any)[MW_COUNT_KEY] ?? 0;
@@ -95,6 +96,24 @@ function _mwPaths(): string[] {
     (globalThis as any)[MW_PATHS_KEY] = [];
   }
   return (globalThis as any)[MW_PATHS_KEY] as string[];
+}
+
+/**
+ * Per-test-id invocation buckets.
+ *
+ * The global counter above is shared across every request the dev server
+ * handles, so concurrent e2e workers hitting any middleware-matched route
+ * (/, /about, …) inflate it. Tests that need an isolated count pass a unique
+ * `x-mw-test-id` header; middleware records under that id and the API route
+ * reads it back, so the assertion only sees this request's invocations.
+ * Double-execution (SSR connect handler + RSC entry) still bumps the same id
+ * because both runs observe the original request header.
+ */
+function _mwById(): Map<string, { count: number; paths: string[] }> {
+  if (!(globalThis as any)[MW_BY_ID_KEY]) {
+    (globalThis as any)[MW_BY_ID_KEY] = new Map<string, { count: number; paths: string[] }>();
+  }
+  return (globalThis as any)[MW_BY_ID_KEY] as Map<string, { count: number; paths: string[] }>;
 }
 
 /** Get the total number of middleware invocations recorded across all environments. */
@@ -107,8 +126,25 @@ export function getMiddlewareInvokedPaths(): string[] {
   return [..._mwPaths()];
 }
 
-/** Record a middleware invocation. */
-export function recordMiddlewareInvocation(pathname: string): void {
+/** Get the invocation count recorded under a specific test id. */
+export function getMiddlewareInvocationCountById(id: string): number {
+  return _mwById().get(id)?.count ?? 0;
+}
+
+/** Get the ordered pathnames recorded under a specific test id. */
+export function getMiddlewareInvokedPathsById(id: string): string[] {
+  return [...(_mwById().get(id)?.paths ?? [])];
+}
+
+/** Record a middleware invocation, optionally scoped to a unique test id. */
+export function recordMiddlewareInvocation(pathname: string, id?: string): void {
   (globalThis as any)[MW_COUNT_KEY] = _mwCount() + 1;
   _mwPaths().push(pathname);
+  if (id) {
+    const map = _mwById();
+    const entry = map.get(id) ?? { count: 0, paths: [] };
+    entry.count += 1;
+    entry.paths.push(pathname);
+    map.set(id, entry);
+  }
 }

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -21,7 +21,9 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // In a hybrid app+pages fixture the Vite connect handler runs middleware
   // via ssrLoadModule (SSR env) and then the RSC entry runs it again inline
   // (RSC env). A single request should produce exactly one invocation.
-  recordMiddlewareInvocation(pathname);
+  // The optional x-mw-test-id scopes the count to a single test so concurrent
+  // e2e workers hitting other matched routes can't inflate it.
+  recordMiddlewareInvocation(pathname, request.headers.get("x-mw-test-id") ?? undefined);
 
   // Test NextRequest.cookies - this would fail with TypeError if request is plain Request
   const sessionToken = request.cookies.get("session");


### PR DESCRIPTION
De-flakes two pre-existing flaky app-router E2E tests that were intermittently reddening CI (surfaced across [run 27017111671](https://github.com/cloudflare/vinext/actions/runs/27017111671/job/79734936336?pr=1748) and [run 27017868468](https://github.com/cloudflare/vinext/actions/runs/27017868468/job/79737582941?pr=1757)). Both flakes are unrelated to any product change — they're test-isolation/timing issues in the shared-dev-server E2E setup.

## 1. `dev-error-overlay.spec.ts` — build-error recovery

*"server component HMR surfaces Vite build errors after a clean load"* waited for an **RSC response** after fixing the build error:

```
TimeoutError: page.waitForResponse: Timeout 10000ms exceeded while waiting for event "response"
```

A build error tears down the RSC tree, so recovery lands via a **full document reload** — [`applyRscHmrUpdate` in `app-browser-entry.ts`](packages/vinext/src/server/app-browser-entry.ts#L2271-L2296) calls `window.location.reload()` when the tree was torn down — not an in-place RSC refetch. No RSC request is ever issued, so `waitForResponse` times out. (The sibling *runtime-throw* test passes because a runtime throw keeps the tree mounted, so its recovery genuinely is an RSC refetch.)

**Fix:** drop the racy `waitForResponse` and assert the user-visible recovered state (overlay hidden + clean content restored), which holds whether recovery reloads or refetches.

## 2. `middleware.spec.ts` — invocation count

*"middleware runs exactly once per App Router request"* asserted a **process-global** counter (`globalThis.__vinext_mw_count__`). Playwright runs parallel workers against one dev server, so concurrent requests to any middleware-matched route (`/`, `/about`, …) bumped the shared counter between the `beforeEach` reset and the assertion:

```
expect(received).toBe(expected)  Expected: 1  Received: 2
```

**Fix:** scope counting to a unique `x-mw-test-id` header — middleware records under that id and the API route reads it back via `?id=`. Concurrent traffic can no longer contaminate the count, and a genuine double-run (SSR connect handler + RSC entry) is still caught because both invocations observe the same request header. The global-reset `beforeEach` is dropped (no longer needed, and its global mutation could clobber concurrent instrumentation tests).

## Verification

Local E2E couldn't run in this worktree (workspace packages aren't linked, so `vp dev` can't start) — relying on CI. `vp fmt --check` is clean. Changes are test-only.