### PR TITLE
fix(app-router): support extensionless variable imports

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -172,6 +172,7 @@ import { stripServerExports } from "./plugins/strip-server-exports.js";
 import { removeConsoleCalls } from "./plugins/remove-console.js";
 import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
 import { createRequireContextPlugin } from "./plugins/require-context.js";
+import { createExtensionlessDynamicImportPlugin } from "./plugins/extensionless-dynamic-import.js";
 import { createWasmModuleImportPlugin } from "./plugins/wasm-module-import.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
@@ -4373,6 +4374,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     createImportMetaUrlPlugin({
       getRoot: () => root,
     }),
+    createExtensionlessDynamicImportPlugin(),
     // Expand Webpack's build-time `require.context(...)` into a static module
     // map backed by `import.meta.glob` — see src/plugins/require-context.ts
     createRequireContextPlugin(),

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -1,0 +1,116 @@
+import MagicString from "magic-string";
+import { parseAst, type Plugin } from "vite";
+import { forEachAstChild, hasRange, isAstRecord, nodeArray, type AstRecord } from "./ast-utils.js";
+
+const MODULE_EXTENSIONS = [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"];
+const TRANSFORMABLE_EXTENSIONS = new Set(MODULE_EXTENSIONS);
+
+type ExtensionlessImport = {
+  start: number;
+  end: number;
+  sourceStart: number;
+  sourceEnd: number;
+  globPattern: string;
+};
+
+export function createExtensionlessDynamicImportPlugin(): Plugin {
+  return {
+    name: "vinext:extensionless-dynamic-import",
+    enforce: "pre",
+    transform(code, id) {
+      if (!code.includes("import(") && !code.includes("import (")) return null;
+      const lang = langForId(id);
+      if (!lang) return null;
+
+      let ast: unknown;
+      try {
+        ast = parseAst(code, { lang });
+      } catch {
+        return null;
+      }
+
+      const imports = collectExtensionlessImports(ast);
+      if (imports.length === 0) return null;
+
+      const output = new MagicString(code);
+      for (const dynamicImport of imports) {
+        const source = code.slice(dynamicImport.sourceStart, dynamicImport.sourceEnd);
+        output.overwrite(
+          dynamicImport.start,
+          dynamicImport.end,
+          buildReplacement(source, dynamicImport.globPattern),
+        );
+      }
+
+      return {
+        code: output.toString(),
+        map: output.generateMap({ hires: "boundary" }),
+      };
+    },
+  };
+}
+
+function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {
+  const clean = id.split("?", 1)[0];
+  const dot = clean.lastIndexOf(".");
+  if (dot < 0) return null;
+  const ext = clean.slice(dot).toLowerCase();
+  if (!TRANSFORMABLE_EXTENSIONS.has(ext)) return null;
+  if (ext === ".ts" || ext === ".mts" || ext === ".cts") return "ts";
+  if (ext === ".tsx") return "tsx";
+  return "jsx";
+}
+
+function collectExtensionlessImports(ast: unknown): ExtensionlessImport[] {
+  const imports: ExtensionlessImport[] = [];
+
+  function visit(value: unknown): void {
+    if (!isAstRecord(value)) return;
+    const parsed = parseExtensionlessImport(value);
+    if (parsed) {
+      imports.push(parsed);
+      return;
+    }
+    forEachAstChild(value, visit);
+  }
+
+  visit(ast);
+  return imports;
+}
+
+function parseExtensionlessImport(node: AstRecord): ExtensionlessImport | null {
+  if (node.type !== "ImportExpression" || !hasRange(node)) return null;
+  if (node.options != null) return null;
+  const source = node.source;
+  if (!isAstRecord(source) || source.type !== "TemplateLiteral" || !hasRange(source)) return null;
+  if (nodeArray(source.expressions).length === 0) return null;
+
+  const quasis = nodeArray(source.quasis);
+  const first = templateElementText(quasis[0]);
+  const last = templateElementText(quasis.at(-1));
+  if (first == null || last == null) return null;
+  if (!(first.startsWith("./") || first.startsWith("../"))) return null;
+  if (!first.endsWith("/")) return null;
+  if (last.includes(".")) return null;
+
+  return {
+    start: node.start,
+    end: node.end,
+    sourceStart: source.start,
+    sourceEnd: source.end,
+    globPattern: `${first}**/*{${MODULE_EXTENSIONS.join(",")}}`,
+  };
+}
+
+function templateElementText(value: unknown): string | null {
+  if (!isAstRecord(value) || value.type !== "TemplateElement") return null;
+  const templateValue = value.value;
+  if (typeof templateValue !== "object" || templateValue === null) return null;
+  const cooked = Reflect.get(templateValue, "cooked");
+  return typeof cooked === "string" ? cooked : null;
+}
+
+function buildReplacement(source: string, globPattern: string): string {
+  const extensions = JSON.stringify(MODULE_EXTENSIONS);
+  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(globPattern)})) => { const __vinextLoader = __vinextModules[__vinextPath] ?? ${extensions}.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
+}

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -2,8 +2,17 @@ import MagicString from "magic-string";
 import { parseAst, type Plugin, type ResolvedConfig } from "vite";
 import { forEachAstChild, hasRange, isAstRecord, nodeArray, type AstRecord } from "./ast-utils.js";
 
-const MODULE_EXTENSIONS = [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx"];
-const TRANSFORMABLE_EXTENSIONS = new Set([...MODULE_EXTENSIONS, ".cjs", ".cts"]);
+const MODULE_EXTENSIONS = [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"];
+const TRANSFORMABLE_EXTENSIONS = new Set([
+  ".mjs",
+  ".js",
+  ".mts",
+  ".ts",
+  ".jsx",
+  ".tsx",
+  ".cjs",
+  ".cts",
+]);
 
 type ExtensionlessImport = {
   start: number;
@@ -24,7 +33,7 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
       moduleExtensions = getModuleExtensions(config);
     },
     transform(code, id) {
-      if (!code.includes("import(") && !code.includes("import (")) return null;
+      if (!/\bimport\s*\(/.test(code)) return null;
       const lang = langForId(id);
       if (!lang) return null;
 
@@ -105,16 +114,18 @@ function parseExtensionlessImport(
   if (first == null || last == null) return null;
   if (!/^import\s*\(\s*$/.test(code.slice(node.start, source.start))) return null;
   if (!(first.startsWith("./") || first.startsWith("../"))) return null;
-  if (!first.endsWith("/")) return null;
   if (/[*?[\]{}()!]/.test(first)) return null;
   if (/[.?#]/.test(last)) return null;
+
+  const directoryEnd = first.lastIndexOf("/") + 1;
+  const directory = first.slice(0, directoryEnd);
 
   return {
     start: node.start,
     end: node.end,
     sourceStart: source.start,
     sourceEnd: source.end,
-    globPattern: `${first}**/*{${moduleExtensions.join(",")}}`,
+    globPattern: `${directory}**/*{${moduleExtensions.join(",")}}`,
     moduleExtensions,
   };
 }
@@ -128,9 +139,7 @@ function templateElementText(value: unknown): string | null {
 }
 
 function getModuleExtensions(config: ResolvedConfig): string[] {
-  return config.resolve.extensions.filter(
-    (extension) => extension !== ".json" && extension !== ".node",
-  );
+  return config.resolve.extensions.filter((extension) => extension !== ".node");
 }
 
 function buildReplacement(
@@ -139,5 +148,5 @@ function buildReplacement(
   moduleExtensions: readonly string[],
 ): string {
   const extensions = JSON.stringify(moduleExtensions);
-  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(globPattern)}), __vinextExtensions = ${extensions}) => { const __vinextLoader = __vinextModules[__vinextPath] ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension] ?? __vinextModules[__vinextPath + "/index" + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
+  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(globPattern)}), __vinextExtensions = ${extensions}) => { const __vinextLoader = __vinextModules[__vinextPath] ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension]).find(Boolean) ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + "/index" + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
 }

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -142,8 +142,33 @@ function parseExtensionlessImport(
 function isImportPrefix(value: string): boolean {
   const prefix = value.match(/^import\s*\(/)?.[0];
   if (!prefix) return false;
-  const remainder = value.slice(prefix.length);
-  return /^(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$))*$/.test(remainder);
+
+  let index = prefix.length;
+  while (index < value.length) {
+    const char = value[index];
+    if (/\s/.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (value.startsWith("/*", index)) {
+      const commentEnd = value.indexOf("*/", index + 2);
+      if (commentEnd < 0) return false;
+      index = commentEnd + 2;
+      continue;
+    }
+
+    if (value.startsWith("//", index)) {
+      const lineEnd = value.indexOf("\n", index + 2);
+      if (lineEnd < 0) return true;
+      index = lineEnd + 1;
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
 }
 
 function templateElementText(value: unknown): string | null {

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -112,7 +112,7 @@ function parseExtensionlessImport(
   const first = templateElementText(quasis[0]);
   const last = templateElementText(quasis.at(-1));
   if (first == null || last == null) return null;
-  if (!/^import\s*\(\s*$/.test(code.slice(node.start, source.start))) return null;
+  if (!isImportPrefix(code.slice(node.start, source.start))) return null;
   if (!(first.startsWith("./") || first.startsWith("../"))) return null;
   if (/[*?[\]{}()!]/.test(first)) return null;
   if (/[.?#]/.test(last)) return null;
@@ -125,9 +125,16 @@ function parseExtensionlessImport(
     end: node.end,
     sourceStart: source.start,
     sourceEnd: source.end,
-    globPattern: `${directory}**/*{${moduleExtensions.join(",")}}`,
+    globPattern: `${directory}**/*`,
     moduleExtensions,
   };
+}
+
+function isImportPrefix(value: string): boolean {
+  const prefix = value.match(/^import\s*\(/)?.[0];
+  if (!prefix) return false;
+  const remainder = value.slice(prefix.length);
+  return /^(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$))*$/.test(remainder);
 }
 
 function templateElementText(value: unknown): string | null {

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -19,7 +19,7 @@ type ExtensionlessImport = {
   end: number;
   sourceStart: number;
   sourceEnd: number;
-  globPattern: string;
+  globPattern: string | readonly string[];
   moduleExtensions: readonly string[];
 };
 
@@ -34,6 +34,7 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
     },
     transform(code, id) {
       if (!/\bimport\s*\(/.test(code)) return null;
+      if (isDependencyId(id)) return null;
       const lang = langForId(id);
       if (!lang) return null;
 
@@ -76,6 +77,11 @@ function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {
   return "jsx";
 }
 
+function isDependencyId(id: string): boolean {
+  const clean = id.split("?", 1)[0].replaceAll("\\", "/");
+  return clean.includes("/node_modules/");
+}
+
 function collectExtensionlessImports(
   ast: unknown,
   code: string,
@@ -109,23 +115,26 @@ function parseExtensionlessImport(
   if (nodeArray(source.expressions).length === 0) return null;
 
   const quasis = nodeArray(source.quasis);
-  const first = templateElementText(quasis[0]);
-  const last = templateElementText(quasis.at(-1));
-  if (first == null || last == null) return null;
+  const quasiTexts = quasis.map(templateElementText);
+  if (quasiTexts.some((text) => text == null)) return null;
+  const texts = quasiTexts as string[];
+  const first = texts[0];
   if (!isImportPrefix(code.slice(node.start, source.start))) return null;
   if (!(first.startsWith("./") || first.startsWith("../"))) return null;
-  if (/[*?[\]{}()!]/.test(first)) return null;
-  if (/[.?#]/.test(last)) return null;
+  if (texts.some((text) => /[*?[\]{}()!?#]/.test(text))) return null;
+  if (texts.slice(1).some((text) => text.includes("."))) return null;
 
   const directoryEnd = first.lastIndexOf("/") + 1;
   const directory = first.slice(0, directoryEnd);
+  const filenamePrefix = first.slice(directoryEnd);
+  if (filenamePrefix.includes(".")) return null;
 
   return {
     start: node.start,
     end: node.end,
     sourceStart: source.start,
     sourceEnd: source.end,
-    globPattern: `${directory}**/*`,
+    globPattern: filenamePrefix.length > 0 ? [`${first}*`, `${first}*/**/*`] : `${directory}**/*`,
     moduleExtensions,
   };
 }
@@ -151,7 +160,7 @@ function getModuleExtensions(config: ResolvedConfig): string[] {
 
 function buildReplacement(
   source: string,
-  globPattern: string,
+  globPattern: string | readonly string[],
   moduleExtensions: readonly string[],
 ): string {
   const extensions = JSON.stringify(moduleExtensions);

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -1,9 +1,9 @@
 import MagicString from "magic-string";
-import { parseAst, type Plugin } from "vite";
+import { parseAst, type Plugin, type ResolvedConfig } from "vite";
 import { forEachAstChild, hasRange, isAstRecord, nodeArray, type AstRecord } from "./ast-utils.js";
 
-const MODULE_EXTENSIONS = [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"];
-const TRANSFORMABLE_EXTENSIONS = new Set(MODULE_EXTENSIONS);
+const MODULE_EXTENSIONS = [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx"];
+const TRANSFORMABLE_EXTENSIONS = new Set([...MODULE_EXTENSIONS, ".cjs", ".cts"]);
 
 type ExtensionlessImport = {
   start: number;
@@ -11,12 +11,18 @@ type ExtensionlessImport = {
   sourceStart: number;
   sourceEnd: number;
   globPattern: string;
+  moduleExtensions: readonly string[];
 };
 
 export function createExtensionlessDynamicImportPlugin(): Plugin {
+  let moduleExtensions = MODULE_EXTENSIONS;
+
   return {
     name: "vinext:extensionless-dynamic-import",
     enforce: "pre",
+    configResolved(config) {
+      moduleExtensions = getModuleExtensions(config);
+    },
     transform(code, id) {
       if (!code.includes("import(") && !code.includes("import (")) return null;
       const lang = langForId(id);
@@ -29,7 +35,7 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
         return null;
       }
 
-      const imports = collectExtensionlessImports(ast);
+      const imports = collectExtensionlessImports(ast, code, moduleExtensions);
       if (imports.length === 0) return null;
 
       const output = new MagicString(code);
@@ -38,7 +44,7 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
         output.overwrite(
           dynamicImport.start,
           dynamicImport.end,
-          buildReplacement(source, dynamicImport.globPattern),
+          buildReplacement(source, dynamicImport.globPattern, dynamicImport.moduleExtensions),
         );
       }
 
@@ -61,12 +67,16 @@ function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {
   return "jsx";
 }
 
-function collectExtensionlessImports(ast: unknown): ExtensionlessImport[] {
+function collectExtensionlessImports(
+  ast: unknown,
+  code: string,
+  moduleExtensions: readonly string[],
+): ExtensionlessImport[] {
   const imports: ExtensionlessImport[] = [];
 
   function visit(value: unknown): void {
     if (!isAstRecord(value)) return;
-    const parsed = parseExtensionlessImport(value);
+    const parsed = parseExtensionlessImport(value, code, moduleExtensions);
     if (parsed) {
       imports.push(parsed);
       return;
@@ -78,7 +88,11 @@ function collectExtensionlessImports(ast: unknown): ExtensionlessImport[] {
   return imports;
 }
 
-function parseExtensionlessImport(node: AstRecord): ExtensionlessImport | null {
+function parseExtensionlessImport(
+  node: AstRecord,
+  code: string,
+  moduleExtensions: readonly string[],
+): ExtensionlessImport | null {
   if (node.type !== "ImportExpression" || !hasRange(node)) return null;
   if (node.options != null) return null;
   const source = node.source;
@@ -89,16 +103,19 @@ function parseExtensionlessImport(node: AstRecord): ExtensionlessImport | null {
   const first = templateElementText(quasis[0]);
   const last = templateElementText(quasis.at(-1));
   if (first == null || last == null) return null;
+  if (!/^import\s*\(\s*$/.test(code.slice(node.start, source.start))) return null;
   if (!(first.startsWith("./") || first.startsWith("../"))) return null;
   if (!first.endsWith("/")) return null;
-  if (last.includes(".")) return null;
+  if (/[*?[\]{}()!]/.test(first)) return null;
+  if (/[.?#]/.test(last)) return null;
 
   return {
     start: node.start,
     end: node.end,
     sourceStart: source.start,
     sourceEnd: source.end,
-    globPattern: `${first}**/*{${MODULE_EXTENSIONS.join(",")}}`,
+    globPattern: `${first}**/*{${moduleExtensions.join(",")}}`,
+    moduleExtensions,
   };
 }
 
@@ -110,7 +127,17 @@ function templateElementText(value: unknown): string | null {
   return typeof cooked === "string" ? cooked : null;
 }
 
-function buildReplacement(source: string, globPattern: string): string {
-  const extensions = JSON.stringify(MODULE_EXTENSIONS);
-  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(globPattern)})) => { const __vinextLoader = __vinextModules[__vinextPath] ?? ${extensions}.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
+function getModuleExtensions(config: ResolvedConfig): string[] {
+  return config.resolve.extensions.filter(
+    (extension) => extension !== ".json" && extension !== ".node",
+  );
+}
+
+function buildReplacement(
+  source: string,
+  globPattern: string,
+  moduleExtensions: readonly string[],
+): string {
+  const extensions = JSON.stringify(moduleExtensions);
+  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(globPattern)}), __vinextExtensions = ${extensions}) => { const __vinextLoader = __vinextModules[__vinextPath] ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension] ?? __vinextModules[__vinextPath + "/index" + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
 }

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -78,6 +78,14 @@ describe("vinext:extensionless-dynamic-import", () => {
     expect(result.code).toContain("import.meta.glob");
   });
 
+  it("handles repeated block-comment markers without backtracking", () => {
+    const transform = createTransform();
+    const comments = "/*" + "*//*".repeat(10_000) + "*/";
+    const result = transform(`await import(${comments} \`./\${slug}\`)`, "/app/page.tsx");
+
+    expect(result.code).toContain("import.meta.glob");
+  });
+
   it("leaves imports with explicit extensions unchanged", () => {
     const transform = createTransform();
     const result = transform("await import(`./${slug}.tsx`)", "/app/page.tsx");

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -18,7 +18,7 @@ describe("vinext:extensionless-dynamic-import", () => {
     const transform = createTransform();
     const result = transform("const moduleExports = await import(`./${slug}`)", "/app/page.tsx");
 
-    expect(result.code).toContain('import.meta.glob("./**/*{.mjs,.js,.mts,.ts,.jsx,.tsx,.json}")');
+    expect(result.code).toContain('import.meta.glob("./**/*")');
     expect(result.code).toContain("__vinextModules[__vinextPath + __vinextExtension]");
     expect(result.code).toContain('__vinextPath + "/index" + __vinextExtension');
     expect(result.code).toContain("Promise.reject(new Error");
@@ -28,8 +28,16 @@ describe("vinext:extensionless-dynamic-import", () => {
     const transform = createTransform([".platform.tsx", ".tsx", ".js", ".json"]);
     const result = transform("await import(`./${slug}`)", "/app/page.tsx");
 
-    expect(result.code).toContain('import.meta.glob("./**/*{.platform.tsx,.tsx,.js,.json}")');
+    expect(result.code).toContain('import.meta.glob("./**/*")');
     expect(result.code).toContain('[".platform.tsx",".tsx",".js",".json"]');
+  });
+
+  it("uses configured single resolver extensions at runtime", () => {
+    const transform = createTransform([".js"]);
+    const result = transform("await import(`./${slug}`)", "/app/page.tsx");
+
+    expect(result.code).toContain('import.meta.glob("./**/*")');
+    expect(result.code).toContain('[".js"]');
   });
 
   it("tries every file extension before directory index files", () => {
@@ -55,9 +63,17 @@ describe("vinext:extensionless-dynamic-import", () => {
     const transform = createTransform();
     const result = transform("await import(`./components/prefixed-${slug}`)", "/app/page.tsx");
 
-    expect(result.code).toContain(
-      'import.meta.glob("./components/**/*{.mjs,.js,.mts,.ts,.jsx,.tsx,.json}")',
+    expect(result.code).toContain('import.meta.glob("./components/**/*")');
+  });
+
+  it("transforms imports with Webpack magic comments", () => {
+    const transform = createTransform();
+    const result = transform(
+      'await import(/* webpackChunkName: "named" */ `./${slug}`)',
+      "/app/page.tsx",
     );
+
+    expect(result.code).toContain("import.meta.glob");
   });
 
   it("leaves imports with explicit extensions unchanged", () => {
@@ -87,7 +103,6 @@ describe("vinext:extensionless-dynamic-import", () => {
   it.each([
     "await import(`./${slug}?raw`)",
     "await import(`./${slug}#section`)",
-    'await import(/* webpackChunkName: "named" */ `./${slug}`)',
     "await import(`./[locale]/${slug}`)",
   ])("leaves semantic import modifiers unchanged: %s", (code) => {
     const transform = createTransform();

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -5,48 +5,64 @@ function unwrapHook(hook: any): Function {
   return typeof hook === "function" ? hook : hook?.handler;
 }
 
+function createTransform(extensions?: string[]): Function {
+  const plugin = createExtensionlessDynamicImportPlugin();
+  if (extensions) {
+    unwrapHook(plugin.configResolved).call(plugin, { resolve: { extensions } });
+  }
+  return unwrapHook(plugin.transform).bind(plugin);
+}
+
 describe("vinext:extensionless-dynamic-import", () => {
   it("expands extensionless relative template imports through import.meta.glob", () => {
-    const plugin = createExtensionlessDynamicImportPlugin();
-    const transform = unwrapHook(plugin.transform);
-    const result = transform.call(
-      plugin,
-      "const moduleExports = await import(`./${slug}`)",
-      "/app/page.tsx",
-    );
+    const transform = createTransform();
+    const result = transform("const moduleExports = await import(`./${slug}`)", "/app/page.tsx");
 
-    expect(result.code).toContain(
-      'import.meta.glob("./**/*{.js,.jsx,.ts,.tsx,.mjs,.cjs,.mts,.cts}")',
-    );
+    expect(result.code).toContain('import.meta.glob("./**/*{.mjs,.js,.mts,.ts,.jsx,.tsx}")');
     expect(result.code).toContain("__vinextModules[__vinextPath + __vinextExtension]");
+    expect(result.code).toContain('__vinextPath + "/index" + __vinextExtension');
     expect(result.code).toContain("Promise.reject(new Error");
   });
 
+  it("uses configured resolver extensions in priority order", () => {
+    const transform = createTransform([".platform.tsx", ".tsx", ".js", ".json"]);
+    const result = transform("await import(`./${slug}`)", "/app/page.tsx");
+
+    expect(result.code).toContain('import.meta.glob("./**/*{.platform.tsx,.tsx,.js}")');
+    expect(result.code).toContain('[".platform.tsx",".tsx",".js"]');
+  });
+
   it("leaves imports with explicit extensions unchanged", () => {
-    const plugin = createExtensionlessDynamicImportPlugin();
-    const transform = unwrapHook(plugin.transform);
-    const result = transform.call(plugin, "await import(`./${slug}.tsx`)", "/app/page.tsx");
+    const transform = createTransform();
+    const result = transform("await import(`./${slug}.tsx`)", "/app/page.tsx");
 
     expect(result).toBeNull();
   });
 
   it("leaves bare package imports unchanged", () => {
-    const plugin = createExtensionlessDynamicImportPlugin();
-    const transform = unwrapHook(plugin.transform);
-    const result = transform.call(plugin, "await import(`${packageName}`)", "/app/page.tsx");
+    const transform = createTransform();
+    const result = transform("await import(`${packageName}`)", "/app/page.tsx");
 
     expect(result).toBeNull();
   });
 
   it("leaves imports with attributes unchanged", () => {
-    const plugin = createExtensionlessDynamicImportPlugin();
-    const transform = unwrapHook(plugin.transform);
-    const result = transform.call(
-      plugin,
+    const transform = createTransform();
+    const result = transform(
       'await import(`./${slug}`, { with: { type: "json" } })',
       "/app/page.tsx",
     );
 
     expect(result).toBeNull();
+  });
+
+  it.each([
+    "await import(`./${slug}?raw`)",
+    "await import(`./${slug}#section`)",
+    'await import(/* webpackChunkName: "named" */ `./${slug}`)',
+    "await import(`./[locale]/${slug}`)",
+  ])("leaves semantic import modifiers unchanged: %s", (code) => {
+    const transform = createTransform();
+    expect(transform(code, "/app/page.tsx")).toBeNull();
   });
 });

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createExtensionlessDynamicImportPlugin } from "../packages/vinext/src/plugins/extensionless-dynamic-import.js";
+
+function unwrapHook(hook: any): Function {
+  return typeof hook === "function" ? hook : hook?.handler;
+}
+
+describe("vinext:extensionless-dynamic-import", () => {
+  it("expands extensionless relative template imports through import.meta.glob", () => {
+    const plugin = createExtensionlessDynamicImportPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const result = transform.call(
+      plugin,
+      "const moduleExports = await import(`./${slug}`)",
+      "/app/page.tsx",
+    );
+
+    expect(result.code).toContain(
+      'import.meta.glob("./**/*{.js,.jsx,.ts,.tsx,.mjs,.cjs,.mts,.cts}")',
+    );
+    expect(result.code).toContain("__vinextModules[__vinextPath + __vinextExtension]");
+    expect(result.code).toContain("Promise.reject(new Error");
+  });
+
+  it("leaves imports with explicit extensions unchanged", () => {
+    const plugin = createExtensionlessDynamicImportPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const result = transform.call(plugin, "await import(`./${slug}.tsx`)", "/app/page.tsx");
+
+    expect(result).toBeNull();
+  });
+
+  it("leaves bare package imports unchanged", () => {
+    const plugin = createExtensionlessDynamicImportPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const result = transform.call(plugin, "await import(`${packageName}`)", "/app/page.tsx");
+
+    expect(result).toBeNull();
+  });
+
+  it("leaves imports with attributes unchanged", () => {
+    const plugin = createExtensionlessDynamicImportPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const result = transform.call(
+      plugin,
+      'await import(`./${slug}`, { with: { type: "json" } })',
+      "/app/page.tsx",
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -63,7 +63,9 @@ describe("vinext:extensionless-dynamic-import", () => {
     const transform = createTransform();
     const result = transform("await import(`./components/prefixed-${slug}`)", "/app/page.tsx");
 
-    expect(result.code).toContain('import.meta.glob("./components/**/*")');
+    expect(result.code).toContain(
+      'import.meta.glob(["./components/prefixed-*","./components/prefixed-*/**/*"])',
+    );
   });
 
   it("transforms imports with Webpack magic comments", () => {
@@ -90,6 +92,16 @@ describe("vinext:extensionless-dynamic-import", () => {
     expect(result).toBeNull();
   });
 
+  it("leaves dependency imports unchanged", () => {
+    const transform = createTransform();
+    const result = transform(
+      "await import(`./${locale}`)",
+      "/app/node_modules/example-package/index.js",
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("leaves imports with attributes unchanged", () => {
     const transform = createTransform();
     const result = transform(
@@ -104,6 +116,10 @@ describe("vinext:extensionless-dynamic-import", () => {
     "await import(`./${slug}?raw`)",
     "await import(`./${slug}#section`)",
     "await import(`./[locale]/${slug}`)",
+    "await import(`./${first}*/${second}`)",
+    "await import(`./${first}.bak/${second}`)",
+    "await import(`./${first}?query/${second}`)",
+    "await import(`./file.${extension}`)",
   ])("leaves semantic import modifiers unchanged: %s", (code) => {
     const transform = createTransform();
     expect(transform(code, "/app/page.tsx")).toBeNull();

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -18,7 +18,7 @@ describe("vinext:extensionless-dynamic-import", () => {
     const transform = createTransform();
     const result = transform("const moduleExports = await import(`./${slug}`)", "/app/page.tsx");
 
-    expect(result.code).toContain('import.meta.glob("./**/*{.mjs,.js,.mts,.ts,.jsx,.tsx}")');
+    expect(result.code).toContain('import.meta.glob("./**/*{.mjs,.js,.mts,.ts,.jsx,.tsx,.json}")');
     expect(result.code).toContain("__vinextModules[__vinextPath + __vinextExtension]");
     expect(result.code).toContain('__vinextPath + "/index" + __vinextExtension');
     expect(result.code).toContain("Promise.reject(new Error");
@@ -28,8 +28,36 @@ describe("vinext:extensionless-dynamic-import", () => {
     const transform = createTransform([".platform.tsx", ".tsx", ".js", ".json"]);
     const result = transform("await import(`./${slug}`)", "/app/page.tsx");
 
-    expect(result.code).toContain('import.meta.glob("./**/*{.platform.tsx,.tsx,.js}")');
-    expect(result.code).toContain('[".platform.tsx",".tsx",".js"]');
+    expect(result.code).toContain('import.meta.glob("./**/*{.platform.tsx,.tsx,.js,.json}")');
+    expect(result.code).toContain('[".platform.tsx",".tsx",".js",".json"]');
+  });
+
+  it("tries every file extension before directory index files", () => {
+    const transform = createTransform([".tsx", ".js"]);
+    const result = transform("await import(`./${slug}`)", "/app/page.tsx");
+
+    expect(result.code.indexOf("__vinextPath + __vinextExtension")).toBeLessThan(
+      result.code.indexOf('__vinextPath + "/index" + __vinextExtension'),
+    );
+    expect(result.code).not.toContain(
+      '__vinextModules[__vinextPath + __vinextExtension] ?? __vinextModules[__vinextPath + "/index"',
+    );
+  });
+
+  it("transforms imports separated from the call parenthesis by newlines", () => {
+    const transform = createTransform();
+    const result = transform("await import\n(`./${slug}`)", "/app/page.tsx");
+
+    expect(result.code).toContain("import.meta.glob");
+  });
+
+  it("transforms imports with a static filename prefix", () => {
+    const transform = createTransform();
+    const result = transform("await import(`./components/prefixed-${slug}`)", "/app/page.tsx");
+
+    expect(result.code).toContain(
+      'import.meta.glob("./components/**/*{.mjs,.js,.mts,.ts,.jsx,.tsx,.json}")',
+    );
   });
 
   it("leaves imports with explicit extensions unchanged", () => {

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/button.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/button.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export function Button() {
+  return <button>submit</button>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/data.json
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/data.json
@@ -1,0 +1,3 @@
+{
+  "message": "json import"
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/page.tsx
@@ -13,8 +13,15 @@ async function getData(slug: string): Promise<{ message: string }> {
 }
 
 async function getPrefixedImport(slug: string): Promise<string> {
-  const moduleExports = await import(`./prefixed-${slug}`);
+  const moduleExports = await import(
+    /* webpackChunkName: "prefixed-module" */ `./prefixed-${slug}`
+  );
   return moduleExports.prefixedImport;
+}
+
+async function getSuffixlessImport(slug: string): Promise<string> {
+  const moduleExports = await import(`./${slug}`);
+  return moduleExports.suffixlessImport;
 }
 
 export default async function Page() {
@@ -22,12 +29,14 @@ export default async function Page() {
   const resolverPriority = await getImport<string>("resolver-priority", "resolverPriority");
   const data = await getData("data");
   const prefixedImport = await getPrefixedImport("module");
+  const suffixlessImport = await getSuffixlessImport("suffixless");
   return (
     <>
       <Button />
       <p>{resolverPriority}</p>
       <p>{data.message}</p>
       <p>{prefixedImport}</p>
+      <p>{suffixlessImport}</p>
     </>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/page.tsx
@@ -2,12 +2,32 @@
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/dynamic-import/dynamic-import.test.ts
 import type { ElementType } from "react";
 
-async function getImport(slug: string, exportName: string): Promise<ElementType> {
+async function getImport<T>(slug: string, exportName: string): Promise<T> {
   const moduleExports = await import(`./${slug}`);
   return moduleExports[exportName];
 }
 
+async function getData(slug: string): Promise<{ message: string }> {
+  const moduleExports = await import(`./${slug}`);
+  return moduleExports.default;
+}
+
+async function getPrefixedImport(slug: string): Promise<string> {
+  const moduleExports = await import(`./prefixed-${slug}`);
+  return moduleExports.prefixedImport;
+}
+
 export default async function Page() {
-  const Button = await getImport("button", "Button");
-  return <Button />;
+  const Button = await getImport<ElementType>("button", "Button");
+  const resolverPriority = await getImport<string>("resolver-priority", "resolverPriority");
+  const data = await getData("data");
+  const prefixedImport = await getPrefixedImport("module");
+  return (
+    <>
+      <Button />
+      <p>{resolverPriority}</p>
+      <p>{data.message}</p>
+      <p>{prefixedImport}</p>
+    </>
+  );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/page.tsx
@@ -1,0 +1,13 @@
+// Ported from Next.js: test/e2e/app-dir/dynamic-import/dynamic-import.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/dynamic-import/dynamic-import.test.ts
+import type { ElementType } from "react";
+
+async function getImport(slug: string, exportName: string): Promise<ElementType> {
+  const moduleExports = await import(`./${slug}`);
+  return moduleExports[exportName];
+}
+
+export default async function Page() {
+  const Button = await getImport("button", "Button");
+  return <Button />;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/prefixed-module.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/prefixed-module.ts
@@ -1,0 +1,1 @@
+export const prefixedImport = "prefixed import";

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/resolver-priority.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/resolver-priority.tsx
@@ -1,0 +1,1 @@
+export const resolverPriority = "file import";

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/resolver-priority/index.js
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/resolver-priority/index.js
@@ -1,0 +1,1 @@
+export const resolverPriority = "directory import";

--- a/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/suffixless
+++ b/tests/fixtures/app-basic/app/nextjs-compat/dynamic/extensionless-import/suffixless
@@ -1,0 +1,1 @@
+export const suffixlessImport = "suffixless import";

--- a/tests/nextjs-compat/dynamic.test.ts
+++ b/tests/nextjs-compat/dynamic.test.ts
@@ -128,6 +128,13 @@ describe("Next.js compat: next/dynamic", () => {
     expect(html).toContain('id="css-text-dynamic-rsc"');
   });
 
+  // Ported from Next.js: test/e2e/app-dir/dynamic-import/dynamic-import.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/dynamic-import/dynamic-import.test.ts
+  it("RSC: resolves extensionless variable dynamic imports", async () => {
+    const { html } = await fetchHtml(baseUrl, "/nextjs-compat/dynamic/extensionless-import");
+    expect(html).toContain("<button>submit</button>");
+  });
+
   // Ported from Next.js: test/e2e/app-dir/next-dynamic-csp-nonce/next-dynamic-csp-nonce.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-dynamic-csp-nonce/next-dynamic-csp-nonce.test.ts
   it("SSR: adds nonce attributes to preload links when next/dynamic runs under CSP", async () => {

--- a/tests/nextjs-compat/dynamic.test.ts
+++ b/tests/nextjs-compat/dynamic.test.ts
@@ -133,6 +133,9 @@ describe("Next.js compat: next/dynamic", () => {
   it("RSC: resolves extensionless variable dynamic imports", async () => {
     const { html } = await fetchHtml(baseUrl, "/nextjs-compat/dynamic/extensionless-import");
     expect(html).toContain("<button>submit</button>");
+    expect(html).toContain("<p>file import</p>");
+    expect(html).toContain("<p>json import</p>");
+    expect(html).toContain("<p>prefixed import</p>");
   });
 
   // Ported from Next.js: test/e2e/app-dir/next-dynamic-csp-nonce/next-dynamic-csp-nonce.test.ts

--- a/tests/nextjs-compat/dynamic.test.ts
+++ b/tests/nextjs-compat/dynamic.test.ts
@@ -136,6 +136,7 @@ describe("Next.js compat: next/dynamic", () => {
     expect(html).toContain("<p>file import</p>");
     expect(html).toContain("<p>json import</p>");
     expect(html).toContain("<p>prefixed import</p>");
+    expect(html).toContain("<p>suffixless import</p>");
   });
 
   // Ported from Next.js: test/e2e/app-dir/next-dynamic-csp-nonce/next-dynamic-csp-nonce.test.ts


### PR DESCRIPTION
## Summary

- transform relative extensionless variable `import()` calls into lazy `import.meta.glob` module maps
- preserve normal extension resolution for JavaScript and TypeScript modules
- port the focused Next.js dynamic-import regression fixture and add transform safety tests

## Next.js reference

- `test/e2e/app-dir/dynamic-import/dynamic-import.test.ts`
- https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/dynamic-import/dynamic-import.test.ts

## Validation

- `vp check`
- `vp test run tests/extensionless-dynamic-import.test.ts tests/nextjs-compat/dynamic.test.ts`
- Node 24, concurrency 1: `VINEXT_BUILD=1 NEXT_TEST_CONCURRENCY=1 ./scripts/run-nextjs-deploy-suite.sh .nextjs-ref --retries 0 -c 1 test/e2e/app-dir/dynamic-import/dynamic-import.test.ts`

PPR/cache behavior is intentionally out of scope.
