### PR TITLE
fix(release): resolve changelog range from latest tag so new packages get entries

### DIFF
--- a/scripts/create-changeset.mts
+++ b/scripts/create-changeset.mts
@@ -191,16 +191,12 @@ export function discoverPublishablePackages(root: string = REPO_ROOT): Record<st
 }
 
 /**
- * Latest release tag version for a package. Accepts both the legacy global
- * `v<version>` and changesets' `<name>@<version>` scheme; picks the highest.
+ * Pick the highest release-tag version for a package out of a tag list. Accepts
+ * both the legacy global `v<version>` and changesets' `<name>@<version>` scheme;
+ * returns null when no tag matches — e.g. a brand-new, never-released package.
+ * Pure (no git), so the tag-selection / no-tag behaviour is unit-testable.
  */
-function latestTagVersion(pkgName: string): string | null {
-  let tags: string[] = [];
-  try {
-    tags = git(["tag", "-l"]).split("\n").filter(Boolean);
-  } catch {
-    return null;
-  }
+export function latestTagVersionFromTags(tags: string[], pkgName: string): string | null {
   const scopedPrefix = `${pkgName}@`;
   const versions = tags
     .map((tag) =>
@@ -213,6 +209,20 @@ function latestTagVersion(pkgName: string): string | null {
     .filter((v): v is string => v != null)
     .sort(compareVersions);
   return versions.at(-1) ?? null;
+}
+
+/**
+ * Latest release tag version for a package, read from `git tag -l`. Returns null
+ * when git fails or the package has no matching tag.
+ */
+function latestTagVersion(pkgName: string): string | null {
+  let tags: string[] = [];
+  try {
+    tags = git(["tag", "-l"]).split("\n").filter(Boolean);
+  } catch {
+    return null;
+  }
+  return latestTagVersionFromTags(tags, pkgName);
 }
 
 /** Git ref to diff from: prefer the scoped tag, else the global `v<version>`. */

--- a/scripts/create-changeset.test.ts
+++ b/scripts/create-changeset.test.ts
@@ -4,6 +4,7 @@ import {
   affectedPackages,
   compareVersions,
   decideGeneration,
+  latestTagVersionFromTags,
   maxBump,
   parseBumpFromSubject,
   renderChangeset,
@@ -136,6 +137,39 @@ describe("decideGeneration (THE CORRECTNESS RULE)", () => {
   it("generates when package.json somehow lags the tag (not a skip case)", () => {
     // Only strictly-greater package version triggers the publish guard.
     expect(decideGeneration("0.0.5", "0.0.55").action).toBe("generate");
+  });
+});
+
+describe("latestTagVersionFromTags (release range source)", () => {
+  const tags = [
+    "v0.0.54",
+    "v0.0.55",
+    "vinext@0.0.55",
+    "@vinext/cloudflare@1.0.0",
+    "@vinext/cloudflare@1.1.0",
+    "some-other-tag",
+  ];
+
+  it("picks the highest scoped tag for a package with the `<name>@<version>` scheme", () => {
+    expect(latestTagVersionFromTags(tags, "@vinext/cloudflare")).toBe("1.1.0");
+  });
+
+  it("falls back to the legacy global `v<version>` tag for the root package", () => {
+    // vinext has both schemes here; scoped/global versions agree, highest wins.
+    expect(latestTagVersionFromTags(tags, "vinext")).toBe("0.0.55");
+  });
+
+  it("falls back to the latest legacy global `v` tag for a never-scoped new package", () => {
+    // The #1759 case: a brand-new package (no `<name>@<version>` tag of its own)
+    // still resolves a real range from the latest global `v` tag, instead of the
+    // non-existent `v<pkg.version>` ref that produced an empty changelog.
+    expect(latestTagVersionFromTags(tags, "@vinext/brand-new")).toBe("0.0.55");
+  });
+
+  it("returns null when there is no scoped or global tag at all (firstCommit fallback)", () => {
+    // No matching tag → null, so releaseRangeStart falls back to firstCommit().
+    expect(latestTagVersionFromTags([], "@vinext/cloudflare")).toBeNull();
+    expect(latestTagVersionFromTags(["some-other-tag"], "@vinext/cloudflare")).toBeNull();
   });
 });
 

--- a/scripts/version.mts
+++ b/scripts/version.mts
@@ -27,7 +27,7 @@ import {
   collectReleaseCommits,
   conventionalParts,
   discoverPublishablePackages,
-  tagRefFor,
+  releaseRangeStart,
 } from "./create-changeset.mts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -228,7 +228,11 @@ function main(): void {
       continue;
     }
 
-    const from = tagRefFor(name, before[name]);
+    // Resolve the range from the latest *existing* tag (or first commit when the
+    // package has never been released), matching the changeset generator. Using
+    // before[name] would derive a ref like `v0.0.1` that need not exist — for a
+    // brand-new package that throws and yields an empty changelog (see #1759).
+    const from = releaseRangeStart(name);
     const body = groupedChangelogBody(collectReleaseCommits(from, name, packages));
     const contributors = repository ? resolveContributors(from, repository) : [];
 


### PR DESCRIPTION
## The bug

`scripts/version.mts` generated an **empty** changelog section for any package whose `package.json` version had no matching git tag — a brand-new package got a `## <version>` heading with zero entries and zero contributors.

This happened for real in #1759: the newly added `@vinext/cloudflare` package got an empty `## 1.0.0` section, while `vinext` (which has a real `v0.0.55` tag) got a full changelog.

## Root cause

In `main()`, the commit range was computed from the package's **pre-bump** `package.json` version:

```ts
const from = tagRefFor(name, before[name]);
```

For a never-released package (e.g. `@vinext/cloudflare` at `0.0.1`) there is no `@vinext/cloudflare@0.0.1` tag and no `v0.0.1` tag, so `tagRefFor` falls back to the literal ref `v0.0.1`, which does not exist. `git log v0.0.1..HEAD` throws, the catch returns `[]`, and the changelog body + contributors come out empty.

A new package with no tag is a legitimate "pending first release" state, so the script must support it.

## The fix

Reuse `releaseRangeStart(name)` — the same helper the changeset generator (`scripts/create-changeset.mts`) already uses:

```ts
export function releaseRangeStart(name: string): string {
  const tagVersion = latestTagVersion(name);
  return tagVersion ? tagRefFor(name, tagVersion) : firstCommit();
}
```

`latestTagVersion` returns the highest **existing** tag (scoped `<name>@<version>` or legacy global `v<version>`), and falls back to `firstCommit()` when there is no tag at all. This makes `version.mts` consistent with the generator and resolves a real range for new/untagged packages. The now-unused `tagRefFor` import is dropped from `version.mts`.

The `before` map / bump comparison (`if (!after[name] || after[name] === before[name]) continue;`) is unchanged.

## Tests

Extracted the pure tag-selection logic into `latestTagVersionFromTags(tags, pkgName)` (no git, unit-testable) and added focused tests in `scripts/create-changeset.test.ts` covering: highest scoped tag, legacy global `v` fallback, brand-new package resolving to the latest global tag (the #1759 case), and the no-tag-at-all → `null` (`firstCommit()`) fallback.

```
Test Files  2 passed (2)
      Tests  36 passed (36)
```

## Release impact

Touches `scripts/` only (not `packages/`), so per the repo's auto-changeset path→package logic this affects no publishable package and is release-neutral.

Motivating case: #1759