### PR TITLE
perf: skip unnecessary import parsing

### DIFF
--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -193,7 +193,7 @@ export function createOptimizedImportSourceMatcher(
   if (!pattern) return () => false;
 
   const importFromPattern = new RegExp(
-    String.raw`(?:^|[;\n\r])\s*import(?!\s*\()[^;]*?\bfrom\s*["'](?:${pattern})["']`,
+    String.raw`(?:^|[;}\n\r])\s*import(?!\s*\()[\s\S]*?\bfrom\s*["'](?:${pattern})["']`,
     "m",
   );
 

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -193,7 +193,7 @@ export function createOptimizedImportSourceMatcher(
   if (!pattern) return () => false;
 
   const importFromPattern = new RegExp(
-    String.raw`(?:^|[;}\n\r])\s*import(?!\s*\()[\s\S]*?\bfrom\s*["'](?:${pattern})["']`,
+    String.raw`(?:^|[;}\n\r])\s*import(?!\s*\()(?:(?!\bfrom\b)[\s\S])*?\bfrom\s*["'](?:${pattern})["']`,
     "m",
   );
 

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -20,6 +20,7 @@ import MagicString from "magic-string";
 import type { ResolvedNextConfig } from "../config/next-config.js";
 import { getAstName } from "./ast-utils.js";
 import { normalizePathSeparators } from "../utils/path.js";
+import { escapeRegExp } from "../utils/regex.js";
 
 /**
  * Read a file's contents, returning null on any error.
@@ -184,6 +185,21 @@ export const DEFAULT_OPTIMIZE_PACKAGES: string[] = [
   "react-icons/wi",
   "radix-ui",
 ];
+
+export function createOptimizedImportSourceMatcher(
+  packages: Iterable<string>,
+): (code: string) => boolean {
+  const pattern = [...packages].map(escapeRegExp).join("|");
+  if (!pattern) return () => false;
+
+  const importFromPattern = new RegExp(
+    String.raw`(?:^|[;\n\r])\s*import(?!\s*\()[^;]*?\bfrom\s*["'](?:${pattern})["']`,
+    "m",
+  );
+
+  return (code: string) =>
+    code.includes("import") && code.includes("from") && importFromPattern.test(code);
+}
 
 /**
  * Resolve a package.json exports value to a string entry path.
@@ -647,9 +663,7 @@ export function createOptimizeImportsPlugin(
   // file that imports from the same barrel package.
   const entryPathCache = new Map<string, string | null>();
   let optimizedPackages: Set<string> = new Set();
-  // Pre-built quoted forms used for the per-file quick-check. Computed once in
-  // buildStart so the transform loop doesn't allocate template literals per file.
-  let quotedPackages: string[] = [];
+  let hasOptimizedImportSource: (code: string) => boolean = () => false;
   // Tracks barrel entries whose sub-package origins have already been registered,
   // so repeated imports of the same barrel (across many files) don't redundantly
   // iterate the full export map. Keys are `${envKey}:${barrelEntry}` so that RSC
@@ -674,9 +688,7 @@ export function createOptimizeImportsPlugin(
         ...DEFAULT_OPTIMIZE_PACKAGES,
         ...(nextConfig?.optimizePackageImports ?? []),
       ]);
-      // Pre-build quoted package strings once so the per-file quick-check
-      // doesn't allocate template literals for every transformed file.
-      quotedPackages = [...optimizedPackages].flatMap((pkg) => [`"${pkg}"`, `'${pkg}'`]);
+      hasOptimizedImportSource = createOptimizedImportSourceMatcher(optimizedPackages);
       // Clear all caches across rebuilds so stale data doesn't linger.
       // exportMapCache and subpkgOrigin hold barrel AST analysis and sub-package
       // origin mappings which may change if a dependency is updated mid-dev.
@@ -724,18 +736,11 @@ export function createOptimizeImportsPlugin(
         // Skip virtual modules
         if (id.startsWith("\0")) return null;
 
-        // Quick string check: does the code mention any optimized package?
-        // Use quoted forms to avoid false positives (e.g. "effect" in "useEffect").
-        // quotedPackages is pre-built in buildStart to avoid per-file allocations.
+        // Quick pre-parse check: only transformable static `import ... from "pkg"`
+        // declarations can be rewritten, so skip files that merely mention an
+        // optimized package in ordinary strings, comments, or side-effect imports.
         const packages = optimizedPackages;
-        let hasBarrelImport = false;
-        for (const quoted of quotedPackages) {
-          if (code.includes(quoted)) {
-            hasBarrelImport = true;
-            break;
-          }
-        }
-        if (!hasBarrelImport) return null;
+        if (!hasOptimizedImportSource(code)) return null;
 
         let ast: ReturnType<typeof parseAst>;
         try {

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -10,6 +10,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
   buildBarrelExportMap,
+  createOptimizedImportSourceMatcher,
   createOptimizeImportsPlugin,
   DEFAULT_OPTIMIZE_PACKAGES,
 } from "../packages/vinext/src/plugins/optimize-imports.js";
@@ -67,6 +68,17 @@ describe("vinext:optimize-imports plugin", () => {
 
     const result = await (transform as any).call(plugin, code, "/app/page.tsx");
     expect(result).toBeNull();
+  });
+
+  it("quick-checks only transformable static import sources", () => {
+    const hasOptimizedImport = createOptimizedImportSourceMatcher(["lucide-react", "radix-ui"]);
+
+    expect(hasOptimizedImport(`import { Sun } from "lucide-react";`)).toBe(true);
+    expect(hasOptimizedImport(`import{Slot}from'radix-ui';`)).toBe(true);
+    expect(hasOptimizedImport(`import type { IconNode } from "lucide-react";`)).toBe(true);
+    expect(hasOptimizedImport(`const source = 'import { Sun } from "lucide-react"';`)).toBe(false);
+    expect(hasOptimizedImport(`// import { Slot } from "radix-ui";`)).toBe(false);
+    expect(hasOptimizedImport(`import "lucide-react";`)).toBe(false);
   });
 
   it("returns null when barrel package mentioned but no resolvable entry", async () => {

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -79,6 +79,8 @@ describe("vinext:optimize-imports plugin", () => {
     expect(hasOptimizedImport(`const source = 'import { Sun } from "lucide-react"';`)).toBe(false);
     expect(hasOptimizedImport(`// import { Slot } from "radix-ui";`)).toBe(false);
     expect(hasOptimizedImport(`import "lucide-react";`)).toBe(false);
+    expect(hasOptimizedImport(`import { Sun /*; */ } from "lucide-react";`)).toBe(true);
+    expect(hasOptimizedImport(`function f(){}import { Sun } from "lucide-react";`)).toBe(true);
   });
 
   it("returns null when barrel package mentioned but no resolvable entry", async () => {


### PR DESCRIPTION
CPU profiling showed most time is in Vite/vite-plus/Rolldown/Node startup, with the largest vinext-owned slice in optimize-imports.

Changes:
- optimize-imports.ts to use a precompiled static import-source matcher before parsing ASTs, and added coverage in optimize-imports.test.ts. This avoids scanning every optimized package and parsing files that only mention optimized packages in strings, comments, or side-effect imports.

Measured impact:
- vinext dev cold-start benchmark mean: 1.83s -> 1.75s
- optimize-imports active CPU: 35.5ms -> 1.3ms
- total vinext active CPU in the cold-start profile: 107.8ms -> 56.2ms

Verification:
- vp check packages/vinext/src/plugins/optimize-imports.ts tests/optimize-imports.test.ts
- vp test run tests/optimize-imports.test.ts → 42 passed