### PR TITLE
refactor(server): extract pages fallback bridge into typed helper

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -94,6 +94,7 @@ const appHookWarningSuppressionPath = resolveEntryPath(
   import.meta.url,
 );
 const serverGlobalsPath = resolveEntryPath("../server/server-globals.js", import.meta.url);
+const appPagesBridgePath = resolveEntryPath("../server/app-pages-bridge.js", import.meta.url);
 
 /**
  * Resolved config options relevant to App Router request handling.
@@ -319,7 +320,12 @@ import { getSSRFontLinks as _getSSRFontLinks, getSSRFontStyles as _getSSRFontSty
 import { getSSRFontStyles as _getSSRFontStylesLocal, getSSRFontPreloads as _getSSRFontPreloadsLocal } from "next/font/local";
 function _getSSRFontStyles() { return [..._getSSRFontStylesGoogle(), ..._getSSRFontStylesLocal()]; }
 function _getSSRFontPreloads() { return [..._getSSRFontPreloadsGoogle(), ..._getSSRFontPreloadsLocal()]; }
-${hasPagesDir ? `// Pages Router routes are loaded lazily from the SSR environment for internal prerender requests.` : ""}
+${
+  hasPagesDir
+    ? `// Pages Router routes are loaded lazily from the SSR environment for internal prerender requests.
+import { renderPagesFallback as __renderPagesFallback } from ${JSON.stringify(appPagesBridgePath)};`
+    : ""
+}
 
 // Suppress expected "Invalid hook call" dev warning when layout/page
 // components are probed outside React's render cycle. The import patches
@@ -911,43 +917,17 @@ export default __createAppRscHandler({
   ${
     hasPagesDir
       ? `async renderPagesFallback({ isRscRequest, middlewareContext, request, url }) {
-    if (isRscRequest) return null;
-
-    const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
-
-    const __pagesRequestHeaders = middlewareContext.requestHeaders
-      ? __buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareContext.requestHeaders)
-      : null;
-    let __pagesRequest = request;
-    if (__pagesRequestHeaders) {
-      const __pagesRequestInit = {
-        method: request.method,
-        headers: __pagesRequestHeaders,
-      };
-      if (request.method !== "GET" && request.method !== "HEAD") {
-        __pagesRequestInit.body = request.body;
-        __pagesRequestInit.duplex = "half";
+    return __renderPagesFallback(
+      { isRscRequest, middlewareContext, request, url },
+      {
+        loadPagesEntry() {
+          return import.meta.viteRsc.loadModule("ssr", "index");
+        },
+        buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse,
+        decodePathParams: __decodePathParams,
+        applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext,
       }
-      __pagesRequest = new Request(request.url, __pagesRequestInit);
-    }
-
-    const __pagesUrl = __decodePathParams(url.pathname) + (url.search || "");
-    const __pagesPathname = url.pathname;
-    if (__pagesPathname.startsWith("/api/") || __pagesPathname === "/api") {
-      if (typeof __pagesEntry.handleApiRoute !== "function") return null;
-      const __pagesApiResponse = await __pagesEntry.handleApiRoute(__pagesRequest, __pagesUrl);
-      return __applyRouteHandlerMiddlewareContext(__pagesApiResponse, middlewareContext);
-    }
-
-    if (typeof __pagesEntry.renderPage !== "function") return null;
-    const __pagesRes = await __pagesEntry.renderPage(
-      __pagesRequest,
-      __pagesUrl,
-      {},
-      undefined,
-      middlewareContext.requestHeaders,
     );
-    return __pagesRes.status !== 404 ? __pagesRes : null;
   },`
       : ""
   }

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -13,7 +13,10 @@ export type PagesEntry = {
 
 type RenderPagesFallbackDependencies = {
   loadPagesEntry: () => Promise<PagesEntry> | PagesEntry;
-  buildRequestHeaders: (requestHeaders: Headers, middlewareRequestHeaders: Headers) => Headers;
+  buildRequestHeaders: (
+    requestHeaders: Headers,
+    middlewareRequestHeaders: Headers,
+  ) => Headers | null;
   decodePathParams: (pathname: string) => string;
   applyRouteHandlerMiddlewareContext: (
     response: Response,

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -1,0 +1,84 @@
+import type { AppMiddlewareContext } from "./app-middleware.js";
+
+export type PagesEntry = {
+  handleApiRoute?: (request: Request, url: string) => Promise<Response> | Response;
+  renderPage?: (
+    request: Request,
+    url: string,
+    query: Record<string, unknown>,
+    parsedUrl: unknown,
+    middlewareRequestHeaders?: Headers | null,
+  ) => Promise<Response> | Response;
+};
+
+type RenderPagesFallbackDependencies = {
+  loadPagesEntry: () => Promise<PagesEntry> | PagesEntry;
+  buildRequestHeaders: (requestHeaders: Headers, middlewareRequestHeaders: Headers) => Headers;
+  decodePathParams: (pathname: string) => string;
+  applyRouteHandlerMiddlewareContext: (
+    response: Response,
+    middlewareContext: AppMiddlewareContext,
+  ) => Response;
+};
+
+type RenderPagesFallbackOptions = {
+  isRscRequest: boolean;
+  middlewareContext: AppMiddlewareContext;
+  request: Request;
+  url: URL;
+};
+
+/**
+ * Fallback handler to route App Router requests to the Pages Router when no App Router route matches.
+ */
+export async function renderPagesFallback(
+  options: RenderPagesFallbackOptions,
+  dependencies: RenderPagesFallbackDependencies,
+): Promise<Response | null> {
+  const { isRscRequest, middlewareContext, request, url } = options;
+  const {
+    loadPagesEntry,
+    buildRequestHeaders,
+    decodePathParams,
+    applyRouteHandlerMiddlewareContext,
+  } = dependencies;
+
+  if (isRscRequest) return null;
+
+  const pagesEntry = await loadPagesEntry();
+
+  const pagesRequestHeaders = middlewareContext.requestHeaders
+    ? buildRequestHeaders(request.headers, middlewareContext.requestHeaders)
+    : null;
+
+  let pagesRequest = request;
+  if (pagesRequestHeaders) {
+    const pagesRequestInit: RequestInit & { duplex?: string } = {
+      method: request.method,
+      headers: pagesRequestHeaders,
+    };
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      pagesRequestInit.body = request.body;
+      pagesRequestInit.duplex = "half";
+    }
+    pagesRequest = new Request(request.url, pagesRequestInit);
+  }
+
+  const pagesUrl = decodePathParams(url.pathname) + (url.search || "");
+  const pagesPathname = url.pathname;
+  if (pagesPathname.startsWith("/api/") || pagesPathname === "/api") {
+    if (typeof pagesEntry.handleApiRoute !== "function") return null;
+    const pagesApiResponse = await pagesEntry.handleApiRoute(pagesRequest, pagesUrl);
+    return applyRouteHandlerMiddlewareContext(pagesApiResponse, middlewareContext);
+  }
+
+  if (typeof pagesEntry.renderPage !== "function") return null;
+  const pagesRes = await pagesEntry.renderPage(
+    pagesRequest,
+    pagesUrl,
+    {},
+    undefined,
+    middlewareContext.requestHeaders,
+  );
+  return pagesRes.status !== 404 ? pagesRes : null;
+}

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  renderPagesFallback,
+  type PagesEntry,
+} from "../packages/vinext/src/server/app-pages-bridge.js";
+import type { AppMiddlewareContext } from "../packages/vinext/src/server/app-middleware.js";
+
+describe("renderPagesFallback", () => {
+  const defaultDeps = {
+    loadPagesEntry: () => ({}) as PagesEntry,
+    buildRequestHeaders: (reqHeaders: Headers, mwHeaders: Headers) => {
+      const merged = new Headers(reqHeaders);
+      for (const [k, v] of mwHeaders) {
+        merged.set(k, v);
+      }
+      return merged;
+    },
+    decodePathParams: (pathname: string) => decodeURIComponent(pathname),
+    applyRouteHandlerMiddlewareContext: (res: Response, mwCtx: AppMiddlewareContext) => {
+      const mergedHeaders = new Headers(res.headers);
+      if (mwCtx.headers) {
+        for (const [k, v] of mwCtx.headers) {
+          mergedHeaders.set(k, v);
+        }
+      }
+      return new Response(res.body, {
+        status: mwCtx.status ?? res.status,
+        headers: mergedHeaders,
+      });
+    },
+  };
+
+  it("returns null for RSC requests and does not call the Pages loader", async () => {
+    const loadPagesEntry = vi.fn(() => ({}) as PagesEntry);
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: true,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request: new Request("http://localhost/about"),
+        url: new URL("http://localhost/about"),
+      },
+      {
+        ...defaultDeps,
+        loadPagesEntry,
+      },
+    );
+    expect(res).toBeNull();
+    expect(loadPagesEntry).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds request when middleware request headers are present", async () => {
+    const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api"));
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ handleApiRoute }) as PagesEntry,
+    };
+
+    const request = new Request("http://localhost/api/test", {
+      headers: { "x-original": "value" },
+    });
+    const url = new URL("http://localhost/api/test");
+
+    const mwRequestHeaders = new Headers({ "x-middleware": "injected" });
+
+    await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: mwRequestHeaders, status: null },
+        request,
+        url,
+      },
+      deps,
+    );
+
+    expect(handleApiRoute).toHaveBeenCalledTimes(1);
+    const forwardedReq = handleApiRoute.mock.calls[0][0];
+    expect(forwardedReq.headers.get("x-original")).toBe("value");
+    expect(forwardedReq.headers.get("x-middleware")).toBe("injected");
+  });
+
+  it("preserves method, body, and duplex for non-GET/HEAD requests", async () => {
+    const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api"));
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ handleApiRoute }) as PagesEntry,
+    };
+
+    const request = new Request("http://localhost/api/test", {
+      method: "POST",
+      headers: { "x-original": "value" },
+      body: "test-body",
+    });
+    const url = new URL("http://localhost/api/test");
+    const mwRequestHeaders = new Headers({ "x-middleware": "injected" });
+
+    await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: mwRequestHeaders, status: null },
+        request,
+        url,
+      },
+      deps,
+    );
+
+    expect(handleApiRoute).toHaveBeenCalledTimes(1);
+    const forwardedReq = handleApiRoute.mock.calls[0][0];
+    expect(forwardedReq.method).toBe("POST");
+    expect(await forwardedReq.text()).toBe("test-body");
+  });
+
+  it("routes /api and /api/* through handleApiRoute and applies middleware context", async () => {
+    const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api-response"));
+    const mwHeaders = new Headers({ "x-res-mw": "value" });
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ handleApiRoute }) as PagesEntry,
+    };
+
+    const request = new Request("http://localhost/api/foo/bar");
+    const url = new URL("http://localhost/api/foo/bar");
+
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: mwHeaders, requestHeaders: null, status: 201 },
+        request,
+        url,
+      },
+      deps,
+    );
+
+    expect(handleApiRoute).toHaveBeenCalledTimes(1);
+    expect(handleApiRoute.mock.calls[0][1]).toBe("/api/foo/bar");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(201);
+    expect(res!.headers.get("x-res-mw")).toBe("value");
+    expect(await res!.text()).toBe("api-response");
+  });
+
+  it("routes normal paths through renderPage and passes decoded pathname + search", async () => {
+    const renderPage = vi.fn((_req: Request, _url: string) => new Response("page-response"));
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ renderPage }) as PagesEntry,
+    };
+
+    const request = new Request("http://localhost/about%20us?foo=bar");
+    const url = new URL("http://localhost/about%20us?foo=bar");
+
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request,
+        url,
+      },
+      deps,
+    );
+
+    expect(renderPage).toHaveBeenCalledTimes(1);
+    expect(renderPage.mock.calls[0][1]).toBe("/about us?foo=bar");
+    expect(res).not.toBeNull();
+    expect(await res!.text()).toBe("page-response");
+  });
+
+  it("returns null when Pages renderPage returns 404 status", async () => {
+    const renderPage = vi.fn(
+      (_req: Request, _url: string) => new Response("not found", { status: 404 }),
+    );
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ renderPage }) as PagesEntry,
+    };
+
+    const request = new Request("http://localhost/nonexistent");
+    const url = new URL("http://localhost/nonexistent");
+
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request,
+        url,
+      },
+      deps,
+    );
+
+    expect(renderPage).toHaveBeenCalledTimes(1);
+    expect(res).toBeNull();
+  });
+});

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -78,6 +78,40 @@ describe("renderPagesFallback", () => {
     expect(forwardedReq.headers.get("x-middleware")).toBe("injected");
   });
 
+  it("forwards the original request unchanged when buildRequestHeaders returns null", async () => {
+    const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api"));
+    const buildRequestHeaders = vi.fn((_req: Headers, _mw: Headers): Headers | null => null);
+    const deps = {
+      ...defaultDeps,
+      buildRequestHeaders,
+      loadPagesEntry: () => ({ handleApiRoute }) as PagesEntry,
+    };
+
+    const request = new Request("http://localhost/api/test", {
+      headers: { "x-original": "value" },
+    });
+    const url = new URL("http://localhost/api/test");
+    const mwRequestHeaders = new Headers({ "x-middleware": "injected" });
+
+    await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: mwRequestHeaders, status: null },
+        request,
+        url,
+      },
+      deps,
+    );
+
+    expect(buildRequestHeaders).toHaveBeenCalledTimes(1);
+    expect(handleApiRoute).toHaveBeenCalledTimes(1);
+    // The original request object is forwarded as-is (not rebuilt).
+    expect(handleApiRoute.mock.calls[0][0]).toBe(request);
+    const forwardedReq = handleApiRoute.mock.calls[0][0];
+    expect(forwardedReq.headers.get("x-original")).toBe("value");
+    expect(forwardedReq.headers.get("x-middleware")).toBeNull();
+  });
+
   it("preserves method, body, and duplex for non-GET/HEAD requests", async () => {
     const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api"));
     const deps = {

--- a/tests/app-router-next-config-codegen.test.ts
+++ b/tests/app-router-next-config-codegen.test.ts
@@ -126,14 +126,13 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
       hasPagesDir: true,
     });
 
-    expect(code).toContain("const __pagesPathname = url.pathname;");
+    expect(code).toContain("renderPagesFallback as __renderPagesFallback");
+    expect(code).toContain("server/app-pages-bridge.js");
+    expect(code).toContain("return __renderPagesFallback(");
+    expect(code).toContain('return import.meta.viteRsc.loadModule("ssr", "index");');
+    expect(code).toContain("buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse");
     expect(code).toContain(
-      'if (__pagesPathname.startsWith("/api/") || __pagesPathname === "/api")',
-    );
-    expect(code).toContain('typeof __pagesEntry.handleApiRoute !== "function"');
-    expect(code).toContain("__pagesEntry.handleApiRoute(");
-    expect(code).toContain(
-      "__applyRouteHandlerMiddlewareContext(__pagesApiResponse, middlewareContext)",
+      "applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext",
     );
   });
 


### PR DESCRIPTION
Extracts the App Router to Pages Router fallback bridge logic from app-rsc-entry.ts into packages/vinext/src/server/app-pages-bridge.ts. Passes all tests successfully.