### PR TITLE
test(e2e): mark flaky dev-overlay build-error HMR test as fixme

### DIFF
--- a/tests/e2e/app-router/dev-error-overlay.spec.ts
+++ b/tests/e2e/app-router/dev-error-overlay.spec.ts
@@ -356,7 +356,12 @@ test.describe("Dev error overlay", () => {
       await expect(page.getByTestId("vinext-dev-error-overlay")).toBeHidden({ timeout: 10_000 });
     });
 
-    test("server component HMR surfaces Vite build errors after a clean load", async ({ page }) => {
+    // FIXME(#1811): flaky — after writing the clean file back, the build-error
+    // overlay intermittently stays visible past the 10s timeout in CI.
+    // https://github.com/cloudflare/vinext/issues/1811
+    test.fixme("server component HMR surfaces Vite build errors after a clean load", async ({
+      page,
+    }) => {
       // Next.js dev redbox labels build-time failures as "Build Error":
       // https://github.com/vercel/next.js/blob/canary/test/e2e/swc-plugins/index.test.ts
       await page.goto(`${BASE}/dev-overlay-hmr-toggle`);


### PR DESCRIPTION
## Summary

Marks the App Router dev error overlay E2E test `server component HMR surfaces Vite build errors after a clean load` (`tests/e2e/app-router/dev-error-overlay.spec.ts`) as `test.fixme` to unblock CI.

The test is flaky: after writing the clean version of the HMR toggle file back, the build-error overlay intermittently stays visible past the 10s timeout.

```
expect(locator).toBeHidden() failed
Locator: getByTestId('vinext-dev-error-overlay')
Expected: hidden
Received: visible
Timeout: 10000ms
```

Observed in CI on #1810:
https://github.com/cloudflare/vinext/actions/runs/27089265749/job/79950083553

## Follow-up

Tracked in #1811 — investigate the build-error recovery → overlay-dismiss path and re-enable the test.