### PR TITLE
test(e2e): close page before temp prod server in remaining browser-specific specs

### DIFF
--- a/tests/e2e/app-router/nextjs-compat/client-reference-runtime-map.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-reference-runtime-map.browser.spec.ts
@@ -238,13 +238,17 @@ export default defineConfig({
 
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks -- Playwright fixture `use`, not a React hook */
 const test = base.extend<{ productionApp: ProductionApp }>({
-  // oxlint-disable-next-line eslint/no-empty-pattern
-  productionApp: async ({}, use) => {
+  productionApp: async ({ page }, use) => {
     const { fixtureRoot, server, app } = await buildAndServeProductionFixture();
 
     try {
       await use(app);
     } finally {
+      // Close the page before the server so requests scheduled after the test
+      // body (e.g. via requestIdleCallback) can't hit a closed port and log
+      // ERR_CONNECTION_REFUSED, which the consoleErrors fixture would turn
+      // into a flaky failure.
+      await page.close();
       await closeServer(server);
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
@@ -256,6 +256,9 @@ test.describe("Next.js compat: hash RSC requests in production", () => {
       // fixture middleware, which would have responded with HTTP 599.
       expect(middlewareLeakResponses).toEqual([]);
     } finally {
+      // Close the page before the server so late idle-scheduled Link
+      // prefetches can't hit a closed port.
+      await page.close();
       await closeServer(app.server);
       await fs.rm(app.fixtureRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
Follow-up to #1927, which fixed a flaky failure in `inline-css.browser.spec.ts`: the spec's temp production server was closed during teardown while the page was still open, so an idle-scheduled `Link` prefetch (`requestIdleCallback` in `packages/vinext/src/shims/link.tsx`) could hit the closed port and log `ERR_CONNECTION_REFUSED`, which the `consoleErrors` fixture turns into a test failure.

The two remaining specs that build and serve their own temp production app have the same teardown race:

- **`client-reference-runtime-map.browser.spec.ts`** — identical fixture shape to inline-css, including the `consoleErrors` fixture, so it can flake the exact same way.
- **`hash-rsc-requests.browser.spec.ts`** — closes the server in the test's `finally` while a page full of prefetching `Link`s is still open. It doesn't use the `consoleErrors` fixture so the symptom would differ, but the race is the same.

Both now close the page before closing the server, so no late request can target a dead port.

## Verification

`vp exec playwright test <both specs> --repeat-each=3` under `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific`: 6/6 passed, plus lint.