### PR TITLE
fix(image-imports): normalize meta specifier separators on Windows

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -168,6 +168,7 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import { randomBytes, randomUUID } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
+import { normalizePathSeparators } from "./utils/path.js";
 
 // Install the process-level peer-disconnect backstop at module load.
 // Vite plugin lifecycle hooks (config / configureServer) proved
@@ -3891,9 +3892,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             const matchStart = match.index;
             const matchEnd = matchStart + fullMatch.length;
 
-            // Resolve the absolute path of the image
+            // Resolve the absolute path of the image. Normalize separators
+            // since the path is embedded in the ESM module specifier below,
+            // which should use forward slashes. fs accepts them on Windows,
+            // so existsSync still works.
             const dir = path.dirname(id);
-            const absImagePath = path.resolve(dir, importPath);
+            const absImagePath = normalizePathSeparators(path.resolve(dir, importPath));
 
             if (!fs.existsSync(absImagePath)) continue;
 

--- a/tests/image-imports.test.ts
+++ b/tests/image-imports.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vite-plus/test";
 import path from "node:path";
 import vinext from "../packages/vinext/src/index.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 import type { Plugin } from "vite-plus";
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -105,7 +106,10 @@ describe("vinext:image-imports — transform", () => {
   function expectImageBinding(code: string, name: string, fileBasename: string) {
     expect(code).not.toMatch(new RegExp(`import\\s+${name}\\s+from`));
     expect(code).toMatch(new RegExp(`const\\s+${name}\\s*=\\s*\\{[^}]*src\\s*:`));
-    expect(code).toContain(path.join(IMAGES_DIR, fileBasename) + "?vinext-meta");
+    // The meta import specifier uses forward slashes — the transform normalizes
+    // the resolved path so generated output is consistent across platforms.
+    const metaSpecifier = normalizePathSeparators(path.join(IMAGES_DIR, fileBasename));
+    expect(code).toContain(metaSpecifier + "?vinext-meta");
   }
 
   it("transforms a PNG import into StaticImageData", async () => {


### PR DESCRIPTION
### Summary

- Normalize the resolved image path with `normalizePathSeparators` before embedding it in the `?vinext-meta` import specifier.
- Update the `image-imports` test to assert the forward-slash specifier, using the same helper.

### Background

The `vinext:image-imports` transform rewrites `import hero from './x.png'` into a URL import plus a `?vinext-meta` import that carries the image dimensions. The meta import embeds the resolved absolute path:

```js
import __vinext_img_meta_hero from "E:\\...\\x.png?vinext-meta"; // Windows, before
import __vinext_img_meta_hero from "E:/.../x.png?vinext-meta"; // after
```

On Windows `path.resolve` produces backslashes, so the generated specifier used backslashes — inconsistent with POSIX output and against the ESM convention that module specifiers use forward slashes.

### Note

This is a consistency/robustness fix, not a crash fix. Verified against a real Vite build: a backslash specifier is passed to `resolveId` unchanged (Vite does not normalize it), and the plugin's slash-agnostic `resolveId`/`load` plus Node's `fs` (which accepts forward slashes on Windows) handle it either way. Normalizing keeps generated output identical across platforms and avoids relying on tools tolerating non-standard backslash specifiers.

### Test plan

- [x] `pnpm test tests/image-imports.test.ts` — 18 pass (6 previously failed on Windows due to the assertion expecting native separators)
- [x] Linux/macOS: no behavior change (`normalizePathSeparators` is a no-op on POSIX)