### PR TITLE
fix(css): load local CommonJS PostCSS plugins

### DIFF
--- a/packages/vinext/src/plugins/postcss.ts
+++ b/packages/vinext/src/plugins/postcss.ts
@@ -1,27 +1,53 @@
 import path from "node:path";
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
-import { createRequire } from "node:module";
-import { randomUUID } from "node:crypto";
+import { createRequire, Module } from "node:module";
+
+type CommonJsModule = Module & {
+  _compile(content: string, filename: string): void;
+};
+
+const CommonJsModule = Module as typeof Module & {
+  _nodeModulePaths(from: string): string[];
+};
 
 function shouldRetryAsCommonJs(error: unknown, resolvedPath: string): boolean {
   return (
     resolvedPath.endsWith(".js") &&
-    error instanceof ReferenceError &&
-    /(?:module|exports|require) is not defined in ES module scope/.test(error.message)
+    ((error instanceof ReferenceError &&
+      /(?:module|exports|require) is not defined in ES module scope/.test(error.message)) ||
+      (error instanceof Error && "code" in error && error.code === "ERR_REQUIRE_ESM"))
   );
 }
 
-function loadCommonJsPlugin(resolvedPath: string): unknown {
-  const temporaryPath = path.join(
-    path.dirname(resolvedPath),
-    `.vinext-postcss-${randomUUID()}.cjs`,
-  );
-  fs.copyFileSync(resolvedPath, temporaryPath);
+function loadCommonJsPlugin(resolvedPath: string, cache = new Map<string, Module>()): unknown {
+  const cached = cache.get(resolvedPath);
+  if (cached) return cached.exports;
+
+  const mod = new CommonJsModule(resolvedPath) as CommonJsModule;
+  mod.filename = resolvedPath;
+  mod.paths = CommonJsModule._nodeModulePaths(path.dirname(resolvedPath));
+  cache.set(resolvedPath, mod);
+
+  const req = createRequire(resolvedPath);
+  const originalRequire = mod.require.bind(mod);
+  mod.require = ((specifier: string) => {
+    try {
+      return originalRequire(specifier);
+    } catch (error) {
+      const dependencyPath = req.resolve(specifier);
+      if (!shouldRetryAsCommonJs(error, dependencyPath)) throw error;
+      return loadCommonJsPlugin(dependencyPath, cache);
+    }
+  }) as Module["require"];
+
   try {
-    return createRequire(temporaryPath)(temporaryPath);
-  } finally {
-    fs.rmSync(temporaryPath, { force: true });
+    mod._compile(fs.readFileSync(resolvedPath, "utf8"), resolvedPath);
+    mod.loaded = true;
+    return mod.exports;
+  } catch (error) {
+    cache.delete(resolvedPath);
+    throw error;
   }
 }
 

--- a/packages/vinext/src/plugins/postcss.ts
+++ b/packages/vinext/src/plugins/postcss.ts
@@ -2,6 +2,38 @@ import path from "node:path";
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
+import { randomUUID } from "node:crypto";
+
+function shouldRetryAsCommonJs(error: unknown, resolvedPath: string): boolean {
+  return (
+    resolvedPath.endsWith(".js") &&
+    error instanceof ReferenceError &&
+    /(?:module|exports|require) is not defined in ES module scope/.test(error.message)
+  );
+}
+
+function loadCommonJsPlugin(resolvedPath: string): unknown {
+  const temporaryPath = path.join(
+    path.dirname(resolvedPath),
+    `.vinext-postcss-${randomUUID()}.cjs`,
+  );
+  fs.copyFileSync(resolvedPath, temporaryPath);
+  try {
+    return createRequire(temporaryPath)(temporaryPath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+async function loadPluginExport(resolvedPath: string): Promise<unknown> {
+  try {
+    const mod = await import(pathToFileURL(resolvedPath).href);
+    return mod.default ?? mod;
+  } catch (error) {
+    if (!shouldRetryAsCommonJs(error, resolvedPath)) throw error;
+    return loadCommonJsPlugin(resolvedPath);
+  }
+}
 
 /**
  * PostCSS config file names to search for, in priority order.
@@ -117,8 +149,7 @@ async function resolvePostcssStringPluginsUncached(
       config.plugins.filter(Boolean).map(async (plugin: unknown) => {
         if (typeof plugin === "string") {
           const resolved = req.resolve(plugin);
-          const mod = await import(pathToFileURL(resolved).href);
-          const fn = mod.default ?? mod;
+          const fn = await loadPluginExport(resolved);
           // If the export is a function, call it to get the plugin instance
           return typeof fn === "function" ? fn() : fn;
         }
@@ -126,8 +157,7 @@ async function resolvePostcssStringPluginsUncached(
         if (Array.isArray(plugin) && typeof plugin[0] === "string") {
           const [name, options] = plugin;
           const resolved = req.resolve(name);
-          const mod = await import(pathToFileURL(resolved).href);
-          const fn = mod.default ?? mod;
+          const fn = await loadPluginExport(resolved);
           return typeof fn === "function" ? fn(options) : fn;
         }
         // Already a function or plugin object — pass through

--- a/tests/postcss-resolve.test.ts
+++ b/tests/postcss-resolve.test.ts
@@ -194,26 +194,42 @@ module.exports.postcss = true;
     }
   });
 
-  it("loads CommonJS .js plugins referenced by a .cjs config after init adds type module", async () => {
+  it("loads CommonJS .js plugins from read-only symlink targets in an ESM monorepo", async () => {
     const fsp = await import("node:fs/promises");
     const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-postcss-local-cjs-"));
+    const packageDir = path.join(dir, "packages", "local-plugin");
+    const pluginLink = path.join(dir, "node_modules", "local-plugin");
+    await fsp.mkdir(packageDir, { recursive: true });
+    await fsp.mkdir(path.dirname(pluginLink), { recursive: true });
     await fsp.writeFile(path.join(dir, "package.json"), JSON.stringify({ type: "module" }));
     await fsp.writeFile(
-      path.join(dir, "plugin.js"),
-      `const plugin = () => ({ postcssPlugin: "local-cjs-plugin", Once() {} });
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "local-plugin", main: "plugin.js", type: "module" }),
+    );
+    await fsp.writeFile(path.join(packageDir, "name.js"), `module.exports = "local-cjs-plugin";`);
+    await fsp.writeFile(
+      path.join(packageDir, "plugin.js"),
+      `const name = require("./name.js");
+const plugin = () => ({ postcssPlugin: name, Once() {} });
 plugin.postcss = true;
 module.exports = plugin;`,
     );
+    await fsp.symlink(packageDir, pluginLink, "junction");
     await fsp.writeFile(
       path.join(dir, "postcss.config.cjs"),
-      `module.exports = { plugins: [require.resolve("./plugin")] };`,
+      `module.exports = { plugins: [require.resolve("local-plugin")] };`,
     );
+    await fsp.chmod(packageDir, 0o555);
 
     try {
       const result = await resolvePostcssStringPlugins(dir);
       expect(result?.plugins).toHaveLength(1);
       expect(result?.plugins[0]).toHaveProperty("postcssPlugin", "local-cjs-plugin");
+      expect(
+        (await fsp.readdir(packageDir)).some((name) => name.startsWith(".vinext-postcss-")),
+      ).toBe(false);
     } finally {
+      await fsp.chmod(packageDir, 0o755).catch(() => {});
       await cleanupDir(dir);
     }
   });

--- a/tests/postcss-resolve.test.ts
+++ b/tests/postcss-resolve.test.ts
@@ -194,6 +194,30 @@ module.exports.postcss = true;
     }
   });
 
+  it("loads CommonJS .js plugins referenced by a .cjs config after init adds type module", async () => {
+    const fsp = await import("node:fs/promises");
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-postcss-local-cjs-"));
+    await fsp.writeFile(path.join(dir, "package.json"), JSON.stringify({ type: "module" }));
+    await fsp.writeFile(
+      path.join(dir, "plugin.js"),
+      `const plugin = () => ({ postcssPlugin: "local-cjs-plugin", Once() {} });
+plugin.postcss = true;
+module.exports = plugin;`,
+    );
+    await fsp.writeFile(
+      path.join(dir, "postcss.config.cjs"),
+      `module.exports = { plugins: [require.resolve("./plugin")] };`,
+    );
+
+    try {
+      const result = await resolvePostcssStringPlugins(dir);
+      expect(result?.plugins).toHaveLength(1);
+      expect(result?.plugins[0]).toHaveProperty("postcssPlugin", "local-cjs-plugin");
+    } finally {
+      await cleanupDir(dir);
+    }
+  });
+
   // --- Unresolvable string plugin must not crash the build ---
   //
   // Regression for #1509: a CSS-modules + PostCSS app (e.g. a config like
@@ -344,6 +368,67 @@ module.exports.postcss = true;`,
       expect(postcssObj.plugins[0]).toHaveProperty("postcssPlugin", "mock-postcss-plugin");
     } finally {
       await server.close();
+    }
+  }, 30000);
+
+  it("applies a local CommonJS PostCSS plugin to CSS and SCSS modules in an ESM app", async () => {
+    // Ported from Next.js: test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
+    const fsp = await import("node:fs/promises");
+    const { build } = await import("vite");
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-css-modules-rsc-postcss-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(dir, "node_modules"), "junction");
+    await fsp.writeFile(path.join(dir, "package.json"), JSON.stringify({ type: "module" }));
+    await fsp.writeFile(
+      path.join(dir, "plugin.js"),
+      `const plugin = () => ({
+  postcssPlugin: "color-change",
+  Declaration: { color(declaration) { declaration.value = "green"; } },
+});
+plugin.postcss = true;
+module.exports = plugin;`,
+    );
+    await fsp.writeFile(
+      path.join(dir, "postcss.config.cjs"),
+      `module.exports = { plugins: [require.resolve("./plugin")] };`,
+    );
+    await fsp.writeFile(path.join(dir, "page.module.css"), `.main { color: red; }`);
+    await fsp.writeFile(path.join(dir, "other.module.scss"), `.other { color: red; }`);
+    await fsp.writeFile(
+      path.join(dir, "entry.js"),
+      `import styles from "./page.module.css";
+import other from "./other.module.scss";
+console.log(styles.main, other.other);`,
+    );
+
+    try {
+      await build({
+        root: dir,
+        configFile: false,
+        plugins: [vinext({ disableAppRouter: true })],
+        logLevel: "silent",
+        build: {
+          outDir: "dist",
+          rolldownOptions: { input: path.join(dir, "entry.js") },
+        },
+      });
+      const distDir = path.join(dir, "dist");
+      const entries = await fsp.readdir(distDir, { recursive: true, withFileTypes: true });
+      const cssEntries = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".css"));
+      expect(cssEntries.length).toBeGreaterThan(0);
+      const css = (
+        await Promise.all(
+          cssEntries.map((entry) => fsp.readFile(path.join(entry.parentPath, entry.name), "utf8")),
+        )
+      ).join("\n");
+      expect(css).toContain("color:green");
+      expect(css).toMatch(/_main[_-]/);
+      expect(css).toMatch(/_other[_-]/);
+      expect(css).not.toContain("color:red");
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
     }
   }, 30000);
 });


### PR DESCRIPTION
## Summary
- preserve CommonJS semantics for local `.js` PostCSS plugins after `vinext init` adds `"type": "module"`
- retry those plugins through a temporary sibling `.cjs` module when ESM loading fails on `module`/`exports`/`require`
- port focused coverage from Next.js `css-modules-rsc-postcss` for CSS and SCSS modules

## Root cause
The upstream fixture uses `postcss.config.js` with `require.resolve('./plugin')`, where `plugin.js` is CommonJS. The deploy adapter runs `vinext init`, which adds `"type": "module"` and renames the config to `postcss.config.cjs`, but the referenced `plugin.js` remains unchanged. vinext's string-plugin resolver dynamically imported that file as ESM, failed on `module.exports`, returned no override, and Vite then rejected both string plugin entries (one failure for each CSS module import).

## Validation
- `vp check packages/vinext/src/plugins/postcss.ts tests/postcss-resolve.test.ts`
- `vp test run tests/postcss-resolve.test.ts` (15 passed)
- `vp run vinext#build`
- exact deploy fixture from `test/e2e/app-dir/css-modules-rsc-postcss/` builds and serves successfully
- local Chrome computed styles: `<p>` and `<span>` both `rgb(0, 128, 0)`

## Harness note
A fresh full Next.js canary preparation was attempted, but the unrelated monorepo build was OOM-killed with exit 137. The exact fixture was therefore exercised directly through `scripts/e2e-deploy.sh`; before the fix it reproduced the two `Invalid PostCSS Plugin found at: plugins[0]` failures, and after the fix both upstream browser assertions pass.

PPR/cache paths are intentionally untouched.
