### PR TITLE
fix(config): avoid duplicate CJS global shims

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -699,6 +699,8 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       const filenameLiteral = JSON.stringify(normalizedTarget);
       const dirnameLiteral = JSON.stringify(dirname);
       const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
+      const hasOwnDirname = /\b(?:const|let|var)\s+__dirname\b/.test(code);
+      const hasOwnFilename = /\b(?:const|let|var)\s+__filename\b/.test(code);
 
       // Only wire up the wrapper `module` object — and the corresponding
       // named export read by unwrapConfig — when the source statically looks
@@ -717,8 +719,8 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       // any global lookups the source would otherwise perform.
       const preamble =
         `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
-        `const __filename = ${filenameLiteral};\n` +
-        `const __dirname = ${dirnameLiteral};\n` +
+        (hasOwnFilename ? "" : `const __filename = ${filenameLiteral};\n`) +
+        (hasOwnDirname ? "" : `const __dirname = ${dirnameLiteral};\n`) +
         `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
         moduleLines;
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -701,6 +701,7 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
       const hasOwnDirname = /\b(?:const|let|var)\s+__dirname\b/.test(code);
       const hasOwnFilename = /\b(?:const|let|var)\s+__filename\b/.test(code);
+      const hasOwnRequire = /\b(?:const|let|var)\s+require\b/.test(code);
 
       // Only wire up the wrapper `module` object — and the corresponding
       // named export read by unwrapConfig — when the source statically looks
@@ -718,10 +719,12 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       // Preamble runs after ESM imports are hoisted; the const bindings shadow
       // any global lookups the source would otherwise perform.
       const preamble =
-        `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
+        (hasOwnRequire
+          ? ""
+          : `import { createRequire as __vinextCreateRequire } from "node:module";\n`) +
         (hasOwnFilename ? "" : `const __filename = ${filenameLiteral};\n`) +
         (hasOwnDirname ? "" : `const __dirname = ${dirnameLiteral};\n`) +
-        `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
+        (hasOwnRequire ? "" : `const require = __vinextCreateRequire(${requireBaseLiteral});\n`) +
         moduleLines;
 
       return {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -228,6 +228,40 @@ describe("loadNextConfig with CJS globals in next.config.ts", () => {
     expect(config?.env?.VIA).toBe("module.exports");
   });
 
+  it("does not inject __dirname when user already declares it", async () => {
+    // Regression test for https://github.com/cloudflare/vinext/issues/1345.
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { dirname } from "node:path";\n` +
+        `import { fileURLToPath } from "node:url";\n` +
+        `const __dirname = dirname(fileURLToPath(import.meta.url));\n` +
+        `export default { env: { DIR: __dirname } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    const dir = config?.env?.DIR;
+    expect(typeof dir).toBe("string");
+    expect(fs.realpathSync(dir as string)).toBe(fs.realpathSync(tmpDir));
+  });
+
+  it("does not inject __filename when user already declares it", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { fileURLToPath } from "node:url";\n` +
+        `const __filename = fileURLToPath(import.meta.url);\n` +
+        `export default { env: { FILE: __filename } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    const file = config?.env?.FILE;
+    expect(typeof file).toBe("string");
+    expect(fs.realpathSync(file as string)).toBe(
+      fs.realpathSync(path.join(tmpDir, "next.config.ts")),
+    );
+  });
+
   it("loads a pure-ESM next.config.ts without injecting CJS shims", async () => {
     // No __filename / __dirname / require / module / exports references —
     // the injector transform should short-circuit. We only assert

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -262,6 +262,21 @@ describe("loadNextConfig with CJS globals in next.config.ts", () => {
     );
   });
 
+  it("does not inject require when user already declares it", async () => {
+    // The createRequire polyfill commonly appears alongside the __dirname one
+    // and hits the same duplicate-`const` Rolldown crash if injected blindly.
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { createRequire } from "node:module";\n` +
+        `const require = createRequire(import.meta.url);\n` +
+        `export default { env: { HAS_REQUIRE: typeof require } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.HAS_REQUIRE).toBe("function");
+  });
+
   it("loads a pure-ESM next.config.ts without injecting CJS shims", async () => {
     // No __filename / __dirname / require / module / exports references —
     // the injector transform should short-circuit. We only assert


### PR DESCRIPTION
## Description

Fixes bug A from #1345 by skipping vinext's injected next.config.ts `__dirname` / `__filename` shims when the config already declares those identifiers. This intentionally excludes the separate node_modules runtime shim work for bug B.

## Related Issue

Part of #1345

## Potential Risk & Impact

Low. Scope is limited to next.config CJS global injection and preserves existing shim behavior when the identifiers are not user-declared.

## How Has This Been Tested?

- `vp test run tests/next-config.test.ts -t "does not inject"`
- `vp test run tests/next-config.test.ts`
- `vp check`
- `vp test` (7145 passed, 4 skipped)