### PR TITLE
fix(config): define cache components flag as boolean

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1420,15 +1420,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // enable functional App Shell prefetching.
         // See: https://github.com/vercel/next.js/pull/93997
         defines["process.env.__NEXT_APP_SHELLS"] = JSON.stringify(nextConfig.appShells);
-        // Cache Components — Next.js gates segment Activity BFCache retention
-        // on this build-time flag. Without the flag the active segment renders
-        // in place (unkeyed); enabling it turns on the three-entry inactive
-        // Activity tree cache.
-        // Deliberately string-shaped: `process.env` consumers compare against
-        // "true", so do not simplify this to a boolean define.
-        // See: packages/next/src/client/components/layout-router.tsx
+        // Cache Components — Next.js exposes this as a boolean build-time
+        // DefinePlugin value. Some upstream fixtures intentionally use
+        // `!!process.env.__NEXT_CACHE_COMPONENTS`, so the disabled state must
+        // compile to `false`, not the truthy string "false".
+        // See: packages/next/src/build/define-env.ts
         defines["process.env.__NEXT_CACHE_COMPONENTS"] = JSON.stringify(
-          String(nextConfig.cacheComponents ?? false),
+          nextConfig.cacheComponents ?? false,
         );
 
         // User-defined compile-time constants from `compiler.define` in

--- a/packages/vinext/src/shims/slot.tsx
+++ b/packages/vinext/src/shims/slot.tsx
@@ -55,7 +55,7 @@ export type BfcacheSlotEntry = {
 };
 
 function isCacheComponentsEnabled(): boolean {
-  return process.env.__NEXT_CACHE_COMPONENTS === "true";
+  return String(process.env.__NEXT_CACHE_COMPONENTS) === "true";
 }
 
 type MergeElementsOptions = {

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -100,14 +100,53 @@ async function withCountingFetchTarget<T>(
   }
 }
 
+type StartedTextSequenceTarget = {
+  close: () => Promise<void>;
+  url: string;
+};
+
+async function startTextSequenceTarget(): Promise<StartedTextSequenceTarget> {
+  let responseCount = 0;
+  const upstream = http.createServer((_req, res) => {
+    responseCount += 1;
+    res.setHeader("content-type", "text/plain; charset=utf-8");
+    res.end(`random-${responseCount}`);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    upstream.once("error", reject);
+    upstream.listen(0, "127.0.0.1", () => {
+      upstream.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = upstream.address();
+  if (!address || typeof address === "string") {
+    await new Promise<void>((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+    throw new Error("Text sequence target did not bind to a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/random`,
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        upstream.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
 async function waitForCondition(
-  condition: () => boolean,
+  condition: () => boolean | Promise<boolean>,
   options?: { intervalMs?: number; timeoutMs?: number },
 ): Promise<void> {
   const intervalMs = options?.intervalMs ?? 100;
   const deadline = Date.now() + (options?.timeoutMs ?? 3000);
 
-  while (!condition()) {
+  while (!(await condition())) {
     if (Date.now() >= deadline) {
       throw new Error("Timed out waiting for condition");
     }
@@ -119,6 +158,7 @@ describe("App Router Production server (startProdServer)", () => {
   const outDir = path.resolve(APP_FIXTURE_DIR, "dist");
   let server: import("node:http").Server | undefined;
   let baseUrl: string;
+  let revalidatePathFetchTarget: StartedTextSequenceTarget | undefined;
 
   function extractRequestId(html: string): string | undefined {
     return (
@@ -128,26 +168,70 @@ describe("App Router Production server (startProdServer)", () => {
     );
   }
 
-  beforeAll(async () => {
-    // Build the app-basic fixture to the default dist/ directory
-    const builder = await createBuilder({
-      root: APP_FIXTURE_DIR,
-      configFile: false,
-      plugins: [vinext({ appDir: APP_FIXTURE_DIR })],
-      logLevel: "silent",
-    });
-    await builder.buildApp();
+  function extractRandomData(html: string): string | undefined {
+    return html.match(/id="random-data"[^>]*>(?:<!--.*?-->)*([^<]+)/)?.[1];
+  }
 
-    // Start the production server on a random available port
-    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
-    ({ server } = await startProdServer({ port: 0, outDir, noCompression: false }));
-    const addr = server!.address();
-    const port = typeof addr === "object" && addr ? addr.port : 4210;
-    baseUrl = `http://localhost:${port}`;
+  async function fetchRandomData(pathname: string): Promise<string> {
+    const response = await fetch(`${baseUrl}${pathname}`);
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    const data = extractRandomData(html);
+    expect(data).toBeTruthy();
+    return data ?? "";
+  }
+
+  async function expectRewrittenPathRevalidates(pathname: "/static" | "/dynamic"): Promise<void> {
+    const initial = await fetchRandomData(pathname);
+    const refreshed = await fetchRandomData(pathname);
+    expect(refreshed).toBe(initial);
+
+    const revalidateRes = await fetch(`${baseUrl}/api/revalidate?path=${pathname}`);
+    expect(revalidateRes.status).toBe(200);
+    expect(await revalidateRes.json()).toEqual({ revalidated: true });
+
+    await waitForCondition(async () => {
+      const revalidated = await fetchRandomData(pathname);
+      return revalidated !== initial;
+    });
+  }
+
+  beforeAll(async () => {
+    revalidatePathFetchTarget = await startTextSequenceTarget();
+    process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET = revalidatePathFetchTarget.url;
+
+    try {
+      // Build the app-basic fixture to the default dist/ directory
+      const builder = await createBuilder({
+        root: APP_FIXTURE_DIR,
+        configFile: false,
+        plugins: [vinext({ appDir: APP_FIXTURE_DIR })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      // Start the production server on a random available port
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      ({ server } = await startProdServer({ port: 0, outDir, noCompression: false }));
+      const addr = server!.address();
+      const port = typeof addr === "object" && addr ? addr.port : 4210;
+      baseUrl = `http://localhost:${port}`;
+    } catch (error) {
+      server?.close();
+      try {
+        await revalidatePathFetchTarget.close();
+      } finally {
+        revalidatePathFetchTarget = undefined;
+        delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
+      }
+      throw error;
+    }
   }, 60000);
 
-  afterAll(() => {
+  afterAll(async () => {
     server?.close();
+    await revalidatePathFetchTarget?.close();
+    delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
     fs.rmSync(outDir, { recursive: true, force: true });
   });
 
@@ -942,6 +1026,22 @@ describe("App Router Production server (startProdServer)", () => {
     expect(reqId3).toBeTruthy();
     expect(reqId3).not.toBe(reqId1);
     expect(res3.headers.get("x-vinext-cache")).toBe("MISS");
+  });
+
+  describe("revalidatePath with rewrites", () => {
+    // Ported from Next.js: test/e2e/app-dir/revalidate-path-with-rewrites/revalidate-path-with-rewrites.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/revalidate-path-with-rewrites/revalidate-path-with-rewrites.test.ts
+    //
+    // The upstream fixture fetches https://next-data-api-endpoint.vercel.app/api/random.
+    // This fixture uses a local text endpoint so the same force-cache/revalidatePath
+    // contract is exercised without an external network dependency.
+    it("static page should revalidate a static page that was rewritten", async () => {
+      await expectRewrittenPathRevalidates("/static");
+    });
+
+    it("dynamic page should revalidate a dynamic page that was rewritten", async () => {
+      await expectRewrittenPathRevalidates("/dynamic");
+    });
   });
 
   it("dedupes identical no-store fetches across metadata and page render during ISR background regeneration", async () => {

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -172,8 +172,8 @@ describe("App Router Production server (startProdServer)", () => {
     return html.match(/id="random-data"[^>]*>(?:<!--.*?-->)*([^<]+)/)?.[1];
   }
 
-  async function fetchRandomData(pathname: string): Promise<string> {
-    const response = await fetch(`${baseUrl}${pathname}`);
+  async function fetchRandomData(pathname: string, url = baseUrl): Promise<string> {
+    const response = await fetch(`${url}${pathname}`);
     expect(response.status).toBe(200);
     const html = await response.text();
     const data = extractRandomData(html);
@@ -181,17 +181,20 @@ describe("App Router Production server (startProdServer)", () => {
     return data ?? "";
   }
 
-  async function expectRewrittenPathRevalidates(pathname: "/static" | "/dynamic"): Promise<void> {
-    const initial = await fetchRandomData(pathname);
-    const refreshed = await fetchRandomData(pathname);
+  async function expectRewrittenPathRevalidates(
+    pathname: "/static" | "/dynamic",
+    url = baseUrl,
+  ): Promise<void> {
+    const initial = await fetchRandomData(pathname, url);
+    const refreshed = await fetchRandomData(pathname, url);
     expect(refreshed).toBe(initial);
 
-    const revalidateRes = await fetch(`${baseUrl}/api/revalidate?path=${pathname}`);
+    const revalidateRes = await fetch(`${url}/api/revalidate?path=${pathname}`);
     expect(revalidateRes.status).toBe(200);
     expect(await revalidateRes.json()).toEqual({ revalidated: true });
 
     await waitForCondition(async () => {
-      const revalidated = await fetchRandomData(pathname);
+      const revalidated = await fetchRandomData(pathname, url);
       return revalidated !== initial;
     });
   }
@@ -1042,6 +1045,97 @@ describe("App Router Production server (startProdServer)", () => {
     it("dynamic page should revalidate a dynamic page that was rewritten", async () => {
       await expectRewrittenPathRevalidates("/dynamic");
     });
+
+    // Coverage for the cacheComponents: true path — the sibling tests above exercise
+    // the default disabled case. The define contract must stay consistent between the
+    // config-load-time environment (used by next.config rewrites) and the bundled
+    // boolean expression (used by the route handler).
+    it("static page should revalidate a rewritten page with cacheComponents enabled", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-app-cache-components-rewrite-"));
+      const fixtureRoot = path.join(tmpDir, "fixture");
+      const ccOutDir = path.join(fixtureRoot, "dist");
+      let ccServer: import("node:http").Server | undefined;
+      const prodGlobalKeys = [
+        "__VINEXT_CLIENT_ENTRY__",
+        "__VINEXT_DYNAMIC_PRELOADS__",
+        "__VINEXT_LAZY_CHUNKS__",
+        "__VINEXT_SSR_MANIFEST__",
+        "__vite_rsc_client_require__",
+        "__vite_rsc_require__",
+        "__vite_rsc_server_require__",
+        "__webpack_chunk_load__",
+        "__webpack_require__",
+      ];
+      const previousGlobals = new Map(
+        prodGlobalKeys.map((key) => [
+          key,
+          {
+            exists: Reflect.has(globalThis, key),
+            value: Reflect.get(globalThis, key),
+          },
+        ]),
+      );
+
+      try {
+        fs.cpSync(APP_FIXTURE_DIR, fixtureRoot, { recursive: true });
+        fs.rmSync(ccOutDir, { recursive: true, force: true });
+        const fixtureNodeModules = path.join(fixtureRoot, "node_modules");
+        if (!fs.existsSync(fixtureNodeModules)) {
+          fs.symlinkSync(
+            path.resolve(__dirname, "..", "node_modules"),
+            fixtureNodeModules,
+            "junction",
+          );
+        }
+
+        const nextConfigPath = path.join(fixtureRoot, "next.config.ts");
+        const nextConfig = fs.readFileSync(nextConfigPath, "utf-8");
+        fs.writeFileSync(
+          nextConfigPath,
+          nextConfig.replace(
+            "const nextConfig: NextConfig = {",
+            "const nextConfig: NextConfig = {\n  cacheComponents: true,",
+          ),
+        );
+
+        // Set the env var so next.config.ts rewrites resolve to the cache-components
+        // prefix (the config is evaluated at load time, before the Vite define replaces
+        // process.env.__NEXT_CACHE_COMPONENTS with the bundled boolean).
+        process.env.__NEXT_CACHE_COMPONENTS = "true";
+
+        const builder = await createBuilder({
+          root: fixtureRoot,
+          configFile: false,
+          plugins: [vinext({ appDir: fixtureRoot })],
+          logLevel: "silent",
+        });
+        await builder.buildApp();
+
+        const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+        ({ server: ccServer } = await startProdServer({
+          port: 0,
+          outDir: ccOutDir,
+          noCompression: true,
+        }));
+        const addr = ccServer.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        const tmpBaseUrl = `http://localhost:${port}`;
+
+        await expectRewrittenPathRevalidates("/static", tmpBaseUrl);
+        await expectRewrittenPathRevalidates("/dynamic", tmpBaseUrl);
+      } finally {
+        delete process.env.__NEXT_CACHE_COMPONENTS;
+        ccServer?.close();
+        for (const [key, previous] of previousGlobals) {
+          if (previous.exists) {
+            Reflect.set(globalThis, key, previous.value);
+          } else {
+            Reflect.deleteProperty(globalThis, key);
+          }
+        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    }, 60000);
   });
 
   it("dedupes identical no-store fetches across metadata and page render during ISR background regeneration", async () => {

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1077,7 +1077,13 @@ describe("App Router Production server (startProdServer)", () => {
       );
 
       try {
-        fs.cpSync(APP_FIXTURE_DIR, fixtureRoot, { recursive: true });
+        fs.cpSync(APP_FIXTURE_DIR, fixtureRoot, {
+          recursive: true,
+          filter: (src) => {
+            const rel = path.relative(APP_FIXTURE_DIR, src);
+            return rel !== "dist" && !rel.startsWith(`dist${path.sep}`);
+          },
+        });
         fs.rmSync(ccOutDir, { recursive: true, force: true });
         const fixtureNodeModules = path.join(fixtureRoot, "node_modules");
         if (!fs.existsSync(fixtureNodeModules)) {

--- a/tests/fixtures/app-basic/app/api/revalidate/route.ts
+++ b/tests/fixtures/app-basic/app/api/revalidate/route.ts
@@ -1,0 +1,17 @@
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+const isCacheComponentsEnabled = !!process.env.__NEXT_CACHE_COMPONENTS;
+
+export async function GET(request: NextRequest) {
+  const sourcePath = request.nextUrl.searchParams.get("path");
+
+  if (!sourcePath) {
+    return NextResponse.json({ error: "Missing path parameter" }, { status: 400 });
+  }
+
+  const prefix = isCacheComponentsEnabled ? "/cache-components" : "/legacy";
+  revalidatePath(`${prefix}${sourcePath}`);
+
+  return NextResponse.json({ revalidated: true });
+}

--- a/tests/fixtures/app-basic/app/cache-components/dynamic/page.tsx
+++ b/tests/fixtures/app-basic/app/cache-components/dynamic/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from "react";
+import { connection } from "next/server";
+import SharedPage from "../../shared-page";
+
+async function CachedContent() {
+  "use cache: remote";
+
+  return <SharedPage isDynamic={true} />;
+}
+
+async function Content() {
+  await connection();
+
+  return <CachedContent />;
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Content />
+    </Suspense>
+  );
+}

--- a/tests/fixtures/app-basic/app/cache-components/static/page.tsx
+++ b/tests/fixtures/app-basic/app/cache-components/static/page.tsx
@@ -1,0 +1,7 @@
+import SharedPage from "../../shared-page";
+
+export default async function Page() {
+  "use cache";
+
+  return <SharedPage isDynamic={false} />;
+}

--- a/tests/fixtures/app-basic/app/legacy/dynamic/page.tsx
+++ b/tests/fixtures/app-basic/app/legacy/dynamic/page.tsx
@@ -1,0 +1,8 @@
+import SharedPage from "../../shared-page";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-cache";
+
+export default function Page() {
+  return <SharedPage isDynamic={true} />;
+}

--- a/tests/fixtures/app-basic/app/legacy/static/page.tsx
+++ b/tests/fixtures/app-basic/app/legacy/static/page.tsx
@@ -1,0 +1,8 @@
+import SharedPage from "../../shared-page";
+
+export const revalidate = 900;
+export const fetchCache = "force-cache";
+
+export default function Page() {
+  return <SharedPage isDynamic={false} />;
+}

--- a/tests/fixtures/app-basic/app/shared-page.tsx
+++ b/tests/fixtures/app-basic/app/shared-page.tsx
@@ -1,0 +1,21 @@
+async function getData() {
+  const target =
+    process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET ??
+    "data:text/plain,revalidate-path-with-rewrites-default";
+
+  const res = await fetch(target);
+  return res.text();
+}
+
+export default async function SharedPage({ isDynamic }: { isDynamic: boolean }) {
+  const data = await getData();
+
+  return (
+    <div>
+      <h1>{isDynamic ? "Dynamic" : "Static"} Page</h1>
+      <p>
+        Random data: <span id="random-data">{data}</span>
+      </p>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -110,6 +110,22 @@ const nextConfig: NextConfig = {
       afterFiles: [
         // Used by Vitest: app-router.test.ts
         { source: "/after-rewrite-about", destination: "/about" },
+        // Ported from Next.js: test/e2e/app-dir/revalidate-path-with-rewrites/next.config.js
+        // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/revalidate-path-with-rewrites/next.config.js
+        {
+          source: "/static",
+          destination:
+            process.env.__NEXT_CACHE_COMPONENTS === "true"
+              ? "/cache-components/static"
+              : "/legacy/static",
+        },
+        {
+          source: "/dynamic",
+          destination:
+            process.env.__NEXT_CACHE_COMPONENTS === "true"
+              ? "/cache-components/dynamic"
+              : "/legacy/dynamic",
+        },
         // Used by E2E: config-redirect.spec.ts
         { source: "/config-rewrite", destination: "/" },
         // Used by Vitest: nextjs-compat/hooks.test.ts — usePathname should


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js' `process.env.__NEXT_CACHE_COMPONENTS` define shape so rewritten `revalidatePath` routes invalidate the correct destination cache. Closes #1486  |
| Core change | Define `process.env.__NEXT_CACHE_COMPONENTS` as a boolean expression instead of the string `"false"` or `"true"`. |
| Main boundary | Bundled app code receives the build-time define, while `next.config` rewrites read the real process env at config load time. Those two views must agree with Next.js semantics. |
| Primary files | `packages/vinext/src/index.ts`, `packages/vinext/src/shims/slot.tsx`, `tests/app-router-production-server.test.ts`, `tests/fixtures/app-basic/**` |
| Expected impact | Fixes `revalidatePath` with rewrites when cache components are disabled, and preserves cache-components slot behavior when the flag is boolean or string-shaped. |

## Why

For rewritten App Router paths, `revalidatePath` must receive the destination route path because that is the cache entry owner. The upstream Next.js fixture intentionally computes that destination with `!!process.env.__NEXT_CACHE_COMPONENTS` inside bundled route-handler code. Next.js defines `process.env.__NEXT_CACHE_COMPONENTS` as a boolean build-time value. Vinext defined the disabled value as the truthy string `"false"`, so bundled route code selected `/cache-components/*` while `next.config` rewrites selected `/legacy/*`, leaving the actual `/legacy/*` cache stale.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Build-time defines | Match the framework contract at the compile boundary. | Emits `false` or `true` as the replacement expression for `process.env.__NEXT_CACHE_COMPONENTS`. |
| Client shim compatibility | Internal runtime checks should tolerate both bundled and test/runtime env shapes. | Reads the slot flag through `String(process.env.__NEXT_CACHE_COMPONENTS) === "true"`. |
| Regression coverage | Test the failing observable contract, not an easier smoke path. | Ports the upstream static and dynamic rewrite cases into the production-server test fixture. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `cacheComponents: false` bundled code | `!!process.env.__NEXT_CACHE_COMPONENTS` compiled truthy because the value was `"false"`. | The same check compiles falsy because the value is the boolean expression `false`. |
| Rewritten `/static` and `/dynamic` routes | Route handler revalidated `/cache-components/...` while rewrites served `/legacy/...`. | Route handler and rewrites agree on `/legacy/...`, so revalidation invalidates the rendered destination cache. |
| Slot shim flag read | Checked only string env equality. | Still supports string env values and now also supports boolean define replacement. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/index.ts` for the define shape and the comment pointing at Next's `define-env` contract.
2. `tests/fixtures/app-basic/next.config.ts` plus the new `app/legacy`, `app/cache-components`, `app/api/revalidate`, and `app/shared-page.tsx` fixture files for upstream route/config parity.
3. `tests/app-router-production-server.test.ts` for the hermetic local text endpoint and the two observable static/dynamic assertions.
4. `packages/vinext/src/shims/slot.tsx` for the runtime compatibility read of the same flag.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-router-production-server.test.ts -t "revalidatePath"`
- `vp test run tests/shims.test.ts -t "cacheComponents config"`
- `vp check tests/app-router-production-server.test.ts packages/vinext/src/index.ts packages/vinext/src/shims/slot.tsx tests/fixtures/app-basic/next.config.ts tests/fixtures/app-basic/app/shared-page.tsx tests/fixtures/app-basic/app/api/revalidate/route.ts tests/fixtures/app-basic/app/legacy/static/page.tsx tests/fixtures/app-basic/app/legacy/dynamic/page.tsx tests/fixtures/app-basic/app/cache-components/static/page.tsx tests/fixtures/app-basic/app/cache-components/dynamic/page.tsx`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/revalidate-path-with-rewrites/revalidate-path-with-rewrites.test.ts`
- Pre-commit hook: staged `vp check --fix`, full check, staged unit/integration tests, and knip.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no API surface change.
- Config/build output: intentionally changes `process.env.__NEXT_CACHE_COMPONENTS` replacement from string literal to boolean expression to match Next.js.
- Runtime: affects code that branches on `!!process.env.__NEXT_CACHE_COMPONENTS`; this is the upstream-compatible behavior. Code comparing the bundled value to `"true"` will now behave like it does in Next.js.
- Test fixture: the upstream fixture fetches `https://next-data-api-endpoint.vercel.app/api/random`; this port uses a local text endpoint so the same cache and revalidation contract is tested without an external network dependency.

</details>

<details>
<summary>Non-goals</summary>

- This does not change `revalidatePath` tag semantics or rewrite matching order.
- This does not implement additional cache-components behavior beyond aligning the flag shape and preserving existing slot-shim behavior.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream test](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/revalidate-path-with-rewrites/revalidate-path-with-rewrites.test.ts) | The behavior ported into Vinext: rewritten static and dynamic pages must update after revalidation. |
| [Next.js fixture route handler](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/revalidate-path-with-rewrites/app/api/revalidate/route.ts) | Shows the intentional `!!process.env.__NEXT_CACHE_COMPONENTS` destination-prefix selection. |
| [Next.js fixture rewrites](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/revalidate-path-with-rewrites/next.config.js) | Shows `next.config` selecting `/cache-components/*` only when the process env string is `"true"`. |
| [Next.js define-env source](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/define-env.ts) | Defines `process.env.__NEXT_CACHE_COMPONENTS` as the boolean `isCacheComponentsEnabled`. |
| [Next.js `revalidatePath` rewrite docs](https://nextjs.org/docs/app/api-reference/functions/revalidatePath#using-revalidatepath-with-rewrites) | Documents that revalidation must use the rewrite destination path, not the browser source path. |