### PR TITLE
fix(cache): honor fetch opt-outs and force-dynamic revalidate parity

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -386,6 +386,13 @@ function __resolveRouteFetchCacheMode(route) {
   });
 }
 
+function __resolveRouteDynamicConfig(route) {
+  return __resolveAppPageSegmentConfig({
+    layouts: route.layouts,
+    page: route.page,
+  }).dynamicConfig ?? null;
+}
+
 function __resolveRouteRuntime(route) {
   return __resolveAppPageSegmentConfig({
     layouts: route.layouts,
@@ -740,6 +747,9 @@ export default __createAppRscHandler({
       revalidateSeconds: __segmentConfig.revalidateSeconds,
       resolveRouteFetchCacheMode(targetRoute) {
         return __resolveRouteFetchCacheMode(targetRoute);
+      },
+      resolveRouteDynamicConfig(targetRoute) {
+        return __resolveRouteDynamicConfig(targetRoute);
       },
       rootForbiddenModule,
       rootNotFoundModule,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -947,6 +947,12 @@ export default __createAppRscHandler({
       readFormDataWithLimit: __readFormDataWithLimit,
       renderToReadableStream,
       reportRequestError: _reportRequestError,
+      resolveRouteFetchCacheMode(targetRoute) {
+        return __resolveRouteFetchCacheMode(targetRoute);
+      },
+      resolveRouteDynamicConfig(targetRoute) {
+        return __resolveRouteDynamicConfig(targetRoute);
+      },
       resolveRouteRuntime: __resolveRouteRuntime,
       request,
       sanitizeErrorForClient(error) {

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -276,6 +276,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   request: Request;
   revalidateSeconds: number | null;
   resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
+  resolveRouteDynamicConfig?: (route: TRoute) => string | undefined;
   rootForbiddenModule?: AppPageModule | null;
   rootNotFoundModule?: AppPageModule | null;
   rootUnauthorizedModule?: AppPageModule | null;
@@ -591,7 +592,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
               options.resolveRouteFetchCacheMode?.(revalidationTarget.route) ??
               (revalidationTarget.route === route ? (options.fetchCache ?? null) : null),
             draftModeSecret: options.draftModeSecret,
-            dynamicConfig,
+            dynamicConfig:
+              options.resolveRouteDynamicConfig?.(revalidationTarget.route) ??
+              (revalidationTarget.route === route ? dynamicConfig : undefined),
             params: revalidationTarget.navigationParams,
             routePattern: revalidationTarget.route.pattern,
             routeSegments: revalidationTarget.route.routeSegments,
@@ -741,6 +744,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       // Hydrate the intercept source route before reading its page module.
       await options.ensureRouteLoaded?.(interceptRoute);
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(interceptRoute) ?? null);
+      setCurrentForceDynamicFetchDefault(
+        options.resolveRouteDynamicConfig?.(interceptRoute) === "force-dynamic",
+      );
       return options.buildPageElement(
         interceptRoute,
         interceptParams,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -743,6 +743,12 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     ) {
       // Hydrate the intercept source route before reading its page module.
       await options.ensureRouteLoaded?.(interceptRoute);
+      // Deliberately no save/restore around buildPageElement: when this
+      // callback runs, resolveAppPageIntercept returns the intercept response
+      // directly and the dispatch never falls through to the original route.
+      // The intercept route's fetch defaults must also stay active past this
+      // call — its server components fetch lazily during the
+      // renderToReadableStream in renderInterceptResponse below.
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(interceptRoute) ?? null);
       setCurrentForceDynamicFetchDefault(
         options.resolveRouteDynamicConfig?.(interceptRoute) === "force-dynamic",

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -29,6 +29,7 @@ import {
   peekDynamicFetchObservations,
   runWithFetchDedupe,
   setCurrentFetchCacheMode,
+  setCurrentForceDynamicFetchDefault,
   setCurrentFetchSoftTags,
 } from "vinext/shims/fetch-cache";
 import { AppElementsWire, type AppOutgoingElements } from "./app-elements.js";
@@ -431,6 +432,7 @@ async function runAppPageRevalidationContext<
   const requestContext = createRequestContext({
     headersContext,
     currentFetchCacheMode: options.currentFetchCacheMode ?? null,
+    currentForceDynamicFetchDefault: options.dynamicConfig === "force-dynamic",
     executionContext: getRequestExecutionContext(),
     unstableCacheRevalidation: "foreground",
   });
@@ -494,6 +496,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
   setCurrentFetchCacheMode(options.fetchCache ?? null);
+  setCurrentForceDynamicFetchDefault(isForceDynamic);
 
   if (options.hasPageModule && !options.hasPageDefaultExport) {
     options.clearRequestContext();

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -276,7 +276,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   request: Request;
   revalidateSeconds: number | null;
   resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
-  resolveRouteDynamicConfig?: (route: TRoute) => string | undefined;
+  resolveRouteDynamicConfig?: (route: TRoute) => string | null | undefined;
   rootForbiddenModule?: AppPageModule | null;
   rootNotFoundModule?: AppPageModule | null;
   rootUnauthorizedModule?: AppPageModule | null;

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -2,7 +2,10 @@ import type { NextI18nConfig } from "../config/next-config.js";
 import {
   getCollectedFetchTags,
   ensureFetchPatch,
+  setCurrentFetchCacheMode,
   setCurrentFetchSoftTags,
+  setCurrentForceDynamicFetchDefault,
+  type FetchCacheMode,
 } from "vinext/shims/fetch-cache";
 import {
   consumeDynamicUsage,
@@ -35,6 +38,7 @@ import {
   applyRouteHandlerMiddlewareContext,
   type RouteHandlerMiddlewareContext,
 } from "./app-route-handler-response.js";
+import { resolveAppRouteHandlerFetchCacheMode } from "./app-segment-config.js";
 import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
 import { makeThenableParams } from "vinext/shims/thenable-params";
@@ -103,6 +107,7 @@ async function runInRouteHandlerRevalidationContext(
     cleanPathname: string;
     draftModeSecret: string;
     dynamicConfig?: string;
+    fetchCacheMode: FetchCacheMode | null;
     routePattern: string;
     routeSegments: string[];
   },
@@ -125,6 +130,10 @@ async function runInRouteHandlerRevalidationContext(
     setCurrentFetchSoftTags(
       buildRouteHandlerPageCacheTags(options.cleanPathname, [], options.routeSegments),
     );
+    // The revalidation render runs in a fresh request context, so the fetch
+    // defaults applied by `dispatchAppRouteHandler` must be re-applied here.
+    setCurrentFetchCacheMode(options.fetchCacheMode);
+    setCurrentForceDynamicFetchDefault(options.dynamicConfig === "force-dynamic");
     await renderFn();
   });
 }
@@ -174,6 +183,15 @@ export async function dispatchAppRouteHandler(
 
   const resolvedHandlerFn = isAppRouteHandlerFunction(handlerFn) ? handlerFn : undefined;
 
+  // Route handler fetches observe the handler's segment config the same way
+  // page fetches do: upstream's app-route module copies `userland.fetchCache`
+  // into the work store and sets `forceDynamic` for `dynamic = "force-dynamic"`,
+  // which patch-fetch turns into a no-store default for fetches without
+  // explicit cache config.
+  const fetchCacheMode = resolveAppRouteHandlerFetchCacheMode(handler);
+  setCurrentFetchCacheMode(fetchCacheMode);
+  setCurrentForceDynamicFetchDefault(handler.dynamic === "force-dynamic");
+
   if (
     revalidateSeconds !== null &&
     shouldReadAppRouteHandlerCache({
@@ -219,6 +237,7 @@ export async function dispatchAppRouteHandler(
             cleanPathname: options.cleanPathname,
             draftModeSecret: options.draftModeSecret,
             dynamicConfig: handler.dynamic,
+            fetchCacheMode,
             routePattern: route.pattern,
             routeSegments: route.routeSegments,
           },

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -187,7 +187,9 @@ export async function dispatchAppRouteHandler(
   // page fetches do: upstream's app-route module copies `userland.fetchCache`
   // into the work store and sets `forceDynamic` for `dynamic = "force-dynamic"`,
   // which patch-fetch turns into a no-store default for fetches without
-  // explicit cache config.
+  // explicit cache config. Both setters are new wiring for the route-handler
+  // path (dispatch previously only set fetch soft tags), closing the gap
+  // where handlers ignored their `fetchCache`/`force-dynamic` segment config.
   const fetchCacheMode = resolveAppRouteHandlerFetchCacheMode(handler);
   setCurrentFetchCacheMode(fetchCacheMode);
   setCurrentForceDynamicFetchDefault(handler.dynamic === "force-dynamic");

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -9,6 +9,7 @@ import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-
 
 export type AppRouteHandlerModule = {
   dynamic?: string;
+  fetchCache?: unknown;
   revalidate?: unknown;
 } & RouteHandlerModule;
 

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -186,11 +186,12 @@ export function resolveAppPageSegmentConfig(
     config.revalidateSeconds = 0;
   }
 
-  // Top-level dynamic modes supply fetchCache defaults unless a segment does.
+  // Static-only dynamic modes supply fetchCache defaults unless a segment does.
+  // `dynamic = "force-dynamic"` is handled at the fetch decision layer: it
+  // defaults no-config fetches to no-store but must not override explicit
+  // per-fetch cache/revalidate options.
   if (config.fetchCache === undefined) {
-    if (config.dynamicConfig === "force-dynamic") {
-      config.fetchCache = "force-no-store";
-    } else if (config.dynamicConfig === "error") {
+    if (config.dynamicConfig === "error") {
       config.fetchCache = "only-cache";
     }
   }

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -213,6 +213,19 @@ export function resolveAppPageFetchCacheMode(
   return resolveAppPageSegmentConfig(options).fetchCache ?? null;
 }
 
+/**
+ * Resolve the `fetchCache` segment config exported by a route handler module.
+ *
+ * Route handlers have no layout chain, so the module's own export applies
+ * directly. Mirrors upstream's app-route module, which copies
+ * `userland.fetchCache` into the work store before invoking the handler.
+ */
+export function resolveAppRouteHandlerFetchCacheMode(
+  handler: Pick<AppRouteSegmentConfigModule, "fetchCache">,
+): FetchCacheMode | null {
+  return isRouteSegmentFetchCache(handler.fetchCache) ? handler.fetchCache : null;
+}
+
 export function isEdgeRuntime(runtime: string | undefined): boolean {
   return isEdgeApiRuntime(runtime);
 }

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -8,6 +8,7 @@ import {
   type FetchCacheMode,
   setCurrentFetchCacheMode,
   setCurrentFetchSoftTags,
+  setCurrentForceDynamicFetchDefault,
 } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
 import { isExternalUrl } from "../config/config-matchers.js";
@@ -258,6 +259,7 @@ export type HandleServerActionRscRequestOptions<
   ) => BodyInit | null | Promise<BodyInit | null>;
   reportRequestError: AppServerActionErrorReporter;
   resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
+  resolveRouteDynamicConfig?: (route: TRoute) => string | null | undefined;
   resolveRouteRuntime?: (route: TRoute) => AppServerActionRouteRuntime;
   request: Request;
   sanitizeErrorForClient: (error: unknown) => unknown;
@@ -1166,6 +1168,9 @@ export async function handleServerActionRscRequest<
         params: targetMatch.params,
       });
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(targetMatch.route) ?? null);
+      setCurrentForceDynamicFetchDefault(
+        options.resolveRouteDynamicConfig?.(targetMatch.route) === "force-dynamic",
+      );
       setCurrentFetchSoftTags(buildServerActionPageTags(targetMatch.route, targetPathname));
       const element = options.buildPageElement({
         cleanPathname: targetPathname,
@@ -1279,6 +1284,9 @@ export async function handleServerActionRscRequest<
       await options.ensureRouteLoaded?.(actionRerenderTarget.route);
       setCurrentFetchCacheMode(
         options.resolveRouteFetchCacheMode?.(actionRerenderTarget.route) ?? null,
+      );
+      setCurrentForceDynamicFetchDefault(
+        options.resolveRouteDynamicConfig?.(actionRerenderTarget.route) === "force-dynamic",
       );
       setCurrentFetchSoftTags(
         buildServerActionPageTags(actionRerenderTarget.route, options.cleanPathname),

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -982,6 +982,10 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // dynamic fetch observation: the per-user response must downgrade the
     // page output to fresh render, or a statically cached page could leak
     // one user's auth-keyed data to everyone else.
+    // Ordering is deliberate: an explicit `no-store`/`no-cache`/`revalidate: 0`
+    // takes the stronger branch above and fully marks the page dynamic even
+    // when auth headers are present — this bypass only handles auth-keyed
+    // fetches that would otherwise be implicitly cacheable.
     const hasExplicitCacheOpt =
       cacheDirective === "force-cache" ||
       nextOpts?.revalidate === false ||

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -648,6 +648,9 @@ function isNoStoreFetch(
   );
 }
 
+// Note: `revalidate: false` is cacheable-indefinitely (it normalizes to
+// INFINITE_CACHE), so it belongs here — and therefore conflicts with
+// `only-no-store` — and must not be re-added to `isNoStoreFetch` above.
 function isCacheableFetch(
   cacheDirective: RequestCache | undefined,
   nextOpts: NextFetchOptions | undefined,
@@ -824,8 +827,11 @@ function buildCachedFetchResponse(data: CachedFetchValue["data"]): Response {
     status: data.status ?? 200,
     headers: data.headers,
   });
+  // `data.url` is typed as required, but cached entries may cross a
+  // serialization boundary (e.g. KV) where a legacy or third-party writer
+  // never populated it — fall back to "" rather than `undefined`.
   Object.defineProperty(response, "url", {
-    value: data.url,
+    value: data.url ?? "",
     configurable: true,
     enumerable: true,
     writable: false,

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -940,6 +940,10 @@ function createPatchedFetch(): typeof globalThis.fetch {
     }
 
     // Explicit no-store or no-cache — bypass cache entirely
+    // Deliberate divergence from upstream: Next.js only calls
+    // markCurrentScopeAsDynamic for 'no-store'/revalidate: 0, while 'no-cache'
+    // merely opts the fetch out of caching. We conservatively mark the page
+    // dynamic for 'no-cache' too, since its response is never reusable.
     if (
       cacheDirective === "no-store" ||
       cacheDirective === "no-cache" ||

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -841,6 +841,9 @@ function buildCachedFetchResponse(
     enumerable: true,
     writable: false,
   });
+  // Intentional change from the previous inline reconstruction: cached
+  // responses now participate in body-stream cleanup too, so an unconsumed
+  // cached body gets cancelled when the Response is GC'd instead of leaking.
   if (_responseBodyRegistry && response.body) {
     _responseBodyRegistry.register(response, new WeakRef(response.body));
   }

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -683,6 +683,9 @@ function resolveSegmentCacheDirective(
   mode: FetchCacheMode | null,
   forceDynamicFetchDefault: boolean,
 ): RequestCache | undefined {
+  // Explicit segment fetchCache modes (e.g. default-cache/default-no-store)
+  // skip this guard and are handled below, taking precedence over the
+  // force-dynamic no-store default.
   if (
     forceDynamicFetchDefault &&
     (!mode || mode === "auto") &&

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -656,8 +656,14 @@ function isCacheableFetch(
   );
 }
 
+// Matches upstream's `!currentFetchRevalidate` truthiness check: `false` and `0`
+// are both falsy, meaning "no fetch revalidate config" for the force-dynamic
+// default evaluation.  Only numeric values > 0 are treated as explicit cache
+// durations that should block the force-dynamic no-store default.
 function hasExplicitRevalidateValue(nextOpts: NextFetchOptions | undefined): boolean {
-  return nextOpts?.revalidate !== undefined;
+  return (
+    nextOpts?.revalidate !== undefined && nextOpts.revalidate !== false && nextOpts.revalidate !== 0
+  );
 }
 
 function resolveSegmentCacheDirective(

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -22,6 +22,7 @@
 import { getDataCacheHandler, type CachedFetchValue } from "./cache.js";
 import { encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
+import { markDynamicUsage } from "./headers.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import {
   isInsideUnifiedScope,
@@ -478,6 +479,7 @@ export type FetchCacheState = {
   currentRequestTags: string[];
   currentFetchSoftTags: string[];
   currentFetchCacheMode: FetchCacheMode | null;
+  currentForceDynamicFetchDefault: boolean;
   dynamicFetchUrls: Set<string>;
   isFetchDedupeActive: boolean;
   currentFetchDedupeEntries: Map<string, FetchDedupeEntry[]>;
@@ -513,6 +515,7 @@ const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   currentRequestTags: [],
   currentFetchSoftTags: [],
   currentFetchCacheMode: null,
+  currentForceDynamicFetchDefault: false,
   dynamicFetchUrls: new Set<string>(),
   isFetchDedupeActive: false,
   currentFetchDedupeEntries: new Map(),
@@ -534,6 +537,7 @@ function _resetFallbackState(isFetchDedupeActive: boolean): void {
   _fallbackState.currentRequestTags = [];
   _fallbackState.currentFetchSoftTags = [];
   _fallbackState.currentFetchCacheMode = null;
+  _fallbackState.currentForceDynamicFetchDefault = false;
   _fallbackState.dynamicFetchUrls = new Set<string>();
   _fallbackState.isFetchDedupeActive = isFetchDedupeActive;
   _fallbackState.currentFetchDedupeEntries = new Map();
@@ -545,6 +549,11 @@ function getFetchObservationUrl(input: string | URL | Request): string {
 
 function recordDynamicFetchObservation(input: string | URL | Request): void {
   _getState().dynamicFetchUrls.add(getFetchObservationUrl(input));
+}
+
+function markUncachedFetchForPageOutput(input: string | URL | Request): void {
+  recordDynamicFetchObservation(input);
+  markDynamicUsage();
 }
 
 function recordCacheableFetchObservation(input: string | URL | Request): void {
@@ -623,6 +632,10 @@ export function setCurrentFetchCacheMode(mode: FetchCacheMode | null): void {
   _getState().currentFetchCacheMode = mode;
 }
 
+export function setCurrentForceDynamicFetchDefault(enabled: boolean): void {
+  _getState().currentForceDynamicFetchDefault = enabled;
+}
+
 function isNoStoreFetch(
   cacheDirective: RequestCache | undefined,
   nextOpts: NextFetchOptions | undefined,
@@ -653,7 +666,17 @@ function resolveSegmentCacheDirective(
   cacheDirective: RequestCache | undefined,
   nextOpts: NextFetchOptions | undefined,
   mode: FetchCacheMode | null,
+  forceDynamicFetchDefault: boolean,
 ): RequestCache | undefined {
+  if (
+    forceDynamicFetchDefault &&
+    (!mode || mode === "auto") &&
+    (cacheDirective === undefined || cacheDirective === "default") &&
+    !hasExplicitRevalidateValue(nextOpts)
+  ) {
+    return "no-store";
+  }
+
   if (!mode || mode === "auto") {
     return cacheDirective;
   }
@@ -784,6 +807,23 @@ function cloneDedupeResponse(response: Response): [Response, Response] {
   return [buildDedupeClone(body1, response), buildDedupeClone(body2, response)];
 }
 
+function buildCachedFetchResponse(data: CachedFetchValue["data"]): Response {
+  const response = new Response(data.body, {
+    status: data.status ?? 200,
+    headers: data.headers,
+  });
+  Object.defineProperty(response, "url", {
+    value: data.url,
+    configurable: true,
+    enumerable: true,
+    writable: false,
+  });
+  if (_responseBodyRegistry && response.body) {
+    _responseBodyRegistry.register(response, new WeakRef(response.body));
+  }
+  return response;
+}
+
 function dedupeFetch(
   input: string | URL | Request,
   init: RequestInit | undefined,
@@ -870,6 +910,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       getFetchCacheDirective(input, init),
       nextOpts,
       _getState().currentFetchCacheMode,
+      _getState().currentForceDynamicFetchDefault,
     );
 
     // Determine caching behavior:
@@ -895,7 +936,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
     ) {
       // Strip the `next` property before passing to real fetch
       const cleanInit = stripNextFromInit(init, cacheDirective);
-      recordDynamicFetchObservation(input);
+      markUncachedFetchForPageOutput(input);
       return dedupeFetch(input, cleanInit);
     }
 
@@ -909,7 +950,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0);
     if (!hasExplicitCacheOpt && hasAuthHeaders(input, init)) {
       const cleanInit = stripNextFromInit(init, cacheDirective);
-      recordDynamicFetchObservation(input);
+      markUncachedFetchForPageOutput(input);
       return dedupeFetch(input, cleanInit);
     }
 
@@ -969,7 +1010,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         err instanceof SkipCacheKeyGenerationError
       ) {
         fetchInit = stripNextFromInit(fetchInit, cacheDirective);
-        recordDynamicFetchObservation(input);
+        markUncachedFetchForPageOutput(input);
         return dedupeFetch(input, fetchInit);
       }
       throw err;
@@ -981,11 +1022,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       const cached = await handler.get(cacheKey, { kind: "FETCH", tags, softTags });
       if (cached?.value && cached.value.kind === "FETCH" && cached.cacheState !== "stale") {
         const cachedData = cached.value.data;
-        // Reconstruct a Response from the cached data
-        return new Response(cachedData.body, {
-          status: cachedData.status ?? 200,
-          headers: cachedData.headers,
-        });
+        return buildCachedFetchResponse(cachedData);
       }
 
       // Stale entry — we could do stale-while-revalidate here, but for fetch()
@@ -1068,10 +1105,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         }
 
         // Return stale data immediately
-        return new Response(staleData.body, {
-          status: staleData.status ?? 200,
-          headers: staleData.headers,
-        });
+        return buildCachedFetchResponse(staleData);
       }
     } catch (cacheErr) {
       // Cache read failed — fall through to network
@@ -1210,6 +1244,7 @@ export async function runWithFetchCache<T>(fn: () => Promise<T>): Promise<T> {
       currentRequestTags: [],
       currentFetchSoftTags: [],
       currentFetchCacheMode: null,
+      currentForceDynamicFetchDefault: false,
       dynamicFetchUrls: new Set<string>(),
       isFetchDedupeActive: true,
       currentFetchDedupeEntries: new Map(),

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -641,10 +641,7 @@ function isNoStoreFetch(
   nextOpts: NextFetchOptions | undefined,
 ): boolean {
   return (
-    cacheDirective === "no-store" ||
-    cacheDirective === "no-cache" ||
-    nextOpts?.revalidate === false ||
-    nextOpts?.revalidate === 0
+    cacheDirective === "no-store" || cacheDirective === "no-cache" || nextOpts?.revalidate === 0
   );
 }
 
@@ -654,6 +651,7 @@ function isCacheableFetch(
 ): boolean {
   return (
     cacheDirective === "force-cache" ||
+    nextOpts?.revalidate === false ||
     (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0)
   );
 }
@@ -916,7 +914,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // Determine caching behavior:
     // - cache: 'no-store' → skip cache entirely
     // - cache: 'force-cache' → cache indefinitely (revalidate = Infinity)
-    // - next.revalidate: false → same as 'no-store'
+    // - next.revalidate: false → cache indefinitely (same as force-cache)
     // - next.revalidate: 0 → same as 'no-store'
     // - next.revalidate: N → cache for N seconds
     // - No cache/next options → default behavior (no caching, pass-through)
@@ -931,7 +929,6 @@ function createPatchedFetch(): typeof globalThis.fetch {
     if (
       cacheDirective === "no-store" ||
       cacheDirective === "no-cache" ||
-      nextOpts?.revalidate === false ||
       nextOpts?.revalidate === 0
     ) {
       // Strip the `next` property before passing to real fetch
@@ -945,12 +942,14 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // `next.revalidate`, skip caching to prevent accidental cross-user data
     // leakage. Developers who understand the implications can still force
     // caching by using `cache: 'force-cache'` or `next: { revalidate: N }`.
+    // This mirrors upstream's autoNoCache path and does NOT mark the page
+    // dynamic — it is an automatic safety bypass, not an explicit opt-out.
     const hasExplicitCacheOpt =
       cacheDirective === "force-cache" ||
+      nextOpts?.revalidate === false ||
       (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0);
     if (!hasExplicitCacheOpt && hasAuthHeaders(input, init)) {
       const cleanInit = stripNextFromInit(init, cacheDirective);
-      markUncachedFetchForPageOutput(input);
       return dedupeFetch(input, cleanInit);
     }
 
@@ -962,6 +961,9 @@ function createPatchedFetch(): typeof globalThis.fetch {
         nextOpts?.revalidate && typeof nextOpts.revalidate === "number"
           ? nextOpts.revalidate
           : 31536000; // 1 year
+    } else if (nextOpts?.revalidate === false) {
+      // revalidate: false means cache indefinitely
+      revalidateSeconds = 31536000; // 1 year
     } else if (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0) {
       revalidateSeconds = nextOpts.revalidate;
     } else {
@@ -1052,12 +1054,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
                 data: {
                   headers: freshHeaders,
                   body: freshBody,
-                  url:
-                    typeof input === "string"
-                      ? input
-                      : input instanceof URL
-                        ? input.toString()
-                        : input.url,
+                  url: freshResp.url,
                   status: freshResp.status,
                 },
                 tags,
@@ -1133,8 +1130,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         data: {
           headers,
           body,
-          url:
-            typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+          url: response.url,
           status: cloned.status,
         },
         tags,

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -45,6 +45,9 @@ const HEADER_BLOCKLIST = ["traceparent", "tracestate"];
 const CACHE_KEY_PREFIX = "v3";
 const MAX_CACHE_KEY_BODY_BYTES = 1024 * 1024; // 1 MiB
 
+// "Cache indefinitely" duration — mirrors upstream's CACHE_ONE_YEAR_SECONDS.
+const ONE_YEAR_SECONDS = 31536000;
+
 class BodyTooLargeForCacheKeyError extends Error {
   constructor() {
     super("Fetch body too large for cache key generation");
@@ -971,10 +974,10 @@ function createPatchedFetch(): typeof globalThis.fetch {
       revalidateSeconds =
         nextOpts?.revalidate && typeof nextOpts.revalidate === "number"
           ? nextOpts.revalidate
-          : 31536000; // 1 year
+          : ONE_YEAR_SECONDS;
     } else if (nextOpts?.revalidate === false) {
       // revalidate: false means cache indefinitely
-      revalidateSeconds = 31536000; // 1 year
+      revalidateSeconds = ONE_YEAR_SECONDS;
     } else if (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0) {
       revalidateSeconds = nextOpts.revalidate;
     } else {
@@ -982,7 +985,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       // caching when `next` is present (force-cache behavior).
       // If only tags are specified, cache indefinitely.
       if (nextOpts?.tags && nextOpts.tags.length > 0) {
-        revalidateSeconds = 31536000;
+        revalidateSeconds = ONE_YEAR_SECONDS;
       } else {
         // next: {} with no revalidate or tags — pass through
         const cleanInit = stripNextFromInit(init, cacheDirective);

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -656,14 +656,19 @@ function isCacheableFetch(
   );
 }
 
-// Matches upstream's `!currentFetchRevalidate` truthiness check: `false` and `0`
-// are both falsy, meaning "no fetch revalidate config" for the force-dynamic
-// default evaluation.  Only numeric values > 0 are treated as explicit cache
-// durations that should block the force-dynamic no-store default.
+// Returns true when the fetch call carries any defined `next.revalidate` value.
+// Used by segment cache defaults (default-cache, default-no-store) where
+// `revalidate: 0` and `revalidate: false` are both explicit opt-outs that
+// should prevent the segment default from kicking in.
 function hasExplicitRevalidateValue(nextOpts: NextFetchOptions | undefined): boolean {
-  return (
-    nextOpts?.revalidate !== undefined && nextOpts.revalidate !== false && nextOpts.revalidate !== 0
-  );
+  return nextOpts?.revalidate !== undefined;
+}
+
+// Matches upstream's `!currentFetchRevalidate` truthiness check in
+// noFetchConfigAndForceDynamic.  `false` and `0` are both falsy, so they
+// count as "no fetch revalidate config" for the force-dynamic default path.
+function isFalsyRevalidate(nextOpts: NextFetchOptions | undefined): boolean {
+  return !nextOpts?.revalidate;
 }
 
 function resolveSegmentCacheDirective(
@@ -676,7 +681,7 @@ function resolveSegmentCacheDirective(
     forceDynamicFetchDefault &&
     (!mode || mode === "auto") &&
     (cacheDirective === undefined || cacheDirective === "default") &&
-    !hasExplicitRevalidateValue(nextOpts)
+    isFalsyRevalidate(nextOpts)
   ) {
     return "no-store";
   }

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -956,14 +956,18 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // `next.revalidate`, skip caching to prevent accidental cross-user data
     // leakage. Developers who understand the implications can still force
     // caching by using `cache: 'force-cache'` or `next: { revalidate: N }`.
-    // This mirrors upstream's autoNoCache path and does NOT mark the page
-    // dynamic — it is an automatic safety bypass, not an explicit opt-out.
+    // This is an automatic safety bypass, not an explicit opt-out, so it does
+    // NOT mark the page dynamic via markDynamicUsage(). It still records a
+    // dynamic fetch observation: the per-user response must downgrade the
+    // page output to fresh render, or a statically cached page could leak
+    // one user's auth-keyed data to everyone else.
     const hasExplicitCacheOpt =
       cacheDirective === "force-cache" ||
       nextOpts?.revalidate === false ||
       (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0);
     if (!hasExplicitCacheOpt && hasAuthHeaders(input, init)) {
       const cleanInit = stripNextFromInit(init, cacheDirective);
+      recordDynamicFetchObservation(input);
       return dedupeFetch(input, cleanInit);
     }
 
@@ -1026,7 +1030,12 @@ function createPatchedFetch(): typeof globalThis.fetch {
         err instanceof SkipCacheKeyGenerationError
       ) {
         fetchInit = stripNextFromInit(fetchInit, cacheDirective);
-        markUncachedFetchForPageOutput(input);
+        // The developer opted into caching but we couldn't build a cache key
+        // (body too large / unserializable). That is an internal vinext
+        // limitation, not an explicit uncached-fetch decision, so record only
+        // the observation (downgrading the page output to fresh render)
+        // without marking the whole page dynamic.
+        recordDynamicFetchObservation(input);
         return dedupeFetch(input, fetchInit);
       }
       throw err;

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -822,16 +822,21 @@ function cloneDedupeResponse(response: Response): [Response, Response] {
   return [buildDedupeClone(body1, response), buildDedupeClone(body2, response)];
 }
 
-function buildCachedFetchResponse(data: CachedFetchValue["data"]): Response {
+function buildCachedFetchResponse(
+  data: CachedFetchValue["data"],
+  input: string | URL | Request,
+): Response {
   const response = new Response(data.body, {
     status: data.status ?? 200,
     headers: data.headers,
   });
   // `data.url` is typed as required, but cached entries may cross a
   // serialization boundary (e.g. KV) where a legacy or third-party writer
-  // never populated it — fall back to "" rather than `undefined`.
+  // never populated it — fall back to the request URL (what an uncached,
+  // redirect-free fetch would report) so consumers that read `response.url`
+  // (e.g. to resolve relative redirects) still see a usable absolute URL.
   Object.defineProperty(response, "url", {
-    value: data.url ?? "",
+    value: data.url ?? getFetchObservationUrl(input),
     configurable: true,
     enumerable: true,
     writable: false,
@@ -1057,7 +1062,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       const cached = await handler.get(cacheKey, { kind: "FETCH", tags, softTags });
       if (cached?.value && cached.value.kind === "FETCH" && cached.cacheState !== "stale") {
         const cachedData = cached.value.data;
-        return buildCachedFetchResponse(cachedData);
+        return buildCachedFetchResponse(cachedData, input);
       }
 
       // Stale entry — we could do stale-while-revalidate here, but for fetch()
@@ -1135,7 +1140,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         }
 
         // Return stale data immediately
-        return buildCachedFetchResponse(staleData);
+        return buildCachedFetchResponse(staleData, input);
       }
     } catch (cacheErr) {
       // Cache read failed — fall through to network

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -103,6 +103,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     currentRequestTags: [],
     currentFetchSoftTags: [],
     currentFetchCacheMode: null,
+    currentForceDynamicFetchDefault: false,
     dynamicFetchUrls: new Set<string>(),
     isFetchDedupeActive: false,
     currentFetchDedupeEntries: new Map(),

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -276,6 +276,7 @@ function createDispatchOptions(
     request?: Request;
     revalidateSeconds?: number | null;
     resolveRouteFetchCacheMode?: DispatchOptions["resolveRouteFetchCacheMode"];
+    resolveRouteDynamicConfig?: DispatchOptions["resolveRouteDynamicConfig"];
     route?: TestRoute;
     scheduleBackgroundRegeneration?: DispatchOptions["scheduleBackgroundRegeneration"];
     searchParams?: URLSearchParams;
@@ -362,6 +363,7 @@ function createDispatchOptions(
     request: overrides.request ?? new Request("https://example.test/posts/hello"),
     revalidateSeconds: overrides.revalidateSeconds ?? null,
     resolveRouteFetchCacheMode: overrides.resolveRouteFetchCacheMode,
+    resolveRouteDynamicConfig: overrides.resolveRouteDynamicConfig,
     route,
     runWithSuppressedHookWarning<T>(probe: () => Promise<T>) {
       return probe();
@@ -1138,6 +1140,103 @@ describe("app page dispatch", () => {
     );
   });
 
+  it("resolves the intercept source route's dynamic config for force-dynamic fetch defaults", async () => {
+    // When the current route is not force-dynamic but the intercepted source route is,
+    // the dispatch must resolve the source route's dynamic config so that fetch
+    // defaults come from the source route, not the current route.
+    const sourceRoute = createRoute({
+      params: [],
+      pattern: "/feed",
+      routeSegments: ["feed"],
+      layouts: [{ default: () => null, dynamic: "force-dynamic" }],
+    });
+    const currentRoute = createRoute({
+      params: ["id"],
+      pattern: "/photos/[id]",
+      routeSegments: ["photos", "[id]"],
+    });
+
+    const resolveRouteDynamicConfig = vi.fn((route: TestRoute) =>
+      route === sourceRoute ? "force-dynamic" : undefined,
+    );
+
+    const { options } = createDispatchOptions({
+      async buildPageElement(route, params, opts) {
+        return `${route.pattern}:${JSON.stringify(params)}:${opts?.interceptSlotKey ?? "direct"}`;
+      },
+      isRscRequest: true,
+      route: currentRoute,
+      resolveRouteDynamicConfig,
+    });
+
+    const response = await dispatchAppPage({
+      ...options,
+      findIntercept() {
+        return {
+          matchedParams: { id: "123" },
+          page: { default: "modal-page" },
+          slotKey: "modal@app/feed/@modal",
+          sourceRouteIndex: 1,
+        };
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return sourceRouteIndex === 1 ? sourceRoute : undefined;
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveRouteDynamicConfig).toHaveBeenCalledWith(sourceRoute);
+  });
+
+  it("does not leak the current route's force-dynamic config into the intercept source route", async () => {
+    // When the current route is force-dynamic but the intercepted source route is not,
+    // the dispatch must resolve the source route's dynamic config so that fetch
+    // defaults do NOT leak from the current route into the source route.
+    const sourceRoute = createRoute({
+      params: [],
+      pattern: "/feed",
+      routeSegments: ["feed"],
+    });
+    const currentRoute = createRoute({
+      params: ["id"],
+      pattern: "/photos/[id]",
+      routeSegments: ["photos", "[id]"],
+      layouts: [{ default: () => null, dynamic: "force-dynamic" }],
+    });
+
+    const resolveRouteDynamicConfig = vi.fn((route: TestRoute) =>
+      route === currentRoute ? "force-dynamic" : undefined,
+    );
+
+    const { options } = createDispatchOptions({
+      async buildPageElement(route, params, opts) {
+        return `${route.pattern}:${JSON.stringify(params)}:${opts?.interceptSlotKey ?? "direct"}`;
+      },
+      dynamicConfig: "force-dynamic",
+      isRscRequest: true,
+      route: currentRoute,
+      resolveRouteDynamicConfig,
+    });
+
+    const response = await dispatchAppPage({
+      ...options,
+      findIntercept() {
+        return {
+          matchedParams: { id: "123" },
+          page: { default: "modal-page" },
+          slotKey: "modal@app/feed/@modal",
+          sourceRouteIndex: 1,
+        };
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return sourceRouteIndex === 1 ? sourceRoute : undefined;
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveRouteDynamicConfig).toHaveBeenCalledWith(sourceRoute);
+  });
+
   it("regenerates stale HTML cache entries with waitForAllReady so suspense fallbacks never leak into the cache", async () => {
     // Stale-while-revalidate regeneration must await React's `allReady` before
     // transforming/buffering the HTML stream — same guarantee as the prerender
@@ -1194,5 +1293,204 @@ describe("app page dispatch", () => {
 
     expect(capturedWaitForAllReady).toBe(true);
     expect(isrSet).toHaveBeenCalled();
+  });
+
+  it("resolves the revalidation target route's dynamic config for force-dynamic fetch defaults", async () => {
+    // When regenerating a stale cache entry for a target route that is force-dynamic,
+    // the dispatch must resolve the target route's dynamic config so that fetch
+    // defaults come from the target route, not the current route.
+    const targetRoute = createRoute({
+      pattern: "/feed",
+      routeSegments: ["feed"],
+      layouts: [{ default: () => null, dynamic: "force-dynamic" }],
+    });
+    const currentRoute = createRoute({
+      params: ["id"],
+      pattern: "/photos/[id]",
+      routeSegments: ["photos", "[id]"],
+    });
+
+    let scheduledRender: unknown = null;
+    const scheduleBackgroundRegeneration: DispatchOptions["scheduleBackgroundRegeneration"] = (
+      _key,
+      renderFn,
+    ) => {
+      scheduledRender = renderFn;
+    };
+
+    const resolveRouteDynamicConfig = vi.fn((route: TestRoute) =>
+      route === targetRoute ? "force-dynamic" : undefined,
+    );
+
+    const buildPageElement = vi.fn(
+      async (
+        route: TestRoute,
+        params: Record<string, string | string[]>,
+        opts: Parameters<DispatchOptions["buildPageElement"]>[2],
+        searchParams: URLSearchParams,
+      ) =>
+        JSON.stringify({
+          params,
+          route: route.pattern,
+          search: searchParams.toString(),
+          slot: opts?.interceptSlotKey ?? "direct",
+        }),
+    );
+
+    const { options } = createDispatchOptions({
+      buildPageElement,
+      cleanPathname: "/photos/123",
+      findIntercept() {
+        return {
+          matchedParams: { id: "123" },
+          page: { default: "modal-page" },
+          slotKey: "modal@app/feed/@modal",
+          sourceRouteIndex: 1,
+        };
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return sourceRouteIndex === 1 ? targetRoute : undefined;
+      },
+      interceptionContext: "/feed",
+      isProduction: true,
+      isRscRequest: true,
+      isrGet: vi.fn(async () =>
+        buildISRCacheEntry(
+          buildCachedAppPageValue(
+            "",
+            new TextEncoder().encode("stale-flight").buffer,
+            undefined,
+            buildQueryInvariantRenderObservation(),
+          ),
+          true,
+        ),
+      ),
+      isrRscKey(pathname, mountedSlotsHeader, _renderMode, interceptionContext) {
+        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}:${interceptionContext ?? "none"}`;
+      },
+      loadSsrHandler: async () => ({
+        async handleSsr(_rscStream, _navigationContext, _fontData, captureOptions) {
+          if (captureOptions?.capturedRscDataRef) {
+            captureOptions.capturedRscDataRef.value = Promise.resolve(
+              new TextEncoder().encode("fresh-flight").buffer,
+            );
+          }
+          void captureOptions?.sideStream?.cancel().catch(() => {});
+          return createStream(["<html>fresh</html>"]);
+        },
+      }),
+      mountedSlotsHeader: "slot:modal:/feed",
+      revalidateSeconds: 60,
+      resolveRouteDynamicConfig,
+      route: currentRoute,
+      scheduleBackgroundRegeneration,
+      searchParams: new URLSearchParams("tab=popular"),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.headers.get("x-vinext-cache")).toBe("STALE");
+    expect(typeof scheduledRender).toBe("function");
+    if (typeof scheduledRender !== "function") {
+      throw new Error("expected stale response to schedule regeneration");
+    }
+
+    await scheduledRender();
+
+    expect(resolveRouteDynamicConfig).toHaveBeenCalledWith(targetRoute);
+    const [routeArg] = buildPageElement.mock.calls[0];
+    expect(routeArg).toBe(targetRoute);
+  });
+
+  it("does not leak the current route's force-dynamic config into the revalidation target route", async () => {
+    // When regenerating a stale cache entry for a target route that is NOT force-dynamic,
+    // the dispatch must resolve the target route's dynamic config so that fetch
+    // defaults do NOT leak from the current route into the target route.
+    const targetRoute = createRoute({
+      pattern: "/feed",
+      routeSegments: ["feed"],
+    });
+    const currentRoute = createRoute({
+      params: ["id"],
+      pattern: "/photos/[id]",
+      routeSegments: ["photos", "[id]"],
+      layouts: [{ default: () => null, dynamic: "force-dynamic" }],
+    });
+
+    const resolveRouteDynamicConfig = vi.fn((route: TestRoute) =>
+      route === currentRoute ? "force-dynamic" : undefined,
+    );
+
+    const buildPageElement = vi.fn(
+      async (
+        route: TestRoute,
+        params: Record<string, string | string[]>,
+        opts: Parameters<DispatchOptions["buildPageElement"]>[2],
+        searchParams: URLSearchParams,
+      ) =>
+        JSON.stringify({
+          params,
+          route: route.pattern,
+          search: searchParams.toString(),
+          slot: opts?.interceptSlotKey ?? "direct",
+        }),
+    );
+
+    const { options } = createDispatchOptions({
+      buildPageElement,
+      cleanPathname: "/photos/123",
+      dynamicConfig: "force-dynamic",
+      findIntercept() {
+        return {
+          matchedParams: { id: "123" },
+          page: { default: "modal-page" },
+          slotKey: "modal@app/feed/@modal",
+          sourceRouteIndex: 1,
+        };
+      },
+      getSourceRoute(sourceRouteIndex) {
+        return sourceRouteIndex === 1 ? targetRoute : undefined;
+      },
+      interceptionContext: "/feed",
+      isProduction: true,
+      isRscRequest: true,
+      isrGet: vi.fn(async () =>
+        buildISRCacheEntry(
+          buildCachedAppPageValue(
+            "",
+            new TextEncoder().encode("stale-flight").buffer,
+            undefined,
+            buildQueryInvariantRenderObservation(),
+          ),
+          true,
+        ),
+      ),
+      isrRscKey(pathname, mountedSlotsHeader, _renderMode, interceptionContext) {
+        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}:${interceptionContext ?? "none"}`;
+      },
+      loadSsrHandler: async () => ({
+        async handleSsr(_rscStream, _navigationContext, _fontData, captureOptions) {
+          if (captureOptions?.capturedRscDataRef) {
+            captureOptions.capturedRscDataRef.value = Promise.resolve(
+              new TextEncoder().encode("fresh-flight").buffer,
+            );
+          }
+          void captureOptions?.sideStream?.cancel().catch(() => {});
+          return createStream(["<html>fresh</html>"]);
+        },
+      }),
+      mountedSlotsHeader: "slot:modal:/feed",
+      revalidateSeconds: 60,
+      resolveRouteDynamicConfig,
+      route: currentRoute,
+      searchParams: new URLSearchParams("tab=popular"),
+    });
+
+    // A force-dynamic current route skips the cache read entirely, so there is no
+    // revalidation path. The intercept path is still exercised, and it must resolve
+    // the target route's dynamic config instead of inheriting the current route's.
+    const response = await dispatchAppPage(options);
+    expect(response.status).toBe(200);
+    expect(resolveRouteDynamicConfig).toHaveBeenCalledWith(targetRoute);
   });
 });

--- a/tests/app-route-handler-dispatch.test.ts
+++ b/tests/app-route-handler-dispatch.test.ts
@@ -316,4 +316,175 @@ describe("app route handler dispatch", () => {
       routeType: "route",
     });
   });
+
+  // Parity with upstream's app-route module: `dynamic = "force-dynamic"` sets
+  // `workStore.forceDynamic`, which patch-fetch turns into a no-store default
+  // for fetches without explicit cache config — for route handlers as well as
+  // pages.
+  it("applies the force-dynamic fetch default before invoking the route handler", async () => {
+    const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
+    const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
+
+    let forceDynamicDefaultAtHandlerTime: boolean | undefined;
+    let fetchCacheModeAtHandlerTime: unknown = "unset";
+
+    const response = await dispatchAppRouteHandler({
+      cleanPathname: "/api/force-dynamic",
+      clearRequestContext() {},
+      draftModeSecret: "test-draft-secret",
+      i18n: null,
+      isDevelopment: false,
+      isProduction: true,
+      async isrGet() {
+        throw new Error("force-dynamic handler should not read route cache");
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {
+        throw new Error("force-dynamic handler should not write route cache");
+      },
+      middlewareContext: { headers: null, status: null },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/force-dynamic"),
+      route: {
+        pattern: "/api/force-dynamic",
+        routeHandler: {
+          dynamic: "force-dynamic",
+          GET() {
+            forceDynamicDefaultAtHandlerTime = forceDynamicSpy.mock.calls.at(-1)?.[0];
+            fetchCacheModeAtHandlerTime = modeSpy.mock.calls.at(-1)?.[0];
+            return new Response("dynamic");
+          },
+        },
+        routeSegments: ["api", "force-dynamic"],
+      },
+      scheduleBackgroundRegeneration() {
+        throw new Error("force-dynamic handler should not schedule regeneration");
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(response.status).toBe(200);
+    expect(forceDynamicDefaultAtHandlerTime).toBe(true);
+    expect(fetchCacheModeAtHandlerTime).toBeNull();
+
+    modeSpy.mockRestore();
+    forceDynamicSpy.mockRestore();
+  });
+
+  it("applies the handler's explicit fetchCache export without the force-dynamic default", async () => {
+    const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
+    const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
+
+    let forceDynamicDefaultAtHandlerTime: boolean | undefined;
+    let fetchCacheModeAtHandlerTime: unknown = "unset";
+
+    const response = await dispatchAppRouteHandler({
+      cleanPathname: "/api/segment-fetch-cache",
+      clearRequestContext() {},
+      draftModeSecret: "test-draft-secret",
+      i18n: null,
+      isDevelopment: false,
+      isProduction: false,
+      async isrGet() {
+        return null;
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {},
+      middlewareContext: { headers: null, status: null },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/segment-fetch-cache"),
+      route: {
+        pattern: "/api/segment-fetch-cache",
+        routeHandler: {
+          fetchCache: "force-cache",
+          GET() {
+            forceDynamicDefaultAtHandlerTime = forceDynamicSpy.mock.calls.at(-1)?.[0];
+            fetchCacheModeAtHandlerTime = modeSpy.mock.calls.at(-1)?.[0];
+            return new Response("cached-fetches");
+          },
+        },
+        routeSegments: ["api", "segment-fetch-cache"],
+      },
+      scheduleBackgroundRegeneration() {
+        throw new Error("uncached handler should not schedule regeneration");
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(response.status).toBe(200);
+    expect(forceDynamicDefaultAtHandlerTime).toBe(false);
+    expect(fetchCacheModeAtHandlerTime).toBe("force-cache");
+
+    modeSpy.mockRestore();
+    forceDynamicSpy.mockRestore();
+  });
+
+  it("re-applies the handler's fetch cache mode inside the background regeneration context", async () => {
+    const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
+    const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
+
+    let scheduledRender: (() => Promise<void>) | undefined;
+    let forceDynamicDefaultAtRegenTime: boolean | undefined;
+    let fetchCacheModeAtRegenTime: unknown = "unset";
+
+    const response = await dispatchAppRouteHandler({
+      cleanPathname: "/api/stale-fetch-cache",
+      clearRequestContext() {},
+      draftModeSecret: "test-draft-secret",
+      i18n: null,
+      isDevelopment: false,
+      isProduction: true,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedRouteValue("stale"), true);
+      },
+      isrRouteKey(pathname) {
+        return "route:" + pathname;
+      },
+      async isrSet() {},
+      middlewareContext: { headers: null, status: null },
+      middlewareRequestHeaders: null,
+      params: {},
+      request: new Request("https://example.com/api/stale-fetch-cache"),
+      route: {
+        pattern: "/api/stale-fetch-cache",
+        routeHandler: {
+          fetchCache: "force-cache",
+          revalidate: 60,
+          GET() {
+            forceDynamicDefaultAtRegenTime = forceDynamicSpy.mock.calls.at(-1)?.[0];
+            fetchCacheModeAtRegenTime = modeSpy.mock.calls.at(-1)?.[0];
+            return new Response("regenerated");
+          },
+        },
+        routeSegments: ["api", "stale-fetch-cache"],
+      },
+      scheduleBackgroundRegeneration(_key, renderFn) {
+        scheduledRender = renderFn;
+      },
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(response.headers.get("x-vinext-cache")).toBe("STALE");
+    expect(typeof scheduledRender).toBe("function");
+    if (typeof scheduledRender !== "function") {
+      throw new Error("expected stale route handler cache to schedule regeneration");
+    }
+
+    await scheduledRender();
+
+    expect(forceDynamicDefaultAtRegenTime).toBe(false);
+    expect(fetchCacheModeAtRegenTime).toBe("force-cache");
+
+    modeSpy.mockRestore();
+    forceDynamicSpy.mockRestore();
+  });
 });

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { cookies, headers, setHeadersContext } from "../packages/vinext/src/shims/headers.js";
+import {
+  consumeDynamicUsage,
+  cookies,
+  headers,
+  markDynamicUsage,
+  setHeadersContext,
+} from "../packages/vinext/src/shims/headers.js";
 import { isKnownDynamicAppRoute } from "../packages/vinext/src/server/app-route-handler-runtime.js";
 import {
   executeAppRouteHandler,
   runAppRouteHandler,
 } from "../packages/vinext/src/server/app-route-handler-execution.js";
+
+// The fetch-cache shim captures `originalFetch` from globalThis at import
+// time, so stub fetch BEFORE importing it (same pattern as
+// tests/fetch-cache.test.ts). None of the static imports above pull
+// fetch-cache.js into the runtime module graph — its only reference there is
+// the type-only `FetchCacheState` re-export — so the stub is in place before
+// the capture happens.
+const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+  Response.json({ ok: true }),
+);
+vi.stubGlobal("fetch", fetchMock);
+const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
 
 function createDynamicUsageState(): {
   consumeDynamicUsage: () => boolean;
@@ -256,6 +274,90 @@ describe("app route handler execution helpers", () => {
     expect(response.headers.get("x-vinext-cache")).toBeNull();
     expect(wroteCache).toBe(false);
     await expect(response.json()).resolves.toEqual({ ping: "from-header" });
+  });
+
+  it("skips cache writes and marks the route dynamic when a revalidating handler fetches with no-store", async () => {
+    // Regression test for the patched fetch's explicit no-store branch
+    // calling markDynamicUsage() (upstream patch-fetch parity, where
+    // markCurrentScopeAsDynamic bails ISR for the surrounding scope): a route
+    // handler with `revalidate = 60` that performs
+    // `fetch(url, { cache: "no-store" })` must not write its ISR entry and
+    // must be marked known-dynamic. Uses the real headers-shim
+    // consumeDynamicUsage/markDynamicUsage pair — the same wiring as
+    // app-route-handler-dispatch — so the mark set by the fetch shim flows
+    // into `dynamicUsedInHandler`.
+    const routePattern = "/api/no-store-fetch-" + Date.now();
+    const waitUntilPromises: Promise<unknown>[] = [];
+    let wroteCache = false;
+    const restoreFetchCache = withFetchCache();
+
+    try {
+      // Clear any dynamic usage left over from earlier tests.
+      consumeDynamicUsage();
+
+      const response = await executeAppRouteHandler({
+        buildPageCacheTags(pathname, extraTags) {
+          return [pathname, ...extraTags];
+        },
+        cleanPathname: "/api/no-store-fetch",
+        clearRequestContext() {},
+        consumeDynamicUsage,
+        executionContext: {
+          waitUntil(promise) {
+            waitUntilPromises.push(promise);
+          },
+        },
+        getAndClearPendingCookies() {
+          return [];
+        },
+        getCollectedFetchTags() {
+          return [];
+        },
+        getDraftModeCookieHeader() {
+          return null;
+        },
+        handler: { dynamic: "auto" },
+        async handlerFn() {
+          const upstream = await fetch("https://api.example.com/live", {
+            cache: "no-store",
+          });
+          return Response.json(await upstream.json());
+        },
+        isAutoHead: false,
+        isProduction: true,
+        isrRouteKey(pathname) {
+          return "route:" + pathname;
+        },
+        async isrSet() {
+          wroteCache = true;
+        },
+        markDynamicUsage,
+        method: "GET",
+        middlewareContext: { headers: null, status: null },
+        params: {},
+        reportRequestError() {},
+        request: new Request("https://example.com/api/no-store-fetch"),
+        revalidateSeconds: 60,
+        routePattern,
+        setHeadersAccessPhase() {
+          return "render";
+        },
+      });
+
+      await Promise.all(waitUntilPromises);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.example.com/live");
+      expect(fetchMock.mock.calls[0]?.[1]?.cache).toBe("no-store");
+      expect(isKnownDynamicAppRoute(routePattern)).toBe(true);
+      expect(wroteCache).toBe(false);
+      expect(response.headers.get("cache-control")).toBeNull();
+      expect(response.headers.get("x-vinext-cache")).toBeNull();
+      await expect(response.json()).resolves.toEqual({ ok: true });
+    } finally {
+      consumeDynamicUsage();
+      restoreFetchCache();
+    }
   });
 
   it("maps special route handler errors and reports generic failures", async () => {

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -3,6 +3,7 @@ import {
   isEdgeRuntime,
   resolveAppPageFetchCacheMode,
   resolveAppPageSegmentConfig,
+  resolveAppRouteHandlerFetchCacheMode,
 } from "../packages/vinext/src/server/app-segment-config.js";
 
 describe("resolveAppPageSegmentConfig", () => {
@@ -283,6 +284,21 @@ describe("resolveAppPageSegmentConfig", () => {
     ).toBe("edge");
 
     expect(resolveAppPageSegmentConfig({ page: {} }).runtime).toBeUndefined();
+  });
+});
+
+describe("resolveAppRouteHandlerFetchCacheMode", () => {
+  it("returns the handler module's fetchCache export when valid", () => {
+    expect(resolveAppRouteHandlerFetchCacheMode({ fetchCache: "force-cache" })).toBe("force-cache");
+    expect(resolveAppRouteHandlerFetchCacheMode({ fetchCache: "default-no-store" })).toBe(
+      "default-no-store",
+    );
+  });
+
+  it("returns null for missing or invalid fetchCache values", () => {
+    expect(resolveAppRouteHandlerFetchCacheMode({})).toBeNull();
+    expect(resolveAppRouteHandlerFetchCacheMode({ fetchCache: "bogus" })).toBeNull();
+    expect(resolveAppRouteHandlerFetchCacheMode({ fetchCache: 42 })).toBeNull();
   });
 });
 

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -37,7 +37,6 @@ describe("resolveAppPageSegmentConfig", () => {
       }),
     ).toEqual({
       dynamicConfig: "force-dynamic",
-      fetchCache: "force-no-store",
       revalidateSeconds: 0,
     });
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1978,6 +1978,89 @@ describe("app server action execution helpers", () => {
     expect(response?.status).toBe(200);
     expect(response?.headers.get("x-edge-runtime")).toBe("1");
   });
+
+  it("resolves the redirect target route's dynamic config and fetch cache mode for force-dynamic fetch defaults", async () => {
+    const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
+    const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
+
+    const targetRoute: TestRoute = {
+      id: "redirect-target",
+      page: {},
+      params: [],
+      pattern: "/redirect-target",
+    };
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return { params: {}, route: targetRoute };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        resolveRouteFetchCacheMode(route) {
+          return route === targetRoute ? "force-cache" : null;
+        },
+        resolveRouteDynamicConfig(route) {
+          return route === targetRoute ? "force-dynamic" : null;
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(modeSpy).toHaveBeenCalledWith("force-cache");
+    expect(forceDynamicSpy).toHaveBeenCalledWith(true);
+
+    modeSpy.mockRestore();
+    forceDynamicSpy.mockRestore();
+  });
+
+  it("resolves the re-render target route's dynamic config and fetch cache mode for force-dynamic fetch defaults", async () => {
+    const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
+    const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
+
+    const targetRoute: TestRoute = {
+      id: "dashboard",
+      page: {},
+      params: [],
+      pattern: "/dashboard",
+    };
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(async () => {
+            await revalidatePath("/dashboard");
+            return "revalidated";
+          });
+        },
+        matchRoute() {
+          return { params: {}, route: targetRoute };
+        },
+        resolveRouteFetchCacheMode(route) {
+          return route === targetRoute ? "force-no-store" : null;
+        },
+        resolveRouteDynamicConfig(route) {
+          return route === targetRoute ? "force-dynamic" : null;
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(modeSpy).toHaveBeenCalledWith("force-no-store");
+    expect(forceDynamicSpy).toHaveBeenCalledWith(true);
+
+    modeSpy.mockRestore();
+    forceDynamicSpy.mockRestore();
+  });
 });
 
 // The client-side counterpart of `createServerActionNotFoundResponse`: when the

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3366,7 +3366,7 @@ describe("fetch cache (extended fetch with next options)", () => {
     }
   });
 
-  it("next.revalidate: false bypasses persistent cache but dedupes within a render", async () => {
+  it("next.revalidate: false caches indefinitely across render scopes", async () => {
     const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
     const { setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
@@ -3383,7 +3383,7 @@ describe("fetch cache (extended fetch with next options)", () => {
       cleanup();
       cleanup = withFetchCache();
       await fetch(`${mockServerUrl}/no-rev`, { next: { revalidate: false } });
-      expect(fetchCallCount).toBe(2);
+      expect(fetchCallCount).toBe(1); // Still cached across render scopes
     } finally {
       cleanup();
       setCacheHandler(new MemoryCacheHandler());

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -225,6 +225,36 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  // revalidate: 0 is an explicit opt-out — default-cache must not override it to force-cache
+  it("segment fetchCache default-cache does not override next.revalidate: 0", async () => {
+    setCurrentFetchCacheMode("default-cache");
+
+    await fetch("https://api.example.com/segment-default-cache-revalidate-zero", {
+      next: { revalidate: 0 },
+    });
+    // revalidate: 0 bypasses cache entirely (no persistent cache entry)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consumeDynamicUsage()).toBe(true);
+  });
+
+  // revalidate: false is an explicit opt-out — default-no-store must not override it
+  it("segment fetchCache default-no-store does not override next.revalidate: false", async () => {
+    setCurrentFetchCacheMode("default-no-store");
+
+    const res1 = await fetch("https://api.example.com/segment-default-no-store-revalidate-false", {
+      next: { revalidate: false },
+    });
+    const data1 = await res1.json();
+    // revalidate: false → cache indefinitely (1 year), so second fetch hits cache
+    const res2 = await fetch("https://api.example.com/segment-default-no-store-revalidate-false", {
+      next: { revalidate: false },
+    });
+    const data2 = await res2.json();
+    expect(data1.count).toBe(1);
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("segment fetchCache default-no-store bypasses cache with metadata-only next options", async () => {
     setCurrentFetchCacheMode("default-no-store");
 

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -1860,6 +1860,22 @@ describe("fetch cache shim", () => {
       expect(consumeDynamicUsage()).toBe(false);
     });
 
+    it("explicit no-store with auth headers marks the page dynamic instead of taking the auth bypass", async () => {
+      await fetch("https://api.example.com/nostore-auth-dynamic", {
+        cache: "no-store",
+        headers: { Authorization: "Bearer alice" },
+      });
+
+      // An explicit `no-store` is an explicit uncached-fetch decision, so it
+      // hits the no-store branch (full markDynamicUsage) before the softer
+      // auth-safety bypass: the page is fully marked dynamic, not merely
+      // downgraded via a dynamic fetch observation.
+      expect(peekDynamicFetchObservations()).toEqual([
+        "https://api.example.com/nostore-auth-dynamic",
+      ]);
+      expect(consumeDynamicUsage()).toBe(true);
+    });
+
     it("X-API-Key header is included in cache key", async () => {
       const res1 = await fetch("https://api.example.com/api-key", {
         headers: { "X-API-Key": "key-alice" },

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -354,6 +354,24 @@ describe("fetch cache shim", () => {
     expect(consumeDynamicUsage()).toBe(false);
   });
 
+  // Ported from Next.js: test/e2e/app-dir/force-dynamic-fetch-revalidate/force-dynamic-fetch-revalidate.test.ts
+  // Upstream noFetchConfigAndForceDynamic uses !currentFetchRevalidate (truthiness),
+  // so revalidate: false is treated as "no fetch revalidate config" and force-dynamic wins.
+  it("force-dynamic overrides next.revalidate: false to no-store (upstream parity)", async () => {
+    setCurrentForceDynamicFetchDefault(true);
+
+    await fetch("https://api.example.com/force-dynamic-revalidate-false", {
+      next: { revalidate: false },
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://api.example.com/force-dynamic-revalidate-false",
+      {
+        cache: "no-store",
+      },
+    );
+    expect(consumeDynamicUsage()).toBe(true);
+  });
+
   it("segment fetchCache only-cache rejects no-store fetches", async () => {
     setCurrentFetchCacheMode("only-cache");
 

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -455,6 +455,36 @@ describe("fetch cache shim", () => {
     );
   });
 
+  // Upstream noFetchConfigAndForceDynamic: tags alone are not cache config, so
+  // a tags-only fetch under force-dynamic still defaults to no-store. The tags
+  // are stripped with the rest of `next` and never registered for
+  // revalidation, so they must not re-enable caching.
+  it("force-dynamic defaults tags-only fetches to no-store without registering tags", async () => {
+    setCurrentForceDynamicFetchDefault(true);
+
+    const res1 = await fetch("https://api.example.com/force-dynamic-tags-only", {
+      next: { tags: ["force-dynamic-tags-only"] },
+    });
+    const data1 = await res1.json();
+    expect(data1.count).toBe(1);
+    expect(fetchMock).toHaveBeenLastCalledWith("https://api.example.com/force-dynamic-tags-only", {
+      cache: "no-store",
+    });
+    expect(getCollectedFetchTags()).toEqual([]);
+    expect(consumeDynamicUsage()).toBe(true);
+
+    // No persistent cache entry: a fresh render scope re-fetches.
+    startNewFetchCacheScope();
+    setCurrentForceDynamicFetchDefault(true);
+
+    const res2 = await fetch("https://api.example.com/force-dynamic-tags-only", {
+      next: { tags: ["force-dynamic-tags-only"] },
+    });
+    const data2 = await res2.json();
+    expect(data2.count).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("segment fetchCache only-cache rejects no-store fetches", async () => {
     setCurrentFetchCacheMode("only-cache");
 

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -38,6 +38,7 @@ const {
   runWithFetchCache,
   getCollectedFetchTags,
   setCurrentFetchCacheMode,
+  setCurrentForceDynamicFetchDefault,
   setCurrentFetchSoftTags,
   getOriginalFetch,
   _resetPendingRefetches,
@@ -46,6 +47,7 @@ const {
 } = await import("../packages/vinext/src/shims/fetch-cache.js");
 const { getCacheHandler, revalidatePath, revalidateTag, MemoryCacheHandler, setCacheHandler } =
   await import("../packages/vinext/src/shims/cache.js");
+const { consumeDynamicUsage } = await import("../packages/vinext/src/shims/headers.js");
 const { runWithExecutionContext } = await import("../packages/vinext/src/shims/request-context.js");
 const { createRequestContext, runWithRequestContext } =
   await import("../packages/vinext/src/shims/unified-request-context.js");
@@ -67,11 +69,13 @@ describe("fetch cache shim", () => {
     setCacheHandler(new MemoryCacheHandler());
     // Clear in-flight refetch dedup state
     _resetPendingRefetches();
+    consumeDynamicUsage();
     // Install the patched fetch
     cleanup = withFetchCache();
   });
 
   afterEach(() => {
+    consumeDynamicUsage();
     cleanup?.();
     cleanup = null;
   });
@@ -106,6 +110,20 @@ describe("fetch cache shim", () => {
     });
     const data2 = await res2.json();
     expect(data2.count).toBe(1); // Cached
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves Response.url on cached fetch responses", async () => {
+    const url = "https://api.example.com/force-url";
+
+    await fetch(url, {
+      cache: "force-cache",
+    });
+    const cached = await fetch(url, {
+      cache: "force-cache",
+    });
+
+    expect(cached.url).toBe(url);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -213,6 +231,89 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledWith("https://api.example.com/segment-force-no-store-init", {
       cache: "no-store",
     });
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+  // Upstream verifies that explicit uncached fetches in /default-cache and
+  // fetchCache = "force-no-store" make the page output non-reusable, while
+  // auto/default fetches can still participate in static prerender output.
+  it("marks page output dynamic for explicit uncached fetch decisions", async () => {
+    setCurrentFetchCacheMode("default-cache");
+
+    await fetch("https://api.example.com/segment-explicit-no-cache", {
+      cache: "no-cache",
+    });
+
+    expect(consumeDynamicUsage()).toBe(true);
+
+    setCurrentFetchCacheMode("force-no-store");
+
+    await fetch("https://api.example.com/segment-force-no-store-dynamic", {
+      cache: "force-cache",
+    });
+
+    expect(consumeDynamicUsage()).toBe(true);
+  });
+
+  it("does not mark page output dynamic for auto/default pass-through fetches", async () => {
+    await fetch("https://api.example.com/auto-pass-through");
+    await fetch("https://api.example.com/default-pass-through", {
+      cache: "default",
+    });
+
+    expect(consumeDynamicUsage()).toBe(false);
+    expect(peekDynamicFetchObservations()).toEqual([
+      "https://api.example.com/auto-pass-through",
+      "https://api.example.com/default-pass-through",
+    ]);
+  });
+
+  it("does not mark page output dynamic for fetchCache default-cache implicit cache hits", async () => {
+    setCurrentFetchCacheMode("default-cache");
+
+    const res1 = await fetch("https://api.example.com/segment-default-cache-static");
+    const data1 = await res1.json();
+    const res2 = await fetch("https://api.example.com/segment-default-cache-static");
+    const data2 = await res2.json();
+
+    expect(data1.count).toBe(1);
+    expect(data2.count).toBe(1);
+    expect(consumeDynamicUsage()).toBe(false);
+  });
+
+  it("uses force-dynamic as a default no-store fetch mode without overriding explicit revalidate", async () => {
+    setCurrentForceDynamicFetchDefault(true);
+
+    await fetch("https://api.example.com/force-dynamic-default");
+    expect(fetchMock).toHaveBeenLastCalledWith("https://api.example.com/force-dynamic-default", {
+      cache: "no-store",
+    });
+    expect(consumeDynamicUsage()).toBe(true);
+
+    await fetch("https://api.example.com/force-dynamic-cache-default", {
+      cache: "default",
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://api.example.com/force-dynamic-cache-default",
+      {
+        cache: "no-store",
+      },
+    );
+    expect(consumeDynamicUsage()).toBe(true);
+
+    const res1 = await fetch("https://api.example.com/force-dynamic-explicit-revalidate", {
+      next: { revalidate: 3 },
+    });
+    const data1 = await res1.json();
+    const res2 = await fetch("https://api.example.com/force-dynamic-explicit-revalidate", {
+      next: { revalidate: 3 },
+    });
+    const data2 = await res2.json();
+
+    expect(data1.count).toBe(3);
+    expect(data2.count).toBe(3);
+    expect(consumeDynamicUsage()).toBe(false);
   });
 
   it("segment fetchCache only-cache rejects no-store fetches", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -402,6 +402,35 @@ describe("fetch cache shim", () => {
     expect(consumeDynamicUsage()).toBe(true);
   });
 
+  // The force-dynamic fetch default only applies when the segment has no
+  // explicit fetchCache mode — an explicit `fetchCache = "default-cache"` /
+  // `"default-no-store"` takes precedence over the force-dynamic default.
+  it("explicit segment fetchCache takes precedence over force-dynamic fetch default", async () => {
+    setCurrentForceDynamicFetchDefault(true);
+    setCurrentFetchCacheMode("default-cache");
+
+    const res1 = await fetch("https://api.example.com/force-dynamic-segment-default-cache");
+    const data1 = await res1.json();
+    const res2 = await fetch("https://api.example.com/force-dynamic-segment-default-cache");
+    const data2 = await res2.json();
+
+    // default-cache promotes the fetch to force-cache despite force-dynamic
+    expect(data1.count).toBe(1);
+    expect(data2.count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consumeDynamicUsage()).toBe(false);
+
+    setCurrentFetchCacheMode("default-no-store");
+
+    await fetch("https://api.example.com/force-dynamic-segment-default-no-store");
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://api.example.com/force-dynamic-segment-default-no-store",
+      {
+        cache: "no-store",
+      },
+    );
+  });
+
   it("segment fetchCache only-cache rejects no-store fetches", async () => {
     setCurrentFetchCacheMode("only-cache");
 
@@ -1760,6 +1789,23 @@ describe("fetch cache shim", () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
+    it("auth-keyed safety bypass records a dynamic fetch observation without marking the page dynamic", async () => {
+      await fetch("https://api.example.com/auth-bypass-page-output", {
+        headers: { Authorization: "Bearer alice" },
+        next: { tags: ["user-data"] },
+      });
+
+      // The fetch itself is bypassed (not cached), but the per-user response
+      // must still downgrade the page output to fresh render so auth-keyed
+      // data is never statically cached and served across users.
+      expect(peekDynamicFetchObservations()).toEqual([
+        "https://api.example.com/auth-bypass-page-output",
+      ]);
+      // The safety bypass is automatic, not an explicit uncached-fetch
+      // decision, so the page is not marked dynamic.
+      expect(consumeDynamicUsage()).toBe(false);
+    });
+
     it("X-API-Key header is included in cache key", async () => {
       const res1 = await fetch("https://api.example.com/api-key", {
         headers: { "X-API-Key": "key-alice" },
@@ -2427,6 +2473,23 @@ describe("fetch cache shim", () => {
       const data2 = await res2.json();
       expect(data2.count).toBe(2); // bypassed cache because body is oversized
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("oversized body with explicit cache opt-in does not mark page output dynamic", async () => {
+      await fetch("https://api.example.com/large-body-page-output", {
+        method: "POST",
+        body: "x".repeat(1024 * 1024 + 1),
+        cache: "force-cache",
+      });
+
+      // The developer opted into caching; failing to build a cache key is an
+      // internal vinext limitation, not an explicit uncached-fetch decision.
+      // The observation downgrades the page output to fresh render, but the
+      // page is not marked dynamic.
+      expect(consumeDynamicUsage()).toBe(false);
+      expect(peekDynamicFetchObservations()).toContain(
+        "https://api.example.com/large-body-page-output",
+      );
     });
 
     it("oversized Request body bypasses cache without cloning the body when content-length exceeds the limit", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -165,7 +165,7 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to an empty Response.url when a cached entry lacks url", async () => {
+  it("falls back to the request URL when a cached entry lacks url", async () => {
     const url = "https://api.example.com/legacy-no-url";
 
     await fetch(url, {
@@ -185,7 +185,7 @@ describe("fetch cache shim", () => {
       cache: "force-cache",
     });
 
-    expect(cached.url).toBe("");
+    expect(cached.url).toBe(url);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -22,10 +22,17 @@ const defaultFetchMockImplementation = async (
   requestCount++;
   const url =
     typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-  return new Response(JSON.stringify({ url, count: requestCount }), {
+  const response = new Response(JSON.stringify({ url, count: requestCount }), {
     status: 200,
     headers: { "content-type": "application/json" },
   });
+  Object.defineProperty(response, "url", {
+    value: url,
+    configurable: true,
+    enumerable: true,
+    writable: false,
+  });
+  return response;
 };
 const fetchMock = vi.fn(defaultFetchMockImplementation);
 
@@ -124,6 +131,37 @@ describe("fetch cache shim", () => {
     });
 
     expect(cached.url).toBe(url);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves actual response URL when it differs from request URL", async () => {
+    const requestUrl = "https://api.example.com/redirect-request";
+    const responseUrl = "https://api.example.com/redirect-actual";
+
+    fetchMock.mockImplementationOnce(async () => {
+      requestCount++;
+      const response = new Response(JSON.stringify({ url: responseUrl, count: requestCount }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+      Object.defineProperty(response, "url", {
+        value: responseUrl,
+        configurable: true,
+        enumerable: true,
+        writable: false,
+      });
+      return response;
+    });
+
+    const res1 = await fetch(requestUrl, {
+      cache: "force-cache",
+    });
+    expect(res1.url).toBe(responseUrl);
+
+    const cached = await fetch(requestUrl, {
+      cache: "force-cache",
+    });
+    expect(cached.url).toBe(responseUrl);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -360,7 +398,7 @@ describe("fetch cache shim", () => {
     ).rejects.toThrow(/only-no-store/);
   });
 
-  // ── No caching (no-store, revalidate: 0, revalidate: false) ─────────
+  // ── No caching (no-store, revalidate: 0) ─────────────────────────────
   // Ported from Next.js: test coverage for packages/next/src/server/lib/dedupe-fetch.test.ts
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/dedupe-fetch.test.ts
 
@@ -414,7 +452,7 @@ describe("fetch cache shim", () => {
     expect(peekDynamicFetchObservations()).toEqual([]);
   });
 
-  it("next.revalidate: false bypasses persistent cache but dedupes identical render fetches", async () => {
+  it("next.revalidate: false caches indefinitely", async () => {
     const res1 = await fetch("https://api.example.com/revfalse", {
       next: { revalidate: false },
     });
@@ -425,8 +463,15 @@ describe("fetch cache shim", () => {
       next: { revalidate: false },
     });
     const data2 = await res2.json();
-    expect(data2.count).toBe(1); // Same render fetch is deduped
+    expect(data2.count).toBe(1); // Cached indefinitely
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("next.revalidate: false does not mark page output dynamic", async () => {
+    await fetch("https://api.example.com/revfalse-dynamic", {
+      next: { revalidate: false },
+    });
+    expect(consumeDynamicUsage()).toBe(false);
   });
 
   it("no cache or next options bypasses persistent cache but dedupes identical render fetches", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -165,6 +165,30 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to an empty Response.url when a cached entry lacks url", async () => {
+    const url = "https://api.example.com/legacy-no-url";
+
+    await fetch(url, {
+      cache: "force-cache",
+    });
+
+    // Simulate a legacy/third-party cache writer (e.g. an external KV backend)
+    // that never populated `data.url` on the serialized entry.
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    for (const [, entry] of store) {
+      delete entry.value.data.url;
+    }
+
+    startNewFetchCacheScope();
+    const cached = await fetch(url, {
+      cache: "force-cache",
+    });
+
+    expect(cached.url).toBe("");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("segment fetchCache default-cache caches fetches without per-fetch options", async () => {
     setCurrentFetchCacheMode("default-cache");
 

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -434,6 +434,16 @@ describe("fetch cache shim", () => {
     ).rejects.toThrow(/only-no-store/);
   });
 
+  it("segment fetchCache only-no-store rejects next.revalidate: false fetches", async () => {
+    setCurrentFetchCacheMode("only-no-store");
+
+    await expect(
+      fetch("https://api.example.com/segment-only-no-store-revalidate-false", {
+        next: { revalidate: false },
+      }),
+    ).rejects.toThrow(/only-no-store/);
+  });
+
   it("segment fetchCache only-no-store rejects cacheable Request inputs", async () => {
     setCurrentFetchCacheMode("only-no-store");
 


### PR DESCRIPTION
## Summary

- Mark explicit uncached fetch decisions as dynamic app-page output, so pages that opt out through `cache: "no-store"`, `cache: "no-cache"`, `next.revalidate: 0`, or `fetchCache = "force-no-store"` do not get reused as static output.
- Stop lowering `dynamic = "force-dynamic"` into `fetchCache = "force-no-store"`; instead track it as a per-request fetch default that only applies to fetches without explicit cache or revalidate config.
- Preserve `Response.url` when reconstructing cached fetch responses.
- Fix `force-dynamic` + `next.revalidate: false` to match upstream: force-dynamic wins over `revalidate: false` (no persistent cache), matching upstream `noFetchConfigAndForceDynamic` truthiness semantics.
- Split `hasExplicitRevalidateValue` into two predicates to correctly separate force-dynamic truthiness from segment cache default opt-outs.

## Force-dynamic / revalidate parity

Upstream `patch-fetch.ts` computes `noFetchConfigAndForceDynamic` using `!currentFetchRevalidate` (truthiness), so `revalidate: false` is treated as "no fetch revalidate config" and force-dynamic wins. The initial fix broadened `hasExplicitRevalidateValue` to exclude `false` and `0`, but this broke segment cache defaults (`default-cache` would override `revalidate: 0` to `force-cache`; `default-no-store` would override `revalidate: false` to `no-store`).

Final approach — two separate helpers:
- `isFalsyRevalidate()`: `false` and `0` are falsy → used by force-dynamic default path only
- `hasExplicitRevalidateValue()`: any defined value is explicit → used by segment defaults (`default-cache`, `default-no-store`)

## Upstream parity

This ports the relevant behavior from the upstream app-static deploy coverage:

- Next.js test file: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
- Next.js fetch implementation: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/patch-fetch.ts
- Route segment config docs: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#fetchcache
- Fetch caching docs: https://nextjs.org/docs/app/api-reference/functions/fetch

The important Next.js semantics are:

- explicit fetch cache opt-outs and `fetchCache = "force-no-store"` make the current app render dynamic,
- `dynamic = "force-dynamic"` defaults no-config fetches to no-store,
- explicit per-fetch `cache` or `next.revalidate` still wins over that force-dynamic default,
- `revalidate: false` is treated as falsy (no fetch revalidate config) for the force-dynamic default path,
- `revalidate: 0` and `revalidate: false` are both explicit opt-outs for segment cache defaults,
- cached fetch responses retain the original fetch response URL.

## Tests added

- `force-dynamic + next.revalidate: false` → `no-store` (upstream parity)
- `default-cache + next.revalidate: 0` → not overridden to `force-cache`, dynamic usage marked
- `default-no-store + next.revalidate: false` → not overridden to `no-store`, response cached indefinitely

## Verification

- `vp test run tests/fetch-cache.test.ts tests/app-segment-config.test.ts`
- `vp check` — format, lint, type checks clean
- Pre-commit hook passed `vp check --fix`, staged unit/integration tests, and knip.
- No merge conflicts with main.

## Remaining upstream gaps (out of scope)

- `should revalidate correctly with config and fetch revalidate`
- `should stream properly for /stale-cache-serving-edge/app-page`
- force-static and dynamic-error route status cases that currently return 404
- `should not error with generateStaticParams and dynamic data`
- lazy `dynamic = "force-static"` route status case
- useSearchParams server response suspense fallback
- draft-mode `unstable_cache` behavior
- updateTag/server-action paths