### PR TITLE
test(pages-router): cover javascript: URL blocking (#1576)

### DIFF
--- a/tests/e2e/pages-router-prod/javascript-urls.spec.ts
+++ b/tests/e2e/pages-router-prod/javascript-urls.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type Page, type Request } from "@playwright/test";
+import { waitForHydration } from "../helpers";
+
+/**
+ * Production-build E2E coverage for Pages Router `javascript:` URL blocking.
+ *
+ * Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+ * (the Pages Router half — the four `pages router` cases)
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+ *
+ * The companion dev-server spec lives at
+ * tests/e2e/pages-router/javascript-urls.spec.ts and runs against `vp dev`.
+ * The Next.js deploy suite, however, exercises these scenarios against a
+ * PRODUCTION build (`vinext build` + `vinext start`), where the dev error
+ * overlay is absent and the client bundle is minified. This spec re-runs the
+ * same four scenarios against the production server (port 4175, started by the
+ * `pages-router-prod` webServer in playwright.config.ts) so a prod-only
+ * regression in the Link dangerous-click handler or the router push/replace
+ * guard is caught here rather than only in the deploy suite.
+ *
+ * Each scenario must:
+ *   (a) NOT navigate (no document request, URL unchanged, `boom` never reached)
+ *   (b) emit a console.error containing
+ *       "has blocked a javascript: URL as a security precaution."
+ * matching App Router behaviour.
+ */
+const BASE = "http://localhost:4175";
+
+function createNavigationInterceptor() {
+  const navigationRequests: Request[] = [];
+
+  const beforePageLoad = (page: Page) => {
+    page.on("request", (request) => {
+      if (request.resourceType() === "document") {
+        navigationRequests.push(request);
+      }
+    });
+  };
+
+  const getNavigationRequests = () => navigationRequests;
+
+  return { beforePageLoad, getNavigationRequests };
+}
+
+async function expectJavascriptUrlBlocked(
+  page: Page,
+  initialUrl: string,
+  getNavigationRequests: () => Request[],
+) {
+  await expect
+    .poll(async () => {
+      const logs = await page.evaluate(() => {
+        const value = Reflect.get(window, "__VINEXT_TEST_CONSOLE_ERRORS__");
+        return Array.isArray(value) ? value.map(String) : [];
+      });
+      return logs.some((message) =>
+        message.includes("has blocked a javascript: URL as a security precaution."),
+      );
+    })
+    .toBe(true);
+
+  const postLoadNavigations = getNavigationRequests().filter(
+    (request) => !request.url().includes(new URL(initialUrl).pathname),
+  );
+  expect(postLoadNavigations).toHaveLength(0);
+  expect(page.url()).toBe(initialUrl);
+}
+
+test.describe("pages-router-prod javascript-urls", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Reflect.set(window, "__VINEXT_TEST_CONSOLE_ERRORS__", []);
+      const originalError = console.error;
+      console.error = (...args: unknown[]) => {
+        const value = Reflect.get(window, "__VINEXT_TEST_CONSOLE_ERRORS__");
+        if (Array.isArray(value)) {
+          value.push(args.map(String).join(" "));
+        }
+        originalError(...args);
+      };
+    });
+  });
+
+  test("should prevent javascript URLs in pages router Link component", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/link-href`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("a").first().click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
+  test("should prevent javascript URLs in pages router Link as prop", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/link-as`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("a").first().click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
+  test("should prevent javascript URLs in pages router router.push", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/router-push`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("button").click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    // No dev error overlay in a production build, so the synchronous
+    // router.push throw does not paint a backdrop over the page — the safe
+    // navigation below can click directly.
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
+  test("should prevent javascript URLs in pages router router.replace", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/router-replace`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("button").click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    // No dev error overlay in a production build (see router.push above).
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+});

--- a/tests/e2e/pages-router/javascript-urls.spec.ts
+++ b/tests/e2e/pages-router/javascript-urls.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page, type Request } from "@playwright/test";
-import { waitForHydration } from "../helpers";
+import { disableDevErrorOverlay, waitForHydration } from "../helpers";
 
 const BASE = "http://localhost:4173";
 
@@ -111,6 +111,12 @@ test.describe("pages-router javascript-urls", () => {
     await page.locator("button").click();
     await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
 
+    // The synchronous `router.push` throw (the #1575 behaviour that surfaces the
+    // console.error) is caught by the dev error overlay, whose backdrop would
+    // otherwise intercept the safe-navigation click below. Suppress it — the
+    // security block has already been asserted above.
+    await disableDevErrorOverlay(page);
+
     await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
   });
@@ -125,6 +131,12 @@ test.describe("pages-router javascript-urls", () => {
 
     await page.locator("button").click();
     await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    // The synchronous `router.replace` throw (the #1575 behaviour that surfaces
+    // the console.error) is caught by the dev error overlay, whose backdrop
+    // would otherwise intercept the safe-navigation click below. Suppress it —
+    // the security block has already been asserted above.
+    await disableDevErrorOverlay(page);
 
     await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);

--- a/tests/e2e/pages-router/javascript-urls.spec.ts
+++ b/tests/e2e/pages-router/javascript-urls.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, type Page, type Request } from "@playwright/test";
+import { waitForHydration } from "../helpers";
+
+const BASE = "http://localhost:4173";
+
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+// (the Pages Router half — `pages/*` fixtures and the four `pages router` cases)
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+//
+// Next.js blocks dangerous URI schemes (javascript:, etc.) in the Pages Router
+// `<Link>` click handler and in `router.push`/`router.replace`, surfacing a
+// `console.error` containing
+//   "has blocked a javascript: URL as a security precaution."
+// without ever performing the navigation. Finishes the Pages Router half of
+// issue #1576 (the App Router half already lands in
+// tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts).
+
+function createNavigationInterceptor() {
+  const navigationRequests: Request[] = [];
+
+  const beforePageLoad = (page: Page) => {
+    page.on("request", (request) => {
+      if (request.resourceType() === "document") {
+        navigationRequests.push(request);
+      }
+    });
+  };
+
+  const getNavigationRequests = () => navigationRequests;
+
+  return { beforePageLoad, getNavigationRequests };
+}
+
+async function expectJavascriptUrlBlocked(
+  page: Page,
+  initialUrl: string,
+  getNavigationRequests: () => Request[],
+) {
+  await expect
+    .poll(async () => {
+      const logs = await page.evaluate(() => {
+        const value = Reflect.get(window, "__VINEXT_TEST_CONSOLE_ERRORS__");
+        return Array.isArray(value) ? value.map(String) : [];
+      });
+      return logs.some((message) =>
+        message.includes("has blocked a javascript: URL as a security precaution."),
+      );
+    })
+    .toBe(true);
+
+  const postLoadNavigations = getNavigationRequests().filter(
+    (request) => !request.url().includes(new URL(initialUrl).pathname),
+  );
+  expect(postLoadNavigations).toHaveLength(0);
+  expect(page.url()).toBe(initialUrl);
+}
+
+test.describe("pages-router javascript-urls", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Reflect.set(window, "__VINEXT_TEST_CONSOLE_ERRORS__", []);
+      const originalError = console.error;
+      console.error = (...args: unknown[]) => {
+        const value = Reflect.get(window, "__VINEXT_TEST_CONSOLE_ERRORS__");
+        if (Array.isArray(value)) {
+          value.push(args.map(String).join(" "));
+        }
+        originalError(...args);
+      };
+    });
+  });
+
+  test("should prevent javascript URLs in pages router Link component", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/link-href`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("a").first().click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
+  test("should prevent javascript URLs in pages router Link as prop", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/link-as`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("a").first().click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
+  test("should prevent javascript URLs in pages router router.push", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/router-push`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("button").click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
+  test("should prevent javascript URLs in pages router router.replace", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/router-replace`);
+    await waitForHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("button").click();
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+});

--- a/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/bad-url.ts
+++ b/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/bad-url.ts
@@ -1,0 +1,4 @@
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/bad-url.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/bad-url.ts
+export const DANGEROUS_JAVASCRIPT_URL =
+  "javascript:window.location.assign('/nextjs-compat/javascript-urls/boom');";

--- a/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/boom.tsx
+++ b/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/boom.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>If you were redirected here then the dangerous javascript URL was executed.</p>;
+}

--- a/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/link-as.tsx
+++ b/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/link-as.tsx
@@ -1,0 +1,21 @@
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/pages/pages/link-as.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/pages/pages/link-as.tsx
+import Link from "next/link";
+
+import { DANGEROUS_JAVASCRIPT_URL } from "./bad-url";
+
+export default function Page() {
+  return (
+    <div>
+      <main>
+        <p>Clicking this link should result in an error where Next.js blocks a javascript URL</p>
+        <Link href="/" as={DANGEROUS_JAVASCRIPT_URL}>
+          Link with javascript URL `as`
+        </Link>
+      </main>
+      <footer>
+        <Link href="/nextjs-compat/javascript-urls/safe">Safe Page</Link>
+      </footer>
+    </div>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/link-href.tsx
+++ b/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/link-href.tsx
@@ -1,0 +1,19 @@
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/pages/pages/link-href.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/pages/pages/link-href.tsx
+import Link from "next/link";
+
+import { DANGEROUS_JAVASCRIPT_URL } from "./bad-url";
+
+export default function Page() {
+  return (
+    <div>
+      <main>
+        <p>Clicking this link should result in an error where Next.js blocks a javascript URL</p>
+        <Link href={DANGEROUS_JAVASCRIPT_URL}>Link with javascript URL `href`</Link>
+      </main>
+      <footer>
+        <Link href="/nextjs-compat/javascript-urls/safe">Safe Page</Link>
+      </footer>
+    </div>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/router-push.tsx
+++ b/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/router-push.tsx
@@ -1,0 +1,21 @@
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/pages/pages/router-push.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/pages/pages/router-push.tsx
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+import { DANGEROUS_JAVASCRIPT_URL } from "./bad-url";
+
+export default function Page() {
+  const router = useRouter();
+  return (
+    <div>
+      <main>
+        <p>Clicking this button should result in an error where Next.js blocks a javascript URL</p>
+        <button onClick={() => router.push(DANGEROUS_JAVASCRIPT_URL)}>push javascript URL</button>
+      </main>
+      <footer>
+        <Link href="/nextjs-compat/javascript-urls/safe">Safe Page</Link>
+      </footer>
+    </div>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/router-replace.tsx
+++ b/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/router-replace.tsx
@@ -1,0 +1,23 @@
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/pages/pages/router-replace.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/pages/pages/router-replace.tsx
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+import { DANGEROUS_JAVASCRIPT_URL } from "./bad-url";
+
+export default function Page() {
+  const router = useRouter();
+  return (
+    <div>
+      <main>
+        <p>Clicking this button should result in an error where Next.js blocks a javascript URL</p>
+        <button onClick={() => router.replace(DANGEROUS_JAVASCRIPT_URL)}>
+          replace javascript URL
+        </button>
+      </main>
+      <footer>
+        <Link href="/nextjs-compat/javascript-urls/safe">Safe Page</Link>
+      </footer>
+    </div>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/safe.tsx
+++ b/tests/fixtures/pages-basic/pages/nextjs-compat/javascript-urls/safe.tsx
@@ -1,0 +1,10 @@
+// Ported from Next.js: test/e2e/app-dir/javascript-urls/pages/pages/safe.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/pages/pages/safe.tsx
+export default function Page() {
+  return (
+    <p id="canary">
+      This page is used as a navigation target to ensure SPA navigation continues to work after
+      pushing/redirecting/linking to a javascript URL.
+    </p>
+  );
+}

--- a/tests/router-javascript-urls.test.ts
+++ b/tests/router-javascript-urls.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, it, expect, vi } from "vite-plus/test";
+import ReactDOMServer from "react-dom/server";
+import type { ElementType, ReactNode } from "react";
 
 // Ported from Next.js: test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
@@ -298,6 +300,183 @@ describe("Pages Router next/router blocks dangerous URI schemes", () => {
     } finally {
       consoleError.mockRestore();
       restoreBrowserGlobals();
+    }
+  });
+});
+
+// Pages Router parity: clicking a `<Link>` whose resolved navigation target
+// (either `href` or the legacy `as` prop) is a dangerous URI scheme must emit
+// the same `console.error` and must never navigate. The Link shim is shared
+// between App Router and Pages Router, so this guards the Pages Router
+// `link-href` / `link-as` scenarios from
+// `test/e2e/app-dir/javascript-urls/javascript-urls.test.ts` (the four
+// `pages router` cases). The browser-level coverage lives in
+// tests/e2e/pages-router/javascript-urls.spec.ts; this unit test pins the
+// click handler behaviour the e2e suite depends on. Part of issue #1576.
+describe("Pages Router next/link blocks dangerous URI schemes on click", () => {
+  let restoreWindowGlobal: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreWindowGlobal?.();
+    restoreWindowGlobal = undefined;
+    vi.resetModules();
+  });
+
+  // Render the Link shim to capture the anchor's onClick handler, then invoke
+  // it. The shim emits the anchor through both React.createElement and the
+  // jsx runtime depending on the build, so both are intercepted.
+  async function renderLinkAndClick(
+    href: string,
+    props: Record<string, unknown> = {},
+    options: { click?: boolean } = {},
+  ): Promise<{
+    consoleError: ReturnType<typeof vi.spyOn>;
+    clickHandled: boolean;
+  }> {
+    const { click = true } = options;
+    vi.resetModules();
+
+    let capturedOnClick: ((event: unknown) => unknown) | undefined;
+    const captureAnchor = (type: unknown, p: unknown): void => {
+      if (type === "a" && p !== null && typeof p === "object") {
+        const onClick = (p as { onClick?: (event: unknown) => unknown }).onClick;
+        if (typeof onClick === "function") capturedOnClick = onClick;
+      }
+    };
+
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      const createElement = ((
+        type: ElementType,
+        p: Record<string, unknown> | null,
+        ...children: ReactNode[]
+      ) => {
+        captureAnchor(type, p);
+        return actual.createElement(type, p, ...children);
+      }) as typeof actual.createElement;
+      return { ...actual, createElement, default: { ...actual, createElement } };
+    });
+    vi.doMock("react/jsx-runtime", async () => {
+      const actual = await vi.importActual<typeof import("react/jsx-runtime")>("react/jsx-runtime");
+      return {
+        ...actual,
+        jsx(type: ElementType, p: Record<string, unknown>, key?: string) {
+          captureAnchor(type, p);
+          return actual.jsx(type, p, key);
+        },
+        jsxs(type: ElementType, p: Record<string, unknown>, key?: string) {
+          captureAnchor(type, p);
+          return actual.jsxs(type, p, key);
+        },
+      };
+    });
+    vi.doMock("react/jsx-dev-runtime", async () => {
+      const actual =
+        await vi.importActual<typeof import("react/jsx-dev-runtime")>("react/jsx-dev-runtime");
+      const jsxRuntime =
+        await vi.importActual<typeof import("react/jsx-runtime")>("react/jsx-runtime");
+      return {
+        ...actual,
+        jsxDEV(
+          type: ElementType,
+          p: Record<string, unknown>,
+          key?: string,
+          isStaticChildren?: boolean,
+          source?: Parameters<typeof actual.jsxDEV>[4],
+          self?: Parameters<typeof actual.jsxDEV>[5],
+        ) {
+          captureAnchor(type, p);
+          if (typeof actual.jsxDEV === "function") {
+            return actual.jsxDEV(type, p, key, isStaticChildren ?? false, source, self);
+          }
+          return jsxRuntime.jsx(type, p, key);
+        },
+      };
+    });
+
+    // Minimal browser globals so the safe-href control case (which reaches the
+    // shim's real `handleClick`, including its async fallback that touches
+    // `window.history`) does not crash. The dangerous cases short-circuit to an
+    // inert anchor before any navigation. Restored in `afterEach` (not here),
+    // because `handleClick`'s async navigation can settle after this returns.
+    const previousWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = {
+      location: {
+        pathname: "/",
+        search: "",
+        hash: "",
+        href: "http://localhost/",
+        origin: "http://localhost",
+        assign() {},
+        replace() {},
+      },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+    };
+    restoreWindowGlobal = () => {
+      (globalThis as { window?: unknown }).window = previousWindow as never;
+    };
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { default: Link } = await import("../packages/vinext/src/shims/link.js");
+    const React = await vi.importActual<typeof import("react")>("react");
+
+    ReactDOMServer.renderToString(
+      React.createElement(Link, { href, prefetch: false, ...props }, "target"),
+    );
+
+    const event = {
+      button: 0,
+      currentTarget: { hasAttribute: () => false, target: "" },
+      defaultPrevented: false,
+      preventDefault() {
+        (this as { defaultPrevented: boolean }).defaultPrevented = true;
+      },
+    };
+
+    let clickHandled = false;
+    if (click && typeof capturedOnClick === "function") {
+      clickHandled = true;
+      await capturedOnClick(event);
+    }
+
+    return { consoleError, clickHandled };
+  }
+
+  it("Link href javascript: emits console.error on click and blocks navigation", async () => {
+    const { consoleError, clickHandled } = await renderLinkAndClick("javascript:alert(1)");
+    try {
+      expect(clickHandled).toBe(true);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("Link as javascript: emits console.error on click and blocks navigation", async () => {
+    const { consoleError, clickHandled } = await renderLinkAndClick("/safe", {
+      as: "javascript:alert(1)",
+    });
+    try {
+      expect(clickHandled).toBe(true);
+      expect(consoleError).toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("Link with a safe href does not emit the block message", async () => {
+    // Render only (no click): a safe Link must not be treated as dangerous, so
+    // the block message must never be emitted. We skip invoking the click here
+    // because a safe click delegates to the real async navigation machinery,
+    // which is out of scope for this guard.
+    const { consoleError } = await renderLinkAndClick("/safe", {}, { click: false });
+    try {
+      expect(consoleError).not.toHaveBeenCalledWith(BLOCK_MESSAGE);
+    } finally {
+      consoleError.mockRestore();
     }
   });
 });


### PR DESCRIPTION
Adds Pages-Router test coverage (unit + dev + production-build e2e) for `javascript:` URL blocking via `<Link>` (href/as) and `router.push`/`router.replace`. **No production change** — vinext's blocking + `console.error` behavior is already correct (verified in a production build). The deploy-suite failures for these cases are an upstream **dev-redbox** assertion that doesn't apply to vinext/deploy mode (see #1576 comment). Refs #1576 (does not auto-close — deploy failure is a harness/redbox nuance, not a code gap).