### PR TITLE
fix(link): preserve basePath hash navigation

### DIFF
--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -1006,7 +1006,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         const routerModule = await import("next/router");
         const Router = routerModule.default;
         await navigatePagesRouterLink(Router, {
-          href: absoluteHref,
+          href: navigateHref,
           replace,
           scroll,
           shallow,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -54,7 +54,6 @@ import {
 import {
   isAbsoluteOrProtocolRelativeUrl,
   normalizePathTrailingSlash,
-  resolveRelativeHref,
   toBrowserNavigationHref,
   toSameOriginAppPath,
   withBasePath,
@@ -945,9 +944,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
     e.preventDefault();
 
-    // Resolve relative hrefs (#hash, ?query) against the current URL once so
-    // onNavigate and the actual navigation target stay in sync.
-    const absoluteHref = resolveRelativeHref(navigateHref, window.location.href, __basePath);
+    // Resolve relative hrefs (#hash, ?query) for onNavigate and the hard-navigation fallback.
     const absoluteFullHref = toBrowserNavigationHref(
       navigateHref,
       window.location.href,

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -877,6 +877,7 @@ describe("Pages Router Link onClick semantics", () => {
   async function renderPagesRouterLinkAndClick(args: {
     href: string;
     props?: Record<string, unknown>;
+    currentHref?: string;
   }) {
     vi.resetModules();
 
@@ -909,6 +910,7 @@ describe("Pages Router Link onClick semantics", () => {
     const pushState = vi.fn();
     const replaceState = vi.fn();
     const dispatchEvent = vi.fn();
+    const currentUrl = new URL(args.currentHref ?? "https://example.com/current");
     vi.stubGlobal("window", {
       // No vinext.navigationRuntime — that selects the Pages Router branch
       // inside Link's click handler.
@@ -916,8 +918,11 @@ describe("Pages Router Link onClick semantics", () => {
       dispatchEvent,
       history: { pushState, replaceState },
       location: {
-        href: "https://example.com/current",
-        origin: "https://example.com",
+        href: currentUrl.href,
+        origin: currentUrl.origin,
+        pathname: currentUrl.pathname,
+        search: currentUrl.search,
+        hash: currentUrl.hash,
       },
       scrollTo: vi.fn(),
       __NEXT_DATA__: { props: {} },
@@ -981,6 +986,28 @@ describe("Pages Router Link onClick semantics", () => {
     expect(result.clickEvent.defaultPrevented).toBe(true);
     // ...and the Pages Router navigation is actually scheduled.
     expect(result.pagesRouterCalls).toEqual([{ href: "/", replace: false }]);
+  });
+
+  it("preserves a basePath page when navigating to a hash link", async () => {
+    // Ported from Next.js: test/e2e/basepath/query-hash.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/query-hash.test.ts
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+
+    try {
+      const result = await renderPagesRouterLinkAndClick({
+        href: "#hashlink",
+        currentHref: "https://example.com/docs/hello",
+      });
+
+      expect(result.pagesRouterCalls).toEqual([{ href: "#hashlink", replace: false }]);
+    } finally {
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+    }
   });
 
   it("cancels client-side navigation when onClick calls preventDefault", async () => {


### PR DESCRIPTION
## Summary

- preserve relative hash-only hrefs when Pages Router Link delegates to router.push/replace
- port regression coverage from Next.js `test/e2e/basepath/query-hash.test.ts`

## Validation

- `vp test run tests/link-navigation.test.ts tests/link.test.ts` — 164 passed
- focused formatting passed

Full suites deferred to CI.