### PR TITLE
fix(scss): resolve tilde (~) imports from node_modules and project root

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -140,7 +140,7 @@ import {
   VINEXT_CLIENT_ENTRY_MANIFEST,
 } from "./utils/client-entry-manifest.js";
 import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
-import { buildSassPreprocessorOptions } from "./plugins/sass.js";
+import { buildSassPreprocessorOptions, createSassTildeImporter } from "./plugins/sass.js";
 import {
   createClientManualChunks,
   createClientOutputConfig,
@@ -1960,25 +1960,43 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // `css.*`, so we merge them into a single `css` object rather
           // than emitting `{ css: ... }` twice (the second would clobber
           // the first).
-          ...(postcssOverride || sassPreprocessorOptions
-            ? {
-                css: {
-                  ...(postcssOverride ? { postcss: postcssOverride } : {}),
-                  ...(sassPreprocessorOptions
-                    ? {
-                        preprocessorOptions: {
-                          // Apply the same options to both `.scss` and `.sass`
-                          // entry points. Next.js's sass-loader rule matches
-                          // /\.s[ca]ss$/, so a single `sassOptions` block
-                          // covers both syntaxes there too.
-                          scss: sassPreprocessorOptions,
-                          sass: sassPreprocessorOptions,
-                        },
-                      }
-                    : {}),
-                },
-              }
-            : {}),
+          //
+          // The tilde importer is ALWAYS injected so that SCSS files can use
+          // webpack-style `~pkg/file` (node_modules) and `~/path` (root)
+          // imports that Next.js (sass-loader) supports out of the box.
+          // See: test/e2e/app-dir/scss/npm-import-tilde and #1825.
+          css: {
+            ...(postcssOverride ? { postcss: postcssOverride } : {}),
+            preprocessorOptions: (() => {
+              // Tilde importer: strip the leading ~ and resolve the rest
+              // either from node_modules (~pkg/...) or project root (~/).
+              // Placed first so it runs before Vite's own internal importer,
+              // which is appended at the end of `importers[]` by the vite:css
+              // plugin (vite/src/node/plugins/css.ts makeScssWorker).
+              const tildeImporter = createSassTildeImporter(root);
+
+              // Base options shared by both .scss and .sass preprocessors.
+              const baseOpts = {
+                ...sassPreprocessorOptions,
+                // Merge user-supplied importers (from sassOptions) with the
+                // tilde importer. Tilde goes first so it gets first crack at
+                // ~ prefixed URLs; other importers follow; Vite's own internal
+                // importer is appended last by the vite:css plugin.
+                importers: [
+                  tildeImporter,
+                  ...((sassPreprocessorOptions?.importers as unknown[]) ?? []),
+                ],
+              };
+
+              return {
+                // Apply the same options to both `.scss` and `.sass` entry
+                // points. Next.js's sass-loader rule matches /\.s[ca]ss$/,
+                // so a single `sassOptions` block covers both syntaxes there.
+                scss: baseOpts,
+                sass: baseOpts,
+              };
+            })(),
+          },
         };
 
         // Collect user-provided ssr.external so we can propagate it into

--- a/packages/vinext/src/plugins/sass.ts
+++ b/packages/vinext/src/plugins/sass.ts
@@ -21,6 +21,11 @@
  *
  * @see https://vite.dev/config/shared-options.html#css-preprocessoroptions
  */
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+
 type AdditionalData = string | ((source: string, filename: string) => string | Promise<string>);
 
 type VitePreprocessorOptions = {
@@ -29,6 +34,98 @@ type VitePreprocessorOptions = {
   // oxlint-disable-next-line typescript/no-explicit-any
   [key: string]: any;
 };
+
+/**
+ * Create a Sass `FileImporter` that resolves webpack-style tilde (`~`) imports.
+ *
+ * Next.js (via sass-loader's `webpackImporter`) supports two tilde forms:
+ *
+ * 1. `~pkg/path` — resolves `pkg/path` from `node_modules`. Used for
+ *    third-party SCSS/CSS, e.g. `@import '~nprogress/nprogress.css'`.
+ *
+ * 2. `~/path` — resolves relative to the **project root** (the `~` acts as
+ *    an alias for the root). Used with Turbopack's `resolveAlias: { '~*': '*' }`
+ *    convention, e.g. `@use '~/styles/variables' as *`.
+ *
+ * Vite's built-in Sass resolver does not strip the `~` prefix, so any SCSS
+ * that uses tilde imports fails with "Can't find stylesheet to import" errors.
+ * This `FileImporter` runs before Vite's internal importer (added at the end
+ * of `importers[]` in the vite:css plugin) and canonicalises tilde URLs so
+ * Sass can load them from the filesystem.
+ *
+ * The returned object implements the modern Sass `FileImporter` interface:
+ * `findFileUrl` returns a `file://` URL and Sass automatically handles partial
+ * resolution (`_variables.scss` for `variables`), index files, and extensions.
+ *
+ * @param root - Absolute path to the Vite project root (used as the base for
+ *   `~/path` resolution and for locating `node_modules`).
+ */
+export function createSassTildeImporter(root: string): { findFileUrl(url: string): URL | null } {
+  // Base URL for root-relative (~/) imports. Must end with "/" so new URL()
+  // treats it as a directory and resolves relative paths correctly.
+  const rootBaseUrl = pathToFileURL(root.endsWith("/") ? root : root + "/");
+
+  // Base URL for node_modules imports. The trailing "/" is critical for
+  // new URL(spec, base) to keep the spec as a relative path inside the dir.
+  const nodeModulesBaseUrl = pathToFileURL(path.join(root, "node_modules") + "/");
+
+  return {
+    findFileUrl(url: string): URL | null {
+      if (!url.startsWith("~")) return null;
+
+      const stripped = url.slice(1); // Remove the leading "~"
+
+      if (stripped.startsWith("/")) {
+        // Form: ~/path/to/file  →  root-relative
+        // stripped = "/path/to/file", we want "<root>/path/to/file"
+        // Slice the leading "/" to make it a relative-to-base URL.
+        return new URL(stripped.slice(1), rootBaseUrl);
+      }
+
+      if (!stripped) {
+        // Bare "~" with nothing after it — not a valid import, skip.
+        return null;
+      }
+
+      // Form: ~pkg/path  →  node_modules resolution
+      // Try the simple path first: root/node_modules/pkg/path
+      const simpleResolved = new URL(stripped, nodeModulesBaseUrl);
+
+      // Verify the package directory exists in root's node_modules before
+      // returning; if not found there, fall back to Node.js module resolution
+      // which walks up the directory tree (handles hoisted pnpm graphs, etc.).
+      const pkgName = stripped.startsWith("@")
+        ? stripped.split("/").slice(0, 2).join("/")
+        : (stripped.split("/")[0] ?? "");
+
+      const directPkgDir = path.join(root, "node_modules", pkgName);
+      if (pkgName && fs.existsSync(directPkgDir)) {
+        // Fast path: package is at root/node_modules/<pkg>
+        return simpleResolved;
+      }
+
+      // Slow path: use Node.js module resolution to locate the package.
+      // This handles pnpm's virtual store layout, yarn PnP, and workspaces
+      // where packages aren't necessarily at <root>/node_modules/<pkg>.
+      const req = createRequire(path.join(root, "package.json"));
+      try {
+        const pkgJsonPath = req.resolve(`${pkgName}/package.json`);
+        const pkgDir = path.dirname(pkgJsonPath);
+        // Build the URL by replacing the package-name segment with the
+        // resolved absolute package directory path.
+        const afterPkg = stripped.startsWith("@")
+          ? stripped.split("/").slice(2).join("/")
+          : stripped.split("/").slice(1).join("/");
+        const resolvedPath = afterPkg ? path.join(pkgDir, afterPkg) : pkgDir;
+        return pathToFileURL(resolvedPath);
+      } catch {
+        // Package not found via Node.js resolution either — let Sass/Vite's
+        // default resolver handle (or report an error for) this import.
+        return null;
+      }
+    },
+  };
+}
 
 export function buildSassPreprocessorOptions(
   sassOptions: Record<string, unknown> | null | undefined,

--- a/tests/sass-options.test.ts
+++ b/tests/sass-options.test.ts
@@ -26,7 +26,6 @@ import {
   buildSassPreprocessorOptions,
   createSassTildeImporter,
 } from "../packages/vinext/src/plugins/sass.js";
-import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
 // The vinext config hook mutates process.env.NODE_ENV as a side effect.
@@ -143,10 +142,7 @@ describe("createSassTildeImporter", () => {
     await fsp.mkdir(path.join(tmpRoot, "node_modules", "mypkg"), { recursive: true });
     await fsp.writeFile(path.join(tmpRoot, "node_modules", "mypkg", "index.scss"), "");
     await fsp.mkdir(path.join(tmpRoot, "node_modules", "@scope", "pkg"), { recursive: true });
-    await fsp.writeFile(
-      path.join(tmpRoot, "node_modules", "@scope", "pkg", "styles.scss"),
-      "",
-    );
+    await fsp.writeFile(path.join(tmpRoot, "node_modules", "@scope", "pkg", "styles.scss"), "");
     // Create styles/variables.scss for root-relative resolution
     await fsp.mkdir(path.join(tmpRoot, "styles"), { recursive: true });
     await fsp.writeFile(path.join(tmpRoot, "styles", "variables.scss"), "$color: red;");
@@ -265,8 +261,10 @@ describe("vinext config hook threads sassOptions into css.preprocessorOptions", 
     const opts = (css as any)?.preprocessorOptions;
     expect(opts).toBeDefined();
     // oxlint-disable-next-line typescript/no-explicit-any
-    expect((opts?.scss?.importers as any[]).length).toBeGreaterThanOrEqual(1);
+    const scssImporters: any[] = opts.scss.importers;
+    expect(scssImporters.length).toBeGreaterThanOrEqual(1);
     // oxlint-disable-next-line typescript/no-explicit-any
-    expect((opts?.sass?.importers as any[]).length).toBeGreaterThanOrEqual(1);
+    const sassImporters: any[] = opts.sass.importers;
+    expect(sassImporters.length).toBeGreaterThanOrEqual(1);
   }, 15000);
 });

--- a/tests/sass-options.test.ts
+++ b/tests/sass-options.test.ts
@@ -22,7 +22,12 @@ import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
 import path from "node:path";
 import os from "node:os";
 import fsp from "node:fs/promises";
-import { buildSassPreprocessorOptions } from "../packages/vinext/src/plugins/sass.js";
+import {
+  buildSassPreprocessorOptions,
+  createSassTildeImporter,
+} from "../packages/vinext/src/plugins/sass.js";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 
 // The vinext config hook mutates process.env.NODE_ENV as a side effect.
 // Save/restore so tests that call config() don't leak between files.
@@ -128,6 +133,76 @@ describe("buildSassPreprocessorOptions", () => {
   });
 });
 
+describe("createSassTildeImporter", () => {
+  let tmpRoot: string;
+  let importer: ReturnType<typeof createSassTildeImporter>;
+
+  beforeEach(async () => {
+    tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-tilde-"));
+    // Create node_modules/mypkg/index.scss so the fast-path can find it
+    await fsp.mkdir(path.join(tmpRoot, "node_modules", "mypkg"), { recursive: true });
+    await fsp.writeFile(path.join(tmpRoot, "node_modules", "mypkg", "index.scss"), "");
+    await fsp.mkdir(path.join(tmpRoot, "node_modules", "@scope", "pkg"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpRoot, "node_modules", "@scope", "pkg", "styles.scss"),
+      "",
+    );
+    // Create styles/variables.scss for root-relative resolution
+    await fsp.mkdir(path.join(tmpRoot, "styles"), { recursive: true });
+    await fsp.writeFile(path.join(tmpRoot, "styles", "variables.scss"), "$color: red;");
+    importer = createSassTildeImporter(tmpRoot);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("returns null for URLs without a leading tilde", () => {
+    expect(importer.findFileUrl("styles/variables")).toBeNull();
+    expect(importer.findFileUrl("./local")).toBeNull();
+    expect(importer.findFileUrl("mypkg/index")).toBeNull();
+  });
+
+  it("returns null for a bare tilde with no path", () => {
+    expect(importer.findFileUrl("~")).toBeNull();
+  });
+
+  it("resolves ~/path relative to the project root", () => {
+    const result = importer.findFileUrl("~/styles/variables");
+    expect(result).not.toBeNull();
+    const resolved = fileURLToPath(result!.href);
+    // Should point to <root>/styles/variables (Sass will add .scss extension)
+    expect(resolved).toBe(path.join(tmpRoot, "styles/variables"));
+  });
+
+  it("resolves ~pkg/path via node_modules fast-path", () => {
+    const result = importer.findFileUrl("~mypkg/index.scss");
+    expect(result).not.toBeNull();
+    const resolved = fileURLToPath(result!.href);
+    expect(resolved).toBe(path.join(tmpRoot, "node_modules", "mypkg", "index.scss"));
+  });
+
+  it("resolves scoped packages ~@scope/pkg/styles.scss", () => {
+    const result = importer.findFileUrl("~@scope/pkg/styles.scss");
+    expect(result).not.toBeNull();
+    const resolved = fileURLToPath(result!.href);
+    expect(resolved).toBe(path.join(tmpRoot, "node_modules", "@scope", "pkg", "styles.scss"));
+  });
+
+  it("returns null for unknown packages not in node_modules", () => {
+    // 'nonexistent-pkg' has no directory in tmpRoot/node_modules, and
+    // createRequire resolution will also fail.
+    const result = importer.findFileUrl("~nonexistent-pkg/styles.scss");
+    expect(result).toBeNull();
+  });
+
+  it("returns a file: URL object (not a plain string)", () => {
+    const result = importer.findFileUrl("~/styles/variables");
+    expect(result).toBeInstanceOf(URL);
+    expect(result?.protocol).toBe("file:");
+  });
+});
+
 describe("vinext config hook threads sassOptions into css.preprocessorOptions", () => {
   async function runConfigHook(
     nextConfigSrc: string,
@@ -180,11 +255,18 @@ describe("vinext config hook threads sassOptions into css.preprocessorOptions", 
     expect((css as any)?.preprocessorOptions?.scss?.loadPaths).toEqual(["./styles"]);
   }, 15000);
 
-  it("does not set preprocessorOptions when sassOptions is absent", async () => {
+  it("always sets preprocessorOptions (tilde importer is always injected)", async () => {
     const css = await runConfigHook(`export default {};`);
-    // css may still be set if there is a postcss override, but preprocessorOptions
-    // should not appear.
+    // preprocessorOptions is ALWAYS set — even without sassOptions — because
+    // vinext injects the tilde importer unconditionally so that SCSS files can
+    // use webpack-style ~pkg/file and ~/path imports (Next.js / sass-loader
+    // behaviour). See: packages/vinext/src/plugins/sass.ts#createSassTildeImporter
     // oxlint-disable-next-line typescript/no-explicit-any
-    expect((css as any)?.preprocessorOptions).toBeUndefined();
+    const opts = (css as any)?.preprocessorOptions;
+    expect(opts).toBeDefined();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((opts?.scss?.importers as any[]).length).toBeGreaterThanOrEqual(1);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect((opts?.sass?.importers as any[]).length).toBeGreaterThanOrEqual(1);
   }, 15000);
 });


### PR DESCRIPTION
**Partial fix for #1825** (does NOT fully close it).

Adds a Sass `~` tilde `FileImporter` (`packages/vinext/src/plugins/sass.ts`) + always-injects `css.preprocessorOptions`, so node_modules **tilde** imports resolve.

**Covered:** `npm-import-tilde` (`~pkg/...`) and `~/...` root-relative.

**NOT covered (remains failing → #1825 stays open):** `nm-module`, `nm-module-nested` (CSS Modules imported from node_modules *without* a tilde) and `composes-external` (`composes: x from 'pkg'`). Those go through Vite's native resolver, not this importer, and need separate investigation.

---
**Design notes (per review):**
- **`~/path` → root-relative** is a deliberate divergence from literal sass-loader behavior (which just strips `~` and defers to the bundler resolver). vinext resolves `~/` against the project root, matching Turbopack's `resolveAlias` convention. Intentional.
- **Importer ordering:** the tilde `FileImporter` is injected first, before Vite's internal importer and any user-supplied `sassOptions.importers`; a user-supplied competing `~` importer would run after this one.