### PR TITLE
fix(app-router): resolve query-only Link href against current path (#1540)

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -159,7 +159,14 @@ const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>
 
 function resolveHref(href: LinkProps["href"]): string {
   if (typeof href === "string") return href;
-  let url = href.pathname ?? "/";
+  // When `pathname` is omitted, leave the base empty so the result is a
+  // query-only href (e.g. `?params=foo`) rather than `/?params=foo`. Mirrors
+  // Next.js's `formatUrl()` (`pathname = urlObj.pathname || ''`) so that a
+  // `<Link href={{ query: {...} }} />` resolves against the *current* path at
+  // navigation time instead of collapsing onto the site root. Defaulting to
+  // "/" here recorded the wrong history entry for shallow links, breaking
+  // back/forward traversal (issue #1540).
+  let url = href.pathname ?? "";
   if (href.query) {
     const params = urlQueryToSearchParams(href.query);
     url = appendSearchParamsToUrl(url, params);

--- a/tests/e2e/pages-router/middleware-shallow-link.spec.ts
+++ b/tests/e2e/pages-router/middleware-shallow-link.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+import { waitForHydration } from "../helpers";
+
+const BASE = "http://localhost:4173";
+
+// Ported from Next.js: test/e2e/middleware-shallow-link/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-shallow-link/index.test.ts
+//
+// Every route in the pages-basic fixture is matched by `middleware.ts`, so
+// these navigations exercise the "middleware-rewritten shallow link" path.
+// Regression coverage for #1540: after a shallow push, a non-shallow
+// navigation to another page, and a shallow replace, traversing back through
+// history (`window.history.back()`) must land on page 1 again.
+test.describe("Middleware shallow link history traversal (Pages Router)", () => {
+  test("back button returns to page 1 after shallow push/replace", async ({ page }) => {
+    await page.goto(`${BASE}/mw-shallow-link`);
+    await expect(page.locator("h1")).toHaveText("Content for page 1");
+    await waitForHydration(page);
+
+    // Shallow push — adds a history entry with new query, stays on page 1.
+    await page.click("[data-next-shallow-push]");
+    await expect(page).toHaveURL(`${BASE}/mw-shallow-link?params=testParams`);
+    await expect(page.locator("[data-next-page]")).toBeVisible();
+
+    // Non-shallow navigation to page 2.
+    await page.click("[data-next-page]");
+    await expect(page.locator("h1")).toHaveText("Content for page 2");
+    await expect(page.locator("[data-next-shallow-replace]")).toBeVisible();
+
+    // Shallow replace on page 2 — replaces the page-2 history entry.
+    await page.click("[data-next-shallow-replace]");
+    await expect(page).toHaveURL(`${BASE}/mw-shallow-link-page2?params=testParams`);
+
+    // The go-back button must render on the rewritten page.
+    await expect(page.locator("[data-go-back]")).toBeVisible();
+
+    // Traverse back through history — must land back on page 1.
+    await page.click("[data-go-back]");
+    await expect(page.locator("h1")).toHaveText("Content for page 1");
+  });
+});

--- a/tests/fixtures/pages-basic/pages/mw-shallow-link-page2.tsx
+++ b/tests/fixtures/pages-basic/pages/mw-shallow-link-page2.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+// Ported from Next.js: test/e2e/middleware-shallow-link/app/pages/page2.js
+// https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-shallow-link/app/pages/page2.js
+//
+// Page 2 of the middleware-rewritten shallow-link history-traversal scenario.
+export default function Page() {
+  return (
+    <>
+      <h1>Content for page 2</h1>
+      <Link data-next-shallow-replace replace shallow href={{ query: { params: "testParams" } }}>
+        Shallow replace
+      </Link>
+      <div>
+        <button data-go-back onClick={() => window.history.back()}>
+          Go Back
+        </button>
+      </div>
+    </>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/mw-shallow-link.tsx
+++ b/tests/fixtures/pages-basic/pages/mw-shallow-link.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+// Ported from Next.js: test/e2e/middleware-shallow-link/app/pages/index.js
+// https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-shallow-link/app/pages/index.js
+//
+// Page 1 of the middleware-rewritten shallow-link history-traversal scenario.
+// Every route here is matched by the fixture's `middleware.ts` (which runs
+// `NextResponse.next()` and stamps `x-custom-middleware`), so the navigations
+// below are "middleware-rewritten" in the sense the upstream test exercises.
+export default function Page() {
+  return (
+    <>
+      <h1>Content for page 1</h1>
+      <div>
+        <Link data-next-shallow-push shallow href={{ query: { params: "testParams" } }}>
+          Shallow push
+        </Link>
+      </div>
+      <div>
+        <Link data-next-page href="/mw-shallow-link-page2">
+          Go to page 2
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -72,11 +72,16 @@ describe("Link rendering", () => {
     expect(html).toContain('href="/search?q=test"');
   });
 
-  it("renders object href with only query (defaults to /)", () => {
+  it("renders object href with only query as a relative query href", () => {
+    // An href object without a `pathname` must resolve as a query-only href
+    // (e.g. `?tab=settings`) so the browser/router applies it against the
+    // *current* path, mirroring Next.js's `formatUrl()` (`pathname || ''`).
+    // Collapsing onto the root (`/?tab=settings`) recorded the wrong history
+    // entry for shallow links and broke back/forward traversal (issue #1540).
     const html = ReactDOMServer.renderToString(
       React.createElement(Link, { href: { query: { tab: "settings" } } }, "Settings"),
     );
-    expect(html).toContain('href="/?tab=settings"');
+    expect(html).toContain('href="?tab=settings"');
   });
 
   it("renders with as prop overriding href", () => {
@@ -431,6 +436,16 @@ describe("Link resolveHref", () => {
       React.createElement(Link, { href: { pathname: "/dashboard" } }, "x"),
     );
     expect(html).toContain('href="/dashboard"');
+  });
+
+  it("object href with only query resolves as a relative query href", () => {
+    // No `pathname` -> query-only href (not rooted at `/`), so the router
+    // resolves it against the current path. Mirrors Next.js's `formatUrl()`
+    // (`pathname = urlObj.pathname || ''`). Regression guard for issue #1540.
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Link, { href: { query: { page: "2", sort: "name" } } }, "x"),
+    );
+    expect(html).toMatch(/href="\?page=2&(?:amp;)?sort=name"/);
   });
 });
 


### PR DESCRIPTION
## Problem

A `<Link href={{ query: { params: "testParams" } }} />` with no `pathname` was resolved by defaulting the base to `"/"`, producing `/?params=testParams` instead of a query-only href. When the link is shallow, the navigation then recorded the wrong history entry (the site root), so back/forward traversal landed on the wrong URL/page.

This surfaced in the Next.js deploy suite as `test/e2e/middleware-shallow-link` — after a middleware-rewritten shallow navigation, `[data-go-back]` never resolved to the right page because the history entries were rooted at `/`.

## Fix

`resolveHref()` in `packages/vinext/src/shims/link.tsx` now leaves the base empty when `pathname` is omitted, mirroring Next.js's `formatUrl()` (`pathname = urlObj.pathname || ''`). The result is a relative query-only href (`?params=...`), which the existing relative-href resolution applies against the *current* path at navigation time — so the correct history entry is recorded and back/forward traversal works.

## Tests

- `tests/e2e/pages-router/middleware-shallow-link.spec.ts` — ported from upstream `test/e2e/middleware-shallow-link/index.test.ts`. Two new fixture pages (`mw-shallow-link`, `mw-shallow-link-page2`) under the all-routes middleware matcher exercise shallow push -> navigate -> shallow replace -> `history.back()` and assert the back button returns to page 1. Fails before the fix (URL collapses to `/?params=...`), passes after.
- `tests/link.test.ts` — updated the query-only-object case and added a `resolveHref` unit test asserting the relative `?query` output.

Verified locally: the new e2e spec plus shallow-routing / link-advanced / navigation / middleware pages-router specs (44 tests) pass, and the Link unit suite (118 tests) + i18n unit suites pass. `vp check` clean on changed files.

### Caveat

In an i18n config with a non-default active locale, a query-only `<Link>` href is still locale-prefixed onto the locale root (`/en/?query`) — but that behaviour is unchanged by this PR (the old `/?query` output collapsed the same way), so it's a pre-existing, narrower edge case left for a follow-up.

Closes #1540
