### PR TITLE
fix(app-router): discover parallel-slot pages inside route groups (catchall-parallel-routes-group)

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1173,7 +1173,16 @@ function discoverSlotSubRoutes(
             `You cannot have two routes that resolve to the same path ("${pattern}").`,
           );
         }
-        applySlotSubPages(existingRoute, slotPages, rawSegments);
+        // When urlParts is empty, all sub-segments are URL-invisible (e.g. route
+        // groups like "(group)"). The slot page is at the same URL level as the
+        // parent route, so discoverParallelSlots already assigned it with the
+        // correct empty routeSegments. Calling applySlotSubPages here would
+        // overwrite routeSegments with the raw filesystem segments (e.g.
+        // ["(group)"]), making useSelectedLayoutSegment return the route-group
+        // name rather than null.
+        if (urlParts.length > 0) {
+          applySlotSubPages(existingRoute, slotPages, rawSegments);
+        }
         continue;
       }
 
@@ -1972,6 +1981,38 @@ function patternsStructurallyEquivalent(a: readonly string[], b: readonly string
 }
 
 /**
+ * Find a page file at the root URL level of a parallel slot directory, including
+ * through transparent route-group subdirectories (e.g. `@slot/(group)/page.tsx`
+ * is equivalent to `@slot/page.tsx` since `(group)` is invisible in the URL).
+ *
+ * Returns the absolute page path, or null if no root-level page is found.
+ *
+ * Only descends into route-group directories (those whose name starts with `(`
+ * and ends with `)`). Dynamic segments, regular named dirs, and `@slot` dirs
+ * are not transparent and are therefore not searched.
+ */
+function findSlotRootPage(slotDir: string, matcher: ValidFileMatcher): string | null {
+  // Fast path: direct page.tsx at slot root.
+  const directPage = findFile(slotDir, "page", matcher);
+  if (directPage) return directPage;
+
+  // Walk route-group subdirectories (transparent in the URL).
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(slotDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!entry.name.startsWith("(") || !entry.name.endsWith(")")) continue;
+    const found = findSlotRootPage(path.join(slotDir, entry.name), matcher);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
  * Discover parallel route slots (@team, @analytics, etc.) in a directory.
  * Returns a ParallelSlot for each @-prefixed subdirectory that has a page or default component.
  */
@@ -1997,7 +2038,10 @@ function discoverParallelSlots(
     const slotName = entry.name.slice(1); // "@team" -> "team"
     const slotDir = path.join(dir, entry.name);
 
-    const pagePath = findFile(slotDir, "page", matcher);
+    // A slot page may live inside a route-group subdirectory of the slot
+    // (e.g. @slot/(group)/page.tsx). Route groups are transparent in the URL,
+    // so that page still represents the slot's root-level content.
+    const pagePath = findSlotRootPage(slotDir, matcher);
     const defaultPath = findFile(slotDir, "default", matcher);
     const interceptingRoutes = discoverInterceptingRoutes(slotDir, dir, appDir, matcher);
 

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -499,6 +499,40 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  // Ported from Next.js: test/e2e/app-dir/catchall-parallel-routes-group/
+  it("discovers a parallel slot page inside a route group (catchall-parallel-routes-group)", async () => {
+    // Fixture mirrors the e2e test:
+    //   app/[...catchAll]/layout.tsx  — layout with `slot` prop
+    //   app/[...catchAll]/page.tsx    — children page
+    //   app/[...catchAll]/@slot/layout.tsx
+    //   app/[...catchAll]/@slot/(group)/page.tsx  ← page inside route group
+    //
+    // The slot has NO direct page.tsx at the @slot root; the page lives inside
+    // a transparent route-group directory. discoverParallelSlots must still
+    // find and include the slot so it renders correctly.
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[...catchAll]/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "[...catchAll]/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[...catchAll]/@slot/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "[...catchAll]/@slot/(group)/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const catchAll = findRoute(graph.routes, "/:catchAll+");
+
+      // The slot must be present and resolve to the page inside the route group.
+      expect(catchAll.parallelSlots).toHaveLength(1);
+      expect(catchAll.parallelSlots[0]).toMatchObject({
+        name: "slot",
+        pagePath: path.join(appDir, "[...catchAll]/@slot/(group)/page.tsx"),
+        hasPage: true,
+        // The route group is transparent in the URL, so routeSegments is empty.
+        routeSegments: [],
+      });
+    });
+  });
+
   it("keeps route groups transparent in materialized URL patterns", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);


### PR DESCRIPTION
## What failed

E2E test `catchall-parallel-routes-group > should work without throwing any errors about invalid pages`.

The fixture has this structure:
```
app/[...catchAll]/layout.tsx       (layout with `slot` prop)
app/[...catchAll]/page.tsx         (catch-all page)
app/[...catchAll]/@slot/layout.tsx (slot layout)
app/[...catchAll]/@slot/(group)/page.tsx  ← page inside route group
```

The route renders without the `@slot` content, causing the navigation to `/foobar` to not show "Catch-all Slot Group Page".

## Root cause

Two bugs in `discoverParallelSlots` / `discoverSlotSubRoutes` in `packages/vinext/src/routing/app-route-graph.ts`:

**Bug 1** — `discoverParallelSlots` only looked for `page.tsx` directly at the slot root via `findFile(slotDir, "page", matcher)`. When the page lives inside a route-group subdirectory (`(group)/page.tsx`), `findFile` returns `null`, the "has content" guard fires, and the entire slot is excluded from the route graph.

**Bug 2** — Even if the slot were included, `discoverSlotSubRoutes` processes the ghost-parent layout's sub-path. `findSlotSubPages` returns `(group)/page.tsx` as a sub-page with `relativePath = "(group)"`. Since `(group)` is URL-invisible, `urlParts = []` and the pattern matches the existing route. `applySlotSubPages` is called with `rawSegments = ["(group)"]`, overwriting `routeSegments` to `["(group)"]`. At render time, `resolveAppPageChildSegments` pushes `"(group)"` into the child-segment list, so `useSelectedLayoutSegment("slot")` would surface the route-group name rather than `null`.

## Fix

1. **`findSlotRootPage`** — new helper that finds a page at the slot's root URL level, descending through transparent route-group directories (`(name)`). `discoverParallelSlots` now uses this instead of a bare `findFile`.

2. **`discoverSlotSubRoutes`** — when `urlParts.length === 0` (all sub-segments are URL-invisible), skip `applySlotSubPages`. The existing route's slot was already populated with the correct empty `routeSegments` by `discoverParallelSlots`; calling `applySlotSubPages` here would corrupt `routeSegments` with raw filesystem segments.

## Mapping to test

`catchall-parallel-routes-group > should work without throwing any errors about invalid pages` navigates to `/foobar`, expects both "Catch-all Page" and "Catch-all Slot Group Page" to appear. With the fix, `/:catchAll+` has the `@slot` correctly populated with `pagePath` pointing to `@slot/(group)/page.tsx`, so the slot renders correctly.

## Verification

- `vp test run tests/app-route-graph.test.ts` — 49/49 pass (includes new regression test)
- `vp test run tests/app-page-route-wiring.test.ts` — 34/34 pass
- `vp test run tests/app-rsc-route-matching.test.ts` — 17/17 pass
- `vp check` — 22 pre-existing env errors, no new errors