### PR TITLE
fix(app-router): preserve page notFound precedence during metadata failure

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -41,6 +41,7 @@ import {
 import { readStreamAsText } from "../utils/text-stream.js";
 import {
   buildAppPageSpecialErrorResponse,
+  probeAppPageThrownError,
   resolveAppPageSpecialError,
   teeAppPageRscStreamForCapture,
   type AppPageFontPreload,
@@ -850,6 +851,21 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         options.searchParams,
         layoutParamAccess,
       );
+    },
+    async probePageSpecialError() {
+      if (
+        !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION) &&
+        route.loading?.default
+      ) {
+        return null;
+      }
+      const pageError = await probeAppPageThrownError({
+        probePage: options.probePage,
+        runWithSuppressedHookWarning(probe) {
+          return options.runWithSuppressedHookWarning(probe);
+        },
+      });
+      return resolveAppPageSpecialError(pageError);
     },
     renderErrorBoundaryPage(buildError) {
       return options.renderErrorBoundaryPage(buildError);

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -197,6 +197,11 @@ type ProbeAppPageComponentOptions = {
   runWithSuppressedHookWarning<T>(probe: () => Promise<T>): Promise<T>;
 };
 
+type ProbeAppPageThrownErrorOptions = {
+  probePage: () => unknown;
+  runWithSuppressedHookWarning<T>(probe: () => Promise<T>): Promise<T>;
+};
+
 function getAppPageStatusText(statusCode: number): string {
   return statusCode === 403 ? "Forbidden" : statusCode === 401 ? "Unauthorized" : "Not Found";
 }
@@ -605,6 +610,27 @@ export async function probeAppPageComponent(
     });
 
     return outcome.completed ? outcome.result : null;
+  });
+}
+
+export async function probeAppPageThrownError(
+  options: ProbeAppPageThrownErrorOptions,
+): Promise<unknown> {
+  return options.runWithSuppressedHookWarning(async () => {
+    const outcome = await runWithConnectionProbe(async () => {
+      try {
+        const pageResult = options.probePage();
+        if (isPromiseLike(pageResult)) {
+          await pageResult;
+        }
+      } catch (error) {
+        return { error, thrown: true } as const;
+      }
+
+      return { error: null, thrown: false } as const;
+    });
+
+    return outcome.completed && outcome.result.thrown ? outcome.result.error : null;
   });
 }
 

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -38,6 +38,7 @@ type ResolveAppPageGenerateStaticParamsSourcesOptions = {
 
 type BuildAppPageElementOptions<TElement> = {
   buildPageElement: () => Promise<TElement>;
+  probePageSpecialError?: () => Promise<AppPageSpecialError | null>;
   renderErrorBoundaryPage: (error: unknown) => Promise<Response | null>;
   renderSpecialError: (specialError: AppPageSpecialError) => Promise<Response>;
   resolveSpecialError: (error: unknown) => AppPageSpecialError | null;
@@ -461,7 +462,9 @@ export async function buildAppPageElement<TElement>(
       response: null,
     };
   } catch (error) {
-    const specialError = options.resolveSpecialError(error);
+    const buildSpecialError = options.resolveSpecialError(error);
+    const pageSpecialError = buildSpecialError ? await options.probePageSpecialError?.() : null;
+    const specialError = pageSpecialError ?? buildSpecialError;
     if (specialError) {
       return {
         element: null,

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -31,6 +31,7 @@ import {
   type RenderObservation,
 } from "../packages/vinext/src/server/cache-proof.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
+import { connection } from "../packages/vinext/src/shims/server.js";
 import type { AppPageMiddlewareContext } from "../packages/vinext/src/server/app-page-response.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
@@ -485,6 +486,24 @@ function createLayoutParamProbe(
 }
 
 describe("app page dispatch", () => {
+  it("does not reuse a speculative connection() page probe", async () => {
+    const probePage = vi.fn(async () => {
+      await connection();
+    });
+    const { options } = createDispatchOptions({ probePage });
+
+    const response = await Promise.race([
+      dispatchAppPage(options),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("dispatch timed out")), 250);
+      }),
+    ]);
+
+    expect(response.status).toBe(200);
+    expect(probePage).toHaveBeenCalledTimes(1);
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
   afterEach(() => {
     consumeDynamicUsage();
     consumeRenderRequestApiUsage();

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -333,6 +333,41 @@ describe("app page request helpers", () => {
     expect(result.element).toBeNull();
     expect(result.response).toBe(boundaryResponse);
   });
+
+  it("prefers an already-thrown page notFound over a later metadata notFound", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-thrown/metadata-thrown.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-thrown/metadata-thrown.test.ts
+    const pageError = { digest: "NEXT_HTTP_ERROR_FALLBACK;404" };
+    const metadataError = { digest: "NEXT_HTTP_ERROR_FALLBACK;404", fromMetadata: true };
+    const result = await buildAppPageElement({
+      async buildPageElement() {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        throw metadataError;
+      },
+      async probePageSpecialError() {
+        return resolveAppPageSpecialError(pageError);
+      },
+      async renderErrorBoundaryPage() {
+        throw new Error("should not render boundary for special errors");
+      },
+      async renderSpecialError(specialError) {
+        return new Response(specialError.fromMetadata ? "metadata" : "page", {
+          status: specialError.statusCode,
+        });
+      },
+      resolveSpecialError(error) {
+        const specialError = resolveAppPageSpecialError(error);
+        if (specialError && error === metadataError) {
+          specialError.fromMetadata = true;
+        }
+        return specialError;
+      },
+    });
+
+    expect(result.element).toBeNull();
+    expect(result.response?.status).toBe(404);
+    await expect(result.response?.text()).resolves.toBe("page");
+  });
 });
 
 describe("resolveAppPageInterceptMatch", () => {


### PR DESCRIPTION
## Summary

- when metadata resolution throws a special error, probe the page through the existing connection-aware mechanism
- prefer an already-thrown page notFound over delayed metadata fallback
- avoid broad eager page execution and speculative promise reuse
- add regression coverage ensuring connection() pages do not hang

## Validation

- 98 focused unit tests passed in independent review
- connection E2E: 4/4 passed
- loading boundary E2E: 3/3 passed
- focused format, lint, types, and package build passed

Full suites deferred to CI.