### PR TITLE
fix(build): don't crash on benign floating asset-import errors (#1510)

### DIFF
--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -14,9 +14,10 @@
  * `uncaughtException`, where this listener filters it.
  *
  * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
- * ECONNABORTED) and synchronously re-throws everything else,
- * preserving Node's default crash semantics for genuine bugs. This
- * is more conservative than Next.js's equivalent
+ * ECONNABORTED) plus benign static-asset `import()` rejections (see
+ * `isBenignAssetImportError`), and synchronously re-throws everything
+ * else, preserving Node's default crash semantics for genuine bugs.
+ * This is more conservative than Next.js's equivalent
  * (`router-server.ts`'s log-only handler), which silently swallows
  * every uncaught — vinext keeps real bugs surfacing.
  *
@@ -90,6 +91,84 @@ export function peerDisconnectCode(err: unknown): string | undefined {
   return code === "ECONNRESET" || code === "EPIPE" || code === "ECONNABORTED" ? code : undefined;
 }
 
+// Static-asset extensions that a bundled server module may reference via
+// `new URL("./asset", import.meta.url)`. A dynamic `import()` of such a URL
+// can never resolve on Node (these are not ES modules), so when a user module
+// leaves one as a floating side-effect — e.g.
+//   import(new URL("./style.css", import.meta.url).href)
+// — Node throws ERR_UNKNOWN_FILE_EXTENSION (asset present) or
+// ERR_MODULE_NOT_FOUND (asset not co-located with the chunk). Next.js treats
+// these "URL dependency" side-effects as build-safe (the test fixture comment
+// literally reads "it shouldn't break the build"), so the prerender backstop
+// must not crash on them. Kept deliberately narrow: JS/TS module extensions
+// are excluded so a genuine missing-module bug still surfaces as a hard crash.
+const STATIC_ASSET_IMPORT_EXTENSIONS = new Set([
+  ".css",
+  ".scss",
+  ".sass",
+  ".less",
+  ".styl",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".svg",
+  ".webp",
+  ".avif",
+  ".ico",
+  ".bmp",
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".otf",
+  ".eot",
+  ".txt",
+  ".md",
+  ".csv",
+  ".xml",
+  ".pdf",
+  ".wasm",
+]);
+
+/**
+ * Pure predicate: returns `true` when `err` is a benign failure from a
+ * dynamic `import()` of a static asset URL — the "URL dependency" pattern
+ * that Next.js tolerates at build time. Two shapes are recognised:
+ *
+ *   - `ERR_UNKNOWN_FILE_EXTENSION`: the asset resolved on disk but is not an
+ *     ES module (e.g. a co-located `./style.css`). The error message ends in
+ *     the offending extension in quotes: `... extension ".css" for /path`.
+ *   - `ERR_MODULE_NOT_FOUND`: the asset URL did not resolve (the chunk lives
+ *     in `dist/server/` but the source asset does not). Node attaches the
+ *     unresolved specifier on `err.url`; we match only when it points at a
+ *     static-asset extension.
+ *
+ * Anything outside this allow-list (including missing `.js`/`.mjs`/`.ts`
+ * modules with no extension) returns `false` so real bugs still crash.
+ * Exported for unit testing in isolation.
+ */
+export function isBenignAssetImportError(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const code = (err as { code?: string }).code;
+
+  if (code === "ERR_UNKNOWN_FILE_EXTENSION") {
+    const message = (err as { message?: string }).message ?? "";
+    const match = /extension\s+"([^"]+)"/.exec(message);
+    return match != null && STATIC_ASSET_IMPORT_EXTENSIONS.has(match[1].toLowerCase());
+  }
+
+  if (code === "ERR_MODULE_NOT_FOUND") {
+    const url = (err as { url?: unknown }).url;
+    if (typeof url !== "string") return false;
+    const pathname = url.split("?", 1)[0].split("#", 1)[0];
+    const dot = pathname.lastIndexOf(".");
+    if (dot === -1) return false;
+    return STATIC_ASSET_IMPORT_EXTENSIONS.has(pathname.slice(dot).toLowerCase());
+  }
+
+  return false;
+}
+
 /**
  * Test-only: returns whether the backstop has been installed in this
  * process. Used by the unit test to assert idempotent install via the
@@ -109,7 +188,26 @@ export function installSocketErrorBackstop(): void {
 
   const debug = process.env.VINEXT_DEBUG_SOCKET_ERRORS === "1";
   if (debug) console.warn("[vinext] socket-error backstop installed");
+
+  // A floating `import(new URL("./asset", import.meta.url).href)` in user
+  // module-load code is a "URL dependency" side-effect that Next.js compiles
+  // without crashing. On Node the dynamic import rejects (a static asset is
+  // not an ES module), and because the promise is never awaited the rejection
+  // surfaces as a process-level unhandledRejection/uncaughtException. Absorb
+  // that narrow case in both phases — during prerender (so the build doesn't
+  // fail) and during the running server (so the route can still respond) —
+  // since the rejection is unrelated to any in-flight render or response.
+  const absorbBenignAssetImport = (reason: unknown, kind: string): boolean => {
+    if (!isBenignAssetImportError(reason)) return false;
+    if (debug) {
+      const code = (reason as { code?: string } | null)?.code;
+      console.warn(`[vinext] absorbed ${kind} ${code} (asset URL import)`);
+    }
+    return true;
+  };
+
   process.on("uncaughtException", (err: Error) => {
+    if (absorbBenignAssetImport(err, "uncaughtException")) return;
     if (process.env.VINEXT_PRERENDER === "1") throw err;
     const code = peerDisconnectCode(err);
     if (code) {
@@ -119,6 +217,7 @@ export function installSocketErrorBackstop(): void {
     throw err;
   });
   process.on("unhandledRejection", (reason: unknown) => {
+    if (absorbBenignAssetImport(reason, "unhandledRejection")) return;
     if (process.env.VINEXT_PRERENDER === "1") throw reason;
     const code = peerDisconnectCode(reason);
     if (code) {

--- a/tests/socket-error-backstop.test.ts
+++ b/tests/socket-error-backstop.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  isBenignAssetImportError,
   isSocketErrorBackstopInstalled,
   peerDisconnectCode,
 } from "../packages/vinext/src/server/socket-error-backstop.js";
@@ -35,6 +36,77 @@ describe("peerDisconnectCode", () => {
     // emits these from native stream errors).
     expect(peerDisconnectCode({ code: "ECONNRESET" })).toBe("ECONNRESET");
     expect(peerDisconnectCode({ code: "OTHER" })).toBeUndefined();
+  });
+});
+
+describe("isBenignAssetImportError", () => {
+  // Regression coverage for the react-version deploy suite (issue #1510):
+  // a floating `import(new URL("./style.css", import.meta.url).href)` in an
+  // edge API route rejects at module-load time and must not crash the build
+  // or the running server.
+
+  it("matches ERR_UNKNOWN_FILE_EXTENSION for static assets present on disk", () => {
+    // Shape Node throws when the asset resolves but is not an ES module.
+    const err = Object.assign(
+      new Error('Unknown file extension ".css" for /app/dist/server/ssr/style.css'),
+      { code: "ERR_UNKNOWN_FILE_EXTENSION" },
+    );
+    expect(isBenignAssetImportError(err)).toBe(true);
+
+    for (const ext of [".scss", ".png", ".svg", ".woff2", ".wasm", ".txt"]) {
+      const e = Object.assign(new Error(`Unknown file extension "${ext}" for /x/y${ext}`), {
+        code: "ERR_UNKNOWN_FILE_EXTENSION",
+      });
+      expect(isBenignAssetImportError(e), ext).toBe(true);
+    }
+  });
+
+  it("matches ERR_MODULE_NOT_FOUND only when the missing URL is a static asset", () => {
+    // Shape Node throws when the asset URL does not resolve (chunk lives in
+    // dist/server/, the source asset is not co-located).
+    const cssMissing = Object.assign(new Error("Cannot find module ..."), {
+      code: "ERR_MODULE_NOT_FOUND",
+      url: "file:///app/dist/server/ssr/style.css",
+    });
+    expect(isBenignAssetImportError(cssMissing)).toBe(true);
+
+    const cssWithQuery = Object.assign(new Error("Cannot find module ..."), {
+      code: "ERR_MODULE_NOT_FOUND",
+      url: "file:///app/dist/server/ssr/style.css?v=123",
+    });
+    expect(isBenignAssetImportError(cssWithQuery)).toBe(true);
+  });
+
+  it("does NOT absorb missing JS/TS modules (real bugs must still crash)", () => {
+    for (const url of [
+      "file:///app/dist/server/missing.js",
+      "file:///app/dist/server/missing.mjs",
+      "file:///app/dist/server/missing.ts",
+      "file:///app/dist/server/missing", // no extension (bare specifier)
+    ]) {
+      const err = Object.assign(new Error("Cannot find module ..."), {
+        code: "ERR_MODULE_NOT_FOUND",
+        url,
+      });
+      expect(isBenignAssetImportError(err), url).toBe(false);
+    }
+
+    // A bare package that can't be resolved has no usable `url` field.
+    const bare = Object.assign(new Error("Cannot find package 'twoslash'"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    expect(isBenignAssetImportError(bare)).toBe(false);
+  });
+
+  it("does NOT absorb unrelated error codes or non-object reasons", () => {
+    expect(isBenignAssetImportError(new Error("boom"))).toBe(false);
+    expect(
+      isBenignAssetImportError(Object.assign(new Error("nope"), { code: "ERR_REQUIRE_ESM" })),
+    ).toBe(false);
+    expect(isBenignAssetImportError(null)).toBe(false);
+    expect(isBenignAssetImportError(undefined)).toBe(false);
+    expect(isBenignAssetImportError("ERR_UNKNOWN_FILE_EXTENSION")).toBe(false);
+    expect(isBenignAssetImportError(42)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #1510 — the `react-version` and `twoslash` test apps crashed the server (exit 7/1) when a floating (un-awaited) `import()` of an asset failed to resolve: the `uncaughtException`/`unhandledRejection` backstop re-threw it and took down the process. The backstop now swallows benign asset-import resolution errors (matching Next.js's non-crashing stance) so the build/serve completes; genuine JS/TS module errors still surface. Tests added in `socket-error-backstop.test.ts`. Closes #1510