### PR TITLE
fix(build): don't crash build when a PostCSS string plugin can't be resolved (#1509)

### DIFF
--- a/packages/vinext/src/plugins/postcss.ts
+++ b/packages/vinext/src/plugins/postcss.ts
@@ -142,6 +142,12 @@ async function resolvePostcssStringPluginsUncached(
     // hook, so a throw here aborts the RSC/SSR/client builds with an opaque
     // error). Fall back to `undefined` so Vite's own postcss-load-config
     // loads and resolves the config relative to the config file instead.
+    //
+    // Note: a single unresolvable entry makes us defer the *entire* config to
+    // Vite (not a per-plugin skip) — the resolved list is only useful if it's
+    // complete, and Vite re-loads the whole config anyway. If the failure was a
+    // genuine plugin-factory error rather than a resolution miss, Vite's loader
+    // re-surfaces it with a clearer message than this opaque build abort.
     return undefined;
   }
 }

--- a/packages/vinext/src/plugins/postcss.ts
+++ b/packages/vinext/src/plugins/postcss.ts
@@ -112,27 +112,36 @@ async function resolvePostcssStringPluginsUncached(
 
   // Resolve string plugin names to actual plugin functions
   const req = createRequire(path.join(projectRoot, "package.json"));
-  const resolved = await Promise.all(
-    config.plugins.filter(Boolean).map(async (plugin: unknown) => {
-      if (typeof plugin === "string") {
-        const resolved = req.resolve(plugin);
-        const mod = await import(pathToFileURL(resolved).href);
-        const fn = mod.default ?? mod;
-        // If the export is a function, call it to get the plugin instance
-        return typeof fn === "function" ? fn() : fn;
-      }
-      // Array tuple form: ["plugin-name", { options }]
-      if (Array.isArray(plugin) && typeof plugin[0] === "string") {
-        const [name, options] = plugin;
-        const resolved = req.resolve(name);
-        const mod = await import(pathToFileURL(resolved).href);
-        const fn = mod.default ?? mod;
-        return typeof fn === "function" ? fn(options) : fn;
-      }
-      // Already a function or plugin object — pass through
-      return plugin;
-    }),
-  );
-
-  return { plugins: resolved };
+  try {
+    const resolved = await Promise.all(
+      config.plugins.filter(Boolean).map(async (plugin: unknown) => {
+        if (typeof plugin === "string") {
+          const resolved = req.resolve(plugin);
+          const mod = await import(pathToFileURL(resolved).href);
+          const fn = mod.default ?? mod;
+          // If the export is a function, call it to get the plugin instance
+          return typeof fn === "function" ? fn() : fn;
+        }
+        // Array tuple form: ["plugin-name", { options }]
+        if (Array.isArray(plugin) && typeof plugin[0] === "string") {
+          const [name, options] = plugin;
+          const resolved = req.resolve(name);
+          const mod = await import(pathToFileURL(resolved).href);
+          const fn = mod.default ?? mod;
+          return typeof fn === "function" ? fn(options) : fn;
+        }
+        // Already a function or plugin object — pass through
+        return plugin;
+      }),
+    );
+    return { plugins: resolved };
+  } catch {
+    // A plugin name failed to resolve or load (e.g. it isn't installed at
+    // `projectRoot`, or resolves differently than postcss-load-config would).
+    // Don't crash the whole build (every Vite environment runs this config
+    // hook, so a throw here aborts the RSC/SSR/client builds with an opaque
+    // error). Fall back to `undefined` so Vite's own postcss-load-config
+    // loads and resolves the config relative to the config file instead.
+    return undefined;
+  }
 }

--- a/tests/postcss-resolve.test.ts
+++ b/tests/postcss-resolve.test.ts
@@ -194,6 +194,43 @@ module.exports.postcss = true;
     }
   });
 
+  // --- Unresolvable string plugin must not crash the build ---
+  //
+  // Regression for #1509: a CSS-modules + PostCSS app (e.g. a config like
+  // `plugins: ["postcss-nested", ...]`) must not abort the build when a
+  // named plugin can't be resolved from the project root. This config hook
+  // runs once per Vite environment (RSC/SSR/client), so a throw here aborts
+  // the whole build with an opaque error. We fall back to `undefined` and let
+  // Vite's own postcss-load-config resolve the config relative to the config
+  // file instead.
+
+  it("returns undefined (does not throw) when a string plugin can't be resolved", async () => {
+    const dir = await createTmpProject(
+      "postcss.config.cjs",
+      // "missing-postcss-plugin" is not installed in this temp project.
+      `module.exports = { plugins: ["mock-postcss-plugin", "missing-postcss-plugin"] };`,
+    );
+    try {
+      const result = await resolvePostcssStringPlugins(dir);
+      expect(result).toBeUndefined();
+    } finally {
+      await cleanupDir(dir);
+    }
+  });
+
+  it("returns undefined when an unresolvable plugin appears in tuple form", async () => {
+    const dir = await createTmpProject(
+      "postcss.config.cjs",
+      `module.exports = { plugins: [["missing-postcss-plugin", { foo: "bar" }]] };`,
+    );
+    try {
+      const result = await resolvePostcssStringPlugins(dir);
+      expect(result).toBeUndefined();
+    } finally {
+      await cleanupDir(dir);
+    }
+  });
+
   // --- JSON/YAML configs are skipped ---
 
   it("returns undefined for .postcssrc.json (postcss-load-config handles these)", async () => {


### PR DESCRIPTION
## Problem

Closes #1509.

When an app combines CSS modules with a PostCSS config in the RSC environment, the build could abort with an opaque `Custom deploy script failed: undefined (1)`.

`resolvePostcssStringPlugins` (`packages/vinext/src/plugins/postcss.ts`) runs inside the Vite `config` hook, which fires **once per Vite environment** (RSC / SSR / client). It resolves array-form PostCSS string plugin names (e.g. `plugins: ["postcss-nested", ...]`) to plugin instances via `require.resolve` + dynamic import. If any named plugin failed to resolve from the project root, the thrown error was **uncaught** — the rejected promise was cached and re-thrown for every environment, aborting the entire build.

## Reproduction

Building an App Router fixture (CSS module + `postcss.config` listing a plugin that doesn't resolve from where vinext looks) crashes during the RSC build:

```
Error: Cannot find module 'postcss-nested'
    at resolvePostcssStringPluginsUncached (packages/vinext/dist/plugins/postcss.js)
    at async ...config (packages/vinext/dist/index.js)
```

With all plugins installed and resolvable, CSS modules + PostCSS already build correctly across all environments — this fix targets the failure path.

## Fix

Wrap the plugin-resolution `Promise.all` in a `try/catch`. On failure, return `undefined` so vinext does **not** inject `css.postcss`, letting Vite's own `postcss-load-config` load and resolve the config relative to the config file instead. This mirrors the existing "let Vite handle it" fallback already used when the config file itself can't be loaded, and is strictly safer than throwing — the happy path (resolvable plugins) is unchanged.

## Tests

Added two regression tests to `tests/postcss-resolve.test.ts`:
- a string plugin that can't be resolved returns `undefined` (does not throw)
- an unresolvable plugin in tuple form returns `undefined`

Both fail on `main` (with the exact `Cannot find module` crash) and pass with the fix. `vp check` clean on both changed files; `tests/sass-options.test.ts` (same css-injection path) still passes.