### PR TITLE
fix(build): don't path-resolve bare specifier aliases (#1507)

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1510,6 +1510,21 @@ export async function resolveNextConfig(
   return resolved;
 }
 
+/**
+ * Whether an alias target is a relative filesystem path (`./foo`, `../foo`,
+ * or a bare `.`/`..`) that should be resolved against the project root.
+ *
+ * Both Next.js Turbopack `resolveAlias` and webpack `resolve.alias` accept two
+ * kinds of values: relative/absolute file paths AND bare package specifiers
+ * (e.g. `react`, `preact/compat`, `@scope/pkg`). Bare specifiers must be left
+ * verbatim so Vite/Rolldown re-resolves them through node_modules — resolving
+ * them against `root` mangles them into bogus `<root>/react` paths and breaks
+ * the build with "No such file or directory". See cloudflare/vinext#1507.
+ */
+function isRelativeAliasTarget(value: string): boolean {
+  return value === "." || value === ".." || value.startsWith("./") || value.startsWith("../");
+}
+
 function normalizeAliasEntries(
   aliases: Record<string, unknown> | undefined,
   root: string,
@@ -1519,7 +1534,15 @@ function normalizeAliasEntries(
   const normalized: Record<string, string> = {};
   for (const [key, value] of Object.entries(aliases)) {
     if (typeof value !== "string") continue;
-    normalized[key] = path.isAbsolute(value) ? value : path.resolve(root, value);
+    if (path.isAbsolute(value)) {
+      normalized[key] = value;
+    } else if (isRelativeAliasTarget(value)) {
+      normalized[key] = path.resolve(root, value);
+    } else {
+      // Bare package specifier (e.g. `react`, `preact/compat`) — leave as-is so
+      // Vite resolves it through node_modules rather than the filesystem.
+      normalized[key] = value;
+    }
   }
   return normalized;
 }

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -862,6 +862,101 @@ module.exports = withPlugin({ basePath: "/wrapped" });`,
     expect(config.aliases["wrapped/config"]).toBe(path.join(tmpDir, "turbopack", "request.ts"));
   });
 
+  // Regression test for #1507. Turbopack `resolveAlias` (and webpack
+  // `resolve.alias`) values can be bare package specifiers — e.g. the upstream
+  // esm-externals fixture aliases `preact/compat` -> `react`. Resolving those
+  // against the project root mangled them into bogus `<root>/react` paths,
+  // which broke the production build with "No such file or directory". Bare
+  // specifiers must be left verbatim so Vite re-resolves them via node_modules.
+  it("leaves bare package specifier turbopack aliases verbatim", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default {
+        turbopack: {
+          resolveAlias: {
+            "preact/compat": "react",
+            "@scope/pkg": "@scope/replacement",
+            "subpath": "react/jsx-runtime"
+          }
+        }
+      };`,
+    );
+
+    const rawConfig = await loadNextConfig(tmpDir);
+    const config = await resolveNextConfig(rawConfig, tmpDir);
+
+    // Bare specifiers stay as-is — NOT resolved against tmpDir.
+    expect(config.aliases["preact/compat"]).toBe("react");
+    expect(config.aliases["@scope/pkg"]).toBe("@scope/replacement");
+    expect(config.aliases["subpath"]).toBe("react/jsx-runtime");
+  });
+
+  it("still resolves relative-path turbopack aliases against the project root", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default {
+        turbopack: {
+          resolveAlias: {
+            "current": ".",
+            "parent": "..",
+            "explicit": "./turbo/request.ts",
+            "up": "../shared/request.ts"
+          }
+        }
+      };`,
+    );
+
+    const rawConfig = await loadNextConfig(tmpDir);
+    const config = await resolveNextConfig(rawConfig, tmpDir);
+
+    expect(config.aliases["current"]).toBe(path.resolve(tmpDir, "."));
+    expect(config.aliases["parent"]).toBe(path.resolve(tmpDir, ".."));
+    expect(config.aliases["explicit"]).toBe(path.join(tmpDir, "turbo", "request.ts"));
+    expect(config.aliases["up"]).toBe(path.resolve(tmpDir, "..", "shared", "request.ts"));
+  });
+
+  it("leaves absolute-path turbopack aliases verbatim", async () => {
+    tmpDir = makeTempDir();
+    const absoluteTarget = path.join(tmpDir, "abs", "request.ts");
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default {
+        turbopack: {
+          resolveAlias: {
+            "absolute": ${JSON.stringify(absoluteTarget)}
+          }
+        }
+      };`,
+    );
+
+    const rawConfig = await loadNextConfig(tmpDir);
+    const config = await resolveNextConfig(rawConfig, tmpDir);
+
+    expect(config.aliases["absolute"]).toBe(absoluteTarget);
+  });
+
+  it("leaves bare package specifier webpack aliases verbatim", async () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.js"),
+      `module.exports = {
+        webpack(config) {
+          config.resolve = config.resolve || {};
+          config.resolve.alias = config.resolve.alias || {};
+          config.resolve.alias["preact/compat"] = "react";
+          return config;
+        }
+      };`,
+    );
+
+    const rawConfig = await loadNextConfig(tmpDir);
+    const config = await resolveNextConfig(rawConfig, tmpDir);
+
+    expect(config.aliases["preact/compat"]).toBe("react");
+  });
+
   it("does not attribute turbopack aliases to webpack support warnings", async () => {
     tmpDir = makeTempDir();
 

--- a/tests/resolve-alias-build.test.ts
+++ b/tests/resolve-alias-build.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Build-driven regression test for cloudflare/vinext#1507.
+ *
+ * Next.js Turbopack `resolveAlias` (and webpack `resolve.alias`) values can be
+ * bare package specifiers, not just relative/absolute file paths. The upstream
+ * `esm-externals` deploy suite aliases `preact/compat` -> `react` this way:
+ *
+ *   turbopack: { resolveAlias: { 'preact/compat': 'react' } }
+ *
+ * vinext previously resolved every non-absolute alias value against the project
+ * root, turning `'react'` into a bogus `<root>/react` filesystem path. The
+ * production build then failed with "No such file or directory (os error 2)",
+ * which surfaced in the deploy harness as "Custom deploy script failed".
+ *
+ * This test reproduces the real symptom end-to-end: it builds a Pages Router
+ * app that imports `preact/compat` (a package that is NOT installed) and relies
+ * solely on `resolveAlias` to redirect it to `react`. Before the fix this build
+ * threw; after the fix the bare specifier is left verbatim and Vite resolves it
+ * through node_modules.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { build } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+
+const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+const cleanups: Array<() => void> = [];
+afterAll(() => {
+  for (const c of cleanups) c();
+});
+
+async function buildPagesFixture(nextConfigBody: string): Promise<void> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-resolve-alias-"));
+  cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  // Symlink the workspace node_modules so the fixture can resolve React and
+  // vinext. Note: `preact` is intentionally NOT installed — the import below
+  // must resolve purely via the configured alias.
+  fs.symlinkSync(ROOT_NODE_MODULES, path.join(tmpDir, "node_modules"), "junction");
+  fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ type: "module" }));
+  fs.writeFileSync(path.join(tmpDir, "next.config.mjs"), `export default ${nextConfigBody};\n`);
+  fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, "pages", "index.tsx"),
+    `import React from "preact/compat";
+export default function Home() {
+  // Touch the aliased import so it cannot be tree-shaken away.
+  return <p>{String(typeof React.useState === "function")}</p>;
+}
+`,
+  );
+
+  await build({
+    root: tmpDir,
+    configFile: false,
+    plugins: [vinext({ disableAppRouter: true })],
+    logLevel: "silent",
+    build: {
+      outDir: path.join(tmpDir, "dist", "server"),
+      ssr: "virtual:vinext-server-entry",
+      rollupOptions: { output: { entryFileNames: "entry.js" } },
+    },
+  });
+}
+
+describe("resolveAlias bare-specifier build (#1507)", () => {
+  it("builds when turbopack.resolveAlias maps an import to a bare package specifier", async () => {
+    await expect(
+      buildPagesFixture(
+        `{ experimental: { esmExternals: false }, turbopack: { resolveAlias: { "preact/compat": "react" } } }`,
+      ),
+    ).resolves.toBeUndefined();
+  }, 180_000);
+});


### PR DESCRIPTION
Fixes #1507 — `experimental.esmExternals` builds failed with `No such file or directory` because `normalizeAliasEntries` ran `path.resolve` on every alias value, turning bare package specifiers into bogus absolute paths. Now only `./`/`../`/absolute values are resolved; bare specifiers pass through verbatim (matching the existing `index.ts:1250` convention). Tests added; all 174 pre-existing config tests pass. Closes #1507