### PR TITLE
perf(utils): skip path separator replace on POSIX

### DIFF
--- a/packages/vinext/src/utils/path.ts
+++ b/packages/vinext/src/utils/path.ts
@@ -1,3 +1,5 @@
+const isWindows = process.platform === "win32";
+
 /**
  * Convert Windows-style backslash path separators to forward slashes.
  *
@@ -5,7 +7,10 @@
  * statements. On Windows the OS-native paths use `\` which is invalid in JS
  * module specifiers, so every entry generator normalizes paths through this
  * helper before stringifying them into the emitted code.
+ *
+ * No-op on POSIX — skips the regex scan entirely since backslashes never
+ * appear in filesystem paths on Linux/macOS.
  */
 export function normalizePathSeparators(p: string): string {
-  return p.replace(/\\/g, "/");
+  return isWindows ? p.replace(/\\/g, "/") : p;
 }


### PR DESCRIPTION
### Summary

Add an `isWindows` guard to `normalizePathSeparators` so it returns the input unchanged on POSIX instead of running a regex scan.

### Motivation

`normalizePathSeparators` is called on hot paths — static file cache lookups, route discovery, and entry-module import generation. On Linux/macOS, backslashes never appear in filesystem paths, so the `.replace(/\\/g, "/")` always scans the full string and finds nothing. Gating it behind `process.platform === "win32"` makes it a no-op on POSIX while preserving the exact Windows behavior.