### PR TITLE
fix(compat): address focused Next.js e2e failures

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -51,6 +51,7 @@ import { resolveAppPageMethodResponse } from "./app-page-method.js";
 import { resolveAppPageNavigationParams } from "./app-page-element-builder.js";
 import {
   buildAppPageElement,
+  observeAppPagePreload,
   resolveAppPageInterceptionRerenderTarget,
   resolveAppPageIntercept,
   validateAppPageDynamicParams,
@@ -838,6 +839,12 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     return interceptResult.response;
   }
 
+  const pagePreload =
+    !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION) &&
+    route.loading?.default
+      ? null
+      : observeAppPagePreload(() => options.probePage());
+
   const pageBuildResult = await buildAppPageElement({
     buildPageElement() {
       if (options.actionFailed) {
@@ -851,6 +858,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         layoutParamAccess,
       );
     },
+    pagePreload,
     renderErrorBoundaryPage(buildError) {
       return options.renderErrorBoundaryPage(buildError);
     },
@@ -951,7 +959,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       return options.probeLayoutAt(layoutIndex, layoutParamAccess);
     },
     probePage() {
-      return options.probePage();
+      return pagePreload?.promise ?? options.probePage();
     },
     classification: {
       getLayoutId(index) {

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -38,6 +38,7 @@ type ResolveAppPageGenerateStaticParamsSourcesOptions = {
 
 type BuildAppPageElementOptions<TElement> = {
   buildPageElement: () => Promise<TElement>;
+  pagePreload?: AppPagePreload | null;
   renderErrorBoundaryPage: (error: unknown) => Promise<Response | null>;
   renderSpecialError: (specialError: AppPageSpecialError) => Promise<Response>;
   resolveSpecialError: (error: unknown) => AppPageSpecialError | null;
@@ -47,6 +48,35 @@ type BuildAppPageElementResult<TElement> = {
   element: TElement | null;
   response: Response | null;
 };
+
+export type AppPagePreload = {
+  error: unknown;
+  failed: boolean;
+  promise: Promise<unknown>;
+  settled: boolean;
+};
+
+export function observeAppPagePreload(preload: () => unknown): AppPagePreload {
+  const state: AppPagePreload = {
+    error: undefined,
+    failed: false,
+    promise: Promise.resolve(),
+    settled: false,
+  };
+  const promise = Promise.resolve().then(preload);
+  state.promise = promise;
+  void promise.then(
+    () => {
+      state.settled = true;
+    },
+    (error) => {
+      state.error = error;
+      state.failed = true;
+      state.settled = true;
+    },
+  );
+  return state;
+}
 
 type AppPageInterceptMatch<TPage = unknown> = {
   matchedParams: AppPageParams;
@@ -461,7 +491,11 @@ export async function buildAppPageElement<TElement>(
       response: null,
     };
   } catch (error) {
-    const specialError = options.resolveSpecialError(error);
+    const pageSpecialError =
+      options.pagePreload?.settled && options.pagePreload.failed
+        ? options.resolveSpecialError(options.pagePreload.error)
+        : null;
+    const specialError = pageSpecialError ?? options.resolveSpecialError(error);
     if (specialError) {
       return {
         element: null,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -555,16 +555,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     makeThenableParams: options.makeThenableParams,
   });
   if (metadataRouteResponse) {
-    applyConfigHeadersToResponse(
-      metadataRouteResponse.headers,
-      {
-        basePathState,
-        configHeaders: options.configHeaders,
-        overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
-        pathname: matchPathname(cleanPathname),
-        requestContext: preMiddlewareRequestContext,
-      },
-    );
+    applyConfigHeadersToResponse(metadataRouteResponse.headers, {
+      basePathState,
+      configHeaders: options.configHeaders,
+      overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
+      pathname: matchPathname(cleanPathname),
+      requestContext: preMiddlewareRequestContext,
+    });
     return applyMiddlewareContextToResponse(metadataRouteResponse, middlewareContext);
   }
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -74,6 +74,7 @@ import {
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
 type MetadataRoutes = Parameters<typeof handleMetadataRouteRequest>[0]["metadataRoutes"];
+const STATIC_METADATA_CONFIG_HEADER_OVERRIDES = new Set(["cache-control"]);
 type MakeThenableParams = Parameters<typeof handleMetadataRouteRequest>[0]["makeThenableParams"];
 type StaticParamsMap = Parameters<typeof handleAppPrerenderEndpoint>[1]["staticParamsMap"];
 type RootParamNamesMap = Parameters<
@@ -554,6 +555,16 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     makeThenableParams: options.makeThenableParams,
   });
   if (metadataRouteResponse) {
+    applyConfigHeadersToResponse(
+      metadataRouteResponse.headers,
+      {
+        basePathState,
+        configHeaders: options.configHeaders,
+        overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
+        pathname: matchPathname(cleanPathname),
+        requestContext: preMiddlewareRequestContext,
+      },
+    );
     return applyMiddlewareContextToResponse(metadataRouteResponse, middlewareContext);
   }
 

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -122,6 +122,8 @@ type ApplyConfigHeadersOptions = {
    * support `basePath: false` headers must pass this in.
    */
   basePathState?: BasePathMatchState;
+  /** Existing framework-generated headers that matching config rules may replace. */
+  overwriteExisting?: ReadonlySet<string>;
 };
 
 type StaticFileSignalContext = {
@@ -199,7 +201,7 @@ export function applyConfigHeadersToResponse(
     const lowerName = header.key.toLowerCase();
     if (lowerName === "vary" || lowerName === "set-cookie") {
       responseHeaders.append(header.key, header.value);
-    } else if (!responseHeaders.has(lowerName)) {
+    } else if (options.overwriteExisting?.has(lowerName) || !responseHeaders.has(lowerName)) {
       responseHeaders.set(header.key, header.value);
     }
   }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -1006,7 +1006,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         const routerModule = await import("next/router");
         const Router = routerModule.default;
         await navigatePagesRouterLink(Router, {
-          href: absoluteHref,
+          href: navigateHref,
           replace,
           scroll,
           shallow,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -54,7 +54,6 @@ import {
 import {
   isAbsoluteOrProtocolRelativeUrl,
   normalizePathTrailingSlash,
-  resolveRelativeHref,
   toBrowserNavigationHref,
   toSameOriginAppPath,
   withBasePath,
@@ -945,9 +944,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
     e.preventDefault();
 
-    // Resolve relative hrefs (#hash, ?query) against the current URL once so
-    // onNavigate and the actual navigation target stay in sync.
-    const absoluteHref = resolveRelativeHref(navigateHref, window.location.href, __basePath);
+    // Resolve relative hrefs (#hash, ?query) for onNavigate and the hard-navigation fallback.
     const absoluteFullHref = toBrowserNavigationHref(
       navigateHref,
       window.location.href,

--- a/scripts/nextjs-deploy-manifest.mjs
+++ b/scripts/nextjs-deploy-manifest.mjs
@@ -58,6 +58,22 @@ function isAppDirSuite(suite) {
  */
 const APP_ROUTER_NON_APP_DIR_SUITES = ["test/e2e/next-form/default/next-form-prefetch.test.ts"];
 
+/**
+ * Suites that cannot work with Next.js's custom deploy adapter contract.
+ *
+ * `NextDeployInstance` invokes `NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH` once during
+ * deployment setup and stores the returned text as an immutable `cliOutput`
+ * snapshot. This suite makes a request after setup and waits for the resulting
+ * runtime warning to appear in `cliOutput`, so no custom deploy adapter can
+ * satisfy it even when the deployed server logs the correct warning.
+ *
+ * Upstream suite:
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts
+ */
+const CUSTOM_DEPLOY_ADAPTER_INCOMPATIBLE_SUITES = [
+  "test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts",
+];
+
 async function main() {
   const positionals = [];
   let filter = "all";
@@ -124,7 +140,13 @@ async function main() {
     include = matches.map(matchToInclude);
   }
 
-  const exclude = Array.from(new Set([...(source.rules?.exclude ?? []), ...extraExcludes]));
+  const exclude = Array.from(
+    new Set([
+      ...(source.rules?.exclude ?? []),
+      ...extraExcludes,
+      ...CUSTOM_DEPLOY_ADAPTER_INCOMPATIBLE_SUITES,
+    ]),
+  );
 
   const manifest = {
     version: 2,

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { resolveAppPageSpecialError } from "../packages/vinext/src/server/app-page-execution.js";
 import {
   buildAppPageElement,
+  observeAppPagePreload,
   resolveAppPageActionRerenderTarget,
   resolveAppPageIntercept,
   resolveAppPageInterceptMatch,
@@ -332,6 +333,47 @@ describe("app page request helpers", () => {
 
     expect(result.element).toBeNull();
     expect(result.response).toBe(boundaryResponse);
+  });
+
+  it("prefers an already-thrown page notFound over a later metadata notFound", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-thrown/metadata-thrown.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-thrown/metadata-thrown.test.ts
+    const pageError = { digest: "NEXT_HTTP_ERROR_FALLBACK;404" };
+    const metadataError = { digest: "NEXT_HTTP_ERROR_FALLBACK;404", fromMetadata: true };
+    const pagePreload = observeAppPagePreload(() =>
+      Promise.resolve().then(() => {
+        throw pageError;
+      }),
+    );
+
+    await Promise.resolve();
+
+    const result = await buildAppPageElement({
+      async buildPageElement() {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        throw metadataError;
+      },
+      pagePreload,
+      async renderErrorBoundaryPage() {
+        throw new Error("should not render boundary for special errors");
+      },
+      async renderSpecialError(specialError) {
+        return new Response(specialError.fromMetadata ? "metadata" : "page", {
+          status: specialError.statusCode,
+        });
+      },
+      resolveSpecialError(error) {
+        const specialError = resolveAppPageSpecialError(error);
+        if (specialError && error === metadataError) {
+          specialError.fromMetadata = true;
+        }
+        return specialError;
+      },
+    });
+
+    expect(result.element).toBeNull();
+    expect(result.response?.status).toBe(404);
+    await expect(result.response?.text()).resolves.toBe("page");
   });
 });
 

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -967,6 +967,39 @@ describe("createAppRscHandler", () => {
     await expect(response.text()).resolves.toBe("icon-bytes");
   });
 
+  it("lets next.config headers override static metadata route defaults", async () => {
+    // Ported from Next.js: test/e2e/app-dir/no-duplicate-headers-next-config/no-duplicate-headers-next-config.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-duplicate-headers-next-config/no-duplicate-headers-next-config.test.ts
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/favicon.ico",
+          headers: [{ key: "cache-control", value: "max-age=1234" }],
+        },
+      ],
+      matchRoute: () => null,
+      metadataRoutes: [
+        {
+          type: "favicon",
+          isDynamic: false,
+          filePath: "/tmp/app/favicon.ico",
+          routePrefix: "",
+          routeSegments: [],
+          servedUrl: "/favicon.ico",
+          contentType: "image/x-icon",
+          fileDataBase64: btoa("icon-bytes"),
+        },
+      ],
+    });
+
+    const response = await handler(new Request("https://example.test/docs/favicon.ico"), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("max-age=1234");
+    expect(response.headers.get("content-type")).toBe("image/x-icon");
+    await expect(response.text()).resolves.toBe("icon-bytes");
+  });
+
   it("lets server actions short-circuit routing while still applying final headers", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
     const handleServerActionRequest = vi.fn(

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -974,7 +974,10 @@ describe("createAppRscHandler", () => {
       configHeaders: [
         {
           source: "/favicon.ico",
-          headers: [{ key: "cache-control", value: "max-age=1234" }],
+          headers: [
+            { key: "cache-control", value: "max-age=1234" },
+            { key: "content-type", value: "text/plain" },
+          ],
         },
       ],
       matchRoute: () => null,
@@ -996,6 +999,47 @@ describe("createAppRscHandler", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("max-age=1234");
+    expect(response.headers.get("content-type")).toBe("image/x-icon");
+    await expect(response.text()).resolves.toBe("icon-bytes");
+  });
+
+  it("keeps middleware Cache-Control above matching config headers for metadata routes", async () => {
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/favicon.ico",
+          headers: [{ key: "cache-control", value: "max-age=1234" }],
+        },
+      ],
+      matchRoute: () => null,
+      metadataRoutes: [
+        {
+          type: "favicon",
+          isDynamic: false,
+          filePath: "/tmp/app/favicon.ico",
+          routePrefix: "",
+          routeSegments: [],
+          servedUrl: "/favicon.ico",
+          contentType: "image/x-icon",
+          fileDataBase64: btoa("icon-bytes"),
+        },
+      ],
+      middlewareModule: {
+        middleware() {
+          return new Response(null, {
+            headers: {
+              "Cache-Control": "max-age=5678",
+              "x-middleware-next": "1",
+            },
+          });
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/favicon.ico"), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("max-age=5678");
     expect(response.headers.get("content-type")).toBe("image/x-icon");
     await expect(response.text()).resolves.toBe("icon-bytes");
   });

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -877,6 +877,7 @@ describe("Pages Router Link onClick semantics", () => {
   async function renderPagesRouterLinkAndClick(args: {
     href: string;
     props?: Record<string, unknown>;
+    currentHref?: string;
   }) {
     vi.resetModules();
 
@@ -909,6 +910,7 @@ describe("Pages Router Link onClick semantics", () => {
     const pushState = vi.fn();
     const replaceState = vi.fn();
     const dispatchEvent = vi.fn();
+    const currentUrl = new URL(args.currentHref ?? "https://example.com/current");
     vi.stubGlobal("window", {
       // No vinext.navigationRuntime — that selects the Pages Router branch
       // inside Link's click handler.
@@ -916,8 +918,11 @@ describe("Pages Router Link onClick semantics", () => {
       dispatchEvent,
       history: { pushState, replaceState },
       location: {
-        href: "https://example.com/current",
-        origin: "https://example.com",
+        href: currentUrl.href,
+        origin: currentUrl.origin,
+        pathname: currentUrl.pathname,
+        search: currentUrl.search,
+        hash: currentUrl.hash,
       },
       scrollTo: vi.fn(),
       __NEXT_DATA__: { props: {} },
@@ -981,6 +986,28 @@ describe("Pages Router Link onClick semantics", () => {
     expect(result.clickEvent.defaultPrevented).toBe(true);
     // ...and the Pages Router navigation is actually scheduled.
     expect(result.pagesRouterCalls).toEqual([{ href: "/", replace: false }]);
+  });
+
+  it("preserves a basePath page when navigating to a hash link", async () => {
+    // Ported from Next.js: test/e2e/basepath/query-hash.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/query-hash.test.ts
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+
+    try {
+      const result = await renderPagesRouterLinkAndClick({
+        href: "#hashlink",
+        currentHref: "https://example.com/docs/hello",
+      });
+
+      expect(result.pagesRouterCalls).toEqual([{ href: "#hashlink", replace: false }]);
+    } finally {
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+    }
   });
 
   it("cancels client-side navigation when onClick calls preventDefault", async () => {

--- a/tests/nextjs-deploy-manifest.test.ts
+++ b/tests/nextjs-deploy-manifest.test.ts
@@ -36,13 +36,7 @@ describe("nextjs deploy manifest", () => {
 
     await execFileAsync(
       process.execPath,
-      [
-        path.resolve("scripts/nextjs-deploy-manifest.mjs"),
-        nextjsDir,
-        outputPath,
-        "--match",
-        suite,
-      ],
+      [path.resolve("scripts/nextjs-deploy-manifest.mjs"), nextjsDir, outputPath, "--match", suite],
       { cwd: path.resolve(".") },
     );
 

--- a/tests/nextjs-deploy-manifest.test.ts
+++ b/tests/nextjs-deploy-manifest.test.ts
@@ -1,0 +1,53 @@
+import { execFile } from "node:child_process";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+const execFileAsync = promisify(execFile);
+const suite = "test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts";
+
+describe("nextjs deploy manifest", () => {
+  let root: string | undefined;
+
+  afterEach(async () => {
+    if (root) await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  // The upstream suite waits for a runtime warning in `next.cliOutput`, but
+  // NextDeployInstance captures custom deploy logs only once during setup:
+  // https://github.com/vercel/next.js/blob/canary/test/lib/next-modes/next-deploy.ts
+  it("excludes suites that require live runtime cliOutput from custom deploy adapters", async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-nextjs-deploy-manifest-"));
+    const nextjsDir = path.join(root, "next.js");
+    const sourcePath = path.join(nextjsDir, "test", "deploy-tests-manifest.json");
+    const outputPath = path.join(root, "manifest.json");
+
+    await fsp.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fsp.writeFile(
+      sourcePath,
+      `${JSON.stringify({
+        version: 2,
+        suites: { [suite]: {} },
+        rules: { include: ["test/e2e/**/*.test.{t,j}s{,x}"], exclude: [] },
+      })}\n`,
+    );
+
+    await execFileAsync(
+      process.execPath,
+      [
+        path.resolve("scripts/nextjs-deploy-manifest.mjs"),
+        nextjsDir,
+        outputPath,
+        "--match",
+        suite,
+      ],
+      { cwd: path.resolve(".") },
+    );
+
+    const manifest = JSON.parse(await fsp.readFile(outputPath, "utf8"));
+    expect(manifest.rules.include).toEqual([suite]);
+    expect(manifest.rules.exclude).toContain(suite);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve relative hash-only Pages Router Link navigation under `basePath`
- let matching `next.config.js` Cache-Control override framework defaults for static metadata assets while preserving middleware precedence
- prioritize a synchronously-thrown page `notFound()` over delayed metadata failure and observe preload rejections
- exclude the repeated-forward-slashes CLI-output suite because Next.js custom deploy adapters snapshot logs before the runtime request; vinext keeps direct regression coverage for the behavior

## Upstream suites

- `test/e2e/basepath/query-hash.test.ts`
- `test/e2e/app-dir/no-duplicate-headers-next-config/no-duplicate-headers-next-config.test.ts`
- `test/e2e/app-dir/metadata-thrown/metadata-thrown.test.ts`
- `test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts` (deploy-adapter harness limitation)

## Validation

- 1,367 targeted vinext tests passed across Link, shims, request pipeline, App RSC handler, manifest, and repeated-slash coverage
- 81 focused App Router request/dispatch/execution tests passed after integrating metadata fix
- independent metadata review: 123 focused tests passed
- package build passed
- formatting and `git diff --check` passed

Full test suites are intentionally deferred to CI.

## Local upstream harness limitations

- exact deploy-mode runs for basePath and metadata were killed by the host with exit 137 before producing results
- the config-header exact suite was blocked when the harness selected Node 20; vinext requires Node 22+
- `use-params` server assertions all passed, but four browser assertions could not run because Playwright's required `chromium_headless_shell-1208` install stalled; no unverified fix was made
