### PR TITLE
feat(deploy): honor Worker-entry cache setters for ISR deploys

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1203,6 +1203,37 @@ export function viteConfigHasCacheAdapter(root: string): boolean {
 }
 
 /**
+ * Detect whether an existing user-authored Worker entry wires up a cache
+ * backend imperatively via one of the `setCacheHandler` / `setDataCacheHandler`
+ * / `setCdnCacheAdapter` setters. These setters are deprecated in favour of the
+ * declarative `vinext({ cache })` option, but older apps that scaffolded a KV
+ * cache handler into their Worker entry must keep working — so a deploy should
+ * not be blocked when the Worker entry already configures a backend.
+ *
+ * This is a heuristic text scan (it doesn't execute the entry), mirroring
+ * {@link viteConfigHasCacheAdapter}'s leniency: an unreadable Worker entry is
+ * treated as configured so a deploy is never blocked on a false negative. A
+ * missing Worker entry returns false (nothing to inspect — defer to other
+ * checks).
+ */
+export function workerEntryHasCacheHandler(root: string): boolean {
+  const candidates = [path.join(root, "worker", "index.ts"), path.join(root, "worker", "index.js")];
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    let content: string;
+    try {
+      content = fs.readFileSync(candidate, "utf-8");
+    } catch {
+      // unreadable — assume it might be fine
+      return true;
+    }
+    return /\b(?:setCacheHandler|setDataCacheHandler|setCdnCacheAdapter)\s*\(/.test(content);
+  }
+  // No Worker entry on disk — nothing to inspect here.
+  return false;
+}
+
+/**
  * Build the error thrown when an ISR/cached app is deployed without a cache
  * adapter configured in the Vite config. Production deployments need a
  * persistent cache backend; vinext no longer scaffolds one into the Worker
@@ -1214,14 +1245,12 @@ export function formatMissingCacheAdapterError(options: { configFile?: string })
     `[vinext] This app uses ISR / caching but no cache adapter is configured in ${configRef}.\n\n` +
     `  Production deployments need a persistent cache backend. Declare one on the\n` +
     `  vinext() plugin in ${configRef}:\n\n` +
-    `    import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";\n` +
     `    import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";\n\n` +
     `    export default defineConfig({\n` +
     `      plugins: [\n` +
     `        vinext({\n` +
     `          cache: {\n` +
     `            data: kvDataAdapter(), // KV-backed data cache (binding: VINEXT_KV_CACHE)\n` +
-    `            cdn: cdnAdapter(),     // optional: edge-managed page-level ISR\n` +
     `          },\n` +
     `        }),\n` +
     `        cloudflare(),\n` +
@@ -1522,7 +1551,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
   // no longer scaffolds a KV cache handler into the Worker entry — the backend
   // must be declared via `vinext({ cache })` so deploys don't silently fall
   // back to the in-memory handler (which loses all cached data per isolate).
-  if (info.hasISR && !viteConfigHasCacheAdapter(root)) {
+  //
+  // For backwards compat, older apps that wired a cache backend imperatively in
+  // their Worker entry (setCacheHandler / setDataCacheHandler / setCdnCacheAdapter)
+  // are still considered configured and must not be blocked.
+  if (info.hasISR && !viteConfigHasCacheAdapter(root) && !workerEntryHasCacheHandler(root)) {
     throw new Error(formatMissingCacheAdapterError({}));
   }
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -20,6 +20,7 @@ import {
   isPackageResolvable,
   viteConfigHasCloudflarePlugin,
   viteConfigHasCacheAdapter,
+  workerEntryHasCacheHandler,
   hasWranglerConfig,
   formatMissingCloudflarePluginError,
   formatMissingCacheAdapterError,
@@ -629,13 +630,68 @@ describe("viteConfigHasCacheAdapter", () => {
   });
 });
 
+describe("workerEntryHasCacheHandler", () => {
+  it("detects a setCacheHandler call in worker/index.ts", () => {
+    writeFile(
+      tmpDir,
+      "worker/index.ts",
+      `import { setCacheHandler } from "vinext/shims/cache";
+       setCacheHandler(new KVCacheHandler(env.VINEXT_KV_CACHE));`,
+    );
+    expect(workerEntryHasCacheHandler(tmpDir)).toBe(true);
+  });
+
+  it("detects a setDataCacheHandler call", () => {
+    writeFile(
+      tmpDir,
+      "worker/index.ts",
+      `import { setDataCacheHandler } from "vinext/shims/cache";
+       setDataCacheHandler(handler);`,
+    );
+    expect(workerEntryHasCacheHandler(tmpDir)).toBe(true);
+  });
+
+  it("detects a setCdnCacheAdapter call", () => {
+    writeFile(
+      tmpDir,
+      "worker/index.ts",
+      `import { setCdnCacheAdapter } from "vinext/shims/cdn-cache";
+       setCdnCacheAdapter(adapter);`,
+    );
+    expect(workerEntryHasCacheHandler(tmpDir)).toBe(true);
+  });
+
+  it("detects a setter in worker/index.js", () => {
+    writeFile(
+      tmpDir,
+      "worker/index.js",
+      `setCacheHandler(new KVCacheHandler(env.VINEXT_KV_CACHE));`,
+    );
+    expect(workerEntryHasCacheHandler(tmpDir)).toBe(true);
+  });
+
+  it("returns false when the Worker entry has no cache setter", () => {
+    writeFile(tmpDir, "worker/index.ts", `export default { fetch() {} };`);
+    expect(workerEntryHasCacheHandler(tmpDir)).toBe(false);
+  });
+
+  it("returns false when there is no Worker entry to inspect", () => {
+    expect(workerEntryHasCacheHandler(tmpDir)).toBe(false);
+  });
+});
+
 describe("formatMissingCacheAdapterError", () => {
-  it("names the adapter builders and the KV namespace command", () => {
+  it("names the data adapter builder and the KV namespace command", () => {
     const msg = formatMissingCacheAdapterError({});
     expect(msg).toContain("no cache adapter is configured");
     expect(msg).toContain("kvDataAdapter()");
-    expect(msg).toContain("cdnAdapter()");
     expect(msg).toContain("npx wrangler kv namespace create VINEXT_KV_CACHE");
+  });
+
+  it("no longer references the cdn adapter", () => {
+    const msg = formatMissingCacheAdapterError({});
+    expect(msg).not.toContain("cdnAdapter");
+    expect(msg).not.toContain("cdn-adapter");
   });
 });
 


### PR DESCRIPTION
## What

When deploying an ISR/cached app, the deploy command requires a cache adapter to be configured. Previously this check only inspected the Vite config (`vinext({ cache })`), so apps that wired a cache backend imperatively in their **Worker entry** were incorrectly blocked.

This PR:

1. **Adds backwards-compat detection for Worker-entry cache setters.** New exported `workerEntryHasCacheHandler(root)` scans an existing user-authored Worker entry (`worker/index.ts` / `worker/index.js`) for `setCacheHandler` / `setDataCacheHandler` / `setCdnCacheAdapter` calls. The ISR deploy gate now passes when either the Vite config *or* the Worker entry configures a backend. It mirrors `viteConfigHasCacheAdapter`'s leniency (unreadable entry treated as configured; missing entry returns `false`).

2. **Removes the CDN part from `formatMissingCacheAdapterError`.** The error message no longer suggests the `cdnAdapter()` import/option and points only at the `kvDataAdapter()` data cache.

## Testing

- Added a `workerEntryHasCacheHandler` test block covering all three setters, both `.ts`/`.js` entries, the no-setter case, and the missing-entry case.
- Added an assertion that the error message no longer references the CDN adapter.
- `vp check` and the targeted `tests/deploy.test.ts` cases pass.