### PR TITLE
feat(shims): add useUntrackedPathname hook for error boundary parity

### DIFF
--- a/packages/vinext/src/shims/error.tsx
+++ b/packages/vinext/src/shims/error.tsx
@@ -115,10 +115,14 @@ export type ErrorInfo = {
   unstable_retry: () => void;
 };
 
-type _UserProps = Record<string, unknown>;
+/** @internal */
+export type _UserProps = Record<string, unknown>;
 
-type _CatchErrorState = { thrownValue: unknown } | null;
-type _CatchErrorProps<P extends _UserProps> = {
+/** @internal */
+export type _CatchErrorState = { thrownValue: unknown } | null;
+
+/** @internal */
+export type _CatchErrorProps<P extends _UserProps = _UserProps> = {
   children?: React.ReactNode;
   fallback: React.ComponentType<{
     props: P;
@@ -129,7 +133,8 @@ type _CatchErrorProps<P extends _UserProps> = {
   props: P;
 };
 
-type _CatchErrorInternalState = {
+/** @internal */
+export type _CatchErrorInternalState = {
   error: _CatchErrorState;
   previousPathname: string | null;
 };
@@ -137,7 +142,8 @@ type _CatchErrorInternalState = {
 const _CatchErrorAppRouterContext =
   AppRouterContext ?? React.createContext<AppRouterInstance | null>(null);
 
-class _CatchError<P extends _UserProps> extends React.Component<
+/** @internal */
+export class _CatchError<P extends _UserProps = _UserProps> extends React.Component<
   _CatchErrorProps<P>,
   _CatchErrorInternalState
 > {

--- a/packages/vinext/src/shims/error.tsx
+++ b/packages/vinext/src/shims/error.tsx
@@ -115,14 +115,10 @@ export type ErrorInfo = {
   unstable_retry: () => void;
 };
 
-/** @internal */
-export type _UserProps = Record<string, unknown>;
+type _UserProps = Record<string, unknown>;
 
-/** @internal */
-export type _CatchErrorState = { thrownValue: unknown } | null;
-
-/** @internal */
-export type _CatchErrorProps<P extends _UserProps = _UserProps> = {
+type _CatchErrorState = { thrownValue: unknown } | null;
+type _CatchErrorProps<P extends _UserProps> = {
   children?: React.ReactNode;
   fallback: React.ComponentType<{
     props: P;
@@ -133,8 +129,7 @@ export type _CatchErrorProps<P extends _UserProps = _UserProps> = {
   props: P;
 };
 
-/** @internal */
-export type _CatchErrorInternalState = {
+type _CatchErrorInternalState = {
   error: _CatchErrorState;
   previousPathname: string | null;
 };
@@ -142,8 +137,7 @@ export type _CatchErrorInternalState = {
 const _CatchErrorAppRouterContext =
   AppRouterContext ?? React.createContext<AppRouterInstance | null>(null);
 
-/** @internal */
-export class _CatchError<P extends _UserProps = _UserProps> extends React.Component<
+class _CatchError<P extends _UserProps> extends React.Component<
   _CatchErrorProps<P>,
   _CatchErrorInternalState
 > {

--- a/packages/vinext/src/shims/error.tsx
+++ b/packages/vinext/src/shims/error.tsx
@@ -10,7 +10,7 @@
  * `next/error`'s public surface.
  */
 import React from "react";
-import { isNextRouterError, usePathname } from "./navigation.js";
+import { isNextRouterError, useUntrackedPathname } from "./navigation.js";
 import { AppRouterContext, type AppRouterInstance } from "./internal/app-router-context.js";
 import { RouterContext } from "./internal/router-context.js";
 
@@ -240,7 +240,7 @@ export function unstable_catchError<P extends _UserProps>(
 
   function CatchErrorBoundary(allProps: P & { children?: React.ReactNode }): React.ReactElement {
     const { children, ...rest } = allProps;
-    const pathname = usePathname();
+    const pathname = useUntrackedPathname();
     const isPagesRouter = React.useContext(RouterContext) !== null;
     // Boundary assertion: React's prop rest type is `Omit<P & { children?: ... }, "children">`;
     // by construction `children` is the only key removed, so the remaining

--- a/packages/vinext/src/shims/error.tsx
+++ b/packages/vinext/src/shims/error.tsx
@@ -10,7 +10,8 @@
  * `next/error`'s public surface.
  */
 import React from "react";
-import { isNextRouterError, useUntrackedPathname } from "./navigation.js";
+import { isNextRouterError } from "./navigation.js";
+import { useUntrackedPathname } from "./internal/navigation-untracked.js";
 import { AppRouterContext, type AppRouterInstance } from "./internal/app-router-context.js";
 import { RouterContext } from "./internal/router-context.js";
 

--- a/packages/vinext/src/shims/internal/navigation-untracked.ts
+++ b/packages/vinext/src/shims/internal/navigation-untracked.ts
@@ -12,62 +12,15 @@ import * as React from "react";
 import {
   getClientNavigationState,
   getClientNavigationRenderContext,
+  getNavigationContext,
   type ClientNavigationRenderSnapshot,
 } from "../navigation.js";
 
 const isServer = typeof window === "undefined";
 
-// ─── Cross-module-instance server context access ────────────────────────────
-// These globals are the same symbols used by navigation.ts so that separate
-// Vite module instances (SSR entry vs "use client" component) still share
-// the same navigation state. See issue #688 in the vinext repo.
-
-type NavigationContext = {
-  pathname: string;
-  searchParams: URLSearchParams;
-  params: Record<string, string | string[]>;
-};
-
-const _GLOBAL_ACCESSORS_KEY = Symbol.for("vinext.navigation.globalAccessors");
-const _GLOBAL_HYDRATION_CONTEXT_KEY = Symbol.for("vinext.navigation.clientHydrationContext");
-
-type _GlobalWithAccessors = typeof globalThis & {
-  [_GLOBAL_ACCESSORS_KEY]?: {
-    getServerContext: () => NavigationContext | null;
-    setServerContext: (ctx: NavigationContext | null) => void;
-    getInsertedHTMLCallbacks: () => Array<() => unknown>;
-    clearInsertedHTMLCallbacks: () => void;
-  };
-};
-
-type _GlobalWithHydrationContext = typeof globalThis & {
-  [_GLOBAL_HYDRATION_CONTEXT_KEY]?: NavigationContext | null;
-};
-
-function _getGlobalAccessors(): _GlobalWithAccessors[typeof _GLOBAL_ACCESSORS_KEY] | undefined {
-  return (globalThis as _GlobalWithAccessors)[_GLOBAL_ACCESSORS_KEY];
-}
-
-function _getClientHydrationContext(): NavigationContext | null | undefined {
-  const globalState = globalThis as _GlobalWithHydrationContext;
-  if (Object.prototype.hasOwnProperty.call(globalState, _GLOBAL_HYDRATION_CONTEXT_KEY)) {
-    return globalState[_GLOBAL_HYDRATION_CONTEXT_KEY] ?? null;
-  }
-  return undefined;
-}
-
-let _serverContext: NavigationContext | null = null;
-
-function _getServerContext(): NavigationContext | null {
-  if (typeof window !== "undefined") {
-    const hydrationContext = _getClientHydrationContext();
-    return hydrationContext !== undefined ? hydrationContext : _serverContext;
-  }
-  const g = _getGlobalAccessors();
-  return g ? g.getServerContext() : _serverContext;
-}
-
 // ─── Pages Router compat ────────────────────────────────────────────────────
+// The Pages Router accessor is not exported from navigation.ts, so we duplicate
+// only this Symbol-based lookup here.
 
 type PagesNavigationContext = {
   pathname: string | null;
@@ -125,8 +78,11 @@ function useClientNavigationRenderSnapshot(): ClientNavigationRenderSnapshot | n
  * when the render is a missing-params shell — vinext does not yet implement
  * fallback-route-param detection, so this path is not currently reachable.
  *
- * Client: reads directly from the navigation snapshot or location without
- * subscribing to URL changes.
+ * Client: prefers the render snapshot **only during an active navigation**
+ * transition (`navigationSnapshotActiveCount > 0`) so the hook returns the
+ * pending URL, not the stale committed one. After commit, falls back to the
+ * cached pathname so user `pushState`/`replaceState` calls are immediately
+ * reflected.
  *
  * Used by `unstable_catchError` error boundaries to avoid unnecessary re-renders.
  *
@@ -135,13 +91,13 @@ function useClientNavigationRenderSnapshot(): ClientNavigationRenderSnapshot | n
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
 export function useUntrackedPathname(): string | null {
   if (isServer) {
-    const ctx = _getServerContext();
+    const ctx = getNavigationContext();
     if (ctx) return ctx.pathname;
     const pagesCtx = _getPagesNavigationContext();
     return pagesCtx ? pagesCtx.pathname : "/";
   }
   const renderSnapshot = useClientNavigationRenderSnapshot();
-  if (renderSnapshot) {
+  if (renderSnapshot && (getClientNavigationState()?.navigationSnapshotActiveCount ?? 0) > 0) {
     return renderSnapshot.pathname;
   }
   const pagesCtx = _getPagesNavigationContext();

--- a/packages/vinext/src/shims/internal/navigation-untracked.ts
+++ b/packages/vinext/src/shims/internal/navigation-untracked.ts
@@ -1,0 +1,151 @@
+/**
+ * Internal navigation-untracked pathname hook.
+ *
+ * Used by `unstable_catchError` error boundaries to avoid subscribing to
+ * pathname changes. This is NOT part of the public `next/navigation` API.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/navigation-untracked.ts
+ */
+
+import * as React from "react";
+import {
+  getClientNavigationState,
+  getClientNavigationRenderContext,
+  type ClientNavigationRenderSnapshot,
+} from "../navigation.js";
+
+const isServer = typeof window === "undefined";
+
+// ─── Cross-module-instance server context access ────────────────────────────
+// These globals are the same symbols used by navigation.ts so that separate
+// Vite module instances (SSR entry vs "use client" component) still share
+// the same navigation state. See issue #688 in the vinext repo.
+
+type NavigationContext = {
+  pathname: string;
+  searchParams: URLSearchParams;
+  params: Record<string, string | string[]>;
+};
+
+const _GLOBAL_ACCESSORS_KEY = Symbol.for("vinext.navigation.globalAccessors");
+const _GLOBAL_HYDRATION_CONTEXT_KEY = Symbol.for("vinext.navigation.clientHydrationContext");
+
+type _GlobalWithAccessors = typeof globalThis & {
+  [_GLOBAL_ACCESSORS_KEY]?: {
+    getServerContext: () => NavigationContext | null;
+    setServerContext: (ctx: NavigationContext | null) => void;
+    getInsertedHTMLCallbacks: () => Array<() => unknown>;
+    clearInsertedHTMLCallbacks: () => void;
+  };
+};
+
+type _GlobalWithHydrationContext = typeof globalThis & {
+  [_GLOBAL_HYDRATION_CONTEXT_KEY]?: NavigationContext | null;
+};
+
+function _getGlobalAccessors(): _GlobalWithAccessors[typeof _GLOBAL_ACCESSORS_KEY] | undefined {
+  return (globalThis as _GlobalWithAccessors)[_GLOBAL_ACCESSORS_KEY];
+}
+
+function _getClientHydrationContext(): NavigationContext | null | undefined {
+  const globalState = globalThis as _GlobalWithHydrationContext;
+  if (Object.prototype.hasOwnProperty.call(globalState, _GLOBAL_HYDRATION_CONTEXT_KEY)) {
+    return globalState[_GLOBAL_HYDRATION_CONTEXT_KEY] ?? null;
+  }
+  return undefined;
+}
+
+let _serverContext: NavigationContext | null = null;
+
+function _getServerContext(): NavigationContext | null {
+  if (typeof window !== "undefined") {
+    const hydrationContext = _getClientHydrationContext();
+    return hydrationContext !== undefined ? hydrationContext : _serverContext;
+  }
+  const g = _getGlobalAccessors();
+  return g ? g.getServerContext() : _serverContext;
+}
+
+// ─── Pages Router compat ────────────────────────────────────────────────────
+
+type PagesNavigationContext = {
+  pathname: string | null;
+  searchParams: URLSearchParams;
+  params: Record<string, string | string[]> | null;
+};
+
+const PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
+  "vinext.navigation.pagesNavigationContextAccessor",
+);
+
+type _GlobalWithPagesAccessor = typeof globalThis & {
+  [PAGES_NAVIGATION_ACCESSOR_KEY]?: () => PagesNavigationContext | null;
+};
+
+function _getPagesNavigationContext(): PagesNavigationContext | null {
+  const accessor = (globalThis as _GlobalWithPagesAccessor)[PAGES_NAVIGATION_ACCESSOR_KEY];
+  if (!accessor) return null;
+  try {
+    return accessor();
+  } catch {
+    return null;
+  }
+}
+
+// ─── Client snapshots ───────────────────────────────────────────────────────
+
+function getPathnameSnapshot(): string | null {
+  const pagesCtx = _getPagesNavigationContext();
+  if (pagesCtx) return pagesCtx.pathname;
+  return getClientNavigationState()?.cachedPathname ?? "/";
+}
+
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
+function useClientNavigationRenderSnapshot(): ClientNavigationRenderSnapshot | null {
+  const ctx = getClientNavigationRenderContext();
+  if (!ctx || typeof React.useContext !== "function") return null;
+  try {
+    return React.useContext(ctx);
+  } catch {
+    return null;
+  }
+}
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
+
+// ─── useUntrackedPathname ───────────────────────────────────────────────────
+
+/**
+ * Returns the current pathname without registering it as a tracked render
+ * dependency. Unlike `usePathname()`, this does not use `useSyncExternalStore`
+ * and therefore does not cause the component to re-render on navigation.
+ *
+ * Server: returns the pathname from context, or `"/"` when no navigation context
+ * is available (the client will hydrate with the real value). Returns `null` only
+ * when the render is a missing-params shell — vinext does not yet implement
+ * fallback-route-param detection, so this path is not currently reachable.
+ *
+ * Client: reads directly from the navigation snapshot or location without
+ * subscribing to URL changes.
+ *
+ * Used by `unstable_catchError` error boundaries to avoid unnecessary re-renders.
+ *
+ * @internal
+ */
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
+export function useUntrackedPathname(): string | null {
+  if (isServer) {
+    const ctx = _getServerContext();
+    if (ctx) return ctx.pathname;
+    const pagesCtx = _getPagesNavigationContext();
+    return pagesCtx ? pagesCtx.pathname : "/";
+  }
+  const renderSnapshot = useClientNavigationRenderSnapshot();
+  if (renderSnapshot) {
+    return renderSnapshot.pathname;
+  }
+  const pagesCtx = _getPagesNavigationContext();
+  if (pagesCtx) return pagesCtx.pathname;
+  return getPathnameSnapshot();
+}
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */

--- a/packages/vinext/src/shims/internal/navigation-untracked.ts
+++ b/packages/vinext/src/shims/internal/navigation-untracked.ts
@@ -8,12 +8,10 @@
  *   https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/navigation-untracked.ts
  */
 
-import * as React from "react";
 import {
   getClientNavigationState,
-  getClientNavigationRenderContext,
   getNavigationContext,
-  type ClientNavigationRenderSnapshot,
+  useClientNavigationRenderSnapshot,
 } from "../navigation.js";
 import { getPagesNavigationContext } from "./pages-router-accessor.js";
 
@@ -27,18 +25,6 @@ function getPathnameSnapshot(): string | null {
   return getClientNavigationState()?.cachedPathname ?? "/";
 }
 
-/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
-function useClientNavigationRenderSnapshot(): ClientNavigationRenderSnapshot | null {
-  const ctx = getClientNavigationRenderContext();
-  if (!ctx || typeof React.useContext !== "function") return null;
-  try {
-    return React.useContext(ctx);
-  } catch {
-    return null;
-  }
-}
-/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
-
 // ─── useUntrackedPathname ───────────────────────────────────────────────────
 
 /**
@@ -47,9 +33,11 @@ function useClientNavigationRenderSnapshot(): ClientNavigationRenderSnapshot | n
  * and therefore does not cause the component to re-render on navigation.
  *
  * Server: returns the pathname from context, or `"/"` when no navigation context
- * is available (the client will hydrate with the real value). Returns `null` only
- * when the render is a missing-params shell — vinext does not yet implement
- * fallback-route-param detection, so this path is not currently reachable.
+ * is available (the client will hydrate with the real value). The `"/"` fallback
+ * deliberately matches vinext's `usePathname()` behavior rather than Next.js's
+ * null context default. Returns `null` only when the render is a missing-params
+ * shell — vinext does not yet implement fallback-route-param detection, so this
+ * path is not currently reachable.
  *
  * Client: prefers the render snapshot **only during an active navigation**
  * transition (`navigationSnapshotActiveCount > 0`) so the hook returns the

--- a/packages/vinext/src/shims/internal/navigation-untracked.ts
+++ b/packages/vinext/src/shims/internal/navigation-untracked.ts
@@ -15,41 +15,14 @@ import {
   getNavigationContext,
   type ClientNavigationRenderSnapshot,
 } from "../navigation.js";
+import { getPagesNavigationContext } from "./pages-router-accessor.js";
 
 const isServer = typeof window === "undefined";
-
-// ─── Pages Router compat ────────────────────────────────────────────────────
-// The Pages Router accessor is not exported from navigation.ts, so we duplicate
-// only this Symbol-based lookup here.
-
-type PagesNavigationContext = {
-  pathname: string | null;
-  searchParams: URLSearchParams;
-  params: Record<string, string | string[]> | null;
-};
-
-const PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
-  "vinext.navigation.pagesNavigationContextAccessor",
-);
-
-type _GlobalWithPagesAccessor = typeof globalThis & {
-  [PAGES_NAVIGATION_ACCESSOR_KEY]?: () => PagesNavigationContext | null;
-};
-
-function _getPagesNavigationContext(): PagesNavigationContext | null {
-  const accessor = (globalThis as _GlobalWithPagesAccessor)[PAGES_NAVIGATION_ACCESSOR_KEY];
-  if (!accessor) return null;
-  try {
-    return accessor();
-  } catch {
-    return null;
-  }
-}
 
 // ─── Client snapshots ───────────────────────────────────────────────────────
 
 function getPathnameSnapshot(): string | null {
-  const pagesCtx = _getPagesNavigationContext();
+  const pagesCtx = getPagesNavigationContext();
   if (pagesCtx) return pagesCtx.pathname;
   return getClientNavigationState()?.cachedPathname ?? "/";
 }
@@ -93,14 +66,14 @@ export function useUntrackedPathname(): string | null {
   if (isServer) {
     const ctx = getNavigationContext();
     if (ctx) return ctx.pathname;
-    const pagesCtx = _getPagesNavigationContext();
+    const pagesCtx = getPagesNavigationContext();
     return pagesCtx ? pagesCtx.pathname : "/";
   }
   const renderSnapshot = useClientNavigationRenderSnapshot();
   if (renderSnapshot && (getClientNavigationState()?.navigationSnapshotActiveCount ?? 0) > 0) {
     return renderSnapshot.pathname;
   }
-  const pagesCtx = _getPagesNavigationContext();
+  const pagesCtx = getPagesNavigationContext();
   if (pagesCtx) return pagesCtx.pathname;
   return getPathnameSnapshot();
 }

--- a/packages/vinext/src/shims/internal/pages-router-accessor.ts
+++ b/packages/vinext/src/shims/internal/pages-router-accessor.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared Pages Router navigation accessor.
+ *
+ * Both `next/navigation` (usePathname/useParams/useSearchParams) and the
+ * internal `useUntrackedPathname` read from the same global Symbol. Keeping
+ * the lookup in one place avoids the Symbol string and the error-handling
+ * shape from drifting across modules.
+ *
+ * @internal
+ */
+
+export type PagesNavigationContext = {
+  pathname: string | null;
+  searchParams: URLSearchParams;
+  params: Record<string, string | string[]> | null;
+};
+
+const PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
+  "vinext.navigation.pagesNavigationContextAccessor",
+);
+
+type _GlobalWithPagesAccessor = typeof globalThis & {
+  [PAGES_NAVIGATION_ACCESSOR_KEY]?: () => PagesNavigationContext | null;
+};
+
+export function getPagesNavigationContext(): PagesNavigationContext | null {
+  const accessor = (globalThis as _GlobalWithPagesAccessor)[PAGES_NAVIGATION_ACCESSOR_KEY];
+  if (!accessor) return null;
+  try {
+    return accessor();
+  } catch {
+    return null;
+  }
+}

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -48,6 +48,7 @@ import { stripBasePath } from "../utils/base-path.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
 import { AppRouterContext, type AppRouterInstance } from "./internal/app-router-context.js";
+import { getPagesNavigationContext as _getPagesNavigationContext } from "./internal/pages-router-accessor.js";
 import { retryScrollTo, scrollToHashTarget } from "./hash-scroll.js";
 import {
   beginAppRouterScrollIntent,
@@ -336,11 +337,6 @@ export function _registerStateAccessors(accessors: _StateAccessors): void {
 // loaded for every consumer of next/router, triggering window.history
 // patches in unit tests that only want the router shim.
 // ---------------------------------------------------------------------------
-
-import {
-  getPagesNavigationContext as _getPagesNavigationContext,
-  type PagesNavigationContext,
-} from "./internal/pages-router-accessor.js";
 
 const PAGES_NAVIGATION_NOTIFY_KEY = Symbol.for("vinext.navigation.pagesNavigationNotify");
 type _GlobalWithPagesNotify = typeof globalThis & {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1515,40 +1515,6 @@ export function usePathname(): string | null {
 
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
 /**
- * Returns the current pathname without registering it as a tracked render
- * dependency. Unlike `usePathname()`, this does not use `useSyncExternalStore`
- * and therefore does not cause the component to re-render on navigation.
- *
- * Server: returns `null` when no navigation context is available (missing-params
- * shell prerender), instead of falling back to `"/"`.
- *
- * Client: reads directly from the navigation snapshot or location without
- * subscribing to URL changes.
- *
- * Used by `unstable_catchError` error boundaries to avoid unnecessary re-renders.
- *
- * Ported from Next.js:
- *   https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/navigation-untracked.ts
- */
-export function useUntrackedPathname(): string | null {
-  if (isServer) {
-    const ctx = _getServerContext();
-    if (ctx) return ctx.pathname;
-    const pagesCtx = _getPagesNavigationContext();
-    return pagesCtx ? pagesCtx.pathname : null;
-  }
-  const renderSnapshot = useClientNavigationRenderSnapshot();
-  if (renderSnapshot) {
-    return renderSnapshot.pathname;
-  }
-  const pagesCtx = _getPagesNavigationContext();
-  if (pagesCtx) return pagesCtx.pathname;
-  return getPathnameSnapshot();
-}
-/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
-
-/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
-/**
  * Returns the current search params as a read-only URLSearchParams.
  */
 export function useSearchParams(): ReadonlyURLSearchParams {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -337,30 +337,15 @@ export function _registerStateAccessors(accessors: _StateAccessors): void {
 // patches in unit tests that only want the router shim.
 // ---------------------------------------------------------------------------
 
-type PagesNavigationContext = {
-  pathname: string | null;
-  searchParams: URLSearchParams;
-  params: Record<string, string | string[]> | null;
-};
+import {
+  getPagesNavigationContext as _getPagesNavigationContext,
+  type PagesNavigationContext,
+} from "./internal/pages-router-accessor.js";
 
-const PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
-  "vinext.navigation.pagesNavigationContextAccessor",
-);
 const PAGES_NAVIGATION_NOTIFY_KEY = Symbol.for("vinext.navigation.pagesNavigationNotify");
-type _GlobalWithPagesAccessor = typeof globalThis & {
-  [PAGES_NAVIGATION_ACCESSOR_KEY]?: () => PagesNavigationContext | null;
+type _GlobalWithPagesNotify = typeof globalThis & {
   [PAGES_NAVIGATION_NOTIFY_KEY]?: () => void;
 };
-
-function _getPagesNavigationContext(): PagesNavigationContext | null {
-  const accessor = (globalThis as _GlobalWithPagesAccessor)[PAGES_NAVIGATION_ACCESSOR_KEY];
-  if (!accessor) return null;
-  try {
-    return accessor();
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Get the navigation context for the current SSR/RSC render.
@@ -1147,7 +1132,7 @@ function notifyNavigationListeners(): void {
 }
 
 if (!isServer) {
-  (globalThis as _GlobalWithPagesAccessor)[PAGES_NAVIGATION_NOTIFY_KEY] = notifyNavigationListeners;
+  (globalThis as _GlobalWithPagesNotify)[PAGES_NAVIGATION_NOTIFY_KEY] = notifyNavigationListeners;
 }
 
 // Cached URLSearchParams, pathname, etc. for referential stability

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1327,7 +1327,8 @@ export function getClientNavigationRenderContext(): React.Context<ClientNavigati
 }
 
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
-function useClientNavigationRenderSnapshot(): ClientNavigationRenderSnapshot | null {
+/** @internal */
+export function useClientNavigationRenderSnapshot(): ClientNavigationRenderSnapshot | null {
   const ctx = getClientNavigationRenderContext();
   if (!ctx || typeof React.useContext !== "function") return null;
   try {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1515,6 +1515,40 @@ export function usePathname(): string | null {
 
 /* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
 /**
+ * Returns the current pathname without registering it as a tracked render
+ * dependency. Unlike `usePathname()`, this does not use `useSyncExternalStore`
+ * and therefore does not cause the component to re-render on navigation.
+ *
+ * Server: returns `null` when no navigation context is available (missing-params
+ * shell prerender), instead of falling back to `"/"`.
+ *
+ * Client: reads directly from the navigation snapshot or location without
+ * subscribing to URL changes.
+ *
+ * Used by `unstable_catchError` error boundaries to avoid unnecessary re-renders.
+ *
+ * Ported from Next.js:
+ *   https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/navigation-untracked.ts
+ */
+export function useUntrackedPathname(): string | null {
+  if (isServer) {
+    const ctx = _getServerContext();
+    if (ctx) return ctx.pathname;
+    const pagesCtx = _getPagesNavigationContext();
+    return pagesCtx ? pagesCtx.pathname : null;
+  }
+  const renderSnapshot = useClientNavigationRenderSnapshot();
+  if (renderSnapshot) {
+    return renderSnapshot.pathname;
+  }
+  const pagesCtx = _getPagesNavigationContext();
+  if (pagesCtx) return pagesCtx.pathname;
+  return getPathnameSnapshot();
+}
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
+
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks */
+/**
  * Returns the current search params as a read-only URLSearchParams.
  */
 export function useSearchParams(): ReadonlyURLSearchParams {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1466,6 +1466,146 @@ describe("next/navigation shim", () => {
   });
 
   // -------------------------------------------------------------------------
+  // useUntrackedPathname
+  //
+  // Ported from Next.js:
+  //   https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/navigation-untracked.ts
+  // -------------------------------------------------------------------------
+  it("useUntrackedPathname returns null on server when no navigation context is set", async () => {
+    const { useUntrackedPathname } = await import("../packages/vinext/src/shims/navigation.js");
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    let captured: string | null = "";
+    function Probe() {
+      captured = useUntrackedPathname();
+      return React.createElement("span", null, captured ?? "null");
+    }
+
+    renderToStaticMarkup(React.createElement(Probe));
+    expect(captured).toBeNull();
+  });
+
+  it("useUntrackedPathname returns pathname from server context", async () => {
+    const { useUntrackedPathname, setNavigationContext } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    setNavigationContext({
+      pathname: "/untracked/test",
+      searchParams: new URLSearchParams(""),
+      params: {},
+    });
+
+    let captured: string | null = "";
+    function Probe() {
+      captured = useUntrackedPathname();
+      return React.createElement("span", null, captured ?? "null");
+    }
+
+    try {
+      renderToStaticMarkup(React.createElement(Probe));
+      expect(captured).toBe("/untracked/test");
+    } finally {
+      setNavigationContext(null);
+    }
+  });
+
+  it("useUntrackedPathname prefers render snapshot during active navigation", async () => {
+    const previousWindow = globalThis.window;
+    const win = {
+      addEventListener() {},
+      dispatchEvent() {
+        return true;
+      },
+      history: {
+        pushState() {},
+        replaceState() {},
+      },
+      location: {
+        href: "http://localhost/committed",
+        origin: "http://localhost",
+        pathname: "/committed",
+        search: "",
+      },
+      removeEventListener() {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const navigation = await import("../packages/vinext/src/shims/navigation.js");
+      const Context = navigation.getClientNavigationRenderContext();
+      if (!Context) {
+        throw new Error("Expected client navigation render context");
+      }
+
+      navigation.activateNavigationSnapshot();
+      const snapshot = navigation.createClientNavigationRenderSnapshot(
+        "http://localhost/pending-untracked?from=snapshot",
+        {},
+      );
+
+      let pathname: string | null = "";
+      function Probe() {
+        pathname = navigation.useUntrackedPathname();
+        return React.createElement("span", null, pathname ?? "null");
+      }
+
+      renderToStaticMarkup(
+        React.createElement(Context.Provider, { value: snapshot }, React.createElement(Probe)),
+      );
+      expect(pathname).toBe("/pending-untracked");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
+  it("useUntrackedPathname returns Pages Router pathname when no App context is set", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const accessorKey = Symbol.for("vinext.navigation.pagesNavigationContextAccessor");
+    const globalRecord = globalThis as Record<PropertyKey, unknown>;
+    const previousAccessor = globalRecord[accessorKey];
+
+    try {
+      globalRecord[accessorKey] = () => ({
+        pathname: "/pages/untracked",
+        searchParams: new URLSearchParams(""),
+        params: {},
+      });
+
+      const hookPath = "../packages/vinext/src/shims/navigation.js?pages-untracked=1";
+      const { useUntrackedPathname } = (await import(
+        hookPath
+      )) as typeof import("../packages/vinext/src/shims/navigation.js");
+
+      let captured: string | null = "";
+      function Probe() {
+        captured = useUntrackedPathname();
+        return React.createElement("span", null, captured ?? "null");
+      }
+
+      renderToStaticMarkup(React.createElement(Probe));
+      expect(captured).toBe("/pages/untracked");
+    } finally {
+      if (previousAccessor === undefined) {
+        delete globalRecord[accessorKey];
+      } else {
+        globalRecord[accessorKey] = previousAccessor;
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
   // react-server re-exports
   // -------------------------------------------------------------------------
   it("navigation.react-server re-exports unstable_rethrow and stubs unstable_isUnrecognizedActionError", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2102,10 +2102,7 @@ describe("next/error shim — unstable_catchError", () => {
   it("getDerivedStateFromProps clears the error when pathname changes and retains it when pathname stays the same", async () => {
     const React = (await import("react")).default;
     const { renderToStaticMarkup } = await import("react-dom/server");
-    const { unstable_catchError, _CatchError } =
-      await import("../packages/vinext/src/shims/error.js");
-    type _CatchErrorInternalState =
-      import("../packages/vinext/src/shims/error.js")._CatchErrorInternalState;
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
 
     function Fallback() {
       return null;
@@ -2116,16 +2113,26 @@ describe("next/error shim — unstable_catchError", () => {
     // We must call it inside a React render so React's dispatcher is active.
     let wrapperResult: React.ReactElement | null = null;
     function Capture() {
-      wrapperResult = Boundary({});
+      wrapperResult = (Boundary as unknown as (p: Record<string, never>) => React.ReactElement)({});
       return React.createElement("span");
     }
     renderToStaticMarkup(React.createElement(Capture));
 
-    // The rendered element's type is the internal _CatchError class.
-    const InnerCatchError = wrapperResult!.type as typeof _CatchError;
+    // Structural type for the internal class component so we can call
+    // getDerivedStateFromProps without importing non-public exports.
+    const InnerCatchError = wrapperResult!.type as unknown as React.ComponentClass<{
+      fallback: typeof Fallback;
+      pathname: string | null;
+      props: Record<string, never>;
+    }> & {
+      getDerivedStateFromProps(
+        props: Pick<{ pathname: string | null }, "pathname">,
+        state: { error: { thrownValue: unknown } | null; previousPathname: string | null },
+      ): { error: { thrownValue: unknown } | null; previousPathname: string | null };
+    };
 
     const thrown = new Error("boom");
-    const initialState: _CatchErrorInternalState = {
+    const initialState = {
       error: { thrownValue: thrown },
       previousPathname: "/initial",
     };

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2102,11 +2102,10 @@ describe("next/error shim — unstable_catchError", () => {
   it("getDerivedStateFromProps clears the error when pathname changes and retains it when pathname stays the same", async () => {
     const React = (await import("react")).default;
     const { renderToStaticMarkup } = await import("react-dom/server");
-    const {
-      unstable_catchError,
-      _CatchError,
-    } = await import("../packages/vinext/src/shims/error.js");
-    type _CatchErrorInternalState = import("../packages/vinext/src/shims/error.js")._CatchErrorInternalState;
+    const { unstable_catchError, _CatchError } =
+      await import("../packages/vinext/src/shims/error.js");
+    type _CatchErrorInternalState =
+      import("../packages/vinext/src/shims/error.js")._CatchErrorInternalState;
 
     function Fallback() {
       return null;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1573,6 +1573,68 @@ describe("next/navigation shim", () => {
     }
   });
 
+  it("useUntrackedPathname ignores stale render snapshot after navigation commits", async () => {
+    const previousWindow = globalThis.window;
+    const win = {
+      addEventListener() {},
+      dispatchEvent() {
+        return true;
+      },
+      history: {
+        pushState() {},
+        replaceState() {},
+      },
+      location: {
+        href: "http://localhost/committed",
+        origin: "http://localhost",
+        pathname: "/committed",
+        search: "",
+      },
+      removeEventListener() {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const { useUntrackedPathname } =
+        await import("../packages/vinext/src/shims/internal/navigation-untracked.js");
+      const navigation = await import("../packages/vinext/src/shims/navigation.js");
+      const Context = navigation.getClientNavigationRenderContext();
+      if (!Context) {
+        throw new Error("Expected client navigation render context");
+      }
+
+      // Snapshot is present but NOT active (navigationSnapshotActiveCount === 0).
+      // This simulates a post-commit re-render where the provider still wraps
+      // the tree but the URL has since changed via user pushState/replaceState.
+      const snapshot = navigation.createClientNavigationRenderSnapshot(
+        "http://localhost/stale-provider?from=snapshot",
+        {},
+      );
+
+      let pathname: string | null = "";
+      function Probe() {
+        pathname = useUntrackedPathname();
+        return React.createElement("span", null, pathname ?? "null");
+      }
+
+      renderToStaticMarkup(
+        React.createElement(Context.Provider, { value: snapshot }, React.createElement(Probe)),
+      );
+      // Must return the committed pathname, not the stale provider snapshot.
+      expect(pathname).toBe("/committed");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("useUntrackedPathname returns Pages Router pathname when no App context is set", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1471,8 +1471,9 @@ describe("next/navigation shim", () => {
   // Ported from Next.js:
   //   https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/navigation-untracked.ts
   // -------------------------------------------------------------------------
-  it("useUntrackedPathname returns null on server when no navigation context is set", async () => {
-    const { useUntrackedPathname } = await import("../packages/vinext/src/shims/navigation.js");
+  it("useUntrackedPathname returns '/' on server when no navigation context is set", async () => {
+    const { useUntrackedPathname } =
+      await import("../packages/vinext/src/shims/internal/navigation-untracked.js");
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
 
@@ -1483,12 +1484,13 @@ describe("next/navigation shim", () => {
     }
 
     renderToStaticMarkup(React.createElement(Probe));
-    expect(captured).toBeNull();
+    expect(captured).toBe("/");
   });
 
   it("useUntrackedPathname returns pathname from server context", async () => {
-    const { useUntrackedPathname, setNavigationContext } =
-      await import("../packages/vinext/src/shims/navigation.js");
+    const { useUntrackedPathname } =
+      await import("../packages/vinext/src/shims/internal/navigation-untracked.js");
+    const { setNavigationContext } = await import("../packages/vinext/src/shims/navigation.js");
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
 
@@ -1537,6 +1539,8 @@ describe("next/navigation shim", () => {
       vi.resetModules();
       const React = await import("react");
       const { renderToStaticMarkup } = await import("react-dom/server");
+      const { useUntrackedPathname } =
+        await import("../packages/vinext/src/shims/internal/navigation-untracked.js");
       const navigation = await import("../packages/vinext/src/shims/navigation.js");
       const Context = navigation.getClientNavigationRenderContext();
       if (!Context) {
@@ -1551,7 +1555,7 @@ describe("next/navigation shim", () => {
 
       let pathname: string | null = "";
       function Probe() {
-        pathname = navigation.useUntrackedPathname();
+        pathname = useUntrackedPathname();
         return React.createElement("span", null, pathname ?? "null");
       }
 
@@ -1583,10 +1587,11 @@ describe("next/navigation shim", () => {
         params: {},
       });
 
-      const hookPath = "../packages/vinext/src/shims/navigation.js?pages-untracked=1";
+      const hookPath =
+        "../packages/vinext/src/shims/internal/navigation-untracked.js?pages-untracked=1";
       const { useUntrackedPathname } = (await import(
         hookPath
-      )) as typeof import("../packages/vinext/src/shims/navigation.js");
+      )) as typeof import("../packages/vinext/src/shims/internal/navigation-untracked.js");
 
       let captured: string | null = "";
       function Probe() {
@@ -2025,6 +2030,79 @@ describe("next/error shim — unstable_catchError", () => {
     expect(() => instance.unstable_retry()).toThrow(
       "`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.",
     );
+  });
+
+  // Integration test: the boundary contract that useUntrackedPathname protects.
+  // The error boundary must clear its captured error when the pathname changes
+  // (navigation) and retain it when the pathname stays the same. This is the
+  // reason useUntrackedPathname exists: it provides a pathname that changes on
+  // navigation without subscribing the component to every URL change.
+  it("getDerivedStateFromProps clears the error when pathname changes and retains it when pathname stays the same", async () => {
+    const React = (await import("react")).default;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+
+    function Fallback() {
+      return null;
+    }
+    const Boundary = unstable_catchError(Fallback);
+
+    // The Boundary wrapper is a function component that calls hooks.
+    // We must call it inside a React render so React's dispatcher is active.
+    let wrapperResult: React.ReactElement | null = null;
+    function Capture() {
+      wrapperResult = (Boundary as unknown as (p: Record<string, never>) => React.ReactElement)({});
+      return React.createElement("span");
+    }
+    renderToStaticMarkup(React.createElement(Capture));
+
+    const InnerCatchError = wrapperResult!.type as unknown as React.ComponentClass<{
+      fallback: typeof Fallback;
+      pathname: string | null;
+      props: Record<string, never>;
+    }> & {
+      getDerivedStateFromProps(
+        props: Pick<{ pathname: string | null }, "pathname">,
+        state: { error: { thrownValue: unknown } | null; previousPathname: string | null },
+      ): { error: { thrownValue: unknown } | null; previousPathname: string | null };
+    };
+
+    const thrown = new Error("boom");
+    const initialState = {
+      error: { thrownValue: thrown },
+      previousPathname: "/initial",
+    };
+
+    // Same pathname: error must be retained
+    const samePath = InnerCatchError.getDerivedStateFromProps(
+      { pathname: "/initial" },
+      initialState,
+    );
+    expect(samePath).toEqual({
+      error: { thrownValue: thrown },
+      previousPathname: "/initial",
+    });
+
+    // Different pathname: error must be cleared
+    const changedPath = InnerCatchError.getDerivedStateFromProps(
+      { pathname: "/new" },
+      initialState,
+    );
+    expect(changedPath).toEqual({
+      error: null,
+      previousPathname: "/new",
+    });
+
+    // Null pathname to real pathname: error must be cleared.
+    // This matches the missing-params shell → real render transition.
+    const nullToReal = InnerCatchError.getDerivedStateFromProps(
+      { pathname: "/real" },
+      { error: { thrownValue: thrown }, previousPathname: null },
+    );
+    expect(nullToReal).toEqual({
+      error: null,
+      previousPathname: "/real",
+    });
   });
 });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2102,7 +2102,11 @@ describe("next/error shim — unstable_catchError", () => {
   it("getDerivedStateFromProps clears the error when pathname changes and retains it when pathname stays the same", async () => {
     const React = (await import("react")).default;
     const { renderToStaticMarkup } = await import("react-dom/server");
-    const { unstable_catchError } = await import("../packages/vinext/src/shims/error.js");
+    const {
+      unstable_catchError,
+      _CatchError,
+    } = await import("../packages/vinext/src/shims/error.js");
+    type _CatchErrorInternalState = import("../packages/vinext/src/shims/error.js")._CatchErrorInternalState;
 
     function Fallback() {
       return null;
@@ -2113,24 +2117,16 @@ describe("next/error shim — unstable_catchError", () => {
     // We must call it inside a React render so React's dispatcher is active.
     let wrapperResult: React.ReactElement | null = null;
     function Capture() {
-      wrapperResult = (Boundary as unknown as (p: Record<string, never>) => React.ReactElement)({});
+      wrapperResult = Boundary({});
       return React.createElement("span");
     }
     renderToStaticMarkup(React.createElement(Capture));
 
-    const InnerCatchError = wrapperResult!.type as unknown as React.ComponentClass<{
-      fallback: typeof Fallback;
-      pathname: string | null;
-      props: Record<string, never>;
-    }> & {
-      getDerivedStateFromProps(
-        props: Pick<{ pathname: string | null }, "pathname">,
-        state: { error: { thrownValue: unknown } | null; previousPathname: string | null },
-      ): { error: { thrownValue: unknown } | null; previousPathname: string | null };
-    };
+    // The rendered element's type is the internal _CatchError class.
+    const InnerCatchError = wrapperResult!.type as typeof _CatchError;
 
     const thrown = new Error("boom");
-    const initialState = {
+    const initialState: _CatchErrorInternalState = {
       error: { thrownValue: thrown },
       previousPathname: "/initial",
     };


### PR DESCRIPTION
## Summary

Next.js upstream provides a `useUntrackedPathname()` hook (in `packages/next/src/client/components/navigation-untracked.ts`) that is used by the `unstable_catchError` error boundary. Unlike `usePathname()`, `useUntrackedPathname()`:

- Does not register the pathname as a tracked render dependency, avoiding unnecessary re-renders of the error boundary
- Returns the pending URL during an active navigation transition, then falls back to the committed URL so user `pushState`/`replaceState` changes are immediately reflected

## What changed

1. **Added `useUntrackedPathname()`** to `packages/vinext/src/shims/internal/navigation-untracked.ts` (internal module, not exported from public `next/navigation`)
   - Server: returns `/` when no navigation context is available (the client will hydrate with the real value). Returns `null` only for missing-params shell prerenders — vinext does not yet implement fallback-route-param detection, so this path is not currently reachable.
   - Client: prefers the render snapshot **only during an active navigation** (`navigationSnapshotActiveCount > 0`), matching the existing invariant used by `usePathname()`, `useSearchParams()`, and `useParams()`. After commit, falls back to the cached pathname.

2. **Switched `error.tsx`** to import and use `useUntrackedPathname()` instead of `usePathname()` in the `unstable_catchError` wrapper.

3. **Added tests** covering:
   - Server-side `/` fallback when no context is set
   - Server-side pathname retrieval from navigation context
   - Client render snapshot preference **during active navigation**
   - Client **committed pathname** when provider snapshot is present but inactive (post-commit)
   - Pages Router pathname fallback
   - `getDerivedStateFromProps` boundary contract: clears errors on pathname changes, retains them when pathname stays the same

## References

- Next.js source: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/navigation-untracked.ts
- Next.js catch-error.tsx: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/catch-error.tsx
- Identified during review of PR #1906

Closes #1920