### PR TITLE
fix(build): define process.env.NEXT_RUNTIME for server bundles

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1370,6 +1370,19 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.NEXT_DEPLOYMENT_ID"] = nextConfig.deploymentId
           ? JSON.stringify(nextConfig.deploymentId)
           : "false";
+        // `process.env.NEXT_RUNTIME` — compile-time constant that identifies
+        // the target runtime for the current bundle.  Next.js sets this in
+        // every environment via its webpack DefinePlugin
+        // (see packages/next/src/build/define-env.ts).  Client bundles receive
+        // `''` (empty string); server bundles receive `'nodejs'` or `'edge'`
+        // depending on the route's configured runtime.
+        //
+        // Here we set the client-bundle default to `''` at the top-level Vite
+        // define, matching Next.js's client value.  The server value
+        // (`'nodejs'`) is overlaid per-environment in the
+        // `vinext:compiler-define-server` configEnvironment hook below, which
+        // Vite merges over this base value for server environments only.
+        defines["process.env.NEXT_RUNTIME"] = '""';
         // Next.js version compat — mirrors Next.js' `process.env.__NEXT_VERSION`,
         // which is substituted by their webpack DefinePlugin at build time
         // (see `packages/next/src/client/next.ts` line 5 and
@@ -3800,20 +3813,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
       },
     },
-    // Inject `compiler.defineServer` substitutions into server environments
-    // only. The universal `compiler.define` map is already merged into the
-    // top-level Vite `define` config above, so it applies to both client
-    // and server bundles. `defineServer` MUST NOT leak into the browser
-    // bundle (it can contain secrets), so we layer it in via the
-    // per-environment `define` hook, which Vite merges over the top-level
+    // Inject server-environment defines (NEXT_RUNTIME + user `compiler.defineServer`
+    // entries) into non-client environments only.  The universal
+    // `compiler.define` map is already merged into the top-level Vite
+    // `define` config above, so it applies to both client and server bundles.
+    // Server-only defines MUST NOT leak into the browser bundle (they can
+    // contain secrets such as the revalidate secret), so we layer them in via
+    // the per-environment `define` hook, which Vite merges over the top-level
     // value for that environment only.
     //
     // Mirrors Next.js: packages/next/src/build/define-env.ts — the
     // `defineServer` entries are only added to the `nodejs` / `edge`
     // serialized define environments, never to `client`.
-    //
-    // Returning `null`/`undefined` means "no change"; the explicit empty
-    // check keeps the hook a no-op when the user never configured it.
     {
       name: "vinext:compiler-define-server",
       configEnvironment(name) {
@@ -3825,6 +3836,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         if (name === "client") return null;
 
         const serverDefines: Record<string, string> = { ...nextConfig.compilerDefineServer };
+
+        // Mirror Next.js's compile-time `process.env.NEXT_RUNTIME` constant
+        // (see packages/next/src/build/define-env.ts).  This is a build-time
+        // define — it is inlined at compile time and has no runtime equivalent.
+        // Next.js compiles each route into its own bundle and stamps the bundle
+        // with the runtime it targets ('edge' or 'nodejs').  Vinext compiles a
+        // single RSC bundle that covers all routes, so we use 'nodejs' for
+        // every server environment — the value that matches Vinext's Workers
+        // Node.js compatibility target.
+        //
+        // Without this define, `process.env.NEXT_RUNTIME` falls back to the
+        // top-level `''` value set for the client bundle.  User-land code (and
+        // the Next.js test fixture at
+        // test/e2e/app-dir/next-after-app-deploy/app/path-prefix.js) that uses
+        // `process.env.NEXT_RUNTIME` to construct revalidation paths would then
+        // compute `'/nodejs'` correctly instead of `''` (issue #1365).
+        serverDefines["process.env.NEXT_RUNTIME"] = JSON.stringify("nodejs");
 
         // On-demand ISR revalidation secret — baked SERVER-ONLY (the `client`
         // early-return above guarantees it never reaches the browser bundle) so
@@ -3843,7 +3871,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             JSON.stringify(sharedRevalidateSecret);
         }
 
-        if (Object.keys(serverDefines).length === 0) return null;
         return { define: serverDefines };
       },
     },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3826,6 +3826,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
         const serverDefines: Record<string, string> = { ...nextConfig.compilerDefineServer };
 
+        // Mirror Next.js's compile-time `process.env.NEXT_RUNTIME` constant
+        // (see packages/next/src/build/define-env.ts).  Next.js compiles each
+        // route into its own bundle and stamps the bundle with the runtime it
+        // targets ('edge' or 'nodejs').  Vinext compiles a single RSC bundle
+        // that covers all routes, so we use 'nodejs' for every server
+        // environment — the value that matches what the Workers Node.js
+        // compatibility layer and `vinext start` both provide at runtime.
+        //
+        // Without this define, `process.env.NEXT_RUNTIME` is `undefined` in
+        // the compiled bundle.  User-land code (and the Next.js test fixture at
+        // test/e2e/app-dir/next-after-app-deploy/app/path-prefix.js) that uses
+        // `process.env.NEXT_RUNTIME` to construct revalidation paths would then
+        // compute `'/undefined'` instead of `'/nodejs'`, causing after()
+        // callbacks to call revalidatePath() for the wrong URL and the ISR
+        // cache never being invalidated (issue #1365).
+        serverDefines["process.env.NEXT_RUNTIME"] = JSON.stringify("nodejs");
+
         // On-demand ISR revalidation secret — baked SERVER-ONLY (the `client`
         // early-return above guarantees it never reaches the browser bundle) so
         // every server bundle, and therefore every Workers isolate, shares the

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3826,23 +3826,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
         const serverDefines: Record<string, string> = { ...nextConfig.compilerDefineServer };
 
-        // Mirror Next.js's compile-time `process.env.NEXT_RUNTIME` constant
-        // (see packages/next/src/build/define-env.ts).  Next.js compiles each
-        // route into its own bundle and stamps the bundle with the runtime it
-        // targets ('edge' or 'nodejs').  Vinext compiles a single RSC bundle
-        // that covers all routes, so we use 'nodejs' for every server
-        // environment — the value that matches what the Workers Node.js
-        // compatibility layer and `vinext start` both provide at runtime.
-        //
-        // Without this define, `process.env.NEXT_RUNTIME` is `undefined` in
-        // the compiled bundle.  User-land code (and the Next.js test fixture at
-        // test/e2e/app-dir/next-after-app-deploy/app/path-prefix.js) that uses
-        // `process.env.NEXT_RUNTIME` to construct revalidation paths would then
-        // compute `'/undefined'` instead of `'/nodejs'`, causing after()
-        // callbacks to call revalidatePath() for the wrong URL and the ISR
-        // cache never being invalidated (issue #1365).
-        serverDefines["process.env.NEXT_RUNTIME"] = JSON.stringify("nodejs");
-
         // On-demand ISR revalidation secret — baked SERVER-ONLY (the `client`
         // early-return above guarantees it never reaches the browser bundle) so
         // every server bundle, and therefore every Workers isolate, shares the

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -145,17 +145,68 @@ describe("compiler.define forwarding to Vite", () => {
         { command: "build" },
       );
 
+      // NEXT_RUNTIME is always injected for server environments in addition to
+      // user-configured defineServer entries.
       expect(rscResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+        "process.env.NEXT_RUNTIME": '"nodejs"',
       });
       expect(ssrResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+        "process.env.NEXT_RUNTIME": '"nodejs"',
       });
       // Client environment must never receive server-only defines.
       expect(clientResult).toBeNull();
     } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  // Mirrors Next.js: packages/next/src/build/define-env.ts (NEXT_RUNTIME define)
+  it("injects `process.env.NEXT_RUNTIME` = 'nodejs' for server envs and '' for client", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    const serverDefinePlugin = plugins.find((p) => p.name === "vinext:compiler-define-server");
+    expect(mainPlugin).toBeDefined();
+    expect(serverDefinePlugin).toBeDefined();
+
+    // Suppress revalidate secret so it doesn't appear in the define output.
+    const prev = process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
+    delete process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
+
+    const tmpDir = await setupTmpProject(`export default {};`);
+    try {
+      const configResult = (await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      )) as { define?: Record<string, string> };
+
+      // Top-level define (applies to all environments including client) must
+      // set NEXT_RUNTIME to '' — matching Next.js's client-bundle value.
+      expect(configResult.define?.["process.env.NEXT_RUNTIME"]).toBe('""');
+
+      // Server environments must override NEXT_RUNTIME to 'nodejs'.
+      for (const env of ["rsc", "ssr"]) {
+        const result = serverDefinePlugin!.configEnvironment!(env, {}, { command: "build" });
+        expect(result?.define?.["process.env.NEXT_RUNTIME"]).toBe('"nodejs"');
+      }
+
+      // Client environment returns null — it receives the top-level '' value
+      // and must never receive the server-only 'nodejs' override.
+      const clientResult = serverDefinePlugin!.configEnvironment!(
+        "client",
+        {},
+        { command: "build" },
+      );
+      expect(clientResult).toBeNull();
+    } finally {
+      if (prev === undefined) delete process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
+      else process.env.__VINEXT_SHARED_REVALIDATE_SECRET = prev;
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);
@@ -218,7 +269,7 @@ describe("compiler.define forwarding to Vite", () => {
     }
   }, 15000);
 
-  it("no-ops the configEnvironment hook when `defineServer` is not configured", async () => {
+  it("still injects NEXT_RUNTIME for server environments even when `defineServer` is not configured", async () => {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
     const plugins = vinext() as VinextPlugin[];
     const mainPlugin = plugins.find(
@@ -229,9 +280,8 @@ describe("compiler.define forwarding to Vite", () => {
     expect(serverDefinePlugin).toBeDefined();
 
     // Explicitly clear the build-time revalidate secret env var so the hook has
-    // no `defineServer` entries AND no baked revalidate-secret define — only
-    // then is the truly-empty no-op path exercised. (Without this the test would
-    // silently depend on the env var happening to be unset in the test process.)
+    // no user `defineServer` entries AND no baked revalidate-secret define —
+    // only the built-in NEXT_RUNTIME define is present.
     const prev = process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
     delete process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
 
@@ -242,7 +292,13 @@ describe("compiler.define forwarding to Vite", () => {
         { command: "build" },
       );
       const rscResult = serverDefinePlugin!.configEnvironment!("rsc", {}, { command: "build" });
-      expect(rscResult).toBeNull();
+      // NEXT_RUNTIME is always injected for server environments, so the hook
+      // always returns a define object (never null) even without user defineServer.
+      expect(rscResult).not.toBeNull();
+      expect(rscResult?.define?.["process.env.NEXT_RUNTIME"]).toBe('"nodejs"');
+      // No other keys should be present when neither defineServer nor revalidate
+      // secret are configured.
+      expect(Object.keys(rscResult!.define!)).toEqual(["process.env.NEXT_RUNTIME"]);
     } finally {
       if (prev === undefined) delete process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
       else process.env.__VINEXT_SHARED_REVALIDATE_SECRET = prev;


### PR DESCRIPTION
**Partial fix for #1365** (does NOT fully close it).

**Failing tests addressed (nodejs runtime):** `test/e2e/app-dir/next-after-app-deploy` — `after() in nodejs runtime > triggers revalidate from a page / server action / route handler`.

**Root cause:** vinext never defined `process.env.NEXT_RUNTIME`. The deploy fixture's `path-prefix.js` (`'/' + process.env.NEXT_RUNTIME`) evaluated to `/undefined`, so `after()` callbacks called `revalidatePath` with the wrong path and ISR was never invalidated.

**Fix:** one line in `packages/vinext/src/index.ts` — define `process.env.NEXT_RUNTIME = 'nodejs'` for all server environments (excluded from client bundle by the existing guard).

**Out of scope (remains failing → #1365 stays open):** the **edge** runtime variants. vinext compiles a single RSC bundle rather than per-route edge bundles, so `NEXT_RUNTIME='edge'` cannot be stamped per-route — that's a pre-existing architectural limitation tracked as follow-up under #1365.