### PR TITLE
feat(web): expose latest compatibility failures

### DIFF
--- a/apps/web/app/api/compatibility/failures/route.ts
+++ b/apps/web/app/api/compatibility/failures/route.ts
@@ -1,0 +1,70 @@
+/**
+ * GET /api/compatibility/failures
+ *
+ * Returns the failing suites from the most recently ingested compatibility
+ * run. The optional `kind` query parameter defaults to `deploy`.
+ */
+import { and, desc, eq, gt } from "drizzle-orm";
+import { getDb } from "../../../lib/db/client";
+import { compatFileResults, compatRuns } from "../../../lib/db/schema";
+
+const DEFAULT_KIND = "deploy";
+
+export async function GET(request: Request): Promise<Response> {
+  const kind = new URL(request.url).searchParams.get("kind")?.trim() || DEFAULT_KIND;
+
+  try {
+    const db = getDb();
+    const latestRuns = await db
+      .select()
+      .from(compatRuns)
+      .where(eq(compatRuns.kind, kind))
+      .orderBy(desc(compatRuns.createdAt), desc(compatRuns.id))
+      .limit(1);
+    const run = latestRuns[0];
+
+    if (!run) {
+      return Response.json({ kind, run: null, failures: [] });
+    }
+
+    const failures = await db
+      .select({
+        suite: compatFileResults.suite,
+        status: compatFileResults.status,
+        total: compatFileResults.total,
+        passed: compatFileResults.passed,
+        failed: compatFileResults.failed,
+        skipped: compatFileResults.skipped,
+      })
+      .from(compatFileResults)
+      .where(
+        and(
+          eq(compatFileResults.runId, run.id),
+          eq(compatFileResults.kind, kind),
+          gt(compatFileResults.failed, 0),
+        ),
+      )
+      .orderBy(desc(compatFileResults.failed), compatFileResults.suite);
+
+    return Response.json({
+      kind,
+      run: {
+        id: run.id,
+        runKey: run.runKey,
+        vinextRef: run.vinextRef,
+        nextRef: run.nextRef,
+        commitSha: run.commitSha,
+        createdAt: run.createdAt,
+        total: run.total,
+        passed: run.passed,
+        failed: run.failed,
+        skipped: run.skipped,
+      },
+      failures,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[/api/compatibility/failures] query failed:", message);
+    return Response.json({ error: "Failed to load failing tests" }, { status: 500 });
+  }
+}

--- a/tests/web-compatibility-failures.test.ts
+++ b/tests/web-compatibility-failures.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDb = vi.fn();
+
+vi.mock("../apps/web/app/lib/db/client", () => ({ getDb }));
+
+const { GET } = await import("../apps/web/app/api/compatibility/failures/route");
+
+function createDb(queryResults: unknown[][]) {
+  let queryIndex = 0;
+
+  const createQuery = () => {
+    const query = {
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      orderBy: vi.fn(() =>
+        queryIndex === 0 ? query : Promise.resolve(queryResults[queryIndex++] ?? []),
+      ),
+      limit: vi.fn(async () => queryResults[queryIndex++] ?? []),
+    };
+    return query;
+  };
+
+  return { select: vi.fn(createQuery) };
+}
+
+describe("GET /api/compatibility/failures", () => {
+  beforeEach(() => {
+    getDb.mockReset();
+  });
+
+  it("returns failures from the latest deploy run", async () => {
+    getDb.mockReturnValue(
+      createDb([
+        [
+          {
+            id: 42,
+            kind: "deploy",
+            runKey: "1234",
+            vinextRef: "main",
+            nextRef: "v16.2.6",
+            commitSha: "abc123",
+            createdAt: 1_750_000_000_000,
+            total: 20,
+            passed: 15,
+            failed: 4,
+            skipped: 1,
+          },
+        ],
+        [
+          {
+            suite: "test/e2e/app-dir/example.test.ts",
+            status: "partial",
+            total: 5,
+            passed: 1,
+            failed: 4,
+            skipped: 0,
+          },
+        ],
+      ]),
+    );
+
+    const response = await GET(new Request("https://example.com/api/compatibility/failures"));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      kind: "deploy",
+      run: {
+        id: 42,
+        runKey: "1234",
+        vinextRef: "main",
+        nextRef: "v16.2.6",
+        commitSha: "abc123",
+        createdAt: 1_750_000_000_000,
+        total: 20,
+        passed: 15,
+        failed: 4,
+        skipped: 1,
+      },
+      failures: [
+        {
+          suite: "test/e2e/app-dir/example.test.ts",
+          status: "partial",
+          total: 5,
+          passed: 1,
+          failed: 4,
+          skipped: 0,
+        },
+      ],
+    });
+  });
+
+  it("returns an empty result when the requested kind has no runs", async () => {
+    getDb.mockReturnValue(createDb([[]]));
+
+    const response = await GET(
+      new Request("https://example.com/api/compatibility/failures?kind=vitest"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ kind: "vitest", run: null, failures: [] });
+  });
+
+  it("returns 500 when the database query fails", async () => {
+    getDb.mockImplementation(() => {
+      throw new Error("DB unavailable");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await GET(new Request("https://example.com/api/compatibility/failures"));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Failed to load failing tests" });
+  });
+});


### PR DESCRIPTION
## Summary
- add `GET /api/compatibility/failures` to return failing suites from the latest compatibility run
- include run metadata and per-suite pass/fail/skip counts
- support selecting another compatibility kind with `?kind=`
- add focused tests for successful, empty, and database-error responses

## Testing
- `vp check apps/web/app/api/compatibility/failures/route.ts tests/web-compatibility-failures.test.ts`
- `vp test run tests/web-compatibility-failures.test.ts`