### PR TITLE
refactor(app-router): extract browser history traversal into AppBrowserHistoryController

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -112,13 +112,9 @@ import {
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createBfcacheSegmentStateKeyMap,
-  createHistoryStateWithNavigationMetadata,
   createInitialBfcacheIdMap,
   isCacheRestorableAppPayloadMetadata,
-  readHistoryStateBfcacheIds,
   readHistoryStatePreviousNextUrl,
-  readHistoryStateTraversalIndex,
-  resolveHistoryTraversalIntent,
   resolveInterceptionContextFromPreviousNextUrl,
   resolveServerActionRequestState,
   type AppNavigationPayloadOrigin,
@@ -126,7 +122,7 @@ import {
   type HistoryTraversalIntent,
   type OperationLane,
 } from "./app-browser-state.js";
-import { RestorableClientStateController } from "./app-history-state.js";
+import { AppBrowserHistoryController } from "./app-browser-history-controller.js";
 import {
   createVisitedResponseCacheEntry,
   isVisitedResponseCacheEntryFresh,
@@ -227,10 +223,26 @@ function getBrowserRouteManifest(): RouteManifest | null {
   return getNavigationRuntime()?.bootstrap.routeManifest ?? null;
 }
 
+const MAX_HISTORY_STATE_SNAPSHOTS = 50;
+const historyController = new AppBrowserHistoryController({
+  initialHistoryState: window.history.state,
+  maxHistoryStateSnapshots: MAX_HISTORY_STATE_SNAPSHOTS,
+  readHistoryState: () => window.history.state,
+  readCurrentHref: () => window.location.href,
+  pushHistoryState: (state, href) => pushHistoryStateWithoutNotify(state, "", href),
+  replaceHistoryState: (state, href) => replaceHistoryStateWithoutNotify(state, "", href),
+  readVisibleNavigationMetadata: () => {
+    if (!hasBrowserRouterState()) return null;
+    const routerState = getBrowserRouterState();
+    return { bfcacheIds: routerState.bfcacheIds, previousNextUrl: routerState.previousNextUrl };
+  },
+});
+
 const browserNavigationController = createAppBrowserNavigationController({
   basePath: __basePath,
   getRouteManifest: getBrowserRouteManifest,
-  syncHistoryStatePreviousNextUrl: syncCurrentHistoryStatePreviousNextUrl,
+  syncHistoryStatePreviousNextUrl: (previousNextUrl, bfcacheIds) =>
+    historyController.syncCurrentHistoryStatePreviousNextUrl(previousNextUrl, bfcacheIds),
 });
 const discardedServerActionRefreshScheduler = createDiscardedServerActionRefreshScheduler({
   runRefresh() {
@@ -298,20 +310,12 @@ const mpaNavigationScheduler = new AppBrowserMpaNavigationScheduler();
 const unresolvedMpaNavigation = new Promise<never>(() => {});
 const RSC_HMR_SETTLE_DELAY_MS = 150;
 let latestRscHmrUpdateId = 0;
-let currentHistoryTraversalIndex: number | null =
-  readHistoryStateTraversalIndex(window.history.state) ?? 0;
-let nextHistoryTraversalIndex: number = currentHistoryTraversalIndex;
 // Single-slot latch tracking the navId of the most recent synchronous
 // popstate snapshot restore. activeNavigationId is strictly monotonic, so
 // shouldSkipScrollRestore can only match the most-recently restored
 // navigation. This is intentionally not a per-navigation set — a future
 // asynchronous scroll restore for an older navId is already stale.
 let synchronousPopstateScrollRestoreNavigationId: number | null = null;
-const MAX_HISTORY_STATE_SNAPSHOTS = 50;
-const restorableClientState = new RestorableClientStateController<AppRouterState>({
-  initialHistoryState: window.history.state,
-  maxHistoryStateSnapshots: MAX_HISTORY_STATE_SNAPSHOTS,
-});
 
 // Vite can notify the browser about an RSC HMR update before the dev server's
 // request runner has swapped to the invalidated module graph. Give the
@@ -323,110 +327,20 @@ function waitForRscHmrSettle(delayMs = RSC_HMR_SETTLE_DELAY_MS): Promise<void> {
   });
 }
 
-function allocateNavigationHistoryTraversalIndex(
-  historyUpdateMode: HistoryUpdateMode | undefined,
-): number | null {
-  switch (historyUpdateMode) {
-    case "push":
-      return nextHistoryTraversalIndex + 1;
-    case "replace":
-      return currentHistoryTraversalIndex;
-    case undefined:
-      return null;
-    default: {
-      const _exhaustive: never = historyUpdateMode;
-      throw new Error("[vinext] Unknown history update mode: " + String(_exhaustive));
-    }
-  }
-}
-
-function commitHistoryTraversalIndex(index: number | null): void {
-  currentHistoryTraversalIndex = index;
-  if (index !== null) {
-    // Keep allocation anchored to the highest app-owned entry we know about.
-    // Traversing to metadata-less entries makes the current index unknown, but
-    // the next app-owned push should still continue from known app history.
-    nextHistoryTraversalIndex = Math.max(nextHistoryTraversalIndex, index);
-  }
-}
-
-function commitHashOnlyNavigation(
-  href: string,
-  historyUpdateMode: Exclude<HistoryUpdateMode, undefined>,
-  scroll: boolean,
-): void {
-  const navigationHistoryIndex = allocateNavigationHistoryTraversalIndex(historyUpdateMode);
-  const previousNextUrl = hasBrowserRouterState()
-    ? getBrowserRouterState().previousNextUrl
-    : readHistoryStatePreviousNextUrl(window.history.state);
-  const bfcacheIds = hasBrowserRouterState()
-    ? getBrowserRouterState().bfcacheIds
-    : restorableClientState.readCurrentBfcacheVersionHistoryIds(window.history.state);
-  const historyState = createHistoryStateWithNavigationMetadata(
-    createHashOnlyNavigationBaseHistoryState(historyUpdateMode, scroll),
-    {
-      bfcacheIds,
-      bfcacheVersion: bfcacheIds === null ? undefined : restorableClientState.currentBfcacheVersion,
-      previousNextUrl,
-      traversalIndex: navigationHistoryIndex,
-    },
-  );
-
-  if (historyUpdateMode === "replace") {
-    replaceHistoryStateWithoutNotify(historyState, "", href);
-  } else {
-    pushHistoryStateWithoutNotify(historyState, "", href);
-  }
-  commitHistoryTraversalIndex(navigationHistoryIndex);
-}
-
-function createHashOnlyNavigationBaseHistoryState(
-  historyUpdateMode: Exclude<HistoryUpdateMode, undefined>,
-  scroll: boolean,
-): unknown {
-  if (historyUpdateMode !== "replace") {
-    return null;
-  }
-  return scroll ? stripVinextScrollState(window.history.state) : window.history.state;
-}
-
-function stripVinextScrollState(state: unknown): unknown {
-  if (!state || typeof state !== "object") {
-    return state;
-  }
-
-  const nextState: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(state)) {
-    if (key === "__vinext_scrollX" || key === "__vinext_scrollY") {
-      continue;
-    }
-    nextState[key] = value;
-  }
-
-  return Object.keys(nextState).length > 0 ? nextState : null;
-}
-
-function commitTraversalIndexFromHistoryState(historyState: unknown): void {
-  commitHistoryTraversalIndex(readHistoryStateTraversalIndex(historyState));
-}
-
 function restoreHistoryStateSnapshot(historyState: unknown): boolean {
-  const decision = restorableClientState.resolveHistoryStateSnapshotRestore(historyState);
-  if (decision.kind === "skip") {
-    return false;
-  }
-
   const navId = browserNavigationController.getActiveNavigationId();
   let restored = false;
   flushSync(() => {
-    restored = browserNavigationController.restoreHistorySnapshotVisibleState({
-      beforeCommit: () => {
-        commitHistoryTraversalIndex(decision.targetHistoryIndex);
-        stageClientParams(decision.state.navigationSnapshot.params);
-      },
-      navId,
-      state: decision.state,
-      targetHref: window.location.href,
+    restored = historyController.restoreHistorySnapshot({
+      historyState,
+      stageClientParams,
+      approveVisibleRestore: ({ state, beforeCommit }) =>
+        browserNavigationController.restoreHistorySnapshotVisibleState({
+          beforeCommit,
+          navId,
+          state,
+          targetHref: window.location.href,
+        }),
     });
   });
   if (!restored) return false;
@@ -479,7 +393,7 @@ function clearPrefetchState(): void {
 function clearClientNavigationCaches(): void {
   clearVisitedResponseCache();
   clearPrefetchState();
-  restorableClientState.invalidateClientState();
+  historyController.invalidateRestorableClientState();
 }
 
 function isSettledPrefetchCacheEntry(
@@ -582,67 +496,6 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
   await Promise.allSettled(learning);
 }
 
-function areBfcacheIdMapsEqual(
-  a: Readonly<Record<string, string>> | null,
-  b: Readonly<Record<string, string>> | null,
-): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  const aEntries = Object.entries(a);
-  const bEntries = Object.entries(b);
-  if (aEntries.length !== bEntries.length) return false;
-  // Equal lengths make this bidirectional: if every a entry exists in b with
-  // the same value, b cannot contain an extra distinct key.
-  return aEntries.every(([key, value]) => b[key] === value);
-}
-
-function isHistoryStateNavigationMetadataInSync(
-  state: unknown,
-  previousNextUrl: string | null,
-  bfcacheIds?: Readonly<Record<string, string>> | null,
-): boolean {
-  return (
-    readHistoryStatePreviousNextUrl(state) === previousNextUrl &&
-    (bfcacheIds === undefined ||
-      (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(state), bfcacheIds) &&
-        restorableClientState.isCurrentBfcacheVersion(state)))
-  );
-}
-
-function syncCurrentHistoryStatePreviousNextUrl(
-  previousNextUrl: string | null,
-  bfcacheIds?: Readonly<Record<string, string>> | null,
-): void {
-  if (isHistoryStateNavigationMetadataInSync(window.history.state, previousNextUrl, bfcacheIds)) {
-    return;
-  }
-
-  const nextHistoryState = createHistoryStateWithNavigationMetadata(window.history.state, {
-    bfcacheIds,
-    bfcacheVersion:
-      bfcacheIds === undefined ? undefined : restorableClientState.currentBfcacheVersion,
-    previousNextUrl,
-  });
-  // First attempt: use replaceHistoryStateWithoutNotify which fires no popstate
-  // or hashchange events. If the browser accepted the state update (checked via
-  // readHistoryStatePreviousNextUrl), we're done. The double-read is needed
-  // because some browsers (notably Safari) can silently coalesce or ignore
-  // replaceState calls when called in rapid succession (e.g. back-to-back
-  // navigation commits). The fallback fires only when the state didn't stick.
-  replaceHistoryStateWithoutNotify(nextHistoryState, "", window.location.href);
-  if (isHistoryStateNavigationMetadataInSync(window.history.state, previousNextUrl, bfcacheIds)) {
-    return;
-  }
-  // Retry via the same notify-suppressing path rather than the patched
-  // window.history.replaceState. This is a URL-unchanged metadata sync (refresh
-  // or traversal commit), so it must not run the patched-path side effects —
-  // commitClientNavigationState and notifyLinkNavigationStart — which would
-  // otherwise clear an unrelated <Link>'s useLinkStatus() pending state mid
-  // navigation on Safari. The browser sees the same native replaceState call,
-  // so the retry behaviour is unchanged.
-  replaceHistoryStateWithoutNotify(nextHistoryState, "", window.location.href);
-}
-
 function createActionInitiationSnapshot() {
   const routerState = getBrowserRouterState();
   return createServerActionInitiationSnapshot({
@@ -683,44 +536,14 @@ function createNavigationCommitEffect(options: {
       return;
     }
 
-    const targetHref = new URL(href, window.location.origin).href;
-    const preserveExistingState = historyUpdateMode === "replace";
-    const navigationHistoryIndex =
-      targetHistoryIndex !== undefined
-        ? targetHistoryIndex
-        : allocateNavigationHistoryTraversalIndex(historyUpdateMode);
-    const historyState = createHistoryStateWithNavigationMetadata(
-      preserveExistingState ? window.history.state : null,
-      {
-        bfcacheIds,
-        bfcacheVersion: restorableClientState.currentBfcacheVersion,
-        previousNextUrl,
-        traversalIndex: navigationHistoryIndex,
-      },
-    );
-
-    let wroteHistoryState = false;
-    if (historyUpdateMode === "replace" && window.location.href !== targetHref) {
-      stageClientParams(params);
-      replaceHistoryStateWithoutNotify(historyState, "", href);
-      wroteHistoryState = true;
-      commitHistoryTraversalIndex(navigationHistoryIndex);
-    } else if (historyUpdateMode === "push" && window.location.href !== targetHref) {
-      stageClientParams(params);
-      pushHistoryStateWithoutNotify(historyState, "", href);
-      wroteHistoryState = true;
-      commitHistoryTraversalIndex(navigationHistoryIndex);
-    }
-
-    if (!wroteHistoryState) {
-      // Traversal and refresh commits may keep the URL unchanged, but still
-      // persist the latest bfcache id map for future history restoration.
-      syncCurrentHistoryStatePreviousNextUrl(previousNextUrl, bfcacheIds);
-      stageClientParams(params);
-      if (targetHistoryIndex !== undefined) {
-        commitHistoryTraversalIndex(targetHistoryIndex);
-      }
-    }
+    historyController.commitNavigationHistory({
+      bfcacheIds,
+      href,
+      historyUpdateMode,
+      previousNextUrl,
+      stageClientParams: () => stageClientParams(params),
+      targetHistoryIndex,
+    });
 
     // URL has been updated; the recovery hard-nav target is no longer needed.
     pendingNavigationRecoveryHref = null;
@@ -1214,18 +1037,15 @@ function BrowserRoot({
     };
   }, [setTreeStateValue]);
 
-  // This effect keys the snapshot by currentHistoryTraversalIndex but only
-  // depends on [treeState]. The ordering works because
-  // commitHistoryTraversalIndex runs inside the navigation commit effect
-  // (before setTreeStateValue fires), so the index is already current when
-  // this layout effect runs for the new treeState. If the commit ordering
-  // ever changes, the snapshot index may not match the traversed history
-  // entry, causing resolveRestore to read the wrong index on back.
+  // This effect snapshots treeState against the controller's current traversal
+  // index but only depends on [treeState]. The ordering works because the
+  // traversal-index commit runs inside the navigation commit effect (before
+  // setTreeStateValue fires), so the index is already current when this layout
+  // effect runs for the new treeState. If the commit ordering ever changes, the
+  // snapshot index may not match the traversed history entry, causing
+  // resolveRestore to read the wrong index on back.
   useLayoutEffect(() => {
-    restorableClientState.rememberHistoryStateSnapshot({
-      historyIndex: currentHistoryTraversalIndex,
-      state: treeState,
-    });
+    historyController.rememberHistoryStateSnapshot(treeState);
   }, [treeState]);
 
   useLayoutEffect(() => {
@@ -1239,16 +1059,10 @@ function BrowserRoot({
       return;
     }
 
-    replaceHistoryStateWithoutNotify(
-      createHistoryStateWithNavigationMetadata(window.history.state, {
-        bfcacheIds: treeState.bfcacheIds,
-        bfcacheVersion: restorableClientState.currentBfcacheVersion,
-        previousNextUrl: treeState.previousNextUrl,
-        traversalIndex: currentHistoryTraversalIndex,
-      }),
-      "",
-      window.location.href,
-    );
+    historyController.writeHydratedHistoryMetadata({
+      bfcacheIds: treeState.bfcacheIds,
+      previousNextUrl: treeState.previousNextUrl,
+    });
   }, [treeState.bfcacheIds, treeState.previousNextUrl, treeState.renderId]);
 
   const routeTree = createElement(
@@ -1552,7 +1366,7 @@ function registerServerActionCallback(): void {
     const actionInitiation = createActionInitiationSnapshot();
     // Keep history aligned with the captured snapshot. Action POST headers
     // read from actionInitiation, not from history, after this point.
-    syncCurrentHistoryStatePreviousNextUrl(
+    historyController.syncCurrentHistoryStatePreviousNextUrl(
       actionInitiation.routerState.previousNextUrl,
       actionInitiation.routerState.bfcacheIds,
     );
@@ -1740,7 +1554,7 @@ function registerServerActionCallback(): void {
   };
 
   setServerCallback((id, args) => {
-    const releaseCacheInvalidationGuard = restorableClientState.beginCacheInvalidationGuard();
+    const releaseCacheInvalidationGuard = historyController.beginCacheInvalidationGuard();
     return Promise.resolve()
       .then(() => serverActionCallback(id, args))
       .finally(releaseCacheInvalidationGuard);
@@ -1772,14 +1586,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     window.location.href,
     latestClientParams,
   );
-  replaceHistoryStateWithoutNotify(
-    createHistoryStateWithNavigationMetadata(window.history.state, {
-      previousNextUrl: null,
-      traversalIndex: currentHistoryTraversalIndex,
-    }),
-    "",
-    window.location.href,
-  );
+  historyController.writeBootstrapHistoryMetadata();
 
   // In dev we route uncaught errors into the dev overlay rather than the
   // hard-nav recovery: the overlay is what the developer needs to see, and a
@@ -1835,11 +1642,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     let detachedNavigationCommits = false;
     const activeTraversalIntent =
       navigationKind === "traverse"
-        ? (traversalIntent ??
-          resolveHistoryTraversalIntent({
-            currentHistoryIndex: currentHistoryTraversalIndex,
-            historyState: window.history.state,
-          }))
+        ? (traversalIntent ?? historyController.resolveTraversalIntent(window.history.state))
         : null;
     const performHardNavigationForScrollIntent = (targetHref: string): boolean => {
       consumeAppRouterScrollIntent(scrollIntent ?? null);
@@ -1855,14 +1658,14 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     // pattern, and not a regression.
     let restoredBfcacheIds =
       navigationKind === "traverse"
-        ? restorableClientState.readCurrentBfcacheVersionHistoryIds(
+        ? historyController.readCurrentBfcacheVersionHistoryIds(
             activeTraversalIntent?.historyState ?? window.history.state,
           )
         : null;
     const reuseCurrentBfcacheIds =
       navigationKind !== "traverse" ||
-      (!restorableClientState.isCacheInvalidationGuarded() &&
-        restorableClientState.isCurrentBfcacheVersion(
+      (!historyController.isCacheInvalidationGuarded() &&
+        historyController.isCurrentBfcacheVersion(
           activeTraversalIntent?.historyState ?? window.history.state,
         ));
     try {
@@ -1889,7 +1692,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         const requestInterceptionContext = requestState.interceptionContext;
         const requestPreviousNextUrl = requestState.previousNextUrl;
         if (navigationKind === "refresh") {
-          syncCurrentHistoryStatePreviousNextUrl(
+          historyController.syncCurrentHistoryStatePreviousNextUrl(
             requestPreviousNextUrl,
             getBrowserRouterState().bfcacheIds,
           );
@@ -2360,7 +2163,8 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   // the browser entry share a single App Router capability contract.
   registerNavigationRuntimeFunctions({
     clearNavigationCaches: clearClientNavigationCaches,
-    commitHashNavigation: commitHashOnlyNavigation,
+    commitHashNavigation: (href, historyUpdateMode, scroll) =>
+      historyController.commitHashOnlyNavigation(href, historyUpdateMode, scroll),
     navigate: navigateRsc,
   });
 
@@ -2398,7 +2202,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     const href = window.location.href;
     if (isSameAppRoutePopstateTarget(href)) {
       notifyAppRouterTransitionStart(href, "traverse");
-      commitTraversalIndexFromHistoryState(event.state);
+      historyController.commitTraversalIndexFromHistoryState(event.state);
       restorePopstateScrollPosition(event.state);
       return;
     }

--- a/packages/vinext/src/server/app-browser-history-controller.ts
+++ b/packages/vinext/src/server/app-browser-history-controller.ts
@@ -1,0 +1,407 @@
+import {
+  RestorableClientStateController,
+  createHistoryStateWithNavigationMetadata,
+  readHistoryStateBfcacheIds,
+  readHistoryStatePreviousNextUrl,
+  readHistoryStateTraversalIndex,
+  resolveHistoryTraversalIntent,
+  type BfcacheIdMap,
+  type HistoryTraversalIntent,
+} from "./app-history-state.js";
+import type { AppRouterState } from "./app-browser-state.js";
+import type { HistoryUpdateMode } from "./app-browser-navigation-controller.js";
+
+/**
+ * Visible router-state metadata at the instant a hash-only navigation commits.
+ * `null` means the browser router tree has not committed yet, so the controller
+ * falls back to reading the same facts off the live history entry.
+ */
+type VisibleNavigationMetadata = {
+  bfcacheIds: BfcacheIdMap | null;
+  previousNextUrl: string | null;
+};
+
+type AppBrowserHistoryControllerDeps = {
+  initialHistoryState: unknown;
+  maxHistoryStateSnapshots: number;
+  /** Reads `window.history.state`. Injected so the controller stays unit-testable. */
+  readHistoryState: () => unknown;
+  /** Reads `window.location.href`. Injected so the controller stays unit-testable. */
+  readCurrentHref: () => string;
+  /** Wraps `pushHistoryStateWithoutNotify(state, "", href)`. */
+  pushHistoryState: (state: unknown, href: string) => void;
+  /** Wraps `replaceHistoryStateWithoutNotify(state, "", href)`. */
+  replaceHistoryState: (state: unknown, href: string) => void;
+  readVisibleNavigationMetadata: () => VisibleNavigationMetadata | null;
+};
+
+/**
+ * Candidate visible state resolved from a restorable history snapshot, handed to
+ * the entry's approved-visible-restore callback. The controller resolves the
+ * candidate and owns the traversal-index commit; the entry owns the actual
+ * `AppBrowserNavigationController.restoreHistorySnapshotVisibleState()` call and
+ * the `ApprovedVisibleCommit` boundary.
+ */
+export type RestorableSnapshotCandidate = {
+  state: AppRouterState;
+  beforeCommit: () => void;
+};
+
+type RestoreHistorySnapshotOptions = {
+  historyState: unknown;
+  stageClientParams: (params: Record<string, string | string[]>) => void;
+  approveVisibleRestore: (candidate: RestorableSnapshotCandidate) => boolean;
+};
+
+type CommitNavigationHistoryOptions = {
+  bfcacheIds: BfcacheIdMap;
+  href: string;
+  historyUpdateMode: HistoryUpdateMode | undefined;
+  previousNextUrl: string | null;
+  targetHistoryIndex?: number | null;
+  stageClientParams: () => void;
+};
+
+function stripVinextScrollState(state: unknown): unknown {
+  if (!state || typeof state !== "object") {
+    return state;
+  }
+
+  const nextState: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(state)) {
+    if (key === "__vinext_scrollX" || key === "__vinext_scrollY") {
+      continue;
+    }
+    nextState[key] = value;
+  }
+
+  return Object.keys(nextState).length > 0 ? nextState : null;
+}
+
+/**
+ * Owns App Router browser-history metadata and traversal bookkeeping behind a
+ * typed seam: traversal index allocation/commit, push/replace/traverse/hash-only
+ * history-state writes, BFCache epoch/snapshot invalidation through
+ * `RestorableClientStateController`, and restorable-snapshot candidate
+ * resolution.
+ *
+ * Ownership boundary: this is not a second router or visible-state authority. It
+ * resolves history facts and delegates visible restoration through an injected
+ * approved-commit callback. It never sets router state directly, never imports
+ * `applyApprovedVisibleCommit()`, and never bypasses the `ApprovedVisibleCommit`
+ * boundary owned by `AppBrowserNavigationController`.
+ */
+export class AppBrowserHistoryController {
+  readonly #restorableClientState: RestorableClientStateController<AppRouterState>;
+  readonly #readHistoryState: () => unknown;
+  readonly #readCurrentHref: () => string;
+  readonly #pushHistoryState: (state: unknown, href: string) => void;
+  readonly #replaceHistoryState: (state: unknown, href: string) => void;
+  readonly #readVisibleNavigationMetadata: () => VisibleNavigationMetadata | null;
+
+  // Highest app-owned traversal index we know about (`#next`) versus the index
+  // of the currently committed entry (`#current`). Traversing to a metadata-less
+  // entry makes `#current` unknown (null), but the next app-owned push must
+  // still continue from the highest known app history.
+  #currentHistoryTraversalIndex: number | null;
+  #nextHistoryTraversalIndex: number;
+
+  constructor(deps: AppBrowserHistoryControllerDeps) {
+    this.#readHistoryState = deps.readHistoryState;
+    this.#readCurrentHref = deps.readCurrentHref;
+    this.#pushHistoryState = deps.pushHistoryState;
+    this.#replaceHistoryState = deps.replaceHistoryState;
+    this.#readVisibleNavigationMetadata = deps.readVisibleNavigationMetadata;
+    this.#restorableClientState = new RestorableClientStateController<AppRouterState>({
+      initialHistoryState: deps.initialHistoryState,
+      maxHistoryStateSnapshots: deps.maxHistoryStateSnapshots,
+    });
+    this.#currentHistoryTraversalIndex =
+      readHistoryStateTraversalIndex(deps.initialHistoryState) ?? 0;
+    this.#nextHistoryTraversalIndex = this.#currentHistoryTraversalIndex;
+  }
+
+  get currentHistoryTraversalIndex(): number | null {
+    return this.#currentHistoryTraversalIndex;
+  }
+
+  allocateNavigationHistoryTraversalIndex(
+    historyUpdateMode: HistoryUpdateMode | undefined,
+  ): number | null {
+    switch (historyUpdateMode) {
+      case "push":
+        return this.#nextHistoryTraversalIndex + 1;
+      case "replace":
+        return this.#currentHistoryTraversalIndex;
+      case undefined:
+        return null;
+      default: {
+        const _exhaustive: never = historyUpdateMode;
+        throw new Error("[vinext] Unknown history update mode: " + String(_exhaustive));
+      }
+    }
+  }
+
+  commitHistoryTraversalIndex(index: number | null): void {
+    this.#currentHistoryTraversalIndex = index;
+    if (index !== null) {
+      this.#nextHistoryTraversalIndex = Math.max(this.#nextHistoryTraversalIndex, index);
+    }
+  }
+
+  commitTraversalIndexFromHistoryState(historyState: unknown): void {
+    this.commitHistoryTraversalIndex(readHistoryStateTraversalIndex(historyState));
+  }
+
+  resolveTraversalIntent(historyState: unknown): HistoryTraversalIntent {
+    return resolveHistoryTraversalIntent({
+      currentHistoryIndex: this.#currentHistoryTraversalIndex,
+      historyState,
+    });
+  }
+
+  // --- BFCache epoch + cache-invalidation delegation ---
+
+  readCurrentBfcacheVersionHistoryIds(historyState: unknown): BfcacheIdMap | null {
+    return this.#restorableClientState.readCurrentBfcacheVersionHistoryIds(historyState);
+  }
+
+  isCacheInvalidationGuarded(): boolean {
+    return this.#restorableClientState.isCacheInvalidationGuarded();
+  }
+
+  isCurrentBfcacheVersion(historyState: unknown): boolean {
+    return this.#restorableClientState.isCurrentBfcacheVersion(historyState);
+  }
+
+  beginCacheInvalidationGuard(): () => void {
+    return this.#restorableClientState.beginCacheInvalidationGuard();
+  }
+
+  invalidateRestorableClientState(): void {
+    this.#restorableClientState.invalidateClientState();
+  }
+
+  rememberHistoryStateSnapshot(state: AppRouterState): void {
+    this.#restorableClientState.rememberHistoryStateSnapshot({
+      historyIndex: this.#currentHistoryTraversalIndex,
+      state,
+    });
+  }
+
+  // --- History metadata writes ---
+
+  commitHashOnlyNavigation(
+    href: string,
+    historyUpdateMode: HistoryUpdateMode,
+    scroll: boolean,
+  ): void {
+    const navigationHistoryIndex = this.allocateNavigationHistoryTraversalIndex(historyUpdateMode);
+    const historyState = this.#readHistoryState();
+    const visible = this.#readVisibleNavigationMetadata();
+    const previousNextUrl = visible
+      ? visible.previousNextUrl
+      : readHistoryStatePreviousNextUrl(historyState);
+    const bfcacheIds = visible
+      ? visible.bfcacheIds
+      : this.#restorableClientState.readCurrentBfcacheVersionHistoryIds(historyState);
+    const nextHistoryState = createHistoryStateWithNavigationMetadata(
+      this.#createHashOnlyNavigationBaseHistoryState(historyUpdateMode, scroll),
+      {
+        bfcacheIds,
+        bfcacheVersion:
+          bfcacheIds === null ? undefined : this.#restorableClientState.currentBfcacheVersion,
+        previousNextUrl,
+        traversalIndex: navigationHistoryIndex,
+      },
+    );
+
+    if (historyUpdateMode === "replace") {
+      this.#replaceHistoryState(nextHistoryState, href);
+    } else {
+      this.#pushHistoryState(nextHistoryState, href);
+    }
+    this.commitHistoryTraversalIndex(navigationHistoryIndex);
+  }
+
+  #createHashOnlyNavigationBaseHistoryState(
+    historyUpdateMode: HistoryUpdateMode,
+    scroll: boolean,
+  ): unknown {
+    if (historyUpdateMode !== "replace") {
+      return null;
+    }
+    const historyState = this.#readHistoryState();
+    return scroll ? stripVinextScrollState(historyState) : historyState;
+  }
+
+  /**
+   * Writes the history entry for an approved push/replace/traverse commit and
+   * advances the traversal index. `stageClientParams` runs at the exact point it
+   * ran inline in the browser-entry commit effect so client-param staging stays
+   * ordered relative to the history write. Mirrors Next.js committing tree state
+   * into the history entry during the navigation commit.
+   */
+  commitNavigationHistory(options: CommitNavigationHistoryOptions): void {
+    const currentHref = this.#readCurrentHref();
+    const origin = new URL(currentHref).origin;
+    const targetHref = new URL(options.href, origin).href;
+    const preserveExistingState = options.historyUpdateMode === "replace";
+    const navigationHistoryIndex =
+      options.targetHistoryIndex !== undefined
+        ? options.targetHistoryIndex
+        : this.allocateNavigationHistoryTraversalIndex(options.historyUpdateMode);
+    const historyState = createHistoryStateWithNavigationMetadata(
+      preserveExistingState ? this.#readHistoryState() : null,
+      {
+        bfcacheIds: options.bfcacheIds,
+        bfcacheVersion: this.#restorableClientState.currentBfcacheVersion,
+        previousNextUrl: options.previousNextUrl,
+        traversalIndex: navigationHistoryIndex,
+      },
+    );
+
+    let wroteHistoryState = false;
+    if (options.historyUpdateMode === "replace" && currentHref !== targetHref) {
+      options.stageClientParams();
+      this.#replaceHistoryState(historyState, options.href);
+      wroteHistoryState = true;
+      this.commitHistoryTraversalIndex(navigationHistoryIndex);
+    } else if (options.historyUpdateMode === "push" && currentHref !== targetHref) {
+      options.stageClientParams();
+      this.#pushHistoryState(historyState, options.href);
+      wroteHistoryState = true;
+      this.commitHistoryTraversalIndex(navigationHistoryIndex);
+    }
+
+    if (!wroteHistoryState) {
+      // Traversal and refresh commits may keep the URL unchanged, but still
+      // persist the latest bfcache id map for future history restoration.
+      this.syncCurrentHistoryStatePreviousNextUrl(options.previousNextUrl, options.bfcacheIds);
+      options.stageClientParams();
+      if (options.targetHistoryIndex !== undefined) {
+        this.commitHistoryTraversalIndex(options.targetHistoryIndex);
+      }
+    }
+  }
+
+  syncCurrentHistoryStatePreviousNextUrl(
+    previousNextUrl: string | null,
+    bfcacheIds?: BfcacheIdMap | null,
+  ): void {
+    if (
+      this.#isHistoryStateNavigationMetadataInSync(
+        this.#readHistoryState(),
+        previousNextUrl,
+        bfcacheIds,
+      )
+    ) {
+      return;
+    }
+
+    const nextHistoryState = createHistoryStateWithNavigationMetadata(this.#readHistoryState(), {
+      bfcacheIds,
+      bfcacheVersion:
+        bfcacheIds === undefined ? undefined : this.#restorableClientState.currentBfcacheVersion,
+      previousNextUrl,
+    });
+    // First attempt: a notify-suppressing replaceState fires no popstate or
+    // hashchange. If the browser accepted it (re-read below), we're done. The
+    // double-read covers Safari silently coalescing back-to-back replaceState
+    // calls (e.g. rapid navigation commits); the fallback fires only when the
+    // state did not stick. The retry stays on the same notify-suppressing path
+    // rather than the patched window.history.replaceState, because this is a
+    // URL-unchanged metadata sync (refresh or traversal commit) that must not
+    // run the patched-path side effects.
+    this.#replaceHistoryState(nextHistoryState, this.#readCurrentHref());
+    if (
+      this.#isHistoryStateNavigationMetadataInSync(
+        this.#readHistoryState(),
+        previousNextUrl,
+        bfcacheIds,
+      )
+    ) {
+      return;
+    }
+    this.#replaceHistoryState(nextHistoryState, this.#readCurrentHref());
+  }
+
+  #isHistoryStateNavigationMetadataInSync(
+    state: unknown,
+    previousNextUrl: string | null,
+    bfcacheIds?: BfcacheIdMap | null,
+  ): boolean {
+    return (
+      readHistoryStatePreviousNextUrl(state) === previousNextUrl &&
+      (bfcacheIds === undefined ||
+        (areBfcacheIdMapsEqual(readHistoryStateBfcacheIds(state), bfcacheIds) &&
+          this.#restorableClientState.isCurrentBfcacheVersion(state)))
+    );
+  }
+
+  /** Initial history write performed before hydration starts. */
+  writeBootstrapHistoryMetadata(): void {
+    this.#replaceHistoryState(
+      createHistoryStateWithNavigationMetadata(this.#readHistoryState(), {
+        previousNextUrl: null,
+        traversalIndex: this.#currentHistoryTraversalIndex,
+      }),
+      this.#readCurrentHref(),
+    );
+  }
+
+  /** History write performed on the first committed (hydrated) render. */
+  writeHydratedHistoryMetadata(options: {
+    bfcacheIds: BfcacheIdMap;
+    previousNextUrl: string | null;
+  }): void {
+    this.#replaceHistoryState(
+      createHistoryStateWithNavigationMetadata(this.#readHistoryState(), {
+        bfcacheIds: options.bfcacheIds,
+        bfcacheVersion: this.#restorableClientState.currentBfcacheVersion,
+        previousNextUrl: options.previousNextUrl,
+        traversalIndex: this.#currentHistoryTraversalIndex,
+      }),
+      this.#readCurrentHref(),
+    );
+  }
+
+  // --- Restorable snapshot restore ---
+
+  /**
+   * Resolves a restorable snapshot candidate for the given history entry and
+   * commits the traversal index after, and only after, the injected
+   * approved-visible-restore callback succeeds. The traversal-index commit and
+   * client-param staging run inside `beforeCommit`, which the
+   * `AppBrowserNavigationController` invokes only once the `ApprovedVisibleCommit`
+   * is approved. Returns false when no snapshot is restorable or the restore is
+   * not approved.
+   */
+  restoreHistorySnapshot(options: RestoreHistorySnapshotOptions): boolean {
+    const decision = this.#restorableClientState.resolveHistoryStateSnapshotRestore(
+      options.historyState,
+    );
+    if (decision.kind === "skip") {
+      return false;
+    }
+
+    return options.approveVisibleRestore({
+      state: decision.state,
+      beforeCommit: () => {
+        this.commitHistoryTraversalIndex(decision.targetHistoryIndex);
+        options.stageClientParams(decision.state.navigationSnapshot.params);
+      },
+    });
+  }
+}
+
+function areBfcacheIdMapsEqual(a: BfcacheIdMap | null, b: BfcacheIdMap | null): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  const aEntries = Object.entries(a);
+  const bEntries = Object.entries(b);
+  if (aEntries.length !== bEntries.length) return false;
+  // Equal lengths make this bidirectional: if every a entry exists in b with
+  // the same value, b cannot contain an extra distinct key.
+  return aEntries.every(([key, value]) => b[key] === value);
+}

--- a/packages/vinext/src/server/pages-readiness.ts
+++ b/packages/vinext/src/server/pages-readiness.ts
@@ -18,7 +18,7 @@ import type { PagesPageModule } from "./pages-page-data.js";
  * The field names/types are projected from the canonical `VinextNextData` so
  * this stays in lockstep with the `__NEXT_DATA__` shape it feeds into.
  */
-export type PagesReadinessNextData = Pick<
+type PagesReadinessNextData = Pick<
   VinextNextData,
   "gssp" | "gsp" | "gip" | "appGip" | "autoExport"
 > & {

--- a/tests/app-browser-history-controller.test.ts
+++ b/tests/app-browser-history-controller.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  AppBrowserHistoryController,
+  type RestorableSnapshotCandidate,
+} from "../packages/vinext/src/server/app-browser-history-controller.js";
+import {
+  createBasePathStrippedPathAndSearch,
+  createSnapshotPathAndSearch,
+} from "../packages/vinext/src/server/app-browser-navigation-controller.js";
+import {
+  createHistoryStateWithNavigationMetadata,
+  readHistoryStateTraversalIndex,
+} from "../packages/vinext/src/server/app-history-state.js";
+import {
+  AppElementsWire,
+  normalizeAppElements,
+  type AppElements,
+} from "../packages/vinext/src/server/app-elements.js";
+import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shims/navigation.js";
+import type { AppRouterState } from "../packages/vinext/src/server/app-browser-state.js";
+
+type HistoryWrite = { state: unknown; href: string };
+
+function readWrittenState(write: HistoryWrite | undefined): Record<string, unknown> {
+  const state = write?.state;
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    throw new Error("expected an object history state");
+  }
+  const record: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(state)) {
+    record[key] = value;
+  }
+  return record;
+}
+
+type VisibleNavigationMetadata = {
+  bfcacheIds: Readonly<Record<string, string>> | null;
+  previousNextUrl: string | null;
+};
+
+function createHistoryStore(initialState: unknown = null, initialHref = "https://example.com/") {
+  let state = initialState;
+  let href = initialHref;
+  const pushed: HistoryWrite[] = [];
+  const replaced: HistoryWrite[] = [];
+
+  return {
+    get state() {
+      return state;
+    },
+    get href() {
+      return href;
+    },
+    get pushed() {
+      return pushed;
+    },
+    get replaced() {
+      return replaced;
+    },
+    readHistoryState: () => state,
+    readCurrentHref: () => href,
+    // Seeds the live history entry for setup without recording a write.
+    setState: (next: unknown) => {
+      state = next;
+    },
+    pushHistoryState: (next: unknown, nextHref: string) => {
+      pushed.push({ state: next, href: nextHref });
+      state = next;
+      href = new URL(nextHref, href).href;
+    },
+    replaceHistoryState: (next: unknown, nextHref: string) => {
+      replaced.push({ state: next, href: nextHref });
+      state = next;
+      href = new URL(nextHref, href).href;
+    },
+  };
+}
+
+function createController(options?: {
+  initialState?: unknown;
+  initialHref?: string;
+  visibleMetadata?: VisibleNavigationMetadata | null;
+}) {
+  const store = createHistoryStore(options?.initialState ?? null, options?.initialHref);
+  let visibleMetadata = options?.visibleMetadata ?? null;
+  const controller = new AppBrowserHistoryController({
+    initialHistoryState: store.state,
+    maxHistoryStateSnapshots: 50,
+    readHistoryState: store.readHistoryState,
+    readCurrentHref: store.readCurrentHref,
+    pushHistoryState: store.pushHistoryState,
+    replaceHistoryState: store.replaceHistoryState,
+    readVisibleNavigationMetadata: () => visibleMetadata,
+  });
+  return {
+    controller,
+    store,
+    setVisibleMetadata: (next: VisibleNavigationMetadata | null) => {
+      visibleMetadata = next;
+    },
+  };
+}
+
+function createResolvedElements(routeId: string, rootLayoutTreePath: string | null): AppElements {
+  return normalizeAppElements({
+    ...AppElementsWire.createMetadataEntries({
+      interception: null,
+      interceptionContext: null,
+      layoutIds:
+        rootLayoutTreePath === null ? [] : [AppElementsWire.encodeLayoutId(rootLayoutTreePath)],
+      rootLayoutTreePath,
+      routeId,
+      slotBindings: [],
+    }),
+  });
+}
+
+function createRouterState(overrides: Partial<AppRouterState> = {}): AppRouterState {
+  return {
+    activeOperation: null,
+    bfcacheIds: {},
+    elements: createResolvedElements("route:/initial", "/"),
+    interception: null,
+    interceptionContext: null,
+    layoutIds: [AppElementsWire.encodeLayoutId("/")],
+    layoutFlags: {},
+    navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/initial", {}),
+    previousNextUrl: null,
+    renderId: 0,
+    rootLayoutTreePath: "/",
+    routeId: "route:/initial",
+    slotBindings: [],
+    visibleCommitVersion: 0,
+    ...overrides,
+  };
+}
+
+describe("AppBrowserHistoryController traversal index allocation", () => {
+  it("allocates per history update mode and anchors to the highest committed index", () => {
+    const initialState = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 3,
+    });
+    const { controller } = createController({ initialState });
+
+    expect(controller.currentHistoryTraversalIndex).toBe(3);
+    // push continues from the highest known app entry; replace stays put; a
+    // metadata-less navigation (undefined mode) allocates no index.
+    expect(controller.allocateNavigationHistoryTraversalIndex("push")).toBe(4);
+    expect(controller.allocateNavigationHistoryTraversalIndex("replace")).toBe(3);
+    expect(controller.allocateNavigationHistoryTraversalIndex(undefined)).toBeNull();
+
+    controller.commitHistoryTraversalIndex(4);
+    expect(controller.currentHistoryTraversalIndex).toBe(4);
+    expect(controller.allocateNavigationHistoryTraversalIndex("push")).toBe(5);
+
+    // Traversing back to a lower index keeps the next-push anchor at the highest
+    // app-owned entry (4), not the index we just traversed to.
+    controller.commitTraversalIndexFromHistoryState(
+      createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 2,
+      }),
+    );
+    expect(controller.currentHistoryTraversalIndex).toBe(2);
+    expect(controller.allocateNavigationHistoryTraversalIndex("push")).toBe(5);
+    expect(controller.allocateNavigationHistoryTraversalIndex("replace")).toBe(2);
+  });
+
+  it("treats a traversal to a metadata-less entry as an unknown current index", () => {
+    const { controller } = createController({
+      initialState: createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 4,
+      }),
+    });
+
+    controller.commitTraversalIndexFromHistoryState(null);
+
+    expect(controller.currentHistoryTraversalIndex).toBeNull();
+    // current is unknown, so replace cannot allocate; push still continues from
+    // the highest known app entry (4).
+    expect(controller.allocateNavigationHistoryTraversalIndex("replace")).toBeNull();
+    expect(controller.allocateNavigationHistoryTraversalIndex("push")).toBe(5);
+  });
+});
+
+describe("AppBrowserHistoryController hash-only navigation", () => {
+  it("strips vinext scroll metadata on a scroll-enabled hash-only replace", () => {
+    const { controller, store } = createController({
+      initialState: { __vinext_scrollX: 5, __vinext_scrollY: 10, __vinext_historyIndex: 0 },
+    });
+
+    controller.commitHashOnlyNavigation("/page#section", "replace", true);
+
+    expect(store.replaced).toHaveLength(1);
+    const writtenState = readWrittenState(store.replaced[0]);
+    expect("__vinext_scrollY" in writtenState).toBe(false);
+    expect("__vinext_scrollX" in writtenState).toBe(false);
+    expect(readHistoryStateTraversalIndex(writtenState)).toBe(0);
+  });
+
+  it("preserves vinext scroll metadata on a scroll-disabled hash-only replace", () => {
+    const { controller, store } = createController({
+      initialState: { __vinext_scrollX: 5, __vinext_scrollY: 10, __vinext_historyIndex: 0 },
+    });
+
+    controller.commitHashOnlyNavigation("/page#section", "replace", false);
+
+    expect(store.replaced).toHaveLength(1);
+    const writtenState = readWrittenState(store.replaced[0]);
+    expect(writtenState.__vinext_scrollY).toBe(10);
+    expect(writtenState.__vinext_scrollX).toBe(5);
+  });
+
+  it("pushes a fresh history entry and advances the traversal index on a hash-only push", () => {
+    const { controller, store } = createController({
+      initialState: { __vinext_scrollY: 10, __vinext_historyIndex: 0 },
+    });
+
+    controller.commitHashOnlyNavigation("/page#section", "push", false);
+
+    expect(store.pushed).toHaveLength(1);
+    const writtenState = readWrittenState(store.pushed[0]);
+    // A push starts from a null base, so prior scroll metadata never carries.
+    expect("__vinext_scrollY" in writtenState).toBe(false);
+    expect(readHistoryStateTraversalIndex(writtenState)).toBe(1);
+    expect(controller.currentHistoryTraversalIndex).toBe(1);
+  });
+});
+
+describe("AppBrowserHistoryController history metadata sync", () => {
+  it("preserves the BFCache epoch check when deciding whether to re-sync", () => {
+    // A fresh document with no stored epoch starts at document epoch 0.
+    const { controller, store } = createController();
+    const bfcacheIds = { [AppElementsWire.encodeLayoutId("/")]: "segment-v1" };
+    // Seed the live entry so previousNextUrl, ids, and the stored epoch (0) all
+    // match the current document epoch (0); nothing should be rewritten.
+    store.setState(
+      createHistoryStateWithNavigationMetadata(null, {
+        bfcacheIds,
+        bfcacheVersion: 0,
+        previousNextUrl: "/from",
+      }),
+    );
+
+    controller.syncCurrentHistoryStatePreviousNextUrl("/from", bfcacheIds);
+    expect(store.replaced).toHaveLength(0);
+
+    // Invalidating the client state bumps the document BFCache epoch. The stored
+    // entry's epoch is now stale even though previousNextUrl and ids still match,
+    // so the controller must rewrite the entry.
+    controller.invalidateRestorableClientState();
+    controller.syncCurrentHistoryStatePreviousNextUrl("/from", bfcacheIds);
+    expect(store.replaced).toHaveLength(1);
+  });
+
+  it("skips the rewrite when previousNextUrl already matches and bfcache ids are not supplied", () => {
+    const syncedState = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: "/from",
+    });
+    const { controller, store } = createController({ initialState: syncedState });
+
+    controller.syncCurrentHistoryStatePreviousNextUrl("/from");
+
+    expect(store.replaced).toHaveLength(0);
+  });
+});
+
+describe("AppBrowserHistoryController snapshot restore", () => {
+  function seedSnapshotAtIndex(
+    controller: AppBrowserHistoryController,
+    historyIndex: number,
+    snapshotState: AppRouterState,
+  ): void {
+    controller.commitHistoryTraversalIndex(historyIndex);
+    controller.rememberHistoryStateSnapshot(snapshotState);
+  }
+
+  it("resolves the restorable candidate and delegates visible restoration to the injected callback", () => {
+    const { controller } = createController();
+    const snapshotState = createRouterState({
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/details", {
+        id: "abc",
+      }),
+      routeId: "route:/details",
+    });
+    seedSnapshotAtIndex(controller, 1, snapshotState);
+    // Move the committed index away from the snapshot's index so we can observe
+    // the restore re-committing it to 1.
+    controller.commitHistoryTraversalIndex(2);
+
+    const stageClientParams = vi.fn();
+    const approveVisibleRestore = vi.fn((candidate: RestorableSnapshotCandidate) => {
+      candidate.beforeCommit();
+      return true;
+    });
+
+    const restored = controller.restoreHistorySnapshot({
+      historyState: createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 1,
+      }),
+      stageClientParams,
+      approveVisibleRestore,
+    });
+
+    expect(restored).toBe(true);
+    expect(approveVisibleRestore).toHaveBeenCalledTimes(1);
+    expect(approveVisibleRestore.mock.calls[0]?.[0].state).toBe(snapshotState);
+    expect(stageClientParams).toHaveBeenCalledWith({ id: "abc" });
+    expect(controller.currentHistoryTraversalIndex).toBe(1);
+  });
+
+  it("does not commit the traversal index when the approved-restore callback declines", () => {
+    const { controller } = createController();
+    const snapshotState = createRouterState({ routeId: "route:/details" });
+    seedSnapshotAtIndex(controller, 1, snapshotState);
+    controller.commitHistoryTraversalIndex(2);
+
+    const stageClientParams = vi.fn();
+    // Mirror the real navigation controller: when the ApprovedVisibleCommit is
+    // not approved, beforeCommit never runs and the call returns false.
+    const approveVisibleRestore = vi.fn(() => false);
+
+    const restored = controller.restoreHistorySnapshot({
+      historyState: createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 1,
+      }),
+      stageClientParams,
+      approveVisibleRestore,
+    });
+
+    expect(restored).toBe(false);
+    expect(stageClientParams).not.toHaveBeenCalled();
+    expect(controller.currentHistoryTraversalIndex).toBe(2);
+  });
+
+  it("commits the traversal index only after the approved-restore callback succeeds", () => {
+    const { controller } = createController();
+    const snapshotState = createRouterState({ routeId: "route:/details" });
+    seedSnapshotAtIndex(controller, 1, snapshotState);
+    controller.commitHistoryTraversalIndex(2);
+
+    let indexAtBeforeCommit: number | null = null;
+    const approveVisibleRestore = (candidate: RestorableSnapshotCandidate) => {
+      // The traversal index is still the pre-restore value until beforeCommit
+      // runs inside the approved commit.
+      indexAtBeforeCommit = controller.currentHistoryTraversalIndex;
+      candidate.beforeCommit();
+      return true;
+    };
+
+    controller.restoreHistorySnapshot({
+      historyState: createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 1,
+      }),
+      stageClientParams: vi.fn(),
+      approveVisibleRestore,
+    });
+
+    expect(indexAtBeforeCommit).toBe(2);
+    expect(controller.currentHistoryTraversalIndex).toBe(1);
+  });
+
+  it("returns false without invoking the approved-restore callback when no snapshot is restorable", () => {
+    const { controller } = createController();
+    const approveVisibleRestore = vi.fn(() => true);
+
+    const restored = controller.restoreHistorySnapshot({
+      historyState: createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 9,
+      }),
+      stageClientParams: vi.fn(),
+      approveVisibleRestore,
+    });
+
+    expect(restored).toBe(false);
+    expect(approveVisibleRestore).not.toHaveBeenCalled();
+  });
+});
+
+describe("history snapshot target normalization shared with same-route popstate matching", () => {
+  it("strips basePath and canonicalizes search identically to a committed snapshot", () => {
+    // isSameAppRoutePopstateTarget (browser entry) and the snapshot-restore
+    // target check (navigation controller) both compare these two helpers, so a
+    // basePath-prefixed, percent-encoded popstate URL must normalize to the same
+    // string the snapshot produced. Guards the #1743 basePath target check.
+    const snapshot = createClientNavigationRenderSnapshot(
+      "https://example.com/scroll-restoration?q=a+b",
+      {},
+    );
+    const popstateTarget = new URL("https://example.com/docs/scroll-restoration?q=a%20b");
+
+    expect(createBasePathStrippedPathAndSearch(popstateTarget, "/docs")).toBe(
+      createSnapshotPathAndSearch(snapshot),
+    );
+  });
+});


### PR DESCRIPTION
## What this changes

Extracts the App Router browser-history traversal cluster out of
`server/app-browser-entry.ts` into a new typed `AppBrowserHistoryController`
under `server/app-browser-history-controller.ts`. The browser entry shrinks back
to runtime bootstrap glue (62 insertions, 256 deletions), and the moved behavior
gains direct unit tests.

The controller now owns:

- current/next traversal-index state, allocation, and commit bookkeeping
- push / replace / traverse / hash-only history-state writes
- hash-only scroll-metadata stripping
- `previousNextUrl` / BFCache id synchronization, with the BFCache epoch check
- BFCache epoch and snapshot invalidation through `RestorableClientStateController`
- restorable-snapshot candidate resolution
- the initial bootstrap and hydrated history-metadata writes

Browser-history I/O (`window.history.state`, `window.location.href`,
push/replace) is injected, so the controller runs without a DOM.

## Why

`app-browser-entry.ts` had grown well past browser-runtime bootstrap. The
history-traversal logic was a coherent, testable subsystem trapped inside
module-private functions, so its index allocation, scroll-strip, epoch-sync, and
snapshot-restore behavior could only be exercised through full E2E navigation.
Follow-up from #1743 and the navigation architecture tracker #1790.

## Approach

The ownership boundary is preserved deliberately. `AppBrowserNavigationController`
remains the only authority for approved visible router-state commits. The
browser entry keeps the `restoreHistorySnapshotVisibleState()` call,
`stageClientParams()`, and `commitClientNavigationState()`.

`AppBrowserHistoryController` resolves history facts and delegates visible
restoration through an injected approved-commit callback. It commits the
traversal index inside the `beforeCommit` hook, which the navigation controller
runs only once the `ApprovedVisibleCommit` is approved, so the index advances
after, and only after, an approved restore. The controller never imports
`applyApprovedVisibleCommit()`, never sets router state directly, and never
bypasses the `ApprovedVisibleCommit` boundary.

Non-goals: this is a pure extraction. No scroll-restoration semantics, basePath
target checks, or server-action cache-invalidation behavior changed.

## Validation

- New `tests/app-browser-history-controller.test.ts` (12 tests): index
  allocation for push/replace/traverse/metadata-less entries, hash-only replace
  scroll-strip gated on the scroll flag, history metadata sync preserving the
  BFCache epoch check, approved-restore delegation, and the traversal-index
  commit gated behind the approved-restore callback.
- `tests/app-browser-entry.test.ts` (180 tests) green.
- `PLAYWRIGHT_PROJECT=app-router` scroll-restoration, hash-popstate-scroll, and
  router-autoscroll specs: 33 passed.
- `PLAYWRIGHT_PROJECT=app-router` navigation, navigation-flows,
  navigation-regressions, use-router-bfcache-id, rapid-navigation: green.
- `vp check` and `vp run build` clean.

## Risks / follow-ups

Touches the scroll/traversal/restore path, which is behavior-sensitive. The
moved logic is byte-for-byte identical and the #1743 regression suites stay
green, so risk is contained to the extraction wiring rather than semantics.

Includes a small unrelated cleanup commit scoping the already-internal
`PagesReadinessNextData` type to its module (it was exported but never imported
elsewhere, which knip flagged).

Closes #1818.