### PR TITLE
test(next-config): make CJS config fixture deterministic on Windows

### DIFF
--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -71,7 +71,9 @@ describe("loadNextConfig with CJS next.config.js under type:module", () => {
     fs.writeFileSync(
       path.join(tmpDir, "next.config.js"),
       `const path = require('node:path');\n` +
-        `module.exports = { basePath: path.join('/', 'docs') };\n`,
+        // posix.join keeps the result "/docs" on Windows too — the point of
+        // this fixture is exercising require(), not platform join behavior.
+        `module.exports = { basePath: path.posix.join('/', 'docs') };\n`,
     );
 
     const config = await loadNextConfig(tmpDir);


### PR DESCRIPTION
## What

Makes the CJS `next.config.js` test fixture in `tests/next-config.test.ts` produce the same `basePath` on all platforms by using `path.posix.join` instead of `path.join`.

## Why

The fixture writes a config file containing `basePath: path.join('/', 'docs')`, and `loadNextConfig` executes that file for real. On Windows `path.join` returns `\docs`, so the test asserts `"\docs" === "/docs"` and fails. The test's purpose is to verify that a CJS config (`module.exports` + `require()`) loads in a `type: "module"` project — the `path.join` call is incidental, and `basePath` is a URL path that should never be platform-dependent anyway. `path.posix.join('/', 'docs')` yields `/docs` everywhere and still exercises `require('node:path')` inside the config, which is the point of the fixture.

No source change: `loadNextConfig` behaves correctly; only the fixture was platform-sensitive.

## Testing

`vp test run --project unit tests/next-config.test.ts` — the previously failing test now passes on Windows; no behavior change on POSIX (`path.posix.join('/', 'docs')` ≡ `path.join('/', 'docs')` there). `vp check` clean.