### PR TITLE
refactor(optimize-imports): drop dead packageName/resolveEntry params from buildBarrelExportMap

### DIFF
--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -582,17 +582,19 @@ async function buildExportMapFromFile(
  * Handles: `export * as X from`, `export { A } from`, `import * as X; export { X }`,
  * and `export * from "./sub"` (recursively resolves wildcard re-exports).
  *
- * Returns null if the entry cannot be resolved, the file cannot be read, or
- * the file has a parse error. Returns an empty map if the file is valid but
- * exports nothing.
+ * Returns null if `entryPath` is empty, the file cannot be read, or the file
+ * has a parse error. Returns an empty map if the file is valid but exports
+ * nothing.
+ *
+ * @param entryPath - Pre-resolved absolute path to the barrel entry file (the
+ *   caller owns entry resolution + its caching), or null when it could not be
+ *   resolved.
  */
 export async function buildBarrelExportMap(
-  packageName: string,
-  resolveEntry: (pkg: string) => string | null,
+  entryPath: string | null,
   readFile: (filepath: string) => Promise<string | null>,
   cache?: Map<string, BarrelExportMap>,
 ): Promise<BarrelExportMap | null> {
-  const entryPath = resolveEntry(packageName);
   if (!entryPath) return null;
 
   const exportMapCache = cache ?? new Map<string, BarrelExportMap>();
@@ -763,10 +765,7 @@ export function createOptimizeImportsPlugin(
             entryPathCache.set(cacheKey, barrelEntry ?? null);
           }
           const exportMap = await buildBarrelExportMap(
-            importSource,
-            // Entry already resolved above via entryPathCache; the callback is a
-            // no-op resolver that simply returns the pre-resolved barrelEntry.
-            () => barrelEntry ?? null,
+            barrelEntry,
             readFileSafe,
             barrelCaches.exportMapCache,
           );

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -168,11 +168,7 @@ describe("buildBarrelExportMap", () => {
     const barrelCode = `export * as Slot from "@radix-ui/react-slot";
 export * as Tooltip from "@radix-ui/react-tooltip";`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     expect(map).not.toBeNull();
     expect(map!.get("Slot")).toEqual({
@@ -191,11 +187,7 @@ export * as Tooltip from "@radix-ui/react-tooltip";`;
     const barrelCode = `export { Button, buttonVariants } from "./button";
 export { Input } from "./input";`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     expect(map).not.toBeNull();
     // Relative sources are resolved to absolute paths during map building
@@ -221,11 +213,7 @@ export { Input } from "./input";`;
     const entryDir = path.dirname(entryPath);
     const barrelCode = `export { default as Calendar } from "./calendar";`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     expect(map).not.toBeNull();
     expect(map!.get("Calendar")).toEqual({
@@ -240,11 +228,7 @@ export { Input } from "./input";`;
     const barrelCode = `import * as AlertDialog from "@radix-ui/react-alert-dialog";
 export { AlertDialog };`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     expect(map).not.toBeNull();
     expect(map!.get("AlertDialog")).toEqual({
@@ -258,11 +242,7 @@ export { AlertDialog };`;
     const barrelCode = `import { format } from "date-fns/format";
 export { format };`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     expect(map).not.toBeNull();
     expect(map!.get("format")).toEqual({
@@ -277,11 +257,7 @@ export { format };`;
     const barrelCode = `const Mo = {};
 export { Mo as Listbox };`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     expect(map).not.toBeNull();
     expect(map!.get("Listbox")).toEqual({
@@ -292,21 +268,13 @@ export { Mo as Listbox };`;
   });
 
   it("returns null when entry cannot be resolved", async () => {
-    const map = await buildBarrelExportMap(
-      "nonexistent-pkg",
-      () => null,
-      () => Promise.resolve(null),
-    );
+    const map = await buildBarrelExportMap(null, () => Promise.resolve(null));
     expect(map).toBeNull();
   });
 
   it("returns null when entry file cannot be read", async () => {
     const entryPath = uniquePath("unreadable");
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(null),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(null));
     expect(map).toBeNull();
   });
 
@@ -315,11 +283,7 @@ export { Mo as Listbox };`;
     // unchanged in the transform), not null. Null is only returned when the
     // entry path itself cannot be resolved or the file cannot be read.
     const entryPath = uniquePath("syntax-error");
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve("export { unclosed"),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve("export { unclosed"));
     expect(map).not.toBeNull();
     expect(map!.size).toBe(0);
   });
@@ -334,11 +298,7 @@ export { Mo as Listbox };`;
       [subPath]: `export { format } from "./format";\nexport { parse } from "./parse";`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     // Button from the barrel — resolved to absolute path relative to entry dir
@@ -361,11 +321,7 @@ export { Mo as Listbox };`;
       [subPath]: `export { format } from "./other-format";`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     // The explicit export wins over the wildcard — resolved to absolute path
@@ -386,11 +342,7 @@ export { Mo as Listbox };`;
 
     // Should not throw or hang
     await expect(
-      buildBarrelExportMap(
-        "test-pkg",
-        () => entryPath,
-        (fp) => Promise.resolve(files[fp] ?? null),
-      ),
+      buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null)),
     ).resolves.not.toThrow();
   });
 
@@ -399,11 +351,7 @@ export { Mo as Listbox };`;
     const barrelCode = `export * from "some-external-pkg";
 export { Button } from "./button";`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     expect(map).not.toBeNull();
     // Only Button is in the map (external wildcard is skipped)
@@ -432,11 +380,7 @@ export { Button } from "./button";`;
       "/fake/nested/components/Button.js": `export function Button() {}`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     const buttonEntry = map!.get("Button");
@@ -457,11 +401,7 @@ export { Button } from "./button";`;
       "/fake/dir-wildcard/components/Button.js": `export function Button() {}`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     const buttonEntry = map!.get("Button");
@@ -480,11 +420,7 @@ export { Button } from "./button";`;
       "/fake/jsx-wildcard/Button.jsx": `export { Button } from "./button-impl";`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     // Button must be resolvable via the .jsx candidate
@@ -500,11 +436,7 @@ export { Button } from "./button";`;
       "/fake/cjs-wildcard/helpers.cjs": `exports.helper = function helper() {};`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     // The .cjs file is found (not null map). The map may be empty if parseAst
     // can't parse CJS syntax, but the important thing is no error is thrown.
@@ -520,11 +452,7 @@ export { Button } from "./button";`;
     const entryPath = uniquePath("malformed-ast");
     const barrelCode = `export { Button } from "./button";`;
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      () => Promise.resolve(barrelCode),
-    );
+    const map = await buildBarrelExportMap(entryPath, () => Promise.resolve(barrelCode));
 
     // Normal exports are still present
     expect(map).not.toBeNull();
@@ -544,11 +472,7 @@ export { Button } from "./button";`;
       [subPath]: `export function formatDistanceToNow(date, options) { return date; }`,
     };
 
-    const map = await buildBarrelExportMap(
-      "date-fns",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     const entry = map!.get("formatDistanceToNow");
@@ -566,11 +490,7 @@ export { Button } from "./button";`;
       [subPath]: `export const add = (a, b) => a + b, subtract = (a, b) => a - b;`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     expect(map!.get("add")).toMatchObject({ source: subPath, isNamespace: false });
@@ -585,11 +505,7 @@ export { Button } from "./button";`;
       [subPath]: `export class MyClass {}`,
     };
 
-    const map = await buildBarrelExportMap(
-      "test-pkg",
-      () => entryPath,
-      (fp) => Promise.resolve(files[fp] ?? null),
-    );
+    const map = await buildBarrelExportMap(entryPath, (fp) => Promise.resolve(files[fp] ?? null));
 
     expect(map).not.toBeNull();
     expect(map!.get("MyClass")).toMatchObject({ source: subPath, isNamespace: false });


### PR DESCRIPTION
### What

`buildBarrelExportMap` resolved its barrel entry via a `(packageName, resolveEntry)` pair, but the indirection was dead: every caller passed a `resolveEntry` thunk that ignored `packageName` and returned a path the caller had already resolved. `packageName` was not used for anything else (the export-map cache is keyed by `entryPath`). Replace the pair with a single pre-resolved `entryPath`.

```diff
 export async function buildBarrelExportMap(
-  packageName: string,
-  resolveEntry: (pkg: string) => string | null,
+  entryPath: string | null,
   readFile: (filepath: string) => Promise<string | null>,
   cache?: Map<string, BarrelExportMap>,
 ): Promise<BarrelExportMap | null> {
-  const entryPath = resolveEntry(packageName);
   if (!entryPath) return null;
```

Plugin call site — pass the resolved entry directly:

```diff
   const exportMap = await buildBarrelExportMap(
-    importSource,
-    // Entry already resolved above via entryPathCache; the callback is a
-    // no-op resolver that simply returns the pre-resolved barrelEntry.
-    () => barrelEntry ?? null,
+    barrelEntry,
     readFileSafe,
     barrelCaches.exportMapCache,
   );
```

`barrelEntry ?? null` is dropped too: it's already narrowed to `string | null` after the `if (barrelEntry === undefined)` block, and that narrowing now applies because the value is passed directly instead of captured in a closure. The ~20 unit-test call sites are updated to the new 2/3-arg form.

### Why

Removes a parameter that no caller used and a thunk that every caller stubbed out, so the entry-resolution ownership (caller resolves + caches) is expressed directly in the signature.

### Behavior-preserving

Pure refactor. The only consumer is this plugin, which already resolved the entry through `entryPathCache` before calling — the function now just receives that value instead of a thunk wrapping it. Typecheck/lint clean (`vp check`).

### Testing

`pnpm test:unit tests/optimize-imports.test.ts` — the `buildBarrelExportMap` cases run against the new signature. Note: the file has some pre-existing, unrelated Windows failures (`path.resolve` drive-letter handling in relative-source resolution, plus a few assertions that expect backslash paths); this refactor neither fixes nor introduces any of them.