### PR TITLE
fix(app-router): fold typeof window before resolution

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -173,6 +173,7 @@ import { removeConsoleCalls } from "./plugins/remove-console.js";
 import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
 import { createRequireContextPlugin } from "./plugins/require-context.js";
 import { createWasmModuleImportPlugin } from "./plugins/wasm-module-import.js";
+import { replaceTypeofWindow } from "./plugins/typeof-window.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
 import { getViteMajorVersion } from "./utils/vite-version.js";
@@ -3913,8 +3914,24 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
       },
     },
-    // Inject server-environment defines (NEXT_RUNTIME + user `compiler.defineServer`
-    // entries) into non-client environments only.  The universal
+    // Fold `typeof window` like Next.js before Rolldown resolves imports. This
+    // removes browser-only dynamic imports from server bundles before package
+    // conditional exports are evaluated.
+    {
+      name: "vinext:typeof-window",
+      enforce: "post",
+      transform: {
+        filter: { code: /typeof\s+window/ },
+        handler(code) {
+          return replaceTypeofWindow(
+            code,
+            this.environment?.name === "client" ? "object" : "undefined",
+          );
+        },
+      },
+    },
+    // Inject server-environment defines. Server environments receive
+    // NEXT_RUNTIME + user `compiler.defineServer` entries. The universal
     // `compiler.define` map is already merged into the top-level Vite
     // `define` config above, so it applies to both client and server bundles.
     // Server-only defines MUST NOT leak into the browser bundle (they can
@@ -3928,11 +3945,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     {
       name: "vinext:compiler-define-server",
       configEnvironment(name) {
-        // The client environment is NEVER given server-only defines. Returning
-        // early here is what makes every define in `serverDefines` below
-        // structurally guaranteed to stay out of the browser bundle. All other
-        // environments (rsc, ssr, custom worker envs, etc.) are server-side per
-        // Vite's `consumer: "server"` default and receive the substitutions.
         if (name === "client") return null;
 
         const serverDefines: Record<string, string> = { ...nextConfig.compilerDefineServer };

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -173,7 +173,7 @@ import { removeConsoleCalls } from "./plugins/remove-console.js";
 import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
 import { createRequireContextPlugin } from "./plugins/require-context.js";
 import { createWasmModuleImportPlugin } from "./plugins/wasm-module-import.js";
-import { replaceTypeofWindow } from "./plugins/typeof-window.js";
+import { getTypeofWindowReplacement, replaceTypeofWindow } from "./plugins/typeof-window.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
 import { getViteMajorVersion } from "./utils/vite-version.js";
@@ -3923,10 +3923,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       transform: {
         filter: { code: /typeof\s+window/ },
         handler(code) {
-          return replaceTypeofWindow(
-            code,
-            this.environment?.name === "client" ? "object" : "undefined",
-          );
+          return replaceTypeofWindow(code, getTypeofWindowReplacement(this.environment));
         },
       },
     },

--- a/packages/vinext/src/plugins/typeof-window.ts
+++ b/packages/vinext/src/plugins/typeof-window.ts
@@ -18,6 +18,12 @@ type Scope = {
   bindings: Set<string>;
 };
 
+type EnvironmentLike = {
+  config: {
+    consumer: "client" | "server";
+  };
+};
+
 function createScope(parent: Scope | null): Scope {
   return { parent, bindings: new Set() };
 }
@@ -70,6 +76,14 @@ function collectVarBindings(node: AstNode, scope: Scope, isRoot = true): void {
   forEachAstChild(node, (child) => collectVarBindings(child, scope, false));
 }
 
+function isFunctionNode(node: AstNode): boolean {
+  return (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  );
+}
+
 function createChildScope(node: AstNode, parent: Scope): Scope | null {
   if (
     node.type !== "Program" &&
@@ -80,9 +94,6 @@ function createChildScope(node: AstNode, parent: Scope): Scope | null {
     node.type !== "ForStatement" &&
     node.type !== "ForInStatement" &&
     node.type !== "ForOfStatement" &&
-    node.type !== "FunctionDeclaration" &&
-    node.type !== "FunctionExpression" &&
-    node.type !== "ArrowFunctionExpression" &&
     node.type !== "ClassDeclaration" &&
     node.type !== "ClassExpression"
   ) {
@@ -90,15 +101,7 @@ function createChildScope(node: AstNode, parent: Scope): Scope | null {
   }
 
   const scope = createScope(parent);
-  if (
-    node.type === "FunctionDeclaration" ||
-    node.type === "FunctionExpression" ||
-    node.type === "ArrowFunctionExpression"
-  ) {
-    collectBindingNames(node.id, scope.bindings);
-    for (const parameter of nodeArray(node.params)) collectBindingNames(parameter, scope.bindings);
-    collectVarBindings(node, scope);
-  } else if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
+  if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
     collectBindingNames(node.id, scope.bindings);
   } else if (node.type === "CatchClause") {
     collectBindingNames(node.param, scope.bindings);
@@ -110,6 +113,10 @@ function createChildScope(node: AstNode, parent: Scope): Scope | null {
     }
   }
   return scope;
+}
+
+export function getTypeofWindowReplacement(environment: EnvironmentLike): WindowType {
+  return environment.config.consumer === "client" ? "object" : "undefined";
 }
 
 function stringLiteralValue(node: unknown): string | null {
@@ -169,6 +176,26 @@ export function replaceTypeofWindow(code: string, replacement: WindowType) {
   collectVarBindings(ast, rootScope);
 
   function visit(node: AstNode, parentScope: Scope): void {
+    if (isFunctionNode(node)) {
+      const parameterScope = createScope(parentScope);
+      collectBindingNames(node.id, parameterScope.bindings);
+      for (const parameter of nodeArray(node.params)) {
+        collectBindingNames(parameter, parameterScope.bindings);
+        if (isAstRecord(parameter)) visit(parameter, parameterScope);
+      }
+
+      if (isAstRecord(node.body)) {
+        if (node.body.type === "BlockStatement") {
+          const bodyScope = createScope(parameterScope);
+          collectVarBindings(node.body, bodyScope);
+          visit(node.body, bodyScope);
+        } else {
+          visit(node.body, parameterScope);
+        }
+      }
+      return;
+    }
+
     const scope = createChildScope(node, parentScope) ?? parentScope;
 
     if (node.type === "IfStatement" && hasRange(node)) {
@@ -182,6 +209,22 @@ export function replaceTypeofWindow(code: string, replacement: WindowType) {
         } else {
           output.overwrite(node.start, node.end, ";");
         }
+        changed = true;
+        return;
+      }
+    }
+
+    if (node.type === "ConditionalExpression" && hasRange(node)) {
+      const result = evaluateTypeofWindowComparison(node.test, replacement, scope);
+      const selected = result ? node.consequent : node.alternate;
+      if (result !== null && isAstRecord(selected) && hasRange(selected)) {
+        output.overwrite(node.start, selected.start, "(");
+        if (selected.end < node.end) {
+          output.overwrite(selected.end, node.end, ")");
+        } else {
+          output.appendLeft(selected.end, ")");
+        }
+        visit(selected, scope);
         changed = true;
         return;
       }

--- a/packages/vinext/src/plugins/typeof-window.ts
+++ b/packages/vinext/src/plugins/typeof-window.ts
@@ -1,0 +1,92 @@
+import { parseAst } from "vite";
+import MagicString from "magic-string";
+import { forEachAstChild, hasRange, isAstRecord, isIdentifierNamed } from "./ast-utils.js";
+
+type WindowType = "object" | "undefined";
+
+type AstNode = Parameters<typeof forEachAstChild>[0];
+
+function stringLiteralValue(node: unknown): string | null {
+  if (!isAstRecord(node)) return null;
+  if (node.type === "Literal" && typeof node.value === "string") return node.value;
+  return null;
+}
+
+function evaluateTypeofWindowComparison(node: unknown, replacement: WindowType): boolean | null {
+  if (!isAstRecord(node) || node.type !== "BinaryExpression") return null;
+  if (!["==", "===", "!=", "!=="].includes(String(node.operator))) return null;
+
+  const left = isAstRecord(node.left) ? node.left : null;
+  const right = isAstRecord(node.right) ? node.right : null;
+  const leftIsTypeofWindow =
+    left?.type === "UnaryExpression" &&
+    left.operator === "typeof" &&
+    isIdentifierNamed(left.argument, "window");
+  const rightIsTypeofWindow =
+    right?.type === "UnaryExpression" &&
+    right.operator === "typeof" &&
+    isIdentifierNamed(right.argument, "window");
+
+  const comparedValue = leftIsTypeofWindow
+    ? stringLiteralValue(right)
+    : rightIsTypeofWindow
+      ? stringLiteralValue(left)
+      : null;
+  if (comparedValue === null) return null;
+
+  const equal = replacement === comparedValue;
+  return node.operator === "==" || node.operator === "===" ? equal : !equal;
+}
+
+export function replaceTypeofWindow(code: string, replacement: WindowType) {
+  if (!/typeof\s+window/.test(code)) return null;
+
+  let ast: ReturnType<typeof parseAst>;
+  try {
+    ast = parseAst(code);
+  } catch {
+    return null;
+  }
+
+  const output = new MagicString(code);
+  let changed = false;
+
+  function visit(node: AstNode): void {
+    if (node.type === "IfStatement" && hasRange(node)) {
+      const result = evaluateTypeofWindowComparison(node.test, replacement);
+      if (result !== null) {
+        const selected = result ? node.consequent : node.alternate;
+        if (isAstRecord(selected) && hasRange(selected)) {
+          output.overwrite(node.start, node.end, code.slice(selected.start, selected.end));
+        } else {
+          output.overwrite(node.start, node.end, ";");
+        }
+        changed = true;
+        return;
+      }
+    }
+
+    if (
+      node.type === "UnaryExpression" &&
+      node.operator === "typeof" &&
+      isIdentifierNamed(node.argument, "window") &&
+      hasRange(node)
+    ) {
+      output.overwrite(node.start, node.end, JSON.stringify(replacement));
+      changed = true;
+      return;
+    }
+
+    forEachAstChild(node, visit);
+  }
+
+  for (const node of ast.body) {
+    if (isAstRecord(node)) visit(node);
+  }
+  if (!changed) return null;
+
+  return {
+    code: output.toString(),
+    map: output.generateMap({ hires: "boundary" }),
+  };
+}

--- a/packages/vinext/src/plugins/typeof-window.ts
+++ b/packages/vinext/src/plugins/typeof-window.ts
@@ -1,10 +1,116 @@
 import { parseAst } from "vite";
 import MagicString from "magic-string";
-import { forEachAstChild, hasRange, isAstRecord, isIdentifierNamed } from "./ast-utils.js";
+import {
+  collectBindingNames,
+  forEachAstChild,
+  hasRange,
+  isAstRecord,
+  isIdentifierNamed,
+  nodeArray,
+} from "./ast-utils.js";
 
 type WindowType = "object" | "undefined";
 
 type AstNode = Parameters<typeof forEachAstChild>[0];
+
+type Scope = {
+  parent: Scope | null;
+  bindings: Set<string>;
+};
+
+function createScope(parent: Scope | null): Scope {
+  return { parent, bindings: new Set() };
+}
+
+function hasBinding(scope: Scope, name: string): boolean {
+  for (let current: Scope | null = scope; current; current = current.parent) {
+    if (current.bindings.has(name)) return true;
+  }
+  return false;
+}
+
+function collectScopeBindings(node: AstNode, scope: Scope): void {
+  forEachAstChild(node, (child) => {
+    if (child.type === "ExportNamedDeclaration" || child.type === "ExportDefaultDeclaration") {
+      if (isAstRecord(child.declaration)) collectScopeBindings(child, scope);
+      return;
+    }
+    if (child.type === "FunctionDeclaration" || child.type === "ClassDeclaration") {
+      collectBindingNames(child.id, scope.bindings);
+      return;
+    }
+    if (child.type === "VariableDeclaration") {
+      for (const declaration of nodeArray(child.declarations)) {
+        if (isAstRecord(declaration)) collectBindingNames(declaration.id, scope.bindings);
+      }
+      return;
+    }
+    if (child.type === "ImportDeclaration") {
+      for (const specifier of nodeArray(child.specifiers)) {
+        if (isAstRecord(specifier)) collectBindingNames(specifier.local, scope.bindings);
+      }
+    }
+  });
+}
+
+function collectVarBindings(node: AstNode, scope: Scope, isRoot = true): void {
+  if (
+    !isRoot &&
+    (node.type === "FunctionDeclaration" ||
+      node.type === "FunctionExpression" ||
+      node.type === "ArrowFunctionExpression")
+  ) {
+    return;
+  }
+  if (node.type === "VariableDeclaration" && node.kind === "var") {
+    for (const declaration of nodeArray(node.declarations)) {
+      if (isAstRecord(declaration)) collectBindingNames(declaration.id, scope.bindings);
+    }
+  }
+  forEachAstChild(node, (child) => collectVarBindings(child, scope, false));
+}
+
+function createChildScope(node: AstNode, parent: Scope): Scope | null {
+  if (
+    node.type !== "Program" &&
+    node.type !== "BlockStatement" &&
+    node.type !== "StaticBlock" &&
+    node.type !== "SwitchStatement" &&
+    node.type !== "CatchClause" &&
+    node.type !== "ForStatement" &&
+    node.type !== "ForInStatement" &&
+    node.type !== "ForOfStatement" &&
+    node.type !== "FunctionDeclaration" &&
+    node.type !== "FunctionExpression" &&
+    node.type !== "ArrowFunctionExpression" &&
+    node.type !== "ClassDeclaration" &&
+    node.type !== "ClassExpression"
+  ) {
+    return null;
+  }
+
+  const scope = createScope(parent);
+  if (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  ) {
+    collectBindingNames(node.id, scope.bindings);
+    for (const parameter of nodeArray(node.params)) collectBindingNames(parameter, scope.bindings);
+    collectVarBindings(node, scope);
+  } else if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
+    collectBindingNames(node.id, scope.bindings);
+  } else if (node.type === "CatchClause") {
+    collectBindingNames(node.param, scope.bindings);
+  }
+  collectScopeBindings(node, scope);
+  if (node.type === "SwitchStatement") {
+    for (const switchCase of nodeArray(node.cases)) {
+      if (isAstRecord(switchCase)) collectScopeBindings(switchCase, scope);
+    }
+  }
+  return scope;
+}
 
 function stringLiteralValue(node: unknown): string | null {
   if (!isAstRecord(node)) return null;
@@ -12,7 +118,11 @@ function stringLiteralValue(node: unknown): string | null {
   return null;
 }
 
-function evaluateTypeofWindowComparison(node: unknown, replacement: WindowType): boolean | null {
+function evaluateTypeofWindowComparison(
+  node: unknown,
+  replacement: WindowType,
+  scope: Scope,
+): boolean | null {
   if (!isAstRecord(node) || node.type !== "BinaryExpression") return null;
   if (!["==", "===", "!=", "!=="].includes(String(node.operator))) return null;
 
@@ -21,11 +131,13 @@ function evaluateTypeofWindowComparison(node: unknown, replacement: WindowType):
   const leftIsTypeofWindow =
     left?.type === "UnaryExpression" &&
     left.operator === "typeof" &&
-    isIdentifierNamed(left.argument, "window");
+    isIdentifierNamed(left.argument, "window") &&
+    !hasBinding(scope, "window");
   const rightIsTypeofWindow =
     right?.type === "UnaryExpression" &&
     right.operator === "typeof" &&
-    isIdentifierNamed(right.argument, "window");
+    isIdentifierNamed(right.argument, "window") &&
+    !hasBinding(scope, "window");
 
   const comparedValue = leftIsTypeofWindow
     ? stringLiteralValue(right)
@@ -50,14 +162,23 @@ export function replaceTypeofWindow(code: string, replacement: WindowType) {
 
   const output = new MagicString(code);
   let changed = false;
+  if (!isAstRecord(ast)) return null;
 
-  function visit(node: AstNode): void {
+  const rootScope = createScope(null);
+  collectScopeBindings(ast, rootScope);
+  collectVarBindings(ast, rootScope);
+
+  function visit(node: AstNode, parentScope: Scope): void {
+    const scope = createChildScope(node, parentScope) ?? parentScope;
+
     if (node.type === "IfStatement" && hasRange(node)) {
-      const result = evaluateTypeofWindowComparison(node.test, replacement);
+      const result = evaluateTypeofWindowComparison(node.test, replacement, scope);
       if (result !== null) {
         const selected = result ? node.consequent : node.alternate;
         if (isAstRecord(selected) && hasRange(selected)) {
-          output.overwrite(node.start, node.end, code.slice(selected.start, selected.end));
+          output.remove(node.start, selected.start);
+          output.remove(selected.end, node.end);
+          visit(selected, scope);
         } else {
           output.overwrite(node.start, node.end, ";");
         }
@@ -70,6 +191,7 @@ export function replaceTypeofWindow(code: string, replacement: WindowType) {
       node.type === "UnaryExpression" &&
       node.operator === "typeof" &&
       isIdentifierNamed(node.argument, "window") &&
+      !hasBinding(scope, "window") &&
       hasRange(node)
     ) {
       output.overwrite(node.start, node.end, JSON.stringify(replacement));
@@ -77,11 +199,11 @@ export function replaceTypeofWindow(code: string, replacement: WindowType) {
       return;
     }
 
-    forEachAstChild(node, visit);
+    forEachAstChild(node, (child) => visit(child, scope));
   }
 
   for (const node of ast.body) {
-    if (isAstRecord(node)) visit(node);
+    if (isAstRecord(node)) visit(node, rootScope);
   }
   if (!changed) return null;
 

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -8,7 +8,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import { createBuilder } from "vite";
 import vinext from "../packages/vinext/src/index.js";
-import { replaceTypeofWindow } from "../packages/vinext/src/plugins/typeof-window.js";
+import {
+  getTypeofWindowReplacement,
+  replaceTypeofWindow,
+} from "../packages/vinext/src/plugins/typeof-window.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -67,6 +70,34 @@ switch (value) {
     expect(result?.code).toContain("serverOnly()");
   });
 
+  it("keeps function body var bindings out of default parameter scope", () => {
+    const result = replaceTypeofWindow(
+      `function load(value = typeof window !== "undefined" ? import("browser-only") : null) {
+  var window
+  return value
+}`,
+      "undefined",
+    );
+
+    expect(result?.code).not.toContain("browser-only");
+    expect(result?.code).toContain("value = (null)");
+    expect(result?.code).toContain("var window");
+  });
+
+  it("preserves selected conditional expression precedence", () => {
+    const result = replaceTypeofWindow(
+      `const value = typeof window === "undefined" ? (serverValue, fallbackValue) : browserValue`,
+      "undefined",
+    );
+
+    expect(result?.code).toBe("const value = (serverValue, fallbackValue)");
+  });
+
+  it("uses the resolved environment consumer for custom client environments", () => {
+    expect(getTypeofWindowReplacement({ config: { consumer: "client" } })).toBe("object");
+    expect(getTypeofWindowReplacement({ config: { consumer: "server" } })).toBe("undefined");
+  });
+
   it("removes browser-only dynamic imports from server bundles", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-"));
     temporaryDirectories.push(root);
@@ -93,6 +124,11 @@ switch (value) {
 if (typeof window !== 'undefined') {
   import('my-differentiated-files/browser').then((mod) => console.log(mod.default))
 }
+function load(value = typeof window !== 'undefined' ? import('my-differentiated-files/browser') : null) {
+  var window
+  return value
+}
+load()
 export default function Page() { return <h1>Page loaded</h1> }`,
     );
     await fs.writeFile(

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Ported from Next.js: test/e2e/app-dir/typeof-window/typeof-window.test.ts
+ * https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/typeof-window/typeof-window.test.ts
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { createBuilder } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("typeof window compilation", () => {
+  it("removes browser-only dynamic imports from server bundles", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-"));
+    temporaryDirectories.push(root);
+
+    await fs.mkdir(path.join(root, "app"), { recursive: true });
+    await fs.mkdir(path.join(root, "node_modules", "my-differentiated-files"), {
+      recursive: true,
+    });
+    const workspaceNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    for (const packageName of ["react", "react-dom"]) {
+      await fs.symlink(
+        path.join(workspaceNodeModules, packageName),
+        path.join(root, "node_modules", packageName),
+        "junction",
+      );
+    }
+    await fs.writeFile(
+      path.join(root, "app", "layout.jsx"),
+      `export default function Root({ children }) { return <html><body>{children}</body></html> }`,
+    );
+    await fs.writeFile(
+      path.join(root, "app", "page.jsx"),
+      `'use client'
+if (typeof window !== 'undefined') {
+  import('my-differentiated-files/browser').then((mod) => console.log(mod.default))
+}
+export default function Page() { return <h1>Page loaded</h1> }`,
+    );
+    await fs.writeFile(
+      path.join(root, "node_modules", "my-differentiated-files", "package.json"),
+      JSON.stringify({
+        name: "my-differentiated-files",
+        version: "1.0.0",
+        type: "module",
+        exports: {
+          "./browser": { browser: "./browser.js", node: null },
+        },
+      }),
+    );
+    await fs.writeFile(
+      path.join(root, "node_modules", "my-differentiated-files", "browser.js"),
+      `export default "BROWSER"`,
+    );
+
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [vinext({ appDir: root })],
+    });
+
+    await expect(builder.buildApp()).resolves.toBeUndefined();
+
+    const ssrFiles = await fs.readdir(path.join(root, "dist", "server", "ssr"), {
+      recursive: true,
+    });
+    const ssrJavaScript = await Promise.all(
+      ssrFiles
+        .filter((file) => typeof file === "string" && /\.[cm]?js$/.test(file))
+        .map((file) => fs.readFile(path.join(root, "dist", "server", "ssr", file), "utf8")),
+    );
+    expect(ssrJavaScript.join("\n")).not.toContain("my-differentiated-files");
+
+    const clientFiles = await fs.readdir(path.join(root, "dist", "client"), { recursive: true });
+    const clientJavaScript = await Promise.all(
+      clientFiles
+        .filter((file) => typeof file === "string" && /\.[cm]?js$/.test(file))
+        .map((file) => fs.readFile(path.join(root, "dist", "client", file), "utf8")),
+    );
+    expect(clientJavaScript.join("\n")).toContain("BROWSER");
+  }, 30000);
+});

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import { createBuilder } from "vite";
 import vinext from "../packages/vinext/src/index.js";
+import { replaceTypeofWindow } from "../packages/vinext/src/plugins/typeof-window.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -20,6 +21,52 @@ afterEach(async () => {
 });
 
 describe("typeof window compilation", () => {
+  it("only folds references to the global window binding", () => {
+    const source = `
+if (typeof window !== "undefined") globalBrowserOnly()
+function check(window) {
+  if (typeof window !== "undefined") localWindowOnly()
+}
+function hoisted() {
+  console.log(typeof window)
+  if (false) var window
+}
+{
+  const window = {}
+  console.log(typeof window)
+}
+export function exported(window) {
+  return typeof window
+}
+const WindowClass = class window {
+  check() { return typeof window }
+}
+switch (value) {
+  case 1:
+    const window = {}
+    console.log(typeof window)
+}`;
+
+    const result = replaceTypeofWindow(source, "undefined");
+
+    expect(result?.code).toContain(";");
+    expect(result?.code).toContain('if (typeof window !== "undefined") localWindowOnly()');
+    expect(result?.code.match(/typeof window/g)).toHaveLength(6);
+  });
+
+  it("removes nested dead branches in the selected branch", () => {
+    const result = replaceTypeofWindow(
+      `if (typeof window === "undefined") {
+  if (typeof window !== "undefined") import("browser-only")
+  serverOnly()
+}`,
+      "undefined",
+    );
+
+    expect(result?.code).not.toContain("browser-only");
+    expect(result?.code).toContain("serverOnly()");
+  });
+
   it("removes browser-only dynamic imports from server bundles", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-"));
     temporaryDirectories.push(root);


### PR DESCRIPTION
## Summary
- fold `typeof window` per Vite environment before Rolldown resolves imports
- remove statically unreachable `if (typeof window ...)` branches so server builds do not resolve browser-only conditional exports
- add a focused App Router production-build regression based on Next.js `test/e2e/app-dir/typeof-window/typeof-window.test.ts`

## Investigation
The requested path `test/e2e/app-dir/type-of-window/type-of-window.test.ts` does not exist in Next.js canary or the CI-pinned `v16.2.6`; the matching suite is `test/e2e/app-dir/typeof-window/typeof-window.test.ts`.

That upstream suite has `skipDeployment: true`, so the exact deploy manifest result is `outputSuites: 0` and no assertion runs in deploy mode. A clean equivalent fixture without the suite's corrupted tarball reproduced the vinext failure under Node 24:

```
"./browser" is not exported under the conditions ["module", "node", "production", "import"]
```

The failure occurred during the SSR build because Rolldown resolved a browser-only dynamic import guarded by `if (typeof window !== 'undefined')` before dead-code elimination.

## Tests
- `vp test run tests/type-of-window.test.ts tests/compiler-define.test.ts`
- `vp check tests/type-of-window.test.ts tests/compiler-define.test.ts packages/vinext/src/plugins/typeof-window.ts packages/vinext/src/index.ts`
- `vp run vinext#build`
