### PR TITLE
fix(deploy): improve deployment id parity

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -99,11 +99,8 @@ import {
 import { proxyExternalRequest } from "./config/config-matchers.js";
 import { detectPackageManager } from "./utils/project.js";
 import { isUnknownRecord as isRecord } from "./utils/record.js";
-import {
-  ASSET_PREFIX_URL_DIR,
-  resolveAssetUrlPrefix,
-  resolveAssetsDir,
-} from "./utils/asset-prefix.js";
+import { ASSET_PREFIX_URL_DIR, resolveAssetsDir } from "./utils/asset-prefix.js";
+import { renderVinextBuiltUrl } from "./utils/built-asset-url.js";
 import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
 import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
@@ -1382,8 +1379,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // generate a separate token so RSC headers do not expose
         // generateBuildId() verbatim.
         defines["process.env.__VINEXT_RSC_COMPATIBILITY_ID"] = JSON.stringify(rscCompatibilityId);
-        // Deployment ID — mirrors Next.js' NEXT_DEPLOYMENT_ID seed for shared
-        // "use cache" entries, falling back to build ID when absent.
+        // Deployment ID — mirrors Next.js' configured NEXT_DEPLOYMENT_ID.
+        // This remains empty when deploymentId is not configured; the separate
+        // "use cache" key builder falls back to __VINEXT_BUILD_ID when needed.
         defines["process.env.__VINEXT_DEPLOYMENT_ID"] = JSON.stringify(
           nextConfig.deploymentId ?? "",
         );
@@ -1991,28 +1989,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // See packages/vinext/src/utils/asset-prefix.ts for the helpers
           // and Next.js docs for the contract:
           // https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
-          ...(nextConfig.assetPrefix
+          ...(nextConfig.assetPrefix || nextConfig.deploymentId
             ? {
                 experimental: {
-                  renderBuiltUrl: (filename: string) => {
-                    // `filename` is the bundler-relative output path,
-                    // e.g. `_next/static/chunk-abc.js` or
-                    // `<assetPrefix-pathname>/_next/static/chunk-abc.js`
-                    // when assetPrefix is a path prefix. Re-anchor it under
-                    // the configured asset URL prefix.
-                    const urlPrefix = resolveAssetUrlPrefix(nextConfig.assetPrefix);
-                    // Strip any leading on-disk `assetsDir` segment so we
-                    // don't double-prefix when the on-disk layout already
-                    // mirrors the URL path.
-                    const onDiskDir = resolveAssetsDir(nextConfig.assetPrefix);
-                    const dirPrefix = onDiskDir + "/";
-                    const stripped = filename.startsWith(dirPrefix)
-                      ? filename.slice(dirPrefix.length)
-                      : filename.startsWith(`${ASSET_PREFIX_URL_DIR}/`)
-                        ? filename.slice(ASSET_PREFIX_URL_DIR.length + 1)
-                        : filename;
-                    return urlPrefix + stripped;
-                  },
+                  renderBuiltUrl: (filename: string) =>
+                    renderVinextBuiltUrl(filename, nextConfig.assetPrefix, nextConfig.deploymentId),
                 },
               }
             : {}),

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -15,6 +15,7 @@ import {
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "./headers.js";
+import { applyDeploymentIdHeader } from "../utils/deployment-id.js";
 
 /**
  * RSC cache-busting hashes cover the headers that make an RSC payload vary.
@@ -279,6 +280,7 @@ export function createRscRequestHeaders(options: CreateRscRequestHeadersOptions 
     Accept: VINEXT_RSC_CONTENT_TYPE,
     [RSC_HEADER]: "1",
   });
+  applyDeploymentIdHeader(headers);
 
   if (options.interceptionContext !== undefined && options.interceptionContext !== null) {
     headers.set(VINEXT_INTERCEPTION_CONTEXT_HEADER, options.interceptionContext);

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -48,6 +48,7 @@ import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/s
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
+import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
 
 /**
  * `@types/react-dom` does not yet type `maxHeadersLength` (it pairs with the
@@ -182,11 +183,11 @@ function renderFontHtml(
   const includeStyles = options.includeStyles ?? true;
 
   for (const url of fontData.links ?? []) {
-    fontHTML += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(url)}" />\n`;
+    fontHTML += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(url))}" />\n`;
   }
 
   for (const preload of fontData.preloads ?? []) {
-    fontHTML += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(preload.href)}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n`;
+    fontHTML += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(preload.href))}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n`;
   }
 
   if (includeStyles && fontData.styles && fontData.styles.length > 0) {
@@ -440,7 +441,10 @@ export async function handleSsr(
         const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent(
           "index",
         );
-        const bootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
+        const rawBootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
+        const bootstrapModuleUrl = rawBootstrapModuleUrl
+          ? appendDeploymentIdQuery(rawBootstrapModuleUrl)
+          : undefined;
         const errorMetaRenderer = createSsrErrorMetaRenderer({
           basePath: options?.basePath,
         });

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -48,7 +48,7 @@ import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/s
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
-import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
+import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 
 /**
  * `@types/react-dom` does not yet type `maxHeadersLength` (it pairs with the
@@ -183,11 +183,11 @@ function renderFontHtml(
   const includeStyles = options.includeStyles ?? true;
 
   for (const url of fontData.links ?? []) {
-    fontHTML += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(url))}" />\n`;
+    fontHTML += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(appendAssetDeploymentIdQuery(url))}" />\n`;
   }
 
   for (const preload of fontData.preloads ?? []) {
-    fontHTML += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(preload.href))}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n`;
+    fontHTML += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(appendAssetDeploymentIdQuery(preload.href))}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n`;
   }
 
   if (includeStyles && fontData.styles && fontData.styles.length > 0) {
@@ -443,7 +443,7 @@ export async function handleSsr(
         );
         const rawBootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
         const bootstrapModuleUrl = rawBootstrapModuleUrl
-          ? appendDeploymentIdQuery(rawBootstrapModuleUrl)
+          ? appendAssetDeploymentIdQuery(rawBootstrapModuleUrl)
           : undefined;
         const errorMetaRenderer = createSsrErrorMetaRenderer({
           basePath: options?.basePath,

--- a/packages/vinext/src/server/pages-asset-tags.ts
+++ b/packages/vinext/src/server/pages-asset-tags.ts
@@ -11,6 +11,7 @@
 
 import { createNonceAttribute } from "./html.js";
 import { assetServingUrlFromBaseAnchored } from "../utils/manifest-paths.js";
+import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
 
 // ---------------------------------------------------------------------------
 // Manifest helpers
@@ -64,13 +65,17 @@ export function resolveClientModuleUrl(
   moduleId: string | null | undefined,
   basePath = "",
   assetPrefix = "",
+  deploymentId?: string,
 ): string | undefined {
   const files = getManifestFilesForModule(resolveSsrManifest(manifest), moduleId);
   if (!files) return undefined;
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     if (!file || !file.endsWith(".js")) continue;
-    return assetServingUrlFromBaseAnchored(file, basePath, assetPrefix);
+    return appendDeploymentIdQuery(
+      assetServingUrlFromBaseAnchored(file, basePath, assetPrefix),
+      deploymentId,
+    );
   }
   return undefined;
 }
@@ -106,6 +111,7 @@ type CollectAssetTagsOptions = {
    */
   basePath?: string;
   assetPrefix?: string;
+  deploymentId?: string;
 };
 
 /**
@@ -143,7 +149,10 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   const basePath = options.basePath ?? "";
   const assetPrefix = options.assetPrefix ?? "";
   const href = (value: string): string =>
-    assetServingUrlFromBaseAnchored(value, basePath, assetPrefix);
+    appendDeploymentIdQuery(
+      assetServingUrlFromBaseAnchored(value, basePath, assetPrefix),
+      options.deploymentId,
+    );
 
   // Load the set of lazy chunk filenames (only reachable via dynamic imports).
   // These should NOT get <link rel="modulepreload"> or <script type="module">

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -46,7 +46,7 @@ import { ensureFetchPatch } from "vinext/shims/fetch-cache";
 import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js";
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
-import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
+import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -494,7 +494,7 @@ export function createPagesPageHandler(
               .map(
                 (p) =>
                   "<" +
-                  appendDeploymentIdQuery(p.href) +
+                  appendAssetDeploymentIdQuery(p.href) +
                   ">; rel=preload; as=font; type=" +
                   p.type +
                   "; crossorigin",

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -46,6 +46,7 @@ import { ensureFetchPatch } from "vinext/shims/fetch-cache";
 import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js";
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
+import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -463,12 +464,14 @@ export function createPagesPageHandler(
           route.filePath,
           vinextConfig.basePath,
           vinextConfig.assetPrefix,
+          process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
         );
         const appModuleUrl = resolveClientModuleUrl(
           manifest,
           appAssetPath,
           vinextConfig.basePath,
           vinextConfig.assetPrefix,
+          process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
         );
         const serializedPagesNextData = {
           ...pagesNextData,
@@ -489,7 +492,12 @@ export function createPagesPageHandler(
           if (allFontPreloads.length > 0) {
             fontLinkHeader = allFontPreloads
               .map(
-                (p) => "<" + p.href + ">; rel=preload; as=font; type=" + p.type + "; crossorigin",
+                (p) =>
+                  "<" +
+                  appendDeploymentIdQuery(p.href) +
+                  ">; rel=preload; as=font; type=" +
+                  p.type +
+                  "; crossorigin",
               )
               .join(", ");
           }
@@ -654,6 +662,7 @@ export function createPagesPageHandler(
           disableOptimizedLoading: vinextConfig.disableOptimizedLoading,
           basePath: vinextConfig.basePath,
           assetPrefix: vinextConfig.assetPrefix,
+          deploymentId: process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
         });
 
         return await renderPagesPageResponse({

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -22,6 +22,7 @@ import {
 import { fnv1a52 } from "../utils/hash.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
+import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
@@ -227,11 +228,11 @@ function buildPagesFontHeadHtml(
   const nonceAttr = createNonceAttribute(scriptNonce);
 
   for (const link of fontLinks) {
-    html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(link)}" />\n  `;
+    html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(link))}" />\n  `;
   }
 
   for (const preload of fontPreloads) {
-    html += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(preload.href)}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n  `;
+    html += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(preload.href))}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n  `;
   }
 
   if (fontStyles.length > 0) {

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -22,7 +22,7 @@ import {
 import { fnv1a52 } from "../utils/hash.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
-import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
+import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
@@ -228,11 +228,11 @@ function buildPagesFontHeadHtml(
   const nonceAttr = createNonceAttribute(scriptNonce);
 
   for (const link of fontLinks) {
-    html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(link))}" />\n  `;
+    html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(appendAssetDeploymentIdQuery(link))}" />\n  `;
   }
 
   for (const preload of fontPreloads) {
-    html += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(appendDeploymentIdQuery(preload.href))}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n  `;
+    html += `<link rel="preload"${nonceAttr} href="${escapeHtmlAttr(appendAssetDeploymentIdQuery(preload.href))}" as="font" type="${escapeHtmlAttr(preload.type)}" crossorigin />\n  `;
   }
 
   if (fontStyles.length > 0) {

--- a/packages/vinext/src/shims/dynamic-preload-chunks.tsx
+++ b/packages/vinext/src/shims/dynamic-preload-chunks.tsx
@@ -27,6 +27,7 @@
 import React from "react";
 import * as ReactDOM from "react-dom";
 import { useScriptNonce } from "./script-nonce-context.js";
+import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
 
 function dynamicPreloadHref(file: string): string {
   if (
@@ -79,8 +80,9 @@ export function DynamicPreloadChunks(props: { moduleIds?: readonly string[] }) {
 
   const stylesheets: React.ReactNode[] = [];
   for (const file of files) {
-    const href = dynamicPreloadHref(file);
-    if (href.endsWith(".css")) {
+    const assetHref = dynamicPreloadHref(file);
+    const href = appendDeploymentIdQuery(assetHref);
+    if (assetHref.endsWith(".css")) {
       stylesheets.push(
         React.createElement("link", {
           key: href,
@@ -93,7 +95,7 @@ export function DynamicPreloadChunks(props: { moduleIds?: readonly string[] }) {
       continue;
     }
 
-    if (href.endsWith(".js") && typeof ReactDOM.preload === "function") {
+    if (assetHref.endsWith(".js") && typeof ReactDOM.preload === "function") {
       // Pass `nonce` directly (React omits the attribute when it is undefined),
       // matching the stylesheet branch above.
       const preloadOptions: ReactDOM.PreloadOptions = {

--- a/packages/vinext/src/shims/dynamic-preload-chunks.tsx
+++ b/packages/vinext/src/shims/dynamic-preload-chunks.tsx
@@ -27,7 +27,7 @@
 import React from "react";
 import * as ReactDOM from "react-dom";
 import { useScriptNonce } from "./script-nonce-context.js";
-import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
+import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 
 function dynamicPreloadHref(file: string): string {
   if (
@@ -81,7 +81,7 @@ export function DynamicPreloadChunks(props: { moduleIds?: readonly string[] }) {
   const stylesheets: React.ReactNode[] = [];
   for (const file of files) {
     const assetHref = dynamicPreloadHref(file);
-    const href = appendDeploymentIdQuery(assetHref);
+    const href = appendAssetDeploymentIdQuery(assetHref);
     if (assetHref.endsWith(".css")) {
       stylesheets.push(
         React.createElement("link", {

--- a/packages/vinext/src/shims/internal/pages-data-target.ts
+++ b/packages/vinext/src/shims/internal/pages-data-target.ts
@@ -111,6 +111,11 @@ export function resolvePagesDataNavigationTarget(
  * warm by the time the user clicks.
  *
  * Used by both `Router.prefetch()` and `<Link>` hover/viewport prefetch. The
+ * JSON request uses `fetch()` rather than `<link rel="prefetch">` so it can
+ * carry Next.js's `x-deployment-id` skew-protection header. The in-flight
+ * request is shared with a racing navigation; after it settles, the browser's
+ * normal HTTP cache remains responsible for reuse.
+ *
  * loader's returned Promise is intentionally discarded — `import()` caches the
  * result, so a subsequent navigation re-invocation hits the cache without
  * paying for a second round trip. Errors are swallowed: prefetch is

--- a/packages/vinext/src/shims/internal/pages-data-target.ts
+++ b/packages/vinext/src/shims/internal/pages-data-target.ts
@@ -11,6 +11,8 @@ import { stripBasePath } from "../../utils/base-path.js";
 import { getLocalePathPrefix } from "../../utils/domain-locale.js";
 import type { VinextNextData } from "../../client/vinext-next-data.js";
 import { buildPagesDataHref, matchPagesPattern } from "./pages-data-url.js";
+import { dedupedPagesDataFetch } from "./pages-data-fetch-dedup.js";
+import { getDeploymentId, NEXT_DEPLOYMENT_ID_HEADER } from "../../utils/deployment-id.js";
 
 export type PagesDataTarget = {
   /** Final fetch URL for the data endpoint, including basePath and search. */
@@ -105,8 +107,8 @@ export function resolvePagesDataNavigationTarget(
 }
 
 /**
- * Inject a `<link rel="prefetch">` for the data JSON and kick off the
- * code-split loader so the chunk is warm by the time the user clicks.
+ * Prefetch the data JSON and kick off the code-split loader so the chunk is
+ * warm by the time the user clicks.
  *
  * Used by both `Router.prefetch()` and `<Link>` hover/viewport prefetch. The
  * loader's returned Promise is intentionally discarded — `import()` caches the
@@ -117,12 +119,15 @@ export function resolvePagesDataNavigationTarget(
 export function prefetchPagesData(target: PagesDataTarget): void {
   if (typeof document === "undefined") return;
 
-  const link = document.createElement("link");
-  link.rel = "prefetch";
-  link.as = "fetch";
-  link.crossOrigin = "anonymous";
-  link.href = target.dataHref;
-  document.head.appendChild(link);
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    purpose: "prefetch",
+    "x-nextjs-data": "1",
+  };
+  const deploymentId = getDeploymentId();
+  if (deploymentId) headers[NEXT_DEPLOYMENT_ID_HEADER] = deploymentId;
+
+  void dedupedPagesDataFetch(target.dataHref, { headers }).catch(() => {});
 
   void target.loader().catch(() => {});
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -74,6 +74,7 @@ import {
 } from "./pages-router-runtime.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
 import { getCurrentBrowserLocale } from "./client-locale.js";
+import { getDeploymentId, NEXT_DEPLOYMENT_ID_HEADER } from "../utils/deployment-id.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
@@ -1334,9 +1335,10 @@ async function navigateClientData(
   }
   let res: Response;
   try {
-    res = await dedupedPagesDataFetch(target.dataHref, {
-      headers: { Accept: "application/json", "x-nextjs-data": "1" },
-    });
+    const headers: Record<string, string> = { Accept: "application/json", "x-nextjs-data": "1" };
+    const deploymentId = getDeploymentId();
+    if (deploymentId) headers[NEXT_DEPLOYMENT_ID_HEADER] = deploymentId;
+    res = await dedupedPagesDataFetch(target.dataHref, { headers });
   } catch (err: unknown) {
     if (err instanceof DOMException && err.name === "AbortError") {
       throw new NavigationCancelledError(url);

--- a/packages/vinext/src/utils/built-asset-url.ts
+++ b/packages/vinext/src/utils/built-asset-url.ts
@@ -1,0 +1,19 @@
+import { ASSET_PREFIX_URL_DIR, resolveAssetUrlPrefix, resolveAssetsDir } from "./asset-prefix.js";
+import { appendDeploymentIdQuery } from "./deployment-id.js";
+
+export function renderVinextBuiltUrl(
+  filename: string,
+  assetPrefix: string,
+  deploymentId?: string,
+): string {
+  const urlPrefix = resolveAssetUrlPrefix(assetPrefix);
+  const onDiskDir = resolveAssetsDir(assetPrefix);
+  const dirPrefix = onDiskDir + "/";
+  const stripped = filename.startsWith(dirPrefix)
+    ? filename.slice(dirPrefix.length)
+    : filename.startsWith(`${ASSET_PREFIX_URL_DIR}/`)
+      ? filename.slice(ASSET_PREFIX_URL_DIR.length + 1)
+      : filename;
+
+  return appendDeploymentIdQuery(urlPrefix + stripped, deploymentId);
+}

--- a/packages/vinext/src/utils/deployment-id.ts
+++ b/packages/vinext/src/utils/deployment-id.ts
@@ -12,7 +12,16 @@ export function appendDeploymentIdQuery(value: string, deploymentId = getDeploym
   const parsed = new URL(url, "http://vinext.local");
   if (parsed.searchParams.has("dpl")) return value;
   const separator = url.includes("?") ? "&" : "?";
-  return `${url}${separator}dpl=${encodeURIComponent(deploymentId)}${fragment}`;
+  return `${url}${separator}dpl=${deploymentId}${fragment}`;
+}
+
+export function appendAssetDeploymentIdQuery(
+  value: string,
+  deploymentId = getDeploymentId(),
+): string {
+  const parsed = new URL(value, "http://vinext.local");
+  if (!parsed.pathname.includes("/_next/static/")) return value;
+  return appendDeploymentIdQuery(value, deploymentId);
 }
 
 export function applyDeploymentIdHeader(headers: Headers, deploymentId = getDeploymentId()): void {

--- a/packages/vinext/src/utils/deployment-id.ts
+++ b/packages/vinext/src/utils/deployment-id.ts
@@ -1,0 +1,20 @@
+export const NEXT_DEPLOYMENT_ID_HEADER = "x-deployment-id";
+
+export function getDeploymentId(): string | undefined {
+  return process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID || undefined;
+}
+
+export function appendDeploymentIdQuery(value: string, deploymentId = getDeploymentId()): string {
+  if (!deploymentId) return value;
+  const hashIndex = value.indexOf("#");
+  const url = hashIndex === -1 ? value : value.slice(0, hashIndex);
+  const fragment = hashIndex === -1 ? "" : value.slice(hashIndex);
+  const parsed = new URL(url, "http://vinext.local");
+  if (parsed.searchParams.has("dpl")) return value;
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}dpl=${encodeURIComponent(deploymentId)}${fragment}`;
+}
+
+export function applyDeploymentIdHeader(headers: Headers, deploymentId = getDeploymentId()): void {
+  if (deploymentId) headers.set(NEXT_DEPLOYMENT_ID_HEADER, deploymentId);
+}

--- a/tests/app-router-rsc-plugin.test.ts
+++ b/tests/app-router-rsc-plugin.test.ts
@@ -49,6 +49,40 @@ describe("RSC plugin auto-registration", () => {
     expect(html).toContain("auto-rsc-test");
   });
 
+  it("serves the browser bootstrap in dev when deploymentId is configured", async () => {
+    const { createServer } = await import("vite");
+    const deploymentServer = await createServer({
+      root: APP_FIXTURE_DIR,
+      configFile: false,
+      plugins: [
+        vinext({
+          appDir: APP_FIXTURE_DIR,
+          nextConfig: () => ({ deploymentId: "dev-deployment-id" }),
+        }),
+      ],
+      optimizeDeps: { holdUntilCrawlEnd: true },
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+    await deploymentServer.listen();
+
+    try {
+      const address = deploymentServer.httpServer?.address();
+      const url = address && typeof address === "object" ? `http://localhost:${address.port}` : "";
+      const response = await fetch(`${url}/`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      const bootstrapUrl = html.match(/<script[^>]+type="module"[^>]+src="([^"]+)"/)?.[1];
+      expect(bootstrapUrl).not.toContain("dpl=");
+
+      const bootstrapResponse = await fetch(new URL(bootstrapUrl!, url));
+      expect(bootstrapResponse.status).toBe(200);
+      expect(bootstrapResponse.headers.get("content-type")).toContain("javascript");
+    } finally {
+      await deploymentServer.close();
+    }
+  }, 30_000);
+
   it("does not double-register when RSC plugin is already present", async () => {
     const { createServer } = await import("vite");
     const rsc = (await import("@vitejs/plugin-rsc")).default;

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -39,6 +39,14 @@ async function sha256CacheBustingHash(input: string): Promise<string> {
 }
 
 describe("App Router RSC cache-busting", () => {
+  // Ported from Next.js: test/production/deployment-id-handling/deployment-id-handling.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/production/deployment-id-handling/deployment-id-handling.test.ts
+  it("adds the deployment ID header to RSC requests", () => {
+    withEnvVar("__VINEXT_DEPLOYMENT_ID", "dpl_123", () => {
+      expect(createRscRequestHeaders().get("x-deployment-id")).toBe("dpl_123");
+    });
+  });
+
   it("adds a bare _rsc search param when no variant headers are present", async () => {
     const headers = createRscRequestHeaders();
 

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -38,6 +38,7 @@ import {
 import { manifestFileWithAssetPrefix } from "../packages/vinext/src/utils/manifest-paths.js";
 import { resolveAppRouterAssetPath } from "../packages/vinext/src/server/prod-server.js";
 import { normalizeAssetPrefix } from "../packages/vinext/src/config/next-config.js";
+import { renderVinextBuiltUrl } from "../packages/vinext/src/utils/built-asset-url.js";
 
 const APP_FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/app-basic");
 const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
@@ -106,6 +107,38 @@ describe("resolveAssetsDir", () => {
   it("returns `_next/static` for absolute-URL prefixes — the CDN owns the URL prefix", () => {
     expect(resolveAssetsDir("https://cdn.example.com")).toBe(ASSET_PREFIX_URL_DIR);
     expect(resolveAssetsDir("https://cdn.example.com/sub")).toBe(ASSET_PREFIX_URL_DIR);
+  });
+});
+
+describe("renderVinextBuiltUrl", () => {
+  it("appends deployment IDs without an asset prefix", () => {
+    expect(renderVinextBuiltUrl("_next/static/chunk.js", "", "dpl_123")).toBe(
+      "/_next/static/chunk.js?dpl=dpl_123",
+    );
+  });
+
+  it("combines path asset prefixes and deployment IDs", () => {
+    expect(renderVinextBuiltUrl("cdn/_next/static/chunk.js", "/cdn", "dpl_123")).toBe(
+      "/cdn/_next/static/chunk.js?dpl=dpl_123",
+    );
+  });
+
+  it("combines absolute asset prefixes and deployment IDs", () => {
+    expect(
+      renderVinextBuiltUrl("_next/static/chunk.js", "https://cdn.example.com", "dpl_123"),
+    ).toBe("https://cdn.example.com/_next/static/chunk.js?dpl=dpl_123");
+  });
+
+  it("is installed for deployment-only builds", async () => {
+    const plugins = vinext({
+      nextConfig: () => ({ deploymentId: "dpl_123" }),
+    }) as any[];
+    const configPlugin = plugins.find((plugin) => plugin.name === "vinext:config");
+    const config = await configPlugin.config({ root: APP_FIXTURE_DIR, plugins: [] });
+    const renderBuiltUrl = config.experimental?.renderBuiltUrl;
+
+    expect(renderBuiltUrl).toBeTypeOf("function");
+    expect(renderBuiltUrl("_next/static/chunk.js", {})).toBe("/_next/static/chunk.js?dpl=dpl_123");
   });
 });
 
@@ -345,6 +378,51 @@ describe("assetPrefix end-to-end build", () => {
     for (const c of cleanups) c();
   });
   const register = (cleanup: () => void) => cleanups.push(cleanup);
+
+  // Ported from Next.js: test/production/deployment-id-handling/deployment-id-handling.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/production/deployment-id-handling/deployment-id-handling.test.ts
+  it("deployment ID: emits dpl queries in built output and SSR asset URLs", async () => {
+    const built = await buildFixtureWithConfig(`deploymentId: "dpl_123",`, register);
+    const clientDir = path.join(built.outDir, "client");
+    const builtFiles: string[] = [];
+    const collectFiles = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const entryPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) collectFiles(entryPath);
+        else if (entry.isFile() && /\.(?:js|css|html)$/.test(entry.name))
+          builtFiles.push(entryPath);
+      }
+    };
+    collectFiles(clientDir);
+    expect(builtFiles.some((file) => fs.readFileSync(file, "utf8").includes("?dpl=dpl_123"))).toBe(
+      true,
+    );
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server } = await startProdServer({
+      port: 0,
+      outDir: built.outDir,
+      noCompression: true,
+    });
+    try {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      const response = await fetch(`http://localhost:${port}/`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      const assetUrls = Array.from(
+        html.matchAll(/<(?:script|link)[^>]+(?:src|href)="([^"]*\/_next\/static\/[^"]+)"/g),
+        (match) => match[1],
+      );
+      expect(assetUrls.length).toBeGreaterThan(0);
+      expect(
+        assetUrls.every((url) => url.includes("dpl=dpl_123")),
+        JSON.stringify(assetUrls),
+      ).toBe(true);
+    } finally {
+      server.close();
+    }
+  }, 180_000);
 
   it("path-prefix: emits assets under <prefix>/_next/static/ on disk and in HTML", async () => {
     const built = await buildFixtureWithConfig(`assetPrefix: "/custom-asset-prefix",`, register);

--- a/tests/deployment-id.test.ts
+++ b/tests/deployment-id.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+import { appendDeploymentIdQuery } from "../packages/vinext/src/utils/deployment-id.js";
+
+describe("appendDeploymentIdQuery", () => {
+  it("inserts the deployment query before URL fragments", () => {
+    expect(appendDeploymentIdQuery("/_next/static/chunk.js#module", "dpl_123")).toBe(
+      "/_next/static/chunk.js?dpl=dpl_123#module",
+    );
+  });
+
+  it("preserves existing queries and fragments", () => {
+    expect(appendDeploymentIdQuery("/_next/static/chunk.js?v=1#module", "dpl_123")).toBe(
+      "/_next/static/chunk.js?v=1&dpl=dpl_123#module",
+    );
+  });
+
+  it("does not append a duplicate deployment query", () => {
+    expect(appendDeploymentIdQuery("/_next/static/chunk.js?dpl=existing#module", "dpl_123")).toBe(
+      "/_next/static/chunk.js?dpl=existing#module",
+    );
+  });
+});

--- a/tests/deployment-id.test.ts
+++ b/tests/deployment-id.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
-import { appendDeploymentIdQuery } from "../packages/vinext/src/utils/deployment-id.js";
+import {
+  appendAssetDeploymentIdQuery,
+  appendDeploymentIdQuery,
+} from "../packages/vinext/src/utils/deployment-id.js";
 
 describe("appendDeploymentIdQuery", () => {
   it("inserts the deployment query before URL fragments", () => {
@@ -17,6 +20,18 @@ describe("appendDeploymentIdQuery", () => {
   it("does not append a duplicate deployment query", () => {
     expect(appendDeploymentIdQuery("/_next/static/chunk.js?dpl=existing#module", "dpl_123")).toBe(
       "/_next/static/chunk.js?dpl=existing#module",
+    );
+  });
+
+  it("only appends asset deployment queries to managed static assets", () => {
+    expect(appendAssetDeploymentIdQuery("/@id/virtual:entry", "dpl_123")).toBe(
+      "/@id/virtual:entry",
+    );
+    expect(
+      appendAssetDeploymentIdQuery("https://fonts.googleapis.com/css2?family=Inter", "dpl_123"),
+    ).toBe("https://fonts.googleapis.com/css2?family=Inter");
+    expect(appendAssetDeploymentIdQuery("/_next/static/chunk.js", "dpl_123")).toBe(
+      "/_next/static/chunk.js?dpl=dpl_123",
     );
   });
 });

--- a/tests/pages-asset-tags.test.ts
+++ b/tests/pages-asset-tags.test.ts
@@ -109,6 +109,11 @@ describe("resolveClientModuleUrl", () => {
     const m = makeManifest({ "page.tsx": ["style.css"] });
     expect(resolveClientModuleUrl(m, "page.tsx")).toBeUndefined();
   });
+
+  it("appends the deployment ID to client module URLs", () => {
+    const m = makeManifest({ "page.tsx": ["page.js"] });
+    expect(resolveClientModuleUrl(m, "page.tsx", "", "", "dpl_123")).toBe("/page.js?dpl=dpl_123");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -138,6 +143,21 @@ describe("collectAssetTags", () => {
     });
     expect(result).toContain('<link rel="stylesheet"');
     expect(result).toContain('href="/style.css"');
+  });
+
+  // Ported from Next.js: test/production/deployment-id-handling/deployment-id-handling.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/production/deployment-id-handling/deployment-id-handling.test.ts
+  it("appends the deployment ID to managed script and stylesheet URLs", () => {
+    const result = collectAssetTags({
+      manifest: makeManifest({ "page.tsx": ["style.css", "page.js"] }),
+      moduleIds: ["page.tsx"],
+      disableOptimizedLoading: true,
+      deploymentId: "dpl_123",
+    });
+
+    expect(result).toContain('href="/style.css?dpl=dpl_123"');
+    expect(result).toContain('href="/page.js?dpl=dpl_123"');
+    expect(result).toContain('src="/page.js?dpl=dpl_123"');
   });
 
   it("emits modulepreload + script for js files", () => {

--- a/tests/pages-data-prefetch.test.ts
+++ b/tests/pages-data-prefetch.test.ts
@@ -2,25 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { clearPagesDataInflight } from "../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js";
 import { prefetchPagesData } from "../packages/vinext/src/shims/internal/pages-data-target.js";
 
-const originalDocument = globalThis.document;
-const originalFetch = globalThis.fetch;
-
 describe("prefetchPagesData", () => {
   beforeEach(() => {
     clearPagesDataInflight();
-    Object.defineProperty(globalThis, "document", { configurable: true, value: {} });
+    vi.stubGlobal("document", {});
   });
 
   afterEach(() => {
     clearPagesDataInflight();
-    vi.restoreAllMocks();
-    if (originalDocument === undefined) delete (globalThis as { document?: Document }).document;
-    else
-      Object.defineProperty(globalThis, "document", {
-        configurable: true,
-        value: originalDocument,
-      });
-    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
     delete process.env.__VINEXT_DEPLOYMENT_ID;
   });
 
@@ -31,7 +21,7 @@ describe("prefetchPagesData", () => {
     const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
       async () => new Response("{}"),
     );
-    globalThis.fetch = fetchMock;
+    vi.stubGlobal("fetch", fetchMock);
     const loader = vi.fn(async () => ({ default: null }));
 
     prefetchPagesData({

--- a/tests/pages-data-prefetch.test.ts
+++ b/tests/pages-data-prefetch.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { clearPagesDataInflight } from "../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js";
+import { prefetchPagesData } from "../packages/vinext/src/shims/internal/pages-data-target.js";
+
+const originalDocument = globalThis.document;
+const originalFetch = globalThis.fetch;
+
+describe("prefetchPagesData", () => {
+  beforeEach(() => {
+    clearPagesDataInflight();
+    Object.defineProperty(globalThis, "document", { configurable: true, value: {} });
+  });
+
+  afterEach(() => {
+    clearPagesDataInflight();
+    vi.restoreAllMocks();
+    if (originalDocument === undefined) delete (globalThis as { document?: Document }).document;
+    else
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    globalThis.fetch = originalFetch;
+    delete process.env.__VINEXT_DEPLOYMENT_ID;
+  });
+
+  // Ported from Next.js: test/production/deployment-id-handling/deployment-id-handling.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/production/deployment-id-handling/deployment-id-handling.test.ts
+  it("sends the deployment ID on Pages data prefetch requests", async () => {
+    process.env.__VINEXT_DEPLOYMENT_ID = "dpl_123";
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () => new Response("{}"),
+    );
+    globalThis.fetch = fetchMock;
+    const loader = vi.fn(async () => ({ default: null }));
+
+    prefetchPagesData({
+      buildId: "build-id",
+      dataHref: "/_next/data/build-id/about.json",
+      loader,
+      locale: undefined,
+      pagePath: "/about",
+      params: {},
+      pattern: "/about",
+      search: "",
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    const init = fetchMock.mock.calls[0][1];
+    if (!init) throw new Error("expected prefetch request options");
+    expect(init.headers).toEqual({
+      Accept: "application/json",
+      purpose: "prefetch",
+      "x-deployment-id": "dpl_123",
+      "x-nextjs-data": "1",
+    });
+    expect(loader).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16186,6 +16186,7 @@ describe("Pages Router _next/data client navigation", () => {
   it("uses the JSON path for prefetch when a loader is registered", async () => {
     const previousWindow = (globalThis as any).window;
     const originalDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
 
     const aboutLoader = vi.fn(async () => makePageModule("about"));
     const { win, buildId } = createDataNavWindow({
@@ -16216,6 +16217,8 @@ describe("Pages Router _next/data client navigation", () => {
         },
       },
     };
+    const fetchMock = vi.fn(async () => new Response("{}"));
+    globalThis.fetch = fetchMock;
     vi.resetModules();
 
     try {
@@ -16223,17 +16226,22 @@ describe("Pages Router _next/data client navigation", () => {
       const Router = routerModule.default;
       await Router.prefetch("/about");
 
-      const prefetchLink = appendedLinks.find((l) => l.rel === "prefetch");
-      expect(prefetchLink).toBeDefined();
-      expect(prefetchLink?.as).toBe("fetch");
-      expect(prefetchLink?.href).toBe(`/_next/data/${buildId}/about.json`);
-      expect(prefetchLink?.crossOrigin).toBe("anonymous");
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      expect(fetchMock).toHaveBeenCalledWith(`/_next/data/${buildId}/about.json`, {
+        headers: {
+          Accept: "application/json",
+          purpose: "prefetch",
+          "x-nextjs-data": "1",
+        },
+      });
+      expect(appendedLinks).toEqual([]);
       // The loader was warmed (chunk fetch kicked off).
       expect(aboutLoader).toHaveBeenCalledTimes(1);
     } finally {
       if (previousWindow === undefined) delete (globalThis as any).window;
       else (globalThis as any).window = previousWindow;
       (globalThis as any).document = originalDocument;
+      globalThis.fetch = originalFetch;
       vi.resetModules();
     }
   });


### PR DESCRIPTION
## Summary
- apply deployment IDs to Vite-generated asset URLs through `renderBuiltUrl`
- add `dpl` to runtime-generated scripts, styles, fonts, and dynamic preloads
- send `x-deployment-id` on App Router RSC/actions and Pages navigation/prefetch requests
- preserve URL fragments and avoid duplicate deployment query parameters

## Next.js parity
- ports coverage from `test/production/deployment-id-handling/deployment-id-handling.test.ts`
- keeps deployment IDs config/env-driven while retaining vinext RSC compatibility IDs

## Validation
- production App Router fixture build and served HTML deployment-ID test
- targeted router, link, asset, prefetch, and cache-busting tests
- focused formatting, lint, and type checks