### PR TITLE
fix(check): normalize scanned file paths to forward slashes on Windows

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -6,6 +6,7 @@
  */
 
 import { detectPackageManager } from "./utils/project.js";
+import { normalizePathSeparators } from "./utils/path.js";
 import { parseAst, type ESTree } from "vite";
 import fs from "node:fs";
 import path from "node:path";
@@ -317,7 +318,10 @@ function findSourceFiles(
 
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
+    // Forward slashes so downstream substring checks (e.g. `f.includes("/api/")`)
+    // and reported paths are consistent across platforms — path.join yields
+    // backslashes on Windows, which would break those checks.
+    const fullPath = normalizePathSeparators(path.join(dir, entry.name));
     if (entry.isDirectory()) {
       if (
         entry.name === "node_modules" ||
@@ -592,7 +596,7 @@ export function scanImports(root: string): CheckItem[] {
         // Normalize: next/font/google -> next/font/google
         const normalized = mod === "next" ? "next" : mod;
         if (!importUsage.has(normalized)) importUsage.set(normalized, []);
-        const relFile = path.relative(root, file);
+        const relFile = normalizePathSeparators(path.relative(root, file));
         const usedInFiles = importUsage.get(normalized) ?? [];
         if (!usedInFiles.includes(relFile)) {
           usedInFiles.push(relFile);
@@ -1047,7 +1051,7 @@ export function checkConventions(root: string): CheckItem[] {
   const cjsGlobalFiles: string[] = [];
   for (const file of allSourceFiles) {
     const content = fs.readFileSync(file, "utf-8");
-    const rel = path.relative(root, file);
+    const rel = normalizePathSeparators(path.relative(root, file));
 
     if (viewTransitionRegex.test(content)) {
       viewTransitionFiles.push(rel);


### PR DESCRIPTION
### Summary

- `findSourceFiles` now returns forward-slash paths (via `normalizePathSeparators`).
- The two reported relative paths in `scanImports` and `checkConventions` are normalized too.

### The bugs

`findSourceFiles` builds paths with `path.join`, so on Windows it returns backslash paths like `pages\api\hello.ts`. That broke two things in `checkConventions` / `scanImports`:

1. **API route detection (functional).** API routes are matched with `f.includes("/api/")` — a forward-slash substring. Against a backslash path it never matches, so on Windows the API-route count was wrong and pages were miscounted.

2. **Report paths (consistency).** Affected files are reported via `path.relative(root, file)`, which is backslash on Windows. The check report then printed `lib\db.ts` instead of the forward-slash `lib/db.ts` used everywhere else (and asserted by the tests).

POSIX was unaffected — `path.join` / `path.relative` already produce forward slashes there, which is why this only showed on Windows.

### The fix

Normalize at the source in `findSourceFiles` so every downstream substring check (`/api/`, etc.) and reported path is forward-slash, and normalize the two `path.relative` report values. All three use `normalizePathSeparators`, which is a no-op on POSIX (so no behavior change there) and a single backslash→slash pass on Windows.