### PR TITLE
fix(config): honor resolve extensions and improve webpack config processing

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -342,6 +342,7 @@ export type ResolvedNextConfig = {
   output: "" | "export" | "standalone";
   pageExtensions: string[];
   resolveExtensions: string[] | null;
+  serverResolveExtensions: string[] | null;
   instrumentationClientInject: string[];
   cacheComponents: boolean;
   /**
@@ -1207,6 +1208,7 @@ function resolveStaleTimes(experimental: Record<string, unknown> | undefined): {
 export async function resolveNextConfig(
   config: NextConfig | null,
   root: string = process.cwd(),
+  options: { dev?: boolean } = {},
 ): Promise<ResolvedNextConfig> {
   if (!config) {
     const buildId = await resolveBuildId(undefined);
@@ -1219,6 +1221,7 @@ export async function resolveNextConfig(
       output: "",
       pageExtensions: normalizePageExtensions(),
       resolveExtensions: null,
+      serverResolveExtensions: null,
       cacheComponents: false,
       gestureTransition: false,
       prefetchInlining: false,
@@ -1316,9 +1319,9 @@ export async function resolveNextConfig(
     headers = await config.headers();
   }
 
-  // Probe wrapped webpack config once so alias extraction and MDX extraction
-  // observe the same mock environment.
-  const webpackProbe = await probeWebpackConfig(config, root);
+  // Probe wrapped webpack config for client and server resolution. Alias and
+  // MDX extraction use the client result, matching the previous behavior.
+  const webpackProbe = await probeWebpackConfig(config, root, options.dev ?? false);
   const mdx = webpackProbe.mdx;
   const aliases = {
     ...extractTurboAliases(config, root),
@@ -1455,10 +1458,13 @@ export async function resolveNextConfig(
   }
 
   const pageExtensions = normalizePageExtensions(config.pageExtensions);
+  const experimentalTurbo = readOptionalRecord(experimental?.turbo);
   const turbopack = readOptionalRecord(config.turbopack);
   const resolveExtensions = Array.isArray(turbopack?.resolveExtensions)
     ? readStringArray(turbopack.resolveExtensions)
-    : null;
+    : Array.isArray(experimentalTurbo?.resolveExtensions)
+      ? readStringArray(experimentalTurbo.resolveExtensions)
+      : null;
 
   // Parse i18n config
   let i18n: NextI18nConfig | null = null;
@@ -1508,6 +1514,7 @@ export async function resolveNextConfig(
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,
     resolveExtensions: resolveExtensions ?? webpackProbe.resolveExtensions,
+    serverResolveExtensions: resolveExtensions ?? webpackProbe.serverResolveExtensions,
     instrumentationClientInject: Array.isArray(config.instrumentationClientInject)
       ? (config.instrumentationClientInject as unknown[]).filter(
           (x): x is string => typeof x === "string",
@@ -1640,10 +1647,12 @@ function extractTurboAliases(config: NextConfig, root: string): Record<string, s
 async function probeWebpackConfig(
   config: NextConfig,
   root: string,
+  dev: boolean,
 ): Promise<{
   aliases: Record<string, string>;
   mdx: MdxOptions | null;
   resolveExtensions: string[] | null;
+  serverResolveExtensions: string[] | null;
   resolveExtensionsCustomized: boolean;
 }> {
   if (typeof config.webpack !== "function") {
@@ -1651,39 +1660,18 @@ async function probeWebpackConfig(
       aliases: {},
       mdx: null,
       resolveExtensions: null,
+      serverResolveExtensions: null,
       resolveExtensionsCustomized: false,
     };
   }
 
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const mockModuleRules: any[] = [];
-  const mockResolve: { alias: Record<string, unknown>; extensions: string[] } = {
-    alias: {},
-    // Match Next.js' webpack defaults so callbacks that spread or mutate the
-    // existing list observe the same starting point.
-    extensions: [".js", ".mjs", ".tsx", ".ts", ".jsx", ".json", ".wasm"],
-  };
-  const defaultResolveExtensions = [...mockResolve.extensions];
-  const mockConfig = {
-    context: root,
-    resolve: mockResolve,
-    module: { rules: mockModuleRules },
-    // oxlint-disable-next-line typescript/no-explicit-any
-    plugins: [] as any[],
-  };
-  const mockOptions = {
-    defaultLoaders: { babel: { loader: "next-babel-loader" } },
-    isServer: false,
-    dev: false,
-    dir: root,
-  };
-
   try {
-    // oxlint-disable-next-line typescript/no-unsafe-function-type
-    const result = await (config.webpack as Function)(mockConfig, mockOptions);
-    const finalConfig = result ?? mockConfig;
-    // oxlint-disable-next-line typescript/no-explicit-any
-    const rules: any[] = finalConfig.module?.rules ?? mockModuleRules;
+    const clientProbe = await runWebpackConfigProbe(config, root, { dev, isServer: false });
+    const serverProbe = await runWebpackConfigProbe(config, root, {
+      dev,
+      isServer: true,
+      nextRuntime: "nodejs",
+    });
     // Invoke loader callbacks for any side effects on `process.env`.
     // Next.js webpack loaders sometimes mutate `process.env.X = ...` at
     // compile time (see issue #1500), and vinext otherwise never sees the
@@ -1691,30 +1679,74 @@ async function probeWebpackConfig(
     // loader once with a dummy source lets build-time env mutations land in
     // the shared Node process so they become visible to defines and
     // server-side code during the same build.
-    invokeLoaderSideEffects(rules, root);
-    const resolveExtensions = Array.isArray(finalConfig.resolve?.extensions)
-      ? readStringArray(finalConfig.resolve.extensions)
-      : null;
-    const resolveExtensionsCustomized =
-      resolveExtensions !== null &&
-      (resolveExtensions.length !== defaultResolveExtensions.length ||
-        resolveExtensions.some(
-          (extension, index) => extension !== defaultResolveExtensions[index],
-        ));
+    invokeLoaderSideEffects(clientProbe.rules, root);
     return {
-      aliases: normalizeAliasEntries(finalConfig.resolve?.alias, root),
-      mdx: extractMdxOptionsFromRules(rules),
-      resolveExtensions: resolveExtensionsCustomized ? resolveExtensions : null,
-      resolveExtensionsCustomized,
+      aliases: normalizeAliasEntries(clientProbe.config.resolve?.alias, root),
+      mdx: extractMdxOptionsFromRules(clientProbe.rules),
+      resolveExtensions: clientProbe.resolveExtensions,
+      serverResolveExtensions: serverProbe.resolveExtensions,
+      resolveExtensionsCustomized:
+        clientProbe.resolveExtensions !== null || serverProbe.resolveExtensions !== null,
     };
   } catch {
     return {
       aliases: {},
       mdx: null,
       resolveExtensions: null,
+      serverResolveExtensions: null,
       resolveExtensionsCustomized: false,
     };
   }
+}
+
+const DEFAULT_WEBPACK_RESOLVE_EXTENSIONS = [".js", ".mjs", ".tsx", ".ts", ".jsx", ".json", ".wasm"];
+
+async function runWebpackConfigProbe(
+  config: NextConfig,
+  root: string,
+  options: { dev: boolean; isServer: boolean; nextRuntime?: "nodejs" | "edge" },
+): Promise<{
+  // oxlint-disable-next-line typescript/no-explicit-any
+  config: any;
+  // oxlint-disable-next-line typescript/no-explicit-any
+  rules: any[];
+  resolveExtensions: string[] | null;
+}> {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const rules: any[] = [];
+  const mockConfig = {
+    context: root,
+    resolve: {
+      alias: {} as Record<string, unknown>,
+      extensions: [...DEFAULT_WEBPACK_RESOLVE_EXTENSIONS],
+    },
+    module: { rules },
+    // oxlint-disable-next-line typescript/no-explicit-any
+    plugins: [] as any[],
+  };
+  // oxlint-disable-next-line typescript/no-unsafe-function-type
+  const result = await (config.webpack as Function)(mockConfig, {
+    defaultLoaders: { babel: { loader: "next-babel-loader" } },
+    ...options,
+    dir: root,
+  });
+  const finalConfig = result ?? mockConfig;
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const finalRules: any[] = finalConfig.module?.rules ?? rules;
+  const extensions = Array.isArray(finalConfig.resolve?.extensions)
+    ? readStringArray(finalConfig.resolve.extensions)
+    : null;
+  const customized =
+    extensions !== null &&
+    (extensions.length !== DEFAULT_WEBPACK_RESOLVE_EXTENSIONS.length ||
+      extensions.some(
+        (extension, index) => extension !== DEFAULT_WEBPACK_RESOLVE_EXTENSIONS[index],
+      ));
+  return {
+    config: finalConfig,
+    rules: finalRules,
+    resolveExtensions: customized ? extensions : null,
+  };
 }
 
 /**
@@ -1834,7 +1866,7 @@ export async function extractMdxOptions(
   config: NextConfig,
   root: string = process.cwd(),
 ): Promise<MdxOptions | null> {
-  return (await probeWebpackConfig(config, root)).mdx;
+  return (await probeWebpackConfig(config, root, false)).mdx;
 }
 
 /**

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1663,7 +1663,7 @@ async function probeWebpackConfig(
     // existing list observe the same starting point.
     extensions: [".js", ".mjs", ".tsx", ".ts", ".jsx", ".json", ".wasm"],
   };
-  const defaultResolveExtensions = mockResolve.extensions;
+  const defaultResolveExtensions = [...mockResolve.extensions];
   const mockConfig = {
     context: root,
     resolve: mockResolve,
@@ -1692,11 +1692,20 @@ async function probeWebpackConfig(
     // the shared Node process so they become visible to defines and
     // server-side code during the same build.
     invokeLoaderSideEffects(rules, root);
+    const resolveExtensions = Array.isArray(finalConfig.resolve?.extensions)
+      ? readStringArray(finalConfig.resolve.extensions)
+      : null;
+    const resolveExtensionsCustomized =
+      resolveExtensions !== null &&
+      (resolveExtensions.length !== defaultResolveExtensions.length ||
+        resolveExtensions.some(
+          (extension, index) => extension !== defaultResolveExtensions[index],
+        ));
     return {
       aliases: normalizeAliasEntries(finalConfig.resolve?.alias, root),
       mdx: extractMdxOptionsFromRules(rules),
-      resolveExtensions: readStringArray(finalConfig.resolve?.extensions),
-      resolveExtensionsCustomized: finalConfig.resolve?.extensions !== defaultResolveExtensions,
+      resolveExtensions: resolveExtensionsCustomized ? resolveExtensions : null,
+      resolveExtensionsCustomized,
     };
   } catch {
     return {

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -214,6 +214,12 @@ export type NextConfig = {
   output?: "export" | "standalone";
   /** File extensions treated as routable pages/routes (Next.js pageExtensions) */
   pageExtensions?: string[];
+  /** Turbopack-compatible module resolution options. */
+  turbopack?: {
+    resolveAlias?: Record<string, unknown>;
+    resolveExtensions?: string[];
+    [key: string]: unknown;
+  };
   /**
    * Module specifiers that are required for side effects on the client before
    * hydration, in array order, ahead of the user's `instrumentation-client.{ts,js}`.
@@ -335,6 +341,7 @@ export type ResolvedNextConfig = {
   trailingSlash: boolean;
   output: "" | "export" | "standalone";
   pageExtensions: string[];
+  resolveExtensions: string[];
   instrumentationClientInject: string[];
   cacheComponents: boolean;
   /**
@@ -1211,6 +1218,7 @@ export async function resolveNextConfig(
       trailingSlash: false,
       output: "",
       pageExtensions: normalizePageExtensions(),
+      resolveExtensions: [],
       cacheComponents: false,
       gestureTransition: false,
       prefetchInlining: false,
@@ -1443,6 +1451,8 @@ export async function resolveNextConfig(
   }
 
   const pageExtensions = normalizePageExtensions(config.pageExtensions);
+  const turbopack = readOptionalRecord(config.turbopack);
+  const resolveExtensions = readStringArray(turbopack?.resolveExtensions);
 
   // Parse i18n config
   let i18n: NextI18nConfig | null = null;
@@ -1491,6 +1501,8 @@ export async function resolveNextConfig(
     trailingSlash: config.trailingSlash ?? false,
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,
+    resolveExtensions:
+      resolveExtensions.length > 0 ? resolveExtensions : webpackProbe.resolveExtensions,
     instrumentationClientInject: Array.isArray(config.instrumentationClientInject)
       ? (config.instrumentationClientInject as unknown[]).filter(
           (x): x is string => typeof x === "string",
@@ -1623,14 +1635,18 @@ function extractTurboAliases(config: NextConfig, root: string): Record<string, s
 async function probeWebpackConfig(
   config: NextConfig,
   root: string,
-): Promise<{ aliases: Record<string, string>; mdx: MdxOptions | null }> {
+): Promise<{
+  aliases: Record<string, string>;
+  mdx: MdxOptions | null;
+  resolveExtensions: string[];
+}> {
   if (typeof config.webpack !== "function") {
-    return { aliases: {}, mdx: null };
+    return { aliases: {}, mdx: null, resolveExtensions: [] };
   }
 
   // oxlint-disable-next-line typescript/no-explicit-any
   const mockModuleRules: any[] = [];
-  const mockResolve: { alias: Record<string, unknown> } = { alias: {} };
+  const mockResolve: { alias: Record<string, unknown>; extensions?: unknown } = { alias: {} };
   const mockConfig = {
     context: root,
     resolve: mockResolve,
@@ -1662,9 +1678,10 @@ async function probeWebpackConfig(
     return {
       aliases: normalizeAliasEntries(finalConfig.resolve?.alias, root),
       mdx: extractMdxOptionsFromRules(rules),
+      resolveExtensions: readStringArray(finalConfig.resolve?.extensions),
     };
   } catch {
-    return { aliases: {}, mdx: null };
+    return { aliases: {}, mdx: null, resolveExtensions: [] };
   }
 }
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -341,7 +341,7 @@ export type ResolvedNextConfig = {
   trailingSlash: boolean;
   output: "" | "export" | "standalone";
   pageExtensions: string[];
-  resolveExtensions: string[];
+  resolveExtensions: string[] | null;
   instrumentationClientInject: string[];
   cacheComponents: boolean;
   /**
@@ -1218,7 +1218,7 @@ export async function resolveNextConfig(
       trailingSlash: false,
       output: "",
       pageExtensions: normalizePageExtensions(),
-      resolveExtensions: [],
+      resolveExtensions: null,
       cacheComponents: false,
       gestureTransition: false,
       prefetchInlining: false,
@@ -1430,13 +1430,17 @@ export async function resolveNextConfig(
     );
   }
 
-  // Warn about unsupported webpack usage. We preserve alias injection and
-  // extract MDX settings, but all other webpack customization is still ignored.
+  // Warn about unsupported webpack usage. We preserve alias injection,
+  // resolve.extensions, and MDX settings, but other customization is ignored.
   if (config.webpack !== undefined) {
-    if (mdx || Object.keys(webpackProbe.aliases).length > 0) {
+    if (
+      mdx ||
+      Object.keys(webpackProbe.aliases).length > 0 ||
+      webpackProbe.resolveExtensionsCustomized
+    ) {
       console.warn(
         '[vinext] next.config option "webpack" is only partially supported. ' +
-          "vinext preserves resolve.alias entries and MDX loader settings, but other webpack customization is ignored",
+          "vinext preserves resolve.alias, resolve.extensions, and MDX loader settings, but other webpack customization is ignored",
       );
     } else {
       console.warn(
@@ -1452,7 +1456,9 @@ export async function resolveNextConfig(
 
   const pageExtensions = normalizePageExtensions(config.pageExtensions);
   const turbopack = readOptionalRecord(config.turbopack);
-  const resolveExtensions = readStringArray(turbopack?.resolveExtensions);
+  const resolveExtensions = Array.isArray(turbopack?.resolveExtensions)
+    ? readStringArray(turbopack.resolveExtensions)
+    : null;
 
   // Parse i18n config
   let i18n: NextI18nConfig | null = null;
@@ -1501,8 +1507,7 @@ export async function resolveNextConfig(
     trailingSlash: config.trailingSlash ?? false,
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,
-    resolveExtensions:
-      resolveExtensions.length > 0 ? resolveExtensions : webpackProbe.resolveExtensions,
+    resolveExtensions: resolveExtensions ?? webpackProbe.resolveExtensions,
     instrumentationClientInject: Array.isArray(config.instrumentationClientInject)
       ? (config.instrumentationClientInject as unknown[]).filter(
           (x): x is string => typeof x === "string",
@@ -1638,15 +1643,27 @@ async function probeWebpackConfig(
 ): Promise<{
   aliases: Record<string, string>;
   mdx: MdxOptions | null;
-  resolveExtensions: string[];
+  resolveExtensions: string[] | null;
+  resolveExtensionsCustomized: boolean;
 }> {
   if (typeof config.webpack !== "function") {
-    return { aliases: {}, mdx: null, resolveExtensions: [] };
+    return {
+      aliases: {},
+      mdx: null,
+      resolveExtensions: null,
+      resolveExtensionsCustomized: false,
+    };
   }
 
   // oxlint-disable-next-line typescript/no-explicit-any
   const mockModuleRules: any[] = [];
-  const mockResolve: { alias: Record<string, unknown>; extensions?: unknown } = { alias: {} };
+  const mockResolve: { alias: Record<string, unknown>; extensions: string[] } = {
+    alias: {},
+    // Match Next.js' webpack defaults so callbacks that spread or mutate the
+    // existing list observe the same starting point.
+    extensions: [".js", ".mjs", ".tsx", ".ts", ".jsx", ".json", ".wasm"],
+  };
+  const defaultResolveExtensions = mockResolve.extensions;
   const mockConfig = {
     context: root,
     resolve: mockResolve,
@@ -1679,9 +1696,15 @@ async function probeWebpackConfig(
       aliases: normalizeAliasEntries(finalConfig.resolve?.alias, root),
       mdx: extractMdxOptionsFromRules(rules),
       resolveExtensions: readStringArray(finalConfig.resolve?.extensions),
+      resolveExtensionsCustomized: finalConfig.resolve?.extensions !== defaultResolveExtensions,
     };
   } catch {
-    return { aliases: {}, mdx: null, resolveExtensions: [] };
+    return {
+      aliases: {},
+      mdx: null,
+      resolveExtensions: null,
+      resolveExtensionsCustomized: false,
+    };
   }
 }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1232,7 +1232,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           } else {
             rawConfig = await loadNextConfig(root, phase);
           }
-          nextConfig = await resolveNextConfig(rawConfig, root);
+          nextConfig = await resolveNextConfig(rawConfig, root, {
+            dev: env?.command !== "build",
+          });
 
           // Build-ID coordination across plugin instances.
           //
@@ -1930,14 +1932,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               ...nextConfig.aliases,
               ...nextShimMap,
             },
-            // Prefer Next.js module resolver extensions, falling back to
-            // pageExtensions when none are configured. This supports imports
-            // such as `./image` resolving to `./image.png`, as exercised by
-            // Next.js' resolve-extensions deploy suite.
-            extensions:
-              nextConfig.resolveExtensions === null
-                ? buildViteResolveExtensions(nextConfig.pageExtensions)
-                : normalizeViteResolveExtensions(nextConfig.resolveExtensions),
             // Dedupe React packages to prevent dual-instance errors.
             // When vinext is linked (npm link / bun link) or any dependency
             // brings its own React copy, multiple React instances can load,
@@ -2396,6 +2390,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
 
         return viteConfig;
+      },
+
+      configEnvironment(name, config) {
+        const configuredExtensions =
+          name === "client" ? nextConfig.resolveExtensions : nextConfig.serverResolveExtensions;
+        const extensions =
+          configuredExtensions === null
+            ? buildViteResolveExtensions(nextConfig.pageExtensions, config.resolve?.extensions)
+            : normalizeViteResolveExtensions(configuredExtensions);
+        config.resolve ??= {};
+        config.resolve.extensions = extensions;
+        return null;
       },
 
       configResolved(config) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -19,6 +19,7 @@ import { appRouteGraph, appRouter, invalidateAppRouteCache } from "./routing/app
 import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import {
   buildViteResolveExtensions,
+  normalizeViteResolveExtensions,
   createValidFileMatcher,
   findFileWithExts,
 } from "./routing/file-matcher.js";
@@ -1933,11 +1934,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // pageExtensions when none are configured. This supports imports
             // such as `./image` resolving to `./image.png`, as exercised by
             // Next.js' resolve-extensions deploy suite.
-            extensions: buildViteResolveExtensions(
-              nextConfig.resolveExtensions.length > 0
-                ? nextConfig.resolveExtensions
-                : nextConfig.pageExtensions,
-            ),
+            extensions:
+              nextConfig.resolveExtensions === null
+                ? buildViteResolveExtensions(nextConfig.pageExtensions)
+                : normalizeViteResolveExtensions(nextConfig.resolveExtensions),
             // Dedupe React packages to prevent dual-instance errors.
             // When vinext is linked (npm link / bun link) or any dependency
             // brings its own React copy, multiple React instances can load,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1162,12 +1162,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             process.env[key] = value;
           }
         }
-        // Align NODE_ENV with Next.js semantics: build -> production, serve -> development.
-        // Next.js unconditionally forces NODE_ENV during build/dev, so we do the same.
+        // Align NODE_ENV with Next.js semantics: build/preview -> production,
+        // development server -> development. Next.js unconditionally forces
+        // NODE_ENV during build/dev, so we do the same.
         let resolvedNodeEnv: string;
         if (mode === "test") {
           resolvedNodeEnv = "test";
-        } else if (env?.command === "build") {
+        } else if (env?.command === "build" || env?.isPreview === true) {
           resolvedNodeEnv = "production";
         } else {
           resolvedNodeEnv = "development";
@@ -1233,7 +1234,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             rawConfig = await loadNextConfig(root, phase);
           }
           nextConfig = await resolveNextConfig(rawConfig, root, {
-            dev: env?.command !== "build",
+            dev: env?.command === "serve" && env?.isPreview !== true,
           });
 
           // Build-ID coordination across plugin instances.

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1929,13 +1929,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               ...nextConfig.aliases,
               ...nextShimMap,
             },
-            // Mirror Next.js `pageExtensions` into Vite's `resolve.extensions`
-            // so extensionless imports of files with custom extensions
-            // (`.mdx`, `.platform.tsx`, `.web.tsx`, etc.) resolve. Without
-            // this the build crashes with "Custom deploy script failed:
-            // undefined (1)" when the user configures pageExtensions beyond
-            // Vite's default set. See cloudflare/vinext#1502.
-            extensions: buildViteResolveExtensions(nextConfig.pageExtensions),
+            // Prefer Next.js module resolver extensions, falling back to
+            // pageExtensions when none are configured. This supports imports
+            // such as `./image` resolving to `./image.png`, as exercised by
+            // Next.js' resolve-extensions deploy suite.
+            extensions: buildViteResolveExtensions(
+              nextConfig.resolveExtensions.length > 0
+                ? nextConfig.resolveExtensions
+                : nextConfig.pageExtensions,
+            ),
             // Dedupe React packages to prevent dual-instance errors.
             // When vinext is linked (npm link / bun link) or any dependency
             // brings its own React copy, multiple React instances can load,

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -140,6 +140,28 @@ export function buildViteResolveExtensions(
 }
 
 /**
+ * Normalize an explicit Next.js resolver extension list for Vite.
+ *
+ * Unlike `pageExtensions`, both Turbopack's `resolveExtensions` and webpack's
+ * `resolve.extensions` replace their resolver defaults. The empty string is a
+ * webpack/Turbopack convention for trying the import exactly as written; Vite
+ * already does that before appending extensions, so it must be omitted here.
+ */
+export function normalizeViteResolveExtensions(extensions: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const extension of extensions) {
+    const trimmed = extension.trim();
+    if (!trimmed) continue;
+    const dotted = trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+    if (seen.has(dotted)) continue;
+    seen.add(dotted);
+    result.push(dotted);
+  }
+  return result;
+}
+
+/**
  * Use function-form exclude for Node < 22.14 compatibility.
  */
 export async function* scanWithExtensions(

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -641,6 +641,22 @@ describe("process.env.NODE_ENV define", () => {
     }
   }, 15000);
 
+  it("is injected as production for preview", async () => {
+    const { mainPlugin, tmpDir, fsp } = await setupTmpProject();
+    try {
+      const mockConfig = { root: tmpDir, build: {}, plugins: [] };
+      const result = await mainPlugin.config(mockConfig, {
+        command: "serve",
+        mode: "production",
+        isPreview: true,
+      });
+
+      expect(result.define?.["process.env.NODE_ENV"]).toBe(JSON.stringify("production"));
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
   it("respects user-defined process.env.NODE_ENV in config.define", async () => {
     const { mainPlugin, tmpDir, fsp } = await setupTmpProject();
     try {

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -784,6 +784,7 @@ describe("resolveNextConfig alias extraction", () => {
       },
     });
     expect(fallback.resolveExtensions).toEqual(["", ".png", ".jsx", ".js"]);
+    expect(fallback.serverResolveExtensions).toEqual(["", ".png", ".jsx", ".js"]);
 
     const preferred = await resolveNextConfig({
       turbopack: { resolveExtensions: ["", ".web.tsx", ".tsx"] },
@@ -793,6 +794,7 @@ describe("resolveNextConfig alias extraction", () => {
       },
     });
     expect(preferred.resolveExtensions).toEqual(["", ".web.tsx", ".tsx"]);
+    expect(preferred.serverResolveExtensions).toEqual(["", ".web.tsx", ".tsx"]);
 
     const explicitlyEmpty = await resolveNextConfig({
       turbopack: { resolveExtensions: [] },
@@ -802,6 +804,26 @@ describe("resolveNextConfig alias extraction", () => {
       },
     });
     expect(explicitlyEmpty.resolveExtensions).toEqual([]);
+    expect(explicitlyEmpty.serverResolveExtensions).toEqual([]);
+  });
+
+  it("supports legacy experimental.turbo resolveExtensions", async () => {
+    const legacy = await resolveNextConfig({
+      experimental: {
+        turbo: { resolveExtensions: ["", ".legacy.ts", ".ts"] },
+      },
+    });
+    expect(legacy.resolveExtensions).toEqual(["", ".legacy.ts", ".ts"]);
+    expect(legacy.serverResolveExtensions).toEqual(["", ".legacy.ts", ".ts"]);
+
+    const preferred = await resolveNextConfig({
+      experimental: {
+        turbo: { resolveExtensions: ["", ".legacy.ts", ".ts"] },
+      },
+      turbopack: { resolveExtensions: ["", ".modern.ts", ".ts"] },
+    });
+    expect(preferred.resolveExtensions).toEqual(["", ".modern.ts", ".ts"]);
+    expect(preferred.serverResolveExtensions).toEqual(["", ".modern.ts", ".ts"]);
   });
 
   it("provides Next.js webpack defaults to resolve.extensions callbacks", async () => {
@@ -857,6 +879,25 @@ describe("resolveNextConfig alias extraction", () => {
       ".json",
       ".wasm",
     ]);
+  });
+
+  it("preserves client/server and dev/build webpack resolve.extensions", async () => {
+    const webpack = (webpackConfig: any, options: any) => {
+      webpackConfig.resolve.extensions = [
+        options.isServer ? ".server.ts" : ".client.ts",
+        options.dev ? ".dev.ts" : ".prod.ts",
+        ".ts",
+      ];
+      return webpackConfig;
+    };
+
+    const build = await resolveNextConfig({ webpack });
+    expect(build.resolveExtensions).toEqual([".client.ts", ".prod.ts", ".ts"]);
+    expect(build.serverResolveExtensions).toEqual([".server.ts", ".prod.ts", ".ts"]);
+
+    const dev = await resolveNextConfig({ webpack }, process.cwd(), { dev: true });
+    expect(dev.resolveExtensions).toEqual([".client.ts", ".dev.ts", ".ts"]);
+    expect(dev.serverResolveExtensions).toEqual([".server.ts", ".dev.ts", ".ts"]);
   });
 
   let tmpDir: string;
@@ -1122,14 +1163,14 @@ module.exports = withPlugin({ basePath: "/wrapped" });`,
     }
   });
 
-  it("extracts aliases and mdx from a single async webpack probe", async () => {
+  it("extracts aliases and mdx while probing client and server webpack configs", async () => {
     tmpDir = makeTempDir();
 
-    let invocations = 0;
+    const invocations: boolean[] = [];
     const fakeRemarkPlugin = () => {};
     const rawConfig = {
-      webpack: async (webpackConfig: any) => {
-        invocations++;
+      webpack: async (webpackConfig: any, options: any) => {
+        invocations.push(options.isServer);
         webpackConfig.resolve = webpackConfig.resolve || {};
         webpackConfig.resolve.alias = webpackConfig.resolve.alias || {};
         webpackConfig.resolve.alias["wrapped/config"] = "./config/request.ts";
@@ -1151,7 +1192,7 @@ module.exports = withPlugin({ basePath: "/wrapped" });`,
 
     const config = await resolveNextConfig(rawConfig, tmpDir);
 
-    expect(invocations).toBe(1);
+    expect(invocations).toEqual([false, true]);
     expect(config.aliases["wrapped/config"]).toBe(path.join(tmpDir, "config", "request.ts"));
     expect(config.mdx?.remarkPlugins).toEqual([fakeRemarkPlugin]);
   });
@@ -1728,6 +1769,7 @@ describe("detectNextIntlConfig", () => {
       output: "",
       pageExtensions: ["tsx", "ts", "jsx", "js"],
       resolveExtensions: null,
+      serverResolveExtensions: null,
       cacheComponents: false,
       gestureTransition: false,
       prefetchInlining: false,

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -793,6 +793,34 @@ describe("resolveNextConfig alias extraction", () => {
       },
     });
     expect(preferred.resolveExtensions).toEqual(["", ".web.tsx", ".tsx"]);
+
+    const explicitlyEmpty = await resolveNextConfig({
+      turbopack: { resolveExtensions: [] },
+      webpack(webpackConfig: any) {
+        webpackConfig.resolve.extensions = [".png"];
+        return webpackConfig;
+      },
+    });
+    expect(explicitlyEmpty.resolveExtensions).toEqual([]);
+  });
+
+  it("provides Next.js webpack defaults to resolve.extensions callbacks", async () => {
+    const resolved = await resolveNextConfig({
+      webpack(webpackConfig: any) {
+        webpackConfig.resolve.extensions = [".web.tsx", ...webpackConfig.resolve.extensions];
+        return webpackConfig;
+      },
+    });
+    expect(resolved.resolveExtensions).toEqual([
+      ".web.tsx",
+      ".js",
+      ".mjs",
+      ".tsx",
+      ".ts",
+      ".jsx",
+      ".json",
+      ".wasm",
+    ]);
   });
 
   let tmpDir: string;
@@ -1663,7 +1691,7 @@ describe("detectNextIntlConfig", () => {
       trailingSlash: false,
       output: "",
       pageExtensions: ["tsx", "ts", "jsx", "js"],
-      resolveExtensions: [],
+      resolveExtensions: null,
       cacheComponents: false,
       gestureTransition: false,
       prefetchInlining: false,

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -776,6 +776,25 @@ describe("loadNextConfig with tsconfig path aliases", () => {
 });
 
 describe("resolveNextConfig alias extraction", () => {
+  it("prefers turbopack resolveExtensions and falls back to webpack extensions", async () => {
+    const fallback = await resolveNextConfig({
+      webpack(webpackConfig: any) {
+        webpackConfig.resolve.extensions = ["", ".png", ".jsx", ".js"];
+        return webpackConfig;
+      },
+    });
+    expect(fallback.resolveExtensions).toEqual(["", ".png", ".jsx", ".js"]);
+
+    const preferred = await resolveNextConfig({
+      turbopack: { resolveExtensions: ["", ".web.tsx", ".tsx"] },
+      webpack(webpackConfig: any) {
+        webpackConfig.resolve.extensions = ["", ".png", ".js"];
+        return webpackConfig;
+      },
+    });
+    expect(preferred.resolveExtensions).toEqual(["", ".web.tsx", ".tsx"]);
+  });
+
   let tmpDir: string;
 
   afterEach(() => {
@@ -1644,6 +1663,7 @@ describe("detectNextIntlConfig", () => {
       trailingSlash: false,
       output: "",
       pageExtensions: ["tsx", "ts", "jsx", "js"],
+      resolveExtensions: [],
       cacheComponents: false,
       gestureTransition: false,
       prefetchInlining: false,

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -823,6 +823,42 @@ describe("resolveNextConfig alias extraction", () => {
     ]);
   });
 
+  it("ignores untouched webpack resolve.extensions defaults", async () => {
+    const untouched = await resolveNextConfig({
+      webpack(webpackConfig: any) {
+        return webpackConfig;
+      },
+    });
+    expect(untouched.resolveExtensions).toBeNull();
+
+    const copied = await resolveNextConfig({
+      webpack(webpackConfig: any) {
+        webpackConfig.resolve.extensions = [...webpackConfig.resolve.extensions];
+        return webpackConfig;
+      },
+    });
+    expect(copied.resolveExtensions).toBeNull();
+  });
+
+  it("captures in-place webpack resolve.extensions mutations", async () => {
+    const resolved = await resolveNextConfig({
+      webpack(webpackConfig: any) {
+        webpackConfig.resolve.extensions.unshift(".web.tsx");
+        return webpackConfig;
+      },
+    });
+    expect(resolved.resolveExtensions).toEqual([
+      ".web.tsx",
+      ".js",
+      ".mjs",
+      ".tsx",
+      ".ts",
+      ".jsx",
+      ".json",
+      ".wasm",
+    ]);
+  });
+
   let tmpDir: string;
 
   afterEach(() => {

--- a/tests/page-extensions-resolve.test.ts
+++ b/tests/page-extensions-resolve.test.ts
@@ -291,4 +291,39 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);
+
+  it("uses production webpack extensions during Vite preview", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
+      // oxlint-disable-next-line typescript/no-explicit-any
+      (plugin: any) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-preview-extensions-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fs.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export default function Page() { return <p>hello</p>; }`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default { webpack(config, { dev }) { config.resolve.extensions = [dev ? ".dev.ts" : ".prod.ts", ".ts"]; return config; } };`,
+    );
+
+    try {
+      await (mainPlugin as any).config(
+        { root: tmpDir, build: {}, plugins: [] },
+        { command: "serve", mode: "production", isPreview: true },
+      );
+      const environmentConfig: any = { resolve: {} };
+      (mainPlugin as any).configEnvironment("client", environmentConfig);
+      expect(environmentConfig.resolve.extensions).toEqual([".prod.ts", ".ts"]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
 });

--- a/tests/page-extensions-resolve.test.ts
+++ b/tests/page-extensions-resolve.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs/promises";
+import { createBuilder } from "vite";
 import { describe, expect, it } from "vite-plus/test";
 import { buildViteResolveExtensions } from "../packages/vinext/src/routing/file-matcher.js";
 
@@ -8,7 +9,7 @@ import { buildViteResolveExtensions } from "../packages/vinext/src/routing/file-
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resolve-extensions/
 //
 // When users configure custom extensions via `pageExtensions` or
-// `turbopack.resolveExtensions` (e.g. `.platform.tsx` or `.mdx`), Vite must
+// `turbopack.resolveExtensions` (e.g. `.platform.tsx`, `.mdx`, or `.png`), Vite must
 // know to attempt those extensions when resolving extensionless imports.
 // Otherwise extensionless imports of files with those custom extensions
 // fail to resolve and the build crashes.
@@ -108,6 +109,96 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
       // so a bare `./Component` import lands on `Component.platform.tsx`
       // (mirrors Next.js / Turbopack resolveExtensions semantics).
       expect(extensions.indexOf(".platform.tsx")).toBeLessThan(extensions.indexOf(".tsx"));
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("builds the Next.js resolve-extensions fixture for server and client graphs", async () => {
+    // Ported from Next.js: test/e2e/app-dir/resolve-extensions/resolve-extensions.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resolve-extensions/resolve-extensions.test.ts
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-resolve-extensions-build-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fs.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "app", "image.png"),
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEAQH/2p5WAAAAAElFTkSuQmCC",
+        "base64",
+      ),
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "resolve-extensions-fixture", private: true, type: "module" }),
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default { turbopack: { resolveExtensions: ["", ".png", ".tsx", ".ts", ".jsx", ".js", ".json"] } };`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      `export default function Layout({ children }) { return <html><body>{children}</body></html>; }`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "app", "component.jsx"),
+      `'use client'; import image from './image'; import Image from 'next/image'; export default function Component() { return <p><Image src={image} alt="hello image 2" />hello world{typeof window !== 'undefined' ? 'hello client' : 'hello server'}</p>; }`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "app", "page.jsx"),
+      `import image from './image'; import Image from 'next/image'; import Component from './component'; export default function Page() { return <p><Image src={image} alt="hello image 1" /><Component /></p>; }`,
+    );
+
+    try {
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+      await expect(fs.stat(path.join(tmpDir, "dist", "client"))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(tmpDir, "dist", "server"))).resolves.toBeDefined();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 30000);
+
+  it("forwards turbopack.resolveExtensions for extensionless asset imports", async () => {
+    // Ported from Next.js: test/e2e/app-dir/resolve-extensions/resolve-extensions.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resolve-extensions/resolve-extensions.test.ts
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const mainPlugin = plugins.find(
+      // oxlint-disable-next-line typescript/no-explicit-any
+      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-resolve-extensions-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fs.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "app", "page.jsx"),
+      `import image from "./image"; export default function Page() { return image.src; }`,
+    );
+    await fs.writeFile(path.join(tmpDir, "app", "image.png"), "fixture");
+    await fs.writeFile(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default { turbopack: { resolveExtensions: ["", ".png", ".tsx", ".ts", ".jsx", ".js", ".json"] } };`,
+    );
+
+    try {
+      const mockConfig = { root: tmpDir, build: {}, plugins: [] };
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const extensions: string[] = result.resolve?.extensions ?? [];
+      expect(extensions[0]).toBe(".png");
+      expect(extensions).toContain(".jsx");
+      expect(extensions).not.toContain("");
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/page-extensions-resolve.test.ts
+++ b/tests/page-extensions-resolve.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import fs from "node:fs/promises";
 import { createBuilder } from "vite";
 import { describe, expect, it } from "vite-plus/test";
-import { buildViteResolveExtensions } from "../packages/vinext/src/routing/file-matcher.js";
+import {
+  buildViteResolveExtensions,
+  normalizeViteResolveExtensions,
+} from "../packages/vinext/src/routing/file-matcher.js";
 
 // Ported in spirit from Next.js: test/e2e/app-dir/resolve-extensions/
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resolve-extensions/
@@ -60,6 +63,16 @@ describe("buildViteResolveExtensions", () => {
     const extensions = buildViteResolveExtensions([".platform.tsx", " tsx ", ""]);
     expect(extensions[0]).toBe(".platform.tsx");
     expect(extensions).toContain(".tsx");
+  });
+});
+
+describe("normalizeViteResolveExtensions", () => {
+  it("treats explicit resolver extensions as a replacement list", () => {
+    expect(normalizeViteResolveExtensions(["", ".png", ".web.tsx", ".tsx"])).toEqual([
+      ".png",
+      ".web.tsx",
+      ".tsx",
+    ]);
   });
 });
 
@@ -135,7 +148,7 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
     );
     await fs.writeFile(
       path.join(tmpDir, "next.config.mjs"),
-      `export default { turbopack: { resolveExtensions: ["", ".png", ".tsx", ".ts", ".jsx", ".js", ".json"] } };`,
+      `export default { turbopack: { resolveExtensions: ["", ".png", ".web.tsx", ".tsx", ".ts", ".jsx", ".js", ".json"] } };`,
     );
     await fs.writeFile(
       path.join(tmpDir, "app", "layout.tsx"),
@@ -146,8 +159,16 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
       `'use client'; import image from './image'; import Image from 'next/image'; export default function Component() { return <p><Image src={image} alt="hello image 2" />hello world{typeof window !== 'undefined' ? 'hello client' : 'hello server'}</p>; }`,
     );
     await fs.writeFile(
+      path.join(tmpDir, "app", "PlatformComponent.web.tsx"),
+      `export default function PlatformComponent() { return <span>hello web platform</span>; }`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "app", "PlatformComponent.tsx"),
+      `export default function PlatformComponent() { return <span>hello default platform</span>; }`,
+    );
+    await fs.writeFile(
       path.join(tmpDir, "app", "page.jsx"),
-      `import image from './image'; import Image from 'next/image'; import Component from './component'; export default function Page() { return <p><Image src={image} alt="hello image 1" /><Component /></p>; }`,
+      `import image from './image'; import Image from 'next/image'; import Component from './component'; import PlatformComponent from './PlatformComponent'; export default function Page() { return <p><Image src={image} alt="hello image 1" /><Component /><PlatformComponent /></p>; }`,
     );
 
     try {
@@ -160,6 +181,19 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
       await builder.buildApp();
       await expect(fs.stat(path.join(tmpDir, "dist", "client"))).resolves.toBeDefined();
       await expect(fs.stat(path.join(tmpDir, "dist", "server"))).resolves.toBeDefined();
+      const builtFiles = await fs.readdir(path.join(tmpDir, "dist", "server"), {
+        recursive: true,
+        encoding: "utf8",
+      });
+      const serverOutput = (
+        await Promise.all(
+          builtFiles
+            .filter((file) => file.endsWith(".js"))
+            .map((file) => fs.readFile(path.join(tmpDir, "dist", "server", file), "utf8")),
+        )
+      ).join("\n");
+      expect(serverOutput).toContain("hello web platform");
+      expect(serverOutput).not.toContain("hello default platform");
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
@@ -199,6 +233,7 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
       expect(extensions[0]).toBe(".png");
       expect(extensions).toContain(".jsx");
       expect(extensions).not.toContain("");
+      expect(extensions).not.toContain(".mjs");
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/page-extensions-resolve.test.ts
+++ b/tests/page-extensions-resolve.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs/promises";
-import { createBuilder } from "vite";
+import { createBuilder, resolveConfig } from "vite";
 import { describe, expect, it } from "vite-plus/test";
 import {
   buildViteResolveExtensions,
@@ -91,6 +91,7 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
       (p: any) => p.name === "vinext:config" && typeof p.config === "function",
     );
     expect(mainPlugin).toBeDefined();
+    expect(typeof (mainPlugin as any).configEnvironment).toBe("function");
 
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-ext-resolve-"));
     const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
@@ -113,8 +114,10 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
         plugins: [],
       };
       // oxlint-disable-next-line typescript/no-explicit-any
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
-      const extensions: string[] = result.resolve?.extensions ?? [];
+      await (mainPlugin as any).config(mockConfig, { command: "build" });
+      const environmentConfig: any = { resolve: { extensions: [".earlier"] } };
+      (mainPlugin as any).configEnvironment("client", environmentConfig);
+      const extensions: string[] = environmentConfig.resolve.extensions;
       expect(extensions).toContain(".platform.tsx");
       expect(extensions).toContain(".mdx");
       expect(extensions).toContain(".tsx");
@@ -210,6 +213,7 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
       (p: any) => p.name === "vinext:config" && typeof p.config === "function",
     );
     expect(mainPlugin).toBeDefined();
+    expect(typeof (mainPlugin as any).configEnvironment).toBe("function");
 
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-resolve-extensions-"));
     const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
@@ -226,14 +230,63 @@ describe("vinext plugin wires pageExtensions into Vite resolve.extensions", () =
     );
 
     try {
-      const mockConfig = { root: tmpDir, build: {}, plugins: [] };
-      // oxlint-disable-next-line typescript/no-explicit-any
-      const result = await (mainPlugin as any).config(mockConfig, { command: "build" });
-      const extensions: string[] = result.resolve?.extensions ?? [];
+      const resolved = await resolveConfig(
+        {
+          root: tmpDir,
+          configFile: false,
+          resolve: { extensions: [".earlier", ".tsx"] },
+          plugins: [vinext({ appDir: tmpDir })],
+          logLevel: "silent",
+        },
+        "build",
+      );
+      const extensions: string[] = resolved.environments.client.resolve.extensions;
       expect(extensions[0]).toBe(".png");
       expect(extensions).toContain(".jsx");
       expect(extensions).not.toContain("");
       expect(extensions).not.toContain(".mjs");
+      expect(extensions).not.toContain(".earlier");
+      expect(extensions.filter((extension) => extension === ".tsx")).toHaveLength(1);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("applies conditional webpack extensions to the matching Vite environments", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-webpack-extensions-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fs.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export default function Page() { return <p>hello</p>; }`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default { webpack(config, { isServer, dev }) { config.resolve.extensions = [isServer ? ".server.ts" : ".client.ts", dev ? ".dev.ts" : ".prod.ts", ".ts"]; return config; } };`,
+    );
+
+    try {
+      const resolved = await resolveConfig(
+        {
+          root: tmpDir,
+          configFile: false,
+          plugins: [vinext({ appDir: tmpDir })],
+          logLevel: "silent",
+        },
+        "build",
+      );
+      expect(resolved.environments.client.resolve.extensions).toEqual([
+        ".client.ts",
+        ".prod.ts",
+        ".ts",
+      ]);
+      expect(resolved.environments.ssr.resolve.extensions).toEqual([
+        ".server.ts",
+        ".prod.ts",
+        ".ts",
+      ]);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }


### PR DESCRIPTION
## Summary
- honor `turbopack.resolveExtensions` when configuring Vite module resolution
- fall back to webpack `resolve.extensions` for the same Next.js fixture configuration
- port the `resolve-extensions` regression as a real App Router production build covering server and client graphs

## Verification
- Node `v24.15.0`
- `vp test run tests/page-extensions-resolve.test.ts tests/next-config.test.ts`
- `vp check tests/page-extensions-resolve.test.ts tests/next-config.test.ts packages/vinext/src/config/next-config.ts packages/vinext/src/index.ts`
- 193 targeted tests passed; production fixture builds both `dist/server` and `dist/client`

## Exact suite status
Attempted with concurrency 1:

```sh
VINEXT_BUILD=0 NEXT_TEST_CONCURRENCY=1 ./scripts/run-nextjs-deploy-suite.sh /Users/jamesanderson/.codex/worktrees/compat-more/server-inserted-html/next.js --retries 0 -c 1 test/e2e/app-dir/resolve-extensions/resolve-extensions.test.ts
```

The shared Next.js checkout is not built, so Jest fails before running the suite with:

```text
Cannot find module './dist/build/jest/jest'
```

I did not invoke the deploy wrapper directly because it performs `pnpm install --no-frozen-lockfile`, which repository policy prohibits agents from running. PPR/cache coverage is intentionally excluded.
