### PR TITLE
refactor(dev-lockfile): normalize stale lock file path in error message

### DIFF
--- a/packages/vinext/src/server/dev-lockfile.ts
+++ b/packages/vinext/src/server/dev-lockfile.ts
@@ -26,6 +26,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { normalizePathSeparators } from "../utils/path.js";
 
 const LOCK_DIR_RELATIVE = path.join(".vinext", "dev");
 const LOCK_FILE_NAME = "lock.json";
@@ -149,7 +150,9 @@ export function formatAlreadyRunningError(opts: FormatErrorOptions): string {
     return [
       "Another vinext dev server appears to be running in this directory.",
       "",
-      `Stale lock file: ${path.relative(cwd, lockfilePath)}`,
+      // Normalized so the message reads the same on every platform — this
+      // output is meant to be parsed by AI agents and CLIs.
+      `Stale lock file: ${normalizePathSeparators(path.relative(cwd, lockfilePath))}`,
       "Remove it manually if no server is running, then re-run `vinext dev`.",
     ].join("\n");
   }


### PR DESCRIPTION
## What

Wraps the `path.relative(cwd, lockfilePath)` embedded in `formatAlreadyRunningError`'s stale-lockfile fallback message with `normalizePathSeparators`, so the message shows `.vinext/dev/lock.json` on every platform.

## Why

`path.relative` joins with the platform separator, so on Windows the message read `Stale lock file: .vinext\dev\lock.json` and the unit test asserting the POSIX form failed there. The module's stated purpose is producing output that AI agents and CLIs can parse (`formatAlreadyRunningError` mirrors Next.js' error layout for exactly this reason), so a platform-uniform path is preferable to native display — and forward slashes are accepted by PowerShell/cmd/Explorer, so the "remove it manually" instruction remains directly usable on Windows.

This is a `refactor`, not a `fix`: the `existing: undefined` branch is a defensive fallback that `tryAcquireLockfile` cannot reach today (documented inline), so no production-observable behavior changes. `normalizePathSeparators` is a no-op on POSIX.

## Testing

`vp test run --project unit tests/dev-lockfile.test.ts` — 22/22 pass on Windows (previously 1 failed: "falls back to a generic message when the lock file is corrupt"). POSIX output is byte-identical before and after. `vp check` clean. No test changes needed — the existing literal assertion `.vinext/dev/lock.json` now holds on all platforms.
