### PR TITLE
fix(actions): prevent Flight graph stack-exhaustion DoS

### DIFF
--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -320,6 +320,11 @@ function resolveActionRevalidationKind(hasModifiedCookies: boolean): ActionReval
   return revalidationKind;
 }
 
+function clearRejectedActionSideEffects(getAndClearPendingCookies: () => string[]): void {
+  getAndClearPendingCookies();
+  getAndClearActionRevalidationKind();
+}
+
 function cloneActionRedirectHeaders(requestHeaders: Headers): Headers {
   const headers = new Headers(requestHeaders);
   for (const header of ACTION_REDIRECT_RENDER_STRIPPED_HEADERS) {
@@ -791,6 +796,7 @@ export async function handleProgressiveServerActionRequest(
 
     const payloadResponse = await validateServerActionPayload(body);
     if (payloadResponse) {
+      clearRejectedActionSideEffects(options.getAndClearPendingCookies);
       options.clearRequestContext();
       return payloadResponse;
     }
@@ -1037,6 +1043,31 @@ export async function handleServerActionRscRequest<
   }
 
   try {
+    let action: AppServerActionFunction | undefined;
+    if (options.contentType.startsWith("multipart/form-data")) {
+      let loadedAction: unknown;
+      try {
+        loadedAction = await options.loadServerAction(options.actionId);
+      } catch (error) {
+        if (isServerActionNotFoundError(error, options.actionId)) {
+          return createActionNotFoundResponse(options.actionId, {
+            clearRequestContext: options.clearRequestContext,
+            getAndClearPendingCookies: options.getAndClearPendingCookies,
+          });
+        }
+
+        throw error;
+      }
+
+      if (!isAppServerActionFunction(loadedAction)) {
+        return createActionNotFoundResponse(options.actionId, {
+          clearRequestContext: options.clearRequestContext,
+          getAndClearPendingCookies: options.getAndClearPendingCookies,
+        });
+      }
+      action = loadedAction;
+    }
+
     let body: string | FormData;
     try {
       body = options.contentType.startsWith("multipart/form-data")
@@ -1051,29 +1082,33 @@ export async function handleServerActionRscRequest<
 
     const payloadResponse = await validateServerActionPayload(body);
     if (payloadResponse) {
+      clearRejectedActionSideEffects(options.getAndClearPendingCookies);
       options.clearRequestContext();
       return payloadResponse;
     }
 
-    let action: unknown;
-    try {
-      action = await options.loadServerAction(options.actionId);
-    } catch (error) {
-      if (isServerActionNotFoundError(error, options.actionId)) {
+    if (action === undefined) {
+      let loadedAction: unknown;
+      try {
+        loadedAction = await options.loadServerAction(options.actionId);
+      } catch (error) {
+        if (isServerActionNotFoundError(error, options.actionId)) {
+          return createActionNotFoundResponse(options.actionId, {
+            clearRequestContext: options.clearRequestContext,
+            getAndClearPendingCookies: options.getAndClearPendingCookies,
+          });
+        }
+
+        throw error;
+      }
+
+      if (!isAppServerActionFunction(loadedAction)) {
         return createActionNotFoundResponse(options.actionId, {
           clearRequestContext: options.clearRequestContext,
           getAndClearPendingCookies: options.getAndClearPendingCookies,
         });
       }
-
-      throw error;
-    }
-
-    if (!isAppServerActionFunction(action)) {
-      return createActionNotFoundResponse(options.actionId, {
-        clearRequestContext: options.clearRequestContext,
-        getAndClearPendingCookies: options.getAndClearPendingCookies,
-      });
+      action = loadedAction;
     }
 
     const temporaryReferences = options.createTemporaryReferenceSet();

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -410,30 +410,46 @@ export function validateCsrfOrigin(
 export async function validateServerActionPayload(
   body: string | FormData,
 ): Promise<Response | null> {
-  const containerRefRe = /"\$([QWi])(\d+)"/g;
+  const maxNumericFields = 4096;
+  const maxContainerReferences = 16384;
+  const maxContainerDepth = 1024;
+  const containerRefRe = /"\$([QWi])([0-9a-f]+)(?=[:"])/gi;
   const fieldRefs = new Map<string, Set<string>>();
+  let referenceCount = 0;
 
-  const collectRefs = (fieldKey: string, text: string): void => {
+  const invalidPayloadResponse = (): Response =>
+    new Response("Invalid server action payload", {
+      status: 400,
+      headers: { "Content-Type": "text/plain" },
+    });
+
+  const collectRefs = (fieldKey: string, text: string): boolean => {
+    if (fieldRefs.has(fieldKey)) return true;
+    if (fieldRefs.size >= maxNumericFields) return false;
+
     const refs = new Set<string>();
     let match: RegExpExecArray | null;
     containerRefRe.lastIndex = 0;
     while ((match = containerRefRe.exec(text)) !== null) {
-      refs.add(match[2]);
+      const previousSize = refs.size;
+      refs.add(String(Number.parseInt(match[2], 16)));
+      if (refs.size !== previousSize && ++referenceCount > maxContainerReferences) return false;
     }
     fieldRefs.set(fieldKey, refs);
+    return true;
   };
 
   if (typeof body === "string") {
-    collectRefs("0", body);
+    if (!collectRefs("0", body)) return invalidPayloadResponse();
   } else {
     for (const [key, value] of body.entries()) {
       if (!/^\d+$/.test(key)) continue;
       if (typeof value === "string") {
-        collectRefs(key, value);
+        if (!collectRefs(key, value)) return invalidPayloadResponse();
         continue;
       }
       if (typeof value?.text === "function") {
-        collectRefs(key, await value.text());
+        if (!collectRefs(key, await value.text())) return invalidPayloadResponse();
       }
     }
   }
@@ -444,36 +460,36 @@ export async function validateServerActionPayload(
   for (const refs of fieldRefs.values()) {
     for (const ref of refs) {
       if (!knownFields.has(ref)) {
-        return new Response("Invalid server action payload", {
-          status: 400,
-          headers: { "Content-Type": "text/plain" },
-        });
+        return invalidPayloadResponse();
       }
     }
   }
 
-  const visited = new Set<string>();
-  const stack = new Set<string>();
+  const state = new Map<string, "visiting" | "visited">();
 
-  const hasCycle = (node: string): boolean => {
-    if (stack.has(node)) return true;
-    if (visited.has(node)) return false;
+  for (const root of fieldRefs.keys()) {
+    if (state.has(root)) continue;
 
-    visited.add(node);
-    stack.add(node);
-    for (const ref of fieldRefs.get(node) ?? []) {
-      if (hasCycle(ref)) return true;
-    }
-    stack.delete(node);
-    return false;
-  };
+    const stack = [{ node: root, refs: [...(fieldRefs.get(root) ?? [])], nextRef: 0 }];
+    state.set(root, "visiting");
 
-  for (const node of fieldRefs.keys()) {
-    if (hasCycle(node)) {
-      return new Response("Invalid server action payload", {
-        status: 400,
-        headers: { "Content-Type": "text/plain" },
-      });
+    while (stack.length > 0) {
+      if (stack.length > maxContainerDepth) return invalidPayloadResponse();
+
+      const frame = stack[stack.length - 1];
+      const ref = frame.refs[frame.nextRef++];
+      if (ref === undefined) {
+        state.set(frame.node, "visited");
+        stack.pop();
+        continue;
+      }
+
+      const refState = state.get(ref);
+      if (refState === "visiting") return invalidPayloadResponse();
+      if (refState === "visited") continue;
+
+      state.set(ref, "visiting");
+      stack.push({ node: ref, refs: [...(fieldRefs.get(ref) ?? [])], nextRef: 0 });
     }
   }
 

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -2071,7 +2071,7 @@ describe("App Router integration", () => {
     expect(await res.text()).toBe("Server action not found.");
   });
 
-  it("rejects cyclic multipart server action payloads before decodeReply", async () => {
+  it("returns action-not-found before reading cyclic multipart payloads for stale ids", async () => {
     const body = new FormData();
     body.set("0", '["$Q0"]');
 
@@ -2086,8 +2086,9 @@ describe("App Router integration", () => {
       signal: AbortSignal.timeout(5_000),
     });
 
-    expect(res.status).toBe(400);
-    expect(await res.text()).toBe("Invalid server action payload");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await res.text()).toBe("Server action not found.");
   });
 
   it("blocks server action POST with Origin 'null' (CSRF via sandboxed context)", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -20,7 +20,12 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
-import { refresh, revalidatePath, revalidateTag } from "../packages/vinext/src/shims/cache.js";
+import {
+  getAndClearActionRevalidationKind,
+  refresh,
+  revalidatePath,
+  revalidateTag,
+} from "../packages/vinext/src/shims/cache.js";
 import {
   cookies,
   setHeadersAccessPhase,
@@ -469,6 +474,54 @@ describe("app server action execution helpers", () => {
     expect((renderedModel.get().returnValue.data as Error).message).toContain("Body exceeded");
   });
 
+  it("bounds chunked multipart bodies after resolving a valid action", async () => {
+    const loadServerAction = vi.fn(() => Promise.resolve(() => "ok"));
+    const renderedModel = captureRenderedModel();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        contentType: "multipart/form-data; boundary=VINEXTDOS",
+        loadServerAction,
+        readFormDataWithLimit() {
+          throw new Error("Request body too large");
+        },
+        renderToReadableStream: renderedModel.capture,
+      }),
+    );
+
+    expect(response?.status).toBe(500);
+    expect(response?.headers.get("content-type")).toBe("text/x-component");
+    expect(loadServerAction).toHaveBeenCalledTimes(1);
+    expect(renderedModel.get().returnValue.ok).toBe(false);
+    expect((renderedModel.get().returnValue.data as Error).message).toContain("Body exceeded");
+  });
+
+  it("rejects declared-oversized stale multipart actions before action lookup", async () => {
+    const loadServerAction = vi.fn();
+    const readFormDataWithLimit = vi.fn();
+    const renderedModel = captureRenderedModel();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        actionId: "stale-action-id",
+        contentType: "multipart/form-data; boundary=VINEXTDOS",
+        loadServerAction,
+        maxActionBodySize: 10,
+        readFormDataWithLimit,
+        renderToReadableStream: renderedModel.capture,
+        request: createFetchActionRequest({
+          "content-length": "11",
+          "content-type": "multipart/form-data; boundary=VINEXTDOS",
+        }),
+      }),
+    );
+
+    expect(response?.status).toBe(500);
+    expect(loadServerAction).not.toHaveBeenCalled();
+    expect(readFormDataWithLimit).not.toHaveBeenCalled();
+    expect(renderedModel.get().returnValue.ok).toBe(false);
+  });
+
   it("rejects malformed action payloads before decoding the action", async () => {
     const formData = new FormData();
     formData.set("0", '"$Q1"');
@@ -488,6 +541,30 @@ describe("app server action execution helpers", () => {
     expect(response.status).toBe(400);
     expect(await response.text()).toBe("Invalid server action payload");
     expect(decodeAction).not.toHaveBeenCalled();
+  });
+
+  it("clears pending cookies and revalidation state for rejected progressive payloads", async () => {
+    const formData = new FormData();
+    formData.set("0", '"$Q1:x"');
+    const getAndClearPendingCookies = vi.fn(() => ["session=stale"]);
+    const previousPhase = setHeadersAccessPhase("action");
+    await revalidatePath("/stale");
+    setHeadersAccessPhase(previousPhase);
+
+    const response = requireProgressiveActionResponse(
+      await handleProgressiveServerActionRequest(
+        createOptions({
+          getAndClearPendingCookies,
+          readFormDataWithLimit() {
+            return Promise.resolve(formData);
+          },
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(getAndClearPendingCookies).toHaveBeenCalledTimes(1);
+    expect(getAndClearActionRevalidationKind()).toBe(0);
   });
 
   it("executes decoded form actions and converts redirects into 303 responses", async () => {
@@ -1400,6 +1477,69 @@ describe("app server action execution helpers", () => {
     expect(decodeReply).not.toHaveBeenCalled();
   });
 
+  it("rejects adversarial multipart payloads through the real request reader", async () => {
+    const formData = new FormData();
+    formData.append("0", '["$Q1:x"]');
+    formData.append("0", "[]");
+    const request = createMultipartBodyRequest(formData);
+    const decodeReply = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        contentType: request.headers.get("content-type") ?? "",
+        decodeReply,
+        maxActionBodySize: 1024 * 1024,
+        readFormDataWithLimit: readActionFormDataWithLimit,
+        request,
+      }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.text()).toBe("Invalid server action payload");
+    expect(decodeReply).not.toHaveBeenCalled();
+  });
+
+  it("rejects cyclic multipart graphs for valid action ids", async () => {
+    const formData = new FormData();
+    formData.set("0", '["$Q0"]');
+    const request = createMultipartBodyRequest(formData);
+    const decodeReply = vi.fn();
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        contentType: request.headers.get("content-type") ?? "",
+        decodeReply,
+        maxActionBodySize: 1024 * 1024,
+        readFormDataWithLimit: readActionFormDataWithLimit,
+        request,
+      }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.text()).toBe("Invalid server action payload");
+    expect(decodeReply).not.toHaveBeenCalled();
+  });
+
+  it("clears pending cookies and revalidation state for rejected fetch payloads", async () => {
+    const getAndClearPendingCookies = vi.fn(() => ["session=stale"]);
+    const previousPhase = setHeadersAccessPhase("action");
+    await revalidatePath("/stale");
+    setHeadersAccessPhase(previousPhase);
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        getAndClearPendingCookies,
+        readBodyWithLimit() {
+          return Promise.resolve('{"0":"$Q1:x"}');
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(getAndClearPendingCookies).toHaveBeenCalledTimes(1);
+    expect(getAndClearActionRevalidationKind()).toBe(0);
+  });
+
   // Regression coverage for #1340: realistic action ids include `#<exportName>`,
   // but @vitejs/plugin-rsc's reference-validation virtual module only knows the
   // module path portion. The dev-mode "invalid server reference '<id>'" error
@@ -1441,6 +1581,7 @@ describe("app server action execution helpers", () => {
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
   it("returns the Next.js action-not-found response for stale fetch action ids", async () => {
     const decodeReply = vi.fn();
+    const readFormDataWithLimit = vi.fn();
     const renderToReadableStream = vi.fn();
     const reportRequestError = vi.fn();
     const clearRequestContext = vi.fn();
@@ -1449,10 +1590,12 @@ describe("app server action execution helpers", () => {
       createRscOptions({
         actionId: "stale-action-id",
         clearRequestContext,
+        contentType: "multipart/form-data; boundary=VINEXTDOS",
         decodeReply,
         loadServerAction() {
           return Promise.reject(new Error("[vite-rsc] invalid server reference 'stale-action-id'"));
         },
+        readFormDataWithLimit,
         renderToReadableStream,
         reportRequestError,
       }),
@@ -1462,6 +1605,7 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-nextjs-action-not-found")).toBe("1");
     expect(response?.headers.get("content-type")).toBe("text/plain");
     expect(await response?.text()).toBe("Server action not found.");
+    expect(readFormDataWithLimit).not.toHaveBeenCalled();
     expect(decodeReply).not.toHaveBeenCalled();
     expect(renderToReadableStream).not.toHaveBeenCalled();
     expect(reportRequestError).not.toHaveBeenCalled();

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -590,6 +590,58 @@ describe("validateServerActionPayload", () => {
     expect(res!.status).toBe(400);
     await expect(res!.text()).resolves.toBe("Invalid server action payload");
   });
+
+  it("validates the first hex chunk id in container references with path suffixes", async () => {
+    for (const reference of ["$Q1:x", "$W1:0:name", "$i1:value"]) {
+      const body = new FormData();
+      body.set("0", JSON.stringify([reference]));
+
+      const res = await validateServerActionPayload(body);
+      expect(res?.status).toBe(400);
+      await expect(res?.text()).resolves.toBe("Invalid server action payload");
+    }
+  });
+
+  it("validates the first duplicate numeric field instead of overwriting it", async () => {
+    const body = new FormData();
+    body.append("0", '["$Q1"]');
+    body.append("0", "[]");
+
+    const res = await validateServerActionPayload(body);
+    expect(res?.status).toBe(400);
+    await expect(res?.text()).resolves.toBe("Invalid server action payload");
+  });
+
+  it("allows duplicate numeric user fields when the first value has no container reference", async () => {
+    const body = new FormData();
+    body.append("0", "first checkbox");
+    body.append("0", "second checkbox");
+
+    await expect(validateServerActionPayload(body)).resolves.toBeNull();
+  });
+
+  it("rejects deeply nested acyclic graphs without overflowing the call stack", async () => {
+    const body = new FormData();
+    const fieldCount = 10_000;
+    for (let index = 0; index < fieldCount; index++) {
+      body.set(String(index), index + 1 < fieldCount ? `["$Q${(index + 1).toString(16)}"]` : "[]");
+    }
+
+    const res = await validateServerActionPayload(body);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+    await expect(res!.text()).resolves.toBe("Invalid server action payload");
+  });
+
+  it("allows valid container graphs below the depth limit", async () => {
+    const body = new FormData();
+    const fieldCount = 128;
+    for (let index = 0; index < fieldCount; index++) {
+      body.set(String(index), index + 1 < fieldCount ? `["$Q${(index + 1).toString(16)}"]` : "[]");
+    }
+
+    await expect(validateServerActionPayload(body)).resolves.toBeNull();
+  });
 });
 
 // ── validateImageUrl ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- replace recursive Flight container graph DFS with bounded iterative validation
- cap numeric backing fields, unique references, and graph depth before React Flight decoding
- recognize hexadecimal `$Q` / `$W` / `$i` references, including `:path` suffixes
- validate the first occurrence of duplicate numeric multipart fields, matching `FormData.get()`
- clear pending cookies and action revalidation state when payload validation fails
- preserve Next.js-compatible multipart action lookup ordering without bypassing body limits

## Security impact

Before this change, an unauthenticated client could POST a sub-1 MiB multipart body containing a deep acyclic Flight container-reference chain. Recursive validation could throw `RangeError: Maximum call stack size exceeded`, producing a `500`. Repeated requests could consume request slots, Worker CPU, and process/isolate resources.

The final multipart fetch ordering preserves both protections:

1. Reject a declared `Content-Length` above `serverActions.bodySizeLimit` before action lookup.
2. For multipart requests with an acceptable or absent declared length, resolve the action ID before multipart parsing. Stale IDs return the normal action-not-found `404` without consuming the body.
3. For a valid action ID, read multipart data through `readFormDataWithLimit()`, so chunked bodies and dishonest `Content-Length` values remain bounded.
4. Validate the bounded Flight graph iteratively before `decodeReply()`.

## Reproduction

```bash
python3 - <<'PY'
from pathlib import Path

count = 10000
boundary = "VINEXTDOS"
parts = []
for i in range(count):
    value = f'["$Q{(i + 1):x}"]' if i + 1 < count else "[]"
    parts.append(
        f"--{boundary}\r\n"
        f'Content-Disposition: form-data; name="{i}"\r\n\r\n'
        f"{value}\r\n"
    )
parts.append(f"--{boundary}--\r\n")
Path("/tmp/vinext-dos.multipart").write_bytes("".join(parts).encode())
PY

curl -i https://TARGET/reachable-app-page \
  -X POST \
  -H 'Origin: https://TARGET' \
  -H 'Next-Action: VALID_ACTION_ID' \
  -H 'Content-Type: multipart/form-data; boundary=VINEXTDOS' \
  --data-binary @/tmp/vinext-dos.multipart
```

Previously this could produce a `500` and `RangeError`. It now returns `400 Invalid server action payload` without recursive traversal.

## Next.js parity

Next.js rejects declared oversized fetch-action bodies before action lookup, then resolves multipart fetch action IDs before Busboy/Flight decoding:

- `packages/next/src/server/app-render/action-handler.ts`
- `test/e2e/app-dir/no-server-actions/no-server-actions.test.ts`
- `test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts`

## Validation

- Four focused multipart ordering/security regressions pass.
- `vp test run tests/request-pipeline.test.ts tests/app-server-action-execution.test.ts` — **172 passed**.
- Full `vp check` — **1,882 files formatted; 858 files linted/type-checked with no issues**.
