### PR TITLE
fix(prod-server): stop double-evaluating the server bundle when chunks import the entry back

### DIFF
--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -107,7 +107,12 @@ const bareServerEntryMtimes = new Map<string, number>();
  * A `?t=<mtime>` query string is appended only when the same path is
  * imported again after a rebuild (different mtime) — e.g. test suites that
  * rebuild a fixture to the same output path within one process — where the
- * bare URL's cache entry would return the stale previous build.
+ * bare URL's cache entry would return the stale previous build. Note this
+ * rebuild branch trades the single-instance guarantee back: chunks that
+ * import the entry by bare path still resolve to the FIRST build's cache
+ * entry, so freshness and single-instance only hold together on the first
+ * import of a path. Production processes import each entry path exactly
+ * once and always get both.
  *
  * The entry is imported via its canonical real path: the bundler
  * canonicalizes module ids with fs.realpathSync.native, so chunks evaluate
@@ -119,6 +124,9 @@ const bareServerEntryMtimes = new Map<string, number>();
  * Exported for direct unit testing of the URL choice.
  */
 export function resolveServerEntryImportUrl(entryPath: string): string {
+  // The catch only covers realpathSync.native failing on filesystems that
+  // don't support it; it does not make a missing entry path "work" — that
+  // still throws at the statSync below, same as before this helper existed.
   let canonicalEntryPath: string;
   try {
     canonicalEntryPath = fs.realpathSync.native(entryPath);

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -79,6 +79,67 @@ import {
   resolveRequestHost as resolveHost,
 } from "./proxy-trust.js";
 
+/**
+ * mtime of the build each bare (query-less) server-entry URL was first
+ * imported from in this process. Node's ESM cache pins a bare URL to that
+ * build forever, so rebuilds to the same path must be detected and loaded
+ * through a cache-busted URL instead.
+ */
+const bareServerEntryMtimes = new Map<string, number>();
+
+/**
+ * Import a built server entry module (App Router RSC entry or Pages Router
+ * server entry) by absolute file path.
+ *
+ * The first import of a given path uses the plain file:// URL with NO query
+ * string. This is load-bearing: code-split builds emit lazy chunks that
+ * import the entry back by bare specifier (default Vite builds on both
+ * supported majors — Rollup on Vite 7 and Rolldown on Vite 8 — hoist modules
+ * shared between the entry's static graph and lazy route chunks into the
+ * entry chunk, which the chunks then import as e.g. "../../index.js").
+ * Node keys its ESM cache on the full URL including the query string, so if
+ * the server imported the entry as `index.js?t=<mtime>`, a chunk's bare
+ * back-import would evaluate the entire server bundle a second time and
+ * module-level singletons (db pools, service registries) would silently
+ * diverge between the two copies. See
+ * https://github.com/cloudflare/vinext/issues/1923.
+ *
+ * A `?t=<mtime>` query string is appended only when the same path is
+ * imported again after a rebuild (different mtime) — e.g. test suites that
+ * rebuild a fixture to the same output path within one process — where the
+ * bare URL's cache entry would return the stale previous build.
+ *
+ * The entry is imported via its canonical real path: the bundler
+ * canonicalizes module ids with fs.realpathSync.native, so chunks evaluate
+ * under realpath-based URLs and their relative imports resolve to realpath
+ * URLs too. Importing the entry through a symlinked path (macOS /var/...
+ * tmpdirs, symlinked deploy directories) would otherwise create a second
+ * instance keyed on the symlinked URL.
+ *
+ * Exported for direct unit testing of the URL choice.
+ */
+export function resolveServerEntryImportUrl(entryPath: string): string {
+  let canonicalEntryPath: string;
+  try {
+    canonicalEntryPath = fs.realpathSync.native(entryPath);
+  } catch {
+    canonicalEntryPath = entryPath;
+  }
+  const href = pathToFileURL(canonicalEntryPath).href;
+  const mtime = fs.statSync(canonicalEntryPath).mtimeMs;
+  const bareMtime = bareServerEntryMtimes.get(href);
+  if (bareMtime === undefined || bareMtime === mtime) {
+    bareServerEntryMtimes.set(href, mtime);
+    return href;
+  }
+  return `${href}?t=${mtime}`;
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any -- built entry modules are untyped, matching the previous inline `await import(...)`
+export async function importServerEntryModule(entryPath: string): Promise<any> {
+  return import(resolveServerEntryImportUrl(entryPath));
+}
+
 /** Convert a Node.js IncomingMessage into a ReadableStream for Web Request body. */
 function readNodeStream(req: IncomingMessage): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -1069,12 +1130,11 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
   // Used to authenticate internal /__vinext/prerender/* HTTP endpoints.
   const prerenderSecret = readPrerenderSecret(path.dirname(rscEntryPath));
 
-  // Import the RSC handler (use file:// URL for reliable dynamic import).
-  // Cache-bust with mtime so that if this function is called multiple times
-  // (e.g. across test describe blocks that rebuild to the same path) Node's
-  // module cache does not return the stale module from a previous build.
-  const rscMtime = fs.statSync(rscEntryPath).mtimeMs;
-  const rscModule = await import(`${pathToFileURL(rscEntryPath).href}?t=${rscMtime}`);
+  // Import the RSC handler. importServerEntryModule uses the bare file://
+  // URL so lazy chunks that import the entry back resolve to the same module
+  // instance, and only cache-busts when this function runs again after a
+  // rebuild to the same path (e.g. across test describe blocks).
+  const rscModule = await importServerEntryModule(rscEntryPath);
   const rscHandler = resolveAppRouterHandler(rscModule.default);
 
   // `assetPrefix` is embedded as a compile-time constant in the generated
@@ -1371,11 +1431,11 @@ function readPagesServerEntryPageRoutes(value: unknown): PagesServerEntryPageRou
 async function startPagesRouterServer(options: PagesRouterServerOptions) {
   const { port, host, clientDir, serverEntryPath, compress, purpose } = options;
 
-  // Import the server entry module (use file:// URL for reliable dynamic import).
-  // Cache-bust with mtime so that rebuilds to the same output path always load
-  // the freshly built module rather than a stale cached copy.
-  const serverMtime = fs.statSync(serverEntryPath).mtimeMs;
-  const serverEntry = await import(`${pathToFileURL(serverEntryPath).href}?t=${serverMtime}`);
+  // Import the server entry module. importServerEntryModule uses the bare
+  // file:// URL so lazy chunks that import the entry back resolve to the same
+  // module instance, and only cache-busts when this function runs again after
+  // a rebuild to the same output path.
+  const serverEntry = await importServerEntryModule(serverEntryPath);
   const {
     renderPage,
     handleApiRoute: handleApi,

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1313,3 +1313,139 @@ describe("App Router Production server (startProdServer)", () => {
     expect(text).toContain("echo:world");
   });
 });
+
+describe("App Router production server entry module identity", () => {
+  // Regression test for cloudflare/vinext#1923.
+  //
+  // Chunks emitted by default Vite builds — Rollup on Vite 7 and Rolldown on
+  // Vite 8 — import the server entry back by its bare path: modules shared
+  // between the entry's static graph (middleware, instrumentation) and lazy
+  // route chunks are hoisted into the entry chunk, and the lazy chunks then
+  // import them via "../../index.js" (e.g. a plain `vite@8.0.16` SSR build
+  // of an entry-shared module emits `import { t as shared } from
+  // "../entry.js"` in the lazy chunk).
+  // Node keys its ESM cache on the full URL *including the query string*, so
+  // while the production server imported the entry as `index.js?t=<mtime>`,
+  // a chunk's bare back-import evaluated the entire server bundle a second
+  // time. Module-level singletons (db pools, service registries) then
+  // silently diverged between the two copies: boot-time initialisation ran
+  // on the server's instance while route handlers read the duplicate.
+  //
+  // The Vite+ toolchain this repo builds with enables rolldown's
+  // shared-chunk extraction, so this fixture build does not naturally emit
+  // the back-import. Recreate the default-Vite layout by prepending a bare
+  // entry import to the lazy route chunk before starting the server.
+  it("evaluates the server bundle once even when a chunk imports the entry back by bare path", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prod-entry-identity-"));
+    const fixtureRoot = path.join(tmpDir, "fixture");
+    const outDir = path.join(fixtureRoot, "dist");
+    let server: import("node:http").Server | undefined;
+    const EVAL_COUNT_KEY = "__vinext_test_entry_evaluations__";
+    const prodGlobalKeys = [
+      "__VINEXT_CLIENT_ENTRY__",
+      "__VINEXT_DYNAMIC_PRELOADS__",
+      "__VINEXT_LAZY_CHUNKS__",
+      "__VINEXT_SSR_MANIFEST__",
+      "__vite_rsc_client_require__",
+      "__vite_rsc_require__",
+      "__vite_rsc_server_require__",
+      "__webpack_chunk_load__",
+      "__webpack_require__",
+    ];
+    const previousGlobals = new Map(
+      prodGlobalKeys.map((key) => [
+        key,
+        {
+          exists: Reflect.has(globalThis, key),
+          value: Reflect.get(globalThis, key),
+        },
+      ]),
+    );
+
+    try {
+      fs.cpSync(APP_FIXTURE_DIR, fixtureRoot, { recursive: true });
+      fs.rmSync(outDir, { recursive: true, force: true });
+      const fixtureNodeModules = path.join(fixtureRoot, "node_modules");
+      if (!fs.existsSync(fixtureNodeModules)) {
+        fs.symlinkSync(
+          path.resolve(__dirname, "..", "node_modules"),
+          fixtureNodeModules,
+          "junction",
+        );
+      }
+
+      const builder = await createBuilder({
+        root: fixtureRoot,
+        configFile: false,
+        plugins: [vinext({ appDir: fixtureRoot })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const serverDir = path.join(outDir, "server");
+      const entryPath = path.join(serverDir, "index.js");
+
+      // Count evaluations of the server entry chunk itself. Imports hoist, so
+      // the prepended statement runs first in the entry's own body each time
+      // the module is evaluated.
+      fs.writeFileSync(
+        entryPath,
+        `globalThis.${EVAL_COUNT_KEY} = [...(globalThis.${EVAL_COUNT_KEY} ?? []), import.meta.url];\n` +
+          fs.readFileSync(entryPath, "utf-8"),
+      );
+
+      // Recreate the Rollup chunk layout: the lazy chunk for
+      // /api/prod-singleton imports the entry back by bare path.
+      const staticDir = path.join(serverDir, "_next", "static");
+      const routeChunkNames = fs
+        .readdirSync(staticDir)
+        .filter(
+          (name) =>
+            name.endsWith(".js") &&
+            fs
+              .readFileSync(path.join(staticDir, name), "utf-8")
+              .includes("x-vinext-prod-singleton"),
+        );
+      expect(routeChunkNames).toHaveLength(1);
+      const routeChunkPath = path.join(staticDir, routeChunkNames[0]);
+      fs.writeFileSync(
+        routeChunkPath,
+        `import "../../index.js";\n` + fs.readFileSync(routeChunkPath, "utf-8"),
+      );
+
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      ({ server } = await startProdServer({ port: 0, outDir, noCompression: true }));
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+
+      expect(Reflect.get(globalThis, EVAL_COUNT_KEY)).toHaveLength(1);
+
+      const res = await fetch(`http://localhost:${port}/api/prod-singleton`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-vinext-prod-singleton")).toBe("1");
+      const body = await res.json();
+
+      // Loading the lazy route chunk pulled in the bare "../../index.js"
+      // import; the server bundle must still have been evaluated only once.
+      // (The recorded values are the import.meta.url of each evaluation, so
+      // a failure shows which URLs the two module instances were keyed on.)
+      expect(Reflect.get(globalThis, EVAL_COUNT_KEY)).toHaveLength(1);
+
+      // The route handler reads the same module-level singleton instance
+      // that boot-time instrumentation register() initialised. A duplicate
+      // bundle instance would report null.
+      expect(body).toEqual({ initializedBy: "instrumentation-register" });
+    } finally {
+      server?.close();
+      Reflect.deleteProperty(globalThis, EVAL_COUNT_KEY);
+      for (const [key, previous] of previousGlobals) {
+        if (previous.exists) {
+          Reflect.set(globalThis, key, previous.value);
+        } else {
+          Reflect.deleteProperty(globalThis, key);
+        }
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 120000);
+});

--- a/tests/fixtures/app-basic/app/api/prod-singleton/route.ts
+++ b/tests/fixtures/app-basic/app/api/prod-singleton/route.ts
@@ -1,0 +1,21 @@
+/**
+ * API route exposing the module-level singleton probe for the
+ * production-server double-evaluation regression test.
+ *
+ * GET /api/prod-singleton
+ *   Returns { initializedBy }. With a healthy production server the bundle
+ *   is evaluated exactly once, so initializedBy reflects the instrumentation
+ *   register() write; a duplicate bundle instance reports null.
+ *
+ * The x-vinext-prod-singleton response header doubles as a marker literal so
+ * tests can locate this route's chunk inside the minified build output.
+ */
+
+import { NextResponse } from "next/server";
+import { getProdSingletonSnapshot } from "../../../prod-singleton-state";
+
+export async function GET() {
+  return NextResponse.json(getProdSingletonSnapshot(), {
+    headers: { "x-vinext-prod-singleton": "1" },
+  });
+}

--- a/tests/fixtures/app-basic/instrumentation.ts
+++ b/tests/fixtures/app-basic/instrumentation.ts
@@ -10,9 +10,16 @@
  */
 
 import { markRegisterCalled, recordRequestError } from "./instrumentation-state";
+import { initializeProdSingleton } from "./prod-singleton-state";
 
 export async function register(): Promise<void> {
   markRegisterCalled();
+  // Initialize the module-level singleton probe. register() runs once, on
+  // the module instance the server imported at boot — mirroring how real
+  // apps initialize db pools or service registries. If the production
+  // server ends up with a second copy of the server bundle (double
+  // evaluation), that copy never sees this write.
+  initializeProdSingleton("instrumentation-register");
 }
 
 export async function onRequestError(

--- a/tests/fixtures/app-basic/prod-singleton-state.ts
+++ b/tests/fixtures/app-basic/prod-singleton-state.ts
@@ -10,6 +10,14 @@
  * server ends up with two copies of the bundle, the copy serving route
  * handlers reads `initializedBy: null` here even though boot-time
  * initialization ran.
+ *
+ * The probe is only meaningful for a freshly built output path (the first
+ * build a process imports). After a rebuild to the SAME output path, the
+ * prod server intentionally cache-busts the entry while bare chunk imports
+ * still resolve to the first build (see resolveServerEntryImportUrl in
+ * prod-server.ts), so this module would report `initializedBy: null` by
+ * design. Tests using this probe must build into a fresh directory, as the
+ * entry-module-identity regression test does.
  */
 
 /** Module-level singleton state — intentionally NOT stored on globalThis. */

--- a/tests/fixtures/app-basic/prod-singleton-state.ts
+++ b/tests/fixtures/app-basic/prod-singleton-state.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-level singleton probe for the production-server double-evaluation
+ * regression test.
+ *
+ * Unlike instrumentation-state.ts (which deliberately stores its state on
+ * globalThis to survive multiple module instances), this module keeps its
+ * state at MODULE level on purpose: real apps hold db pools, repository
+ * registries, and config caches in module scope, and that only works when
+ * the production server evaluates the server bundle exactly once. If the
+ * server ends up with two copies of the bundle, the copy serving route
+ * handlers reads `initializedBy: null` here even though boot-time
+ * initialization ran.
+ */
+
+/** Module-level singleton state — intentionally NOT stored on globalThis. */
+export const prodSingleton: { initializedBy: string | null } = { initializedBy: null };
+
+/**
+ * Called from instrumentation.ts register(), which the production server
+ * invokes once on the module instance it imported at boot. A duplicate
+ * instance of the server bundle never sees this write.
+ */
+export function initializeProdSingleton(source: string): void {
+  if (prodSingleton.initializedBy === null) {
+    prodSingleton.initializedBy = source;
+  }
+}
+
+export function getProdSingletonSnapshot(): { initializedBy: string | null } {
+  return { initializedBy: prodSingleton.initializedBy };
+}

--- a/tests/prod-server-entry-import.test.ts
+++ b/tests/prod-server-entry-import.test.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  importServerEntryModule,
+  resolveServerEntryImportUrl,
+} from "../packages/vinext/src/server/prod-server.js";
+
+/**
+ * Unit tests for the production server's entry import helper.
+ *
+ * The helper must satisfy two requirements that used to conflict:
+ *
+ * 1. The first import of a built entry must use the bare (query-less)
+ *    canonical file:// URL, so emitted chunks that import the entry back by
+ *    bare specifier (Rollup-based Vite 7 builds) or via realpath-derived
+ *    URLs resolve to the SAME module instance. The previous unconditional
+ *    `?t=<mtime>` query created a second instance of the whole server bundle
+ *    and module-level singletons diverged.
+ *
+ * 2. Re-importing the same path after a rebuild (test suites rebuilding a
+ *    fixture to the same output path within one process) must still load the
+ *    fresh build, not Node's cached copy — the reason the `?t=` query
+ *    existed in the first place.
+ *
+ * The URL choice is asserted via resolveServerEntryImportUrl: Node's
+ * native ESM loader keys its cache on the full URL (query included), so the
+ * chosen URL fully determines the cache behavior. (The end-to-end module
+ * identity for the bare-URL case is additionally covered here and by the
+ * production-server integration test; the rebuild case cannot be asserted
+ * end-to-end under the Vitest module runner, which does not replicate
+ * Node's query-sensitive ESM cache for externalized files.)
+ */
+describe("server entry import URL resolution", () => {
+  const tmpDirs: string[] = [];
+
+  function makeTmpDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-entry-import-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    while (tmpDirs.length > 0) {
+      fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the bare canonical URL for the first import of a path", () => {
+    const dir = makeTmpDir();
+    const entryPath = path.join(dir, "entry.mjs");
+    fs.writeFileSync(entryPath, `export const state = {};\n`);
+
+    const url = resolveServerEntryImportUrl(entryPath);
+
+    expect(url).toBe(pathToFileURL(fs.realpathSync.native(entryPath)).href);
+    expect(url).not.toContain("?");
+  });
+
+  it("keeps the bare URL for repeated imports of an unchanged build", () => {
+    const dir = makeTmpDir();
+    const entryPath = path.join(dir, "entry.mjs");
+    fs.writeFileSync(entryPath, `export const state = {};\n`);
+
+    const first = resolveServerEntryImportUrl(entryPath);
+    const second = resolveServerEntryImportUrl(entryPath);
+
+    expect(second).toBe(first);
+    expect(second).not.toContain("?");
+  });
+
+  it("resolves symlinked paths to the same canonical bare URL", () => {
+    const dir = makeTmpDir();
+    const realDir = path.join(dir, "real");
+    const linkDir = path.join(dir, "link");
+    fs.mkdirSync(realDir);
+    fs.symlinkSync(realDir, linkDir, "junction");
+    const realEntryPath = path.join(realDir, "entry.mjs");
+    fs.writeFileSync(realEntryPath, `export const state = {};\n`);
+
+    const viaLink = resolveServerEntryImportUrl(path.join(linkDir, "entry.mjs"));
+    const viaReal = resolveServerEntryImportUrl(realEntryPath);
+
+    expect(viaLink).toBe(viaReal);
+    expect(viaLink).not.toContain("?");
+  });
+
+  it("cache-busts only when the same path is reimported after a rebuild", () => {
+    const dir = makeTmpDir();
+    const entryPath = path.join(dir, "entry.mjs");
+
+    fs.writeFileSync(entryPath, `export const state = { marker: "build-1" };\n`);
+    const firstBuildUrl = resolveServerEntryImportUrl(entryPath);
+    expect(firstBuildUrl).not.toContain("?");
+
+    // Rebuild to the same path with a guaranteed-different mtime.
+    fs.writeFileSync(entryPath, `export const state = { marker: "build-2" };\n`);
+    const bumped = new Date(Date.now() + 10_000);
+    fs.utimesSync(entryPath, bumped, bumped);
+    const rebuiltMtime = fs.statSync(entryPath).mtimeMs;
+
+    const secondBuildUrl = resolveServerEntryImportUrl(entryPath);
+    expect(secondBuildUrl).toBe(`${firstBuildUrl}?t=${rebuiltMtime}`);
+
+    // Importing again without another rebuild keeps the busted URL stable,
+    // so the rebuilt module instance is reused rather than re-evaluated or
+    // replaced by the original bare-URL cache entry.
+    const thirdImportUrl = resolveServerEntryImportUrl(entryPath);
+    expect(thirdImportUrl).toBe(secondBuildUrl);
+  });
+
+  it("shares the module instance with chunks that import the entry by bare specifier", async () => {
+    const dir = makeTmpDir();
+    const entryPath = path.join(dir, "entry.mjs");
+    const chunkPath = path.join(dir, "chunk.mjs");
+    fs.writeFileSync(entryPath, `export const state = { ready: false };\n`);
+    fs.writeFileSync(chunkPath, `export { state } from "./entry.mjs";\n`);
+
+    const entry = await importServerEntryModule(entryPath);
+    entry.state.ready = true;
+
+    // The chunk resolves "./entry.mjs" bare — exactly like a code-split
+    // server chunk importing the entry back. It must observe the same
+    // instance the server is using, not a second evaluation.
+    const chunk = await import(pathToFileURL(fs.realpathSync.native(chunkPath)).href);
+    expect(chunk.state).toBe(entry.state);
+    expect(chunk.state.ready).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #1923.

The prod server imported the built server entry as `index.js?t=<mtime>`. Node's ESM cache keys on the full URL including the query string, so any chunk that imports the entry back by its plain path evaluated the entire server bundle a second time. Default Vite builds on both supported majors emit exactly that layout whenever a module is shared between the entry's static graph (middleware, instrumentation) and a lazy route chunk — the shared module is hoisted into the entry chunk and the lazy chunk imports it back via `../../index.js`. Module-level singletons then exist twice: boot-time initialization runs in the copy the server imported, while route handlers can read the uninitialized duplicate. Symlinked output paths hit the same dual-instance problem through a different mismatch — chunk ids are canonicalized with `fs.realpathSync.native`, but the entry import used the caller-supplied path.

The `?t=` query exists for a documented reason (rebuilds to the same output path within one process — test suites, and `vinext build` imports the entry in-process for prerendering — must not get a stale module), so the fix keeps that while making the first import safe:

- Both routers now import the entry through `importServerEntryModule`, which uses the bare canonical (realpathed) `file://` URL on first import of a path, so chunk back-imports and realpath-derived resolution converge on one module instance.
- `?t=<mtime>` is appended only when the same path is imported again with a different mtime — an actual same-process rebuild.

### Tests

- Integration (`tests/app-router-production-server.test.ts`): builds the app-basic fixture, recreates the default-Vite chunk layout by prepending a bare `import "../../index.js"` to the lazy route chunk (the repo's own Vite+ toolchain enables rolldown's shared-chunk extraction, so fixture builds don't emit the back-import naturally — plain vite does), boots the prod server, and asserts the bundle is evaluated exactly once and a route handler observes the module-level singleton initialized by instrumentation `register()`. Fails on main with the entry evaluated twice; passes with the fix.
- Unit (`tests/prod-server-entry-import.test.ts`): pins the URL choice via `resolveServerEntryImportUrl` — bare canonical URL on first import, stable for unchanged builds, symlinked paths collapse to one canonical URL, and `?t=` appears only after a same-path rebuild. (Asserted at the URL level because the Vitest module runner doesn't replicate Node's query-sensitive ESM cache for externalized files.)
- New fixture probe (`tests/fixtures/app-basic/prod-singleton-state.ts` + `/api/prod-singleton` route): deliberately module-level state — unlike `instrumentation-state.ts`, which works around multiple module instances via `globalThis` — initialized from instrumentation `register()`, read back by the route handler.

`vp check` passes; the prod-server-related test files (`app-router-production-server`, `prod-server-logs`, `standalone-build`, `invalid-static-asset-404`, `asset-prefix`, `pages-i18n-prod`, `pages-router`, plus the new unit file — 407 tests) pass. Prerender behavior is unchanged: repeated imports of the same path with the same mtime resolve to the same cached instance, as before.
