### PR TITLE
fix(image): prevent optimizer cache-key amplification

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -201,6 +201,8 @@ export type NextConfig = {
     deviceSizes?: number[];
     /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [16, 32, 48, 64, 96, 128, 256, 384] */
     imageSizes?: number[];
+    /** Allowed image qualities. Defaults to Next.js 16's `[75]`. */
+    qualities?: number[];
     /** Allow SVG images through the image optimization endpoint. SVG can contain scripts, so only enable if you trust all image sources. */
     dangerouslyAllowSVG?: boolean;
     /** Allow image optimization for hostnames that resolve to private IP addresses. This is a security risk (SSRF) — only enable for private networks when you understand the risk. */

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -478,6 +478,17 @@ import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isI
 import type { ImageConfig } from "vinext/server/image-optimization";
 import handler from "vinext/server/app-router-entry";
 
+const imageConfig: ImageConfig = {
+  deviceSizes: JSON.parse(
+    process.env.__VINEXT_IMAGE_DEVICE_SIZES ?? JSON.stringify(DEFAULT_DEVICE_SIZES),
+  ),
+  imageSizes: JSON.parse(
+    process.env.__VINEXT_IMAGE_SIZES ?? JSON.stringify(DEFAULT_IMAGE_SIZES),
+  ),
+  qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "[75]"),
+  dangerouslyAllowSVG: process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG === "true",
+};
+
 interface Env {
   ASSETS: Fetcher;
   IMAGES: {
@@ -508,14 +519,17 @@ export default {
     // The parseImageParams validation inside handleImageOptimization
     // normalizes backslashes and validates the origin hasn't changed.
     if (isImageOptimizationPath(url.pathname)) {
-      const allowedWidths = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES];
+      const allowedWidths = [
+        ...(imageConfig.deviceSizes ?? DEFAULT_DEVICE_SIZES),
+        ...(imageConfig.imageSizes ?? DEFAULT_IMAGE_SIZES),
+      ];
       return handleImageOptimization(request, {
         fetchAsset: (path) => env.ASSETS.fetch(new Request(new URL(path, request.url))),
         transformImage: async (body, { width, format, quality }) => {
           const result = await env.IMAGES.input(body).transform(width > 0 ? { width } : {}).output({ format, quality });
           return result.response();
         },
-      }, allowedWidths);
+      }, allowedWidths, imageConfig);
     }
 
     // Delegate everything else to vinext, forwarding ctx so that

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -572,6 +572,7 @@ const configRedirects = vinextConfig?.redirects ?? [];
 const configRewrites = vinextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] };
 const configHeaders = vinextConfig?.headers ?? [];
 const imageConfig: ImageConfig | undefined = vinextConfig?.images ? {
+  qualities: vinextConfig.images.qualities,
   dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
   dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
   contentDispositionType: vinextConfig.images.contentDispositionType,
@@ -637,7 +638,10 @@ export default {
       // ── Image optimization via Cloudflare Images binding ──────────
       // Checked after basePath stripping so /<basePath>/_next/image works.
       if (isImageOptimizationPath(pathname)) {
-        const allowedWidths = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES];
+        const allowedWidths = [
+          ...(vinextConfig?.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
+          ...(vinextConfig?.images?.imageSizes ?? DEFAULT_IMAGE_SIZES),
+        ];
         return handleImageOptimization(request, {
           fetchAsset: (path) => env.ASSETS.fetch(new Request(new URL(path, request.url))),
           transformImage: async (body, { width, format, quality }) => {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -611,6 +611,7 @@ export default __createAppRscHandler({
   configRedirects: __configRedirects,
   configRewrites: __configRewrites,
   imageConfig: __imageConfig,
+  isDev: process.env.NODE_ENV !== "production",
   draftModeSecret: __draftModeSecret,
   dispatchMatchedPage({
     clientReuseManifest,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -17,6 +17,7 @@ import type {
   NextRedirect,
   NextRewrite,
 } from "../config/next-config.js";
+import type { ImageConfig } from "../server/image-optimization.js";
 import type { AppRoute } from "../routing/app-router.js";
 import { generateDevOriginCheckCode } from "../server/dev-origin-check.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
@@ -149,6 +150,7 @@ type AppRouterConfig = {
   cacheComponents?: boolean;
   /** Internationalization routing config for middleware matcher locale handling. */
   i18n?: NextI18nConfig | null;
+  imageConfig?: ImageConfig;
   /**
    * Absolute path to `app/global-not-found.{tsx,ts,js,jsx}` when present.
    * When provided, route-miss 404s render this module standalone (it owns its
@@ -542,6 +544,7 @@ const __i18nConfig = ${JSON.stringify(i18nConfig)};
 const __configRedirects = ${JSON.stringify(redirects)};
 const __configRewrites = ${JSON.stringify(rewrites)};
 const __configHeaders = ${JSON.stringify(headers)};
+const __imageConfig = ${JSON.stringify(config?.imageConfig)};
 const __publicFiles = new Set(${JSON.stringify(publicFiles)});
 const __allowedOrigins = ${JSON.stringify(allowedOrigins)};
 const __expireTime = ${JSON.stringify(expireTime)};
@@ -607,6 +610,7 @@ export default __createAppRscHandler({
   configHeaders: __configHeaders,
   configRedirects: __configRedirects,
   configRewrites: __configRewrites,
+  imageConfig: __imageConfig,
   draftModeSecret: __draftModeSecret,
   dispatchMatchedPage({
     clientReuseManifest,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -123,6 +123,7 @@ export async function generateServerEntry(
     images: {
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
+      qualities: nextConfig?.images?.qualities,
       dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
       dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
       contentDispositionType: nextConfig?.images?.contentDispositionType,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2663,6 +2663,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
               inlineCss: nextConfig?.inlineCss,
               i18n: nextConfig?.i18n,
+              imageConfig: {
+                deviceSizes: nextConfig?.images?.deviceSizes,
+                imageSizes: nextConfig?.images?.imageSizes,
+                qualities: nextConfig?.images?.qualities,
+              },
               hasPagesDir,
               publicFiles: scanPublicFileRoutes(root),
               globalNotFoundPath,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4405,6 +4405,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (!outDir) return;
 
           const imageConfig = {
+            deviceSizes: nextConfig?.images?.deviceSizes,
+            imageSizes: nextConfig?.images?.imageSizes,
+            qualities: nextConfig?.images?.qualities,
             dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
             contentDispositionType: nextConfig?.images?.contentDispositionType,
             contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -24,7 +24,13 @@ import {
 } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
-import { isImageOptimizationPath } from "./server/image-optimization.js";
+import {
+  DEFAULT_DEVICE_SIZES,
+  DEFAULT_IMAGE_QUALITIES,
+  DEFAULT_IMAGE_SIZES,
+  isImageOptimizationPath,
+  resolveDevImageRedirect,
+} from "./server/image-optimization.js";
 
 import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
 import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
@@ -1361,6 +1367,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             JSON.stringify(deviceSizes),
           );
           defines["process.env.__VINEXT_IMAGE_SIZES"] = JSON.stringify(JSON.stringify(imageSizes));
+          defines["process.env.__VINEXT_IMAGE_QUALITIES"] = JSON.stringify(
+            JSON.stringify(nextConfig.images?.qualities ?? DEFAULT_IMAGE_QUALITIES),
+          );
         }
         // Expose dangerouslyAllowSVG flag for the image shim's auto-skip logic.
         // When false (default), .svg sources bypass the optimization endpoint.
@@ -3370,35 +3379,21 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // ── Image optimization passthrough (dev mode) ─────────────
               // In dev, redirect to the original asset URL so Vite serves it.
               if (isImageOptimizationPath(url.split("?")[0]!)) {
-                const imgParams = new URLSearchParams(url.split("?")[1] ?? "");
-                const rawImgUrl = imgParams.get("url");
-                // Normalize backslashes: browsers and the URL constructor treat
-                // /\evil.com as //evil.com, bypassing the // check.
-                const imgUrl = rawImgUrl?.replaceAll("\\", "/") ?? null;
-                // Allowlist: must start with "/" but not "//" — blocks absolute
-                // URLs, protocol-relative, backslash variants, and exotic schemes.
-                // Also block internal Vite paths (/@*, /__vite*, /node_modules*)
-                // to prevent redirecting to dev server endpoints.
-                if (
-                  !imgUrl ||
-                  !imgUrl.startsWith("/") ||
-                  imgUrl.startsWith("//") ||
-                  imgUrl.startsWith("/@") ||
-                  imgUrl.startsWith("/__vite") ||
-                  imgUrl.startsWith("/node_modules")
-                ) {
+                const imageRequestUrl = new URL(url, `http://${req.headers.host || "localhost"}`);
+                const allowedWidths = [
+                  ...(nextConfig.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
+                  ...(nextConfig.images?.imageSizes ?? DEFAULT_IMAGE_SIZES),
+                ];
+                const encodedLocation = resolveDevImageRedirect(
+                  imageRequestUrl,
+                  allowedWidths,
+                  nextConfig.images?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+                );
+                if (!encodedLocation) {
                   res.writeHead(400);
-                  res.end(!rawImgUrl ? "Missing url parameter" : "Only relative URLs allowed");
+                  res.end("Invalid image optimization parameters");
                   return;
                 }
-                // Validate the constructed URL's origin hasn't changed (defense in depth).
-                const resolvedImg = new URL(imgUrl, `http://${req.headers.host || "localhost"}`);
-                if (resolvedImg.origin !== `http://${req.headers.host || "localhost"}`) {
-                  res.writeHead(400);
-                  res.end("Only relative URLs allowed");
-                  return;
-                }
-                const encodedLocation = resolvedImg.pathname + resolvedImg.search;
                 res.writeHead(302, { Location: encodedLocation });
                 res.end();
                 return;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -262,6 +262,7 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   ) => Promise<Response | null>;
   i18nConfig: NextI18nConfig | null;
   imageConfig?: ImageConfig;
+  isDev: boolean;
   isMiddlewareProxy: boolean;
   loadPrerenderPagesRoutes?: () => Promise<unknown>;
   makeThenableParams: MakeThenableParams;
@@ -557,6 +558,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ],
       options.imageConfig?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+      { isDev: options.isDev },
     );
     if (!imageRedirect)
       return new Response("Invalid image optimization parameters", { status: 400 });

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -49,7 +49,14 @@ import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
-import { isImageOptimizationPath } from "./image-optimization.js";
+import {
+  DEFAULT_DEVICE_SIZES,
+  DEFAULT_IMAGE_QUALITIES,
+  DEFAULT_IMAGE_SIZES,
+  isImageOptimizationPath,
+  resolveDevImageRedirect,
+  type ImageConfig,
+} from "./image-optimization.js";
 import { handleMetadataRouteRequest } from "./metadata-route-response.js";
 import type { MiddlewareModule } from "./middleware-runtime.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
@@ -63,7 +70,6 @@ import {
   applyConfigHeadersToResponse,
   normalizeTrailingSlash,
   resolvePublicFileRoute,
-  validateImageUrl,
 } from "./request-pipeline.js";
 import {
   prerenderRouteParamsPayloadMatchesRoute,
@@ -255,6 +261,7 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
     options: HandleServerActionRequestOptions,
   ) => Promise<Response | null>;
   i18nConfig: NextI18nConfig | null;
+  imageConfig?: ImageConfig;
   isMiddlewareProxy: boolean;
   loadPrerenderPagesRoutes?: () => Promise<unknown>;
   makeThenableParams: MakeThenableParams;
@@ -543,9 +550,17 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   if (beforeFilesRewrite) cleanPathname = beforeFilesRewrite;
 
   if (isImageOptimizationPath(cleanPathname)) {
-    const imageUrlResult = validateImageUrl(url.searchParams.get("url"), request.url);
-    if (imageUrlResult instanceof Response) return imageUrlResult;
-    return Response.redirect(new URL(imageUrlResult, url.origin).href, 302);
+    const imageRedirect = resolveDevImageRedirect(
+      url,
+      [
+        ...(options.imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
+        ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
+      ],
+      options.imageConfig?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+    );
+    if (!imageRedirect)
+      return new Response("Invalid image optimization parameters", { status: 400 });
+    return Response.redirect(new URL(imageRedirect, url.origin).href, 302);
   }
 
   const metadataRouteResponse = await handleMetadataRouteRequest({

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -133,9 +133,10 @@ export function parseImageParams(
   const quality = Number.parseInt(qualityParam, 10);
   if (String(width) !== widthParam || String(quality) !== qualityParam) return null;
 
-  const isDevBlur = options.isDev && width <= DEV_BLUR_MAX_WIDTH && quality === DEV_BLUR_QUALITY;
-  if (width <= 0 || (!allowedWidths.includes(width) && !isDevBlur)) return null;
-  if (quality < 1 || quality > 100 || (!allowedQualities.includes(quality) && !isDevBlur)) {
+  const isDevBlurWidth = options.isDev && width <= DEV_BLUR_MAX_WIDTH;
+  const isDevBlurQuality = options.isDev && quality === DEV_BLUR_QUALITY;
+  if (width <= 0 || (!allowedWidths.includes(width) && !isDevBlurWidth)) return null;
+  if (quality < 1 || quality > 100 || (!allowedQualities.includes(quality) && !isDevBlurQuality)) {
     return null;
   }
 

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -40,6 +40,12 @@ export function isImageOptimizationPath(pathname: string): boolean {
  * Controls SVG handling and security headers for the image endpoint.
  */
 export type ImageConfig = {
+  /** Allowed device widths. Defaults to Next.js device sizes. */
+  deviceSizes?: number[];
+  /** Allowed fixed-image widths. Defaults to Next.js image sizes. */
+  imageSizes?: number[];
+  /** Allowed output qualities. Defaults to Next.js's `[75]`. */
+  qualities?: number[];
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
   /**
@@ -65,41 +71,34 @@ export type ImageConfig = {
  */
 export const DEFAULT_DEVICE_SIZES = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 export const DEFAULT_IMAGE_SIZES = [16, 32, 48, 64, 96, 128, 256, 384];
-
-/**
- * Absolute maximum image width. Even if custom deviceSizes/imageSizes are
- * configured, widths above this are always rejected. This prevents resource
- * exhaustion from absurdly large resize requests.
- */
-const ABSOLUTE_MAX_WIDTH = 3840;
+export const DEFAULT_IMAGE_QUALITIES = [75];
 
 /**
  * Parse and validate image optimization query parameters.
  * Returns null if the request is malformed.
  *
- * When `allowedWidths` is provided, the width must be 0 (no resize) or
- * exactly match one of the allowed values. This matches Next.js behavior
- * where only configured deviceSizes and imageSizes are accepted.
- *
- * When `allowedWidths` is not provided, any width from 0 to ABSOLUTE_MAX_WIDTH
- * is accepted (backwards-compatible fallback).
+ * Ported from Next.js:
+ * test/integration/image-optimizer/test/index.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/integration/image-optimizer/test/index.test.ts
  */
 export function parseImageParams(
   url: URL,
-  allowedWidths?: number[],
+  allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
+  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
 ): { imageUrl: string; width: number; quality: number } | null {
   const imageUrl = url.searchParams.get("url");
   if (!imageUrl) return null;
+  if (imageUrl.length > 3072) return null;
 
-  const w = parseInt(url.searchParams.get("w") || "0", 10);
-  const q = parseInt(url.searchParams.get("q") || "75", 10);
+  const widthParam = url.searchParams.get("w");
+  const qualityParam = url.searchParams.get("q");
+  if (!widthParam || !/^[0-9]+$/.test(widthParam)) return null;
+  if (!qualityParam || !/^[0-9]+$/.test(qualityParam)) return null;
 
-  // Validate width (0 = no resize, otherwise must be positive and bounded)
-  if (Number.isNaN(w) || w < 0) return null;
-  if (w > ABSOLUTE_MAX_WIDTH) return null;
-  if (allowedWidths && w !== 0 && !allowedWidths.includes(w)) return null;
-  // Validate quality (1-100)
-  if (Number.isNaN(q) || q < 1 || q > 100) return null;
+  const width = Number.parseInt(widthParam, 10);
+  const quality = Number.parseInt(qualityParam, 10);
+  if (width <= 0 || !allowedWidths.includes(width)) return null;
+  if (quality < 1 || quality > 100 || !allowedQualities.includes(quality)) return null;
 
   // Prevent open redirect / SSRF — only allow path-relative URLs.
   // Normalize backslashes to forward slashes first: browsers and the URL
@@ -123,7 +122,7 @@ export function parseImageParams(
     return null;
   }
 
-  return { imageUrl: normalizedUrl, width: w, quality: q };
+  return { imageUrl: normalizedUrl, width, quality };
 }
 
 /**
@@ -238,7 +237,7 @@ export async function handleImageOptimization(
   imageConfig?: ImageConfig,
 ): Promise<Response> {
   const url = new URL(request.url);
-  const params = parseImageParams(url, allowedWidths);
+  const params = parseImageParams(url, allowedWidths, imageConfig?.qualities);
 
   if (!params) {
     return badRequestResponse();

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -72,6 +72,31 @@ export type ImageConfig = {
 export const DEFAULT_DEVICE_SIZES = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 export const DEFAULT_IMAGE_SIZES = [16, 32, 48, 64, 96, 128, 256, 384];
 export const DEFAULT_IMAGE_QUALITIES = [75];
+const DEV_BLUR_MAX_WIDTH = 8;
+const DEV_BLUR_QUALITY = 70;
+
+export type ParseImageParamsOptions = {
+  isDev?: boolean;
+};
+
+export function resolveDevImageRedirect(
+  requestUrl: URL,
+  allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
+  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
+): string | null {
+  const params = parseImageParams(requestUrl, allowedWidths, allowedQualities, { isDev: true });
+  if (!params) return null;
+  if (
+    params.imageUrl.startsWith("/@") ||
+    params.imageUrl.startsWith("/__vite") ||
+    params.imageUrl.startsWith("/node_modules")
+  ) {
+    return null;
+  }
+  const resolved = new URL(params.imageUrl, requestUrl.origin);
+  if (resolved.origin !== requestUrl.origin) return null;
+  return resolved.pathname + resolved.search;
+}
 
 /**
  * Parse and validate image optimization query parameters.
@@ -85,7 +110,16 @@ export function parseImageParams(
   url: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
   allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
+  options: ParseImageParamsOptions = {},
 ): { imageUrl: string; width: number; quality: number } | null {
+  // Intentional hardening divergence from Next.js: reject duplicate and unknown
+  // parameters so semantically identical transforms cannot occupy distinct
+  // cache keys and amplify image transformation work.
+  const allowedParamNames = new Set(["url", "w", "q"]);
+  for (const name of url.searchParams.keys()) {
+    if (!allowedParamNames.has(name) || url.searchParams.getAll(name).length !== 1) return null;
+  }
+
   const imageUrl = url.searchParams.get("url");
   if (!imageUrl) return null;
   if (imageUrl.length > 3072) return null;
@@ -97,8 +131,13 @@ export function parseImageParams(
 
   const width = Number.parseInt(widthParam, 10);
   const quality = Number.parseInt(qualityParam, 10);
-  if (width <= 0 || !allowedWidths.includes(width)) return null;
-  if (quality < 1 || quality > 100 || !allowedQualities.includes(quality)) return null;
+  if (String(width) !== widthParam || String(quality) !== qualityParam) return null;
+
+  const isDevBlur = options.isDev && width <= DEV_BLUR_MAX_WIDTH && quality === DEV_BLUR_QUALITY;
+  if (width <= 0 || (!allowedWidths.includes(width) && !isDevBlur)) return null;
+  if (quality < 1 || quality > 100 || (!allowedQualities.includes(quality) && !isDevBlur)) {
+    return null;
+  }
 
   // Prevent open redirect / SSRF — only allow path-relative URLs.
   // Normalize backslashes to forward slashes first: browsers and the URL

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -83,8 +83,9 @@ export function resolveDevImageRedirect(
   requestUrl: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
   allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
+  options: ParseImageParamsOptions = { isDev: true },
 ): string | null {
-  const params = parseImageParams(requestUrl, allowedWidths, allowedQualities, { isDev: true });
+  const params = parseImageParams(requestUrl, allowedWidths, allowedQualities, options);
   if (!params) return null;
   if (
     params.imageUrl.startsWith("/@") ||

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1283,8 +1283,11 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     // serves the original file with cache headers and security headers)
     if (isImageOptimizationPath(pathname)) {
       const parsedUrl = new URL(rawUrl, "http://localhost");
-      const defaultAllowedWidths = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES];
-      const params = parseImageParams(parsedUrl, defaultAllowedWidths);
+      const allowedWidths = [
+        ...(imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
+        ...(imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
+      ];
+      const params = parseImageParams(parsedUrl, allowedWidths, imageConfig?.qualities);
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");
@@ -1494,6 +1497,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     ? {
         dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
         dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
+        qualities: vinextConfig.images.qualities,
         contentDispositionType: vinextConfig.images.contentDispositionType,
         contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
       }
@@ -1614,7 +1618,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // ── Image optimization passthrough ──────────────────────────────
     if (isImageOptimizationPath(pathname) || isImageOptimizationPath(staticLookupPath)) {
       const parsedUrl = new URL(rawUrl, "http://localhost");
-      const params = parseImageParams(parsedUrl, allowedImageWidths);
+      const params = parseImageParams(parsedUrl, allowedImageWidths, pagesImageConfig?.qualities);
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -540,41 +540,6 @@ export function isOriginAllowed(origin: string, allowed: string[]): boolean {
 }
 
 /**
- * Validate an image optimization URL parameter.
- *
- * Ensures the URL is a relative path that doesn't escape the origin:
- * - Must start with "/" but not "//"
- * - Backslashes are normalized (browsers treat `\` as `/`)
- * - Origin validation as defense-in-depth
- *
- * @param rawUrl - The raw `url` query parameter value
- * @param requestUrl - The full request URL for origin comparison
- * @returns An error Response if validation fails, or the normalized image URL
- */
-export function validateImageUrl(rawUrl: string | null, requestUrl: string): Response | string {
-  // Normalize backslashes: browsers and the URL constructor treat
-  // /\evil.com as protocol-relative (//evil.com), bypassing the // check.
-  const imgUrl = rawUrl?.replaceAll("\\", "/") ?? null;
-  // Allowlist: must start with "/" but not "//" — blocks absolute URLs,
-  // protocol-relative, backslash variants, and exotic schemes.
-  if (!imgUrl || !imgUrl.startsWith("/") || imgUrl.startsWith("//")) {
-    return new Response(!rawUrl ? "Missing url parameter" : "Only relative URLs allowed", {
-      status: 400,
-    });
-  }
-  // Defense-in-depth origin check. Resolving a root-relative path against
-  // the request's own origin is tautologically same-origin today, but this
-  // guard protects against future changes to the upstream guards that might
-  // let a non-relative path slip through (e.g. a path with encoded slashes).
-  const url = new URL(requestUrl);
-  const resolvedImg = new URL(imgUrl, url.origin);
-  if (resolvedImg.origin !== url.origin) {
-    return new Response("Only relative URLs allowed", { status: 400 });
-  }
-  return imgUrl;
-}
-
-/**
  * Strip internal `x-middleware-*` headers from a Headers object.
  *
  * Middleware uses `x-middleware-*` headers as internal signals (e.g.

--- a/tests/app-router-next-config-codegen.test.ts
+++ b/tests/app-router-next-config-codegen.test.ts
@@ -115,6 +115,20 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("vinext");
   });
 
+  it("embeds image validation config in the pure App Router RSC handler", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
+      imageConfig: {
+        deviceSizes: [320, 640],
+        imageSizes: [16],
+        qualities: [60, 75],
+      },
+    });
+    expect(code).toContain("const __imageConfig");
+    expect(code).toContain('"deviceSizes":[320,640]');
+    expect(code).toContain('"qualities":[60,75]');
+    expect(code).toContain("imageConfig: __imageConfig");
+  });
+
   it("routes hybrid Pages API misses through the Pages server entry", () => {
     // Ported from Next.js: test/e2e/og-api/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/index.test.ts

--- a/tests/app-router-next-config-codegen.test.ts
+++ b/tests/app-router-next-config-codegen.test.ts
@@ -127,6 +127,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain('"deviceSizes":[320,640]');
     expect(code).toContain('"qualities":[60,75]');
     expect(code).toContain("imageConfig: __imageConfig");
+    expect(code).toContain('isDev: process.env.NODE_ENV !== "production"');
   });
 
   it("routes hybrid Pages API misses through the Pages server entry", () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -66,6 +66,7 @@ function createHandler(overrides: Partial<HandlerOptions> = {}) {
     handleProgressiveActionRequest: overrides.handleProgressiveActionRequest ?? (async () => null),
     handleServerActionRequest: overrides.handleServerActionRequest ?? (async () => null),
     i18nConfig: overrides.i18nConfig ?? null,
+    imageConfig: overrides.imageConfig,
     isMiddlewareProxy: overrides.isMiddlewareProxy ?? false,
     makeThenableParams,
     matchRoute:
@@ -96,6 +97,48 @@ function prerenderRouteParamsHeader(payload: unknown): string {
 }
 
 describe("createAppRscHandler", () => {
+  it.each([
+    "url=%2Fimg.jpg&w=640junk&q=75",
+    "url=%2Fimg.jpg&w=640&q=75&extra=1",
+    "url=%2Fimg.jpg&w=640&w=640&q=75",
+  ])("rejects malformed pure App Router dev image parameters: %s", async (query) => {
+    const handler = createHandler();
+    const response = await handler(
+      new Request(`https://example.test/docs/_next/image?${query}`),
+      null,
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("uses configured image widths and qualities in pure App Router dev", async () => {
+    const handler = createHandler({
+      imageConfig: { deviceSizes: [320], imageSizes: [16], qualities: [60] },
+    });
+    const allowed = await handler(
+      new Request("https://example.test/docs/_next/image?url=%2Fimg.jpg&w=320&q=60"),
+      null,
+    );
+    expect(allowed.status).toBe(302);
+    expect(allowed.headers.get("location")).toBe("https://example.test/img.jpg");
+
+    const defaultOnly = await handler(
+      new Request("https://example.test/docs/_next/image?url=%2Fimg.jpg&w=640&q=75"),
+      null,
+    );
+    expect(defaultOnly.status).toBe(400);
+  });
+
+  it("allows independent Next.js blur width and quality exceptions in pure App Router dev", async () => {
+    const handler = createHandler();
+    for (const query of ["url=%2Fimg.jpg&w=8&q=75", "url=%2Fimg.jpg&w=640&q=70"]) {
+      const response = await handler(
+        new Request(`https://example.test/docs/_next/image?${query}`),
+        null,
+      );
+      expect(response.status).toBe(302);
+    }
+  });
+
   it("wraps dispatch responses with request-scoped finalization", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
     const handler = createHandler({ dispatchMatchedPage });

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -67,6 +67,7 @@ function createHandler(overrides: Partial<HandlerOptions> = {}) {
     handleServerActionRequest: overrides.handleServerActionRequest ?? (async () => null),
     i18nConfig: overrides.i18nConfig ?? null,
     imageConfig: overrides.imageConfig,
+    isDev: overrides.isDev ?? true,
     isMiddlewareProxy: overrides.isMiddlewareProxy ?? false,
     makeThenableParams,
     matchRoute:
@@ -136,6 +137,17 @@ describe("createAppRscHandler", () => {
         null,
       );
       expect(response.status).toBe(302);
+    }
+  });
+
+  it("rejects Next.js blur width and quality exceptions in production", async () => {
+    const handler = createHandler({ isDev: false });
+    for (const query of ["url=%2Fimg.jpg&w=8&q=75", "url=%2Fimg.jpg&w=640&q=70"]) {
+      const response = await handler(
+        new Request(`https://example.test/docs/_next/image?${query}`),
+        null,
+      );
+      expect(response.status).toBe(400);
     }
   });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1165,6 +1165,14 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(basePathPos).toBeLessThan(imagePos);
   });
 
+  it("threads configured image widths and qualities into optimization validation", () => {
+    const content = generatePagesRouterWorkerEntry();
+    expect(content).toContain("vinextConfig?.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES");
+    expect(content).toContain("vinextConfig?.images?.imageSizes ?? DEFAULT_IMAGE_SIZES");
+    expect(content).toContain("qualities: vinextConfig.images.qualities");
+    expect(content).toContain("}, allowedWidths, imageConfig)");
+  });
+
   it("uses segment-boundary check before skipping redirect destination prefixing", () => {
     const content = generatePagesRouterWorkerEntry();
     // Segment-boundary checks for redirect destination prefixing are now

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -574,6 +574,16 @@ describe("generateAppRouterWorkerEntry", () => {
     expect(content).toContain("handleImageOptimization");
   });
 
+  it("threads configured image widths and qualities into the App Router worker", () => {
+    const content = generateAppRouterWorkerEntry();
+    expect(content).toContain("process.env.__VINEXT_IMAGE_DEVICE_SIZES");
+    expect(content).toContain("process.env.__VINEXT_IMAGE_SIZES");
+    expect(content).toContain("process.env.__VINEXT_IMAGE_QUALITIES");
+    expect(content).toContain("JSON.stringify(DEFAULT_DEVICE_SIZES)");
+    expect(content).toContain("JSON.stringify(DEFAULT_IMAGE_SIZES)");
+    expect(content).toContain("}, allowedWidths, imageConfig)");
+  });
+
   it("declares Env interface with IMAGES binding", () => {
     const content = generateAppRouterWorkerEntry();
     expect(content).toContain("interface Env");

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -15,7 +15,6 @@ import {
   resolvePublicFileRoute,
   validateCsrfOrigin,
   validateServerActionPayload,
-  validateImageUrl,
   processMiddlewareHeaders,
   VINEXT_INTERNAL_HEADERS,
 } from "../packages/vinext/src/server/request-pipeline.js";
@@ -589,46 +588,6 @@ describe("validateServerActionPayload", () => {
     expect(res).not.toBeNull();
     expect(res!.status).toBe(400);
     await expect(res!.text()).resolves.toBe("Invalid server action payload");
-  });
-});
-
-// ── validateImageUrl ────────────────────────────────────────────────────
-
-describe("validateImageUrl", () => {
-  const requestUrl = "http://localhost:3000/page";
-
-  it("returns the normalized image URL for valid relative paths", () => {
-    expect(validateImageUrl("/images/photo.png", requestUrl)).toBe("/images/photo.png");
-  });
-
-  it("returns 400 for missing url parameter", () => {
-    const res = validateImageUrl(null, requestUrl);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).status).toBe(400);
-  });
-
-  it("returns 400 for empty string", () => {
-    const res = validateImageUrl("", requestUrl);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).status).toBe(400);
-  });
-
-  it("returns 400 for absolute URLs", () => {
-    const res = validateImageUrl("http://evil.com/image.png", requestUrl);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).status).toBe(400);
-  });
-
-  it("returns 400 for protocol-relative URLs", () => {
-    const res = validateImageUrl("//evil.com/image.png", requestUrl);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).status).toBe(400);
-  });
-
-  it("normalizes backslashes and blocks protocol-relative variants", () => {
-    const res = validateImageUrl("/\\evil.com/image.png", requestUrl);
-    expect(res).toBeInstanceOf(Response);
-    expect((res as Response).status).toBe(400);
   });
 });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17337,6 +17337,12 @@ describe("image optimization request parsing", () => {
       resolveDevImageRedirect(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=8&q=70")),
     ).toBe("/img.jpg");
     expect(
+      resolveDevImageRedirect(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=8&q=75")),
+    ).toBe("/img.jpg");
+    expect(
+      resolveDevImageRedirect(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=70")),
+    ).toBe("/img.jpg");
+    expect(
       resolveDevImageRedirect(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=08&q=70")),
     ).toBeNull();
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17054,39 +17054,76 @@ describe("image optimization request parsing", () => {
   it("parseImageParams returns null when url is missing", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const url = new URL("http://localhost/_next/image?w=800&q=75");
+    const url = new URL("http://localhost/_next/image?w=640&q=75");
     expect(parseImageParams(url)).toBeNull();
   });
 
   it("parseImageParams blocks absolute http URLs", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const url = new URL("http://localhost/_next/image?url=http%3A%2F%2Fevil.com%2Fimg.jpg&w=800");
+    const url = new URL(
+      "http://localhost/_next/image?url=http%3A%2F%2Fevil.com%2Fimg.jpg&w=640&q=75",
+    );
     expect(parseImageParams(url)).toBeNull();
   });
 
   it("parseImageParams blocks absolute https URLs", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const url = new URL("http://localhost/_next/image?url=https%3A%2F%2Fevil.com%2Fimg.jpg&w=800");
+    const url = new URL(
+      "http://localhost/_next/image?url=https%3A%2F%2Fevil.com%2Fimg.jpg&w=640&q=75",
+    );
     expect(parseImageParams(url)).toBeNull();
   });
 
   it("parseImageParams blocks protocol-relative URLs", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const url = new URL("http://localhost/_next/image?url=%2F%2Fevil.com%2Fimg.jpg&w=800");
+    const url = new URL("http://localhost/_next/image?url=%2F%2Fevil.com%2Fimg.jpg&w=640&q=75");
     expect(parseImageParams(url)).toBeNull();
   });
 
-  it("parseImageParams defaults width to 0 and quality to 75", async () => {
+  // Ported from Next.js: test/integration/image-optimizer/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/integration/image-optimizer/test/index.test.ts
+  it("parseImageParams requires width and quality", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const url = new URL("http://localhost/_next/image?url=%2Fimg.jpg");
-    const params = parseImageParams(url);
-    expect(params).not.toBeNull();
-    expect(params!.width).toBe(0);
-    expect(params!.quality).toBe(75);
+    expect(parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg"))).toBeNull();
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640")),
+    ).toBeNull();
+  });
+
+  it("parseImageParams rejects cache-key aliases with integer suffixes", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640junk&q=75")),
+    ).toBeNull();
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75junk")),
+    ).toBeNull();
+  });
+
+  it("parseImageParams rejects zero, signed, and decimal widths", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    for (const width of ["0", "-640", "+640", "640.0"]) {
+      expect(
+        parseImageParams(new URL(`http://localhost/_next/image?url=%2Fimg.jpg&w=${width}&q=75`)),
+      ).toBeNull();
+    }
+  });
+
+  it("parseImageParams rejects source URLs longer than 3072 characters", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    const imageUrl = `/${"a".repeat(3072)}`;
+    const url = new URL("http://localhost/_next/image");
+    url.searchParams.set("url", imageUrl);
+    url.searchParams.set("w", "640");
+    url.searchParams.set("q", "75");
+    expect(parseImageParams(url)).toBeNull();
   });
 
   it("parseImageParams blocks data: URIs (exotic scheme bypass)", async () => {
@@ -17095,7 +17132,7 @@ describe("image optimization request parsing", () => {
     expect(
       parseImageParams(
         new URL(
-          "http://localhost/_next/image?url=data%3Atext%2Fhtml%2C%3Cscript%3Ealert(1)%3C%2Fscript%3E&w=800",
+          "http://localhost/_next/image?url=data%3Atext%2Fhtml%2C%3Cscript%3Ealert(1)%3C%2Fscript%3E&w=640&q=75",
         ),
       ),
     ).toBeNull();
@@ -17105,22 +17142,28 @@ describe("image optimization request parsing", () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=javascript%3Aalert(1)&w=800")),
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=javascript%3Aalert(1)&w=640&q=75"),
+      ),
     ).toBeNull();
   });
 
   it("parseImageParams blocks bare filenames (no leading slash)", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    expect(parseImageParams(new URL("http://localhost/_next/image?url=img.jpg&w=800"))).toBeNull();
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=img.jpg&w=640&q=75")),
+    ).toBeNull();
   });
 
   it("parseImageParams rejects quality outside 1-100", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    expect(parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&q=0"))).toBeNull();
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&q=101")),
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=0")),
+    ).toBeNull();
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=101")),
     ).toBeNull();
   });
 
@@ -17129,7 +17172,7 @@ describe("image optimization request parsing", () => {
       await import("../packages/vinext/src/server/image-optimization.js");
     // /\evil.com — browsers and the URL constructor treat this as //evil.com
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2F%5Cevil.com&w=800")),
+      parseImageParams(new URL("http://localhost/_next/image?url=%2F%5Cevil.com&w=640&q=75")),
     ).toBeNull();
   });
 
@@ -17138,11 +17181,13 @@ describe("image optimization request parsing", () => {
       await import("../packages/vinext/src/server/image-optimization.js");
     // /\evil.com/img.jpg
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2F%5Cevil.com%2Fimg.jpg&w=800")),
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2F%5Cevil.com%2Fimg.jpg&w=640&q=75"),
+      ),
     ).toBeNull();
     // /\\evil.com (double backslash)
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2F%5C%5Cevil.com&w=800")),
+      parseImageParams(new URL("http://localhost/_next/image?url=%2F%5C%5Cevil.com&w=640&q=75")),
     ).toBeNull();
   });
 
@@ -17153,7 +17198,7 @@ describe("image optimization request parsing", () => {
     // the origin check catches it.
     // A valid relative URL should pass
     const good = parseImageParams(
-      new URL("http://localhost/_next/image?url=%2Fimages%2Fhero.webp&w=800"),
+      new URL("http://localhost/_next/image?url=%2Fimages%2Fhero.webp&w=640&q=75"),
     );
     expect(good).not.toBeNull();
     expect(good!.imageUrl).toBe("/images/hero.webp");
@@ -17165,7 +17210,7 @@ describe("image optimization request parsing", () => {
     // /images\hero.webp should be normalized to /images/hero.webp
     // (backslash in the middle of a valid path)
     const result = parseImageParams(
-      new URL("http://localhost/_next/image?url=%2Fimages%5Chero.webp&w=800"),
+      new URL("http://localhost/_next/image?url=%2Fimages%5Chero.webp&w=640&q=75"),
     );
     expect(result).not.toBeNull();
     expect(result!.imageUrl).toBe("/images/hero.webp");
@@ -17175,20 +17220,22 @@ describe("image optimization request parsing", () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=3841")),
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=3841&q=75")),
     ).toBeNull();
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=999999999")),
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=999999999&q=75")),
     ).toBeNull();
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=2147483647")),
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=2147483647&q=75")),
     ).toBeNull();
   });
 
   it("parseImageParams accepts width at the absolute maximum (3840)", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const params = parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=3840"));
+    const params = parseImageParams(
+      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=3840&q=75"),
+    );
     expect(params).not.toBeNull();
     expect(params!.width).toBe(3840);
   });
@@ -17199,22 +17246,46 @@ describe("image optimization request parsing", () => {
     const allowedWidths = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
     // Allowed width passes
     const params = parseImageParams(
-      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=1080"),
+      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=1080&q=75"),
       allowedWidths,
     );
     expect(params).not.toBeNull();
     expect(params!.width).toBe(1080);
     // Non-allowed width is rejected
     expect(
-      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=999"), allowedWidths),
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=999&q=75"),
+        allowedWidths,
+      ),
     ).toBeNull();
-    // w=0 (no resize) is always allowed even with allowedWidths
-    const noResize = parseImageParams(
-      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=0"),
-      allowedWidths,
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=0&q=75"),
+        allowedWidths,
+      ),
+    ).toBeNull();
+  });
+
+  it("parseImageParams defaults allowed qualities to 75", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75")),
+    ).not.toBeNull();
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=80")),
+    ).toBeNull();
+  });
+
+  it("parseImageParams accepts configured qualities", async () => {
+    const { parseImageParams, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    const params = parseImageParams(
+      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=80"),
+      [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
+      [75, 80],
     );
-    expect(noResize).not.toBeNull();
-    expect(noResize!.width).toBe(0);
+    expect(params?.quality).toBe(80);
   });
 
   it("parseImageParams allows imageSizes (small widths) in allowedWidths", async () => {
@@ -17224,7 +17295,7 @@ describe("image optimization request parsing", () => {
       16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080, 1200, 1920, 2048, 3840,
     ];
     const params = parseImageParams(
-      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=64"),
+      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=64&q=75"),
       allowedWidths,
     );
     expect(params).not.toBeNull();
@@ -17366,7 +17437,7 @@ describe("handleImageOptimization", () => {
   it("returns 404 when fetchAsset fails", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () => new Response("", { status: 404 }),
     };
@@ -17377,7 +17448,7 @@ describe("handleImageOptimization", () => {
   it("returns original image when no transformImage handler", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("original-image-data", {
@@ -17395,7 +17466,7 @@ describe("handleImageOptimization", () => {
   it("calls transformImage when provided", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800&q=90", {
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=90", {
       headers: { Accept: "image/webp" },
     });
     let capturedOptions: { width: number; format: string; quality: number } | null = null;
@@ -17413,16 +17484,18 @@ describe("handleImageOptimization", () => {
         return new Response("transformed", { headers: { "Content-Type": options.format } });
       },
     };
-    const response = await handleImageOptimization(request, handlers);
+    const response = await handleImageOptimization(request, handlers, undefined, {
+      qualities: [90],
+    });
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("transformed");
-    expect(capturedOptions).toEqual({ width: 800, format: "image/webp", quality: 90 });
+    expect(capturedOptions).toEqual({ width: 640, format: "image/webp", quality: 90 });
   });
 
   it("falls back to original on transform error", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     let fetchCount = 0;
     const handlers = {
       fetchAsset: async () => {
@@ -17445,7 +17518,7 @@ describe("handleImageOptimization", () => {
   it("refetches the source when transform consumes the stream before failing", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     let fetchCount = 0;
     const handlers = {
       fetchAsset: async () => {
@@ -17469,7 +17542,7 @@ describe("handleImageOptimization", () => {
   it("uses refetched source headers when consumed transform falls back", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     let fetchCount = 0;
     const handlers = {
       fetchAsset: async () => {
@@ -17499,7 +17572,7 @@ describe("handleImageOptimization", () => {
   it("returns 404 when refetch fallback cannot reload the source image", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     let fetchCount = 0;
     const handlers = {
       fetchAsset: async () => {
@@ -17525,7 +17598,7 @@ describe("handleImageOptimization", () => {
   it("returns 400 when refetch fallback reloads an unsafe content type", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     let fetchCount = 0;
     const handlers = {
       fetchAsset: async () => {
@@ -17551,7 +17624,7 @@ describe("handleImageOptimization", () => {
   it("returns 400 for backslash open redirect (/\\evil.com)", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2F%5Cevil.com&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2F%5Cevil.com&w=640&q=75");
     const handlers = {
       fetchAsset: async () => new Response("should not be called", { status: 200 }),
     };
@@ -17563,7 +17636,7 @@ describe("handleImageOptimization", () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
     const request = new Request(
-      "http://localhost/_next/image?url=%2F%5Cgoogle.com%2Fimg.jpg&w=800",
+      "http://localhost/_next/image?url=%2F%5Cgoogle.com%2Fimg.jpg&w=640&q=75",
     );
     let fetchCalled = false;
     const handlers = {
@@ -17580,7 +17653,7 @@ describe("handleImageOptimization", () => {
   it("blocks SVG content type", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fmalicious.svg&w=100&q=75");
+    const request = new Request("http://localhost/_next/image?url=%2Fmalicious.svg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("<svg><script>alert(1)</script></svg>", {
@@ -17596,7 +17669,7 @@ describe("handleImageOptimization", () => {
   it("blocks text/html content type", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Ffake.jpg&w=100&q=75");
+    const request = new Request("http://localhost/_next/image?url=%2Ffake.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("<html><script>alert(1)</script></html>", {
@@ -17611,7 +17684,7 @@ describe("handleImageOptimization", () => {
   it("blocks responses with no Content-Type", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () => new Response("data", { status: 200 }),
     };
@@ -17622,7 +17695,7 @@ describe("handleImageOptimization", () => {
   it("sets Content-Security-Policy header on fallback responses", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("image-data", {
@@ -17642,7 +17715,7 @@ describe("handleImageOptimization", () => {
   it("sets Content-Security-Policy header on transformed responses", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800&q=90", {
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=90", {
       headers: { Accept: "image/webp" },
     });
     const handlers = {
@@ -17656,7 +17729,9 @@ describe("handleImageOptimization", () => {
         options: { width: number; format: string; quality: number },
       ) => new Response("transformed", { headers: { "Content-Type": options.format } }),
     };
-    const response = await handleImageOptimization(request, handlers);
+    const response = await handleImageOptimization(request, handlers, undefined, {
+      qualities: [90],
+    });
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Security-Policy")).toBe(
       "script-src 'none'; frame-src 'none'; sandbox;",
@@ -17668,7 +17743,7 @@ describe("handleImageOptimization", () => {
   it("overrides unsafe Content-Type from transform handler", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800&q=90", {
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=90", {
       headers: { Accept: "image/webp" },
     });
     const handlers = {
@@ -17680,7 +17755,9 @@ describe("handleImageOptimization", () => {
       transformImage: async () =>
         new Response("transformed", { headers: { "Content-Type": "text/html" } }),
     };
-    const response = await handleImageOptimization(request, handlers);
+    const response = await handleImageOptimization(request, handlers, undefined, {
+      qualities: [90],
+    });
     expect(response.status).toBe(200);
     // Should override to the negotiated format, not pass through text/html
     expect(response.headers.get("Content-Type")).toBe("image/webp");
@@ -17689,7 +17766,7 @@ describe("handleImageOptimization", () => {
   it("allows SVG passthrough with dangerouslyAllowSVG: true", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=100&q=75");
+    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>', {
@@ -17708,7 +17785,7 @@ describe("handleImageOptimization", () => {
   it("still blocks SVG when dangerouslyAllowSVG is false", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=100&q=75");
+    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("<svg></svg>", {
@@ -17725,7 +17802,7 @@ describe("handleImageOptimization", () => {
   it("SVG passthrough skips transformImage", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=100&q=75");
+    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=640&q=75");
     let transformCalled = false;
     const handlers = {
       fetchAsset: async () =>
@@ -17749,7 +17826,7 @@ describe("handleImageOptimization", () => {
   it("applies security headers on SVG passthrough", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=100&q=75");
+    const request = new Request("http://localhost/_next/image?url=%2Flogo.svg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("<svg></svg>", {
@@ -17771,7 +17848,7 @@ describe("handleImageOptimization", () => {
   it("applies custom contentDispositionType", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("image-data", {
@@ -17789,7 +17866,7 @@ describe("handleImageOptimization", () => {
   it("defaults Content-Disposition to inline when contentDispositionType is invalid", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("image-data", {
@@ -17807,7 +17884,7 @@ describe("handleImageOptimization", () => {
   it("applies custom contentSecurityPolicy", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("image-data", {
@@ -17826,7 +17903,7 @@ describe("handleImageOptimization", () => {
   it("default behavior unchanged when no imageConfig provided", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=800");
+    const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
     const handlers = {
       fetchAsset: async () =>
         new Response("image-data", {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17115,6 +17115,30 @@ describe("image optimization request parsing", () => {
     }
   });
 
+  it("parseImageParams rejects leading-zero cache-key aliases", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=0640&q=75")),
+    ).toBeNull();
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=075")),
+    ).toBeNull();
+  });
+
+  it("parseImageParams rejects duplicate and unknown query parameters", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&w=640&q=75")),
+    ).toBeNull();
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75&cacheBust=1"),
+      ),
+    ).toBeNull();
+  });
+
   it("parseImageParams rejects source URLs longer than 3072 characters", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
@@ -17286,6 +17310,35 @@ describe("image optimization request parsing", () => {
       [75, 80],
     );
     expect(params?.quality).toBe(80);
+  });
+
+  it("resolveDevImageRedirect applies validation before passthrough", async () => {
+    const { resolveDevImageRedirect } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      resolveDevImageRedirect(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640junk&q=75"),
+      ),
+    ).toBeNull();
+    expect(
+      resolveDevImageRedirect(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75&extra=1"),
+      ),
+    ).toBeNull();
+    expect(
+      resolveDevImageRedirect(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75")),
+    ).toBe("/img.jpg");
+  });
+
+  it("resolveDevImageRedirect preserves Next.js blur requests", async () => {
+    const { resolveDevImageRedirect } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      resolveDevImageRedirect(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=8&q=70")),
+    ).toBe("/img.jpg");
+    expect(
+      resolveDevImageRedirect(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=08&q=70")),
+    ).toBeNull();
   });
 
   it("parseImageParams allows imageSizes (small widths) in allowedWidths", async () => {


### PR DESCRIPTION
## Summary

Fixes image optimizer parameter validation to prevent cache-key / transformation amplification across production and all development runtimes, including the pure App Router RSC handler.

- requires canonical positive decimal `w` and canonical decimal `q`
- rejects malformed aliases such as `w=640junk`, `q=75junk`, `w=0640`, and `q=075`
- rejects duplicate and unknown query parameters
- limits source image URLs to 3072 characters
- validates widths against configured `deviceSizes` + `imageSizes`
- adds `images.qualities` support with Next.js default `[75]`
- threads custom widths/qualities through generated App/Pages Cloudflare workers, Node runtimes, shared Vite dev middleware, and the pure App Router RSC dev handler
- preserves Next.js's independent development blur exceptions: width `<= 8` is accepted independently of quality, and quality `70` is accepted independently of width

## Security impact

Previously many distinct URLs produced an identical image transformation:

```bash
for i in $(seq 1 10000); do
  curl -sS -o /dev/null \
    "https://TARGET/_next/image?url=%2Fhero.jpg&w=640junk${i}&q=75junk${i}"
done
```

Additional aliases included leading zeros, repeated parameters, and arbitrary ignored parameters:

```text
w=0640&q=75
w=640&q=075
w=640&w=640&q=75
w=640&q=75&cacheBust=UNIQUE
```

These variants could occupy separate CDN/cache keys while triggering the same Cloudflare Images operation, enabling unauthenticated billing amplification, cache pollution, origin traffic amplification, and availability degradation.

## Next.js compatibility

Width/quality syntax, configured widths, URL length, quality configuration, and independent development blur exceptions follow current Next.js.

Vinext intentionally diverges by rejecting duplicate and unknown optimizer parameters. Next.js may ignore some extras, but accepting them leaves an unbounded cache-key alias surface. The endpoint has a fixed public contract of `url`, `w`, and `q`, so noncanonical requests now receive `400`.

Compared against:

- `packages/next/src/server/image-optimizer.ts`
- `packages/next/src/shared/lib/image-config.ts`
- `test/integration/image-optimizer/test/index.test.ts`

## Tests

```text
vp test run tests/app-rsc-handler.test.ts tests/app-router-next-config-codegen.test.ts
69 passed

vp test run tests/app-rsc-handler.test.ts -t "image|blur"
5 passed

vp test run tests/app-router-next-config-codegen.test.ts -t "image validation config"
1 passed

vp test run tests/shims.test.ts -t "image optimization|handleImageOptimization|resolveDevImageRedirect|isSafeImageContentType"
71 passed

vp test run tests/deploy.test.ts -t "image optimization|image widths and qualities|App Router worker"
7 passed

vp test run tests/pages-router.test.ts -t "image"
4 passed

vp check packages/vinext/src/server/image-optimization.ts packages/vinext/src/server/app-rsc-handler.ts packages/vinext/src/entries/app-rsc-entry.ts packages/vinext/src/index.ts tests/shims.test.ts tests/app-rsc-handler.test.ts tests/app-router-next-config-codegen.test.ts
No formatting, lint, or type errors
```
