### PR TITLE
fix(config): guard against duplicate __dirname/__filename injection

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -701,12 +701,15 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
 
       // Skip injecting a shim for identifiers the user already declared.
-      // Without this guard, a config that writes its own ESM polyfill:
+      // Without this guard, a config that writes its own ESM polyfills:
       //   const __dirname = dirname(fileURLToPath(import.meta.url))
-      // would get a duplicate `const __dirname` declaration and Rolldown
-      // would reject the file with a parse error.
+      //   const require = createRequire(import.meta.url)
+      // would get a duplicate `const` declaration and Rolldown would reject
+      // the file with a parse error. These polyfills commonly appear together,
+      // so all three identifiers are guarded the same way.
       const hasOwnDirname = /\b(?:const|let|var)\s+__dirname\b/.test(code);
       const hasOwnFilename = /\b(?:const|let|var)\s+__filename\b/.test(code);
+      const hasOwnRequire = /\b(?:const|let|var)\s+require\b/.test(code);
 
       // Only wire up the wrapper `module` object — and the corresponding
       // named export read by unwrapConfig — when the source statically looks
@@ -724,10 +727,12 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       // Preamble runs after ESM imports are hoisted; the const bindings shadow
       // any global lookups the source would otherwise perform.
       const preamble =
-        `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
+        (hasOwnRequire
+          ? ""
+          : `import { createRequire as __vinextCreateRequire } from "node:module";\n`) +
         (hasOwnFilename ? "" : `const __filename = ${filenameLiteral};\n`) +
         (hasOwnDirname ? "" : `const __dirname = ${dirnameLiteral};\n`) +
-        `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
+        (hasOwnRequire ? "" : `const require = __vinextCreateRequire(${requireBaseLiteral});\n`) +
         moduleLines;
 
       return {

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -700,6 +700,14 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       const dirnameLiteral = JSON.stringify(dirname);
       const requireBaseLiteral = JSON.stringify(path.join(dirname, "package.json"));
 
+      // Skip injecting a shim for identifiers the user already declared.
+      // Without this guard, a config that writes its own ESM polyfill:
+      //   const __dirname = dirname(fileURLToPath(import.meta.url))
+      // would get a duplicate `const __dirname` declaration and Rolldown
+      // would reject the file with a parse error.
+      const hasOwnDirname = /\b(?:const|let|var)\s+__dirname\b/.test(code);
+      const hasOwnFilename = /\b(?:const|let|var)\s+__filename\b/.test(code);
+
       // Only wire up the wrapper `module` object — and the corresponding
       // named export read by unwrapConfig — when the source statically looks
       // like it assigns to module.exports. Pure-ESM configs avoid the extra
@@ -717,8 +725,8 @@ function cjsGlobalsInjectorPlugin(configPath: string): {
       // any global lookups the source would otherwise perform.
       const preamble =
         `import { createRequire as __vinextCreateRequire } from "node:module";\n` +
-        `const __filename = ${filenameLiteral};\n` +
-        `const __dirname = ${dirnameLiteral};\n` +
+        (hasOwnFilename ? "" : `const __filename = ${filenameLiteral};\n`) +
+        (hasOwnDirname ? "" : `const __dirname = ${dirnameLiteral};\n`) +
         `const require = __vinextCreateRequire(${requireBaseLiteral});\n` +
         moduleLines;
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -228,6 +228,41 @@ describe("loadNextConfig with CJS globals in next.config.ts", () => {
     expect(config?.env?.VIA).toBe("module.exports");
   });
 
+  it("does not inject __dirname when user already declares it (no duplicate declaration)", async () => {
+    // Regression test for https://github.com/cloudflare/vinext/issues/1345:
+    // if the injector blindly prepends `const __dirname = ...` onto a file
+    // that already contains `const __dirname = dirname(fileURLToPath(...))`,
+    // Rolldown rejects the file with a duplicate-declaration parse error.
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { dirname } from "node:path";\n` +
+        `import { fileURLToPath } from "node:url";\n` +
+        `const __dirname = dirname(fileURLToPath(import.meta.url));\n` +
+        `export default { env: { DIR: __dirname } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    const dir = config?.env?.DIR;
+    expect(typeof dir).toBe("string");
+    expect((dir as string).length).toBeGreaterThan(0);
+  });
+
+  it("does not inject __filename when user already declares it (no duplicate declaration)", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { fileURLToPath } from "node:url";\n` +
+        `const __filename = fileURLToPath(import.meta.url);\n` +
+        `export default { env: { FILE: __filename } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    const file = config?.env?.FILE;
+    expect(typeof file).toBe("string");
+    expect((file as string).endsWith("next.config.ts")).toBe(true);
+  });
+
   it("loads a pure-ESM next.config.ts without injecting CJS shims", async () => {
     // No __filename / __dirname / require / module / exports references —
     // the injector transform should short-circuit. We only assert

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -245,7 +245,10 @@ describe("loadNextConfig with CJS globals in next.config.ts", () => {
     const config = await loadNextConfig(tmpDir);
     const dir = config?.env?.DIR;
     expect(typeof dir).toBe("string");
-    expect((dir as string).length).toBeGreaterThan(0);
+    // Prove the user's own declaration won rather than the injected shim: the
+    // resolved value must point at the config's own directory. realpathSync on
+    // both sides normalizes the macOS /var -> /private/var symlink.
+    expect(fs.realpathSync(dir as string)).toBe(fs.realpathSync(tmpDir));
   });
 
   it("does not inject __filename when user already declares it (no duplicate declaration)", async () => {
@@ -261,6 +264,21 @@ describe("loadNextConfig with CJS globals in next.config.ts", () => {
     const file = config?.env?.FILE;
     expect(typeof file).toBe("string");
     expect((file as string).endsWith("next.config.ts")).toBe(true);
+  });
+
+  it("does not inject require when user already declares it (no duplicate declaration)", async () => {
+    // The createRequire polyfill commonly appears alongside the __dirname one,
+    // and hits the same duplicate-`const` Rolldown crash if injected blindly.
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.ts"),
+      `import { createRequire } from "node:module";\n` +
+        `const require = createRequire(import.meta.url);\n` +
+        `export default { env: { HAS_REQUIRE: typeof require } };\n`,
+    );
+
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.env?.HAS_REQUIRE).toBe("function");
   });
 
   it("loads a pure-ESM next.config.ts without injecting CJS shims", async () => {


### PR DESCRIPTION
Extracted from #1749 (by @Divkix) as a standalone, focused fix. Closes #1345.

## Problem

`cjsGlobalsInjectorPlugin` (`packages/vinext/src/config/next-config.ts`) unconditionally prepended `const __dirname = ...` and `const __filename = ...` without checking if the user had already declared them. A config file using a common ESM polyfill pattern:

```ts
const __dirname = dirname(fileURLToPath(import.meta.url));
```

would receive a second `const __dirname` declaration, which Rolldown rejects with a duplicate-declaration parse error, crashing the build.

## Fix

Before emitting each preamble line, check for an existing declaration:

```ts
const hasOwnDirname  = /\b(?:const|let|var)\s+__dirname\b/.test(code);
const hasOwnFilename = /\b(?:const|let|var)\s+__filename\b/.test(code);
```

Only inject `const __dirname` / `const __filename` when the user hasn't already declared them.

## Tests

Two new regression tests in `tests/next-config.test.ts`:

- Config file with its own `const __dirname = dirname(fileURLToPath(import.meta.url))` — verifies no duplicate-declaration error.
- Config file with its own `const __filename = fileURLToPath(import.meta.url)` — same.

All 169 `next-config.test.ts` tests pass; `vp check` is clean.

## Credit

This change is extracted from #1749 by @Divkix, which bundled this guard (Bug A) together with a separate node_modules CJS-globals shim (Bug B). This PR isolates the config-file duplicate-declaration guard so it can be reviewed and merged independently. Full credit to @Divkix for the original fix.