### PR TITLE
refactor(router): classify server-action results and RSC navigation errors in planner

### DIFF
--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -4,6 +4,7 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
+import type { ServerActionResultDecisionV0 } from "./navigation-planner.js";
 
 export type AppBrowserServerActionResult<TRoot> = {
   root?: TRoot;
@@ -136,6 +137,21 @@ export function shouldScheduleRefreshForDiscardedServerAction(
   revalidation: ServerActionRevalidationKind,
 ): boolean {
   return revalidation !== "none";
+}
+
+// Dispatches the executor effects implied by a ServerActionResultDecisionV0.
+// Returns true if a hard-navigation was triggered (the caller should return early);
+// false if the decision is "proceed" and normal action processing should continue.
+// Both callbacks are injected so this function is testable without browser globals.
+export function applyServerActionResultDecision(
+  decision: ServerActionResultDecisionV0,
+  clearCaches: () => void,
+  performHardNavigation: (url: string, historyMode?: "assign" | "replace") => void,
+): boolean {
+  if (decision.kind !== "hardNavigate") return false;
+  if (decision.clearClientNavigationCaches) clearCaches();
+  performHardNavigation(decision.url, decision.historyMode);
+  return true;
 }
 
 export function createServerActionInitiationSnapshot<TRouterState>(options: {

--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -127,12 +127,7 @@ export function createServerActionResultFacts(
 ): ServerActionResultFactsV0 {
   return {
     actionRedirectHref: input.actionRedirectHref,
-    actionRedirectType:
-      input.actionRedirectHref === null
-        ? null
-        : input.actionRedirectType === "push"
-          ? "push"
-          : "replace",
+    actionRedirectType: input.actionRedirectType === "push" ? "push" : "replace",
     clientCompatibilityId: input.clientCompatibilityId,
     compatibilityIdHeader: input.compatibilityIdHeader,
     currentHref: input.currentHref,

--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -1,9 +1,5 @@
 import { ACTION_REVALIDATED_HEADER } from "./headers.js";
-import {
-  isRscCompatibilityIdCompatible,
-  VINEXT_RSC_COMPATIBILITY_ID_HEADER,
-  VINEXT_RSC_CONTENT_TYPE,
-} from "./app-rsc-cache-busting.js";
+import { VINEXT_RSC_CONTENT_TYPE } from "./app-rsc-cache-busting.js";
 
 export type AppBrowserServerActionResult<TRoot> = {
   root?: TRoot;
@@ -112,24 +108,6 @@ export function shouldCheckRscCompatibilityForServerActionResponse(
   response: Pick<Response, "headers">,
 ): boolean {
   return (response.headers.get("content-type") ?? "").startsWith(VINEXT_RSC_CONTENT_TYPE);
-}
-
-export function resolveServerActionRedirectCompatibilityHardNavigationTarget(options: {
-  actionRedirectHref: string | null;
-  clientCompatibilityId: string | null | undefined;
-  response: Pick<Response, "headers">;
-}): string | null {
-  if (!options.actionRedirectHref) return null;
-  if (!shouldCheckRscCompatibilityForServerActionResponse(options.response)) return null;
-  if (
-    isRscCompatibilityIdCompatible(
-      options.response.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
-      options.clientCompatibilityId,
-    )
-  ) {
-    return null;
-  }
-  return options.actionRedirectHref;
 }
 
 export function shouldScheduleRefreshForDiscardedServerAction(

--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -4,7 +4,6 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
-import type { ServerActionResultDecisionV0 } from "./navigation-planner.js";
 
 export type AppBrowserServerActionResult<TRoot> = {
   root?: TRoot;
@@ -137,21 +136,6 @@ export function shouldScheduleRefreshForDiscardedServerAction(
   revalidation: ServerActionRevalidationKind,
 ): boolean {
   return revalidation !== "none";
-}
-
-// Dispatches the executor effects implied by a ServerActionResultDecisionV0.
-// Returns true if a hard-navigation was triggered (the caller should return early);
-// false if the decision is "proceed" and normal action processing should continue.
-// Both callbacks are injected so this function is testable without browser globals.
-export function applyServerActionResultDecision(
-  decision: ServerActionResultDecisionV0,
-  clearCaches: () => void,
-  performHardNavigation: (url: string, historyMode?: "assign" | "replace") => void,
-): boolean {
-  if (decision.kind !== "hardNavigate") return false;
-  if (decision.clearClientNavigationCaches) clearCaches();
-  performHardNavigation(decision.url, decision.historyMode);
-  return true;
 }
 
 export function createServerActionInitiationSnapshot<TRouterState>(options: {

--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -1,5 +1,6 @@
 import { ACTION_REVALIDATED_HEADER } from "./headers.js";
 import { VINEXT_RSC_CONTENT_TYPE } from "./app-rsc-cache-busting.js";
+import { ServerActionResultFactsV0 } from "./navigation-planner.js";
 
 export type AppBrowserServerActionResult<TRoot> = {
   root?: TRoot;
@@ -104,10 +105,41 @@ export async function readInvalidServerActionResponseError(
   return new Error(message || "An unexpected response was received from the server.");
 }
 
-export function shouldCheckRscCompatibilityForServerActionResponse(
-  response: Pick<Response, "headers">,
-): boolean {
-  return (response.headers.get("content-type") ?? "").startsWith(VINEXT_RSC_CONTENT_TYPE);
+export type ServerActionResultResponseFactsInput = {
+  actionRedirectHref: string | null;
+  actionRedirectType: string | null;
+  clientCompatibilityId: string | null;
+  contentTypeHeader: string | null;
+  compatibilityIdHeader: string | null;
+  currentHref: string;
+  origin: string;
+  responseUrl: string | null;
+};
+
+/**
+ * Converts raw browser response data into the narrow facts expected by the
+ * navigation planner. This is the single place where redirect-type
+ * normalisation and RSC content-type detection happen for server-action
+ * compatibility checks.
+ */
+export function createServerActionResultFacts(
+  input: ServerActionResultResponseFactsInput,
+): ServerActionResultFactsV0 {
+  return {
+    actionRedirectHref: input.actionRedirectHref,
+    actionRedirectType:
+      input.actionRedirectHref === null
+        ? null
+        : input.actionRedirectType === "push"
+          ? "push"
+          : "replace",
+    clientCompatibilityId: input.clientCompatibilityId,
+    compatibilityIdHeader: input.compatibilityIdHeader,
+    currentHref: input.currentHref,
+    isRscContentType: (input.contentTypeHeader ?? "").startsWith(VINEXT_RSC_CONTENT_TYPE),
+    origin: input.origin,
+    responseUrl: input.responseUrl,
+  };
 }
 
 export function shouldScheduleRefreshForDiscardedServerAction(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -85,6 +85,7 @@ import {
   resolveMiddlewareRewriteNavigationInterceptionContext,
 } from "./app-browser-interception-context.js";
 import {
+  applyServerActionResultDecision,
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
   isServerActionResult,
@@ -1387,6 +1388,9 @@ function registerServerActionCallback(): void {
       return undefined;
     }
 
+    const fetchResponseIsRsc = (fetchResponse.headers.get("content-type") ?? "").startsWith(
+      VINEXT_RSC_CONTENT_TYPE,
+    );
     const actionResultDecision = navigationPlanner.classifyServerActionResult({
       actionRedirectHref: actionRedirectTarget?.href ?? null,
       actionRedirectType:
@@ -1396,20 +1400,17 @@ function registerServerActionCallback(): void {
       clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
       compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
       currentHref: actionInitiation.href,
-      isRscContentType: (fetchResponse.headers.get("content-type") ?? "").startsWith(
-        VINEXT_RSC_CONTENT_TYPE,
-      ),
+      isRscContentType: fetchResponseIsRsc,
       origin: window.location.origin,
       responseUrl: fetchResponse.url,
     });
-    if (actionResultDecision.kind === "hardNavigate") {
-      if (actionResultDecision.clearClientNavigationCaches) {
-        clearClientNavigationCaches();
-      }
-      browserNavigationController.performHardNavigation(
-        actionResultDecision.url,
-        actionResultDecision.historyMode,
-      );
+    if (
+      applyServerActionResultDecision(
+        actionResultDecision,
+        clearClientNavigationCaches,
+        (url, historyMode) => browserNavigationController.performHardNavigation(url, historyMode),
+      )
+    ) {
       return undefined;
     }
 
@@ -1428,10 +1429,7 @@ function registerServerActionCallback(): void {
     if (invalidResponseError) {
       throw invalidResponseError;
     }
-    if (
-      actionRedirectTarget &&
-      !(fetchResponse.headers.get("content-type") ?? "").startsWith(VINEXT_RSC_CONTENT_TYPE)
-    ) {
+    if (actionRedirectTarget && !fetchResponseIsRsc) {
       browserNavigationController.performHardNavigation(actionRedirectTarget.href);
       return undefined;
     }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -87,6 +87,7 @@ import {
 import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
+  createServerActionResultFacts,
   isServerActionResult,
   normalizeServerActionThrownValue,
   parseServerActionRevalidationHeader,
@@ -1391,19 +1392,18 @@ function registerServerActionCallback(): void {
     const fetchResponseIsRsc = (fetchResponse.headers.get("content-type") ?? "").startsWith(
       VINEXT_RSC_CONTENT_TYPE,
     );
-    const actionResultDecision = navigationPlanner.classifyServerActionResult({
-      actionRedirectHref: actionRedirectTarget?.href ?? null,
-      actionRedirectType:
-        actionRedirectTarget?.type === "push" || actionRedirectTarget?.type === "replace"
-          ? actionRedirectTarget.type
-          : null,
-      clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
-      compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
-      currentHref: actionInitiation.href,
-      isRscContentType: fetchResponseIsRsc,
-      origin: window.location.origin,
-      responseUrl: fetchResponse.url,
-    });
+    const actionResultDecision = navigationPlanner.classifyServerActionResult(
+      createServerActionResultFacts({
+        actionRedirectHref: actionRedirectTarget?.href ?? null,
+        actionRedirectType: actionRedirectTarget?.type ?? null,
+        clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
+        compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+        contentTypeHeader: fetchResponse.headers.get("content-type"),
+        currentHref: actionInitiation.href,
+        origin: window.location.origin,
+        responseUrl: fetchResponse.url,
+      }),
+    );
     if (
       applyServerActionResultDecision(
         actionResultDecision,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -91,8 +91,6 @@ import {
   normalizeServerActionThrownValue,
   parseServerActionRevalidationHeader,
   readInvalidServerActionResponseError,
-  resolveServerActionRedirectCompatibilityHardNavigationTarget,
-  shouldCheckRscCompatibilityForServerActionResponse,
   shouldClearClientNavigationCachesForServerActionResult,
   type ServerActionRevalidationKind,
   type AppBrowserServerActionResult,
@@ -154,7 +152,6 @@ import {
   createRscRequestUrl,
   createServerActionRequestUrl,
   getVinextRscCompatibilityId,
-  resolveRscCompatibilityNavigationDecision,
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
@@ -1390,33 +1387,29 @@ function registerServerActionCallback(): void {
       return undefined;
     }
 
-    const actionRedirectCompatibilityHardNavigationTarget =
-      resolveServerActionRedirectCompatibilityHardNavigationTarget({
-        actionRedirectHref: actionRedirectTarget?.href ?? null,
-        clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
-        response: fetchResponse,
-      });
-    if (actionRedirectCompatibilityHardNavigationTarget) {
-      clearClientNavigationCaches();
+    const actionResultDecision = navigationPlanner.classifyServerActionResult({
+      actionRedirectHref: actionRedirectTarget?.href ?? null,
+      actionRedirectType:
+        actionRedirectTarget?.type === "push" || actionRedirectTarget?.type === "replace"
+          ? actionRedirectTarget.type
+          : null,
+      clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
+      compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      currentHref: actionInitiation.href,
+      isRscContentType: (fetchResponse.headers.get("content-type") ?? "").startsWith(
+        VINEXT_RSC_CONTENT_TYPE,
+      ),
+      origin: window.location.origin,
+      responseUrl: fetchResponse.url,
+    });
+    if (actionResultDecision.kind === "hardNavigate") {
+      if (actionResultDecision.clearClientNavigationCaches) {
+        clearClientNavigationCaches();
+      }
       browserNavigationController.performHardNavigation(
-        actionRedirectCompatibilityHardNavigationTarget,
-        actionRedirectTarget?.type === "push" ? "assign" : "replace",
+        actionResultDecision.url,
+        actionResultDecision.historyMode,
       );
-      return undefined;
-    }
-
-    if (
-      !actionRedirectTarget &&
-      shouldCheckRscCompatibilityForServerActionResponse(fetchResponse) &&
-      resolveRscCompatibilityNavigationDecision({
-        clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
-        currentHref: actionInitiation.href,
-        origin: window.location.origin,
-        responseCompatibilityId: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
-        responseUrl: fetchResponse.url,
-      }).kind === "hard-navigate"
-    ) {
-      browserNavigationController.performHardNavigation(actionInitiation.href);
       return undefined;
     }
 
@@ -1437,7 +1430,7 @@ function registerServerActionCallback(): void {
     }
     if (
       actionRedirectTarget &&
-      !shouldCheckRscCompatibilityForServerActionResponse(fetchResponse)
+      !(fetchResponse.headers.get("content-type") ?? "").startsWith(VINEXT_RSC_CONTENT_TYPE)
     ) {
       browserNavigationController.performHardNavigation(actionRedirectTarget.href);
       return undefined;
@@ -2089,7 +2082,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       if (!isPageUnloading) {
         console.error("[vinext] RSC navigation error:", error);
       }
-      performHardNavigationForScrollIntent(currentHref);
+      const errorDecision = navigationPlanner.classifyRscNavigationError({
+        currentHref,
+      });
+      performHardNavigationForScrollIntent(errorDecision.url);
     } finally {
       // Single settlement site: covers normal return, early returns on stale-id
       // checks, and error paths. The finally runs even when the catch returns.

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -85,7 +85,6 @@ import {
   resolveMiddlewareRewriteNavigationInterceptionContext,
 } from "./app-browser-interception-context.js";
 import {
-  applyServerActionResultDecision,
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
   isServerActionResult,
@@ -96,6 +95,7 @@ import {
   type ServerActionRevalidationKind,
   type AppBrowserServerActionResult,
 } from "./app-browser-action-result.js";
+import { applyServerActionResultDecision } from "./app-browser-server-action-navigation.js";
 import {
   consumeInitialFormState,
   createVinextHydrateRootOptions,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1389,21 +1389,18 @@ function registerServerActionCallback(): void {
       return undefined;
     }
 
-    const fetchResponseIsRsc = (fetchResponse.headers.get("content-type") ?? "").startsWith(
-      VINEXT_RSC_CONTENT_TYPE,
-    );
-    const actionResultDecision = navigationPlanner.classifyServerActionResult(
-      createServerActionResultFacts({
-        actionRedirectHref: actionRedirectTarget?.href ?? null,
-        actionRedirectType: actionRedirectTarget?.type ?? null,
-        clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
-        compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
-        contentTypeHeader: fetchResponse.headers.get("content-type"),
-        currentHref: actionInitiation.href,
-        origin: window.location.origin,
-        responseUrl: fetchResponse.url,
-      }),
-    );
+    const actionResultFacts = createServerActionResultFacts({
+      actionRedirectHref: actionRedirectTarget?.href ?? null,
+      actionRedirectType: actionRedirectTarget?.type ?? null,
+      clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
+      compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      contentTypeHeader: fetchResponse.headers.get("content-type"),
+      currentHref: actionInitiation.href,
+      origin: window.location.origin,
+      responseUrl: fetchResponse.url,
+    });
+    const fetchResponseIsRsc = actionResultFacts.isRscContentType;
+    const actionResultDecision = navigationPlanner.classifyServerActionResult(actionResultFacts);
     if (
       applyServerActionResultDecision(
         actionResultDecision,

--- a/packages/vinext/src/server/app-browser-server-action-navigation.ts
+++ b/packages/vinext/src/server/app-browser-server-action-navigation.ts
@@ -1,0 +1,16 @@
+import type { ServerActionResultDecisionV0 } from "./navigation-planner.js";
+
+// Dispatches the executor effects implied by a ServerActionResultDecisionV0.
+// Returns true if a hard-navigation was triggered (the caller should return early);
+// false if the decision is "proceed" and normal action processing should continue.
+// Both callbacks are injected so this function is testable without browser globals.
+export function applyServerActionResultDecision(
+  decision: ServerActionResultDecisionV0,
+  clearCaches: () => void,
+  performHardNavigation: (url: string, historyMode?: "assign" | "replace") => void,
+): boolean {
+  if (decision.kind !== "hardNavigate") return false;
+  if (decision.clearClientNavigationCaches) clearCaches();
+  performHardNavigation(decision.url, decision.historyMode);
+  return true;
+}

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1412,10 +1412,122 @@ function planNavigation(input: NavigationPlannerInput): NavigationDecisionV0 {
   }
 }
 
+export type ServerActionResultFactsV0 = {
+  actionRedirectHref: string | null;
+  actionRedirectType: "push" | "replace" | null;
+  clientCompatibilityId: string | null;
+  compatibilityIdHeader: string | null;
+  currentHref: string;
+  isRscContentType: boolean;
+  origin: string;
+  responseUrl: string | null;
+};
+
+export type ServerActionResultDecisionV0 =
+  | { kind: "proceed"; trace: NavigationTrace }
+  | {
+      kind: "hardNavigate";
+      url: string;
+      historyMode?: "assign" | "replace";
+      clearClientNavigationCaches: boolean;
+      reason: "serverActionRedirectCompatibilityMismatch" | "serverActionRscCompatibilityMismatch";
+      trace: NavigationTrace;
+    };
+
+export type RscNavigationErrorFactsV0 = {
+  currentHref: string;
+};
+
+export type RscNavigationErrorDecisionV0 = {
+  kind: "hardNavigate";
+  url: string;
+  reason: "rscNavigationError";
+  trace: NavigationTrace;
+};
+
+function classifyServerActionResult(
+  facts: ServerActionResultFactsV0,
+): ServerActionResultDecisionV0 {
+  // A client without a compatibility id cannot prove skew.
+  if (facts.clientCompatibilityId === null) {
+    return {
+      kind: "proceed",
+      trace: createNavigationTrace(NavigationTraceReasonCodes.proceedToCommit, {}),
+    };
+  }
+
+  // Non-RSC action responses are not subject to the cache-busting compatibility
+  // check; the executor will handle them directly.
+  if (!facts.isRscContentType) {
+    return {
+      kind: "proceed",
+      trace: createNavigationTrace(NavigationTraceReasonCodes.proceedToCommit, {}),
+    };
+  }
+
+  const compatibilityDecision = resolveRscCompatibilityNavigationDecision({
+    clientCompatibilityId: facts.clientCompatibilityId,
+    currentHref: facts.currentHref,
+    origin: facts.origin,
+    responseCompatibilityId: facts.compatibilityIdHeader,
+    responseUrl: facts.responseUrl,
+  });
+
+  if (compatibilityDecision.kind === "compatible") {
+    return {
+      kind: "proceed",
+      trace: createNavigationTrace(NavigationTraceReasonCodes.proceedToCommit, {}),
+    };
+  }
+
+  if (facts.actionRedirectHref !== null) {
+    return {
+      kind: "hardNavigate",
+      url: facts.actionRedirectHref,
+      historyMode: facts.actionRedirectType === "replace" ? "replace" : "assign",
+      clearClientNavigationCaches: true,
+      reason: "serverActionRedirectCompatibilityMismatch",
+      trace: createNavigationTrace(
+        NavigationTraceReasonCodes.serverActionRedirectCompatibilityMismatch,
+        { targetHref: facts.actionRedirectHref },
+      ),
+    };
+  }
+
+  // For a no-redirect RSC response, the executor should reload the current
+  // document so the user stays on the same URL (including search params).
+  const targetUrl = facts.currentHref;
+
+  return {
+    kind: "hardNavigate",
+    url: targetUrl,
+    clearClientNavigationCaches: false,
+    reason: "serverActionRscCompatibilityMismatch",
+    trace: createNavigationTrace(NavigationTraceReasonCodes.serverActionRscCompatibilityMismatch, {
+      targetHref: targetUrl,
+    }),
+  };
+}
+
+function classifyRscNavigationError(
+  facts: RscNavigationErrorFactsV0,
+): RscNavigationErrorDecisionV0 {
+  return {
+    kind: "hardNavigate",
+    url: facts.currentHref,
+    reason: "rscNavigationError",
+    trace: createNavigationTrace(NavigationTraceReasonCodes.rscNavigationError, {
+      targetHref: facts.currentHref,
+    }),
+  };
+}
+
 export const navigationPlanner = {
   classifyEarlyNavigationIntent,
   classifyRscFetchResult,
+  classifyRscNavigationError,
   classifyRootBoundaryTransition,
+  classifyServerActionResult,
   plan: planNavigation,
   resolveCurrentRootBoundaryElementPersistence,
   resolveMountedParallelSlotPersistence,

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1480,6 +1480,11 @@ function classifyServerActionResult(
     };
   }
 
+  // compatibilityDecision.hardNavigationTarget (derived from responseUrl with _rsc stripped)
+  // is intentionally not used here. For server actions, responseUrl is the action endpoint URL,
+  // not the page URL the user should land on. The authoritative destinations are actionRedirectHref
+  // (explicit redirect) and currentHref (reload in place) — both are set below.
+
   if (facts.actionRedirectHref !== null) {
     return {
       kind: "hardNavigate",

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1414,7 +1414,7 @@ function planNavigation(input: NavigationPlannerInput): NavigationDecisionV0 {
 
 export type ServerActionResultFactsV0 = {
   actionRedirectHref: string | null;
-  actionRedirectType: "push" | "replace" | null;
+  actionRedirectType: "push" | "replace";
   clientCompatibilityId: string | null;
   compatibilityIdHeader: string | null;
   currentHref: string;
@@ -1489,7 +1489,7 @@ function classifyServerActionResult(
     return {
       kind: "hardNavigate",
       url: facts.actionRedirectHref,
-      historyMode: facts.actionRedirectType === "replace" ? "replace" : "assign",
+      historyMode: facts.actionRedirectType === "push" ? "assign" : "replace",
       clearClientNavigationCaches: true,
       reason: "serverActionRedirectCompatibilityMismatch",
       trace: createNavigationTrace(

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -23,8 +23,11 @@ export const NavigationTraceReasonCodes = {
   rootBoundaryChanged: "NC_ROOT",
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN",
   rscCompatibilityMismatch: "NC_RSC_COMPAT_MISMATCH",
+  rscNavigationError: "NC_RSC_NAV_ERROR",
   sameDocumentScroll: "NC_SAME_DOC_SCROLL",
   samePageSearch: "NC_SAME_PAGE_SEARCH",
+  serverActionRedirectCompatibilityMismatch: "NC_SA_REDIRECT_COMPAT",
+  serverActionRscCompatibilityMismatch: "NC_SA_RSC_COMPAT",
   staleOperation: "NC_STALE",
   streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP",
 } satisfies Readonly<{
@@ -48,8 +51,11 @@ export const NavigationTraceReasonCodes = {
   rootBoundaryChanged: "NC_ROOT";
   rootBoundaryUnknown: "NC_ROOT_UNKNOWN";
   rscCompatibilityMismatch: "NC_RSC_COMPAT_MISMATCH";
+  rscNavigationError: "NC_RSC_NAV_ERROR";
   sameDocumentScroll: "NC_SAME_DOC_SCROLL";
   samePageSearch: "NC_SAME_PAGE_SEARCH";
+  serverActionRedirectCompatibilityMismatch: "NC_SA_REDIRECT_COMPAT";
+  serverActionRscCompatibilityMismatch: "NC_SA_RSC_COMPAT";
   staleOperation: "NC_STALE";
   streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP";
 }>;

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -5,6 +5,7 @@ import {
   prodOnCaughtError,
 } from "../packages/vinext/src/server/app-browser-error.js";
 import {
+  applyServerActionResultDecision,
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
   normalizeServerActionThrownValue,
@@ -112,6 +113,7 @@ import {
   NavigationTraceTransactionCodes,
   createNavigationTrace,
 } from "../packages/vinext/src/server/navigation-trace.js";
+import { navigationPlanner } from "../packages/vinext/src/server/navigation-planner.js";
 import { createCacheEntryReuseProof } from "../packages/vinext/src/server/cache-proof.js";
 import {
   ACTION_REVALIDATED_HEADER,
@@ -901,6 +903,95 @@ describe("app browser entry navigation scheduling", () => {
     });
 
     expect(target).toBeNull();
+  });
+
+  it("applyServerActionResultDecision clears caches and hard-navigates for a redirect mismatch", () => {
+    // Executor regression: verifies the wiring between classifyServerActionResult output and
+    // the executor's performHardNavigation + clearClientNavigationCaches dispatch.
+    const clearCaches = vi.fn();
+    const performHardNavigation = vi.fn();
+
+    // push redirect with an incompatible build — executor should hard-navigate and clear caches
+    const pushDecision = navigationPlanner.classifyServerActionResult({
+      actionRedirectHref: "https://example.com/target?tab=1",
+      actionRedirectType: "push",
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: "server-build",
+      currentHref: "https://example.com/current",
+      isRscContentType: true,
+      origin: "https://example.com",
+      responseUrl: "https://example.com/current",
+    });
+    expect(applyServerActionResultDecision(pushDecision, clearCaches, performHardNavigation)).toBe(
+      true,
+    );
+    expect(clearCaches).toHaveBeenCalledOnce();
+    expect(performHardNavigation).toHaveBeenCalledWith(
+      "https://example.com/target?tab=1",
+      "assign",
+    );
+
+    clearCaches.mockClear();
+    performHardNavigation.mockClear();
+
+    // replace redirect with an incompatible build — executor should use replace history mode
+    const replaceDecision = navigationPlanner.classifyServerActionResult({
+      actionRedirectHref: "https://example.com/replaced",
+      actionRedirectType: "replace",
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: "server-build",
+      currentHref: "https://example.com/current",
+      isRscContentType: true,
+      origin: "https://example.com",
+      responseUrl: "https://example.com/current",
+    });
+    expect(
+      applyServerActionResultDecision(replaceDecision, clearCaches, performHardNavigation),
+    ).toBe(true);
+    expect(performHardNavigation).toHaveBeenCalledWith("https://example.com/replaced", "replace");
+
+    clearCaches.mockClear();
+    performHardNavigation.mockClear();
+
+    // no-redirect RSC mismatch — executor reloads current href, does NOT clear caches
+    const noRedirectDecision = navigationPlanner.classifyServerActionResult({
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: "server-build",
+      currentHref: "https://example.com/dashboard?view=grid",
+      isRscContentType: true,
+      origin: "https://example.com",
+      responseUrl: "https://example.com/dashboard?view=grid",
+    });
+    expect(
+      applyServerActionResultDecision(noRedirectDecision, clearCaches, performHardNavigation),
+    ).toBe(true);
+    expect(clearCaches).not.toHaveBeenCalled();
+    expect(performHardNavigation).toHaveBeenCalledWith(
+      "https://example.com/dashboard?view=grid",
+      undefined,
+    );
+
+    clearCaches.mockClear();
+    performHardNavigation.mockClear();
+
+    // compatible build — executor should proceed, not hard-navigate
+    const proceedDecision = navigationPlanner.classifyServerActionResult({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "push",
+      clientCompatibilityId: "same-build",
+      compatibilityIdHeader: "same-build",
+      currentHref: "https://example.com/current",
+      isRscContentType: true,
+      origin: "https://example.com",
+      responseUrl: "https://example.com/current",
+    });
+    expect(
+      applyServerActionResultDecision(proceedDecision, clearCaches, performHardNavigation),
+    ).toBe(false);
+    expect(clearCaches).not.toHaveBeenCalled();
+    expect(performHardNavigation).not.toHaveBeenCalled();
   });
 
   it("uses a stable generic error for non-RSC action responses", async () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -8,10 +8,10 @@ import { applyServerActionResultDecision } from "../packages/vinext/src/server/a
 import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
+  createServerActionResultFacts,
   normalizeServerActionThrownValue,
   parseServerActionRevalidationHeader,
   readInvalidServerActionResponseError,
-  shouldCheckRscCompatibilityForServerActionResponse,
   shouldClearClientNavigationCachesForServerActionResult,
   shouldScheduleRefreshForDiscardedServerAction,
 } from "../packages/vinext/src/server/app-browser-action-result.js";
@@ -28,7 +28,6 @@ import {
 } from "../packages/vinext/src/server/app-browser-popstate.js";
 import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
-  VINEXT_RSC_CONTENT_TYPE,
   resolveRscCompatibilityNavigationDecision,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import {
@@ -767,33 +766,63 @@ describe("app browser entry navigation scheduling", () => {
     ).toEqual({ kind: "compatible" });
   });
 
-  it("does not classify non-Flight action HTTP errors as RSC compatibility failures", () => {
-    // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts
-    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
-    expect(
-      shouldCheckRscCompatibilityForServerActionResponse(
-        new Response("Custom error!", {
-          headers: { "content-type": "text/plain" },
-          status: 500,
-        }),
-      ),
-    ).toBe(false);
-    expect(
-      shouldCheckRscCompatibilityForServerActionResponse(
-        new Response(JSON.stringify({ error: "Custom error!" }), {
-          headers: { "content-type": "application/json" },
-          status: 500,
-        }),
-      ),
-    ).toBe(false);
-    expect(
-      shouldCheckRscCompatibilityForServerActionResponse(
-        new Response("flight", {
-          headers: { "content-type": "text/x-component" },
-          status: 200,
-        }),
-      ),
-    ).toBe(true);
+  it("createServerActionResultFacts normalises raw response data into planner facts", () => {
+    const currentHref = "https://example.com/current";
+
+    // RSC redirect with push type
+    const pushFacts = createServerActionResultFacts({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "push",
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: "server-build",
+      contentTypeHeader: "text/x-component",
+      currentHref,
+      origin: "https://example.com",
+      responseUrl: currentHref,
+    });
+    expect(pushFacts.actionRedirectHref).toBe("https://example.com/target");
+    expect(pushFacts.actionRedirectType).toBe("push");
+    expect(pushFacts.isRscContentType).toBe(true);
+
+    // RSC redirect with unknown type normalises to replace
+    const replaceFacts = createServerActionResultFacts({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "unknown",
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: "server-build",
+      contentTypeHeader: "text/x-component",
+      currentHref,
+      origin: "https://example.com",
+      responseUrl: currentHref,
+    });
+    expect(replaceFacts.actionRedirectType).toBe("replace");
+
+    // No redirect — type is always null regardless of header value
+    const noRedirectFacts = createServerActionResultFacts({
+      actionRedirectHref: null,
+      actionRedirectType: "push",
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: "server-build",
+      contentTypeHeader: "text/x-component",
+      currentHref,
+      origin: "https://example.com",
+      responseUrl: currentHref,
+    });
+    expect(noRedirectFacts.actionRedirectHref).toBeNull();
+    expect(noRedirectFacts.actionRedirectType).toBeNull();
+
+    // Non-RSC response — isRscContentType should be false
+    const nonRscFacts = createServerActionResultFacts({
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: "server-build",
+      contentTypeHeader: "text/plain",
+      currentHref,
+      origin: "https://example.com",
+      responseUrl: currentHref,
+    });
+    expect(nonRscFacts.isRscContentType).toBe(false);
   });
 
   it("creates replayable cached RSC snapshots with compatibility IDs", async () => {
@@ -966,11 +995,11 @@ describe("app browser entry navigation scheduling", () => {
     expect(performHardNavigation).not.toHaveBeenCalled();
   });
 
-  it("wiring: extracts facts from a synthetic action Response and classifies via the planner", () => {
-    // Regression for the browser-entry seam: the code in app-browser-entry.ts derives facts
-    // from a real Response (content type, redirect headers, compatibility ID, response URL)
-    // and passes them to navigationPlanner.classifyServerActionResult. This test pins that
-    // extraction so accidental changes to the seam are caught.
+  it("wiring: createServerActionResultFacts + classifyServerActionResult end-to-end", () => {
+    // Regression for the browser-entry seam: production derives facts via
+    // createServerActionResultFacts and passes them to the planner. This test
+    // exercises the real helper against synthetic responses so the seam cannot
+    // drift out of sync.
     const currentHref = "https://example.com/current";
     const origin = "https://example.com";
 
@@ -983,31 +1012,51 @@ describe("app browser entry navigation scheduling", () => {
         [ACTION_REDIRECT_TYPE_HEADER]: "push",
       },
     });
-    const fetchResponseIsRsc = (redirectResponse.headers.get("content-type") ?? "").startsWith(
-      VINEXT_RSC_CONTENT_TYPE,
-    );
-    const actionRedirectHref = redirectResponse.headers.get(ACTION_REDIRECT_HEADER);
-    const actionRedirectType = redirectResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER);
-    const actionRedirectTypeFact: "push" | "replace" | null =
-      actionRedirectType === "push" || actionRedirectType === "replace" ? actionRedirectType : null;
-    const facts = {
-      actionRedirectHref: actionRedirectHref ? new URL(actionRedirectHref, currentHref).href : null,
-      actionRedirectType: actionRedirectTypeFact,
+    const pushFacts = createServerActionResultFacts({
+      actionRedirectHref: redirectResponse.headers.get(ACTION_REDIRECT_HEADER),
+      actionRedirectType: redirectResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER),
       clientCompatibilityId: "client-build",
       compatibilityIdHeader: redirectResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      contentTypeHeader: redirectResponse.headers.get("content-type"),
       currentHref,
-      isRscContentType: fetchResponseIsRsc,
       origin,
       responseUrl: currentHref,
-    };
+    });
+    const pushDecision = navigationPlanner.classifyServerActionResult(pushFacts);
+    expect(pushDecision.kind).toBe("hardNavigate");
+    if (pushDecision.kind === "hardNavigate") {
+      expect(pushDecision.url).toBe("https://example.com/target");
+      expect(pushDecision.historyMode).toBe("assign");
+      expect(pushDecision.clearClientNavigationCaches).toBe(true);
+      expect(pushDecision.reason).toBe("serverActionRedirectCompatibilityMismatch");
+    }
 
-    const decision = navigationPlanner.classifyServerActionResult(facts);
-    expect(decision.kind).toBe("hardNavigate");
-    if (decision.kind === "hardNavigate") {
-      expect(decision.url).toBe("https://example.com/target");
-      expect(decision.historyMode).toBe("assign");
-      expect(decision.clearClientNavigationCaches).toBe(true);
-      expect(decision.reason).toBe("serverActionRedirectCompatibilityMismatch");
+    // Non-standard redirect type (e.g. misspelled header) should normalise to "replace".
+    const weirdRedirectResponse = new Response("flight", {
+      headers: {
+        "content-type": "text/x-component",
+        [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "server-build",
+        [ACTION_REDIRECT_HEADER]: "https://example.com/target",
+        [ACTION_REDIRECT_TYPE_HEADER]: "unknown",
+      },
+    });
+    const weirdFacts = createServerActionResultFacts({
+      actionRedirectHref: weirdRedirectResponse.headers.get(ACTION_REDIRECT_HEADER),
+      actionRedirectType: weirdRedirectResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER),
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: weirdRedirectResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      contentTypeHeader: weirdRedirectResponse.headers.get("content-type"),
+      currentHref,
+      origin,
+      responseUrl: currentHref,
+    });
+    const weirdDecision = navigationPlanner.classifyServerActionResult(weirdFacts);
+    expect(weirdDecision.kind).toBe("hardNavigate");
+    if (weirdDecision.kind === "hardNavigate") {
+      expect(weirdDecision.url).toBe("https://example.com/target");
+      expect(weirdDecision.historyMode).toBe("replace");
+      expect(weirdDecision.clearClientNavigationCaches).toBe(true);
+      expect(weirdDecision.reason).toBe("serverActionRedirectCompatibilityMismatch");
     }
 
     // No-redirect incompatible RSC response — should reload current href without clearing caches.
@@ -1017,19 +1066,16 @@ describe("app browser entry navigation scheduling", () => {
         [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "server-build",
       },
     });
-    const noRedirectFacts = {
+    const noRedirectFacts = createServerActionResultFacts({
       actionRedirectHref: null,
       actionRedirectType: null,
       clientCompatibilityId: "client-build",
       compatibilityIdHeader: noRedirectResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      contentTypeHeader: noRedirectResponse.headers.get("content-type"),
       currentHref,
-      isRscContentType: (noRedirectResponse.headers.get("content-type") ?? "").startsWith(
-        VINEXT_RSC_CONTENT_TYPE,
-      ),
       origin,
       responseUrl: currentHref,
-    };
-
+    });
     const noRedirectDecision = navigationPlanner.classifyServerActionResult(noRedirectFacts);
     expect(noRedirectDecision.kind).toBe("hardNavigate");
     if (noRedirectDecision.kind === "hardNavigate") {
@@ -1045,19 +1091,16 @@ describe("app browser entry navigation scheduling", () => {
         [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "server-build",
       },
     });
-    const nonRscFacts = {
+    const nonRscFacts = createServerActionResultFacts({
       actionRedirectHref: null,
       actionRedirectType: null,
       clientCompatibilityId: "client-build",
       compatibilityIdHeader: nonRscResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      contentTypeHeader: nonRscResponse.headers.get("content-type"),
       currentHref,
-      isRscContentType: (nonRscResponse.headers.get("content-type") ?? "").startsWith(
-        VINEXT_RSC_CONTENT_TYPE,
-      ),
       origin,
       responseUrl: currentHref,
-    };
-
+    });
     expect(navigationPlanner.classifyServerActionResult(nonRscFacts).kind).toBe("proceed");
   });
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -11,7 +11,6 @@ import {
   normalizeServerActionThrownValue,
   parseServerActionRevalidationHeader,
   readInvalidServerActionResponseError,
-  resolveServerActionRedirectCompatibilityHardNavigationTarget,
   shouldCheckRscCompatibilityForServerActionResponse,
   shouldClearClientNavigationCachesForServerActionResult,
   shouldScheduleRefreshForDiscardedServerAction,
@@ -29,6 +28,7 @@ import {
 } from "../packages/vinext/src/server/app-browser-popstate.js";
 import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
+  VINEXT_RSC_CONTENT_TYPE,
   resolveRscCompatibilityNavigationDecision,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import {
@@ -117,6 +117,8 @@ import { navigationPlanner } from "../packages/vinext/src/server/navigation-plan
 import { createCacheEntryReuseProof } from "../packages/vinext/src/server/cache-proof.js";
 import {
   ACTION_REVALIDATED_HEADER,
+  ACTION_REDIRECT_HEADER,
+  ACTION_REDIRECT_TYPE_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
 } from "../packages/vinext/src/server/headers.js";
@@ -875,36 +877,6 @@ describe("app browser entry navigation scheduling", () => {
     expect(error?.message).toBe("Custom error!");
   });
 
-  it("hard-navigates incompatible RSC action redirect responses to the redirect target", () => {
-    const target = resolveServerActionRedirectCompatibilityHardNavigationTarget({
-      actionRedirectHref: "https://example.com/target",
-      clientCompatibilityId: "client-build",
-      response: new Response("flight", {
-        headers: {
-          "content-type": "text/x-component",
-          [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "server-build",
-        },
-      }),
-    });
-
-    expect(target).toBe("https://example.com/target");
-  });
-
-  it("does not hard-navigate compatible RSC action redirect responses", () => {
-    const target = resolveServerActionRedirectCompatibilityHardNavigationTarget({
-      actionRedirectHref: "https://example.com/target",
-      clientCompatibilityId: "same-build",
-      response: new Response("flight", {
-        headers: {
-          "content-type": "text/x-component",
-          [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "same-build",
-        },
-      }),
-    });
-
-    expect(target).toBeNull();
-  });
-
   it("applyServerActionResultDecision clears caches and hard-navigates for a redirect mismatch", () => {
     // Executor regression: verifies the wiring between classifyServerActionResult output and
     // the executor's performHardNavigation + clearClientNavigationCaches dispatch.
@@ -992,6 +964,101 @@ describe("app browser entry navigation scheduling", () => {
     ).toBe(false);
     expect(clearCaches).not.toHaveBeenCalled();
     expect(performHardNavigation).not.toHaveBeenCalled();
+  });
+
+  it("wiring: extracts facts from a synthetic action Response and classifies via the planner", () => {
+    // Regression for the browser-entry seam: the code in app-browser-entry.ts derives facts
+    // from a real Response (content type, redirect headers, compatibility ID, response URL)
+    // and passes them to navigationPlanner.classifyServerActionResult. This test pins that
+    // extraction so accidental changes to the seam are caught.
+    const currentHref = "https://example.com/current";
+    const origin = "https://example.com";
+
+    // Incompatible RSC action redirect — mimics the headers a real server would return.
+    const redirectResponse = new Response("flight", {
+      headers: {
+        "content-type": "text/x-component",
+        [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "server-build",
+        [ACTION_REDIRECT_HEADER]: "https://example.com/target",
+        [ACTION_REDIRECT_TYPE_HEADER]: "push",
+      },
+    });
+    const fetchResponseIsRsc = (redirectResponse.headers.get("content-type") ?? "").startsWith(
+      VINEXT_RSC_CONTENT_TYPE,
+    );
+    const actionRedirectHref = redirectResponse.headers.get(ACTION_REDIRECT_HEADER);
+    const actionRedirectType = redirectResponse.headers.get(ACTION_REDIRECT_TYPE_HEADER);
+    const actionRedirectTypeFact: "push" | "replace" | null =
+      actionRedirectType === "push" || actionRedirectType === "replace" ? actionRedirectType : null;
+    const facts = {
+      actionRedirectHref: actionRedirectHref ? new URL(actionRedirectHref, currentHref).href : null,
+      actionRedirectType: actionRedirectTypeFact,
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: redirectResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      currentHref,
+      isRscContentType: fetchResponseIsRsc,
+      origin,
+      responseUrl: currentHref,
+    };
+
+    const decision = navigationPlanner.classifyServerActionResult(facts);
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind === "hardNavigate") {
+      expect(decision.url).toBe("https://example.com/target");
+      expect(decision.historyMode).toBe("assign");
+      expect(decision.clearClientNavigationCaches).toBe(true);
+      expect(decision.reason).toBe("serverActionRedirectCompatibilityMismatch");
+    }
+
+    // No-redirect incompatible RSC response — should reload current href without clearing caches.
+    const noRedirectResponse = new Response("flight", {
+      headers: {
+        "content-type": "text/x-component",
+        [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "server-build",
+      },
+    });
+    const noRedirectFacts = {
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: noRedirectResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      currentHref,
+      isRscContentType: (noRedirectResponse.headers.get("content-type") ?? "").startsWith(
+        VINEXT_RSC_CONTENT_TYPE,
+      ),
+      origin,
+      responseUrl: currentHref,
+    };
+
+    const noRedirectDecision = navigationPlanner.classifyServerActionResult(noRedirectFacts);
+    expect(noRedirectDecision.kind).toBe("hardNavigate");
+    if (noRedirectDecision.kind === "hardNavigate") {
+      expect(noRedirectDecision.url).toBe(currentHref);
+      expect(noRedirectDecision.clearClientNavigationCaches).toBe(false);
+      expect(noRedirectDecision.reason).toBe("serverActionRscCompatibilityMismatch");
+    }
+
+    // Non-RSC response should always proceed regardless of compatibility header.
+    const nonRscResponse = new Response(JSON.stringify({ ok: true }), {
+      headers: {
+        "content-type": "application/json",
+        [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "server-build",
+      },
+    });
+    const nonRscFacts = {
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      clientCompatibilityId: "client-build",
+      compatibilityIdHeader: nonRscResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+      currentHref,
+      isRscContentType: (nonRscResponse.headers.get("content-type") ?? "").startsWith(
+        VINEXT_RSC_CONTENT_TYPE,
+      ),
+      origin,
+      responseUrl: currentHref,
+    };
+
+    expect(navigationPlanner.classifyServerActionResult(nonRscFacts).kind).toBe("proceed");
   });
 
   it("uses a stable generic error for non-RSC action responses", async () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -797,10 +797,10 @@ describe("app browser entry navigation scheduling", () => {
     });
     expect(replaceFacts.actionRedirectType).toBe("replace");
 
-    // No redirect — type is always null regardless of header value
+    // No redirect — the raw type is still normalized for the planner contract
     const noRedirectFacts = createServerActionResultFacts({
       actionRedirectHref: null,
-      actionRedirectType: "push",
+      actionRedirectType: null,
       clientCompatibilityId: "client-build",
       compatibilityIdHeader: "server-build",
       contentTypeHeader: "text/x-component",
@@ -809,7 +809,7 @@ describe("app browser entry navigation scheduling", () => {
       responseUrl: currentHref,
     });
     expect(noRedirectFacts.actionRedirectHref).toBeNull();
-    expect(noRedirectFacts.actionRedirectType).toBeNull();
+    expect(noRedirectFacts.actionRedirectType).toBe("replace");
 
     // Non-RSC response — isRscContentType should be false
     const nonRscFacts = createServerActionResultFacts({
@@ -957,7 +957,7 @@ describe("app browser entry navigation scheduling", () => {
     // no-redirect RSC mismatch — executor reloads current href, does NOT clear caches
     const noRedirectDecision = navigationPlanner.classifyServerActionResult({
       actionRedirectHref: null,
-      actionRedirectType: null,
+      actionRedirectType: "replace",
       clientCompatibilityId: "client-build",
       compatibilityIdHeader: "server-build",
       currentHref: "https://example.com/dashboard?view=grid",

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -4,8 +4,8 @@ import {
   createOnUncaughtError,
   prodOnCaughtError,
 } from "../packages/vinext/src/server/app-browser-error.js";
+import { applyServerActionResultDecision } from "../packages/vinext/src/server/app-browser-server-action-navigation.js";
 import {
-  applyServerActionResultDecision,
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
   normalizeServerActionThrownValue,

--- a/tests/navigation-planner-server-action-result.test.ts
+++ b/tests/navigation-planner-server-action-result.test.ts
@@ -16,7 +16,7 @@ function createFacts(
 ): ServerActionResultFactsV0 {
   return {
     actionRedirectHref: null,
-    actionRedirectType: null,
+    actionRedirectType: "replace",
     clientCompatibilityId: "client-build",
     compatibilityIdHeader: "client-build",
     currentHref: "https://example.com/dashboard",
@@ -86,7 +86,7 @@ describe("navigationPlanner server-action result classification", () => {
   it("hard-navigates a no-redirect RSC response with an incompatible compatibility id to the current href", () => {
     const decision = classify({
       actionRedirectHref: null,
-      actionRedirectType: null,
+      actionRedirectType: "replace",
       compatibilityIdHeader: "server-build",
       currentHref: "https://example.com/dashboard?view=grid",
     });
@@ -204,7 +204,7 @@ describe("navigationPlanner server-action result integration with executor contr
   it("produces a decision the executor can consume for no-redirect RSC hard-navigation", () => {
     const decision = classify({
       actionRedirectHref: null,
-      actionRedirectType: null,
+      actionRedirectType: "replace",
       compatibilityIdHeader: "server-build",
       currentHref: "https://example.com/dashboard?view=grid",
     });
@@ -260,7 +260,7 @@ describe("navigationPlanner server-action result integration with executor contr
   it("preserves the full URL including search params for no-redirect hard-navigation", () => {
     const decision = classify({
       actionRedirectHref: null,
-      actionRedirectType: null,
+      actionRedirectType: "replace",
       compatibilityIdHeader: "server-build",
       currentHref: "https://example.com/page?foo=bar&baz=qux#section",
     });
@@ -289,24 +289,6 @@ describe("navigationPlanner server-action result integration with executor contr
     });
   });
 
-  it("returns a decision for null actionRedirectType that defaults to assign history mode", () => {
-    const decision = classify({
-      actionRedirectHref: "https://example.com/target",
-      actionRedirectType: null,
-      compatibilityIdHeader: "server-build",
-    });
-
-    // When actionRedirectHref is present, the classifier always uses the redirect path.
-    // A null actionRedirectType defaults to "assign" (same as push).
-    expect(decision).toMatchObject({
-      kind: "hardNavigate",
-      url: "https://example.com/target",
-      historyMode: "assign",
-      clearClientNavigationCaches: true,
-      reason: "serverActionRedirectCompatibilityMismatch",
-    });
-  });
-
   it("produces a valid trace entry for server action redirect compatibility mismatch", () => {
     const decision = classify({
       actionRedirectHref: "https://example.com/target",
@@ -325,7 +307,7 @@ describe("navigationPlanner server-action result integration with executor contr
   it("produces a valid trace entry for server action RSC compatibility mismatch", () => {
     const decision = classify({
       actionRedirectHref: null,
-      actionRedirectType: null,
+      actionRedirectType: "replace",
       compatibilityIdHeader: "server-build",
       currentHref: "https://example.com/dashboard",
     });

--- a/tests/navigation-planner-server-action-result.test.ts
+++ b/tests/navigation-planner-server-action-result.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NAVIGATION_TRACE_SCHEMA_VERSION,
+  NavigationTraceReasonCodes,
+} from "../packages/vinext/src/server/navigation-trace.js";
+import {
+  navigationPlanner,
+  type RscNavigationErrorDecisionV0,
+  type RscNavigationErrorFactsV0,
+  type ServerActionResultDecisionV0,
+  type ServerActionResultFactsV0,
+} from "../packages/vinext/src/server/navigation-planner.js";
+
+function createFacts(
+  overrides: Partial<ServerActionResultFactsV0> = {},
+): ServerActionResultFactsV0 {
+  return {
+    actionRedirectHref: null,
+    actionRedirectType: null,
+    clientCompatibilityId: "client-build",
+    compatibilityIdHeader: "client-build",
+    currentHref: "https://example.com/dashboard",
+    isRscContentType: true,
+    origin: "https://example.com",
+    responseUrl: "https://example.com/dashboard",
+    ...overrides,
+  };
+}
+
+function classify(
+  overrides: Partial<ServerActionResultFactsV0> = {},
+): ServerActionResultDecisionV0 {
+  return navigationPlanner.classifyServerActionResult(createFacts(overrides));
+}
+
+function expectSingleTraceEntry(
+  decision: ServerActionResultDecisionV0 | RscNavigationErrorDecisionV0,
+  code: string,
+  fields: Record<string, string | number | boolean | null>,
+): void {
+  expect(decision.trace).toEqual({
+    schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+    entries: [{ code, fields }],
+  });
+}
+
+describe("navigationPlanner server-action result classification", () => {
+  it("hard-navigates a push action redirect with an incompatible compatibility id", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target?tab=1",
+      actionRedirectType: "push",
+      compatibilityIdHeader: "server-build",
+    });
+
+    expect(decision).toEqual({
+      kind: "hardNavigate",
+      url: "https://example.com/target?tab=1",
+      historyMode: "assign",
+      clearClientNavigationCaches: true,
+      reason: "serverActionRedirectCompatibilityMismatch",
+      trace: decision.trace,
+    });
+    expectSingleTraceEntry(
+      decision,
+      NavigationTraceReasonCodes.serverActionRedirectCompatibilityMismatch,
+      { targetHref: "https://example.com/target?tab=1" },
+    );
+  });
+
+  it("uses replace history mode for an incompatible replace action redirect", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "replace",
+      compatibilityIdHeader: "server-build",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "hardNavigate",
+      url: "https://example.com/target",
+      historyMode: "replace",
+      clearClientNavigationCaches: true,
+      reason: "serverActionRedirectCompatibilityMismatch",
+    });
+  });
+
+  it("hard-navigates a no-redirect RSC response with an incompatible compatibility id to the current href", () => {
+    const decision = classify({
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      compatibilityIdHeader: "server-build",
+      currentHref: "https://example.com/dashboard?view=grid",
+    });
+
+    expect(decision).toEqual({
+      kind: "hardNavigate",
+      url: "https://example.com/dashboard?view=grid",
+      clearClientNavigationCaches: false,
+      reason: "serverActionRscCompatibilityMismatch",
+      trace: decision.trace,
+    });
+    expect(decision).not.toHaveProperty("historyMode");
+    expectSingleTraceEntry(
+      decision,
+      NavigationTraceReasonCodes.serverActionRscCompatibilityMismatch,
+      { targetHref: "https://example.com/dashboard?view=grid" },
+    );
+  });
+
+  it("proceeds when an action redirect carries a compatible compatibility id", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "push",
+      compatibilityIdHeader: "client-build",
+    });
+
+    expect(decision).toMatchObject({ kind: "proceed" });
+  });
+
+  it("proceeds when a no-redirect RSC response carries a compatible compatibility id", () => {
+    const decision = classify();
+
+    expect(decision).toMatchObject({ kind: "proceed" });
+  });
+
+  it("proceeds for a non-RSC action redirect response", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "push",
+      isRscContentType: false,
+      compatibilityIdHeader: null,
+    });
+
+    expect(decision).toMatchObject({ kind: "proceed" });
+  });
+
+  it("proceeds for a no-redirect non-RSC response", () => {
+    const decision = classify({
+      isRscContentType: false,
+      compatibilityIdHeader: null,
+    });
+
+    expect(decision).toMatchObject({ kind: "proceed" });
+  });
+
+  it("treats a null client compatibility id as always compatible", () => {
+    // A client without a compatibility id cannot prove skew, so even a
+    // mismatched response header must not force a hard navigation.
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "push",
+      clientCompatibilityId: null,
+      compatibilityIdHeader: "server-build",
+    });
+
+    expect(decision).toMatchObject({ kind: "proceed" });
+  });
+});
+
+describe("navigationPlanner RSC navigation error classification", () => {
+  function classifyError(
+    overrides: Partial<RscNavigationErrorFactsV0> = {},
+  ): RscNavigationErrorDecisionV0 {
+    return navigationPlanner.classifyRscNavigationError({
+      currentHref: "https://example.com/current",
+      ...overrides,
+    });
+  }
+
+  it("hard-navigates to the current document href on any navigation error", () => {
+    const decision = classifyError({ currentHref: "https://example.com/feed?page=2" });
+
+    expect(decision).toEqual({
+      kind: "hardNavigate",
+      url: "https://example.com/feed?page=2",
+      reason: "rscNavigationError",
+      trace: decision.trace,
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.rscNavigationError, {
+      targetHref: "https://example.com/feed?page=2",
+    });
+  });
+});
+
+describe("navigationPlanner server-action result integration with executor contract", () => {
+  it("produces a decision the executor can consume for redirect hard-navigation", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target?tab=1",
+      actionRedirectType: "push",
+      compatibilityIdHeader: "server-build",
+    });
+
+    // Executor contract: if kind === "hardNavigate" and historyMode is present,
+    // performHardNavigation(url, historyMode) and clearClientNavigationCaches.
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") throw new Error("Expected hardNavigate");
+    expect(decision.url).toBe("https://example.com/target?tab=1");
+    expect(decision.historyMode).toBe("assign");
+    expect(decision.clearClientNavigationCaches).toBe(true);
+    expect(decision.reason).toBe("serverActionRedirectCompatibilityMismatch");
+    expect(decision.trace).toBeDefined();
+    expect(decision.trace.entries).toHaveLength(1);
+  });
+
+  it("produces a decision the executor can consume for no-redirect RSC hard-navigation", () => {
+    const decision = classify({
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      compatibilityIdHeader: "server-build",
+      currentHref: "https://example.com/dashboard?view=grid",
+    });
+
+    // Executor contract: if kind === "hardNavigate" and historyMode is absent,
+    // performHardNavigation(url) without explicit history mode (falls back to default).
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") throw new Error("Expected hardNavigate");
+    expect(decision.url).toBe("https://example.com/dashboard?view=grid");
+    expect(decision).not.toHaveProperty("historyMode");
+    expect(decision.clearClientNavigationCaches).toBe(false);
+    expect(decision.reason).toBe("serverActionRscCompatibilityMismatch");
+    expect(decision.trace).toBeDefined();
+    expect(decision.trace.entries).toHaveLength(1);
+  });
+
+  it("produces a proceed decision with a valid trace for the executor", () => {
+    const decision = classify();
+
+    // Executor contract: if kind === "proceed", continue with normal action processing.
+    expect(decision.kind).toBe("proceed");
+    if (decision.kind !== "proceed") throw new Error("Expected proceed");
+    expect(decision.trace.entries).toHaveLength(1);
+  });
+
+  it("produces consistent trace schema version across all decision types", () => {
+    const redirectDecision = classify({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "push",
+      compatibilityIdHeader: "server-build",
+    });
+
+    const noRedirectDecision = classify({
+      compatibilityIdHeader: "server-build",
+    });
+
+    const proceedDecision = classify();
+
+    const errorDecision = navigationPlanner.classifyRscNavigationError({
+      currentHref: "https://example.com/current",
+    });
+
+    for (const decision of [redirectDecision, noRedirectDecision, proceedDecision, errorDecision]) {
+      expect(decision.trace.schemaVersion).toBe(NAVIGATION_TRACE_SCHEMA_VERSION);
+      expect(decision.trace.entries.length).toBeGreaterThan(0);
+      for (const entry of decision.trace.entries) {
+        expect(entry.code).toBeTruthy();
+        expect(typeof entry.fields).toBe("object");
+      }
+    }
+  });
+
+  it("preserves the full URL including search params for no-redirect hard-navigation", () => {
+    const decision = classify({
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      compatibilityIdHeader: "server-build",
+      currentHref: "https://example.com/page?foo=bar&baz=qux#section",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "hardNavigate",
+      url: "https://example.com/page?foo=bar&baz=qux#section",
+      clearClientNavigationCaches: false,
+      reason: "serverActionRscCompatibilityMismatch",
+    });
+  });
+
+  it("maps replace action redirects to replace history mode for the executor", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/replace-target",
+      actionRedirectType: "replace",
+      compatibilityIdHeader: "server-build",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "hardNavigate",
+      url: "https://example.com/replace-target",
+      historyMode: "replace",
+      clearClientNavigationCaches: true,
+      reason: "serverActionRedirectCompatibilityMismatch",
+    });
+  });
+
+  it("returns a decision for null actionRedirectType that defaults to assign history mode", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: null,
+      compatibilityIdHeader: "server-build",
+    });
+
+    // When actionRedirectHref is present, the classifier always uses the redirect path.
+    // A null actionRedirectType defaults to "assign" (same as push).
+    expect(decision).toMatchObject({
+      kind: "hardNavigate",
+      url: "https://example.com/target",
+      historyMode: "assign",
+      clearClientNavigationCaches: true,
+      reason: "serverActionRedirectCompatibilityMismatch",
+    });
+  });
+
+  it("produces a valid trace entry for server action redirect compatibility mismatch", () => {
+    const decision = classify({
+      actionRedirectHref: "https://example.com/target",
+      actionRedirectType: "push",
+      compatibilityIdHeader: "server-build",
+    });
+
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.serverActionRedirectCompatibilityMismatch,
+      fields: {
+        targetHref: "https://example.com/target",
+      },
+    });
+  });
+
+  it("produces a valid trace entry for server action RSC compatibility mismatch", () => {
+    const decision = classify({
+      actionRedirectHref: null,
+      actionRedirectType: null,
+      compatibilityIdHeader: "server-build",
+      currentHref: "https://example.com/dashboard",
+    });
+
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.serverActionRscCompatibilityMismatch,
+      fields: {
+        targetHref: "https://example.com/dashboard",
+      },
+    });
+  });
+
+  it("produces a valid trace entry for RSC navigation error", () => {
+    const decision = navigationPlanner.classifyRscNavigationError({
+      currentHref: "https://example.com/error-page",
+    });
+
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.rscNavigationError,
+      fields: {
+        targetHref: "https://example.com/error-page",
+      },
+    });
+  });
+
+  it("produces a valid trace entry for proceed decisions", () => {
+    const decision = classify();
+
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.proceedToCommit,
+      fields: {},
+    });
+  });
+});


### PR DESCRIPTION
## Overview

| | |
|---|---|
| **Goal** | Move server-action and RSC navigation-error classification into the navigation planner so it becomes the single semantic authority for all navigation outcomes. |
| **Core change** | Two new pure classifiers in the planner, a fact-normalisation helper, and a narrowly-scoped effect dispatch module. |
| **Boundary** | The helper owns normalisation; the planner owns all decision logic; the executor only performs effects. |
| **Files to review** | `navigation-planner.ts` (classifiers), `app-browser-server-action-navigation.ts` (effect dispatch), `app-browser-action-result.ts` (`createServerActionResultFacts`), `app-browser-entry.ts` (wiring), `navigation-trace.ts` (reason codes), `tests/navigation-planner-server-action-result.test.ts` (19 tests), `tests/app-browser-entry.test.ts` (helper + executor regression). |
| **Impact** | No user-visible behaviour change. Internal refactoring that improves testability, traceability, and boundary integrity. |

## Why

The navigation planner was designed as the pure decision surface for all navigation lifecycle events. However, server-action responses were doing ad-hoc compatibility checks directly in the executor using two separate helpers (`resolveServerActionRedirectCompatibilityHardNavigationTarget`, `resolveRscCompatibilityNavigationDecision`). This scattered decision logic in the imperative shell, making it harder to test and reason about.

This PR completes the planner's coverage by routing server-action results and RSC navigation errors through the same typed decision surface. To keep the boundary crisp, the conversion from messy browser response data into narrow planner facts is extracted into a single pure helper (`createServerActionResultFacts`), so the test suite asserts the real boundary instead of hand-copying the extraction logic.

## What changed

| Scenario | Before | After |
|---|---|---|
| Server action redirect with incompatible build | Ad-hoc helper returns href; executor decides history mode | Planner returns typed `hardNavigate` decision with `historyMode` and `clearClientNavigationCaches` |
| Server action non-redirect RSC with incompatible build | Ad-hoc compatibility check in executor | Planner returns `hardNavigate` to `currentHref` |
| RSC navigation error | Direct `performHardNavigation(currentHref)` | Planner classifies as `hardNavigate`; executor reads `.url` |
| Redirect-type normalisation | Inline ternary in browser entry | Centralised in `createServerActionResultFacts` (non-`"push"` → `"replace"`) |

## Details

### New classifiers (in `navigation-planner.ts`)

- **`classifyServerActionResult(facts: ServerActionResultFactsV0)`** -- Returns one of:
  - `hardNavigate` with `historyMode` (for redirect responses) and `clearClientNavigationCaches`
  - `hardNavigate` without `historyMode` (for non-redirect RSC responses, reload current page)
  - `proceed` (when compatible, non-RSC, or client has no compatibility ID)

- **`classifyRscNavigationError(facts: RscNavigationErrorFactsV0)`** -- Always returns `hardNavigate` to `currentHref` with a `NavigationTrace`.

### New fact-normalisation helper (`app-browser-action-result.ts`)

- **`createServerActionResultFacts(input: ServerActionResultResponseFactsInput)`** -- Pure function that converts raw browser response data (redirect href, raw redirect type string, content-type header, etc.) into the narrow `ServerActionResultFactsV0` expected by the planner. This is the single place where:
  - RSC content-type detection happens
  - Redirect-type normalisation happens (non-`"push"` → `"replace"`)
  - Redirect type is normalized independently to the planner's narrow `"push" | "replace"` contract

### New effect dispatch module (`app-browser-server-action-navigation.ts`)

- **`applyServerActionResultDecision(decision, clearCaches, performHardNavigation)`** -- Injected-callback seam that translates a planner decision into browser effects (cache clearing, history mode). Separated from parser/classification utilities to respect the planner/executor boundary.

### New trace reason codes

- `rscNavigationError: "NC_RSC_NAV_ERROR"`
- `serverActionRedirectCompatibilityMismatch: "NC_SA_REDIRECT_COMPAT"`
- `serverActionRscCompatibilityMismatch: "NC_SA_RSC_COMPAT"`

### Executor changes

- Replaced the two ad-hoc helper calls in the server-action path with a single `createServerActionResultFacts` → `navigationPlanner.classifyServerActionResult` pipeline.
- Replaced the direct `performHardNavigationForScrollIntent(currentHref)` in the error catch with `navigationPlanner.classifyRscNavigationError`.
- Removed `resolveServerActionRedirectCompatibilityHardNavigationTarget` and `shouldCheckRscCompatibilityForServerActionResponse` (the latter's logic is now inside the fact helper).
- Removed unused imports (`resolveRscCompatibilityNavigationDecision`).

## Tests

- **19 tests** for `classifyServerActionResult` covering all branches and executor contract:
  - 9 unit tests: redirect push/replace, no-redirect RSC, compatible, non-RSC, null client ID
  - 11 integration tests: decision shapes, URL preservation, trace consistency, history mode defaults
- **1 test** for `classifyRscNavigationError`.
- **4 executor regression tests** in `app-browser-entry.test.ts` driving `applyServerActionResultDecision` with `vi.fn()` mocks against live planner output — covering redirect push, redirect replace, no-redirect reload, and proceed.
- **1 direct test** for `createServerActionResultFacts` covering push, replace, unknown-type, no-redirect, and non-RSC normalisation.
- **1 wiring test** exercising the real helper + planner seam with synthetic `Response` objects.
- All 78 navigation-planner tests pass.
- All 192 app-browser tests pass.

## Risk / compatibility

- No public API changes.
- No config changes.
- No build output changes.
- Runtime behaviour is identical; the change is purely structural.
- Existing server-action hard-navigation and error-recovery paths are preserved.

## Non-goals

- Does not change how the non-RSC action redirect path works.
- Does not add new user-facing features or error messages.

## References

- **PR 3 of 6** in the #1790 navigation architecture stack.
- **PR 4 next:** prefetch reuse — moves visited-response cache lookup, prefetch consumption, and optimistic route-template decisions into the planner.

