### PR TITLE
fix(fonts): normalize shims dir so shim-skip guards match on Windows

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -538,8 +538,14 @@ const RESOLVED_INSTRUMENTATION_CLIENT = `\0${VIRTUAL_INSTRUMENTATION_CLIENT}.mjs
  *  Shared between the Rolldown hook filter and the transform handler regex. */
 const IMAGE_EXTS = "png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?";
 
-/** Absolute path to vinext's shims directory, used by clientManualChunks. */
-const _shimsDir = path.resolve(__dirname, "shims") + "/";
+/**
+ * Absolute path to vinext's shims directory, with a trailing slash. Normalized
+ * to forward slashes because it is prefix-matched against Vite module ids (which
+ * Vite always normalizes to forward slashes) in the font plugins and
+ * clientManualChunks — a raw path.resolve value has backslashes on Windows and
+ * the `id.startsWith(_shimsDir)` checks would never match.
+ */
+const _shimsDir = normalizePathSeparators(path.resolve(__dirname, "shims")) + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
 
 function isValidExportIdentifier(name: string): boolean {


### PR DESCRIPTION
### Summary

Normalize `_shimsDir` to forward slashes at its definition in `index.ts`.

### The bug

`_shimsDir` is built as `path.resolve(__dirname, "shims") + "/"`. On Windows that is a backslash path (`E:\...\shims/`). It is then prefix-matched against Vite module ids in three guards:

- `createLocalFontsPlugin` — `if (id.startsWith(shimsDir)) return null;`
- `createGoogleFontsPlugin` — same guard
- `createClientManualChunks` (`build/client-build-config.ts`) — `if (id.startsWith(shimsDir))`

Vite always normalizes module ids to **forward slashes** (`E:/.../shims/font-local.ts`). So on Windows `id.startsWith("E:\\...\\shims/")` is always false, and:

- the font plugins **fail to skip vinext's own font shims** and rewrite the example paths inside them, and
- shim modules **miss their intended client manual chunk**.

POSIX is unaffected (`path.resolve` already returns forward slashes there), which is why this only shows up on Windows.