### PR TITLE
perf: cache fs probes and precompute route sort keys in scan/deploy paths

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -227,14 +227,36 @@ export function detectProject(root: string): ProjectInfo {
       .replace(/^-|-$/g, "");
   }
 
-  // Detect ISR usage (rough heuristic: search for `revalidate` exports)
-  const hasISR = detectISR(root, isAppRouter);
-
   // Detect "type": "module" in package.json
   const hasTypeModule = pkg?.type === "module";
 
-  // Detect MDX usage
-  const hasMDX = detectMDX(root, isAppRouter, hasPages);
+  // Detect ISR (`export const revalidate`) and MDX usage. Both scan the same
+  // app/ tree, so they share a single recursive walk per directory instead of
+  // walking it twice. ISR is App-Router-only (Pages Router ISR isn't detected
+  // here — see note below); MDX may also be declared in next.config.
+  let hasISR = false;
+  let hasMDX = detectMDXFromConfig(root);
+
+  if (isAppRouter) {
+    // ISR detection is only implemented for App Router (scans for
+    // `export const revalidate`). Pages Router ISR (getStaticProps + revalidate)
+    // is not detected here — wrangler.jsonc will not include the KV namespace
+    // binding for Pages Router projects even if they use ISR. This is a known
+    // gap; KV must be configured manually for Pages Router ISR.
+    const appDir = resolveProjectDir(root, "app");
+    if (appDir) {
+      const found = scanTreeForDetection(appDir, { isr: true, mdx: !hasMDX });
+      hasISR = found.isr;
+      hasMDX = hasMDX || found.mdx;
+    }
+  }
+
+  if (hasPages && !hasMDX) {
+    const pagesDir = resolveProjectDir(root, "pages");
+    if (pagesDir) {
+      hasMDX = scanTreeForDetection(pagesDir, { isr: false, mdx: true }).mdx;
+    }
+  }
 
   // Detect CodeHike dependency
   const allDeps = {
@@ -243,8 +265,9 @@ export function detectProject(root: string): ProjectInfo {
   };
   const hasCodeHike = "codehike" in allDeps;
 
-  // Detect native Node modules that need stubbing for Workers
-  const nativeModulesToStub = detectNativeModules(root);
+  // Detect native Node modules that need stubbing for Workers. Reuses the
+  // already-merged dependency map instead of re-reading/re-parsing package.json.
+  const nativeModulesToStub = detectNativeModules(allDeps);
 
   return {
     root,
@@ -265,50 +288,85 @@ export function detectProject(root: string): ProjectInfo {
   };
 }
 
-function detectISR(root: string, isAppRouter: boolean): boolean {
-  // ISR detection is only implemented for App Router (scans for `export const revalidate`).
-  // Pages Router ISR (getStaticProps + revalidate) is not detected here — wrangler.jsonc
-  // will not include the KV namespace binding for Pages Router projects even if they use ISR.
-  // This is a known gap; KV must be configured manually for Pages Router ISR.
-  if (!isAppRouter) return false;
-  try {
-    // Check root-level app/ first, then fall back to src/app/
-    let appDir = path.join(root, "app");
-    if (!fs.existsSync(appDir)) {
-      appDir = path.join(root, "src", "app");
-    }
-    if (!fs.existsSync(appDir)) return false;
-    // Quick check: search .ts/.tsx files in app/ for `export const revalidate`
-    return scanDirForPattern(appDir, /export\s+const\s+revalidate\s*=/);
-  } catch {
-    return false;
-  }
-}
+/** Matches `export const revalidate = …` (ISR opt-in) in App Router source. */
+const ISR_REVALIDATE_PATTERN = /export\s+const\s+revalidate\s*=/;
 
-function scanDirForPattern(dir: string, pattern: RegExp): boolean {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
-      if (scanDirForPattern(fullPath, pattern)) return true;
-    } else if (entry.isFile() && /\.(ts|tsx|js|jsx)$/.test(entry.name)) {
-      try {
-        const content = fs.readFileSync(fullPath, "utf-8");
-        if (pattern.test(content)) return true;
-      } catch {
-        // skip unreadable files
-      }
-    }
-  }
-  return false;
+/** Source extensions whose contents are scanned for the ISR pattern. */
+const ISR_SCANNABLE_EXTENSION = /\.(ts|tsx|js|jsx)$/;
+
+/**
+ * Resolve a project subdirectory (`app`/`pages`), preferring the root-level
+ * location and falling back to the `src/` variant. Returns null when neither
+ * exists.
+ */
+function resolveProjectDir(root: string, name: string): string | null {
+  const rootDir = path.join(root, name);
+  if (fs.existsSync(rootDir)) return rootDir;
+  const srcDir = path.join(root, "src", name);
+  if (fs.existsSync(srcDir)) return srcDir;
+  return null;
 }
 
 /**
- * Detect .mdx files in the project's app/ or pages/ directory,
- * or `pageExtensions` including "mdx" in next.config.
+ * Recursively walk `dir` once, evaluating the requested detection predicates
+ * per entry. Each flag short-circuits independently: an `.mdx` file sets `mdx`;
+ * a scannable source file containing `export const revalidate` sets `isr`. The
+ * walk stops as soon as every requested flag is satisfied, so callers that only
+ * want one signal don't pay for the other.
+ *
+ * Replaces the previous pair of single-purpose recursive walkers
+ * (`scanDirForPattern` + `scanDirForExtension`) that traversed the same tree
+ * twice. Detection semantics are unchanged: same dirs skipped (dotfiles,
+ * node_modules), same extension and content tests.
  */
-function detectMDX(root: string, isAppRouter: boolean, hasPages: boolean): boolean {
-  // Check next.config for pageExtensions with mdx
+function scanTreeForDetection(
+  dir: string,
+  want: { isr: boolean; mdx: boolean },
+): { isr: boolean; mdx: boolean } {
+  const found = { isr: false, mdx: false };
+
+  const walk = (current: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      // Stop early once every requested flag is satisfied.
+      if ((!want.isr || found.isr) && (!want.mdx || found.mdx)) return;
+
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        if (want.mdx && !found.mdx && entry.name.endsWith(".mdx")) {
+          found.mdx = true;
+        }
+        if (want.isr && !found.isr && ISR_SCANNABLE_EXTENSION.test(entry.name)) {
+          try {
+            if (ISR_REVALIDATE_PATTERN.test(fs.readFileSync(fullPath, "utf-8"))) {
+              found.isr = true;
+            }
+          } catch {
+            // skip unreadable files
+          }
+        }
+      }
+    }
+  };
+
+  walk(dir);
+  return found;
+}
+
+/**
+ * Detect MDX usage declared in next.config (`pageExtensions` including "mdx" or
+ * an `@next/mdx` import). Filesystem `.mdx` detection is handled separately by
+ * the shared app/pages tree walk in `detectProject`.
+ */
+function detectMDXFromConfig(root: string): boolean {
   // Mirror the Next.js-compatible set in shims/constants.ts. We accept
   // `.cjs` and `.cts` defensively in case a user has them — Next.js itself
   // does not, but `findNextConfigPath` will only return the first match in
@@ -331,39 +389,6 @@ function detectMDX(root: string, isAppRouter: boolean, hasPages: boolean): boole
       }
     }
   }
-
-  // Check for .mdx files in app/ or pages/ (with src/ fallback)
-  const dirs: string[] = [];
-  if (isAppRouter) {
-    const appDir = fs.existsSync(path.join(root, "app"))
-      ? path.join(root, "app")
-      : path.join(root, "src", "app");
-    dirs.push(appDir);
-  }
-  if (hasPages) {
-    const pagesDir = fs.existsSync(path.join(root, "pages"))
-      ? path.join(root, "pages")
-      : path.join(root, "src", "pages");
-    dirs.push(pagesDir);
-  }
-
-  for (const dir of dirs) {
-    if (fs.existsSync(dir) && scanDirForExtension(dir, ".mdx")) return true;
-  }
-
-  return false;
-}
-
-function scanDirForExtension(dir: string, ext: string): boolean {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules") {
-      if (scanDirForExtension(fullPath, ext)) return true;
-    } else if (entry.isFile() && entry.name.endsWith(ext)) {
-      return true;
-    }
-  }
   return false;
 }
 
@@ -377,19 +402,12 @@ const NATIVE_MODULES_TO_STUB = [
 ];
 
 /**
- * Detect native Node modules in dependencies that need stubbing for Workers.
+ * Detect native Node modules in the project's merged dependency map that need
+ * stubbing for Workers. Accepts the already-built `allDeps` (dependencies +
+ * devDependencies) so package.json is not re-read or re-parsed.
  */
-function detectNativeModules(root: string): string[] {
-  const pkgPath = path.join(root, "package.json");
-  if (!fs.existsSync(pkgPath)) return [];
-
-  try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
-    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
-    return NATIVE_MODULES_TO_STUB.filter((mod) => mod in allDeps);
-  } catch {
-    return [];
-  }
+function detectNativeModules(allDeps: Record<string, unknown>): string[] {
+  return NATIVE_MODULES_TO_STUB.filter((mod) => mod in allDeps);
 }
 
 // ─── Project Preparation (pre-build transforms) ─────────────────────────────

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -110,7 +110,7 @@ const appLoader = undefined;
 // Object.keys(pageLoaders), exposed separately so navigateClient() can iterate
 // it without re-keying the map. Ordering is the insertion order of pageRoutes,
 // which pagesRouter() has already sorted by specificity (static → dynamic →
-// catch-all → optional catch-all) via compareRoutes — so matchPagesPattern()
+// catch-all → optional catch-all) via sortRoutes — so matchPagesPattern()
 // can iterate in order and trust the first match.
 window.__VINEXT_PAGE_LOADERS__ = pageLoaders;
 window.__VINEXT_PAGE_PATTERNS__ = Object.keys(pageLoaders);

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import { createHash } from "node:crypto";
-import { compareRoutes, decodeRouteSegment, isInvisibleSegment } from "./utils.js";
+import { decodeRouteSegment, isInvisibleSegment, sortRoutes } from "./utils.js";
 import { findFileWithExts, scanWithExtensions, type ValidFileMatcher } from "./file-matcher.js";
 import { validateRoutePatterns } from "./route-validation.js";
 import { compareStrings } from "../utils/compare.js";
@@ -958,7 +958,7 @@ export async function buildAppRouteGraph(
   validateRoutePatterns(interceptTargetPatterns);
 
   // Sort: static routes first, then dynamic, then catch-all
-  routes.sort(compareRoutes);
+  sortRoutes(routes);
 
   return { routes, routeManifest: createRouteManifest(routes) };
 }

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -883,6 +883,16 @@ export async function buildAppRouteGraph(
   // See https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/interception-routes.ts
   const routes: AppRouteGraphRoute[] = [];
 
+  // Per-scan matcher clone used as the cache key for `findFileProbeCache` (and,
+  // transitively, the slot-subpage cache). Cloning gives every scan a fresh
+  // key, so the convention-file probe memo is scoped to exactly this
+  // `buildAppRouteGraph` call: it captures the heavy cross-route re-probing of
+  // shared ancestor directories, then becomes unreachable when the scan returns.
+  // The clone carries the same extensions/regexes/methods, so probe and scan
+  // results are identical to using `matcher` directly.
+  const scanMatcher: ValidFileMatcher = { ...matcher };
+  findFileProbeCache.set(scanMatcher, new Map());
+
   const excludeDir = (name: string) =>
     (name.startsWith("@") && name !== "@children") ||
     name.startsWith("_") ||
@@ -890,14 +900,24 @@ export async function buildAppRouteGraph(
 
   // Process page files in a single pass
   // Use function form of exclude for Node < 22.14 compatibility (string arrays require >= 22.14)
-  for await (const file of scanWithExtensions("**/page", appDir, matcher.extensions, excludeDir)) {
-    const route = fileToAppRoute(file, appDir, "page", matcher);
+  for await (const file of scanWithExtensions(
+    "**/page",
+    appDir,
+    scanMatcher.extensions,
+    excludeDir,
+  )) {
+    const route = fileToAppRoute(file, appDir, "page", scanMatcher);
     if (route) routes.push(route);
   }
 
   // Process route handler files (API routes) in a single pass
-  for await (const file of scanWithExtensions("**/route", appDir, matcher.extensions, excludeDir)) {
-    const route = fileToAppRoute(file, appDir, "route", matcher);
+  for await (const file of scanWithExtensions(
+    "**/route",
+    appDir,
+    scanMatcher.extensions,
+    excludeDir,
+  )) {
+    const route = fileToAppRoute(file, appDir, "route", scanMatcher);
     if (route) routes.push(route);
   }
 
@@ -914,15 +934,15 @@ export async function buildAppRouteGraph(
   for await (const file of scanWithExtensions(
     "**/layout",
     appDir,
-    matcher.extensions,
+    scanMatcher.extensions,
     excludeDir,
   )) {
     const dir = path.dirname(file);
     const routeDir = dir === "." ? appDir : path.join(appDir, dir);
     if (!hasParallelSlotDirectory(routeDir)) continue;
-    if (discoverParallelSlots(routeDir, appDir, matcher).length === 0) continue;
+    if (discoverParallelSlots(routeDir, appDir, scanMatcher).length === 0) continue;
 
-    const route = directoryToAppRoute(dir, appDir, matcher, null, null);
+    const route = directoryToAppRoute(dir, appDir, scanMatcher, null, null);
     if (!route) continue;
     if (routePatterns.has(route.pattern)) {
       ghostParentRoutes.push(route);
@@ -937,11 +957,11 @@ export async function buildAppRouteGraph(
   // In Next.js, pages nested inside @slot directories create additional URL routes.
   // For example, @audience/demographics/page.tsx at app/parallel-routes/ creates
   // a route at /parallel-routes/demographics.
-  const slotSubRoutes = discoverSlotSubRoutes(routes, matcher, ghostParentRoutes);
+  const slotSubRoutes = discoverSlotSubRoutes(routes, scanMatcher, ghostParentRoutes);
   routes.push(...slotSubRoutes);
 
   // Discover sibling-style interception markers (markers not inside an @slot directory).
-  discoverSiblingInterceptingRoutes(routes, appDir, matcher);
+  discoverSiblingInterceptingRoutes(routes, appDir, scanMatcher);
 
   validatePageRouteConflicts(routes, appDir);
   validateRoutePatterns(routes.map((route) => route.pattern));
@@ -1261,14 +1281,14 @@ function discoverSlotSubRoutes(
  */
 type SlotSubPageEntry = { relativePath: string; pagePath: string };
 
-// Per-build memo: a slot directory's sub-pages depend only on the directory
+// Per-scan memo: a slot directory's sub-pages depend only on the directory
 // contents and the matcher's accepted extensions. Inherited slots get scanned
 // once per descendant route, so without memoization a route N segments deep
 // pays O(N) full subtree walks for every shared ancestor slot.
 //
-// Keyed by matcher (one matcher per build) so the cache is naturally scoped
-// to a single build run and gets collected when the build finishes — no
-// cross-build pollution in long-lived dev servers.
+// Keyed by the per-scan matcher clone that `buildAppRouteGraph` registers, so
+// the cache is naturally scoped to a single scan and gets collected when the
+// scan finishes — no cross-scan pollution in long-lived dev servers.
 const findSlotSubPagesCache = new WeakMap<ValidFileMatcher, Map<string, SlotSubPageEntry[]>>();
 
 function findSlotSubPages(slotDir: string, matcher: ValidFileMatcher): SlotSubPageEntry[] {
@@ -2558,10 +2578,43 @@ function markerForInterceptionConvention(convention: string): string {
 }
 
 /**
- * Find a file by name (without extension) in a directory.
- * Checks configured pageExtensions.
+ * Scan-scoped cache of convention-file probes, keyed by the per-scan matcher
+ * created in `buildAppRouteGraph`. A single scan walks the appDir→leaf chain
+ * separately for every route (layouts, templates, errors, boundaries, slots),
+ * so shared ancestor directories — the `app/` root above all — get re-probed
+ * once per descendant route. The probe result is deterministic within one scan
+ * (the filesystem does not change mid-build), so memoizing it removes the
+ * dominant cross-route redundancy.
+ *
+ * Keyed by matcher so the cache lifetime is exactly one `buildAppRouteGraph`
+ * call: the scan registers a fresh matcher clone, and the entry is unreachable
+ * (and GC-eligible) once the scan returns. A fresh key per scan is also what
+ * makes this concurrency-safe — overlapping builds never share probe state.
  */
-const findFile = findFileWithExts;
+const findFileProbeCache = new WeakMap<ValidFileMatcher, Map<string, string | null>>();
+
+/**
+ * Find a file by name (without extension) in a directory, checking configured
+ * pageExtensions. Memoizes through `findFileProbeCache` when the matcher has a
+ * registered per-scan cache; otherwise falls back to a direct probe (identical
+ * result). The `null` "not found" outcome is cached too, so repeated misses on
+ * shared ancestors cost a single set of `existsSync` calls per scan.
+ */
+function findFile(dir: string, name: string, matcher: ValidFileMatcher): string | null {
+  const cache = findFileProbeCache.get(matcher);
+  if (!cache) return findFileWithExts(dir, name, matcher);
+
+  const key = `${dir}\0${name}`;
+  // `findFileWithExts` returns `string | null`, so a stored miss reads back as
+  // `null` (not `undefined`). Only a genuinely absent key yields `undefined`,
+  // which is what distinguishes a cache miss from a cached not-found result.
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const result = findFileWithExts(dir, name, matcher);
+  cache.set(key, result);
+  return result;
+}
 
 /**
  * Convert filesystem path segments to URL route parts, skipping invisible segments

--- a/packages/vinext/src/routing/pages-router.ts
+++ b/packages/vinext/src/routing/pages-router.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { compareRoutes, decodeRouteSegment } from "./utils.js";
+import { decodeRouteSegment, sortRoutes } from "./utils.js";
 import {
   createValidFileMatcher,
   scanWithExtensions,
@@ -88,7 +88,7 @@ async function scanPageRoutes(pagesDir: string, matcher: ValidFileMatcher): Prom
   validateRoutePatterns(routes.map((route) => route.pattern));
 
   // Sort: static routes first, then dynamic, then catch-all
-  routes.sort(compareRoutes);
+  sortRoutes(routes);
 
   return routes;
 }
@@ -240,7 +240,7 @@ async function scanApiRoutes(pagesDir: string, matcher: ValidFileMatcher): Promi
   validateRoutePatterns(routes.map((route) => route.pattern));
 
   // Sort same as page routes
-  routes.sort(compareRoutes);
+  sortRoutes(routes);
 
   return routes;
 }

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -72,14 +72,29 @@ function routePrecedence(pattern: string): number {
 }
 
 /**
- * Sort comparator for routes — lower precedence score sorts first (higher priority).
- * Lexicographic tiebreaker on pattern for determinism.
+ * Sort routes by precedence — lower score sorts first (higher priority), with a
+ * lexicographic tiebreaker on the pattern for determinism. Sorts in place and
+ * returns the same array (mirrors `Array.prototype.sort`).
  *
- * Usage: routes.sort(compareRoutes)
+ * `routePrecedence` is a pure function of the pattern, so each pattern's score
+ * is computed exactly once up front (decorate-sort) instead of ~2·log n times
+ * by a comparator that re-parses on every comparison. The `localeCompare`
+ * tiebreaker already guarantees a total order, so the result is byte-identical
+ * to comparing precedence inline.
+ *
+ * Usage: sortRoutes(routes)
  */
-export function compareRoutes<T extends { pattern: string }>(a: T, b: T): number {
-  const diff = routePrecedence(a.pattern) - routePrecedence(b.pattern);
-  return diff !== 0 ? diff : a.pattern.localeCompare(b.pattern);
+export function sortRoutes<T extends { pattern: string }>(routes: T[]): T[] {
+  const scores = new Map<string, number>();
+  for (const route of routes) {
+    if (!scores.has(route.pattern)) {
+      scores.set(route.pattern, routePrecedence(route.pattern));
+    }
+  }
+  return routes.sort((a, b) => {
+    const diff = (scores.get(a.pattern) ?? 0) - (scores.get(b.pattern) ?? 0);
+    return diff !== 0 ? diff : a.pattern.localeCompare(b.pattern);
+  });
 }
 
 // Matches literal delimiter characters and their percent-encoded equivalents.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -413,7 +413,7 @@ export function createSSRHandler(
   const matcher = fileMatcher ?? createValidFileMatcher();
 
   // Page route patterns in Next.js bracket format, sorted by specificity
-  // (compareRoutes via pagesRouter). Mirrors the production client entry's
+  // (sortRoutes via pagesRouter). Mirrors the production client entry's
   // `window.__VINEXT_PAGE_PATTERNS__ = Object.keys(pageLoaders)` so the
   // `next/navigation` compat hooks (resolvePagesRoutePatternForPath in
   // shims/router.ts) can resolve a dynamic pattern from a resolved path in

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -635,7 +635,7 @@ function findRouteManifestRouteByMatchedUrl(
 ): RouteManifestRoute | null {
   const urlParts = splitMatchedUrlIntoRouteParts(matchedUrl);
 
-  // RouteManifest preserves buildAppRouteGraph's compareRoutes() order, so the
+  // RouteManifest preserves buildAppRouteGraph's sortRoutes() order, so the
   // first pattern match follows the same static/dynamic/catch-all precedence as
   // request-time route matching instead of raw filesystem scan order.
   for (const route of routeManifest.segmentGraph.routes.values()) {

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -152,6 +152,44 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  // Guards the scan-scoped fs-probe cache (issue #1912): sibling routes share
+  // ancestor layouts/boundaries, and a missing root-level convention (the
+  // not-found probe at app/) is memoized as `null`. Every route must still
+  // resolve the same shared ancestor files and the same nearest boundary —
+  // proving the cache returns identical results, including the null-miss path.
+  it("resolves shared ancestors and nearest boundaries for sibling routes (probe cache)", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "dashboard/layout.tsx", EMPTY_LAYOUT);
+      // not-found lives at the shared dashboard ancestor; app/not-found is absent
+      // (its probe is memoized as null and must stay null for every descendant).
+      await writeAppFile(appDir, "dashboard/not-found.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/reports/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/reports/details/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/settings/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+
+      const sharedLayouts = [
+        path.join(appDir, "layout.tsx"),
+        path.join(appDir, "dashboard/layout.tsx"),
+      ];
+      const nearestNotFound = path.join(appDir, "dashboard/not-found.tsx");
+
+      for (const pattern of [
+        "/dashboard/reports",
+        "/dashboard/reports/details",
+        "/dashboard/settings",
+      ]) {
+        const route = findRoute(graph.routes, pattern);
+        // Shared ancestor layouts resolve identically for every sibling.
+        expect(route.layouts).toEqual(sharedLayouts);
+        // Nearest not-found walks up to the shared dashboard boundary.
+        expect(route.notFoundPath).toBe(nearestNotFound);
+      }
+    });
+  });
+
   it("materializes synthetic routes from nested parallel slot pages", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1924,11 +1924,38 @@ describe("detectProject — new detection features", () => {
     expect(info.nativeModulesToStub).toContain("satori");
   });
 
+  it("detects native modules listed only in devDependencies", () => {
+    mkdir(tmpDir, "app");
+    writeFile(
+      tmpDir,
+      "package.json",
+      JSON.stringify({ devDependencies: { sharp: "^0.33.0", lightningcss: "^1.0.0" } }),
+    );
+    const info = detectProject(tmpDir);
+    expect(info.nativeModulesToStub).toContain("sharp");
+    expect(info.nativeModulesToStub).toContain("lightningcss");
+  });
+
   it("nativeModulesToStub is empty when no native deps", () => {
     mkdir(tmpDir, "app");
     writeFile(tmpDir, "package.json", JSON.stringify({ dependencies: { react: "^19.0.0" } }));
     const info = detectProject(tmpDir);
     expect(info.nativeModulesToStub).toEqual([]);
+  });
+
+  it("detects ISR and MDX from a single app/ tree walk", () => {
+    // ISR (`export const revalidate`) and a `.mdx` file live in the same tree;
+    // detection shares one recursive walk and reports both.
+    mkdir(tmpDir, "app");
+    writeFile(
+      tmpDir,
+      "app/posts/page.tsx",
+      "export const revalidate = 60;\nexport default function() { return <div/> }",
+    );
+    writeFile(tmpDir, "app/about/page.mdx", "# About");
+    const info = detectProject(tmpDir);
+    expect(info.hasISR).toBe(true);
+    expect(info.hasMDX).toBe(true);
   });
 });
 

--- a/tests/route-sorting.test.ts
+++ b/tests/route-sorting.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../packages/vinext/src/routing/pages-router.js";
 import { appRouter, invalidateAppRouteCache } from "../packages/vinext/src/routing/app-router.js";
 import { validateRoutePatterns } from "../packages/vinext/src/routing/route-validation.js";
+import { sortRoutes } from "../packages/vinext/src/routing/utils.js";
 
 const PAGES_DIR = path.resolve(import.meta.dirname, "./fixtures/pages-basic/pages");
 const APP_DIR = path.resolve(import.meta.dirname, "./fixtures/app-basic/app");
@@ -678,5 +679,76 @@ describe("Pages Router API routes", () => {
       const firstDynamicIdx = routes.indexOf(dynamicRoutes[0]);
       expect(lastStaticIdx).toBeLessThan(firstDynamicIdx);
     }
+  });
+});
+
+// ─── sortRoutes (precomputed precedence) ────────────────────────────────
+
+describe("sortRoutes", () => {
+  const order = (patterns: string[]): string[] =>
+    sortRoutes(patterns.map((pattern) => ({ pattern }))).map((r) => r.pattern);
+
+  it("orders static → dynamic → catch-all → optional catch-all", () => {
+    expect(order(["/:slug*", "/:id+", "/:id", "/about"])).toEqual([
+      "/about",
+      "/:id",
+      "/:id+",
+      "/:slug*",
+    ]);
+  });
+
+  it("prefers a static prefix over a bare dynamic segment at the same depth", () => {
+    // /_sites/:subdomain must sort before /:subdomain (static-prefix reduction).
+    expect(order(["/:subdomain", "/_sites/:subdomain"])).toEqual([
+      "/_sites/:subdomain",
+      "/:subdomain",
+    ]);
+  });
+
+  it("breaks ties lexicographically for a deterministic total order", () => {
+    expect(order(["/zebra", "/apple", "/mango"])).toEqual(["/apple", "/mango", "/zebra"]);
+  });
+
+  it("sorts in place and returns the same array reference", () => {
+    const routes = [{ pattern: "/:id" }, { pattern: "/about" }];
+    const result = sortRoutes(routes);
+    expect(result).toBe(routes);
+    expect(result.map((r) => r.pattern)).toEqual(["/about", "/:id"]);
+  });
+
+  it("is idempotent — sorting an already-sorted array is a no-op", () => {
+    const patterns = ["/about", "/blog/:slug", "/:id", "/:rest+", "/:rest*"];
+    const once = order(patterns);
+    expect(order(once)).toEqual(once);
+  });
+
+  it("produces the same order as comparing precedence inline (decorate-sort parity)", () => {
+    // Shuffled input must still land in the documented precedence order. This
+    // is the property the decorate-sort optimization preserves byte-for-byte.
+    // Scores: "/"=0, "/about"=0, "/blog/:slug"=51, "/:id"=100,
+    // "/blog/:year/:month/:slug"=256, "/:rest+"=1000, "/:rest*"=2000.
+    const patterns = [
+      "/blog/:year/:month/:slug",
+      "/:rest*",
+      "/about",
+      "/blog/:slug",
+      "/:rest+",
+      "/",
+      "/:id",
+    ];
+    expect(order(patterns)).toEqual([
+      "/",
+      "/about",
+      "/blog/:slug",
+      "/:id",
+      "/blog/:year/:month/:slug",
+      "/:rest+",
+      "/:rest*",
+    ]);
+  });
+
+  it("handles empty and single-element arrays", () => {
+    expect(order([])).toEqual([]);
+    expect(order(["/only"])).toEqual(["/only"]);
   });
 });


### PR DESCRIPTION
Closes #1912.

The route scanners and the deploy analyzer repeat deterministic filesystem and parsing work. The route graph is rebuilt on every watcher invalidation in dev, so this lands directly on HMR rebuild latency for larger apps. All three changes preserve output exactly — identical sort order, identical probe results, identical detection booleans — so no existing expectations change.

Implemented as three reviewable commits:

### 1. `perf(routing)`: precompute route precedence before sorting
`compareRoutes` re-parsed every pattern on each comparison, so `Array.prototype.sort` called `routePrecedence` ~2·log n times per route. Replaced with `sortRoutes`, which scores each pattern once into a `Map` and sorts by `(score, pattern.localeCompare)`. The `localeCompare` tiebreaker already guarantees a total order, so ordering is byte-identical — this just drops the redundant re-parsing on every scan (`routing/utils.ts`, callers in `pages-router.ts` and `app-route-graph.ts`).

### 2. `perf(app-router)`: cache convention-file probes per route-graph scan
`buildAppRouteGraph` walks the appDir→leaf chain separately for every route (layouts, templates, errors, boundaries, slots), each step probing up to 4 extensions per convention file via `existsSync`. Shared ancestors — the `app/` root above all — were re-stat'd once per descendant route. Memoized `findFile` through a `WeakMap<ValidFileMatcher, Map>` keyed by a per-scan matcher clone. Results are immutable within one scan, so no invalidation is needed: the cache lives exactly as long as the scan and is GC'd afterward. The fresh per-scan key keeps overlapping scans isolated, and the `null` not-found outcome is cached too.

### 3. `perf(deploy)`: single tree walk for detection and reuse parsed package.json
`analyzeProject` walked the `app/` tree twice (`detectISR` + `detectMDX`) and `detectNativeModules` re-read/re-parsed `package.json` that was already parsed into `allDeps`. Merged the two walkers into one `scanTreeForDetection(dir, { isr, mdx })` that evaluates both predicates per entry with each flag short-circuiting independently, extracted `detectMDXFromConfig`, added `resolveProjectDir` for the shared root/`src` precedence, and passed the already-merged `allDeps` into `detectNativeModules`. Same files visited, same patterns tested, same booleans out.

## Tests
- `tests/route-sorting.test.ts`: `sortRoutes` unit tests — documented precedence ordering, in-place/same-reference, idempotency, decorate-sort parity, empty/single-element edges.
- `tests/app-route-graph.test.ts`: sibling-route case asserting shared-ancestor layouts and nearest boundaries resolve identically (exercises the probe cache incl. the `null`-miss path).
- `tests/deploy.test.ts`: combined ISR+MDX single-walk case and a devDependencies-only native-module case.

All touched suites pass locally and `vp check` (format, lint, types) is clean.