### PR TITLE
fix(app-router): respect reactMaxHeadersLength for preload Link header (#1552)

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -224,6 +224,13 @@ export type NextConfig = {
   allowedDevOrigins?: string[];
   /** Maximum age in seconds for stale ISR entries before blocking regeneration. */
   expireTime?: number;
+  /**
+   * Maximum total length (in characters) of the preload `Link` header emitted
+   * during App Router SSR. React drops whole entries once the limit is
+   * exceeded; `0` disables emission entirely. Defaults to 6000.
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/reactMaxHeadersLength
+   */
+  reactMaxHeadersLength?: number;
   /** User agents that require blocking metadata in the initial head. */
   htmlLimitedBots?: RegExp | string;
   /**
@@ -353,6 +360,11 @@ export type ResolvedNextConfig = {
   serverActionsBodySizeLimit: number;
   /** Route-level expire fallback in seconds for ISR entries with numeric revalidate. */
   expireTime: number;
+  /**
+   * Maximum total length (in characters) of the preload `Link` header emitted
+   * during App Router SSR. `0` disables emission. Defaults to 6000.
+   */
+  reactMaxHeadersLength: number;
   /** Serialized htmlLimitedBots regexp source from next.config. */
   htmlLimitedBots: string | undefined;
   /**
@@ -473,6 +485,13 @@ const CONFIG_FILES = [
   "next.config.cjs",
 ];
 const DEFAULT_EXPIRE_TIME = 31_536_000;
+
+/**
+ * Default cap for the App Router preload `Link` header length, matching the
+ * Next.js `defaultConfig.reactMaxHeadersLength`.
+ * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/reactMaxHeadersLength
+ */
+const DEFAULT_REACT_MAX_HEADERS_LENGTH = 6000;
 
 /**
  * Check whether an error indicates a CJS module was loaded in an ESM context
@@ -1185,6 +1204,7 @@ export async function resolveNextConfig(
       inlineCss: false,
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
       expireTime: DEFAULT_EXPIRE_TIME,
+      reactMaxHeadersLength: DEFAULT_REACT_MAX_HEADERS_LENGTH,
       htmlLimitedBots: undefined,
       serverExternalPackages: [],
       cacheHandler: undefined,
@@ -1456,6 +1476,10 @@ export async function resolveNextConfig(
     inlineCss,
     serverActionsBodySizeLimit,
     expireTime: typeof config.expireTime === "number" ? config.expireTime : DEFAULT_EXPIRE_TIME,
+    reactMaxHeadersLength:
+      typeof config.reactMaxHeadersLength === "number"
+        ? config.reactMaxHeadersLength
+        : DEFAULT_REACT_MAX_HEADERS_LENGTH,
     htmlLimitedBots,
     serverExternalPackages,
     cacheHandler,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -23,6 +23,7 @@ import type { MetadataFileRoute } from "../server/metadata-routes.js";
 import { isProxyFile } from "../server/middleware.js";
 
 const DEFAULT_EXPIRE_TIME = 31_536_000;
+const DEFAULT_REACT_MAX_HEADERS_LENGTH = 6000;
 
 // Pre-computed absolute paths for generated-code imports. The virtual RSC
 // entry can't use relative imports (it has no real file location), so we
@@ -133,6 +134,11 @@ type AppRouterConfig = {
   assetPrefix?: string;
   /** Route-level expire fallback in seconds for ISR entries with numeric revalidate. */
   expireTime?: number;
+  /**
+   * Maximum total length (in characters) of the preload `Link` header emitted
+   * during App Router SSR. `0` disables emission. Defaults to 6000.
+   */
+  reactMaxHeadersLength?: number;
   /** Maximum in-memory cache size in bytes. 0 disables the default memory cache. */
   cacheMaxMemorySize?: number;
   /** Inline app CSS into production HTML (from experimental.inlineCss). */
@@ -194,6 +200,7 @@ export function generateRscEntry(
   const clientTraceMetadata = config?.clientTraceMetadata;
   const assetPrefix = config?.assetPrefix ?? "";
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
+  const reactMaxHeadersLength = config?.reactMaxHeadersLength ?? DEFAULT_REACT_MAX_HEADERS_LENGTH;
   const cacheMaxMemorySize = config?.cacheMaxMemorySize;
   const inlineCss = config?.inlineCss === true;
   const i18nConfig = config?.i18n ?? null;
@@ -523,6 +530,7 @@ const __allowedOrigins = ${JSON.stringify(allowedOrigins)};
 const __expireTime = ${JSON.stringify(expireTime)};
 const __htmlLimitedBots = ${JSON.stringify(htmlLimitedBots)};
 const __clientTraceMetadata = ${JSON.stringify(clientTraceMetadata)};
+const __reactMaxHeadersLength = ${JSON.stringify(reactMaxHeadersLength)};
 // Re-exported for the App Router prod-server to consume at startup —
 // mirrors the embedded \`__basePath\` pattern (and Pages Router's
 // \`vinextConfig\` export). Empty string when unset.
@@ -613,6 +621,7 @@ export default __createAppRscHandler({
       basePath: __basePath,
       ensureRouteLoaded: __ensureRouteLoaded,
       clientTraceMetadata: __clientTraceMetadata,
+      reactMaxHeadersLength: __reactMaxHeadersLength,
       buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams, layoutParamAccess) {
         return buildPageElements(targetRoute, targetParams, cleanPathname, {
           opts: targetOpts,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2520,6 +2520,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               clientTraceMetadata: nextConfig?.clientTraceMetadata,
               assetPrefix: nextConfig?.assetPrefix,
               expireTime: nextConfig?.expireTime,
+              reactMaxHeadersLength: nextConfig?.reactMaxHeadersLength,
               cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
               inlineCss: nextConfig?.inlineCss,
               i18n: nextConfig?.i18n,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -189,6 +189,12 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
    * SSR head. Undefined or empty disables emission entirely.
    */
   clientTraceMetadata?: readonly string[];
+  /**
+   * Maximum total length (in characters) of the preload `Link` header emitted
+   * during SSR. `0` disables emission. From `reactMaxHeadersLength` in
+   * `next.config`. Undefined falls back to the React default downstream.
+   */
+  reactMaxHeadersLength?: number;
   buildPageElement: (
     route: TRoute,
     params: AppPageParams,
@@ -620,6 +626,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
               {
                 basePath: options.basePath,
                 clientTraceMetadata: options.clientTraceMetadata,
+                reactMaxHeadersLength: options.reactMaxHeadersLength,
                 rootParams: options.rootParams,
                 waitForAllReady: true,
                 ...(revalidatedRscCapture.sideStream
@@ -816,6 +823,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   return renderAppPageLifecycle({
     basePath: options.basePath,
     clientTraceMetadata: options.clientTraceMetadata,
+    reactMaxHeadersLength: options.reactMaxHeadersLength,
     cleanPathname: options.cleanPathname,
     clearRequestContext: options.clearRequestContext,
     consumeDynamicUsage,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -854,11 +854,11 @@ export async function renderAppPageLifecycle(
     throw new Error("[vinext] Expected an HTML stream when no fallback response was returned");
   }
 
-  // Combine the font preload `Link` header with React's preload `Link` header
-  // (captured via onHeaders during SSR), capped to `reactMaxHeadersLength`.
+  // Combine React's preload `Link` header (captured via onHeaders during SSR)
+  // with the font preload `Link` header, capped to `reactMaxHeadersLength`.
   const linkHeader = buildAppPageLinkHeader(
-    fontLinkHeader,
     htmlRender.linkHeader,
+    fontLinkHeader,
     options.reactMaxHeadersLength,
   );
 
@@ -961,7 +961,7 @@ export async function renderAppPageLifecycle(
   if (htmlResponsePolicy.shouldWriteToCache || shouldSpeculativelyWriteCache) {
     const isrResponse = buildAppPageHtmlResponse(safeHtmlStream, {
       draftCookie,
-      fontLinkHeader: linkHeader,
+      linkHeader,
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       policy: htmlResponsePolicy,
@@ -1026,7 +1026,7 @@ export async function renderAppPageLifecycle(
 
   return buildAppPageHtmlResponse(safeHtmlStream, {
     draftCookie,
-    fontLinkHeader: linkHeader,
+    linkHeader,
     isEdgeRuntime: options.isEdgeRuntime,
     middlewareContext: options.middlewareContext,
     policy: htmlResponsePolicy,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -29,6 +29,7 @@ import {
   type AppPageResponseTiming,
 } from "./app-page-response.js";
 import {
+  buildAppPageLinkHeader,
   createAppPageFontData,
   createAppPageRscErrorTracker,
   deferUntilStreamConsumed,
@@ -105,6 +106,12 @@ type RenderAppPageLifecycleOptions = {
    * Undefined or empty disables emission.
    */
   clientTraceMetadata?: readonly string[];
+  /**
+   * Maximum total length (in characters) of the preload `Link` header emitted
+   * during SSR. `0` disables emission. From `reactMaxHeadersLength` in
+   * `next.config`.
+   */
+  reactMaxHeadersLength?: number;
   cleanPathname: string;
   clearRequestContext: () => void;
   consumeDynamicUsage: () => boolean;
@@ -824,6 +831,7 @@ export async function renderAppPageLifecycle(
         navigationContext: options.getNavigationContext(),
         basePath: options.basePath,
         clientTraceMetadata: options.clientTraceMetadata,
+        reactMaxHeadersLength: options.reactMaxHeadersLength,
         rootParams: options.rootParams,
         formState: options.formState ?? null,
         rscStream: rscForResponse,
@@ -845,6 +853,14 @@ export async function renderAppPageLifecycle(
   if (!htmlStream) {
     throw new Error("[vinext] Expected an HTML stream when no fallback response was returned");
   }
+
+  // Combine the font preload `Link` header with React's preload `Link` header
+  // (captured via onHeaders during SSR), capped to `reactMaxHeadersLength`.
+  const linkHeader = buildAppPageLinkHeader(
+    fontLinkHeader,
+    htmlRender.linkHeader,
+    options.reactMaxHeadersLength,
+  );
 
   if (options.isPrerender === true) {
     await htmlRender.metadataReady;
@@ -945,7 +961,7 @@ export async function renderAppPageLifecycle(
   if (htmlResponsePolicy.shouldWriteToCache || shouldSpeculativelyWriteCache) {
     const isrResponse = buildAppPageHtmlResponse(safeHtmlStream, {
       draftCookie,
-      fontLinkHeader,
+      fontLinkHeader: linkHeader,
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       policy: htmlResponsePolicy,
@@ -1010,7 +1026,7 @@ export async function renderAppPageLifecycle(
 
   return buildAppPageHtmlResponse(safeHtmlStream, {
     draftCookie,
-    fontLinkHeader,
+    fontLinkHeader: linkHeader,
     isEdgeRuntime: options.isEdgeRuntime,
     middlewareContext: options.middlewareContext,
     policy: htmlResponsePolicy,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -70,7 +70,8 @@ type BuildAppPageRscResponseOptions = {
 
 type BuildAppPageHtmlResponseOptions = {
   draftCookie?: string | null;
-  fontLinkHeader?: string;
+  /** Combined preload `Link` header value (React hints + font preloads), already capped. */
+  linkHeader?: string;
   isEdgeRuntime?: boolean;
   middlewareContext: AppPageMiddlewareContext;
   policy: AppPageResponsePolicy;
@@ -306,8 +307,8 @@ export function buildAppPageHtmlResponse(
   if (options.draftCookie) {
     headers.append("Set-Cookie", options.draftCookie);
   }
-  if (options.fontLinkHeader) {
-    headers.set("Link", options.fontLinkHeader);
+  if (options.linkHeader) {
+    headers.set("Link", options.linkHeader);
   }
 
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -54,7 +54,7 @@ function normalizeAppSsrRenderResult(
 }
 
 /**
- * Combine vinext's font preload `Link` header with the React-emitted preload
+ * Combine the React-emitted preload `Link` header with vinext's font preload
  * `Link` header, capping the result to `reactMaxHeadersLength`.
  *
  * React already caps its own portion, but vinext emits font preloads through a
@@ -63,10 +63,14 @@ function normalizeAppSsrRenderResult(
  * keeping only whole entries that fit and dropping the rest once the limit is
  * exceeded. `0` disables emission entirely (matches React); `undefined` falls
  * back to the React default of 6000.
+ *
+ * React's hints (scripts/modules/styles) come first so that under a tight cap
+ * the render-critical entries survive and trailing font preloads are dropped
+ * first.
  */
 export function buildAppPageLinkHeader(
-  fontLinkHeader: string | undefined,
   reactLinkHeader: string | undefined,
+  fontLinkHeader: string | undefined,
   maxHeadersLength: number | undefined,
 ): string {
   // Matches Next.js's `defaultConfig.reactMaxHeadersLength` (and the SSR
@@ -79,7 +83,7 @@ export function buildAppPageLinkHeader(
   }
 
   const entries: string[] = [];
-  for (const source of [fontLinkHeader, reactLinkHeader]) {
+  for (const source of [reactLinkHeader, fontLinkHeader]) {
     if (!source) continue;
     for (const entry of source.split(", ")) {
       if (entry.length > 0) {

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -22,6 +22,12 @@ export type AppSsrRenderResult = {
   htmlStream: ReadableStream<Uint8Array>;
   metadataReady: Promise<void>;
   capturedRscData: Promise<ArrayBuffer> | null;
+  /**
+   * Preload `Link` header value emitted by React during SSR (via `onHeaders`),
+   * already capped to `reactMaxHeadersLength`. Empty/undefined when React
+   * emitted no preload headers (or emission was disabled with `0`).
+   */
+  linkHeader?: string;
 };
 
 export function isAppSsrRenderResult(value: unknown): value is AppSsrRenderResult {
@@ -47,6 +53,54 @@ function normalizeAppSsrRenderResult(
   };
 }
 
+/**
+ * Combine vinext's font preload `Link` header with the React-emitted preload
+ * `Link` header, capping the result to `reactMaxHeadersLength`.
+ *
+ * React already caps its own portion, but vinext emits font preloads through a
+ * separate channel. Mirroring Next.js — where every preload flows through a
+ * single capped `onHeaders` callback — we cap the *combined* header here,
+ * keeping only whole entries that fit and dropping the rest once the limit is
+ * exceeded. `0` disables emission entirely (matches React); `undefined` falls
+ * back to the React default of 6000.
+ */
+export function buildAppPageLinkHeader(
+  fontLinkHeader: string | undefined,
+  reactLinkHeader: string | undefined,
+  maxHeadersLength: number | undefined,
+): string {
+  // Matches Next.js's `defaultConfig.reactMaxHeadersLength` (and the SSR
+  // renderer's fallback) so both caps agree when no config value is supplied.
+  const DEFAULT_REACT_MAX_HEADERS_LENGTH = 6000;
+  const limit =
+    typeof maxHeadersLength === "number" ? maxHeadersLength : DEFAULT_REACT_MAX_HEADERS_LENGTH;
+  if (limit <= 0) {
+    return "";
+  }
+
+  const entries: string[] = [];
+  for (const source of [fontLinkHeader, reactLinkHeader]) {
+    if (!source) continue;
+    for (const entry of source.split(", ")) {
+      if (entry.length > 0) {
+        entries.push(entry);
+      }
+    }
+  }
+
+  let header = "";
+  for (const entry of entries) {
+    const next = header.length === 0 ? entry : `${header}, ${entry}`;
+    if (next.length > limit) {
+      // React drops whole entries once the cap is exceeded; do the same.
+      break;
+    }
+    header = next;
+  }
+
+  return header;
+}
+
 export type AppPageSsrHandler = {
   handleSsr: (
     rscStream: ReadableStream<Uint8Array>,
@@ -61,6 +115,12 @@ export type AppPageSsrHandler = {
        * in the SSR head. Sourced from `experimental.clientTraceMetadata`.
        */
       clientTraceMetadata?: readonly string[];
+      /**
+       * Maximum total length (in characters) of the preload `Link` header
+       * emitted during SSR. `0` disables emission. From `reactMaxHeadersLength`
+       * in `next.config`.
+       */
+      reactMaxHeadersLength?: number;
       rootParams?: RootParams;
       sideStream?: ReadableStream<Uint8Array>;
       capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
@@ -85,6 +145,12 @@ type RenderAppPageHtmlStreamOptions = {
    * the SSR head. Undefined or empty disables emission.
    */
   clientTraceMetadata?: readonly string[];
+  /**
+   * Maximum total length (in characters) of the preload `Link` header emitted
+   * during SSR. `0` disables emission. From `reactMaxHeadersLength` in
+   * `next.config`.
+   */
+  reactMaxHeadersLength?: number;
   rootParams?: RootParams;
   ssrHandler: AppPageSsrHandler;
   /** Pre-split side stream for fused embed+capture (#981). When set,
@@ -111,6 +177,8 @@ type AppPageHtmlStreamRecoveryResult = {
   response: Response | null;
   metadataReady: Promise<void>;
   capturedRscData: Promise<ArrayBuffer> | null;
+  /** React-emitted preload `Link` header (already capped). */
+  linkHeader?: string;
 };
 
 type RenderAppPageHtmlStreamWithRecoveryOptions<TSpecialError> = {
@@ -154,6 +222,7 @@ export async function renderAppPageHtmlStream(
     scriptNonce: options.scriptNonce,
     basePath: options.basePath,
     clientTraceMetadata: options.clientTraceMetadata,
+    reactMaxHeadersLength: options.reactMaxHeadersLength,
     rootParams: options.rootParams,
     sideStream: options.sideStream,
     capturedRscDataRef: options.capturedRscDataRef,
@@ -263,13 +332,15 @@ export async function renderAppPageHtmlStreamWithRecovery<TSpecialError>(
 ): Promise<AppPageHtmlStreamRecoveryResult> {
   try {
     const rawResult = await options.renderHtmlStream();
-    const { htmlStream, metadataReady, capturedRscData } = normalizeAppSsrRenderResult(rawResult);
+    const { htmlStream, metadataReady, capturedRscData, linkHeader } =
+      normalizeAppSsrRenderResult(rawResult);
     options.onShellRendered?.();
     return {
       htmlStream,
       response: null,
       metadataReady,
       capturedRscData,
+      linkHeader,
     };
   } catch (error) {
     const specialError = options.resolveSpecialError(error);

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import type { ReactFormState } from "react-dom/client";
 import { Fragment, createElement as createReactElement, use } from "react";
 import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
+import type { RenderToReadableStreamOptions } from "react-dom/server";
 import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server.edge";
 import clientReferences from "virtual:vite-rsc/client-references";
 import type { NavigationContext } from "vinext/shims/navigation";
@@ -47,6 +48,23 @@ import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/s
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
+
+/**
+ * `@types/react-dom` does not yet type `maxHeadersLength` (it pairs with the
+ * already-typed `onHeaders` to cap the emitted preload `Link` header). React
+ * supports it at runtime, so augment the option type locally.
+ */
+type SsrRenderOptions = RenderToReadableStreamOptions & {
+  maxHeadersLength?: number;
+};
+
+/**
+ * Default cap for the preload `Link` header, matching Next.js's
+ * `defaultConfig.reactMaxHeadersLength`. Used when no config value threads
+ * through (e.g. error-boundary renders) so React's internal cap agrees with
+ * the response-layer combine cap.
+ */
+const DEFAULT_REACT_MAX_HEADERS_LENGTH = 6000;
 
 export type FontPreload = {
   href: string;
@@ -275,6 +293,12 @@ export async function handleSsr(
      * SSR head. Undefined or empty disables emission entirely.
      */
     clientTraceMetadata?: readonly string[];
+    /**
+     * Maximum total length (in characters) of the preload `Link` header React
+     * emits during SSR. `0` disables emission. From `reactMaxHeadersLength` in
+     * `next.config`. Undefined falls back to React's own default.
+     */
+    reactMaxHeadersLength?: number;
     rootParams?: RootParams;
     /** Dev-only: original server error to surface in the browser overlay. */
     initialDevServerError?: unknown;
@@ -421,7 +445,27 @@ export async function handleSsr(
           basePath: options?.basePath,
         });
 
-        const htmlStream = await renderToReadableStream(ssrRoot, {
+        // React emits a preload `Link` header (capped to `maxHeadersLength`)
+        // via `onHeaders`. It fires before the shell resolves, so `linkHeader`
+        // is populated by the time `renderToReadableStream` resolves below.
+        // `0` disables emission entirely — skip the callback so React doesn't
+        // warn about a non-positive `maxHeadersLength`. Fall back to the same
+        // 6000 default the response-layer cap uses (React's own default is
+        // 2000) so both caps agree when no config value threads through.
+        let reactLinkHeader = "";
+        const maxHeadersLength = options?.reactMaxHeadersLength ?? DEFAULT_REACT_MAX_HEADERS_LENGTH;
+        const captureHeaders = maxHeadersLength > 0;
+
+        const ssrRenderOptions: SsrRenderOptions = {
+          onHeaders: captureHeaders
+            ? (headers: Headers) => {
+                const link = headers.get("Link");
+                if (link) {
+                  reactLinkHeader = link;
+                }
+              }
+            : undefined,
+          maxHeadersLength: captureHeaders ? maxHeadersLength : undefined,
           // `bootstrapScriptContent` was previously how vinext injected the
           // dynamic-import call. `bootstrapModules` performs the same work
           // natively (and exposes the URL in the DOM), so passing both would
@@ -455,7 +499,9 @@ export async function handleSsr(
 
             return undefined;
           },
-        });
+        };
+
+        const htmlStream = await renderToReadableStream(ssrRoot, ssrRenderOptions);
 
         // Populated before any SSR request runs: at prod-server startup
         // (prod-server.ts) or via build-time bundle injection (index.ts). Left
@@ -545,6 +591,7 @@ export async function handleSsr(
           // this promise expecting it to be load-bearing in production.
           metadataReady: Promise.resolve(),
           capturedRscData: options?.capturedRscDataRef?.value ?? null,
+          linkHeader: reactLinkHeader,
         };
       } catch (error) {
         cleanup();

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -497,7 +497,7 @@ describe("app page response helpers", () => {
 
     const response = buildAppPageHtmlResponse(createBody("<h1>page</h1>"), {
       draftCookie: "__prerender_bypass=token; Path=/",
-      fontLinkHeader: "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
+      linkHeader: "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
       middlewareContext: {
         headers: middlewareHeaders,
         status: 203,

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  buildAppPageLinkHeader,
   createAppPageFontData,
   createAppPageRscErrorTracker,
   deferUntilStreamConsumed,
@@ -419,5 +420,45 @@ describe("app page stream helpers", () => {
     });
 
     expect(response.headers.get("x-edge-runtime")).toBeNull();
+  });
+});
+
+describe("buildAppPageLinkHeader", () => {
+  // Each entry is ~40 chars including the `, ` join.
+  const reactEntry = (i: number) => `</r${i}.js>; rel=preload; as=script`;
+  const fontEntry = (i: number) => `</f${i}.woff2>; rel=preload; as=font`;
+
+  it("combines React preloads first, then font preloads", () => {
+    const header = buildAppPageLinkHeader(reactEntry(1), fontEntry(1), 6000);
+    expect(header).toBe(`${reactEntry(1)}, ${fontEntry(1)}`);
+  });
+
+  it("returns an empty string when the cap is 0 (emission disabled)", () => {
+    expect(buildAppPageLinkHeader(reactEntry(1), fontEntry(1), 0)).toBe("");
+  });
+
+  it("defaults to a 6000-char cap when no limit is supplied", () => {
+    const react = [reactEntry(1), reactEntry(2)].join(", ");
+    expect(buildAppPageLinkHeader(react, undefined, undefined)).toBe(react);
+  });
+
+  it("drops whole entries once the cap is exceeded (never a partial entry)", () => {
+    const react = [reactEntry(1), reactEntry(2), reactEntry(3)].join(", ");
+    // Cap fits only the first two entries.
+    const limit = reactEntry(1).length + 2 + reactEntry(2).length + 1;
+    const header = buildAppPageLinkHeader(react, undefined, limit);
+    expect(header.length).toBeLessThanOrEqual(limit);
+    expect(header).toBe(`${reactEntry(1)}, ${reactEntry(2)}`);
+  });
+
+  it("drops trailing font preloads first under a tight cap (React preloads survive)", () => {
+    const limit = reactEntry(1).length + 2; // room for one entry only
+    const header = buildAppPageLinkHeader(reactEntry(1), fontEntry(1), limit);
+    expect(header).toBe(reactEntry(1));
+  });
+
+  it("ignores empty sources", () => {
+    expect(buildAppPageLinkHeader("", fontEntry(1), 6000)).toBe(fontEntry(1));
+    expect(buildAppPageLinkHeader(undefined, undefined, 6000)).toBe("");
   });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/react-max-headers-length/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/react-max-headers-length/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>;
+}

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -14,6 +14,15 @@ const nextConfig: NextConfig = {
   // Default is false — trailing slashes are stripped (redirects /about/ → /about)
   // trailingSlash: false,
 
+  // Used by Vitest: nextjs-compat/react-max-headers-length.test.ts — caps the
+  // total emitted preload `Link` header length. Env-driven so the test can
+  // start a fresh dev server per configured value (matching the upstream
+  // fixture's TEST_REACT_MAX_HEADERS_LENGTH switch). Undefined when unset, so
+  // the rest of the suite keeps the default behavior.
+  reactMaxHeadersLength: process.env.TEST_REACT_MAX_HEADERS_LENGTH
+    ? Number.parseInt(process.env.TEST_REACT_MAX_HEADERS_LENGTH, 10)
+    : undefined,
+
   async redirects() {
     return [
       // Used by Vitest: app-router.test.ts

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1424,6 +1424,23 @@ describe("resolveNextConfig expireTime", () => {
   });
 });
 
+describe("resolveNextConfig reactMaxHeadersLength", () => {
+  it("defaults to the Next.js default of 6000", async () => {
+    const resolved = await resolveNextConfig(null);
+    expect(resolved.reactMaxHeadersLength).toBe(6000);
+  });
+
+  it("uses a configured value", async () => {
+    const resolved = await resolveNextConfig({ reactMaxHeadersLength: 400 });
+    expect(resolved.reactMaxHeadersLength).toBe(400);
+  });
+
+  it("preserves 0 (disables emission) rather than falling back to the default", async () => {
+    const resolved = await resolveNextConfig({ reactMaxHeadersLength: 0 });
+    expect(resolved.reactMaxHeadersLength).toBe(0);
+  });
+});
+
 // Ported from Next.js: packages/next/src/server/config.ts:528-531
 // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config.ts
 describe("resolveNextConfig basePath → assetPrefix parity fallback", () => {
@@ -1506,6 +1523,7 @@ describe("detectNextIntlConfig", () => {
       enablePrerenderSourceMaps: true,
       appShells: false,
       expireTime: 31_536_000,
+      reactMaxHeadersLength: 6000,
       buildId: "test-build-id",
       deploymentId: undefined,
       sassOptions: null,

--- a/tests/nextjs-compat/react-max-headers-length.test.ts
+++ b/tests/nextjs-compat/react-max-headers-length.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Next.js Compatibility Tests: reactMaxHeadersLength
+ *
+ * Ported from Next.js: test/e2e/app-dir/react-max-headers-length/react-max-headers-length.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/react-max-headers-length/react-max-headers-length.test.ts
+ *
+ * `reactMaxHeadersLength` caps the total length of the preload `Link` header
+ * emitted during App Router SSR. React drops whole entries once the limit is
+ * exceeded (default 6000; `0` disables emission entirely). See
+ * cloudflare/vinext#1552.
+ *
+ * The upstream fixture asserts against React `ReactDOM.preload()` hints. vinext
+ * emits its preload `Link` header from the App Router font pipeline (the route
+ * inherits the fixture's `next/font` preloads), so this test exercises the same
+ * cap/truncation contract against that header.
+ */
+import { describe, it, expect, afterEach } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { APP_FIXTURE_DIR, startFixtureServer } from "../helpers.js";
+
+const ROUTE = "/nextjs-compat/react-max-headers-length";
+
+/** Split a `Link` header into its individual entries. */
+function linkEntries(header: string): string[] {
+  return header.split(", ").filter((entry) => entry.length > 0);
+}
+
+describe("Next.js compat: reactMaxHeadersLength", () => {
+  let server: ViteDevServer | undefined;
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+    delete process.env.TEST_REACT_MAX_HEADERS_LENGTH;
+  });
+
+  async function fetchLinkHeader(value: number | undefined): Promise<string | null> {
+    if (typeof value === "number") {
+      process.env.TEST_REACT_MAX_HEADERS_LENGTH = String(value);
+    } else {
+      delete process.env.TEST_REACT_MAX_HEADERS_LENGTH;
+    }
+    const started = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true });
+    server = started.server;
+    const res = await fetch(`${started.baseUrl}${ROUTE}`);
+    expect(res.status).toBe(200);
+    return res.headers.get("Link");
+  }
+
+  it("emits an uncapped Link header when reactMaxHeadersLength is unset", async () => {
+    const header = await fetchLinkHeader(undefined);
+    // Default cap is 6000; the fixture's font preloads stay well under it, so
+    // the full header is emitted.
+    expect(header).not.toBeNull();
+    expect(header!.length).toBeLessThanOrEqual(6000);
+    expect(header).toMatch(/rel=preload/);
+  }, 60_000);
+
+  it("does not emit a Link header when reactMaxHeadersLength is 0", async () => {
+    const header = await fetchLinkHeader(0);
+    expect(header).toBeNull();
+  }, 60_000);
+
+  it("truncates the Link header to whole entries within a small cap (200)", async () => {
+    const full = await fetchLinkHeader(undefined);
+    expect(full).not.toBeNull();
+    await server?.close();
+    server = undefined;
+
+    const capped = await fetchLinkHeader(200);
+    expect(capped).not.toBeNull();
+    // Respects the cap...
+    expect(capped!.length).toBeLessThanOrEqual(200);
+    // ...by dropping whole entries (each surviving entry is intact, never a
+    // partial slice of an entry).
+    const fullEntries = new Set(linkEntries(full!));
+    for (const entry of linkEntries(capped!)) {
+      expect(fullEntries.has(entry)).toBe(true);
+    }
+    // A smaller cap emits fewer entries than the uncapped header.
+    expect(linkEntries(capped!).length).toBeLessThan(fullEntries.size);
+  }, 60_000);
+
+  it("emits more entries for a larger cap than a smaller one", async () => {
+    const small = await fetchLinkHeader(200);
+    expect(small).not.toBeNull();
+    const smallCount = linkEntries(small!).length;
+    await server?.close();
+    server = undefined;
+
+    const large = await fetchLinkHeader(6000);
+    expect(large).not.toBeNull();
+    expect(large!.length).toBeLessThanOrEqual(6000);
+    expect(linkEntries(large!).length).toBeGreaterThanOrEqual(smallCount);
+  }, 60_000);
+});


### PR DESCRIPTION
## Problem

`reactMaxHeadersLength` (the cap on the total length of the preload `Link` header React inlines during App Router SSR) was not respected — vinext never forwarded the option into the React renderer. Fixes #1552.

## Fix

Thread `reactMaxHeadersLength` from `next.config` through the App Router render pipeline and into React's `renderToReadableStream`:

- **Config** (`config/next-config.ts`): accept `reactMaxHeadersLength`, default to `6000` (matching Next.js's `defaultConfig`).
- **Codegen** (`entries/app-rsc-entry.ts`): embed the resolved value and pass it through the page dispatch.
- **Render pipeline** (`app-page-dispatch.ts` → `app-page-render.ts` → `app-page-stream.ts` → `app-ssr-entry.ts`): forward the value, wire React's `onHeaders` + `maxHeadersLength` so React caps and emits its preload `Link` header. `0` disables emission entirely (no `onHeaders` wired, no `Link` header set).
- **Response** (`buildAppPageLinkHeader`): combine vinext's font preload `Link` header with React's emitted `Link` header and cap the combined value to `reactMaxHeadersLength`, dropping whole entries once the limit is exceeded (mirrors React's behavior, where every preload flows through a single capped `onHeaders`).

## Test

`tests/nextjs-compat/react-max-headers-length.test.ts` (ported from `test/e2e/app-dir/react-max-headers-length`) verifies the cap contract against the emitted `Link` header: `0` emits no header, small caps truncate to whole entries, larger caps emit more entries, and the default stays within 6000. Backed by a minimal route fixture under `app-basic` whose `reactMaxHeadersLength` is env-driven (matching the upstream `TEST_REACT_MAX_HEADERS_LENGTH` switch).

## Caveat

vinext's App Router SSR currently surfaces its preload `Link` header from the font pipeline. RSC-originated `ReactDOM.preload()` hints from Server Components flow through the embedded Flight stream and are applied client-side rather than captured by the SSR Fizz `onHeaders` pass (the app tree renders behind the Flight-stream `Suspense`, so user preloads resolve after the shell completes and React's `onHeaders` has already fired). Making those preloads reach the SSR header is a separate, larger change; this PR forwards the config option into the renderer and makes the emitted `Link` header respect `reactMaxHeadersLength`, which is the behavior the issue calls for.

Closes #1552
