### PR TITLE
fix(release): scope changelog contributors to each package's own commits

### DIFF
--- a/scripts/version.mts
+++ b/scripts/version.mts
@@ -185,10 +185,26 @@ function readVersions(packageDirToName: Record<string, string>): Record<string, 
 }
 
 /**
- * GitHub contributor logins for `from..HEAD` via a single (paginated) compare
- * call. Bots are dropped by dedupeSortLogins. Returns [] on any failure.
+ * Pick the deduped, sorted GitHub logins for exactly `commits`, looking each
+ * commit's sha up in a `sha → login` map. Commits with no mapped login (or an
+ * empty one) are dropped. Pure — no git/gh. Bots and non-login shapes are
+ * filtered by dedupeSortLogins.
  */
-function resolveContributors(from: string, repository: string): string[] {
+export function contributorsForCommits(
+  shaToLogin: Map<string, string>,
+  commits: Commit[],
+): string[] {
+  const logins = commits.map((c) => shaToLogin.get(c.sha)).filter((l): l is string => !!l);
+  return dedupeSortLogins(logins);
+}
+
+/**
+ * GitHub contributor logins for exactly `commits` (the same per-package set used
+ * to build the changelog body), not the whole `from..HEAD` range. One paginated
+ * compare call builds a `sha → login` map; only the package's own commits are
+ * then selected. Returns [] on any failure.
+ */
+function resolveContributors(from: string, repository: string, commits: Commit[]): string[] {
   try {
     const out = execFileSync(
       "gh",
@@ -196,14 +212,20 @@ function resolveContributors(from: string, repository: string): string[] {
         "api",
         "--paginate",
         `repos/${repository}/compare/${from}...HEAD`,
-        // Only linked GitHub authors; `// empty` drops commits whose author is
-        // an unlinked email (no valid login to @-mention).
+        // sha/login pairs for the whole range; `// ""` keeps a placeholder for
+        // commits whose author is an unlinked email (no valid login).
         "--jq",
-        ".commits[] | .author.login // empty",
+        '.commits[] | [.sha, (.author.login // "")] | @tsv',
       ],
       { cwd: REPO_ROOT, encoding: "utf8" },
     );
-    return dedupeSortLogins(out.split("\n").filter(Boolean));
+    const shaToLogin = new Map<string, string>();
+    for (const line of out.split("\n")) {
+      if (!line) continue;
+      const [sha, login = ""] = line.split("\t");
+      if (sha && login) shaToLogin.set(sha, login);
+    }
+    return contributorsForCommits(shaToLogin, commits);
   } catch {
     return [];
   }
@@ -233,8 +255,9 @@ function main(): void {
     // before[name] would derive a ref like `v0.0.1` that need not exist — for a
     // brand-new package that throws and yields an empty changelog (see #1759).
     const from = releaseRangeStart(name);
-    const body = groupedChangelogBody(collectReleaseCommits(from, name, packages));
-    const contributors = repository ? resolveContributors(from, repository) : [];
+    const commits = collectReleaseCommits(from, name, packages);
+    const body = groupedChangelogBody(commits);
+    const contributors = repository ? resolveContributors(from, repository, commits) : [];
 
     const original = readFileSync(changelogPath, "utf8");
     const updated = rewriteReleaseSection(original, body, contributors);

--- a/scripts/version.test.ts
+++ b/scripts/version.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import type { Commit } from "./create-changeset.mts";
 import {
+  contributorsForCommits,
   dedupeSortLogins,
   groupedChangelogBody,
   humanizeArea,
@@ -9,6 +10,8 @@ import {
 } from "./version.mts";
 
 const commit = (subject: string): Commit => ({ sha: subject, subject, body: "", files: [] });
+
+const commitSha = (sha: string): Commit => ({ sha, subject: sha, body: "", files: [] });
 
 describe("dedupeSortLogins", () => {
   it("strips @, dedupes case-insensitively, and sorts", () => {
@@ -24,6 +27,42 @@ describe("dedupeSortLogins", () => {
       // @ts-expect-error testing runtime robustness
       dedupeSortLogins(["@x", "", "  ", null, undefined, 5, "dependabot[bot]", "Full Name"]),
     ).toEqual(["x"]);
+  });
+});
+
+describe("contributorsForCommits", () => {
+  it("returns only the authors of the package's own commits", () => {
+    const shaToLogin = new Map([
+      ["a", "alice"],
+      ["b", "bob"],
+      ["c", "carol"], // commit outside this package's set
+    ]);
+    expect(contributorsForCommits(shaToLogin, [commitSha("a"), commitSha("b")])).toEqual([
+      "alice",
+      "bob",
+    ]);
+  });
+
+  it("dedupes across multiple commits by the same author and sorts", () => {
+    const shaToLogin = new Map([
+      ["a", "Bob"],
+      ["b", "alice"],
+      ["c", "bob"],
+    ]);
+    expect(
+      contributorsForCommits(shaToLogin, [commitSha("a"), commitSha("b"), commitSha("c")]),
+    ).toEqual(["alice", "Bob"]);
+  });
+
+  it("drops commits with no mapped login or an empty login", () => {
+    const shaToLogin = new Map([
+      ["a", "alice"],
+      ["b", ""], // empty login
+      // "c" has no mapping at all
+    ]);
+    expect(
+      contributorsForCommits(shaToLogin, [commitSha("a"), commitSha("b"), commitSha("c")]),
+    ).toEqual(["alice"]);
   });
 });
 


### PR DESCRIPTION
## The bug

In the auto-generated Version PR (real example: https://github.com/cloudflare/vinext/pull/1759), each package's CHANGELOG gets a `### Contributors` list that includes **every contributor in the release window**, not just the authors of the commits that actually affected that package. So a package picks up `@`-mentions for people who never touched it — the same union of logins is attached identically to every bumped package.

## Root cause

In `scripts/version.mts`, the changelog **body** is correctly filtered per-package via `collectReleaseCommits(from, name, packages)` (conventional + release-worthy + files map to the package). But `resolveContributors(from, repository)` queried the GitHub compare endpoint for the whole `from..HEAD` range and used **every** commit author in it, ignoring the per-package commit set.

## The fix

Derive contributors from the **same** `collectReleaseCommits` set used to build the changelog body:

- `main()` now captures the per-package commits once (`const commits = collectReleaseCommits(...)`) and feeds that single array to both `groupedChangelogBody(commits)` and contributor resolution (no second `collectReleaseCommits` call).
- `resolveContributors` now builds a `sha → login` map from the compare endpoint (jq `[.sha, (.author.login // "")] | @tsv`) and selects only the logins whose sha is in the package's commit set.
- Pure selection logic is factored into a new exported, side-effect-free helper `contributorsForCommits(shaToLogin, commits)`, unit-tested without git/gh.
- `dedupeSortLogins` (dedupe/sort/bot-filter) is unchanged. Existing resilience preserved: any `gh`/API failure returns `[]`, and the `repository ? ... : []` guard stays.

## Tests

Added focused unit tests for `contributorsForCommits` in `scripts/version.test.ts`: only authors of the package's own commits are returned; authors outside the set are excluded; dedupe across commits by the same author; commits with no/empty login dropped; result sorted. Ran `vp test run scripts/version.test.ts scripts/create-changeset.test.ts` — 35 passed.

This touches only `scripts/`, so it maps to no publishable package (release-neutral).

## Coordination

Independent of #1761 and #1762 but touches the same file (`scripts/version.mts`), so a trivial conflict may need resolving on merge. In particular this PR deliberately leaves the `const from = ...` line as-is to avoid conflicting with #1761's `releaseRangeStart(name)` change.