### PR TITLE
fix(pages-router): hard-navigate to App Router destinations from Pages Router links

### DIFF
--- a/packages/vinext/src/shims/internal/app-route-detection.ts
+++ b/packages/vinext/src/shims/internal/app-route-detection.ts
@@ -36,7 +36,7 @@
  */
 import type { VinextLinkPrefetchRoute } from "../../client/vinext-next-data.js";
 import { createRouteTrieCache, matchRouteWithTrie } from "../../routing/route-matching.js";
-import { stripBasePath } from "../../utils/base-path.js";
+import { stripBasePath, removeTrailingSlash } from "../../utils/base-path.js";
 
 const appRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
@@ -115,16 +115,22 @@ function matchesAppRoute(href: string, basePath: string): boolean {
  * Pages Router map when the href matches an App Router route. No-op when the
  * manifest is absent, the URL is external, or no app route matches.
  *
- * `pathname` is the basePath-stripped path — matching Next.js's
- * `router.components[urlPathname]` key (see the source link in this file's
- * leading comment).
+ * `pathname` is the basePath-stripped, trailing-slash-stripped path —
+ * matching Next.js's `removeTrailingSlash(removeBasePath(pathname))` key used
+ * at read time (router.ts:1442). Stripping here ensures the write and read
+ * keys agree regardless of whether the caller normalised trailing slashes
+ * first (e.g. `link.tsx` normalises to match `trailingSlash` config before
+ * calling, while `router.prefetch()` passes the raw user-supplied URL).
  */
 export function markAppRouteDetectedOnPrefetch(href: string, basePath: string): void {
   if (typeof window === "undefined") return;
   if (!matchesAppRoute(href, basePath)) return;
 
-  const pathname = resolveSameOriginPathname(href, basePath);
-  if (pathname === null) return;
+  const rawPathname = resolveSameOriginPathname(href, basePath);
+  if (rawPathname === null) return;
 
+  // Normalise to stripped form so the key agrees with the read-side lookup in
+  // performNavigation, which also strips trailing slashes before checking.
+  const pathname = removeTrailingSlash(rawPathname);
   getPagesRouterComponentsMap()[pathname] = { __appRouter: true };
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1828,6 +1828,23 @@ async function performNavigation(
     return true;
   }
 
+  // If this destination was detected as an App Router route during prefetch,
+  // skip the Pages Router SPA fetch and do an immediate hard navigation.
+  // The Pages Router client-side stack cannot render App Router pages; a hard
+  // navigation lets the browser bootstrap the App Router runtime from scratch.
+  //
+  // Mirrors Next.js: packages/next/src/shared/lib/router/router.ts:1448-1453
+  //   if ((this.components[pathname] as any)?.__appRouter) {
+  //     handleHardNavigation({ url: as, router: this })
+  //     return new Promise(() => {})
+  //   }
+  const _appPath = getLocalPathname(resolved);
+  if (_appPath !== null && (getPagesRouterComponentsMap()[_appPath] as any)?.__appRouter) {
+    if (mode === "push") window.location.assign(full);
+    else window.location.replace(full);
+    return new Promise<boolean>(() => {});
+  }
+
   if (mode === "push") saveScrollPosition();
   routerEvents.emit("routeChangeStart", resolved, { shallow });
   routerEvents.emit("beforeHistoryChange", resolved, { shallow });

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1839,7 +1839,8 @@ async function performNavigation(
   //     return new Promise(() => {})
   //   }
   const _appPath = getLocalPathname(resolved);
-  if (_appPath !== null && (getPagesRouterComponentsMap()[_appPath] as any)?.__appRouter) {
+  const _appPathEntry = _appPath !== null ? getPagesRouterComponentsMap()[_appPath] : undefined;
+  if (_appPathEntry !== undefined && "__appRouter" in _appPathEntry && _appPathEntry.__appRouter) {
     if (mode === "push") window.location.assign(full);
     else window.location.replace(full);
     return new Promise<boolean>(() => {});

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -47,7 +47,7 @@ import {
   getWindowOrigin,
   withBasePath,
 } from "./url-utils.js";
-import { stripBasePath } from "../utils/base-path.js";
+import { stripBasePath, removeTrailingSlash } from "../utils/base-path.js";
 import {
   addLocalePrefix,
   getDomainLocaleUrl,
@@ -1838,9 +1838,16 @@ async function performNavigation(
   //     handleHardNavigation({ url: as, router: this })
   //     return new Promise(() => {})
   //   }
-  const _appPath = getLocalPathname(resolved);
-  const _appPathEntry = _appPath !== null ? getPagesRouterComponentsMap()[_appPath] : undefined;
-  if (_appPathEntry !== undefined && "__appRouter" in _appPathEntry && _appPathEntry.__appRouter) {
+  //
+  // Key normalisation: strip trailing slash so the lookup always matches the
+  // canonical key written by markAppRouteDetectedOnPrefetch, regardless of
+  // whether trailingSlash:true added a slash to `resolved` above (line 1797).
+  // Mirrors Next.js: removeTrailingSlash(removeBasePath(pathname)) at line 1442.
+  const appPath = getLocalPathname(resolved);
+  const appPathNorm = appPath !== null ? removeTrailingSlash(appPath) : null;
+  const appPathEntry =
+    appPathNorm !== null ? getPagesRouterComponentsMap()[appPathNorm] : undefined;
+  if (appPathEntry !== undefined && "__appRouter" in appPathEntry && appPathEntry.__appRouter) {
     if (mode === "push") window.location.assign(full);
     else window.location.replace(full);
     return new Promise<boolean>(() => {});

--- a/tests/e2e/app-router/pages-to-app-routing.spec.ts
+++ b/tests/e2e/app-router/pages-to-app-routing.spec.ts
@@ -1,0 +1,46 @@
+// Regression test ported from the Next.js deploy suite:
+// .nextjs-ref/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+//   → "should work using browser"
+//
+// In a hybrid build (app/ + pages/), clicking a Next.js <Link> on a Pages
+// Router page that points to an App Router destination must result in a hard
+// navigation to the App Router page — not an in-place SPA swap that the Pages
+// Router client cannot complete.
+//
+// The mechanism: when the Pages Router <Link> component runs its prefetch
+// for /about it detects (via __VINEXT_LINK_PREFETCH_ROUTES__) that /about is
+// an App Router route and records  `router.components["/about"] = {
+// __appRouter: true }`. On click, performNavigation() checks for that marker
+// and immediately calls window.location.assign/replace rather than attempting
+// a Pages Router fetch cycle.
+//
+// Fixture:
+//   tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx  (Pages Router, GSSP)
+//   tests/fixtures/app-basic/app/about/page.tsx             (App Router)
+import { test, expect } from "@playwright/test";
+import { waitForHydration } from "../helpers";
+
+const BASE = "http://localhost:4174";
+
+test.describe("pages-to-app-routing: navigate from Pages Router to App Router via Link", () => {
+  test("renders GSSP params on the Pages Router page", async ({ page }) => {
+    await page.goto(`${BASE}/pages-to-app/hello`);
+    await waitForHydration(page);
+
+    await expect(page.locator("#params")).toHaveText('Params: {"slug":"hello"}');
+  });
+
+  test("clicking Link navigates to the App Router /about page", async ({ page }) => {
+    await page.goto(`${BASE}/pages-to-app/abc`);
+    await waitForHydration(page);
+
+    await expect(page.locator("#params")).toHaveText('Params: {"slug":"abc"}');
+
+    // Clicking the link must navigate to the App Router /about page.
+    // Because /about is an App Router route, a hard navigation is triggered;
+    // we wait for the new DOM to settle.
+    await page.click("#to-about-link");
+    await expect(page.locator("#app-page")).toHaveText("About", { timeout: 10_000 });
+    expect(page.url()).toContain("/about");
+  });
+});

--- a/tests/e2e/app-router/pages-to-app-routing.spec.ts
+++ b/tests/e2e/app-router/pages-to-app-routing.spec.ts
@@ -18,7 +18,7 @@
 //   tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx  (Pages Router, GSSP)
 //   tests/fixtures/app-basic/app/about/page.tsx             (App Router)
 import { test, expect } from "@playwright/test";
-import { waitForHydration } from "../helpers";
+import { waitForHydration, waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
@@ -38,9 +38,11 @@ test.describe("pages-to-app-routing: navigate from Pages Router to App Router vi
 
     // Clicking the link must navigate to the App Router /about page.
     // Because /about is an App Router route, a hard navigation is triggered;
-    // we wait for the new DOM to settle.
+    // wait for App Router hydration to make the App Router landing explicit
+    // rather than only asserting on the new DOM.
     await page.click("#to-about-link");
-    await expect(page.locator("#app-page")).toHaveText("About", { timeout: 10_000 });
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#app-page")).toHaveText("About");
     expect(page.url()).toContain("/about");
   });
 });

--- a/tests/fixtures/app-basic/app/about/page.tsx
+++ b/tests/fixtures/app-basic/app/about/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function AboutPage() {
   return (
     <main>
-      <h1>About</h1>
+      <h1 id="app-page">About</h1>
       <p>This is the about page.</p>
       <Link href="/">Back to Home</Link>
     </main>

--- a/tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx
+++ b/tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx
@@ -1,0 +1,25 @@
+// Regression fixture for the deploy-suite test:
+// .nextjs-ref/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+//
+// A dynamic Pages Router page with GSSP that renders a Link to an App Router
+// destination (/about). Clicking the link must trigger a hard navigation to
+// the App Router page — not an in-place SPA swap — because the Pages Router
+// client recognises /about as an App Router route via the prefetch manifest.
+import Link from "next/link";
+
+type Props = { params: Record<string, string> };
+
+export async function getServerSideProps({ params }: { params: Record<string, string> }) {
+  return { props: { params } };
+}
+
+export default function PagesToAppPage({ params }: Props) {
+  return (
+    <>
+      <h1 id="params">Params: {JSON.stringify(params)}</h1>
+      <Link id="to-about-link" href="/about">
+        To About
+      </Link>
+    </>
+  );
+}

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -30,28 +30,52 @@ afterEach(() => {
   delete (globalThis as { document?: unknown }).document;
 });
 
+type FakeWindow = {
+  location: {
+    pathname: string;
+    search: string;
+    hash: string;
+    href: string;
+    origin: string;
+    assign: ReturnType<typeof vi.fn>;
+    replace: ReturnType<typeof vi.fn>;
+  };
+  history: { state: null; pushState(): void; replaceState(): void };
+  addEventListener(): void;
+  dispatchEvent(): void;
+  __VINEXT_LINK_PREFETCH_ROUTES__: Array<{
+    canPrefetchLoadingShell: boolean;
+    patternParts: string[];
+    isDynamic: boolean;
+  }>;
+  next?: unknown;
+};
+
 function installFakeBrowserGlobals(
   prefetchRoutes: Array<{
     canPrefetchLoadingShell: boolean;
     patternParts: string[];
     isDynamic: boolean;
   }>,
-): void {
+): FakeWindow {
   // Minimal fake window/document so importing shims/router.ts (which touches
   // window at module load to attach popstate) does not crash.
-  (globalThis as { window?: unknown }).window = {
+  const fakeWindow: FakeWindow = {
     location: {
       pathname: "/",
       search: "",
       hash: "",
       href: "http://localhost/",
       origin: "http://localhost",
+      assign: vi.fn(),
+      replace: vi.fn(),
     },
     history: { state: null, pushState() {}, replaceState() {} },
     addEventListener() {},
     dispatchEvent() {},
     __VINEXT_LINK_PREFETCH_ROUTES__: prefetchRoutes,
   };
+  (globalThis as { window?: unknown }).window = fakeWindow;
   (globalThis as { document?: unknown }).document = {
     addEventListener() {},
     createElement: () => ({
@@ -63,6 +87,7 @@ function installFakeBrowserGlobals(
     }),
     head: { appendChild() {} },
   };
+  return fakeWindow;
 }
 
 describe("Pages Router records app routes as detected on prefetch", () => {
@@ -122,5 +147,53 @@ describe("Pages Router records app routes as detected on prefetch", () => {
     ).window;
     expect(win.next?.router?.components?.["/dashboard"]).toEqual({ __appRouter: true });
     expect(win.next?.router).toBe(Router);
+  });
+
+  it("stores the marker under the trailing-slash-stripped key (trailingSlash: true compat)", async () => {
+    // When trailingSlash:true, link.tsx normalises /about → /about/ before
+    // calling markAppRouteDetectedOnPrefetch. The key must still be stored
+    // without the trailing slash so the read-side lookup in performNavigation
+    // (which also strips) always hits regardless of which form was written.
+    installFakeBrowserGlobals([
+      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+    ]);
+
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    // Simulate the call that link.tsx makes when trailingSlash:true adds a slash.
+    await Router.prefetch("/about/");
+
+    // Key must be the stripped form, not "/about/".
+    expect(Router.components["/about"]).toEqual({ __appRouter: true });
+    expect(Router.components["/about/"]).toBeUndefined();
+  });
+
+  it("fast-paths to window.location.assign when the __appRouter marker is set", async () => {
+    // This pins the new performNavigation fast-path: after a prefetch that
+    // records the __appRouter marker, the next navigation must call
+    // window.location.assign (hard nav) rather than falling through to the
+    // Pages Router SPA fetch cycle.
+    const fakeWindow = installFakeBrowserGlobals([
+      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+    ]);
+
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    // 1. Prefetch records the marker.
+    await Router.prefetch("/about");
+    expect(Router.components["/about"]).toEqual({ __appRouter: true });
+
+    // 2. Navigate — the fast-path must invoke window.location.assign.
+    //    We don't await the returned Promise because the fast-path returns a
+    //    never-resolving Promise (matching Next.js's own "freeze" pattern).
+    void Router.push("/about");
+
+    // Give the microtask queue one tick to run the async preamble of
+    // performNavigation before it hits the fast-path check.
+    await Promise.resolve();
+
+    expect(fakeWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining("/about"));
   });
 });

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -188,11 +188,11 @@ describe("Pages Router records app routes as detected on prefetch", () => {
     // 2. Navigate — the fast-path must invoke window.location.assign.
     //    We don't await the returned Promise because the fast-path returns a
     //    never-resolving Promise (matching Next.js's own "freeze" pattern).
+    //    There is no `await` between performNavigation entry and the
+    //    fast-path return, so `assign` must have fired synchronously by the
+    //    time `push()` returns — assert immediately to pin that synchronicity
+    //    (the hard navigation must not lose a race against the SPA path).
     void Router.push("/about");
-
-    // Give the microtask queue one tick to run the async preamble of
-    // performNavigation before it hits the fast-path check.
-    await Promise.resolve();
 
     expect(fakeWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining("/about"));
   });


### PR DESCRIPTION
## Summary

- In a hybrid (app/ + pages/) build, clicking a Next.js `<Link>` on a Pages Router page that targets an App Router route was attempting a Pages Router SPA fetch cycle instead of performing a hard navigation. The Pages Router client cannot render App Router pages so the navigation would fail or stall.
- Added an `__appRouter` marker check to `performNavigation` in `packages/vinext/src/shims/router.ts`. When the destination was detected as an App Router route during prefetch (recorded as `components[path] = { __appRouter: true }` via `markAppRouteDetectedOnPrefetch`), the function now immediately calls `window.location.assign/replace` and returns a never-resolving Promise — exactly mirroring Next.js `router.ts:1448-1453`.
- Added regression fixture (`tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx`) and Playwright test (`tests/e2e/app-router/pages-to-app-routing.spec.ts`) ported from the deploy-suite test `pages-to-app-routing > should work using browser`.

Fixes deploy-suite failure: `test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts` → `should work using browser`.

## Test plan

- [ ] `vp check` passes (no new TS errors beyond the ~23 pre-existing env errors)
- [ ] New Playwright test `tests/e2e/app-router/pages-to-app-routing.spec.ts` passes under `app-router` project
- [ ] Existing `pages-router-use-params.spec.ts` tests unaffected
- [ ] Deploy-suite `pages-to-app-routing > should work using browser` passes in CI