### PR TITLE
fix(app-router): preserve _rsc query across redirects (#1529)

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1170,6 +1170,55 @@ export function isExternalUrl(url: string): boolean {
 }
 
 /**
+ * Merge the original request's query params into a config-redirect
+ * destination, preserving them on the resulting `Location`.
+ *
+ * Next.js carries the original request query across config redirects
+ * (`prepareDestination({ query: parsedUrl.query })` →
+ * `stringifyQuery(...)` in resolve-routes.ts). This matters for App Router
+ * RSC client navigations: the cache-busting `_rsc` query must survive the
+ * redirect so the browser's auto-followed request to the destination is
+ * still treated as an RSC fetch. Dropping it breaks RSC fetch semantics
+ * (issue #1529).
+ *
+ * Destination query params win — a request param is only carried over when
+ * the destination does not already specify that key. Mirrors the merge
+ * semantics in `proxyExternalRequest`. External destinations are returned
+ * untouched (a config redirect to another origin should not leak the
+ * original request's query).
+ */
+export function preserveRedirectDestinationQuery(
+  destination: string,
+  requestSearch: string,
+): string {
+  if (requestSearch === "" || requestSearch === "?" || isExternalUrl(destination)) {
+    return destination;
+  }
+
+  const requestParams = new URLSearchParams(requestSearch);
+  if ([...requestParams.keys()].length === 0) return destination;
+
+  const hashIndex = destination.indexOf("#");
+  const hash = hashIndex === -1 ? "" : destination.slice(hashIndex);
+  const beforeHash = hashIndex === -1 ? destination : destination.slice(0, hashIndex);
+
+  const queryIndex = beforeHash.indexOf("?");
+  const pathPart = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+  const destQuery = queryIndex === -1 ? "" : beforeHash.slice(queryIndex + 1);
+
+  const merged = new URLSearchParams(destQuery);
+  const destKeys = new Set(merged.keys());
+  for (const [key, value] of requestParams) {
+    if (!destKeys.has(key)) {
+      merged.append(key, value);
+    }
+  }
+
+  const mergedQuery = merged.toString();
+  return mergedQuery === "" ? `${pathPart}${hash}` : `${pathPart}?${mergedQuery}${hash}`;
+}
+
+/**
  * Proxy an incoming request to an external URL and return the upstream response.
  *
  * Used for external rewrites (e.g. `/ph/:path*` → `https://us.i.posthog.com/:path*`).

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -520,6 +520,7 @@ import type { ImageConfig } from "vinext/server/image-optimization";
 import {
   matchRedirect,
   matchRewrite,
+  preserveRedirectDestinationQuery,
   requestContextFromRequest,
   applyMiddlewareRequestHeaders,
   isExternalUrl,
@@ -703,9 +704,14 @@ export default {
               ? basePath + redirect.destination
               : redirect.destination,
           );
+          // Carry the original request query (e.g. the App Router RSC
+          // cache-busting \`_rsc\` param) onto the redirect Location so the
+          // browser's auto-followed request is still treated as an RSC fetch.
+          // Mirrors Next.js resolve-routes.ts (issue #1529).
+          const location = preserveRedirectDestinationQuery(dest, url.search);
           return new Response(null, {
             status: redirect.permanent ? 308 : 307,
-            headers: { Location: dest },
+            headers: { Location: location },
           });
         }
       }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -89,6 +89,7 @@ import {
   matchHeaders,
   matchRedirect,
   matchRewrite,
+  preserveRedirectDestinationQuery,
   requestContextFromRequest,
   sanitizeDestination,
   type RequestContext,
@@ -3436,6 +3437,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   nextConfig.redirects,
                   preMiddlewareReqCtx,
                   nextConfig.basePath ?? "",
+                  url.includes("?") ? url.slice(url.indexOf("?")) : "",
                 );
                 if (redirected) return;
               }
@@ -4966,6 +4968,7 @@ function applyRedirects(
   redirects: NextRedirect[],
   ctx: RequestContext,
   basePath = "",
+  requestSearch = "",
 ): boolean {
   // Vite strips the basePath before our middleware sees the request, so any
   // pathname we see is implicitly "under basePath" for matching purposes.
@@ -4979,7 +4982,12 @@ function applyRedirects(
         ? basePath + result.destination
         : result.destination,
     );
-    res.writeHead(result.permanent ? 308 : 307, { Location: dest });
+    // Carry the original request query (e.g. the App Router RSC cache-busting
+    // `_rsc` param) onto the redirect Location so the browser's auto-followed
+    // request is still treated as an RSC fetch. Mirrors Next.js
+    // resolve-routes.ts (issue #1529).
+    const location = preserveRedirectDestinationQuery(dest, requestSearch);
+    res.writeHead(result.permanent ? 308 : 307, { Location: location });
     res.end();
     return true;
   }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -8,6 +8,7 @@ import {
   isExternalUrl,
   matchRedirect,
   matchRewrite,
+  preserveRedirectDestinationQuery,
   proxyExternalRequest,
   requestContextFromRequest,
   sanitizeDestination,
@@ -458,10 +459,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     const destination = sanitizeDestination(
       redirectDestinationWithBasePath(redirect.destination, options.basePath),
     );
+    // For RSC navigations `createRscRedirectLocation` recomputes the
+    // cache-busting `_rsc` param onto the Location. For plain (document)
+    // requests, carry the original request query onto the Location so it
+    // survives the redirect, mirroring Next.js resolve-routes.ts (issue #1529).
     const location =
       isRscRequest && request.headers.get(RSC_HEADER) === "1"
         ? await createRscRedirectLocation(destination, request)
-        : destination;
+        : preserveRedirectDestinationQuery(destination, url.search);
     return new Response(null, {
       status: redirect.permanent ? 308 : 307,
       headers: { Location: location },

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1712,8 +1712,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           // cache-busting `_rsc` param) onto the redirect Location so the
           // browser's auto-followed request is still treated as an RSC
           // fetch. Mirrors Next.js resolve-routes.ts (issue #1529).
-          const redirectQs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-          const location = preserveRedirectDestinationQuery(dest, redirectQs);
+          // `rawQs` already holds the original (un-re-encoded) query string
+          // that `url` was rebuilt from above.
+          const location = preserveRedirectDestinationQuery(dest, rawQs);
           res.writeHead(redirect.permanent ? 308 : 307, { Location: location });
           res.end();
           return;

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -28,6 +28,7 @@ import { StaticFileCache, CONTENT_TYPES, etagFromFilenameHash } from "./static-f
 import {
   matchRedirect,
   matchRewrite,
+  preserveRedirectDestinationQuery,
   requestContextFromRequest,
   applyMiddlewareRequestHeaders,
   isExternalUrl,
@@ -1707,7 +1708,13 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
               ? basePath + redirect.destination
               : redirect.destination,
           );
-          res.writeHead(redirect.permanent ? 308 : 307, { Location: dest });
+          // Carry the original request query (e.g. the App Router RSC
+          // cache-busting `_rsc` param) onto the redirect Location so the
+          // browser's auto-followed request is still treated as an RSC
+          // fetch. Mirrors Next.js resolve-routes.ts (issue #1529).
+          const redirectQs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+          const location = preserveRedirectDestinationQuery(dest, redirectQs);
+          res.writeHead(redirect.permanent ? 308 : 307, { Location: location });
           res.end();
           return;
         }

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -1188,6 +1188,23 @@ describe("App Router integration", () => {
     expect(location).toContain("/about");
   });
 
+  // Issue #1529: an RSC client navigation that hits a next.config.js redirect
+  // must keep the cache-busting `_rsc` query on the redirect Location so the
+  // browser's auto-followed request to the destination is still treated as an
+  // RSC fetch. The vinext client addresses RSC navigations via the `RSC: 1`
+  // header + `?_rsc=` query (not a `.rsc` suffix), so we replicate that shape.
+  it("preserves the _rsc query on config-redirect Location for RSC navigations (#1529)", async () => {
+    const res = await fetch(`${baseUrl}/old-about?_rsc=abc123`, {
+      redirect: "manual",
+      headers: { Accept: "text/x-component", RSC: "1" },
+    });
+    expect(res.status).toBe(308);
+    const location = res.headers.get("location");
+    expect(location).toBeTruthy();
+    expect(location).toContain("/about");
+    expect(location).toContain("_rsc=abc123");
+  });
+
   // Ported from Next.js: test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
   //

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -384,6 +384,26 @@ describe("App Router Production server (startProdServer)", () => {
     expect(location).toContain("/about");
   });
 
+  // Issue #1529: an RSC client navigation that hits a next.config.js redirect
+  // must keep the cache-busting `_rsc` query on the redirect Location so the
+  // browser's auto-followed request to the destination is still treated as an
+  // RSC fetch. The vinext client addresses RSC navigations via the `RSC: 1`
+  // header + `?_rsc=` query, so we replicate that request shape here.
+  it("preserves the _rsc query on config-redirect Location for RSC navigations (#1529)", async () => {
+    const res = await fetch(`${baseUrl}/old-about?_rsc=abc123`, {
+      redirect: "manual",
+      headers: { Accept: "text/x-component", RSC: "1" },
+    });
+    expect(res.status).toBe(308);
+    const location = res.headers.get("location");
+    expect(location).toBeTruthy();
+    expect(location).toContain("/about");
+    // The App Router RSC handler canonicalizes the redirect Location by
+    // recomputing the cache-busting `_rsc` param from the request headers
+    // (rather than echoing the literal client value), so assert presence.
+    expect(location).toContain("_rsc");
+  });
+
   it("serves static assets with cache headers", async () => {
     // Find an actual hashed asset from the build (on disk under
     // `_next/static/`, matching `resolveAssetsDir("")`).

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -581,6 +581,46 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  it("preserves the _rsc query on config redirects for .rsc requests without the RSC header (#1529)", async () => {
+    // A `.rsc`-suffixed request is an RSC request even when the `RSC: 1`
+    // header is absent (e.g. a CDN-style or auto-followed fetch). The redirect
+    // Location must still carry the cache-busting `_rsc` query so the followed
+    // request is treated as an RSC fetch. The non-header branch preserves the
+    // original request query rather than recomputing the hash.
+    const handler = createHandler({
+      configHeaders: [],
+      configRedirects: [{ source: "/old-about", destination: "/about", permanent: true }],
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/old-about.rsc?_rsc=abc123", {
+        headers: { Accept: "text/x-component" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("/docs/about?_rsc=abc123");
+  });
+
+  it("preserves the original request query on config redirects for document requests (#1529)", async () => {
+    // A plain (non-RSC) document request that hits a config redirect must
+    // carry its original query onto the Location, matching Next.js
+    // resolve-routes.ts. The destination's own query wins on key conflicts.
+    const handler = createHandler({
+      configHeaders: [],
+      configRedirects: [{ source: "/old-about", destination: "/about?from=old", permanent: true }],
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/old-about?foo=bar&from=req"),
+      null,
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("/docs/about?from=old&foo=bar");
+  });
+
   it("redirects invalid RSC cache-busting requests before middleware", async () => {
     const middleware = vi.fn(() => new Response("middleware"));
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -583,10 +583,13 @@ describe("createAppRscHandler", () => {
 
   it("preserves the _rsc query on config redirects for .rsc requests without the RSC header (#1529)", async () => {
     // A `.rsc`-suffixed request is an RSC request even when the `RSC: 1`
-    // header is absent (e.g. a CDN-style or auto-followed fetch). The redirect
-    // Location must still carry the cache-busting `_rsc` query so the followed
-    // request is treated as an RSC fetch. The non-header branch preserves the
-    // original request query rather than recomputing the hash.
+    // header is absent (e.g. a CDN-style or auto-followed fetch). Without the
+    // header the handler can't recompute the cache-busting hash, so the
+    // non-header branch carries the original request query onto the Location
+    // verbatim (mirroring Next.js resolve-routes.ts) rather than dropping it.
+    // (Note: the `.rsc` suffix is not re-applied to the destination, so the
+    // followed request isn't re-detected as RSC purely from `_rsc` — the
+    // guarantee here is query preservation, not RSC re-detection.)
     const handler = createHandler({
       configHeaders: [],
       configRedirects: [{ source: "/old-about", destination: "/about", permanent: true }],

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6454,6 +6454,33 @@ describe("middleware bypass prevention", () => {
     expect(rawResult).toBeNull();
   });
 
+  it("preserveRedirectDestinationQuery merges the original request query onto the destination (#1529)", async () => {
+    const { preserveRedirectDestinationQuery } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+
+    // Carries the RSC cache-busting `_rsc` param onto a query-less destination.
+    expect(preserveRedirectDestinationQuery("/dest", "?_rsc=abc123")).toBe("/dest?_rsc=abc123");
+
+    // Merges with a destination that already has its own query; destination
+    // params win on key conflicts (mirrors Next.js + proxyExternalRequest).
+    expect(preserveRedirectDestinationQuery("/dest?from=cfg", "?from=req&_rsc=abc")).toBe(
+      "/dest?from=cfg&_rsc=abc",
+    );
+
+    // No request query → destination untouched.
+    expect(preserveRedirectDestinationQuery("/dest?a=1", "")).toBe("/dest?a=1");
+    expect(preserveRedirectDestinationQuery("/dest", "?")).toBe("/dest");
+
+    // External destinations are returned untouched (no query leak across origins).
+    expect(preserveRedirectDestinationQuery("https://example.com/x", "?_rsc=abc")).toBe(
+      "https://example.com/x",
+    );
+    expect(preserveRedirectDestinationQuery("//evil.com", "?_rsc=abc")).toBe("//evil.com");
+
+    // Preserves a hash fragment on the destination.
+    expect(preserveRedirectDestinationQuery("/dest#frag", "?_rsc=abc")).toBe("/dest?_rsc=abc#frag");
+  });
+
   it("config header matcher works with decoded percent-encoded paths", async () => {
     const { matchHeaders } = await import("../packages/vinext/src/config/config-matchers.js");
     const { normalizePath } = await import("../packages/vinext/src/server/normalize-path.js");


### PR DESCRIPTION
## Problem

When an App Router RSC client navigation hits a `next.config.js` redirect, vinext dropped the request's query string when building the redirect `Location`. For RSC navigations the browser auto-follows the 307/308, but without the cache-busting `_rsc` query the followed request to the destination was no longer recognized as an RSC fetch — breaking RSC fetch semantics (issue #1529).

Next.js itself carries the original request query across config redirects (`prepareDestination({ query: parsedUrl.query })` → `stringifyQuery(...)` in `resolve-routes.ts`).

## Fix

Add a shared helper `preserveRedirectDestinationQuery(destination, requestSearch)` in `config/config-matchers.ts` that merges the original request query onto the redirect destination:

- Destination's own query params win on key conflicts (mirrors `proxyExternalRequest` merge semantics and Next.js).
- External destinations (`https:`, `//host`) are returned untouched — no cross-origin query leak.
- Hash fragments on the destination are preserved.

Wired into every config-redirect site:
- `deploy.ts` (Worker entry)
- `index.ts` (dev middleware `applyRedirects`)
- `server/prod-server.ts` (Pages Router prod server)
- `server/app-rsc-handler.ts` — RSC requests with the `RSC: 1` header still go through `createRscRedirectLocation` (recomputes `_rsc`); other requests (document loads and `.rsc`-suffixed requests without the header) now carry the original query through the new helper.

## Tests

- `tests/shims.test.ts` — unit coverage of `preserveRedirectDestinationQuery` (merge, conflict precedence, empty query, external-destination passthrough, hash preservation).
- `tests/app-rsc-handler.test.ts` — `.rsc` request without RSC header preserves `_rsc`; document request carries original query with destination-wins conflict resolution.
- `tests/app-router-dev-server.test.ts` / `tests/app-router-production-server.test.ts` — integration: an RSC navigation (`RSC: 1` + `?_rsc=`) hitting a config redirect keeps the `_rsc` query on the 308 `Location`.

Closes #1529