### PR TITLE
fix(image): scan image imports via AST instead of regex

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3874,22 +3874,49 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (id.startsWith("\0")) return null;
           if (!id.match(/\.(tsx?|jsx?|mjs)$/)) return null;
 
-          const imageImportRe = new RegExp(
-            `import\\s+(\\w+)\\s+from\\s+['"]([^'"]+\\.(${IMAGE_EXTS}))['"];?`,
-            "g",
-          );
-          if (!imageImportRe.test(code)) return null;
+          // The `code` filter above (a regex) only decides whether to invoke
+          // this handler; it can fire on text inside comments, strings, or
+          // template literals. Scanning must therefore be AST-based so we only
+          // rewrite real `import X from '...'` declarations, not text that
+          // merely looks like one. Regex-based scanning generated phantom
+          // variables for commented-out imports, crashing SSR with
+          // `__vinext_img_url_X is not defined`.
+          const imageExtRe = new RegExp(`\\.(${IMAGE_EXTS})$`);
 
-          imageImportRe.lastIndex = 0;
+          let ast: ReturnType<typeof parseAst>;
+          try {
+            ast = parseAst(code);
+          } catch {
+            // Unparseable input (e.g. unsupported syntax) — leave untouched.
+            return null;
+          }
 
           const s = new MagicString(code);
           let hasChanges = false;
 
-          let match;
-          while ((match = imageImportRe.exec(code)) !== null) {
-            const [fullMatch, varName, importPath] = match;
-            const matchStart = match.index;
-            const matchEnd = matchStart + fullMatch.length;
+          for (const node of ast.body) {
+            if (node.type !== "ImportDeclaration") continue;
+
+            const importNode = node as ASTNode & {
+              start: number;
+              end: number;
+              source?: { value?: unknown };
+              specifiers?: Array<{ type?: string; local?: { name?: string } }>;
+            };
+
+            const importPath = importNode.source?.value;
+            if (typeof importPath !== "string") continue;
+            if (!imageExtRe.test(importPath)) continue;
+
+            // Only handle a single default import (`import X from '...'`),
+            // matching the original behavior. Skip named/namespace imports and
+            // side-effect-only imports (`import '...'`).
+            const specifiers = importNode.specifiers ?? [];
+            if (specifiers.length !== 1) continue;
+            const specifier = specifiers[0];
+            if (specifier.type !== "ImportDefaultSpecifier") continue;
+            const varName = specifier.local?.name;
+            if (!varName) continue;
 
             // Resolve the absolute path of the image
             const dir = path.dirname(id);
@@ -3908,7 +3935,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               `import ${metaVar} from ${JSON.stringify(absImagePath + "?vinext-meta")};\n` +
               `const ${varName} = { src: ${urlVar}, width: ${metaVar}.width, height: ${metaVar}.height };`;
 
-            s.overwrite(matchStart, matchEnd, replacement);
+            s.overwrite(importNode.start, importNode.end, replacement);
             hasChanges = true;
           }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3883,9 +3883,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // `__vinext_img_url_X is not defined`.
           const imageExtRe = new RegExp(`\\.(${IMAGE_EXTS})$`);
 
+          // This plugin uses `enforce: "pre"`, so the handler runs on RAW
+          // source — before the JSX/TS transform. `parseAst` defaults to plain
+          // JavaScript and would throw on JSX or TS type annotations, which
+          // would silently skip image transforms for every `.tsx`/`.jsx`/typed
+          // `.ts` file. Parse as `tsx` so JSX + TS + JS all parse. (The adjacent
+          // `use-cache` plugin avoids this by running after the JSX transform;
+          // we can't, since the import must be rewritten before Vite resolves
+          // the asset.)
           let ast: ReturnType<typeof parseAst>;
           try {
-            ast = parseAst(code);
+            ast = parseAst(code, { lang: "tsx" });
           } catch {
             // Unparseable input (e.g. unsupported syntax) — leave untouched.
             return null;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3887,13 +3887,21 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // source — before the JSX/TS transform. `parseAst` defaults to plain
           // JavaScript and would throw on JSX or TS type annotations, which
           // would silently skip image transforms for every `.tsx`/`.jsx`/typed
-          // `.ts` file. Parse as `tsx` so JSX + TS + JS all parse. (The adjacent
-          // `use-cache` plugin avoids this by running after the JSX transform;
-          // we can't, since the import must be rewritten before Vite resolves
-          // the asset.)
+          // `.ts` file. (The adjacent `use-cache` plugin avoids this by running
+          // after the JSX transform; we can't, since the import must be
+          // rewritten before Vite resolves the asset.)
+          //
+          // Pick the parser language by extension. `.tsx`/`.jsx`/`.js`/`.mjs`
+          // can contain JSX, so parse those as `tsx`. Plain `.ts` files must be
+          // parsed as `ts`: the `tsx` grammar treats `<T>` as the start of a JSX
+          // element, so legitimate TS-only syntax such as angle-bracket casts
+          // (`<Foo>bar`) and non-comma generic arrows (`<T>(x) => x`) would throw
+          // — which the `catch` below would swallow, silently leaving image
+          // imports in those files untransformed.
+          const lang = id.endsWith(".ts") ? "ts" : "tsx";
           let ast: ReturnType<typeof parseAst>;
           try {
-            ast = parseAst(code, { lang: "tsx" });
+            ast = parseAst(code, { lang });
           } catch {
             // Unparseable input (e.g. unsupported syntax) — leave untouched.
             return null;

--- a/tests/image-imports.test.ts
+++ b/tests/image-imports.test.ts
@@ -273,4 +273,43 @@ describe("vinext:image-imports — transform", () => {
     const result = await transform.call(plugin, code, fakeId);
     expect(result).toBeNull();
   });
+
+  // Regression: the plugin runs with `enforce: "pre"`, so the handler sees RAW
+  // source containing JSX and TS type annotations. `parseAst` defaults to plain
+  // JS and throws on that syntax; if the handler swallows the error and returns
+  // null, image imports in every real component silently skip transformation
+  // (hero.src/width/height become undefined). These cases use real TSX/TS
+  // syntax that plain-JS parsing would reject.
+  it("transforms an image import in a TSX component (JSX in body)", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import Image from 'next/image';`,
+      `import hero from './test-4x3.png';`,
+      `export default function Home() {`,
+      `  return <Image src={hero} alt="hero" width={100} height={100} />;`,
+      `}`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, fakeId);
+    expect(result).not.toBeNull();
+    expectImageBinding(result.code, "hero", "test-4x3.png");
+    // JSX is left intact for the downstream JSX transform.
+    expect(result.code).toContain(`<Image src={hero}`);
+  });
+
+  it("transforms an image import in a typed .ts file (type annotations)", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import hero from './test-4x3.png';`,
+      `const count: number = 1;`,
+      `function load(arg: string): void { console.log(arg, count); }`,
+      `console.log(hero);`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, path.join(IMAGES_DIR, "page.ts"));
+    expect(result).not.toBeNull();
+    expectImageBinding(result.code, "hero", "test-4x3.png");
+    // Type annotations are preserved for the downstream TS transform.
+    expect(result.code).toContain(`const count: number = 1;`);
+  });
 });

--- a/tests/image-imports.test.ts
+++ b/tests/image-imports.test.ts
@@ -206,4 +206,71 @@ describe("vinext:image-imports — transform", () => {
     expect(result).not.toBeNull();
     expectImageBinding(result.code, "hero", "test-4x3.png");
   });
+
+  // Regression: a regex-based scanner matched `import X from '...img'` text
+  // anywhere it appeared, including inside comments — even when a real image
+  // existed at that path. This generated `const X = { src: __vinext_img_url_X }`
+  // referencing an undefined `__vinext_img_url_X`, crashing SSR (dev + prod 500).
+  // The scan must be AST-based and only rewrite real ImportDeclaration nodes.
+  it("ignores a commented-out image import (line comment)", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import hero from './test-4x3.png';`,
+      `// import ghost from './test-8x6.jpg';`,
+      `console.log(hero);`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, fakeId);
+    expect(result).not.toBeNull();
+    // The real import is rewritten.
+    expectImageBinding(result.code, "hero", "test-4x3.png");
+    // The commented-out import must not produce any synthesized variables.
+    expect(result.code).not.toContain("__vinext_img_url_ghost");
+    expect(result.code).not.toContain("__vinext_img_meta_ghost");
+    expect(result.code).not.toMatch(/const\s+ghost\s*=/);
+    // The comment is preserved verbatim.
+    expect(result.code).toContain(`// import ghost from './test-8x6.jpg';`);
+  });
+
+  it("ignores a commented-out image import (block comment)", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import hero from './test-4x3.png';`,
+      `/* import ghost from './test-8x6.jpg'; */`,
+      `console.log(hero);`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, fakeId);
+    expect(result).not.toBeNull();
+    expectImageBinding(result.code, "hero", "test-4x3.png");
+    expect(result.code).not.toContain("__vinext_img_url_ghost");
+    expect(result.code).not.toMatch(/const\s+ghost\s*=/);
+  });
+
+  it("ignores image-import text inside a string literal", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import hero from './test-4x3.png';`,
+      `const example = "import ghost from './test-8x6.jpg';";`,
+      `console.log(hero, example);`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, fakeId);
+    expect(result).not.toBeNull();
+    expectImageBinding(result.code, "hero", "test-4x3.png");
+    expect(result.code).not.toContain("__vinext_img_url_ghost");
+    expect(result.code).not.toMatch(/const\s+ghost\s*=/);
+  });
+
+  it("does not transform named or namespace image imports", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    // These are not the `import X from '...'` default form, so they're left as-is.
+    const code = [
+      `import * as ns from './test-4x3.png';`,
+      `import { foo } from './test-8x6.jpg';`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, fakeId);
+    expect(result).toBeNull();
+  });
 });

--- a/tests/image-imports.test.ts
+++ b/tests/image-imports.test.ts
@@ -312,4 +312,36 @@ describe("vinext:image-imports — transform", () => {
     // Type annotations are preserved for the downstream TS transform.
     expect(result.code).toContain(`const count: number = 1;`);
   });
+
+  // Regression: parsing a plain `.ts` file as `tsx` throws on TS-only syntax
+  // because `<T>` is read as the start of a JSX element. The handler swallows
+  // parse errors and returns null, which would silently skip the image
+  // transform (hero.src/width/height become undefined). `.ts` must parse as
+  // `ts`, not `tsx`.
+  it("transforms an image import in a .ts file using an angle-bracket cast", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import hero from './test-4x3.png';`,
+      `const value: unknown = hero;`,
+      `const widened = <{ src: string }>value;`,
+      `console.log(widened.src);`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, path.join(IMAGES_DIR, "cast.ts"));
+    expect(result).not.toBeNull();
+    expectImageBinding(result.code, "hero", "test-4x3.png");
+  });
+
+  it("transforms an image import in a .ts file using a non-comma generic arrow", async () => {
+    const plugin = getImagePlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import hero from './test-4x3.png';`,
+      `const identity = <T>(x: T): T => x;`,
+      `console.log(identity(hero));`,
+    ].join("\n");
+    const result = await transform.call(plugin, code, path.join(IMAGES_DIR, "arrow.ts"));
+    expect(result).not.toBeNull();
+    expectImageBinding(result.code, "hero", "test-4x3.png");
+  });
 });


### PR DESCRIPTION
## Problem

The `vinext:image-imports` transform scanned raw source text with a regex to find local image imports. A regex over raw text matches `import X from '...img'` anywhere the text appears — including inside comments, strings, and template literals.

When a **commented-out** image import points at a file that exists on disk, the transform still matched it and rewrote the span via `MagicString.overwrite()`. The first generated line stayed behind the `//`, but the synthesized meta-import and `const` declaration escaped the comment, producing:

```js
// import AbstractCat from './_images/AbstractCat.webp';
import __vinext_img_meta_AbstractCat from "/abs/.../AbstractCat.webp?vinext-meta";
const AbstractCat = { src: __vinext_img_url_AbstractCat, width: ..., height: ... };
```

`__vinext_img_url_AbstractCat` is never defined (its import is commented out), so SSR throws `ReferenceError: __vinext_img_url_AbstractCat is not defined` — page errors in dev and a 500 on every page in production.

The bug only triggers when all of these hold:
- a real image file exists at the commented-out import path
- at least one real (non-commented) image import exists in the same file
- the commented-out line matches the `import X from '...(image ext)'` pattern

## Fix

Replace the regex scan with AST-based scanning using Vite's `parseAst`. The handler now only rewrites real top-level `ImportDeclaration` nodes that:
- have a source ending in an image extension, and
- use a single default specifier (`import X from '...'`)

Comments, strings, template literals, named/namespace imports, and side-effect-only imports are all correctly ignored. The existing `code` regex filter is retained purely as a cheap pre-check for whether to invoke the handler (false positives there only cost a parse).

## Tests

Added regression cases to `tests/image-imports.test.ts`:
- commented-out image import (line comment) — the original failure
- commented-out image import (block comment)
- image-import text inside a string literal
- named/namespace image imports are left untransformed

All 22 tests in the file pass; `vp check` is clean.