### PR TITLE
fix(entries): load app route handlers via SSR loadAppRouteHandler

### DIFF
--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -142,13 +142,14 @@ function registerRouteModules(routes: AppRoute[], imports: ImportAllocator): voi
     // reached via lazy `{ load }` sources in generateStaticParamsMap, resolved
     // on demand at prerender time.
     if (route.pagePath) imports.getLazyLoaderVar(route.pagePath);
-    // Route handlers are always lazy: they are never referenced by
-    // generateStaticParamsMap (buildGenerateStaticParamsEntries sources only
-    // from layouts + page, never route.routePath), so unlike dynamic-route
-    // pages they have no module-load-time consumer. (Next.js route handlers can
-    // export generateStaticParams for prerendering, but vinext does not wire
-    // that into the map yet — a separate gap, unaffected by lazy loading.)
-    if (route.routePath) imports.getLazyLoaderVar(route.routePath);
+    // Route handlers (e.g. `app/api/<segment>/route.ts`) are NOT pre-registered
+    // as eager imports or lazy loaders here. Instead, the SSR entry generated
+    // by `app-ssr-entry.ts` statically imports every route handler and exposes
+    // a `loadAppRouteHandler(pattern)` resolver. The RSC manifest emits a
+    // thunk that, at runtime, asks the SSR environment to load the matching
+    // handler via `import.meta.viteRsc.loadModule("ssr", "index")`. This
+    // keeps route handler modules out of the `react-server` condition while
+    // still letting them use `react-dom/server` to build Response bodies.
     for (const layout of route.layouts) imports.getImportVar(layout);
     for (const tmpl of route.templates) imports.getImportVar(tmpl);
     if (route.loadingPath) imports.getImportVar(route.loadingPath);
@@ -269,11 +270,12 @@ ${interceptEntries.join(",\n")}
       ep ? imports.getImportVar(ep) : "null",
     );
     const errorVars = (route.errorPaths ?? []).map((ep) => imports.getImportVar(ep));
-    // Page and route handler are always lazy-loaded; hydrated onto route.page /
-    // route.routeHandler by ensureAppRouteModulesLoaded before any read.
+    // Page is always lazy-loaded; hydrated onto route.page by
+    // ensureAppRouteModulesLoaded before any read. Route handler loading is
+    // delegated to the SSR entry — see `loadRouteHandlerField` below.
     const loadPageField = route.pagePath ? imports.getLazyLoaderVar(route.pagePath) : "null";
     const loadRouteHandlerField = route.routePath
-      ? imports.getLazyLoaderVar(route.routePath)
+      ? `(async () => (await import.meta.viteRsc.loadModule("ssr", "index")).loadAppRouteHandler(${JSON.stringify(route.pattern)}))`
       : "null";
     return `  {
     __buildTimeClassifications: __VINEXT_CLASS(${routeIdx}), // evaluated once at module load

--- a/packages/vinext/src/entries/app-ssr-entry.ts
+++ b/packages/vinext/src/entries/app-ssr-entry.ts
@@ -1,4 +1,6 @@
 import { resolveRuntimeEntryModule } from "./runtime-entry-module.js";
+import type { AppRoute } from "../routing/app-router.js";
+import { normalizePathSeparators } from "../utils/path.js";
 
 /**
  * Generate the virtual SSR entry module.
@@ -10,13 +12,36 @@ import { resolveRuntimeEntryModule } from "./runtime-entry-module.js";
  * entry also re-exports selected Pages server entry hooks from
  * `virtual:vinext-server-entry` so the RSC bundle can access Pages Router
  * route metadata and fallback dispatchers via `import("./ssr/index.js")`.
+ *
+ * Route handlers (for example `app/api/<segment>/route.ts`) are loaded on demand from the
+ * RSC environment via `import.meta.viteRsc.loadModule("ssr", "index")` to
+ * avoid the `react-server` condition being applied to modules that need
+ * `react-dom/server` to construct NextResponse / Response bodies.
  */
-export function generateSsrEntry(hasPagesDir = false): string {
+export function generateSsrEntry(routes: AppRoute[] = [], hasPagesDir = false): string {
   const entryPath = resolveRuntimeEntryModule("app-ssr-entry");
+  const routeHandlerImports: string[] = [];
+  const routeHandlerEntries: string[] = [];
+  let routeHandlerIndex = 0;
+  for (const route of routes) {
+    if (!route.routePath) continue;
+    const routeHandlerVar = `__appRouteHandler_${routeHandlerIndex++}`;
+    routeHandlerImports.push(
+      `import * as ${routeHandlerVar} from ${JSON.stringify(normalizePathSeparators(route.routePath))};`,
+    );
+    routeHandlerEntries.push(`  ${JSON.stringify(route.pattern)}: ${routeHandlerVar},`);
+  }
 
   return `
+${routeHandlerImports.join("\n")}
 export * from ${JSON.stringify(entryPath)};
 export { default } from ${JSON.stringify(entryPath)};
+const __appRouteHandlers = {
+${routeHandlerEntries.join("\n")}
+};
+export function loadAppRouteHandler(pattern) {
+	return __appRouteHandlers[pattern] ?? null;
+}
 ${
   hasPagesDir
     ? `

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2604,7 +2604,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           return generateCacheAdaptersModule(options.cache);
         }
         if (id === RESOLVED_APP_SSR_ENTRY && hasAppDir) {
-          return generateSsrEntry(hasPagesDir);
+          return generateSsrEntry(
+            await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher),
+            hasPagesDir,
+          );
         }
         if (id === RESOLVED_APP_BROWSER_ENTRY && hasAppDir) {
           const graph = await appRouteGraph(appDir, nextConfig?.pageExtensions, fileMatcher);


### PR DESCRIPTION
## Problem

App Router route handlers (e.g. `app/api/<segment>/route.ts`) are imported and registered by the RSC entry's manifest, which runs under the `react-server` condition. Modules that need `react-dom/server` to construct `NextResponse` / `Response` bodies (notably any handler that returns a streaming or DOM-typed body) fail to evaluate in that environment.

The current code eagerly pulls `route.routePath` modules into the RSC entry via `getLazyLoaderVar`, but those modules still get parsed under `react-server` and crash at import time when they reach for `react-dom/server`.

## Fix

Move route handler loading to the SSR environment:

- **`packages/vinext/src/entries/app-ssr-entry.ts`** — `generateSsrEntry` now accepts the resolved `AppRoute[]`, statically imports every `route.routePath` into a `__appRouteHandlers` pattern-indexed map, and exports a `loadAppRouteHandler(pattern)` resolver.
- **`packages/vinext/src/entries/app-rsc-manifest.ts`** — drops the eager `getLazyLoaderVar(route.routePath)` registration in `registerRouteModules`; the emitted `__loadRouteHandler` thunk now calls `import.meta.viteRsc.loadModule("ssr", "index").loadAppRouteHandler(pattern)` on demand.
- **`packages/vinext/src/index.ts`** — passes the resolved routes through to `generateSsrEntry`.

Result: route handler modules are evaluated in the SSR environment (where `react-dom/server` is available) while still being loaded lazily on first request from the RSC entry.

## Verification

- `npx tsc --noEmit -p packages/vinext/tsconfig.json` — clean
- `npx vp test run --project unit` on the affected suites (`app-route-handler-response`, `app-route-handler-dispatch`, `app-route-handler-policy`, `app-route-handler-trailing-slash`, `app-route-handler-execution`, `app-route-handler-runtime`, `app-route-handler-cache`, `route-classification-injector`, `app-rsc-route-matching`) — 86/86 pass

## Notes

- The repro / exact failing handlers are downstream of the issue: any `route.ts` that imports `react-dom/server` (directly or transitively via `next/server`) under an App Router tree.
- Mirrors what Next.js does in production: route handler modules live in the SSR environment and the RSC layer only knows their patterns.