### PR TITLE
perf(server): eliminate redundant per-request parsing in the request pipeline

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -473,10 +473,10 @@ export function escapeHeaderSource(source: string): string {
  * Callers extract the relevant parts from the incoming Request.
  */
 export type RequestContext = {
-  headers: Headers;
-  cookies: Record<string, string>;
-  query: URLSearchParams;
-  host: string;
+  readonly headers: Headers;
+  readonly cookies: Record<string, string>;
+  readonly query: URLSearchParams;
+  readonly host: string;
 };
 
 /**
@@ -540,13 +540,26 @@ export function parseCookies(cookieHeader: string | null): Record<string, string
 
 /**
  * Build a RequestContext from a Web Request object.
+ *
+ * `cookies` and `query` are lazy memoized getters: they are consumed only by
+ * `has`/`missing` condition evaluation (`checkHasConditions` /
+ * `matchesRuleConditions`), and most apps configure no such conditions. The
+ * cookie split and `searchParams` access are therefore deferred until first
+ * read and computed at most once. Mirrors `headersContextFromRequest` in
+ * `shims/headers.ts`.
  */
 export function requestContextFromRequest(request: Request): RequestContext {
   const url = new URL(request.url);
+  let cookies: Record<string, string> | undefined;
+  let query: URLSearchParams | undefined;
   return {
     headers: request.headers,
-    cookies: parseCookies(request.headers.get("cookie")),
-    query: url.searchParams,
+    get cookies() {
+      return (cookies ??= parseCookies(request.headers.get("cookie")));
+    },
+    get query() {
+      return (query ??= url.searchParams);
+    },
     host: normalizeHost(request.headers.get("host"), url.hostname),
   };
 }

--- a/packages/vinext/src/server/metadata-route-response.ts
+++ b/packages/vinext/src/server/metadata-route-response.ts
@@ -129,9 +129,10 @@ function matchMetadataRoute(
   route: MetadataRuntimeRoute,
   cleanPathname: string,
   functions: MetadataRouteFunctions,
+  getUrlParts: () => string[],
 ): MatchedMetadataRoute | null {
   if (route.patternParts) {
-    const urlParts = cleanPathname.split("/").filter(Boolean);
+    const urlParts = getUrlParts();
     if (functions.hasGeneratedImageMetadata && urlParts.length > 0) {
       const params = matchMetadataRoutePattern(urlParts.slice(0, -1), route.patternParts);
       if (params) {
@@ -365,6 +366,12 @@ function serveStaticMetadataRoute(route: MetadataRuntimeRoute): Response {
 export async function handleMetadataRouteRequest(
   options: MetadataRouteRequestOptions,
 ): Promise<Response | null> {
+  // `cleanPathname` is invariant across the loop, so its split is computed
+  // lazily and memoized: only dynamic (`patternParts`) routes need it, and the
+  // common case of zero dynamic metadata routes never splits at all.
+  let urlParts: string[] | undefined;
+  const getUrlParts = () => (urlParts ??= options.cleanPathname.split("/").filter(Boolean));
+
   for (const route of options.metadataRoutes) {
     const functions = getMetadataRouteFunctions(route);
     if (route.type === "sitemap" && route.isDynamic) {
@@ -384,7 +391,7 @@ export async function handleMetadataRouteRequest(
       }
     }
 
-    const match = matchMetadataRoute(route, options.cleanPathname, functions);
+    const match = matchMetadataRoute(route, options.cleanPathname, functions, getUrlParts);
     if (!match) {
       continue;
     }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -314,11 +314,22 @@ function nodeHeadersToWebHeaders(headersRecord: IncomingMessage["headers"]): Hea
 
 const NO_BODY_RESPONSE_STATUSES = new Set([204, 205, 304]);
 
+// Constant header-name sets for `omitHeadersCaseInsensitive`. Hoisted to module
+// scope so the `.map().toLowerCase()` + `Set` allocation happens once at module
+// load instead of per response. All entries must be lowercase; the static-file
+// header constant is already `x-vinext-static-file`.
+const OMIT_BODY_HEADERS: ReadonlySet<string> = new Set(["content-length", "content-type"]);
+const OMIT_STATIC_RESPONSE_HEADERS: ReadonlySet<string> = new Set([
+  VINEXT_STATIC_FILE_HEADER,
+  "content-encoding",
+  "content-length",
+  "content-type",
+]);
+
 function omitHeadersCaseInsensitive(
   headersRecord: Record<string, string | string[]>,
-  names: readonly string[],
+  targets: ReadonlySet<string>,
 ): Record<string, string | string[]> {
-  const targets = new Set(names.map((name) => name.toLowerCase()));
   const filtered: Record<string, string | string[]> = {};
   for (const [key, value] of Object.entries(headersRecord)) {
     if (targets.has(key.toLowerCase())) continue;
@@ -410,10 +421,7 @@ function sendCompressed(
   const buf = typeof body === "string" ? Buffer.from(body) : body;
   const baseType = contentType.split(";")[0].trim();
   const encoding = compress ? negotiateEncoding(req) : null;
-  const headersWithoutBodyHeaders = omitHeadersCaseInsensitive(extraHeaders, [
-    "content-length",
-    "content-type",
-  ]);
+  const headersWithoutBodyHeaders = omitHeadersCaseInsensitive(extraHeaders, OMIT_BODY_HEADERS);
 
   const writeHead = (headers: Record<string, string | string[]>) => {
     if (statusText) {
@@ -1339,7 +1347,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
 
         const staticResponseHeaders = omitHeadersCaseInsensitive(
           mergeResponseHeaders({}, response),
-          [VINEXT_STATIC_FILE_HEADER, "content-encoding", "content-length", "content-type"],
+          OMIT_STATIC_RESPONSE_HEADERS,
         );
 
         const served = await tryServeStatic(


### PR DESCRIPTION
Closes #1911.

A few spots in the request pipeline redid parsing work on every request even when the result was never used, or was already computed earlier in the same request. All three changes preserve observable behavior — identical parse results, computed at most once, skipped when unused — and are landed as separate commits.

## Task 1 — lazy `cookies`/`query` in `requestContextFromRequest`

`cookies` and `query` are consumed exclusively by `has`/`missing` condition evaluation (`checkHasConditions` / `matchesRuleConditions`), and most apps configure no such conditions. They are now lazy memoized getters, so `parseCookies` (full `;`-split of the Cookie header) and `url.searchParams` run at most once and only when actually read. This mirrors the existing `headersContextFromRequest` pattern in `shims/headers.ts`.

The `RequestContext` type fields were tightened to `readonly` to lock in the read-only contract (verified: no call site reassigns, spreads, or otherwise mutates these fields). This also covers the middleware-matcher case for free — plain string matchers like `["/dashboard/:path*"]` never touch cookies or query.

## Task 2 — hoist pathname split out of the metadata route loop

`handleMetadataRouteRequest` runs on every App Router request and iterates all registered metadata routes; `matchMetadataRoute` re-split the invariant `cleanPathname` once per dynamic route, allocating O(routes) intermediate arrays per request. The split is now computed lazily once via a memoizing closure and shared across the loop — the common case of zero dynamic metadata routes never splits at all. The shared array is only read (`matchRoutePattern` takes `readonly string[]`; `.slice(0,-1)` allocates a copy), so reuse is safe.

## Task 3 — module-scope header sets in `prod-server.ts`

Both call sites of `omitHeadersCaseInsensitive` pass constant literal arrays, so the `.map(toLowerCase)` + `Set` allocation per response is avoidable. The two sets are now hoisted to module scope as `ReadonlySet<string>` (all entries already lowercase, including `x-vinext-static-file`), and the function takes them precomputed.

## Verification

- Targeted unit/integration tests pass (302 across the 10 issue-listed files: `pages-request-pipeline`, `app-rsc-handler`, `middleware-runtime`, `app-post-middleware-context`, `metadata-route-response`, `metadata-routes`, `app-router-metadata-routes`, `serve-static`, `precompress`, `static-file-cache`), plus `request-pipeline`, `app-rsc-response-finalizer`, `nextjs-compat/basepath`, `shims`.
- `vp check` (format, lint, typecheck) passes across the whole `packages/vinext/src`.
- No test expectations changed — each change is a strict reduction in work.