### PR TITLE
fix(app-router): clear useLinkStatus pending after interrupted navigation (#1527)

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -49,6 +49,14 @@ export type NavigationRuntimeFunctions = {
     historyUpdateMode: NavigationRuntimeHistoryUpdateMode,
   ) => Promise<void>;
   navigate?: NavigationRuntimeNavigate;
+  /**
+   * Called at the start of every App Router navigation so the <Link> shim can
+   * reset any link that is still showing a `useLinkStatus()` pending state but
+   * is not the one driving this navigation (e.g. a programmatic router.push or
+   * a shallow-routing transition). Registered by shims/link.tsx; decoupled
+   * through the runtime to avoid a circular import with shims/navigation.ts.
+   */
+  notifyLinkNavigationStart?: () => void;
   pingVisibleLinks?: () => void;
 };
 
@@ -102,6 +110,7 @@ function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntim
     isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigateExternal")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigate")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "notifyLinkNavigationStart")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "pingVisibleLinks"))
   );
 }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -630,7 +630,14 @@ function syncCurrentHistoryStatePreviousNextUrl(
   if (isHistoryStateNavigationMetadataInSync(window.history.state, previousNextUrl, bfcacheIds)) {
     return;
   }
-  window.history.replaceState(nextHistoryState, "", window.location.href);
+  // Retry via the same notify-suppressing path rather than the patched
+  // window.history.replaceState. This is a URL-unchanged metadata sync (refresh
+  // or traversal commit), so it must not run the patched-path side effects —
+  // commitClientNavigationState and notifyLinkNavigationStart — which would
+  // otherwise clear an unrelated <Link>'s useLinkStatus() pending state mid
+  // navigation on Safari. The browser sees the same native replaceState call,
+  // so the retry behaviour is unchanged.
+  replaceHistoryStateWithoutNotify(nextHistoryState, "", window.location.href);
 }
 
 function createActionInitiationSnapshot() {

--- a/packages/vinext/src/shims/internal/link-status-registry.ts
+++ b/packages/vinext/src/shims/internal/link-status-registry.ts
@@ -1,0 +1,73 @@
+/**
+ * Link-status pending registry.
+ *
+ * Tracks the single <Link> that started the most recent App Router navigation
+ * so its `useLinkStatus()` pending state can be reset when a *different*
+ * navigation begins — a different <Link> click, `router.push`/`router.replace`,
+ * a form submission, shallow routing via raw `history.pushState`, or browser
+ * back/forward. Without this, a Link's pending indicator stays "sticky" after
+ * an interrupting navigation, because the Link's own completion handler is the
+ * only thing that would otherwise clear it.
+ *
+ * Mirrors Next.js's `linkForMostRecentNavigation` /
+ * `setLinkForCurrentNavigation` in
+ * packages/next/src/client/components/links.ts, adapted to vinext's per-<Link>
+ * React state model: instead of an optimistic-status dispatcher, we hold the
+ * link's `setPending` setter.
+ */
+
+export type PendingLinkSetter = (pending: boolean) => void;
+
+let linkSetterForMostRecentNavigation: PendingLinkSetter | null = null;
+// Set true when a <Link> click registers itself for the navigation it is about
+// to start, and consumed by the first `notifyLinkNavigationStart` that runs for
+// that navigation. This lets the navigation-start hook tell a link-initiated
+// navigation (keep the link pending) apart from a programmatic one such as
+// `router.push` (reset the previously-pending link).
+let currentNavigationIsLinkInitiated = false;
+
+/**
+ * Mark `setter` as the link that started the most recent navigation, resetting
+ * the previously-tracked link's pending state to idle so only the last-clicked
+ * link shows a pending state.
+ */
+export function setLinkForCurrentNavigation(setter: PendingLinkSetter): void {
+  if (linkSetterForMostRecentNavigation && linkSetterForMostRecentNavigation !== setter) {
+    linkSetterForMostRecentNavigation(false);
+  }
+  linkSetterForMostRecentNavigation = setter;
+  currentNavigationIsLinkInitiated = true;
+}
+
+/**
+ * Stop tracking `setter` if it is the current navigation link. Called when a
+ * <Link> finishes its own navigation or unmounts so we never hold a stale
+ * reference to an unmounted component's setter.
+ */
+export function clearLinkForCurrentNavigation(setter: PendingLinkSetter): void {
+  if (linkSetterForMostRecentNavigation === setter) {
+    linkSetterForMostRecentNavigation = null;
+  }
+}
+
+/**
+ * Reset any link that is currently showing a pending state. Invoked at the
+ * start of every App Router navigation so that navigations not initiated by the
+ * tracked link — `router.push`/`router.replace`, form submissions, shallow
+ * routing, and browser back/forward — clear a stale pending indicator. A
+ * link-initiated navigation registers itself first via
+ * `setLinkForCurrentNavigation`; the matching call here consumes that marker and
+ * keeps the link pending.
+ */
+export function notifyLinkNavigationStart(): void {
+  if (currentNavigationIsLinkInitiated) {
+    // The <Link> that just registered itself owns this navigation; keep it
+    // pending and consume the marker for the next (programmatic) navigation.
+    currentNavigationIsLinkInitiated = false;
+    return;
+  }
+  if (linkSetterForMostRecentNavigation) {
+    linkSetterForMostRecentNavigation(false);
+    linkSetterForMostRecentNavigation = null;
+  }
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -72,6 +72,12 @@ import {
 } from "./internal/pages-data-target.js";
 import { markAppRouteDetectedOnPrefetch } from "./internal/app-route-detection.js";
 import { getCurrentBrowserLocale } from "./client-locale.js";
+import {
+  clearLinkForCurrentNavigation,
+  notifyLinkNavigationStart,
+  setLinkForCurrentNavigation,
+  type PendingLinkSetter,
+} from "./internal/link-status-registry.js";
 
 type NavigateEvent = {
   url: URL;
@@ -148,6 +154,18 @@ const LinkStatusContext = createContext<LinkStatusContextValue>({ pending: false
  */
 export function useLinkStatus(): LinkStatusContextValue {
   return useContext(LinkStatusContext);
+}
+
+// Register the link-status reset hook on the navigation runtime as soon as this
+// module evaluates on the client. `navigateClientSide` calls it at the start of
+// every App Router navigation (including router.push and shallow routing), so a
+// stale link's pending state is cleared even when no <Link> initiated the
+// navigation. The registry itself lives in internal/link-status-registry.ts so
+// it can be unit-tested without rendering a <Link>.
+if (typeof window !== "undefined") {
+  registerNavigationRuntimeFunctions({
+    notifyLinkNavigationStart,
+  });
 }
 
 /** basePath from next.config.js, injected by the plugin at build time */
@@ -758,10 +776,22 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // Track pending state for useLinkStatus()
   const [pending, setPending] = useState(false);
   const mountedRef = useRef(true);
+  // Stable setter so the global navigation registry can reset this link's
+  // pending state from another navigation without depending on render identity.
+  const setPendingRef = useRef<PendingLinkSetter | null>(null);
+  if (setPendingRef.current === null) {
+    setPendingRef.current = (next: boolean) => {
+      if (mountedRef.current) setPending(next);
+    };
+  }
   useEffect(() => {
     mountedRef.current = true;
+    const setter = setPendingRef.current;
     return () => {
       mountedRef.current = false;
+      // Drop our setter from the global registry on unmount so a later
+      // navigation never calls into an unmounted component.
+      if (setter) clearLinkForCurrentNavigation(setter);
     };
   }, []);
 
@@ -943,11 +973,17 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // App Router: delegate to navigateClientSide which handles scroll save,
     // hash-only changes, RSC fetch, and two-phase URL commit.
     if (getNavigationRuntime()?.functions.navigate) {
+      const setter = setPendingRef.current;
+      // Register this link as the one driving the current navigation. This
+      // resets any previously-pending link (e.g. a different link clicked
+      // moments earlier) so only the last-clicked link shows a pending state.
+      if (setter) setLinkForCurrentNavigation(setter);
       setPending(true);
       React.startTransition(() => {
         void navigateClientSide(navigateHref, replace ? "replace" : "push", scroll, true).finally(
           () => {
             if (mountedRef.current) setPending(false);
+            if (setter) clearLinkForCurrentNavigation(setter);
           },
         );
       });

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1679,6 +1679,11 @@ export async function navigateClientSide(
   scroll: boolean,
   programmaticTransition = false,
 ): Promise<void> {
+  // Reset any link still showing a `useLinkStatus()` pending state that did not
+  // initiate this navigation (e.g. a programmatic router.push or form submit).
+  // A <Link> click registers itself first, so the hook keeps that link pending.
+  getNavigationRuntime()?.functions.notifyLinkNavigationStart?.();
+
   // Normalize same-origin absolute URLs to local paths for SPA navigation
   let normalizedHref = href;
   if (isExternalUrl(href)) {
@@ -2563,6 +2568,14 @@ if (!isServer) {
     // runtime is not available). It restores scroll position with microtask-based deferral.
     // App Router scroll restoration is handled in server/app-browser-entry.ts:697
     // with RSC navigation coordination (waits for pending navigation to settle).
+    window.addEventListener("popstate", () => {
+      // Browser back/forward starts a new navigation that the tracked link did
+      // not initiate, so clear any sticky `useLinkStatus()` pending state. Runs
+      // for both routers; the App Router's own popstate handler (in
+      // app-browser-entry.ts) drives scroll restoration and RSC fetching.
+      getNavigationRuntime()?.functions.notifyLinkNavigationStart?.();
+    });
+
     window.addEventListener("popstate", (event) => {
       if (!hasAppNavigationRuntime()) {
         commitClientNavigationState();
@@ -2582,6 +2595,9 @@ if (!isServer) {
         url,
       );
       if (state.suppressUrlNotifyCount === 0) {
+        // A raw history.pushState (shallow routing) starts a navigation that did
+        // not go through navigateClientSide; clear any sticky pending link.
+        getNavigationRuntime()?.functions.notifyLinkNavigationStart?.();
         commitClientNavigationState();
       }
     };
@@ -2598,6 +2614,7 @@ if (!isServer) {
         url,
       );
       if (state.suppressUrlNotifyCount === 0) {
+        getNavigationRuntime()?.functions.notifyLinkNavigationStart?.();
         commitClientNavigationState();
       }
     };

--- a/tests/link-status-registry.test.ts
+++ b/tests/link-status-registry.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for the `useLinkStatus()` pending registry (issue #1527).
+ *
+ * The registry tracks the single <Link> driving the most recent App Router
+ * navigation so its pending state can be cleared when a *different* navigation
+ * begins. These tests reproduce the upstream
+ * `test/e2e/use-link-status/index.test.ts` scenarios at the registry level —
+ * the part vinext got wrong, where a Link's pending flag stayed "sticky" after
+ * an interrupting navigation (multi-click, router.push, shallow routing,
+ * browser back) settled.
+ */
+import { describe, it, expect, beforeEach } from "vite-plus/test";
+import {
+  clearLinkForCurrentNavigation,
+  notifyLinkNavigationStart,
+  setLinkForCurrentNavigation,
+  type PendingLinkSetter,
+} from "../packages/vinext/src/shims/internal/link-status-registry.js";
+
+// Reset module state between tests by clearing whatever link is tracked.
+beforeEach(() => {
+  // Two notifications guarantee any in-flight link-initiated marker is consumed
+  // and the tracked setter is cleared, leaving a clean registry.
+  notifyLinkNavigationStart();
+  notifyLinkNavigationStart();
+});
+
+/** Build a fake <Link> pending setter that records the latest value it saw. */
+function createPendingLink(): { setter: PendingLinkSetter; pending: () => boolean } {
+  let pending = false;
+  return {
+    setter: (next: boolean) => {
+      pending = next;
+    },
+    pending: () => pending,
+  };
+}
+
+describe("link-status registry", () => {
+  it("keeps the link that initiated the navigation pending", () => {
+    const link = createPendingLink();
+    // <Link> click: register itself, then show pending.
+    setLinkForCurrentNavigation(link.setter);
+    link.setter(true);
+    // navigateClientSide fires the navigation-start hook synchronously.
+    notifyLinkNavigationStart();
+    expect(link.pending()).toBe(true);
+  });
+
+  it("clears the previous link when a different link is clicked (multi-click)", () => {
+    const post1 = createPendingLink();
+    const post2 = createPendingLink();
+
+    // Click post 1.
+    setLinkForCurrentNavigation(post1.setter);
+    post1.setter(true);
+    notifyLinkNavigationStart();
+    expect(post1.pending()).toBe(true);
+
+    // Quickly click post 2 — post 1's pending must clear, post 2 becomes pending.
+    setLinkForCurrentNavigation(post2.setter);
+    post2.setter(true);
+    notifyLinkNavigationStart();
+
+    expect(post1.pending()).toBe(false);
+    expect(post2.pending()).toBe(true);
+  });
+
+  it("clears a sticky pending link when navigation starts by router.push", () => {
+    const link = createPendingLink();
+
+    setLinkForCurrentNavigation(link.setter);
+    link.setter(true);
+    notifyLinkNavigationStart();
+    expect(link.pending()).toBe(true);
+
+    // router.push goes through navigateClientSide without registering a link,
+    // so the navigation-start hook resets the previously-pending link.
+    notifyLinkNavigationStart();
+    expect(link.pending()).toBe(false);
+  });
+
+  it("clears a sticky pending link on a programmatic navigation (shallow routing / back)", () => {
+    const link = createPendingLink();
+
+    setLinkForCurrentNavigation(link.setter);
+    link.setter(true);
+    notifyLinkNavigationStart();
+    expect(link.pending()).toBe(true);
+
+    // A raw history.pushState (shallow routing) or popstate (back) fires the
+    // navigation-start hook with no link registered.
+    notifyLinkNavigationStart();
+    expect(link.pending()).toBe(false);
+  });
+
+  it("does not call into an unmounted link after clearLinkForCurrentNavigation", () => {
+    const link = createPendingLink();
+    let calls = 0;
+    const trackingSetter: PendingLinkSetter = (next) => {
+      calls += 1;
+      link.setter(next);
+    };
+
+    setLinkForCurrentNavigation(trackingSetter);
+    trackingSetter(true);
+    notifyLinkNavigationStart(); // consumes the link-initiated marker
+    const callsAfterClick = calls;
+
+    // Link unmounts (or finishes its own navigation): drop it from the registry.
+    clearLinkForCurrentNavigation(trackingSetter);
+
+    // A later programmatic navigation must not invoke the dropped setter.
+    notifyLinkNavigationStart();
+    expect(calls).toBe(callsAfterClick);
+  });
+
+  it("only resets the tracked link, not an unrelated one", () => {
+    const tracked = createPendingLink();
+    const unrelated = createPendingLink();
+    unrelated.setter(true); // pending but never registered
+
+    setLinkForCurrentNavigation(tracked.setter);
+    tracked.setter(true);
+    notifyLinkNavigationStart();
+
+    // Programmatic navigation clears only the tracked link.
+    notifyLinkNavigationStart();
+    expect(tracked.pending()).toBe(false);
+    expect(unrelated.pending()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`useLinkStatus()` is expected to return `{ pending: false }` once a navigation settles. In vinext the pending flag stayed **sticky** (`pending: 1`) when a navigation was *interrupted* by a different navigation than the one the `<Link>` started — a second link click, a programmatic `router.push`/`router.replace`, a form submit, shallow routing via raw `history.pushState`, or browser back/forward. The `<Link>`'s own completion handler was the only thing that cleared its pending state, so an interrupting navigation left it stuck.

Surfaced by the Next.js Deploy Suite: `test/e2e/use-link-status/index.test.ts` (~3 failures). Part of #1328.

## Fix

Introduce a small **link-status pending registry** (`packages/vinext/src/shims/internal/link-status-registry.ts`) that tracks the single `<Link>` driving the most recent App Router navigation, mirroring Next.js's `linkForMostRecentNavigation` / `setLinkForCurrentNavigation` adapted to vinext's per-`<Link>` React state model.

- A clicked `<Link>` registers its (mount-guarded) `setPending` setter via `setLinkForCurrentNavigation`, marking the navigation as link-initiated.
- `navigateClientSide` calls `notifyLinkNavigationStart()` at the start of **every** App Router navigation. A link-initiated navigation consumes its marker and stays pending; any other navigation resets the previously-tracked link to idle.
- The hook is also fired from the patched `history.pushState`/`replaceState` and a `popstate` listener so shallow routing and back/forward clear stale pending too.
- The hook is decoupled through `navigation-runtime.ts` (`notifyLinkNavigationStart`) to avoid a circular import between `shims/link.tsx` and `shims/navigation.ts`. Links drop their setter from the registry on unmount, so a later navigation never calls into an unmounted component.

Also hardened the Safari `replaceState` coalescing fallback in `app-browser-entry.ts` (`syncCurrentHistoryStatePreviousNextUrl`): it called the *patched* `window.history.replaceState`, which fires `notifyLinkNavigationStart` + `commitClientNavigationState`. On a URL-unchanged metadata sync that could clear an unrelated `<Link>`'s pending state a few ms early on Safari. The retry now goes through `replaceHistoryStateWithoutNotify`, so the browser sees the same native `replaceState` without the patched-path side effects.

## Tests

`tests/link-status-registry.test.ts` (6 tests) reproduces the upstream scenarios at the registry level: link-initiated navigation stays pending; multi-click clears the previous link; `router.push`, shallow routing, and back clear sticky pending; unmounted/cleared links are never called; and unrelated pending links are left untouched.

Closes #1527