### PR TITLE
fix(app-router): scroll to top with hoisted children and loading.js (#1368)

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -817,9 +817,7 @@ export function buildAppPageElements<
 
   let routeChildren: ReactNode = (
     <LayoutSegmentProvider segmentMap={{ children: [] }}>
-      <AppRouterScrollTarget>
-        <Slot id={pageId} />
-      </AppRouterScrollTarget>
+      <Slot id={pageId} />
     </LayoutSegmentProvider>
   );
 
@@ -863,6 +861,16 @@ export function buildAppPageElements<
         </Suspense>
       );
     }
+
+    // Mount the scroll/focus target *outside* the loading Suspense so it does
+    // not suspend with the page content. Next.js places ScrollAndMaybeFocusHandler
+    // above the LoadingBoundary for the same reason: the handler must stay
+    // committed while the loading.js fallback renders, so the default-navigation
+    // scroll fires against the loading boundary's DOM (`should apply scroll when
+    // loading.js is used`) and again when the final content commits — rather than
+    // relying on a raw post-navigation scrollTo fallback that only runs after the
+    // streamed content resolves.
+    routeChildren = <AppRouterScrollTarget>{routeChildren}</AppRouterScrollTarget>;
   }
 
   const lastLayoutErrorModule =

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -822,6 +822,10 @@ export function buildAppPageElements<
   );
 
   if (isPrefetchLoadingShell) {
+    // A prefetch loading shell is a cached payload, not a committed navigation,
+    // so it intentionally does not mount AppRouterScrollTarget — the scroll/focus
+    // effect belongs to the real render that replaces this shell (handled in the
+    // else branch below).
     if (routeLoadingComponent === null) {
       routeChildren = null;
     } else {

--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -68,9 +68,29 @@ function getHashFragmentDomNode(hash: string): HTMLElement | null {
   return element instanceof HTMLElement ? element : null;
 }
 
-function findNextScrollTarget(node: Element | Text | null): HTMLElement | null {
+function isInDocumentHead(node: Element | Text): boolean {
+  const head = node.ownerDocument?.head;
+  return head != null && head.contains(node);
+}
+
+type NextScrollTarget =
+  | { kind: "element"; element: HTMLElement }
+  // The route content's first DOM node was hoisted into <head> (e.g. a
+  // `<style precedence>` or metadata element) so there is no in-body element to
+  // scroll into view. Next.js skips this layout-router level and lets a higher
+  // one scroll the document to the top; vinext owns the whole page branch in a
+  // single scroll target, so it performs that document-top scroll here instead
+  // of leaving the navigation without a committed scroll.
+  | { kind: "document-top" }
+  | null;
+
+function findNextScrollTarget(node: Element | Text | null): NextScrollTarget {
   if (!(node instanceof Element)) {
     return null;
+  }
+
+  if (isInDocumentHead(node)) {
+    return { kind: "document-top" };
   }
 
   let target: Element = node;
@@ -81,7 +101,7 @@ function findNextScrollTarget(node: Element | Text | null): HTMLElement | null {
     target = target.nextElementSibling;
   }
 
-  return target;
+  return { kind: "element", element: target };
 }
 
 function scrollToElement(target: HTMLElement, hash: string | null): void {
@@ -121,11 +141,25 @@ export class AppRouterScrollTargetInner extends React.Component<{
     let target: HTMLElement | null;
     if (intent.hash !== null) {
       target = getHashFragmentDomNode(intent.hash);
+      if (target === null) return;
     } else {
       // oxlint-disable-next-line react/no-find-dom-node -- Next's default App Router scroll handler targets wrapperless route content after commit.
-      target = findNextScrollTarget(findDOMNode(this));
+      const next = findNextScrollTarget(findDOMNode(this));
+      if (next === null) return;
+
+      if (next.kind === "document-top") {
+        // The route content hoisted its first DOM node into <head>, so there is
+        // no in-body element to focus or scroll into view. Claim the intent and
+        // scroll the document to the top — the committed-effect equivalent of
+        // Next.js letting a higher layout-router handle the document scroll.
+        const consumedTop = consumeAppRouterScrollIntent(intent, this.props.commitId);
+        if (consumedTop === null) return;
+        document.documentElement.scrollTop = 0;
+        return;
+      }
+
+      target = next.element;
     }
-    if (target === null) return;
 
     const consumed = consumeAppRouterScrollIntent(intent, this.props.commitId);
     if (consumed === null) return;


### PR DESCRIPTION
Finishes the scroll-to-top-with-hoisted-children / loading.js cases of #1368 (autoscroll parity landed in #1599-1602). Closes #1368

## Problem

Two deploy-suite cases of `test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts` still failed:

- `should scroll to top even if React hoists children`
- `bugs > Should apply scroll when loading.js is used`

Both relied on the post-navigation `scrollTo` fallback in `navigateClientSide` rather than a committed route effect:

- **loading.js**: the `AppRouterScrollTarget` was mounted *inside* the route loading Suspense, so it suspended with the page content and could not scroll while the `loading.js` fallback was on screen. Scroll only happened via the fallback after the final streamed content resolved.
- **hoisted children**: when the route's first DOM node is hoisted into `<head>` (e.g. `<style precedence>`), `findDOMNode` resolves a head element with no in-body sibling, so the committed effect found no target and bailed — again leaving the raw fallback as the source of truth.

## Fix

- Mount `AppRouterScrollTarget` *outside* the route loading Suspense, matching Next.js placing `ScrollAndMaybeFocusHandler` above the `LoadingBoundary`. The handler now stays committed while the loading fallback renders, so default-navigation scroll fires against the loading boundary DOM and again when final content commits.
- When `findNextScrollTarget` resolves a node hoisted into `<head>`, scroll the document to the top as a committed effect — the equivalent of Next.js deferring the document scroll to a higher layout-router level.

This makes the scroll a traceable committed navigation effect instead of a raw post-promise `scrollTo`, per the issue's architectural contract.

## Verification

- All 23 `router-autoscroll.spec.ts` cases pass (incl. the ported hoisted + loading.js cases).
- Verified the committed effect now owns the scroll by temporarily disabling the `scrollTo` fallback — both cases still scroll to top, confirming the effect (not the fallback) is now the source of truth.
- No regressions in `navigation.spec.ts`, `hash-popstate-scroll.spec.ts`, `loading.spec.ts`, `streaming.spec.ts`, `router-push-pending.spec.ts`, and `shims.test.ts` (1033 unit tests).
- `vp check` clean on both changed files.