### PR TITLE
perf(server): hoist per-request regex compilation out of SSR streaming and shim hot paths

### DIFF
--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -162,6 +162,17 @@ const HTML_REWRITE_EXCLUDED_REGION_RE =
   /<!--[\s\S]*?-->|<(script|style|textarea|title)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
 const HTML_REWRITE_EXCLUDED_REGION_START_RE = /<!--|<(script|style|textarea|title)\b[^>]*>/gi;
 
+// Pre-compiled close-tag regexes for the four tags captured by
+// HTML_REWRITE_EXCLUDED_REGION_START_RE. `match[1]` is always one of these
+// four names (lowercased below), so the lookup always hits. `i`-only flags —
+// no `lastIndex` state — safe to share across concurrent requests/chunks.
+const CLOSE_TAG_RES: Record<string, RegExp> = {
+  script: /<\/script\s*>/i,
+  style: /<\/style\s*>/i,
+  textarea: /<\/textarea\s*>/i,
+  title: /<\/title\s*>/i,
+};
+
 function getHtmlAttribute(tag: string, name: string): string | null {
   const attrRe = /\s([^\s"'=<>`]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
   let match: RegExpExecArray | null;
@@ -234,7 +245,8 @@ function findTrailingOpenHtmlRewriteExcludedRegionStart(html: string): number | 
     const tagName = match[1]?.toLowerCase();
     if (!tagName) continue;
 
-    const closeTagRe = new RegExp(`</${tagName}\\s*>`, "i");
+    const closeTagRe = CLOSE_TAG_RES[tagName];
+    if (!closeTagRe) continue;
     const close = closeTagRe.exec(html.slice(HTML_REWRITE_EXCLUDED_REGION_START_RE.lastIndex));
     if (!close) return start;
     HTML_REWRITE_EXCLUDED_REGION_START_RE.lastIndex += close.index + close[0].length;

--- a/packages/vinext/src/server/normalize-path.ts
+++ b/packages/vinext/src/server/normalize-path.ts
@@ -6,9 +6,15 @@
  * Ported from Next.js: packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
  */
+// Pre-compiled variants — avoids recompiling per segment per request.
+// Sharing `g`-flagged regexes is safe here: String.prototype.replace always
+// starts from index 0 and resets lastIndex on completion.
+const PATH_DELIMITERS_RE = /([/#?])/gi;
+const PATH_DELIMITERS_ENCODED_RE = /([/#?]|%(2f|23|3f|5c))/gi;
+
 export function escapePathDelimiters(segment: string, escapeEncoded?: boolean): string {
   return segment.replace(
-    new RegExp(`([/#?]${escapeEncoded ? "|%(2f|23|3f|5c)" : ""})`, "gi"),
+    escapeEncoded ? PATH_DELIMITERS_ENCODED_RE : PATH_DELIMITERS_RE,
     (char: string) => encodeURIComponent(char),
   );
 }

--- a/packages/vinext/src/shims/head.ts
+++ b/packages/vinext/src/shims/head.ts
@@ -126,6 +126,14 @@ const SELF_CLOSING_HEAD_TAGS = new Set(["meta", "link", "base"]);
 /** Tags whose content is raw text — closing-tag sequences must be escaped during SSR. */
 const RAW_CONTENT_TAGS = new Set(["script", "style"]);
 
+// Pre-compiled regexes for escapeInlineContent — one per RAW_CONTENT_TAGS member.
+// The capture group preserves original casing in the replacement. `gi` flags,
+// no `lastIndex` hazard since they're only used via String.prototype.replace.
+const INLINE_CLOSE_TAG_RES: Record<string, RegExp> = {
+  script: /<\/(script)/gi,
+  style: /<\/(style)/gi,
+};
+
 type HeadDOMElement = Pick<HTMLElement, "innerHTML" | "setAttribute" | "textContent">;
 
 function warnDisallowedHeadTag(tag: string): void {
@@ -367,10 +375,8 @@ export function escapeAttr(s: string): string {
  * context but prevents the HTML parser from seeing a closing tag.
  */
 export function escapeInlineContent(content: string, tag: string): string {
-  // Build a pattern like `<\/script` or `<\/style`, case-insensitive.
-  // `tag` is always a literal developer-controlled value ("script" or "style")
-  // guarded by the RAW_CONTENT_TAGS.has(tag) check at all call sites — never user input.
-  const pattern = new RegExp(`<\\/(${tag})`, "gi");
+  const pattern = INLINE_CLOSE_TAG_RES[tag];
+  if (!pattern) return content;
   return content.replace(pattern, "<\\/$1");
 }
 

--- a/packages/vinext/src/shims/image-config.ts
+++ b/packages/vinext/src/shims/image-config.ts
@@ -22,6 +22,12 @@ export type RemotePattern = {
   search?: string;
 };
 
+// Cache compiled glob regexes — bounded by the number of distinct configured
+// remotePatterns. Key uses \0 as a separator; \0 cannot appear in a valid glob
+// or separator character, so there are no collisions. Compiled regexes are
+// flagless, so sharing via .test() is safe.
+const globRegexCache = new Map<string, RegExp>();
+
 /**
  * Convert a glob pattern (with `*` and `**`) to a RegExp.
  *
@@ -36,6 +42,9 @@ export type RemotePattern = {
  * Literal characters are escaped for regex safety.
  */
 function globToRegex(pattern: string, separator: "." | "/"): RegExp {
+  const key = `${separator}\0${pattern}`;
+  const cached = globRegexCache.get(key);
+  if (cached !== undefined) return cached;
   // Split by ** first, then handle * within each part
   let regexStr = "^";
   const doubleStar = separator === "." ? ".+" : ".*";
@@ -57,7 +66,9 @@ function globToRegex(pattern: string, separator: "." | "/"): RegExp {
     }
   }
   regexStr += "$";
-  return new RegExp(regexStr);
+  const re = new RegExp(regexStr);
+  globRegexCache.set(key, re);
+  return re;
 }
 
 /**


### PR DESCRIPTION
Closes #1910

Implements all three tasks from the issue as separate commits.

## Changes

### Commit 1 — `server/app-ssr-stream.ts`
Replace per-iteration `new RegExp(`</\\s*>`, "i")` in `findTrailingOpenHtmlRewriteExcludedRegionStart` with a module-level frozen lookup `CLOSE_TAG_RES`. This runs on every SSR streaming flush; a page with N Suspense boundaries previously compiled O(N) regexes per chunk.

### Commit 2 — `server/normalize-path.ts`
Hoist both variants of the pattern in `escapePathDelimiters` to module-level constants `PATH_DELIMITERS_RE` / `PATH_DELIMITERS_ENCODED_RE`. `decodePathParams` calls this once per path segment per request. Aligns with the already-hoisted `PATH_DELIMITER_REGEX` form in `routing/utils.ts`.

### Commit 3 — `shims/head.ts` + `shims/image-config.ts`
- **`escapeInlineContent`**: replace per-call `new RegExp(...)` with a 2-entry `INLINE_CLOSE_TAG_RES` map — runs once per inline `<script>`/`<style>` element per render.
- **`globToRegex`**: add `globRegexCache` so each distinct `(separator, pattern)` pair is compiled once. Mirrors Next.js's own `Map<string, RegExp>` memoization.

## Safety

- Shared `i`-only regexes (`CLOSE_TAG_RES`, `INLINE_CLOSE_TAG_RES`): no `lastIndex` state — safe across concurrent requests.
- Shared `g`-flagged regexes (`PATH_DELIMITERS_*`): only used via `String.prototype.replace`, which resets `lastIndex` — no `exec`/`test` loop.
- `globRegexCache` regexes are flagless; `.test()` is safe.

## Tests

All 1283 tests across the 8 listed test files pass unchanged — no expectation edits needed, matching behavior is identical by construction.

```
Test Files  8 passed (8)
      Tests  1283 passed (1283)
```

## Task checklist

- [x] Task 1: precompiled close-tag regexes in `app-ssr-stream.ts`
- [x] Task 2: hoisted delimiter regexes in `normalize-path.ts`
- [x] Task 3: constant/memoized regexes in `shims/head.ts` + `shims/image-config.ts`