### PR TITLE
test(pages-router): wait for hydration after middleware redirect

### DIFF
--- a/tests/e2e/pages-router/middleware.spec.ts
+++ b/tests/e2e/pages-router/middleware.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForHydration } from "../helpers";
 
 const BASE = "http://localhost:4173";
 
@@ -70,6 +71,7 @@ test.describe("Middleware (Pages Router)", () => {
     // After redirect from /old-page to /about, verify the page is fully functional
     await page.goto(`${BASE}/old-page`);
     await expect(page.locator("h1")).toHaveText("About");
+    await waitForHydration(page);
 
     // The about page should have a link back to home
     const homeLink = page.locator('a[href="/"]');


### PR DESCRIPTION
## Overview

Fixes #1770 by making the Pages Router middleware redirect E2E test wait for the shared hydration marker before asserting client-side Link navigation from the redirected target page.

## Why

The test used a window marker to prove the `/about -> /` click stayed in the same document. Seeing the redirected `/about` heading proves SSR content is present, but it does not prove the Pages Router Link click handler has hydrated. If Playwright clicks before hydration, the raw anchor can perform a full document navigation and clear the marker.

## What changed

- Imported `waitForHydration` in `tests/e2e/pages-router/middleware.spec.ts`.
- Waited for hydration after `/old-page` redirects to `/about` and before setting `window.__NAV_MARKER__` / clicking the home link.

## Validation

- `vp install`
- `vp check tests/e2e/pages-router/middleware.spec.ts`
- `PLAYWRIGHT_PROJECT=pages-router npx playwright test tests/e2e/pages-router/middleware.spec.ts --project=pages-router`

## Notes

Searched the local Next.js reference tests for the same marker shape and middleware redirect navigation coverage. I did not find an exact Pages Router equivalent; this follows the existing vinext Pages Router navigation tests, which wait for hydration before marker-based client navigation assertions.