### PR TITLE
fix(app-router): resolve explicit parallel slot with no page (#1535)

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1102,6 +1102,13 @@ function discoverSlotSubRoutes(
     // `@slot/baz/page.tsx` for the slot. Without this, the synthetic sub-route
     // shadows the catch-all with an empty children prop and the request hangs.
     // See test/e2e/app-dir/parallel-routes-catchall ("explicit slot but no page").
+    //
+    // Known limitation: the synthetic route's URL pattern is static (e.g.
+    // `/baz`), so the catch-all children page receives empty params — Next.js
+    // would pass `params.catchAll = ["baz"]`. The route still renders correctly;
+    // only a catch-all children page that *reads* its catch-all param diverges.
+    // Populating that param needs the slot-override style request-time pattern
+    // matching threaded to the children prop; tracked as a follow-up.
     const childrenCatchAll = childrenDefault ? null : findCatchAllPage(parentPageDir, matcher);
     const childrenFallback = childrenDefault ?? childrenCatchAll;
 

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1094,6 +1094,17 @@ function discoverSlotSubRoutes(
     const childrenDefault = findFile(parentPageDir, "default", matcher);
     if (parentRoute.pagePath && !childrenDefault) continue;
 
+    // When a slot sub-route has no children page of its own (no page.tsx for
+    // the sub-path and no default.tsx for the children slot), Next.js falls
+    // the children prop through to a sibling catch-all page at the parent
+    // level. e.g. `@slot/baz/page.tsx` exists but `baz/page.tsx` does not, so
+    // `/baz` is served by `[...catchAll]/page.tsx` for children and by
+    // `@slot/baz/page.tsx` for the slot. Without this, the synthetic sub-route
+    // shadows the catch-all with an empty children prop and the request hangs.
+    // See test/e2e/app-dir/parallel-routes-catchall ("explicit slot but no page").
+    const childrenCatchAll = childrenDefault ? null : findCatchAllPage(parentPageDir, matcher);
+    const childrenFallback = childrenDefault ?? childrenCatchAll;
+
     for (const { rawSegments, converted: convertedSubRoute, slotPages } of subPathMap.values()) {
       const {
         urlSegments: urlParts,
@@ -1140,7 +1151,7 @@ function discoverSlotSubRoutes(
       const newRoute: AppRouteGraphRoute = {
         ids: createAppRouteSemanticIds({
           pattern,
-          pagePath: childrenDefault,
+          pagePath: childrenFallback,
           routePath: null,
           routeSegments: [...parentRoute.routeSegments, ...rawSegments],
           layoutTreePositions: parentRoute.layoutTreePositions,
@@ -1148,7 +1159,9 @@ function discoverSlotSubRoutes(
           slots: subSlots,
         }),
         pattern,
-        pagePath: childrenDefault, // children slot uses parent's default.tsx as page
+        // children slot uses the parent's default.tsx, or — when none exists —
+        // a sibling catch-all page so the slot sub-route still renders children.
+        pagePath: childrenFallback,
         routePath: null,
         layouts: parentRoute.layouts,
         templates: parentRoute.templates,
@@ -1231,6 +1244,38 @@ function findSlotSubPages(slotDir: string, matcher: ValidFileMatcher): SlotSubPa
   scan(slotDir);
   perMatcher.set(slotDir, results);
   return results;
+}
+
+/**
+ * Find a sibling catch-all page directly under `dir`, i.e. a `[...slug]` or
+ * `[[...slug]]` directory that contains a `page` file. Returns the absolute
+ * page path, or null when no catch-all sibling exists.
+ *
+ * Used as the children fallback for slot-only sub-routes (an explicit `@slot`
+ * sub-page with no corresponding children page or `default.tsx`): Next.js
+ * serves the children prop from the nearest catch-all, so `/baz` renders
+ * `[...catchAll]/page.tsx` for children while `@slot/baz/page.tsx` fills the
+ * slot. Optional catch-alls (`[[...slug]]`) qualify because they also match a
+ * single extra segment.
+ */
+function findCatchAllPage(dir: string, matcher: ValidFileMatcher): string | null {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const name = entry.name;
+    const isCatchAll =
+      (name.startsWith("[...") && name.endsWith("]")) ||
+      (name.startsWith("[[...") && name.endsWith("]]"));
+    if (!isCatchAll) continue;
+    const page = findFile(path.join(dir, name), "page", matcher);
+    if (page) return page;
+  }
+  return null;
 }
 
 /**

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -413,6 +413,68 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  // Regression for https://github.com/cloudflare/vinext/issues/1535
+  // Ported from Next.js: test/e2e/app-dir/parallel-routes-catchall/
+  // ("should match correctly when defining an explicit slot but no page").
+  describe("explicit slot but no page (issue #1535)", () => {
+    it("falls children through to the sibling catch-all for a slot-only sub-route", async () => {
+      // /baz: @slot/baz/page.tsx exists, but there is no baz/page.tsx and no
+      // root default.tsx. Next.js serves /baz's children from the sibling
+      // [...catchAll]/page.tsx ("main catchall") while the @slot slot renders
+      // @slot/baz/page.tsx ("baz slot"). Without the catch-all children
+      // fallback the synthetic /baz route shadows the catch-all with an empty
+      // children prop and the request hangs.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/foo/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/baz/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/[...catchAll]/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[...catchAll]/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "foo/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "bar/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((r) => r.pattern).sort();
+
+        // The slot-only sub-route must materialise so @slot/baz wins over the
+        // slot's own catch-all.
+        expect(patterns).toContain("/baz");
+        const baz = findRoute(graph.routes, "/baz");
+
+        // Children fall through to the sibling catch-all (not null → no hang).
+        expect(baz.pagePath).toBe(path.join(appDir, "[...catchAll]/page.tsx"));
+
+        // The @slot slot resolves to the explicit @slot/baz page, not the
+        // slot's catch-all.
+        const slot = baz.parallelSlots.find((s) => s.name === "slot");
+        expect(slot?.pagePath).toBe(path.join(appDir, "@slot/baz/page.tsx"));
+
+        // The top-level catch-all is still present for fully-unmatched paths.
+        expect(patterns).toContain("/:catchAll+");
+      });
+    });
+
+    it("prefers a children default.tsx over the catch-all when both exist", async () => {
+      // When the parent provides a default.tsx for the children slot, it wins
+      // over a sibling catch-all (default.tsx is the canonical children
+      // fallback). This guards the new catch-all fallback from displacing it.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/baz/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[...catchAll]/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const baz = findRoute(graph.routes, "/baz");
+        expect(baz.pagePath).toBe(path.join(appDir, "default.tsx"));
+      });
+    });
+  });
+
   it("keeps route groups transparent in materialized URL patterns", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -456,6 +456,30 @@ describe("App Router route graph builder", () => {
       });
     });
 
+    it("builds the slot-only catch-all sub-route with a static pattern (documents params limitation)", async () => {
+      // The synthetic /baz route's URL pattern is static, so its catch-all
+      // children page receives empty params at render time (Next.js would pass
+      // params.catchAll = ["baz"]). Lock in the current shape so a future fix
+      // that populates the catch-all param has to update this assertion. See
+      // the "Known limitation" note in discoverSlotSubRoutes.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "@slot/baz/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[...catchAll]/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const baz = findRoute(graph.routes, "/baz");
+
+        expect(baz.pagePath).toBe(path.join(appDir, "[...catchAll]/page.tsx"));
+        // Static pattern → no catch-all param captured for the children page.
+        expect(baz.isDynamic).toBe(false);
+        expect(baz.params).toEqual([]);
+        expect(baz.patternParts).toEqual(["baz"]);
+      });
+    });
+
     it("prefers a children default.tsx over the catch-all when both exist", async () => {
       // When the parent provides a default.tsx for the children slot, it wins
       // over a sibling catch-all (default.tsx is the canonical children


### PR DESCRIPTION
Finishes the explicit-slot-but-no-page case of #1535 (children-slot priority landed in #1659).

## Problem

When a parallel slot defines an explicit sub-page (e.g. `@slot/baz/page.tsx`) but there is **no** corresponding children page (`baz/page.tsx`) and **no** `default.tsx` for the children slot, vinext minted a synthetic `/baz` route with a `null` children page. That static route shadowed the sibling catch-all (`[...catchAll]`) and rendered an empty children prop, so the request hung — the upstream `should match correctly when defining an explicit slot but no page` test timed out.

## Fix

Next.js serves such a slot-only sub-route's children from the nearest sibling catch-all. `discoverSlotSubRoutes` now falls the children prop through to a sibling catch-all page (`findCatchAllPage`) when no children `default.tsx` exists. For the upstream fixture, `/baz` renders `[...catchAll]/page.tsx` ("main catchall") for children while `@slot/baz/page.tsx` ("baz slot") fills the slot. A children `default.tsx` still wins over the catch-all when both are present.

The change is localized to `discoverSlotSubRoutes`; the children-slot priority case (`/` and `/nested`) from #1659 is untouched and still passes.

## Tests

Added a regression `describe("explicit slot but no page (issue #1535)")` in `tests/app-route-graph.test.ts`, ported from Next.js' `test/e2e/app-dir/parallel-routes-catchall`:
- slot-only sub-route resolves children to the sibling catch-all and the slot to `@slot/baz/page.tsx`
- a children `default.tsx` still wins over the catch-all when both exist

Closes #1535