### PR TITLE
fix(routing): propagate middleware draft cookie to pages/api fallback (#1520)

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -936,6 +936,7 @@ export default __createAppRscHandler({
         buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse,
         decodePathParams: __decodePathParams,
         applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext,
+        getDraftModeCookieHeader,
       }
     );
   },`

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -28,6 +28,14 @@ type RenderPagesFallbackDependencies = {
    * it clears it. Mirrors how App Router route handlers and page renders surface
    * the middleware-enabled draft cookie so the same flow works when the request
    * falls through to a Pages Router route.
+   *
+   * Note: this closes the draft-mode flow for production (Cloudflare Workers /
+   * Node), where middleware runs inline in the same RSC handler context that
+   * builds this fallback. In hybrid *dev*, middleware runs in a separate Vite
+   * Pages SSR runner and `draftMode()` inside middleware is not yet permitted
+   * there (it throws a scope error before any cookie is set), so this getter
+   * returns `null` and no cookie is appended. That dev limitation is pre-existing
+   * and tracked separately from #1520.
    */
   getDraftModeCookieHeader: () => string | null | undefined;
 };

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -22,6 +22,14 @@ type RenderPagesFallbackDependencies = {
     response: Response,
     middlewareContext: AppMiddlewareContext,
   ) => Response;
+  /**
+   * Returns the `__prerender_bypass` Set-Cookie header emitted by a
+   * `draftMode().enable()`/`disable()` call inside middleware, if any. Reading
+   * it clears it. Mirrors how App Router route handlers and page renders surface
+   * the middleware-enabled draft cookie so the same flow works when the request
+   * falls through to a Pages Router route.
+   */
+  getDraftModeCookieHeader: () => string | null | undefined;
 };
 
 type RenderPagesFallbackOptions = {
@@ -44,6 +52,7 @@ export async function renderPagesFallback(
     buildRequestHeaders,
     decodePathParams,
     applyRouteHandlerMiddlewareContext,
+    getDraftModeCookieHeader,
   } = dependencies;
 
   if (isRscRequest) return null;
@@ -72,7 +81,11 @@ export async function renderPagesFallback(
   if (pagesPathname.startsWith("/api/") || pagesPathname === "/api") {
     if (typeof pagesEntry.handleApiRoute !== "function") return null;
     const pagesApiResponse = await pagesEntry.handleApiRoute(pagesRequest, pagesUrl);
-    return applyRouteHandlerMiddlewareContext(pagesApiResponse, middlewareContext);
+    const draftCookie = getDraftModeCookieHeader();
+    return applyDraftModeCookie(
+      applyRouteHandlerMiddlewareContext(pagesApiResponse, middlewareContext),
+      draftCookie,
+    );
   }
 
   if (typeof pagesEntry.renderPage !== "function") return null;
@@ -83,5 +96,27 @@ export async function renderPagesFallback(
     undefined,
     middlewareContext.requestHeaders,
   );
-  return pagesRes.status !== 404 ? pagesRes : null;
+  if (pagesRes.status === 404) return null;
+  return applyDraftModeCookie(pagesRes, getDraftModeCookieHeader());
+}
+
+/**
+ * Append a middleware-emitted `__prerender_bypass` Set-Cookie header to a Pages
+ * Router fallback response. Returns the response unchanged when there is no
+ * draft cookie to add. App Router route handlers/page renders surface this same
+ * cookie via `finalizeRouteHandlerResponse`/the page response builder; this
+ * keeps draft-mode parity for requests that fall through to the Pages Router.
+ */
+function applyDraftModeCookie(
+  response: Response,
+  draftCookie: string | null | undefined,
+): Response {
+  if (!draftCookie) return response;
+  const headers = new Headers(response.headers);
+  headers.append("Set-Cookie", draftCookie);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -28,6 +28,7 @@ describe("renderPagesFallback", () => {
         headers: mergedHeaders,
       });
     },
+    getDraftModeCookieHeader: (): string | null | undefined => null,
   };
 
   it("returns null for RSC requests and does not call the Pages loader", async () => {
@@ -196,6 +197,76 @@ describe("renderPagesFallback", () => {
     expect(renderPage.mock.calls[0][1]).toBe("/about us?foo=bar");
     expect(res).not.toBeNull();
     expect(await res!.text()).toBe("page-response");
+  });
+
+  it("appends the middleware draft cookie to an API fallback response (#1520)", async () => {
+    const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api-response"));
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ handleApiRoute }) as PagesEntry,
+      getDraftModeCookieHeader: () => "__prerender_bypass=secret; Path=/; HttpOnly",
+    };
+
+    const request = new Request("http://localhost/api/draft");
+    const url = new URL("http://localhost/api/draft");
+
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request,
+        url,
+      },
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    const setCookies = res!.headers.getSetCookie();
+    expect(setCookies.some((c) => c.includes("__prerender_bypass"))).toBe(true);
+  });
+
+  it("does not append a draft cookie when middleware did not enable draft mode", async () => {
+    const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api-response"));
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ handleApiRoute }) as PagesEntry,
+      getDraftModeCookieHeader: () => null,
+    };
+
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request: new Request("http://localhost/api/draft"),
+        url: new URL("http://localhost/api/draft"),
+      },
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.headers.has("set-cookie")).toBe(false);
+  });
+
+  it("appends the middleware draft cookie to a renderPage fallback response (#1520)", async () => {
+    const renderPage = vi.fn((_req: Request, _url: string) => new Response("page-response"));
+    const deps = {
+      ...defaultDeps,
+      loadPagesEntry: () => ({ renderPage }) as PagesEntry,
+      getDraftModeCookieHeader: () => "__prerender_bypass=secret; Path=/; HttpOnly",
+    };
+
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request: new Request("http://localhost/page"),
+        url: new URL("http://localhost/page"),
+      },
+      deps,
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.headers.getSetCookie().some((c) => c.includes("__prerender_bypass"))).toBe(true);
   });
 
   it("returns null when Pages renderPage returns 404 status", async () => {

--- a/tests/fixtures/cf-app-basic/middleware.ts
+++ b/tests/fixtures/cf-app-basic/middleware.ts
@@ -1,0 +1,17 @@
+import { draftMode } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Mirrors the upstream `app-middleware` fixture: mutate the *request* headers
+ * so downstream handlers (including Pages Router `pages/api/*`) observe the
+ * injected header, and enable draft mode on `?draft=true`. Regression coverage
+ * for #1520.
+ */
+export async function middleware(request: NextRequest) {
+  if (request.nextUrl.searchParams.get("draft")) {
+    (await draftMode()).enable();
+  }
+  const headers = new Headers(request.headers);
+  headers.set("x-from-middleware", "hello-from-middleware");
+  return NextResponse.next({ request: { headers } });
+}

--- a/tests/fixtures/cf-app-basic/pages/api/dump-headers-edge.ts
+++ b/tests/fixtures/cf-app-basic/pages/api/dump-headers-edge.ts
@@ -1,0 +1,12 @@
+export const config = {
+  runtime: "edge",
+};
+
+/**
+ * Edge-runtime Pages Router API route that echoes request headers as JSON.
+ * Mirrors the upstream `app-middleware` `dump-headers-edge` endpoint.
+ * Regression coverage for #1520.
+ */
+export default function handler(req: Request) {
+  return Response.json(Object.fromEntries(req.headers.entries()));
+}

--- a/tests/fixtures/cf-app-basic/pages/api/dump-headers.ts
+++ b/tests/fixtures/cf-app-basic/pages/api/dump-headers.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+/**
+ * Echoes the request headers as JSON. Used to assert that middleware-mutated
+ * request headers reach a Pages Router API route in a hybrid app/ + pages/ app.
+ * Regression coverage for #1520.
+ */
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json(req.headers);
+}

--- a/tests/nextjs-compat/hybrid-pages-api.test.ts
+++ b/tests/nextjs-compat/hybrid-pages-api.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Next.js Compatibility Tests: hybrid App Router + Pages Router API routes
+ *
+ * Regression coverage for #1520.
+ *
+ * When an App Router app (`app/`) coexists with Pages Router API endpoints
+ * (`pages/api/*`), requests to the Pages API routes must execute the handler
+ * and return its JSON response — not fall through to the App Router not-found
+ * page.
+ *
+ * The deploy suite hit this against `test/e2e/app-dir/app-middleware`, where
+ * `/api/dump-headers-serverless` returned the HTML "This page could not be
+ * found" page instead of JSON.
+ *
+ * This test exercises the production (Cloudflare Workers) build path via the
+ * Node prod server, which is the same dispatch path the deploy suite uses.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import path from "node:path";
+import type { Server } from "node:http";
+import { buildCloudflareAppFixture } from "../helpers.js";
+import { startProdServer } from "../../packages/vinext/src/server/prod-server.js";
+
+const CF_FIXTURE = path.resolve(import.meta.dirname, "../fixtures/cf-app-basic");
+
+describe("Next.js compat: hybrid app/ + pages/api/*", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const { root } = await buildCloudflareAppFixture(CF_FIXTURE);
+    const outDir = path.join(root, "dist");
+    const handle = await startProdServer({ port: 0, host: "127.0.0.1", outDir });
+    server = handle.server;
+    baseUrl = `http://127.0.0.1:${handle.port}`;
+  }, 180_000);
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+  });
+
+  it("executes pages/api/* route and returns JSON in a hybrid app", async () => {
+    const res = await fetch(`${baseUrl}/api/ping`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("still serves the App Router route handler in the same app", async () => {
+    const res = await fetch(`${baseUrl}/api/hello`);
+    expect(res.status).toBe(200);
+  });
+
+  it("passes middleware-mutated request headers into pages/api/*", async () => {
+    const res = await fetch(`${baseUrl}/api/dump-headers`, {
+      headers: { "x-from-client": "hello-from-client" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toMatchObject({
+      "x-from-client": "hello-from-client",
+      "x-from-middleware": "hello-from-middleware",
+    });
+  });
+
+  it("passes middleware-mutated request headers into edge-runtime pages/api/*", async () => {
+    const res = await fetch(`${baseUrl}/api/dump-headers-edge`, {
+      headers: { "x-from-client": "hello-from-client" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toMatchObject({
+      "x-from-client": "hello-from-client",
+      "x-from-middleware": "hello-from-middleware",
+    });
+  });
+
+  it("supports draft mode enabled in middleware for a pages/api/* request", async () => {
+    const res = await fetch(`${baseUrl}/api/dump-headers?draft=true`);
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain("__prerender_bypass");
+  });
+});


### PR DESCRIPTION
## Problem

In a hybrid app (an `app/` directory alongside Pages Router `pages/api/*` routes), requests with no matching App Router route fall through to the Pages Router via `renderPagesFallback` (the app→pages bridge).

The bridge already forwards middleware-mutated **request** headers and middleware **response** headers to the Pages handler. But it dropped the `__prerender_bypass` `Set-Cookie` that `draftMode().enable()` / `disable()` emit when called **inside middleware**.

That cookie isn't part of the `NextResponse` headers — it lives in a request-scoped side channel that App Router route handlers and page renders read via `getDraftModeCookieHeader()` (see `finalizeRouteHandlerResponse` / the page response builder). The Pages fallback path never read it, so draft-mode-via-middleware was lost when the request fell through to `pages/api/*`.

This is the draft-mode flow called out in #1520 (the basic `pages/api/*` fall-through and middleware request-header propagation already work on `main`).

## Fix

Thread `getDraftModeCookieHeader` into the bridge dependencies and append the draft cookie to the Pages Router fallback response (both the `handleApiRoute` and `renderPage` branches), mirroring how App Router responses surface it. When middleware didn't touch draft mode the getter returns `null` and the response is returned unchanged.

The fix lives in the single shared `renderPagesFallback` bridge, so dev and prod (Cloudflare Workers / Node) paths stay in sync.

## Test

Added `tests/nextjs-compat/hybrid-pages-api.test.ts` — builds the `cf-app-basic` hybrid fixture as a Cloudflare Workers bundle and serves it through the Node prod server (the same dispatch path the deploy suite uses). Covers:

- `pages/api/*` returns JSON in a hybrid app
- App Router route handler still served in the same app
- middleware-mutated request headers reach `pages/api/*` (serverless + edge runtime)
- **draft mode enabled in middleware sets `__prerender_bypass` on a `pages/api/*` request** (the case that failed before this change)

Extended the `cf-app-basic` fixture with a header-mutating + draft-enabling `middleware.ts` and `pages/api/dump-headers{,-edge}.ts`, mirroring the upstream `app-dir/app-middleware` fixture.

Closes #1520