### PR TITLE
fix(pages-router): support stream proxying in API routes

### DIFF
--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -154,22 +154,18 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
 
     // Track whether `res` has had a pipe destination attached. Next.js skips
     // auto-ending when a stream is being piped (matching the Node.js "pipe"
-    // event on ServerResponse). A handler can pipe without returning the
-    // chain result, so the handler-return check alone is insufficient.
+    // event on ServerResponse). The "pipe" event is the canonical stream
+    // signal; the handler return value is not — chainable helpers like
+    // `return res.status(202)` return `this` without implying streaming.
     let resWasPiped = false;
     res.once("pipe", () => {
       resWasPiped = true;
     });
 
-    const handlerResult: unknown = await route.module.default(req, res);
-    // Node's `req.pipe(upstream).pipe(res)` returns the destination `res`.
-    // When a handler returns the response writable we must not auto-end it,
-    // because the stream will close itself when the source exhausts. For
-    // every other return value (including undefined) we end the response if
-    // the handler has not already sent headers — this prevents requests from
-    // hanging when a handler forgets to call res.end().
-    const returnedResponseWritable = handlerResult === res;
-    if (!returnedResponseWritable && !resWasPiped && !res.headersSent) {
+    await route.module.default(req, res);
+    // Auto-end if no stream is in progress. Without this guard a handler
+    // that forgets to call res.end() would leave the request hanging.
+    if (!resWasPiped && !res.headersSent) {
       res.end();
     }
     return await responsePromise;

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -24,8 +24,7 @@ type PagesApiRouteConfig = {
    * `bodyParser: false` is critical for webhook handlers (Stripe, GitHub,
    * Slack, etc.) that need to read the raw bytes to verify an HMAC
    * signature. With it set, `req.body` is left undefined and the raw stream
-   * is exposed on `req.body` as a Web `ReadableStream<Uint8Array>` so user
-   * code can consume it.
+   * remains available through the Node-readable request object.
    *
    * @see https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config
    */
@@ -35,10 +34,7 @@ type PagesApiRouteConfig = {
   };
 };
 
-type PagesNodeApiRouteHandler = (
-  req: PagesReqResRequest,
-  res: PagesReqResResponse,
-) => void | Promise<void>;
+type PagesNodeApiRouteHandler = (req: PagesReqResRequest, res: PagesReqResResponse) => unknown;
 
 type PagesEdgeApiRouteHandler = (request: Request) => Response | Promise<Response>;
 
@@ -139,9 +135,9 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     // Honour `export const config = { api: { bodyParser: ... } }` on the
     // route module. When the handler opts out (`bodyParser: false`) we must
     // not consume the stream — `req.body` stays `undefined` and the raw
-    // bytes are exposed via the async-iterator on `req` itself, matching
-    // Next.js's Node `IncomingMessage` contract. User code (e.g. a Stripe/
-    // GitHub webhook) drains them with `for await (const chunk of req)`.
+    // bytes are exposed via the Node-readable `req` itself, matching Next.js's
+    // `IncomingMessage` contract. User code can drain them with
+    // `for await (const chunk of req)` or stream them with `req.pipe(...)`.
     // See issue #1479.
     const bodyParserConfig = resolveBodyParserConfig(route.module.config);
 
@@ -156,8 +152,10 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       url: options.url,
     });
 
-    await route.module.default(req, res);
-    res.end();
+    const handlerResult: unknown = await route.module.default(req, res);
+    if (handlerResult === undefined && !res.headersSent) {
+      res.end();
+    }
     return await responsePromise;
   } catch (error) {
     if (error instanceof PagesApiBodyParseError) {

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -152,6 +152,15 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       url: options.url,
     });
 
+    // Track whether `res` has had a pipe destination attached. Next.js skips
+    // auto-ending when a stream is being piped (matching the Node.js "pipe"
+    // event on ServerResponse). A handler can pipe without returning the
+    // chain result, so the handler-return check alone is insufficient.
+    let resWasPiped = false;
+    res.once("pipe", () => {
+      resWasPiped = true;
+    });
+
     const handlerResult: unknown = await route.module.default(req, res);
     // Node's `req.pipe(upstream).pipe(res)` returns the destination `res`.
     // When a handler returns the response writable we must not auto-end it,
@@ -160,7 +169,7 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     // the handler has not already sent headers — this prevents requests from
     // hanging when a handler forgets to call res.end().
     const returnedResponseWritable = handlerResult === res;
-    if (!returnedResponseWritable && !res.headersSent) {
+    if (!returnedResponseWritable && !resWasPiped && !res.headersSent) {
       res.end();
     }
     return await responsePromise;

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -31,6 +31,18 @@ type PagesApiRouteConfig = {
   api?: {
     bodyParser?: boolean | { sizeLimit?: string | number };
     responseLimit?: boolean | string | number;
+    /**
+     * `externalResolver: true` declares that the response is sent by an
+     * external resolver (e.g. express/connect proxy middleware) that may
+     * complete after the handler's promise settles. Next.js uses it to
+     * suppress the "API resolved without sending a response" dev warning;
+     * vinext additionally uses it to suppress the auto-`end()` safety net,
+     * which would otherwise resolve an empty response before the external
+     * resolver writes.
+     *
+     * @see https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config
+     */
+    externalResolver?: boolean;
   };
 };
 
@@ -162,10 +174,18 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       resWasPiped = true;
     });
 
+    // Mirrors apiResolver: `config.api?.externalResolver || false`. Next.js
+    // never auto-ends — when this flag is set it only suppresses the dev
+    // warning and the response is delivered whenever the external resolver
+    // (e.g. proxy middleware that attaches its pipe asynchronously) sends it.
+    const externalResolver = route.module.config?.api?.externalResolver || false;
+
     await route.module.default(req, res);
     // Auto-end if no stream is in progress. Without this guard a handler
     // that forgets to call res.end() would leave the request hanging.
-    if (!resWasPiped && !res.headersSent) {
+    // Skipped for `externalResolver: true` routes, which legitimately
+    // respond after the handler settles.
+    if (!externalResolver && !resWasPiped && !res.headersSent) {
       res.end();
     }
     return await responsePromise;

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -153,7 +153,14 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     });
 
     const handlerResult: unknown = await route.module.default(req, res);
-    if (handlerResult === undefined && !res.headersSent) {
+    // Node's `req.pipe(upstream).pipe(res)` returns the destination `res`.
+    // When a handler returns the response writable we must not auto-end it,
+    // because the stream will close itself when the source exhausts. For
+    // every other return value (including undefined) we end the response if
+    // the handler has not already sent headers — this prevents requests from
+    // hanging when a handler forgets to call res.end().
+    const returnedResponseWritable = handlerResult === res;
+    if (!returnedResponseWritable && !res.headersSent) {
       res.end();
     }
     return await responsePromise;

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -1,5 +1,5 @@
 import { decode as decodeQueryString } from "node:querystring";
-import { Readable, Writable } from "node:stream";
+import { PassThrough, Readable, Writable } from "node:stream";
 import { parseCookies } from "../config/config-matchers.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { DEFAULT_PAGES_API_BODY_SIZE_LIMIT } from "./pages-body-parser-config.js";
@@ -146,14 +146,21 @@ class PagesResponseStream extends Writable {
   private resStatusCode = 200;
   private readonly resHeaders: Record<string, string | number | boolean> = {};
   private readonly setCookieHeaders: string[] = [];
-  private readonly chunks: Buffer[] = [];
   private resolved = false;
+  private readonly passThrough = new PassThrough();
 
   constructor(
     private readonly resolveResponse: (value: Response) => void,
+    private readonly rejectResponse: (error: Error) => void,
     private readonly requestHeaders: Headers,
   ) {
     super();
+    this.once("error", (err) => {
+      if (!this.resolved) {
+        this.resolved = true;
+        this.rejectResponse(err);
+      }
+    });
   }
 
   get statusCode(): number {
@@ -248,17 +255,12 @@ class PagesResponseStream extends Writable {
     encoding: BufferEncoding,
     callback: (error?: Error | null) => void,
   ): void {
-    try {
-      this.chunks.push(
-        typeof chunk === "string" ? Buffer.from(chunk, encoding) : Buffer.from(chunk),
-      );
-      callback();
-    } catch (error) {
-      callback(error instanceof Error ? error : new Error(String(error)));
-    }
+    this.passThrough.write(chunk, encoding, callback);
+    this.resolveOnce();
   }
 
   override _final(callback: (error?: Error | null) => void): void {
+    this.passThrough.end();
     this.resolveOnce();
     callback();
   }
@@ -297,7 +299,7 @@ class PagesResponseStream extends Writable {
       headers.append("set-cookie", cookie);
     }
 
-    const body = this.chunks.length > 0 ? new Uint8Array(Buffer.concat(this.chunks)) : null;
+    const body = Readable.toWeb(this.passThrough) as ReadableStream;
     this.resolveResponse(new Response(body, { status: this.resStatusCode, headers }));
   }
 }
@@ -322,11 +324,14 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
   });
 
   let resolveResponse!: (value: Response) => void;
-  const responsePromise = new Promise<Response>((resolve) => {
+  let rejectResponse!: (error: Error) => void;
+  const responsePromise = new Promise<Response>((resolve, reject) => {
     resolveResponse = resolve;
+    rejectResponse = reject;
   });
   const res: PagesReqResResponse = new PagesResponseStream(
     resolveResponse,
+    rejectResponse,
     options.request.headers,
   );
 

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -1,4 +1,5 @@
 import { decode as decodeQueryString } from "node:querystring";
+import { Readable, Writable } from "node:stream";
 import { parseCookies } from "../config/config-matchers.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { DEFAULT_PAGES_API_BODY_SIZE_LIMIT } from "./pages-body-parser-config.js";
@@ -15,34 +16,25 @@ export { PagesBodyParseError as PagesApiBodyParseError };
 
 export type PagesRequestQuery = Record<string, string | string[]>;
 
-export type PagesReqResRequest = {
+export type PagesReqResRequest = Readable & {
   method: string;
   url: string;
   headers: Record<string, string>;
   query: PagesRequestQuery;
   body: unknown;
   cookies: Record<string, string>;
-  /**
-   * Async-iterator hook so handlers can `for await (const chunk of req)` —
-   * matching Node's `IncomingMessage` contract. Critical for the
-   * `bodyParser: false` opt-out (webhook signature verification etc.) where
-   * `req.body` is left undefined and user code is expected to drain the raw
-   * stream off `req` itself.
-   */
-  [Symbol.asyncIterator]: () => AsyncIterator<Uint8Array>;
 };
 
 type PagesReqResHeaders = {
   [key: string]: string | number | boolean | string[];
 };
 
-export type PagesReqResResponse = {
+export type PagesReqResResponse = Writable & {
   statusCode: number;
   readonly headersSent: boolean;
   writeHead: (code: number, headers?: PagesReqResHeaders) => PagesReqResResponse;
   setHeader: (name: string, value: string | number | boolean | string[]) => PagesReqResResponse;
   getHeader: (name: string) => string | number | boolean | string[] | undefined;
-  end: (data?: BodyInit | null) => void;
   status: (code: number) => PagesReqResResponse;
   json: (data: unknown) => void;
   send: (data: unknown) => void;
@@ -127,191 +119,216 @@ export async function parsePagesApiBody(
   return rawBody;
 }
 
+async function* requestBodyChunks(request: Request): AsyncGenerator<Uint8Array> {
+  if (!request.body || request.bodyUsed) {
+    return;
+  }
+
+  const reader = request.body.getReader();
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function createRequestReadable(request: Request): Readable {
+  return Readable.from(requestBodyChunks(request));
+}
+
+class PagesResponseStream extends Writable {
+  private resStatusCode = 200;
+  private readonly resHeaders: Record<string, string | number | boolean> = {};
+  private readonly setCookieHeaders: string[] = [];
+  private readonly chunks: Buffer[] = [];
+  private resolved = false;
+
+  constructor(
+    private readonly resolveResponse: (value: Response) => void,
+    private readonly requestHeaders: Headers,
+  ) {
+    super();
+  }
+
+  get statusCode(): number {
+    return this.resStatusCode;
+  }
+
+  set statusCode(code: number) {
+    this.resStatusCode = code;
+  }
+
+  get headersSent(): boolean {
+    return this.writableEnded || this.resolved;
+  }
+
+  writeHead(code: number, headers?: PagesReqResHeaders): PagesReqResResponse {
+    this.resStatusCode = code;
+    if (headers) {
+      for (const [key, value] of Object.entries(headers)) {
+        this.setHeaderValue(key, value, { replaceSetCookie: false });
+      }
+    }
+    return this;
+  }
+
+  setHeader(name: string, value: string | number | boolean | string[]): PagesReqResResponse {
+    this.setHeaderValue(name, value, { replaceSetCookie: true });
+    return this;
+  }
+
+  getHeader(name: string): string | number | boolean | string[] | undefined {
+    if (name.toLowerCase() === "set-cookie") {
+      return this.setCookieHeaders.length > 0 ? this.setCookieHeaders : undefined;
+    }
+    return this.resHeaders[name.toLowerCase()];
+  }
+
+  status(code: number): PagesReqResResponse {
+    this.resStatusCode = code;
+    return this;
+  }
+
+  json(data: unknown): void {
+    this.resHeaders["content-type"] = "application/json";
+    this.end(JSON.stringify(data));
+  }
+
+  send(data: unknown): void {
+    if (Buffer.isBuffer(data)) {
+      if (!this.resHeaders["content-type"]) {
+        this.resHeaders["content-type"] = "application/octet-stream";
+      }
+      this.resHeaders["content-length"] = String(data.length);
+      this.end(data);
+      return;
+    }
+
+    if (typeof data === "object" && data !== null) {
+      this.resHeaders["content-type"] = "application/json";
+      this.end(JSON.stringify(data));
+      return;
+    }
+
+    if (!this.resHeaders["content-type"]) {
+      this.resHeaders["content-type"] = "text/plain";
+    }
+    this.end(String(data));
+  }
+
+  redirect(statusOrUrl: number | string, url?: string): void {
+    if (typeof statusOrUrl === "string") {
+      this.writeHead(307, { Location: statusOrUrl });
+    } else {
+      this.writeHead(statusOrUrl, { Location: url ?? "" });
+    }
+    this.end();
+  }
+
+  getHeaders(): PagesReqResHeaders {
+    const headers: PagesReqResHeaders = { ...this.resHeaders };
+    if (this.setCookieHeaders.length > 0) {
+      headers["set-cookie"] = this.setCookieHeaders;
+    }
+    return headers;
+  }
+
+  async revalidate(urlPath: string, opts?: RevalidateOptions): Promise<void> {
+    await performOnDemandRevalidate(this.requestHeaders, urlPath, opts);
+  }
+
+  override _write(
+    chunk: Uint8Array | string,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    try {
+      this.chunks.push(
+        typeof chunk === "string" ? Buffer.from(chunk, encoding) : Buffer.from(chunk),
+      );
+      callback();
+    } catch (error) {
+      callback(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  override _final(callback: (error?: Error | null) => void): void {
+    this.resolveOnce();
+    callback();
+  }
+
+  private setHeaderValue(
+    name: string,
+    value: string | number | boolean | string[],
+    options: { replaceSetCookie: boolean },
+  ): void {
+    if (name.toLowerCase() === "set-cookie") {
+      if (options.replaceSetCookie) {
+        this.setCookieHeaders.length = 0;
+      }
+      if (Array.isArray(value)) {
+        this.setCookieHeaders.push(...value.map(String));
+      } else {
+        this.setCookieHeaders.push(String(value));
+      }
+      return;
+    }
+
+    this.resHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(", ") : value;
+  }
+
+  private resolveOnce(): void {
+    if (this.resolved) {
+      return;
+    }
+    this.resolved = true;
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(this.resHeaders)) {
+      headers.set(key, String(value));
+    }
+    for (const cookie of this.setCookieHeaders) {
+      headers.append("set-cookie", cookie);
+    }
+
+    const body = this.chunks.length > 0 ? new Uint8Array(Buffer.concat(this.chunks)) : null;
+    this.resolveResponse(new Response(body, { status: this.resStatusCode, headers }));
+  }
+}
+
 export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePagesReqResResult {
   const headersObj: Record<string, string> = {};
   for (const [key, value] of options.request.headers) {
     headersObj[key.toLowerCase()] = value;
   }
 
-  // Surface the raw request body as an async-iterator on `req` so handlers
-  // can do `for await (const chunk of req)`, matching Node's
-  // `IncomingMessage` contract. This is the documented escape hatch when
-  // `bodyParser: false` is set (Stripe/GitHub/Slack webhooks need the raw
-  // bytes for HMAC signature verification).
-  //
-  // Cf. Next.js test/e2e/middleware-fetches-with-body fixture
-  // `body_parser_false.js`, which calls `for await (const chunk of req)`
-  // on the `IncomingMessage`-shaped req object. See issue #1479.
-  const requestBody = options.request.body;
-  const reqAsyncIterator = (): AsyncIterator<Uint8Array> => {
-    if (!requestBody) {
-      // No body — yield nothing. Use an inert iterator so `for await` is
-      // a no-op rather than throwing.
-      return {
-        next(): Promise<IteratorResult<Uint8Array>> {
-          return Promise.resolve({ value: undefined, done: true });
-        },
-      };
-    }
-    const reader = requestBody.getReader();
-    return {
-      async next(): Promise<IteratorResult<Uint8Array>> {
-        const { value, done } = await reader.read();
-        if (done) {
-          return { value: undefined, done: true };
-        }
-        return { value, done: false };
-      },
-      async return(): Promise<IteratorResult<Uint8Array>> {
-        // `for await ... break` path — release the lock so the stream is
-        // discardable. Cancellation propagates to the underlying source.
-        try {
-          await reader.cancel();
-        } catch {
-          // Ignore errors during cancellation.
-        }
-        return { value: undefined, done: true };
-      },
-    };
-  };
-
-  const req: PagesReqResRequest = {
+  // Next.js Pages API routes receive Node IncomingMessage/ServerResponse
+  // objects. The Workers/prod adapter starts from a Fetch Request, so expose a
+  // real Readable here instead of a plain object. That keeps both documented
+  // raw-body iteration and legacy stream proxying (`req.pipe(...)`) working.
+  const req: PagesReqResRequest = Object.assign(createRequestReadable(options.request), {
     method: options.request.method,
     url: options.url,
     headers: headersObj,
     query: options.query,
     body: options.body,
     cookies: parseCookies(options.request.headers.get("cookie")),
-    [Symbol.asyncIterator]: reqAsyncIterator,
-  };
+  });
 
-  let resStatusCode = 200;
-  const resHeaders: Record<string, string | number | boolean> = {};
-  const setCookieHeaders: string[] = [];
-  let resBody: BodyInit | null = null;
-  let ended = false;
   let resolveResponse!: (value: Response) => void;
   const responsePromise = new Promise<Response>((resolve) => {
     resolveResponse = resolve;
   });
-
-  const res: PagesReqResResponse = {
-    get statusCode() {
-      return resStatusCode;
-    },
-    set statusCode(code) {
-      resStatusCode = code;
-    },
-    get headersSent() {
-      return ended;
-    },
-    writeHead(code, headers) {
-      resStatusCode = code;
-      if (headers) {
-        for (const [key, value] of Object.entries(headers)) {
-          if (key.toLowerCase() === "set-cookie") {
-            if (Array.isArray(value)) {
-              setCookieHeaders.push(...value.map(String));
-            } else {
-              setCookieHeaders.push(String(value));
-            }
-          } else {
-            resHeaders[key.toLowerCase()] = Array.isArray(value) ? value.join(", ") : value;
-          }
-        }
-      }
-      return res;
-    },
-    setHeader(name, value) {
-      if (name.toLowerCase() === "set-cookie") {
-        // Node.js res.setHeader() replaces the existing value entirely.
-        setCookieHeaders.length = 0;
-        if (Array.isArray(value)) {
-          setCookieHeaders.push(...value.map(String));
-        } else {
-          setCookieHeaders.push(String(value));
-        }
-      } else {
-        resHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(", ") : value;
-      }
-      return res;
-    },
-    getHeader(name) {
-      if (name.toLowerCase() === "set-cookie") {
-        return setCookieHeaders.length > 0 ? setCookieHeaders : undefined;
-      }
-      return resHeaders[name.toLowerCase()];
-    },
-    end(data) {
-      if (ended) {
-        return;
-      }
-      ended = true;
-      if (data !== undefined && data !== null) {
-        resBody = data;
-      }
-      const headers = new Headers();
-      for (const [key, value] of Object.entries(resHeaders)) {
-        headers.set(key, String(value));
-      }
-      for (const cookie of setCookieHeaders) {
-        headers.append("set-cookie", cookie);
-      }
-      resolveResponse(new Response(resBody, { status: resStatusCode, headers }));
-    },
-    status(code) {
-      resStatusCode = code;
-      return res;
-    },
-    json(data) {
-      resHeaders["content-type"] = "application/json";
-      res.end(JSON.stringify(data));
-    },
-    send(data) {
-      if (Buffer.isBuffer(data)) {
-        if (!resHeaders["content-type"]) {
-          resHeaders["content-type"] = "application/octet-stream";
-        }
-        resHeaders["content-length"] = String(data.length);
-        res.end(new Uint8Array(data));
-        return;
-      }
-
-      if (typeof data === "object" && data !== null) {
-        resHeaders["content-type"] = "application/json";
-        res.end(JSON.stringify(data));
-        return;
-      }
-
-      if (!resHeaders["content-type"]) {
-        resHeaders["content-type"] = "text/plain";
-      }
-      res.end(String(data));
-    },
-    redirect(statusOrUrl, url) {
-      if (typeof statusOrUrl === "string") {
-        res.writeHead(307, { Location: statusOrUrl });
-      } else {
-        res.writeHead(statusOrUrl, { Location: url ?? "" });
-      }
-      res.end();
-    },
-    getHeaders() {
-      const headers: PagesReqResHeaders = { ...resHeaders };
-      if (setCookieHeaders.length > 0) {
-        headers["set-cookie"] = setCookieHeaders;
-      }
-      return headers;
-    },
-
-    // `res.revalidate(urlPath)` triggers on-demand ISR regeneration of a Pages
-    // Router route. Delegates to the shared helper so the secret wiring and
-    // success detection stay identical to the prod (`api-handler.ts`) path. See
-    // `pages-revalidate.ts`.
-    async revalidate(urlPath, opts) {
-      await performOnDemandRevalidate(options.request.headers, urlPath, opts);
-    },
-  };
+  const res: PagesReqResResponse = new PagesResponseStream(
+    resolveResponse,
+    options.request.headers,
+  );
 
   return { req, res, responsePromise };
 }

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -262,11 +262,6 @@ class PagesResponseStream extends Writable {
     encoding: BufferEncoding,
     callback: (error?: Error | null) => void,
   ): void {
-    if (this.streamEnded || this.destroyed) {
-      callback(new Error("Response stream is closed"));
-      return;
-    }
-
     const buffer = typeof chunk === "string" ? Buffer.from(chunk, encoding) : Buffer.from(chunk);
     if (this.controller && !this.streamEnded) {
       try {
@@ -294,7 +289,7 @@ class PagesResponseStream extends Writable {
     callback();
   }
 
-  override destroy(error?: Error): this {
+  override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
     this.streamEnded = true;
     if (!this.resolved) {
       if (error) {
@@ -315,7 +310,7 @@ class PagesResponseStream extends Writable {
         // Already closed or errored
       }
     }
-    return super.destroy(error);
+    callback(error);
   }
 
   private setHeaderValue(

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -134,6 +134,11 @@ async function* requestBodyChunks(request: Request): AsyncGenerator<Uint8Array> 
       yield value;
     }
   } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Ignore cancellation errors from the upstream source.
+    }
     reader.releaseLock();
   }
 }

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -1,5 +1,5 @@
 import { decode as decodeQueryString } from "node:querystring";
-import { PassThrough, Readable, Writable } from "node:stream";
+import { Readable, Writable } from "node:stream";
 import { parseCookies } from "../config/config-matchers.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { DEFAULT_PAGES_API_BODY_SIZE_LIMIT } from "./pages-body-parser-config.js";
@@ -147,7 +147,9 @@ class PagesResponseStream extends Writable {
   private readonly resHeaders: Record<string, string | number | boolean> = {};
   private readonly setCookieHeaders: string[] = [];
   private resolved = false;
-  private readonly passThrough = new PassThrough();
+  private controller: ReadableStreamDefaultController | null = null;
+  private readonly bufferedChunks: Buffer[] = [];
+  private streamEnded = false;
 
   constructor(
     private readonly resolveResponse: (value: Response) => void,
@@ -182,12 +184,12 @@ class PagesResponseStream extends Writable {
         this.setHeaderValue(key, value, { replaceSetCookie: false });
       }
     }
-    return this;
+    return this as PagesReqResResponse;
   }
 
   setHeader(name: string, value: string | number | boolean | string[]): PagesReqResResponse {
     this.setHeaderValue(name, value, { replaceSetCookie: true });
-    return this;
+    return this as PagesReqResResponse;
   }
 
   getHeader(name: string): string | number | boolean | string[] | undefined {
@@ -199,7 +201,7 @@ class PagesResponseStream extends Writable {
 
   status(code: number): PagesReqResResponse {
     this.resStatusCode = code;
-    return this;
+    return this as PagesReqResResponse;
   }
 
   json(data: unknown): void {
@@ -255,14 +257,47 @@ class PagesResponseStream extends Writable {
     encoding: BufferEncoding,
     callback: (error?: Error | null) => void,
   ): void {
-    this.passThrough.write(chunk, encoding, callback);
+    const buffer = typeof chunk === "string" ? Buffer.from(chunk, encoding) : Buffer.from(chunk);
+    if (this.controller && !this.streamEnded) {
+      try {
+        this.controller.enqueue(buffer);
+      } catch {
+        // Controller closed — consumer cancelled or stream finished
+      }
+    } else {
+      this.bufferedChunks.push(buffer);
+    }
     this.resolveOnce();
+    callback();
   }
 
   override _final(callback: (error?: Error | null) => void): void {
-    this.passThrough.end();
+    this.streamEnded = true;
+    if (this.controller) {
+      try {
+        this.controller.close();
+      } catch {
+        // Already closed
+      }
+    }
     this.resolveOnce();
     callback();
+  }
+
+  override destroy(error?: Error): this {
+    this.streamEnded = true;
+    if (this.controller) {
+      try {
+        if (error) {
+          this.controller.error(error);
+        } else {
+          this.controller.close();
+        }
+      } catch {
+        // Already closed or errored
+      }
+    }
+    return super.destroy(error);
   }
 
   private setHeaderValue(
@@ -299,8 +334,31 @@ class PagesResponseStream extends Writable {
       headers.append("set-cookie", cookie);
     }
 
-    const body = Readable.toWeb(this.passThrough) as ReadableStream;
-    this.resolveResponse(new Response(body, { status: this.resStatusCode, headers }));
+    const stream = new ReadableStream({
+      start: (controller) => {
+        this.controller = controller;
+        for (const buffer of this.bufferedChunks) {
+          try {
+            controller.enqueue(buffer);
+          } catch {
+            // Controller closed, ignore
+          }
+        }
+        this.bufferedChunks.length = 0;
+        if (this.streamEnded) {
+          try {
+            controller.close();
+          } catch {
+            // Already closed
+          }
+        }
+      },
+      cancel: () => {
+        this.streamEnded = true;
+      },
+    });
+
+    this.resolveResponse(new Response(stream, { status: this.resStatusCode, headers }));
   }
 }
 
@@ -333,7 +391,7 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     resolveResponse,
     rejectResponse,
     options.request.headers,
-  );
+  ) as PagesReqResResponse;
 
   return { req, res, responsePromise };
 }

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -257,6 +257,11 @@ class PagesResponseStream extends Writable {
     encoding: BufferEncoding,
     callback: (error?: Error | null) => void,
   ): void {
+    if (this.streamEnded || this.destroyed) {
+      callback(new Error("Response stream is closed"));
+      return;
+    }
+
     const buffer = typeof chunk === "string" ? Buffer.from(chunk, encoding) : Buffer.from(chunk);
     if (this.controller && !this.streamEnded) {
       try {
@@ -353,8 +358,9 @@ class PagesResponseStream extends Writable {
           }
         }
       },
-      cancel: () => {
-        this.streamEnded = true;
+      cancel: (reason) => {
+        this.bufferedChunks.length = 0;
+        this.destroy(reason instanceof Error ? reason : new Error("Response body cancelled"));
       },
     });
 

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -119,7 +119,7 @@ export async function parsePagesApiBody(
   return rawBody;
 }
 
-async function* requestBodyChunks(request: Request): AsyncGenerator<Uint8Array> {
+async function* requestBodyChunks(request: Request): AsyncGenerator<Buffer> {
   if (!request.body || request.bodyUsed) {
     return;
   }
@@ -131,7 +131,11 @@ async function* requestBodyChunks(request: Request): AsyncGenerator<Uint8Array> 
       if (done) {
         return;
       }
-      yield value;
+      // Node `IncomingMessage` yields `Buffer` chunks, not `Uint8Array`:
+      // handler code routinely calls `chunk.toString("utf8")`, which on a
+      // raw Uint8Array comma-joins the byte values instead of decoding.
+      // Buffer.from(buffer, offset, length) is a zero-copy view.
+      yield Buffer.from(value.buffer, value.byteOffset, value.byteLength);
     }
   } finally {
     try {
@@ -144,7 +148,10 @@ async function* requestBodyChunks(request: Request): AsyncGenerator<Uint8Array> 
 }
 
 function createRequestReadable(request: Request): Readable {
-  return Readable.from(requestBodyChunks(request));
+  // `Readable.from` defaults to objectMode — opt out so the request is a
+  // byte stream like `IncomingMessage` (`setEncoding()`/`read(n)` byte
+  // semantics, byte-based highWaterMark).
+  return Readable.from(requestBodyChunks(request), { objectMode: false });
 }
 
 class PagesResponseStream extends Writable {

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -291,6 +291,14 @@ class PagesResponseStream extends Writable {
 
   override destroy(error?: Error): this {
     this.streamEnded = true;
+    if (!this.resolved) {
+      if (error) {
+        this.resolved = true;
+        this.rejectResponse(error);
+      } else {
+        this.resolveOnce();
+      }
+    }
     if (this.controller) {
       try {
         if (error) {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -379,4 +379,68 @@ describe("pages api route", () => {
       });
     }
   });
+
+  it("auto-ends the response when a handler returns a non-stream value and does not call res.end()", async () => {
+    // Regression: handlers that return a plain value (e.g. a number) and
+    // forget to call res.end() must not hang the request. Only returning
+    // the response writable itself (from req.pipe(...).pipe(res)) should
+    // defer auto-ending.
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.status(202);
+        return 42;
+      }),
+      request: new Request("https://example.com/api/non-stream-return"),
+      url: "/api/non-stream-return",
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("");
+  });
+
+  it("streams multi-chunk res.write() / res.end() without buffering the whole body", async () => {
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.write("chunk-1");
+        res.write("chunk-2");
+        res.write("chunk-3");
+        res.end();
+      }),
+      request: new Request("https://example.com/api/multi-chunk"),
+      url: "/api/multi-chunk",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("chunk-1chunk-2chunk-3");
+  });
+
+  it("returns a 500 when the response stream is destroyed with an error", async () => {
+    const reportRequestError = vi.fn();
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (_req, res) => {
+          // Simulate a proxy handler where the upstream errors and the
+          // handler forwards the error to the response stream. Node's
+          // `req.pipe(upstream).pipe(res)` does NOT auto-forward errors,
+          // so well-behaved handlers must attach error listeners and
+          // explicitly destroy `res` to avoid hanging the request.
+          res.destroy(new Error("upstream exploded"));
+          return res;
+        },
+        {},
+        { api: { bodyParser: false } },
+      ),
+      reportRequestError,
+      request: new Request("https://example.com/api/stream-error", {
+        method: "POST",
+        body: "some-body",
+      }),
+      url: "/api/stream-error",
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.toBe("Internal Server Error");
+    expect(reportRequestError).toHaveBeenCalledWith(expect.any(Error), "/api/test");
+  });
 });

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -414,17 +414,17 @@ describe("pages api route", () => {
     await expect(response.text()).resolves.toBe("chunk-1chunk-2chunk-3");
   });
 
-  it("returns a 500 when the response stream is destroyed with an error", async () => {
+  it("returns a 500 when the response stream is destroyed with an error before any body has been written", async () => {
     const reportRequestError = vi.fn();
 
     const response = await handlePagesApiRoute({
       match: createMatch(
         (_req, res) => {
           // Simulate a proxy handler where the upstream errors and the
-          // handler forwards the error to the response stream. Node's
-          // `req.pipe(upstream).pipe(res)` does NOT auto-forward errors,
-          // so well-behaved handlers must attach error listeners and
-          // explicitly destroy `res` to avoid hanging the request.
+          // handler forwards the error to the response stream before
+          // anything is written. In this case the responsePromise should
+          // reject and the normal 500 error path in handlePagesApiRoute
+          // should surface.
           res.destroy(new Error("upstream exploded"));
           return res;
         },
@@ -442,5 +442,29 @@ describe("pages api route", () => {
     expect(response.status).toBe(500);
     await expect(response.text()).resolves.toBe("Internal Server Error");
     expect(reportRequestError).toHaveBeenCalledWith(expect.any(Error), "/api/test");
+  });
+
+  it("does not hang when the response stream is destroyed after partial output has started", async () => {
+    // Regression: after the first write, the Fetch Response has already been
+    // resolved. Destroying the Node-compatible res must error the body
+    // ReadableStream so the consumer sees a failure instead of an open
+    // stream that never terminates.
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (_req, res) => {
+          res.write("partial");
+          res.destroy(new Error("upstream exploded"));
+          return res;
+        },
+        {},
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/stream-error-partial"),
+      url: "/api/stream-error-partial",
+    });
+
+    expect(response.status).toBe(200);
+    // The body stream should reject because it was destroyed mid-stream.
+    await expect(response.text()).rejects.toThrow("upstream exploded");
   });
 });

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   handlePagesApiRoute,
@@ -512,5 +513,54 @@ describe("pages api route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("");
+  });
+
+  it("does not auto-end when the handler pipes into res without returning it", async () => {
+    const body = "raw-body-data";
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (req, res) => {
+          // Handler pipes req through a transform into res, matching the
+          // real-world pattern: a webhook handler forwarding the raw body
+          // upstream without returning the pipe chain.
+          req.pipe(new PassThrough()).pipe(res);
+          // Note: does NOT return res — handler returns undefined.
+        },
+        {},
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/pipe-no-return", {
+        method: "POST",
+        body,
+      }),
+      url: "/api/pipe-no-return",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe(body);
+  });
+
+  it("streams a piped request body through to the response", async () => {
+    const body = "piped-body-content";
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (req, res) => {
+          // Handler pipes req directly to res and returns the result,
+          // matching the fixture pattern in the upstream PR.
+          const result = req.pipe(new PassThrough()).pipe(res);
+          return result;
+        },
+        {},
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/pipe-with-return", {
+        method: "POST",
+        body,
+      }),
+      url: "/api/pipe-with-return",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe(body);
   });
 });

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -594,4 +594,64 @@ describe("pages api route", () => {
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe(body);
   });
+
+  it("exposes the raw body as a byte-mode stream of Buffer chunks", async () => {
+    // Parity: Node `IncomingMessage` is a non-objectMode stream yielding
+    // `Buffer`s. Handlers routinely call `chunk.toString("utf8")` per chunk
+    // (webhook signature verification etc.) — on a raw Uint8Array that
+    // comma-joins byte values instead of decoding.
+    const body = "buffer-parity-body";
+    let objectMode: boolean | undefined;
+    let allBuffers = true;
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        async (req, res) => {
+          objectMode = req.readableObjectMode;
+          let text = "";
+          for await (const chunk of req) {
+            allBuffers &&= Buffer.isBuffer(chunk);
+            text += chunk.toString("utf8");
+          }
+          res.send(text);
+        },
+        {},
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/buffer-chunks", {
+        method: "POST",
+        body,
+      }),
+      url: "/api/buffer-chunks",
+    });
+
+    expect(response.status).toBe(200);
+    expect(objectMode).toBe(false);
+    expect(allBuffers).toBe(true);
+    await expect(response.text()).resolves.toBe(body);
+  });
+
+  it("does not auto-end when config.api.externalResolver is true and the handler responds late", async () => {
+    // Parity: Next.js never auto-ends a response — `externalResolver: true`
+    // is the documented contract for handlers (e.g. proxy middleware) that
+    // send the response after the handler's promise settles. Without the
+    // flag the auto-end safety net would resolve an empty 200 first.
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (_req, res) => {
+          setTimeout(() => {
+            res.status(201).json({ late: true });
+          }, 10);
+          // Returns before anything is written or piped.
+        },
+        {},
+        { api: { externalResolver: true } },
+      ),
+      request: new Request("https://example.com/api/external-resolver"),
+      url: "/api/external-resolver",
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ late: true });
+  });
 });

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -413,9 +413,11 @@ describe("pages api route", () => {
   });
 
   it("streams multi-chunk res.write() / res.end() through a ReadableStream body", async () => {
+    let headersSentAfterWrite = false;
     const response = await handlePagesApiRoute({
       match: createMatch((_req, res) => {
         res.write("chunk-1");
+        headersSentAfterWrite = res.headersSent;
         res.write("chunk-2");
         res.write("chunk-3");
         res.end();
@@ -425,6 +427,7 @@ describe("pages api route", () => {
     });
 
     expect(response.status).toBe(200);
+    expect(headersSentAfterWrite).toBe(true);
     await expect(response.text()).resolves.toBe("chunk-1chunk-2chunk-3");
   });
 
@@ -522,6 +525,21 @@ describe("pages api route", () => {
       }),
       request: new Request("https://example.com/api/destroy-no-error"),
       url: "/api/destroy-no-error",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("");
+  });
+
+  it("settles the response only once when res.destroy() is called repeatedly", async () => {
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.destroy();
+        res.destroy(new Error("second destroy must be ignored"));
+        return res;
+      }),
+      request: new Request("https://example.com/api/destroy-idempotent"),
+      url: "/api/destroy-idempotent",
     });
 
     expect(response.status).toBe(200);

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -398,7 +398,7 @@ describe("pages api route", () => {
     await expect(response.text()).resolves.toBe("");
   });
 
-  it("streams multi-chunk res.write() / res.end() without buffering the whole body", async () => {
+  it("streams multi-chunk res.write() / res.end() through a ReadableStream body", async () => {
     const response = await handlePagesApiRoute({
       match: createMatch((_req, res) => {
         res.write("chunk-1");
@@ -412,6 +412,36 @@ describe("pages api route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("chunk-1chunk-2chunk-3");
+  });
+
+  it("does not accumulate chunks after the response body is cancelled", async () => {
+    let resRef: any;
+
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        resRef = res;
+        res.write("first");
+        // Keep the stream open so the test can cancel the body before the
+        // Node side finishes.
+      }),
+      request: new Request("https://example.com/api/cancel"),
+      url: "/api/cancel",
+    });
+
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    expect(new TextDecoder().decode(value)).toBe("first");
+
+    await reader.cancel();
+
+    // After the Fetch body is cancelled, the Node-compatible writable must
+    // reject further writes instead of silently buffering them.
+    const writeErr = await new Promise<Error | null>((resolve) => {
+      resRef.write("second", (err: Error | null) => resolve(err));
+    });
+
+    expect(writeErr).toBeInstanceOf(Error);
+    expect(writeErr!.message).toMatch(/Cannot call write after a stream was destroyed/);
   });
 
   it("returns a 500 when the response stream is destroyed with an error before any body has been written", async () => {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -383,9 +383,8 @@ describe("pages api route", () => {
 
   it("auto-ends the response when a handler returns a non-stream value and does not call res.end()", async () => {
     // Regression: handlers that return a plain value (e.g. a number) and
-    // forget to call res.end() must not hang the request. Only returning
-    // the response writable itself (from req.pipe(...).pipe(res)) should
-    // defer auto-ending.
+    // forget to call res.end() must not hang the request. Auto-end is
+    // gated on the "pipe" event only — return values do not defer it.
     const response = await handlePagesApiRoute({
       match: createMatch((_req, res) => {
         res.status(202);
@@ -393,6 +392,20 @@ describe("pages api route", () => {
       }),
       request: new Request("https://example.com/api/non-stream-return"),
       url: "/api/non-stream-return",
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("");
+  });
+
+  it("auto-ends when a handler returns the response object without piping or sending", async () => {
+    // Regression: chainable helpers like `return res.status(202)` return
+    // `this` (the response object), but that does not mean streaming is
+    // in progress. Only the "pipe" event should defer auto-ending.
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => res.status(202)),
+      request: new Request("https://example.com/api/return-res-status"),
+      url: "/api/return-res-status",
     });
 
     expect(response.status).toBe(202);

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -497,4 +497,20 @@ describe("pages api route", () => {
     // The body stream should reject because it was destroyed mid-stream.
     await expect(response.text()).rejects.toThrow("upstream exploded");
   });
+
+  it("does not hang when res.destroy() is called without an error before any body is written", async () => {
+    // Regression: destroy() with no error before resolveOnce() must still
+    // resolve the response promise so the request does not hang.
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.destroy();
+        return res;
+      }),
+      request: new Request("https://example.com/api/destroy-no-error"),
+      url: "/api/destroy-no-error",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("");
+  });
 });

--- a/tests/pages-bodyparser-config.test.ts
+++ b/tests/pages-bodyparser-config.test.ts
@@ -16,7 +16,7 @@
  *   honours `config.api?.bodyParser !== false` and
  *   `config.api?.bodyParser?.sizeLimit`.
  */
-import { PassThrough } from "node:stream";
+import { PassThrough, Transform } from "node:stream";
 import { Buffer } from "node:buffer";
 import http from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
@@ -29,6 +29,10 @@ import {
   parseSizeLimit,
   resolveBodyParserConfig,
 } from "../packages/vinext/src/server/pages-body-parser-config.js";
+import type {
+  PagesReqResRequest,
+  PagesReqResResponse,
+} from "../packages/vinext/src/server/pages-node-compat.js";
 import type { ModuleImporter } from "../packages/vinext/src/server/instrumentation.js";
 import type { Route } from "../packages/vinext/src/routing/pages-router.js";
 
@@ -434,6 +438,79 @@ function createMatch(
 }
 
 describe("handlePagesApiRoute body parser config (Workers/prod path)", () => {
+  // Ported from Next.js: test/e2e/proxy-request-with-middleware/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/proxy-request-with-middleware/test/index.test.ts
+  //
+  // The upstream fixture pipes the API route's `req` through the deprecated
+  // `request` package and then pipes the proxied response into `res`. That
+  // proves a Pages API route still receives an IncomingMessage/ServerResponse-
+  // shaped stream surface when middleware is present. At this lower boundary
+  // we keep the same observable contract with a local Transform: `req.pipe`
+  // must preserve method, headers, and body, and `res` must be writable.
+  for (const { method, body } of [
+    { method: "GET", body: undefined },
+    { method: "POST", body: JSON.stringify({ key: "value" }) },
+  ]) {
+    it(`bodyParser: false supports req.pipe(...).pipe(res) for ${method}`, async () => {
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        "x-custom-header": "some value",
+      };
+      if (body) {
+        headers["content-length"] = String(body.length);
+      }
+
+      const response = await handlePagesApiRoute({
+        match: createMatch(
+          (req: PagesReqResRequest, res: PagesReqResResponse) => {
+            const chunks: Buffer[] = [];
+            const upstream = new Transform({
+              transform(chunk: Buffer, _encoding, callback) {
+                chunks.push(Buffer.from(chunk));
+                callback();
+              },
+              flush(callback) {
+                this.push(
+                  JSON.stringify({
+                    method: req.method,
+                    headers: req.headers,
+                    rawBody: Buffer.concat(chunks).toString("utf8"),
+                  }),
+                );
+                callback();
+              },
+            });
+
+            return req.pipe(upstream).pipe(res);
+          },
+          { api: { bodyParser: false } },
+        ),
+        request: new Request("https://example.com/api", {
+          method,
+          headers,
+          body,
+        }),
+        url: "/api",
+      });
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as {
+        method: string;
+        headers: Record<string, string>;
+        rawBody: string;
+      };
+
+      expect(data.method).toBe(method);
+      if (body) {
+        expect(data.headers["content-length"] || String(body.length)).toBe(String(body.length));
+        expect(data.rawBody).toBe(body);
+      } else {
+        expect(data.rawBody).toBe("");
+      }
+      expect(data.headers).toEqual(expect.objectContaining(headers));
+    });
+  }
+
   // Ported from Next.js: test/e2e/middleware-fetches-with-body/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-fetches-with-body/index.test.ts
   //

--- a/tests/pages-bodyparser-config.test.ts
+++ b/tests/pages-bodyparser-config.test.ts
@@ -502,7 +502,7 @@ describe("handlePagesApiRoute body parser config (Workers/prod path)", () => {
 
       expect(data.method).toBe(method);
       if (body) {
-        expect(data.headers["content-length"] || String(body.length)).toBe(String(body.length));
+        expect(data.headers["content-length"]).toBe(String(body.length));
         expect(data.rawBody).toBe(body);
       } else {
         expect(data.rawBody).toBe("");


### PR DESCRIPTION
## Summary

Fixes Pages Router API route stream compatibility in the Workers/prod path so Node-style proxy handlers can use `req.pipe(...).pipe(res)` with `api.bodyParser: false`.

The upstream Next.js deploy candidate `test/e2e/proxy-request-with-middleware/test/index.test.ts` failed because vinext exposed a plain synthetic request object with async iteration but no `pipe()` method. The fixture's `/api` route pipes the incoming API request through the deprecated `request` package and then pipes the proxied `/api/post` response into `res`, so the observable contract includes both an `IncomingMessage`-like request and writable response.

## Changes

- Back `PagesReqResRequest` with a real Node `Readable` created from the Fetch request body.
- Back `PagesReqResResponse` with a real Node `Writable` while preserving existing `status`, `json`, `send`, `redirect`, header, cookie, and `revalidate` helpers.
- Avoid auto-ending stream-returning handlers so `req.pipe(...).pipe(res)` can finish asynchronously.
- Port focused regression coverage for the upstream GET and POST proxy behavior at the Pages API runtime boundary.

## Upstream References

- Next.js upstream test: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/proxy-request-with-middleware/test/index.test.ts
- Upstream proxying API route fixture: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/proxy-request-with-middleware/app/pages/api/index.js
- Upstream echo target fixture: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/proxy-request-with-middleware/app/pages/api/post.js
- Next.js `apiResolver` receives `IncomingMessage` and only parses the body when `bodyParser` is enabled: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/api-utils/node/api-resolver.ts#L311-L362
- Next.js API route docs for disabling body parsing to consume the body as a stream: https://github.com/vercel/next.js/blob/v16.2.6/docs/02-pages/03-building-your-application/01-routing/07-api-routes.mdx#L109-L116

## Verification

- `vp test run tests/pages-bodyparser-config.test.ts tests/pages-api-route.test.ts tests/after-deploy.test.ts`
- `vp check packages/vinext/src/server/pages-node-compat.ts packages/vinext/src/server/pages-api-route.ts tests/pages-bodyparser-config.test.ts tests/pages-api-route.test.ts tests/after-deploy.test.ts`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/proxy-request-with-middleware/test/index.test.ts`