### PR TITLE
fix(e2e): use Playwright fixture pattern for inline-css server lifecycle

### DIFF
--- a/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
@@ -3,8 +3,7 @@ import type { Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { waitForServer } from "../../helpers";
-import { test, expect } from "../../fixtures";
+import { test as base, expect } from "../../fixtures";
 
 type ProductionApp = {
   baseUrl: string;
@@ -190,6 +189,22 @@ async function buildAndServeInlineCssFixture(): Promise<ProductionApp> {
   };
 }
 
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks -- Playwright fixture `use`, not a React hook */
+const test = base.extend<{ inlineCssApp: ProductionApp }>({
+  // oxlint-disable-next-line eslint/no-empty-pattern
+  inlineCssApp: async ({}, use) => {
+    const app = await buildAndServeInlineCssFixture();
+
+    try {
+      await use(app);
+    } finally {
+      await closeServer(app.server);
+      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+    }
+  },
+});
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
+
 test.setTimeout(90_000);
 
 test.describe("App Router experimental.inlineCss production parity", () => {
@@ -198,50 +213,45 @@ test.describe("App Router experimental.inlineCss production parity", () => {
   test("inlines CSS in HTML while keeping dynamic RSC navigations free of inline CSS bodies", async ({
     page,
     consoleErrors,
+    inlineCssApp,
   }) => {
-    const app = await buildAndServeInlineCssFixture();
+    await page.goto(`${inlineCssApp.baseUrl}/`, { waitUntil: "load" });
 
-    try {
-      await waitForServer(app.baseUrl);
-      await page.goto(`${app.baseUrl}/`, { waitUntil: "load" });
+    const inlineStyleText = await page
+      .locator("style")
+      .first()
+      .evaluate((style) => style.textContent ?? "");
+    expect(inlineStyleText).toContain("color");
+    expect(inlineStyleText).toContain("@font-face");
+    const fontUrl = inlineStyleText.match(/src:\s*url\(['"]?([^)'"]+)/)?.[1];
+    expect(fontUrl).toBeTruthy();
+    const fontResponse = await page.request.get(
+      new URL(fontUrl ?? "", inlineCssApp.baseUrl).toString(),
+    );
+    expect(fontResponse.status()).toBe(200);
+    expect(fontResponse.headers()["content-type"]).toContain("font");
+    await expect(page.locator("#home")).toHaveCSS("color", "rgb(255, 255, 0)");
 
-      const inlineStyleText = await page
-        .locator("style")
-        .first()
-        .evaluate((style) => style.textContent ?? "");
-      expect(inlineStyleText).toContain("color");
-      expect(inlineStyleText).toContain("@font-face");
-      const fontUrl = inlineStyleText.match(/src:\s*url\(['"]?([^)'"]+)/)?.[1];
-      expect(fontUrl).toBeTruthy();
-      const fontResponse = await page.request.get(new URL(fontUrl ?? "", app.baseUrl).toString());
-      expect(fontResponse.status()).toBe(200);
-      expect(fontResponse.headers()["content-type"]).toContain("font");
-      await expect(page.locator("#home")).toHaveCSS("color", "rgb(255, 255, 0)");
+    const rscPayload = await (
+      await page.request.get(`${inlineCssApp.baseUrl}/a?_rsc`, {
+        headers: {
+          rsc: "1",
+        },
+      })
+    ).text();
+    expect(rscPayload).toContain("__route");
+    expect(rscPayload).not.toContain("font-size");
 
-      const rscPayload = await (
-        await page.request.get(`${app.baseUrl}/a?_rsc`, {
-          headers: {
-            rsc: "1",
-          },
-        })
-      ).text();
-      expect(rscPayload).toContain("__route");
-      expect(rscPayload).not.toContain("font-size");
+    const htmlPayload = await (await page.request.get(`${inlineCssApp.baseUrl}/a?_rsc`)).text();
+    expect(htmlPayload).toContain("font-size");
 
-      const htmlPayload = await (await page.request.get(`${app.baseUrl}/a?_rsc`)).text();
-      expect(htmlPayload).toContain("font-size");
-
-      await page.locator("#link-b").click();
-      await expect(page.locator("#page-b")).toBeVisible();
-      await expect(page.locator("style")).toHaveCount(1);
-      const stylesheetLinks = await page
-        .locator('link[rel="stylesheet"]')
-        .evaluateAll((links) => links.map((link) => link.outerHTML));
-      expect(stylesheetLinks).toEqual([]);
-      expect(consoleErrors).toEqual([]);
-    } finally {
-      await closeServer(app.server);
-      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
-    }
+    await page.locator("#link-b").click();
+    await expect(page.locator("#page-b")).toBeVisible();
+    await expect(page.locator("style")).toHaveCount(1);
+    const stylesheetLinks = await page
+      .locator('link[rel="stylesheet"]')
+      .evaluateAll((links) => links.map((link) => link.outerHTML));
+    expect(stylesheetLinks).toEqual([]);
+    expect(consoleErrors).toEqual([]);
   });
 });

--- a/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { waitForServer } from "../../helpers";
 import { test, expect } from "../../fixtures";
 
 type ProductionApp = {
@@ -201,6 +202,7 @@ test.describe("App Router experimental.inlineCss production parity", () => {
     const app = await buildAndServeInlineCssFixture();
 
     try {
+      await waitForServer(app.baseUrl);
       await page.goto(`${app.baseUrl}/`, { waitUntil: "load" });
 
       const inlineStyleText = await page

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,36 +1,6 @@
 import type { Page, Request } from "@playwright/test";
 import { expect } from "@playwright/test";
 
-const SERVER_READY_TIMEOUT = 30_000;
-const SERVER_READY_POLL_INTERVAL = 300;
-const SERVER_READY_REQUEST_TIMEOUT = 2_000;
-
-/**
- * Poll the local server until it responds or the timeout is reached.
- * Used when a test manages its own server lifecycle outside of Playwright's
- * webServer config, which is the case for tests that build and serve a
- * temporary fixture inline.
- */
-export async function waitForServer(baseUrl: string): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < SERVER_READY_TIMEOUT) {
-    try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), SERVER_READY_REQUEST_TIMEOUT);
-      const response = await fetch(baseUrl, {
-        redirect: "manual",
-        signal: controller.signal,
-      });
-      clearTimeout(timer);
-      await response.text();
-      return;
-    } catch {
-      await new Promise<void>((r) => setTimeout(r, SERVER_READY_POLL_INTERVAL));
-    }
-  }
-  throw new Error(`Server at ${baseUrl} failed to start within ${SERVER_READY_TIMEOUT / 1000}s`);
-}
-
 export function isAppRouterRscRequestForPath(request: Request, pathname: string): boolean {
   const url = new URL(request.url());
   return (

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,6 +1,36 @@
 import type { Page, Request } from "@playwright/test";
 import { expect } from "@playwright/test";
 
+const SERVER_READY_TIMEOUT = 30_000;
+const SERVER_READY_POLL_INTERVAL = 300;
+const SERVER_READY_REQUEST_TIMEOUT = 2_000;
+
+/**
+ * Poll the local server until it responds or the timeout is reached.
+ * Used when a test manages its own server lifecycle outside of Playwright's
+ * webServer config, which is the case for tests that build and serve a
+ * temporary fixture inline.
+ */
+export async function waitForServer(baseUrl: string): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < SERVER_READY_TIMEOUT) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), SERVER_READY_REQUEST_TIMEOUT);
+      const response = await fetch(baseUrl, {
+        redirect: "manual",
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      await response.text();
+      return;
+    } catch {
+      await new Promise<void>((r) => setTimeout(r, SERVER_READY_POLL_INTERVAL));
+    }
+  }
+  throw new Error(`Server at ${baseUrl} failed to start within ${SERVER_READY_TIMEOUT / 1000}s`);
+}
+
 export function isAppRouterRscRequestForPath(request: Request, pathname: string): boolean {
   const url = new URL(request.url());
   return (


### PR DESCRIPTION
The inline-css browser test builds and serves a temporary fixture
inside the test body, managing its own server lifecycle. The previous
approach added a waitForServer polling utility in shared helpers.ts to
race against server readiness, but startProdServer already awaits the
server.listen() callback, making the polling redundant.

Replace with Playwright's fixture pattern (base.extend) — matching the
approach used in client-reference-runtime-map.browser.spec.ts. The
server lifecycle is now managed via a fixture that builds, starts, and
tears down the server, guaranteeing readiness before the test body runs
and cleanup in the finally block.

Fixes https://github.com/cloudflare/vinext/issues/1913