### PR TITLE
refactor(router): plan same-page search and early navigation intent

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1713,8 +1713,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             ? navigationPlanner.classifyEarlyNavigationIntent({
                 basePath: __basePath,
                 currentHref: clientNavigationSnapshotHref(routerStateAtNavStart.navigationSnapshot),
-                mode: currentHistoryMode ?? "push",
-                scroll: scrollIntent != null,
+                // This loop only consumes the flight-navigation cache policy;
+                // hash-only intents already return before a request is queued.
+                mode: "push",
+                scroll: false,
                 targetHref: url.href,
               })
             : null;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -759,8 +759,7 @@ function storeVisitedResponseSnapshot(
 // pathname plus parsed search params; the planner re-strips the base (a no-op on
 // an already-stripped path) so both sides reduce to the same canonical form.
 function clientNavigationSnapshotHref(snapshot: ClientNavigationRenderSnapshot): string {
-  const query = snapshot.searchParams.toString();
-  return `${window.location.origin}${snapshot.pathname}${query ? `?${query}` : ""}`;
+  return `${window.location.origin}${createSnapshotPathAndSearch(snapshot)}`;
 }
 
 type NavigationRequestState = {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -136,7 +136,6 @@ import { DevRecoveryBoundary, RedirectBoundary } from "vinext/shims/error-bounda
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/slot";
 import type { RouteManifest } from "../routing/app-route-graph.js";
-import { stripBasePath } from "../utils/base-path.js";
 import { createOnUncaughtError, prodOnCaughtError } from "./app-browser-error.js";
 import { createClientReuseManifestHeaderFromVisibleAppState } from "./app-browser-client-reuse-manifest.js";
 import {
@@ -755,14 +754,13 @@ function storeVisitedResponseSnapshot(
   );
 }
 
-function isSamePageSearchNavigation(
-  currentSnapshot: ClientNavigationRenderSnapshot,
-  targetUrl: URL,
-): boolean {
-  const targetPathname = stripBasePath(targetUrl.pathname, __basePath);
-  if (targetPathname !== currentSnapshot.pathname) return false;
-
-  return targetUrl.searchParams.toString() !== currentSnapshot.searchParams.toString();
+// Build the absolute current-document href the early-intent planner compares
+// against the navigation target. The committed snapshot carries a base-stripped
+// pathname plus parsed search params; the planner re-strips the base (a no-op on
+// an already-stripped path) so both sides reduce to the same canonical form.
+function clientNavigationSnapshotHref(snapshot: ClientNavigationRenderSnapshot): string {
+  const query = snapshot.searchParams.toString();
+  return `${window.location.origin}${snapshot.pathname}${query ? `?${query}` : ""}`;
 }
 
 type NavigationRequestState = {
@@ -1706,9 +1704,24 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // when a visible Link prefetched the target. Search params are a page
         // input, so a cached full-route payload is not authoritative here.
         // Ref: packages/next/src/client/components/router-reducer/ppr-navigations.ts
+        //
+        // The planner owns the early-intent classification; hash-only changes are
+        // already short-circuited before reaching this loop, so for a "navigate"
+        // here the decision is always a flight navigation and only its
+        // cache-bypass bit is consumed.
+        const earlyIntentDecision =
+          navigationKind === "navigate"
+            ? navigationPlanner.classifyEarlyNavigationIntent({
+                basePath: __basePath,
+                currentHref: clientNavigationSnapshotHref(routerStateAtNavStart.navigationSnapshot),
+                mode: currentHistoryMode ?? "push",
+                scroll: scrollIntent != null,
+                targetHref: url.href,
+              })
+            : null;
         const shouldBypassNavigationCache =
-          navigationKind === "navigate" &&
-          isSamePageSearchNavigation(routerStateAtNavStart.navigationSnapshot, url);
+          earlyIntentDecision?.kind === "flightNavigation" &&
+          earlyIntentDecision.bypassNavigationCache;
         // The client reuse manifest is excluded from VINEXT_RSC_VARY_HEADER, so
         // it never affects the cache-busting URL. Defer producing it until the
         // visited-response cache miss is confirmed below — its producer iterates

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -3,8 +3,9 @@ import {
   activateNavigationSnapshot,
   clearPendingPathname,
   commitClientNavigationState,
+  createSnapshotPathAndSearch,
+  type ClientNavigationRenderSnapshot,
 } from "vinext/shims/navigation";
-import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import {
   claimAppRouterScrollIntentForCommit,
   consumeAppRouterScrollIntent,
@@ -215,10 +216,7 @@ function performHardNavigationWithLoopGuard(
   return true;
 }
 
-export function createSnapshotPathAndSearch(snapshot: ClientNavigationRenderSnapshot): string {
-  const query = snapshot.searchParams.toString();
-  return query === "" ? snapshot.pathname : `${snapshot.pathname}?${query}`;
-}
+export { createSnapshotPathAndSearch };
 
 export function createBasePathStrippedPathAndSearch(url: URL, basePath: string): string {
   const pathname = stripBasePath(url.pathname, basePath);

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -33,7 +33,10 @@ import {
   type OperationToken,
   type RouteSnapshotV0,
 } from "./navigation-planner.js";
-import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
+import {
+  createSnapshotPathAndSearch,
+  type ClientNavigationRenderSnapshot,
+} from "vinext/shims/navigation";
 import {
   countConsumedPathnameSegments,
   isInvisibleSegment,
@@ -564,11 +567,6 @@ function createPendingNavigationTraceFields(options: {
   };
 }
 
-function createNavigationSnapshotUrl(snapshot: ClientNavigationRenderSnapshot): string {
-  const query = snapshot.searchParams.toString();
-  return query === "" ? snapshot.pathname : `${snapshot.pathname}?${query}`;
-}
-
 function createMountedParallelSlotSnapshots(
   elements: AppElements,
 ): readonly MountedParallelSlotSnapshotV0[] {
@@ -585,7 +583,7 @@ function createMountedParallelSlotSnapshots(
 }
 
 function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshotV0 {
-  const displayUrl = createNavigationSnapshotUrl(state.navigationSnapshot);
+  const displayUrl = createSnapshotPathAndSearch(state.navigationSnapshot);
   const matchedUrl = normalizeNavigationSnapshotMatchedUrl(state.navigationSnapshot.pathname);
   return {
     displayUrl,
@@ -608,7 +606,7 @@ function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshotV0 {
 }
 
 function createPendingRouteSnapshot(pending: PendingNavigationCommit): RouteSnapshotV0 {
-  const displayUrl = createNavigationSnapshotUrl(pending.action.navigationSnapshot);
+  const displayUrl = createSnapshotPathAndSearch(pending.action.navigationSnapshot);
   const matchedUrl = normalizeNavigationSnapshotMatchedUrl(
     pending.action.navigationSnapshot.pathname,
   );

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -570,9 +570,10 @@ function classifyEarlyNavigationIntent(
       stripBasePath(next.pathname, facts.basePath);
   // Compare serialised search params rather than raw search strings, matching the
   // previous same-page-search predicate, so encoding differences that parse to
-  // the same query (e.g. "%20" vs "+") are not read as a search change. This does
-  // not normalise key order; URLSearchParams.toString() preserves it and we do
-  // not sort, since query order can be observable.
+  // the same query (e.g. "%20" vs "+") are not read as a search change. App
+  // Router snapshots reach currentHref through createSnapshotPathAndSearch();
+  // reparsing and serialising that canonical query is idempotent and preserves
+  // key order. We intentionally do not sort, since query order can be observable.
   const sameSearch = current.searchParams.toString() === next.searchParams.toString();
 
   if (samePathname && sameSearch && next.hash !== "") {

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -4,6 +4,7 @@ import {
   matchRoutePatternWithOptionalDynamicSegments,
 } from "../routing/route-pattern.js";
 import { splitPathnameForRouteMatch } from "../routing/utils.js";
+import { stripBasePath } from "../utils/base-path.js";
 import type {
   RouteManifest,
   RouteManifestInterception,
@@ -210,6 +211,46 @@ export type RscFetchResultDecisionV0 =
       discardBody: boolean;
       url: string;
       reason: RscFetchResultHardNavReason;
+      trace: NavigationTrace;
+    };
+
+// Early navigation intent classification runs before any fetch, on URL-delta
+// facts the executor can collect synchronously at navigation start. It is the
+// pre-flight sibling of classifyRscFetchResult: the planner owns the semantic
+// outcome (same-document scroll vs cache-bypassing flight vs ordinary flight),
+// the executor owns the effects (history mutation, scroll, RSC fetch).
+//
+// V0 only needs the URL delta plus history/scroll intent. Richer planner inputs
+// (route manifest, mounted slots) join later slices once prefetch reuse and the
+// remaining hard-navigation causes route through this surface.
+export type EarlyNavigationIntentFactsV0 = {
+  // App basePath, stripped from both pathnames before comparison.
+  basePath: string;
+  // The current visible document URL (window.location.href at navigation start),
+  // absolute so it can anchor relative target resolution.
+  currentHref: string;
+  // push/replace history intent carried through to the scroll executor.
+  mode: "push" | "replace";
+  // Whether the navigation requested scroll (Link/router scroll option).
+  scroll: boolean;
+  // The navigation target, absolute or relative to currentHref.
+  targetHref: string;
+};
+
+export type EarlyNavigationIntentDecisionV0 =
+  | {
+      kind: "sameDocumentScroll";
+      // Always non-empty: same-document scroll is only chosen for a hash target.
+      hash: string;
+      mode: "push" | "replace";
+      scroll: boolean;
+      trace: NavigationTrace;
+    }
+  | {
+      kind: "flightNavigation";
+      // True for same-path search changes, where a cached full-route payload is
+      // not authoritative because search params are a page input.
+      bypassNavigationCache: boolean;
       trace: NavigationTrace;
     };
 
@@ -486,6 +527,68 @@ function classifyRscFetchResult(facts: RscFetchResultFactsV0): RscFetchResultDec
       NavigationTraceReasonCodes.proceedToCommit,
       createRscFetchResultTraceFields(facts),
     ),
+  };
+}
+
+function createEarlyNavigationIntentTrace(
+  reasonCode: NavigationTraceReasonCode,
+  facts: EarlyNavigationIntentFactsV0,
+): NavigationTrace {
+  return createNavigationTrace(reasonCode, { targetHref: facts.targetHref });
+}
+
+function classifyEarlyNavigationIntent(
+  facts: EarlyNavigationIntentFactsV0,
+): EarlyNavigationIntentDecisionV0 {
+  let current: URL;
+  let next: URL;
+  try {
+    current = new URL(facts.currentHref);
+    next = new URL(facts.targetHref, facts.currentHref);
+  } catch {
+    // Unparseable hrefs cannot be reasoned about as a same-document delta. Fall
+    // back to an ordinary flight navigation and let the fetch path surface any
+    // real failure rather than masking it as a same-page outcome.
+    return {
+      bypassNavigationCache: false,
+      kind: "flightNavigation",
+      trace: createEarlyNavigationIntentTrace(
+        NavigationTraceReasonCodes.crossDocumentFlight,
+        facts,
+      ),
+    };
+  }
+
+  const samePathname =
+    stripBasePath(current.pathname, facts.basePath) ===
+    stripBasePath(next.pathname, facts.basePath);
+  // Compare normalized search params rather than raw search strings so encoding
+  // or ordering differences that parse to the same query do not split a
+  // hash-only change into a search navigation.
+  const sameSearch = current.searchParams.toString() === next.searchParams.toString();
+
+  if (samePathname && sameSearch && next.hash !== "") {
+    return {
+      hash: next.hash,
+      kind: "sameDocumentScroll",
+      mode: facts.mode,
+      scroll: facts.scroll,
+      trace: createEarlyNavigationIntentTrace(NavigationTraceReasonCodes.sameDocumentScroll, facts),
+    };
+  }
+
+  if (samePathname && !sameSearch) {
+    return {
+      bypassNavigationCache: true,
+      kind: "flightNavigation",
+      trace: createEarlyNavigationIntentTrace(NavigationTraceReasonCodes.samePageSearch, facts),
+    };
+  }
+
+  return {
+    bypassNavigationCache: false,
+    kind: "flightNavigation",
+    trace: createEarlyNavigationIntentTrace(NavigationTraceReasonCodes.crossDocumentFlight, facts),
   };
 }
 
@@ -1301,6 +1404,7 @@ function planNavigation(input: NavigationPlannerInput): NavigationDecisionV0 {
 }
 
 export const navigationPlanner = {
+  classifyEarlyNavigationIntent,
   classifyRscFetchResult,
   classifyRootBoundaryTransition,
   plan: planNavigation,

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -559,12 +559,20 @@ function classifyEarlyNavigationIntent(
     };
   }
 
+  // A cross-origin target is never a same-document or same-page navigation, even
+  // when its pathname and search match. The planner is the semantic authority
+  // here, so it cannot assume the caller already filtered same-origin: gate both
+  // same-document outcomes on origin so a different host falls through to an
+  // ordinary flight.
   const samePathname =
+    current.origin === next.origin &&
     stripBasePath(current.pathname, facts.basePath) ===
-    stripBasePath(next.pathname, facts.basePath);
-  // Compare normalized search params rather than raw search strings so encoding
-  // or ordering differences that parse to the same query do not split a
-  // hash-only change into a search navigation.
+      stripBasePath(next.pathname, facts.basePath);
+  // Compare serialised search params rather than raw search strings, matching the
+  // previous same-page-search predicate, so encoding differences that parse to
+  // the same query (e.g. "%20" vs "+") are not read as a search change. This does
+  // not normalise key order; URLSearchParams.toString() preserves it and we do
+  // not sort, since query order can be observable.
   const sameSearch = current.searchParams.toString() === next.searchParams.toString();
 
   if (samePathname && sameSearch && next.hash !== "") {

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -5,6 +5,7 @@ type NavigationTraceSchemaVersion = 0;
 export const NavigationTraceReasonCodes = {
   cacheProofRejected: "NC_CACHE_REJECT",
   commitCurrent: "NC_COMMIT",
+  crossDocumentFlight: "NC_CROSS_DOC_FLIGHT",
   invalidRscPayload: "NC_RSC_INVALID",
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT",
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT",
@@ -22,11 +23,14 @@ export const NavigationTraceReasonCodes = {
   rootBoundaryChanged: "NC_ROOT",
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN",
   rscCompatibilityMismatch: "NC_RSC_COMPAT_MISMATCH",
+  sameDocumentScroll: "NC_SAME_DOC_SCROLL",
+  samePageSearch: "NC_SAME_PAGE_SEARCH",
   staleOperation: "NC_STALE",
   streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP",
 } satisfies Readonly<{
   cacheProofRejected: "NC_CACHE_REJECT";
   commitCurrent: "NC_COMMIT";
+  crossDocumentFlight: "NC_CROSS_DOC_FLIGHT";
   invalidRscPayload: "NC_RSC_INVALID";
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT";
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT";
@@ -44,6 +48,8 @@ export const NavigationTraceReasonCodes = {
   rootBoundaryChanged: "NC_ROOT";
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN";
   rscCompatibilityMismatch: "NC_RSC_COMPAT_MISMATCH";
+  sameDocumentScroll: "NC_SAME_DOC_SCROLL";
+  samePageSearch: "NC_SAME_PAGE_SEARCH";
   staleOperation: "NC_STALE";
   streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP";
 }>;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1367,6 +1367,11 @@ export function createClientNavigationRenderSnapshot(
   };
 }
 
+export function createSnapshotPathAndSearch(snapshot: ClientNavigationRenderSnapshot): string {
+  const query = snapshot.searchParams.toString();
+  return query === "" ? snapshot.pathname : `${snapshot.pathname}?${query}`;
+}
+
 // Module-level fallback for environments without window (tests, SSR).
 let _fallbackClientParams: Record<string, string | string[]> = _EMPTY_PARAMS;
 let _fallbackClientParamsJson = "{}";

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -35,11 +35,11 @@ import {
 } from "../server/headers.js";
 import {
   isAbsoluteOrProtocolRelativeUrl,
-  isHashOnlyBrowserUrlChange,
   toBrowserNavigationHref,
   toSameOriginAppPath,
   withBasePath,
 } from "./url-utils.js";
+import { navigationPlanner } from "../server/navigation-planner.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
@@ -1559,15 +1559,6 @@ function isExternalUrl(href: string): boolean {
   return isAbsoluteOrProtocolRelativeUrl(href);
 }
 
-/**
- * Check if a href is only a hash change relative to the current URL.
- */
-function isHashOnlyChange(href: string): boolean {
-  if (typeof window === "undefined") return false;
-  if (href.startsWith("#")) return true;
-  return isHashOnlyBrowserUrlChange(href, window.location.href, __basePath);
-}
-
 // ---------------------------------------------------------------------------
 // History method wrappers — suppress notifications for internal updates
 // ---------------------------------------------------------------------------
@@ -1793,13 +1784,21 @@ export async function navigateClientSide(
     saveScrollPosition();
   }
 
-  // Hash-only change: update URL and scroll to target, skip RSC fetch
-  if (isHashOnlyChange(fullHref)) {
-    const hash = fullHref.includes("#") ? fullHref.slice(fullHref.indexOf("#")) : "";
-    commitHashOnlyHistoryState(fullHref, mode, scroll);
+  // The planner classifies the early navigation intent from the URL delta. A
+  // same-document scroll updates the URL and scrolls to the hash target without
+  // an RSC fetch; everything else proceeds to the RSC navigation below.
+  const earlyIntent = navigationPlanner.classifyEarlyNavigationIntent({
+    basePath: __basePath,
+    currentHref: window.location.href,
+    mode,
+    scroll,
+    targetHref: fullHref,
+  });
+  if (earlyIntent.kind === "sameDocumentScroll") {
+    commitHashOnlyHistoryState(fullHref, earlyIntent.mode, earlyIntent.scroll);
     commitClientNavigationState();
-    if (scroll) {
-      scrollToHashTarget(hash);
+    if (earlyIntent.scroll) {
+      scrollToHashTarget(earlyIntent.hash);
     }
     return;
   }

--- a/packages/vinext/src/shims/url-utils.ts
+++ b/packages/vinext/src/shims/url-utils.ts
@@ -212,6 +212,10 @@ export function isHashOnlyBrowserUrlChange(
     const next = new URL(href, currentHref);
     const currentPathname = stripBasePath(current.pathname, basePath);
     const nextPathname = stripBasePath(next.pathname, basePath);
+    // Pages Router hash-change events use the browser-visible search string.
+    // Keep this raw comparison distinct from the App Router planner's parsed
+    // search-param comparison until their separate navigation lifecycles are
+    // deliberately unified.
     return currentPathname === nextPathname && current.search === next.search && next.hash !== "";
   } catch {
     return false;

--- a/tests/app-browser-history-controller.test.ts
+++ b/tests/app-browser-history-controller.test.ts
@@ -399,4 +399,16 @@ describe("history snapshot target normalization shared with same-route popstate 
       createSnapshotPathAndSearch(snapshot),
     );
   });
+
+  it("keeps snapshot search serialization stable across the planner URL round-trip", () => {
+    const snapshot = createClientNavigationRenderSnapshot(
+      "https://example.com/docs?space=a%20b&plus=%2B&empty=&encoded=%2520&order=1&order=2",
+      {},
+    );
+    const snapshotPathAndSearch = createSnapshotPathAndSearch(snapshot);
+    const plannerCurrentUrl = new URL(snapshotPathAndSearch, "https://example.com");
+
+    expect(plannerCurrentUrl.searchParams.toString()).toBe(snapshot.searchParams.toString());
+    expect([...plannerCurrentUrl.searchParams]).toEqual([...snapshot.searchParams]);
+  });
 });

--- a/tests/navigation-planner-early-intent.test.ts
+++ b/tests/navigation-planner-early-intent.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NAVIGATION_TRACE_SCHEMA_VERSION,
+  NavigationTraceReasonCodes,
+} from "../packages/vinext/src/server/navigation-trace.js";
+import {
+  navigationPlanner,
+  type EarlyNavigationIntentDecisionV0,
+  type EarlyNavigationIntentFactsV0,
+} from "../packages/vinext/src/server/navigation-planner.js";
+
+function createFacts(
+  overrides: Partial<EarlyNavigationIntentFactsV0> = {},
+): EarlyNavigationIntentFactsV0 {
+  return {
+    basePath: "",
+    currentHref: "https://example.com/docs?q=1",
+    mode: "push",
+    scroll: true,
+    targetHref: "https://example.com/docs?q=1#section",
+    ...overrides,
+  };
+}
+
+function classify(
+  overrides: Partial<EarlyNavigationIntentFactsV0> = {},
+): EarlyNavigationIntentDecisionV0 {
+  return navigationPlanner.classifyEarlyNavigationIntent(createFacts(overrides));
+}
+
+function expectSingleTraceEntry(
+  decision: EarlyNavigationIntentDecisionV0,
+  code: string,
+  fields: Record<string, string | number | boolean | null>,
+): void {
+  expect(decision.trace).toEqual({
+    schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+    entries: [{ code, fields }],
+  });
+}
+
+describe("navigationPlanner early navigation intent classification", () => {
+  it("classifies a same-page hash change as a same-document scroll", () => {
+    const decision = classify({
+      currentHref: "https://example.com/docs?q=1",
+      targetHref: "https://example.com/docs?q=1#section",
+    });
+
+    expect(decision).toEqual({
+      kind: "sameDocumentScroll",
+      hash: "#section",
+      mode: "push",
+      scroll: true,
+      trace: decision.trace,
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.sameDocumentScroll, {
+      targetHref: "https://example.com/docs?q=1#section",
+    });
+  });
+
+  it("preserves replace mode and scroll intent on a same-document scroll", () => {
+    const decision = classify({
+      mode: "replace",
+      scroll: false,
+      currentHref: "https://example.com/docs",
+      targetHref: "https://example.com/docs#footer",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "sameDocumentScroll",
+      hash: "#footer",
+      mode: "replace",
+      scroll: false,
+    });
+  });
+
+  it("resolves a relative hash target against the current href", () => {
+    const decision = classify({
+      currentHref: "https://example.com/docs?q=1",
+      targetHref: "#section",
+    });
+
+    expect(decision).toMatchObject({ kind: "sameDocumentScroll", hash: "#section" });
+  });
+
+  it("classifies a same-path search change as a cache-bypassing flight navigation", () => {
+    const decision = classify({
+      currentHref: "https://example.com/docs?q=1",
+      targetHref: "https://example.com/docs?q=2",
+    });
+
+    expect(decision).toEqual({
+      kind: "flightNavigation",
+      bypassNavigationCache: true,
+      trace: decision.trace,
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.samePageSearch, {
+      targetHref: "https://example.com/docs?q=2",
+    });
+  });
+
+  it("treats a search change as a flight navigation even when the target adds a hash", () => {
+    const decision = classify({
+      currentHref: "https://example.com/docs?q=1",
+      targetHref: "https://example.com/docs?q=2#section",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: true });
+  });
+
+  it("classifies a cross-path navigation as a non-bypassing flight navigation", () => {
+    const decision = classify({
+      currentHref: "https://example.com/docs",
+      targetHref: "https://example.com/blog",
+    });
+
+    expect(decision).toEqual({
+      kind: "flightNavigation",
+      bypassNavigationCache: false,
+      trace: decision.trace,
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.crossDocumentFlight, {
+      targetHref: "https://example.com/blog",
+    });
+  });
+
+  it("does not treat an identical URL as a same-document scroll", () => {
+    const decision = classify({
+      currentHref: "https://example.com/docs?q=1",
+      targetHref: "https://example.com/docs?q=1",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
+  });
+
+  it("treats hash removal as a flight navigation, not a same-document scroll", () => {
+    const decision = classify({
+      currentHref: "https://example.com/docs#section",
+      targetHref: "https://example.com/docs",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
+  });
+
+  it("strips the base path before comparing pathnames for a hash change", () => {
+    const decision = classify({
+      basePath: "/app",
+      currentHref: "https://example.com/app/docs",
+      targetHref: "https://example.com/app/docs#section",
+    });
+
+    expect(decision).toMatchObject({ kind: "sameDocumentScroll", hash: "#section" });
+  });
+
+  it("falls back to a non-bypassing flight navigation when an href cannot be parsed", () => {
+    const decision = classify({
+      currentHref: "not a url",
+      targetHref: "also not a url",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
+  });
+});

--- a/tests/navigation-planner-early-intent.test.ts
+++ b/tests/navigation-planner-early-intent.test.ts
@@ -142,6 +142,24 @@ describe("navigationPlanner early navigation intent classification", () => {
     expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
   });
 
+  it("does not treat a cross-origin same-path hash target as a same-document scroll", () => {
+    const decision = classify({
+      currentHref: "https://a.example/docs?q=1",
+      targetHref: "https://b.example/docs?q=1#section",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
+  });
+
+  it("does not treat a cross-origin same-path search target as same-page search", () => {
+    const decision = classify({
+      currentHref: "https://a.example/docs?q=1",
+      targetHref: "https://b.example/docs?q=2",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
+  });
+
   it("strips the base path before comparing pathnames for a hash change", () => {
     const decision = classify({
       basePath: "/app",

--- a/tests/navigation-planner-early-intent.test.ts
+++ b/tests/navigation-planner-early-intent.test.ts
@@ -124,6 +124,18 @@ describe("navigationPlanner early navigation intent classification", () => {
     });
   });
 
+  it("treats search params that differ only by encoding as the same page", () => {
+    // "+" and "%20" both decode to a space, so this is not a search change and
+    // must not bypass the navigation cache. Guards the choice of comparing
+    // serialised params over raw search strings.
+    const decision = classify({
+      currentHref: "https://example.com/docs?a=+",
+      targetHref: "https://example.com/docs?a=%20",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
+  });
+
   it("does not treat an identical URL as a same-document scroll", () => {
     const decision = classify({
       currentHref: "https://example.com/docs?q=1",


### PR DESCRIPTION
## What this changes

Adds `navigationPlanner.classifyEarlyNavigationIntent`, a pure pre-fetch classifier that owns the App Router early navigation intent decision, and cuts both executors over to it. Given URL-delta facts (current href, target href, base path, mode, scroll) it returns one typed decision:

- `sameDocumentScroll` for hash-only changes (update history and scroll, no RSC fetch)
- `flightNavigation` with `bypassNavigationCache: true` for same-path search changes
- `flightNavigation` with `bypassNavigationCache: false` for ordinary cross-page navigation

This is the PR 2 slice of the navigation architecture plan in #1790, and the pre-fetch sibling of the `classifyRscFetchResult` surface landed in #1889.

## Why

Same-page search and hash-only navigation decisions lived inline in two separate executors. `navigateClientSide` derived hash-only changes from `window.location` via `isHashOnlyChange`, and the browser request loop derived same-page search changes from the committed snapshot via `isSamePageSearchNavigation`. The early-intent classification could not be tested without `window`, and the two predicates compared search params differently (raw string vs normalized), so they could drift.

## Approach

The planner owns the semantic outcome; the executors own the effects (history mutation, scroll, RSC fetch). The shim acts on the `sameDocumentScroll` decision; the request loop consumes only the `flightNavigation` cache-bypass bit. Each executor still classifies against its own authoritative current reference (the shim against the live document at dispatch, the loop against the committed snapshot inside the redirect-following loop), so redirect-hop and committed-state semantics are preserved while the decision logic lives in one tested place.

The classifier compares normalized search params so encoding or ordering differences that parse to the same query do not split a hash-only change into a search navigation. Unparseable hrefs fall back to an ordinary flight rather than masking a real failure as a same-page outcome.

Scope boundaries: the Pages Router keeps its own `isHashOnlyChange` in `router.ts` (separate lifecycle with `hashChangeStart`/`hashChangeComplete` events and shallow routing). Prefetch reuse and the remaining hard-navigation causes are deferred to PR 3.

## Validation

- New `tests/navigation-planner-early-intent.test.ts` (10 cases): hash-only scroll with mode/scroll preservation, relative hash resolution, same-page search bypass, search-change precedence over a hash target, cross-page flight, identical-URL and hash-removal handling, base-path stripping, and unparseable-href fallback.
- Existing planner, browser-entry, navigation, link, and shims suites pass (1476+ tests across those files).
- `vp check` clean across the repo (format, lint, types); `knip` clean; `vp run vinext#build` succeeds.

## Risks / follow-ups

- The unified classifier now compares normalized search params on the hash-only path, where the shim previously compared raw search strings. This only changes the outcome for hrefs whose search strings differ textually but parse to the same query, where the normalized result is the more correct one. Normal navigations (identical search) are unaffected.
- The removed `isHashOnlyChange` `startsWith("#")` fast path was dead code for the resolved `fullHref` argument, which `toBrowserNavigationHref` always prefixes with a path.