### PR TITLE
fix(use-cache): pass soft tags to cache lookup so revalidatePath invalidates use-cache entries in route handlers

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -38,7 +38,7 @@ import {
   type CacheLifeConfig,
 } from "./cache.js";
 import { VINEXT_RSC_MARKER_HEADER } from "../server/headers.js";
-import { addCollectedRequestTags } from "./fetch-cache.js";
+import { addCollectedRequestTags, getCurrentFetchSoftTags } from "./fetch-cache.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   isInsideUnifiedScope,
@@ -528,8 +528,13 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
     // Shared cache ("use cache" / "use cache: remote")
     const handler = getDataCacheHandler();
 
-    // Check cache — deserialize via RSC stream when available, JSON otherwise
-    const existing = await handler.get(cacheKey, { kind: "FETCH" });
+    // Check cache — deserialize via RSC stream when available, JSON otherwise.
+    // Pass soft tags so that revalidatePath() / revalidateTag() invalidation
+    // applies to "use cache" entries even when the entry carries no hard tags.
+    // The soft tags are path-derived implicit tags set by the enclosing route
+    // handler or page dispatch — see setCurrentFetchSoftTags in fetch-cache.ts.
+    const softTags = getCurrentFetchSoftTags();
+    const existing = await handler.get(cacheKey, { kind: "FETCH", softTags });
     if (existing?.value && existing.value.kind === "FETCH" && existing.cacheState !== "stale") {
       try {
         // Surface the cached entry's tags to the surrounding request so the

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -608,6 +608,17 @@ export function setCurrentFetchSoftTags(tags: string[]): void {
   _getState().currentFetchSoftTags = [...tags];
 }
 
+/**
+ * Read the path-derived soft tags for the current render.
+ *
+ * Used by the "use cache" runtime to pass soft tags to the cache handler
+ * so that `revalidatePath()` invalidates "use cache" entries during the
+ * affected route's next request, even when the entry carries no hard tags.
+ */
+export function getCurrentFetchSoftTags(): string[] {
+  return _getState().currentFetchSoftTags;
+}
+
 export function setCurrentFetchCacheMode(mode: FetchCacheMode | null): void {
   _getState().currentFetchCacheMode = mode;
 }


### PR DESCRIPTION
## What failed

`test/e2e/app-dir/use-cache-route-handler-only` > `should be able to revalidate prerendered route handlers`

The test has a route handler (`/node`) that calls a `"use cache"` function (`getCachedDate`). It calls `revalidatePath('/node')` via a `POST /revalidate` endpoint and expects the next request to `/node` to return a different (fresh) date.

## Root cause

When `revalidatePath('/node')` is called it records the implicit tag `_N_T_/node` as revalidated in `MemoryCacheHandler.tagRevalidatedAt`. For the subsequent `/node` request to miss the `"use cache"` entry, the cache lookup must check whether any relevant tags have been revalidated.

Route handlers already set path-derived *soft tags* before dispatch (via `setCurrentFetchSoftTags` in `app-rsc-handler.ts`), and `MemoryCacheHandler.get` already checks `_ctx.softTags` against `tagRevalidatedAt` — this mechanism is used correctly by the patched `fetch()`. But `registerCachedFunction` in `cache-runtime.ts` was calling:

```ts
const existing = await handler.get(cacheKey, { kind: "FETCH" });
```

…with **no `softTags`**, so the soft-tag invalidation was never consulted. The `"use cache"` entry has no hard tags (no `cacheTag()` call), so it was never evicted, and `revalidatePath` had no visible effect.

## Fix

1. **`packages/vinext/src/shims/fetch-cache.ts`**: Export `getCurrentFetchSoftTags()` — a simple getter that returns the soft tags already stored in the per-request `FetchCacheState`.

2. **`packages/vinext/src/shims/cache-runtime.ts`**: Import and use `getCurrentFetchSoftTags()` in the `handler.get` call inside `registerCachedFunction`, threading the soft tags into the context object already understood by `MemoryCacheHandler`.

## Mapping to the test

After the fix, when `/node` is requested after `revalidatePath('/node')`:
- Soft tags include `_N_T_/node` (set by `app-rsc-handler.ts` before dispatching the route handler)
- The `"use cache"` lookup calls `handler.get(cacheKey, { kind: "FETCH", softTags: ["_N_T_/node", ...] })`
- `MemoryCacheHandler.get` finds that `_N_T_/node` was revalidated after the entry was written → returns `null`
- `getCachedDate` executes fresh → new date → assertion `date1a !== date1b` passes

## What was verified

- `vp check`: no new TS errors (all ~20 errors are pre-existing env TS2307 stubs)
- `vp test run tests/app-route-handler-execution.test.ts` — 6 tests pass
- `vp test run tests/fetch-cache.test.ts` — 104 tests pass
- `vp test run tests/isr-cache.test.ts` — 64 tests pass
- `vp test run tests/app-page-cache.test.ts` — 30 tests pass
- `vp test run tests/app-route-handler-policy.test.ts tests/app-route-handler-dispatch.test.ts` — 13 tests pass