### PR TITLE
docs(agents): forbid installing with --no-frozen-lockfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,10 @@ Always use Node.js built-in modules and APIs before reaching for third-party pac
 
 If a Node built-in does the job, use it. Only reach for a dependency when the built-in is genuinely insufficient.
 
+### Never Install With `--no-frozen-lockfile`
+
+**NEVER run installs with `--no-frozen-lockfile`** (e.g. `pnpm install --no-frozen-lockfile`). This silently mutates the lockfile to satisfy mismatched dependencies, masking version drift and producing non-reproducible installs. If an install fails because the lockfile is out of date, fix the root cause — update `package.json` and regenerate the lockfile with a normal `vp install` (or `pnpm install`) and commit the result. A frozen lockfile is the default for a reason: it guarantees that what you install matches what was committed.
+
 ---
 
 ## Git Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ If a Node built-in does the job, use it. Only reach for a dependency when the bu
 
 ### Never Install With `--no-frozen-lockfile`
 
-**NEVER run installs with `--no-frozen-lockfile`** (e.g. `pnpm install --no-frozen-lockfile`). This silently mutates the lockfile to satisfy mismatched dependencies, masking version drift and producing non-reproducible installs. If an install fails because the lockfile is out of date, fix the root cause — update `package.json` and regenerate the lockfile with a normal `vp install` (or `pnpm install`) and commit the result. A frozen lockfile is the default for a reason: it guarantees that what you install matches what was committed.
+**NEVER run installs with `--no-frozen-lockfile`** (e.g. `pnpm install --no-frozen-lockfile`) on your own. This flag silently mutates the lockfile to satisfy mismatched dependencies, which opens the door to supply chain attacks: a frozen lockfile pins exact, vetted dependency versions and integrity hashes, and bypassing it can pull in unreviewed or tampered packages. If an install fails because the lockfile is out of date, fix the root cause — update `package.json` and regenerate the lockfile with a normal `vp install` (or `pnpm install`) and commit the result. If you genuinely believe `--no-frozen-lockfile` is required, stop and ask the user to run it explicitly; never run it yourself.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ If a Node built-in does the job, use it. Only reach for a dependency when the bu
 
 ### Never Install With `--no-frozen-lockfile`
 
-**NEVER run installs with `--no-frozen-lockfile`** (e.g. `pnpm install --no-frozen-lockfile`) on your own. This flag silently mutates the lockfile to satisfy mismatched dependencies, which opens the door to supply chain attacks: a frozen lockfile pins exact, vetted dependency versions and integrity hashes, and bypassing it can pull in unreviewed or tampered packages. If an install fails because the lockfile is out of date, fix the root cause — update `package.json` and regenerate the lockfile with a normal `vp install` (or `pnpm install`) and commit the result. If you genuinely believe `--no-frozen-lockfile` is required, stop and ask the user to run it explicitly; never run it yourself.
+**NEVER run installs with `--no-frozen-lockfile`** (e.g. `pnpm install --no-frozen-lockfile`) on your own. Installs are frozen by default, so updating the lockfile requires this flag — which is exactly why an agent must never run it unattended. Bypassing the frozen lockfile opens the door to supply chain attacks: a frozen lockfile pins exact, vetted dependency versions and integrity hashes, and unfreezing it can pull in unreviewed or tampered packages. If you genuinely believe the lockfile needs to change, stop and ask the user to run the install with `--no-frozen-lockfile` themselves; never run it yourself.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an explicit instruction to `AGENTS.md` to never run installs with `--no-frozen-lockfile`.

The rule exists to avoid **supply chain attacks**: a frozen lockfile pins exact, vetted dependency versions and integrity hashes. `--no-frozen-lockfile` silently mutates the lockfile to satisfy mismatched dependencies, which can pull in unreviewed or tampered packages. Agents must never run it on their own — if they believe it's required, they must stop and ask the user to run it explicitly.

## Changes

- Add a "Never Install With `--no-frozen-lockfile`" subsection under **Code Style & Dependencies** in `AGENTS.md`.