### PR TITLE
test(og): pass POSIX-style ids to the og-font-patch transform fixture

### DIFF
--- a/tests/og-font-patch.test.ts
+++ b/tests/og-font-patch.test.ts
@@ -48,9 +48,9 @@ let fakeOgDistDir: string;
 
 beforeAll(async () => {
   tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "og-font-patch-test-"));
-  fakeOgDistDir = path.join(tmpDir, "node_modules/@vercel/og/dist");
+  fakeOgDistDir = path.posix.join(tmpDir, "node_modules/@vercel/og/dist");
   await fsp.mkdir(fakeOgDistDir, { recursive: true });
-  await fsp.writeFile(path.join(fakeOgDistDir, "resvg.wasm"), Buffer.from("fake-resvg-wasm"));
+  await fsp.writeFile(path.posix.join(fakeOgDistDir, "resvg.wasm"), Buffer.from("fake-resvg-wasm"));
 });
 
 afterAll(async () => {
@@ -91,7 +91,7 @@ describe("vinext:og-font-patch plugin", () => {
       const result = transform.call(
         plugin,
         fakeEdgeEntry(FAKE_YOGA_B64),
-        path.join(fakeOgDistDir, "index.edge.js"),
+        path.posix.join(fakeOgDistDir, "index.edge.js"),
       );
       if (!result) throw new Error("Expected transform to produce output, got null");
       code = result.code;
@@ -163,14 +163,18 @@ describe("vinext:og-font-patch plugin", () => {
   // conflicting with the shared transform above.
 
   it("writes yoga.wasm to disk at transform time", () => {
-    const writeDistDir = path.join(tmpDir, "write-test/node_modules/@vercel/og/dist");
+    const writeDistDir = path.posix.join(tmpDir, "write-test/node_modules/@vercel/og/dist");
     fs.mkdirSync(writeDistDir, { recursive: true });
 
     const plugin = createOgFontPatchPlugin();
     const transform = unwrapHook(plugin.transform);
-    transform.call(plugin, fakeEdgeEntry(FAKE_YOGA_B64), path.join(writeDistDir, "index.edge.js"));
+    transform.call(
+      plugin,
+      fakeEdgeEntry(FAKE_YOGA_B64),
+      path.posix.join(writeDistDir, "index.edge.js"),
+    );
 
-    const yogaPath = path.join(writeDistDir, "yoga.wasm");
+    const yogaPath = path.posix.join(writeDistDir, "yoga.wasm");
     expect(fs.existsSync(yogaPath)).toBe(true);
     expect(fs.readFileSync(yogaPath)).toEqual(Buffer.from(FAKE_YOGA_B64, "base64"));
   });


### PR DESCRIPTION
## What

Builds the `vinext:og-font-patch` test fixture paths in `tests/og-font-patch.test.ts` with `path.posix.join` instead of `path.join`, so the ids passed to the plugin's `transform` hook are slash-separated on Windows too.

## Why

The plugin guards with `id.includes("@vercel/og")`. On Windows the fixture id came out as `...node_modules\@vercel\og\dist\index.edge.js`, the substring never matched, and `transform` returned `null` — the shared `beforeAll` threw "Expected transform to produce output, got null" (taking down all 8 nested assertions) and "writes yoga.wasm to disk at transform time" failed because the transform never ran.

This is a fixture problem, not a plugin problem. In a real build `"@vercel/og"` is resolved by Vite's built-in resolver, which POSIX-normalizes the resolved id before it reaches any `transform` hook — the plugin can never see `@vercel\og` in production. The fixture has to uphold the same invariant and hand the plugin a slash-separated id, hence `path.posix.join`. No source change.

## Testing

`vp test run --project unit tests/og-font-patch.test.ts` — 12/12 pass on Windows (previously 2 failed + 8 skipped). On POSIX `path.posix.join` ≡ `path.join`, so nothing changes there. `vp check` clean.