### PR TITLE
fix(routing): normalize route root to forward slashes, drop downstream path workarounds

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -72,23 +72,21 @@ export async function generateServerEntry(
   // (e.g. global stylesheets imported by `_app.tsx`) alongside the page's
   // own assets. Without this, `_app`-imported CSS is emitted by Vite but
   // never `<link>`ed from the rendered HTML — see LHF-5 cluster.
-  const appAssetPathJson =
-    appFilePath !== null ? JSON.stringify(normalizePathSeparators(appFilePath)) : "null";
+  const appAssetPathJson = appFilePath !== null ? JSON.stringify(appFilePath) : "null";
   const appImportCode =
     appFilePath !== null
-      ? `import { default as AppComponent } from ${JSON.stringify(normalizePathSeparators(appFilePath))};`
+      ? `import { default as AppComponent } from ${JSON.stringify(appFilePath)};`
       : `const AppComponent = null;`;
 
   const docImportCode =
     docFilePath !== null
-      ? `import { default as DocumentComponent } from ${JSON.stringify(normalizePathSeparators(docFilePath))};`
+      ? `import { default as DocumentComponent } from ${JSON.stringify(docFilePath)};`
       : `const DocumentComponent = null;`;
 
-  const errorAssetPathJson =
-    errorFilePath !== null ? JSON.stringify(normalizePathSeparators(errorFilePath)) : "null";
+  const errorAssetPathJson = errorFilePath !== null ? JSON.stringify(errorFilePath) : "null";
   const errorImportCode =
     errorFilePath !== null
-      ? `import * as ErrorPageModule from ${JSON.stringify(normalizePathSeparators(errorFilePath))};`
+      ? `import * as ErrorPageModule from ${JSON.stringify(errorFilePath)};`
       : `const ErrorPageModule = null;`;
 
   // Serialize i18n config for embedding in the server entry

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1132,7 +1132,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       enforce: "pre",
 
       async config(config, env) {
-        root = config.root ?? process.cwd();
+        root = normalizePathSeparators(config.root ?? process.cwd());
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
         const shouldEnableNativeTsconfigPaths =
           viteMajorVersion >= 8 && userResolve?.tsconfigPaths === undefined;
@@ -1170,27 +1170,28 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // If not provided, auto-detect: check root first, then src/ subdirectory.
         let baseDir: string;
         if (options.appDir) {
-          baseDir = path.isAbsolute(options.appDir)
+          const dir = path.isAbsolute(options.appDir)
             ? options.appDir
             : path.resolve(root, options.appDir);
+          baseDir = normalizePathSeparators(dir);
         } else {
           // Auto-detect: prefer root-level app/ and pages/, fall back to src/
-          const hasRootApp = fs.existsSync(path.join(root, "app"));
-          const hasRootPages = fs.existsSync(path.join(root, "pages"));
-          const hasSrcApp = fs.existsSync(path.join(root, "src", "app"));
-          const hasSrcPages = fs.existsSync(path.join(root, "src", "pages"));
+          const hasRootApp = fs.existsSync(path.posix.join(root, "app"));
+          const hasRootPages = fs.existsSync(path.posix.join(root, "pages"));
+          const hasSrcApp = fs.existsSync(path.posix.join(root, "src", "app"));
+          const hasSrcPages = fs.existsSync(path.posix.join(root, "src", "pages"));
 
           if (hasRootApp || hasRootPages) {
             baseDir = root;
           } else if (hasSrcApp || hasSrcPages) {
-            baseDir = path.join(root, "src");
+            baseDir = path.posix.join(root, "src");
           } else {
             baseDir = root;
           }
         }
 
-        pagesDir = path.join(baseDir, "pages");
-        appDir = path.join(baseDir, "app");
+        pagesDir = path.posix.join(baseDir, "pages");
+        appDir = path.posix.join(baseDir, "app");
         hasPagesDir = fs.existsSync(pagesDir);
         hasAppDir = !options.disableAppRouter && fs.existsSync(appDir);
 

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2147,7 +2147,8 @@ function discoverSiblingInterceptingRoutes(
   for (const route of routes) {
     const filePath = route.pagePath ?? route.routePath;
     if (!filePath) continue;
-    const routeDir = path.dirname(filePath);
+    // Keys are forward-slash — findOwnerRouteForDir compares in that space.
+    const routeDir = path.dirname(filePath).replace(/\\/g, "/");
     if (!routesByDir.has(routeDir)) {
       routesByDir.set(routeDir, route);
     }
@@ -2220,14 +2221,24 @@ function discoverSiblingInterceptingRoutes(
  *    any of the above. This handles the case where the marker directory has
  *    no sibling pages at all (e.g. `deep/path/(...)target` with no
  *    `deep/path/page.tsx`).
+ *
+ * All comparisons happen in forward-slash space: `appDir` is forward-slash
+ * (normalized once in the config hook), but `dir` and route file paths
+ * descend through native `path.join`/`path.dirname`, which reintroduce
+ * backslashes on Windows. Without normalizing, the `current === appDir`
+ * termination never fires there and the walk overshoots the app root.
+ * `routesByDir` keys must be forward-slash dirnames of the route file paths.
+ *
+ * Exported for tests.
  */
-function findOwnerRouteForDir(
+export function findOwnerRouteForDir(
   dir: string,
   appDir: string,
   routes: readonly AppRouteGraphRoute[],
   routesByDir: Map<string, AppRouteGraphRoute>,
 ): AppRouteGraphRoute | null {
-  let current = dir;
+  const appRoot = appDir.replace(/\\/g, "/");
+  let current = dir.replace(/\\/g, "/");
   while (true) {
     // Exact match: a route whose page/handler file lives directly in `current`
     const exact = routesByDir.get(current);
@@ -2235,12 +2246,12 @@ function findOwnerRouteForDir(
 
     // Subtree match: a route whose page is somewhere under `current` — pick
     // the one with the fewest pattern parts (shallowest / least specific).
-    const currentWithSep = current + path.sep;
+    const currentWithSep = current + "/";
     let best: AppRouteGraphRoute | null = null;
     for (const route of routes) {
       const filePath = route.pagePath ?? route.routePath;
       if (!filePath) continue;
-      if (!filePath.startsWith(currentWithSep)) continue;
+      if (!filePath.replace(/\\/g, "/").startsWith(currentWithSep)) continue;
       if (!best || route.patternParts.length < best.patternParts.length) {
         best = route;
       }
@@ -2248,7 +2259,7 @@ function findOwnerRouteForDir(
     if (best) return best;
 
     // Stop if we've reached the app root
-    if (current === appDir) break;
+    if (current === appRoot) break;
     const parent = path.dirname(current);
     if (parent === current) break; // filesystem root safety guard
     current = parent;

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -11,6 +11,7 @@ import { compareRoutes, decodeRouteSegment, isInvisibleSegment } from "./utils.j
 import { findFileWithExts, scanWithExtensions, type ValidFileMatcher } from "./file-matcher.js";
 import { validateRoutePatterns } from "./route-validation.js";
 import { compareStrings } from "../utils/compare.js";
+import { normalizePathSeparators } from "../utils/path.js";
 
 type InterceptingRoute = {
   /** The interception convention: "." | ".." | "../.." | "..." */
@@ -2148,7 +2149,7 @@ function discoverSiblingInterceptingRoutes(
     const filePath = route.pagePath ?? route.routePath;
     if (!filePath) continue;
     // Keys are forward-slash — findOwnerRouteForDir compares in that space.
-    const routeDir = path.dirname(filePath).replace(/\\/g, "/");
+    const routeDir = normalizePathSeparators(path.dirname(filePath));
     if (!routesByDir.has(routeDir)) {
       routesByDir.set(routeDir, route);
     }
@@ -2237,8 +2238,8 @@ export function findOwnerRouteForDir(
   routes: readonly AppRouteGraphRoute[],
   routesByDir: Map<string, AppRouteGraphRoute>,
 ): AppRouteGraphRoute | null {
-  const appRoot = appDir.replace(/\\/g, "/");
-  let current = dir.replace(/\\/g, "/");
+  const appRoot = normalizePathSeparators(appDir);
+  let current = normalizePathSeparators(dir);
   while (true) {
     // Exact match: a route whose page/handler file lives directly in `current`
     const exact = routesByDir.get(current);
@@ -2251,7 +2252,7 @@ export function findOwnerRouteForDir(
     for (const route of routes) {
       const filePath = route.pagePath ?? route.routePath;
       if (!filePath) continue;
-      if (!filePath.replace(/\\/g, "/").startsWith(currentWithSep)) continue;
+      if (!normalizePathSeparators(filePath).startsWith(currentWithSep)) continue;
       if (!best || route.patternParts.length < best.patternParts.length) {
         best = route;
       }

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -98,7 +98,7 @@ export function findFileWithExts(
   matcher: ValidFileMatcher,
 ): string | null {
   for (const ext of matcher.dottedExtensions) {
-    const filePath = path.join(dir, name + ext);
+    const filePath = path.posix.join(dir, name + ext);
     if (existsSync(filePath)) return filePath;
   }
   return null;

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vite-plus/test";
+import { describe, it, expect, vi } from "vite-plus/test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -9,6 +9,15 @@ import {
   type AppRouteGraphRoute,
   type RouteManifest,
 } from "../packages/vinext/src/routing/app-route-graph.js";
+
+// normalizePathSeparators is a platform-gated no-op on POSIX. CI never runs
+// Windows, so force the Windows behavior to let the separator-mismatch tests
+// below exercise the real normalization logic. Harmless for the other tests:
+// POSIX paths contain no backslashes, so the replace is an identity for them.
+vi.mock("../packages/vinext/src/utils/path.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../packages/vinext/src/utils/path.js")>();
+  return { ...actual, normalizePathSeparators: (p: string) => p.replace(/\\/g, "/") };
+});
 
 const EMPTY_PAGE = "export default function Page() { return null; }\n";
 const EMPTY_LAYOUT = "export default function Layout({ children }) { return children; }\n";

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { createValidFileMatcher } from "../packages/vinext/src/routing/file-matcher.js";
 import {
   buildAppRouteGraph,
+  findOwnerRouteForDir,
   type AppRouteGraphRoute,
   type RouteManifest,
 } from "../packages/vinext/src/routing/app-route-graph.js";
@@ -1537,6 +1538,62 @@ describe("App Router route graph builder", () => {
         expect(intercept).toBeDefined();
         // The nearest ancestor route with a page is "/" (the root)
         expect(intercept?.ownerRoute).toBe("/");
+      });
+    });
+
+    describe("findOwnerRouteForDir with Windows-style separators", () => {
+      // On Windows the config hook normalizes `appDir` to forward slashes,
+      // but marker directories and route file paths descend through native
+      // path.join/path.dirname and stay backslash. findOwnerRouteForDir must
+      // compare in forward-slash space; CI is POSIX-only, so simulate the
+      // Windows shapes directly.
+      function makeRoute(pagePath: string, patternParts: string[]): AppRouteGraphRoute {
+        return { pagePath, routePath: null, patternParts } as unknown as AppRouteGraphRoute;
+      }
+
+      const appDir = "C:/proj/app";
+      const rootRoute = makeRoute("C:\\proj\\app\\page.tsx", []);
+      const templatesRoute = makeRoute("C:\\proj\\app\\templates\\page.tsx", ["templates"]);
+      const routes = [rootRoute, templatesRoute];
+      const routesByDir = new Map([
+        ["C:/proj/app", rootRoute],
+        ["C:/proj/app/templates", templatesRoute],
+      ]);
+
+      it("terminates the ancestor walk at the forward-slash app root", () => {
+        // deep/path has no route — the walk must stop at appDir and attach to
+        // the nearest ancestor route instead of overshooting the app root.
+        const owner = findOwnerRouteForDir(
+          "C:\\proj\\app\\deep\\path",
+          appDir,
+          routes,
+          routesByDir,
+        );
+        expect(owner).toBe(rootRoute);
+      });
+
+      it("finds the exact owner for a backslash marker parent dir", () => {
+        const owner = findOwnerRouteForDir("C:\\proj\\app\\templates", appDir, routes, routesByDir);
+        expect(owner).toBe(templatesRoute);
+      });
+
+      it("matches catch-all subtree routes across separator styles", () => {
+        const catchAll = makeRoute("C:\\proj\\app\\templates\\[...slug]\\page.tsx", [
+          "templates",
+          ":slug+",
+        ]);
+        const owner = findOwnerRouteForDir(
+          "C:\\proj\\app\\templates",
+          appDir,
+          [catchAll],
+          new Map([["C:/proj/app/templates/[...slug]", catchAll]]),
+        );
+        expect(owner).toBe(catchAll);
+      });
+
+      it("resolves the root owner when the marker parent is the app root itself", () => {
+        const owner = findOwnerRouteForDir(appDir, appDir, routes, routesByDir);
+        expect(owner).toBe(rootRoute);
       });
     });
 


### PR DESCRIPTION
### What

Normalize the routing root once, at the source, and let the forward-slash invariant flow through route discovery — then remove the ad-hoc normalization it made redundant. Three coordinated pieces:

**1. `index.ts` — normalize root, derive dirs with `path.posix.join`:**

```diff
-        root = config.root ?? process.cwd();
+        root = normalizePathSeparators(config.root ?? process.cwd());
 ...
-          baseDir = path.isAbsolute(options.appDir)
-            ? options.appDir
-            : path.resolve(root, options.appDir);
+          const dir = path.isAbsolute(options.appDir)
+            ? options.appDir
+            : path.resolve(root, options.appDir);
+          baseDir = normalizePathSeparators(dir);
 ...
-          const hasRootApp = fs.existsSync(path.join(root, "app"));
+          const hasRootApp = fs.existsSync(path.posix.join(root, "app"));
 ...
-        pagesDir = path.join(baseDir, "pages");
-        appDir = path.join(baseDir, "app");
+        pagesDir = path.posix.join(baseDir, "pages");
+        appDir = path.posix.join(baseDir, "app");
```

**2. `routing/file-matcher.ts` — `findFileWithExts` joins in POSIX space:**

```diff
   for (const ext of matcher.dottedExtensions) {
-    const filePath = path.join(dir, name + ext);
+    const filePath = path.posix.join(dir, name + ext);
     if (existsSync(filePath)) return filePath;
   }
```

Every `dir` passed to `findFileWithExts` now derives from the normalized `appDir` / `pagesDir`, so it is already forward-slash; `path.posix.join` keeps the returned path forward-slash too.

**3. `entries/pages-server-entry.ts` — drop the now-redundant `normalizePathSeparators`:**

```diff
-  const appAssetPathJson =
-    appFilePath !== null ? JSON.stringify(normalizePathSeparators(appFilePath)) : "null";
+  const appAssetPathJson = appFilePath !== null ? JSON.stringify(appFilePath) : "null";
```

`appFilePath` / `docFilePath` / `errorFilePath` come from `findFileWithExts`, which now returns forward-slash paths, so the per-embed normalization is no longer needed when stringifying them into the generated import code.

### Why

In the `config` hook, `config.root` is the raw user/default value — Vite hasn't normalized it yet, and the `process.cwd()` fallback is backslash-separated on Windows (`E:\proj`). Building `appDir` / `pagesDir` with `path.join` propagated those backslashes into route discovery, which treats these as forward-slash paths everywhere (comparison, matching, emitted module ids). Normalizing once at the root and deriving with `path.posix.join` makes the whole chain consistently forward-slash, which also lets the downstream `pages-server-entry` stop normalizing path-by-path.

`existsSync` accepts forward slashes on Windows, so the auto-detect probes and the file-matcher lookups behave the same; only the separator style of the stored/propagated paths changes.