### PR TITLE
fix(router): hard navigate Pages links to App routes

### DIFF
--- a/packages/vinext/src/shims/internal/app-route-detection.ts
+++ b/packages/vinext/src/shims/internal/app-route-detection.ts
@@ -37,6 +37,7 @@
 import type { VinextLinkPrefetchRoute } from "../../client/vinext-next-data.js";
 import { createRouteTrieCache, matchRouteWithTrie } from "../../routing/route-matching.js";
 import { stripBasePath, removeTrailingSlash } from "../../utils/base-path.js";
+import { getLocalePathPrefix } from "../../utils/domain-locale.js";
 
 const appRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
@@ -91,7 +92,12 @@ function resolveSameOriginPathname(href: string, basePath: string): string | nul
     return null;
   }
   if (url.origin !== window.location.origin) return null;
-  return stripBasePath(url.pathname, basePath);
+  const pathname = stripBasePath(url.pathname, basePath);
+  const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
+  if (!locale) return pathname;
+
+  const localePrefixLength = locale.length + 1;
+  return pathname.length === localePrefixLength ? "/" : pathname.slice(localePrefixLength);
 }
 
 /**

--- a/packages/vinext/src/shims/internal/app-route-detection.ts
+++ b/packages/vinext/src/shims/internal/app-route-detection.ts
@@ -99,7 +99,7 @@ function resolveSameOriginPathname(href: string, basePath: string): string | nul
  * prefetch manifest (static or dynamic). Returns false when the manifest is
  * absent (Pages-Router-only build), the URL is external, or no route matches.
  */
-function matchesAppRoute(href: string, basePath: string): boolean {
+export function matchesAppRoute(href: string, basePath: string): boolean {
   if (typeof window === "undefined") return false;
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes || routes.length === 0) return false;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -36,6 +36,7 @@ import { buildPagesDataHref } from "./internal/pages-data-url.js";
 import {
   getPagesRouterComponentsMap,
   markAppRouteDetectedOnPrefetch,
+  matchesAppRoute,
 } from "./internal/app-route-detection.js";
 import { dedupedPagesDataFetch } from "./internal/pages-data-fetch-dedup.js";
 import { installWindowNext, type PagesRouterPublicInstance } from "../client/window-next.js";
@@ -2074,7 +2075,10 @@ async function performNavigation(
   const appPathNorm = appPath !== null ? removeTrailingSlash(appPath) : null;
   const appPathEntry =
     appPathNorm !== null ? getPagesRouterComponentsMap()[appPathNorm] : undefined;
-  if (appPathEntry !== undefined && "__appRouter" in appPathEntry && appPathEntry.__appRouter) {
+  const appRouteDetected =
+    (appPathEntry !== undefined && "__appRouter" in appPathEntry && appPathEntry.__appRouter) ||
+    matchesAppRoute(resolved, __basePath);
+  if (appRouteDetected) {
     if (mode === "push") window.location.assign(full);
     else window.location.replace(full);
     return new Promise<boolean>(() => {});

--- a/tests/e2e/app-router/pages-to-app-routing.spec.ts
+++ b/tests/e2e/app-router/pages-to-app-routing.spec.ts
@@ -54,4 +54,14 @@ test.describe("pages-to-app-routing: navigate from Pages Router to App Router vi
     await expect(page.locator("#app-page")).toHaveText("About");
     expect(page.url()).toContain("/about");
   });
+
+  test("clicking a rewrite source navigates to its App Router destination", async ({ page }) => {
+    await page.goto(`${BASE}/pages-to-app/rewrite`);
+    await waitForHydration(page);
+
+    await page.click("#to-rewritten-about-link");
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#app-page")).toHaveText("About");
+    expect(page.url()).toContain("/rewrite-about");
+  });
 });

--- a/tests/e2e/app-router/pages-to-app-routing.spec.ts
+++ b/tests/e2e/app-router/pages-to-app-routing.spec.ts
@@ -31,13 +31,22 @@ test.describe("pages-to-app-routing: navigate from Pages Router to App Router vi
   });
 
   test("clicking Link navigates to the App Router /about page", async ({ page }) => {
+    await page.route("**/*", async (route) => {
+      const purpose = route.request().headers()["purpose"];
+      if (purpose === "prefetch") {
+        await route.abort();
+        return;
+      }
+      await route.continue();
+    });
     await page.goto(`${BASE}/pages-to-app/abc`);
     await waitForHydration(page);
 
     await expect(page.locator("#params")).toHaveText('Params: {"slug":"abc"}');
 
-    // Clicking the link must navigate to the App Router /about page.
-    // Because /about is an App Router route, a hard navigation is triggered;
+    // Clicking the link must navigate to the App Router /about page even when
+    // viewport prefetch has not completed. Because /about is an App Router
+    // route, a hard navigation is triggered;
     // wait for App Router hydration to make the App Router landing explicit
     // rather than only asserting on the new DOM.
     await page.click("#to-about-link");

--- a/tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx
+++ b/tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx
@@ -20,6 +20,9 @@ export default function PagesToAppPage({ params }: Props) {
       <Link id="to-about-link" href="/about">
         To About
       </Link>
+      <Link id="to-rewritten-about-link" href="/rewrite-about">
+        To Rewritten About
+      </Link>
     </>
   );
 }

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -26,6 +26,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 afterEach(() => {
   vi.resetModules();
+  delete (globalThis as Record<symbol, unknown>)[Symbol.for("vinext.pagesRouter.components")];
   delete (globalThis as { window?: unknown }).window;
   delete (globalThis as { document?: unknown }).document;
 });
@@ -192,6 +193,28 @@ describe("Pages Router records app routes as detected on prefetch", () => {
     //    fast-path return, so `assign` must have fired synchronously by the
     //    time `push()` returns — assert immediately to pin that synchronicity
     //    (the hard navigation must not lose a race against the SPA path).
+    void Router.push("/about");
+
+    expect(fakeWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining("/about"));
+  });
+
+  it("hard-navigates to an App Router route even when prefetch has not completed", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+    //
+    // Link viewport prefetch is asynchronous. A user can click before it has
+    // written the __appRouter marker, so navigation must also consult the
+    // generated App Router route manifest directly.
+    const fakeWindow = installFakeBrowserGlobals([
+      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+    ]);
+
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const Router = routerModule.default;
+
+    expect(Router.components["/about"]).toBeUndefined();
+
     void Router.push("/about");
 
     expect(fakeWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining("/about"));

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -49,6 +49,8 @@ type FakeWindow = {
     patternParts: string[];
     isDynamic: boolean;
   }>;
+  __VINEXT_LOCALES__?: string[];
+  __VINEXT_DEFAULT_LOCALE__?: string;
   next?: unknown;
 };
 
@@ -218,5 +220,56 @@ describe("Pages Router records app routes as detected on prefetch", () => {
     void Router.push("/about");
 
     expect(fakeWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining("/about"));
+  });
+
+  it.each([
+    ["static route", "/about", ["about"]],
+    ["dynamic route", "/blog/hello", ["blog", ":slug"]],
+    ["route-group route", "/grouped", ["grouped"]],
+    ["trailing slash", "/about/", ["about"]],
+    ["query and hash", "/about?from=pages#details", ["about"]],
+    ["interception target", "/photos/123", ["photos", ":id"]],
+  ])("synchronously detects %s destinations", async (_label, href, patternParts) => {
+    const fakeWindow = installFakeBrowserGlobals([
+      {
+        canPrefetchLoadingShell: false,
+        patternParts,
+        isDynamic: patternParts.some((part) => part.startsWith(":")),
+      },
+    ]);
+
+    const { matchesAppRoute } =
+      await import("../packages/vinext/src/shims/internal/app-route-detection.js");
+
+    expect(matchesAppRoute(href, "")).toBe(true);
+    expect(fakeWindow.location.assign).not.toHaveBeenCalled();
+  });
+
+  it("strips basePath and locale prefixes before matching App routes", async () => {
+    const fakeWindow = installFakeBrowserGlobals([
+      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+    ]);
+    fakeWindow.__VINEXT_LOCALES__ = ["en", "fr"];
+    fakeWindow.__VINEXT_DEFAULT_LOCALE__ = "en";
+
+    const { matchesAppRoute, markAppRouteDetectedOnPrefetch } =
+      await import("../packages/vinext/src/shims/internal/app-route-detection.js");
+
+    expect(matchesAppRoute("/docs/fr/about?from=pages#details", "/docs")).toBe(true);
+    markAppRouteDetectedOnPrefetch("/docs/fr/about", "/docs");
+
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    expect(routerModule.default.components["/about"]).toEqual({ __appRouter: true });
+  });
+
+  it("does not classify external URLs as App routes", async () => {
+    installFakeBrowserGlobals([
+      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+    ]);
+
+    const { matchesAppRoute } =
+      await import("../packages/vinext/src/shims/internal/app-route-detection.js");
+
+    expect(matchesAppRoute("https://example.com/about", "")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- detect App Router destinations synchronously during Pages Router navigation
- preserve the existing prefetch marker behavior for `window.next.router.components`
- port the `pages-to-app-routing` regression with prefetch blocked

## Verification
- `vp test run tests/pages-router-app-prefetch-detection.test.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm exec playwright test tests/e2e/app-router/pages-to-app-routing.spec.ts --workers=1 --retries=0`
- production build/start of `tests/fixtures/app-basic`, then the same Playwright spec with `--workers=1`
- `vp check packages/vinext/src/shims/internal/app-route-detection.ts packages/vinext/src/shims/router.ts tests/pages-router-app-prefetch-detection.test.ts tests/e2e/app-router/pages-to-app-routing.spec.ts`

## Upstream suite note
The exact Next.js deploy test was invoked on Node 24 with concurrency 1, but the prepared Next.js runner rewrites PATH for its isolated deploy subprocess and selects Node 20.20.2. That subprocess fails before the test at `node:fs/promises` `glob`, so the exact upstream harness could not complete locally. The equivalent dev and production hybrid-app regressions pass with prefetch explicitly aborted.

PPR/cache behavior is intentionally out of scope.
