### PR TITLE
chore(release): keep changelog Contributors in the GitHub Release (h3)

### DIFF
--- a/scripts/version.mts
+++ b/scripts/version.mts
@@ -119,8 +119,13 @@ export function groupedChangelogBody(commits: Commit[]): string {
 
 /**
  * Replace the body of the newest `## <version>` section with `body`, then append
- * a `## Contributors` list. Older sections are untouched. Only `## <digit>`
+ * a `### Contributors` list. Older sections are untouched. Only `## <digit>`
  * counts as a section boundary, so re-running is idempotent. Pure.
+ *
+ * Contributors is `###` (not `##`) deliberately: changesets' getChangelogEntry
+ * extracts the GitHub Release body by slicing from the `## <version>` heading to
+ * the next *same-depth* (`##`) heading, so a `## Contributors` would truncate
+ * the release notes and drop the list. `###` keeps it inside the release body.
  */
 export function rewriteReleaseSection(
   changelog: string,
@@ -142,7 +147,7 @@ export function rewriteReleaseSection(
   const block = [lines[start]]; // the `## <version>` heading
   if (body.trim()) block.push("", body);
   const logins = dedupeSortLogins(contributors);
-  if (logins.length) block.push("", "## Contributors", "", ...logins.map((l) => `- @${l}`));
+  if (logins.length) block.push("", "### Contributors", "", ...logins.map((l) => `- @${l}`));
   block.push("");
 
   const rebuilt = [...lines.slice(0, start), ...block, ...lines.slice(end)].join("\n");

--- a/scripts/version.test.ts
+++ b/scripts/version.test.ts
@@ -108,7 +108,7 @@ describe("rewriteReleaseSection", () => {
     const out = rewriteReleaseSection(base, body, ["@bob", "@alice"]);
     expect(out).toContain("### Features");
     expect(out).not.toContain("Minor Changes"); // raw dump replaced
-    expect(out).toContain("## Contributors");
+    expect(out).toContain("### Contributors");
     expect(out.indexOf("- @alice")).toBeLessThan(out.indexOf("- @bob"));
     // older section untouched
     expect(out).toContain("## 0.0.55");
@@ -118,7 +118,7 @@ describe("rewriteReleaseSection", () => {
   it("is idempotent — only `## <digit>` is a section boundary", () => {
     const once = rewriteReleaseSection(base, body, ["@bob"]);
     const twice = rewriteReleaseSection(once, body, ["@bob", "@carol"]);
-    expect(twice.match(/## Contributors/g)?.length).toBe(1);
+    expect(twice.match(/### Contributors/g)?.length).toBe(1);
     expect(twice.match(/## 0\.0\.55/g)?.length).toBe(1);
     expect(twice).toContain("- @carol");
   });


### PR DESCRIPTION
Follow-up to [#1753](https://github.com/cloudflare/vinext/pull/1753) — this one fix was pushed after that PR merged, so it didn't land.

## Problem
`changesets/action` builds the GitHub Release body via `getChangelogEntry(CHANGELOG.md, version)`, which slices from the `## <version>` heading to **the next heading of the same depth**. The contributor list was written as `## Contributors` (h2) — the same depth as `## 0.1.0` — so it acted as the section boundary and got **excluded from the GitHub Release** (it stayed in the committed `CHANGELOG.md`, but the release notes were truncated just before it).

Verified against [changesets/action v1.9.0](https://github.com/changesets/action/blob/v1.9.0/src/utils.ts) `getChangelogEntry` (boundary = next same-depth heading).

## Fix
Emit `### Contributors` (h3) instead. `getChangelogEntry` includes deeper headings, so the list now stays inside the extracted release body. The in-file section-boundary logic (`/^##\s+\d/`) is unchanged.

## Testing
- `vp test run scripts/version.test.ts` — 9/9 pass (assertions updated to `### Contributors`).
- `vp check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
