### PR TITLE
fix(config): share CommonJS module fallback

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -17,6 +17,7 @@ import { isUnknownRecord } from "../utils/record.js";
 import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
 import { loadTsconfigResolutionForRoot } from "./tsconfig-paths.js";
 import { getViteMajorVersion } from "../utils/vite-version.js";
+import { loadCommonJsModule, shouldRetryAsCommonJs } from "../utils/commonjs-loader.js";
 
 /**
  * Parse a body size limit value (string or number) into bytes.
@@ -798,11 +799,8 @@ export async function resolveNextConfigInput(
  *
  * For `.cjs` (or `.js` in a non-type-module package) Node's loader picks the
  * right format automatically and `require()` just works. For `.js` in a
- * `"type": "module"` package, Node infers ESM from package.json and the file
- * fails with `require is not defined`. In that case we copy the source to a
- * sibling temp `.cjs` (where the explicit extension forces CJS regardless of
- * the parent type field) and require *that*. Relative imports inside the
- * config still resolve against the original directory.
+ * `"type": "module"` package, retry through the shared in-memory CommonJS
+ * loader so nested local `.js` dependencies retain CommonJS semantics too.
  */
 async function loadConfigViaRequire(
   configPath: string,
@@ -813,30 +811,8 @@ async function loadConfigViaRequire(
   try {
     return await unwrapConfig(require(configPath), phase);
   } catch (e) {
-    if (!isCjsError(e) || !configPath.endsWith(".js")) throw e;
-    return await loadConfigViaCjsTempCopy(configPath, root, phase);
-  }
-}
-
-async function loadConfigViaCjsTempCopy(
-  configPath: string,
-  root: string,
-  phase: string,
-): Promise<NextConfig> {
-  const dir = path.dirname(configPath);
-  // Hidden + uniquely-named to avoid clashing with user files or being picked
-  // up by next.js's own config scanner if a concurrent next dev is running.
-  const tmpPath = path.join(dir, `.vinext-next-config.${process.pid}.${Date.now()}.cjs`);
-  fs.copyFileSync(configPath, tmpPath);
-  try {
-    const require = createRequire(path.join(root, "package.json"));
-    return await unwrapConfig(require(tmpPath), phase);
-  } finally {
-    try {
-      fs.unlinkSync(tmpPath);
-    } catch {
-      // Best-effort cleanup; a stray tmp file is harmless.
-    }
+    if (!shouldRetryAsCommonJs(e, configPath)) throw e;
+    return await unwrapConfig(loadCommonJsModule(configPath), phase);
   }
 }
 

--- a/packages/vinext/src/plugins/postcss.ts
+++ b/packages/vinext/src/plugins/postcss.ts
@@ -1,64 +1,10 @@
 import path from "node:path";
 import fs from "node:fs";
-import { pathToFileURL } from "node:url";
-import { createRequire, Module } from "node:module";
-
-type CommonJsModule = Module & {
-  _compile(content: string, filename: string): void;
-};
-
-const CommonJsModule = Module as typeof Module & {
-  _nodeModulePaths(from: string): string[];
-};
-
-function shouldRetryAsCommonJs(error: unknown, resolvedPath: string): boolean {
-  return (
-    resolvedPath.endsWith(".js") &&
-    ((error instanceof ReferenceError &&
-      /(?:module|exports|require) is not defined in ES module scope/.test(error.message)) ||
-      (error instanceof Error && "code" in error && error.code === "ERR_REQUIRE_ESM"))
-  );
-}
-
-function loadCommonJsPlugin(resolvedPath: string, cache = new Map<string, Module>()): unknown {
-  const cached = cache.get(resolvedPath);
-  if (cached) return cached.exports;
-
-  const mod = new CommonJsModule(resolvedPath) as CommonJsModule;
-  mod.filename = resolvedPath;
-  mod.paths = CommonJsModule._nodeModulePaths(path.dirname(resolvedPath));
-  cache.set(resolvedPath, mod);
-
-  const req = createRequire(resolvedPath);
-  const originalRequire = mod.require.bind(mod);
-  mod.require = ((specifier: string) => {
-    try {
-      return originalRequire(specifier);
-    } catch (error) {
-      const dependencyPath = req.resolve(specifier);
-      if (!shouldRetryAsCommonJs(error, dependencyPath)) throw error;
-      return loadCommonJsPlugin(dependencyPath, cache);
-    }
-  }) as Module["require"];
-
-  try {
-    mod._compile(fs.readFileSync(resolvedPath, "utf8"), resolvedPath);
-    mod.loaded = true;
-    return mod.exports;
-  } catch (error) {
-    cache.delete(resolvedPath);
-    throw error;
-  }
-}
+import { createRequire } from "node:module";
+import { importExportWithCommonJsFallback } from "../utils/commonjs-loader.js";
 
 async function loadPluginExport(resolvedPath: string): Promise<unknown> {
-  try {
-    const mod = await import(pathToFileURL(resolvedPath).href);
-    return mod.default ?? mod;
-  } catch (error) {
-    if (!shouldRetryAsCommonJs(error, resolvedPath)) throw error;
-    return loadCommonJsPlugin(resolvedPath);
-  }
+  return importExportWithCommonJsFallback(resolvedPath);
 }
 
 /**
@@ -149,8 +95,7 @@ async function resolvePostcssStringPluginsUncached(
         return undefined;
       }
     }
-    const mod = await import(pathToFileURL(configPath).href);
-    config = mod.default ?? mod;
+    config = await importExportWithCommonJsFallback(configPath);
   } catch {
     // If we can't load the config, let Vite/postcss-load-config handle it
     return undefined;

--- a/packages/vinext/src/utils/commonjs-loader.ts
+++ b/packages/vinext/src/utils/commonjs-loader.ts
@@ -40,6 +40,9 @@ export function shouldRetryAsCommonJs(error: unknown, resolvedPath: string): boo
   if (!match || !error.stack) return false;
 
   const identifier = match[1];
+  // This validation intentionally assumes the executed config/plugin source
+  // is byte-identical to the on-disk file. Current callers load raw user files;
+  // transformed modules should not use this fallback without source-map logic.
   for (const line of error.stack.split("\n").slice(1)) {
     const location = line.match(/(?:\(|at )(.+):(\d+):(\d+)\)?$/);
     if (!location) continue;
@@ -56,7 +59,7 @@ export function shouldRetryAsCommonJs(error: unknown, resolvedPath: string): boo
       continue;
     }
     const column = Number(columnNumberText) - 1;
-    return sourceLine?.slice(column, column + identifier.length) === identifier;
+    if (sourceLine?.slice(column, column + identifier.length) === identifier) return true;
   }
 
   return false;
@@ -83,6 +86,10 @@ function compileCommonJsModule(resolvedPath: string, parent?: Module): unknown {
     }
 
     if (dependencyPath.endsWith(".cjs")) {
+      // Keep `.cjs` modules inside this loader so their deferred `require()`
+      // calls retain the same `.js` fallback and share Node's module cache.
+      // This deliberately bypasses third-party `require.extensions[".cjs"]`
+      // hooks; the supported config/plugin paths are raw JavaScript modules.
       return compileCommonJsModule(dependencyPath, mod);
     }
 

--- a/packages/vinext/src/utils/commonjs-loader.ts
+++ b/packages/vinext/src/utils/commonjs-loader.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import { createRequire, Module } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+type CompilableCommonJsModule = Module & {
+  _compile(content: string, filename: string): void;
+};
+
+const CommonJsModule = Module as typeof Module & {
+  _nodeModulePaths(from: string): string[];
+};
+
+function canonicalPath(filePath: string): string {
+  const normalizedPath = filePath.startsWith("/@fs/") ? filePath.slice(4) : filePath;
+  const resolvedPath = normalizedPath.startsWith("file://")
+    ? fileURLToPath(normalizedPath)
+    : normalizedPath;
+  try {
+    return fs.realpathSync.native(resolvedPath);
+  } catch {
+    return path.resolve(resolvedPath);
+  }
+}
+
+export function shouldRetryAsCommonJs(error: unknown, resolvedPath: string): boolean {
+  if (!resolvedPath.endsWith(".js") || !(error instanceof Error)) return false;
+  if ("code" in error && error.code === "ERR_REQUIRE_ESM") {
+    const canonicalResolvedPath = canonicalPath(resolvedPath);
+    return (
+      error.message.includes(canonicalResolvedPath) ||
+      error.message.includes(pathToFileURL(canonicalResolvedPath).href)
+    );
+  }
+  if (!(error instanceof ReferenceError)) return false;
+
+  const match = error.message.match(
+    /^(module|exports|require|__dirname|__filename) is not defined(?: in ES module scope)?/,
+  );
+  if (!match || !error.stack) return false;
+
+  const identifier = match[1];
+  for (const line of error.stack.split("\n").slice(1)) {
+    const location = line.match(/(?:\(|at )(.+):(\d+):(\d+)\)?$/);
+    if (!location) continue;
+    const [, framePath, lineNumberText, columnNumberText] = location;
+    const canonicalFramePath = canonicalPath(framePath);
+    if (!canonicalFramePath.endsWith(".js")) continue;
+
+    let sourceLine: string | undefined;
+    try {
+      sourceLine = fs.readFileSync(canonicalFramePath, "utf8").split(/\r?\n/)[
+        Number(lineNumberText) - 1
+      ];
+    } catch {
+      continue;
+    }
+    const column = Number(columnNumberText) - 1;
+    return sourceLine?.slice(column, column + identifier.length) === identifier;
+  }
+
+  return false;
+}
+
+function compileCommonJsModule(resolvedPath: string, parent?: Module): unknown {
+  resolvedPath = canonicalPath(resolvedPath);
+  const req = createRequire(resolvedPath);
+  const cached = req.cache[resolvedPath];
+  if (cached) return cached.exports;
+
+  const mod = new CommonJsModule(resolvedPath, parent) as CompilableCommonJsModule;
+  mod.filename = resolvedPath;
+  mod.paths = CommonJsModule._nodeModulePaths(path.dirname(resolvedPath));
+  req.cache[resolvedPath] = mod;
+
+  const originalRequire = mod.require.bind(mod);
+  mod.require = ((specifier: string) => {
+    let dependencyPath: string;
+    try {
+      dependencyPath = req.resolve(specifier);
+    } catch {
+      return originalRequire(specifier);
+    }
+
+    if (dependencyPath.endsWith(".cjs")) {
+      return compileCommonJsModule(dependencyPath, mod);
+    }
+
+    try {
+      return originalRequire(specifier);
+    } catch (error) {
+      if (!shouldRetryAsCommonJs(error, dependencyPath)) throw error;
+      return compileCommonJsModule(dependencyPath, mod);
+    }
+  }) as Module["require"];
+
+  try {
+    mod._compile(fs.readFileSync(resolvedPath, "utf8"), resolvedPath);
+    mod.loaded = true;
+    return mod.exports;
+  } catch (error) {
+    if (req.cache[resolvedPath] === mod) delete req.cache[resolvedPath];
+    throw error;
+  }
+}
+
+/**
+ * Load a `.js` file as CommonJS even when a surrounding `package.json`
+ * declares `"type": "module"`. Nested misclassified `.js` dependencies are
+ * compiled the same way, while Node keeps handling builtins, JSON, native
+ * addons, and correctly classified modules through its normal loader.
+ */
+export function loadCommonJsModule(resolvedPath: string): unknown {
+  return compileCommonJsModule(resolvedPath);
+}
+
+/**
+ * Import a module normally, retrying only `.js` files that fail because Node
+ * classified CommonJS source as ESM.
+ */
+export async function importExportWithCommonJsFallback(resolvedPath: string): Promise<unknown> {
+  try {
+    const mod = await import(pathToFileURL(resolvedPath).href);
+    return mod.default ?? mod;
+  } catch (error) {
+    if (!shouldRetryAsCommonJs(error, resolvedPath)) throw error;
+    return loadCommonJsModule(resolvedPath);
+  }
+}

--- a/tests/commonjs-loader.test.ts
+++ b/tests/commonjs-loader.test.ts
@@ -1,0 +1,226 @@
+import fs, { globSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  importExportWithCommonJsFallback,
+  loadCommonJsModule,
+} from "../packages/vinext/src/utils/commonjs-loader.js";
+
+const tempDirs: string[] = [];
+
+function createEsmProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-commonjs-loader-"));
+  tempDirs.push(dir);
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ type: "module" }));
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.chmodSync(dir, 0o755);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("loadCommonJsModule", () => {
+  it("loads nested CommonJS .js files with circular dependencies", () => {
+    const dir = createEsmProject();
+    fs.writeFileSync(
+      path.join(dir, "a.js"),
+      `exports.name = "a";
+const b = require("./b.js");
+exports.fromB = b.name;
+exports.seenByB = b.fromA;
+`,
+    );
+    fs.writeFileSync(
+      path.join(dir, "b.js"),
+      `exports.name = "b";
+const a = require("./a.js");
+exports.fromA = a.name;
+`,
+    );
+
+    expect(loadCommonJsModule(path.join(dir, "a.js"))).toEqual({
+      name: "a",
+      fromB: "b",
+      seenByB: "a",
+    });
+  });
+
+  it("keeps fallback active across CommonJS .cjs boundaries", () => {
+    const dir = createEsmProject();
+    fs.writeFileSync(
+      path.join(dir, "entry.js"),
+      `module.exports = require("./bridge.cjs");
+`,
+    );
+    fs.writeFileSync(
+      path.join(dir, "bridge.cjs"),
+      `module.exports = require("./value.js");
+`,
+    );
+    fs.writeFileSync(
+      path.join(dir, "value.js"),
+      `module.exports = { value: "nested" };
+`,
+    );
+
+    expect(loadCommonJsModule(path.join(dir, "entry.js"))).toEqual({ value: "nested" });
+  });
+
+  it("preserves Node cache and parent semantics across CommonJS .cjs boundaries", () => {
+    const dir = createEsmProject();
+    const counterKey = `__vinext_commonjs_bridge_${Date.now()}`;
+    fs.writeFileSync(
+      path.join(dir, "entry.js"),
+      `const first = require("./bridge.cjs");
+const second = require("./bridge.cjs");
+module.exports = { first, same: first === second };
+`,
+    );
+    fs.writeFileSync(
+      path.join(dir, "bridge.cjs"),
+      `globalThis[${JSON.stringify(counterKey)}] = (globalThis[${JSON.stringify(counterKey)}] ?? 0) + 1;
+module.exports = {
+  cached: require.cache[__filename] === module,
+  parent: module.parent?.filename,
+};
+`,
+    );
+
+    const result = loadCommonJsModule(path.join(dir, "entry.js")) as {
+      first: { cached: boolean; parent?: string };
+      same: boolean;
+    };
+    expect(result.first.cached).toBe(true);
+    expect(result.first.parent).toBe(fs.realpathSync(path.join(dir, "entry.js")));
+    expect(result.same).toBe(true);
+    expect((globalThis as Record<string, unknown>)[counterKey]).toBe(1);
+    delete (globalThis as Record<string, unknown>)[counterKey];
+  });
+
+  it("keeps fallback active for deferred exported function requires", () => {
+    const dir = createEsmProject();
+    fs.writeFileSync(
+      path.join(dir, "entry.js"),
+      `module.exports = () => require("./value.js");
+`,
+    );
+    fs.writeFileSync(path.join(dir, "value.js"), `module.exports = "deferred";\n`);
+
+    const loadValue = loadCommonJsModule(path.join(dir, "entry.js")) as () => string;
+    expect(loadValue()).toBe("deferred");
+  });
+
+  it("keeps fallback active for deferred async exported function requires", async () => {
+    const dir = createEsmProject();
+    fs.writeFileSync(
+      path.join(dir, "entry.js"),
+      `module.exports = async () => require("./value.js");
+`,
+    );
+    fs.writeFileSync(path.join(dir, "value.js"), `module.exports = "async-deferred";\n`);
+
+    const loadValue = loadCommonJsModule(path.join(dir, "entry.js")) as () => Promise<string>;
+    await expect(loadValue()).resolves.toBe("async-deferred");
+  });
+
+  it("delegates builtins and JSON files to Node's loader", () => {
+    const dir = createEsmProject();
+    fs.writeFileSync(path.join(dir, "data.json"), JSON.stringify({ value: "json" }));
+    fs.writeFileSync(
+      path.join(dir, "entry.js"),
+      `const path = require("node:path");
+const data = require("./data.json");
+module.exports = path.posix.join(data.value, "builtin");
+`,
+    );
+
+    expect(loadCommonJsModule(path.join(dir, "entry.js"))).toBe("json/builtin");
+  });
+
+  it("delegates packages with native addons to Node's loader", () => {
+    const dir = createEsmProject();
+    const [addonPath] = globSync(
+      "node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+      { cwd: path.join(import.meta.dirname, "..") },
+    );
+    expect(addonPath).toBeDefined();
+    const resolvedAddonPath = path.resolve(import.meta.dirname, "..", addonPath!);
+    fs.writeFileSync(
+      path.join(dir, "entry.js"),
+      `const watcher = require(${JSON.stringify(resolvedAddonPath)});
+module.exports = typeof watcher;
+`,
+    );
+
+    expect(loadCommonJsModule(path.join(dir, "entry.js"))).toBe("object");
+  });
+
+  it("does not retry syntax errors as CommonJS", async () => {
+    const dir = createEsmProject();
+    const entryPath = path.join(dir, "entry.js");
+    fs.writeFileSync(
+      entryPath,
+      `export default { invalid: };
+`,
+    );
+
+    await expect(importExportWithCommonJsFallback(entryPath)).rejects.toThrow("Unexpected token");
+  });
+
+  it("does not retry user-thrown errors that mimic missing CommonJS globals", async () => {
+    const dir = createEsmProject();
+    const entryPath = path.join(dir, "entry.js");
+    const counterKey = `__vinext_commonjs_loader_${Date.now()}`;
+    fs.writeFileSync(
+      entryPath,
+      `globalThis[${JSON.stringify(counterKey)}] = (globalThis[${JSON.stringify(counterKey)}] ?? 0) + 1;
+throw new ReferenceError("require is not defined in ES module scope");
+`,
+    );
+
+    await expect(importExportWithCommonJsFallback(entryPath)).rejects.toThrow(
+      "require is not defined in ES module scope",
+    );
+    expect((globalThis as Record<string, unknown>)[counterKey]).toBe(1);
+    delete (globalThis as Record<string, unknown>)[counterKey];
+  });
+
+  it("does not retry user-thrown errors that spoof ERR_REQUIRE_ESM", async () => {
+    const dir = createEsmProject();
+    const entryPath = path.join(dir, "entry.js");
+    const counterKey = `__vinext_commonjs_loader_code_${Date.now()}`;
+    fs.writeFileSync(
+      entryPath,
+      `globalThis[${JSON.stringify(counterKey)}] = (globalThis[${JSON.stringify(counterKey)}] ?? 0) + 1;
+const error = new Error("application failure");
+error.code = "ERR_REQUIRE_ESM";
+throw error;
+`,
+    );
+
+    await expect(importExportWithCommonJsFallback(entryPath)).rejects.toThrow(
+      "application failure",
+    );
+    expect((globalThis as Record<string, unknown>)[counterKey]).toBe(1);
+    delete (globalThis as Record<string, unknown>)[counterKey];
+  });
+
+  it("preserves CommonJS exports that contain a default property", async () => {
+    const dir = createEsmProject();
+    const entryPath = path.join(dir, "entry.js");
+    fs.writeFileSync(
+      entryPath,
+      `module.exports = { default: "value", named: true };
+`,
+    );
+
+    await expect(importExportWithCommonJsFallback(entryPath)).resolves.toEqual({
+      default: "value",
+      named: true,
+    });
+  });
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -109,14 +109,72 @@ describe("loadNextConfig with CJS next.config.js under type:module", () => {
     expect(config?.env?.WRAPPED).toBe("yes");
   });
 
-  it("does not leave temp .cjs files in the project root", async () => {
-    fs.writeFileSync(path.join(tmpDir, "next.config.js"), `module.exports = { basePath: '/x' };\n`);
+  it("loads nested CommonJS .js dependencies", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config-helper.js"),
+      `const values = require("./config-values.js");
+module.exports = { basePath: values.basePath };
+`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "config-values.js"),
+      `module.exports = { basePath: "/nested" };
+`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.js"),
+      `module.exports = require("./config-helper.js");
+`,
+    );
 
-    await loadNextConfig(tmpDir);
+    const config = await loadNextConfig(tmpDir);
+    expect(config?.basePath).toBe("/nested");
+  });
+
+  it("loads nested CommonJS .js dependencies from read-only symlink targets", async () => {
+    const packageDir = path.join(tmpDir, "packages", "config-wrapper");
+    const packageLink = path.join(tmpDir, "node_modules", "config-wrapper");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.mkdirSync(path.dirname(packageLink), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "config-wrapper", main: "index.js", type: "module" }),
+    );
+    fs.writeFileSync(path.join(packageDir, "value.js"), `module.exports = "/linked";\n`);
+    fs.writeFileSync(
+      path.join(packageDir, "index.js"),
+      `module.exports = { basePath: require("./value.js") };\n`,
+    );
+    fs.symlinkSync(packageDir, packageLink, "junction");
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.js"),
+      `module.exports = require("config-wrapper");\n`,
+    );
+    fs.chmodSync(packageDir, 0o555);
+
+    try {
+      const config = await loadNextConfig(tmpDir);
+      expect(config?.basePath).toBe("/linked");
+      expect(fs.readdirSync(packageDir).some((name) => name.startsWith(".vinext-"))).toBe(false);
+    } finally {
+      fs.chmodSync(packageDir, 0o755);
+    }
+  });
+
+  it("does not write temporary modules beside the config", async () => {
+    fs.writeFileSync(path.join(tmpDir, "next.config.js"), `module.exports = { basePath: '/x' };\n`);
+    fs.chmodSync(tmpDir, 0o555);
+
+    try {
+      const config = await loadNextConfig(tmpDir);
+      expect(config?.basePath).toBe("/x");
+    } finally {
+      fs.chmodSync(tmpDir, 0o755);
+    }
 
     const stray = fs
       .readdirSync(tmpDir)
-      .filter((name) => name.startsWith(".vinext-next-config.") && name.endsWith(".cjs"));
+      .filter((name) => name.startsWith(".vinext-") && name.endsWith(".cjs"));
     expect(stray).toEqual([]);
   });
 });

--- a/tests/postcss-resolve.test.ts
+++ b/tests/postcss-resolve.test.ts
@@ -101,6 +101,25 @@ module.exports.postcss = true;
     }
   });
 
+  it("loads a CommonJS postcss.config.js in an ESM project", async () => {
+    const dir = await createTmpProject(
+      "postcss.config.js",
+      `const plugins = require("./plugins.js");
+module.exports = { plugins };
+`,
+    );
+    const fsp = await import("node:fs/promises");
+    await fsp.writeFile(path.join(dir, "package.json"), JSON.stringify({ type: "module" }));
+    await fsp.writeFile(path.join(dir, "plugins.js"), `module.exports = ["mock-postcss-plugin"];`);
+    try {
+      const result = await resolvePostcssStringPlugins(dir);
+      expect(result?.plugins).toHaveLength(1);
+      expect(result?.plugins[0]).toHaveProperty("postcssPlugin", "mock-postcss-plugin");
+    } finally {
+      await cleanupDir(dir);
+    }
+  });
+
   // --- Object form (should be skipped) ---
 
   it("returns undefined for object-form plugins (postcss-load-config handles these)", async () => {


### PR DESCRIPTION
## Summary
- extract the CommonJS `.js` fallback introduced in #1961 into a shared Node-only loader
- use it for PostCSS config files, PostCSS string plugins, and legacy `next.config.js` loading
- remove temporary sibling `.cjs` files from the next-config fallback
- preserve recursive and deferred CommonJS `require()` behavior across `.js` and `.cjs` boundaries

## Compatibility
- preserves Node module cache, `module.parent`, circular dependencies, JSON, builtins, and native addons
- supports synchronous and asynchronous exported factories that call `require()` after initial module evaluation
- avoids retrying syntax errors or user-thrown errors that mimic CommonJS loader failures
- supports read-only and symlinked package targets without writing temporary files

## Tests
- `vp check packages/vinext/src/utils/commonjs-loader.ts packages/vinext/src/plugins/postcss.ts packages/vinext/src/config/next-config.ts tests/commonjs-loader.test.ts tests/postcss-resolve.test.ts tests/next-config.test.ts`
- `vp test run tests/commonjs-loader.test.ts tests/postcss-resolve.test.ts tests/next-config.test.ts` (211 passed)
- `vp run vinext#build`

## Upstream reference
Next.js uses `Module._compile` plus a `.js` require hook for config loading:
- https://github.com/vercel/next.js/blob/canary/packages/next/src/build/next-config-ts/transpile-config.ts
- https://github.com/vercel/next.js/blob/canary/packages/next/src/build/next-config-ts/require-hook.ts
