### PR TITLE
fix(font): resolve next/font/local paths inside node_modules packages

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3924,7 +3924,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Google Fonts import rewrite + self-hosting — see src/plugins/fonts.ts
     createGoogleFontsPlugin(_fontGoogleShimPath, _shimsDir),
     // Local font path resolution — see src/plugins/fonts.ts
-    createLocalFontsPlugin(),
+    createLocalFontsPlugin(_shimsDir),
     // Barrel import optimization:
     // Rewrites `import { Slot } from "radix-ui"` → `import * as Slot from "@radix-ui/react-slot"`
     // for packages listed in optimizePackageImports or DEFAULT_OPTIMIZE_PACKAGES.

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -1120,21 +1120,32 @@ export function createLocalFontsPlugin(): Plugin {
     enforce: "pre",
 
     transform: {
+      // NOTE: node_modules is intentionally NOT excluded here. npm packages
+      // commonly wrap `next/font/local` and ship the font files alongside the
+      // module (e.g. `geist/dist/mono.js` calls
+      // `localFont({ src: "./fonts/geist-mono/GeistMono-Variable.woff2" })`).
+      // Those relative `src` paths are resolved against the package's own
+      // directory and must be promoted to Vite asset imports just like a user's
+      // source files, otherwise the runtime `@font-face` references the raw
+      // relative path and the font 404s. Next.js's font loader runs on these
+      // package files too, so vinext must as well. The `code` filter plus the
+      // default-import check below keep this from touching unrelated modules.
       filter: {
         id: {
           include: /\.(tsx?|jsx?|mjs)$/,
-          exclude: /node_modules/,
         },
         code: "next/font/local",
       },
       handler(code, id) {
         // Defensive guards — duplicate filter logic
-        if (id.includes("node_modules")) return null;
         if (id.startsWith("\0")) return null;
         if (!id.match(/\.(tsx?|jsx?|mjs)$/)) return null;
         if (!code.includes("next/font/local")) return null;
         // Skip vinext's own font-local shim — it contains example paths
-        // in comments that would be incorrectly rewritten.
+        // in comments that would be incorrectly rewritten. When vinext is
+        // installed as a dependency this lives under
+        // `node_modules/vinext/.../shims/font-local.*`, so the guard must run
+        // even though node_modules is no longer excluded above.
         if (id.includes("font-local")) return null;
 
         // Verify there's actually a default import from next/font/local and

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -1113,8 +1113,19 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
  * Rewrites relative font file paths in `next/font/local` calls into Vite
  * asset import references so that both dev (/@fs/...) and prod
  * (/assets/font-xxx.woff2) URLs resolve correctly.
+ *
+ * @param shimsDir - Absolute path to the shims directory (with trailing
+ *   separator). Used to skip vinext's own shim files from transform — they
+ *   contain example `next/font/local` paths in comments that must not be
+ *   rewritten. A precise prefix check is required (rather than a loose
+ *   substring match) because, now that `node_modules` is no longer excluded,
+ *   the guard runs against arbitrary third-party package paths — some of
+ *   which may legitimately contain the substring `font-local` (e.g. a
+ *   package named `font-local-loader`) and must still be transformed. This
+ *   mirrors `createGoogleFontsPlugin`, which takes `shimsDir` for the same
+ *   reason.
  */
-export function createLocalFontsPlugin(): Plugin {
+export function createLocalFontsPlugin(shimsDir: string): Plugin {
   return {
     name: "vinext:local-fonts",
     enforce: "pre",
@@ -1141,12 +1152,13 @@ export function createLocalFontsPlugin(): Plugin {
         if (id.startsWith("\0")) return null;
         if (!id.match(/\.(tsx?|jsx?|mjs)$/)) return null;
         if (!code.includes("next/font/local")) return null;
-        // Skip vinext's own font-local shim — it contains example paths
-        // in comments that would be incorrectly rewritten. When vinext is
-        // installed as a dependency this lives under
-        // `node_modules/vinext/.../shims/font-local.*`, so the guard must run
-        // even though node_modules is no longer excluded above.
-        if (id.includes("font-local")) return null;
+        // Skip vinext's own shim files — the font-local shim contains example
+        // paths in comments that would be incorrectly rewritten. A precise
+        // prefix check against `shimsDir` (not a loose `id.includes("font-local")`
+        // substring) is required now that node_modules is no longer excluded,
+        // so legitimate third-party packages whose path happens to contain
+        // `font-local` are still transformed. Mirrors `createGoogleFontsPlugin`.
+        if (id.startsWith(shimsDir)) return null;
 
         // Verify there's actually a default import from next/font/local and
         // remember its local binding so family payloads only attach to real

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -1,9 +1,18 @@
 import { describe, it, expect } from "vite-plus/test";
+import path from "node:path";
 import vinext from "../packages/vinext/src/index.js";
 import localFont, { getSSRFontStyles } from "../packages/vinext/src/shims/font-local.js";
 import type { Plugin } from "vite-plus";
 
 // ── Helpers ───────────────────────────────────────────────────
+
+// Absolute path to vinext's own font-local shim — the plugin guards against
+// rewriting any file under its shims directory via a prefix check, so tests
+// that exercise the guard must use the real resolved path.
+const FONT_LOCAL_SHIM_PATH = path.resolve(
+  import.meta.dirname,
+  "../packages/vinext/src/shims/font-local.ts",
+);
 
 /** Unwrap a Vite plugin hook that may use the object-with-filter format */
 function unwrapHook(hook: any): Function {
@@ -59,19 +68,34 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.code).toContain(`_vinext: { font: { family: "GeistMono" } }`);
   });
 
-  it("still skips vinext's own font-local shim inside node_modules", () => {
-    // When vinext is installed as a dependency the shim lives under
-    // node_modules/vinext/.../shims/font-local.js. It must never be rewritten
-    // (it contains example paths in comments).
+  it("skips vinext's own font-local shim (it has example paths in comments)", () => {
+    // The shim must never be rewritten. The guard is a prefix check against the
+    // resolved shims directory, so use the real shim path.
     const plugin = getLocalFontsPlugin();
     const transform = unwrapHook(plugin.transform);
     const code = `import localFont from 'next/font/local';\nconst f = localFont({ src: './font.woff2' });`;
+    const result = transform.call(plugin, code, FONT_LOCAL_SHIM_PATH);
+    expect(result).toBeNull();
+  });
+
+  it("transforms third-party packages whose path contains 'font-local'", () => {
+    // Guard against a loose substring match regressing the fix: a real package
+    // named `font-local-loader` (or one shipping fonts under a `font-local/`
+    // dir) must still be transformed. Only vinext's own shims directory is
+    // skipped, via a precise prefix check.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `export const Custom = localFont({ src: './font-local/Custom.woff2' });`,
+    ].join("\n");
     const result = transform.call(
       plugin,
       code,
-      "/proj/node_modules/vinext/dist/shims/font-local.js",
+      "/proj/node_modules/font-local-loader/dist/index.js",
     );
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./font-local/Custom.woff2");
   });
 
   it("returns null for virtual modules", () => {

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -37,11 +37,40 @@ describe("vinext:local-fonts plugin", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null for node_modules files", () => {
+  it("transforms node_modules packages that wrap next/font/local", () => {
+    // Regression: npm packages like `geist` ship their own font files and call
+    // localFont() with paths relative to the package's dist/ directory. The
+    // transform previously excluded node_modules, so the raw relative path
+    // (e.g. "./fonts/geist-mono/GeistMono-Variable.woff2") leaked into the
+    // runtime @font-face src and 404'd. Next.js's font loader runs on these
+    // package files, so vinext must too.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `export const GeistMono = localFont({`,
+      `  src: './fonts/geist-mono/GeistMono-Variable.woff2',`,
+      `  variable: '--font-geist-mono',`,
+      `});`,
+    ].join("\n");
+    const result = transform.call(plugin, code, "/proj/node_modules/geist/dist/mono.js");
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./fonts/geist-mono/GeistMono-Variable.woff2");
+    expect(result.code).toContain(`_vinext: { font: { family: "GeistMono" } }`);
+  });
+
+  it("still skips vinext's own font-local shim inside node_modules", () => {
+    // When vinext is installed as a dependency the shim lives under
+    // node_modules/vinext/.../shims/font-local.js. It must never be rewritten
+    // (it contains example paths in comments).
     const plugin = getLocalFontsPlugin();
     const transform = unwrapHook(plugin.transform);
     const code = `import localFont from 'next/font/local';\nconst f = localFont({ src: './font.woff2' });`;
-    const result = transform.call(plugin, code, "node_modules/some-pkg/index.ts");
+    const result = transform.call(
+      plugin,
+      code,
+      "/proj/node_modules/vinext/dist/shims/font-local.js",
+    );
     expect(result).toBeNull();
   });
 


### PR DESCRIPTION
## Problem

vinext's `localFont` shim works (CSS classes + `@font-face` are generated), but for npm packages that wrap `next/font/local` the font file URL was the **raw relative path** from the package module rather than a Vite-resolvable URL.

For example, `geist/dist/mono.js` calls:

```js
import localFont from "next/font/local";
export const GeistMono = localFont({
  src: "./fonts/geist-mono/GeistMono-Variable.woff2",
  variable: "--font-geist-mono",
});
```

The generated `@font-face { src: url(...) }` referenced `./fonts/geist-mono/GeistMono-Variable.woff2` (relative to the package's `dist/` dir), which 404s at request time.

## Root cause

`createLocalFontsPlugin` (`packages/vinext/src/plugins/fonts.ts`) excluded `node_modules` files — both via the filter (`filter.id.exclude: /node_modules/`) and a defensive `if (id.includes("node_modules")) return null;` guard. So the transform that promotes relative `src` paths to Vite asset imports never ran on package files. This affects **any** npm package wrapping `next/font/local`.

## Fix

Remove the `node_modules` exclusion from both the filter and the defensive guard so package files are transformed like user source — matching Next.js, whose font loader also runs on these package files. The `code: "next/font/local"` filter plus the required default-import check keep the transform from touching unrelated modules, and the `font-local` shim guard still skips vinext's own shim when it lives under `node_modules/vinext/.../shims/font-local.*`.

## Verification

- Reproduced at the unit level: the transform previously returned `null` for a `node_modules/geist/dist/mono.js` id.
- Verified end-to-end with a synthetic `node_modules` font package built through the full App Router pipeline: before the fix the relative path leaked; after the fix the font is emitted as a hashed asset (`_next/static/MyMono-Variable-<hash>.woff2`) and the raw relative path no longer appears in any bundle. (The App Router renders the package server-side via `noExternal`, so the asset import resolves rather than being bypassed by the dep optimizer.)

## Tests

- Replaced the test that encoded the buggy behavior (`returns null for node_modules files`) with a regression test asserting geist-style `node_modules` packages are transformed.
- Added a test confirming vinext's own `font-local` shim is still skipped inside `node_modules`.
- All 37 font-local tests and 1058 shim tests pass; `vp check` is clean.