### PR TITLE
fix(shims): use path.posix.join in resolveShimModulePath for Windows

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -308,12 +308,12 @@ function resolveShimModulePath(shimsDir: string, moduleName: string): string {
   // JavaScript. Check .ts first to avoid an extra stat in development.
   const candidates = [".ts", ".tsx", ".js"];
   for (const ext of candidates) {
-    const candidate = path.join(shimsDir, `${moduleName}${ext}`);
+    const candidate = path.posix.join(shimsDir, `${moduleName}${ext}`);
     if (fs.existsSync(candidate)) {
       return candidate;
     }
   }
-  return path.join(shimsDir, `${moduleName}.js`);
+  return path.posix.join(shimsDir, `${moduleName}.js`);
 }
 
 function isVercelOgImport(id: string): boolean {


### PR DESCRIPTION
### Summary

In `resolveShimModulePath`, build the candidate/returned shim paths with `path.posix.join` instead of `path.join`.

### Why

`resolveShimModulePath` resolves vinext's shim module paths (e.g. `font-google`, `og`, `root-params`) and the result is consumed as a Vite **module id / alias target** — which must use forward slashes.

Native `path.join` produces backslashes on Windows. Verified behavior:

```
path.join("E:/Users/x/shims/", "font-google.ts")        → "E:\Users\x\shims\font-google.ts"   (re-nativized!)
path.posix.join("E:/Users/x/shims/", "font-google.ts")  → "E:/Users/x/shims/font-google.ts"
```

Note the first case: `path.join` re-nativizes to backslashes **even when the input already uses forward slashes**. So a backslash id leaks out of `resolveShimModulePath` and fails to match Vite's normalized (forward-slash) module ids on Windows. `path.posix.join` keeps the result forward-slash on every platform (no-op effect on POSIX).