### PR TITLE
fix(build): drop browser export condition for Workers SSR rendering

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -121,6 +121,7 @@ import { generateRouteTypes } from "./typegen.js";
 import {
   mergeOptimizeDepsExclude,
   SSR_EXTERNAL_REACT_ENTRIES,
+  stripBrowserConditionFromServerEnv,
   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
 } from "./plugins/rsc-client-shim-excludes.js";
 import { createServerExternalsManifestPlugin } from "./plugins/server-externals-manifest.js";
@@ -2305,6 +2306,21 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               (entry) => typeof entry !== "string" || !SSR_EXTERNAL_REACT_ENTRIES.includes(entry),
             );
           }
+
+          // Strip the `browser` export condition from the server (rsc/ssr)
+          // environments. SSR/RSC run in Node or the Cloudflare Workers runtime,
+          // never in a browser, so isomorphic libraries that gate DOM access on
+          // the `browser` condition (e.g. `esm-env`'s `BROWSER`) must resolve
+          // their server-safe entry. Without this, a `"use client"` component
+          // that imports a library which evaluates `class extends HTMLElement`
+          // at module-init time (number-flow, lit-based web components, etc.)
+          // crashes with `ReferenceError: HTMLElement is not defined` on Workers,
+          // where `@cloudflare/vite-plugin` injects `browser` into every worker
+          // environment's resolve conditions. No-op on plain Node (the server
+          // environments never carry `browser` there). The client environment is
+          // intentionally left untouched.
+          stripBrowserConditionFromServerEnv(config.environments?.rsc);
+          stripBrowserConditionFromServerEnv(config.environments?.ssr);
         }
 
         // Detect double React plugin registration. When vinext auto-injects

--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -54,3 +54,85 @@ export function mergeOptimizeDepsExclude(
 
   return [...seen];
 }
+
+// The `browser` export condition must never be active when vinext resolves
+// modules for server-side rendering. The RSC and SSR environments execute in
+// Node.js or the Cloudflare Workers runtime — neither is a browser, and neither
+// defines DOM globals like `HTMLElement`, `window`, or `customElements`.
+//
+// Isomorphic libraries use the `browser` condition (often via `esm-env`'s
+// `BROWSER` flag, whose `./browser` export resolves to `true` only under the
+// `browser` condition) to decide whether to touch the DOM at module-init time.
+// A common pattern — used by `number-flow` / `@number-flow/react`, among others
+// that register a custom element — is:
+//
+//     const Base = BROWSER ? HTMLElement : class {};
+//     class MyElement extends Base {}   // evaluated at import time
+//
+// When the SSR/RSC bundle resolves such a library with the `browser` condition,
+// `BROWSER` becomes `true` and `class extends HTMLElement` runs as soon as the
+// module loads — crashing with `ReferenceError: HTMLElement is not defined` in
+// Node and Workers.
+//
+// Plain Node SSR already resolves with server conditions (no `browser`), so the
+// crash only appears on bundled runtimes whose plugins add `browser` to the
+// worker environment's resolve conditions — most notably `@cloudflare/vite-plugin`,
+// which sets `["workerd", "worker", "module", "browser", ...]` for every worker
+// environment (including the rsc/ssr environments vinext renders through).
+// Removing `browser` makes those environments resolve the same server-safe entry
+// that `next build && next start` does. The client environment keeps `browser`,
+// so the browser bundle is unaffected.
+const BROWSER_RESOLVE_CONDITION = "browser";
+
+/**
+ * Return a copy of `conditions` with the `browser` export condition removed.
+ * Returns the input unchanged when it is not an array (so callers can pass an
+ * absent/undefined conditions list through without a guard).
+ */
+export function withoutBrowserCondition(
+  conditions: readonly string[] | undefined,
+): string[] | undefined {
+  if (!Array.isArray(conditions)) return conditions as string[] | undefined;
+  return conditions.filter((condition) => condition !== BROWSER_RESOLVE_CONDITION);
+}
+
+/**
+ * Minimal structural shape of a resolved Vite environment's resolution config.
+ * Kept loose on purpose so this helper works across Vite's `esbuild`/`rolldown`
+ * dep-optimizer variants without depending on version-specific types.
+ */
+type ServerEnvResolveConfig = {
+  resolve?: { conditions?: string[] };
+  optimizeDeps?: {
+    rolldownOptions?: { resolve?: { conditionNames?: string[] } };
+    esbuildOptions?: { conditions?: string[] };
+  };
+};
+
+/**
+ * Strip the `browser` export condition from a server environment's resolve
+ * conditions and its dep-optimizer conditions, in place.
+ *
+ * No-op when `browser` is absent, so this is safe to call unconditionally on
+ * plain-Node builds where the server environments never carry the `browser`
+ * condition. Both the resolver conditions (used by production builds) and the
+ * dep-optimizer conditions (used by dev/`wrangler dev`) are handled so the two
+ * code paths stay in sync.
+ */
+export function stripBrowserConditionFromServerEnv(env: ServerEnvResolveConfig | undefined): void {
+  if (!env) return;
+
+  if (env.resolve?.conditions) {
+    env.resolve.conditions = withoutBrowserCondition(env.resolve.conditions) ?? [];
+  }
+
+  const rolldownResolve = env.optimizeDeps?.rolldownOptions?.resolve;
+  if (rolldownResolve?.conditionNames) {
+    rolldownResolve.conditionNames = withoutBrowserCondition(rolldownResolve.conditionNames) ?? [];
+  }
+
+  const esbuildOptions = env.optimizeDeps?.esbuildOptions;
+  if (esbuildOptions?.conditions) {
+    esbuildOptions.conditions = withoutBrowserCondition(esbuildOptions.conditions) ?? [];
+  }
+}

--- a/tests/use-client-html-element-build.test.ts
+++ b/tests/use-client-html-element-build.test.ts
@@ -1,0 +1,332 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createBuilder } from "vite";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import {
+  stripBrowserConditionFromServerEnv,
+  withoutBrowserCondition,
+} from "../packages/vinext/src/plugins/rsc-client-shim-excludes.js";
+
+// ── Unit tests for the resolve-condition helper ────────────────────────────
+
+describe("withoutBrowserCondition", () => {
+  it("removes the browser condition while preserving order of the rest", () => {
+    expect(
+      withoutBrowserCondition(["workerd", "worker", "module", "browser", "development|production"]),
+    ).toEqual(["workerd", "worker", "module", "development|production"]);
+  });
+
+  it("is a no-op when browser is absent", () => {
+    expect(withoutBrowserCondition(["react-server", "node", "import"])).toEqual([
+      "react-server",
+      "node",
+      "import",
+    ]);
+  });
+
+  it("passes through undefined", () => {
+    expect(withoutBrowserCondition(undefined)).toBeUndefined();
+  });
+});
+
+describe("stripBrowserConditionFromServerEnv", () => {
+  it("strips browser from resolve.conditions and dep-optimizer conditions in place", () => {
+    const env = {
+      resolve: { conditions: ["workerd", "worker", "module", "browser", "development|production"] },
+      optimizeDeps: {
+        rolldownOptions: {
+          resolve: { conditionNames: ["workerd", "worker", "module", "browser", "development"] },
+        },
+        esbuildOptions: { conditions: ["browser", "module"] },
+      },
+    };
+    stripBrowserConditionFromServerEnv(env);
+    expect(env.resolve.conditions).toEqual([
+      "workerd",
+      "worker",
+      "module",
+      "development|production",
+    ]);
+    expect(env.optimizeDeps.rolldownOptions.resolve.conditionNames).toEqual([
+      "workerd",
+      "worker",
+      "module",
+      "development",
+    ]);
+    expect(env.optimizeDeps.esbuildOptions.conditions).toEqual(["module"]);
+  });
+
+  it("is a no-op for undefined env", () => {
+    expect(() => stripBrowserConditionFromServerEnv(undefined)).not.toThrow();
+  });
+});
+
+// ── Integration build test (Cloudflare Workers) ────────────────────────────
+//
+// Reproduces the crash described in the bug report: a `"use client"` component
+// that imports a library which registers a custom web component (extends
+// HTMLElement) at module-init time. `@cloudflare/vite-plugin` injects the
+// `browser` export condition into the worker (rsc/ssr) environments, so an
+// `esm-env`-style `BROWSER` flag resolves to `true`, and the bundle would run
+// `class extends HTMLElement` at import time — crashing with
+// `ReferenceError: HTMLElement is not defined` in workerd.
+//
+// We model `@number-flow/react` + `number-flow` + `esm-env` with three tiny
+// local packages that share the exact resolution shape (conditional `browser`
+// export + `BROWSER ? HTMLElement : class {}`). We assert that the value the
+// build resolves for `BROWSER` is `false` (server-safe), which is the root-cause
+// signal — before the fix it resolved to `true`.
+
+const tmpDirs: string[] = [];
+const workerEntryPath = path
+  .resolve(import.meta.dirname, "../packages/vinext/src/server/app-router-entry.ts")
+  .replace(/\\/g, "/");
+const cfPluginPath = path.resolve(
+  import.meta.dirname,
+  "./fixtures/cf-app-basic/node_modules/@cloudflare/vite-plugin/dist/index.mjs",
+);
+
+type CloudflarePluginFactory = (opts?: {
+  viteEnvironment?: { name: string; childEnvironments?: string[] };
+}) => import("vite").Plugin;
+
+function writeFile(root: string, filePath: string, content: string) {
+  const absPath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content);
+}
+
+function writePackage(nodeModules: string, name: string, files: Record<string, string>) {
+  const dir = path.join(nodeModules, name);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [file, content] of Object.entries(files)) {
+    writeFile(dir, file, content);
+  }
+}
+
+/**
+ * Build a real `node_modules` for the temp project: per-entry symlinks to the
+ * workspace root node_modules (so react / @vitejs/plugin-rsc / etc. resolve),
+ * plus the local fake packages written as real directories alongside them. A
+ * single symlink of the whole root node_modules would not let us add packages.
+ */
+function setupNodeModulesWithFakes(root: string) {
+  const repoNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  const nodeModules = path.join(root, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  for (const entry of fs.readdirSync(repoNodeModules)) {
+    fs.symlinkSync(path.join(repoNodeModules, entry), path.join(nodeModules, entry), "junction");
+  }
+  // vinext is the workspace package (not present at the root node_modules top
+  // level); link it so any bare `vinext/...` specifier resolves during the build.
+  const vinextLink = path.join(nodeModules, "vinext");
+  fs.rmSync(vinextLink, { recursive: true, force: true });
+  fs.symlinkSync(path.resolve(import.meta.dirname, "../packages/vinext"), vinextLink, "junction");
+
+  // fake-esm-env: mirrors esm-env — `BROWSER` is `true` only under the `browser`
+  // export condition, `false` otherwise.
+  writePackage(nodeModules, "fake-esm-env", {
+    "package.json": JSON.stringify({
+      name: "fake-esm-env",
+      version: "1.0.0",
+      type: "module",
+      exports: {
+        ".": { default: "./index.js" },
+        "./browser": {
+          browser: "./true.js",
+          development: "./false.js",
+          production: "./false.js",
+          default: "./false.js",
+        },
+      },
+    }),
+    "index.js": `export { default as BROWSER } from "fake-esm-env/browser";\n`,
+    "true.js": `export default true;\n`,
+    "false.js": `export default false;\n`,
+  });
+
+  // fake-number-flow: mirrors `number-flow` — extends HTMLElement at module init
+  // when BROWSER is true (the exact crash pattern).
+  writePackage(nodeModules, "fake-number-flow", {
+    "package.json": JSON.stringify({
+      name: "fake-number-flow",
+      version: "1.0.0",
+      type: "module",
+      main: "./index.js",
+      module: "./index.js",
+      exports: { ".": { default: "./index.js" } },
+      dependencies: { "fake-esm-env": "1.0.0" },
+    }),
+    "index.js": `import { BROWSER } from "fake-esm-env";
+const Base = BROWSER ? HTMLElement : class {};
+export class NumberFlowElement extends Base {}
+function define(name, cls) {
+  if (BROWSER && typeof customElements !== "undefined" && !customElements.get(name)) {
+    customElements.define(name, cls);
+  }
+}
+define("fake-number-flow", NumberFlowElement);
+// Distinct, minification-stable sentinel reflecting the resolved BROWSER value.
+export const RESOLVED_BROWSER = BROWSER ? "VINEXT_NF_BROWSER_TRUE" : "VINEXT_NF_BROWSER_FALSE";
+export function formatValue(value) { return String(value); }
+`,
+  });
+
+  // fake-number-flow-react: the "use client" React wrapper (mirrors @number-flow/react).
+  writePackage(nodeModules, "fake-number-flow-react", {
+    "package.json": JSON.stringify({
+      name: "fake-number-flow-react",
+      version: "1.0.0",
+      type: "module",
+      main: "./index.js",
+      module: "./index.js",
+      exports: { ".": { default: "./index.js" } },
+      dependencies: { "fake-number-flow": "1.0.0" },
+    }),
+    "index.js": `"use client";
+import { createElement } from "react";
+import { formatValue, NumberFlowElement, RESOLVED_BROWSER } from "fake-number-flow";
+const _retain = NumberFlowElement;
+export default function NumberFlow({ value }) {
+  return createElement(
+    "span",
+    { "data-testid": "number-flow", "data-resolved-browser": RESOLVED_BROWSER },
+    formatValue(value),
+  );
+}
+`,
+  });
+}
+
+function writeCloudflareApp(root: string, name: string) {
+  writeFile(root, "package.json", JSON.stringify({ name, private: true, type: "module" }, null, 2));
+  writeFile(
+    root,
+    "wrangler.jsonc",
+    `{
+  "name": ${JSON.stringify(name)},
+  "compatibility_date": "2026-02-12",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./worker/index.ts",
+  "assets": { "not_found_handling": "none", "binding": "ASSETS" }
+}
+`,
+  );
+  writeFile(
+    root,
+    "tsconfig.json",
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          jsx: "react-jsx",
+          strict: true,
+          skipLibCheck: true,
+          types: ["vite/client", "@vitejs/plugin-rsc/types"],
+        },
+        include: ["app", "*.ts", "*.tsx"],
+      },
+      null,
+      2,
+    ),
+  );
+  writeFile(
+    root,
+    "worker/index.ts",
+    `import handler from ${JSON.stringify(workerEntryPath)};\n\nexport default handler;\n`,
+  );
+  writeFile(
+    root,
+    "app/layout.tsx",
+    `import type { ReactNode } from "react";
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (<html lang="en"><body>{children}</body></html>);
+}
+`,
+  );
+  writeFile(
+    root,
+    "app/page.tsx",
+    `"use client";
+import NumberFlow from "fake-number-flow-react";
+import { useState } from "react";
+export default function Home() {
+  const [value, setValue] = useState(123);
+  return (
+    <div>
+      <NumberFlow value={value} />
+      <button onClick={() => setValue((v) => v + 1)}>Increment</button>
+    </div>
+  );
+}
+`,
+  );
+}
+
+function readJsFilesRecursive(root: string): string {
+  let output = "";
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      output += readJsFilesRecursive(entryPath);
+      continue;
+    }
+    if (entry.name.endsWith(".js")) output += fs.readFileSync(entryPath, "utf-8");
+  }
+  return output;
+}
+
+async function buildCloudflareApp(root: string) {
+  const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
+    cloudflare: CloudflarePluginFactory;
+  };
+  const builder = await createBuilder({
+    root,
+    configFile: false,
+    plugins: [
+      vinext({ appDir: root }),
+      cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+    ],
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+}
+
+describe("App Router 'use client' web-component library on Cloudflare Workers", () => {
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // A library that does `class extends (BROWSER ? HTMLElement : class {})` at
+  // module-init time must resolve BROWSER to `false` in the worker (rsc/ssr)
+  // build — otherwise it runs `class extends HTMLElement` during SSR and crashes
+  // with `ReferenceError: HTMLElement is not defined` in workerd. The CF plugin
+  // injects the `browser` condition; vinext must strip it from the server
+  // environments so the server-safe entry is resolved (matching `next start`).
+  it("resolves the `browser` export condition to the server-safe entry", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-html-element-build-"));
+    tmpDirs.push(root);
+    setupNodeModulesWithFakes(root);
+    writeCloudflareApp(root, "vinext-html-element-build");
+
+    await buildCloudflareApp(root);
+
+    const serverOutput = readJsFilesRecursive(path.join(root, "dist", "server"));
+    // BROWSER must have resolved to the server entry (false). Before the fix the
+    // CF plugin's `browser` condition resolved it to `true`.
+    expect(serverOutput).toContain("VINEXT_NF_BROWSER_FALSE");
+    expect(serverOutput).not.toContain("VINEXT_NF_BROWSER_TRUE");
+
+    // The client bundle must keep `browser` semantics (real browser has the DOM),
+    // so the browser branch (HTMLElement / true) is expected there.
+    const clientOutput = readJsFilesRecursive(path.join(root, "dist", "client"));
+    expect(clientOutput).toContain("VINEXT_NF_BROWSER_TRUE");
+  }, 90_000);
+});


### PR DESCRIPTION
## Problem

A `"use client"` component that imports a library which registers a custom web component (extends `HTMLElement`) at module-init time crashes on **Cloudflare Workers** with:

```
ReferenceError: HTMLElement is not defined
```

Affected library in the report: `@number-flow/react` (animated numbers). Any library that does `class … extends HTMLElement` at module load triggers it.

## Root cause

The crash hinges on this pattern inside `number-flow` (via `esm-env`):

```js
const Base = BROWSER ? HTMLElement : class {};   // BROWSER from esm-env
class NumberFlowElement extends Base {}          // evaluated at import time
```

`esm-env`'s `BROWSER` resolves to `true` **only** under the `browser` export condition, and `false` otherwise. So the crash requires the `browser` condition to be active during server rendering.

`@cloudflare/vite-plugin` sets `conditions: ["workerd", "worker", "module", "browser", …]` for every worker environment — including the `rsc`/`ssr` environments vinext renders `"use client"` components through. Because `browser` precedes `development`/`production` in `esm-env`'s export map, `BROWSER` resolves to `true`, and the SSR client-reference chunk bakes `const i = HTMLElement, a = class extends i{}`, which throws at module-init in workerd (no DOM globals).

Plain Node SSR already resolves with server conditions (no `browser`), which is exactly why `next build && next start` works — and why this only reproduces on Workers, not on `vinext build && vinext start` (verified: the Node SSR bundle resolves `BROWSER=false` and renders fine).

## Fix

In `configResolved` (after the Cloudflare plugin has merged its conditions), strip the `browser` export condition from the `rsc` and `ssr` environments' `resolve.conditions` and dep-optimizer conditions. SSR/RSC never run in a real browser, so isomorphic libraries now resolve their server-safe entry — matching Node SSR. The `client` environment is left untouched, so the browser bundle is unaffected. It is a no-op on plain Node (those environments never carry `browser`).

- `plugins/rsc-client-shim-excludes.ts`: add `withoutBrowserCondition()` + `stripBrowserConditionFromServerEnv()` (pure, typed helpers).
- `index.ts`: call the helper for the `rsc`/`ssr` environments.

## Testing

`tests/use-client-html-element-build.test.ts`:

- Unit tests for `withoutBrowserCondition` / `stripBrowserConditionFromServerEnv`.
- A Cloudflare build regression test using local `esm-env`/`number-flow`/`@number-flow/react` look-alikes that share the exact resolution shape. It asserts the worker server bundle resolves the **server-safe** entry (`BROWSER=false`) while the client bundle keeps the browser entry. **Fails before this change, passes after.**

No regressions in the affected build/SSR suites: `tsconfig-path-alias-build`, `prerender`, `build-optimization`, `features`, `app-router-production-build`, `app-router-production-server`, `app-router-worker-entry`, `app-router-client-preloading`, `app-router-rsc-plugin`. `vp check` (format/lint/types) passes.

## Notes / scope

- Scoped to App Router (`rsc`/`ssr`), which is the reported and reproduced case. A pure Pages-Router-on-Workers app importing such a library could in theory hit the same condition — that's a separate environment-setup path and would warrant its own reproduction + follow-up.
- The report also mentions `vinext build && vinext start` (Node) crashing; that part does **not** reproduce with current vinext (Node SSR resolves `BROWSER=false`). The Workers crash is the real, verifiable bug this PR fixes.
