### PR TITLE
fix(pages-router): bridge deprecated Router.on<Event> property callbacks

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2401,7 +2401,10 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
 // The reference implementation wraps this in `singletonRouter.ready()` so it
 // runs after the router instance is created; vinext's routerEvents is a module-
 // level singleton that exists from the start, so we can register directly.
-const _deprecatedRouterEvents = [
+// Registering unconditionally at module load (without a client-only guard) is
+// safe here because every routerEvents.emit() call is already gated behind
+// typeof window checks, so these listeners never fire in SSR contexts.
+const deprecatedRouterEvents = [
   "routeChangeStart",
   "beforeHistoryChange",
   "routeChangeComplete",
@@ -2410,8 +2413,8 @@ const _deprecatedRouterEvents = [
   "hashChangeComplete",
 ] as const;
 
-for (const event of _deprecatedRouterEvents) {
-  const eventField = `on${event.charAt(0).toUpperCase()}${event.substring(1)}` as string;
+for (const event of deprecatedRouterEvents) {
+  const eventField = `on${event.charAt(0).toUpperCase()}${event.substring(1)}`;
   routerEvents.on(event, (...args: unknown[]) => {
     const handler = (Router as Record<string, unknown>)[eventField];
     if (typeof handler === "function") {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2390,6 +2390,41 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
     },
   }) as typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods>;
 
+// Deprecated event property bridging: when userland code does
+// `Router.onRouteChangeComplete = handler` (the legacy Next.js pattern),
+// the handler must be called whenever the corresponding event fires.
+//
+// For each known router event, register a listener that reads the deprecated
+// `on<EventName>` property off the singleton and calls it if present.
+//
+// Ported from Next.js: packages/next/src/client/router.ts (lines 105–124).
+// The reference implementation wraps this in `singletonRouter.ready()` so it
+// runs after the router instance is created; vinext's routerEvents is a module-
+// level singleton that exists from the start, so we can register directly.
+const _deprecatedRouterEvents = [
+  "routeChangeStart",
+  "beforeHistoryChange",
+  "routeChangeComplete",
+  "routeChangeError",
+  "hashChangeStart",
+  "hashChangeComplete",
+] as const;
+
+for (const event of _deprecatedRouterEvents) {
+  const eventField = `on${event.charAt(0).toUpperCase()}${event.substring(1)}` as string;
+  routerEvents.on(event, (...args: unknown[]) => {
+    const handler = (Router as Record<string, unknown>)[eventField];
+    if (typeof handler === "function") {
+      try {
+        (handler as (...a: unknown[]) => void)(...args);
+      } catch (err) {
+        console.error(`Error when running the Router event: ${eventField}`);
+        console.error(err instanceof Error ? `${err.message}\n${err.stack}` : String(err));
+      }
+    }
+  });
+}
+
 // Expose `window.next.router` for Next.js parity. Pages Router test suites,
 // userland scripts, and third-party libraries reach for this global directly
 // (e.g. `window.next.router.push(...)`, `window.next.router.events.on(...)`,

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14808,6 +14808,92 @@ describe("Pages Router concurrent navigation", () => {
   });
 });
 
+describe("deprecated Router.on<Event> property bridge", () => {
+  // These tests verify that assigning a function to a deprecated property such
+  // as `Router.onRouteChangeComplete` causes that function to be invoked when
+  // the corresponding event fires via Router.events.emit().  The bridge is the
+  // code added in fix/with-router-deprecated-nav-events.
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("Router.onRouteChangeComplete is called when routeChangeComplete fires", async () => {
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    const calls: unknown[][] = [];
+    (Router as any).onRouteChangeComplete = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    try {
+      Router.events.emit("routeChangeComplete", "/test-path", { shallow: false });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toBe("/test-path");
+    } finally {
+      delete (Router as any).onRouteChangeComplete;
+    }
+  });
+
+  it("Router.onRouteChangeStart is called when routeChangeStart fires", async () => {
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    const calls: unknown[][] = [];
+    (Router as any).onRouteChangeStart = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    try {
+      Router.events.emit("routeChangeStart", "/start-path", { shallow: false });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toBe("/start-path");
+    } finally {
+      delete (Router as any).onRouteChangeStart;
+    }
+  });
+
+  it("emitting an event with no on<Event> handler assigned does not throw", async () => {
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    // Ensure no handler is set
+    delete (Router as any).onRouteChangeComplete;
+
+    expect(() => {
+      Router.events.emit("routeChangeComplete", "/no-handler", { shallow: false });
+    }).not.toThrow();
+  });
+
+  it("previously-cleared on<Event> handler is not called after removal", async () => {
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    const calls: unknown[][] = [];
+    (Router as any).onRouteChangeComplete = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    // Fire once — should be called
+    Router.events.emit("routeChangeComplete", "/first", { shallow: false });
+    expect(calls).toHaveLength(1);
+
+    // Clear the handler
+    delete (Router as any).onRouteChangeComplete;
+
+    // Fire again — should NOT be called
+    Router.events.emit("routeChangeComplete", "/second", { shallow: false });
+    expect(calls).toHaveLength(1);
+  });
+});
+
 describe("Pages Router _next/data client navigation", () => {
   // These tests exercise the JSON path in navigateClient: when
   // `__VINEXT_PAGE_LOADERS__` is populated (prod-style hydration), navigation


### PR DESCRIPTION
## What failed

The e2e test `withRouter > production mode > allows observation of navigation events using top level Router deprecated behavior` was failing. The test navigates from `/a` to `/b` and asserts that the element `.active-top-level-router-deprecated-behavior` updates to reflect the new page.

The test fixture (`header-nav.js`) uses the legacy/deprecated pattern of setting a property directly on the top-level `Router` singleton:

```js
Router.onRouteChangeComplete = this.handleRouteChangeTopLevelRouterDeprecatedBehavior
```

## Root cause

Next.js's reference implementation (`packages/next/src/client/router.ts`, lines 105–124) bridges the deprecated property pattern by registering listeners on `Router.events` for each known router event. When an event fires, it checks whether a corresponding `Router.on<EventName>` property is set on the singleton and calls it.

Vinext's `Router` singleton was missing this bridging entirely. So when `Router.onRouteChangeComplete = handler` was set, the handler was stored on the object but never invoked — no listener existed to call it when `routeChangeComplete` fired.

The other two tests in the same describe block (`withRouter` and `top level Router`) use `router.events.on(...)` / `Router.events.on(...)` directly, which worked fine because `routerEvents` (the shared emitter) was correctly wired.

## Fix

After the `Router` singleton is constructed, register one `routerEvents` listener per known router event. Each listener checks if `Router.on<EventName>` is set (the deprecated pattern) and calls it when fired.

This matches the reference implementation verbatim (just adapted to vinext's code style):

- `routeChangeStart` → `Router.onRouteChangeStart`
- `beforeHistoryChange` → `Router.onBeforeHistoryChange`
- `routeChangeComplete` → `Router.onRouteChangeComplete`
- `routeChangeError` → `Router.onRouteChangeError`
- `hashChangeStart` → `Router.onHashChangeStart`
- `hashChangeComplete` → `Router.onHashChangeComplete`

## Test mapping

Failing test: `test/e2e/with-router/index.test.ts` → `allows observation of navigation events using top level Router deprecated behavior`

The test sets `Router.onRouteChangeComplete = handler` in `componentDidMount` and asserts the handler fires when the button click triggers `router.push('/b')`. With the bridging in place, `performNavigation` emits `routeChangeComplete` on `routerEvents`, which triggers the new bridge listener, which calls `Router.onRouteChangeComplete(url)`, which updates the component state.

## Verification

- `vp check`: 22 pre-existing env TS errors, zero new errors introduced
- `vp test run tests/navigation-runtime.test.ts`: 8/8 pass
- `vp test run tests/router-javascript-urls.test.ts`: 25/25 pass