### PR TITLE
chore: disable package sourcemaps

### DIFF
--- a/packages/cloudflare/vite.config.ts
+++ b/packages/cloudflare/vite.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
     dts: true,
     fixedExtension: false,
     format: "esm",
-    sourcemap: true,
     unbundle: true,
   },
 });

--- a/packages/vinext/vite.config.ts
+++ b/packages/vinext/vite.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
     dts: true,
     fixedExtension: false,
     format: "esm",
-    sourcemap: true,
     unbundle: true,
   },
 });


### PR DESCRIPTION
## Summary

Disable package sourcemap generation for the `vinext` and `@vinext/cloudflare` package builds.

## Why

The package builds run in unbundled mode and already emit readable JavaScript and declaration files. Publishing full sourcemaps adds a large number of `.map` files and significantly increases package size, especially because the maps include source content.

## Size comparison

`vp pack` output:

| Package | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `vinext` | 981 files, 8.43 MB | 660 files, 3.56 MB | -321 files, -4.87 MB (~58% smaller) |
| `@vinext/cloudflare` | 15 files, 75.87 kB | 10 files, 29.48 kB | -5 files, -46.39 kB (~61% smaller) |

`npm pack --dry-run --ignore-scripts` output:

| Package | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `vinext` compressed tarball | 2,176,455 bytes | 875,851 bytes | -1,300,604 bytes (~60% smaller) |
| `vinext` unpacked | 8,432,082 bytes, 984 entries | 3,562,273 bytes, 663 entries | -4,869,809 bytes, -321 entries (~58% smaller) |
| `@vinext/cloudflare` compressed tarball | 22,673 bytes | 10,098 bytes | -12,575 bytes (~55% smaller) |
| `@vinext/cloudflare` unpacked | 78,799 bytes, 18 entries | 32,417 bytes, 13 entries | -46,382 bytes, -5 entries (~59% smaller) |

## Impact

Package tarballs are smaller and no longer include generated sourcemap files. Runtime behavior is unchanged.

## Validation

- `vp pack --sourcemap` in both packages to measure the previous sourcemap-enabled output
- `vp pack` in `packages/vinext` reports `660 files, total: 3.56 MB`
- `vp pack` in `packages/cloudflare` reports `10 files, total: 29.48 kB`
- `npm pack --dry-run --ignore-scripts` in both packages for compressed and unpacked package sizes
- Confirmed no `.map` files remain in the rebuilt package dist directories
- `git diff --check`