### PR TITLE
fix(app-router): propagate "use cache" tags to route-handler ISR entries (#1453)

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -38,6 +38,7 @@ import {
   type CacheLifeConfig,
 } from "./cache.js";
 import { VINEXT_RSC_MARKER_HEADER } from "../server/headers.js";
+import { addCollectedRequestTags } from "./fetch-cache.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   isInsideUnifiedScope,
@@ -531,6 +532,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
     const existing = await handler.get(cacheKey, { kind: "FETCH" });
     if (existing?.value && existing.value.kind === "FETCH" && existing.cacheState !== "stale") {
       try {
+        // Surface the cached entry's tags to the surrounding request so the
+        // enclosing page / route-handler ISR entry carries them even on a data
+        // cache HIT — otherwise `revalidateTag()` could not evict the rendered
+        // output that embeds this cached value (issue #1453).
+        propagateCacheTagsToRequest(existing.value.tags);
         if (rsc && existing.value.data.headers[VINEXT_RSC_MARKER_HEADER] === "1") {
           // RSC-serialized entry: base64 → bytes → stream → deserialize
           const bytes = base64ToUint8(existing.value.data.body);
@@ -556,6 +562,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
     );
 
     recordRequestScopedCacheLife(effectiveLife);
+    // Bubble the cache scope's tags up to the surrounding request so the
+    // enclosing page / route-handler ISR entry is tagged for on-demand
+    // revalidation (issue #1453). `ctx.tags` already includes any nested
+    // child cache's tags via `runCachedFunctionWithContext`.
+    propagateCacheTagsToRequest(ctx.tags);
     const revalidateSeconds =
       effectiveLife.revalidate ?? cacheLifeProfiles.default.revalidate ?? 900;
 
@@ -637,6 +648,23 @@ function recordRequestScopedCacheControl(cacheControl: CacheControlMetadata | un
 
 function recordRequestScopedCacheLife(cacheLife: CacheLifeConfig): void {
   _setRequestScopedCacheLife(cacheLife);
+}
+
+/**
+ * Bubble a `"use cache"` scope's tags up to the surrounding request's collected
+ * tags so the enclosing page / route-handler ISR entry carries them. When a
+ * cache scope is nested inside another (`parentCtx` present), the tags only need
+ * to flow into the parent — `runCachedFunctionWithContext` already merges a
+ * child's tags into its parent, and the outermost scope is what records onto the
+ * request. This avoids tagging the request with a private/inner-only tag before
+ * its parent has decided how to surface it. See issue #1453.
+ */
+function propagateCacheTagsToRequest(tags: readonly string[] | undefined): void {
+  if (!tags || tags.length === 0) return;
+  // A nested cache scope's tags are propagated to its parent scope instead, so
+  // only the outermost `"use cache"` writes onto the request tag list.
+  if (cacheContextStorage.getStore()) return;
+  addCollectedRequestTags(tags);
 }
 
 // ---------------------------------------------------------------------------
@@ -781,6 +809,16 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
   // suppress the throw — see the longer comment below.)
   if (parentCtx) {
     parentCtx.lifeConfigs.push(effectiveLife);
+    // Bubble this inner cache's tags into the parent cache scope so the
+    // outer entry (and ultimately the request) is invalidated when a tag
+    // declared by a nested `"use cache"` is revalidated. Matches Next.js's
+    // `propagateCacheLifeAndTagsToRevalidateStore`. Deduped to keep the
+    // parent's tag list tidy across many nested calls (issue #1453).
+    for (const tag of ctx.tags) {
+      if (!parentCtx.tags.includes(tag)) {
+        parentCtx.tags.push(tag);
+      }
+    }
   }
 
   // Propagate the eager error to the parent if this inner cache resolved

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -651,19 +651,31 @@ function recordRequestScopedCacheLife(cacheLife: CacheLifeConfig): void {
 }
 
 /**
- * Bubble a `"use cache"` scope's tags up to the surrounding request's collected
- * tags so the enclosing page / route-handler ISR entry carries them. When a
- * cache scope is nested inside another (`parentCtx` present), the tags only need
- * to flow into the parent — `runCachedFunctionWithContext` already merges a
- * child's tags into its parent, and the outermost scope is what records onto the
- * request. This avoids tagging the request with a private/inner-only tag before
- * its parent has decided how to surface it. See issue #1453.
+ * Bubble a `"use cache"` scope's tags toward where they can drive invalidation.
+ *
+ * When this cache is nested inside another (`parentCtx` present), the tags flow
+ * into the parent scope so they end up on the outer cache entry — mirroring
+ * Next.js's `propagateCacheLifeAndTagsToRevalidateStore`. The outermost scope
+ * (no parent) instead records onto the surrounding request's collected tags, so
+ * the enclosing page / route-handler ISR entry carries them and `revalidateTag`
+ * can evict the rendered output (issue #1453).
+ *
+ * Used by both the data cache HIT and MISS paths. On MISS the parent-bubble for
+ * the *executed* scope also happens in `runCachedFunctionWithContext`; this keeps
+ * the HIT path (where that function never runs) correct without dropping a nested
+ * inner entry's stored tags. Deduped to keep tag lists tidy.
  */
 function propagateCacheTagsToRequest(tags: readonly string[] | undefined): void {
   if (!tags || tags.length === 0) return;
-  // A nested cache scope's tags are propagated to its parent scope instead, so
-  // only the outermost `"use cache"` writes onto the request tag list.
-  if (cacheContextStorage.getStore()) return;
+  const parentCtx = cacheContextStorage.getStore();
+  if (parentCtx) {
+    for (const tag of tags) {
+      if (!parentCtx.tags.includes(tag)) {
+        parentCtx.tags.push(tag);
+      }
+    }
+    return;
+  }
   addCollectedRequestTags(tags);
 }
 

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -576,6 +576,28 @@ export function getCollectedFetchTags(): string[] {
 }
 
 /**
+ * Append cache tags to the current request's collected tags.
+ *
+ * Mirrors Next.js's `propagateCacheLifeAndTagsToRevalidateStore`: tags declared
+ * inside a `"use cache"` function (via `cacheTag()`, persisted on the data cache
+ * entry) must also bubble up to the surrounding page / route-handler ISR entry
+ * so `revalidateTag()` / `revalidatePath()` can evict the rendered output, not
+ * just the inner data cache entry. Without this, a cached `"use cache"` result
+ * keeps being served from a stale page/route entry after its tag is revalidated
+ * (issue #1453). Tags are already encoded by the caller; deduped to match the
+ * tagged-fetch path. A no-op for empty input.
+ */
+export function addCollectedRequestTags(tags: readonly string[]): void {
+  if (tags.length === 0) return;
+  const reqTags = _getState().currentRequestTags;
+  for (const tag of tags) {
+    if (!reqTags.includes(tag)) {
+      reqTags.push(tag);
+    }
+  }
+}
+
+/**
  * Set path-derived implicit tags for fetch cache reads in the current render.
  *
  * These are intentionally not persisted on fetch entries. They mirror Next.js

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -843,6 +843,40 @@ describe("App Router Production server (startProdServer)", () => {
     expect(body).toBe("");
   });
 
+  // Regression for issue #1453 (route-handler revalidate sub-part): a route
+  // handler whose body comes from a `"use cache"` function tagged with
+  // `cacheTag()` must be evictable via `revalidateTag()`. `cacheTag()` tags
+  // declared inside `"use cache"` were attached only to the inner data cache
+  // entry and never propagated to the surrounding route-handler ISR entry, so
+  // `revalidateTag()` left the cached route-handler response in place.
+  // Fixtures: /api/use-cache-tagged (no revalidate window, tagged via
+  // cacheTag("use-cache-rh-tag")) + /api/revalidate-use-cache-rh-tag.
+  it("route handler ISR: revalidateTag evicts a 'use cache' cacheTag()-tagged route handler", async () => {
+    // Cold request populates the cache.
+    const res1 = await fetch(`${baseUrl}/api/use-cache-tagged`);
+    expect(res1.status).toBe(200);
+    expect(res1.headers.get("x-vinext-cache")).toBe("MISS");
+    const body1 = await res1.json();
+
+    // Second request HITs the cache — there is no revalidate window, so the
+    // timestamp is stable until the tag is invalidated.
+    const res2 = await fetch(`${baseUrl}/api/use-cache-tagged`);
+    expect(res2.headers.get("x-vinext-cache")).toBe("HIT");
+    const body2 = await res2.json();
+    expect(body2.timestamp).toBe(body1.timestamp);
+
+    // Invalidate the cacheTag declared inside the "use cache" function.
+    const tagRes = await fetch(`${baseUrl}/api/revalidate-use-cache-rh-tag`);
+    expect(tagRes.status).toBe(200);
+    expect(await tagRes.text()).toBe("ok");
+
+    // The next request must miss the cache and produce a fresh timestamp.
+    const res3 = await fetch(`${baseUrl}/api/use-cache-tagged`);
+    expect(res3.headers.get("x-vinext-cache")).toBe("MISS");
+    const body3 = await res3.json();
+    expect(body3.timestamp).not.toBe(body1.timestamp);
+  });
+
   it("middleware request header overrides still apply after middleware calls headers() first", async () => {
     // Regression for a bug where a middleware that reads `next/headers` →
     // `headers()` *before* returning `NextResponse.next({ request: { headers } })`

--- a/tests/fixtures/app-basic/app/api/revalidate-use-cache-rh-tag/route.ts
+++ b/tests/fixtures/app-basic/app/api/revalidate-use-cache-rh-tag/route.ts
@@ -1,0 +1,12 @@
+/**
+ * API route to trigger `revalidateTag("use-cache-rh-tag")` — invalidates the
+ * cached `/api/use-cache-tagged` route handler.
+ *
+ * Repro support for issue #1453 (route-handler revalidate sub-part).
+ */
+import { revalidateTag } from "next/cache";
+
+export async function GET() {
+  await revalidateTag("use-cache-rh-tag");
+  return new Response("ok", { status: 200 });
+}

--- a/tests/fixtures/app-basic/app/api/use-cache-tagged/route.ts
+++ b/tests/fixtures/app-basic/app/api/use-cache-tagged/route.ts
@@ -1,0 +1,28 @@
+/**
+ * Route handler whose body is produced by a `"use cache"` function tagged with
+ * `cacheTag()`. It exports a long `revalidate` window so the route-handler ISR
+ * entry is only ever invalidated on demand via
+ * `revalidateTag("use-cache-rh-tag")`, never by time — a plain second GET must
+ * serve the cached timestamp (HIT).
+ *
+ * Repro for issue #1453 (route-handler revalidate sub-part): `cacheTag()` tags
+ * declared inside a `"use cache"` function were attached only to the inner data
+ * cache entry, never to the surrounding route-handler ISR entry, so
+ * `revalidateTag()` could not evict the cached route-handler response.
+ */
+import { cacheTag } from "next/cache";
+
+// Long revalidate window so the route-handler ISR entry is only invalidated on
+// demand via `revalidateTag("use-cache-rh-tag")`, never by time.
+export const revalidate = 3600;
+
+async function getTaggedPayload() {
+  "use cache";
+  cacheTag("use-cache-rh-tag");
+  return { timestamp: Date.now() };
+}
+
+export async function GET() {
+  const payload = await getTaggedPayload();
+  return Response.json(payload);
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4698,6 +4698,44 @@ describe('"use cache" runtime', () => {
     expect(callCount).toBe(2);
   });
 
+  it("nested cacheTag bubbles to the outer cache entry even when the inner HITs", async () => {
+    // Regression for issue #1453 (nested-HIT path): when an inner "use cache"
+    // function HITs the data cache while nested inside an outer cache that is
+    // being (re)generated, the inner entry's stored tags must bubble into the
+    // outer entry's tags. Otherwise revalidateTag("inner-tag") evicts the inner
+    // entry but leaves the outer page/route-handler ISR entry stale.
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler, cacheTag } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const handler = new MemoryCacheHandler();
+    setCacheHandler(handler);
+
+    const inner = registerCachedFunction(async () => {
+      cacheTag("inner-tag");
+      return { inner: true };
+    }, "test:nested-inner");
+
+    const outer = registerCachedFunction(async () => {
+      cacheTag("outer-tag");
+      await inner();
+      return { outer: true };
+    }, "test:nested-outer");
+
+    // Warm the inner entry on its own so the next outer call HITs it.
+    await inner();
+    // Now build the outer entry; its body re-runs `inner()`, which HITs.
+    await outer();
+
+    const outerEntry = await handler.get("use-cache:test:nested-outer");
+    expect(outerEntry?.value).toHaveProperty("kind", "FETCH");
+    if (outerEntry?.value && outerEntry.value.kind === "FETCH") {
+      // The outer entry must carry both its own tag and the nested inner tag.
+      expect(outerEntry.value.tags).toContain("outer-tag");
+      expect(outerEntry.value.tags).toContain("inner-tag");
+    }
+  });
+
   it("private variant uses per-request cache", async () => {
     const { registerCachedFunction, clearPrivateCache } =
       await import("../packages/vinext/src/shims/cache-runtime.js");


### PR DESCRIPTION
## Summary

Addresses #1453 (the **route-handler revalidate** sub-part); the other sub-parts
are deferred (see below).

A route handler whose body is produced by a `"use cache"` function tagged with
`cacheTag()` could not be invalidated via `revalidateTag()` / `revalidatePath()`.
`cacheTag()` tags were attached only to the inner **data cache** entry and never
propagated to the surrounding **route-handler ISR** entry, so on-demand
revalidation evicted the data cache entry but left the cached route-handler
response in place — the handler kept serving stale (`HIT`) output.

## Fix

In the `"use cache"` runtime (`packages/vinext/src/shims/cache-runtime.ts`),
propagate a cache scope's tags up to the surrounding request's collected tags
(which feed the page / route-handler ISR entry), mirroring Next.js's
`propagateCacheLifeAndTagsToRevalidateStore`:

- On a data cache **HIT**, surface the cached entry's stored `tags`.
- On a **MISS**, surface the resolved scope's `ctx.tags`.
- Nested `"use cache"` scopes bubble their tags into the parent scope, so only
  the outermost scope writes onto the request tag list. `"use cache: private"`
  tags stay isolated (private caches only nest inside private caches).

New helper `addCollectedRequestTags()` in `fetch-cache.ts` appends (deduped)
into the same `currentRequestTags` list that tagged `fetch()` already uses.

## Test

`tests/app-router-production-server.test.ts` — new case:
"route handler ISR: revalidateTag evicts a 'use cache' cacheTag()-tagged route
handler". Fixtures: `app/api/use-cache-tagged` (a `"use cache"`-bodied GET tagged
`use-cache-rh-tag`, long `revalidate` so only tag invalidation evicts it) and
`app/api/revalidate-use-cache-rh-tag`. Fails before the fix (post-revalidate
request still `HIT` with the old timestamp), passes after.

## Deferred (other #1453 sub-parts, out of scope here)

- Build-time `"use cache"` evaluation for metadata route handlers / sitemap /
  robots (`sentinel=buildtime`).
- `"use cache: private"` exposing cookies / searchParams.
- A `"use cache"`-bodied route handler with **no** `export const revalidate`
  being implicitly ISR-cacheable from its resolved `cacheLife`.
- Nested cached function passed as a prop into a server action.

These need broader/separate changes and are intentionally not bundled here to
keep this PR small.