### PR TITLE
fix(shims): match next/error RSC diagnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,10 +282,6 @@ jobs:
             label: app-router-bfcache
             shardIndex: 1
             shardTotal: 1
-          - project: catch-error
-            label: catch-error
-            shardIndex: 1
-            shardTotal: 1
           - project: app-router
             label: app-router 3/3
             shardIndex: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,10 @@ jobs:
             label: app-router-bfcache
             shardIndex: 1
             shardTotal: 1
+          - project: catch-error
+            label: catch-error
+            shardIndex: 1
+            shardTotal: 1
           - project: app-router
             label: app-router 3/3
             shardIndex: 3

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -647,6 +647,8 @@ const _reactServerShims = new Map<string, string>([
   ["next/navigation", "navigation"],
   ["next/navigation.js", "navigation"],
   ["next/dist/client/components/navigation", "navigation"],
+  ["next/error", "error"],
+  ["next/error.js", "error"],
 ]);
 
 const clientManualChunks = createClientManualChunks(_shimsDir);
@@ -1491,7 +1493,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             "next/web-vitals": path.join(shimsDir, "web-vitals"),
             "next/amp": path.join(shimsDir, "amp"),
             "next/offline": path.join(shimsDir, "offline"),
-            "next/error": path.join(shimsDir, "error"),
+            // "next/error" is NOT here — it's in _reactServerShims so Server
+            // Components receive Next.js's client-only throwing stub.
             "next/constants": path.join(shimsDir, "constants"),
             // Internal next/dist/* paths used by popular libraries
             // (next-intl, @clerk/nextjs, @sentry/nextjs, next-nprogress-bar, etc.)

--- a/packages/vinext/src/shims/error.react-server.ts
+++ b/packages/vinext/src/shims/error.react-server.ts
@@ -1,0 +1,9 @@
+export type ErrorInfo = {
+  error: unknown;
+  reset: () => void;
+  unstable_retry: () => void;
+};
+
+export function unstable_catchError(): never {
+  throw new Error("`unstable_catchError` can only be used in Client Components.");
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1429,6 +1429,18 @@ describe("next/navigation shim", () => {
 //   https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/catch-error/
 // ---------------------------------------------------------------------------
 describe("next/error shim — unstable_catchError", () => {
+  // Ported from Next.js:
+  // packages/next/src/api/error.react-server.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/api/error.react-server.ts
+  it("error.react-server throws the exact Client Components diagnostic", async () => {
+    const { unstable_catchError } =
+      await import("../packages/vinext/src/shims/error.react-server.js");
+
+    expect(() => unstable_catchError()).toThrow(
+      "`unstable_catchError` can only be used in Client Components.",
+    );
+  });
+
   it("exports unstable_catchError as a function", async () => {
     const mod = await import("../packages/vinext/src/shims/error.js");
     expect(typeof mod.unstable_catchError).toBe("function");
@@ -18877,6 +18889,29 @@ describe("shim alias map .js variants", () => {
 
     const missing = topLevel.filter((key) => !(key + ".js" in aliases!));
     expect(missing, `Missing .js aliases for: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("resolves next/error to the react-server shim only in the RSC environment", () => {
+    const plugins = vinext() as Plugin[];
+    const configPlugin = plugins.find((plugin) => plugin.name === "vinext:config");
+    if (!configPlugin?.resolveId || typeof configPlugin.resolveId === "function") {
+      throw new Error("vinext:config resolveId hook not found");
+    }
+
+    const hook = configPlugin.resolveId as {
+      handler: (this: { environment?: { name?: string } }, id: string) => string | undefined;
+    };
+    const clientShim = path.resolve(import.meta.dirname, "../packages/vinext/src/shims/error.tsx");
+    const reactServerShim = path.resolve(
+      import.meta.dirname,
+      "../packages/vinext/src/shims/error.react-server.ts",
+    );
+
+    expect(hook.handler.call({ environment: { name: "rsc" } }, "next/error")).toBe(reactServerShim);
+    expect(hook.handler.call({ environment: { name: "ssr" } }, "next/error")).toBe(clientShim);
+    expect(hook.handler.call({ environment: { name: "rsc" } }, "next/error.js")).toBe(
+      reactServerShim,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- add a React Server-specific `next/error` shim
- throw Next.js's exact diagnostic when `unstable_catchError()` is called from a Server Component
- resolve both `next/error` and `next/error.js` to the RSC stub only in the RSC environment
- keep the existing implementation for SSR, browser, and Pages Router environments

## Next.js parity

Matches `packages/next/src/api/error.react-server.ts` in Next.js v16.2.6:

```text
`unstable_catchError` can only be used in Client Components.
```

https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/api/error.react-server.ts

## Verification

- `vp test run tests/shims.test.ts -t 'error.react-server|resolves next/error'`
- `vp test run tests/shims.test.ts` — 1,049 passed
- `vp check`
