### PR TITLE
fix(release): stop changesets force-majoring @vinext/cloudflare on every vinext bump

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,8 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
-  "privatePackages": { "version": false, "tag": false }
+  "privatePackages": { "version": false, "tag": false },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -29,7 +29,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "vinext": "workspace:*"
+    "vinext": ">=0.0.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Symptom

In auto-generated Version PRs, `@vinext/cloudflare` is bumped to a **MAJOR** version when it should be a minor (or untouched). Motivating case: [#1759](https://github.com/cloudflare/vinext/pull/1759) bumped it `0.0.1` → **`1.0.0`**.

Worse, this happens on essentially **every** release. Because `vinext` very commonly gets a minor bump, `@vinext/cloudflare` gets force-majored even when it has **zero** changes — so it would march `1.0.0` → `2.0.0` → `3.0.0`… for no real reason.

| Scenario | Before this PR | After this PR |
| --- | --- | --- |
| Combined release (cloudflare's own minor + vinext minor) | cloudflare → `1.0.0` (bogus major) | cloudflare → `0.1.0` (correct minor) |
| vinext-only release (no cloudflare changes) | cloudflare → `1.0.0` (bogus major) | cloudflare **untouched** (`0.0.1`) |

## Root cause

This is stock **changesets** behaviour, not the repo's custom release scripts. Verified empirically with `@changesets/cli@2.31.0`.

`packages/cloudflare/package.json` declares `vinext` as a **peerDependency** with range `workspace:*`:

```json
"peerDependencies": { "vinext": "workspace:*" }
```

Two changesets rules combine to cause the force-major:

1. **`shouldBumpMajor`** (in `@changesets/assemble-release-plan`): when a package's **peer** dependency receives any non-patch bump, the dependent is force-bumped to **major**.
2. Changesets resolves **`workspace:*` as an exact pin** to the dependency's current version, *not* a wildcard (per its own source comments: "workspace:* actually means the current exact version, and not a wildcard").

So any `vinext` version change puts cloudflare "out of range" against its peer pin → force major. Every release.

## Why the simpler fixes don't work

- **`onlyUpdatePeerDependentsWhenOutOfRange: true` alone** — no help while the range is `workspace:*`, because that's an exact pin and is therefore *always* out of range on any vinext change.
- **`workspace:^` / `workspace:~`** — pre-1.0, caret/tilde on `0.x` are strict: any minor is treated as breaking, so the range still breaks on a normal vinext minor.
- **changesets `fixed` / `linked`** — makes it *worse*: the bogus major then propagates onto `vinext` itself too.

## The fix (two parts, both required)

1. **`.changeset/config.json`** — enable the documented changesets knob so peer-dependent bumps respect the declared range instead of force-majoring:

   ```json
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
   ```

2. **`packages/cloudflare/package.json`** — widen the published peer range off the exact pin so normal vinext bumps stay in range:

   ```json
   "peerDependencies": { "vinext": ">=0.0.0" }
   ```

   Pre-1.0 there is no caret/tilde range that tolerates minor bumps (`0.x` treats every minor as breaking), so an open lower bound is the honest contract for a sibling adapter released in lockstep with vinext. A floor like `>=0.0.55` would be equally valid; `>=0.0.0` is used for simplicity.

### Notes

- The peerDependency is **intentionally kept** — only its *published* compatibility range is widened.
- `devDependencies.vinext: "workspace:*"` is **unchanged**, so local workspace linking for builds/typecheck is unaffected. Only the published contract changed.

### Verified outcomes (with `@changesets/cli@2.31.0`)

- Combined release (cloudflare's own minor + vinext minor) → cloudflare **`0.1.0`**.
- vinext-only release → cloudflare **untouched (`0.0.1`)**.
