### PR TITLE
fix(app-router): apply trailingSlash to route handler request URL (#1827)

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -750,6 +750,7 @@ export default __createAppRscHandler({
       },
       draftModeSecret: __draftModeSecret,
       i18n: __i18nConfig,
+      trailingSlash: __trailingSlash,
       isrDebug: __isrDebug,
       isrGet: __isrGet,
       isrRouteKey: __isrRouteKey,

--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -34,6 +34,7 @@ type ReadAppRouteHandlerCacheOptions = {
   getCollectedFetchTags: () => string[];
   handlerFn: AppRouteHandlerFunction;
   i18n?: NextI18nConfig | null;
+  trailingSlash?: boolean;
   isAutoHead: boolean;
   isrDebug?: AppRouteDebugLogger;
   isrGet: RouteHandlerCacheGetter;
@@ -112,6 +113,7 @@ export async function readAppRouteHandlerCacheResponse(
             dynamicConfig: options.dynamicConfig,
             handlerFn: options.handlerFn,
             i18n: options.i18n,
+            trailingSlash: options.trailingSlash,
             markDynamicUsage: options.markDynamicUsage,
             params: options.params === null ? null : makeThenableParams(options.params),
             request: new Request(options.requestUrl, { method: "GET" }),

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -71,6 +71,7 @@ type DispatchAppRouteHandlerOptions = {
   isrGet: RouteHandlerCacheGetter;
   isrRouteKey: (pathname: string) => string;
   isrSet: RouteHandlerCacheSetter;
+  trailingSlash?: boolean;
   middlewareContext: RouteHandlerMiddlewareContext;
   middlewareRequestHeaders?: Headers | null;
   /**
@@ -198,6 +199,7 @@ export async function dispatchAppRouteHandler(
       getCollectedFetchTags,
       handlerFn: resolvedHandlerFn,
       i18n: options.i18n,
+      trailingSlash: options.trailingSlash,
       isAutoHead,
       isrDebug: options.isrDebug,
       isrGet: options.isrGet,
@@ -255,6 +257,7 @@ export async function dispatchAppRouteHandler(
       handler,
       handlerFn: resolvedHandlerFn,
       i18n: options.i18n,
+      trailingSlash: options.trailingSlash,
       isAutoHead,
       isProduction,
       isrDebug: options.isrDebug,

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -67,6 +67,7 @@ type RunAppRouteHandlerOptions = {
   dynamicConfig?: string;
   handlerFn: AppRouteHandlerFunction;
   i18n?: NextI18nConfig | null;
+  trailingSlash?: boolean;
   markDynamicUsage: MarkAppRouteDynamicUsageFn;
   middlewareRequestHeaders?: Headers | null;
   /**
@@ -129,6 +130,7 @@ export async function runAppRouteHandler(
   const trackedRequest = createTrackedAppRouteRequest(options.request, {
     basePath: options.basePath,
     i18n: options.i18n,
+    trailingSlash: options.trailingSlash,
     middlewareHeaders: options.middlewareRequestHeaders,
     onDynamicAccess() {
       options.markDynamicUsage();

--- a/packages/vinext/src/server/app-route-handler-runtime.ts
+++ b/packages/vinext/src/server/app-route-handler-runtime.ts
@@ -99,6 +99,7 @@ type AppRouteRequestMode = "auto" | "force-static" | "error";
 type TrackedAppRouteRequestOptions = {
   basePath?: string;
   i18n?: NextI18nConfig | null;
+  trailingSlash?: boolean;
   middlewareHeaders?: Headers | null;
   onDynamicAccess?: (access: AppRouteDynamicRequestAccess) => void;
   requestMode?: AppRouteRequestMode;
@@ -117,14 +118,16 @@ function bindMethodIfNeeded<T>(value: T, target: object): T {
 function buildNextConfig(options: TrackedAppRouteRequestOptions): {
   basePath?: string;
   i18n?: NextI18nConfig;
+  trailingSlash?: boolean;
 } | null {
-  if (!options.basePath && !options.i18n) {
+  if (!options.basePath && !options.i18n && !options.trailingSlash) {
     return null;
   }
 
   return {
     basePath: options.basePath,
     i18n: options.i18n ?? undefined,
+    trailingSlash: options.trailingSlash,
   };
 }
 

--- a/tests/app-route-handler-trailing-slash.test.ts
+++ b/tests/app-route-handler-trailing-slash.test.ts
@@ -81,18 +81,20 @@ describe("App Router route-handler trailingSlash: false (#1827)", () => {
     if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("redirects /runtime/edge/ → /runtime/edge with 308", async () => {
-    const res = await fetch(`${baseUrl}/runtime/edge/`, { redirect: "manual" });
-    expect(res.status).toBe(308);
-    expect(new URL(res.headers.get("location")!, baseUrl).pathname).toBe("/runtime/edge");
-  });
+  it.each(["edge", "node"])(
+    "redirects /runtime/%s/ with 308 and serves the unslashed path",
+    async (runtime) => {
+      const res = await fetch(`${baseUrl}/runtime/${runtime}/`, { redirect: "manual" });
+      expect(res.status).toBe(308);
+      expect(new URL(res.headers.get("location")!, baseUrl).pathname).toBe(`/runtime/${runtime}`);
 
-  it("serves /runtime/edge with 200", async () => {
-    const res = await fetch(`${baseUrl}/runtime/edge`, { redirect: "manual" });
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({
-      url: "/runtime/edge",
-      nextUrl: "/runtime/edge",
-    });
-  }, 30000);
+      const unslashed = await fetch(`${baseUrl}/runtime/${runtime}`, { redirect: "manual" });
+      expect(unslashed.status).toBe(200);
+      await expect(unslashed.json()).resolves.toEqual({
+        url: `/runtime/${runtime}`,
+        nextUrl: `/runtime/${runtime}`,
+      });
+    },
+    30000,
+  );
 });

--- a/tests/app-route-handler-trailing-slash.test.ts
+++ b/tests/app-route-handler-trailing-slash.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression coverage for issue #1827 — `trailingSlash` not applied to App
+ * Router route handlers (`app/**​/route.ts`).
+ *
+ * Mirrors Next.js test/e2e/app-dir/app-routes-trailing-slash:
+ *   - With `trailingSlash: true`, a request to `/runtime/edge` returns
+ *     308 → `/runtime/edge/`
+ *   - The redirected `/runtime/edge/` request returns 200 and the handler
+ *     observes the trailing-slash pathname.
+ *
+ * Refs cloudflare/vinext#1827
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { APP_FIXTURE_DIR, startFixtureServer } from "./helpers.js";
+
+function copyAppFixtureWithTrailingSlash(prefix: string, trailingSlash: boolean): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.cpSync(APP_FIXTURE_DIR, tmpDir, { recursive: true });
+  fs.rmSync(path.join(tmpDir, "node_modules", ".vite"), { recursive: true, force: true });
+  fs.writeFileSync(
+    path.join(tmpDir, "next.config.ts"),
+    `import type { NextConfig } from "vinext";
+const nextConfig: NextConfig = { trailingSlash: ${trailingSlash} };
+export default nextConfig;
+`,
+  );
+  return tmpDir;
+}
+
+describe("App Router route-handler trailingSlash: true (#1827)", () => {
+  let tmpDir: string;
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    tmpDir = copyAppFixtureWithTrailingSlash("vinext-route-ts-true-", true);
+    ({ server, baseUrl } = await startFixtureServer(tmpDir));
+  }, 60000);
+
+  afterAll(async () => {
+    await server?.close();
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.each(["edge", "node"])(
+    "redirects /runtime/%s with 308 and serves the slashed path",
+    async (runtime) => {
+      const res = await fetch(`${baseUrl}/runtime/${runtime}`, { redirect: "manual" });
+      expect(res.status).toBe(308);
+      const location = res.headers.get("location");
+      expect(location).not.toBeNull();
+      expect(new URL(location!, baseUrl).pathname).toBe(`/runtime/${runtime}/`);
+
+      const slashed = await fetch(`${baseUrl}/runtime/${runtime}/`, { redirect: "manual" });
+      expect(slashed.status).toBe(200);
+      await expect(slashed.json()).resolves.toEqual({
+        url: `/runtime/${runtime}/`,
+        nextUrl: `/runtime/${runtime}/`,
+      });
+    },
+    30000,
+  );
+});
+
+describe("App Router route-handler trailingSlash: false (#1827)", () => {
+  let tmpDir: string;
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    tmpDir = copyAppFixtureWithTrailingSlash("vinext-route-ts-false-", false);
+    ({ server, baseUrl } = await startFixtureServer(tmpDir));
+  }, 60000);
+
+  afterAll(async () => {
+    await server?.close();
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("redirects /runtime/edge/ → /runtime/edge with 308", async () => {
+    const res = await fetch(`${baseUrl}/runtime/edge/`, { redirect: "manual" });
+    expect(res.status).toBe(308);
+    expect(new URL(res.headers.get("location")!, baseUrl).pathname).toBe("/runtime/edge");
+  });
+
+  it("serves /runtime/edge with 200", async () => {
+    const res = await fetch(`${baseUrl}/runtime/edge`, { redirect: "manual" });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      url: "/runtime/edge",
+      nextUrl: "/runtime/edge",
+    });
+  }, 30000);
+});

--- a/tests/fixtures/app-basic/app/runtime/edge/route.ts
+++ b/tests/fixtures/app-basic/app/runtime/edge/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+export const GET = (req: NextRequest) => {
+  const url = new URL(req.url);
+  return NextResponse.json({
+    url: url.pathname,
+    nextUrl: req.nextUrl.pathname,
+  });
+};

--- a/tests/fixtures/app-basic/app/runtime/node/route.ts
+++ b/tests/fixtures/app-basic/app/runtime/node/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = (req: NextRequest) => {
+  const url = new URL(req.url);
+  return NextResponse.json({
+    url: url.pathname,
+    nextUrl: req.nextUrl.pathname,
+  });
+};


### PR DESCRIPTION
## Problem

The `trailingSlash` config was not applied to App Router **route handlers** (`app/**/route.ts`). A request to `/runtime/edge/` with `trailingSlash: true` surfaced `req.url` **without** the trailing slash, even though `req.nextUrl.pathname` correctly retained it.

This caused the upstream suite `test/e2e/app-dir/app-routes-trailing-slash` (edge + node runtime variants) to fail: the handler reads `new URL(req.url).pathname` and expects `/runtime/edge/`.

## Root cause

Route-handler dispatch builds the handler's `NextRequest` via `createTrackedAppRouteRequest` -> `buildNextConfig`. `buildNextConfig` threaded `basePath` and `i18n` into the `NextRequest`'s `NextURL`, but **omitted `trailingSlash`**. With `trailingSlash` unset, `NextURL` defaulted to `false` and `NextURL.toString()` (used to compute `NextRequest.url`) stripped the trailing slash from `req.url`.

Note: the 308 redirect itself already worked (via the central `normalizeTrailingSlash`); only the *served* request's `req.url` was wrong.

## Fix

Thread the configured `trailingSlash` through the route-handler dispatch chain so `NextURL` applies the correct policy when computing `request.url`:

`app-rsc-entry` (codegen) -> `dispatchAppRouteHandler` -> `executeAppRouteHandler` / cache revalidation -> `runAppRouteHandler` -> `createTrackedAppRouteRequest` -> `buildNextConfig` -> `NextRequest`/`NextURL`.

This mirrors the existing `i18n` threading exactly. When `trailingSlash` is `false` (default) and no basePath/i18n is set, `buildNextConfig` still returns `null` as before, so the common case is unchanged.

The codegen entry (`app-rsc-entry.ts`) is shared by dev, prod, and Cloudflare Workers runtimes, so all three are covered by the single change.

## Test

Added `tests/app-route-handler-trailing-slash.test.ts` (mirrors the upstream test) plus fixture route handlers `tests/fixtures/app-basic/app/runtime/{edge,node}/route.ts`. Covers:
- `trailingSlash: true`: `/runtime/{edge,node}` -> 308 -> `/runtime/{edge,node}/`, then 200 with the handler observing the slashed `url` and `nextUrl`.
- `trailingSlash: false`: `/runtime/edge/` -> 308 -> `/runtime/edge`, then 200.

Confirmed the test fails before the fix and passes after. Existing `request-pipeline`, `trailing-slash`, and route-handler dispatch/execution/cache/runtime suites remain green.

Closes #1827