### PR TITLE
chore(deploy-suite): bump playwright/playwright-chromium to 1.60.0 after install

### DIFF
--- a/scripts/run-nextjs-deploy-suite.sh
+++ b/scripts/run-nextjs-deploy-suite.sh
@@ -62,6 +62,8 @@ if [ "${NEXTJS_PREPARE:-0}" = "1" ]; then
     cd "${NEXTJS_DIR}"
     echo ">>> $(date -Iseconds) pnpm install"
     run_pnpm install
+    echo ">>> $(date -Iseconds) bump playwright to 1.60.0"
+    run_pnpm add -w playwright@1.60.0 playwright-chromium@1.60.0
     echo ">>> $(date -Iseconds) pnpm build"
     run_pnpm build
     echo ">>> $(date -Iseconds) pnpm playwright install"


### PR DESCRIPTION
## What

In `scripts/run-nextjs-deploy-suite.sh`, the `NEXTJS_PREPARE` block now bumps `playwright` and `playwright-chromium` to `1.60.0` immediately after `pnpm install` (before build / `playwright install`).

```bash
echo ">>> $(date -Iseconds) pnpm install"
run_pnpm install
echo ">>> $(date -Iseconds) bump playwright to 1.60.0"
run_pnpm add -w playwright@1.60.0 playwright-chromium@1.60.0
echo ">>> $(date -Iseconds) pnpm build"
run_pnpm build
```

## Why

Pins the Playwright version used by the Next.js deploy suite to 1.60.0, overriding whatever the Next.js checkout's lockfile resolves to.