### PR TITLE
fix(build): share one RSC compatibility ID across all plugin instances

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -31,7 +31,12 @@ import { deploy as runDeploy, parseDeployArgs } from "./deploy.js";
 import { runCheck, formatReport } from "./check.js";
 import { init as runInit, getReactUpgradeDeps } from "./init.js";
 import { loadDotenv } from "./config/dotenv.js";
-import { loadNextConfig, resolveNextConfig, PHASE_PRODUCTION_BUILD } from "./config/next-config.js";
+import {
+  createRscCompatibilityId,
+  loadNextConfig,
+  resolveNextConfig,
+  PHASE_PRODUCTION_BUILD,
+} from "./config/next-config.js";
 import { emitStandaloneOutput } from "./build/standalone.js";
 import { cleanBuildOutput } from "./build/clean-output.js";
 import { resolveVinextPackageRoot } from "./utils/vinext-root.js";
@@ -458,6 +463,14 @@ async function buildApp() {
   // exits, so there is no in-process reuse to leak into. The var is namespaced
   // to vinext's build flow and is never read by dev or standalone resolveBuildId.
   process.env.__VINEXT_SHARED_BUILD_ID = resolvedNextConfig.buildId;
+
+  // Same coordination for the App Router RSC compatibility token. Without a
+  // pinned deploymentId, createRscCompatibilityId() mints a random UUID per
+  // plugin instance, so a hybrid app+pages build would bake two different
+  // compatibility tokens. Resolve it once and share it (see the plugin's
+  // adoption site). Reuses deploymentId when set (already stable across
+  // instances).
+  process.env.__VINEXT_SHARED_RSC_COMPATIBILITY_ID = createRscCompatibilityId(resolvedNextConfig);
 
   const outputMode = resolvedNextConfig.output;
   const distDir = path.resolve(root, "dist");

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1031,6 +1031,27 @@ function resolveDeploymentId(configDeploymentId: unknown): string | undefined {
 }
 
 /**
+ * Resolve the App Router RSC compatibility identity for a build.
+ *
+ * This token is baked into the client bundle and echoed by the server in the
+ * `X-Vinext-RSC-Compatibility-Id` response header; browser navigation rejects
+ * RSC payloads whose token differs (deploy skew) without exposing the raw
+ * build ID. When the user pins a `deploymentId` we reuse it (already stable
+ * across plugin instances); otherwise we mint a random UUID.
+ *
+ * NOTE: like `resolveBuildId`, this is non-deterministic in the no-deploymentId
+ * case, so a single `vinext build` that instantiates the plugin more than once
+ * (App Router `buildApp()` + the hybrid Pages Router `vite.build()`) must
+ * resolve it once and share it — see `__VINEXT_SHARED_RSC_COMPATIBILITY_ID`.
+ */
+export function createRscCompatibilityId(
+  nextConfig: Pick<ResolvedNextConfig, "deploymentId">,
+): string {
+  if (nextConfig.deploymentId) return nextConfig.deploymentId;
+  return randomUUID();
+}
+
+/**
  * Converts a cache handler path to a filesystem path.
  * ESM's import.meta.resolve() returns file:// URLs which break when concatenated
  * with path operations like path.join or path.relative.

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -370,6 +370,14 @@ declare global {
       __VINEXT_RSC_COMPATIBILITY_ID?: string;
 
       /**
+       * Build-only coordination variable set by the `vinext build` CLI so that
+       * every vinext() plugin instance in a single build resolves the same RSC
+       * compatibility token (companion to `__VINEXT_SHARED_BUILD_ID`). Never read
+       * by dev or standalone createRscCompatibilityId() resolution.
+       */
+      __VINEXT_SHARED_RSC_COMPATIBILITY_ID?: string;
+
+      /**
        * Deployment ID string injected via Vite `define` when
        * `NEXT_DEPLOYMENT_ID` is present at build time.
        */

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -41,6 +41,7 @@ import {
 import { planRouteClassificationInjection } from "./build/route-classification-injector.js";
 import { normalizePathnameForRouteMatchStrict } from "./routing/utils.js";
 import {
+  createRscCompatibilityId,
   findNextConfigPath,
   loadNextConfig,
   resolveNextConfigInput,
@@ -179,11 +180,6 @@ import { normalizePathSeparators } from "./utils/path.js";
 // via env-var gate; bypasses during prerender via fire-time
 // VINEXT_PRERENDER check. See socket-error-backstop.ts.
 installSocketErrorBackstop();
-
-function createRscCompatibilityId(nextConfig: ResolvedNextConfig): string {
-  if (nextConfig.deploymentId) return nextConfig.deploymentId;
-  return randomUUID();
-}
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
 
@@ -1232,7 +1228,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             nextConfig = { ...nextConfig, buildId: sharedBuildId };
           }
         }
-        rscCompatibilityId ??= createRscCompatibilityId(nextConfig);
+        // RSC-compat ID coordination across plugin instances — same rationale as
+        // the build ID above. createRscCompatibilityId() falls back to a random
+        // UUID per instance when no deploymentId is pinned, so a hybrid app+pages
+        // build would otherwise bake two different compatibility tokens. The CLI
+        // resolves it once and publishes it via __VINEXT_SHARED_RSC_COMPATIBILITY_ID;
+        // we always adopt it when set (only the build CLI ever sets it, so dev and
+        // standalone resolution are unchanged).
+        if (rscCompatibilityId === undefined) {
+          const sharedRscCompatibilityId = process.env.__VINEXT_SHARED_RSC_COMPATIBILITY_ID;
+          rscCompatibilityId =
+            sharedRscCompatibilityId && sharedRscCompatibilityId.length > 0
+              ? sharedRscCompatibilityId
+              : createRscCompatibilityId(nextConfig);
+        }
         fileMatcher = createValidFileMatcher(nextConfig.pageExtensions);
         instrumentationPath = findInstrumentationFile(root, fileMatcher);
         instrumentationClientPath = findInstrumentationClientFile(root, fileMatcher);

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -13,6 +13,17 @@ function isBuiltAppHandler(value: unknown): value is BuiltAppHandler {
   return typeof value === "function";
 }
 
+/** Concatenate every `.js` file under `dir` (recursively) for substring checks. */
+function readAllJs(dir: string): string {
+  let out = "";
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out += readAllJs(full);
+    else if (entry.name.endsWith(".js")) out += fs.readFileSync(full, "utf-8");
+  }
+  return out;
+}
+
 describe("App Router Production build", () => {
   const outDir = path.resolve(APP_FIXTURE_DIR, "dist");
 
@@ -121,6 +132,39 @@ describe("App Router Production build", () => {
     } finally {
       if (previous === undefined) delete process.env.__VINEXT_SHARED_BUILD_ID;
       else process.env.__VINEXT_SHARED_BUILD_ID = previous;
+    }
+  }, 30000);
+
+  it("adopts __VINEXT_SHARED_RSC_COMPATIBILITY_ID across the App Router build", async () => {
+    // Companion to the build-ID coordination: createRscCompatibilityId() mints a
+    // random UUID per plugin instance when no deploymentId is pinned, so a hybrid
+    // app+pages build would otherwise bake two different RSC-compat tokens. The
+    // CLI resolves it once and shares it via __VINEXT_SHARED_RSC_COMPATIBILITY_ID;
+    // the plugin always adopts it when set. Both the App Router server bundle and
+    // the client bundle (which compares its baked token against the server's
+    // X-Vinext-RSC-Compatibility-Id header) must carry the shared value.
+    const sharedCompatId = "shared-rsc-compat-id-9012";
+    const previous = process.env.__VINEXT_SHARED_RSC_COMPATIBILITY_ID;
+    process.env.__VINEXT_SHARED_RSC_COMPATIBILITY_ID = sharedCompatId;
+    try {
+      const builder = await createBuilder({
+        root: APP_FIXTURE_DIR,
+        configFile: false,
+        plugins: [vinext({ appDir: APP_FIXTURE_DIR })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      // The compat token is baked via Vite `define`; depending on chunking it
+      // can land in the RSC entry or a shared server/client chunk, so scan the
+      // whole server and client output trees. Both sides must carry the same
+      // adopted token — that is what lets the client reject mismatched RSC
+      // payloads (the X-Vinext-RSC-Compatibility-Id header check).
+      expect(readAllJs(path.join(outDir, "server"))).toContain(sharedCompatId);
+      expect(readAllJs(path.join(outDir, "client"))).toContain(sharedCompatId);
+    } finally {
+      if (previous === undefined) delete process.env.__VINEXT_SHARED_RSC_COMPATIBILITY_ID;
+      else process.env.__VINEXT_SHARED_RSC_COMPATIBILITY_ID = previous;
     }
   }, 30000);
 


### PR DESCRIPTION
Follow-up to #1810 (build-ID coordination), addressing the reviewer's note there:

> `rscCompatibilityId` still diverges per instance. `createRscCompatibilityId()` returns a fresh `randomUUID()` per plugin instance when no `deploymentId` is set, so a hybrid app+pages build still gets two different RSC-compat IDs.

## Why it matters

The RSC compatibility token is baked into the **client** bundle and echoed by the **server** via the `X-Vinext-RSC-Compatibility-Id` response header. Browser navigation rejects RSC payloads whose token differs (deploy-skew protection) without exposing the raw build ID.

`createRscCompatibilityId()` falls back to `randomUUID()` per plugin instance when no `deploymentId` is pinned. A single `vinext build` can instantiate `vinext()` more than once — the App Router `buildApp()` (RSC + SSR + client) and the separate Pages Router `vite.build()` for hybrid app+pages apps — so each instance minted its own token. For App Router today the client and server both come from the `buildApp()` instance so they happen to agree, but the divergence with the Pages instance is a latent hazard and inconsistent with the build-ID coordination just landed.

## Fix

Mirror the build-ID approach exactly:

1. **Single source of truth** — relocate `createRscCompatibilityId` from `index.ts` into `config/next-config.ts`, beside `resolveBuildId` / `resolveDeploymentId`, and export it.
2. **Resolve once** — the CLI computes the token once (reusing `deploymentId` when configured, else one random UUID) and publishes it via `__VINEXT_SHARED_RSC_COMPATIBILITY_ID`.
3. **Always adopt** — the plugin adopts the shared token whenever the env var is set. The var is only ever set by the build CLI, so dev and standalone `createRscCompatibilityId()` resolution are unchanged.

Verified on the hybrid `app-router-cloudflare` example: the App Router server bundle and client bundle now carry the same RSC-compat token (distinct from the build ID and the draft-mode secret, as intended).

## Tests

Adds `adopts __VINEXT_SHARED_RSC_COMPATIBILITY_ID across the App Router build` to `tests/app-router-production-build.test.ts` — sets the shared token, runs `buildApp()`, and asserts it lands in both the server and client output (the token can be code-split into a shared chunk, so the test scans the full output trees).

```
✓ tests/app-router-production-build.test.ts (6 tests)
✓ tests/app-rsc-cache-busting / next-config / app-browser-entry / deploy (600 tests)
```