### PR TITLE
fix(build): bundle @vinext/cloudflare into vinext to break dependency cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,6 @@ jobs:
         run: vp pm pack --pack-destination "${{ runner.temp }}"
         working-directory: packages/vinext
 
-      - name: Pack @vinext/cloudflare for local install
-        # vinext depends on @vinext/cloudflare, which isn't published to npm yet.
-        # Pack it locally so the scaffolded project can resolve it offline (see
-        # the override step below).
-        run: vp pm pack --pack-destination "${{ runner.temp }}"
-        working-directory: packages/cloudflare
-
       - name: Scaffold a fresh create-next-app project
         run: vp dlx create-next-app@16.2.7 "${{ runner.temp }}/cna-test" --yes
 
@@ -167,30 +160,6 @@ jobs:
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
           echo "Pinned packageManager to $PKG_MGR"
-
-      - name: Override @vinext/cloudflare to the local tarball
-        working-directory: ${{ runner.temp }}/cna-test
-        shell: bash
-        # vinext's tarball declares a dependency on @vinext/cloudflare, which is
-        # not on npm yet. Point pnpm's resolution at the locally-packed tarball
-        # so installing (and running) the local vinext works without registry
-        # access to the new package.
-        run: |
-          node -e '
-            const fs = require("fs");
-            const path = require("path");
-            const tmp = process.env.RUNNER_TEMP;
-            const tgz = fs.readdirSync(tmp).find((f) => /^vinext-cloudflare-.*\.tgz$/.test(f));
-            if (!tgz) throw new Error("@vinext/cloudflare tarball not found in " + tmp);
-            const spec = "file:" + path.join(tmp, tgz).split(path.sep).join("/");
-            const f = "pnpm-workspace.yaml";
-            let y = fs.existsSync(f) ? fs.readFileSync(f, "utf8") : "";
-            y = y.trimEnd() + "\n\noverrides:\n  \"@vinext/cloudflare\": \"" + spec + "\"\n";
-            fs.writeFileSync(f, y);
-            console.log("Added override @vinext/cloudflare ->", spec);
-          '
-        env:
-          RUNNER_TEMP: ${{ runner.temp }}
 
       - name: Install vinext from local tarball
         working-directory: ${{ runner.temp }}/cna-test

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -74,7 +74,6 @@
   "dependencies": {
     "@unpic/react": "catalog:",
     "@vercel/og": "catalog:",
-    "@vinext/cloudflare": "workspace:*",
     "image-size": "catalog:",
     "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
@@ -86,6 +85,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@vinext/cloudflare": "workspace:*",
     "@vitejs/plugin-react": "catalog:",
     "@vitejs/plugin-rsc": "catalog:",
     "react-server-dom-webpack": "catalog:",

--- a/packages/vinext/vite.config.ts
+++ b/packages/vinext/vite.config.ts
@@ -1,51 +1,47 @@
-import { isAbsolute } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite-plus";
 
 /**
- * Dependencies bundled into vinext's `dist` instead of being kept external.
+ * Absolute path to the `@vinext/cloudflare` cache source.
  *
  * vinext consumes a few runtime helpers from `@vinext/cloudflare`
  * (`KVCacheHandler`, `CloudflareCdnCacheAdapter`, `ENTRY_PREFIX`). Keeping it as
  * an external runtime `dependency` created a cycle
  * (`vinext` -> `@vinext/cloudflare` -> `vinext`, the latter via its `peerDep`),
  * which forced changesets to force-major `@vinext/cloudflare` on every vinext
- * release. Bundling that small surface lets `@vinext/cloudflare` stay a dev-only
+ * release. Bundling that surface lets `@vinext/cloudflare` stay a dev-only
  * dependency, so the install graph only points one way
  * (`@vinext/cloudflare` -> `vinext`).
- *
- * `@vinext/cloudflare` is still published independently: user `vite.config`
- * files import its `cdnAdapter()` / `kvDataAdapter()` builders, and the
- * generated worker resolves its `*.runtime.js` factories by absolute path. The
- * bundled-in code's `vinext/shims/*` imports stay external and resolve through
- * vinext's own package exports at runtime (Node self-referencing).
  */
-const BUNDLED_DEPS = ["@vinext/cloudflare"];
-
-/**
- * Externalize every bare import (npm packages, `node:` builtins, `next/*` and
- * `vinext/*` specifiers resolved by the plugin, `virtual:*` ids) — i.e. the
- * behaviour of `deps.skipNodeModulesBundle` — except the deps in
- * {@link BUNDLED_DEPS}, which are bundled in.
- *
- * The carve-out has to live inside `neverBundle`: tsdown rejects
- * `skipNodeModulesBundle` + `alwaysBundle` as mutually exclusive, and a
- * catch-all `neverBundle` takes precedence over `alwaysBundle`, so the only
- * place to force a single dep to be bundled is here.
- */
-const externalizeAllExceptBundled = (id: string): boolean => {
-  if (BUNDLED_DEPS.some((dep) => id === dep || id.startsWith(`${dep}/`))) {
-    return false;
-  }
-  return !id.startsWith(".") && !isAbsolute(id);
-};
+const cloudflareCacheSrc = fileURLToPath(new URL("../cloudflare/src/cache", import.meta.url));
 
 export default defineConfig({
   pack: {
     entry: ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"],
     clean: true,
     deps: {
-      neverBundle: externalizeAllExceptBundled,
-      dts: { neverBundle: externalizeAllExceptBundled },
+      // Keep externalizing node_modules (and rewriting vinext's own
+      // `vinext/shims/*` tsconfig-path self-imports to relative). This must stay
+      // untouched: replacing it with a custom external predicate breaks the
+      // self-import rewrite and duplicates shim modules across Vite's separate
+      // RSC/SSR/client dev graphs (e.g. `instanceof ReadonlyURLSearchParams`).
+      skipNodeModulesBundle: true,
+    },
+    // Bundle `@vinext/cloudflare` in by aliasing its `cache/*` subpath to source.
+    // `skipNodeModulesBundle` externalizes bare package specifiers before
+    // tsconfig paths apply, so the alias rewrites the import to a file path up
+    // front — tsdown then treats it as local source and bundles it. The
+    // bundled code's own `vinext/shims/*` imports still resolve to vinext's
+    // relative output (single module instance). `@vinext/cloudflare` remains a
+    // published package: user `vite.config` files import its `cdnAdapter()` /
+    // `kvDataAdapter()` builders, and the generated worker resolves its
+    // `*.runtime.js` factories by absolute path.
+    inputOptions: {
+      resolve: {
+        alias: {
+          "@vinext/cloudflare/cache": cloudflareCacheSrc,
+        },
+      },
     },
     dts: true,
     fixedExtension: false,

--- a/packages/vinext/vite.config.ts
+++ b/packages/vinext/vite.config.ts
@@ -1,11 +1,44 @@
 import { defineConfig } from "vite-plus";
 
+/**
+ * Externalize every bare specifier (npm packages, `node:` builtins, `vinext/*`
+ * self-references, `virtual:*` ids) so the published `dist` keeps its imports —
+ * EXCEPT `@vinext/cloudflare`, which is bundled in.
+ *
+ * vinext consumes a handful of runtime helpers from `@vinext/cloudflare`
+ * (`KVCacheHandler`, `CloudflareCdnCacheAdapter`, `ENTRY_PREFIX`). Importing
+ * them as an external runtime dependency created a dependency cycle
+ * (`vinext` -> `@vinext/cloudflare` -> `vinext`), which forced changesets to
+ * force-major `@vinext/cloudflare` on every vinext release. Bundling the small
+ * amount of code vinext actually uses lets `@vinext/cloudflare` stay a
+ * dev-only dependency, so the install graph only points one way
+ * (`@vinext/cloudflare` -> `vinext`).
+ *
+ * `@vinext/cloudflare` itself remains a published package: user `vite.config`
+ * files import its `cdnAdapter()` / `kvDataAdapter()` builders, and the
+ * generated worker resolves its `*.runtime.js` factories by absolute path. Its
+ * internal `vinext/shims/*` imports stay external here and resolve through
+ * vinext's own package exports at runtime (Node self-referencing).
+ */
+const externalizeExceptCloudflare = (id: string): boolean => {
+  if (id === "@vinext/cloudflare" || id.startsWith("@vinext/cloudflare/")) {
+    return false; // bundle it
+  }
+  // Bundle relative/absolute (our own source); externalize everything else.
+  const isInternal = id.startsWith(".") || id.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(id);
+  return !isInternal;
+};
+
 export default defineConfig({
   pack: {
     entry: ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"],
     clean: true,
     deps: {
-      skipNodeModulesBundle: true,
+      // `skipNodeModulesBundle` can't be combined with bundling a specific dep,
+      // so we replicate "externalize node_modules" via `neverBundle` and carve
+      // out `@vinext/cloudflare` to be bundled in.
+      neverBundle: externalizeExceptCloudflare,
+      dts: { neverBundle: externalizeExceptCloudflare },
     },
     dts: true,
     fixedExtension: false,

--- a/packages/vinext/vite.config.ts
+++ b/packages/vinext/vite.config.ts
@@ -1,32 +1,42 @@
+import { isAbsolute } from "node:path";
 import { defineConfig } from "vite-plus";
 
 /**
- * Externalize every bare specifier (npm packages, `node:` builtins, `vinext/*`
- * self-references, `virtual:*` ids) so the published `dist` keeps its imports —
- * EXCEPT `@vinext/cloudflare`, which is bundled in.
+ * Dependencies bundled into vinext's `dist` instead of being kept external.
  *
- * vinext consumes a handful of runtime helpers from `@vinext/cloudflare`
- * (`KVCacheHandler`, `CloudflareCdnCacheAdapter`, `ENTRY_PREFIX`). Importing
- * them as an external runtime dependency created a dependency cycle
- * (`vinext` -> `@vinext/cloudflare` -> `vinext`), which forced changesets to
- * force-major `@vinext/cloudflare` on every vinext release. Bundling the small
- * amount of code vinext actually uses lets `@vinext/cloudflare` stay a
- * dev-only dependency, so the install graph only points one way
+ * vinext consumes a few runtime helpers from `@vinext/cloudflare`
+ * (`KVCacheHandler`, `CloudflareCdnCacheAdapter`, `ENTRY_PREFIX`). Keeping it as
+ * an external runtime `dependency` created a cycle
+ * (`vinext` -> `@vinext/cloudflare` -> `vinext`, the latter via its `peerDep`),
+ * which forced changesets to force-major `@vinext/cloudflare` on every vinext
+ * release. Bundling that small surface lets `@vinext/cloudflare` stay a dev-only
+ * dependency, so the install graph only points one way
  * (`@vinext/cloudflare` -> `vinext`).
  *
- * `@vinext/cloudflare` itself remains a published package: user `vite.config`
+ * `@vinext/cloudflare` is still published independently: user `vite.config`
  * files import its `cdnAdapter()` / `kvDataAdapter()` builders, and the
- * generated worker resolves its `*.runtime.js` factories by absolute path. Its
- * internal `vinext/shims/*` imports stay external here and resolve through
+ * generated worker resolves its `*.runtime.js` factories by absolute path. The
+ * bundled-in code's `vinext/shims/*` imports stay external and resolve through
  * vinext's own package exports at runtime (Node self-referencing).
  */
-const externalizeExceptCloudflare = (id: string): boolean => {
-  if (id === "@vinext/cloudflare" || id.startsWith("@vinext/cloudflare/")) {
-    return false; // bundle it
+const BUNDLED_DEPS = ["@vinext/cloudflare"];
+
+/**
+ * Externalize every bare import (npm packages, `node:` builtins, `next/*` and
+ * `vinext/*` specifiers resolved by the plugin, `virtual:*` ids) — i.e. the
+ * behaviour of `deps.skipNodeModulesBundle` — except the deps in
+ * {@link BUNDLED_DEPS}, which are bundled in.
+ *
+ * The carve-out has to live inside `neverBundle`: tsdown rejects
+ * `skipNodeModulesBundle` + `alwaysBundle` as mutually exclusive, and a
+ * catch-all `neverBundle` takes precedence over `alwaysBundle`, so the only
+ * place to force a single dep to be bundled is here.
+ */
+const externalizeAllExceptBundled = (id: string): boolean => {
+  if (BUNDLED_DEPS.some((dep) => id === dep || id.startsWith(`${dep}/`))) {
+    return false;
   }
-  // Bundle relative/absolute (our own source); externalize everything else.
-  const isInternal = id.startsWith(".") || id.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(id);
-  return !isInternal;
+  return !id.startsWith(".") && !isAbsolute(id);
 };
 
 export default defineConfig({
@@ -34,11 +44,8 @@ export default defineConfig({
     entry: ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"],
     clean: true,
     deps: {
-      // `skipNodeModulesBundle` can't be combined with bundling a specific dep,
-      // so we replicate "externalize node_modules" via `neverBundle` and carve
-      // out `@vinext/cloudflare` to be bundled in.
-      neverBundle: externalizeExceptCloudflare,
-      dts: { neverBundle: externalizeExceptCloudflare },
+      neverBundle: externalizeAllExceptBundled,
+      dts: { neverBundle: externalizeAllExceptBundled },
     },
     dts: true,
     fixedExtension: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,9 +963,6 @@ importers:
       '@vercel/og':
         specifier: 'catalog:'
         version: 0.8.6
-      '@vinext/cloudflare':
-        specifier: workspace:*
-        version: link:../cloudflare
       image-size:
         specifier: 'catalog:'
         version: 2.0.2
@@ -997,6 +994,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.16)
+      '@vinext/cloudflare':
+        specifier: workspace:*
+        version: link:../cloudflare
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.2.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.8.3))


### PR DESCRIPTION
## Problem

`vinext` and `@vinext/cloudflare` form a circular dependency:

```
vinext ──(dependencies: workspace:*)──▶ @vinext/cloudflare
   ▲                                            │
   └──────────(peerDependencies)────────────────┘
```

`vinext` only needs a handful of runtime helpers from `@vinext/cloudflare`:

- `cloudflare/tpr.ts` → `ENTRY_PREFIX`
- `cloudflare/index.ts` → re-exports `KVCacheHandler`
- `shims/cdn-cache.ts` → `CloudflareCdnCacheAdapter` (auto-detect edge default)

Combined with `@vinext/cloudflare`'s `peerDependencies` on `vinext`, this cycle forced changesets to force-major `@vinext/cloudflare` on essentially every `vinext` release (mitigated defensively in #1764, but the cycle itself remained).

## Fix

Bundle the small amount of `@vinext/cloudflare` code `vinext` actually imports into `vinext`'s `dist` (via tsdown's `deps.neverBundle`), and move `@vinext/cloudflare` to `devDependencies`. The published install graph now points one way: `@vinext/cloudflare → vinext`.

`@vinext/cloudflare` **remains a published package** — nothing user-facing changes:

- User `vite.config` files still import `cdnAdapter()` / `kvDataAdapter()` from `@vinext/cloudflare/cache/*`.
- The generated worker still resolves its `*.runtime.js` factories by absolute path from `@vinext/cloudflare`.
- The bundled-in code's `vinext/shims/*` imports stay external and resolve through `vinext`'s own package exports at runtime (Node self-referencing) — identical to how `@vinext/cloudflare` resolves them today.

Also drops the now-obsolete `create-next-app` CI steps that packed and overrode `@vinext/cloudflare`, since `vinext`'s tarball no longer declares it as a dependency.

## Verification

- `vp run vinext#build` → `dist` has **no** `@vinext/cloudflare` runtime imports; internal imports now point at bundled local files (e.g. `./src/cache/kv-data-adapter.runtime.js`). Generated `.d.ts` likewise reference local paths (remaining `@vinext/cloudflare` strings are JSDoc only).
- `vp run @vinext/cloudflare#build` → still builds independently.
- Tests: `deploy`, `cache-adapters-config`, `kv-cache-handler`, `isr-cache`, `build-optimization` all green (463 tests).
- `vp check` on the config + `pnpm knip` clean.

## Notes

- Non-breaking: the supported pattern already requires users who configure caching to declare `@vinext/cloudflare` directly (see `examples/workers-cache`). No scaffolding relied on transitive resolution.
- The pnpm dev-graph cyclic-workspace warning is pre-existing (both packages build from each other's source at dev time) and is unrelated to the published/release cycle this PR removes; changesets ignores `devDependencies`.