### PR TITLE
fix(test): package workspace deps in deploy harness

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -285,6 +285,9 @@ const rootPkg = JSON.parse(fs.readFileSync(path.join(vinextDir, 'package.json'),
 const vinextPkg = JSON.parse(
   fs.readFileSync(path.join(vinextDir, 'packages', 'vinext', 'package.json'), 'utf8'),
 )
+const cloudflarePkg = JSON.parse(
+  fs.readFileSync(path.join(vinextDir, 'packages', 'cloudflare', 'package.json'), 'utf8'),
+)
 const workspaceConfig = fs.readFileSync(
   path.join(vinextDir, 'pnpm-workspace.yaml'),
   'utf8',
@@ -324,6 +327,15 @@ function parseCatalog(yaml) {
 }
 
 const catalog = parseCatalog(workspaceConfig)
+const localCloudflarePkgDir = path.join(process.cwd(), '.vinext-local-cloudflare-package')
+
+function workspaceDependencySpecFor(name) {
+  if (name === cloudflarePkg.name) {
+    return 'file:../.vinext-local-cloudflare-package'
+  }
+
+  throw new Error(`Unable to resolve workspace dependency spec for ${name}`)
+}
 
 function dependencySpecFor(name) {
   for (const deps of [
@@ -335,6 +347,7 @@ function dependencySpecFor(name) {
   ]) {
     const spec = deps?.[name]
     if (!spec) continue
+    if (spec.startsWith('workspace:')) return workspaceDependencySpecFor(name)
     if (spec !== 'catalog:') return spec
     if (catalog[name]) return catalog[name]
   }
@@ -352,14 +365,42 @@ function resolveManifestDeps(deps) {
   return Object.fromEntries(
     Object.entries(deps).map(([name, spec]) => [
       name,
-      spec === 'catalog:' ? dependencySpecFor(name) : spec,
+      spec === 'catalog:' || spec.startsWith('workspace:') ? dependencySpecFor(name) : spec,
     ]),
   )
 }
 
 const localVinextPkgDir = path.join(process.cwd(), '.vinext-local-package')
 fs.rmSync(localVinextPkgDir, { recursive: true, force: true })
+fs.rmSync(localCloudflarePkgDir, { recursive: true, force: true })
 fs.mkdirSync(localVinextPkgDir, { recursive: true })
+fs.mkdirSync(localCloudflarePkgDir, { recursive: true })
+fs.cpSync(
+  path.join(vinextDir, 'packages', 'cloudflare', 'dist'),
+  path.join(localCloudflarePkgDir, 'dist'),
+  {
+    recursive: true,
+  },
+)
+fs.writeFileSync(
+  path.join(localCloudflarePkgDir, 'package.json'),
+  JSON.stringify(
+    {
+      name: cloudflarePkg.name,
+      version: cloudflarePkg.version,
+      description: cloudflarePkg.description,
+      license: cloudflarePkg.license,
+      repository: cloudflarePkg.repository,
+      type: cloudflarePkg.type,
+      files: ['dist'],
+      exports: cloudflarePkg.exports,
+      peerDependencies: resolveManifestDeps(cloudflarePkg.peerDependencies),
+      engines: cloudflarePkg.engines,
+    },
+    null,
+    2,
+  ) + '\n',
+)
 fs.cpSync(path.join(vinextDir, 'packages', 'vinext', 'dist'), path.join(localVinextPkgDir, 'dist'), {
   recursive: true,
 })


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Keep Next.js deploy-suite temp app installs self-contained when local vinext depends on workspace packages. |
| Core change | Copy the built `@vinext/cloudflare` package into the temp app and rewrite `workspace:*` in the generated local `vinext` package manifest to a sibling `file:` dependency. |
| Primary file | `scripts/e2e-deploy.sh` |
| Impact | Deploy-suite fixtures can install the throwaway local `vinext` package outside the monorepo workspace. |

## Why

The deploy harness runs inside isolated Next.js fixture directories, not inside the vinext pnpm workspace. Any generated package manifest installed there must only contain dependency specs that the fixture package manager can resolve locally or from the registry. A raw `workspace:*` dependency violates that boundary and causes `pnpm install` to fail before the upstream test behaviour can run.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Local `vinext` package has `@vinext/cloudflare: workspace:*` | Temp app install fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. | Harness creates `.vinext-local-cloudflare-package` from `packages/cloudflare/dist` and points the generated `vinext` manifest at it. |
| Unknown future workspace dependency | Could leak into the temp manifest silently. | Fails explicitly through `workspaceDependencySpecFor()` unless the harness knows how to package it. |

## Validation

- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts`
- Result: harness install and deployment now succeed. The suite reaches the known behavioural `searchParams` assertions, which are being handled separately.

## References

| Link | Why it matters |
| --- | --- |
| https://github.com/cloudflare/vinext/blob/main/scripts/e2e-deploy.sh | Deploy harness that generates the throwaway local package manifest. |
| https://pnpm.io/workspaces#workspace-protocol-workspace | `workspace:` specs are workspace-local and are not resolvable from isolated temp fixture apps. |
| https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts | Reproduction suite that now gets past fixture install and reaches behavioural assertions. |

## Non-goals

This PR does not fix the `searchParams` rendering behaviour. It only restores the deploy-suite harness so those failures can be reproduced and fixed in a separate PR.