### PR TITLE
fix(cloudflare): prevent auth-dependent edge caching

### DIFF
--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -79,6 +79,11 @@ namespace binding — both are configured there.
    header listing both the bare path (`/cached/intro`) and Next.js's internal
    `_N_T_<path>` form. The Workers Cache reads these to cache and tag-purge.
 
+   Responses influenced by `Cookie`, `Authorization`, Cloudflare Access identity
+   headers, or user middleware instead carry `Cache-Control: no-store` and no
+   `CDN-Cache-Control`. This prevents an authenticated request from filling an
+   outer-edge cache entry reusable by an unauthenticated request.
+
 5. **`revalidateTag` / `revalidatePath`** in your route handlers fan out to
    both the KV data cache and `ctx.cache.purge(...)` on the platform layer.
 

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -143,6 +143,10 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
   }
 
   buildResponseHeaders(input: CdnCacheableHeaderInput): CdnResponseHeaders {
+    if (input.requestDependent) {
+      return { "Cache-Control": NO_STORE };
+    }
+
     // No cacheable policy → nobody stores it.
     if (!input.cacheControl) {
       return { "Cache-Control": NO_STORE };

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -177,7 +177,7 @@ export async function runMiddleware(request, ctx, options) {
   // rewrite to something else).
   const __dataNorm = __normalizePagesDataRequest(request, buildId);
   if (__dataNorm.notFoundResponse) {
-    return { continue: false, response: __dataNorm.notFoundResponse };
+    return { continue: false, executed: false, response: __dataNorm.notFoundResponse };
   }
   const __result = await __runGeneratedMiddleware({
     basePath: vinextConfig.basePath,
@@ -201,12 +201,12 @@ export async function runMiddleware(request) {
   // the worker pipeline sees the page path. Mismatched buildId → JSON 404.
   const __dataNorm = __normalizePagesDataRequest(request, buildId);
   if (__dataNorm.notFoundResponse) {
-    return { continue: false, response: __dataNorm.notFoundResponse };
+    return { continue: false, executed: false, response: __dataNorm.notFoundResponse };
   }
   if (__dataNorm.isDataReq) {
-    return { continue: true, rewriteUrl: __dataNorm.normalizedPathname + __dataNorm.search };
+    return { continue: true, executed: false, rewriteUrl: __dataNorm.normalizedPathname + __dataNorm.search };
   }
-  return { continue: true };
+  return { continue: true, executed: false };
 }
 `;
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3626,7 +3626,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                       // Forward middleware context to the RSC entry so it can
                       // populate _mwCtx without re-running the middleware function.
                       // This prevents double execution in hybrid app+pages dev mode.
-                      if (hasAppDir && result.continue) {
+                      if (hasAppDir && result.continue && result.executed) {
                         const mwCtxEntries: [string, string][] = [];
                         if (result.responseHeaders) {
                           for (const [key, value] of result.responseHeaders) {

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -1,6 +1,7 @@
 import type { NextI18nConfig } from "../config/next-config.js";
 import { isExternalUrl, proxyExternalRequest } from "../config/config-matchers.js";
 import { applyMiddlewareRequestHeaders, setHeadersContext } from "vinext/shims/headers";
+import { markCdnCacheRequestDependent } from "vinext/shims/cdn-cache";
 import { setNavigationContext } from "vinext/shims/navigation";
 import { FLIGHT_HEADERS, VINEXT_MW_CTX_HEADER } from "./headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "./middleware-request-headers.js";
@@ -250,6 +251,10 @@ export async function applyAppMiddleware(
       request: middlewareRequest,
       trailingSlash: options.trailingSlash,
     });
+
+    if (result.executed) {
+      markCdnCacheRequestDependent();
+    }
 
     if (!result.continue) {
       if (result.redirectUrl) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -31,6 +31,10 @@ import {
 } from "vinext/shims/request-context";
 import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/root-params";
 import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
+import {
+  hasCdnSensitiveRequestHeaders,
+  markCdnCacheRequestDependent,
+} from "vinext/shims/cdn-cache";
 import { flattenErrorCauses } from "../utils/error-cause.js";
 import { hasBasePath } from "../utils/base-path.js";
 import { applyAppMiddleware, type AppMiddlewareContext } from "./app-middleware.js";
@@ -493,6 +497,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   };
 
   if (options.middlewareModule) {
+    markCdnCacheRequestDependent();
     const middlewareResult = await applyAppMiddleware({
       basePath: options.basePath,
       cleanPathname,
@@ -893,6 +898,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     const requestContext = createRequestContext({
       headersContext,
       executionContext,
+      cdnCacheRequestDependent: hasCdnSensitiveRequestHeaders(request.headers),
       unstableCacheRevalidation: "background",
     });
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -31,10 +31,7 @@ import {
 } from "vinext/shims/request-context";
 import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/root-params";
 import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
-import {
-  hasCdnSensitiveRequestHeaders,
-  markCdnCacheRequestDependent,
-} from "vinext/shims/cdn-cache";
+import { hasCdnSensitiveRequestHeaders } from "vinext/shims/cdn-cache";
 import { flattenErrorCauses } from "../utils/error-cause.js";
 import { hasBasePath } from "../utils/base-path.js";
 import { applyAppMiddleware, type AppMiddlewareContext } from "./app-middleware.js";
@@ -497,7 +494,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   };
 
   if (options.middlewareModule) {
-    markCdnCacheRequestDependent();
     const middlewareResult = await applyAppMiddleware({
       basePath: options.basePath,
       cleanPathname,

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -1,7 +1,7 @@
 import type { NextHeader, NextI18nConfig } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
 import { VINEXT_STATIC_FILE_HEADER } from "./headers.js";
-import { applyCdnResponseHeaders } from "./cache-control.js";
+import { applyCdnResponseHeaders, finalizeCdnResponsePolicy } from "./cache-control.js";
 import { applyConfigHeadersToResponse } from "./request-pipeline.js";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { mergeVaryHeader } from "./middleware-response-headers.js";
@@ -49,7 +49,7 @@ export function finalizeAppRscResponse(
   // 3xx responses: Response.redirect() headers are immutable (throws on write),
   // and Next.js deliberately excludes config headers from redirect responses.
   if (response.status >= 300 && response.status < 400) {
-    return response;
+    return finalizeCdnResponsePolicy(response);
   }
 
   if (!response.headers.has(VINEXT_STATIC_FILE_HEADER)) {
@@ -69,7 +69,7 @@ export function finalizeAppRscResponse(
   }
 
   if (!options.configHeaders.length) {
-    return response;
+    return finalizeCdnResponsePolicy(response);
   }
 
   const url = new URL(request.url);
@@ -106,5 +106,5 @@ export function finalizeAppRscResponse(
     basePathState: { basePath: options.basePath, hadBasePath },
   });
 
-  return response;
+  return finalizeCdnResponsePolicy(response);
 }

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -1,4 +1,8 @@
-import { getCdnCacheAdapter, type CdnCacheableHeaderInput } from "vinext/shims/cdn-cache";
+import {
+  getCdnCacheAdapter,
+  isCdnCacheRequestDependent,
+  type CdnCacheableHeaderInput,
+} from "vinext/shims/cdn-cache";
 
 export const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
@@ -21,7 +25,12 @@ export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
  */
 export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHeaderInput): void {
   headers.delete("Cache-Control");
-  const map = getCdnCacheAdapter().buildResponseHeaders(input);
+  headers.delete("CDN-Cache-Control");
+  headers.delete("Cache-Tag");
+  const map = getCdnCacheAdapter().buildResponseHeaders({
+    ...input,
+    requestDependent: input.requestDependent ?? isCdnCacheRequestDependent(),
+  });
   for (const [name, value] of Object.entries(map)) {
     // Never stamp an empty header. An adapter returns an empty `Cache-Control`
     // only when it has no default for an empty policy (e.g. the default

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -52,17 +52,42 @@ export function finalizeCdnResponsePolicy(
   response: Response,
   requestDependent = isCdnCacheRequestDependent(),
 ): Response {
-  if (!requestDependent) return response;
+  if (!requestDependent || process.env.VINEXT_PRERENDER === "1") return response;
+
+  const currentCacheControl = response.headers.get("Cache-Control");
+  const cacheControl =
+    currentCacheControl && /\b(?:no-store|no-cache|private)\b/i.test(currentCacheControl)
+      ? currentCacheControl
+      : "no-store";
+  const needsCleanup = CDN_RESPONSE_POLICY_HEADERS.some((name) => response.headers.has(name));
+  if (currentCacheControl === cacheControl && !needsCleanup) return response;
+
+  try {
+    response.headers.set("Cache-Control", cacheControl);
+    for (const name of CDN_RESPONSE_POLICY_HEADERS) response.headers.delete(name);
+    return response;
+  } catch {
+    // Response.redirect() and other platform responses can expose immutable
+    // headers. Clone only those responses; ordinary streamed responses stay
+    // untouched so their vinext streaming metadata remains attached.
+  }
 
   const headers = new Headers(response.headers);
-  headers.set("Cache-Control", "no-store");
+  headers.set("Cache-Control", cacheControl);
   for (const name of CDN_RESPONSE_POLICY_HEADERS) headers.delete(name);
 
-  return new Response(response.body, {
+  const finalized = new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers,
   });
+  const streamingMetadata = response as Response & { __vinextStreamedHtmlResponse?: boolean };
+  if (streamingMetadata.__vinextStreamedHtmlResponse === true) {
+    (
+      finalized as Response & { __vinextStreamedHtmlResponse?: boolean }
+    ).__vinextStreamedHtmlResponse = true;
+  }
+  return finalized;
 }
 
 /**

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -41,6 +41,30 @@ export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHea
   }
 }
 
+const CDN_RESPONSE_POLICY_HEADERS = [
+  "CDN-Cache-Control",
+  "Cloudflare-CDN-Cache-Control",
+  "Cache-Tag",
+];
+
+/** Enforce request-dependent no-store after every response/header merge has completed. */
+export function finalizeCdnResponsePolicy(
+  response: Response,
+  requestDependent = isCdnCacheRequestDependent(),
+): Response {
+  if (!requestDependent) return response;
+
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "no-store");
+  for (const name of CDN_RESPONSE_POLICY_HEADERS) headers.delete(name);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 /**
  * Matches Next.js's `getCacheControlHeader` stale window semantics while
  * preserving vinext's legacy unbounded SWR header when no expire ceiling is

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -23,6 +23,7 @@ export type MiddlewareModule = Record<string, unknown>;
 
 export type MiddlewareResult = {
   continue: boolean;
+  executed: boolean;
   redirectUrl?: string;
   redirectStatus?: number;
   rewriteUrl?: string;
@@ -256,7 +257,7 @@ export async function executeMiddleware(
   const normalizedPathname =
     options.normalizedPathname ?? resolveMiddlewarePathname(options.request);
   if (normalizedPathname instanceof Response) {
-    return { continue: false, response: normalizedPathname };
+    return { continue: false, executed: false, response: normalizedPathname };
   }
 
   // Default: derive in-basePath state from the request URL. The Pages
@@ -287,7 +288,7 @@ export async function executeMiddleware(
       options.i18nConfig,
     )
   ) {
-    return { continue: true };
+    return { continue: true, executed: false };
   }
 
   const nextRequest = createNextRequest(
@@ -311,6 +312,7 @@ export async function executeMiddleware(
       : "Internal Server Error";
     return {
       continue: false,
+      executed: true,
       response: internalServerErrorResponse(message),
       waitUntilPromises,
     };
@@ -319,12 +321,13 @@ export async function executeMiddleware(
   const waitUntilPromises = drainFetchEvent(fetchEvent);
 
   if (!response) {
-    return { continue: true, waitUntilPromises };
+    return { continue: true, executed: true, waitUntilPromises };
   }
 
   if (response.headers.get(MIDDLEWARE_NEXT_HEADER) === "1") {
     return {
       continue: true,
+      executed: true,
       responseHeaders: collectMiddlewareHeaders(response),
       status: response.status !== 200 ? response.status : undefined,
       waitUntilPromises,
@@ -377,6 +380,7 @@ export async function executeMiddleware(
       if (options.isDataRequest) {
         return {
           continue: false,
+          executed: true,
           response: dataRedirectResponse(normalizedLocation, response),
           waitUntilPromises,
         };
@@ -400,6 +404,7 @@ export async function executeMiddleware(
       });
       return {
         continue: false,
+        executed: true,
         redirectUrl: normalizedLocation,
         redirectStatus: response.status,
         response: stripMiddlewareHeadersFromResponse(relativizedResponse),
@@ -448,6 +453,7 @@ export async function executeMiddleware(
     }
     return {
       continue: true,
+      executed: true,
       rewriteUrl: rewritePath,
       rewriteStatus: response.status !== 200 ? response.status : undefined,
       responseHeaders: collectMiddlewareHeaders(response),
@@ -458,6 +464,7 @@ export async function executeMiddleware(
 
   return {
     continue: false,
+    executed: true,
     response: stripMiddlewareHeadersFromResponse(response),
     waitUntilPromises,
   };

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -41,6 +41,7 @@ import {
 import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { reportRequestError } from "./instrumentation.js";
 import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
+import { hasCdnSensitiveRequestHeaders } from "vinext/shims/cdn-cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { ensureFetchPatch } from "vinext/shims/fetch-cache";
 import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js";
@@ -182,6 +183,7 @@ type RenderPageOptions = {
   __isInternalErrorRender?: boolean;
   __forcedRoute?: PageRoute;
   err?: unknown;
+  cdnCacheRequestDependent?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -380,6 +382,9 @@ export function createPagesPageHandler(
     const { route, params } = match;
     const uCtx = createRequestContext({
       executionContext: getRequestExecutionContext(),
+      cdnCacheRequestDependent:
+        options?.cdnCacheRequestDependent === true ||
+        hasCdnSensitiveRequestHeaders(request.headers),
     });
 
     return runWithRequestContext(uCtx, async () => {

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -40,6 +40,7 @@ import { addBasePathToPathname, hasBasePath } from "../utils/base-path.js";
 export type PagesRenderOptions = {
   isDataReq?: boolean;
   renderErrorPageOnMiss?: boolean;
+  cdnCacheRequestDependent?: boolean;
 };
 
 export type MiddlewareResult = {
@@ -269,6 +270,7 @@ export async function runPagesRequest(
   let resolvedUrl = pathname + search;
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
+  const middlewareExecuted = typeof deps.runMiddleware === "function";
 
   if (typeof deps.runMiddleware === "function") {
     const result = await deps.runMiddleware(request, deps.ctx ?? null, { isDataRequest });
@@ -496,11 +498,13 @@ export async function runPagesRequest(
     // on the header). No-op for Node/dev, where a data request already has isDataReq=true.
     const shouldDeferErrorPageOnMiss =
       !isDataReq && !isDataRequest && !!deps.matchPageRoute && !renderPageMatch;
-    const initialRenderOptions: PagesRenderOptions | undefined = shouldDeferErrorPageOnMiss
-      ? { renderErrorPageOnMiss: false }
-      : isDataReq
-        ? { isDataReq: true }
-        : undefined;
+    const initialRenderOptions: PagesRenderOptions = {
+      ...(shouldDeferErrorPageOnMiss ? { renderErrorPageOnMiss: false } : {}),
+      ...(isDataReq ? { isDataReq: true } : {}),
+      ...(middlewareExecuted ? { cdnCacheRequestDependent: true } : {}),
+    };
+    const effectiveInitialRenderOptions =
+      Object.keys(initialRenderOptions).length > 0 ? initialRenderOptions : undefined;
 
     // Convert staged middleware headers to a Web Headers object for renderPage.
     // Adapters that need to inject per-request values (e.g. CSP nonces) into the
@@ -514,7 +518,12 @@ export async function runPagesRequest(
       }
     }
 
-    let response = await deps.renderPage(request, resolvedUrl, initialRenderOptions, stagedHeaders);
+    let response = await deps.renderPage(
+      request,
+      resolvedUrl,
+      effectiveInitialRenderOptions,
+      stagedHeaders,
+    );
 
     // Fallback rewrites if 404 + deferred
     let matchedFallbackRewrite = false;
@@ -536,7 +545,7 @@ export async function runPagesRequest(
         response = await deps.renderPage(
           request,
           mergeRewriteQuery(resolvedUrl, fallbackRewrite),
-          undefined,
+          middlewareExecuted ? { cdnCacheRequestDependent: true } : undefined,
           stagedHeaders,
         );
         matchedFallbackRewrite = true;
@@ -545,7 +554,12 @@ export async function runPagesRequest(
 
     // Deferred 404 re-render
     if (response.status === 404 && shouldDeferErrorPageOnMiss && !matchedFallbackRewrite) {
-      response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+      response = await deps.renderPage(
+        request,
+        resolvedUrl,
+        middlewareExecuted ? { cdnCacheRequestDependent: true } : undefined,
+        stagedHeaders,
+      );
     }
 
     const merged = mergeHeaders(response, middlewareHeaders, middlewareStatus);
@@ -589,7 +603,13 @@ export async function runPagesRequest(
   return {
     type: "render",
     resolvedUrl,
-    renderOptions: isDataReq ? { isDataReq: true } : undefined,
+    renderOptions:
+      isDataReq || middlewareExecuted
+        ? {
+            ...(isDataReq ? { isDataReq: true } : {}),
+            ...(middlewareExecuted ? { cdnCacheRequestDependent: true } : {}),
+          }
+        : undefined,
     stagedHeaders: middlewareHeaders,
     requestHeaders: request.headers,
     middlewareStatus,

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -35,6 +35,8 @@ import { mergeHeaders } from "./worker-utils.js";
 import { normalizeDefaultLocalePathname, stripI18nLocaleForApiRoute } from "./pages-i18n.js";
 import { mergeRewriteQuery } from "../utils/query.js";
 import { addBasePathToPathname, hasBasePath } from "../utils/base-path.js";
+import { finalizeCdnResponsePolicy } from "./cache-control.js";
+import { hasCdnSensitiveRequestHeaders } from "vinext/shims/cdn-cache";
 
 // All "render options" that are passed through to the renderPage callback
 export type PagesRenderOptions = {
@@ -45,6 +47,7 @@ export type PagesRenderOptions = {
 
 export type MiddlewareResult = {
   continue: boolean;
+  executed: boolean;
   redirectUrl?: string;
   redirectStatus?: number;
   rewriteUrl?: string;
@@ -270,10 +273,12 @@ export async function runPagesRequest(
   let resolvedUrl = pathname + search;
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
-  const middlewareExecuted = typeof deps.runMiddleware === "function";
+  let middlewareExecuted = false;
+  const hasSensitiveRequestHeaders = hasCdnSensitiveRequestHeaders(request.headers);
 
   if (typeof deps.runMiddleware === "function") {
     const result = await deps.runMiddleware(request, deps.ctx ?? null, { isDataRequest });
+    middlewareExecuted = result.executed;
 
     // Bubble waitUntil promises
     if (result.waitUntilPromises && result.waitUntilPromises.length > 0) {
@@ -315,14 +320,23 @@ export async function runPagesRequest(
         }
         return {
           type: "response",
-          response: new Response(null, {
-            status: result.redirectStatus ?? 307,
-            headers,
-          }),
+          response: finalizeCdnResponsePolicy(
+            new Response(null, {
+              status: result.redirectStatus ?? 307,
+              headers,
+            }),
+            middlewareExecuted || hasSensitiveRequestHeaders,
+          ),
         };
       }
       if (result.response) {
-        return { type: "response", response: result.response };
+        return {
+          type: "response",
+          response: finalizeCdnResponsePolicy(
+            result.response,
+            middlewareExecuted || hasSensitiveRequestHeaders,
+          ),
+        };
       }
     }
 
@@ -386,7 +400,10 @@ export async function runPagesRequest(
     const proxyResponse = await proxyExternal(request, resolvedUrl);
     return {
       type: "response",
-      response: mergeHeaders(proxyResponse, middlewareHeaders, undefined),
+      response: finalizeCdnResponsePolicy(
+        mergeHeaders(proxyResponse, middlewareHeaders, undefined),
+        middlewareExecuted || hasSensitiveRequestHeaders,
+      ),
     };
   }
 
@@ -415,7 +432,13 @@ export async function runPagesRequest(
     if (rewritten) {
       if (isExternalUrl(rewritten)) {
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
-        return { type: "response", response: await proxyExternal(request, rewritten) };
+        return {
+          type: "response",
+          response: finalizeCdnResponsePolicy(
+            await proxyExternal(request, rewritten),
+            middlewareExecuted || hasSensitiveRequestHeaders,
+          ),
+        };
       }
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
       resolvedPathname = resolvedUrl.split("?")[0];
@@ -445,7 +468,10 @@ export async function runPagesRequest(
         // API routes return arbitrary data; default a missing content-type to
         // application/octet-stream (not text/html) to avoid content sniffing.
         defaultContentType: "application/octet-stream",
-        response: mergeHeaders(response, middlewareHeaders, middlewareStatus),
+        response: finalizeCdnResponsePolicy(
+          mergeHeaders(response, middlewareHeaders, middlewareStatus),
+          middlewareExecuted || hasSensitiveRequestHeaders,
+        ),
       };
     } else {
       // dev: emit intent
@@ -474,7 +500,13 @@ export async function runPagesRequest(
     if (rewritten) {
       if (isExternalUrl(rewritten)) {
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
-        return { type: "response", response: await proxyExternal(request, rewritten) };
+        return {
+          type: "response",
+          response: finalizeCdnResponsePolicy(
+            await proxyExternal(request, rewritten),
+            middlewareExecuted || hasSensitiveRequestHeaders,
+          ),
+        };
       }
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
       resolvedPathname = resolvedUrl.split("?")[0];
@@ -539,7 +571,10 @@ export async function runPagesRequest(
           // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
           return {
             type: "response",
-            response: await proxyExternal(request, fallbackRewrite),
+            response: finalizeCdnResponsePolicy(
+              await proxyExternal(request, fallbackRewrite),
+              middlewareExecuted || hasSensitiveRequestHeaders,
+            ),
           };
         }
         response = await deps.renderPage(
@@ -572,7 +607,11 @@ export async function runPagesRequest(
       ).__vinextStreamedHtmlResponse;
     }
     // Page renders default a missing content-type to text/html.
-    return { type: "response", response: merged, defaultContentType: "text/html" };
+    return {
+      type: "response",
+      response: finalizeCdnResponsePolicy(merged, middlewareExecuted || hasSensitiveRequestHeaders),
+      defaultContentType: "text/html",
+    };
   }
   // dev: apply fallback rewrites eagerly (no renderPage to 404-gate on).
   // If matchPageRoute says there's no match, try fallback rewrites before
@@ -594,7 +633,13 @@ export async function runPagesRequest(
     if (fallbackRewrite) {
       if (isExternalUrl(fallbackRewrite)) {
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
-        return { type: "response", response: await proxyExternal(request, fallbackRewrite) };
+        return {
+          type: "response",
+          response: finalizeCdnResponsePolicy(
+            await proxyExternal(request, fallbackRewrite),
+            middlewareExecuted || hasSensitiveRequestHeaders,
+          ),
+        };
       }
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
     }

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -31,6 +31,7 @@ import {
   type IncrementalCacheValue,
 } from "./cache.js";
 import { getRequestExecutionContext } from "./request-context.js";
+import { getRequestContext, isInsideUnifiedScope } from "./unified-request-context.js";
 // The edge adapter lives with the Cloudflare integration; the resolver below
 // imports it to use as the built-in default when a request-context host cache
 // is present.
@@ -64,7 +65,27 @@ export type CdnCacheableHeaderInput = {
    * The default adapter ignores them.
    */
   tags?: readonly string[];
+  /** True when credentials or middleware influenced the current request. */
+  requestDependent?: boolean;
 };
+
+const CREDENTIAL_HEADERS = new Set(["authorization", "cookie"]);
+
+export function hasCdnSensitiveRequestHeaders(headers: Headers): boolean {
+  for (const [name] of headers) {
+    const normalized = name.toLowerCase();
+    if (CREDENTIAL_HEADERS.has(normalized) || normalized.startsWith("cf-access-")) return true;
+  }
+  return false;
+}
+
+export function markCdnCacheRequestDependent(): void {
+  if (isInsideUnifiedScope()) getRequestContext().cdnCacheRequestDependent = true;
+}
+
+export function isCdnCacheRequestDependent(): boolean {
+  return isInsideUnifiedScope() && getRequestContext().cdnCacheRequestDependent;
+}
 
 /**
  * The serving strategy for page-level ISR. Implement this to delegate

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -41,6 +41,9 @@ export type UnifiedRequestContext = {
   /** Cloudflare Workers ExecutionContext, or null on Node.js dev. */
   executionContext: ExecutionContextLike | null;
 
+  /** Whether credentials or user middleware make this response unsafe for a shared CDN cache. */
+  cdnCacheRequestDependent: boolean;
+
   // ── cache-for-request.ts ──────────────────────────────────────────
   /** Per-request cache for cacheForRequest(). Keyed by factory function reference. */
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,6 +75,10 @@ function _getInheritedExecutionContext(): ExecutionContextLike | null {
     | AsyncLocalStorage<ExecutionContextLike | null>
     | undefined;
   return executionContextAls?.getStore() ?? null;
+}
+
+function _getInheritedCdnCacheRequestDependent(): boolean {
+  return _als.getStore()?.cdnCacheRequestDependent ?? false;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,6 +116,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     isFetchDedupeActive: false,
     currentFetchDedupeEntries: new Map(),
     executionContext: _getInheritedExecutionContext(), // inherits from standalone ALS if present
+    cdnCacheRequestDependent: _getInheritedCdnCacheRequestDependent(),
     requestCache: new WeakMap(),
     ssrContext: null,
     ssrHeadChildren: [],

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -108,6 +108,31 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
   });
 
+  it("keeps public caching when the middleware matcher skips the route", async () => {
+    const middleware = vi.fn(() => undefined);
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage: async () =>
+        new Response("page", {
+          headers: {
+            "Cache-Control": "public, max-age=0, must-revalidate",
+            "CDN-Cache-Control": "public, max-age=300",
+            "Cache-Tag": "public-page",
+          },
+        }),
+      middlewareModule: {
+        middleware,
+        config: { matcher: "/admin" },
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/about"), null);
+
+    expect(middleware).not.toHaveBeenCalled();
+    expect(response.headers.get("CDN-Cache-Control")).toBe("public, max-age=300");
+    expect(response.headers.get("Cache-Tag")).toBe("public-page");
+  });
+
   it("does not trailing-slash redirect RSC requests built from already-canonical trailingSlash paths", async () => {
     const headers = createRscRequestHeaders();
     const requestPath = await createRscRequestUrl("/about/", headers);
@@ -929,7 +954,7 @@ describe("createAppRscHandler", () => {
     expect(matchRoute).not.toHaveBeenCalled();
   });
 
-  it("lets middleware Cache-Control override static metadata route defaults", async () => {
+  it("forces no-store after middleware overrides static metadata route defaults", async () => {
     // Ported from Next.js: test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts
     // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts
     const handler = createHandler({
@@ -962,7 +987,7 @@ describe("createAppRscHandler", () => {
     const response = await handler(new Request("https://example.test/docs/favicon.ico"), null);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("max-age=1234");
+    expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("content-type")).toBe("image/x-icon");
     await expect(response.text()).resolves.toBe("icon-bytes");
   });

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
+import {
+  createRequestContext,
+  runWithRequestContext,
+} from "../packages/vinext/src/shims/unified-request-context.js";
 import type { RequestContext } from "../packages/vinext/src/config/config-matchers.js";
 
 function makeRequestContext(headers: Headers = new Headers()): RequestContext {
@@ -306,5 +310,53 @@ describe("finalizeAppRscResponse — default-locale path normalisation", () => {
 
     expect(response.headers.get("x-fr")).toBe("yes");
     expect(response.headers.get("x-en")).toBeNull();
+  });
+});
+
+describe("finalizeAppRscResponse — request-dependent CDN policy", () => {
+  it("removes cache config headers after config header application", async () => {
+    await runWithRequestContext(createRequestContext({ cdnCacheRequestDependent: true }), () => {
+      const response = new Response("body", { status: 200 });
+      const finalized = finalizeAppRscResponse(response, new Request("http://example.com/about"), {
+        basePath: "",
+        configHeaders: [
+          {
+            source: "/about",
+            headers: [
+              { key: "CDN-Cache-Control", value: "public, max-age=300" },
+              { key: "Cloudflare-CDN-Cache-Control", value: "public, max-age=300" },
+              { key: "Cache-Tag", value: "private-admin" },
+            ],
+          },
+        ],
+        i18nConfig: null,
+        requestContext: makeRequestContext(),
+      });
+
+      expect(finalized.headers.get("Cache-Control")).toBe("no-store");
+      expect(finalized.headers.get("CDN-Cache-Control")).toBeNull();
+      expect(finalized.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+      expect(finalized.headers.get("Cache-Tag")).toBeNull();
+    });
+  });
+
+  it("cleans request-dependent redirect cache headers", async () => {
+    await runWithRequestContext(createRequestContext({ cdnCacheRequestDependent: true }), () => {
+      const finalized = finalizeAppRscResponse(
+        Response.redirect("http://example.com/login"),
+        new Request("http://example.com/about"),
+        {
+          basePath: "",
+          configHeaders: [],
+          i18nConfig: null,
+          requestContext: makeRequestContext(),
+        },
+      );
+
+      expect(finalized.status).toBe(302);
+      expect(finalized.headers.get("Location")).toBe("http://example.com/login");
+      expect(finalized.headers.get("Cache-Control")).toBe("no-store");
+      expect(finalized.headers.get("CDN-Cache-Control")).toBeNull();
+    });
   });
 });

--- a/tests/cdn-cache.test.ts
+++ b/tests/cdn-cache.test.ts
@@ -15,6 +15,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test"
 import {
   DefaultCdnCacheAdapter,
   getCdnCacheAdapter,
+  hasCdnSensitiveRequestHeaders,
+  markCdnCacheRequestDependent,
   setCdnCacheAdapter,
   type CdnCacheAdapter,
   type CdnCacheableHeaderInput,
@@ -38,6 +40,12 @@ import {
   buildPagesCacheValue,
 } from "../packages/vinext/src/server/isr-cache.js";
 import { setHeadersAccessPhase } from "../packages/vinext/src/shims/headers.js";
+import { CloudflareCdnCacheAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
+import { applyCdnResponseHeaders } from "../packages/vinext/src/server/cache-control.js";
+import {
+  createRequestContext,
+  runWithRequestContext,
+} from "../packages/vinext/src/shims/unified-request-context.js";
 
 function resetAdapters(): void {
   setDataCacheHandler(new MemoryCacheHandler());
@@ -146,6 +154,85 @@ class EdgeCdnAdapter implements CdnCacheAdapter {
 }
 
 describe("edge CDN adapter integration", () => {
+  it.each([
+    ["Cookie", "session=admin"],
+    ["Authorization", "Bearer secret"],
+    ["CF-Access-Jwt-Assertion", "signed-identity"],
+    ["CF-Access-Authenticated-User-Email", "admin@example.com"],
+  ])("does not publish ISR responses dependent on %s", async (name, value) => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const request = new Request("https://example.com/admin", { headers: { [name]: value } });
+    const responseHeaders = new Headers();
+
+    await runWithRequestContext(
+      createRequestContext({
+        cdnCacheRequestDependent: hasCdnSensitiveRequestHeaders(request.headers),
+      }),
+      () => {
+        applyCdnResponseHeaders(responseHeaders, {
+          cacheControl: "s-maxage=300, stale-while-revalidate",
+          tags: ["admin"],
+        });
+      },
+    );
+
+    expect(responseHeaders.get("Cache-Control")).toBe("no-store");
+    expect(responseHeaders.get("CDN-Cache-Control")).toBeNull();
+    expect(responseHeaders.get("Cache-Tag")).toBeNull();
+  });
+
+  it("does not publish a middleware-approved ISR response to the outer edge cache", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const responseHeaders = new Headers();
+
+    await runWithRequestContext(createRequestContext(), () => {
+      markCdnCacheRequestDependent();
+      applyCdnResponseHeaders(responseHeaders, {
+        cacheControl: "s-maxage=300, stale-while-revalidate",
+        tags: ["admin"],
+      });
+    });
+
+    expect(responseHeaders.get("Cache-Control")).toBe("no-store");
+    expect(responseHeaders.get("CDN-Cache-Control")).toBeNull();
+    expect(responseHeaders.get("Cache-Tag")).toBeNull();
+  });
+
+  it("preserves middleware dependence across nested render contexts", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const responseHeaders = new Headers();
+
+    await runWithRequestContext(createRequestContext(), async () => {
+      markCdnCacheRequestDependent();
+      await runWithRequestContext(createRequestContext(), () => {
+        applyCdnResponseHeaders(responseHeaders, {
+          cacheControl: "s-maxage=300, stale-while-revalidate",
+        });
+      });
+    });
+
+    expect(responseHeaders.get("Cache-Control")).toBe("no-store");
+    expect(responseHeaders.get("CDN-Cache-Control")).toBeNull();
+  });
+
+  it("continues to publish credential-free public ISR responses", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const responseHeaders = new Headers();
+
+    await runWithRequestContext(createRequestContext(), () => {
+      applyCdnResponseHeaders(responseHeaders, {
+        cacheControl: "s-maxage=300, stale-while-revalidate",
+        tags: ["public-page"],
+      });
+    });
+
+    expect(responseHeaders.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
+    expect(responseHeaders.get("CDN-Cache-Control")).toBe(
+      "public, max-age=300, stale-while-revalidate=31536000",
+    );
+    expect(responseHeaders.get("Cache-Tag")).toBe("public-page");
+  });
+
   it("isrGet returns null (origin renders) even after isrSet", async () => {
     setCdnCacheAdapter(new EdgeCdnAdapter());
     await isrSet("app:/p:html", buildPagesCacheValue("<p>cached</p>", {}), 60, []);

--- a/tests/cdn-cache.test.ts
+++ b/tests/cdn-cache.test.ts
@@ -41,7 +41,10 @@ import {
 } from "../packages/vinext/src/server/isr-cache.js";
 import { setHeadersAccessPhase } from "../packages/vinext/src/shims/headers.js";
 import { CloudflareCdnCacheAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
-import { applyCdnResponseHeaders } from "../packages/vinext/src/server/cache-control.js";
+import {
+  applyCdnResponseHeaders,
+  finalizeCdnResponsePolicy,
+} from "../packages/vinext/src/server/cache-control.js";
 import {
   createRequestContext,
   runWithRequestContext,
@@ -154,6 +157,46 @@ class EdgeCdnAdapter implements CdnCacheAdapter {
 }
 
 describe("edge CDN adapter integration", () => {
+  it("does not alter internal prerender response policies", () => {
+    const previous = process.env.VINEXT_PRERENDER;
+    process.env.VINEXT_PRERENDER = "1";
+    try {
+      const response = new Response("static", {
+        headers: { "CDN-Cache-Control": "public, max-age=300" },
+      });
+      const finalized = finalizeCdnResponsePolicy(response, true);
+
+      expect(finalized).toBe(response);
+      expect(finalized.headers.get("CDN-Cache-Control")).toBe("public, max-age=300");
+      expect(finalized.headers.get("Cache-Control")).toBeNull();
+    } finally {
+      if (previous === undefined) delete process.env.VINEXT_PRERENDER;
+      else process.env.VINEXT_PRERENDER = previous;
+    }
+  });
+
+  it("preserves stronger no-store policies and streamed response metadata", () => {
+    const response = new Response("stream", {
+      headers: {
+        "Cache-Control": "no-store, must-revalidate",
+        "CDN-Cache-Control": "public, max-age=300",
+      },
+    });
+    (
+      response as Response & { __vinextStreamedHtmlResponse?: boolean }
+    ).__vinextStreamedHtmlResponse = true;
+
+    const finalized = finalizeCdnResponsePolicy(response, true);
+
+    expect(finalized).toBe(response);
+    expect(finalized.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(finalized.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(
+      (finalized as Response & { __vinextStreamedHtmlResponse?: boolean })
+        .__vinextStreamedHtmlResponse,
+    ).toBe(true);
+  });
+
   it.each([
     ["Cookie", "session=admin"],
     ["Authorization", "Bearer secret"],

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { executeMiddleware } from "../packages/vinext/src/server/middleware-runtime.js";
 import type { NextRequest } from "../packages/vinext/src/shims/server.js";
 
@@ -259,5 +259,17 @@ describe("middleware nextUrl basePath", () => {
     expect(result.continue).toBe(true);
     expect(captured.request?.nextUrl.basePath).toBe("/root");
     expect(captured.request?.nextUrl.pathname).toBe("/dashboard");
+  });
+
+  it("reports when a matcher skips middleware execution", async () => {
+    const handler = vi.fn(() => undefined);
+    const result = await executeMiddleware({
+      isProxy: false,
+      module: { middleware: handler, config: { matcher: "/admin" } },
+      request: new Request("http://localhost:3000/public"),
+    });
+
+    expect(result).toMatchObject({ continue: true, executed: false });
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -159,7 +159,7 @@ describe("middleware", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/bar",
-      undefined,
+      { cdnCacheRequestDependent: true },
       expect.any(Headers),
     );
   });

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -31,6 +31,7 @@ function baseDeps(overrides?: Partial<PagesPipelineDeps>): PagesPipelineDeps {
 function makeMiddleware(result: Partial<MiddlewareResult>) {
   return vi.fn(async (_req: Request, _ctx: unknown, _opts: { isDataRequest: boolean }) => ({
     continue: true,
+    executed: true,
     ...result,
   }));
 }
@@ -164,6 +165,112 @@ describe("middleware", () => {
     );
   });
 
+  it("keeps public caching when the middleware matcher skips the route", async () => {
+    const renderPage = vi.fn(
+      async (_req: Request, _url: string, _opts?: PagesRenderOptions, _headers?: Headers) =>
+        new Response("public", {
+          headers: {
+            "Cache-Control": "public, max-age=0, must-revalidate",
+            "CDN-Cache-Control": "public, max-age=300",
+            "Cache-Tag": "public-page",
+          },
+        }),
+    );
+    const result = await runPagesRequest(
+      makeRequest("/public"),
+      baseDeps({
+        runMiddleware: makeMiddleware({ executed: false }),
+        renderPage,
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(renderPage.mock.calls[0][2]).toBeUndefined();
+    expect(result.response.headers.get("CDN-Cache-Control")).toBe("public, max-age=300");
+    expect(result.response.headers.get("Cache-Tag")).toBe("public-page");
+  });
+
+  it("removes config cache headers after a middleware-dependent render", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/admin"),
+      baseDeps({
+        configHeaders: [
+          {
+            source: "/admin",
+            headers: [
+              { key: "CDN-Cache-Control", value: "public, max-age=300" },
+              { key: "Cloudflare-CDN-Cache-Control", value: "public, max-age=300" },
+              { key: "Cache-Tag", value: "private-admin" },
+            ],
+          },
+        ],
+        runMiddleware: makeMiddleware({ executed: true }),
+        renderPage: makeRenderPage(),
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.headers.get("Cache-Control")).toBe("no-store");
+    expect(result.response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(result.response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(result.response.headers.get("Cache-Tag")).toBeNull();
+  });
+
+  it("removes cache headers from middleware redirects", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/admin"),
+      baseDeps({
+        runMiddleware: makeMiddleware({
+          continue: false,
+          executed: true,
+          redirectUrl: "http://localhost/login",
+          responseHeaders: [
+            ["CDN-Cache-Control", "public, max-age=300"],
+            ["Cloudflare-CDN-Cache-Control", "public, max-age=300"],
+            ["Cache-Tag", "private-admin"],
+          ],
+        }),
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.status).toBe(307);
+    expect(result.response.headers.get("Cache-Control")).toBe("no-store");
+    expect(result.response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(result.response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(result.response.headers.get("Cache-Tag")).toBeNull();
+  });
+
+  it("removes config cache headers from middleware-dependent API responses", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/api/private"),
+      baseDeps({
+        configHeaders: [
+          {
+            source: "/api/private",
+            headers: [
+              { key: "CDN-Cache-Control", value: "public, max-age=300" },
+              { key: "Cloudflare-CDN-Cache-Control", value: "public, max-age=300" },
+              { key: "Cache-Tag", value: "private-api" },
+            ],
+          },
+        ],
+        runMiddleware: makeMiddleware({ executed: true }),
+        handleApi: async () => new Response("secret"),
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.headers.get("Cache-Control")).toBe("no-store");
+    expect(result.response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(result.response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(result.response.headers.get("Cache-Tag")).toBeNull();
+  });
+
   // 6. Middleware response short-circuit → {type:"response"} with middleware response
   it("middleware response short-circuit returns the middleware response", async () => {
     const middlewareResponse = new Response("blocked", { status: 403 });
@@ -176,8 +283,8 @@ describe("middleware", () => {
     );
     expect(result.type).toBe("response");
     if (result.type !== "response") return;
-    expect(result.response).toBe(middlewareResponse);
     expect(result.response.status).toBe(403);
+    expect(result.response.headers.get("Cache-Control")).toBe("no-store");
     // Passthrough response: no content-type default → Node sends it verbatim.
     expect(result.defaultContentType).toBeUndefined();
   });
@@ -212,6 +319,7 @@ describe("middleware", () => {
       baseDeps({
         runMiddleware: vi.fn(async () => ({
           continue: true,
+          executed: true,
           responseHeaders: [...responseHeaders.entries()],
         })),
         renderPage,


### PR DESCRIPTION
## Summary

Prevent Cloudflare's outer edge cache from publishing App Router or Pages Router responses whose contents or routing decision depended on request credentials or user middleware.

## Security impact

With `cdnAdapter()` and Cloudflare platform caching enabled, vinext previously emitted public `CDN-Cache-Control` for otherwise-static/ISR responses after middleware ran inside the Worker. Cloudflare can serve a later edge hit without invoking the Worker, so middleware authentication/authorization would not execute for that hit.

An authenticated request could therefore fill a shared outer-edge cache entry that was reusable by an unauthenticated request.

## Prerequisites

- Cloudflare CDN adapter enabled.
- Platform-level cache enabled for the Worker route.
- A static/ISR page or route protected only by middleware or request credentials.
- The authenticated response is cacheable under the framework policy.

## Reproduction before this fix

```ts
// middleware.ts
export function middleware(request: Request) {
  if (request.headers.get("cookie") !== "session=admin") {
    return new Response("Unauthorized", { status: 401 });
  }
}
```

```tsx
// app/admin/page.tsx
export const revalidate = 300;

export default function Admin() {
  return <pre>Private administration data</pre>;
}
```

```bash
# Authenticated request reaches the Worker and fills the outer cache.
curl -i -H 'Cookie: session=admin' https://TARGET/admin

# A later request can be answered by the edge before middleware runs.
curl -i https://TARGET/admin
```

The first response previously carried a public policy such as:

```http
CDN-Cache-Control: public, max-age=300, stale-while-revalidate=...
```

## Fix

- Add a request-scoped `cdnCacheRequestDependent` safety signal.
- Mark requests dependent when they carry `Cookie`, `Authorization`, or any `CF-Access-*` identity header.
- Mark every request that executes user middleware, including middleware request-header and response-header/rewrite decisions.
- Propagate the signal across nested App Router render/route-handler contexts and the Pages Router pipeline without using a spoofable HTTP header.
- Make the Cloudflare CDN adapter emit only `Cache-Control: no-store` for request-dependent responses.
- Remove any stale `CDN-Cache-Control` and `Cache-Tag` headers when applying the no-store decision.
- Preserve public outer-edge caching for credential-free routes without middleware.

## Tests

```bash
vp check tests/cdn-cache.test.ts tests/pages-request-pipeline.test.ts \
  packages/vinext/src/shims/cdn-cache.ts \
  packages/vinext/src/shims/unified-request-context.ts \
  packages/vinext/src/server/cache-control.ts \
  packages/vinext/src/server/app-rsc-handler.ts \
  packages/vinext/src/server/pages-request-pipeline.ts \
  packages/vinext/src/server/pages-page-handler.ts \
  packages/cloudflare/src/cache/cdn-adapter.runtime.ts

vp test run tests/cdn-cache.test.ts \
  tests/pages-request-pipeline.test.ts \
  tests/pages-page-handler.test.ts \
  tests/app-rsc-handler.test.ts \
  tests/cloudflare-cdn-cache.test.ts
```

Result: 137 tests passed.

## Review notes

An adversarial review found that nested App Router request contexts initially reset the safety bit after middleware. The final patch inherits the bit into nested contexts and includes a regression for that path.

## Limitations

- Local Miniflare does not implement Cloudflare's outer cache, so tests assert the response-policy boundary (`no-store`, no `CDN-Cache-Control`, no `Cache-Tag`) rather than a deployed `CF-Cache-Status` HIT.
- This intentionally disables outer-edge caching for all routes traversing user middleware because middleware may make authorization decisions without leaving observable response headers.
- Framework/origin ISR behavior is unchanged; this patch only prevents unsafe shared outer-edge reuse.
