### PR TITLE
fix(headers): prioritize config cache headers for metadata assets

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -555,16 +555,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     makeThenableParams: options.makeThenableParams,
   });
   if (metadataRouteResponse) {
-    applyConfigHeadersToResponse(
-      metadataRouteResponse.headers,
-      {
-        basePathState,
-        configHeaders: options.configHeaders,
-        overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
-        pathname: matchPathname(cleanPathname),
-        requestContext: preMiddlewareRequestContext,
-      },
-    );
+    applyConfigHeadersToResponse(metadataRouteResponse.headers, {
+      basePathState,
+      configHeaders: options.configHeaders,
+      overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
+      pathname: matchPathname(cleanPathname),
+      requestContext: preMiddlewareRequestContext,
+    });
     return applyMiddlewareContextToResponse(metadataRouteResponse, middlewareContext);
   }
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -74,6 +74,7 @@ import {
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
 type MetadataRoutes = Parameters<typeof handleMetadataRouteRequest>[0]["metadataRoutes"];
+const STATIC_METADATA_CONFIG_HEADER_OVERRIDES = new Set(["cache-control"]);
 type MakeThenableParams = Parameters<typeof handleMetadataRouteRequest>[0]["makeThenableParams"];
 type StaticParamsMap = Parameters<typeof handleAppPrerenderEndpoint>[1]["staticParamsMap"];
 type RootParamNamesMap = Parameters<
@@ -554,6 +555,16 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     makeThenableParams: options.makeThenableParams,
   });
   if (metadataRouteResponse) {
+    applyConfigHeadersToResponse(
+      metadataRouteResponse.headers,
+      {
+        basePathState,
+        configHeaders: options.configHeaders,
+        overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
+        pathname: matchPathname(cleanPathname),
+        requestContext: preMiddlewareRequestContext,
+      },
+    );
     return applyMiddlewareContextToResponse(metadataRouteResponse, middlewareContext);
   }
 

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -122,6 +122,8 @@ type ApplyConfigHeadersOptions = {
    * support `basePath: false` headers must pass this in.
    */
   basePathState?: BasePathMatchState;
+  /** Existing framework-generated headers that matching config rules may replace. */
+  overwriteExisting?: ReadonlySet<string>;
 };
 
 type StaticFileSignalContext = {
@@ -199,7 +201,7 @@ export function applyConfigHeadersToResponse(
     const lowerName = header.key.toLowerCase();
     if (lowerName === "vary" || lowerName === "set-cookie") {
       responseHeaders.append(header.key, header.value);
-    } else if (!responseHeaders.has(lowerName)) {
+    } else if (options.overwriteExisting?.has(lowerName) || !responseHeaders.has(lowerName)) {
       responseHeaders.set(header.key, header.value);
     }
   }

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -967,6 +967,39 @@ describe("createAppRscHandler", () => {
     await expect(response.text()).resolves.toBe("icon-bytes");
   });
 
+  it("lets next.config headers override static metadata route defaults", async () => {
+    // Ported from Next.js: test/e2e/app-dir/no-duplicate-headers-next-config/no-duplicate-headers-next-config.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/no-duplicate-headers-next-config/no-duplicate-headers-next-config.test.ts
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/favicon.ico",
+          headers: [{ key: "cache-control", value: "max-age=1234" }],
+        },
+      ],
+      matchRoute: () => null,
+      metadataRoutes: [
+        {
+          type: "favicon",
+          isDynamic: false,
+          filePath: "/tmp/app/favicon.ico",
+          routePrefix: "",
+          routeSegments: [],
+          servedUrl: "/favicon.ico",
+          contentType: "image/x-icon",
+          fileDataBase64: btoa("icon-bytes"),
+        },
+      ],
+    });
+
+    const response = await handler(new Request("https://example.test/docs/favicon.ico"), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("max-age=1234");
+    expect(response.headers.get("content-type")).toBe("image/x-icon");
+    await expect(response.text()).resolves.toBe("icon-bytes");
+  });
+
   it("lets server actions short-circuit routing while still applying final headers", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page", { status: 200 }));
     const handleServerActionRequest = vi.fn(

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -974,7 +974,10 @@ describe("createAppRscHandler", () => {
       configHeaders: [
         {
           source: "/favicon.ico",
-          headers: [{ key: "cache-control", value: "max-age=1234" }],
+          headers: [
+            { key: "cache-control", value: "max-age=1234" },
+            { key: "content-type", value: "text/plain" },
+          ],
         },
       ],
       matchRoute: () => null,
@@ -996,6 +999,47 @@ describe("createAppRscHandler", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("max-age=1234");
+    expect(response.headers.get("content-type")).toBe("image/x-icon");
+    await expect(response.text()).resolves.toBe("icon-bytes");
+  });
+
+  it("keeps middleware Cache-Control above matching config headers for metadata routes", async () => {
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/favicon.ico",
+          headers: [{ key: "cache-control", value: "max-age=1234" }],
+        },
+      ],
+      matchRoute: () => null,
+      metadataRoutes: [
+        {
+          type: "favicon",
+          isDynamic: false,
+          filePath: "/tmp/app/favicon.ico",
+          routePrefix: "",
+          routeSegments: [],
+          servedUrl: "/favicon.ico",
+          contentType: "image/x-icon",
+          fileDataBase64: btoa("icon-bytes"),
+        },
+      ],
+      middlewareModule: {
+        middleware() {
+          return new Response(null, {
+            headers: {
+              "Cache-Control": "max-age=5678",
+              "x-middleware-next": "1",
+            },
+          });
+        },
+      },
+    });
+
+    const response = await handler(new Request("https://example.test/docs/favicon.ico"), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("max-age=5678");
     expect(response.headers.get("content-type")).toBe("image/x-icon");
     await expect(response.text()).resolves.toBe("icon-bytes");
   });


### PR DESCRIPTION
## Summary

- allow matching next.config Cache-Control to replace the framework default on static metadata assets
- preserve metadata Content-Type and middleware header precedence
- port regression coverage from Next.js `no-duplicate-headers-next-config`

## Validation

- `vp test run tests/request-pipeline.test.ts tests/app-rsc-handler.test.ts` — 137 passed
- focused formatting passed

Full suites deferred to CI.