### PR TITLE
ci(bigbonk): reduce job timeout to 10 minutes

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.comment.author_association == 'OWNER'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Changes the Big Bonk workflow job timeout from 30 minutes to 10 minutes.