### PR TITLE
test(e2e): fix flaky inline-css spec by closing page before prod server

### DIFF
--- a/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
@@ -191,13 +191,16 @@ async function buildAndServeInlineCssFixture(): Promise<ProductionApp> {
 
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks -- Playwright fixture `use`, not a React hook */
 const test = base.extend<{ inlineCssApp: ProductionApp }>({
-  // oxlint-disable-next-line eslint/no-empty-pattern
-  inlineCssApp: async ({}, use) => {
+  inlineCssApp: async ({ page }, use) => {
     const app = await buildAndServeInlineCssFixture();
 
     try {
       await use(app);
     } finally {
+      // Close the page before the server: Link prefetches are scheduled via
+      // requestIdleCallback and can fire after the test body finishes, hitting
+      // a closed port and logging ERR_CONNECTION_REFUSED to the console.
+      await page.close();
       await closeServer(app.server);
       await fs.rm(app.fixtureRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

The `inline-css.browser.spec.ts` e2e flakes in CI with:

```
Error: Test failed due to 1 console error(s):
  1. Failed to load resource: net::ERR_CONNECTION_REFUSED
```

Seen on [this run](https://github.com/cloudflare/vinext/actions/runs/27383447642/job/80925268751?pr=1902) (PR #1902 was an innocent bystander — the spec is unchanged there).

## Root cause

The failure is thrown from the `consoleErrors` fixture teardown (`fixtures.ts:60`), not from the in-test `expect(consoleErrors).toEqual([])`, so the console error arrives **after** the test body finishes. The `inlineCssApp` fixture teardown closes its temp production server while the page is still open. `Link` prefetches are scheduled via `requestIdleCallback` (`packages/vinext/src/shims/link.tsx`), so a prefetch queued during the final navigation to `/b` can fire in that window, hit the now-closed port, and log `ERR_CONNECTION_REFUSED`.

## Fix

Close the page before closing the server in the fixture teardown, so no late request can target a dead port. The fixture now depends on `page` (which also drops the empty-pattern lint suppression).

## Verification

`vp exec playwright test tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts --repeat-each=5` under `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific`: 5/5 passed.