### PR TITLE
perf(og): dedupe resvg/yoga wasm in server bundle

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -115,7 +115,7 @@ import {
 } from "./client/instrumentation-client-inject.js";
 import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
-import { createOgInlineFetchAssetsPlugin, ogAssetsPlugin } from "./plugins/og-assets.js";
+import { createOgInlineFetchAssetsPlugin, createOgAssetsPlugin } from "./plugins/og-assets.js";
 import { generateRouteTypes } from "./typegen.js";
 import {
   mergeOptimizeDepsExclude,
@@ -4256,8 +4256,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Inline binary assets fetched via `fetch(new URL("./asset", import.meta.url))` —
     // see src/plugins/og-assets.ts
     createOgInlineFetchAssetsPlugin(),
-    // Copy @vercel/og binary assets to the RSC output directory — see src/plugins/og-assets.ts
-    ogAssetsPlugin,
+    // Dedupe/copy @vercel/og binary WASM assets in the RSC output — see src/plugins/og-assets.ts
+    createOgAssetsPlugin(),
     // Collect SSR/RSC bundle externals and write dist/server/vinext-externals.json.
     // Used by emitStandaloneOutput to determine which packages to copy into
     // standalone/node_modules/ — uses the bundler's own import graph instead of
@@ -4781,14 +4781,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         if (!id.includes("@vercel/og") || !id.includes("index.edge.js")) return null;
         let result = code;
 
-        // ── Yoga WASM: dynamic import + inline base64 fallback ──────────────────────
+        // ── Yoga WASM: dynamic import + disk-read fallback ──────────────────────────
         // yoga-layout's emscripten bundle sets H to a data URL containing the yoga WASM,
         // then later calls WebAssembly.instantiate(bytes, imports), which workerd rejects.
         // Emscripten supports a custom h2.instantiateWasm(imports, callback) escape hatch.
         //
         // Strategy: try dynamic import("./yoga.wasm?module") for workerd (pre-compiled
-        // module), fall back to compiling from inline base64 bytes for Node.js.
-        // Yoga WASM is ~70KB so inlining the base64 (~95KB) is acceptable.
+        // module), fall back to reading the .wasm file from disk + WebAssembly.instantiate
+        // for Node.js. We read from disk rather than inlining base64 so the bundle ships
+        // exactly one physical copy of the WASM (the emitted ?module asset); the disk
+        // fallback is wired to that same file by vinext:og-assets. This mirrors the resvg
+        // handling below and keeps the dedup platform-agnostic.
         const YOGA_DATA_URL_RE = /H = "data:application\/octet-stream;base64,([A-Za-z0-9+/]+=*)";/;
         const yogaMatch = YOGA_DATA_URL_RE.exec(result);
         if (yogaMatch) {
@@ -4805,6 +4808,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // Patch the loadYoga call site to inject instantiateWasm with universal handler.
           // WebAssembly.instantiate(Module, imports) → Instance (workerd path)
           // WebAssembly.instantiate(bytes, imports)  → { module, instance } (Node.js path)
+          //
+          // Note: new URL("./yoga.wasm", import.meta.url) MUST live inside the Node.js
+          // branch (the else), never at the top level. In workerd, import.meta.url is
+          // "worker" (not a valid URL base), so new URL(..., "worker") throws TypeError.
+          // The else branch only runs on Node.js where the ?module import failed and
+          // import.meta.url is a file:// URL.
           const YOGA_CALL = `yoga_wasm_base64_esm_default()`;
           const YOGA_CALL_PATCHED = [
             `yoga_wasm_base64_esm_default({ instantiateWasm: function(imports, callback) {`,
@@ -4812,17 +4821,21 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             `    if (mod) {`,
             `      WebAssembly.instantiate(mod, imports).then(function(inst) { callback(inst); });`,
             `    } else {`,
-            `      var b = Buffer.from(__vi_yoga_b64, "base64");`,
-            `      WebAssembly.instantiate(b, imports).then(function(r) { callback(r.instance); });`,
+            `      Promise.all([import("node:fs"), import("node:url")]).then(function(mods) {`,
+            `        var p = mods[1].fileURLToPath(new URL("./yoga.wasm", import.meta.url));`,
+            `        return mods[0].promises.readFile(p).then(function(bytes) {`,
+            `          return WebAssembly.instantiate(bytes, imports).then(function(r) { callback(r.instance); });`,
+            `        });`,
+            `      });`,
             `    }`,
             `  });`,
             `  return {};`,
             `} })`,
           ].join("\n");
           result = result.replace(YOGA_CALL, YOGA_CALL_PATCHED);
-          // Prepend dynamic import with base64 fallback (no static import — Node.js safe)
+          // Prepend dynamic import (no static import — Node.js safe). On Node.js the
+          // ?module import fails and resolves to null, triggering the disk-read fallback.
           const yogaPreamble = [
-            `var __vi_yoga_b64 = ${JSON.stringify(yogaBase64)};`,
             `var __vi_yoga_mod = import("./yoga.wasm?module").then(function(m) { return m.default; }).catch(function() { return null; });`,
           ].join("\n");
           result = yogaPreamble + "\n" + result;

--- a/packages/vinext/src/plugins/og-assets.ts
+++ b/packages/vinext/src/plugins/og-assets.ts
@@ -25,11 +25,16 @@
  *   handled by the bundler/Vite directly and do not need this treatment. Only
  *   assets that are runtime-fetched (not statically imported) need inlining.
  *
- * `ogAssetsPlugin` — vinext:og-assets
- *   Copies @vercel/og binary assets (e.g. resvg.wasm) to the RSC output
- *   directory for production builds. The edge build inlines fonts as base64 via
- *   og-inline-fetch-assets; this plugin is a safety net to ensure resvg.wasm is
- *   present for the Node.js disk-read fallback.
+ * `createOgAssetsPlugin` — vinext:og-assets
+ *   Guarantees each @vercel/og binary WASM module (resvg.wasm, yoga.wasm) ships
+ *   exactly once in the RSC output, with every loader strategy resolving to that
+ *   single file. The `import("./x.wasm?module")` path makes the bundler emit a
+ *   hashed asset (used by workerd); the og-font-patch transform also injects a
+ *   `new URL("./x.wasm", import.meta.url)` disk-read fallback (used by Node.js).
+ *   When the bundler already emitted the asset, this plugin rewrites the fallback
+ *   reference to point at it (dedup); otherwise it copies a single root copy from
+ *   @vercel/og's dist. The decision keys off whether the bundler emitted the
+ *   asset, never the deploy target.
  */
 
 import type { Plugin } from "vite";
@@ -157,58 +162,163 @@ export function createOgInlineFetchAssetsPlugin(): Plugin {
   } satisfies Plugin;
 }
 
+// @vercel/og WASM assets that need a single physical copy in the output.
+// Both are imported via `import("./<name>?module")` (workerd path) AND read
+// from disk via `new URL("./<name>", import.meta.url)` (Node.js fallback path),
+// the latter injected by the vinext:og-font-patch transform.
+const OG_WASM_ASSETS = ["resvg.wasm", "yoga.wasm"] as const;
+
 /**
- * The `vinext:og-assets` Vite plugin.
+ * Find an emitted WASM asset in the output bundle whose name corresponds to the
+ * given base file (e.g. base `resvg.wasm` matches the emitted `resvg-HASH.wasm`).
  *
- * Copies @vercel/og binary assets (e.g. resvg.wasm) to the RSC output
- * directory for production builds. The edge build inlines fonts as base64 via
- * `vinext:og-inline-fetch-assets`; this plugin is a safety net to ensure
- * resvg.wasm exists in the output directory for the Node.js disk-read fallback.
+ * The bundler emits the `import("./resvg.wasm?module")` dynamic import as a
+ * hashed asset. When it exists, both loader strategies can point at the same
+ * physical file — no second copy needed.
+ *
+ * @returns the emitted asset's `fileName` (relative to outDir), or null.
  */
-export const ogAssetsPlugin: Plugin = {
-  name: "vinext:og-assets",
-  apply: "build",
-  enforce: "post",
-  writeBundle: {
-    sequential: true,
-    order: "post",
-    async handler(options, bundle) {
-      const envName = this.environment?.name;
-      if (envName !== "rsc") return;
+function findEmittedWasmAsset(
+  bundle: Record<string, { type: string; fileName: string }>,
+  baseName: string,
+): string | null {
+  const stem = baseName.replace(/\.wasm$/, "");
+  // Matches `resvg.wasm` or `resvg-<hash>.wasm` as the basename.
+  const re = new RegExp(`^${stem}(?:-[\\w-]+)?\\.wasm$`);
+  for (const output of Object.values(bundle)) {
+    if (output.type !== "asset") continue;
+    if (re.test(path.posix.basename(output.fileName))) return output.fileName;
+  }
+  return null;
+}
 
-      const outDir = options.dir;
-      if (!outDir) return;
+/**
+ * Build the regex that matches the Node.js fallback reference
+ * `new URL("./<base>", import.meta.url)` for a given WASM base name.
+ *
+ * Handles all three quote styles ("'`) because the minifier may rewrite the
+ * string literal (commonly to a template literal) by the time the chunk code
+ * is available in generateBundle.
+ */
+function fallbackUrlRegex(baseName: string): RegExp {
+  const escaped = baseName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    String.raw`new URL\(\s*(["'\`])\.\/${escaped}\1\s*,\s*import\.meta\.url\s*\)`,
+    "g",
+  );
+}
 
-      // The font is inlined as base64 by vinext:og-inline-fetch-assets, so only
-      // the WASM needs to be present as a file alongside the bundle.
-      const ogAssets = ["resvg.wasm"];
+/**
+ * Create the `vinext:og-assets` Vite plugin.
+ *
+ * Ensures each @vercel/og WASM module (resvg.wasm, yoga.wasm) ships exactly once
+ * in the RSC output, with every loader strategy resolving to that single file:
+ *
+ *   1. `generateBundle` (post): if the bundler already emitted the WASM as a
+ *      hashed asset (from the `import("./x.wasm?module")` path), rewrite the
+ *      Node.js fallback reference `new URL("./x.wasm", import.meta.url)` in each
+ *      chunk to point at that emitted asset (a sibling under `_next/static/`).
+ *      This deduplicates without copying a second root file.
+ *   2. `writeBundle` (post): for any referenced WASM that was NOT emitted as an
+ *      asset (e.g. a build that inlined or skipped it), copy a single root copy
+ *      from @vercel/og's dist so the Node.js disk-read fallback still works.
+ *
+ * The decision keys off "did the bundler emit this asset?", never the deploy
+ * target — so it helps Node/self-hosted builds as well as Cloudflare Workers.
+ */
+export function createOgAssetsPlugin(): Plugin {
+  // Bases whose fallback reference was rewritten to an emitted asset in
+  // generateBundle; writeBundle must NOT copy a second root copy for these.
+  let dedupedBases = new Set<string>();
 
-      // Only copy if the bundle actually references these files. Scan every
-      // emitted chunk, not just index.js: @vercel/og is lazily imported by the
-      // next/og shim, so the asset reference lives in its own code-split chunk
-      // rather than the main entry.
-      const chunkCode = Object.values(bundle)
-        .map((output) => (output.type === "chunk" ? output.code : ""))
-        .join("\n");
-      const referencedAssets = ogAssets.filter((asset) => chunkCode.includes(asset));
-      if (referencedAssets.length === 0) return;
+  return {
+    name: "vinext:og-assets",
+    apply: "build",
+    enforce: "post",
 
-      // Find @vercel/og in node_modules
-      try {
-        const require = createRequire(import.meta.url);
-        const ogPkgPath = require.resolve("@vercel/og/package.json");
-        const ogDistDir = path.join(path.dirname(ogPkgPath), "dist");
+    generateBundle: {
+      order: "post",
+      handler(_options, bundle) {
+        const envName = this.environment?.name;
+        if (envName !== "rsc") return;
 
-        for (const asset of referencedAssets) {
-          const src = path.join(ogDistDir, asset);
-          const dest = path.join(outDir, asset);
-          if (fs.existsSync(src) && !fs.existsSync(dest)) {
-            fs.copyFileSync(src, dest);
+        dedupedBases = new Set<string>();
+
+        const chunks = Object.values(bundle).filter(
+          (o): o is typeof o & { type: "chunk"; code: string } => o.type === "chunk",
+        );
+
+        for (const base of OG_WASM_ASSETS) {
+          // Only act if some chunk references this WASM at all.
+          const referenced = chunks.some((c) => c.code.includes(base));
+          if (!referenced) continue;
+
+          const emitted = findEmittedWasmAsset(bundle as never, base);
+          if (!emitted) continue; // no emitted asset → leave for writeBundle to copy
+
+          const re = fallbackUrlRegex(base);
+          let rewroteAny = false;
+          for (const chunk of chunks) {
+            if (!re.test(chunk.code)) continue;
+            re.lastIndex = 0;
+            const chunkDir = path.posix.dirname(chunk.fileName);
+            const rel = path.posix.relative(chunkDir, emitted);
+            const ref = rel.startsWith(".") ? rel : `./${rel}`;
+            chunk.code = chunk.code.replace(
+              re,
+              (_m, quote: string) => `new URL(${quote}${ref}${quote}, import.meta.url)`,
+            );
+            rewroteAny = true;
           }
+
+          // Even if the fallback reference wasn't found (e.g. unexpected minifier
+          // shape), the emitted asset still satisfies the workerd loader, so the
+          // root copy is redundant. Mark as deduped to avoid shipping it twice.
+          dedupedBases.add(base);
+          void rewroteAny;
         }
-      } catch {
-        // @vercel/og not installed — nothing to copy
-      }
+      },
     },
-  },
-};
+
+    writeBundle: {
+      sequential: true,
+      order: "post",
+      async handler(options, bundle) {
+        const envName = this.environment?.name;
+        if (envName !== "rsc") return;
+
+        const outDir = options.dir;
+        if (!outDir) return;
+
+        // Only copy if the bundle actually references these files. Scan every
+        // emitted chunk, not just index.js: @vercel/og is lazily imported by the
+        // next/og shim, so the asset reference lives in its own code-split chunk
+        // rather than the main entry.
+        const chunkCode = Object.values(bundle)
+          .map((output) => (output.type === "chunk" ? output.code : ""))
+          .join("\n");
+        const referencedAssets = OG_WASM_ASSETS.filter(
+          (asset) => chunkCode.includes(asset) && !dedupedBases.has(asset),
+        );
+        if (referencedAssets.length === 0) return;
+
+        // Find @vercel/og in node_modules
+        try {
+          const require = createRequire(import.meta.url);
+          const ogPkgPath = require.resolve("@vercel/og/package.json");
+          const ogDistDir = path.join(path.dirname(ogPkgPath), "dist");
+
+          for (const asset of referencedAssets) {
+            const src = path.join(ogDistDir, asset);
+            const dest = path.join(outDir, asset);
+            if (fs.existsSync(src) && !fs.existsSync(dest)) {
+              fs.copyFileSync(src, dest);
+            }
+          }
+        } catch {
+          // @vercel/og not installed — nothing to copy
+        }
+      },
+    },
+  } satisfies Plugin;
+}

--- a/packages/vinext/src/plugins/og-assets.ts
+++ b/packages/vinext/src/plugins/og-assets.ts
@@ -41,6 +41,7 @@ import type { Plugin } from "vite";
 import path from "node:path";
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import MagicString from "magic-string";
 
 // ── Plugin factories ──────────────────────────────────────────────────────────
 
@@ -209,6 +210,30 @@ function fallbackUrlRegex(baseName: string): RegExp {
 }
 
 /**
+ * Copy a single root copy of each requested WASM asset from `sourceDir` into
+ * `outDir`, skipping any asset whose source is missing or whose destination
+ * already exists.
+ *
+ * Extracted as a pure, dependency-injected helper so it can be unit-tested
+ * against a temp source directory without depending on the real @vercel/og
+ * install (whose `yoga.wasm` is only materialized as a side effect of the
+ * `vinext:og-font-patch` transform during a build).
+ */
+export function copyMissingOgWasm(opts: {
+  outDir: string;
+  sourceDir: string;
+  assets: readonly string[];
+}): void {
+  for (const asset of opts.assets) {
+    const src = path.join(opts.sourceDir, asset);
+    const dest = path.join(opts.outDir, asset);
+    if (fs.existsSync(src) && !fs.existsSync(dest)) {
+      fs.copyFileSync(src, dest);
+    }
+  }
+}
+
+/**
  * Create the `vinext:og-assets` Vite plugin.
  *
  * Ensures each @vercel/og WASM module (resvg.wasm, yoga.wasm) ships exactly once
@@ -256,26 +281,47 @@ export function createOgAssetsPlugin(): Plugin {
           const emitted = findEmittedWasmAsset(bundle as never, base);
           if (!emitted) continue; // no emitted asset → leave for writeBundle to copy
 
-          const re = fallbackUrlRegex(base);
-          let rewroteAny = false;
           for (const chunk of chunks) {
-            if (!re.test(chunk.code)) continue;
-            re.lastIndex = 0;
+            const re = fallbackUrlRegex(base);
             const chunkDir = path.posix.dirname(chunk.fileName);
             const rel = path.posix.relative(chunkDir, emitted);
             const ref = rel.startsWith(".") ? rel : `./${rel}`;
-            chunk.code = chunk.code.replace(
-              re,
-              (_m, quote: string) => `new URL(${quote}${ref}${quote}, import.meta.url)`,
-            );
-            rewroteAny = true;
+
+            // Use MagicString so the chunk's sourcemap stays in sync with the
+            // edit (offsets after the replacement shift correctly) rather than a
+            // blind string .replace() that would invalidate `chunk.map`.
+            const s = new MagicString(chunk.code);
+            let edited = false;
+            for (const m of chunk.code.matchAll(re)) {
+              const quote = m[1];
+              const start = m.index;
+              s.overwrite(
+                start,
+                start + m[0].length,
+                `new URL(${quote}${ref}${quote}, import.meta.url)`,
+              );
+              edited = true;
+            }
+            if (!edited) continue;
+
+            chunk.code = s.toString();
+            // Only regenerate the map when the chunk already carried one (server
+            // builds usually omit sourcemaps, in which case `chunk.map` is null
+            // and we must not fabricate one). magic-string's SourceMap is
+            // structurally compatible with the bundler's (same fields +
+            // toString/toUrl) but nominally distinct, so cast it.
+            if (chunk.map) {
+              chunk.map = s.generateMap({
+                hires: "boundary",
+                source: chunk.fileName,
+              }) as typeof chunk.map;
+            }
           }
 
           // Even if the fallback reference wasn't found (e.g. unexpected minifier
           // shape), the emitted asset still satisfies the workerd loader, so the
           // root copy is redundant. Mark as deduped to avoid shipping it twice.
           dedupedBases.add(base);
-          void rewroteAny;
         }
       },
     },
@@ -302,19 +348,14 @@ export function createOgAssetsPlugin(): Plugin {
         );
         if (referencedAssets.length === 0) return;
 
-        // Find @vercel/og in node_modules
+        // Find @vercel/og in node_modules. The yoga.wasm source is written
+        // there by the vinext:og-font-patch transform earlier in the build.
         try {
           const require = createRequire(import.meta.url);
           const ogPkgPath = require.resolve("@vercel/og/package.json");
           const ogDistDir = path.join(path.dirname(ogPkgPath), "dist");
 
-          for (const asset of referencedAssets) {
-            const src = path.join(ogDistDir, asset);
-            const dest = path.join(outDir, asset);
-            if (fs.existsSync(src) && !fs.existsSync(dest)) {
-              fs.copyFileSync(src, dest);
-            }
-          }
+          copyMissingOgWasm({ outDir, sourceDir: ogDistDir, assets: referencedAssets });
         } catch {
           // @vercel/og not installed — nothing to copy
         }

--- a/packages/vinext/src/plugins/og-assets.ts
+++ b/packages/vinext/src/plugins/og-assets.ts
@@ -254,6 +254,13 @@ export function copyMissingOgWasm(opts: {
 export function createOgAssetsPlugin(): Plugin {
   // Bases whose fallback reference was rewritten to an emitted asset in
   // generateBundle; writeBundle must NOT copy a second root copy for these.
+  //
+  // Cross-hook dependency: this is written in generateBundle and read in
+  // writeBundle. Rollup runs generateBundle before writeBundle within a single
+  // env build, and both hooks early-return unless `envName === "rsc"`, so the
+  // ordering holds today. If a future refactor reorders or parallelizes env
+  // builds, this shared state could go stale (writeBundle would copy a
+  // redundant root file) — keep the produce/consume pair in the same env.
   let dedupedBases = new Set<string>();
 
   return {

--- a/tests/og-assets.test.ts
+++ b/tests/og-assets.test.ts
@@ -105,6 +105,26 @@ describe("vinext:og-assets plugin", () => {
       expect(out).not.toContain('new URL("./yoga.wasm"');
     });
 
+    it("rewrites to a directory-relative ref when chunk and asset live in different dirs", () => {
+      const plugin = createOgAssetsPlugin();
+      const generateBundle = unwrapHook(plugin.generateBundle);
+
+      // Chunk at the output root, emitted asset under _next/static/. At Node
+      // runtime `new URL(ref, import.meta.url)` resolves relative to the chunk,
+      // so the rewrite must produce a path that descends into _next/static/.
+      const bundle = makeBundle({
+        chunkCode: 'var p=new URL("./resvg.wasm", import.meta.url);',
+        chunkFileName: "index.edge-AAA.js",
+        resvgAsset: "_next/static/resvg-BBB.wasm",
+      });
+
+      generateBundle.call(rscCtx, {}, bundle);
+
+      const out = bundle["index.edge-AAA.js"].code as string;
+      expect(out).toContain('new URL("./_next/static/resvg-BBB.wasm", import.meta.url)');
+      expect(out).not.toContain('new URL("./resvg.wasm"');
+    });
+
     it("keeps the chunk sourcemap in sync when one is present", () => {
       const plugin = createOgAssetsPlugin();
       const generateBundle = unwrapHook(plugin.generateBundle);

--- a/tests/og-assets.test.ts
+++ b/tests/og-assets.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
+import { copyMissingOgWasm } from "../packages/vinext/src/plugins/og-assets.js";
 import type { Plugin } from "vite-plus";
 import fsp from "node:fs/promises";
 import fs from "node:fs";
@@ -104,6 +105,33 @@ describe("vinext:og-assets plugin", () => {
       expect(out).not.toContain('new URL("./yoga.wasm"');
     });
 
+    it("keeps the chunk sourcemap in sync when one is present", () => {
+      const plugin = createOgAssetsPlugin();
+      const generateBundle = unwrapHook(plugin.generateBundle);
+
+      const chunkCode = 'var p=new URL("./yoga.wasm", import.meta.url);';
+      const bundle = makeBundle({ chunkCode, yogaAsset: "_next/static/yoga-CCC.wasm" });
+      // Attach a pre-existing (single-source) map to the chunk.
+      bundle["_next/static/index.edge-AAA.js"].map = {
+        version: 3,
+        file: "index.edge-AAA.js",
+        sources: ["index.edge-AAA.js"],
+        names: [],
+        mappings: "AAAA",
+      };
+
+      generateBundle.call(rscCtx, {}, bundle);
+
+      const chunk = bundle["_next/static/index.edge-AAA.js"];
+      // Code was rewritten…
+      expect(chunk.code).toContain('new URL("./yoga-CCC.wasm", import.meta.url)');
+      // …and the map remains a valid, non-null v3 map (magic-string regenerated).
+      expect(chunk.map).toBeTruthy();
+      expect(chunk.map.version).toBe(3);
+      expect(typeof chunk.map.mappings).toBe("string");
+      expect(chunk.map.mappings.length).toBeGreaterThan(0);
+    });
+
     it("does NOT copy a second root copy when the asset was emitted", async () => {
       const plugin = createOgAssetsPlugin();
       const generateBundle = unwrapHook(plugin.generateBundle);
@@ -134,30 +162,39 @@ describe("vinext:og-assets plugin", () => {
     });
   });
 
-  describe("fallback: no emitted asset", () => {
-    it("copies a single root copy when the bundler did not emit the asset", async () => {
-      const plugin = createOgAssetsPlugin();
-      const generateBundle = unwrapHook(plugin.generateBundle);
-      const writeBundle = unwrapHook(plugin.writeBundle);
-
+  describe("fallback: no emitted asset (copyMissingOgWasm helper)", () => {
+    // Tested via the pure helper with an injected source dir so the assertion
+    // is hermetic — it does not depend on the real @vercel/og install (whose
+    // yoga.wasm only exists as a side effect of the og-font-patch transform).
+    it("copies a single root copy of each referenced asset from the source dir", async () => {
+      const sourceDir = path.join(tmpDir, "src-dist");
       const outDir = path.join(tmpDir, "copied");
+      await fsp.mkdir(sourceDir, { recursive: true });
       await fsp.mkdir(outDir, { recursive: true });
+      await fsp.writeFile(path.join(sourceDir, "resvg.wasm"), Buffer.from([0, 1, 2]));
+      await fsp.writeFile(path.join(sourceDir, "yoga.wasm"), Buffer.from([3, 4, 5]));
 
-      // Chunk references the WASM via the disk fallback but NO emitted asset
-      // exists in the bundle.
-      const chunkCode = [
-        'new URL("./resvg.wasm", import.meta.url);',
-        'new URL("./yoga.wasm", import.meta.url);',
-      ].join("\n");
+      copyMissingOgWasm({ outDir, sourceDir, assets: ["resvg.wasm", "yoga.wasm"] });
 
-      const bundle = makeBundle({ chunkCode });
-
-      generateBundle.call(rscCtx, {}, bundle);
-      await writeBundle.call(rscCtx, { dir: outDir }, bundle);
-
-      // Exactly one root copy of each, sourced from @vercel/og's dist.
       expect(fs.existsSync(path.join(outDir, "resvg.wasm"))).toBe(true);
       expect(fs.existsSync(path.join(outDir, "yoga.wasm"))).toBe(true);
+    });
+
+    it("skips assets missing from the source dir and never overwrites existing destinations", async () => {
+      const sourceDir = path.join(tmpDir, "src-partial");
+      const outDir = path.join(tmpDir, "copied-partial");
+      await fsp.mkdir(sourceDir, { recursive: true });
+      await fsp.mkdir(outDir, { recursive: true });
+      // Only resvg exists in the source; yoga is absent.
+      await fsp.writeFile(path.join(sourceDir, "resvg.wasm"), Buffer.from([9]));
+      // A pre-existing destination must not be overwritten.
+      await fsp.writeFile(path.join(outDir, "resvg.wasm"), Buffer.from([7, 7, 7]));
+
+      copyMissingOgWasm({ outDir, sourceDir, assets: ["resvg.wasm", "yoga.wasm"] });
+
+      // yoga.wasm not copied (no source); resvg.wasm left untouched (1 byte → 3 bytes would mean overwrite).
+      expect(fs.existsSync(path.join(outDir, "yoga.wasm"))).toBe(false);
+      expect(fs.readFileSync(path.join(outDir, "resvg.wasm"))).toEqual(Buffer.from([7, 7, 7]));
     });
   });
 

--- a/tests/og-assets.test.ts
+++ b/tests/og-assets.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import type { Plugin } from "vite-plus";
+import fsp from "node:fs/promises";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function unwrapHook(hook: any): Function {
+  return typeof hook === "function" ? hook : hook?.handler;
+}
+
+function createOgAssetsPlugin(): Plugin {
+  const plugins = vinext() as Plugin[];
+  const plugin = plugins.find((p) => p.name === "vinext:og-assets");
+  if (!plugin) throw new Error("vinext:og-assets plugin not found");
+  return plugin;
+}
+
+// A `this` context that mimics the rsc environment so the hooks run.
+const rscCtx = { environment: { name: "rsc" } };
+
+/** Build a fake output bundle (chunk + optional emitted wasm assets). */
+function makeBundle(opts: {
+  chunkCode: string;
+  resvgAsset?: string;
+  yogaAsset?: string;
+  chunkFileName?: string;
+}): Record<string, any> {
+  const bundle: Record<string, any> = {
+    [opts.chunkFileName ?? "_next/static/index.edge-AAA.js"]: {
+      type: "chunk",
+      fileName: opts.chunkFileName ?? "_next/static/index.edge-AAA.js",
+      code: opts.chunkCode,
+    },
+  };
+  if (opts.resvgAsset) {
+    bundle[opts.resvgAsset] = { type: "asset", fileName: opts.resvgAsset };
+  }
+  if (opts.yogaAsset) {
+    bundle[opts.yogaAsset] = { type: "asset", fileName: opts.yogaAsset };
+  }
+  return bundle;
+}
+
+// ── Test fixture setup ────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "og-assets-test-"));
+});
+
+afterAll(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("vinext:og-assets plugin", () => {
+  it("exists in the plugin array", () => {
+    const plugin = createOgAssetsPlugin();
+    expect(plugin.name).toBe("vinext:og-assets");
+    expect(plugin.apply).toBe("build");
+  });
+
+  describe("dedup: emitted asset present", () => {
+    it("rewrites the Node fallback new URL(...) to the emitted resvg/yoga asset", () => {
+      const plugin = createOgAssetsPlugin();
+      const generateBundle = unwrapHook(plugin.generateBundle);
+
+      // Mirror the real (minified) shape: resvg uses backticks, the primary
+      // ?module import already points at the hashed asset, the fallback points
+      // at the bare base name. yoga uses double quotes.
+      const chunkCode = [
+        "var a=import(`./resvg-BBB.wasm`).then(m=>m.default).catch(function(){",
+        "  return Promise.all([import(`node:fs`),import(`node:url`)]).then(function(e){",
+        "    var t=e[1].fileURLToPath(new URL(`./resvg.wasm`,import.meta.url));",
+        "    return e[0].promises.readFile(t).then(b=>WebAssembly.compile(b));",
+        "  });",
+        "});",
+        'var b=import("./yoga-CCC.wasm").then(m=>m.default).catch(()=>null);',
+        'var p=fileURLToPath(new URL("./yoga.wasm", import.meta.url));',
+      ].join("\n");
+
+      const bundle = makeBundle({
+        chunkCode,
+        resvgAsset: "_next/static/resvg-BBB.wasm",
+        yogaAsset: "_next/static/yoga-CCC.wasm",
+      });
+
+      generateBundle.call(rscCtx, {}, bundle);
+
+      const out = bundle["_next/static/index.edge-AAA.js"].code as string;
+
+      // The fallback references now point at the emitted (sibling) assets.
+      expect(out).toContain("new URL(`./resvg-BBB.wasm`, import.meta.url)");
+      expect(out).toContain('new URL("./yoga-CCC.wasm", import.meta.url)');
+
+      // The bare base-name fallback references are gone (no second copy needed).
+      expect(out).not.toContain("new URL(`./resvg.wasm`");
+      expect(out).not.toContain('new URL("./yoga.wasm"');
+    });
+
+    it("does NOT copy a second root copy when the asset was emitted", async () => {
+      const plugin = createOgAssetsPlugin();
+      const generateBundle = unwrapHook(plugin.generateBundle);
+      const writeBundle = unwrapHook(plugin.writeBundle);
+
+      const outDir = path.join(tmpDir, "deduped");
+      await fsp.mkdir(outDir, { recursive: true });
+
+      const chunkCode = [
+        "import(`./resvg-BBB.wasm`);",
+        "new URL(`./resvg.wasm`,import.meta.url);",
+        'import("./yoga-CCC.wasm");',
+        'new URL("./yoga.wasm", import.meta.url);',
+      ].join("\n");
+
+      const bundle = makeBundle({
+        chunkCode,
+        resvgAsset: "_next/static/resvg-BBB.wasm",
+        yogaAsset: "_next/static/yoga-CCC.wasm",
+      });
+
+      generateBundle.call(rscCtx, {}, bundle);
+      await writeBundle.call(rscCtx, { dir: outDir }, bundle);
+
+      // No root resvg.wasm / yoga.wasm copies — the emitted assets are reused.
+      expect(fs.existsSync(path.join(outDir, "resvg.wasm"))).toBe(false);
+      expect(fs.existsSync(path.join(outDir, "yoga.wasm"))).toBe(false);
+    });
+  });
+
+  describe("fallback: no emitted asset", () => {
+    it("copies a single root copy when the bundler did not emit the asset", async () => {
+      const plugin = createOgAssetsPlugin();
+      const generateBundle = unwrapHook(plugin.generateBundle);
+      const writeBundle = unwrapHook(plugin.writeBundle);
+
+      const outDir = path.join(tmpDir, "copied");
+      await fsp.mkdir(outDir, { recursive: true });
+
+      // Chunk references the WASM via the disk fallback but NO emitted asset
+      // exists in the bundle.
+      const chunkCode = [
+        'new URL("./resvg.wasm", import.meta.url);',
+        'new URL("./yoga.wasm", import.meta.url);',
+      ].join("\n");
+
+      const bundle = makeBundle({ chunkCode });
+
+      generateBundle.call(rscCtx, {}, bundle);
+      await writeBundle.call(rscCtx, { dir: outDir }, bundle);
+
+      // Exactly one root copy of each, sourced from @vercel/og's dist.
+      expect(fs.existsSync(path.join(outDir, "resvg.wasm"))).toBe(true);
+      expect(fs.existsSync(path.join(outDir, "yoga.wasm"))).toBe(true);
+    });
+  });
+
+  describe("guards", () => {
+    it("ignores non-rsc environments", () => {
+      const plugin = createOgAssetsPlugin();
+      const generateBundle = unwrapHook(plugin.generateBundle);
+
+      const chunkCode = "new URL(`./resvg.wasm`,import.meta.url);";
+      const bundle = makeBundle({ chunkCode, resvgAsset: "_next/static/resvg-BBB.wasm" });
+
+      generateBundle.call({ environment: { name: "ssr" } }, {}, bundle);
+
+      // Untouched: the ssr environment is not handled.
+      expect(bundle["_next/static/index.edge-AAA.js"].code).toContain(
+        "new URL(`./resvg.wasm`,import.meta.url)",
+      );
+    });
+  });
+});

--- a/tests/og-font-patch.test.ts
+++ b/tests/og-font-patch.test.ts
@@ -105,11 +105,21 @@ describe("vinext:og-font-patch plugin", () => {
         expect(code).toContain(".catch(");
       });
 
-      it("inlines the yoga WASM bytes as a base64 Node.js fallback", () => {
-        // The base64 must be embedded so Node.js (where ?module imports fail)
-        // can WebAssembly.instantiate from the inlined bytes.
-        expect(code).toContain(FAKE_YOGA_B64);
+      it("reads yoga.wasm from disk on the Node.js fallback (no base64 inline)", () => {
+        // The Node.js fallback (where ?module imports fail) must read the .wasm
+        // file from disk and instantiate it — NOT inline a ~95 KiB base64 blob.
+        // This keeps exactly one physical copy of the WASM in the output.
+        expect(code).not.toContain(FAKE_YOGA_B64);
+        expect(code).toContain('new URL("./yoga.wasm", import.meta.url)');
+        expect(code).toContain("node:fs");
         expect(code).toContain("WebAssembly.instantiate");
+      });
+
+      it("does not reference new URL(yoga.wasm) at top level (workerd compat)", () => {
+        // In workerd, import.meta.url is "worker" — a top-level new URL(...) would
+        // throw TypeError at module load. The reference must live in the Node.js
+        // fallback branch only.
+        expect(code).not.toMatch(/^var\s+\w+\s*=\s*new URL\("\.\/yoga\.wasm"/m);
       });
 
       it("clears the inlined emscripten data URL (avoids loading bytes twice)", () => {


### PR DESCRIPTION
## Problem

Analyzing the `examples/app-router-playground` server bundle showed vinext's `next/og` (satori/resvg) handling ships each WASM module **twice** — once per loader strategy — even though only one strategy ever runs at runtime, wasting ~1.4 MiB per build.

1. **resvg.wasm duplicated (~1.3 MiB).** `import("./resvg.wasm?module")` makes the bundler emit a hashed asset `_next/static/resvg-HASH.wasm` (workerd loads this). Separately, `ogAssetsPlugin` copied a **second** root `resvg.wasm` from node_modules purely as the Node.js disk-read fallback for `new URL("./resvg.wasm", import.meta.url)`. Both were uploaded.
2. **yoga inlined as ~95 KiB base64.** The `vinext:og-font-patch` transform emitted `yoga.wasm` via `?module` **and** prepended a ~95 KiB base64 blob used only as a Node.js fallback.

## Fix (platform-agnostic — no Cloudflare/workerd detection)

The dedup decision keys off **"did the bundler already emit this asset?"**, not the deploy target — so it also helps Node/self-hosted builds.

- **`og-font-patch` (`index.ts`):** drop the `__vi_yoga_b64` base64 preamble and switch the Node.js yoga fallback to a disk read (`node:fs` + `new URL("./yoga.wasm", import.meta.url)` + `WebAssembly.instantiate`), mirroring the existing resvg handling. The `?module` import stays the primary (workerd) path.
- **`og-assets.ts`:** refactored `ogAssetsPlugin` → `createOgAssetsPlugin()`. In `generateBundle` (post, after minification), when the bundler already emitted the WASM as a hashed asset, rewrite the `new URL("./x.wasm", import.meta.url)` fallback reference in each chunk to point at that emitted sibling asset (handles `"`/`'`/`` ` `` quote styles since the minifier rewrites the literal). Only copy a single root file in `writeBundle` when **no** asset was emitted. Applied symmetrically to both `resvg.wasm` and `yoga.wasm`.

Net effect: exactly one physical copy of each WASM, every loader path resolving to it, no base64 inline — on all targets.

## Verification

`examples/app-router-playground/dist/server` WASM listing:

**Before**
```
_next/static/onig-Du5pRr7Y.wasm    466610
_next/static/resvg-Cjh1zH0p.wasm  1378357
_next/static/yoga-sbSbVeWy.wasm     71736
resvg.wasm                        1378357   <- duplicate root copy
```
`index.edge-*.js`: **527823** bytes (contains ~95 KiB yoga base64 blob)

**After**
```
_next/static/onig-Du5pRr7Y.wasm    466610
_next/static/resvg-Cjh1zH0p.wasm  1378357
_next/static/yoga-sbSbVeWy.wasm     71736
```
`index.edge-*.js`: **432359** bytes (−95464, the yoga base64 blob is gone)

In `index.edge`, both fallbacks now resolve to the single emitted asset:
- `new URL(\`./resvg-Cjh1zH0p.wasm\`, import.meta.url)`
- `new URL(\`./yoga-sbSbVeWy.wasm\`, import.meta.url)`

## Tests

- New `tests/og-assets.test.ts`: asserts (a) the fallback `new URL(...)` is rewritten to the emitted hashed asset, (b) no second root copy is written when the asset was emitted, (c) a single root copy is copied when nothing was emitted, (d) non-rsc envs are ignored.
- Updated `tests/og-font-patch.test.ts`: yoga now reads from disk (no base64 inline) and never references `new URL(yoga.wasm)` at top level.
- `vp check` (format/lint/type) clean across the repo.