### PR TITLE
fix(app-router): return HTTP 200 when notFound() is thrown from generateMetadata

### DIFF
--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -430,8 +430,14 @@ export async function buildAppPageSpecialErrorResponse(
       // Mirrors the redirect-from-metadata path above, which also returns 200.
       // Reference: test/e2e/app-dir/metadata-navigation
       //   "should support notFound in generateMetadata"
+      //
+      // Exception: when serveStreamingMetadata === false (html-limited bots),
+      // metadata blocks the render synchronously. Next.js sets the real HTTP
+      // error status in this case (app-render.tsx ~2845). Mirror by not
+      // overriding the status, symmetrically with the redirect-from-metadata
+      // path which is already gated on serveStreamingMetadata !== false.
       const responseToMerge =
-        options.specialError.fromMetadata === true
+        options.specialError.fromMetadata === true && options.serveStreamingMetadata !== false
           ? new Response(fallbackResponse.body, {
               headers: fallbackResponse.headers,
               status: 200,
@@ -446,8 +452,14 @@ export async function buildAppPageSpecialErrorResponse(
   // When notFound() is thrown from generateMetadata() with no fallback page
   // available, keep the 200 status to stay consistent with the streamed
   // metadata contract (the error is surfaced in the page UI, not the status).
+  // Exception: when serveStreamingMetadata === false (html-limited bots),
+  // metadata blocks the render synchronously — Next.js sets the real HTTP
+  // error status in this case (app-render.tsx ~2845), symmetric with the
+  // redirect-from-metadata path that is already gated on the same flag.
   const responseStatus =
-    options.specialError.fromMetadata === true ? 200 : options.specialError.statusCode;
+    options.specialError.fromMetadata === true && options.serveStreamingMetadata !== false
+      ? 200
+      : options.specialError.statusCode;
   return mergeAppPageSpecialErrorHeaders(
     new Response(getAppPageStatusText(options.specialError.statusCode), {
       status: responseStatus,

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -422,14 +422,35 @@ export async function buildAppPageSpecialErrorResponse(
   if (options.renderFallbackPage) {
     const fallbackResponse = await options.renderFallbackPage(options.specialError.statusCode);
     if (fallbackResponse) {
-      return mergeAppPageSpecialErrorHeaders(fallbackResponse, options.middlewareContext);
+      // When notFound() / forbidden() / unauthorized() is thrown from
+      // generateMetadata(), Next.js treats the error as a suspended metadata
+      // result — the not-found UI is rendered through the React boundary
+      // client-side while the HTTP response itself stays 200. Mirror that
+      // behavior by overriding the rendered boundary response status to 200.
+      // Mirrors the redirect-from-metadata path above, which also returns 200.
+      // Reference: test/e2e/app-dir/metadata-navigation
+      //   "should support notFound in generateMetadata"
+      const responseToMerge =
+        options.specialError.fromMetadata === true
+          ? new Response(fallbackResponse.body, {
+              headers: fallbackResponse.headers,
+              status: 200,
+              statusText: fallbackResponse.statusText,
+            })
+          : fallbackResponse;
+      return mergeAppPageSpecialErrorHeaders(responseToMerge, options.middlewareContext);
     }
   }
 
   options.clearRequestContext();
+  // When notFound() is thrown from generateMetadata() with no fallback page
+  // available, keep the 200 status to stay consistent with the streamed
+  // metadata contract (the error is surfaced in the page UI, not the status).
+  const responseStatus =
+    options.specialError.fromMetadata === true ? 200 : options.specialError.statusCode;
   return mergeAppPageSpecialErrorHeaders(
     new Response(getAppPageStatusText(options.specialError.statusCode), {
-      status: options.specialError.statusCode,
+      status: responseStatus,
     }),
     options.middlewareContext,
   );

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -598,6 +598,61 @@ describe("app page execution helpers", () => {
     expect(response.status).toBe(200);
   });
 
+  it("returns HTTP 404 when notFound() is thrown from generateMetadata with serveStreamingMetadata:false (html-limited bot, with fallback)", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+    //   "should render blocking 404 response status when html limited bots access notFound"
+    //
+    // When serveStreamingMetadata === false (html-limited bots), metadata blocks
+    // the render synchronously. Next.js sets the real HTTP error status in this
+    // path (app-render.tsx ~2845). Mirror the redirect-from-metadata path, which
+    // is already gated on serveStreamingMetadata !== false.
+    const fallbackBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("not-found-boundary-html"));
+        controller.close();
+      },
+    });
+    const fallbackResponse = new Response(fallbackBody, {
+      status: 404,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      renderFallbackPage: async () => fallbackResponse,
+      request: new Request("https://example.com/async/not-found"),
+      serveStreamingMetadata: false,
+      specialError: {
+        kind: "http-access-fallback",
+        statusCode: 404,
+        fromMetadata: true,
+      },
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("not-found-boundary-html");
+  });
+
+  it("returns HTTP 404 when notFound() is thrown from generateMetadata with serveStreamingMetadata:false (html-limited bot, no fallback)", async () => {
+    // Same bot scenario but with no renderFallbackPage (no not-found.tsx).
+    // The plain text fallback must also use the real error status.
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      request: new Request("https://example.com/async/not-found"),
+      serveStreamingMetadata: false,
+      specialError: {
+        kind: "http-access-fallback",
+        statusCode: 404,
+        fromMetadata: true,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+
   it("returns the original status for non-metadata http-access-fallback errors", async () => {
     // Page-level notFound() calls (fromMetadata absent/false) must still return
     // the original 404 status — only metadata-originated errors get the 200

--- a/tests/app-page-execution.test.ts
+++ b/tests/app-page-execution.test.ts
@@ -544,6 +544,80 @@ describe("app page execution helpers", () => {
     );
   });
 
+  it("returns HTTP 200 when notFound() is thrown from generateMetadata (fromMetadata)", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
+    //   "should support notFound in generateMetadata"
+    //
+    // When notFound() / forbidden() / unauthorized() is thrown from
+    // generateMetadata(), Next.js treats the error as a suspended metadata
+    // result — the React not-found boundary handles the UI client-side while
+    // the HTTP response stays 200. The rendered fallback response (status 404
+    // from renderAppPageHttpAccessFallback) must be overridden to 200.
+    const fallbackBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("not-found-boundary-html"));
+        controller.close();
+      },
+    });
+    const fallbackResponse = new Response(fallbackBody, {
+      status: 404,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      renderFallbackPage: async () => fallbackResponse,
+      request: new Request("https://example.com/async/not-found"),
+      specialError: {
+        kind: "http-access-fallback",
+        statusCode: 404,
+        fromMetadata: true,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("not-found-boundary-html");
+  });
+
+  it("returns HTTP 200 for metadata notFound when no fallback page is available", async () => {
+    // When there is no renderFallbackPage (e.g. no not-found.tsx exists), the
+    // plain text fallback should also be 200 for fromMetadata errors.
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      request: new Request("https://example.com/async/not-found"),
+      specialError: {
+        kind: "http-access-fallback",
+        statusCode: 404,
+        fromMetadata: true,
+      },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns the original status for non-metadata http-access-fallback errors", async () => {
+    // Page-level notFound() calls (fromMetadata absent/false) must still return
+    // the original 404 status — only metadata-originated errors get the 200
+    // override.
+    const fallbackResponse = new Response("page-level-not-found", { status: 404 });
+
+    const response = await buildAppPageSpecialErrorResponse({
+      clearRequestContext: vi.fn(),
+      isRscRequest: false,
+      renderFallbackPage: async () => fallbackResponse,
+      request: new Request("https://example.com/page"),
+      specialError: {
+        kind: "http-access-fallback",
+        statusCode: 404,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+
   it("probes layouts from inner to outer and stops on a handled special response", async () => {
     const probedLayouts: number[] = [];
 


### PR DESCRIPTION
## What failed

The e2e test `app dir - metadata navigation > navigation > should support notFound in generateMetadata` was failing because vinext returned HTTP 404 when `generateMetadata()` called `notFound()`, but the test asserts `expect(res.status).toBe(200)`.

**Test fixture** (`test/e2e/app-dir/metadata-navigation/app/async/not-found/page.tsx`):
```typescript
export async function generateMetadata() {
  notFound()
}
```

## Root cause

When `notFound()` is thrown from `generateMetadata()`, it propagates out of `resolveAppPageHead` in `buildPageElements`. The error is caught by `buildAppPageElement`, classified as `{ kind: "http-access-fallback", statusCode: 404, fromMetadata: true }`, and rendered via `renderPageSpecialError` → `buildAppPageSpecialErrorResponse`.

For the `http-access-fallback` case, `buildAppPageSpecialErrorResponse` called `renderFallbackPage(404)` which rendered the local not-found boundary correctly — but with HTTP status 404 (from `renderAppPageHttpAccessFallback`). The `fromMetadata: true` flag was not consulted.

Next.js treats `notFound()` thrown from `generateMetadata()` as a suspended metadata result: the not-found UI is rendered client-side through the React `NotFoundBoundary`, while the HTTP response itself stays **200**. The test comment says: `// metadata is suspended in SSR, it won't affect the response status`.

## Fix

In `buildAppPageSpecialErrorResponse` (`packages/vinext/src/server/app-page-execution.ts`), when `specialError.fromMetadata === true` for an `http-access-fallback` error, override the rendered fallback response status from 404 to 200 before returning it. This mirrors the existing redirect-from-metadata path which already returns 200.

The fix preserves the existing behavior for page-level `notFound()` calls (no `fromMetadata` flag) — those still return 404.

## Mapping to the test

- `expect(res.status).toBe(200)` — fixed: the HTTP response is now 200
- `expect(flightText).toContain('Local found boundary')` — already worked: the not-found boundary was already being rendered; only the status was wrong
- Client-side metadata assertions (`keywords: 'parent'`, `robots: 'noindex'`, `description: 'Local not found description'`, `title: 'Local not found'`) — already worked: `renderPageSpecialError` includes parent layout modules in the metadata resolution

## Verification

- `vp check`: 22 pre-existing errors, 0 new errors
- `vp test run tests/app-page-execution.test.ts`: 34 tests pass (31 existing + 3 new tests covering the fix)
- The Playwright e2e test `should support notFound in generateMetadata` is expected to pass in CI