### PR TITLE
fix(build): write BUILD_ID via writeBundle so App Router builds emit it

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -448,10 +448,15 @@ async function buildApp() {
   // Coordinate a single build ID across every vinext() plugin instance in this
   // build. A hybrid app+pages build runs the App Router multi-environment build
   // (buildApp) and a separate Pages Router SSR build (vite.build) as distinct
-  // plugin instances; without this, each resolves its own random UUID and the
-  // runtime, prerender manifest, and dist/server/BUILD_ID disagree. We resolve
-  // it once here (honoring the user's generateBuildId) and share it via env; the
-  // plugin adopts it unless the user supplied their own generateBuildId.
+  // plugin instances; without this, each resolves its own (potentially random)
+  // ID and the runtime, prerender manifest, and dist/server/BUILD_ID disagree.
+  // We resolve it once here — resolveNextConfig() already ran resolveBuildId()
+  // honoring the user's generateBuildId (including the null→UUID fallback) — and
+  // share that authoritative value via env so every plugin instance adopts it.
+  //
+  // Not cleaned up intentionally: `vinext build` runs once and the process
+  // exits, so there is no in-process reuse to leak into. The var is namespaced
+  // to vinext's build flow and is never read by dev or standalone resolveBuildId.
   process.env.__VINEXT_SHARED_BUILD_ID = resolvedNextConfig.buildId;
 
   const outputMode = resolvedNextConfig.output;

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -444,6 +444,16 @@ async function buildApp() {
     await loadNextConfig(root, PHASE_PRODUCTION_BUILD),
     root,
   );
+
+  // Coordinate a single build ID across every vinext() plugin instance in this
+  // build. A hybrid app+pages build runs the App Router multi-environment build
+  // (buildApp) and a separate Pages Router SSR build (vite.build) as distinct
+  // plugin instances; without this, each resolves its own random UUID and the
+  // runtime, prerender manifest, and dist/server/BUILD_ID disagree. We resolve
+  // it once here (honoring the user's generateBuildId) and share it via env; the
+  // plugin adopts it unless the user supplied their own generateBuildId.
+  process.env.__VINEXT_SHARED_BUILD_ID = resolvedNextConfig.buildId;
+
   const outputMode = resolvedNextConfig.output;
   const distDir = path.resolve(root, "dist");
 

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -354,6 +354,15 @@ declare global {
       __VINEXT_BUILD_ID?: string;
 
       /**
+       * Build-only coordination variable set by the `vinext build` CLI so that
+       * every vinext() plugin instance in a single build (App Router buildApp +
+       * the separate hybrid Pages Router vite.build) resolves the same build ID.
+       * Distinct from `__VINEXT_BUILD_ID` (the runtime value baked via `define`)
+       * so it never leaks into dev or standalone resolveBuildId() semantics.
+       */
+      __VINEXT_SHARED_BUILD_ID?: string;
+
+      /**
        * Public App Router RSC compatibility identity injected via Vite
        * `define`. Used by browser navigation code to reject RSC payloads from
        * a different vinext build without exposing the raw build ID header.

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4293,18 +4293,24 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     },
     // Write BUILD_ID to dist/server/ so post-build tools (TPR, seed-cache) can
     // read the build identifier without depending on the prerender manifest.
-    // Uses closeBundle (not writeBundle) with a one-time write guard so the file
+    // Uses writeBundle (not closeBundle) with a one-time write guard so the file
     // is written exactly once per build regardless of how many environments are
     // active (App Router RSC+SSR+client, Pages Router SSR+client, etc.).
-    // The path is always dist/server/BUILD_ID — derived from root, not from the
-    // per-environment options.dir — so it works for all router types.
+    //
+    // closeBundle does not fire reliably during the multi-environment
+    // createBuilder().buildApp() pipeline used for App Router production builds,
+    // so the file was silently never written for pure App Router apps. writeBundle
+    // fires for every emitted bundle (matching the vinext:image-config plugin
+    // above), so the guard captures the first one. The path is always
+    // dist/server/BUILD_ID — derived from root, not from the per-environment
+    // options.dir — so it works for all router types.
     (() => {
       let buildIdWritten = false;
       return {
         name: "vinext:build-id",
         apply: "build" as const,
         enforce: "post" as const,
-        closeBundle: {
+        writeBundle: {
           sequential: true,
           order: "post" as const,
           handler() {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1205,6 +1205,28 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             rawConfig = await loadNextConfig(root, phase);
           }
           nextConfig = await resolveNextConfig(rawConfig, root);
+
+          // Build-ID coordination across plugin instances.
+          //
+          // A single `vinext build` can instantiate vinext() more than once —
+          // the App Router multi-environment build (createBuilder().buildApp())
+          // and the separate Pages Router SSR build for hybrid app+pages apps
+          // are distinct plugin instances, each resolving its own config. With
+          // no user `generateBuildId`, resolveNextConfig() mints a fresh random
+          // UUID per instance, so the App Router runtime, the Pages Router
+          // runtime, the prerender manifest, and dist/server/BUILD_ID would each
+          // get a different build ID.
+          //
+          // The CLI resolves the build ID once (honoring the user's
+          // generateBuildId) and publishes it via __VINEXT_SHARED_BUILD_ID. We
+          // adopt it here when the user did not supply their own generateBuildId
+          // (a user-provided generateBuildId is authoritative and already shared
+          // because every instance calls it). This keeps all instances coherent
+          // without changing resolveBuildId()'s standalone semantics.
+          const sharedBuildId = process.env.__VINEXT_SHARED_BUILD_ID;
+          if (sharedBuildId && sharedBuildId.length > 0 && !rawConfig?.generateBuildId) {
+            nextConfig = { ...nextConfig, buildId: sharedBuildId };
+          }
         }
         rscCompatibilityId ??= createRscCompatibilityId(nextConfig);
         fileMatcher = createValidFileMatcher(nextConfig.pageExtensions);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1211,20 +1211,24 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // A single `vinext build` can instantiate vinext() more than once —
           // the App Router multi-environment build (createBuilder().buildApp())
           // and the separate Pages Router SSR build for hybrid app+pages apps
-          // are distinct plugin instances, each resolving its own config. With
-          // no user `generateBuildId`, resolveNextConfig() mints a fresh random
-          // UUID per instance, so the App Router runtime, the Pages Router
-          // runtime, the prerender manifest, and dist/server/BUILD_ID would each
-          // get a different build ID.
+          // are distinct plugin instances, each resolving its own config. Each
+          // instance runs resolveBuildId() independently, so any non-deterministic
+          // build ID diverges per instance: no `generateBuildId` (random UUID), a
+          // `generateBuildId` that returns `null` (also a random UUID — see
+          // resolveBuildId()), or any side-effecting `generateBuildId`. The result
+          // is that the App Router runtime, the Pages Router runtime, the prerender
+          // manifest, and dist/server/BUILD_ID could each get a different ID.
           //
-          // The CLI resolves the build ID once (honoring the user's
-          // generateBuildId) and publishes it via __VINEXT_SHARED_BUILD_ID. We
-          // adopt it here when the user did not supply their own generateBuildId
-          // (a user-provided generateBuildId is authoritative and already shared
-          // because every instance calls it). This keeps all instances coherent
-          // without changing resolveBuildId()'s standalone semantics.
+          // The CLI resolves the build ID exactly once via the same
+          // resolveBuildId() (so it already honors the user's generateBuildId,
+          // including the null→UUID fallback) and publishes that authoritative
+          // value via __VINEXT_SHARED_BUILD_ID. We always adopt it when set —
+          // there is no case where a per-instance re-resolution should win over
+          // the single shared value. The env var is only ever set by the build
+          // CLI, so resolveBuildId()'s standalone semantics (dev, tests) are
+          // unchanged.
           const sharedBuildId = process.env.__VINEXT_SHARED_BUILD_ID;
-          if (sharedBuildId && sharedBuildId.length > 0 && !rawConfig?.generateBuildId) {
+          if (sharedBuildId && sharedBuildId.length > 0) {
             nextConfig = { ...nextConfig, buildId: sharedBuildId };
           }
         }

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -47,6 +47,16 @@ describe("App Router Production build", () => {
 
     // Asset manifest should be generated
     expect(fs.existsSync(path.join(outDir, "server", "__vite_rsc_assets_manifest.js"))).toBe(true);
+
+    // BUILD_ID must be written to dist/server so post-build tools (TPR,
+    // seed-cache) and the e2e deploy harness can read the build identifier
+    // without parsing the (minified) server bundle. Regression guard: the
+    // vinext:build-id plugin previously used closeBundle, which does not fire
+    // during the multi-environment buildApp() pipeline, so the file was
+    // silently never written for pure App Router apps.
+    const buildIdPath = path.join(outDir, "server", "BUILD_ID");
+    expect(fs.existsSync(buildIdPath)).toBe(true);
+    expect(fs.readFileSync(buildIdPath, "utf-8").trim().length).toBeGreaterThan(0);
   }, 30000);
 
   it("builds proxy.ts that reads __filename before redirecting", async () => {

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -92,6 +92,38 @@ describe("App Router Production build", () => {
     }
   }, 30000);
 
+  it("adopts the shared build ID even when generateBuildId is set", async () => {
+    // The shared ID must win over a per-instance generateBuildId, because the
+    // CLI already resolved it through the user's generateBuildId once. A
+    // non-deterministic generateBuildId (e.g. returning null → a fresh random
+    // UUID per instance, per resolveBuildId()) would otherwise re-diverge across
+    // the buildApp() and hybrid Pages vite.build() instances — the exact bug
+    // this coordination exists to prevent.
+    const sharedBuildId = "shared-wins-over-generate-5678";
+    const previous = process.env.__VINEXT_SHARED_BUILD_ID;
+    process.env.__VINEXT_SHARED_BUILD_ID = sharedBuildId;
+    try {
+      const builder = await createBuilder({
+        root: APP_FIXTURE_DIR,
+        configFile: false,
+        // generateBuildId returning null falls back to a random UUID per
+        // instance; the shared ID must still be adopted.
+        plugins: [vinext({ appDir: APP_FIXTURE_DIR, nextConfig: { generateBuildId: () => null } })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      expect(fs.readFileSync(path.join(outDir, "server", "BUILD_ID"), "utf-8").trim()).toBe(
+        sharedBuildId,
+      );
+      const rscEntry = fs.readFileSync(path.join(outDir, "server", "index.js"), "utf-8");
+      expect(rscEntry).toContain(sharedBuildId);
+    } finally {
+      if (previous === undefined) delete process.env.__VINEXT_SHARED_BUILD_ID;
+      else process.env.__VINEXT_SHARED_BUILD_ID = previous;
+    }
+  }, 30000);
+
   it("builds proxy.ts that reads __filename before redirecting", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -59,6 +59,39 @@ describe("App Router Production build", () => {
     expect(fs.readFileSync(buildIdPath, "utf-8").trim().length).toBeGreaterThan(0);
   }, 30000);
 
+  it("adopts __VINEXT_SHARED_BUILD_ID so the runtime and BUILD_ID file agree", async () => {
+    // The `vinext build` CLI resolves the build ID once and shares it via
+    // __VINEXT_SHARED_BUILD_ID so that every plugin instance in a build (App
+    // Router buildApp + the separate hybrid Pages Router vite.build) uses the
+    // same ID. Without it, each instance mints its own random UUID and the
+    // runtime buildId, prerender manifest, and dist/server/BUILD_ID diverge.
+    const sharedBuildId = "shared-test-build-id-1234";
+    const previous = process.env.__VINEXT_SHARED_BUILD_ID;
+    process.env.__VINEXT_SHARED_BUILD_ID = sharedBuildId;
+    try {
+      const builder = await createBuilder({
+        root: APP_FIXTURE_DIR,
+        configFile: false,
+        plugins: [vinext({ appDir: APP_FIXTURE_DIR })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      // The emitted BUILD_ID file uses the shared ID.
+      expect(fs.readFileSync(path.join(outDir, "server", "BUILD_ID"), "utf-8").trim()).toBe(
+        sharedBuildId,
+      );
+      // The shared ID is baked into the App Router runtime bundle (the value
+      // process.env.__VINEXT_BUILD_ID is defined as), so cache keys and data
+      // routes line up with the BUILD_ID file.
+      const rscEntry = fs.readFileSync(path.join(outDir, "server", "index.js"), "utf-8");
+      expect(rscEntry).toContain(sharedBuildId);
+    } finally {
+      if (previous === undefined) delete process.env.__VINEXT_SHARED_BUILD_ID;
+      else process.env.__VINEXT_SHARED_BUILD_ID = previous;
+    }
+  }, 30000);
+
   it("builds proxy.ts that reads __filename before redirecting", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts


### PR DESCRIPTION
## What regressed

The nightly **Next.js Deploy Suite** regressed by ~700 tests between [run 27057467752](https://github.com/cloudflare/vinext/actions/runs/27057467752) (2143 passing) and [run 27081060115](https://github.com/cloudflare/vinext/actions/runs/27081060115) (1444 passing). Nearly every App Router fixture failed at **setup** with:

```
Failed to extract build ID from dist/server/index.js
Custom deploy script failed:  undefined (1)
```

## Root cause

Two interacting facts:

1. The `vinext:build-id` plugin wrote `dist/server/BUILD_ID` from a **`closeBundle`** hook. `closeBundle` does **not** fire during the multi-environment `createBuilder().buildApp()` pipeline used for App Router production builds, so the file was *silently never written for pure App Router apps*. Only hybrid apps (which run a second `vite.build()` pass with a fresh plugin instance) and Pages Router apps produced the file.

2. The e2e deploy harness (`scripts/e2e-deploy.sh` → `read_build_id`) falls back to regex-parsing the buildId out of `dist/server/index.js` when `BUILD_ID` is absent. That fallback worked while server bundles were unminified — until **#1777 (`perf(build): minify server build environments by default`)** landed between the two runs. Minification mangles the `get buildId() { return "..." }` / `buildId = "..."` patterns the regex relies on, so the fallback started returning no match and every App Router deploy failed at setup.

Confirmed by reproducing locally: a pure App Router `buildApp()` did not emit `dist/server/BUILD_ID`, and the regex returns `NO MATCH` against the minified `index.js`.

## Fix 1 — emit BUILD_ID reliably

Switch the `vinext:build-id` plugin from `closeBundle` to **`writeBundle`** (mirroring the already-working `vinext:image-config` plugin). `writeBundle` fires for every emitted bundle across all environments; the existing one-time write guard ensures the file is written exactly once. Verified `dist/server/BUILD_ID` is now emitted for pure App Router, hybrid, and Pages Router builds.

## Fix 2 — one build ID across all plugin instances

While reviewing Fix 1 we found a pre-existing divergence: a single `vinext build` can instantiate `vinext()` more than once (App Router `buildApp()` + the separate Pages Router `vite.build()` for hybrid apps). With no user `generateBuildId`, each instance resolved its **own random UUID**, so the App Router runtime, Pages runtime, prerender manifest, and `BUILD_ID` file could each get a different ID — risking ISR/seed-cache key mismatches for hybrid apps.

The CLI now resolves the build ID **once** (honoring the user's `generateBuildId`) and publishes it via `__VINEXT_SHARED_BUILD_ID`; the plugin adopts it unless the user supplied their own `generateBuildId`. `resolveBuildId()`'s standalone semantics are unchanged, so this build-only coordination never leaks into dev or tests.

Verified on the hybrid `app-router-cloudflare` example — the App Router RSC/SSR runtime, Pages `entry.js`, `vinext-prerender.json`, and `dist/server/BUILD_ID` now all carry the same build ID.

## Tests

`tests/app-router-production-build.test.ts` gains two assertions on the `buildApp()` path:
- `dist/server/BUILD_ID` is emitted and non-empty (the regression guard).
- With `__VINEXT_SHARED_BUILD_ID` set, the emitted file **and** the value baked into the runtime bundle both equal the shared ID.

```
✓ tests/app-router-production-build.test.ts (4 tests)
✓ tests/next-config.test.ts / prerender.test.ts (252 tests)
✓ tests/deploy / build-optimization / features / pages-router / static-export / app-router-static-export (927 tests)
```