### PR TITLE
refactor(cache): deprecate imperative cache handler setters and exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,7 +481,7 @@ The ISR cache layer sits **above** `CacheHandler`, not inside it. `CacheHandler`
 - **Revalidate tracking:** A side map stores revalidate durations by cache key (populated on MISS, read on HIT/STALE)
 - **Tag invalidation:** Tag-invalidated entries are hard-deleted (return null), unlike time-expired entries which return stale
 
-The caching layer is pluggable via `setCacheHandler()`. KV is the default for Cloudflare Workers. The ISR logic works automatically with any backend.
+The caching layer is pluggable. The default data cache handler is the in-memory `MemoryCacheHandler` in **all** runtimes (including Cloudflare Workers) when nothing is configured — KV is opt-in, not the default. Configure a backend declaratively via the `cache` option on the `vinext()` plugin (e.g. `cache: { data: kvDataAdapter({ binding: "VINEXT_KV_CACHE" }) }` from `@vinext/cloudflare/cache/kv-data-adapter`); the generated `virtual:vinext-cache-adapters` module registers it on the first request. The imperative `setDataCacheHandler()` / `setCdnCacheAdapter()` setters still work but are deprecated for consumers. The ISR logic works automatically with any backend.
 
 ### Next.js Request Execution Order
 

--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -8,11 +8,10 @@
  * KV namespace from `env[binding]` at request time and constructs the handler.
  *
  * Configure it from vite.config via the {@link kvDataAdapter} builder in
- * `./kv-data-adapter.ts` (which `require.resolve`s this file), or imperatively:
- *
- *   import { KVCacheHandler } from "@vinext/cloudflare/cache/kv-data-adapter.runtime";
- *   import { setDataCacheHandler } from "vinext/shims/cache";
- *   setDataCacheHandler(new KVCacheHandler(env.VINEXT_KV_CACHE));
+ * `./kv-data-adapter.ts` (which `require.resolve`s this file). The legacy
+ * imperative path (constructing `KVCacheHandler` and calling
+ * `setDataCacheHandler` from a worker entry) is deprecated — prefer the
+ * `cache.data` plugin option.
  *
  * Wrangler config (wrangler.jsonc):
  *
@@ -152,6 +151,27 @@ function isPathChildOf(path: string, prefix: string): boolean {
   return path.startsWith(prefix + "/");
 }
 
+/**
+ * Cloudflare KV data cache handler.
+ *
+ * @deprecated Consumers should not instantiate or register this handler by
+ * hand. Configure it declaratively via the `cache.data` option on the
+ * `vinext()` plugin, using the {@link kvDataAdapter} builder:
+ *
+ * ```ts
+ * import { vinext } from "vinext";
+ * import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";
+ *
+ * export default defineConfig({
+ *   plugins: [vinext({ cache: { data: kvDataAdapter({ binding: "VINEXT_KV_CACHE" }) } })],
+ * });
+ * ```
+ *
+ * `kvDataAdapter()` is safe to call from `vite.config.ts` — it never touches
+ * the Workers runtime — and the plugin defers instantiation of this handler to
+ * the first request. This class stays exported for the runtime factory and for
+ * backwards compatibility, but is not the recommended consumer API.
+ */
 export class KVCacheHandler implements CacheHandler {
   private kv: KVNamespace;
   private prefix: string;

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -9,12 +9,14 @@
  * existing community adapters (@neshca/cache-handler, @opennextjs/aws, etc.)
  * can be used directly.
  *
- * Configuration (in vite.config.ts or next.config.js):
- *   vinext({ cacheHandler: './my-cache-handler.ts' })
+ * Recommended configuration is declarative, via the `cache` option on the
+ * `vinext()` plugin in vite.config.ts:
+ *   import { kvDataAdapter } from '@vinext/cloudflare/cache/kv-data-adapter';
+ *   vinext({ cache: { data: kvDataAdapter({ binding: 'VINEXT_KV_CACHE' }) } })
  *
- * Or set at runtime:
- *   import { setCacheHandler } from 'next/cache';
- *   setCacheHandler(new MyCacheHandler());
+ * The imperative `setCacheHandler` / `setDataCacheHandler` setters are
+ * deprecated for consumers and retained only as the internal registration
+ * target used by the generated cache-adapter module.
  */
 
 import { getHeadersAccessPhase, markDynamicUsage as _markDynamic } from "./headers.js";
@@ -258,6 +260,16 @@ function readStringArrayField(ctx: Record<string, unknown> | undefined, field: s
   return value.filter((item): item is string => typeof item === "string");
 }
 
+/**
+ * In-memory data cache handler. This is the built-in default — vinext installs
+ * it automatically, so consumers should not construct or register it by hand.
+ *
+ * @deprecated Consumers should not instantiate cache handlers directly.
+ * Configure caching declaratively via the `cache` option on the `vinext()`
+ * plugin (see {@link setDataCacheHandler}); the in-memory handler is the
+ * default when nothing is configured, and its size is tuned via the
+ * `cacheMaxMemorySize` plugin option.
+ */
 export class MemoryCacheHandler implements CacheHandler {
   private store = new Map<string, MemoryEntry>();
   private tagRevalidatedAt = new Map<string, number>();
@@ -468,9 +480,26 @@ export function configureMemoryCacheHandler(options?: MemoryCacheHandlerOptions)
  * `fetch` caching, `"use cache"`, `unstable_cache` — and is also the default
  * underlying store for page-level ISR (via the default CDN cache adapter).
  *
- * Call this during server startup to plug in Cloudflare KV, Redis, DynamoDB,
- * or any other backend. The handler must implement the CacheHandler interface
- * (same shape as Next.js 16's CacheHandler class).
+ * The handler must implement the CacheHandler interface (same shape as
+ * Next.js 16's CacheHandler class).
+ *
+ * @deprecated Don't wire up the data cache imperatively. Configure it
+ * declaratively via the `cache.data` option on the `vinext()` plugin in your
+ * `vite.config.ts`, using a config-time adapter builder. On Cloudflare Workers:
+ *
+ * ```ts
+ * import { vinext } from "vinext";
+ * import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";
+ *
+ * export default defineConfig({
+ *   plugins: [vinext({ cache: { data: kvDataAdapter({ binding: "VINEXT_KV_CACHE" }) } })],
+ * });
+ * ```
+ *
+ * The plugin defers instantiation to the first request and registers the
+ * handler across every runtime/router entry, so you don't have to call this
+ * from a worker entry. This setter remains as the internal registration target
+ * and for backwards compatibility, but is not the recommended consumer API.
  */
 export function setDataCacheHandler(handler: CacheHandler): void {
   _gHandler[_HANDLER_KEY] = handler;
@@ -484,8 +513,12 @@ export function getDataCacheHandler(): CacheHandler {
 }
 
 /**
- * @deprecated Prefer {@link setDataCacheHandler}. Retained as a backwards-compatible
- * alias — `setCacheHandler` has always configured the data cache handler.
+ * @deprecated Don't wire up the data cache imperatively. Configure it
+ * declaratively via the `cache.data` option on the `vinext()` plugin (e.g.
+ * `kvDataAdapter()` from `@vinext/cloudflare/cache/kv-data-adapter`). See
+ * {@link setDataCacheHandler} for the migration example. Retained as a
+ * backwards-compatible alias — `setCacheHandler` has always configured the
+ * data cache handler.
  */
 export function setCacheHandler(handler: CacheHandler): void {
   setDataCacheHandler(handler);

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -188,9 +188,27 @@ const _gCdn = globalThis as unknown as Record<PropertyKey, unknown>;
 let _defaultAdapter: DefaultCdnCacheAdapter | null = null;
 
 /**
- * Set a custom CDN cache adapter. Call during server startup to delegate
- * page-level ISR to a CDN edge. An explicit adapter always wins over the
- * built-in request-context / default selection.
+ * Set a custom CDN cache adapter to delegate page-level ISR to a CDN edge. An
+ * explicit adapter always wins over the built-in request-context / default
+ * selection.
+ *
+ * @deprecated Don't wire up the CDN cache adapter imperatively. Configure it
+ * declaratively via the `cache.cdn` option on the `vinext()` plugin in your
+ * `vite.config.ts`, using a config-time adapter builder. On Cloudflare Workers:
+ *
+ * ```ts
+ * import { vinext } from "vinext";
+ * import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
+ *
+ * export default defineConfig({
+ *   plugins: [vinext({ cache: { cdn: cdnAdapter() } })],
+ * });
+ * ```
+ *
+ * The plugin registers the adapter across every runtime/router entry, so you
+ * don't have to call this from a worker entry. This setter remains as the
+ * internal registration target and for backwards compatibility, but is not the
+ * recommended consumer API.
  */
 export function setCdnCacheAdapter(adapter: CdnCacheAdapter): void {
   _gCdn[_CDN_KEY] = adapter;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -691,6 +691,11 @@ declare module "next/cache" {
     | { kind: "REDIRECT"; props: object }
     | { kind: "IMAGE"; etag: string; buffer: ArrayBuffer; extension: string; revalidate?: number };
 
+  /**
+   * @deprecated Consumers should not instantiate cache handlers directly.
+   * Configure caching via the `cache` option on the `vinext()` plugin; the
+   * in-memory handler is the default when nothing is configured.
+   */
   export class MemoryCacheHandler implements CacheHandler {
     constructor(options?: number | { cacheMaxMemorySize?: number; maxMemoryCacheSize?: number });
     get(key: string, ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null>;
@@ -703,9 +708,18 @@ declare module "next/cache" {
     resetRequestCache(): void;
   }
 
+  /**
+   * @deprecated Don't wire up the data cache imperatively. Configure it via the
+   * `cache.data` option on the `vinext()` plugin (e.g. `kvDataAdapter()` from
+   * `@vinext/cloudflare/cache/kv-data-adapter`) in your `vite.config.ts`.
+   */
   export function setDataCacheHandler(handler: CacheHandler): void;
   export function getDataCacheHandler(): CacheHandler;
-  /** @deprecated Use setDataCacheHandler. */
+  /**
+   * @deprecated Don't wire up the data cache imperatively. Configure it via the
+   * `cache.data` option on the `vinext()` plugin (e.g. `kvDataAdapter()` from
+   * `@vinext/cloudflare/cache/kv-data-adapter`) in your `vite.config.ts`.
+   */
   export function setCacheHandler(handler: CacheHandler): void;
   /** @deprecated Use getDataCacheHandler. */
   export function getCacheHandler(): CacheHandler;


### PR DESCRIPTION
## What

Marks the imperative cache-handler API and the manually-instantiated handler/adapter exports as `@deprecated`, steering consumers toward the declarative `cache` option on the `vinext()` plugin (using the `@vinext/cloudflare` builders `kvDataAdapter()` / `cdnAdapter()`).

Nothing changes at runtime — the deprecated setters remain the internal registration target used by the generated `virtual:vinext-cache-adapters` module, so they keep working for backwards compatibility.

## Why

The recommended way to configure caching is now declarative:

```ts
import { vinext } from "vinext";
import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";

export default defineConfig({
  plugins: [vinext({ cache: { data: kvDataAdapter({ binding: "VINEXT_KV_CACHE" }) } })],
});
```

Consumers were previously encouraged (via docs/JSDoc) to call `setCacheHandler()` / `setDataCacheHandler()` / `setCdnCacheAdapter()` and to `new` up `KVCacheHandler` from a worker entry. These are error-prone (must run in every runtime/router entry) and the plugin config handles registration automatically.

## Changes

- `@deprecated` on `setDataCacheHandler`, `setCacheHandler`, `setCdnCacheAdapter` with config-based migration examples (still functional).
- `@deprecated` on the consumer-instantiated handler exports `MemoryCacheHandler` and `KVCacheHandler`.
- Updated the `next/cache` type declarations in `next-shims.d.ts` to match.
- Refreshed stale file-header examples in `shims/cache.ts` and `kv-data-adapter.runtime.ts`.
- Fixed a stale `AGENTS.md` claim: the default data cache is the in-memory `MemoryCacheHandler` in **all** runtimes (including Cloudflare Workers) — KV is opt-in, not the default.

## Scope notes

- Internal getters (`getDataCacheHandler` / `getCdnCacheAdapter`), the recommended builders (`kvDataAdapter` / `cdnAdapter`), and `configureMemoryCacheHandler` are intentionally **not** deprecated.
- Confirmed no `no-deprecated` lint rule fires on internal usage of these symbols (`prerender.ts`, the KV factory, the default `MemoryCacheHandler` instantiation).

## Testing

- `vp check` passes on all edited files and internal consumers.
- `vp test run tests/shims.test.ts -t "setCacheHandler"` passes.