### PR TITLE
Add explicit return type annotation for exported function

### DIFF
--- a/examples/app-router-playground/app/intercepting-routes/@modal/default.tsx
+++ b/examples/app-router-playground/app/intercepting-routes/@modal/default.tsx
@@ -1,3 +1,3 @@
-export default function Default() {
+export default function Default(): null {
   return null;
 }


### PR DESCRIPTION
## 问题背景
在 TypeScript 代码中，显式类型注解有助于提高代码的可读性和类型安全性。尽管 TypeScript 可以推断类型，但为公共导出函数添加返回类型注解是最佳实践，可以避免潜在的类型歧义并增强代码维护性。

## 修改内容
本次修改为 `examples/app-router-playground/app/intercepting-routes/@modal/default.tsx` 文件中的 `Default` 函数添加了显式返回类型注解 `null`。原函数缺少返回类型注解，通过显式标注，使函数签名更清晰。

## 验证方式
- 代码功能未改变，函数仍返回 `null`，不影响现有行为。
- TypeScript 编译通过，无类型错误或警告。
- 通过代码审查和运行测试确保没有引入回归，保持向后兼容。