### PR TITLE
fix(app-router): track searchParams access for static bailout

### DIFF
--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -165,7 +165,6 @@ export async function buildPageElements<
   }
 
   const {
-    hasSearchParams,
     hasDynamicMetadata,
     metadata: resolvedMetadata,
     pageSearchParams,
@@ -193,11 +192,12 @@ export async function buildPageElements<
 
   const pageProps: Record<string, unknown> = { params: makeThenableParams(params) };
   if (searchParams) {
-    pageProps.searchParams = makeThenableParams(pageSearchParams);
-    if (hasSearchParams) {
-      markDynamicUsage();
-      markRenderRequestApiUsage("searchParams");
-    }
+    pageProps.searchParams = makeThenableParams(pageSearchParams, {
+      observeParamAccess() {
+        markDynamicUsage();
+        markRenderRequestApiUsage("searchParams");
+      },
+    });
   }
 
   const mountedSlotIds = mountedSlotsHeader ? new Set(mountedSlotsHeader.split(" ")) : null;

--- a/packages/vinext/src/shims/thenable-params.ts
+++ b/packages/vinext/src/shims/thenable-params.ts
@@ -94,6 +94,10 @@ function isPromiseContinuation(prop: PropertyKey): boolean {
   return prop === "then" || prop === "catch" || prop === "finally";
 }
 
+function isReactPromiseStatusRead(prop: PropertyKey): boolean {
+  return prop === "status";
+}
+
 export function makeThenableParams<T extends Record<string, unknown>>(
   obj: T,
   observer?: ThenableParamsObserver,
@@ -107,6 +111,11 @@ export function makeThenableParams<T extends Record<string, unknown>>(
   // the boundary so the handler above stays fully type-checked.
   return new Proxy(promise, {
     get(target, prop, receiver) {
+      if (isReactPromiseStatusRead(prop)) {
+        observeAllParamKeys(observer, plain);
+        return Reflect.get(target, prop, receiver);
+      }
+
       if (isPromiseContinuation(prop)) {
         const value = Reflect.get(target, prop, receiver);
         if (typeof value !== "function") return value;

--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -285,6 +285,9 @@ const rootPkg = JSON.parse(fs.readFileSync(path.join(vinextDir, 'package.json'),
 const vinextPkg = JSON.parse(
   fs.readFileSync(path.join(vinextDir, 'packages', 'vinext', 'package.json'), 'utf8'),
 )
+const cloudflarePkg = JSON.parse(
+  fs.readFileSync(path.join(vinextDir, 'packages', 'cloudflare', 'package.json'), 'utf8'),
+)
 const workspaceConfig = fs.readFileSync(
   path.join(vinextDir, 'pnpm-workspace.yaml'),
   'utf8',
@@ -324,6 +327,15 @@ function parseCatalog(yaml) {
 }
 
 const catalog = parseCatalog(workspaceConfig)
+const localCloudflarePkgDir = path.join(process.cwd(), '.vinext-local-cloudflare-package')
+
+function workspaceDependencySpecFor(name) {
+  if (name === cloudflarePkg.name) {
+    return 'file:../.vinext-local-cloudflare-package'
+  }
+
+  throw new Error(`Unable to resolve workspace dependency spec for ${name}`)
+}
 
 function dependencySpecFor(name) {
   for (const deps of [
@@ -335,6 +347,7 @@ function dependencySpecFor(name) {
   ]) {
     const spec = deps?.[name]
     if (!spec) continue
+    if (spec.startsWith('workspace:')) return workspaceDependencySpecFor(name)
     if (spec !== 'catalog:') return spec
     if (catalog[name]) return catalog[name]
   }
@@ -352,14 +365,42 @@ function resolveManifestDeps(deps) {
   return Object.fromEntries(
     Object.entries(deps).map(([name, spec]) => [
       name,
-      spec === 'catalog:' ? dependencySpecFor(name) : spec,
+      spec === 'catalog:' || spec.startsWith('workspace:') ? dependencySpecFor(name) : spec,
     ]),
   )
 }
 
 const localVinextPkgDir = path.join(process.cwd(), '.vinext-local-package')
 fs.rmSync(localVinextPkgDir, { recursive: true, force: true })
+fs.rmSync(localCloudflarePkgDir, { recursive: true, force: true })
 fs.mkdirSync(localVinextPkgDir, { recursive: true })
+fs.mkdirSync(localCloudflarePkgDir, { recursive: true })
+fs.cpSync(
+  path.join(vinextDir, 'packages', 'cloudflare', 'dist'),
+  path.join(localCloudflarePkgDir, 'dist'),
+  {
+    recursive: true,
+  },
+)
+fs.writeFileSync(
+  path.join(localCloudflarePkgDir, 'package.json'),
+  JSON.stringify(
+    {
+      name: cloudflarePkg.name,
+      version: cloudflarePkg.version,
+      description: cloudflarePkg.description,
+      license: cloudflarePkg.license,
+      repository: cloudflarePkg.repository,
+      type: cloudflarePkg.type,
+      files: ['dist'],
+      exports: cloudflarePkg.exports,
+      peerDependencies: resolveManifestDeps(cloudflarePkg.peerDependencies),
+      engines: cloudflarePkg.engines,
+    },
+    null,
+    2,
+  ) + '\n',
+)
 fs.cpSync(path.join(vinextDir, 'packages', 'vinext', 'dist'), path.join(localVinextPkgDir, 'dist'), {
   recursive: true,
 })

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -422,7 +422,7 @@ describe("buildPageElements", () => {
     ).rejects.toThrow("App Router slot id mismatch");
   });
 
-  it("calls markDynamicUsage when search params have content", async () => {
+  it("calls markDynamicUsage when the page awaits searchParams, even when the query is empty", async () => {
     function SearchPage(): React.ReactNode {
       return React.createElement("div", null, "Search");
     }
@@ -434,19 +434,30 @@ describe("buildPageElements", () => {
       pattern: "/search",
     });
 
-    await buildPageElements(
+    const result = await buildPageElements(
       createBaseOptions({
         route,
         routePath: "/search",
-        searchParams: new URLSearchParams("q=test"),
+        searchParams: new URLSearchParams(""),
       }),
     );
+    const record = result as Record<string, unknown>;
+    const pageElement = record["page:/search"];
+    expect(
+      React.isValidElement<{ searchParams?: Promise<Record<string, unknown>> }>(pageElement),
+    ).toBe(true);
+
+    if (!React.isValidElement<{ searchParams?: Promise<Record<string, unknown>> }>(pageElement)) {
+      throw new Error("Expected page element");
+    }
+
+    await pageElement.props.searchParams;
 
     expect(markDynamicUsageMock).toHaveBeenCalled();
     expect(markRenderRequestApiUsageMock).toHaveBeenCalledWith("searchParams");
   });
 
-  it("does NOT call markDynamicUsage when search params are empty", async () => {
+  it("does NOT call markDynamicUsage just because the request query has content", async () => {
     function NoSearchPage(): React.ReactNode {
       return React.createElement("div", null, "No Search");
     }
@@ -462,7 +473,7 @@ describe("buildPageElements", () => {
       createBaseOptions({
         route,
         routePath: "/no-search",
-        searchParams: new URLSearchParams(""),
+        searchParams: new URLSearchParams("q=test"),
       }),
     );
 


### PR DESCRIPTION
## Overview

| Area | Detail |
| --- | --- |
| Goal | Match Next.js App Router static bailout behavior when a page consumes `searchParams`. |
| Core change | Classify `searchParams` as dynamic when the page prop is actually read or awaited, not when the incoming query string happens to contain keys. |
| Main boundary | App Router prerender/static generation classification for page props. |
| Primary files | `packages/vinext/src/server/app-page-element-builder.ts`, `packages/vinext/src/shims/thenable-params.ts`, `tests/app-page-element-builder.test.ts` |
| Expected impact | Routes that consume `searchParams` no longer seed empty-query static output and serve it for queryful requests. Routes that ignore `searchParams` are not forced dynamic just because a request has a query string. |

This PR is stacked on #1786 for the deploy harness packaging fix. For behavior review, start at commit `25ef0426` after `c1bf9b4e`.

## Why

For App Router static classification to be correct, the dynamic signal must describe what the route consumed during prerender, not incidental request shape. Next.js passes `searchParams` as an instrumented page prop and bails out when that prop is consumed. Vinext was instead using whether the query string had entries, which misses empty-query prerenders for pages that await `searchParams` and over-classifies pages that ignore it.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Server page props | Dynamic request APIs are usage-based contracts. | `searchParams` now observes access through the thenable prop and marks dynamic usage at the point of consumption. |
| React `use(searchParams)` | React may inspect promise status before reading the fulfilled value. | The thenable observer also treats `status` reads as consumption so client component `use(searchParams)` participates in the same bailout path. |
| Static pages | Query string presence alone is not a route dependency. | Pages that receive but ignore `searchParams` are no longer marked dynamic solely because `?q=...` exists. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Server Component awaits `searchParams` during empty-query prerender | Classified static, cached `Parameter: ` output. | Classified dynamic when `searchParams` is awaited. |
| Client Component uses `use(searchParams)` | The bailout could be missed because the prerender query had no keys. | The thenable status read marks `searchParams` usage. |
| Page ignores `searchParams` with a queryful request | Classified dynamic because the URL had search params. | Remains static unless the prop is consumed. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-page-element-builder.ts`: verify the page prop observer is wired where the page element is created and no longer uses query-string content as the bailout signal.
2. `packages/vinext/src/shims/thenable-params.ts`: verify `await searchParams`, direct property reads, and React promise status reads all notify the observer without changing the public thenable shape.
3. `tests/app-page-element-builder.test.ts`: verify the regression covers both sides of the contract: empty-query prop consumption bails out, queryful non-consumption does not.

</details>

<details>
<summary>Validation</summary>

- `vp check --fix packages/vinext/src/server/app-page-element-builder.ts packages/vinext/src/shims/thenable-params.ts tests/app-page-element-builder.test.ts`
- `vp test run tests/app-page-element-builder.test.ts`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts`

The upstream deploy-suite file passes all 5 tests, including the three previously failing `searchParams` bailout cases.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no API shape change. `searchParams` remains a thenable object.
- Runtime: narrows dynamic bailout to real prop consumption and adds React `use()` compatibility for status inspection.
- Cache/static behavior: intended behavior change for routes that consume `searchParams`, preventing stale empty-query static output from being served for queryful requests.
- Non-goal: this does not address unrelated `app-static` failures outside the `searchparams-static-bailout` candidate scope.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js searchparams-static-bailout test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts) | Upstream observable contract being ported through the deploy harness. |
| [Server Component fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/searchparams-static-bailout/app/server-component-page/page.tsx) | Shows `await searchParams` must trigger bailout even for an empty prerender query. |
| [Client Component page fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/searchparams-static-bailout/app/client-component-page/page.tsx) | Shows `use(searchParams)` inside a client page must trigger the same bailout. |
| [Server page passing searchParams to client component](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/searchparams-static-bailout/app/client-component/page.tsx) | Covers forwarding the page prop into a client component. |
| [Client component consumer](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/searchparams-static-bailout/app/client-component/component.tsx) | Shows the forwarded prop is consumed with React `use()`. |
| [Next.js page prop creation](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/app-render/create-component-tree.tsx) | Source reference for passing query-derived `searchParams` into App Router page props. |
| [Next.js searchParams instrumentation](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/request/search-params.ts) | Source reference for instrumenting `searchParams` access during prerender. |
| [Next.js page `searchParams` docs](https://nextjs.org/docs/app/api-reference/file-conventions/page#searchparams-optional) | Public API contract for the page prop. |
