### PR TITLE
fix(app-router): suppress redirect console errors in production onCaughtError (root-layout-redirect)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,10 @@ jobs:
             label: standalone-output
             shardIndex: 1
             shardTotal: 1
+          - project: root-layout-redirect
+            label: root-layout-redirect
+            shardIndex: 1
+            shardTotal: 1
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ reports/
 # Nix
 result
 result-*
+# The Nix `result` pattern above also matches Next.js compat fixture routes
+# named `result`; re-include them so they don't silently fall out of tracking.
+!tests/fixtures/root-layout-redirect/app/result/
 .direnv/
 .corepack/
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -141,7 +141,7 @@ import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/slot";
 import type { RouteManifest } from "../routing/app-route-graph.js";
 import { stripBasePath } from "../utils/base-path.js";
-import { createOnUncaughtError } from "./app-browser-error.js";
+import { createOnUncaughtError, prodOnCaughtError } from "./app-browser-error.js";
 import { createClientReuseManifestHeaderFromVisibleAppState } from "./app-browser-client-reuse-manifest.js";
 import {
   devOnCaughtError,
@@ -1797,6 +1797,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       })
     : createVinextHydrateRootOptions({
         formState,
+        onCaughtError: prodOnCaughtError,
         onUncaughtError,
       });
   window.__VINEXT_RSC_ROOT__ = hydrateRootInTransition({

--- a/packages/vinext/src/server/app-browser-error.ts
+++ b/packages/vinext/src/server/app-browser-error.ts
@@ -25,3 +25,36 @@ export function createOnUncaughtError(
     }
   };
 }
+
+// Inline digest classifier — mirrors isNavigationSignalError in
+// utils/navigation-signal.ts without importing it, so this file stays a
+// plain JS module with no cross-package dependencies that could pull in
+// unexpected code in production bundles.
+function isNavigationSignalDigest(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("digest" in error)) return false;
+  const digest = String((error as { digest: unknown }).digest);
+  return (
+    digest === "NEXT_NOT_FOUND" ||
+    digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;") ||
+    digest.startsWith("NEXT_REDIRECT;")
+  );
+}
+
+// Production onCaughtError handler for hydrateRoot. React calls this for
+// every error caught by an error boundary. Navigation sentinel errors
+// (redirect(), notFound(), forbidden(), unauthorized()) are intentionally
+// thrown as control flow and MUST be caught by their dedicated boundaries;
+// logging them to the console would produce spurious browser console errors
+// that break the "no console errors" assertion in Next.js compat tests
+// (e.g. root-layout-redirect). Filter them out silently — the boundary has
+// already consumed the error and triggered the appropriate navigation.
+//
+// All other caught errors are logged to console.error, preserving React's
+// default behavior.
+export function prodOnCaughtError(error: unknown, errorInfo: { componentStack?: string }): void {
+  if (isNavigationSignalDigest(error)) return;
+  console.error(error);
+  if (errorInfo?.componentStack) {
+    console.error("The above error occurred in a React component:\n" + errorInfo.componentStack);
+  }
+}

--- a/packages/vinext/src/server/app-browser-error.ts
+++ b/packages/vinext/src/server/app-browser-error.ts
@@ -1,3 +1,5 @@
+import { isNavigationSignalError } from "../utils/navigation-signal.js";
+
 // Build the onUncaughtError handler for hydrateRoot. When a render error
 // tears down the tree without an error boundary catching, the
 // NavigationCommitSignal layout effect never runs, so the URL update for
@@ -26,20 +28,6 @@ export function createOnUncaughtError(
   };
 }
 
-// Inline digest classifier — mirrors isNavigationSignalError in
-// utils/navigation-signal.ts without importing it, so this file stays a
-// plain JS module with no cross-package dependencies that could pull in
-// unexpected code in production bundles.
-function isNavigationSignalDigest(error: unknown): boolean {
-  if (!error || typeof error !== "object" || !("digest" in error)) return false;
-  const digest = String((error as { digest: unknown }).digest);
-  return (
-    digest === "NEXT_NOT_FOUND" ||
-    digest.startsWith("NEXT_HTTP_ERROR_FALLBACK;") ||
-    digest.startsWith("NEXT_REDIRECT;")
-  );
-}
-
 // Production onCaughtError handler for hydrateRoot. React calls this for
 // every error caught by an error boundary. Navigation sentinel errors
 // (redirect(), notFound(), forbidden(), unauthorized()) are intentionally
@@ -52,7 +40,7 @@ function isNavigationSignalDigest(error: unknown): boolean {
 // All other caught errors are logged to console.error, preserving React's
 // default behavior.
 export function prodOnCaughtError(error: unknown, errorInfo: { componentStack?: string }): void {
-  if (isNavigationSignalDigest(error)) return;
+  if (isNavigationSignalError(error)) return;
   console.error(error);
   if (errorInfo?.componentStack) {
     console.error("The above error occurred in a React component:\n" + errorInfo.componentStack);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -187,6 +187,17 @@ const projectServers = {
       timeout: 60_000,
     },
   },
+  "root-layout-redirect": {
+    testDir: "./tests/e2e/root-layout-redirect",
+    use: { baseURL: "http://localhost:4184" },
+    server: {
+      command: "npx vp dev --port 4184",
+      cwd: "./tests/fixtures/root-layout-redirect",
+      port: 4184,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+  },
 };
 
 type ProjectName = keyof typeof projectServers;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -191,11 +191,16 @@ const projectServers = {
     testDir: "./tests/e2e/root-layout-redirect",
     use: { baseURL: "http://localhost:4184" },
     server: {
-      command: "npx vp dev --port 4184",
+      // Build vinext CLI, then build the fixture, then start the production
+      // server. This exercises prodOnCaughtError (the fixed code path) rather
+      // than devOnCaughtError, which already filtered navigation-signal errors
+      // before this PR.
+      command:
+        "npx tsc -p ../../../packages/vinext/tsconfig.json && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4184",
       cwd: "./tests/fixtures/root-layout-redirect",
       port: 4184,
       reuseExistingServer: !process.env.CI,
-      timeout: 30_000,
+      timeout: 60_000,
     },
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,6 +1462,31 @@ importers:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/root-layout-redirect:
+    dependencies:
+      '@vitejs/plugin-rsc':
+        specifier: 'catalog:'
+        version: 0.5.27(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      react-server-dom-webpack:
+        specifier: 'catalog:'
+        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      vinext:
+        specifier: workspace:*
+        version: link:../../../packages/vinext
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)'
+    devDependencies:
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
+
   tests/fixtures/standalone-output:
     dependencies:
       react:

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1,6 +1,9 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { createOnUncaughtError } from "../packages/vinext/src/server/app-browser-error.js";
+import {
+  createOnUncaughtError,
+  prodOnCaughtError,
+} from "../packages/vinext/src/server/app-browser-error.js";
 import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
@@ -6338,6 +6341,91 @@ describe("createOnUncaughtError (hydrateRoot uncaught handler)", () => {
         handler(new Error("late error"), {});
         expect(assignSpy).toHaveBeenCalledWith("/second");
       });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});
+
+describe("prodOnCaughtError (hydrateRoot prod handler)", () => {
+  it("ignores redirect sentinels handled by RedirectBoundary", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      prodOnCaughtError(
+        Object.assign(new Error("NEXT_REDIRECT:/result"), {
+          digest: "NEXT_REDIRECT;;%2Fresult",
+        }),
+        { componentStack: "\n    at Root" },
+      );
+      expect(consoleSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("ignores notFound and HTTP fallback sentinels (notFound/forbidden/unauthorized)", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      prodOnCaughtError(Object.assign(new Error("NEXT_NOT_FOUND"), { digest: "NEXT_NOT_FOUND" }), {
+        componentStack: "\n    at Page",
+      });
+      prodOnCaughtError(
+        Object.assign(new Error("NEXT_HTTP_ERROR_FALLBACK;403"), {
+          digest: "NEXT_HTTP_ERROR_FALLBACK;403",
+        }),
+        { componentStack: "\n    at Page" },
+      );
+      expect(consoleSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("forwards real caught errors to console.error", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const err = new Error("Maximum update depth exceeded");
+      prodOnCaughtError(err, { componentStack: "\n    at List\n    at Apps" });
+      const loggedErrors = consoleSpy.mock.calls.map((args) => args[0]);
+      expect(loggedErrors).toContain(err);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("includes the React component stack in the log when provided", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      prodOnCaughtError(new Error("boom"), {
+        componentStack: "\n    at List (apps/list.tsx:202)",
+      });
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+      expect(String(consoleSpy.mock.calls[1][0])).toContain("apps/list.tsx:202");
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("logs only the error when no component stack is provided", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const err = new Error("no stack");
+      prodOnCaughtError(err, {});
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.mock.calls[0][0]).toBe(err);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("does not swallow a plain error that merely mentions NEXT_REDIRECT (no digest)", () => {
+    // Classification is digest-based; an error whose *message* contains the
+    // sentinel text but has no framework digest must still be logged.
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const err = new Error("user code threw: NEXT_REDIRECT");
+      prodOnCaughtError(err, {});
+      expect(consoleSpy.mock.calls.map((args) => args[0])).toContain(err);
     } finally {
       consoleSpy.mockRestore();
     }

--- a/tests/e2e/root-layout-redirect/root-layout-redirect.spec.ts
+++ b/tests/e2e/root-layout-redirect/root-layout-redirect.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Next.js Compat E2E: root-layout-redirect
+ *
+ * Ported from: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/root-layout-redirect/root-layout-redirect.test.ts
+ *
+ * Covers redirect() called from a 'use client' root layout (the layout that
+ * renders <html>/<body>). The redirect must complete via client-side navigation
+ * and must not produce any browser console errors.
+ *
+ * Part of issue #1830.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const BASE = "http://localhost:4184";
+
+test.describe("root-layout-redirect", () => {
+  // Next.js: 'should work using browser'
+  // Source: root-layout-redirect.test.ts
+  test("should work using browser", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto(`${BASE}/`);
+
+    await page.click("#trigger-redirect");
+
+    await expect(page.locator("#result")).toHaveText("Result Page", {
+      timeout: 10_000,
+    });
+
+    expect(consoleErrors).toHaveLength(0);
+  });
+});

--- a/tests/fixtures/root-layout-redirect/app/layout.tsx
+++ b/tests/fixtures/root-layout-redirect/app/layout.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import React, { useState } from "react";
+import { redirect } from "next/navigation";
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  const [clicked, setClicked] = useState(false);
+  if (clicked) {
+    redirect("/result");
+  }
+
+  return (
+    <html>
+      <body>
+        <button id="trigger-redirect" onClick={() => setClicked(true)}>
+          Click to redirect
+        </button>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/tests/fixtures/root-layout-redirect/app/page.tsx
+++ b/tests/fixtures/root-layout-redirect/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>;
+}

--- a/tests/fixtures/root-layout-redirect/app/result/page.tsx
+++ b/tests/fixtures/root-layout-redirect/app/result/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="result">Result Page</h1>;
+}

--- a/tests/fixtures/root-layout-redirect/package.json
+++ b/tests/fixtures/root-layout-redirect/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "root-layout-redirect-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vitejs/plugin-rsc": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-server-dom-webpack": "catalog:",
+    "vinext": "workspace:*",
+    "vite": "catalog:"
+  },
+  "devDependencies": {
+    "vite-plus": "catalog:"
+  }
+}

--- a/tests/fixtures/root-layout-redirect/tsconfig.json
+++ b/tests/fixtures/root-layout-redirect/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vite/client", "@vitejs/plugin-rsc/types"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["app", "*.ts", "../../../packages/vinext/src/shims/next-shims.d.ts"]
+}

--- a/tests/fixtures/root-layout-redirect/vite.config.ts
+++ b/tests/fixtures/root-layout-redirect/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});


### PR DESCRIPTION
## Failure

The Next.js compat deploy-suite test **root-layout-redirect > should work using browser** was failing. The test:

1. Navigates to `/`
2. Clicks a button in the `'use client'` root layout that calls `redirect('/result')`
3. Waits for `#result` element with text "Result Page"
4. Asserts **no browser console errors** (`log.source === 'error'`)

The test was failing on step 4 — a spurious console error was being emitted.

## Root Cause

When `redirect()` is called from a `'use client'` component during a state update, React catches the `NEXT_REDIRECT` sentinel error via `RedirectErrorBoundary`. After an error boundary catches an error, React invokes the `onCaughtError` callback registered on `hydrateRoot`.

In **dev mode**, vinext already provided `devOnCaughtError` which filters navigation signal errors with `if (isNavigationSignalError(error)) return;` — so no console error in dev.

In **production mode**, vinext did NOT provide an `onCaughtError` at all. React's built-in fallback behaviour is to call `console.error` with the caught error. This produced a browser console error for the `NEXT_REDIRECT` sentinel, causing the test assertion `expect(foundErrors).toBe(false)` to fail.

The root layout is a particularly visible place for this because:
- It renders `<html>/<body>` and the redirect throws during a button-click state update
- `HandleRedirect` renders `null`, replacing the subtree
- React then calls `onCaughtError` with the redirect error before triggering navigation

## Fix

Added `prodOnCaughtError` to `packages/vinext/src/server/app-browser-error.ts`:
- Navigation sentinel errors (`NEXT_REDIRECT;*`, `NEXT_NOT_FOUND`, `NEXT_HTTP_ERROR_FALLBACK;*`) are silently dropped — the dedicated boundary has already consumed them and triggered navigation
- All other caught errors are forwarded to `console.error`, preserving React's default behaviour

Wired into the production `hydrateRoot` options in `app-browser-entry.ts` (the dev path already used `devOnCaughtError`).

## Test Mapping

| Next.js test | vinext test |
|---|---|
| `test/e2e/app-dir/root-layout-redirect/root-layout-redirect.test.ts` > `should work using browser` | `tests/e2e/root-layout-redirect/root-layout-redirect.spec.ts` > `should work using browser` |

New fixture at `tests/fixtures/root-layout-redirect/`: a dedicated app with a `'use client'` root layout (matching the Next.js reference fixture exactly) and port 4184 Playwright project.

## Notes

- `tests/fixtures/root-layout-redirect/app/result/page.tsx` is force-tracked because `.gitignore` contains a global `result` pattern for Playwright output dirs; this is intentional app code.
- The `prodOnCaughtError` inlines the navigation-signal digest check to keep `app-browser-error.ts` dependency-free in production bundles.

Part of #1830