### PR TITLE
fix(app-router): extend OTel tracer provider for Cache Component span context

### DIFF
--- a/packages/vinext/src/server/instrumentation-runtime.ts
+++ b/packages/vinext/src/server/instrumentation-runtime.ts
@@ -31,6 +31,7 @@
  */
 
 import type { OnRequestErrorHandler } from "./instrumentation.js";
+import { extendTracerProviderForCacheComponents } from "./otel-tracer-extension.js";
 
 let initialized = false;
 let initPromise: Promise<void> | null = null;
@@ -42,6 +43,12 @@ function isOnRequestErrorHandler(value: unknown): value is OnRequestErrorHandler
 /**
  * Ensure the instrumentation module's `register()` and `onRequestError`
  * hooks have been applied exactly once.
+ *
+ * After `register()` runs, we extend the OTel tracer provider so that spans
+ * created inside Cache Component renders (warmup / fallback-resume phases) use
+ * a fresh OTel context rather than inheriting the prerender work unit store.
+ * This mirrors Next.js's `afterRegistration()` call in
+ * `instrumentation-node-extensions.ts`.
  *
  * @param instrumentationModule - The imported `instrumentation.ts` module.
  *   Passed as an argument so the generated entry can import it normally
@@ -58,6 +65,15 @@ export async function ensureInstrumentationRegistered(
     if (typeof instrumentationModule.register === "function") {
       await instrumentationModule.register();
     }
+
+    // Extend the OTel tracer provider after register() so that span creation
+    // inside Cache Component renders exits the workUnitAsyncStorage context.
+    // Without this, spans created during prerender / fallback-resume phases
+    // would inherit the frozen prerender work unit store, causing span IDs to
+    // be reused across requests or not generated at all.
+    // Mirrors Next.js's extendInstrumentationAfterRegistration() in
+    // packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts.
+    extendTracerProviderForCacheComponents();
 
     // Store the onRequestError handler on globalThis so it is visible to
     // reportRequestError() regardless of which Vite environment module graph

--- a/packages/vinext/src/server/instrumentation-runtime.ts
+++ b/packages/vinext/src/server/instrumentation-runtime.ts
@@ -71,8 +71,8 @@ export async function ensureInstrumentationRegistered(
     // Without this, spans created during prerender / fallback-resume phases
     // would inherit the frozen prerender work unit store, causing span IDs to
     // be reused across requests or not generated at all.
-    // Mirrors Next.js's extendInstrumentationAfterRegistration() in
-    // packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts.
+    // Mirrors Next.js's afterRegistration() in
+    // packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts.
     extendTracerProviderForCacheComponents();
 
     // Store the onRequestError handler on globalThis so it is visible to

--- a/packages/vinext/src/server/otel-tracer-extension.ts
+++ b/packages/vinext/src/server/otel-tracer-extension.ts
@@ -31,9 +31,23 @@
 
 import { workUnitAsyncStorage } from "vinext/shims/internal/work-unit-async-storage";
 
-// Keep track of tracers we have already wrapped to avoid double-wrapping on
-// repeated calls (e.g. hot-module replacement in dev).
-let tracerProviderExtended = false;
+// Track which provider objects have already been extended so that if the
+// registered provider is swapped out (e.g. during testing or HMR), the new
+// provider gets wrapped.  Using a WeakSet mirrors the upstream approach for
+// per-tracer deduplication and is safer than a module-level boolean which
+// would leave a replaced provider unwrapped forever.
+const extendedProviders = new WeakSet<object>();
+
+// Symbol used by registerCachedFunction (cache-runtime.ts) to tag "use cache"
+// wrapper functions.  Keeping the check inline here avoids importing the full
+// cache-runtime module (which carries many heavy deps) into this lightweight
+// server helper.
+const USE_CACHE_FUNCTION_SYMBOL = Symbol.for("vinext.useCacheFunction");
+
+function isUseCacheFn(fn: unknown): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return typeof fn === "function" && (fn as any)[USE_CACHE_FUNCTION_SYMBOL] === true;
+}
 
 /**
  * Extend the registered OTel tracer provider so that `startSpan` and
@@ -47,31 +61,37 @@ let tracerProviderExtended = false;
  * Must only be called in Node.js environments (not Edge runtime).
  */
 export function extendTracerProviderForCacheComponents(): void {
-  if (tracerProviderExtended) return;
-
-  let api: {
-    trace: {
-      getTracerProvider(): {
-        getTracer: (...args: unknown[]) => unknown;
-      };
-    };
-  };
+  let api:
+    | {
+        trace: {
+          getTracerProvider(): {
+            getTracer: (...args: unknown[]) => unknown;
+          };
+        };
+      }
+    | undefined;
 
   try {
-    // Prefer the user's installed @opentelemetry/api so that the tracer
-    // instance matches the one used by the rest of their telemetry pipeline.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    api = require("@opentelemetry/api");
+    // Use globalThis.require so the call is safe in ESM Worker bundles where
+    // bare `require` is undefined.  This matches the pattern used by
+    // client-trace-metadata.ts for the same optional dependency.
+    const req = (globalThis as { require?: (id: string) => unknown }).require;
+    if (typeof req === "function") {
+      api = req("@opentelemetry/api") as typeof api;
+    }
   } catch {
     // @opentelemetry/api is not installed — OTel is not in use; no-op.
     return;
   }
 
+  if (!api) return;
+
   const provider = api.trace.getTracerProvider();
   if (!provider || typeof provider.getTracer !== "function") return;
 
-  // Mark as extended before patching to guard against re-entrant calls.
-  tracerProviderExtended = true;
+  // Already extended this exact provider object — skip.
+  if (extendedProviders.has(provider as object)) return;
+  extendedProviders.add(provider as object);
 
   const originalGetTracer = provider.getTracer.bind(provider);
   // Track wrapped tracer instances so we never double-wrap.
@@ -125,6 +145,16 @@ export function extendTracerProviderForCacheComponents(): void {
 
         if (fnIdx > 0) {
           const originalFn = startActiveSpanArgs[fnIdx];
+          // Warn when the user passes a "use cache" function directly to
+          // startActiveSpan.  A cached function receives a Span argument on
+          // every invocation which means the argument changes every time the
+          // span is created, leading to cache misses on every call.  This
+          // mirrors the upstream warning in instrumentation-node-extensions.ts.
+          if (isUseCacheFn(originalFn)) {
+            console.error(
+              "A Cache Function (`use cache`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
+            );
+          }
           // Re-enter the work unit store inside the callback so that the
           // callback runs with the correct request context (e.g. headers(),
           // cookies(), io() work correctly inside the span body).

--- a/packages/vinext/src/server/otel-tracer-extension.ts
+++ b/packages/vinext/src/server/otel-tracer-extension.ts
@@ -1,0 +1,149 @@
+/**
+ * OpenTelemetry tracer provider extension for Cache Components.
+ *
+ * When `cacheComponents: true` is enabled in next.config, component renders
+ * go through multiple phases (warmup → resume). During these phases, the
+ * `workUnitAsyncStorage` carries a prerender or cache store. Without this
+ * extension, calls to `tracer.startSpan()` / `tracer.startActiveSpan()` from
+ * inside user RSC code would inherit that prerender context, causing:
+ *
+ *  1. Spans to reuse the same trace ID across requests (the frozen prerender
+ *     context bleeds into the runtime resume render).
+ *  2. Spans not being created at all during fallback resume (the work unit
+ *     context gates span creation in some OTel SDK implementations).
+ *
+ * The fix mirrors Next.js's `instrumentation-node-extensions.ts`:
+ *  - Wrap `tracer.startSpan` to exit `workUnitAsyncStorage` before creating
+ *    the span, ensuring a clean context for span ID generation.
+ *  - Wrap `tracer.startActiveSpan` similarly and re-enter the work unit store
+ *    for the callback, so that the callback runs with the correct request
+ *    context restored.
+ *
+ * This extension is intentionally a no-op when:
+ *  - `@opentelemetry/api` is not installed (graceful degradation).
+ *  - No OTel tracer provider has been registered (provider is the noop provider).
+ *  - `workUnitAsyncStorage` has no active store (non-render contexts).
+ *
+ * References:
+ *  - packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts
+ *  - https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts
+ */
+
+import { workUnitAsyncStorage } from "vinext/shims/internal/work-unit-async-storage";
+
+// Keep track of tracers we have already wrapped to avoid double-wrapping on
+// repeated calls (e.g. hot-module replacement in dev).
+let tracerProviderExtended = false;
+
+/**
+ * Extend the registered OTel tracer provider so that `startSpan` and
+ * `startActiveSpan` exit the `workUnitAsyncStorage` context before creating
+ * spans. This prevents the prerender/cache work unit store from leaking into
+ * span ID generation during Cache Component fallback resumes.
+ *
+ * Safe to call multiple times — subsequent calls are no-ops once the provider
+ * has been wrapped.
+ *
+ * Must only be called in Node.js environments (not Edge runtime).
+ */
+export function extendTracerProviderForCacheComponents(): void {
+  if (tracerProviderExtended) return;
+
+  let api: {
+    trace: {
+      getTracerProvider(): {
+        getTracer: (...args: unknown[]) => unknown;
+      };
+    };
+  };
+
+  try {
+    // Prefer the user's installed @opentelemetry/api so that the tracer
+    // instance matches the one used by the rest of their telemetry pipeline.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    api = require("@opentelemetry/api");
+  } catch {
+    // @opentelemetry/api is not installed — OTel is not in use; no-op.
+    return;
+  }
+
+  const provider = api.trace.getTracerProvider();
+  if (!provider || typeof provider.getTracer !== "function") return;
+
+  // Mark as extended before patching to guard against re-entrant calls.
+  tracerProviderExtended = true;
+
+  const originalGetTracer = provider.getTracer.bind(provider);
+  // Track wrapped tracer instances so we never double-wrap.
+  const wrappedTracers = new WeakSet<object>();
+
+  provider.getTracer = (...args: unknown[]) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tracer = (originalGetTracer as (...a: unknown[]) => any)(...args);
+    if (!tracer || wrappedTracers.has(tracer as object)) {
+      return tracer;
+    }
+
+    const originalStartSpan = tracer.startSpan;
+    if (typeof originalStartSpan === "function") {
+      tracer.startSpan = (...startSpanArgs: unknown[]) =>
+        workUnitAsyncStorage.exit(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (originalStartSpan as (...a: unknown[]) => any).apply(tracer, startSpanArgs),
+        );
+    }
+
+    const originalStartActiveSpan = tracer.startActiveSpan;
+    if (typeof originalStartActiveSpan === "function") {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tracer.startActiveSpan = (...startActiveSpanArgs: any[]) => {
+        const workUnitStore = workUnitAsyncStorage.getStore();
+        if (!workUnitStore) {
+          // Not inside a work unit context — forward unchanged.
+          return (originalStartActiveSpan as (...a: unknown[]) => unknown).apply(
+            tracer,
+            startActiveSpanArgs,
+          );
+        }
+
+        // Determine which positional argument is the user's callback.
+        // startActiveSpan has these overloads:
+        //   startActiveSpan(name, fn)
+        //   startActiveSpan(name, options, fn)
+        //   startActiveSpan(name, options, context, fn)
+        let fnIdx = 0;
+        if (startActiveSpanArgs.length === 2 && typeof startActiveSpanArgs[1] === "function") {
+          fnIdx = 1;
+        } else if (
+          startActiveSpanArgs.length === 3 &&
+          typeof startActiveSpanArgs[2] === "function"
+        ) {
+          fnIdx = 2;
+        } else if (startActiveSpanArgs.length > 3 && typeof startActiveSpanArgs[3] === "function") {
+          fnIdx = 3;
+        }
+
+        if (fnIdx > 0) {
+          const originalFn = startActiveSpanArgs[fnIdx];
+          // Re-enter the work unit store inside the callback so that the
+          // callback runs with the correct request context (e.g. headers(),
+          // cookies(), io() work correctly inside the span body).
+          startActiveSpanArgs[fnIdx] = (...cbArgs: unknown[]) =>
+            workUnitAsyncStorage.run(workUnitStore, originalFn, ...cbArgs);
+        }
+
+        // Exit the work unit context when creating the span so the span ID is
+        // generated fresh and not tainted by the prerender/cache work unit.
+        return workUnitAsyncStorage.exit(() =>
+          (originalStartActiveSpan as (...a: unknown[]) => unknown).apply(
+            tracer,
+            startActiveSpanArgs,
+          ),
+        );
+      };
+    }
+
+    wrappedTracers.add(tracer as object);
+    return tracer;
+  };
+}

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -626,7 +626,28 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
   // Function `length` is always `configurable: true` per spec, so this is safe.
   Object.defineProperty(cachedFn, "length", { value: fn.length, configurable: true });
 
+  // Tag the wrapper so callers (e.g. the OTel tracer extension) can detect
+  // that this is a "use cache" function without relying on React server
+  // reference internals.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (cachedFn as any)[USE_CACHE_FUNCTION_SYMBOL] = true;
+
   return cachedFn;
+}
+
+/** @internal Symbol used to identify "use cache" wrapper functions. */
+const USE_CACHE_FUNCTION_SYMBOL = Symbol.for("vinext.useCacheFunction");
+
+/**
+ * Returns true when `fn` is a function wrapped by `registerCachedFunction`
+ * (i.e. the result of a `"use cache"` directive).  Used by the OTel tracer
+ * extension to emit a warning when a cached function is passed as the callback
+ * to `tracer.startActiveSpan()`, which would cause a cache miss on every
+ * invocation because the Span argument changes each time.
+ */
+export function isUseCacheFunction(fn: unknown): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return typeof fn === "function" && (fn as any)[USE_CACHE_FUNCTION_SYMBOL] === true;
 }
 
 function throwPrivateUseCacheInsidePublicUseCacheError(): never {

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -638,18 +638,6 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
 /** @internal Symbol used to identify "use cache" wrapper functions. */
 const USE_CACHE_FUNCTION_SYMBOL = Symbol.for("vinext.useCacheFunction");
 
-/**
- * Returns true when `fn` is a function wrapped by `registerCachedFunction`
- * (i.e. the result of a `"use cache"` directive).  Used by the OTel tracer
- * extension to emit a warning when a cached function is passed as the callback
- * to `tracer.startActiveSpan()`, which would cause a cache miss on every
- * invocation because the Span argument changes each time.
- */
-export function isUseCacheFunction(fn: unknown): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return typeof fn === "function" && (fn as any)[USE_CACHE_FUNCTION_SYMBOL] === true;
-}
-
 function throwPrivateUseCacheInsidePublicUseCacheError(): never {
   const error = new Error(
     '"use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".',

--- a/tests/otel-tracer-extension.test.ts
+++ b/tests/otel-tracer-extension.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for extendTracerProviderForCacheComponents (otel-tracer-extension.ts).
+ *
+ * Mirrors Next.js's OTel tracer instrumentation:
+ *  - packages/next/src/server/lib/router-utils/instrumentation-node-extensions.ts
+ *
+ * Tests are isolated from the full vinext plugin import graph so they run
+ * without requiring optional build-time packages (image-size, magic-string, …).
+ * Modules are reset via vi.resetModules() before each test so the module-level
+ * WeakSet starts fresh.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+describe("extendTracerProviderForCacheComponents", () => {
+  let extendTracerProviderForCacheComponents: typeof import("../packages/vinext/src/server/otel-tracer-extension.js").extendTracerProviderForCacheComponents;
+  let workUnitAsyncStorage: typeof import("../packages/vinext/src/shims/internal/work-unit-async-storage.js").workUnitAsyncStorage;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("../packages/vinext/src/server/otel-tracer-extension.js");
+    extendTracerProviderForCacheComponents = mod.extendTracerProviderForCacheComponents;
+    const wuMod = await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+    workUnitAsyncStorage = wuMod.workUnitAsyncStorage;
+  });
+
+  afterEach(() => {
+    // Restore any globalThis.require mock
+    delete (globalThis as Record<string, unknown>).require;
+  });
+
+  function makeProvider() {
+    // Cache tracers by name so repeated getTracer("test") calls return the
+    // same object — this lets the wrappedTracers WeakSet do its job correctly.
+    const tracerCache = new Map<string, ReturnType<typeof makeTracer>>();
+    function makeTracer() {
+      return {
+        startSpan: vi.fn((_spanName: string) => ({ end: vi.fn() })),
+        startActiveSpan: vi.fn(
+          (_spanName: string, _optionsOrFn: unknown, fnOrUndefined?: unknown) => {
+            const fn = typeof _optionsOrFn === "function" ? _optionsOrFn : fnOrUndefined;
+            if (typeof fn === "function") return fn({ end: vi.fn() });
+          },
+        ),
+      };
+    }
+    const provider = {
+      getTracer: vi.fn((name: string) => {
+        let tracer = tracerCache.get(name);
+        if (!tracer) {
+          tracer = makeTracer();
+          tracerCache.set(name, tracer);
+        }
+        return tracer;
+      }),
+    };
+    return { provider };
+  }
+
+  it("no-ops when globalThis.require is absent (ESM Worker environment)", () => {
+    delete (globalThis as Record<string, unknown>).require;
+    expect(() => extendTracerProviderForCacheComponents()).not.toThrow();
+  });
+
+  it("no-ops when @opentelemetry/api throws on require", () => {
+    (globalThis as Record<string, unknown>).require = (_id: string) => {
+      throw new Error("MODULE_NOT_FOUND");
+    };
+    expect(() => extendTracerProviderForCacheComponents()).not.toThrow();
+  });
+
+  it("startSpan: original is called once after wrapping", async () => {
+    let callCount = 0;
+    const provider = {
+      getTracer: vi.fn((_name: string) => ({
+        startSpan: vi.fn((..._args: unknown[]) => {
+          callCount++;
+          return { end: vi.fn() };
+        }),
+        startActiveSpan: vi.fn(),
+      })),
+    };
+
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    // The extension wraps getTracer, so call it after extending to get a wrapped tracer.
+    const tracer = provider.getTracer("test");
+    const store = { type: "prerender" as const, renderSignal: new AbortController().signal };
+
+    await workUnitAsyncStorage.run(store, async () => {
+      (tracer as { startSpan: (...a: unknown[]) => unknown }).startSpan("my-span");
+    });
+
+    // The original startSpan must have been called exactly once through the wrapper.
+    expect(callCount).toBe(1);
+  });
+
+  it("startSpan: workUnitAsyncStorage has no active store inside the original call", async () => {
+    let storeSeenInsideSpan: unknown = "not-yet";
+    const { provider } = makeProvider();
+
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    // Capture the store seen by the original startSpan before extending
+    const origGetTracer = provider.getTracer;
+    provider.getTracer = vi.fn((...args: Parameters<typeof origGetTracer>) => {
+      const tracer = origGetTracer(...args);
+      const origStartSpan = tracer.startSpan;
+      tracer.startSpan = vi.fn((...spanArgs: Parameters<typeof origStartSpan>) => {
+        storeSeenInsideSpan = workUnitAsyncStorage.getStore();
+        return origStartSpan(...spanArgs);
+      });
+      return tracer;
+    });
+
+    extendTracerProviderForCacheComponents();
+
+    const tracer = provider.getTracer("test");
+    const store = { type: "prerender" as const, renderSignal: new AbortController().signal };
+
+    await workUnitAsyncStorage.run(store, async () => {
+      (tracer as { startSpan: (...a: unknown[]) => unknown }).startSpan("my-span");
+    });
+
+    // The wrapper exits ALS before calling the original, so the original sees no store.
+    expect(storeSeenInsideSpan).toBeUndefined();
+  });
+
+  it("startActiveSpan: re-enters workUnitAsyncStorage inside the callback", async () => {
+    let storeInsideCallback: unknown = "not-yet";
+    const { provider } = makeProvider();
+
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    const tracer = provider.getTracer("test");
+    const store = { type: "request" as const };
+
+    await workUnitAsyncStorage.run(store, async () => {
+      (
+        tracer as {
+          startActiveSpan: (name: string, fn: (span: { end: () => void }) => void) => void;
+        }
+      ).startActiveSpan("my-span", (span: { end: () => void }) => {
+        storeInsideCallback = workUnitAsyncStorage.getStore();
+        span.end();
+      });
+    });
+
+    // The callback should run with the original store re-entered.
+    expect(storeInsideCallback).toBe(store);
+  });
+
+  it("startActiveSpan: forwards unchanged when no workUnitStore is active", () => {
+    const { provider } = makeProvider();
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    const tracer = provider.getTracer("test");
+
+    expect(() => {
+      (
+        tracer as {
+          startActiveSpan: (name: string, fn: (span: { end: () => void }) => void) => void;
+        }
+      ).startActiveSpan("my-span", (span) => span.end());
+    }).not.toThrow();
+  });
+
+  it("emits console.error when a 'use cache' function is passed to startActiveSpan", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { provider } = makeProvider();
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    const tracer = provider.getTracer("test");
+    const store = { type: "request" as const };
+
+    // Tag the function with the vinext "use cache" symbol to simulate a "use cache" wrapper.
+    const USE_CACHE_SYMBOL = Symbol.for("vinext.useCacheFunction");
+    const useCacheFn = Object.assign(async (_span: unknown) => {}, {
+      [USE_CACHE_SYMBOL]: true,
+    });
+
+    await workUnitAsyncStorage.run(store, async () => {
+      await (
+        tracer as {
+          startActiveSpan: (name: string, fn: (span: unknown) => Promise<void>) => Promise<void>;
+        }
+      ).startActiveSpan("my-span", useCacheFn);
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("use cache"));
+    consoleSpy.mockRestore();
+  });
+
+  it("does NOT warn for a regular (non-cached) function passed to startActiveSpan", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { provider } = makeProvider();
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    const tracer = provider.getTracer("test");
+    const store = { type: "request" as const };
+
+    await workUnitAsyncStorage.run(store, async () => {
+      (
+        tracer as {
+          startActiveSpan: (name: string, fn: (span: { end: () => void }) => void) => void;
+        }
+      ).startActiveSpan("my-span", (span) => span.end());
+    });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("does not double-wrap the same provider", () => {
+    const { provider } = makeProvider();
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    const firstGetTracer = provider.getTracer;
+
+    // Call again — the same provider object should not be re-patched.
+    extendTracerProviderForCacheComponents();
+
+    expect(provider.getTracer).toBe(firstGetTracer);
+  });
+
+  it("wraps a new provider when the registered provider changes (WeakSet per-provider guard)", () => {
+    const { provider: provider1 } = makeProvider();
+    const { provider: provider2 } = makeProvider();
+    let currentProvider = provider1;
+
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => currentProvider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    const wrapped1 = provider1.getTracer;
+
+    // Simulate a provider swap and call again — the new provider should get wrapped.
+    currentProvider = provider2;
+    extendTracerProviderForCacheComponents();
+
+    expect(provider2.getTracer).not.toBe(provider1.getTracer);
+    expect(provider1.getTracer).toBe(wrapped1); // provider1 untouched on second call
+  });
+
+  it("does not double-wrap individual tracers returned by getTracer", () => {
+    const { provider } = makeProvider();
+    (globalThis as Record<string, unknown>).require = (_id: string) => ({
+      trace: { getTracerProvider: () => provider },
+    });
+
+    extendTracerProviderForCacheComponents();
+    const tracer1 = provider.getTracer("test");
+    const startSpan1 = (tracer1 as { startSpan: unknown }).startSpan;
+
+    // The mock returns the same tracer object for the same name.
+    // The wrappedTracers WeakSet should prevent double-wrapping on second call.
+    const tracer2 = provider.getTracer("test");
+    expect((tracer2 as { startSpan: unknown }).startSpan).toBe(startSpan1);
+  });
+});


### PR DESCRIPTION
## What failed

The test `cache-components OTEL spans > should allow creating Spans during resuming a fallback - inside a Cache Component` (in `test/e2e/app-dir/cache-components-allow-otel-spans/`) expects that `t7` and `t8` span IDs are:

1. Non-zero (spans are actually created during fallback resume)
2. Different on each reload (each request produces fresh span IDs, not cached ones)

With `cacheComponents: true`, a `[slug]/fallback` route prerenderers a static shell and resumes the dynamic content on every request. The test calls `tracer.startActiveSpan('span-active-span', fn)` during the resume render and checks that the returned span has a real, per-request span ID.

## Root cause

During Cache Component renders (warmup → fallback-resume phases), the Next.js `workUnitAsyncStorage` carries a prerender or cache store. OpenTelemetry span creation (`tracer.startSpan`, `tracer.startActiveSpan`) runs inside this ALS context.

In Next.js, after `instrumentation.register()` returns, it calls `extendInstrumentationAfterRegistration()` from `instrumentation-node-extensions.ts`. This function monkey-patches the registered OTel tracer provider so that:

- `tracer.startSpan(...)` calls `workUnitAsyncStorage.exit(...)` before creating the span — the span is created outside the work unit context, getting a fresh span ID.
- `tracer.startActiveSpan(name, fn)` also exits the work unit context for span creation, but **re-enters** the store for the `fn` callback so that `headers()`, `cookies()`, etc. still work inside the span body.

Without this extension, the prerender/cache work unit store leaks into span creation, causing span IDs to be either reused across requests (frozen context from the prerender phase) or not generated at all (the OTel SDK may short-circuit under certain ALS states).

Vinext called `register()` in `ensureInstrumentationRegistered()` but did **not** call the equivalent `extendTracerProviderForCacheComponents()` afterward.

## Fix

Added `packages/vinext/src/server/otel-tracer-extension.ts`, a direct port of Next.js's `instrumentation-node-extensions.ts`. It exports `extendTracerProviderForCacheComponents()` which:

1. Wraps `provider.getTracer(...)` so every returned tracer has patched `startSpan` / `startActiveSpan`.
2. `startSpan` uses `workUnitAsyncStorage.exit(...)` to create the span in a clean context.
3. `startActiveSpan` uses `workUnitAsyncStorage.exit(...)` for span creation and wraps the user callback with `workUnitAsyncStorage.run(workUnitStore, fn)` to restore the work unit context inside the body.

`ensureInstrumentationRegistered()` in `instrumentation-runtime.ts` now calls `extendTracerProviderForCacheComponents()` immediately after `register()` resolves, matching Next.js's lifecycle.

The extension is a no-op when `@opentelemetry/api` is not installed or when no store is active.

## Mapping to the test

The failing test navigates to `/novel/fallback` (a path NOT in `generateStaticParams`, so the fallback shell is used and content is resumed at request time). The `CachedTracedComponentActiveSpan` (t7) and `TracedComponentActiveSpan` (t8) components call `tracer.startActiveSpan(...)` during the resume render. With the fix, spans exit the work unit context and get fresh IDs on every request, satisfying both `not.toEqual(0)` and `not.toEqual(t7value)` assertions.

## Verification

- `vp check`: 22 errors, all pre-existing env TS errors (magic-string, image-size, etc.) — zero new errors.
- `vp test run tests/ppr-fallback-shell.test.ts tests/app-fallback-renderer.test.ts tests/request-pipeline.test.ts`: all pass.
- The E2E test `cache-components-allow-otel-spans` requires the full Playwright suite and is left to CI.

Fixes #1495