### PR TITLE
fix(trailing-slash): canonical url trailing slash support

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -437,6 +437,10 @@ ${metaRouteEntries.join(",\n")}
 // recognising /_next/static/* paths (parity with __assetPrefix below).
 export const __basePath = ${JSON.stringify(bp)};
 
+// Hoisted alongside __basePath so __fallbackRenderer / buildPageElements can
+// thread the configured trailingSlash flag through canonical URL rendering.
+const __trailingSlash = ${JSON.stringify(ts)};
+
 const rootNotFoundModule = ${rootNotFoundVar ? rootNotFoundVar : "null"};
 const rootForbiddenModule = ${rootForbiddenVar ? rootForbiddenVar : "null"};
 const rootUnauthorizedModule = ${rootUnauthorizedVar ? rootUnauthorizedVar : "null"};
@@ -462,6 +466,7 @@ const createRscOnErrorHandler = (request, pathname, routePath) =>
 
 const __fallbackRenderer = __createAppFallbackRenderer({
   basePath: __basePath,
+  trailingSlash: __trailingSlash,
   rootBoundaries: {
     rootForbiddenModule,
     rootLayouts,
@@ -521,11 +526,11 @@ async function buildPageElements(route, params, routePath, pageRequest, layoutPa
     metadataRoutes,
     layoutParamAccess,
     basePath: __basePath,
+    trailingSlash: __trailingSlash,
     htmlLimitedBots: __htmlLimitedBots,
   });
 }
 
-const __trailingSlash = ${JSON.stringify(ts)};
 const __i18nConfig = ${JSON.stringify(i18nConfig)};
 const __configRedirects = ${JSON.stringify(redirects)};
 const __configRewrites = ${JSON.stringify(rewrites)};

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -71,6 +71,8 @@ type AppFallbackRendererOptions<TModule extends AppPageModule = AppPageModule> =
   metadataRoutes: MetadataFileRoute[];
   /** Configured next.config `basePath`, threaded into file-based metadata href emission. */
   basePath?: string;
+  /** Configured next.config `trailingSlash`, threaded into canonical URL rendering. */
+  trailingSlash?: boolean;
   resolveChildSegments: (
     routeSegments: readonly string[],
     treePosition: number,
@@ -152,6 +154,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
     rscRenderer,
     sanitizer,
     ssrLoader,
+    trailingSlash,
   } = options;
 
   const { rootForbiddenModule, rootLayouts, rootNotFoundModule, rootUnauthorizedModule } =
@@ -253,6 +256,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
 
       return renderAppPageHttpAccessFallback({
         basePath,
+        trailingSlash,
         boundaryComponent: opts?.boundaryComponent ?? null,
         boundaryModule: opts?.boundaryModule ?? null,
         buildFontLinkHeader: fontProviders.buildFontLinkHeader,
@@ -319,6 +323,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
     ) {
       return renderAppPageErrorBoundary({
         basePath,
+        trailingSlash,
         buildFontLinkHeader: fontProviders.buildFontLinkHeader,
         clearRequestContext,
         createRscOnErrorHandler(pathname, routePath) {

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -86,6 +86,8 @@ type AppPageBoundaryRenderCommonOptions<TModule extends AppPageModule = AppPageM
   metadataRoutes: MetadataFileRoute[];
   /** Configured next.config `basePath`, threaded into file-based metadata href emission. */
   basePath?: string;
+  /** Configured next.config `trailingSlash`, threaded into canonical URL rendering. */
+  trailingSlash?: boolean;
   renderToReadableStream: (
     element: ReactNode | AppElements,
     options: { onError: AppPageBoundaryOnError },
@@ -361,7 +363,14 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
     createElement("meta", { key: "robots", name: "robots", content: "noindex" }),
   ];
   if (metadata) {
-    headElements.push(createElement(MetadataHead, { key: "metadata", metadata, pathname }));
+    headElements.push(
+      createElement(MetadataHead, {
+        key: "metadata",
+        metadata,
+        pathname,
+        trailingSlash: options.trailingSlash,
+      }),
+    );
   }
   headElements.push(createElement(ViewportHead, { key: "viewport", viewport }));
 
@@ -430,7 +439,14 @@ export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(
         routeSegments: options.route?.routeSegments,
       });
       if (metadata) {
-        headElements.push(createElement(MetadataHead, { key: "metadata", metadata, pathname }));
+        headElements.push(
+          createElement(MetadataHead, {
+            key: "metadata",
+            metadata,
+            pathname,
+            trailingSlash: options.trailingSlash,
+          }),
+        );
       }
       headElements.push(createElement(ViewportHead, { key: "viewport", viewport }));
     } catch (error) {

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -92,6 +92,8 @@ export type BuildPageElementsOptions<
    * so file-based metadata route URLs emitted in <head> are prefixed.
    */
   basePath?: string;
+  /** Configured next.config `trailingSlash`, threaded into canonical URL rendering. */
+  trailingSlash?: boolean;
   /** Serialized next.config `htmlLimitedBots` regexp source. */
   htmlLimitedBots?: string;
 };
@@ -306,6 +308,7 @@ export async function buildPageElements<
     searchParams: pageSearchParamsThenable,
     slotOverrides,
     renderMode,
+    trailingSlash: options.trailingSlash,
   });
 }
 

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -180,6 +180,7 @@ type BuildAppPageRouteElementOptions<
   resolvedMetadata: Metadata | null;
   resolvedMetadataPathname?: string;
   resolvedViewport: Viewport;
+  trailingSlash?: boolean;
   rootForbiddenModule?: TModule | null;
   rootNotFoundModule?: TModule | null;
   rootUnauthorizedModule?: TModule | null;
@@ -475,12 +476,13 @@ function createAppPageRouteHead(
   viewport: Viewport,
   pathname: string,
   metadataPlacement: "body" | "head",
+  trailingSlash?: boolean,
 ): ReactNode {
   return (
     <>
       <meta charSet="utf-8" />
       {metadata && metadataPlacement === "head" ? (
-        <MetadataHead metadata={metadata} pathname={pathname} />
+        <MetadataHead metadata={metadata} pathname={pathname} trailingSlash={trailingSlash} />
       ) : null}
       <ViewportHead viewport={viewport} />
     </>
@@ -491,10 +493,16 @@ function createAppPageRouteBodyMetadata(
   metadata: Metadata | null,
   pathname: string,
   metadataPlacement: "body" | "head",
+  trailingSlash?: boolean,
 ): ReactNode {
   if (!metadata || metadataPlacement !== "body") return null;
   return (
-    <div hidden dangerouslySetInnerHTML={{ __html: renderMetadataToHtml(metadata, pathname) }} />
+    <div
+      hidden
+      dangerouslySetInnerHTML={{
+        __html: renderMetadataToHtml(metadata, pathname, { trailingSlash }),
+      }}
+    />
   );
 }
 
@@ -1051,12 +1059,14 @@ export function buildAppPageElements<
         options.resolvedViewport,
         options.resolvedMetadataPathname ?? options.routePath,
         metadataPlacement,
+        options.trailingSlash,
       )}
       {routeChildren}
       {createAppPageRouteBodyMetadata(
         options.resolvedMetadata,
         options.resolvedMetadataPathname ?? options.routePath,
         metadataPlacement,
+        options.trailingSlash,
       )}
     </>
   );

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -489,7 +489,7 @@ function createAppPageRouteHead(
   );
 }
 
-function createAppPageRouteBodyMetadata(
+export function createAppPageRouteBodyMetadata(
   metadata: Metadata | null,
   pathname: string,
   metadataPlacement: "body" | "head",

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -695,12 +695,18 @@ function resolveMetadataUrl(
   trailingSlash?: boolean,
 ): string {
   const value = stringifyUrl(url);
-  if (isAbsoluteOrProtocolRelativeUrl(value) || !metadataBase) {
+  if (!metadataBase) {
     return value;
   }
 
   try {
-    const composed = new URL(joinMetadataPath(metadataBase.pathname, value), metadataBase);
+    const isAbsolute = isAbsoluteOrProtocolRelativeUrl(value);
+    const composed = isAbsolute
+      ? new URL(value, metadataBase)
+      : new URL(joinMetadataPath(metadataBase.pathname, value), metadataBase);
+    if (isAbsolute && composed.origin !== metadataBase.origin) {
+      return value;
+    }
     // Match Next.js's resolveAbsoluteUrlWithPathname: only ADD a trailing slash
     // when trailingSlash is true; never strip when false. See
     // packages/next/src/lib/metadata/resolvers/resolve-url.ts.
@@ -735,6 +741,20 @@ function resolveCanonicalUrl(
     return resolveMetadataUrl(url, metadataBase, trailingSlash);
   }
   return resolveMetadataUrl(resolveRelativeMetadataUrl(url, pathname), metadataBase, trailingSlash);
+}
+
+function resolveAlternateUrl(
+  url: string | URL,
+  metadataBase: URL | null | undefined,
+  pathname: string,
+  trailingSlash?: boolean,
+): string {
+  if (url instanceof URL) {
+    const resolvedUrl = new URL(pathname, url);
+    url.searchParams.forEach((value, key) => resolvedUrl.searchParams.set(key, value));
+    return resolveMetadataUrl(resolvedUrl, metadataBase, trailingSlash);
+  }
+  return resolveCanonicalUrl(url, metadataBase, pathname, trailingSlash);
 }
 
 function isSocialImageDescriptor(
@@ -1219,7 +1239,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
             key={key++}
             rel="alternate"
             hrefLang={lang}
-            href={resolveCanonicalUrl(href, base, pathname, trailingSlash)}
+            href={resolveAlternateUrl(href, base, pathname, trailingSlash)}
           />,
         );
       }
@@ -1231,7 +1251,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
             key={key++}
             rel="alternate"
             media={media}
-            href={resolveCanonicalUrl(href, base, pathname, trailingSlash)}
+            href={resolveAlternateUrl(href, base, pathname, trailingSlash)}
           />,
         );
       }
@@ -1243,7 +1263,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
             key={key++}
             rel="alternate"
             type={type}
-            href={resolveCanonicalUrl(href, base, pathname, trailingSlash)}
+            href={resolveAlternateUrl(href, base, pathname, trailingSlash)}
           />,
         );
       }

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -708,6 +708,7 @@ function resolveMetadataUrl(
       if (
         composed.pathname !== "/" &&
         !composed.pathname.endsWith("/") &&
+        !composed.pathname.startsWith("/.well-known/") &&
         !TRAILING_SLASH_FILE_REGEX.test(composed.pathname)
       ) {
         composed.pathname += "/";

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -708,7 +708,6 @@ function resolveMetadataUrl(
       if (
         composed.pathname !== "/" &&
         !composed.pathname.endsWith("/") &&
-        !composed.pathname.startsWith("/.well-known/") &&
         !TRAILING_SLASH_FILE_REGEX.test(composed.pathname)
       ) {
         composed.pathname += "/";
@@ -848,7 +847,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
   function resolveUrl(url: string | URL | undefined): string | undefined;
   function resolveUrl(url: string | URL | undefined): string | undefined {
     if (!url) return undefined;
-    return resolveMetadataUrl(url, base, trailingSlash);
+    return resolveMetadataUrl(url, base);
   }
 
   // Title

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -966,7 +966,15 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
     if (og.title) elements.push(<meta key={key++} property="og:title" content={og.title} />);
     if (og.description)
       elements.push(<meta key={key++} property="og:description" content={og.description} />);
-    if (og.url) elements.push(<meta key={key++} property="og:url" content={resolveUrl(og.url)} />);
+    if (og.url) {
+      elements.push(
+        <meta
+          key={key++}
+          property="og:url"
+          content={resolveCanonicalUrl(og.url, base, pathname, trailingSlash)}
+        />,
+      );
+    }
     if (og.siteName)
       elements.push(<meta key={key++} property="og:site_name" content={og.siteName} />);
     if (og.type) elements.push(<meta key={key++} property="og:type" content={og.type} />);
@@ -1206,17 +1214,38 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
     }
     if (alt.languages) {
       for (const [lang, href] of Object.entries(alt.languages)) {
-        elements.push(<link key={key++} rel="alternate" hrefLang={lang} href={resolveUrl(href)} />);
+        elements.push(
+          <link
+            key={key++}
+            rel="alternate"
+            hrefLang={lang}
+            href={resolveCanonicalUrl(href, base, pathname, trailingSlash)}
+          />,
+        );
       }
     }
     if (alt.media) {
       for (const [media, href] of Object.entries(alt.media)) {
-        elements.push(<link key={key++} rel="alternate" media={media} href={resolveUrl(href)} />);
+        elements.push(
+          <link
+            key={key++}
+            rel="alternate"
+            media={media}
+            href={resolveCanonicalUrl(href, base, pathname, trailingSlash)}
+          />,
+        );
       }
     }
     if (alt.types) {
       for (const [type, href] of Object.entries(alt.types)) {
-        elements.push(<link key={key++} rel="alternate" type={type} href={resolveUrl(href)} />);
+        elements.push(
+          <link
+            key={key++}
+            rel="alternate"
+            type={type}
+            href={resolveCanonicalUrl(href, base, pathname, trailingSlash)}
+          />,
+        );
       }
     }
   }

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -684,16 +684,42 @@ function formatResolvedMetadataUrl(url: URL): string {
   return url.href;
 }
 
-function resolveMetadataUrl(url: string | URL, metadataBase: URL | null | undefined): string {
+// Next.js's exact file-extension regex for trailingSlash canonical rule.
+// Matches paths like /foo.xml, /bar/baz.json but NOT /.well-known/... paths.
+const TRAILING_SLASH_FILE_REGEX =
+  /^(?:\/((?!\.well-known(?:\/.*)?)((?:[^/]+\/)*)([^/]+\.\w+)))(\/?|$)/i;
+
+function resolveMetadataUrl(
+  url: string | URL,
+  metadataBase: URL | null | undefined,
+  trailingSlash?: boolean,
+): string {
   const value = stringifyUrl(url);
   if (isAbsoluteOrProtocolRelativeUrl(value) || !metadataBase) {
     return value;
   }
 
   try {
-    return formatResolvedMetadataUrl(
-      new URL(joinMetadataPath(metadataBase.pathname, value), metadataBase),
-    );
+    const composed = new URL(joinMetadataPath(metadataBase.pathname, value), metadataBase);
+    // Match Next.js's resolveAbsoluteUrlWithPathname: only ADD a trailing slash
+    // when trailingSlash is true; never strip when false. See
+    // packages/next/src/lib/metadata/resolvers/resolve-url.ts.
+    if (trailingSlash === true && composed.search === "") {
+      if (
+        composed.pathname !== "/" &&
+        !composed.pathname.endsWith("/") &&
+        !TRAILING_SLASH_FILE_REGEX.test(composed.pathname)
+      ) {
+        composed.pathname += "/";
+      }
+    }
+    const result = formatResolvedMetadataUrl(composed);
+    // formatResolvedMetadataUrl collapses pathname '/' with no query to bare
+    // origin (no trailing slash). For trailingSlash:true restore the slash.
+    if (trailingSlash === true && result === metadataBase.origin) {
+      return `${metadataBase.origin}/`;
+    }
+    return result;
   } catch {
     return value;
   }
@@ -703,11 +729,12 @@ function resolveCanonicalUrl(
   url: string | URL,
   metadataBase: URL | null | undefined,
   pathname: string,
+  trailingSlash?: boolean,
 ): string {
   if (url instanceof URL) {
-    return resolveMetadataUrl(url, metadataBase);
+    return resolveMetadataUrl(url, metadataBase, trailingSlash);
   }
-  return resolveMetadataUrl(resolveRelativeMetadataUrl(url, pathname), metadataBase);
+  return resolveMetadataUrl(resolveRelativeMetadataUrl(url, pathname), metadataBase, trailingSlash);
 }
 
 function isSocialImageDescriptor(
@@ -739,6 +766,7 @@ function resolveSocialImageUrl(
 type MetadataHeadProps = {
   metadata: Metadata;
   pathname?: string;
+  trailingSlash?: boolean;
 };
 
 function escapeHtmlText(value: string): string {
@@ -799,11 +827,17 @@ function renderMetadataElementToHtml(node: unknown): string {
   }
 }
 
-export function renderMetadataToHtml(metadata: Metadata, pathname = "/"): string {
-  return renderMetadataElementToHtml(MetadataHead({ metadata, pathname }));
+export function renderMetadataToHtml(
+  metadata: Metadata,
+  pathname = "/",
+  options?: { trailingSlash?: boolean },
+): string {
+  return renderMetadataElementToHtml(
+    MetadataHead({ metadata, pathname, trailingSlash: options?.trailingSlash }),
+  );
 }
 
-export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
+export function MetadataHead({ metadata, pathname = "/", trailingSlash }: MetadataHeadProps) {
   const elements: React.ReactElement[] = [];
   let key = 0;
 
@@ -813,7 +847,7 @@ export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
   function resolveUrl(url: string | URL | undefined): string | undefined;
   function resolveUrl(url: string | URL | undefined): string | undefined {
     if (!url) return undefined;
-    return resolveMetadataUrl(url, base);
+    return resolveMetadataUrl(url, base, trailingSlash);
   }
 
   // Title
@@ -1166,7 +1200,7 @@ export function MetadataHead({ metadata, pathname = "/" }: MetadataHeadProps) {
         <link
           key={key++}
           rel="canonical"
-          href={resolveCanonicalUrl(alt.canonical, base, pathname)}
+          href={resolveCanonicalUrl(alt.canonical, base, pathname, trailingSlash)}
         />,
       );
     }

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3031,6 +3031,93 @@ describe("MetadataHead rendering", () => {
     expect(html).toContain('content="val1"');
     expect(html).toContain('content="val2"');
   });
+
+  // trailingSlash canonical URL tests
+  // Ported from Next.js app-dir trailing-slash e2e: "should contain trailing slash to canonical url"
+  // see https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/trailingslash/trailingslash.test.ts#L31
+
+  it("trailingSlash:true appends slash to root canonical '/'", () => {
+    // metadataBase='http://trailingslash.com', canonical='/', pathname='/'
+    // → href='http://trailingslash.com/'
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "/" },
+      },
+      "/",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://trailingslash.com/"');
+  });
+
+  it("trailingSlash:true appends slash to relative canonical './' at pathname '/a'", () => {
+    // metadataBase='http://trailingslash.com', canonical='./', pathname='/a'
+    // → href='http://trailingslash.com/a/'
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "./" },
+      },
+      "/a",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://trailingslash.com/a/"');
+  });
+
+  it("trailingSlash:true does not append slash before query string", () => {
+    // canonical='/q?x=1' → href='http://trailingslash.com/q?x=1' (no slash before '?')
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "/q?x=1" },
+      },
+      "/q",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://trailingslash.com/q?x=1"');
+    expect(html).not.toContain("/q/");
+  });
+
+  it("trailingSlash:true leaves external canonical unchanged", () => {
+    // canonical='http://other.com/a' → href='http://other.com/a' (external host)
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "http://other.com/a" },
+      },
+      "/a",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://other.com/a"');
+    expect(html).not.toContain('href="http://other.com/a/"');
+  });
+
+  it("trailingSlash:false preserves a user-provided trailing slash on canonical", () => {
+    // Match Next.js: trailingSlash:false (the default) does NOT strip a
+    // user-provided slash; canonical='/a/' renders verbatim.
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "/a/" },
+      },
+      "/a",
+      { trailingSlash: false },
+    );
+    expect(html).toContain('href="http://trailingslash.com/a/"');
+  });
+
+  it("trailingSlash:true is idempotent when canonical already ends with slash", () => {
+    // canonical='http://trailingslash.com/a/' → href='http://trailingslash.com/a/' (unchanged)
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "http://trailingslash.com/a/" },
+      },
+      "/a",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://trailingslash.com/a/"');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3075,7 +3075,7 @@ describe("MetadataHead rendering", () => {
       { trailingSlash: true },
     );
     expect(html).toContain('href="http://trailingslash.com/q?x=1"');
-    expect(html).not.toContain("/q/");
+    expect(html).not.toContain('href="http://trailingslash.com/q/?x=1"');
   });
 
   it("trailingSlash:true leaves external canonical unchanged", () => {
@@ -3144,9 +3144,9 @@ describe("MetadataHead rendering", () => {
       { trailingSlash: true },
     );
     expect(html).toContain(
-      'href="http://trailingslash.com/.well-known/apple-app-site-association"',
+      'href="http://trailingslash.com/.well-known/apple-app-site-association/"',
     );
-    expect(html).not.toContain("apple-app-site-association/");
+    expect(html).not.toContain('"http://trailingslash.com/.well-known/apple-app-site-association"');
   });
 });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3118,6 +3118,36 @@ describe("MetadataHead rendering", () => {
     );
     expect(html).toContain('href="http://trailingslash.com/a/"');
   });
+
+  it("trailingSlash:true does not append slash to file-like canonical urls", () => {
+    // canonical='/sitemap.xml' → href='http://trailingslash.com/sitemap.xml'
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "/sitemap.xml" },
+      },
+      "/",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://trailingslash.com/sitemap.xml"');
+    expect(html).not.toContain("sitemap.xml/");
+  });
+
+  it("trailingSlash:true does not append slash to .well-known canonical urls", () => {
+    // canonical='/.well-known/apple-app-site-association' → href='http://trailingslash.com/.well-known/apple-app-site-association'
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "/.well-known/apple-app-site-association" },
+      },
+      "/",
+      { trailingSlash: true },
+    );
+    expect(html).toContain(
+      'href="http://trailingslash.com/.well-known/apple-app-site-association"',
+    );
+    expect(html).not.toContain("apple-app-site-association/");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3150,6 +3150,66 @@ describe("MetadataHead rendering", () => {
   });
 });
 
+describe("createAppPageRouteBodyMetadata (body-placement canonical)", () => {
+  let createAppPageRouteBodyMetadata: typeof import("../packages/vinext/src/server/app-page-route-wiring.js").createAppPageRouteBodyMetadata;
+  let _React: typeof import("react");
+  let renderToStaticMarkup: typeof import("react-dom/server").renderToStaticMarkup;
+
+  beforeAll(async () => {
+    ({ createAppPageRouteBodyMetadata } =
+      await import("../packages/vinext/src/server/app-page-route-wiring.js"));
+    _React = await import("react");
+    ({ renderToStaticMarkup } = await import("react-dom/server"));
+  });
+
+  it("body placement: applies trailingSlash to canonical href in the streamed body branch", () => {
+    const node = createAppPageRouteBodyMetadata(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "/a" },
+      },
+      "/a",
+      "body",
+      true, // trailingSlash
+    );
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    // Body branch wraps the metadata HTML in a hidden div (htmlLimitedBots
+    // / streamed-body path used when metadata can't be flushed into <head>
+    // before the first shell chunk).
+    expect(html).toContain("<div hidden");
+    expect(html).toContain('href="http://trailingslash.com/a/"');
+  });
+
+  it("body placement: no slash inserted before query string", () => {
+    const node = createAppPageRouteBodyMetadata(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "/q?x=1" },
+      },
+      "/q",
+      "body",
+      true,
+    );
+    const html = renderToStaticMarkup(node as React.ReactElement);
+    expect(html).toContain('href="http://trailingslash.com/q?x=1"');
+    expect(html).not.toContain("/q/?");
+  });
+
+  it("body placement: returns null when placement is 'head' (no double-render)", () => {
+    const node = createAppPageRouteBodyMetadata(
+      { metadataBase: new URL("http://trailingslash.com"), alternates: { canonical: "/a" } },
+      "/a",
+      "head",
+      true,
+    );
+    expect(node).toBeNull();
+  });
+
+  it("body placement: returns null when metadata is null", () => {
+    expect(createAppPageRouteBodyMetadata(null, "/a", "body", true)).toBeNull();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // ViewportHead rendering tests
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3133,8 +3133,10 @@ describe("MetadataHead rendering", () => {
     expect(html).not.toContain("sitemap.xml/");
   });
 
-  it("trailingSlash:true does not append slash to .well-known canonical urls", () => {
-    // canonical='/.well-known/apple-app-site-association' → href='http://trailingslash.com/.well-known/apple-app-site-association'
+  it("trailingSlash:true appends slash to .well-known canonical urls", () => {
+    // Ported from Next.js: packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+    // .well-known is excluded from the file regex, so it is treated as a normal path.
     const html = renderMetadataToHtml(
       {
         metadataBase: new URL("http://trailingslash.com"),
@@ -3147,6 +3149,28 @@ describe("MetadataHead rendering", () => {
       'href="http://trailingslash.com/.well-known/apple-app-site-association/"',
     );
     expect(html).not.toContain('"http://trailingslash.com/.well-known/apple-app-site-association"');
+  });
+
+  it("trailingSlash:true appends slash to openGraph.url and alternate urls", () => {
+    // Ported from the resolver call sites in Next.js:
+    // packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts and resolve-basics.ts
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        openGraph: { url: "/og" },
+        alternates: {
+          languages: { en: "/en" },
+          media: { print: "/print" },
+          types: { "application/rss+xml": "/feed" },
+        },
+      },
+      "/",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('property="og:url" content="http://trailingslash.com/og/"');
+    expect(html).toContain('href="http://trailingslash.com/en/" hreflang="en"');
+    expect(html).toContain('href="http://trailingslash.com/print/" media="print"');
+    expect(html).toContain('href="http://trailingslash.com/feed/" type="application/rss+xml"');
   });
 });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3119,6 +3119,18 @@ describe("MetadataHead rendering", () => {
     expect(html).toContain('href="http://trailingslash.com/a/"');
   });
 
+  it("trailingSlash:true appends slash to same-origin absolute canonical urls", () => {
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: { canonical: "http://trailingslash.com/a" },
+      },
+      "/a",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://trailingslash.com/a/"');
+  });
+
   it("trailingSlash:true does not append slash to file-like canonical urls", () => {
     // canonical='/sitemap.xml' → href='http://trailingslash.com/sitemap.xml'
     const html = renderMetadataToHtml(
@@ -3171,6 +3183,24 @@ describe("MetadataHead rendering", () => {
     expect(html).toContain('href="http://trailingslash.com/en/" hreflang="en"');
     expect(html).toContain('href="http://trailingslash.com/print/" media="print"');
     expect(html).toContain('href="http://trailingslash.com/feed/" type="application/rss+xml"');
+  });
+
+  it("resolves URL-object alternates as bases for the current pathname", () => {
+    // Ported from Next.js: packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+    // URL-object alternates are bases for pathname resolution and retain their query params.
+    const html = renderMetadataToHtml(
+      {
+        metadataBase: new URL("http://trailingslash.com"),
+        alternates: {
+          languages: { en: new URL("http://trailingslash.com/base") },
+          media: { print: new URL("http://trailingslash.com/base?source=print") },
+        },
+      },
+      "/docs",
+      { trailingSlash: true },
+    );
+    expect(html).toContain('href="http://trailingslash.com/docs/" hreflang="en"');
+    expect(html).toContain('href="http://trailingslash.com/docs?source=print" media="print"');
   });
 });
 


### PR DESCRIPTION
# Summary

This PR fixes App Router canonical URL handling so metadata-generated canonical links respect trailingSlash when resolving against metadataBase.

Canonical URLs now honor `trailingSlash: true`. When metadata resolves a canonical URL under a base URL, vinext now appends a trailing slash for non-file paths, matching Next.js behavior. This covers root canonical URLs, relative canonicals like ./, and normal pathname canonicals.

# File Touched
`metadata.tsx` — add trailing-slash-aware canonical URL resolution and expose the option through metadata rendering.
`app-rsc-entry.ts` — pass trailing-slash config into the App Router rendering pipeline.
`app-page-route-wiring.tsx`, `app-page-boundary-render.ts`, `app-page-element-builder.ts`, `app-fallback-renderer.ts` — thread the config through the App Router render path.
`features.test.ts` — add canonical URL regression coverage ported from Next.js.

# Testing Plan
`pnpm test tests/features.test.ts` — new canonical URL assertions covering:
- trailingSlash: true for root and relative canonicals
- query string preservation
- external URL passthrough
- trailingSlash: false preserving user-provided slashes
- idempotent slash handling

`pnpm test tests/trailing-slash.test.ts tests/app-route-handler-trailing-slash.test.ts tests/middleware-runtime-trailing-slash.test.ts` all green

# Reference
https://github.com/cloudflare/vinext/issues/1832
https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/trailingslash/trailingslash.test.ts