### PR TITLE
chore: standardize prod-build project commands in playwright.config.ts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -102,7 +102,7 @@ const projectServers = {
       // Use node to invoke the CLI directly — npx vinext may not be on PATH
       // in fixture subdirectories since vinext is a workspace dependency.
       command:
-        "npx tsc -p ../../../packages/vinext/tsconfig.json && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4175",
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4175",
       cwd: "./tests/fixtures/pages-basic",
       port: 4175,
       reuseExistingServer: !process.env.CI,
@@ -167,7 +167,7 @@ const projectServers = {
       // lightweight static file server. No vinext runtime is needed —
       // the output is pure pre-rendered HTML files.
       command:
-        "npx tsc -p ../../../packages/vinext/tsconfig.json && node ../../../packages/vinext/dist/cli.js build && node ../../../tests/e2e/static-export/serve-static.mjs dist/client 4180",
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../tests/e2e/static-export/serve-static.mjs dist/client 4180",
       cwd: "./tests/fixtures/static-export",
       port: 4180,
       reuseExistingServer: !process.env.CI,
@@ -192,7 +192,7 @@ const projectServers = {
       // Build vinext CLI, then build the fixture, then start the standalone
       // server. The standalone server.js reads PORT from the environment.
       command:
-        "npx tsc -p ../../../packages/vinext/tsconfig.json && node ../../../packages/vinext/dist/cli.js build && PORT=4182 node dist/standalone/server.js",
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && PORT=4182 node dist/standalone/server.js",
       cwd: "./tests/fixtures/standalone-output",
       port: 4182,
       reuseExistingServer: !process.env.CI,
@@ -208,7 +208,7 @@ const projectServers = {
       // than devOnCaughtError, which already filtered navigation-signal errors
       // before this PR.
       command:
-        "npx tsc -p ../../../packages/vinext/tsconfig.json && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4184",
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4184",
       cwd: "./tests/fixtures/root-layout-redirect",
       port: 4184,
       reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary

Standardizes all prod-build Playwright project commands to use `npx vp run vinext#build` instead of the inconsistent `npx tsc -p ../../../packages/vinext/tsconfig.json`.

## Changed projects

| Project | Before | After |
|---|---|---|
| `pages-router-prod` | `npx tsc -p …/tsconfig.json` | `npx vp run vinext#build` |
| `static-export` | `npx tsc -p …/tsconfig.json` | `npx vp run vinext#build` |
| `standalone-output` | `npx tsc -p …/tsconfig.json` | `npx vp run vinext#build` |
| `root-layout-redirect` | `npx tsc -p …/tsconfig.json` | `npx vp run vinext#build` |
| `catch-error` | (already standardized) | unchanged |

## Why

1. **Consistency with AGENTS.md** — the Production Builds section explicitly recommends using `vp` over direct `tsc` for day-to-day work.
2. **`tsc` was a no-op** — the root `tsconfig.json` has `noEmit: true` (inherited by `packages/vinext/tsconfig.json`), so the `tsc -p` command type-checked but never actually produced `dist/cli.js`. The CLI binary must have existed from a prior build step (postinstall or CI setup).
3. **Aligns with existing precedent** — `catch-error` already uses `npx vp run vinext#build` (added in its initial setup), proving this approach works from fixture subdirectories.

## Verification

- ✅ `vp fmt --check` — formatting passes
- ✅ `vp lint` — 0 warnings, 0 errors
- ✅ `vp run vinext#build` — builds successfully (the worktree build ran clean)

Fixes https://github.com/cloudflare/vinext/issues/1921