### PR TITLE
refactor(optimize-imports): normalize resolvePackageEntry paths via normalizePathSeparators

### DIFF
--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -19,6 +19,7 @@ import path from "node:path";
 import MagicString from "magic-string";
 import type { ResolvedNextConfig } from "../config/next-config.js";
 import { getAstName } from "./ast-utils.js";
+import { normalizePathSeparators } from "../utils/path.js";
 
 /**
  * Read a file's contents, returning null on any error.
@@ -293,18 +294,18 @@ async function resolvePackageEntry(
       if (dotExport) {
         const entryPath = resolveExportsValue(dotExport, preferReactServer);
         if (entryPath) {
-          return path.resolve(pkgDir, entryPath).split(path.sep).join("/");
+          return normalizePathSeparators(path.resolve(pkgDir, entryPath));
         }
       }
     }
 
     const entryField = pkgJson.module ?? pkgJson.main;
     if (typeof entryField === "string") {
-      return path.resolve(pkgDir, entryField).split(path.sep).join("/");
+      return normalizePathSeparators(path.resolve(pkgDir, entryField));
     }
 
     const req = createRequire(path.join(projectRoot, "package.json"));
-    return req.resolve(packageName).split(path.sep).join("/");
+    return normalizePathSeparators(req.resolve(packageName));
   } catch {
     return null;
   }


### PR DESCRIPTION
### What

`resolvePackageEntry` returns a barrel package's entry path as a forward-slash module specifier. On Windows `path.resolve` / `req.resolve` emit backslashes, which were flattened to forward slashes with an inline `.split(path.sep).join("/")`. Swap that for the shared `normalizePathSeparators` helper:

```diff
+import { normalizePathSeparators } from "../utils/path.js";
 ...
-          return path.resolve(pkgDir, entryPath).split(path.sep).join("/");
+          return normalizePathSeparators(path.resolve(pkgDir, entryPath));
 ...
-      return path.resolve(pkgDir, entryField).split(path.sep).join("/");
+      return normalizePathSeparators(path.resolve(pkgDir, entryField));
 ...
-    return req.resolve(packageName).split(path.sep).join("/");
+    return normalizePathSeparators(req.resolve(packageName));
```

### Why

Consistency: `normalizePathSeparators` is the helper the codebase already uses for exactly this (introduced/used across #1885–1887). It expresses the intent ("flip Windows separators to forward slashes") directly instead of via a split/join idiom, and is marginally cheaper — a no-op on POSIX and a single regex replace on Windows, versus always allocating an array.

### Behavior-preserving

Pure refactor. `normalizePathSeparators(p)` is `isWindows ? p.replace(/\\/g, "/") : p`, which yields the same string as `.split(path.sep).join("/")` on both platforms (Windows `path.sep` is `\`, POSIX `path.sep` is `/`). `path.resolve` / `req.resolve` only emit one separator style, so there is no mixed-separator edge case.