### PR TITLE
fix(deploy): prevent Windows shell injection

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1145,62 +1145,86 @@ type WranglerDeployArgs = {
   env: string | undefined;
 };
 
+export function validateWranglerEnvName(env: string): string {
+  if (env.includes("\0")) {
+    throw new Error("Wrangler environment names cannot contain null bytes.");
+  }
+  if (env.length > 255) {
+    throw new Error("Wrangler environment names cannot exceed 255 characters.");
+  }
+  return env;
+}
+
 export function buildWranglerDeployArgs(
   options: Pick<DeployOptions, "preview" | "env">,
 ): WranglerDeployArgs {
   const args = ["deploy"];
   const env = options.env || (options.preview ? "preview" : undefined);
   if (env) {
-    args.push("--env", env);
+    args.push("--env", validateWranglerEnvName(env));
   }
   return { args, env };
 }
 
 /**
- * Resolve the wrangler executable in node_modules.
+ * Resolve Wrangler's JavaScript CLI entrypoint in node_modules.
  *
- * Walks up ancestor directories so the binary is found even when node_modules
- * is hoisted to the workspace root in a monorepo.
- *
- * On Windows, `node_modules/.bin/` contains both a Unix shebang script (no
- * extension) and a `.CMD` shim. Node's `execFileSync` uses CreateProcess(),
- * which only resolves PATHEXT extensions (`.cmd`, `.exe`, ...) — spawning the
- * bare-name shebang file fails with ENOENT even though the file exists. So on
- * Windows we prefer the `.CMD` shim and only fall back to the bare name for a
- * clearer error message if neither is present.
+ * Invoking the JavaScript file through `process.execPath` avoids the `.cmd`
+ * shim and command shell that package managers create on Windows.
  */
 export function resolveWranglerBin(
   root: string,
-  platform: NodeJS.Platform = process.platform,
+  resolvePackageJson: (root: string) => string | null = (projectRoot) => {
+    try {
+      return createRequire(path.join(projectRoot, "package.json")).resolve("wrangler/package.json");
+    } catch {
+      return _findInNodeModules(projectRoot, "wrangler/package.json");
+    }
+  },
 ): string {
-  const candidates =
-    platform === "win32"
-      ? [".bin/wrangler.CMD", ".bin/wrangler.cmd", ".bin/wrangler"]
-      : [".bin/wrangler"];
-
-  for (const candidate of candidates) {
-    const found = _findInNodeModules(root, candidate);
-    if (found) return found;
+  const packageJsonPath = resolvePackageJson(root);
+  if (packageJsonPath) {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+      bin?: string | Record<string, string>;
+    };
+    const bin = typeof packageJson.bin === "string" ? packageJson.bin : packageJson.bin?.wrangler;
+    if (bin) return path.resolve(path.dirname(packageJsonPath), bin);
   }
 
-  // Not found — return platform-appropriate path under root for error clarity.
-  return path.join(root, "node_modules", ...candidates[0].split("/"));
+  return path.join(root, "node_modules", "wrangler", "bin", "wrangler.js");
 }
 
-function runWranglerDeploy(root: string, options: Pick<DeployOptions, "preview" | "env">): string {
-  const wranglerBin = resolveWranglerBin(root);
+export function buildNodeCliInvocation(
+  scriptPath: string,
+  args: string[],
+  nodeExecutable: string = process.execPath,
+): { file: string; args: string[] } {
+  return { file: nodeExecutable, args: [scriptPath, ...args] };
+}
 
+export function buildWranglerInvocation(
+  root: string,
+  options: Pick<DeployOptions, "preview" | "env">,
+  nodeExecutable: string = process.execPath,
+): { file: string; args: string[]; env: string | undefined } {
+  const wranglerBin = resolveWranglerBin(root);
+  const { args, env } = buildWranglerDeployArgs(options);
+  return { ...buildNodeCliInvocation(wranglerBin, args, nodeExecutable), env };
+}
+
+export function runWranglerDeploy(
+  root: string,
+  options: Pick<DeployOptions, "preview" | "env">,
+  execute: typeof execFileSync = execFileSync,
+): string {
   const execOpts: ExecFileSyncOptions = {
     cwd: root,
     stdio: "pipe",
     encoding: "utf-8",
-    // On Windows, .bin/wrangler is a .cmd wrapper; execFileSync can't run
-    // it without a shell.  Enabling shell only on win32 keeps the
-    // no-shell-injection guarantee on other platforms.
-    shell: process.platform === "win32",
+    shell: false,
   };
 
-  const { args, env } = buildWranglerDeployArgs(options);
+  const { file, args, env } = buildWranglerInvocation(root, options);
 
   if (env) {
     console.log(`\n  Deploying to env: ${env}...`);
@@ -1208,10 +1232,7 @@ function runWranglerDeploy(root: string, options: Pick<DeployOptions, "preview" 
     console.log("\n  Deploying to production...");
   }
 
-  // execFileSync passes args as an array, avoiding shell injection on Unix.
-  // On Windows, shell: true is required for .cmd wrappers but the array form
-  // still prevents trivial injection.
-  const output = execFileSync(wranglerBin, args, execOpts) as string;
+  const output = execute(file, args, execOpts) as string;
 
   // Parse the deployed URL from wrangler output
   // Wrangler prints: "Published <name> (version_id)\n  https://<name>.<subdomain>.workers.dev"
@@ -1231,6 +1252,9 @@ function runWranglerDeploy(root: string, options: Pick<DeployOptions, "preview" 
 // ─── Main Entry ──────────────────────────────────────────────────────────────
 
 export async function deploy(options: DeployOptions): Promise<void> {
+  const deployEnv = validateWranglerEnvName(
+    options.env || (options.preview ? "preview" : "production"),
+  );
   const root = path.resolve(options.root);
   loadDotenv({ root, mode: "production" });
 
@@ -1327,10 +1351,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
 
   // Step 5: Build
   if (!options.skipBuild) {
-    // Resolve the env name the same way buildWranglerDeployArgs does, so the
-    // build emits a wrangler.json that matches the env we'll deploy with.
-    const buildEnv = options.env || (options.preview ? "preview" : undefined);
-    await runBuild(info, buildEnv);
+    await runBuild(info, deployEnv === "production" && !options.env ? undefined : deployEnv);
   } else {
     console.log("\n  Skipping build (--skip-build)");
   }
@@ -1374,8 +1395,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
 
   // Step 7: Deploy via wrangler
   const url = runWranglerDeploy(root, {
-    preview: options.preview ?? false,
-    env: options.env,
+    env: deployEnv === "production" && !options.env ? undefined : deployEnv,
   });
 
   console.log("\n  ─────────────────────────────────────────");

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -1149,9 +1149,6 @@ export function validateWranglerEnvName(env: string): string {
   if (env.includes("\0")) {
     throw new Error("Wrangler environment names cannot contain null bytes.");
   }
-  if (env.length > 255) {
-    throw new Error("Wrangler environment names cannot exceed 255 characters.");
-  }
   return env;
 }
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { execFileSync } from "node:child_process";
 import {
   detectProject,
+  deploy,
   generateWranglerConfig,
   generateAppRouterWorkerEntry,
   generatePagesRouterWorkerEntry,
@@ -13,9 +15,13 @@ import {
   getFilesToGenerate,
   ensureESModule,
   renameCJSConfigs,
+  buildNodeCliInvocation,
+  buildWranglerInvocation,
   buildWranglerDeployArgs,
   parseDeployArgs,
   resolveWranglerBin,
+  runWranglerDeploy,
+  validateWranglerEnvName,
   withCloudflareEnv,
   isPackageResolvable,
   viteConfigHasCloudflarePlugin,
@@ -134,6 +140,40 @@ describe("buildWranglerDeployArgs", () => {
   it("treats empty string env as production", () => {
     expect(buildWranglerDeployArgs({ env: "" })).toEqual({ args: ["deploy"], env: undefined });
   });
+
+  it("preserves shell metacharacters as a literal environment argument", () => {
+    const env = "preview & whoami > vinext-pwned.txt & rem";
+    expect(buildWranglerDeployArgs({ env })).toEqual({
+      args: ["deploy", "--env", env],
+      env,
+    });
+  });
+
+  it.each(["production", "preview-1", "staging_eu", "release.2026", "team/app @ 1"])(
+    "accepts Wrangler environment name %s",
+    (env) => {
+      expect(validateWranglerEnvName(env)).toBe(env);
+    },
+  );
+
+  it("rejects null bytes and excessively long environment names", () => {
+    expect(() => validateWranglerEnvName("preview\0prod")).toThrow("null bytes");
+    expect(() => validateWranglerEnvName("a".repeat(256))).toThrow("255 characters");
+  });
+});
+
+describe("deploy environment validation", () => {
+  it("rejects invalid environment names before project side effects", async () => {
+    writeFile(tmpDir, "package.json", '{"name":"unchanged"}\n');
+    const before = fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8");
+
+    await expect(deploy({ root: tmpDir, env: "a".repeat(256), dryRun: true })).rejects.toThrow(
+      "255 characters",
+    );
+
+    expect(fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8")).toBe(before);
+    expect(fs.existsSync(path.join(tmpDir, ".vinext"))).toBe(false);
+  });
 });
 
 // ─── CLOUDFLARE_ENV propagation (issue #1210) ──────────────────────────────
@@ -211,50 +251,105 @@ describe("withCloudflareEnv", () => {
   });
 });
 
-// ─── Wrangler bin resolution (Windows shim handling) ────────────────────────
+// ─── Wrangler JavaScript entrypoint resolution ──────────────────────────────
 
 describe("resolveWranglerBin", () => {
-  it("uses bare name on non-Windows platforms", () => {
-    mkdir(tmpDir, "node_modules/.bin");
-    writeFile(tmpDir, "node_modules/.bin/wrangler", "#!/usr/bin/env node");
+  function writeWranglerPackage(
+    bin: string | Record<string, string> = { wrangler: "bin/wrangler.js" },
+  ) {
+    writeFile(
+      tmpDir,
+      "node_modules/wrangler/package.json",
+      JSON.stringify({ name: "wrangler", bin }),
+    );
+    writeFile(tmpDir, "node_modules/wrangler/bin/wrangler.js", "#!/usr/bin/env node");
+  }
 
-    const resolved = resolveWranglerBin(tmpDir, "linux");
-    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler"));
+  function expectedWranglerBin(): string {
+    return fs.realpathSync(path.join(tmpDir, "node_modules", "wrangler", "bin", "wrangler.js"));
+  }
+
+  it("resolves the JavaScript entrypoint from Wrangler's bin map", () => {
+    writeWranglerPackage();
+    expect(resolveWranglerBin(tmpDir)).toBe(expectedWranglerBin());
   });
 
-  it("prefers .CMD shim on Windows when present", () => {
-    mkdir(tmpDir, "node_modules/.bin");
-    writeFile(tmpDir, "node_modules/.bin/wrangler", "#!/usr/bin/env node");
-    writeFile(tmpDir, "node_modules/.bin/wrangler.CMD", "@ECHO off");
-
-    const resolved = resolveWranglerBin(tmpDir, "win32");
-    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler.CMD"));
+  it("supports a string-valued package bin", () => {
+    writeWranglerPackage("bin/wrangler.js");
+    expect(resolveWranglerBin(tmpDir)).toBe(expectedWranglerBin());
   });
 
-  it("falls back to bare name on Windows if no .CMD shim exists", () => {
-    mkdir(tmpDir, "node_modules/.bin");
-    writeFile(tmpDir, "node_modules/.bin/wrangler", "#!/usr/bin/env node");
-
-    const resolved = resolveWranglerBin(tmpDir, "win32");
-    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler"));
-  });
-
-  it("walks up to a hoisted workspace node_modules on Windows", () => {
+  it("walks up to a hoisted workspace node_modules", () => {
     mkdir(tmpDir, "apps/web");
-    mkdir(tmpDir, "node_modules/.bin");
-    writeFile(tmpDir, "node_modules/.bin/wrangler.CMD", "@ECHO off");
-
-    const resolved = resolveWranglerBin(path.join(tmpDir, "apps", "web"), "win32");
-    expect(resolved).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler.CMD"));
+    writeWranglerPackage();
+    expect(resolveWranglerBin(path.join(tmpDir, "apps", "web"))).toBe(expectedWranglerBin());
   });
 
-  it("returns platform-appropriate fallback path when nothing is found", () => {
-    expect(resolveWranglerBin(tmpDir, "win32")).toBe(
-      path.join(tmpDir, "node_modules", ".bin", "wrangler.CMD"),
+  it("supports package resolvers such as Yarn Plug'n'Play", () => {
+    writeWranglerPackage();
+    const packageJsonPath = path.join(tmpDir, "node_modules", "wrangler", "package.json");
+    expect(resolveWranglerBin("/virtual/project", () => packageJsonPath)).toBe(
+      path.join(tmpDir, "node_modules", "wrangler", "bin", "wrangler.js"),
     );
-    expect(resolveWranglerBin(tmpDir, "linux")).toBe(
-      path.join(tmpDir, "node_modules", ".bin", "wrangler"),
+  });
+
+  it("returns a clear fallback path when Wrangler is missing", () => {
+    expect(resolveWranglerBin(tmpDir)).toBe(
+      path.join(tmpDir, "node_modules", "wrangler", "bin", "wrangler.js"),
     );
+  });
+
+  it("passes deploy arguments literally to Node without a command shell", () => {
+    writeWranglerPackage();
+    expect(buildWranglerInvocation(tmpDir, { env: "preview-1" }, "node.exe")).toEqual({
+      file: "node.exe",
+      args: [expectedWranglerBin(), "deploy", "--env", "preview-1"],
+      env: "preview-1",
+    });
+  });
+
+  it("keeps Windows shell metacharacters in one literal argument", () => {
+    const payload = "preview & whoami > vinext-pwned.txt & rem";
+    expect(buildNodeCliInvocation("wrangler.js", ["deploy", "--env", payload], "node.exe")).toEqual(
+      {
+        file: "node.exe",
+        args: ["wrangler.js", "deploy", "--env", payload],
+      },
+    );
+  });
+
+  it("executes Wrangler with shell disabled and literal metacharacters", () => {
+    writeWranglerPackage();
+    const payload = "preview & whoami > vinext-pwned.txt & rem";
+    let observed: Parameters<typeof execFileSync> | undefined;
+    const execute = ((...args: Parameters<typeof execFileSync>) => {
+      observed = args;
+      return "";
+    }) as typeof execFileSync;
+
+    runWranglerDeploy(tmpDir, { env: payload }, execute);
+
+    expect(observed?.[0]).toBe(process.execPath);
+    expect(observed?.[1]).toEqual([expectedWranglerBin(), "deploy", "--env", payload]);
+    expect(observed?.[2]).toMatchObject({ shell: false });
+  });
+
+  it("does not execute metacharacters in a real subprocess", () => {
+    const argvPath = path.join(tmpDir, "argv.json");
+    const pwnedPath = path.join(tmpDir, "vinext-pwned.txt");
+    const scriptPath = path.join(tmpDir, "capture-argv.cjs");
+    const payload = `preview & echo pwned > ${pwnedPath} & rem`;
+    writeFile(
+      tmpDir,
+      "capture-argv.cjs",
+      `require("node:fs").writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)))`,
+    );
+    const invocation = buildNodeCliInvocation(scriptPath, ["deploy", "--env", payload]);
+
+    execFileSync(invocation.file, invocation.args, { cwd: tmpDir, shell: false });
+
+    expect(JSON.parse(fs.readFileSync(argvPath, "utf-8"))).toEqual(["deploy", "--env", payload]);
+    expect(fs.existsSync(pwnedPath)).toBe(false);
   });
 });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -156,9 +156,9 @@ describe("buildWranglerDeployArgs", () => {
     },
   );
 
-  it("rejects null bytes and excessively long environment names", () => {
+  it("rejects null bytes without imposing an artificial length limit", () => {
     expect(() => validateWranglerEnvName("preview\0prod")).toThrow("null bytes");
-    expect(() => validateWranglerEnvName("a".repeat(256))).toThrow("255 characters");
+    expect(validateWranglerEnvName("a".repeat(1024))).toBe("a".repeat(1024));
   });
 });
 
@@ -167,8 +167,8 @@ describe("deploy environment validation", () => {
     writeFile(tmpDir, "package.json", '{"name":"unchanged"}\n');
     const before = fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8");
 
-    await expect(deploy({ root: tmpDir, env: "a".repeat(256), dryRun: true })).rejects.toThrow(
-      "255 characters",
+    await expect(deploy({ root: tmpDir, env: "preview\0prod", dryRun: true })).rejects.toThrow(
+      "null bytes",
     );
 
     expect(fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8")).toBe(before);


### PR DESCRIPTION
## Summary

Fixes Windows command injection in `vinext deploy --env` by removing the command shell from Wrangler execution.

## Vulnerability

On Windows, vinext resolved the package-manager `.cmd` shim and called:

```ts
execFileSync(wranglerBin, args, { shell: true })
```

With `shell: true`, an attacker-controlled `--env` value was interpreted by `cmd.exe` rather than remaining one argument.

### Previous POC

```powershell
vinext deploy --env 'preview & whoami > vinext-pwned.txt & rem'
```

This could execute `whoami` on the developer workstation or CI runner.

## Impact

A malicious repository command, copied deployment command, or attacker-controlled CI parameter could execute commands with the deploy process's privileges, including access to Cloudflare credentials and other CI secrets. This affects the build/deploy plane on Windows, not deployed Worker request handling.

## Fix

- Resolve Wrangler's JavaScript `bin` entry from its package manifest, including hoisted and Yarn Plug'n'Play resolution.
- Execute the entrypoint with `process.execPath` and `shell: false` on every platform.
- Keep `--env` as a discrete argument, preserving Wrangler-compatible names while rejecting null bytes and excessive lengths.
- Validate the resolved environment before any deploy-side filesystem or subprocess side effects.
- Audited the other `shell: true` calls in `deploy.ts`; they only receive framework-generated package-manager dependency arguments, not `--env` or other direct deploy CLI strings.

## Regression coverage

- Verifies shell metacharacters remain one literal argv value.
- Runs a real subprocess reproduction and proves no injected output file is created.
- Asserts `runWranglerDeploy()` uses `process.execPath` with `shell: false`.
- Covers hoisted package resolution, string/object package `bin` forms, and a Plug'n'Play-style resolver.
- Verifies invalid environment input is rejected before project mutation.

## Tests

```text
vp test run tests/deploy.test.ts
266 tests passed

vp check packages/vinext/src/deploy.ts tests/deploy.test.ts
format, lint, and type checks passed
```

## Review

An independent Codex review agent reviewed the change three times. Initial findings around PnP resolution, environment compatibility, validation ordering, and subprocess-level reproduction were addressed. The final review reported no actionable findings.
