### PR TITLE
test(actions): cover server action POST under node-runtime middleware (#1480)

### DIFF
--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -886,4 +886,39 @@ describe("App Router Production server (startProdServer)", () => {
     expect(html).toContain('id="middleware-header">hello-from-middleware<');
     expect(html).toContain('id="cookie-count">0<');
   });
+
+  // Regression for cloudflare/vinext#1480: a node-runtime middleware that
+  // matches the action path and reads the request body on POST (then falls
+  // through with `NextResponse.next()`) must not prevent the server-action
+  // POST from being intercepted and executed. The app-basic middleware matches
+  // `/nextjs-compat/action-node-mw` and consumes the body for POSTs, mirroring
+  // Next.js' `middleware-node.js`. This runs against the production server
+  // because the upstream failure surfaced in the deploy suite.
+  it("dispatches a server action POST under a body-reading node middleware", async () => {
+    const html = await (await fetch(`${baseUrl}/nextjs-compat/action-node-mw`)).text();
+    // Production action ids are hashed; extract the id from the bound form's
+    // `$ACTION_1:0` reference payload rather than hardcoding it.
+    const refValue = html.match(/name="\$ACTION_[^"]*:0"\s+value="([^"]+)"/)?.[1];
+    expect(refValue).toBeDefined();
+    const decoded = refValue!
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&");
+    const actionId = JSON.parse(decoded).id as string;
+    expect(actionId).toBeTruthy();
+
+    const res = await fetch(`${baseUrl}/nextjs-compat/action-node-mw.rsc`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+        "x-rsc-action": actionId,
+      },
+      body: JSON.stringify(["world"]),
+    });
+    const text = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-nextjs-action-not-found")).toBeNull();
+    expect(text).not.toContain("Server action not found");
+    expect(text).toContain("echo:world");
+  });
 });

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -900,9 +900,7 @@ describe("App Router Production server (startProdServer)", () => {
     // `$ACTION_1:0` reference payload rather than hardcoding it.
     const refValue = html.match(/name="\$ACTION_[^"]*:0"\s+value="([^"]+)"/)?.[1];
     expect(refValue).toBeDefined();
-    const decoded = refValue!
-      .replace(/&quot;/g, '"')
-      .replace(/&amp;/g, "&");
+    const decoded = refValue!.replace(/&quot;/g, '"').replace(/&amp;/g, "&");
     const actionId = JSON.parse(decoded).id as string;
     expect(actionId).toBeTruthy();
 

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-node-mw/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-node-mw/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+/**
+ * Server action used by the node-runtime-middleware regression test
+ * (cloudflare/vinext#1480). The middleware in this fixture matches this
+ * page's path and reads the request body before falling through; the action
+ * POST must still be dispatched and able to read its own body.
+ */
+export async function echoAction(value: string): Promise<string> {
+  return `echo:${value}`;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-node-mw/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-node-mw/page.tsx
@@ -1,0 +1,25 @@
+import { echoAction } from "./actions";
+
+/**
+ * Page for the node-runtime-middleware server-action regression test
+ * (cloudflare/vinext#1480). The fixture middleware matches `/nextjs-compat/
+ * action-node-mw`, reads the request body on POST (simulating a node-runtime
+ * middleware that consumes the body), then falls through. The action POST to
+ * this page must still be intercepted and executed.
+ *
+ * A bound `<form action>` is used so the action reference is registered and
+ * its `$ACTION_ID_` is emitted into the HTML for the test to extract.
+ */
+export default function ActionNodeMiddlewarePage() {
+  const bound = echoAction.bind(null, "hi");
+  return (
+    <main>
+      <h1>Action Node Middleware Test</h1>
+      <form action={bound}>
+        <button id="submit" type="submit">
+          Submit
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -336,10 +336,12 @@ export const config = {
   // Declare the Node.js runtime so the `/nextjs-compat/action-node-mw`
   // server-action regression (cloudflare/vinext#1480) faithfully mirrors
   // Next.js' `middleware-node.js` fixture (`export const config = { runtime:
-  // 'nodejs' }`). vinext runs all middleware on Node regardless of this value
-  // (see packages/vinext/src/server/middleware.ts), so it is a behavioural
-  // no-op for the other matcher entries — but it guards the named scenario and
-  // documents intent.
+  // 'nodejs' }`). vinext runs all middleware on Node regardless of this value:
+  // middleware dispatch reads config only via `middlewareMatcher()` (i.e.
+  // `config.matcher`) with no `config.runtime` branch — see
+  // packages/vinext/src/server/middleware-runtime.ts (resolveMiddlewareModuleHandler /
+  // middlewareMatcher). So this is a behavioural no-op for the other matcher
+  // entries — but it guards the named scenario and documents intent.
   runtime: "nodejs",
   matcher: [
     "/about",

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -333,6 +333,14 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
 }
 
 export const config = {
+  // Declare the Node.js runtime so the `/nextjs-compat/action-node-mw`
+  // server-action regression (cloudflare/vinext#1480) faithfully mirrors
+  // Next.js' `middleware-node.js` fixture (`export const config = { runtime:
+  // 'nodejs' }`). vinext runs all middleware on Node regardless of this value
+  // (see packages/vinext/src/server/middleware.ts), so it is a behavioural
+  // no-op for the other matcher entries — but it guards the named scenario and
+  // documents intent.
+  runtime: "nodejs",
   matcher: [
     "/about",
     "/middleware-redirect",

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -23,6 +23,16 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // (RSC env). A single request should produce exactly one invocation.
   recordMiddlewareInvocation(pathname);
 
+  // Regression for cloudflare/vinext#1480: a node-runtime middleware that
+  // reads the request body on POST (auth, logging, body-size accounting, …)
+  // and then falls through must NOT prevent the downstream server-action POST
+  // from being intercepted and reading its own body. We consume the body here
+  // exactly as Next.js' `middleware-node.js` fixture does, then `.next()`.
+  if (pathname === "/nextjs-compat/action-node-mw" && request.method === "POST") {
+    await request.text();
+    return NextResponse.next();
+  }
+
   // Test NextRequest.cookies - this would fail with TypeError if request is plain Request
   const sessionToken = request.cookies.get("session");
   const acceptsRsc = request.headers.get("accept")?.startsWith("text/x-component") ?? false;
@@ -349,6 +359,7 @@ export const config = {
     "/pages-script-manual-nonce",
     "/nextjs-compat/dynamic/:path*",
     "/nextjs-compat/action-forward-loop",
+    "/nextjs-compat/action-node-mw",
     "/use-client-page-pathname/:path*",
     "/rsc-fetch-redirect-src",
     "/rsc-fetch-error-target",

--- a/tests/nextjs-compat/action-node-middleware.test.ts
+++ b/tests/nextjs-compat/action-node-middleware.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Next.js Compatibility Tests: server actions under a node-runtime middleware.
+ *
+ * Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
+ * and app-action-size-limit-invalid-node-middleware.test.ts, which re-run the
+ * regular server-action suites with `middleware.js` swapped for a node-runtime
+ * middleware (`middleware-node.js`) that matches every path and reads the
+ * request body on POST.
+ *
+ * Issue: cloudflare/vinext#1480 — "Server actions: request tracker never
+ * intercepts action POST when node-runtime middleware is configured". When a
+ * middleware that matches the action path reads the request body and then
+ * falls through (`NextResponse.next()`), the server-action POST must still be
+ * dispatched to the action handler and able to read its own body.
+ *
+ * The app-basic fixture's `middleware.ts` matches `/nextjs-compat/action-node-mw`
+ * and consumes the request body on POST before returning `NextResponse.next()`,
+ * mirroring `middleware-node.js`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { APP_FIXTURE_DIR, fetchHtml, startFixtureServer } from "../helpers.js";
+
+const ACTION_PATH = "/nextjs-compat/action-node-mw";
+// Stable module-path action id for `echoAction` (mirrors the ids used in
+// action-headers.test.ts). The page also renders a bound `<form action>` that
+// references the same action, ensuring it is registered.
+const ECHO_ACTION_ID = "/app/nextjs-compat/action-node-mw/actions.ts#echoAction";
+
+describe("Next.js compat: server action under node-runtime middleware", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true }));
+    await fetch(`${baseUrl}${ACTION_PATH}`).catch(() => {});
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("renders the page even though middleware matches and reads its POST body", async () => {
+    const { res, html } = await fetchHtml(baseUrl, ACTION_PATH);
+    expect(res.status).toBe(200);
+    expect(html).toContain("Action Node Middleware Test");
+    // The bound form action references the echo action id.
+    expect(html).toContain("action-node-mw/actions.ts#echoAction");
+  });
+
+  it("dispatches the action POST after the node middleware consumed the body", async () => {
+    const res = await fetch(`${baseUrl}${ACTION_PATH}.rsc`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+        "x-rsc-action": ECHO_ACTION_ID,
+      },
+      // `echoAction(value: string)` → encode a single string arg.
+      body: JSON.stringify(["world"]),
+    });
+    const text = await res.text();
+
+    // The action must run: a 404 here is the bug (action-not-found because the
+    // POST was never intercepted / its body was unavailable after the node
+    // middleware read it).
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-nextjs-action-not-found")).toBeNull();
+    expect(text).not.toContain("Server action not found");
+    // The action returns `echo:world`; a successful dispatch encodes it in the
+    // RSC payload's returnValue.
+    expect(text).toContain("echo:world");
+  });
+});

--- a/tests/nextjs-compat/action-node-middleware.test.ts
+++ b/tests/nextjs-compat/action-node-middleware.test.ts
@@ -13,9 +13,9 @@
  * falls through (`NextResponse.next()`), the server-action POST must still be
  * dispatched to the action handler and able to read its own body.
  *
- * The app-basic fixture's `middleware.ts` matches `/nextjs-compat/action-node-mw`
- * and consumes the request body on POST before returning `NextResponse.next()`,
- * mirroring `middleware-node.js`.
+ * The app-basic fixture's `middleware.ts` declares `config.runtime = "nodejs"`,
+ * matches `/nextjs-compat/action-node-mw`, and consumes the request body on POST
+ * before returning `NextResponse.next()`, mirroring `middleware-node.js`.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";


### PR DESCRIPTION
## Summary

Adds regression coverage for #1480 — *"Server actions: request tracker never intercepts action POST when node-runtime middleware is configured"*.

The issue (raised by a CI-analysis agent from the Next.js deploy suite) hypothesised that when a node-runtime middleware is configured, the server-action POST is short-circuited by the middleware — likely a dispatch-ordering / body-consumption bug.

## Investigation

I reproduced the exact scenario at three layers and **the bug does not reproduce on `main`**:

- **Dev** (inline middleware path) — `tests/nextjs-compat/action-node-middleware.test.ts`
- **Production** (RSC entry path the deploy suite exercises) — added to `tests/app-router-production-server.test.ts`
- **Unit** — confirmed `executeMiddleware` runs and continues with `config: { runtime: "nodejs" }`, and that `applyAppMiddleware` leaves the original request body intact for the action handler even when the middleware reads the body.

Root cause analysis:
- vinext treats node-runtime and edge middleware identically (it has no `config.runtime` branch), so a `runtime: "nodejs"` export does not change dispatch.
- `applyAppMiddleware` (`requestWithoutFlightHeaders`) and `createNextRequest` already give the middleware an **isolated body branch** (`request.clone()`), so a middleware that reads `req.text()` / `req.json()` does not consume the body the downstream server-action handler reads.
- The body-size-limit check reads `content-length` from the original request headers, which survive the middleware clone.

So the action POST is intercepted and executed correctly even when a node-runtime middleware matches the path and consumes the body. This change locks that behavior in with regression tests across the dev and production request paths (which the repo keeps in sync).

## Changes (tests only)

- `tests/fixtures/app-basic/app/nextjs-compat/action-node-mw/{page.tsx,actions.ts}` — a page with a bound `<form>` server action.
- `tests/fixtures/app-basic/middleware.ts` — match `/nextjs-compat/action-node-mw` and read the POST body before `NextResponse.next()` (mirrors Next.js' `middleware-node.js`).
- `tests/nextjs-compat/action-node-middleware.test.ts` — dev-path coverage.
- `tests/app-router-production-server.test.ts` — production-path coverage.

No `packages/vinext/src` changes were needed.

## Verification

- `tests/nextjs-compat/action-node-middleware.test.ts` — 2 passed
- `tests/app-router-production-server.test.ts` — 44 passed (incl. the new case; no regressions to the existing 43)
- `tests/nextjs-compat/action-headers.test.ts`, `tests/app-router-middleware-next-request.test.ts` — passed (no regression to actions-without-middleware or middleware-without-actions)
- `vp check` clean on all changed files.

Closes #1480