### PR TITLE
refactor(server): replace prerender HTML buffering with metadataReady contract

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -75,7 +75,7 @@ import {
 } from "./app-rsc-render-mode.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 import { createAppPageTreePath } from "./app-page-route-wiring.js";
-import type { AppPageSsrHandler } from "./app-page-stream.js";
+import { isAppSsrRenderResult, type AppPageSsrHandler } from "./app-page-stream.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
 import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
@@ -608,7 +608,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
             const revalidatedCapturedRscRef: { value: Promise<ArrayBuffer> | null } = {
               value: null,
             };
-            const revalidatedHtmlStream = await revalidatedSsrEntry.handleSsr(
+            const revalidatedHtmlResult = await revalidatedSsrEntry.handleSsr(
               revalidatedRscCapture.ssrStream,
               options.getNavigationContext(),
               {
@@ -628,6 +628,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
                   : {}),
               },
             );
+            const revalidatedHtmlStream = isAppSsrRenderResult(revalidatedHtmlResult)
+              ? revalidatedHtmlResult.htmlStream
+              : revalidatedHtmlResult;
             const html = await readStreamAsText(revalidatedHtmlStream);
             const rscData = await getCapturedRscDataPromise(revalidatedCapturedRscRef.value);
             const cacheLife = _consumeRequestScopedCacheLife();

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -620,6 +620,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
                 basePath: options.basePath,
                 clientTraceMetadata: options.clientTraceMetadata,
                 rootParams: options.rootParams,
+                waitForAllReady: true,
                 ...(revalidatedRscCapture.sideStream
                   ? {
                       sideStream: revalidatedRscCapture.sideStream,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -57,7 +57,7 @@ import type {
   ClientReuseManifestTraceFields,
 } from "./client-reuse-manifest.js";
 import { NO_STORE_CACHE_CONTROL } from "./cache-control.js";
-import { readStreamAsText } from "../utils/text-stream.js";
+
 import {
   createClientReuseSkipTransportPlan,
   createStaticLayoutClientReuseArtifactCompatibility,
@@ -179,8 +179,6 @@ type RenderAppPageLifecycleOptions = {
   classification?: LayoutClassificationOptions | null;
 };
 
-const textEncoder = new TextEncoder();
-
 function buildResponseTiming(
   options: Pick<RenderAppPageLifecycleOptions, "handlerStart" | "isProduction"> & {
     compileEnd?: number;
@@ -198,18 +196,6 @@ function buildResponseTiming(
     renderEnd: options.renderEnd,
     responseKind: options.responseKind,
   };
-}
-
-function createBufferedHtmlStream(html: string): ReadableStream<Uint8Array> {
-  const encoded = textEncoder.encode(html);
-  return new ReadableStream({
-    start(controller) {
-      if (encoded.byteLength > 0) {
-        controller.enqueue(encoded);
-      }
-      controller.close();
-    },
-  });
 }
 
 function readRequestCacheLifeForPrerender(
@@ -899,9 +885,8 @@ export async function renderAppPageLifecycle(
 
   // Eagerly read values that must be captured before the stream is consumed.
   if (options.isPrerender === true) {
-    const bufferedHtml = await readStreamAsText(htmlStream);
-    htmlStream = createBufferedHtmlStream(bufferedHtml);
-    await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+    await htmlRender.metadataReady;
+    await settleCapturedRscRenderForCacheMetadata(htmlRender.capturedRscData);
     ({ expireSeconds, revalidateSeconds } = applyRequestCacheLife({
       expireSeconds,
       requestCacheLife: readRequestCacheLifeForPrerender(options),

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -57,7 +57,6 @@ import type {
   ClientReuseManifestTraceFields,
 } from "./client-reuse-manifest.js";
 import { NO_STORE_CACHE_CONTROL } from "./cache-control.js";
-
 import {
   createClientReuseSkipTransportPlan,
   createStaticLayoutClientReuseArtifactCompatibility,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -846,6 +846,10 @@ export async function renderAppPageLifecycle(
     throw new Error("[vinext] Expected an HTML stream when no fallback response was returned");
   }
 
+  if (options.isPrerender === true) {
+    await htmlRender.metadataReady;
+  }
+
   // Routes with a route-level Suspense boundary (loading.tsx) skip the page
   // probe — the page render happens once, inside the RSC stream. Mirror
   // Next.js's `app-render.tsx:4293` catch shape: by the time the SSR shell
@@ -885,7 +889,6 @@ export async function renderAppPageLifecycle(
 
   // Eagerly read values that must be captured before the stream is consumed.
   if (options.isPrerender === true) {
-    await htmlRender.metadataReady;
     await settleCapturedRscRenderForCacheMetadata(htmlRender.capturedRscData);
     ({ expireSeconds, revalidateSeconds } = applyRequestCacheLife({
       expireSeconds,

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -17,6 +17,18 @@ type CreateAppPageFontDataOptions = {
   getStyles: () => string[];
 };
 
+export type AppSsrRenderResult = {
+  htmlStream: ReadableStream<Uint8Array>;
+  metadataReady: Promise<void>;
+  capturedRscData: Promise<ArrayBuffer> | null;
+};
+
+export function isAppSsrRenderResult(value: unknown): value is AppSsrRenderResult {
+  return (
+    typeof value === "object" && value !== null && "htmlStream" in value && "metadataReady" in value
+  );
+}
+
 export type AppPageSsrHandler = {
   handleSsr: (
     rscStream: ReadableStream<Uint8Array>,
@@ -39,7 +51,7 @@ export type AppPageSsrHandler = {
       /** Dev-only: original server error to surface in the browser overlay. */
       initialDevServerError?: unknown;
     },
-  ) => Promise<ReadableStream<Uint8Array>>;
+  ) => Promise<ReadableStream<Uint8Array> | AppSsrRenderResult>;
 };
 
 type RenderAppPageHtmlStreamOptions = {
@@ -79,12 +91,14 @@ type RenderAppPageHtmlResponseOptions = {
 type AppPageHtmlStreamRecoveryResult = {
   htmlStream: ReadableStream<Uint8Array> | null;
   response: Response | null;
+  metadataReady: Promise<void>;
+  capturedRscData: Promise<ArrayBuffer> | null;
 };
 
 type RenderAppPageHtmlStreamWithRecoveryOptions<TSpecialError> = {
   onShellRendered?: () => void;
   renderErrorBoundaryResponse: (error: unknown) => Promise<Response | null>;
-  renderHtmlStream: () => Promise<ReadableStream<Uint8Array>>;
+  renderHtmlStream: () => Promise<ReadableStream<Uint8Array> | AppSsrRenderResult>;
   renderSpecialErrorResponse: (specialError: TSpecialError) => Promise<Response>;
   resolveSpecialError: (error: unknown) => TSpecialError | null;
 };
@@ -116,7 +130,7 @@ export function createAppPageFontData(options: CreateAppPageFontDataOptions): Ap
 
 export async function renderAppPageHtmlStream(
   options: RenderAppPageHtmlStreamOptions,
-): Promise<ReadableStream<Uint8Array>> {
+): Promise<AppSsrRenderResult> {
   const ssrOptions = {
     formState: options.formState ?? null,
     scriptNonce: options.scriptNonce,
@@ -129,12 +143,22 @@ export async function renderAppPageHtmlStream(
     initialDevServerError: options.initialDevServerError,
   };
 
-  return options.ssrHandler.handleSsr(
+  const rawResult = await options.ssrHandler.handleSsr(
     options.rscStream,
     options.navigationContext,
     options.fontData,
     ssrOptions,
   );
+
+  if (isAppSsrRenderResult(rawResult)) {
+    return rawResult;
+  }
+
+  return {
+    htmlStream: rawResult,
+    metadataReady: Promise.resolve(),
+    capturedRscData: options.capturedRscDataRef?.value ?? null,
+  };
 }
 
 /**
@@ -195,7 +219,7 @@ export function deferUntilStreamConsumed(
 export async function renderAppPageHtmlResponse(
   options: RenderAppPageHtmlResponseOptions,
 ): Promise<Response> {
-  const htmlStream = await renderAppPageHtmlStream(options);
+  const { htmlStream } = await renderAppPageHtmlStream(options);
 
   // Defer clearRequestContext() until the stream is fully consumed by the HTTP
   // layer. Calling it synchronously here would race the lazy RSC/SSR pipeline:
@@ -228,11 +252,21 @@ export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
   options: RenderAppPageHtmlStreamWithRecoveryOptions<TSpecialError>,
 ): Promise<AppPageHtmlStreamRecoveryResult> {
   try {
-    const htmlStream = await options.renderHtmlStream();
+    const rawResult = await options.renderHtmlStream();
+    const result = isAppSsrRenderResult(rawResult)
+      ? rawResult
+      : {
+          htmlStream: rawResult,
+          metadataReady: Promise.resolve(),
+          capturedRscData: null,
+        };
+    const { htmlStream, metadataReady, capturedRscData } = result;
     options.onShellRendered?.();
     return {
       htmlStream,
       response: null,
+      metadataReady,
+      capturedRscData,
     };
   } catch (error) {
     const specialError = options.resolveSpecialError(error);
@@ -240,6 +274,8 @@ export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
       return {
         htmlStream: null,
         response: await options.renderSpecialErrorResponse(specialError),
+        metadataReady: Promise.resolve(),
+        capturedRscData: null,
       };
     }
 
@@ -248,6 +284,8 @@ export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
       return {
         htmlStream: null,
         response: boundaryResponse,
+        metadataReady: Promise.resolve(),
+        capturedRscData: null,
       };
     }
 

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -29,6 +29,23 @@ export function isAppSsrRenderResult(value: unknown): value is AppSsrRenderResul
   );
 }
 
+const resolvedMetadataReady = Promise.resolve();
+
+function normalizeAppSsrRenderResult(
+  raw: ReadableStream<Uint8Array> | AppSsrRenderResult,
+  fallbackCapturedRscData: Promise<ArrayBuffer> | null = null,
+): AppSsrRenderResult {
+  if (isAppSsrRenderResult(raw)) {
+    return raw;
+  }
+
+  return {
+    htmlStream: raw,
+    metadataReady: resolvedMetadataReady,
+    capturedRscData: fallbackCapturedRscData,
+  };
+}
+
 export type AppPageSsrHandler = {
   handleSsr: (
     rscStream: ReadableStream<Uint8Array>,
@@ -150,15 +167,7 @@ export async function renderAppPageHtmlStream(
     ssrOptions,
   );
 
-  if (isAppSsrRenderResult(rawResult)) {
-    return rawResult;
-  }
-
-  return {
-    htmlStream: rawResult,
-    metadataReady: Promise.resolve(),
-    capturedRscData: options.capturedRscDataRef?.value ?? null,
-  };
+  return normalizeAppSsrRenderResult(rawResult, options.capturedRscDataRef?.value ?? null);
 }
 
 /**
@@ -253,14 +262,7 @@ export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
 ): Promise<AppPageHtmlStreamRecoveryResult> {
   try {
     const rawResult = await options.renderHtmlStream();
-    const result = isAppSsrRenderResult(rawResult)
-      ? rawResult
-      : {
-          htmlStream: rawResult,
-          metadataReady: Promise.resolve(),
-          capturedRscData: null,
-        };
-    const { htmlStream, metadataReady, capturedRscData } = result;
+    const { htmlStream, metadataReady, capturedRscData } = normalizeAppSsrRenderResult(rawResult);
     options.onShellRendered?.();
     return {
       htmlStream,
@@ -274,7 +276,7 @@ export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
       return {
         htmlStream: null,
         response: await options.renderSpecialErrorResponse(specialError),
-        metadataReady: Promise.resolve(),
+        metadataReady: resolvedMetadataReady,
         capturedRscData: null,
       };
     }
@@ -284,7 +286,7 @@ export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
       return {
         htmlStream: null,
         response: boundaryResponse,
-        metadataReady: Promise.resolve(),
+        metadataReady: resolvedMetadataReady,
         capturedRscData: null,
       };
     }

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -37,7 +37,7 @@ import {
   createRscEmbedTransform,
   createTickBufferedTransform,
 } from "./app-ssr-stream.js";
-import { deferUntilStreamConsumed } from "./app-page-stream.js";
+import { deferUntilStreamConsumed, type AppSsrRenderResult } from "./app-page-stream.js";
 import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { createInitialDevServerErrorScript } from "./dev-initial-server-error.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
@@ -272,7 +272,7 @@ export async function handleSsr(
      *  and ISR cache writes to avoid caching fallback content. */
     waitForAllReady?: boolean;
   },
-): Promise<ReadableStream<Uint8Array>> {
+): Promise<AppSsrRenderResult> {
   return runWithNavigationContext(async () => {
     await clientReferencePreloader.preload();
 
@@ -434,14 +434,6 @@ export async function handleSsr(
           },
         });
 
-        // When producing static output (prerender / ISR cache writes), wait for
-        // the full React tree to resolve before emitting bytes. This prevents
-        // Suspense fallback content from being serialized to the cache.
-        // Matches Next.js waitForAllReady forkpoint in renderToNodeFizzStream.
-        if (options?.waitForAllReady === true) {
-          await htmlStream.allReady;
-        }
-
         // Populated before any SSR request runs: at prod-server startup
         // (prod-server.ts) or via build-time bundle injection (index.ts). Left
         // undefined in dev, which naturally disables inline CSS there.
@@ -499,7 +491,7 @@ export async function handleSsr(
         const getBeforeInteractiveHeadHTML = (): string =>
           renderBeforeInteractiveInlineScripts(beforeInteractiveInlineScripts);
 
-        return deferUntilStreamConsumed(
+        const finalStream = deferUntilStreamConsumed(
           htmlStream.pipeThrough(
             createTickBufferedTransform(
               rscEmbed,
@@ -513,12 +505,19 @@ export async function handleSsr(
           ),
           cleanup,
         );
+
+        return {
+          htmlStream: finalStream,
+          metadataReady:
+            options?.waitForAllReady === true ? htmlStream.allReady : Promise.resolve(),
+          capturedRscData: options?.capturedRscDataRef?.value ?? null,
+        };
       } catch (error) {
         cleanup();
         throw error;
       }
     });
-  }) as Promise<ReadableStream<Uint8Array>>;
+  }) as Promise<AppSsrRenderResult>;
 }
 
 export default {

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -491,6 +491,10 @@ export async function handleSsr(
         const getBeforeInteractiveHeadHTML = (): string =>
           renderBeforeInteractiveInlineScripts(beforeInteractiveInlineScripts);
 
+        if (options?.waitForAllReady === true) {
+          await htmlStream.allReady;
+        }
+
         const finalStream = deferUntilStreamConsumed(
           htmlStream.pipeThrough(
             createTickBufferedTransform(

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -512,6 +512,14 @@ export async function handleSsr(
 
         return {
           htmlStream: finalStream,
+          // `metadataReady` resolves eagerly precisely *because* `allReady` was
+          // already awaited above when `waitForAllReady` is set (the prerender
+          // path). At that point the React tree is fully rendered, so all
+          // render-time metadata (cache life, headers, captured RSC errors) is
+          // already settled and there is nothing left for the lifecycle to wait
+          // on. The promise exists to keep `renderAppPageLifecycle` agnostic to
+          // *where* the blocking happens — do not move the `allReady` await onto
+          // this promise expecting it to be load-bearing in production.
           metadataReady: Promise.resolve(),
           capturedRscData: options?.capturedRscDataRef?.value ?? null,
         };

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -512,8 +512,7 @@ export async function handleSsr(
 
         return {
           htmlStream: finalStream,
-          metadataReady:
-            options?.waitForAllReady === true ? htmlStream.allReady : Promise.resolve(),
+          metadataReady: Promise.resolve(),
           capturedRscData: options?.capturedRscDataRef?.value ?? null,
         };
       } catch (error) {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -56,7 +56,7 @@ type PagesGsspContextResponse = {
   responsePromise: Promise<Response>;
 };
 
-type PagesPageModule = {
+export type PagesPageModule = {
   default?: unknown;
   getStaticPaths?: (context: {
     locales: string[];

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -1144,4 +1144,62 @@ describe("app page dispatch", () => {
       undefined,
     );
   });
+
+  it("regenerates stale HTML cache entries with waitForAllReady so suspense fallbacks never leak into the cache", async () => {
+    // Stale-while-revalidate regeneration must await React's `allReady` before
+    // transforming/buffering the HTML stream — same guarantee as the prerender
+    // path. Without `waitForAllReady: true`, Suspense fallback content could be
+    // written to the regenerated cache entry instead of the resolved content.
+    const route = createRoute({ pattern: "/posts/[slug]", routeSegments: ["posts", "[slug]"] });
+    let scheduledRender: unknown = null;
+    const scheduleBackgroundRegeneration: DispatchOptions["scheduleBackgroundRegeneration"] = (
+      _key,
+      renderFn,
+    ) => {
+      scheduledRender = renderFn;
+    };
+    let capturedWaitForAllReady: boolean | undefined;
+    const isrSet = vi.fn(async () => {});
+    const { options } = createDispatchOptions({
+      buildPageElement: async () => React.createElement("main", null, "fresh"),
+      cleanPathname: "/posts/hello",
+      isProduction: true,
+      isrGet: vi.fn(async () =>
+        buildISRCacheEntry(buildCachedAppPageValue("<html>stale</html>"), true),
+      ),
+      isrSet,
+      loadSsrHandler: async () => ({
+        async handleSsr(_rscStream, _navigationContext, _fontData, captureOptions) {
+          capturedWaitForAllReady = captureOptions?.waitForAllReady;
+          if (captureOptions?.capturedRscDataRef) {
+            captureOptions.capturedRscDataRef.value = Promise.resolve(
+              new TextEncoder().encode("fresh-flight").buffer,
+            );
+          }
+          void captureOptions?.sideStream?.cancel().catch(() => {});
+          return createStream(["<html>fresh</html>"]);
+        },
+      }),
+      renderToReadableStream() {
+        return createStream(["flight"]);
+      },
+      revalidateSeconds: 60,
+      route,
+      scheduleBackgroundRegeneration,
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.headers.get("x-vinext-cache")).toBe("STALE");
+    await expect(response.text()).resolves.toBe("<html>stale</html>");
+    expect(typeof scheduledRender).toBe("function");
+    if (typeof scheduledRender !== "function") {
+      throw new Error("expected stale HTML response to schedule regeneration");
+    }
+
+    await scheduledRender();
+
+    expect(capturedWaitForAllReady).toBe(true);
+    expect(isrSet).toHaveBeenCalled();
+  });
 });

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -776,7 +776,7 @@ describe("app page render lifecycle", () => {
       isProduction: false,
       loadSsrHandler: async () => ({
         async handleSsr(
-          _rscStream: ReadableStream<Uint8Array>,
+          rscStream: ReadableStream<Uint8Array>,
           _navContext: unknown,
           _fontData: unknown,
           options?: {
@@ -784,21 +784,24 @@ describe("app page render lifecycle", () => {
             capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
           },
         ) {
-          let sent = false;
-          return new ReadableStream<Uint8Array>({
-            pull(controller) {
-              if (sent) {
-                controller.close();
-                return;
-              }
-              sent = true;
-              if (options?.sideStream && options.capturedRscDataRef) {
-                options.capturedRscDataRef.value = new Response(options.sideStream).arrayBuffer();
-              }
+          const stream = options?.sideStream ?? rscStream;
+          const capturedRscData = new Response(stream).arrayBuffer();
+          if (options?.capturedRscDataRef) {
+            options.capturedRscDataRef.value = capturedRscData;
+          }
+
+          const htmlStream = new ReadableStream<Uint8Array>({
+            start(controller) {
               controller.enqueue(new TextEncoder().encode("<html>page</html>"));
               controller.close();
             },
           });
+
+          return {
+            htmlStream,
+            metadataReady: capturedRscData.then(() => {}),
+            capturedRscData,
+          };
         },
       }),
       renderToReadableStream() {
@@ -998,6 +1001,45 @@ describe("app page render lifecycle", () => {
     });
     expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
     await expect(response.text()).resolves.toBe("flight-data");
+  });
+
+  it("streams runtime HTML responses progressively without buffering the body", async () => {
+    const common = createCommonOptions();
+    const releaseSsr = createDeferred();
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isPrerender: false,
+      loadSsrHandler: async () => ({
+        async handleSsr() {
+          const htmlStream = new ReadableStream<Uint8Array>({
+            async pull(controller) {
+              controller.enqueue(new TextEncoder().encode("<html>part1</html>"));
+              await releaseSsr.promise;
+              controller.enqueue(new TextEncoder().encode("<html>part2</html>"));
+              controller.close();
+            },
+          });
+          return {
+            htmlStream,
+            metadataReady: Promise.resolve(),
+            capturedRscData: null,
+          };
+        },
+      }),
+    });
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Expected a response body");
+    }
+
+    const { value: chunk1 } = await reader.read();
+    expect(new TextDecoder().decode(chunk1)).toBe("<html>part1</html>");
+
+    releaseSsr.resolve();
+    const { value: chunk2 } = await reader.read();
+    expect(new TextDecoder().decode(chunk2)).toBe("<html>part2</html>");
   });
 });
 

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1081,7 +1081,7 @@ describe("app page render lifecycle", () => {
   it("captures special errors thrown during the full prerender SSR pass and converts them to 307/404 response", async () => {
     const common = createCommonOptions();
     const notFoundError = Object.assign(new Error("NEXT_NOT_FOUND"), { digest: "NEXT_NOT_FOUND" });
-    let capturedOnError: any = null;
+    let capturedOnError: ((error: unknown, ...args: unknown[]) => void) | null = null;
 
     const response = await renderAppPageLifecycle({
       ...common.options,

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1041,6 +1041,78 @@ describe("app page render lifecycle", () => {
     const { value: chunk2 } = await reader.read();
     expect(new TextDecoder().decode(chunk2)).toBe("<html>part2</html>");
   });
+
+  it("waits for metadataReady to resolve before returning the response in prerender mode", async () => {
+    const common = createCommonOptions();
+    let metadataReadyResolved = false;
+    const releaseMetadata = createDeferred();
+
+    const responsePromise = renderAppPageLifecycle({
+      ...common.options,
+      isPrerender: true,
+      loadSsrHandler: async () => ({
+        async handleSsr() {
+          return {
+            htmlStream: createStream(["<html>page</html>"]),
+            metadataReady: releaseMetadata.promise.then(() => {
+              metadataReadyResolved = true;
+            }),
+            capturedRscData: null,
+          };
+        },
+      }),
+    });
+
+    // Verify that the response is NOT returned yet because metadataReady is pending
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    let responseReturned = false;
+    void responsePromise.then(() => {
+      responseReturned = true;
+    });
+    expect(responseReturned).toBe(false);
+
+    // Resolve metadataReady
+    releaseMetadata.resolve();
+    const response = await responsePromise;
+    expect(metadataReadyResolved).toBe(true);
+    expect(response.status).toBe(200);
+  });
+
+  it("captures special errors thrown during the full prerender SSR pass and converts them to 307/404 response", async () => {
+    const common = createCommonOptions();
+    const notFoundError = Object.assign(new Error("NEXT_NOT_FOUND"), { digest: "NEXT_NOT_FOUND" });
+    let capturedOnError: any = null;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isPrerender: true,
+      hasLoadingBoundary: true,
+      loadSsrHandler: async () => ({
+        async handleSsr(_rscStream, _navContext, _fontData, _options) {
+          // Trigger the captured onError callback representing a component throw
+          if (capturedOnError) {
+            capturedOnError(notFoundError, null, null);
+          }
+          return {
+            htmlStream: createStream(["<html>fallback</html>"]),
+            metadataReady: Promise.resolve(),
+            capturedRscData: null,
+          };
+        },
+      }),
+      renderToReadableStream(_element, opts) {
+        capturedOnError = opts.onError;
+        return createStream(["flight-data"]);
+      },
+    });
+
+    expect(response.status).toBe(404);
+    expect(common.renderPageSpecialError).toHaveBeenCalledTimes(1);
+    expect(common.renderPageSpecialError).toHaveBeenCalledWith({
+      kind: "http-access-fallback",
+      statusCode: 404,
+    });
+  });
 });
 
 describe("layoutFlags injection into RSC payload", () => {

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -48,7 +48,7 @@ describe("app page stream helpers", () => {
       getStyles: () => [],
     });
 
-    const htmlStream = await renderAppPageHtmlStream({
+    const { htmlStream } = await renderAppPageHtmlStream({
       fontData,
       navigationContext: { pathname: "/test" },
       rscStream: createStream(["flight"]),
@@ -67,7 +67,7 @@ describe("app page stream helpers", () => {
   it("forwards waitForAllReady to the SSR handler", async () => {
     const ssrHandler = vi.fn(async () => createStream(["<html>all-ready</html>"]));
 
-    const htmlStream = await renderAppPageHtmlStream({
+    const { htmlStream } = await renderAppPageHtmlStream({
       fontData: createAppPageFontData({
         getLinks: () => [],
         getPreloads: () => [],
@@ -93,7 +93,7 @@ describe("app page stream helpers", () => {
     const formState = ["action-result", "key-path", "reference-id", 1] as never;
     const ssrHandler = vi.fn(async () => createStream(["<html>form-state</html>"]));
 
-    const htmlStream = await renderAppPageHtmlStream({
+    const { htmlStream } = await renderAppPageHtmlStream({
       fontData: createAppPageFontData({
         getLinks: () => [],
         getPreloads: () => [],
@@ -117,7 +117,7 @@ describe("app page stream helpers", () => {
   it("forwards basePath to the SSR handler", async () => {
     const ssrHandler = vi.fn(async () => createStream(["<html>base-path</html>"]));
 
-    const htmlStream = await renderAppPageHtmlStream({
+    const { htmlStream } = await renderAppPageHtmlStream({
       basePath: "/docs",
       fontData: createAppPageFontData({
         getLinks: () => [],


### PR DESCRIPTION
### Triage / Issue Context
This PR resolves [Issue #1795](https://github.com/cloudflare/vinext/issues/1795). 

Previously, `renderAppPageLifecycle()` implicitly buffered the entire HTML stream using `readStreamAsText(htmlStream)` during prerendering in order to discover metadata (such as cache life revalidation and headers) generated during component rendering. While this worked, it forced full stream buffering of the body.

### Proposed Changes
We introduce an explicit `metadataReady` promise contract between the SSR handler (`app-ssr-entry.ts`) and the app-page rendering lifecycle (`app-page-render.ts`).

1. **`AppSsrRenderResult`**:
   Introduced a unified return result for `handleSsr()` under `app-page-stream.ts`:
   ```ts
   export type AppSsrRenderResult = {
     htmlStream: ReadableStream<Uint8Array>;
     metadataReady: Promise<void>;
     capturedRscData: Promise<ArrayBuffer> | null;
   };
   ```

2. **SSR Entry Contract (`handleSsr`)**:
   - Modified `handleSsr()` to return `AppSsrRenderResult`.
   - **For dynamic requests**: It returns immediately with `metadataReady: Promise.resolve()`, ensuring fully unbuffered progressive streaming.
   - **For static/prerender requests** (`waitForAllReady: true`): It blocks and awaits `htmlStream.allReady` inside `handleSsr()` *before* piping the HTML stream through the tick-buffered transform pipeline. This guarantees that Fizz HTML is not pulled or transformed before the React rendering tree is fully ready, preventing suspense fallback leaks. The returned `metadataReady` promise is set to `Promise.resolve()` since `allReady` is already resolved.

3. **Lifecycle Integration**:
   Modified `renderAppPageLifecycle()` to:
   - Await `htmlRender.metadataReady` and `settleCapturedRscRenderForCacheMetadata(htmlRender.capturedRscData)` when `options.isPrerender === true`.
   - Completely remove the `readStreamAsText` and `createBufferedHtmlStream` logic from the rendering flow.
   - Serve the HTML response to the build/prerender engine as a live, unbuffered `ReadableStream`.
   - Perform the route-level Suspense check (capturing `redirect()` / `notFound()` thrown during the full SSR pass) *after* awaiting `metadataReady` to ensure those errors are correctly captured and processed before the response is returned.

4. **ISR Revalidation**:
   - Updated `app-page-dispatch.ts` to pass `waitForAllReady: true` when rendering fresh cache output to block stream transformations until React is fully ready, preserving correct cache state.

5. **Refactored Compatibility Glue**:
   - Added a private `normalizeAppSsrRenderResult` helper and a shared `resolvedMetadataReady` constant in `app-page-stream.ts` to normalize return results cleanly, avoiding duplicate compatibility code in `renderAppPageHtmlStream` and `renderAppPageHtmlStreamWithRecovery`.

### Verification Plan
- Added behavior test `"streams runtime HTML responses progressively without buffering the body"` verifying that runtime requests stream chunks progressively.
- Added test `"waits for metadataReady to resolve before returning the response in prerender mode"`.
- Added test `"captures special errors thrown during the full prerender SSR pass and converts them to 307/404 response"`.
- Ran full toolchain check: `vp check` (passed with zero lint/formatting/type/knip errors).
- Built package: `pnpm run build` (successful).

Next.js Reference: matches Next.js static rendering flow where `allReady` is awaited asynchronously for static/ISR targets: [Next.js app-render.tsx](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx)
