### PR TITLE
refactor(router): plan RSC fetch result classification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       # changesets/action to push the Version PR branch, tags, and releases.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: true # required for changesets/action git pushes
           fetch-depth: 0 # full history + tags for the guard and contributor list
 
       - uses: ./.github/actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
       # changesets/action to push the Version PR branch, tags, and releases.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          persist-credentials: true # required for changesets/action git pushes
           fetch-depth: 0 # full history + tags for the guard and contributor list
 
       - uses: ./.github/actions/setup

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -154,16 +154,11 @@ import {
   createRscRequestUrl,
   createServerActionRequestUrl,
   getVinextRscCompatibilityId,
-  resolveHardNavigationTargetFromRscResponse,
   resolveRscCompatibilityNavigationDecision,
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "./app-rsc-render-mode.js";
-import {
-  MAX_RSC_REDIRECT_DEPTH,
-  resolveRscRedirectLifecycleHop,
-} from "./app-browser-rsc-redirect.js";
 import {
   createOptimisticRouteTemplate,
   getOptimisticPrefetchSourceKey,
@@ -180,6 +175,7 @@ import {
   VINEXT_RSC_REDIRECT_HEADER,
 } from "./headers.js";
 import { removeStylesheetLinksCoveredByInlineCss } from "./app-inline-css-client.js";
+import { navigationPlanner } from "./navigation-planner.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -1733,42 +1729,38 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
               navigationKind,
             );
         if (cachedRoute) {
-          const compatibilityDecision = resolveRscCompatibilityNavigationDecision({
+          const cachedFetchDecision = navigationPlanner.classifyRscFetchResult({
             clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
+            compatibilityIdHeader: cachedRoute.response.compatibilityIdHeader ?? null,
             currentHref,
-            origin: window.location.origin,
-            responseCompatibilityId: cachedRoute.response.compatibilityIdHeader,
-            responseUrl: cachedRoute.response.url,
-          });
-          if (compatibilityDecision.kind === "hard-navigate") {
-            performHardNavigationForScrollIntent(compatibilityDecision.hardNavigationTarget);
-            return;
-          }
-          const cachedRedirectDecision = resolveRscRedirectLifecycleHop({
-            currentHref,
-            historyUpdateMode: currentHistoryMode ?? "replace",
+            effectiveHistoryUpdateMode: currentHistoryMode ?? "replace",
+            hasBody: true,
+            isRscContentType: true,
             origin: window.location.origin,
             redirectDepth: redirectCount,
             requestPreviousNextUrl,
+            responseOk: true,
             responseUrl: cachedRoute.response.url,
+            source: "cached",
+            streamedRedirectTarget: null,
           });
-          if (cachedRedirectDecision.kind === "terminal-hard-navigation") {
-            if (cachedRedirectDecision.reason === "maxRedirectsExceeded") {
+          if (cachedFetchDecision.kind === "hardNavigate") {
+            if (cachedFetchDecision.reason === "redirectDepthExhausted") {
               console.error(
                 "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
               );
             }
-            performHardNavigationForScrollIntent(cachedRedirectDecision.href);
+            performHardNavigationForScrollIntent(cachedFetchDecision.url);
             return;
           }
-          if (cachedRedirectDecision.kind === "follow") {
+          if (cachedFetchDecision.kind === "followRedirect") {
             if (navigationKind === "traverse") {
               restoredBfcacheIds = null;
             }
-            currentHref = cachedRedirectDecision.href;
-            currentHistoryMode = cachedRedirectDecision.historyUpdateMode;
-            currentPrevNextUrl = cachedRedirectDecision.previousNextUrl;
-            redirectCount = cachedRedirectDecision.redirectDepth;
+            currentHref = cachedFetchDecision.redirect.href;
+            currentHistoryMode = cachedFetchDecision.redirect.historyUpdateMode;
+            currentPrevNextUrl = cachedFetchDecision.redirect.previousNextUrl;
+            redirectCount = cachedFetchDecision.redirect.redirectDepth;
             continue;
           }
           // Check stale-navigation before and after createFromFetch. The pre-check
@@ -1923,125 +1915,51 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
 
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 
-        // Any response that isn't a valid RSC payload (non-ok status,
-        // missing/rewritten Content-Type, or missing body) means the server
-        // returned something we cannot parse — typically an HTML error page
-        // or a proxy-rewritten response. Parsing such a body as an RSC stream
-        // throws a cryptic "Connection closed" error. Match Next.js behavior
-        // (fetch-server-response.ts:211, `!isFlightResponse || !res.ok || !res.body`):
-        // hard-navigate to the response URL so the server can render the correct
-        // error page as HTML. The outer finally handles
-        // settlePendingBrowserRouterState and clearPendingPathname on this
-        // return path.
-        //
-        // Prefer the post-redirect response URL over `currentHref`: on a
-        // redirect chain like `/old` → 307 → `/new` → 500, the browser's
-        // fetch already followed the redirect, so `navResponse.url` is the
-        // failing `/new` destination. Hard-navigating there directly avoids
-        // bouncing off `/old` just to re-follow the same 307, which would
-        // flash the wrong URL in the address bar and mis-key analytics.
-        // Matches Next.js' `doMpaNavigation(responseUrl.toString())`. Falls
-        // back to `currentHref` when no response URL is available.
         const navContentType = navResponse.headers.get("content-type") ?? "";
-        const isRscResponse = navContentType.startsWith("text/x-component");
-        if (!navResponse.ok || !isRscResponse || !navResponse.body) {
-          const responseUrl = navResponseUrl ?? navResponse.url;
-          performHardNavigationForScrollIntent(
-            resolveHardNavigationTargetFromRscResponse(
-              responseUrl,
-              currentHref,
-              window.location.origin,
-            ),
-          );
-          return;
-        }
-
-        const compatibilityDecision = resolveRscCompatibilityNavigationDecision({
+        const liveFetchDecision = navigationPlanner.classifyRscFetchResult({
           clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
+          compatibilityIdHeader: navResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
           currentHref,
-          origin: window.location.origin,
-          responseCompatibilityId: navResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
-          responseUrl: navResponseUrl ?? navResponse.url,
-        });
-        if (compatibilityDecision.kind === "hard-navigate") {
-          performHardNavigationForScrollIntent(compatibilityDecision.hardNavigationTarget);
-          return;
-        }
-
-        const redirectDecision = resolveRscRedirectLifecycleHop({
-          currentHref,
-          historyUpdateMode: currentHistoryMode ?? "replace",
+          effectiveHistoryUpdateMode: currentHistoryMode ?? "replace",
+          hasBody: navResponse.body !== null,
+          isRscContentType: navContentType.startsWith(VINEXT_RSC_CONTENT_TYPE),
           origin: window.location.origin,
           redirectDepth: redirectCount,
           requestPreviousNextUrl,
+          responseOk: navResponse.ok,
           responseUrl: navResponseUrl ?? navResponse.url,
+          source: "live",
+          streamedRedirectTarget: navResponse.headers.get(VINEXT_RSC_REDIRECT_HEADER),
         });
-
-        if (redirectDecision.kind === "terminal-hard-navigation") {
-          if (redirectDecision.reason === "maxRedirectsExceeded") {
+        if (liveFetchDecision.kind === "hardNavigate") {
+          if (liveFetchDecision.discardBody) {
+            void navResponse.body?.cancel().catch(() => {});
+          }
+          if (liveFetchDecision.reason === "redirectDepthExhausted") {
             console.error(
               "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
             );
           }
-          performHardNavigationForScrollIntent(redirectDecision.href);
+          if (liveFetchDecision.reason === "streamedRedirectLoop") {
+            console.error(
+              "[vinext] RSC streamed redirect resolved to the current URL — aborting navigation to prevent infinite loop.",
+            );
+          }
+          performHardNavigationForScrollIntent(liveFetchDecision.url);
           return;
         }
 
-        if (redirectDecision.kind === "follow") {
-          // Server-side redirect: keep the redirect chain inside this operation
-          // and defer URL/history mutation to the eventual approved commit.
-          // This keeps isPending true across all hops and avoids publishing a
-          // destination URL before its RSC payload is lifecycle-approved.
-          // Traverse restored ids belong to the history entry being traversed
-          // to. Once a server redirect changes the target href, those ids no
-          // longer describe the redirected payload and must not win over fresh
-          // segment identities.
-          if (navigationKind === "traverse") {
-            restoredBfcacheIds = null;
-          }
-          currentHref = redirectDecision.href;
-          currentHistoryMode = redirectDecision.historyUpdateMode;
-          currentPrevNextUrl = redirectDecision.previousNextUrl;
-          redirectCount = redirectDecision.redirectDepth;
-          continue;
-        }
-
-        // RSC redirect encoded as 200 + flight payload (the server's response
-        // for `redirect()` thrown from a server component during RSC rendering;
-        // see issue #1347 and `buildAppPageSpecialErrorResponse`). The flight
-        // body carries the canonical `NEXT_REDIRECT;...` digest for clients
-        // that decode it through React's RedirectBoundary, but vinext's
-        // browser-navigation loop catches it ahead of decode via this
-        // side-channel header so the redirect-following loop above can drain
-        // the body and continue without bouncing through the catch path.
-        // Reusing the same loop variables keeps `pendingRouterState` and the
-        // outer `useTransition` pending state continuous across the hop —
-        // matching the pre-1347 fetch-auto-follow-307 behavior.
-        const flightRedirectTarget = navResponse.headers.get(VINEXT_RSC_REDIRECT_HEADER);
-        if (flightRedirectTarget) {
-          // Drain the response body so the underlying connection is released.
-          // We do this best-effort: the destination's `.rsc` fetch on the next
-          // loop iteration will replace this response entirely.
-          void navResponse.body?.cancel().catch(() => {});
-          const resolvedTarget = new URL(flightRedirectTarget, window.location.origin);
-          if (resolvedTarget.origin !== window.location.origin) {
-            performHardNavigationForScrollIntent(resolvedTarget.href);
-            return;
-          }
-          if (redirectCount >= MAX_RSC_REDIRECT_DEPTH) {
-            console.error(
-              "[vinext] Too many RSC redirects — aborting navigation to prevent infinite loop.",
-            );
-            performHardNavigationForScrollIntent(resolvedTarget.href);
-            return;
+        if (liveFetchDecision.kind === "followRedirect") {
+          if (liveFetchDecision.discardBody) {
+            void navResponse.body?.cancel().catch(() => {});
           }
           if (navigationKind === "traverse") {
             restoredBfcacheIds = null;
           }
-          currentHref = `${resolvedTarget.pathname}${resolvedTarget.search}${resolvedTarget.hash}`;
-          currentHistoryMode = currentHistoryMode ?? "replace";
-          currentPrevNextUrl = requestPreviousNextUrl;
-          redirectCount += 1;
+          currentHref = liveFetchDecision.redirect.href;
+          currentHistoryMode = liveFetchDecision.redirect.historyUpdateMode;
+          currentPrevNextUrl = liveFetchDecision.redirect.previousNextUrl;
+          redirectCount = liveFetchDecision.redirect.redirectDepth;
           continue;
         }
 

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -9,7 +9,7 @@ const MAX_RSC_REDIRECT_DEPTH = 10;
 type RscRedirectHistoryUpdateMode = "push" | "replace" | undefined;
 
 type RscRedirectLifecycleDecision =
-  | { kind: "no-redirect" }
+  | { href: string; kind: "no-redirect" }
   | {
       href: string;
       historyUpdateMode: RscRedirectHistoryUpdateMode;
@@ -61,7 +61,7 @@ export function resolveRscRedirectLifecycleHop(options: {
     options.origin,
   );
   if (redirectedHref === toVisibleAppHref(options.currentHref, options.origin)) {
-    return { kind: "no-redirect" };
+    return { href: redirectedHref, kind: "no-redirect" };
   }
 
   const maxRedirectDepth = options.maxRedirectDepth ?? MAX_RSC_REDIRECT_DEPTH;
@@ -108,7 +108,7 @@ export function resolveStreamedRscRedirectLifecycleHop(options: {
     options.origin,
   );
   if (redirectedHref === toVisibleAppHref(options.currentHref, options.origin)) {
-    return { kind: "no-redirect" };
+    return { href: redirectedHref, kind: "no-redirect" };
   }
 
   const maxRedirectDepth = options.maxRedirectDepth ?? MAX_RSC_REDIRECT_DEPTH;

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -4,7 +4,7 @@ import {
   stripRscSuffix,
 } from "./app-rsc-cache-busting.js";
 
-export const MAX_RSC_REDIRECT_DEPTH = 10;
+const MAX_RSC_REDIRECT_DEPTH = 10;
 
 type RscRedirectHistoryUpdateMode = "push" | "replace" | undefined;
 

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -35,31 +35,26 @@ function toStreamedRedirectVisibleAppHref(href: string, origin: string): string 
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
-export function resolveRscRedirectLifecycleHop(options: {
+function resolveRedirectLifecycleHopFromTarget(options: {
   currentHref: string;
   historyUpdateMode: RscRedirectHistoryUpdateMode;
   maxRedirectDepth?: number;
   origin: string;
+  redirectedHref: string;
   redirectDepth: number;
   requestPreviousNextUrl: string | null;
-  responseUrl: string;
+  targetUrl: URL;
 }): RscRedirectLifecycleDecision {
-  const responseUrl = new URL(options.responseUrl, options.origin);
-
-  if (responseUrl.origin !== options.origin) {
+  if (options.targetUrl.origin !== options.origin) {
     return {
-      href: responseUrl.href,
+      href: options.targetUrl.href,
       kind: "terminal-hard-navigation",
       reason: "externalRedirect",
       redirectDepth: options.redirectDepth,
     };
   }
 
-  const redirectedHref = resolveHardNavigationTargetFromRscResponse(
-    responseUrl.href,
-    options.currentHref,
-    options.origin,
-  );
+  const redirectedHref = options.redirectedHref;
   if (redirectedHref === toVisibleAppHref(options.currentHref, options.origin)) {
     return { href: redirectedHref, kind: "no-redirect" };
   }
@@ -83,6 +78,27 @@ export function resolveRscRedirectLifecycleHop(options: {
   };
 }
 
+export function resolveRscRedirectLifecycleHop(options: {
+  currentHref: string;
+  historyUpdateMode: RscRedirectHistoryUpdateMode;
+  maxRedirectDepth?: number;
+  origin: string;
+  redirectDepth: number;
+  requestPreviousNextUrl: string | null;
+  responseUrl: string;
+}): RscRedirectLifecycleDecision {
+  const responseUrl = new URL(options.responseUrl, options.origin);
+  return resolveRedirectLifecycleHopFromTarget({
+    ...options,
+    redirectedHref: resolveHardNavigationTargetFromRscResponse(
+      responseUrl.href,
+      options.currentHref,
+      options.origin,
+    ),
+    targetUrl: responseUrl,
+  });
+}
+
 export function resolveStreamedRscRedirectLifecycleHop(options: {
   currentHref: string;
   historyUpdateMode: Exclude<RscRedirectHistoryUpdateMode, undefined>;
@@ -93,39 +109,14 @@ export function resolveStreamedRscRedirectLifecycleHop(options: {
   streamedRedirectTarget: string;
 }): RscRedirectLifecycleDecision {
   const streamedRedirectUrl = new URL(options.streamedRedirectTarget, options.origin);
-
-  if (streamedRedirectUrl.origin !== options.origin) {
-    return {
-      href: streamedRedirectUrl.href,
-      kind: "terminal-hard-navigation",
-      reason: "externalRedirect",
-      redirectDepth: options.redirectDepth,
-    };
-  }
-
-  const redirectedHref = toStreamedRedirectVisibleAppHref(
-    options.streamedRedirectTarget,
-    options.origin,
-  );
-  if (redirectedHref === toVisibleAppHref(options.currentHref, options.origin)) {
-    return { href: redirectedHref, kind: "no-redirect" };
-  }
-
-  const maxRedirectDepth = options.maxRedirectDepth ?? MAX_RSC_REDIRECT_DEPTH;
-  if (options.redirectDepth >= maxRedirectDepth) {
-    return {
-      href: redirectedHref,
-      kind: "terminal-hard-navigation",
-      reason: "maxRedirectsExceeded",
-      redirectDepth: options.redirectDepth,
-    };
-  }
-
-  return {
-    href: redirectedHref,
-    historyUpdateMode: options.historyUpdateMode,
-    kind: "follow",
-    previousNextUrl: options.requestPreviousNextUrl,
-    redirectDepth: options.redirectDepth + 1,
-  };
+  // Streamed headers are semantic redirect targets, so preserve their target
+  // path/search/hash while the shared same-target guard normalizes currentHref.
+  return resolveRedirectLifecycleHopFromTarget({
+    ...options,
+    redirectedHref: toStreamedRedirectVisibleAppHref(
+      options.streamedRedirectTarget,
+      options.origin,
+    ),
+    targetUrl: streamedRedirectUrl,
+  });
 }

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -30,6 +30,11 @@ function toVisibleAppHref(href: string, origin: string): string {
   return `${stripRscSuffix(url.pathname)}${url.search}${url.hash}`;
 }
 
+function toStreamedRedirectVisibleAppHref(href: string, origin: string): string {
+  const url = new URL(href, origin);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 export function resolveRscRedirectLifecycleHop(options: {
   currentHref: string;
   historyUpdateMode: RscRedirectHistoryUpdateMode;
@@ -53,6 +58,53 @@ export function resolveRscRedirectLifecycleHop(options: {
   const redirectedHref = resolveHardNavigationTargetFromRscResponse(
     responseUrl.href,
     options.currentHref,
+    options.origin,
+  );
+  if (redirectedHref === toVisibleAppHref(options.currentHref, options.origin)) {
+    return { kind: "no-redirect" };
+  }
+
+  const maxRedirectDepth = options.maxRedirectDepth ?? MAX_RSC_REDIRECT_DEPTH;
+  if (options.redirectDepth >= maxRedirectDepth) {
+    return {
+      href: redirectedHref,
+      kind: "terminal-hard-navigation",
+      reason: "maxRedirectsExceeded",
+      redirectDepth: options.redirectDepth,
+    };
+  }
+
+  return {
+    href: redirectedHref,
+    historyUpdateMode: options.historyUpdateMode,
+    kind: "follow",
+    previousNextUrl: options.requestPreviousNextUrl,
+    redirectDepth: options.redirectDepth + 1,
+  };
+}
+
+export function resolveStreamedRscRedirectLifecycleHop(options: {
+  currentHref: string;
+  historyUpdateMode: Exclude<RscRedirectHistoryUpdateMode, undefined>;
+  maxRedirectDepth?: number;
+  origin: string;
+  redirectDepth: number;
+  requestPreviousNextUrl: string | null;
+  streamedRedirectTarget: string;
+}): RscRedirectLifecycleDecision {
+  const streamedRedirectUrl = new URL(options.streamedRedirectTarget, options.origin);
+
+  if (streamedRedirectUrl.origin !== options.origin) {
+    return {
+      href: streamedRedirectUrl.href,
+      kind: "terminal-hard-navigation",
+      reason: "externalRedirect",
+      redirectDepth: options.redirectDepth,
+    };
+  }
+
+  const redirectedHref = toStreamedRedirectVisibleAppHref(
+    options.streamedRedirectTarget,
     options.origin,
   );
   if (redirectedHref === toVisibleAppHref(options.currentHref, options.origin)) {

--- a/packages/vinext/src/server/isr-decision.ts
+++ b/packages/vinext/src/server/isr-decision.ts
@@ -21,7 +21,7 @@ import {
 
 type IsrDisposition = "HIT" | "STALE" | "MISS";
 
-export type IsrDecision = {
+type IsrDecision = {
   disposition: IsrDisposition;
   /** True when the caller must schedule a background regeneration. */
   scheduleRegeneration: boolean;

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -314,6 +314,8 @@ function createRscFetchResultHardNavigationDecision(options: {
       options.reasonCode,
       createRscFetchResultTraceFields(options.facts, {
         ...(options.redirectSignal !== undefined ? { redirectSignal: options.redirectSignal } : {}),
+        // Terminal redirects report the depth that was evaluated; followed
+        // redirects report the next depth that the executor should request.
         redirectDepth: options.facts.redirectDepth,
         targetHref: options.url,
       }),

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -164,8 +164,8 @@ export type FlightResultV0 = {
   targetSnapshot: RouteSnapshotV0;
 };
 
-export type RscFetchResultSource = "cached" | "live";
-export type RscRedirectSignal = "response-url" | "streamed-header";
+type RscFetchResultSource = "cached" | "live";
+type RscRedirectSignal = "response-url" | "streamed-header";
 
 export type RscFetchResultFactsV0 = {
   source: RscFetchResultSource;
@@ -183,14 +183,14 @@ export type RscFetchResultFactsV0 = {
   streamedRedirectTarget: string | null;
 };
 
-export type RscRedirectFollowV0 = {
+type RscRedirectFollowV0 = {
   href: string;
   historyUpdateMode: "push" | "replace";
   previousNextUrl: string | null;
   redirectDepth: number;
 };
 
-export type RscFetchResultHardNavReason =
+type RscFetchResultHardNavReason =
   | "invalidRscPayload"
   | "rscCompatibilityMismatch"
   | "externalRedirectTarget"

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -10,6 +10,14 @@ import type {
   RouteManifestRoute,
 } from "../routing/app-route-graph.js";
 import { compareAppElementsSlotIds, type AppElementsSlotBinding } from "./app-elements.js";
+import {
+  resolveRscRedirectLifecycleHop,
+  resolveStreamedRscRedirectLifecycleHop,
+} from "./app-browser-rsc-redirect.js";
+import {
+  resolveHardNavigationTargetFromRscResponse,
+  resolveRscCompatibilityNavigationDecision,
+} from "./app-rsc-cache-busting.js";
 import type {
   CacheEntryReuseDecision,
   CacheEntryReuseProof,
@@ -156,6 +164,55 @@ export type FlightResultV0 = {
   targetSnapshot: RouteSnapshotV0;
 };
 
+export type RscFetchResultSource = "cached" | "live";
+export type RscRedirectSignal = "response-url" | "streamed-header";
+
+export type RscFetchResultFactsV0 = {
+  source: RscFetchResultSource;
+  currentHref: string;
+  origin: string;
+  effectiveHistoryUpdateMode: "push" | "replace";
+  redirectDepth: number;
+  requestPreviousNextUrl: string | null;
+  clientCompatibilityId: string | null;
+  responseOk: boolean;
+  isRscContentType: boolean;
+  hasBody: boolean;
+  compatibilityIdHeader: string | null;
+  responseUrl: string | null;
+  streamedRedirectTarget: string | null;
+};
+
+export type RscRedirectFollowV0 = {
+  href: string;
+  historyUpdateMode: "push" | "replace";
+  previousNextUrl: string | null;
+  redirectDepth: number;
+};
+
+export type RscFetchResultHardNavReason =
+  | "invalidRscPayload"
+  | "rscCompatibilityMismatch"
+  | "externalRedirectTarget"
+  | "redirectDepthExhausted"
+  | "streamedRedirectLoop";
+
+export type RscFetchResultDecisionV0 =
+  | { kind: "proceedToCommit"; discardBody: false; trace: NavigationTrace }
+  | {
+      kind: "followRedirect";
+      discardBody: boolean;
+      redirect: RscRedirectFollowV0;
+      trace: NavigationTrace;
+    }
+  | {
+      kind: "hardNavigate";
+      discardBody: boolean;
+      url: string;
+      reason: RscFetchResultHardNavReason;
+      trace: NavigationTrace;
+    };
+
 export type NavigationPlannerInput = {
   // Graph-owned route topology is the semantic authority for root/layout/slot
   // decisions whenever the caller can supply it. Null keeps the legacy
@@ -229,6 +286,214 @@ function getRequestedWorkTargetHref(work: RequestedWork): string | null {
       throw new Error("[vinext] Unknown requested navigation work: " + String(_exhaustive));
     }
   }
+}
+
+function createRscFetchResultTraceFields(
+  facts: RscFetchResultFactsV0,
+  fields: NavigationTraceFields = {},
+): NavigationTraceFields {
+  return {
+    fetchResultSource: facts.source,
+    ...fields,
+  };
+}
+
+function createRscFetchResultHardNavigationDecision(options: {
+  discardBody: boolean;
+  facts: RscFetchResultFactsV0;
+  reason: RscFetchResultHardNavReason;
+  reasonCode: NavigationTraceReasonCode;
+  redirectSignal?: RscRedirectSignal;
+  url: string;
+}): RscFetchResultDecisionV0 {
+  return {
+    discardBody: options.discardBody,
+    kind: "hardNavigate",
+    reason: options.reason,
+    trace: createNavigationTrace(
+      options.reasonCode,
+      createRscFetchResultTraceFields(options.facts, {
+        ...(options.redirectSignal !== undefined ? { redirectSignal: options.redirectSignal } : {}),
+        redirectDepth: options.facts.redirectDepth,
+        targetHref: options.url,
+      }),
+    ),
+    url: options.url,
+  };
+}
+
+function createRscFetchResultFollowRedirectDecision(options: {
+  discardBody: boolean;
+  facts: RscFetchResultFactsV0;
+  redirect: RscRedirectFollowV0;
+  redirectSignal: RscRedirectSignal;
+}): RscFetchResultDecisionV0 {
+  return {
+    discardBody: options.discardBody,
+    kind: "followRedirect",
+    redirect: options.redirect,
+    trace: createNavigationTrace(
+      NavigationTraceReasonCodes.redirectFollow,
+      createRscFetchResultTraceFields(options.facts, {
+        redirectDepth: options.redirect.redirectDepth,
+        redirectSignal: options.redirectSignal,
+        targetHref: options.redirect.href,
+      }),
+    ),
+  };
+}
+
+function mapRscRedirectTerminalReason(reason: "externalRedirect" | "maxRedirectsExceeded"): {
+  hardNavigationReason: RscFetchResultHardNavReason;
+  traceReasonCode: NavigationTraceReasonCode;
+} {
+  switch (reason) {
+    case "externalRedirect":
+      return {
+        hardNavigationReason: "externalRedirectTarget",
+        traceReasonCode: NavigationTraceReasonCodes.redirectTerminalExternal,
+      };
+    case "maxRedirectsExceeded":
+      return {
+        hardNavigationReason: "redirectDepthExhausted",
+        traceReasonCode: NavigationTraceReasonCodes.redirectTerminalDepth,
+      };
+    default: {
+      const _exhaustive: never = reason;
+      throw new Error("[vinext] Unknown RSC redirect terminal reason: " + String(_exhaustive));
+    }
+  }
+}
+
+function resolveStreamedRedirectVisibleTarget(target: string, origin: string): string {
+  const url = new URL(target, origin);
+  if (url.origin !== origin) {
+    return url.href;
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function classifyRscFetchResult(facts: RscFetchResultFactsV0): RscFetchResultDecisionV0 {
+  if (!facts.responseOk || !facts.isRscContentType || !facts.hasBody) {
+    const url = resolveHardNavigationTargetFromRscResponse(
+      facts.responseUrl,
+      facts.currentHref,
+      facts.origin,
+    );
+    return createRscFetchResultHardNavigationDecision({
+      discardBody: false,
+      facts,
+      reason: "invalidRscPayload",
+      reasonCode: NavigationTraceReasonCodes.invalidRscPayload,
+      url,
+    });
+  }
+
+  const compatibilityDecision = resolveRscCompatibilityNavigationDecision({
+    clientCompatibilityId: facts.clientCompatibilityId,
+    currentHref: facts.currentHref,
+    origin: facts.origin,
+    responseCompatibilityId: facts.compatibilityIdHeader,
+    responseUrl: facts.responseUrl,
+  });
+  if (compatibilityDecision.kind === "hard-navigate") {
+    return createRscFetchResultHardNavigationDecision({
+      discardBody: false,
+      facts,
+      reason: "rscCompatibilityMismatch",
+      reasonCode: NavigationTraceReasonCodes.rscCompatibilityMismatch,
+      url: compatibilityDecision.hardNavigationTarget,
+    });
+  }
+
+  if (facts.responseUrl !== null) {
+    const redirectDecision = resolveRscRedirectLifecycleHop({
+      currentHref: facts.currentHref,
+      historyUpdateMode: facts.effectiveHistoryUpdateMode,
+      origin: facts.origin,
+      redirectDepth: facts.redirectDepth,
+      requestPreviousNextUrl: facts.requestPreviousNextUrl,
+      responseUrl: facts.responseUrl,
+    });
+    if (redirectDecision.kind === "terminal-hard-navigation") {
+      const terminalReason = mapRscRedirectTerminalReason(redirectDecision.reason);
+      return createRscFetchResultHardNavigationDecision({
+        discardBody: false,
+        facts,
+        reason: terminalReason.hardNavigationReason,
+        reasonCode: terminalReason.traceReasonCode,
+        redirectSignal: "response-url",
+        url: redirectDecision.href,
+      });
+    }
+    if (redirectDecision.kind === "follow") {
+      return createRscFetchResultFollowRedirectDecision({
+        discardBody: false,
+        facts,
+        redirect: {
+          href: redirectDecision.href,
+          historyUpdateMode: facts.effectiveHistoryUpdateMode,
+          previousNextUrl: redirectDecision.previousNextUrl,
+          redirectDepth: redirectDecision.redirectDepth,
+        },
+        redirectSignal: "response-url",
+      });
+    }
+  }
+
+  if (facts.streamedRedirectTarget !== null) {
+    const redirectDecision = resolveStreamedRscRedirectLifecycleHop({
+      currentHref: facts.currentHref,
+      historyUpdateMode: facts.effectiveHistoryUpdateMode,
+      origin: facts.origin,
+      redirectDepth: facts.redirectDepth,
+      requestPreviousNextUrl: facts.requestPreviousNextUrl,
+      streamedRedirectTarget: facts.streamedRedirectTarget,
+    });
+    if (redirectDecision.kind === "terminal-hard-navigation") {
+      const terminalReason = mapRscRedirectTerminalReason(redirectDecision.reason);
+      return createRscFetchResultHardNavigationDecision({
+        discardBody: true,
+        facts,
+        reason: terminalReason.hardNavigationReason,
+        reasonCode: terminalReason.traceReasonCode,
+        redirectSignal: "streamed-header",
+        url: redirectDecision.href,
+      });
+    }
+    if (redirectDecision.kind === "follow") {
+      return createRscFetchResultFollowRedirectDecision({
+        discardBody: true,
+        facts,
+        redirect: {
+          href: redirectDecision.href,
+          historyUpdateMode: facts.effectiveHistoryUpdateMode,
+          previousNextUrl: redirectDecision.previousNextUrl,
+          redirectDepth: redirectDecision.redirectDepth,
+        },
+        redirectSignal: "streamed-header",
+      });
+    }
+
+    const url = resolveStreamedRedirectVisibleTarget(facts.streamedRedirectTarget, facts.origin);
+    return createRscFetchResultHardNavigationDecision({
+      discardBody: true,
+      facts,
+      reason: "streamedRedirectLoop",
+      reasonCode: NavigationTraceReasonCodes.streamedRedirectLoop,
+      redirectSignal: "streamed-header",
+      url,
+    });
+  }
+
+  return {
+    discardBody: false,
+    kind: "proceedToCommit",
+    trace: createNavigationTrace(
+      NavigationTraceReasonCodes.proceedToCommit,
+      createRscFetchResultTraceFields(facts),
+    ),
+  };
 }
 
 function createSnapshotRouteTopology(snapshot: RouteSnapshotV0): RouteTopologySnapshot {
@@ -1043,6 +1308,7 @@ function planNavigation(input: NavigationPlannerInput): NavigationDecisionV0 {
 }
 
 export const navigationPlanner = {
+  classifyRscFetchResult,
   classifyRootBoundaryTransition,
   plan: planNavigation,
   resolveCurrentRootBoundaryElementPersistence,

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -365,14 +365,6 @@ function mapRscRedirectTerminalReason(reason: "externalRedirect" | "maxRedirects
   }
 }
 
-function resolveStreamedRedirectVisibleTarget(target: string, origin: string): string {
-  const url = new URL(target, origin);
-  if (url.origin !== origin) {
-    return url.href;
-  }
-  return `${url.pathname}${url.search}${url.hash}`;
-}
-
 function classifyRscFetchResult(facts: RscFetchResultFactsV0): RscFetchResultDecisionV0 {
   if (!facts.responseOk || !facts.isRscContentType || !facts.hasBody) {
     const url = resolveHardNavigationTargetFromRscResponse(
@@ -475,14 +467,13 @@ function classifyRscFetchResult(facts: RscFetchResultFactsV0): RscFetchResultDec
       });
     }
 
-    const url = resolveStreamedRedirectVisibleTarget(facts.streamedRedirectTarget, facts.origin);
     return createRscFetchResultHardNavigationDecision({
       discardBody: true,
       facts,
       reason: "streamedRedirectLoop",
       reasonCode: NavigationTraceReasonCodes.streamedRedirectLoop,
       redirectSignal: "streamed-header",
-      url,
+      url: redirectDecision.href,
     });
   }
 

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -5,6 +5,7 @@ type NavigationTraceSchemaVersion = 0;
 export const NavigationTraceReasonCodes = {
   cacheProofRejected: "NC_CACHE_REJECT",
   commitCurrent: "NC_COMMIT",
+  invalidRscPayload: "NC_RSC_INVALID",
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT",
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT",
   interceptedRejectedMissingProof: "NC_INTERCEPT_REJECT_MISSING_PROOF",
@@ -13,13 +14,20 @@ export const NavigationTraceReasonCodes = {
   interceptedRejectedUndeclaredTopology: "NC_INTERCEPT_REJECT_GRAPH",
   interceptedRejectedUnknownSource: "NC_INTERCEPT_REJECT_SOURCE",
   prefetchOnly: "NC_PREFETCH_ONLY",
+  proceedToCommit: "NC_RSC_PROCEED",
+  redirectFollow: "NC_RSC_REDIRECT_FOLLOW",
+  redirectTerminalDepth: "NC_RSC_REDIRECT_DEPTH",
+  redirectTerminalExternal: "NC_RSC_REDIRECT_EXTERNAL",
   requestWork: "NC_REQUEST",
   rootBoundaryChanged: "NC_ROOT",
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN",
+  rscCompatibilityMismatch: "NC_RSC_COMPAT_MISMATCH",
   staleOperation: "NC_STALE",
+  streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP",
 } satisfies Readonly<{
   cacheProofRejected: "NC_CACHE_REJECT";
   commitCurrent: "NC_COMMIT";
+  invalidRscPayload: "NC_RSC_INVALID";
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT";
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT";
   interceptedRejectedMissingProof: "NC_INTERCEPT_REJECT_MISSING_PROOF";
@@ -28,10 +36,16 @@ export const NavigationTraceReasonCodes = {
   interceptedRejectedUndeclaredTopology: "NC_INTERCEPT_REJECT_GRAPH";
   interceptedRejectedUnknownSource: "NC_INTERCEPT_REJECT_SOURCE";
   prefetchOnly: "NC_PREFETCH_ONLY";
+  proceedToCommit: "NC_RSC_PROCEED";
+  redirectFollow: "NC_RSC_REDIRECT_FOLLOW";
+  redirectTerminalDepth: "NC_RSC_REDIRECT_DEPTH";
+  redirectTerminalExternal: "NC_RSC_REDIRECT_EXTERNAL";
   requestWork: "NC_REQUEST";
   rootBoundaryChanged: "NC_ROOT";
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN";
+  rscCompatibilityMismatch: "NC_RSC_COMPAT_MISMATCH";
   staleOperation: "NC_STALE";
+  streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP";
 }>;
 
 export const NavigationTraceTransactionCodes = {
@@ -62,8 +76,11 @@ type NavigationTraceFieldName =
   | "currentVisibleCommitVersion"
   | "nextRootLayoutTreePath"
   | "eventKind"
+  | "fetchResultSource"
   | "operationLane"
   | "pendingOperationId"
+  | "redirectDepth"
+  | "redirectSignal"
   | "startedVisibleCommitVersion"
   | "startedNavigationId"
   | "targetHref"

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -93,7 +93,10 @@ import {
   HistoryStateSnapshotCache,
   RestorableClientStateController,
 } from "../packages/vinext/src/server/app-history-state.js";
-import { resolveRscRedirectLifecycleHop } from "../packages/vinext/src/server/app-browser-rsc-redirect.js";
+import {
+  resolveRscRedirectLifecycleHop,
+  resolveStreamedRscRedirectLifecycleHop,
+} from "../packages/vinext/src/server/app-browser-rsc-redirect.js";
 import {
   applyApprovedVisibleCommit,
   approveHmrVisibleCommit,
@@ -5721,6 +5724,113 @@ describe("app browser RSC redirect lifecycle", () => {
 
     expect(decision).toEqual({
       href: "/b",
+      kind: "terminal-hard-navigation",
+      reason: "maxRedirectsExceeded",
+      redirectDepth: 2,
+    });
+  });
+
+  it("preserves streamed redirect target hashes", () => {
+    const decision = resolveStreamedRscRedirectLifecycleHop({
+      currentHref: "/old#old",
+      historyUpdateMode: "replace",
+      origin: "https://example.com",
+      redirectDepth: 0,
+      requestPreviousNextUrl: null,
+      streamedRedirectTarget: "/new#new",
+    });
+
+    expect(decision).toEqual({
+      href: "/new#new",
+      historyUpdateMode: "replace",
+      kind: "follow",
+      previousNextUrl: null,
+      redirectDepth: 1,
+    });
+  });
+
+  it("treats streamed hash-only same-path changes as redirects", () => {
+    const decision = resolveStreamedRscRedirectLifecycleHop({
+      currentHref: "/same#old",
+      historyUpdateMode: "push",
+      origin: "https://example.com",
+      redirectDepth: 0,
+      requestPreviousNextUrl: "/feed",
+      streamedRedirectTarget: "/same#new",
+    });
+
+    expect(decision).toEqual({
+      href: "/same#new",
+      historyUpdateMode: "push",
+      kind: "follow",
+      previousNextUrl: "/feed",
+      redirectDepth: 1,
+    });
+  });
+
+  it("preserves streamed redirect visible query params and hash", () => {
+    const decision = resolveStreamedRscRedirectLifecycleHop({
+      currentHref: "/source",
+      historyUpdateMode: "replace",
+      origin: "https://example.com",
+      redirectDepth: 1,
+      requestPreviousNextUrl: null,
+      streamedRedirectTarget: "/target.rsc?visible=1&_rsc=abc#details",
+    });
+
+    expect(decision).toEqual({
+      href: "/target.rsc?visible=1&_rsc=abc#details",
+      historyUpdateMode: "replace",
+      kind: "follow",
+      previousNextUrl: null,
+      redirectDepth: 2,
+    });
+  });
+
+  it("turns same-target streamed redirects into no-redirect decisions", () => {
+    const decision = resolveStreamedRscRedirectLifecycleHop({
+      currentHref: "/same?tab=1#section",
+      historyUpdateMode: "replace",
+      origin: "https://example.com",
+      redirectDepth: 0,
+      requestPreviousNextUrl: null,
+      streamedRedirectTarget: "/same?tab=1#section",
+    });
+
+    expect(decision).toEqual({ kind: "no-redirect" });
+  });
+
+  it("turns external streamed redirects into terminal hard navigations", () => {
+    const decision = resolveStreamedRscRedirectLifecycleHop({
+      currentHref: "/account",
+      historyUpdateMode: "replace",
+      origin: "https://example.com",
+      redirectDepth: 0,
+      requestPreviousNextUrl: null,
+      streamedRedirectTarget: "https://idp.example/login#step",
+    });
+
+    expect(decision).toEqual({
+      href: "https://idp.example/login#step",
+      kind: "terminal-hard-navigation",
+      reason: "externalRedirect",
+      redirectDepth: 0,
+    });
+  });
+
+  it("turns over-budget streamed redirects into terminal hard navigations", () => {
+    const decision = resolveStreamedRscRedirectLifecycleHop({
+      currentHref: "/a",
+      historyUpdateMode: "replace",
+      maxRedirectDepth: 2,
+      origin: "https://example.com",
+      redirectDepth: 2,
+      requestPreviousNextUrl: null,
+      streamedRedirectTarget: "/b#target",
+    });
+
+    expect(decision).toEqual({
+      href: "/b#target",
       kind: "terminal-hard-navigation",
       reason: "maxRedirectsExceeded",
       redirectDepth: 2,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -5797,7 +5797,7 @@ describe("app browser RSC redirect lifecycle", () => {
       streamedRedirectTarget: "/same?tab=1#section",
     });
 
-    expect(decision).toEqual({ kind: "no-redirect" });
+    expect(decision).toEqual({ href: "/same?tab=1#section", kind: "no-redirect" });
   });
 
   it("turns external streamed redirects into terminal hard navigations", () => {

--- a/tests/navigation-planner-rsc-fetch-result.test.ts
+++ b/tests/navigation-planner-rsc-fetch-result.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NAVIGATION_TRACE_SCHEMA_VERSION,
+  NavigationTraceReasonCodes,
+} from "../packages/vinext/src/server/navigation-trace.js";
+import {
+  navigationPlanner,
+  type RscFetchResultDecisionV0,
+  type RscFetchResultFactsV0,
+} from "../packages/vinext/src/server/navigation-planner.js";
+
+function createFacts(overrides: Partial<RscFetchResultFactsV0> = {}): RscFetchResultFactsV0 {
+  return {
+    clientCompatibilityId: "client-build",
+    compatibilityIdHeader: "client-build",
+    currentHref: "/current",
+    effectiveHistoryUpdateMode: "replace",
+    hasBody: true,
+    isRscContentType: true,
+    origin: "https://example.com",
+    redirectDepth: 0,
+    requestPreviousNextUrl: null,
+    responseOk: true,
+    responseUrl: "https://example.com/current.rsc?_rsc=abc",
+    source: "live",
+    streamedRedirectTarget: null,
+    ...overrides,
+  };
+}
+
+function classify(overrides: Partial<RscFetchResultFactsV0> = {}): RscFetchResultDecisionV0 {
+  return navigationPlanner.classifyRscFetchResult(createFacts(overrides));
+}
+
+function expectSingleTraceEntry(
+  decision: RscFetchResultDecisionV0,
+  code: string,
+  fields: Record<string, string | number | boolean | null>,
+): void {
+  expect(decision.trace).toEqual({
+    schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+    entries: [
+      {
+        code,
+        fields,
+      },
+    ],
+  });
+}
+
+describe("navigationPlanner RSC fetch-result classification", () => {
+  it("hard-navigates non-ok RSC responses as invalid payloads", () => {
+    const decision = classify({
+      responseOk: false,
+      responseUrl: "https://example.com/error.rsc?_rsc=abc",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: false,
+      kind: "hardNavigate",
+      reason: "invalidRscPayload",
+      url: "/error",
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.invalidRscPayload, {
+      fetchResultSource: "live",
+      redirectDepth: 0,
+      targetHref: "/error",
+    });
+  });
+
+  it("hard-navigates non-RSC content types as invalid payloads", () => {
+    const decision = classify({
+      isRscContentType: false,
+      responseUrl: "https://example.com/html-error",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: false,
+      kind: "hardNavigate",
+      reason: "invalidRscPayload",
+      url: "/html-error",
+    });
+  });
+
+  it("hard-navigates missing response bodies as invalid payloads", () => {
+    const decision = classify({
+      hasBody: false,
+      responseUrl: null,
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: false,
+      kind: "hardNavigate",
+      reason: "invalidRscPayload",
+      url: "/current",
+    });
+  });
+
+  it("hard-navigates RSC compatibility mismatches before redirect classification", () => {
+    const decision = classify({
+      compatibilityIdHeader: "server-build",
+      responseUrl: "https://example.com/redirected.rsc?_rsc=abc",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: false,
+      kind: "hardNavigate",
+      reason: "rscCompatibilityMismatch",
+      url: "/redirected",
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.rscCompatibilityMismatch, {
+      fetchResultSource: "live",
+      redirectDepth: 0,
+      targetHref: "/redirected",
+    });
+  });
+
+  it("follows response-URL redirects without discarding the body", () => {
+    const decision = classify({
+      effectiveHistoryUpdateMode: "push",
+      redirectDepth: 2,
+      requestPreviousNextUrl: "/feed",
+      responseUrl: "https://example.com/target.rsc?tab=1&_rsc=abc",
+    });
+
+    expect(decision).toEqual({
+      discardBody: false,
+      kind: "followRedirect",
+      redirect: {
+        href: "/target?tab=1",
+        historyUpdateMode: "push",
+        previousNextUrl: "/feed",
+        redirectDepth: 3,
+      },
+      trace: {
+        schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.redirectFollow,
+            fields: {
+              fetchResultSource: "live",
+              redirectDepth: 3,
+              redirectSignal: "response-url",
+              targetHref: "/target?tab=1",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("hard-navigates external response-URL redirect targets without discarding the body", () => {
+    const decision = classify({
+      responseUrl: "https://idp.example/login",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: false,
+      kind: "hardNavigate",
+      reason: "externalRedirectTarget",
+      url: "https://idp.example/login",
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.redirectTerminalExternal, {
+      fetchResultSource: "live",
+      redirectDepth: 0,
+      redirectSignal: "response-url",
+      targetHref: "https://idp.example/login",
+    });
+  });
+
+  it("hard-navigates over-budget response-URL redirect chains without discarding the body", () => {
+    const decision = classify({
+      redirectDepth: 10,
+      responseUrl: "https://example.com/target.rsc?_rsc=abc",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: false,
+      kind: "hardNavigate",
+      reason: "redirectDepthExhausted",
+      url: "/target",
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.redirectTerminalDepth, {
+      fetchResultSource: "live",
+      redirectDepth: 10,
+      redirectSignal: "response-url",
+      targetHref: "/target",
+    });
+  });
+
+  it("follows streamed redirects and requires body discard", () => {
+    const decision = classify({
+      effectiveHistoryUpdateMode: "push",
+      requestPreviousNextUrl: "/feed",
+      responseUrl: "https://example.com/current.rsc?_rsc=abc",
+      streamedRedirectTarget: "/streamed?tab=1#details",
+    });
+
+    expect(decision).toEqual({
+      discardBody: true,
+      kind: "followRedirect",
+      redirect: {
+        href: "/streamed?tab=1#details",
+        historyUpdateMode: "push",
+        previousNextUrl: "/feed",
+        redirectDepth: 1,
+      },
+      trace: {
+        schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.redirectFollow,
+            fields: {
+              fetchResultSource: "live",
+              redirectDepth: 1,
+              redirectSignal: "streamed-header",
+              targetHref: "/streamed?tab=1#details",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("hard-navigates external streamed redirects and requires body discard", () => {
+    const decision = classify({
+      streamedRedirectTarget: "https://idp.example/login#step",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: true,
+      kind: "hardNavigate",
+      reason: "externalRedirectTarget",
+      url: "https://idp.example/login#step",
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.redirectTerminalExternal, {
+      fetchResultSource: "live",
+      redirectDepth: 0,
+      redirectSignal: "streamed-header",
+      targetHref: "https://idp.example/login#step",
+    });
+  });
+
+  it("hard-navigates over-budget streamed redirects and requires body discard", () => {
+    const decision = classify({
+      redirectDepth: 10,
+      streamedRedirectTarget: "/streamed#details",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: true,
+      kind: "hardNavigate",
+      reason: "redirectDepthExhausted",
+      url: "/streamed#details",
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.redirectTerminalDepth, {
+      fetchResultSource: "live",
+      redirectDepth: 10,
+      redirectSignal: "streamed-header",
+      targetHref: "/streamed#details",
+    });
+  });
+
+  it("hard-navigates same-target streamed redirects as loop guards", () => {
+    const decision = classify({
+      currentHref: "/same?tab=1#section",
+      responseUrl: "https://example.com/same.rsc?tab=1&_rsc=abc#section",
+      streamedRedirectTarget: "/same?tab=1#section",
+    });
+
+    expect(decision).toMatchObject({
+      discardBody: true,
+      kind: "hardNavigate",
+      reason: "streamedRedirectLoop",
+      url: "/same?tab=1#section",
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.streamedRedirectLoop, {
+      fetchResultSource: "live",
+      redirectDepth: 0,
+      redirectSignal: "streamed-header",
+      targetHref: "/same?tab=1#section",
+    });
+  });
+
+  it("preserves streamed redirect target hashes", () => {
+    const decision = classify({
+      currentHref: "/old#old",
+      responseUrl: "https://example.com/old.rsc?_rsc=abc#old",
+      streamedRedirectTarget: "/new#new",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "followRedirect",
+      redirect: {
+        href: "/new#new",
+      },
+    });
+  });
+
+  it("follows streamed hash-only redirects instead of treating them as loops", () => {
+    const decision = classify({
+      currentHref: "/same#old",
+      responseUrl: "https://example.com/same.rsc?_rsc=abc#old",
+      streamedRedirectTarget: "/same#new",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "followRedirect",
+      redirect: {
+        href: "/same#new",
+      },
+    });
+  });
+
+  it("preserves streamed visible query params and hashes", () => {
+    const decision = classify({
+      streamedRedirectTarget: "/target.rsc?visible=1&_rsc=abc#details",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "followRedirect",
+      redirect: {
+        href: "/target.rsc?visible=1&_rsc=abc#details",
+      },
+    });
+  });
+
+  it("proceeds to commit for valid non-redirect RSC responses", () => {
+    const decision = classify();
+
+    expect(decision).toEqual({
+      discardBody: false,
+      kind: "proceedToCommit",
+      trace: {
+        schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.proceedToCommit,
+            fields: {
+              fetchResultSource: "live",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("keeps cached-source precedence at compat, redirect, then proceed", () => {
+    const compatDecision = classify({
+      compatibilityIdHeader: "server-build",
+      source: "cached",
+      responseUrl: "https://example.com/cached-target.rsc?_rsc=abc",
+    });
+    expect(compatDecision).toMatchObject({
+      kind: "hardNavigate",
+      reason: "rscCompatibilityMismatch",
+      url: "/cached-target",
+    });
+
+    const redirectDecision = classify({
+      source: "cached",
+      responseUrl: "https://example.com/cached-target.rsc?_rsc=abc",
+    });
+    expect(redirectDecision).toMatchObject({
+      discardBody: false,
+      kind: "followRedirect",
+      redirect: {
+        href: "/cached-target",
+      },
+    });
+
+    const proceedDecision = classify({
+      source: "cached",
+    });
+    expect(proceedDecision).toMatchObject({
+      kind: "proceedToCommit",
+    });
+  });
+});


### PR DESCRIPTION
## Overview

| Field | Value |
| --- | --- |
| Goal | Move pre-decode RSC fetch-result decisions into the navigation planner |
| Core change | Classify invalid RSC payloads, compatibility mismatches, response URL redirects, streamed redirects, and proceed-to-commit as typed planner decisions |
| Main boundary | Planner owns semantic decisions; browser executor owns effects like body discard, diagnostics, loop state, and hard navigation |
| Primary files | `navigation-planner.ts`, `app-browser-entry.ts`, `app-browser-rsc-redirect.ts`, `navigation-trace.ts` |
| Expected impact | Same response-URL behavior, typed hard-navigation causes, and a streamed redirect loop guard |
| Reference | Refs #1790 |

## Why

RSC navigation correctness depends on separating semantic decisions from browser effects. The fetch result decides whether navigation can proceed, must follow a redirect, or must leave the SPA path. The executor should only apply that decision.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Redirect lifecycle | Response URL redirects and streamed-header redirects should share one lifecycle law | Adds a streamed redirect helper that preserves target hash semantics |
| Planner contract | Hard navigation causes should be typed and assertable | Adds `classifyRscFetchResult` with typed decisions and trace reasons |
| Browser executor | The hot loop should execute decisions, not own semantic classification | Replaces inline fetch-result branches with planner calls |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Invalid or non-RSC live response | Inline hard navigation in `navigateRsc` | Planner returns `hardNavigate` with `invalidRscPayload` |
| RSC compatibility mismatch | Inline helper call in cached and live paths | Planner returns `hardNavigate` with `rscCompatibilityMismatch` |
| Response URL redirect | Inline redirect lifecycle handling | Planner returns `followRedirect` or terminal `hardNavigate` |
| Streamed redirect header | Separate inline branch with different loop behavior | Shared lifecycle handling with target hash preservation and same-target loop guard |
| Traceability | No pre-decode fetch-result reason codes | Trace codes and fields for source, signal, depth, and target |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-browser-rsc-redirect.ts`: streamed redirect helper and hash semantics.
2. `packages/vinext/src/server/navigation-trace.ts`: new reason codes and trace fields.
3. `packages/vinext/src/server/navigation-planner.ts`: `classifyRscFetchResult` precedence ladder and typed decision output.
4. `tests/navigation-planner-rsc-fetch-result.test.ts`: full matrix for causes, targets, discard-body, and trace fields.
5. `packages/vinext/src/server/app-browser-entry.ts`: executor cutover in cached and live response paths.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/navigation-planner-rsc-fetch-result.test.ts tests/navigation-planner.test.ts tests/app-browser-entry.test.ts`
- `vp check`
- `pnpm run knip` passed with existing configuration hints only
- `vp run vinext#build` passed with existing unresolved virtual-module warnings
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/redirect-once.spec.ts tests/e2e/app-router/nextjs-compat/external-redirect.spec.ts tests/e2e/app-router/nextjs-compat/server-actions-relative-redirect.spec.ts tests/e2e/app-router/navigation.spec.ts tests/e2e/app-router/routes.spec.ts tests/e2e/app-router/rsc-fetch-errors.spec.ts tests/e2e/app-router/scroll-restoration.spec.ts` passed, 44 tests

</details>

<details>
<summary>Risk / compatibility</summary>

- Runtime behavior intentionally changes for streamed redirects that resolve to the same visible target: those now hard-navigate with `streamedRedirectLoop` instead of continuing indefinitely.
- Response URL redirect hash semantics are preserved through the existing helper.
- Streamed redirect headers preserve the streamed target pathname, search, and hash because they are semantic redirect targets, not network request URLs.
- Server-action compatibility handling remains out of scope and still calls the existing compatibility helper directly.

</details>

<details>
<summary>Non-goals</summary>

- Same-page-search planner classification.
- Folding this classifier into the unified `plan()` event surface.
- OperationToken authority, BFCache changes, segment-cache work, or server-action redirect compatibility causes.

</details>
