### PR TITLE
refactor(navigation): route prefetch reuse through planner

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -177,6 +177,7 @@ import {
 import { removeStylesheetLinksCoveredByInlineCss } from "./app-inline-css-client.js";
 import {
   navigationPlanner,
+  type NavigationReuseFactsV0,
   type VisitedResponseCacheCandidateFactsV0,
 } from "./navigation-planner.js";
 
@@ -1783,10 +1784,16 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           visitedResponseCandidate,
           visitedResponseDecision,
         );
+        const visitedResponse: NavigationReuseFactsV0["visitedResponse"] =
+          cachedRoute === null ? { status: "unavailable" } : { status: "available" };
+        const prefetchProbeDecision = navigationPlanner.classifyNavigationPrefetchProbe({
+          bypassNavigationCache: shouldBypassNavigationCache,
+          navigationKind,
+          visitedResponse,
+        });
         const routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;
         const hasPrefetchCandidate =
-          navigationKind !== "refresh" &&
-          !shouldBypassNavigationCache &&
+          prefetchProbeDecision.kind === "probe" &&
           hasPrefetchCacheEntryForNavigation(
             rscUrl,
             requestInterceptionContext,
@@ -1802,8 +1809,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
               : { status: "available" },
           prefetch: hasPrefetchCandidate ? { status: "available" } : { status: "unavailable" },
           targetHref: currentHref,
-          visitedResponse:
-            cachedRoute === null ? { status: "unavailable" } : { status: "available" },
+          visitedResponse,
         });
         if (reuseDecision.kind === "reuseVisitedResponse" && cachedRoute) {
           const cachedFetchDecision = navigationPlanner.classifyRscFetchResult({

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -31,6 +31,7 @@ import {
   getClientNavigationRenderContext,
   getBfcacheIdMapContext,
   getPrefetchCache,
+  hasPrefetchCacheEntryForNavigation,
   invalidatePrefetchCache,
   decodeRedirectError,
   isRedirectError,
@@ -704,30 +705,28 @@ function getVisitedResponse(
     return null;
   }
 
-  if ((cached.response.mountedSlotsHeader ?? null) !== mountedSlotsHeader) {
-    visitedResponseCache.delete(cacheKey);
-    return null;
-  }
-
-  // `isVisitedResponseCacheEntryFresh` is the single source of truth for
-  // freshness and returns `false` for `navigationKind === "refresh"`, so a
-  // refresh falls through to the miss path below.
-  if (
-    isVisitedResponseCacheEntryFresh(cached, {
+  const cacheDecision = navigationPlanner.classifyVisitedResponseCacheCandidate({
+    candidate: "present",
+    fresh: isVisitedResponseCacheEntryFresh(cached, {
       navigationKind,
       now: Date.now(),
-    })
-  ) {
+    }),
+    mountedSlotsMatch: (cached.response.mountedSlotsHeader ?? null) === mountedSlotsHeader,
+    navigationKind,
+  });
+
+  if (cacheDecision.kind === "reuse") {
     // LRU: promote to most-recently-used
     visitedResponseCache.delete(cacheKey);
     visitedResponseCache.set(cacheKey, cached);
     return cached;
   }
 
-  // Stale (or refresh) entries are evicted on read. A refresh intentionally
-  // drops any prior snapshot here — the navigation re-fetches and re-stores a
-  // fresh one, so leaving the old entry around would only risk a later
-  // non-refresh navigation reusing a snapshot the user explicitly refreshed.
+  // Stale, slot-mismatched, and refresh entries are evicted on read. A refresh
+  // intentionally drops any prior snapshot here — the navigation re-fetches and
+  // re-stores a fresh one, so leaving the old entry around would only risk a
+  // later non-refresh navigation reusing a snapshot the user explicitly
+  // refreshed.
   visitedResponseCache.delete(cacheKey);
   return null;
 }
@@ -1735,7 +1734,29 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
               mountedSlotsHeader,
               navigationKind,
             );
-        if (cachedRoute) {
+        const routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;
+        const hasPrefetchCandidate =
+          navigationKind !== "refresh" &&
+          !shouldBypassNavigationCache &&
+          hasPrefetchCacheEntryForNavigation(
+            rscUrl,
+            requestInterceptionContext,
+            mountedSlotsHeader,
+            { notifyInvalidation: false },
+          );
+        const reuseDecision = navigationPlanner.classifyNavigationReuse({
+          bypassNavigationCache: shouldBypassNavigationCache,
+          navigationKind,
+          optimisticRouteShell:
+            routeManifest === null
+              ? { reason: "routeManifestMissing", status: "unavailable" }
+              : { status: "available" },
+          prefetch: hasPrefetchCandidate ? { status: "available" } : { status: "unavailable" },
+          targetHref: currentHref,
+          visitedResponse:
+            cachedRoute === null ? { status: "unavailable" } : { status: "available" },
+        });
+        if (reuseDecision.kind === "reuseVisitedResponse" && cachedRoute) {
           const cachedFetchDecision = navigationPlanner.classifyRscFetchResult({
             clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
             compatibilityIdHeader: cachedRoute.response.compatibilityIdHeader ?? null,
@@ -1824,7 +1845,8 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         let navResponse: Response | undefined;
         let navResponseExpiresAt: number | undefined;
         let navResponseUrl: string | null = null;
-        if (navigationKind !== "refresh" && !shouldBypassNavigationCache) {
+        let fallbackReuseDecision = reuseDecision;
+        if (reuseDecision.kind === "consumePrefetch") {
           const prefetchedResponse = await consumePrefetchResponseForNavigation(
             rscUrl,
             requestInterceptionContext,
@@ -1839,6 +1861,19 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             navResponseExpiresAt = prefetchedResponse.expiresAt;
             navResponseUrl = prefetchedResponse.url;
           }
+          if (!navResponse) {
+            fallbackReuseDecision = navigationPlanner.classifyNavigationReuse({
+              bypassNavigationCache: shouldBypassNavigationCache,
+              navigationKind,
+              optimisticRouteShell:
+                routeManifest === null
+                  ? { reason: "routeManifestMissing", status: "unavailable" }
+                  : { status: "available" },
+              prefetch: { status: "unavailable" },
+              targetHref: currentHref,
+              visitedResponse: { status: "unavailable" },
+            });
+          }
         }
 
         // The optimistic shell is intentionally not gated by
@@ -1847,8 +1882,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         // real fetch commits, but that shell is a detached commit (see below)
         // that is always superseded by the authoritative fetch — the same as
         // cross-route navigations — so it never persists stale page content.
-        if (!navResponse && navigationKind === "navigate") {
-          const routeManifest = getBrowserRouteManifest();
+        if (!navResponse && fallbackReuseDecision.kind === "attemptOptimisticRouteShell") {
           await learnOptimisticRouteTemplatesFromPrefetchCache({
             interceptionContext: requestInterceptionContext,
             mountedSlotsHeader,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1791,14 +1791,14 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           navigationKind,
           visitedResponse,
         });
-        const routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;
+        let routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;
         const hasPrefetchCandidate =
           prefetchProbeDecision.kind === "probe" &&
           hasPrefetchCacheEntryForNavigation(
             rscUrl,
             requestInterceptionContext,
             mountedSlotsHeader,
-            { notifyInvalidation: false },
+            { evictIncompatibleExactEntry: true, notifyInvalidation: false },
           );
         const reuseDecision = navigationPlanner.classifyNavigationReuse({
           bypassNavigationCache: shouldBypassNavigationCache,
@@ -1917,6 +1917,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             navResponseUrl = prefetchedResponse.url;
           }
           if (!navResponse) {
+            routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;
             fallbackReuseDecision = navigationPlanner.classifyNavigationReuse({
               bypassNavigationCache: shouldBypassNavigationCache,
               navigationKind,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -175,7 +175,10 @@ import {
   VINEXT_RSC_REDIRECT_HEADER,
 } from "./headers.js";
 import { removeStylesheetLinksCoveredByInlineCss } from "./app-inline-css-client.js";
-import { navigationPlanner } from "./navigation-planner.js";
+import {
+  navigationPlanner,
+  type VisitedResponseCacheCandidateFactsV0,
+} from "./navigation-planner.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -693,33 +696,65 @@ function evictVisitedResponseCacheIfNeeded(): void {
   }
 }
 
-function getVisitedResponse(
+type VisitedResponseCacheCandidate =
+  | {
+      cacheKey: string;
+      entry: VisitedResponseCacheEntry;
+      facts: Extract<VisitedResponseCacheCandidateFactsV0, { candidate: "present" }>;
+    }
+  | {
+      cacheKey: string;
+      entry: null;
+      facts: Extract<VisitedResponseCacheCandidateFactsV0, { candidate: "missing" }>;
+    };
+
+function readVisitedResponseCacheCandidate(
   rscUrl: string,
   interceptionContext: string | null,
   mountedSlotsHeader: string | null,
   navigationKind: NavigationKind,
-): VisitedResponseCacheEntry | null {
+): VisitedResponseCacheCandidate {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cached = visitedResponseCache.get(cacheKey);
   if (!cached) {
+    return {
+      cacheKey,
+      entry: null,
+      facts: {
+        candidate: "missing",
+        navigationKind,
+      },
+    };
+  }
+
+  return {
+    cacheKey,
+    entry: cached,
+    facts: {
+      candidate: "present",
+      fresh: isVisitedResponseCacheEntryFresh(cached, {
+        navigationKind,
+        now: Date.now(),
+      }),
+      mountedSlotsMatch: (cached.response.mountedSlotsHeader ?? null) === mountedSlotsHeader,
+      navigationKind,
+    },
+  };
+}
+
+function applyVisitedResponseCacheCandidateDecision(
+  candidate: VisitedResponseCacheCandidate,
+  decision: ReturnType<typeof navigationPlanner.classifyVisitedResponseCacheCandidate>,
+): VisitedResponseCacheEntry | null {
+  if (candidate.entry === null) {
     return null;
   }
 
-  const cacheDecision = navigationPlanner.classifyVisitedResponseCacheCandidate({
-    candidate: "present",
-    fresh: isVisitedResponseCacheEntryFresh(cached, {
-      navigationKind,
-      now: Date.now(),
-    }),
-    mountedSlotsMatch: (cached.response.mountedSlotsHeader ?? null) === mountedSlotsHeader,
-    navigationKind,
-  });
-
-  if (cacheDecision.kind === "reuse") {
+  if (decision.kind === "reuse") {
     // LRU: promote to most-recently-used
-    visitedResponseCache.delete(cacheKey);
-    visitedResponseCache.set(cacheKey, cached);
-    return cached;
+    visitedResponseCache.delete(candidate.cacheKey);
+    visitedResponseCache.set(candidate.cacheKey, candidate.entry);
+    return candidate.entry;
   }
 
   // Stale, slot-mismatched, and refresh entries are evicted on read. A refresh
@@ -727,7 +762,7 @@ function getVisitedResponse(
   // re-stores a fresh one, so leaving the old entry around would only risk a
   // later non-refresh navigation reusing a snapshot the user explicitly
   // refreshed.
-  visitedResponseCache.delete(cacheKey);
+  visitedResponseCache.delete(candidate.cacheKey);
   return null;
 }
 
@@ -1726,14 +1761,28 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
         });
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
-        const cachedRoute = shouldBypassNavigationCache
-          ? null
-          : getVisitedResponse(
+        const visitedResponseCandidate = shouldBypassNavigationCache
+          ? {
+              cacheKey: AppElementsWire.encodeCacheKey(rscUrl, requestInterceptionContext),
+              entry: null,
+              facts: {
+                candidate: "missing",
+                navigationKind,
+              } satisfies Extract<VisitedResponseCacheCandidateFactsV0, { candidate: "missing" }>,
+            }
+          : readVisitedResponseCacheCandidate(
               rscUrl,
               requestInterceptionContext,
               mountedSlotsHeader,
               navigationKind,
             );
+        const visitedResponseDecision = navigationPlanner.classifyVisitedResponseCacheCandidate(
+          visitedResponseCandidate.facts,
+        );
+        const cachedRoute = applyVisitedResponseCacheCandidateDecision(
+          visitedResponseCandidate,
+          visitedResponseDecision,
+        );
         const routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;
         const hasPrefetchCandidate =
           navigationKind !== "refresh" &&

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1798,7 +1798,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
             rscUrl,
             requestInterceptionContext,
             mountedSlotsHeader,
-            { evictIncompatibleExactEntry: true, notifyInvalidation: false },
+            { notifyInvalidation: false },
           );
         const reuseDecision = navigationPlanner.classifyNavigationReuse({
           bypassNavigationCache: shouldBypassNavigationCache,

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -254,6 +254,50 @@ export type EarlyNavigationIntentDecisionV0 =
       trace: NavigationTrace;
     };
 
+type NavigationReuseNavigationKind = "navigate" | "refresh" | "traverse";
+
+export type VisitedResponseCacheCandidateFactsV0 =
+  | {
+      candidate: "missing";
+      navigationKind: NavigationReuseNavigationKind;
+    }
+  | {
+      candidate: "present";
+      fresh: boolean;
+      mountedSlotsMatch: boolean;
+      navigationKind: NavigationReuseNavigationKind;
+    };
+
+type VisitedResponseCacheCandidateDecisionV0 =
+  | { kind: "miss" }
+  | {
+      kind: "evict";
+      reason: "mountedSlotsMismatch" | "refresh" | "stale";
+    }
+  | { kind: "reuse" };
+
+type NavigationReuseCandidateAvailability = { status: "available" } | { status: "unavailable" };
+type OptimisticRouteShellCandidateAvailability =
+  | { status: "available" }
+  | { status: "unavailable"; reason: "routeManifestMissing" };
+
+export type NavigationReuseFactsV0 = {
+  bypassNavigationCache: boolean;
+  navigationKind: NavigationReuseNavigationKind;
+  optimisticRouteShell: OptimisticRouteShellCandidateAvailability;
+  prefetch: NavigationReuseCandidateAvailability;
+  targetHref: string;
+  visitedResponse: NavigationReuseCandidateAvailability;
+};
+
+type FreshFetchReason = "cacheBypassed" | "cacheMiss" | "refresh" | "routeManifestMissing";
+
+export type NavigationReuseDecisionV0 =
+  | { kind: "reuseVisitedResponse"; trace: NavigationTrace }
+  | { kind: "consumePrefetch"; trace: NavigationTrace }
+  | { kind: "attemptOptimisticRouteShell"; trace: NavigationTrace }
+  | { kind: "fetchFresh"; reason: FreshFetchReason; trace: NavigationTrace };
+
 export type NavigationPlannerInput = {
   // Graph-owned route topology is the semantic authority for root/layout/slot
   // decisions whenever the caller can supply it. Null keeps the legacy
@@ -599,6 +643,102 @@ function classifyEarlyNavigationIntent(
     kind: "flightNavigation",
     trace: createEarlyNavigationIntentTrace(NavigationTraceReasonCodes.crossDocumentFlight, facts),
   };
+}
+
+function classifyVisitedResponseCacheCandidate(
+  facts: VisitedResponseCacheCandidateFactsV0,
+): VisitedResponseCacheCandidateDecisionV0 {
+  if (facts.candidate === "missing") {
+    return { kind: "miss" };
+  }
+
+  if (!facts.mountedSlotsMatch) {
+    return {
+      kind: "evict",
+      reason: "mountedSlotsMismatch",
+    };
+  }
+
+  if (facts.navigationKind === "refresh") {
+    return {
+      kind: "evict",
+      reason: "refresh",
+    };
+  }
+
+  if (!facts.fresh) {
+    return {
+      kind: "evict",
+      reason: "stale",
+    };
+  }
+
+  return { kind: "reuse" };
+}
+
+function createNavigationReuseTrace(
+  code: NavigationTraceReasonCode,
+  facts: NavigationReuseFactsV0,
+  fields: NavigationTraceFields = {},
+): NavigationTrace {
+  return createNavigationTrace(code, {
+    eventKind: facts.navigationKind,
+    targetHref: facts.targetHref,
+    ...fields,
+  });
+}
+
+function createFreshFetchDecision(
+  facts: NavigationReuseFactsV0,
+  reason: FreshFetchReason,
+): NavigationReuseDecisionV0 {
+  return {
+    kind: "fetchFresh",
+    reason,
+    trace: createNavigationReuseTrace(NavigationTraceReasonCodes.fetchFresh, facts, {
+      freshFetchReason: reason,
+    }),
+  };
+}
+
+function classifyNavigationReuse(facts: NavigationReuseFactsV0): NavigationReuseDecisionV0 {
+  if (facts.navigationKind === "refresh") {
+    return createFreshFetchDecision(facts, "refresh");
+  }
+
+  if (!facts.bypassNavigationCache && facts.visitedResponse.status === "available") {
+    return {
+      kind: "reuseVisitedResponse",
+      trace: createNavigationReuseTrace(NavigationTraceReasonCodes.visitedResponseReuse, facts),
+    };
+  }
+
+  if (!facts.bypassNavigationCache && facts.prefetch.status === "available") {
+    return {
+      kind: "consumePrefetch",
+      trace: createNavigationReuseTrace(NavigationTraceReasonCodes.prefetchResponseReuse, facts),
+    };
+  }
+
+  if (facts.navigationKind === "navigate") {
+    if (facts.optimisticRouteShell.status === "available") {
+      return {
+        kind: "attemptOptimisticRouteShell",
+        trace: createNavigationReuseTrace(NavigationTraceReasonCodes.optimisticRouteShell, facts),
+      };
+    }
+
+    return createFreshFetchDecision(
+      facts,
+      facts.bypassNavigationCache ? "cacheBypassed" : facts.optimisticRouteShell.reason,
+    );
+  }
+
+  if (facts.bypassNavigationCache) {
+    return createFreshFetchDecision(facts, "cacheBypassed");
+  }
+
+  return createFreshFetchDecision(facts, "cacheMiss");
 }
 
 function createSnapshotRouteTopology(snapshot: RouteSnapshotV0): RouteTopologySnapshot {
@@ -1529,10 +1669,12 @@ function classifyRscNavigationError(
 
 export const navigationPlanner = {
   classifyEarlyNavigationIntent,
+  classifyNavigationReuse,
   classifyRscFetchResult,
   classifyRscNavigationError,
   classifyRootBoundaryTransition,
   classifyServerActionResult,
+  classifyVisitedResponseCacheCandidate,
   plan: planNavigation,
   resolveCurrentRootBoundaryElementPersistence,
   resolveMountedParallelSlotPersistence,

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -298,6 +298,16 @@ export type NavigationReuseDecisionV0 =
   | { kind: "attemptOptimisticRouteShell"; trace: NavigationTrace }
   | { kind: "fetchFresh"; reason: FreshFetchReason; trace: NavigationTrace };
 
+type NavigationPrefetchProbeFactsV0 = {
+  bypassNavigationCache: boolean;
+  navigationKind: NavigationReuseNavigationKind;
+  visitedResponse: NavigationReuseCandidateAvailability;
+};
+
+type NavigationPrefetchProbeDecisionV0 =
+  | { kind: "probe" }
+  | { kind: "skip"; reason: "cacheBypassed" | "refresh" | "visitedResponseAvailable" };
+
 export type NavigationPlannerInput = {
   // Graph-owned route topology is the semantic authority for root/layout/slot
   // decisions whenever the caller can supply it. Null keeps the legacy
@@ -739,6 +749,24 @@ function classifyNavigationReuse(facts: NavigationReuseFactsV0): NavigationReuse
   }
 
   return createFreshFetchDecision(facts, "cacheMiss");
+}
+
+function classifyNavigationPrefetchProbe(
+  facts: NavigationPrefetchProbeFactsV0,
+): NavigationPrefetchProbeDecisionV0 {
+  if (facts.visitedResponse.status === "available") {
+    return { kind: "skip", reason: "visitedResponseAvailable" };
+  }
+
+  if (facts.navigationKind === "refresh") {
+    return { kind: "skip", reason: "refresh" };
+  }
+
+  if (facts.bypassNavigationCache) {
+    return { kind: "skip", reason: "cacheBypassed" };
+  }
+
+  return { kind: "probe" };
 }
 
 function createSnapshotRouteTopology(snapshot: RouteSnapshotV0): RouteTopologySnapshot {
@@ -1669,6 +1697,7 @@ function classifyRscNavigationError(
 
 export const navigationPlanner = {
   classifyEarlyNavigationIntent,
+  classifyNavigationPrefetchProbe,
   classifyNavigationReuse,
   classifyRscFetchResult,
   classifyRscNavigationError,

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -6,6 +6,7 @@ export const NavigationTraceReasonCodes = {
   cacheProofRejected: "NC_CACHE_REJECT",
   commitCurrent: "NC_COMMIT",
   crossDocumentFlight: "NC_CROSS_DOC_FLIGHT",
+  fetchFresh: "NC_FETCH_FRESH",
   invalidRscPayload: "NC_RSC_INVALID",
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT",
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT",
@@ -14,7 +15,9 @@ export const NavigationTraceReasonCodes = {
   interceptedRejectedTargetMismatch: "NC_INTERCEPT_REJECT_TARGET",
   interceptedRejectedUndeclaredTopology: "NC_INTERCEPT_REJECT_GRAPH",
   interceptedRejectedUnknownSource: "NC_INTERCEPT_REJECT_SOURCE",
+  optimisticRouteShell: "NC_OPTIMISTIC_SHELL",
   prefetchOnly: "NC_PREFETCH_ONLY",
+  prefetchResponseReuse: "NC_PREFETCH_REUSE",
   proceedToCommit: "NC_RSC_PROCEED",
   redirectFollow: "NC_RSC_REDIRECT_FOLLOW",
   redirectTerminalDepth: "NC_RSC_REDIRECT_DEPTH",
@@ -30,10 +33,12 @@ export const NavigationTraceReasonCodes = {
   serverActionRscCompatibilityMismatch: "NC_SA_RSC_COMPAT",
   staleOperation: "NC_STALE",
   streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP",
+  visitedResponseReuse: "NC_VISITED_REUSE",
 } satisfies Readonly<{
   cacheProofRejected: "NC_CACHE_REJECT";
   commitCurrent: "NC_COMMIT";
   crossDocumentFlight: "NC_CROSS_DOC_FLIGHT";
+  fetchFresh: "NC_FETCH_FRESH";
   invalidRscPayload: "NC_RSC_INVALID";
   interceptedCommitCurrent: "NC_INTERCEPT_COMMIT";
   interceptedRejectedIncompatibleRoot: "NC_INTERCEPT_REJECT_ROOT";
@@ -42,7 +47,9 @@ export const NavigationTraceReasonCodes = {
   interceptedRejectedTargetMismatch: "NC_INTERCEPT_REJECT_TARGET";
   interceptedRejectedUndeclaredTopology: "NC_INTERCEPT_REJECT_GRAPH";
   interceptedRejectedUnknownSource: "NC_INTERCEPT_REJECT_SOURCE";
+  optimisticRouteShell: "NC_OPTIMISTIC_SHELL";
   prefetchOnly: "NC_PREFETCH_ONLY";
+  prefetchResponseReuse: "NC_PREFETCH_REUSE";
   proceedToCommit: "NC_RSC_PROCEED";
   redirectFollow: "NC_RSC_REDIRECT_FOLLOW";
   redirectTerminalDepth: "NC_RSC_REDIRECT_DEPTH";
@@ -58,6 +65,7 @@ export const NavigationTraceReasonCodes = {
   serverActionRscCompatibilityMismatch: "NC_SA_RSC_COMPAT";
   staleOperation: "NC_STALE";
   streamedRedirectLoop: "NC_RSC_STREAMED_REDIRECT_LOOP";
+  visitedResponseReuse: "NC_VISITED_REUSE";
 }>;
 
 export const NavigationTraceTransactionCodes = {
@@ -89,6 +97,7 @@ type NavigationTraceFieldName =
   | "nextRootLayoutTreePath"
   | "eventKind"
   | "fetchResultSource"
+  | "freshFetchReason"
   | "operationLane"
   | "pendingOperationId"
   | "redirectDepth"

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -619,8 +619,21 @@ export function hasPrefetchCacheEntryForNavigation(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
-  options: { notifyInvalidation?: boolean } = {},
+  options: { evictIncompatibleExactEntry?: boolean; notifyInvalidation?: boolean } = {},
 ): boolean {
+  if (options.evictIncompatibleExactEntry) {
+    const cache = getPrefetchCache();
+    const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+    const exactEntry = cache.get(exactCacheKey);
+    if (
+      exactEntry &&
+      exactEntry.cacheForNavigation !== false &&
+      !isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
+    ) {
+      deletePrefetchCacheEntry(cache, getPrefetchedUrls(), exactCacheKey, exactEntry, false);
+    }
+  }
+
   const match = findPrefetchCacheEntryForNavigation(
     rscUrl,
     interceptionContext,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -619,6 +619,7 @@ export function hasPrefetchCacheEntryForNavigation(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
+  options: { notifyInvalidation?: boolean } = {},
 ): boolean {
   const match = findPrefetchCacheEntryForNavigation(
     rscUrl,
@@ -635,7 +636,7 @@ export function hasPrefetchCacheEntryForNavigation(
     getPrefetchedUrls(),
     match.cacheKey,
     match.entry,
-    true,
+    options.notifyInvalidation ?? true,
   );
   return false;
 }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -619,21 +619,8 @@ export function hasPrefetchCacheEntryForNavigation(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
-  options: { evictIncompatibleExactEntry?: boolean; notifyInvalidation?: boolean } = {},
+  options: { notifyInvalidation?: boolean } = {},
 ): boolean {
-  if (options.evictIncompatibleExactEntry) {
-    const cache = getPrefetchCache();
-    const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
-    const exactEntry = cache.get(exactCacheKey);
-    if (
-      exactEntry &&
-      exactEntry.cacheForNavigation !== false &&
-      !isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
-    ) {
-      deletePrefetchCacheEntry(cache, getPrefetchedUrls(), exactCacheKey, exactEntry, false);
-    }
-  }
-
   const match = findPrefetchCacheEntryForNavigation(
     rscUrl,
     interceptionContext,

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -259,7 +259,7 @@ declare module "next/navigation" {
     rscUrl: string,
     interceptionContext?: string | null,
     mountedSlotsHeader?: string | null,
-    options?: { evictIncompatibleExactEntry?: boolean; notifyInvalidation?: boolean },
+    options?: { notifyInvalidation?: boolean },
   ): boolean;
   export function storePrefetchResponse(
     rscUrl: string,

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -259,7 +259,7 @@ declare module "next/navigation" {
     rscUrl: string,
     interceptionContext?: string | null,
     mountedSlotsHeader?: string | null,
-    options?: { notifyInvalidation?: boolean },
+    options?: { evictIncompatibleExactEntry?: boolean; notifyInvalidation?: boolean },
   ): boolean;
   export function storePrefetchResponse(
     rscUrl: string,

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -259,6 +259,7 @@ declare module "next/navigation" {
     rscUrl: string,
     interceptionContext?: string | null,
     mountedSlotsHeader?: string | null,
+    options?: { notifyInvalidation?: boolean },
   ): boolean;
   export function storePrefetchResponse(
     rscUrl: string,

--- a/tests/navigation-planner-prefetch-reuse.test.ts
+++ b/tests/navigation-planner-prefetch-reuse.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NAVIGATION_TRACE_SCHEMA_VERSION,
+  NavigationTraceReasonCodes,
+} from "../packages/vinext/src/server/navigation-trace.js";
+import {
+  navigationPlanner,
+  type NavigationReuseDecisionV0,
+  type NavigationReuseFactsV0,
+  type VisitedResponseCacheCandidateFactsV0,
+} from "../packages/vinext/src/server/navigation-planner.js";
+
+function createReuseFacts(overrides: Partial<NavigationReuseFactsV0> = {}): NavigationReuseFactsV0 {
+  return {
+    bypassNavigationCache: false,
+    navigationKind: "navigate",
+    optimisticRouteShell: { status: "available" },
+    prefetch: { status: "unavailable" },
+    targetHref: "/dashboard",
+    visitedResponse: { status: "unavailable" },
+    ...overrides,
+  };
+}
+
+function classifyReuse(overrides: Partial<NavigationReuseFactsV0> = {}): NavigationReuseDecisionV0 {
+  return navigationPlanner.classifyNavigationReuse(createReuseFacts(overrides));
+}
+
+describe("navigationPlanner prefetch reuse classification", () => {
+  it("reuses visited responses before prefetch or optimistic candidates", () => {
+    const decision = classifyReuse({
+      prefetch: { status: "available" },
+      visitedResponse: { status: "available" },
+    });
+
+    expect(decision).toEqual({
+      kind: "reuseVisitedResponse",
+      trace: {
+        schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.visitedResponseReuse,
+            fields: {
+              eventKind: "navigate",
+              targetHref: "/dashboard",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("consumes an eligible prefetch when no visited response exists", () => {
+    const decision = classifyReuse({
+      prefetch: { status: "available" },
+    });
+
+    expect(decision).toMatchObject({
+      kind: "consumePrefetch",
+      trace: {
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.prefetchResponseReuse,
+          },
+        ],
+      },
+    });
+  });
+
+  it("attempts an optimistic route shell for navigate misses with a route manifest", () => {
+    const decision = classifyReuse();
+
+    expect(decision).toMatchObject({
+      kind: "attemptOptimisticRouteShell",
+      trace: {
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.optimisticRouteShell,
+          },
+        ],
+      },
+    });
+  });
+
+  it("skips visited and prefetch reuse when navigation cache is bypassed", () => {
+    const decision = classifyReuse({
+      bypassNavigationCache: true,
+      prefetch: { status: "available" },
+      visitedResponse: { status: "available" },
+    });
+
+    expect(decision.kind).toBe("attemptOptimisticRouteShell");
+  });
+
+  it("fetches fresh for refresh even when cache candidates exist", () => {
+    const decision = classifyReuse({
+      navigationKind: "refresh",
+      prefetch: { status: "available" },
+      visitedResponse: { status: "available" },
+    });
+
+    expect(decision).toEqual({
+      kind: "fetchFresh",
+      reason: "refresh",
+      trace: {
+        schemaVersion: NAVIGATION_TRACE_SCHEMA_VERSION,
+        entries: [
+          {
+            code: NavigationTraceReasonCodes.fetchFresh,
+            fields: {
+              eventKind: "refresh",
+              freshFetchReason: "refresh",
+              targetHref: "/dashboard",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("fetches fresh for traverse misses instead of attempting optimistic shells", () => {
+    const decision = classifyReuse({
+      navigationKind: "traverse",
+    });
+
+    expect(decision).toMatchObject({
+      kind: "fetchFresh",
+      reason: "cacheMiss",
+    });
+  });
+
+  it("fetches fresh for navigate misses without an optimistic shell candidate", () => {
+    const decision = classifyReuse({
+      optimisticRouteShell: { reason: "routeManifestMissing", status: "unavailable" },
+    });
+
+    expect(decision).toMatchObject({
+      kind: "fetchFresh",
+      reason: "routeManifestMissing",
+    });
+  });
+
+  it("fetches fresh for bypassed navigate misses without an optimistic shell candidate", () => {
+    const decision = classifyReuse({
+      bypassNavigationCache: true,
+      optimisticRouteShell: { reason: "routeManifestMissing", status: "unavailable" },
+      prefetch: { status: "available" },
+      visitedResponse: { status: "available" },
+    });
+
+    expect(decision).toMatchObject({
+      kind: "fetchFresh",
+      reason: "cacheBypassed",
+    });
+  });
+});
+
+describe("navigationPlanner visited-response cache candidate classification", () => {
+  function classifyVisited(
+    overrides: Partial<
+      Extract<VisitedResponseCacheCandidateFactsV0, { candidate: "present" }>
+    > = {},
+  ) {
+    return navigationPlanner.classifyVisitedResponseCacheCandidate({
+      candidate: "present",
+      fresh: true,
+      mountedSlotsMatch: true,
+      navigationKind: "navigate",
+      ...overrides,
+    });
+  }
+
+  it("reuses fresh matching candidates", () => {
+    expect(classifyVisited()).toEqual({ kind: "reuse" });
+  });
+
+  it("misses absent candidates", () => {
+    expect(
+      navigationPlanner.classifyVisitedResponseCacheCandidate({
+        candidate: "missing",
+        navigationKind: "navigate",
+      }),
+    ).toEqual({ kind: "miss" });
+  });
+
+  it("evicts slot-mismatched candidates before evaluating freshness", () => {
+    expect(
+      classifyVisited({
+        fresh: false,
+        mountedSlotsMatch: false,
+      }),
+    ).toEqual({
+      kind: "evict",
+      reason: "mountedSlotsMismatch",
+    });
+  });
+
+  it("evicts refresh candidates even when still fresh", () => {
+    expect(
+      classifyVisited({
+        navigationKind: "refresh",
+      }),
+    ).toEqual({
+      kind: "evict",
+      reason: "refresh",
+    });
+  });
+
+  it("evicts stale candidates", () => {
+    expect(
+      classifyVisited({
+        fresh: false,
+      }),
+    ).toEqual({
+      kind: "evict",
+      reason: "stale",
+    });
+  });
+});

--- a/tests/navigation-planner-prefetch-reuse.test.ts
+++ b/tests/navigation-planner-prefetch-reuse.test.ts
@@ -27,6 +27,51 @@ function classifyReuse(overrides: Partial<NavigationReuseFactsV0> = {}): Navigat
 }
 
 describe("navigationPlanner prefetch reuse classification", () => {
+  it("skips prefetch probes when a visited response is already reusable", () => {
+    expect(
+      navigationPlanner.classifyNavigationPrefetchProbe({
+        bypassNavigationCache: false,
+        navigationKind: "navigate",
+        visitedResponse: { status: "available" },
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason: "visitedResponseAvailable",
+    });
+  });
+
+  it("probes prefetch only for non-refresh cacheable visited-response misses", () => {
+    expect(
+      navigationPlanner.classifyNavigationPrefetchProbe({
+        bypassNavigationCache: false,
+        navigationKind: "navigate",
+        visitedResponse: { status: "unavailable" },
+      }),
+    ).toEqual({ kind: "probe" });
+
+    expect(
+      navigationPlanner.classifyNavigationPrefetchProbe({
+        bypassNavigationCache: false,
+        navigationKind: "refresh",
+        visitedResponse: { status: "unavailable" },
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason: "refresh",
+    });
+
+    expect(
+      navigationPlanner.classifyNavigationPrefetchProbe({
+        bypassNavigationCache: true,
+        navigationKind: "navigate",
+        visitedResponse: { status: "unavailable" },
+      }),
+    ).toEqual({
+      kind: "skip",
+      reason: "cacheBypassed",
+    });
+  });
+
   it("reuses visited responses before prefetch or optimistic candidates", () => {
     const decision = classifyReuse({
       prefetch: { status: "available" },

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -688,6 +688,37 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
   });
 
+  it("can probe stale navigation candidates without notifying invalidation callbacks", () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const onInvalidate = vi.fn();
+    const now = 1_000_000;
+    const rscUrl = "/dynamic-stale-navigation.rsc";
+    cache.set(rscUrl, {
+      onInvalidateCallbacks: new Set([onInvalidate]),
+      outcome: "cache-seeded",
+      snapshot: {
+        buffer: new TextEncoder().encode("dynamic-navigation").buffer,
+        contentType: "text/x-component",
+        dynamicStaleTimeSeconds: 10,
+        mountedSlotsHeader: null,
+        paramsHeader: null,
+        url: rscUrl,
+      },
+      timestamp: now,
+    });
+    prefetched.add(rscUrl);
+
+    vi.spyOn(Date, "now").mockReturnValue(now + 10_000);
+
+    expect(
+      hasPrefetchCacheEntryForNavigation(rscUrl, null, null, { notifyInvalidation: false }),
+    ).toBe(false);
+    expect(onInvalidate).not.toHaveBeenCalled();
+    expect(getPrefetchCache().has(rscUrl)).toBe(false);
+    expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
+  });
+
   it("preserves the original expiry when consuming a prefetched response", () => {
     const cache = getPrefetchCache();
     const prefetched = getPrefetchedUrls();

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -299,6 +299,37 @@ describe("prefetch cache eviction", () => {
     expect(prefetched.has(originalRscUrl)).toBe(false);
   });
 
+  it("can evict a slot-incompatible exact navigation candidate before fallback", () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const rscUrl = "/parallel-slots.rsc";
+    const prefetchedSlotsHeader = "slot:slotA:/parallel-slots";
+    const navigationSlotsHeader = "slot:slotB:/parallel-slots";
+
+    cache.set(rscUrl, {
+      mountedSlotsHeader: prefetchedSlotsHeader,
+      outcome: "cache-seeded",
+      snapshot: {
+        buffer: new TextEncoder().encode("parallel-flight").buffer,
+        contentType: "text/x-component",
+        mountedSlotsHeader: prefetchedSlotsHeader,
+        paramsHeader: null,
+        url: rscUrl,
+      },
+      timestamp: Date.now(),
+    });
+    prefetched.add(rscUrl);
+
+    expect(
+      hasPrefetchCacheEntryForNavigation(rscUrl, null, navigationSlotsHeader, {
+        evictIncompatibleExactEntry: true,
+        notifyInvalidation: false,
+      }),
+    ).toBe(false);
+    expect(cache.has(rscUrl)).toBe(false);
+    expect(prefetched.has(rscUrl)).toBe(false);
+  });
+
   it("keeps learning-only prefetch responses out of navigation consumption", () => {
     const cache = getPrefetchCache();
     const prefetched = getPrefetchedUrls();

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -299,37 +299,6 @@ describe("prefetch cache eviction", () => {
     expect(prefetched.has(originalRscUrl)).toBe(false);
   });
 
-  it("can evict a slot-incompatible exact navigation candidate before fallback", () => {
-    const cache = getPrefetchCache();
-    const prefetched = getPrefetchedUrls();
-    const rscUrl = "/parallel-slots.rsc";
-    const prefetchedSlotsHeader = "slot:slotA:/parallel-slots";
-    const navigationSlotsHeader = "slot:slotB:/parallel-slots";
-
-    cache.set(rscUrl, {
-      mountedSlotsHeader: prefetchedSlotsHeader,
-      outcome: "cache-seeded",
-      snapshot: {
-        buffer: new TextEncoder().encode("parallel-flight").buffer,
-        contentType: "text/x-component",
-        mountedSlotsHeader: prefetchedSlotsHeader,
-        paramsHeader: null,
-        url: rscUrl,
-      },
-      timestamp: Date.now(),
-    });
-    prefetched.add(rscUrl);
-
-    expect(
-      hasPrefetchCacheEntryForNavigation(rscUrl, null, navigationSlotsHeader, {
-        evictIncompatibleExactEntry: true,
-        notifyInvalidation: false,
-      }),
-    ).toBe(false);
-    expect(cache.has(rscUrl)).toBe(false);
-    expect(prefetched.has(rscUrl)).toBe(false);
-  });
-
   it("keeps learning-only prefetch responses out of navigation consumption", () => {
     const cache = getPrefetchCache();
     const prefetched = getPrefetchedUrls();


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Implement PR 4 from #1790 by moving prefetch reuse selection into the navigation planner. |
| Core change | The browser executor now supplies typed visited-response, prefetch, and optimistic-shell candidate facts to `navigationPlanner`. |
| Boundary | Planner decides reuse/fetch intent. Executor still owns cache maps, awaiting prefetches, fetches, React rendering, and history effects. |
| Primary files | `navigation-planner.ts`, `app-browser-entry.ts`, `navigation.ts`, planner/cache tests. |
| Expected impact | No intended user-visible behavior change. This makes prefetch reuse policy testable without browser or React execution. |

## Why

Navigation cache reuse is a control-plane decision: it depends on navigation kind, cache-bypass policy, candidate availability, and whether an optimistic shell can be attempted. The browser executor should collect those facts and perform effects, but it should not own the semantic ordering of visited response reuse, prefetch consumption, optimistic shell attempts, and fresh fetch fallback.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Visited response cache | Freshness, refresh, and mounted-slot compatibility decide whether a cached response may be reused. | Adds planner classification for visited-response candidates while leaving LRU and eviction effects in the cache helper. |
| Prefetch consumption | A navigation may share an eligible prefetch candidate, including an in-flight request, before issuing a fresh fetch. | Adds a planner reuse decision and keeps the actual await/consume path in the browser executor. |
| Optimistic shell | Optimistic route shell rendering is a detached fallback only after authoritative cache/prefetch reuse is unavailable. | Planner decides when the executor may attempt optimistic shell learning and rendering. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Fresh visited response | Browser entry chose the branch inline. | Planner returns `reuseVisitedResponse`. |
| Eligible prefetch | Browser entry checked navigation kind/cache bypass inline before consuming. | Planner returns `consumePrefetch` from typed candidate facts. |
| Failed or stale prefetch probe | Navigation fell through to optimistic shell/fetch. | Same behavior, with a second planner decision after failed consumption. |
| Stale navigation probe | Expired entries were removed silently through the consume path. | Candidate probing can opt out of invalidation notifications to preserve that behavior. |
| Optimistic shell | Browser entry decided when to learn/render optimistic templates. | Planner returns `attemptOptimisticRouteShell`; executor still performs learning/rendering. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/navigation-planner.ts`: review the new candidate fact and reuse decision types, plus the decision ordering in `classifyNavigationReuse`.
2. `packages/vinext/src/server/app-browser-entry.ts`: review how the executor collects candidate facts and how failed prefetch consumption is replanned before optimistic/fresh fetch fallback.
3. `packages/vinext/src/shims/navigation.ts`: review the backward-compatible `notifyInvalidation` option used only by navigation candidate probes.
4. `tests/navigation-planner-prefetch-reuse.test.ts` and `tests/prefetch-cache.test.ts`: review the planner decision table and stale-probe notification regression coverage.

</details>

<details>
<summary>Validation</summary>

- `vp check`
- `vp test run tests/navigation-planner-prefetch-reuse.test.ts tests/navigation-planner.test.ts tests/navigation-planner-rsc-fetch-result.test.ts tests/navigation-planner-early-intent.test.ts tests/prefetch-cache.test.ts tests/app-visited-response-cache.test.ts tests/app-optimistic-routing.test.ts`
- `pnpm knip`
- `pnpm run test:e2e tests/e2e/app-router/nextjs-compat/prefetch.spec.ts`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: adds an optional `notifyInvalidation` option to the existing internal prefetch cache probe. Existing callers keep the previous default behavior.
- Runtime: no intended user-visible behavior change. The PR preserves refresh cache bypass, same-page search cache bypass, in-flight prefetch reuse, and silent stale-prefetch eviction for navigation probes.
- Architecture: this is intentionally a control-plane slice. It does not introduce segment cache storage or `OperationToken` authority.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| #1790 | Tracks PR 4 scope: visited-response cache lookup, prefetch consumption, and optimistic route shell learning. |
| Next.js segment-cache prefetch tests | Informs the prefetch reuse expectation and the in-flight duplicate request regression shape. |
