### PR TITLE
fix(pages-router): restore scroll across reload history traversal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,10 @@ jobs:
             label: pages-router-prod
             shardIndex: 1
             shardTotal: 1
+          - project: pages-scroll-restoration
+            label: pages-scroll-restoration
+            shardIndex: 1
+            shardTotal: 1
           - project: cloudflare-workers
             label: cloudflare-workers
             shardIndex: 1

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -448,6 +448,13 @@ export type ResolvedNextConfig = {
    */
   disableOptimizedLoading: boolean;
   /**
+   * Mirrors Next.js `experimental.scrollRestoration`. When true, the Pages
+   * Router client takes ownership of browser history scroll restoration by
+   * setting `window.history.scrollRestoration = "manual"` and snapshotting
+   * scroll positions per history entry.
+   */
+  scrollRestoration: boolean;
+  /**
    * Build-time constant replacement map applied to BOTH client and server
    * bundles. Sourced from `compiler.define` in next.config. Values are
    * pre-serialized via `JSON.stringify` so they can be fed straight into
@@ -1234,6 +1241,7 @@ export async function resolveNextConfig(
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      scrollRestoration: false,
       compilerDefine: {},
       compilerDefineServer: {},
       instrumentationClientInject: [],
@@ -1528,6 +1536,7 @@ export async function resolveNextConfig(
     // Next.js stores this under `experimental.disableOptimizedLoading`.
     // Default `false` matches Next.js: page scripts get `defer` in <head>.
     disableOptimizedLoading: experimental?.disableOptimizedLoading === true,
+    scrollRestoration: experimental?.scrollRestoration === true,
     compilerDefine: serializeCompilerDefine(config.compiler?.define),
     compilerDefineServer: serializeCompilerDefine(config.compiler?.defineServer),
     clientTraceMetadata: Array.isArray(experimental?.clientTraceMetadata)

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -72,7 +72,6 @@ export async function generateClientEntry(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
-import { installPagesRouterRuntime } from "vinext/pages-router-runtime";
 // Statically import next/router as the very first vinext shim so that
 // (a) installWindowNext runs at top-level — \`window.next.router\` is
 //     available to test harnesses and third-party scripts BEFORE
@@ -193,7 +192,6 @@ async function hydrate() {
 
   const root = hydrateRoot(container, element, hydrateRootOptions);
   window.__VINEXT_ROOT__ = root;
-  installPagesRouterRuntime();
   const hydratedAt = performance.now();
   window.__VINEXT_HYDRATED_AT = hydratedAt;
   window.__NEXT_HYDRATED = true;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1329,6 +1329,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.__NEXT_GESTURE_TRANSITION"] = JSON.stringify(
           nextConfig.gestureTransition,
         );
+        // Expose experimental.scrollRestoration to the Pages Router client.
+        // Next.js defines this from config.experimental.scrollRestoration in
+        // packages/next/src/build/define-env.ts.
+        defines["process.env.__NEXT_SCROLL_RESTORATION"] = JSON.stringify(
+          nextConfig.scrollRestoration ? "true" : "false",
+        );
         // Expose trailingSlash to client-side code so <Link> can render hrefs
         // in the canonical form and avoid an unnecessary 308 redirect bounce.
         defines["process.env.__VINEXT_TRAILING_SLASH"] = JSON.stringify(

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1351,7 +1351,6 @@ export function createSSRHandler(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
-import { installPagesRouterRuntime } from "vinext/pages-router-runtime";
 import { wrapWithRouterContext } from "next/router";
 
 const nextData = window.__NEXT_DATA__;
@@ -1388,7 +1387,6 @@ async function hydrate() {
   element = wrapWithRouterContext(element);
   const root = hydrateRoot(document.getElementById("__next"), element, hydrateRootOptions);
   window.__VINEXT_ROOT__ = root;
-  installPagesRouterRuntime();
   const hydratedAt = performance.now();
   window.__VINEXT_HYDRATED_AT = hydratedAt;
   window.__NEXT_HYDRATED = true;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -10,6 +10,8 @@ import {
   useEffect,
   useMemo,
   useContext,
+  useLayoutEffect,
+  Fragment,
   createElement,
   type ReactElement,
   type ReactNode,
@@ -65,6 +67,7 @@ import {
 import { matchRoutePattern, routePatternParts } from "../routing/route-pattern.js";
 import { scrollToHashTarget } from "./hash-scroll.js";
 import {
+  installPagesRouterRuntime,
   setPagesRouterPopStateHandler,
   setStampInitialHistoryState,
 } from "./pages-router-runtime.js";
@@ -75,6 +78,65 @@ import { getCurrentBrowserLocale } from "./client-locale.js";
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 /** trailingSlash from next.config.js, injected by the plugin at build time */
 const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
+/** experimental.scrollRestoration from next.config.js, injected by the plugin at build time */
+const __scrollRestoration: boolean = process.env.__NEXT_SCROLL_RESTORATION === "true";
+
+type ScrollPosition = { x: number; y: number };
+
+const noopCommit = (): void => {};
+
+function PagesRouterCommitBoundary({
+  children,
+  onCommit,
+}: {
+  children?: ReactNode;
+  onCommit: () => void;
+}): ReactElement {
+  useLayoutEffect(() => {
+    onCommit();
+  }, [onCommit]);
+
+  return createElement(Fragment, null, children);
+}
+
+function renderPagesRouterElement(element: ReactElement): Promise<void> {
+  const root = window.__VINEXT_ROOT__;
+  if (!root) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve) => {
+    root.render(wrapWithRouterContext(element, resolve));
+    if (typeof document === "undefined") {
+      resolve();
+    }
+  });
+}
+
+function canUseSessionStorageForScrollRestoration(): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    const key = "__next";
+    window.sessionStorage.setItem(key, key);
+    window.sessionStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const manualScrollRestoration =
+  __scrollRestoration &&
+  typeof window !== "undefined" &&
+  "scrollRestoration" in window.history &&
+  canUseSessionStorageForScrollRestoration();
+
+function installManualScrollRestoration(): void {
+  if (manualScrollRestoration) {
+    window.history.scrollRestoration = "manual";
+  }
+}
 
 type BeforePopStateCallback = (state: {
   url: string;
@@ -346,6 +408,8 @@ export function isHashOnlyChange(href: string): boolean {
   return isHashOnlyBrowserUrlChange(href, window.location.href, __basePath);
 }
 
+let _currentHistoryKey: string | undefined;
+
 /**
  * Build router-shaped state for the initial document entry. Captures the
  * active locale (from `window.__VINEXT_LOCALE__`) so a back-navigation
@@ -372,8 +436,17 @@ function buildInitialRouterState(): VinextHistoryState {
  * locale stamped before any push could overwrite the active locale global.
  */
 function stampInitialHistoryState(): void {
-  if (window.history.state !== null && window.history.state !== undefined) return;
-  window.history.replaceState(buildInitialRouterState(), "");
+  installManualScrollRestoration();
+
+  const existingState = window.history.state;
+  if (existingState !== null && existingState !== undefined) {
+    _currentHistoryKey = getRouterStateKey(existingState) ?? _currentHistoryKey;
+    return;
+  }
+
+  const initialState = buildInitialRouterState();
+  _currentHistoryKey = initialState.key;
+  window.history.replaceState(initialState, "");
 }
 
 setStampInitialHistoryState(stampInitialHistoryState);
@@ -386,26 +459,73 @@ setStampInitialHistoryState(stampInitialHistoryState);
  * minting the same shape here so the entry isn't treated as foreign.
  */
 function saveScrollPosition(): void {
-  const existing =
-    typeof window.history.state === "object" && window.history.state !== null
-      ? (window.history.state as Record<string, unknown>)
-      : null;
+  const position = getWindowScrollPosition();
+  const existing = isUnknownRecord(window.history.state) ? window.history.state : null;
   const scroll = {
-    __vinext_scrollX: window.scrollX,
-    __vinext_scrollY: window.scrollY,
+    __vinext_scrollX: position.x,
+    __vinext_scrollY: position.y,
   };
   const base: Record<string, unknown> = existing ?? buildInitialRouterState();
+  const key = getRouterStateKey(base);
+  if (key !== undefined) {
+    _currentHistoryKey = key;
+    saveScrollPositionToSessionStorage(key, position);
+  }
   window.history.replaceState({ ...base, ...scroll }, "");
 }
 
-/** Restore scroll position from history state */
-function restoreScrollPosition(state: unknown): void {
-  if (state && typeof state === "object" && "__vinext_scrollY" in state) {
-    const { __vinext_scrollX: x, __vinext_scrollY: y } = state as {
-      __vinext_scrollX: number;
-      __vinext_scrollY: number;
-    };
-    requestAnimationFrame(() => window.scrollTo(x, y));
+function getWindowScrollPosition(): ScrollPosition {
+  return { x: window.scrollX, y: window.scrollY };
+}
+
+function getScrollStorageKey(historyKey: string): string {
+  return `__next_scroll_${historyKey}`;
+}
+
+function readScrollPosition(value: unknown): ScrollPosition | null {
+  if (!isUnknownRecord(value)) return null;
+
+  const nextX = value.x;
+  const nextY = value.y;
+  if (typeof nextX === "number" && typeof nextY === "number") {
+    return { x: nextX, y: nextY };
+  }
+
+  const vinextX = value.__vinext_scrollX;
+  const vinextY = value.__vinext_scrollY;
+  if (typeof vinextX === "number" && typeof vinextY === "number") {
+    return { x: vinextX, y: vinextY };
+  }
+
+  return null;
+}
+
+function saveScrollPositionToSessionStorage(key: string, position: ScrollPosition): void {
+  if (!manualScrollRestoration) return;
+
+  try {
+    window.sessionStorage.setItem(getScrollStorageKey(key), JSON.stringify(position));
+  } catch {}
+}
+
+function readScrollPositionFromSessionStorage(key: string): ScrollPosition | null {
+  if (!manualScrollRestoration) return null;
+
+  try {
+    const value = window.sessionStorage.getItem(getScrollStorageKey(key));
+    if (value === null) return null;
+    const parsed: unknown = JSON.parse(value);
+    return readScrollPosition(parsed);
+  } catch {
+    return null;
+  }
+}
+
+/** Restore scroll position from history state or a Next-style scroll snapshot. */
+function restoreScrollPosition(stateOrPosition: unknown): void {
+  const position = readScrollPosition(stateOrPosition);
+  if (position !== null) {
+    requestAnimationFrame(() => window.scrollTo(position.x, position.y));
   }
 }
 
@@ -1227,8 +1347,6 @@ async function navigateClientData(
   } else {
     element = React.createElement(PageComponent, pageProps);
   }
-  element = wrapWithRouterContext(element);
-
   // Build the updated __NEXT_DATA__. The JSON envelope is intentionally
   // minimal (just `pageProps`), so we synthesise the surrounding fields
   // from the data we already have: the matched pattern, the params, and
@@ -1272,12 +1390,14 @@ async function navigateClientData(
     ...(nextLocale !== undefined ? { locale: nextLocale } : {}),
   } as unknown as NonNullable<Window["__NEXT_DATA__"]> & VinextNextData;
 
-  // INVARIANT: Everything between the final assertStillCurrent() above and
-  // root.render() must be synchronous. If a future change introduces another
-  // await, add an assertStillCurrent() before mutating window.__NEXT_DATA__.
+  // INVARIANT: __NEXT_DATA__ is mutated only after all pre-render async work
+  // has passed assertStillCurrent(). The post-render await below waits for the
+  // stable Pages Router commit boundary before routeChangeComplete, matching
+  // Next.js's client Root callback without remounting the page tree.
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  root.render(element);
+  await renderPagesRouterElement(element);
+  assertStillCurrent();
 }
 
 /**
@@ -1434,22 +1554,20 @@ async function navigateClientHtml(
     element = React.createElement(PageComponent, pageProps);
   }
 
-  // Wrap with RouterContext.Provider so next/router and next/compat/router work.
-  element = wrapWithRouterContext(element);
-
   // Commit __NEXT_DATA__ only after all assertStillCurrent() checks have passed,
   // so a stale navigation can never pollute the global.
-  // INVARIANT: Everything after the final assertStillCurrent() above (the
-  // checkpoint immediately after the optional _app import) through
-  // root.render() is synchronous. If any step here ever becomes async, add
-  // another assertStillCurrent() before writing __NEXT_DATA__.
+  // INVARIANT: __NEXT_DATA__ is mutated only after all pre-render async work
+  // has passed assertStillCurrent(). The post-render await below waits for the
+  // stable Pages Router commit boundary before routeChangeComplete, matching
+  // Next.js's client Root callback without remounting the page tree.
   if (pendingRedirectHistoryUrl) {
     window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
     _lastPathnameAndSearch = window.location.pathname + window.location.search;
   }
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  root.render(element);
+  await renderPagesRouterElement(element);
+  assertStillCurrent();
 }
 
 /**
@@ -1679,11 +1797,11 @@ function updateHistory(
   fullUrl: string,
   navState?: { url?: string; as?: string; options?: { locale?: string; shallow?: boolean } },
 ): void {
-  const previousState =
-    typeof window.history.state === "object" && window.history.state !== null
-      ? (window.history.state as { key?: string })
-      : null;
-  const key = mode === "push" ? createHistoryKey() : (previousState?.key ?? createHistoryKey());
+  const previousKey = getRouterStateKey(window.history.state);
+  const key =
+    mode === "push"
+      ? createHistoryKey()
+      : (previousKey ?? _currentHistoryKey ?? createHistoryKey());
   const stateUrl = navState?.url ?? fullUrl;
   const stateAs = navState?.as ?? fullUrl;
   const options = navState?.options ?? {};
@@ -1696,6 +1814,7 @@ function updateHistory(
   };
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
+  _currentHistoryKey = key;
   _lastPathnameAndSearch = window.location.pathname + window.location.search;
   _routerDidNavigate = true;
 }
@@ -2049,6 +2168,11 @@ function isNextRouterState(state: unknown): state is {
   );
 }
 
+function getRouterStateKey(state: unknown): string | undefined {
+  if (!isNextRouterState(state)) return undefined;
+  return typeof state.key === "string" ? state.key : undefined;
+}
+
 function handlePagesRouterPopState(e: PopStateEvent): void {
   const browserUrl = window.location.pathname + window.location.search;
   const appUrl = stripBasePath(window.location.pathname, __basePath) + window.location.search;
@@ -2106,6 +2230,23 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
 
   // Detect hash-only back/forward: pathname+search unchanged, only hash differs.
   const isHashOnly = browserUrl === _lastPathnameAndSearch;
+  const targetKey = getRouterStateKey(state);
+  let forcedScroll: ScrollPosition | undefined;
+
+  if (manualScrollRestoration) {
+    const currentKey = _currentHistoryKey;
+    if (currentKey !== undefined && currentKey !== targetKey) {
+      saveScrollPositionToSessionStorage(currentKey, getWindowScrollPosition());
+    }
+
+    if (targetKey !== undefined && currentKey !== targetKey) {
+      forcedScroll = readScrollPositionFromSessionStorage(targetKey) ?? { x: 0, y: 0 };
+    }
+  }
+
+  if (targetKey !== undefined) {
+    _currentHistoryKey = targetKey;
+  }
 
   // Check beforePopState callback
   if (_beforePopStateCb !== undefined) {
@@ -2154,7 +2295,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     );
     if (result === "completed") {
       routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: false });
-      restoreScrollPosition(e.state);
+      restoreScrollPosition(forcedScroll ?? e.state);
       dispatchNavigateEvent();
     }
     // "cancelled": superseded by a newer navigation, so this popstate no longer wins.
@@ -2172,8 +2313,15 @@ setPagesRouterPopStateHandler(handlePagesRouterPopState);
  * next/compat/router consumers share one context value instead of each hook
  * installing its own global URL-change listener.
  */
-export function wrapWithRouterContext(element: ReactElement): ReactElement {
-  return createElement(PagesRouterProvider, null, element);
+export function wrapWithRouterContext(
+  element: ReactElement,
+  onCommit: () => void = noopCommit,
+): ReactElement {
+  return createElement(
+    PagesRouterCommitBoundary,
+    { onCommit },
+    createElement(PagesRouterProvider, null, element),
+  );
 }
 
 /**
@@ -2465,6 +2613,10 @@ for (const event of deprecatedRouterEvents) {
 // singleton is constructed synchronously here, so by the time this module
 // finishes loading the value is final.
 if (typeof window !== "undefined") {
+  // Match Next.js's Router constructor: stamp the initial history entry and
+  // attach the popstate listener while next/router itself is evaluating,
+  // before window.next.router is exposed to userland.
+  installPagesRouterRuntime();
   // Cast: `NextRouter.push`/`replace` are typed with narrow parameters
   // (UrlObject | string) while `PagesRouterPublicInstance` accepts unknown
   // args. The two are structurally compatible at runtime; TypeScript flags

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -482,6 +482,8 @@ function buildInitialRouterState(): VinextHistoryState {
 function stampInitialHistoryState(): void {
   installManualScrollRestoration();
 
+  if (!window.history) return;
+
   const existingState = window.history.state;
   if (existingState !== null && existingState !== undefined) {
     _currentHistoryKey = getRouterStateKey(existingState) ?? _currentHistoryKey;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -12,6 +12,7 @@ import {
   useContext,
   useLayoutEffect,
   Fragment,
+  Component,
   createElement,
   type ReactElement,
   type ReactNode,
@@ -82,10 +83,27 @@ const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
 const __scrollRestoration: boolean = process.env.__NEXT_SCROLL_RESTORATION === "true";
 
 type ScrollPosition = { x: number; y: number };
-
 const noopCommit = (): void => {};
 
-function PagesRouterCommitBoundary({
+class PagesRouterCommitBoundary extends Component<{
+  children?: ReactNode;
+  onCommit: () => void;
+  onError: (error: Error) => void;
+}> {
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+  }
+
+  render() {
+    return createElement(
+      PagesRouterCommitBoundaryHelper,
+      { onCommit: this.props.onCommit },
+      this.props.children,
+    );
+  }
+}
+
+function PagesRouterCommitBoundaryHelper({
   children,
   onCommit,
 }: {
@@ -99,14 +117,40 @@ function PagesRouterCommitBoundary({
   return createElement(Fragment, null, children);
 }
 
-function renderPagesRouterElement(element: ReactElement): Promise<void> {
+function renderPagesRouterElement(
+  element: ReactElement,
+  scroll?: ScrollPosition | string | null,
+): Promise<void> {
   const root = window.__VINEXT_ROOT__;
   if (!root) {
     return Promise.resolve();
   }
 
-  return new Promise<void>((resolve) => {
-    root.render(wrapWithRouterContext(element, resolve));
+  return new Promise<void>((resolve, reject) => {
+    const scrollHandler = () => {
+      if (scroll) {
+        if (typeof scroll === "string") {
+          scrollToHashTarget(scroll);
+        } else {
+          window.scrollTo(scroll.x, scroll.y);
+        }
+      }
+    };
+
+    root.render(
+      wrapWithRouterContext(
+        element,
+        () => {
+          try {
+            scrollHandler();
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        },
+        reject,
+      ),
+    );
     if (typeof document === "undefined") {
       resolve();
     }
@@ -518,14 +562,6 @@ function readScrollPositionFromSessionStorage(key: string): ScrollPosition | nul
     return readScrollPosition(parsed);
   } catch {
     return null;
-  }
-}
-
-/** Restore scroll position from history state or a Next-style scroll snapshot. */
-function restoreScrollPosition(stateOrPosition: unknown): void {
-  const position = readScrollPosition(stateOrPosition);
-  if (position !== null) {
-    requestAnimationFrame(() => window.scrollTo(position.x, position.y));
   }
 }
 
@@ -1032,6 +1068,7 @@ type NavigateClientOptions = {
    * Next.js's `this.change(method, ...)` re-dispatch.
    */
   mode?: "push" | "replace";
+  scroll?: ScrollPosition | string | null;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -1396,7 +1433,7 @@ async function navigateClientData(
   // Next.js's client Root callback without remounting the page tree.
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  await renderPagesRouterElement(element);
+  await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();
 }
 
@@ -1566,7 +1603,7 @@ async function navigateClientHtml(
   }
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  await renderPagesRouterElement(element);
+  await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();
 }
 
@@ -1920,11 +1957,13 @@ async function performNavigation(
   );
   const errorRouteHtmlFetchUrl = resolvePagesErrorHtmlFetchUrl(url, navigationLocale);
   const htmlFetchUrl = errorRouteHtmlFetchUrl ?? getPagesHtmlFetchUrl(full, navigationLocale);
-  const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
-    ? { allowNotFoundResponse: true, mode }
-    : { mode };
   const shallow = options?.shallow ?? false;
   const doScroll = options?.scroll !== false;
+  const hash = extractHash(resolved);
+  const scrollTarget = doScroll ? (hash ? hash : { x: 0, y: 0 }) : null;
+  const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
+    ? { allowNotFoundResponse: true, mode, scroll: scrollTarget }
+    : { mode, scroll: scrollTarget };
 
   // History state metadata — surfaces the active locale to popstate and the
   // Safari-replay filter. `as` is the canonical app-relative path (no
@@ -1980,15 +2019,14 @@ async function performNavigation(
     const result = await runNavigateClient(full, resolved, htmlFetchUrl, navigateOptions);
     if (result === "cancelled") return true;
     if (result === "failed") return false;
+  } else {
+    if (doScroll) {
+      if (hash) scrollToHashTarget(hash);
+      else window.scrollTo(0, 0);
+    }
   }
   onStateUpdate?.();
   routerEvents.emit("routeChangeComplete", resolved, { shallow });
-
-  const hash = extractHash(resolved);
-  if (doScroll) {
-    if (hash) scrollToHashTarget(hash);
-    else window.scrollTo(0, 0);
-  }
   dispatchNavigateEvent();
   return true;
 }
@@ -2288,14 +2326,17 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // compatibility.
   routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow: false });
   void (async () => {
+    const scrollTarget = manualScrollRestoration
+      ? (forcedScroll ?? readScrollPosition(state) ?? { x: 0, y: 0 })
+      : null;
     const result = await runNavigateClient(
       browserUrl,
       fullAppUrl,
       getPagesHtmlFetchUrl(browserUrl, effectiveLocale),
+      { scroll: scrollTarget },
     );
     if (result === "completed") {
       routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: false });
-      restoreScrollPosition(forcedScroll ?? e.state);
       dispatchNavigateEvent();
     }
     // "cancelled": superseded by a newer navigation, so this popstate no longer wins.
@@ -2316,10 +2357,11 @@ setPagesRouterPopStateHandler(handlePagesRouterPopState);
 export function wrapWithRouterContext(
   element: ReactElement,
   onCommit: () => void = noopCommit,
+  onError: (error: Error) => void = noopCommit,
 ): ReactElement {
   return createElement(
     PagesRouterCommitBoundary,
-    { onCommit },
+    { onCommit, onError },
     createElement(PagesRouterProvider, null, element),
   );
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -85,6 +85,15 @@ const __scrollRestoration: boolean = process.env.__NEXT_SCROLL_RESTORATION === "
 type ScrollPosition = { x: number; y: number };
 const noopCommit = (): void => {};
 
+/**
+ * A version of useLayoutEffect that doesn't warn during SSR.
+ * `wrapWithRouterContext` is shared with the server-side Pages Router render
+ * path, where a raw useLayoutEffect would log React's "useLayoutEffect does
+ * nothing on the server" warning on every render. Same pattern as
+ * `shims/image.tsx`; Next.js only runs the commit callback on the client.
+ */
+const useNonWarningLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
 class PagesRouterCommitBoundary extends Component<{
   children?: ReactNode;
   onCommit: () => void;
@@ -110,7 +119,7 @@ function PagesRouterCommitBoundaryHelper({
   children?: ReactNode;
   onCommit: () => void;
 }): ReactElement {
-  useLayoutEffect(() => {
+  useNonWarningLayoutEffect(() => {
     onCommit();
   }, [onCommit]);
 
@@ -2047,6 +2056,11 @@ async function performNavigation(
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {
+    // Shallow navigations skip the render-commit path, so apply the scroll
+    // reset synchronously here — before routeChangeComplete. This matches the
+    // non-shallow path, where the x/y reset runs inside the render-commit
+    // callback (also ahead of routeChangeComplete), mirroring Next.js's
+    // ordering of scroll-during-commit, then completion event.
     if (doScroll) {
       if (hash) scrollToHashTarget(hash);
       else window.scrollTo(0, 0);
@@ -2386,6 +2400,14 @@ setPagesRouterPopStateHandler(handlePagesRouterPopState);
  * The provider owns the reactive Pages Router snapshot so next/router and
  * next/compat/router consumers share one context value instead of each hook
  * installing its own global URL-change listener.
+ *
+ * The PagesRouterCommitBoundary exists for client navigations: its onCommit
+ * callback resolves the render-commit promise (so scroll restoration runs at
+ * commit time) and its onError rejection drives the hard-navigation fallback
+ * in runNavigateClient. The same boundary intentionally also wraps SSR and
+ * initial hydration, where both callbacks default to noopCommit: a
+ * hydration-time render error is caught here (React still console.error's
+ * it) instead of propagating, matching the navigation-path containment.
  */
 export function wrapWithRouterContext(
   element: ReactElement,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -126,7 +126,14 @@ function renderPagesRouterElement(
     return Promise.resolve();
   }
 
+  cancelPreviousRenderCommit();
+
   return new Promise<void>((resolve, reject) => {
+    _cancelPendingRenderCommit = () => {
+      _cancelPendingRenderCommit = null;
+      reject(new NavigationCancelledError("superseded"));
+    };
+
     const scrollHandler = () => {
       if (scroll) {
         window.scrollTo(scroll.x, scroll.y);
@@ -137,6 +144,7 @@ function renderPagesRouterElement(
       wrapWithRouterContext(
         element,
         () => {
+          _cancelPendingRenderCommit = null;
           try {
             scrollHandler();
             resolve();
@@ -144,10 +152,14 @@ function renderPagesRouterElement(
             reject(err);
           }
         },
-        reject,
+        (error) => {
+          _cancelPendingRenderCommit = null;
+          reject(error);
+        },
       ),
     );
     if (typeof document === "undefined") {
+      _cancelPendingRenderCommit = null;
       resolve();
     }
   });
@@ -1049,6 +1061,18 @@ let _navigationId = 0;
 /** AbortController for the in-flight fetch, so superseded navigations abort network I/O. */
 let _activeAbortController: AbortController | null = null;
 
+/**
+ * Pending render-commit rejection, so superseded navigations settle their
+ * render-commit Promise instead of hanging when a newer root.render() call
+ * starts before the previous tree commits.
+ */
+let _cancelPendingRenderCommit: (() => void) | null = null;
+
+function cancelPreviousRenderCommit(): void {
+  _cancelPendingRenderCommit?.();
+  _cancelPendingRenderCommit = null;
+}
+
 function scheduleHardNavigationAndThrow(url: string, message: string): never {
   if (typeof window === "undefined") {
     throw new HardNavigationScheduledError(message);
@@ -1626,8 +1650,9 @@ async function navigateClient(
 ): Promise<void> {
   if (typeof window === "undefined") return;
 
-  // Cancel any in-flight navigation (abort its fetch, mark it stale)
+  // Cancel any in-flight navigation (abort its fetch, settle its render-commit wait)
   _activeAbortController?.abort();
+  cancelPreviousRenderCommit();
   const controller = new AbortController();
   _activeAbortController = controller;
 
@@ -1962,7 +1987,7 @@ async function performNavigation(
   // callback. Hash scrolling is deferred until after routeChangeComplete so
   // the event ordering matches Next.js: x/y reset before completion, hash
   // scroll after completion.
-  const scrollTarget = doScroll && !hash ? { x: 0, y: 0 } : null;
+  const scrollTarget = doScroll ? { x: 0, y: 0 } : null;
   const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
     ? { allowNotFoundResponse: true, mode, scroll: scrollTarget }
     : { mode, scroll: scrollTarget };

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -119,7 +119,7 @@ function PagesRouterCommitBoundaryHelper({
 
 function renderPagesRouterElement(
   element: ReactElement,
-  scroll?: ScrollPosition | string | null,
+  scroll?: ScrollPosition | null,
 ): Promise<void> {
   const root = window.__VINEXT_ROOT__;
   if (!root) {
@@ -129,11 +129,7 @@ function renderPagesRouterElement(
   return new Promise<void>((resolve, reject) => {
     const scrollHandler = () => {
       if (scroll) {
-        if (typeof scroll === "string") {
-          scrollToHashTarget(scroll);
-        } else {
-          window.scrollTo(scroll.x, scroll.y);
-        }
+        window.scrollTo(scroll.x, scroll.y);
       }
     };
 
@@ -1070,7 +1066,7 @@ type NavigateClientOptions = {
    * Next.js's `this.change(method, ...)` re-dispatch.
    */
   mode?: "push" | "replace";
-  scroll?: ScrollPosition | string | null;
+  scroll?: ScrollPosition | null;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1962,7 +1962,11 @@ async function performNavigation(
   const shallow = options?.shallow ?? false;
   const doScroll = options?.scroll !== false;
   const hash = extractHash(resolved);
-  const scrollTarget = doScroll ? (hash ? hash : { x: 0, y: 0 }) : null;
+  // Only pass {x, y} restoration through renderPagesRouterElement's commit
+  // callback. Hash scrolling is deferred until after routeChangeComplete so
+  // the event ordering matches Next.js: x/y reset before completion, hash
+  // scroll after completion.
+  const scrollTarget = doScroll && !hash ? { x: 0, y: 0 } : null;
   const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
     ? { allowNotFoundResponse: true, mode, scroll: scrollTarget }
     : { mode, scroll: scrollTarget };
@@ -2029,6 +2033,12 @@ async function performNavigation(
   }
   onStateUpdate?.();
   routerEvents.emit("routeChangeComplete", resolved, { shallow });
+  // Hash scrolling after routeChangeComplete, matching Next.js ordering:
+  // x/y restoration happens during the render commit, then hash scrolling
+  // happens after the completion event.
+  if (doScroll && hash && !shallow) {
+    scrollToHashTarget(hash);
+  }
   dispatchNavigateEvent();
   return true;
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2321,6 +2321,9 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   if (manualScrollRestoration) {
     const currentKey = _currentHistoryKey;
     if (currentKey !== undefined && currentKey !== targetKey) {
+      // Reading window scroll here is only correct because manualScrollRestoration
+      // implies history.scrollRestoration = "manual", so the browser hasn't yet
+      // moved the viewport to the target entry's position when popstate fires.
       saveScrollPositionToSessionStorage(currentKey, getWindowScrollPosition());
     }
 
@@ -2373,9 +2376,14 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // compatibility.
   routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow: false });
   void (async () => {
+    // When manual scroll restoration is enabled we drive the position from the
+    // sessionStorage snapshot keyed by history key. When it is disabled we
+    // still restore the per-entry scroll saved in history state on push, since
+    // a soft popstate re-renders content the browser's native restoration
+    // can't position correctly.
     const scrollTarget = manualScrollRestoration
       ? (forcedScroll ?? readScrollPosition(state) ?? { x: 0, y: 0 })
-      : null;
+      : readScrollPosition(state);
     const result = await runNavigateClient(
       browserUrl,
       fullAppUrl,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2415,7 +2415,11 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     // sessionStorage snapshot keyed by history key. When it is disabled we
     // still restore the per-entry scroll saved in history state on push, since
     // a soft popstate re-renders content the browser's native restoration
-    // can't position correctly.
+    // can't position correctly. The fallbacks differ on purpose: with manual
+    // restoration the browser is hands-off, so we default to { x: 0, y: 0 };
+    // with it disabled, an entry we never stamped resolves to null (no scroll
+    // from us) and native "auto" restoration — still enabled — handles it,
+    // matching the old restoreScrollPosition no-op on main.
     const scrollTarget = manualScrollRestoration
       ? (forcedScroll ?? readScrollPosition(state) ?? { x: 0, y: 0 })
       : readScrollPosition(state);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2433,6 +2433,9 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     // with it disabled, an entry we never stamped resolves to null (no scroll
     // from us) and native "auto" restoration — still enabled — handles it,
     // matching the old restoreScrollPosition no-op on main.
+    // The manual chain is not three independent fallbacks: keyed entries always
+    // resolve via forcedScroll (already `?? { x: 0, y: 0 }`), so the middle term
+    // only handles entries without a router key, via the history-state shape.
     const scrollTarget = manualScrollRestoration
       ? (forcedScroll ?? readScrollPosition(state) ?? { x: 0, y: 0 })
       : readScrollPosition(state);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2364,6 +2364,9 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     }
 
     if (targetKey !== undefined && currentKey !== targetKey) {
+      // `?? {x: 0, y: 0}` is the missing-snapshot fallback, not just a type
+      // guard: with no saved position for the target entry, top is the only
+      // safe default under manual restoration.
       forcedScroll = readScrollPositionFromSessionStorage(targetKey) ?? { x: 0, y: 0 };
     }
   }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -195,25 +195,30 @@ function canUseSessionStorageForScrollRestoration(): boolean {
   }
 }
 
+// The `experimental.scrollRestoration` manual opt-in is Pages-Router-only.
+// Next.js sets `history.scrollRestoration = "manual"` inside the Router
+// class constructor (.nextjs-ref/packages/next/src/shared/lib/router/
+// router.ts around L892), which only runs when client/index.tsx hydrates a
+// Pages Router document — a bare value import of next/router never flips
+// it, and App Router owns its own scroll behavior. The vinext shim installs
+// at module eval instead, so an App Router app that value-imports
+// next/router for compat would otherwise disable the browser's native
+// restoration. The App Router bootstrap stamps `window.next.appDir = true`
+// at entry eval, before any client-component module (and therefore this
+// shim) can evaluate, so it is a reliable router-mode gate even though this
+// constant is computed at module eval. Folding the check into the constant
+// (rather than only into installManualScrollRestoration) keeps every
+// consumer Pages-Router-only — including the popstate handler's
+// sessionStorage save/read branches, which would otherwise rely solely on
+// the `__N: true` state filter to stay inert on App Router documents.
 const manualScrollRestoration =
   __scrollRestoration &&
   typeof window !== "undefined" &&
+  window.next?.appDir !== true &&
   "scrollRestoration" in window.history &&
   canUseSessionStorageForScrollRestoration();
 
 function installManualScrollRestoration(): void {
-  // The `experimental.scrollRestoration` manual opt-in is Pages-Router-only.
-  // Next.js sets `history.scrollRestoration = "manual"` inside the Router
-  // class constructor (.nextjs-ref/packages/next/src/shared/lib/router/
-  // router.ts around L892), which only runs when client/index.tsx hydrates a
-  // Pages Router document — a bare value import of next/router never flips
-  // it, and App Router owns its own scroll behavior. The vinext shim installs
-  // at module eval instead, so an App Router app that value-imports
-  // next/router for compat would otherwise disable the browser's native
-  // restoration. The App Router bootstrap stamps `window.next.appDir = true`
-  // at entry eval, before any client-component module (and therefore this
-  // shim) can evaluate, so it is a reliable router-mode gate here.
-  if (window.next?.appDir === true) return;
   if (manualScrollRestoration) {
     window.history.scrollRestoration = "manual";
   }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -202,6 +202,18 @@ const manualScrollRestoration =
   canUseSessionStorageForScrollRestoration();
 
 function installManualScrollRestoration(): void {
+  // The `experimental.scrollRestoration` manual opt-in is Pages-Router-only.
+  // Next.js sets `history.scrollRestoration = "manual"` inside the Router
+  // class constructor (.nextjs-ref/packages/next/src/shared/lib/router/
+  // router.ts around L892), which only runs when client/index.tsx hydrates a
+  // Pages Router document — a bare value import of next/router never flips
+  // it, and App Router owns its own scroll behavior. The vinext shim installs
+  // at module eval instead, so an App Router app that value-imports
+  // next/router for compat would otherwise disable the browser's native
+  // restoration. The App Router bootstrap stamps `window.next.appDir = true`
+  // at entry eval, before any client-component module (and therefore this
+  // shim) can evaluate, so it is a reliable router-mode gate here.
+  if (window.next?.appDir === true) return;
   if (manualScrollRestoration) {
     window.history.scrollRestoration = "manual";
   }
@@ -2365,7 +2377,17 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   _lastPathnameAndSearch = browserUrl;
 
   if (isHashOnly) {
-    // Hash-only back/forward — no page fetch needed
+    // Hash-only back/forward — no page fetch needed.
+    //
+    // `forcedScroll` is intentionally discarded here: only the hash anchor is
+    // honoured, never the target entry's `__next_scroll_<key>` snapshot. This
+    // matches Next.js, where `change()`'s onlyAHashChange branch calls
+    // `this.set(nextState, this.components[nextState.route], null)` and only
+    // `scrollToHash` runs — `forcedScroll` is consumed solely by the later
+    // `upcomingScrollState = forcedScroll ?? resetScroll` full-navigation
+    // path (.nextjs-ref/packages/next/src/shared/lib/router/router.ts around
+    // L1381-1403 and L1780). The snapshot stays in sessionStorage, so a later
+    // non-hash popstate to this entry still restores the saved position.
     const hashUrl = appUrl + window.location.hash;
     routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
     scrollToHashTarget(window.location.hash);
@@ -2737,6 +2759,10 @@ if (typeof window !== "undefined") {
   // intentionally unconditional at module eval — any value import of
   // next/router (even from an App Router app) triggers it, mirroring
   // Next.js where the Router singleton's constructor runs at module eval.
+  // The one Pages-Router-only side effect it carries — flipping
+  // `history.scrollRestoration` to "manual" under
+  // `experimental.scrollRestoration` — is gated on the document not being
+  // an App Router one (see installManualScrollRestoration).
   installPagesRouterRuntime();
   // Cast: `NextRouter.push`/`replace` are typed with narrow parameters
   // (UrlObject | string) while `PagesRouterPublicInstance` accepts unknown

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2340,10 +2340,6 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     }
   }
 
-  if (targetKey !== undefined) {
-    _currentHistoryKey = targetKey;
-  }
-
   // Check beforePopState callback
   if (_beforePopStateCb !== undefined) {
     const shouldContinue = _beforePopStateCb({
@@ -2354,9 +2350,15 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     if (!shouldContinue) return;
   }
 
-  // Update tracker only after beforePopState confirms navigation proceeds.
-  // If beforePopState cancels, the tracker must retain the previous value
-  // so the next popstate compares against the correct baseline.
+  // Update trackers only after beforePopState confirms navigation proceeds.
+  // If beforePopState cancels, the app stays on the previous history entry,
+  // so both must retain their previous values: `_lastPathnameAndSearch` so
+  // the next popstate compares against the correct baseline, and
+  // `_currentHistoryKey` so subsequent scroll bookkeeping keys off the entry
+  // the app is actually on.
+  if (targetKey !== undefined) {
+    _currentHistoryKey = targetKey;
+  }
   _lastPathnameAndSearch = browserUrl;
 
   if (isHashOnly) {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2037,6 +2037,14 @@ async function performNavigation(
 
   // Hash-only change — no page fetch needed
   if (isHashOnlyChange(full)) {
+    // Snapshot the outgoing entry's scroll before updateHistory mints a new
+    // key, so a later back-popstate restores the position the user had
+    // reached here rather than {x: 0, y: 0}. Upstream snapshots inside
+    // Router.push() itself — before change()'s onlyAHashChange short-circuit
+    // — so hash-only pushes still write `__next_scroll_<key>` for the
+    // departed entry.
+    // Mirrors Next.js: packages/next/src/shared/lib/router/router.ts:1034-1046.
+    if (mode === "push") saveScrollPosition();
     const eventUrl = resolveHashUrl(full);
     routerEvents.emit("hashChangeStart", eventUrl, { shallow });
     updateHistory(mode, resolved.startsWith("#") ? resolved : full, navState);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2332,6 +2332,9 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
       // Reading window scroll here is only correct because manualScrollRestoration
       // implies history.scrollRestoration = "manual", so the browser hasn't yet
       // moved the viewport to the target entry's position when popstate fires.
+      // Snapshotting eagerly (before the beforePopState gate below) is
+      // intentional: if the traversal is cancelled the app stays on
+      // `currentKey`, so the saved value is still that entry's live scroll.
       saveScrollPositionToSessionStorage(currentKey, getWindowScrollPosition());
     }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -138,9 +138,17 @@ function renderPagesRouterElement(
   cancelPreviousRenderCommit();
 
   return new Promise<void>((resolve, reject) => {
-    _cancelPendingRenderCommit = () => {
-      _cancelPendingRenderCommit = null;
+    const cancel = () => {
+      if (_cancelPendingRenderCommit === cancel) _cancelPendingRenderCommit = null;
       reject(new NavigationCancelledError("superseded"));
+    };
+    _cancelPendingRenderCommit = cancel;
+
+    // Only clear the module-level canceller if it still belongs to this
+    // render; a superseded tree can commit late and must not null out the
+    // canceller installed by a newer navigation.
+    const clearIfCurrent = () => {
+      if (_cancelPendingRenderCommit === cancel) _cancelPendingRenderCommit = null;
     };
 
     const scrollHandler = () => {
@@ -153,7 +161,7 @@ function renderPagesRouterElement(
       wrapWithRouterContext(
         element,
         () => {
-          _cancelPendingRenderCommit = null;
+          clearIfCurrent();
           try {
             scrollHandler();
             resolve();
@@ -162,13 +170,13 @@ function renderPagesRouterElement(
           }
         },
         (error) => {
-          _cancelPendingRenderCommit = null;
+          clearIfCurrent();
           reject(error);
         },
       ),
     );
     if (typeof document === "undefined") {
-      _cancelPendingRenderCommit = null;
+      clearIfCurrent();
       resolve();
     }
   });
@@ -2720,7 +2728,10 @@ for (const event of deprecatedRouterEvents) {
 if (typeof window !== "undefined") {
   // Match Next.js's Router constructor: stamp the initial history entry and
   // attach the popstate listener while next/router itself is evaluating,
-  // before window.next.router is exposed to userland.
+  // before window.next.router is exposed to userland. This install is
+  // intentionally unconditional at module eval — any value import of
+  // next/router (even from an App Router app) triggers it, mirroring
+  // Next.js where the Router singleton's constructor runs at module eval.
   installPagesRouterRuntime();
   // Cast: `NextRouter.push`/`replace` are typed with narrow parameters
   // (UrlObject | string) while `PagesRouterPublicInstance` accepts unknown

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -109,6 +109,18 @@ const projectServers = {
       timeout: 60_000,
     },
   },
+  "pages-scroll-restoration": {
+    testDir: "./tests/e2e/pages-scroll-restoration",
+    use: { baseURL: "http://localhost:4185" },
+    server: {
+      command:
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4185",
+      cwd: "./tests/fixtures/pages-scroll-restoration",
+      port: 4185,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  },
   "cloudflare-workers": {
     testDir: "./tests/e2e",
     testMatch: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1468,6 +1468,8 @@ importers:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/pages-scroll-restoration: {}
+
   tests/fixtures/root-layout-redirect:
     dependencies:
       '@vitejs/plugin-rsc':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1468,7 +1468,24 @@ importers:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
-  tests/fixtures/pages-scroll-restoration: {}
+  tests/fixtures/pages-scroll-restoration:
+    dependencies:
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      vinext:
+        specifier: workspace:*
+        version: link:../../../packages/vinext
+    devDependencies:
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
   tests/fixtures/root-layout-redirect:
     dependencies:

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -22,7 +22,19 @@ async function expectScrollPosition(page: Page, expected: ScrollPosition) {
 }
 
 async function expectRouteChangeComplete(page: Page): Promise<void> {
-  await expect(page.locator("html")).toContainText("routeChangeComplete");
+  // Register a one-shot listener for the next routeChangeComplete event,
+  // then return the promise so the caller can await it alongside navigation.
+  return page.evaluate(() => {
+    const router = (window as any).next?.router;
+    if (!router?.events) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const handler = () => {
+        router.events.off("routeChangeComplete", handler);
+        resolve();
+      };
+      router.events.on("routeChangeComplete", handler);
+    });
+  });
 }
 
 async function pushWithPagesRouter(page: Page, href: string): Promise<void> {
@@ -65,16 +77,18 @@ test.describe("reload-scroll-back-restoration", () => {
     scrollPositionMemories.push(await getScrollPosition(page));
     await pushWithPagesRouter(page, "/2");
 
+    const rc1 = expectRouteChangeComplete(page);
     await page.goBack();
-    await expectRouteChangeComplete(page);
+    await rc1;
     await expectScrollPosition(page, scrollPositionMemories[1]);
 
     await page.reload();
 
     await expect.poll(() => isPagesRouterReady(page)).toBe(true);
 
+    const rc2 = expectRouteChangeComplete(page);
     await page.goBack();
-    await expectRouteChangeComplete(page);
+    await rc2;
     await expectScrollPosition(page, scrollPositionMemories[0]);
   });
 
@@ -101,16 +115,18 @@ test.describe("reload-scroll-back-restoration", () => {
 
     await page.goBack();
     await page.goBack();
+    const rc3 = expectRouteChangeComplete(page);
     await page.goForward();
-    await expectRouteChangeComplete(page);
+    await rc3;
     await expectScrollPosition(page, scrollPositionMemories[1]);
 
     await page.reload();
 
     await expect.poll(() => isPagesRouterReady(page)).toBe(true);
 
+    const rc4 = expectRouteChangeComplete(page);
     await page.goForward();
-    await expectRouteChangeComplete(page);
+    await rc4;
     await expectScrollPosition(page, scrollPositionMemories[2]);
   });
 
@@ -125,27 +141,26 @@ test.describe("reload-scroll-back-restoration", () => {
     await pushWithPagesRouter(page, "/1");
     await expectRouteChangeComplete(page);
 
-    // Register event listener on routeChangeComplete to record scroll position
-    await page.evaluate(() => {
-      (window as any).scrollAtEvent = null;
+    // Register a one-shot listener on routeChangeComplete to record scroll position
+    const scrollAtEventPromise = page.evaluate(() => {
       const router = (window as any).next?.router;
-      if (router && router.events) {
-        router.events.on("routeChangeComplete", () => {
-          (window as any).scrollAtEvent = { x: window.scrollX, y: window.scrollY };
-        });
-      }
+      if (!router?.events) return null;
+      return new Promise<{ x: number; y: number }>((resolve) => {
+        const handler = () => {
+          router.events.off("routeChangeComplete", handler);
+          resolve({ x: window.scrollX, y: window.scrollY });
+        };
+        router.events.on("routeChangeComplete", handler);
+      });
     });
 
     // Go back, which triggers scroll restoration
     await page.goBack();
 
     // Verify routeChangeComplete fired and recorded the restored scroll position
-    await expect
-      .poll(async () => page.evaluate(() => (window as any).scrollAtEvent))
-      .not.toBeNull();
-
-    const scrollAtEvent = await page.evaluate(() => (window as any).scrollAtEvent);
-    expect(scrollAtEvent.y).toBe(initialScroll.y);
+    const scrollAtEvent = await scrollAtEventPromise;
+    expect(scrollAtEvent).not.toBeNull();
+    expect(scrollAtEvent!.y).toBe(initialScroll.y);
   });
 
   test("should reject navigation, emit routeChangeError and fallback to hard navigation on render error", async ({

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -113,4 +113,63 @@ test.describe("reload-scroll-back-restoration", () => {
     await expectRouteChangeComplete(page);
     await expectScrollPosition(page, scrollPositionMemories[2]);
   });
+
+  test("should apply scroll position before emitting routeChangeComplete", async ({ page }) => {
+    await page.goto(`${BASE}/0`);
+    await waitForHydration(page);
+    await scrollLinkIntoView(page);
+
+    const initialScroll = await getScrollPosition(page);
+    expect(initialScroll.y).not.toBe(0);
+
+    await pushWithPagesRouter(page, "/1");
+    await expectRouteChangeComplete(page);
+
+    // Register event listener on routeChangeComplete to record scroll position
+    await page.evaluate(() => {
+      (window as any).scrollAtEvent = null;
+      const router = (window as any).next?.router;
+      if (router && router.events) {
+        router.events.on("routeChangeComplete", () => {
+          (window as any).scrollAtEvent = { x: window.scrollX, y: window.scrollY };
+        });
+      }
+    });
+
+    // Go back, which triggers scroll restoration
+    await page.goBack();
+
+    // Verify routeChangeComplete fired and recorded the restored scroll position
+    await expect
+      .poll(async () => page.evaluate(() => (window as any).scrollAtEvent))
+      .not.toBeNull();
+
+    const scrollAtEvent = await page.evaluate(() => (window as any).scrollAtEvent);
+    expect(scrollAtEvent.y).toBe(initialScroll.y);
+  });
+
+  test("should reject navigation, emit routeChangeError and fallback to hard navigation on render error", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/0`);
+    await waitForHydration(page);
+
+    // Set marker on window to detect full page reload
+    await page.evaluate(() => {
+      (window as any).isSoftNavigation = true;
+    });
+
+    // Push to the page that throws render error
+    await pushWithPagesRouter(page, "/error");
+
+    // Since it falls back to hard navigation, the page fully reloads.
+    // The reload clears the window context, so `window.isSoftNavigation` will be undefined.
+    // We should wait until the url is "/error" and we are hydrated.
+    await expect(page).toHaveURL(`${BASE}/error`);
+    await waitForHydration(page);
+
+    // Verify that the window marker is indeed gone (hard navigation occurred)
+    const isSoft = await page.evaluate(() => (window as any).isSoftNavigation);
+    expect(isSoft).toBeUndefined();
+  });
 });

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -22,11 +22,17 @@ async function expectScrollPosition(page: Page, expected: ScrollPosition) {
 }
 
 async function expectRouteChangeComplete(page: Page): Promise<void> {
-  // Register a one-shot listener for the next routeChangeComplete event,
-  // then return the promise so the caller can await it alongside navigation.
+  // Register a one-shot listener for the next routeChangeComplete event.
+  // MUST be started before the navigation that triggers the event — calling
+  // this after an awaited router.push() will deadlock because the event has
+  // already fired.
   return page.evaluate(() => {
     const router = (window as any).next?.router;
-    if (!router?.events) return Promise.resolve();
+    if (!router?.events) {
+      throw new Error(
+        "expectRouteChangeComplete: window.next.router.events is not available",
+      );
+    }
     return new Promise<void>((resolve) => {
       const handler = () => {
         router.events.off("routeChangeComplete", handler);
@@ -139,7 +145,8 @@ test.describe("reload-scroll-back-restoration", () => {
     expect(initialScroll.y).not.toBe(0);
 
     await pushWithPagesRouter(page, "/1");
-    await expectRouteChangeComplete(page);
+    // pushWithPagesRouter already awaits router.push() which resolves after
+    // routeChangeComplete — no separate wait needed here.
 
     // Register a one-shot listener on routeChangeComplete to record scroll position
     const scrollAtEventPromise = page.evaluate(() => {

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -1,0 +1,116 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../fixtures";
+import { waitForHydration } from "../helpers";
+
+const BASE = "http://localhost:4185";
+
+type ScrollPosition = { x: number; y: number };
+
+async function scrollLinkIntoView(page: Page): Promise<void> {
+  await page.evaluate(() => document.querySelector("#link")?.scrollIntoView());
+}
+
+async function getScrollPosition(page: Page): Promise<ScrollPosition> {
+  return page.evaluate(() => ({
+    x: Math.floor(window.scrollX),
+    y: Math.floor(window.scrollY),
+  }));
+}
+
+async function expectScrollPosition(page: Page, expected: ScrollPosition) {
+  await expect.poll(() => getScrollPosition(page)).toEqual(expected);
+}
+
+async function expectRouteChangeComplete(page: Page): Promise<void> {
+  await expect(page.locator("html")).toContainText("routeChangeComplete");
+}
+
+async function pushWithPagesRouter(page: Page, href: string): Promise<void> {
+  await page.evaluate(async (target) => {
+    const router = window.next?.router;
+    if (!router) {
+      throw new Error("window.next.router is not installed");
+    }
+    await Promise.resolve(router.push(target));
+  }, href);
+}
+
+async function isPagesRouterReady(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const router = window.next?.router;
+    if (!router || !("isReady" in router)) return false;
+    return router.isReady === true;
+  });
+}
+
+test.describe("reload-scroll-back-restoration", () => {
+  // Ported from Next.js: test/e2e/reload-scroll-backforward-restoration/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/index.test.ts
+  test("should restore the scroll position on navigating back", async ({ page }) => {
+    await page.goto(`${BASE}/0`);
+    await waitForHydration(page);
+    await scrollLinkIntoView(page);
+
+    const scrollRestoration = await page.evaluate(() => window.history.scrollRestoration);
+    expect(scrollRestoration).toBe("manual");
+
+    const scrollPositionMemories: ScrollPosition[] = [];
+    scrollPositionMemories.push(await getScrollPosition(page));
+
+    expect(scrollPositionMemories[0].x).not.toBe(0);
+    expect(scrollPositionMemories[0].y).not.toBe(0);
+
+    await pushWithPagesRouter(page, "/1");
+    await scrollLinkIntoView(page);
+    scrollPositionMemories.push(await getScrollPosition(page));
+    await pushWithPagesRouter(page, "/2");
+
+    await page.goBack();
+    await expectRouteChangeComplete(page);
+    await expectScrollPosition(page, scrollPositionMemories[1]);
+
+    await page.reload();
+
+    await expect.poll(() => isPagesRouterReady(page)).toBe(true);
+
+    await page.goBack();
+    await expectRouteChangeComplete(page);
+    await expectScrollPosition(page, scrollPositionMemories[0]);
+  });
+
+  test("should restore the scroll position on navigating forward", async ({ page }) => {
+    await page.goto(`${BASE}/0`);
+    await waitForHydration(page);
+    await scrollLinkIntoView(page);
+
+    const scrollRestoration = await page.evaluate(() => window.history.scrollRestoration);
+    expect(scrollRestoration).toBe("manual");
+
+    const scrollPositionMemories: ScrollPosition[] = [];
+    scrollPositionMemories.push(await getScrollPosition(page));
+
+    expect(scrollPositionMemories[0].x).not.toBe(0);
+    expect(scrollPositionMemories[0].y).not.toBe(0);
+
+    await pushWithPagesRouter(page, "/1");
+    await scrollLinkIntoView(page);
+    scrollPositionMemories.push(await getScrollPosition(page));
+    await pushWithPagesRouter(page, "/2");
+    await scrollLinkIntoView(page);
+    scrollPositionMemories.push(await getScrollPosition(page));
+
+    await page.goBack();
+    await page.goBack();
+    await page.goForward();
+    await expectRouteChangeComplete(page);
+    await expectScrollPosition(page, scrollPositionMemories[1]);
+
+    await page.reload();
+
+    await expect.poll(() => isPagesRouterReady(page)).toBe(true);
+
+    await page.goForward();
+    await expectRouteChangeComplete(page);
+    await expectScrollPosition(page, scrollPositionMemories[2]);
+  });
+});

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -6,6 +6,13 @@ const BASE = "http://localhost:4185";
 
 type ScrollPosition = { x: number; y: number };
 
+declare global {
+  // oxlint-disable-next-line typescript/consistent-type-definitions -- Window augmentation requires interface merging.
+  interface Window {
+    isSoftNavigation?: boolean;
+  }
+}
+
 async function scrollLinkIntoView(page: Page): Promise<void> {
   await page.evaluate(() => document.querySelector("#link")?.scrollIntoView());
 }
@@ -27,11 +34,9 @@ async function expectRouteChangeComplete(page: Page): Promise<void> {
   // this after an awaited router.push() will deadlock because the event has
   // already fired.
   return page.evaluate(() => {
-    const router = (window as any).next?.router;
-    if (!router?.events) {
-      throw new Error(
-        "expectRouteChangeComplete: window.next.router.events is not available",
-      );
+    const router = window.next?.router;
+    if (!router || !("events" in router)) {
+      throw new Error("expectRouteChangeComplete: window.next.router.events is not available");
     }
     return new Promise<void>((resolve) => {
       const handler = () => {
@@ -57,7 +62,7 @@ async function isPagesRouterReady(page: Page): Promise<boolean> {
   return page.evaluate(() => {
     const router = window.next?.router;
     if (!router || !("isReady" in router)) return false;
-    return router.isReady === true;
+    return (router as { isReady: boolean }).isReady === true;
   });
 }
 
@@ -150,8 +155,8 @@ test.describe("reload-scroll-back-restoration", () => {
 
     // Register a one-shot listener on routeChangeComplete to record scroll position
     const scrollAtEventPromise = page.evaluate(() => {
-      const router = (window as any).next?.router;
-      if (!router?.events) return null;
+      const router = window.next?.router;
+      if (!router || !("events" in router)) return null;
       return new Promise<{ x: number; y: number }>((resolve) => {
         const handler = () => {
           router.events.off("routeChangeComplete", handler);
@@ -178,7 +183,7 @@ test.describe("reload-scroll-back-restoration", () => {
 
     // Set marker on window to detect full page reload
     await page.evaluate(() => {
-      (window as any).isSoftNavigation = true;
+      window.isSoftNavigation = true;
     });
 
     // Push to the page that throws render error
@@ -191,7 +196,7 @@ test.describe("reload-scroll-back-restoration", () => {
     await waitForHydration(page);
 
     // Verify that the window marker is indeed gone (hard navigation occurred)
-    const isSoft = await page.evaluate(() => (window as any).isSoftNavigation);
+    const isSoft = await page.evaluate(() => window.isSoftNavigation);
     expect(isSoft).toBeUndefined();
   });
 });

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -199,4 +199,69 @@ test.describe("reload-scroll-back-restoration", () => {
     const isSoft = await page.evaluate(() => window.isSoftNavigation);
     expect(isSoft).toBeUndefined();
   });
+
+  // Ported from Next.js: test/e2e/reload-scroll-backforward-restoration/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/index.test.ts
+  test("should reset x/y scroll to (0,0) before routeChangeComplete on route with hash", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/0`);
+    await waitForHydration(page);
+
+    // Scroll down so we can detect the reset
+    await page.evaluate(() => window.scrollTo(0, 500));
+    expect((await getScrollPosition(page)).y).toBe(500);
+
+    // Set up a one-shot routeChangeComplete listener that records scroll position
+    const scrollAtEvent = page.evaluate(() => {
+      const router = window.next?.router;
+      if (!router || !("events" in router)) return null;
+      return new Promise<{ x: number; y: number }>((resolve) => {
+        const handler = () => {
+          router.events.off("routeChangeComplete", handler);
+          resolve({ x: window.scrollX, y: window.scrollY });
+        };
+        router.events.on("routeChangeComplete", handler);
+      });
+    });
+
+    await pushWithPagesRouter(page, "/1#end-el");
+
+    const scrollAtEventValue = await scrollAtEvent;
+    expect(scrollAtEventValue).not.toBeNull();
+    // x/y reset (0,0) should have happened before routeChangeComplete fires
+    expect(scrollAtEventValue!.y).toBe(0);
+
+    // After routeChangeComplete, hash scroll should have moved the page
+    const finalScroll = await getScrollPosition(page);
+    // Hash scroll to #end-el should have moved away from (0,0)
+    expect(finalScroll.y).toBeGreaterThan(0);
+  });
+
+  test("should settle superseded navigation promises instead of hanging", async ({ page }) => {
+    await page.goto(`${BASE}/0`);
+    await waitForHydration(page);
+
+    // Start two navigations in rapid succession — the first should be
+    // superseded and settle (not hang) while the second completes.
+    const result = await page.evaluate(async (base) => {
+      const router = window.next?.router;
+      if (!router) return "no-router";
+
+      const p1 = router.push(`${base}/1`);
+      const p2 = router.push(`${base}/2`);
+
+      const settled = await Promise.allSettled([p1, p2]);
+      // Both must settle — the first may reject with NavigationCancelledError
+      // or resolve with true (runNavigateClient returns "cancelled" → true).
+      // The second must resolve successfully.
+      if (settled[0].status !== "fulfilled") return "p1-unsettled";
+      if (settled[1].status !== "fulfilled") return "p2-unsettled";
+      return "ok";
+    }, BASE);
+
+    expect(result).toBe("ok");
+    // Verify the final URL is /2, not /1
+    await expect(page).toHaveURL(`${BASE}/2`);
+  });
 });

--- a/tests/fixtures/pages-scroll-restoration/next.config.mjs
+++ b/tests/fixtures/pages-scroll-restoration/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    scrollRestoration: true,
+  },
+};
+
+export default nextConfig;

--- a/tests/fixtures/pages-scroll-restoration/package.json
+++ b/tests/fixtures/pages-scroll-restoration/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-pages-scroll-restoration",
+  "private": true,
+  "type": "module"
+}

--- a/tests/fixtures/pages-scroll-restoration/package.json
+++ b/tests/fixtures/pages-scroll-restoration/package.json
@@ -1,5 +1,14 @@
 {
   "name": "fixture-pages-scroll-restoration",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "vinext": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
 }

--- a/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
+++ b/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
@@ -6,6 +6,10 @@ const Page = ({ id }) => {
   const router = useRouter();
   const [ready, setReady] = useState(false);
 
+  if (typeof window !== "undefined" && id === "error") {
+    throw new Error("Simulated client-side render error");
+  }
+
   useEffect(() => {
     router.events.on("routeChangeComplete", () => {
       setReady(true);

--- a/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
+++ b/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+const Page = ({ id }) => {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    router.events.on("routeChangeComplete", () => {
+      setReady(true);
+    });
+  }, [router, ready, setReady]);
+
+  return (
+    <>
+      <div
+        style={{
+          width: 10000,
+          height: 10000,
+          background: "blue",
+        }}
+      />
+      <p>{ready ? "routeChangeComplete" : "loading"}</p>
+      <Link
+        href={`/${id + 1}`}
+        id="link"
+        style={{
+          marginLeft: 5000,
+          width: 95000,
+          display: "block",
+        }}
+      >
+        next page
+      </Link>
+      <div id="end-el">hello, world</div>
+    </>
+  );
+};
+
+export default Page;
+
+export const getServerSideProps = (context) => {
+  const { id = 0 } = context.query;
+  return {
+    props: {
+      id,
+    },
+  };
+};

--- a/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
+++ b/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
@@ -11,10 +11,14 @@ const Page = ({ id }) => {
   }
 
   useEffect(() => {
-    router.events.on("routeChangeComplete", () => {
+    const handler = () => {
       setReady(true);
-    });
-  }, [router, ready, setReady]);
+    };
+    router.events.on("routeChangeComplete", handler);
+    return () => {
+      router.events.off("routeChangeComplete", handler);
+    };
+  }, [router]);
 
   return (
     <>

--- a/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
+++ b/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
@@ -31,7 +31,7 @@ const Page = ({ id }) => {
       />
       <p>{ready ? "routeChangeComplete" : "loading"}</p>
       <Link
-        href={`/${id + 1}`}
+        href={`/${Number(id) + 1}`}
         id="link"
         style={{
           marginLeft: 5000,

--- a/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
+++ b/tests/fixtures/pages-scroll-restoration/pages/[id].jsx
@@ -49,7 +49,7 @@ const Page = ({ id }) => {
 export default Page;
 
 export const getServerSideProps = (context) => {
-  const { id = 0 } = context.query;
+  const { id = "0" } = context.query;
   return {
     props: {
       id,

--- a/tests/fixtures/pages-scroll-restoration/vite.config.ts
+++ b/tests/fixtures/pages-scroll-restoration/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "../../../packages/vinext/dist/index.js";
+
+export default defineConfig({
+  plugins: [vinext()],
+});

--- a/tests/fixtures/pages-scroll-restoration/vite.config.ts
+++ b/tests/fixtures/pages-scroll-restoration/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
-import vinext from "../../../packages/vinext/dist/index.js";
+import { defineConfig } from "vite-plus";
+import vinext from "vinext";
 
 export default defineConfig({
   plugins: [vinext()],

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1257,6 +1257,20 @@ describe("resolveNextConfig disableOptimizedLoading", () => {
   });
 });
 
+describe("resolveNextConfig scrollRestoration", () => {
+  it("defaults scrollRestoration to false", async () => {
+    const resolved = await resolveNextConfig({});
+    expect(resolved.scrollRestoration).toBe(false);
+  });
+
+  it("reads experimental.scrollRestoration from next.config", async () => {
+    const resolved = await resolveNextConfig({
+      experimental: { scrollRestoration: true },
+    });
+    expect(resolved.scrollRestoration).toBe(true);
+  });
+});
+
 describe("resolveNextConfig prefetchInlining", () => {
   it("reads experimental.prefetchInlining from next.config", async () => {
     const disabled = await resolveNextConfig({});
@@ -1660,6 +1674,7 @@ describe("detectNextIntlConfig", () => {
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      scrollRestoration: false,
       compilerDefine: {},
       compilerDefineServer: {},
       instrumentationClientInject: [],

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14055,6 +14055,96 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  // When beforePopState cancels a popstate the app stays on the previous
+  // history entry, so the internal current-key tracker must keep pointing at
+  // that entry — otherwise later scroll bookkeeping saves the outgoing
+  // position under the wrong (never-visited) key. Observable via the next
+  // popstate's sessionStorage scroll save, which is keyed off the tracker.
+  it("beforePopState cancellation leaves the current history key unchanged", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalScrollRestorationEnv = process.env.__NEXT_SCROLL_RESTORATION;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    // Enable the manual scroll restoration path: the flag also requires
+    // history.scrollRestoration support and a working sessionStorage.
+    (win.history as any).scrollRestoration = "auto";
+    const sessionStore = new Map<string, string>();
+    (win as any).sessionStorage = {
+      getItem: (key: string) => sessionStore.get(key) ?? null,
+      setItem: (key: string, value: string) => void sessionStore.set(key, value),
+      removeItem: (key: string) => void sessionStore.delete(key),
+    };
+    // Pre-stamped router-owned entry so install picks up its key.
+    (win.history as any).state = {
+      __N: true,
+      url: "/",
+      as: "/",
+      options: {},
+      key: "key-initial",
+    };
+
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn();
+    process.env.__NEXT_SCROLL_RESTORATION = "true";
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+
+      const beforePopState = vi.fn(() => false);
+      (win as any).next.router.beforePopState(beforePopState);
+
+      // Back/forward to another entry, cancelled by beforePopState.
+      win.location.pathname = "/other";
+      win.location.href = "http://localhost/other";
+      popstateHandler!({
+        state: { __N: true, url: "/other", as: "/other", options: {}, key: "key-target" },
+      });
+      expect(beforePopState).toHaveBeenCalledTimes(1);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+
+      // A later popstate snapshots the outgoing scroll position under the
+      // tracked current key. The app never left the initial entry, so the
+      // snapshot must land on key-initial — not the cancelled key-target.
+      win.scrollX = 120;
+      win.scrollY = 450;
+      win.location.pathname = "/third";
+      win.location.href = "http://localhost/third";
+      popstateHandler!({
+        state: { __N: true, url: "/third", as: "/third", options: {}, key: "key-other" },
+      });
+
+      expect(sessionStore.get("__next_scroll_key-initial")).toBe(
+        JSON.stringify({ x: 120, y: 450 }),
+      );
+      expect(sessionStore.has("__next_scroll_key-target")).toBe(false);
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+      if (originalScrollRestorationEnv === undefined) {
+        delete process.env.__NEXT_SCROLL_RESTORATION;
+      } else {
+        process.env.__NEXT_SCROLL_RESTORATION = originalScrollRestorationEnv;
+      }
+    }
+  });
+
   it("does not prefix a locale-qualified target with the current locale", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14171,9 +14171,7 @@ describe("Pages Router concurrent navigation", () => {
       setItem: (key: string, value: string) => void sessionStore.set(key, value),
       removeItem: (key: string) => void sessionStore.delete(key),
     };
-    // Pre-stamped router-owned entry so install picks up its key, plus a
-    // saved snapshot for that entry — the position the user had reached on
-    // the target entry before navigating away from it.
+    // Pre-stamped router-owned entry so install picks up its key.
     (win.history as any).state = {
       __N: true,
       url: "/",
@@ -14181,7 +14179,6 @@ describe("Pages Router concurrent navigation", () => {
       options: {},
       key: "key-initial",
     };
-    sessionStore.set("__next_scroll_key-initial", JSON.stringify({ x: 5, y: 500 }));
 
     (globalThis as any).window = win;
     globalThis.fetch = vi.fn();
@@ -14201,9 +14198,15 @@ describe("Pages Router concurrent navigation", () => {
       const popstateHandler = listeners.get("popstate");
       expect(popstateHandler).toBeDefined();
 
+      // The position the user reached on the initial entry; the hash-only
+      // push below snapshots it under key-initial on departure.
+      win.scrollX = 5;
+      win.scrollY = 500;
+
       // Hash-only push mints a new history entry ("#top" avoids the
       // document-dependent getElementById branch of scrollToHashTarget).
       await (win as any).next.router.push("/#top");
+      expect(sessionStore.get("__next_scroll_key-initial")).toBe(JSON.stringify({ x: 5, y: 500 }));
       const pushedKey = pushState.mock.calls.at(-1)![0].key as string;
       expect(typeof pushedKey).toBe("string");
 
@@ -14243,6 +14246,79 @@ describe("Pages Router concurrent navigation", () => {
       // non-hash popstate to this entry.
       expect(sessionStore.get(`__next_scroll_${pushedKey}`)).toBe(JSON.stringify({ x: 7, y: 70 }));
       expect(sessionStore.get("__next_scroll_key-initial")).toBe(JSON.stringify({ x: 5, y: 500 }));
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+      if (originalScrollRestorationEnv === undefined) {
+        delete process.env.__NEXT_SCROLL_RESTORATION;
+      } else {
+        process.env.__NEXT_SCROLL_RESTORATION = originalScrollRestorationEnv;
+      }
+    }
+  });
+
+  // A hash-only push must snapshot the outgoing entry's scroll under its key
+  // before updateHistory mints the new entry's key — otherwise a later
+  // back-popstate to the departed entry restores {x: 0, y: 0} instead of the
+  // position the user had reached there. Upstream snapshots in Router.push()
+  // itself, ahead of change()'s onlyAHashChange short-circuit, so hash-only
+  // pushes still write `__next_scroll_<key>` for the departed entry.
+  it("hash-only push snapshots the outgoing entry's scroll under the old key", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalScrollRestorationEnv = process.env.__NEXT_SCROLL_RESTORATION;
+    const { win, pushState } = createNavWindow();
+
+    // Enable the manual scroll restoration path: the flag also requires
+    // history.scrollRestoration support and a working sessionStorage.
+    (win.history as any).scrollRestoration = "auto";
+    const sessionStore = new Map<string, string>();
+    (win as any).sessionStorage = {
+      getItem: (key: string) => sessionStore.get(key) ?? null,
+      setItem: (key: string, value: string) => void sessionStore.set(key, value),
+      removeItem: (key: string) => void sessionStore.delete(key),
+    };
+    // Pre-stamped router-owned entry so install picks up its key.
+    (win.history as any).state = {
+      __N: true,
+      url: "/",
+      as: "/",
+      options: {},
+      key: "key-initial",
+    };
+
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn();
+    process.env.__NEXT_SCROLL_RESTORATION = "true";
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      // The live position on the outgoing entry at push time ("#top" avoids
+      // the document-dependent getElementById branch of scrollToHashTarget).
+      win.scrollX = 30;
+      win.scrollY = 300;
+      await (win as any).next.router.push("/#top");
+
+      // Hash-only: no page fetch; a new entry was minted with a fresh key.
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      const pushedKey = pushState.mock.calls.at(-1)![0].key as string;
+      expect(typeof pushedKey).toBe("string");
+      expect(pushedKey).not.toBe("key-initial");
+
+      // The departed entry's position was snapshotted under its own key —
+      // not the freshly minted one — so a later back-popstate restores it.
+      expect(sessionStore.get("__next_scroll_key-initial")).toBe(JSON.stringify({ x: 30, y: 300 }));
+      expect(sessionStore.has(`__next_scroll_${pushedKey}`)).toBe(false);
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14341,6 +14341,14 @@ describe("Pages Router concurrent navigation", () => {
   // value-imports next/router for compat must not have the browser's native
   // restoration disabled. Upstream only flips history.scrollRestoration in
   // the Pages Router constructor, which never runs on App Router documents.
+  //
+  // This test guards the bootstrap eval-order invariant: the
+  // manualScrollRestoration constant in router.ts reads window.next?.appDir
+  // at module-eval time, which is only correct because installWindowNext in
+  // app-browser-entry.ts stamps appDir: true before the first next/router
+  // value-import evaluates. The failure mode is silent — if that ordering
+  // regressed, manual scroll restoration would flip on under App Router
+  // documents with no error, only subtly broken back/forward scroll.
   it("does not flip history.scrollRestoration to manual on App Router documents", async () => {
     const previousWindow = (globalThis as any).window;
     const originalScrollRestorationEnv = process.env.__NEXT_SCROLL_RESTORATION;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2118,6 +2118,47 @@ describe("window.next debug global", () => {
     }
   });
 
+  // Shallow navigations skip the render-commit path, so the scroll reset is
+  // applied synchronously in performNavigation — before routeChangeComplete.
+  // This matches the non-shallow path, where the x/y reset runs inside the
+  // render-commit callback (also ahead of routeChangeComplete). Pins the
+  // ordering so listeners observe the final scroll position.
+  it("shallow push applies the scroll reset before routeChangeComplete", async () => {
+    const previousWindow = (globalThis as any).window;
+    const order: string[] = [];
+    const win: any = {
+      location: {
+        pathname: "/",
+        search: "",
+        hash: "",
+        href: "http://localhost/",
+        origin: "http://localhost",
+      },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo(x: number, y: number) {
+        order.push(`scrollTo:${x},${y}`);
+      },
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+
+      win.next.router.events.on("routeChangeComplete", () => {
+        order.push("routeChangeComplete");
+      });
+      const result = await win.next.router.push("/foo", undefined, { shallow: true });
+      expect(result).toBe(true);
+      expect(order).toEqual(["scrollTo:0,0", "routeChangeComplete"]);
+    } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
   // Issue #1522 — shallow `Router.push(url, as, { shallow: true })` must
   // update history to `as` (the visible URL) without fetching the server,
   // even when `as` matches a server-side redirect rule (e.g. `/redirect-1`
@@ -2353,6 +2394,9 @@ describe("next/router withRouter HOC", () => {
           return [typeof initialValue === "function" ? initialValue() : initialValue, vi.fn()];
         },
         useEffect(effect: () => void | (() => void)) {
+          effect();
+        },
+        useLayoutEffect(effect: () => void | (() => void)) {
           effect();
         },
         useMemo(factory: () => unknown) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2339,6 +2339,7 @@ describe("next/router withRouter HOC", () => {
     vi.resetModules();
     vi.doMock("react", () => {
       const react = {
+        Component: class {},
         createContext(defaultValue: unknown) {
           return { Provider: "Provider", Consumer: "Consumer", defaultValue };
         },

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14145,6 +14145,167 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  // A hash-only back/forward under manual scroll restoration honors only the
+  // hash anchor: the target entry's `__next_scroll_<key>` snapshot is read but
+  // intentionally not applied, matching Next.js where change()'s
+  // onlyAHashChange branch passes `null` to this.set() and only scrollToHash
+  // runs (forcedScroll feeds the full-navigation path exclusively). The
+  // departed entry's position is still snapshotted, and the unconsumed target
+  // snapshot stays in sessionStorage for a later non-hash popstate.
+  it("hash-only popstate scrolls to the hash anchor and leaves the entry snapshot for later", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalScrollRestorationEnv = process.env.__NEXT_SCROLL_RESTORATION;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win, pushState } = createNavWindow();
+
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    // Enable the manual scroll restoration path: the flag also requires
+    // history.scrollRestoration support and a working sessionStorage.
+    (win.history as any).scrollRestoration = "auto";
+    const sessionStore = new Map<string, string>();
+    (win as any).sessionStorage = {
+      getItem: (key: string) => sessionStore.get(key) ?? null,
+      setItem: (key: string, value: string) => void sessionStore.set(key, value),
+      removeItem: (key: string) => void sessionStore.delete(key),
+    };
+    // Pre-stamped router-owned entry so install picks up its key, plus a
+    // saved snapshot for that entry — the position the user had reached on
+    // the target entry before navigating away from it.
+    (win.history as any).state = {
+      __N: true,
+      url: "/",
+      as: "/",
+      options: {},
+      key: "key-initial",
+    };
+    sessionStore.set("__next_scroll_key-initial", JSON.stringify({ x: 5, y: 500 }));
+
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn();
+    process.env.__NEXT_SCROLL_RESTORATION = "true";
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      // Positive control: a Pages Router document with the flag enabled
+      // switches the browser to manual restoration at install time.
+      expect((win.history as any).scrollRestoration).toBe("manual");
+
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+
+      // Hash-only push mints a new history entry ("#top" avoids the
+      // document-dependent getElementById branch of scrollToHashTarget).
+      await (win as any).next.router.push("/#top");
+      const pushedKey = pushState.mock.calls.at(-1)![0].key as string;
+      expect(typeof pushedKey).toBe("string");
+
+      const hashEvents: string[] = [];
+      (win as any).next.router.events.on("hashChangeStart", () =>
+        hashEvents.push("hashChangeStart"),
+      );
+      (win as any).next.router.events.on("hashChangeComplete", () =>
+        hashEvents.push("hashChangeComplete"),
+      );
+
+      // The live position on the hash entry, snapshotted on departure.
+      win.scrollX = 7;
+      win.scrollY = 70;
+      win.scrollTo.mockClear();
+
+      // Back to the initial entry: same pathname+search, only the hash
+      // differs, so this is a hash-only popstate.
+      win.location.hash = "";
+      win.location.pathname = "/";
+      win.location.href = "http://localhost/";
+      popstateHandler!({
+        state: { __N: true, url: "/", as: "/", options: {}, key: "key-initial" },
+      });
+
+      // Hash-only: no page fetch, hash events fired in order.
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(hashEvents).toEqual(["hashChangeStart", "hashChangeComplete"]);
+
+      // Only the hash anchor is honored (empty hash scrolls to top); the
+      // target entry's saved {x: 5, y: 500} is not applied (upstream parity).
+      expect(win.scrollTo).toHaveBeenCalledWith(0, 0);
+      expect(win.scrollTo).not.toHaveBeenCalledWith(5, 500);
+
+      // The departed hash entry's live position was snapshotted under its
+      // key, and the unconsumed target snapshot survives for a later
+      // non-hash popstate to this entry.
+      expect(sessionStore.get(`__next_scroll_${pushedKey}`)).toBe(JSON.stringify({ x: 7, y: 70 }));
+      expect(sessionStore.get("__next_scroll_key-initial")).toBe(JSON.stringify({ x: 5, y: 500 }));
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+      if (originalScrollRestorationEnv === undefined) {
+        delete process.env.__NEXT_SCROLL_RESTORATION;
+      } else {
+        process.env.__NEXT_SCROLL_RESTORATION = originalScrollRestorationEnv;
+      }
+    }
+  });
+
+  // The experimental.scrollRestoration manual opt-in is Pages-Router-only:
+  // an App Router document (window.next.appDir === true, stamped by the App
+  // Router bootstrap before any client-component module evaluates) that
+  // value-imports next/router for compat must not have the browser's native
+  // restoration disabled. Upstream only flips history.scrollRestoration in
+  // the Pages Router constructor, which never runs on App Router documents.
+  it("does not flip history.scrollRestoration to manual on App Router documents", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalScrollRestorationEnv = process.env.__NEXT_SCROLL_RESTORATION;
+    const { win } = createNavWindow();
+
+    (win.history as any).scrollRestoration = "auto";
+    const sessionStore = new Map<string, string>();
+    (win as any).sessionStorage = {
+      getItem: (key: string) => sessionStore.get(key) ?? null,
+      setItem: (key: string, value: string) => void sessionStore.set(key, value),
+      removeItem: (key: string) => void sessionStore.delete(key),
+    };
+    // The App Router bootstrap stamp, in place before next/router evaluates.
+    (win as any).next = { version: "test", appDir: true };
+
+    (globalThis as any).window = win;
+    process.env.__NEXT_SCROLL_RESTORATION = "true";
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      expect((win.history as any).scrollRestoration).toBe("auto");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (originalScrollRestorationEnv === undefined) {
+        delete process.env.__NEXT_SCROLL_RESTORATION;
+      } else {
+        process.env.__NEXT_SCROLL_RESTORATION = originalScrollRestorationEnv;
+      }
+    }
+  });
+
   it("does not prefix a locale-qualified target with the current locale", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12914,17 +12914,25 @@ describe("Pages Router router helpers", () => {
 });
 
 describe("Pages Router concurrent navigation", () => {
-  it("does not install the Pages Router popstate runtime when next/router is imported", async () => {
+  it("installs the Pages Router popstate runtime before exposing window.next.router", async () => {
     const previousWindow = (globalThis as any).window;
     const { win } = createNavWindow();
-    win.addEventListener = vi.fn();
+    const calls: string[] = [];
+    win.addEventListener = vi.fn((type: string) => {
+      const next = Reflect.get(win, "next");
+      const router =
+        typeof next === "object" && next !== null ? Reflect.get(next, "router") : undefined;
+      calls.push(
+        `${type}:${router === undefined ? "before-window-next-router" : "after-window-next-router"}`,
+      );
+    });
     (globalThis as any).window = win;
 
     try {
       vi.resetModules();
       await import("../packages/vinext/src/shims/router.js");
 
-      expect(win.addEventListener).not.toHaveBeenCalledWith("popstate", expect.any(Function));
+      expect(calls).toEqual(["popstate:before-window-next-router"]);
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13980,6 +13980,81 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  // Without experimental.scrollRestoration, popstate must still restore the
+  // per-entry scroll saved into history state on push (__vinext_scrollX/Y):
+  // a soft popstate re-renders content the browser's native "auto" scroll
+  // restoration can't position correctly.
+  it("popstate restores history-state scroll when manual scroll restoration is off", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalCustomEvent = globalThis.CustomEvent;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win, render } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+
+    (globalThis as any).window = win;
+    (globalThis as any).CustomEvent = class CustomEventMock {
+      constructor(public type: string) {}
+    } as any;
+
+    globalThis.fetch = vi.fn(
+      async () => new Response(buildNavHtml("/other", pageModuleUrl), { status: 200 }),
+    );
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+
+      const routeChangeComplete = new Promise<void>((resolve, reject) => {
+        (win as any).next.router.events.on("routeChangeComplete", () => resolve());
+        (win as any).next.router.events.on("routeChangeError", (err: unknown) => reject(err));
+      });
+
+      win.location.pathname = "/other";
+      win.location.href = "http://localhost/other";
+      // The router-owned state shape saveScrollPosition() writes on push:
+      // the Next.js state stamp plus the merged __vinext_scrollX/Y fields.
+      popstateHandler!({
+        state: {
+          __N: true,
+          url: "/other",
+          as: "/other",
+          options: {},
+          __vinext_scrollX: 12,
+          __vinext_scrollY: 345,
+        },
+      });
+      await routeChangeComplete;
+
+      // The scroll target is applied inside the render-commit callback; the
+      // mocked root.render never mounts React, so fire the commit manually.
+      expect(render).toHaveBeenCalled();
+      const committed = render.mock.calls.at(-1)![0];
+      committed.props.onCommit();
+
+      expect(win.scrollTo).toHaveBeenCalledWith(12, 345);
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+      (globalThis as any).CustomEvent = originalCustomEvent;
+    }
+  });
+
   it("does not prefix a locale-qualified target with the current locale", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Match Next.js Pages Router scroll restoration after reload plus back and forward traversal. |
| Core change | Enable `experimental.scrollRestoration`, persist per-entry scroll snapshots, and install the Pages Router runtime before `window.next.router` is exposed. |
| Main boundary | Pages Router client navigation and browser history state. |
| Primary files | `packages/vinext/src/shims/router.ts`, `packages/vinext/src/config/next-config.ts`, `packages/vinext/src/index.ts`, `tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts`. |
| Expected impact | Pages apps that opt into scroll restoration now keep exact scroll positions across reload, back, and forward navigation. |

## Why

When `experimental.scrollRestoration` is enabled, the Pages Router owns browser scroll restoration. That requires `history.scrollRestoration = "manual"`, a stable key for each history entry, durable scroll snapshots that survive reload, and `routeChangeComplete` only after the new page has committed.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Config | The Next.js experimental flag must become a client-side define. | Resolves `experimental.scrollRestoration` and defines `process.env.__NEXT_SCROLL_RESTORATION`. |
| History state | Scroll memory belongs to the history entry key, not only the current JS heap. | Writes and reads Next-style `sessionStorage` entries named `__next_scroll_<key>`. |
| Runtime ordering | Test harnesses and userland must not observe `window.next.router.isReady` before the popstate runtime exists. | Installs the Pages Router runtime while `next/router` evaluates, before `window.next.router` is exposed. |
| Navigation lifecycle | `routeChangeComplete` should represent a committed route. | Routes navigation renders through a stable commit boundary before emitting completion. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| Initial load with `experimental.scrollRestoration` | Browser stayed on `history.scrollRestoration = "auto"`. | Browser switches to manual restoration when sessionStorage is usable. |
| Reload then back or forward | The target entry could lose its scroll position and the popstate handler could race router readiness. | The current entry is snapshotted before traversal and the target key restores from sessionStorage. |
| Pages navigation render | The initial hydration tree did not include the same commit boundary used by later route renders. | Initial and navigated Pages Router trees share the same wrapper shape. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/router.ts`: runtime ordering, history key tracking, sessionStorage scroll snapshots, and the commit boundary around client renders.
2. `packages/vinext/src/config/next-config.ts` and `packages/vinext/src/index.ts`: config resolution and client define parity with Next.js.
3. `tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts` plus `tests/fixtures/pages-scroll-restoration`: the ported upstream regression test and fixture.
4. `tests/shims.test.ts` and `tests/next-config.test.ts`: focused lower-boundary coverage for runtime install ordering and config parsing.

</details>

<details>
<summary>Validation</summary>

- `vp check`
- `vp test run tests/next-config.test.ts -t scrollRestoration`
- `vp test run tests/shims.test.ts -t "Pages Router concurrent navigation"`
- `vp test run tests/pages-router.test.ts -t "client entry statically imports next/router"`
- `CI=1 PLAYWRIGHT_PROJECT=pages-scroll-restoration vp run test:e2e tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/reload-scroll-backforward-restoration/index.test.ts`

The pre-commit hook also passed entry template snapshots, `vp check --fix`, full check, staged tests, and knip.

</details>

<details>
<summary>Risk / Compatibility</summary>

- Public API: no new public API.
- Config: newly honors an existing Next.js experimental config flag.
- Runtime: only opts into manual restoration when the flag is true and `sessionStorage` is usable, matching the Next.js guard.
- Existing apps: apps without `experimental.scrollRestoration` keep browser-managed scroll restoration.
- Intentional divergence: none intended. The port uses Playwright against a vinext production fixture instead of Next.js `next-webdriver`, but preserves the same route structure, config flag, navigation sequence, readiness wait, `routeChangeComplete` wait, and exact scroll assertions.

</details>

<details>
<summary>Non-goals</summary>

- Does not change App Router scroll behavior.
- Does not add broader hash-scroll or shallow-routing coverage beyond the upstream bug candidate.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream regression test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/index.test.ts#L8-L157) | Defines the reload plus back and forward scroll restoration contract ported here. |
| [Next.js fixture config](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/next.config.js#L1-L6) | Shows the behavior is gated by `experimental.scrollRestoration`. |
| [Next.js fixture page](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/pages/%5Bid%5D.js) | Provides the route structure and `routeChangeComplete` observable used by the test. |
| [Next.js define-env](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/define-env.ts#L256) | Maps the config flag to `process.env.__NEXT_SCROLL_RESTORATION`. |
| [Next.js config default](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/config-shared.ts#L1751) | Confirms the default is false unless the experimental flag is enabled. |
| [Next.js router scroll restoration](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts#L395-L398) | Guards manual scroll restoration on the env flag, history support, and sessionStorage. |
| [Next.js sessionStorage snapshots](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts#L883-L895) | Shows scroll snapshots are keyed as `__next_scroll_<key>`. |
| [Next.js route commit ordering](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/index.tsx#L404-L406) | Uses a layout-effect callback so render completion represents a committed route. |
| [Next.js router events docs](https://nextjs.org/docs/pages/api-reference/functions/use-router#routerevents) | Documents `routeChangeComplete` as the Pages Router completion signal observed by the fixture. |