### PR TITLE
fix(pages-router): pass rewrite URL to edge API requests

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -551,7 +551,7 @@ import { runPagesRequest, wrapMiddlewareWithBasePath } from "vinext/server/pages
 import type { PagesPipelineDeps } from "vinext/server/pages-request-pipeline";
 import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isImageOptimizationPath } from "vinext/server/image-optimization";
 import type { ImageConfig } from "vinext/server/image-optimization";
-import { cloneRequestWithHeaders, filterInternalHeaders, isOpenRedirectShaped } from "vinext/server/request-pipeline";
+import { cloneRequestWithHeaders, cloneRequestWithUrl, filterInternalHeaders, isOpenRedirectShaped } from "vinext/server/request-pipeline";
 import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses";
 import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix";
 import { hasBasePath, stripBasePath } from "vinext/utils/base-path";
@@ -644,7 +644,7 @@ export default {
         if (stripped !== pathname) {
           const strippedUrl = new URL(request.url);
           strippedUrl.pathname = stripped;
-          request = new Request(strippedUrl, request);
+          request = cloneRequestWithUrl(request, strippedUrl.toString());
           pathname = stripped;
         }
       }

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -438,6 +438,7 @@ export async function handleApiRoute(request, url, ctx) {
   return __handlePagesApiRoute({
     ctx,
     match,
+    nextConfig: vinextConfig,
     request,
     url,
     reportRequestError(error, routePattern) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3769,6 +3769,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   res,
                   pipelineResult.apiUrl,
                   apiRoutes,
+                  {
+                    basePath: nextConfig?.basePath,
+                    i18n: nextConfig?.i18n,
+                    trailingSlash: nextConfig?.trailingSlash,
+                  },
                 );
                 if (handled) return;
 

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -196,6 +196,9 @@ function createEdgeApiRequest(
   const host = resolveRequestHost(req, "localhost");
   // Keep this in sync with pages-api-route.ts: preserve the visible incoming
   // pathname while replacing only the resolved query and dynamic params.
+  // Dev runs after Vite has stripped its configured basePath, so reconstruct
+  // it here; prod/Workers do this earlier in pages-request-pipeline.ts using
+  // the adapter's hadBasePath state before calling pages-api-route.ts.
   const requestUrl = new URL(req.url ?? url, `${proto}://${host}`);
   const basePath = nextConfig?.basePath;
   if (basePath && !hasBasePath(requestUrl.pathname, basePath)) {

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -13,7 +13,11 @@ import { decode as decodeQueryString } from "node:querystring";
 import { Buffer } from "node:buffer";
 import { type Route, matchRoute } from "../routing/pages-router.js";
 import { reportRequestError, importModule, type ModuleImporter } from "./instrumentation.js";
-import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
+import {
+  mergeRouteParamsIntoQuery,
+  parseQueryString,
+  urlQueryToSearchParams,
+} from "../utils/query.js";
 import { parseCookieHeader } from "../utils/parse-cookie.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
@@ -165,7 +169,11 @@ function readEdgeRequestBody(req: IncomingMessage): ReadableStream<Uint8Array> |
   });
 }
 
-function createEdgeApiRequest(req: IncomingMessage, url: string): Request {
+function createEdgeApiRequest(
+  req: IncomingMessage,
+  url: string,
+  params: Record<string, string | string[]>,
+): Request {
   const headers = new Headers();
   for (const [name, value] of Object.entries(req.headers)) {
     if (Array.isArray(value)) {
@@ -183,7 +191,9 @@ function createEdgeApiRequest(req: IncomingMessage, url: string): Request {
   // TLS-terminated. See: Finding F-PROD-7 in SECURITY-AUDIT-2026-05.md.
   const proto = resolveRequestProtocol(req);
   const host = resolveRequestHost(req, "localhost");
-  const requestUrl = new URL(url, `${proto}://${host}`);
+  const requestUrl = new URL(req.url ?? url, `${proto}://${host}`);
+  const query = mergeRouteParamsIntoQuery(parseQueryString(url), params);
+  requestUrl.search = urlQueryToSearchParams(query).toString();
   const body = readEdgeRequestBody(req);
 
   const init: RequestInit & { duplex?: "half" } = {
@@ -343,7 +353,7 @@ export async function handleApiRoute(
       // Next.js wraps the incoming Request in a NextRequest before invoking
       // edge API handlers, so handlers can use `req.nextUrl.searchParams`,
       // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
-      const nextRequest = new NextRequest(createEdgeApiRequest(req, url));
+      const nextRequest = new NextRequest(createEdgeApiRequest(req, url, params));
       const response = await apiModule.default(nextRequest);
       if (!(response instanceof Response)) {
         throw new Error("Edge API route did not return a Response");

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -194,6 +194,8 @@ function createEdgeApiRequest(
   // TLS-terminated. See: Finding F-PROD-7 in SECURITY-AUDIT-2026-05.md.
   const proto = resolveRequestProtocol(req);
   const host = resolveRequestHost(req, "localhost");
+  // Keep this in sync with pages-api-route.ts: preserve the visible incoming
+  // pathname while replacing only the resolved query and dynamic params.
   const requestUrl = new URL(req.url ?? url, `${proto}://${host}`);
   const basePath = nextConfig?.basePath;
   if (basePath && !hasBasePath(requestUrl.pathname, basePath)) {

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -174,6 +174,7 @@ function createEdgeApiRequest(
   req: IncomingMessage,
   url: string,
   params: Record<string, string | string[]>,
+  nextConfig?: { basePath?: string },
 ): Request {
   const headers = new Headers();
   for (const [name, value] of Object.entries(req.headers)) {
@@ -193,6 +194,10 @@ function createEdgeApiRequest(
   const proto = resolveRequestProtocol(req);
   const host = resolveRequestHost(req, "localhost");
   const requestUrl = new URL(req.url ?? url, `${proto}://${host}`);
+  const basePath = nextConfig?.basePath;
+  if (basePath && !requestUrl.pathname.startsWith(`${basePath}/`)) {
+    requestUrl.pathname = `${basePath}${requestUrl.pathname}`;
+  }
   const query = mergeRouteParamsIntoQuery(parseQueryString(url), params);
   requestUrl.search = urlQueryToSearchParams(query).toString();
   const body = readEdgeRequestBody(req);
@@ -360,7 +365,7 @@ export async function handleApiRoute(
       // edge API handlers, so handlers can use `req.nextUrl.searchParams`,
       // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
       const nextRequest = new NextRequest(
-        createEdgeApiRequest(req, url, params),
+        createEdgeApiRequest(req, url, params, nextConfig),
         nextConfig
           ? {
               nextConfig: {

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -29,6 +29,7 @@ import {
 import { resolveRequestProtocol, resolveRequestHost } from "./proxy-trust.js";
 import { performOnDemandRevalidate, type RevalidateOptions } from "./pages-revalidate.js";
 import { NextRequest } from "vinext/shims/server";
+import { hasBasePath } from "../utils/base-path.js";
 
 /**
  * Extend the Node.js request with Next.js-style helpers.
@@ -195,7 +196,7 @@ function createEdgeApiRequest(
   const host = resolveRequestHost(req, "localhost");
   const requestUrl = new URL(req.url ?? url, `${proto}://${host}`);
   const basePath = nextConfig?.basePath;
-  if (basePath && !requestUrl.pathname.startsWith(`${basePath}/`)) {
+  if (basePath && !hasBasePath(requestUrl.pathname, basePath)) {
     requestUrl.pathname = `${basePath}${requestUrl.pathname}`;
   }
   const query = mergeRouteParamsIntoQuery(parseQueryString(url), params);

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -9,6 +9,7 @@
  */
 import "./server-globals.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { NextI18nConfig } from "../config/next-config.js";
 import { decode as decodeQueryString } from "node:querystring";
 import { Buffer } from "node:buffer";
 import { type Route, matchRoute } from "../routing/pages-router.js";
@@ -340,6 +341,11 @@ export async function handleApiRoute(
   res: ServerResponse,
   url: string,
   apiRoutes: Route[],
+  nextConfig?: {
+    basePath?: string;
+    i18n?: NextI18nConfig | null;
+    trailingSlash?: boolean;
+  },
 ): Promise<boolean> {
   const match = matchRoute(url, apiRoutes);
   if (!match) return false;
@@ -353,7 +359,18 @@ export async function handleApiRoute(
       // Next.js wraps the incoming Request in a NextRequest before invoking
       // edge API handlers, so handlers can use `req.nextUrl.searchParams`,
       // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
-      const nextRequest = new NextRequest(createEdgeApiRequest(req, url, params));
+      const nextRequest = new NextRequest(
+        createEdgeApiRequest(req, url, params),
+        nextConfig
+          ? {
+              nextConfig: {
+                basePath: nextConfig.basePath,
+                i18n: nextConfig.i18n ?? undefined,
+                trailingSlash: nextConfig.trailingSlash,
+              },
+            }
+          : undefined,
+      );
       const response = await apiModule.default(nextRequest);
       if (!(response instanceof Response)) {
         throw new Error("Edge API route did not return a Response");

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -96,6 +96,11 @@ function buildPagesApiQuery(url: string, params: PagesRequestQuery): PagesReques
   return mergeRouteParamsIntoQuery(parseQueryString(url), params);
 }
 
+function createEdgeApiRequest(request: Request, url: string): Request {
+  const resolvedUrl = new URL(url, request.url).toString();
+  return resolvedUrl === request.url ? request : new Request(resolvedUrl, request);
+}
+
 function isEdgeApiRouteModule(
   module: PagesApiRouteModule,
 ): module is PagesApiRouteModule & { default: PagesEdgeApiRouteHandler } {
@@ -127,7 +132,7 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       // Next.js wraps the incoming Request in a NextRequest before invoking
       // edge API handlers, so handlers can use `req.nextUrl.searchParams`,
       // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
-      const nextRequest = new NextRequest(options.request);
+      const nextRequest = new NextRequest(createEdgeApiRequest(options.request, options.url));
       const response = await route.module.default(nextRequest);
       if (response instanceof Response) {
         return response;

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -1,6 +1,10 @@
 import "./server-globals.js";
 import type { Route } from "../routing/pages-router.js";
-import { mergeRouteParamsIntoQuery, parseQueryString } from "../utils/query.js";
+import {
+  mergeRouteParamsIntoQuery,
+  parseQueryString,
+  urlQueryToSearchParams,
+} from "../utils/query.js";
 import {
   createPagesReqRes,
   parsePagesApiBody,
@@ -96,9 +100,11 @@ function buildPagesApiQuery(url: string, params: PagesRequestQuery): PagesReques
   return mergeRouteParamsIntoQuery(parseQueryString(url), params);
 }
 
-function createEdgeApiRequest(request: Request, url: string): Request {
-  const resolvedUrl = new URL(url, request.url).toString();
-  return resolvedUrl === request.url ? request : new Request(resolvedUrl, request);
+function createEdgeApiRequest(request: Request, url: string, params: PagesRequestQuery): Request {
+  const resolvedUrl = new URL(request.url);
+  resolvedUrl.search = urlQueryToSearchParams(buildPagesApiQuery(url, params)).toString();
+  const resolvedUrlString = resolvedUrl.toString();
+  return resolvedUrlString === request.url ? request : new Request(resolvedUrlString, request);
 }
 
 function isEdgeApiRouteModule(
@@ -132,7 +138,9 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       // Next.js wraps the incoming Request in a NextRequest before invoking
       // edge API handlers, so handlers can use `req.nextUrl.searchParams`,
       // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
-      const nextRequest = new NextRequest(createEdgeApiRequest(options.request, options.url));
+      const nextRequest = new NextRequest(
+        createEdgeApiRequest(options.request, options.url, params),
+      );
       const response = await route.module.default(nextRequest);
       if (response instanceof Response) {
         return response;

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -16,6 +16,7 @@ import {
 } from "./pages-node-compat.js";
 import { resolveBodyParserConfig } from "./pages-body-parser-config.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
+import { cloneRequestWithUrl } from "./request-pipeline.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 import { NextRequest } from "vinext/shims/server";
@@ -110,7 +111,9 @@ function createEdgeApiRequest(request: Request, url: string, params: PagesReques
   const resolvedUrl = new URL(request.url);
   resolvedUrl.search = urlQueryToSearchParams(buildPagesApiQuery(url, params)).toString();
   const resolvedUrlString = resolvedUrl.toString();
-  return resolvedUrlString === request.url ? request : new Request(resolvedUrlString, request);
+  return resolvedUrlString === request.url
+    ? request
+    : cloneRequestWithUrl(request, resolvedUrlString);
 }
 
 function isEdgeApiRouteModule(

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -1,5 +1,6 @@
 import "./server-globals.js";
 import type { Route } from "../routing/pages-router.js";
+import type { NextI18nConfig } from "../config/next-config.js";
 import {
   mergeRouteParamsIntoQuery,
   parseQueryString,
@@ -94,6 +95,11 @@ type HandlePagesApiRouteOptions = {
   reportRequestError?: (error: Error, routePattern: string) => void | Promise<void>;
   request: Request;
   url: string;
+  nextConfig?: {
+    basePath?: string;
+    i18n?: NextI18nConfig | null;
+    trailingSlash?: boolean;
+  };
 };
 
 function buildPagesApiQuery(url: string, params: PagesRequestQuery): PagesRequestQuery {
@@ -140,6 +146,15 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       // `req.cookies`, etc. (Cf. NextRequestHint in next/src/server/web/adapter.ts.)
       const nextRequest = new NextRequest(
         createEdgeApiRequest(options.request, options.url, params),
+        options.nextConfig
+          ? {
+              nextConfig: {
+                basePath: options.nextConfig.basePath,
+                i18n: options.nextConfig.i18n ?? undefined,
+                trailingSlash: options.nextConfig.trailingSlash,
+              },
+            }
+          : undefined,
       );
       const response = await route.module.default(nextRequest);
       if (response instanceof Response) {

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -442,6 +442,9 @@ export async function runPagesRequest(
   if (apiLookupPathname.startsWith("/api/") || apiLookupPathname === "/api") {
     if (typeof deps.handleApi === "function") {
       let apiRequest = request;
+      // Prod re-adds basePath only when the original request carried it.
+      // Dev reconstructs Vite's stripped basePath in api-handler.ts; the paths
+      // differ only for an out-of-basePath request config-rewritten into an API.
       if (basePath && hadBasePath) {
         const apiRequestUrl = new URL(request.url);
         apiRequestUrl.pathname = addBasePathToPathname(apiRequestUrl.pathname, basePath);

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -29,7 +29,11 @@ import {
   proxyExternalRequest,
   sanitizeDestination,
 } from "../config/config-matchers.js";
-import { applyConfigHeadersToHeaderRecord, normalizeTrailingSlash } from "./request-pipeline.js";
+import {
+  applyConfigHeadersToHeaderRecord,
+  cloneRequestWithUrl,
+  normalizeTrailingSlash,
+} from "./request-pipeline.js";
 import type { HeaderRecord } from "./request-pipeline.js";
 import { mergeHeaders } from "./worker-utils.js";
 import { normalizeDefaultLocalePathname, stripI18nLocaleForApiRoute } from "./pages-i18n.js";
@@ -441,7 +445,7 @@ export async function runPagesRequest(
       if (basePath && hadBasePath) {
         const apiRequestUrl = new URL(request.url);
         apiRequestUrl.pathname = addBasePathToPathname(apiRequestUrl.pathname, basePath);
-        apiRequest = new Request(apiRequestUrl, request);
+        apiRequest = cloneRequestWithUrl(request, apiRequestUrl.toString());
       }
       const response = await deps.handleApi(apiRequest, apiLookupUrl, deps.ctx ?? null);
       return {

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -437,7 +437,13 @@ export async function runPagesRequest(
   const apiLookupPathname = apiLookupUrl.split("?")[0];
   if (apiLookupPathname.startsWith("/api/") || apiLookupPathname === "/api") {
     if (typeof deps.handleApi === "function") {
-      const response = await deps.handleApi(request, apiLookupUrl, deps.ctx ?? null);
+      let apiRequest = request;
+      if (basePath && hadBasePath) {
+        const apiRequestUrl = new URL(request.url);
+        apiRequestUrl.pathname = addBasePathToPathname(apiRequestUrl.pathname, basePath);
+        apiRequest = new Request(apiRequestUrl, request);
+      }
+      const response = await deps.handleApi(apiRequest, apiLookupUrl, deps.ctx ?? null);
       return {
         type: "response",
         // API routes return arbitrary data; default a missing content-type to

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -419,7 +419,8 @@ export class NextURL {
     // Build prefix: basePath + locale (skip defaultLocale — Next.js omits it)
     let prefix = this._basePath;
     const inner = this._url.pathname;
-    const isApiPath = inner === "/api" || inner.startsWith("/api/");
+    const innerLower = inner.toLowerCase();
+    const isApiPath = innerLower === "/api" || innerLower.startsWith("/api/");
     if (!isApiPath && this._locale && this._locale !== this._defaultLocale) {
       prefix += "/" + this._locale;
     }

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -418,10 +418,11 @@ export class NextURL {
   private _formatPathname(): string {
     // Build prefix: basePath + locale (skip defaultLocale — Next.js omits it)
     let prefix = this._basePath;
-    if (this._locale && this._locale !== this._defaultLocale) {
+    const inner = this._url.pathname;
+    const isApiPath = inner === "/api" || inner.startsWith("/api/");
+    if (!isApiPath && this._locale && this._locale !== this._defaultLocale) {
       prefix += "/" + this._locale;
     }
-    const inner = this._url.pathname;
     const composed = !prefix ? inner : inner === "/" ? prefix : prefix + inner;
     return this._applyTrailingSlash(composed);
   }

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -93,7 +93,15 @@ export class NextRequest extends Request {
     init?: RequestInit & {
       nextConfig?: {
         basePath?: string;
-        i18n?: { locales: string[]; defaultLocale: string };
+        i18n?: {
+          locales: string[];
+          defaultLocale: string;
+          domains?: Array<{
+            domain: string;
+            defaultLocale: string;
+            locales?: string[];
+          }>;
+        };
         trailingSlash?: boolean;
       };
     },
@@ -296,6 +304,11 @@ export type NextURLConfig = {
     i18n?: {
       locales: string[];
       defaultLocale: string;
+      domains?: Array<{
+        domain: string;
+        defaultLocale: string;
+        locales?: string[];
+      }>;
     };
     /**
      * When true, `href`/`toString()` formats non-root, non-file-like pathnames
@@ -319,8 +332,10 @@ export class NextURL {
   private _basePath: string;
   private _trailingSlash: boolean;
   private _locale: string | undefined;
+  private _configDefaultLocale: string | undefined;
   private _defaultLocale: string | undefined;
   private _locales: string[] | undefined;
+  private _domains: NonNullable<NonNullable<NextURLConfig["nextConfig"]>["i18n"]>["domains"];
 
   constructor(input: string | URL, base?: string | URL, config?: NextURLConfig) {
     this._url = new URL(input.toString(), base);
@@ -331,8 +346,12 @@ export class NextURL {
     const i18n = config?.nextConfig?.i18n;
     if (i18n) {
       this._locales = [...i18n.locales];
-      this._defaultLocale = i18n.defaultLocale;
-      this._analyzeLocale(this._locales);
+      this._domains = i18n.domains?.map((domain) => ({
+        ...domain,
+        locales: domain.locales ? [...domain.locales] : undefined,
+      }));
+      this._configDefaultLocale = i18n.defaultLocale;
+      this._analyzeI18n();
     }
   }
 
@@ -368,6 +387,16 @@ export class NextURL {
     } else {
       this._locale = this._defaultLocale;
     }
+  }
+
+  private _analyzeI18n(): void {
+    if (!this._locales || !this._configDefaultLocale) return;
+    const hostname = this._url.hostname.toLowerCase();
+    const domainLocale = this._domains?.find(
+      (domain) => domain.domain.split(":", 1)[0].toLowerCase() === hostname,
+    );
+    this._defaultLocale = domainLocale?.defaultLocale ?? this._configDefaultLocale;
+    this._analyzeLocale(this._locales);
   }
 
   /**
@@ -413,7 +442,7 @@ export class NextURL {
   set href(value: string) {
     this._url.href = value;
     this._stripBasePath();
-    if (this._locales) this._analyzeLocale(this._locales);
+    this._analyzeI18n();
   }
 
   get origin(): string {
@@ -524,7 +553,14 @@ export class NextURL {
   clone(): NextURL {
     const nextConfig: NonNullable<NextURLConfig["nextConfig"]> = {};
     if (this._locales) {
-      nextConfig.i18n = { locales: [...this._locales], defaultLocale: this._defaultLocale! };
+      nextConfig.i18n = {
+        locales: [...this._locales],
+        defaultLocale: this._configDefaultLocale!,
+        domains: this._domains?.map((domain) => ({
+          ...domain,
+          locales: domain.locales ? [...domain.locales] : undefined,
+        })),
+      };
     }
     if (this._trailingSlash) {
       nextConfig.trailingSlash = true;

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -388,26 +388,29 @@ export class NextURL {
   }
 
   /** Extract locale from pathname, stripping it from the internal URL. */
-  private _analyzeLocale(locales: string[]): void {
+  private _detectPathnameLocale(locales: string[]): string | undefined {
     const segments = this._url.pathname.split("/");
     const candidate = segments[1]?.toLowerCase();
     const match = locales.find((l) => l.toLowerCase() === candidate);
     if (match) {
-      this._locale = match;
       this._url.pathname = "/" + segments.slice(2).join("/");
-    } else {
-      this._locale = this._defaultLocale;
     }
+    return match;
   }
 
   private _analyzeI18n(): void {
     if (!this._locales || !this._configDefaultLocale) return;
+    const detectedLocale = this._detectPathnameLocale(this._locales);
+    const detectedLocaleLower = detectedLocale?.toLowerCase();
     const hostname = this._url.hostname.toLowerCase();
     this._domainLocale = this._domains?.find(
-      (domain) => domain.domain.split(":", 1)[0].toLowerCase() === hostname,
+      (domain) =>
+        domain.domain.split(":", 1)[0].toLowerCase() === hostname ||
+        detectedLocaleLower === domain.defaultLocale.toLowerCase() ||
+        domain.locales?.some((locale) => locale.toLowerCase() === detectedLocaleLower),
     );
     this._defaultLocale = this._domainLocale?.defaultLocale ?? this._configDefaultLocale;
-    this._analyzeLocale(this._locales);
+    this._locale = detectedLocale ?? this._defaultLocale;
   }
 
   /**

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -123,6 +123,14 @@ export class NextRequest extends Request {
       const requestInput =
         requestInit.body === undefined && input.body && !input.bodyUsed ? input.clone() : input;
       super(requestInput, requestInit);
+      const cf = Reflect.get(input, "cf");
+      if (cf !== undefined) {
+        Object.defineProperty(this, "cf", {
+          value: cf,
+          enumerable: true,
+          configurable: true,
+        });
+      }
     } else {
       super(input, requestInit);
     }
@@ -336,6 +344,9 @@ export class NextURL {
   private _defaultLocale: string | undefined;
   private _locales: string[] | undefined;
   private _domains: NonNullable<NonNullable<NextURLConfig["nextConfig"]>["i18n"]>["domains"];
+  private _domainLocale:
+    | NonNullable<NonNullable<NonNullable<NextURLConfig["nextConfig"]>["i18n"]>["domains"]>[number]
+    | undefined;
 
   constructor(input: string | URL, base?: string | URL, config?: NextURLConfig) {
     this._url = new URL(input.toString(), base);
@@ -392,10 +403,10 @@ export class NextURL {
   private _analyzeI18n(): void {
     if (!this._locales || !this._configDefaultLocale) return;
     const hostname = this._url.hostname.toLowerCase();
-    const domainLocale = this._domains?.find(
+    this._domainLocale = this._domains?.find(
       (domain) => domain.domain.split(":", 1)[0].toLowerCase() === hostname,
     );
-    this._defaultLocale = domainLocale?.defaultLocale ?? this._configDefaultLocale;
+    this._defaultLocale = this._domainLocale?.defaultLocale ?? this._configDefaultLocale;
     this._analyzeLocale(this._locales);
   }
 
@@ -544,6 +555,14 @@ export class NextURL {
 
   get defaultLocale(): string | undefined {
     return this._defaultLocale;
+  }
+
+  get domainLocale(): typeof this._domainLocale {
+    if (!this._domainLocale) return undefined;
+    return {
+      ...this._domainLocale,
+      locales: this._domainLocale.locales ? [...this._domainLocale.locales] : undefined,
+    };
   }
 
   get locales(): string[] | undefined {

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -1058,6 +1058,26 @@ describe("handleApiRoute", () => {
       });
     });
 
+    it("reconstructs Vite-stripped basePath for edge API nextUrl", async () => {
+      const handler = vi.fn((request: Request) => {
+        const nextUrl = (request as Request & { nextUrl?: { basePath: string; pathname: string } })
+          .nextUrl;
+        return Response.json({ basePath: nextUrl?.basePath, pathname: nextUrl?.pathname });
+      });
+      const server = mockServer({ config: { runtime: "edge" }, default: handler });
+      const req = mockReq("GET", "/api/hello?a=b", undefined, { host: "example.com" });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/hello?a=b", [route("/api/hello")], {
+        basePath: "/docs",
+      });
+
+      expect(JSON.parse(res._body.toString())).toEqual({
+        basePath: "/docs",
+        pathname: "/api/hello",
+      });
+    });
+
     it("recognises bare \"export const runtime = 'edge'\" as an edge API route", async () => {
       // Ported from Next.js: packages/next/src/build/analysis/get-page-static-info.ts
       // Both `export const runtime = "edge"` and `export const config = { runtime: "edge" }`

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -1078,6 +1078,19 @@ describe("handleApiRoute", () => {
       });
     });
 
+    it("does not double-prefix an exact basePath edge API rewrite", async () => {
+      const handler = vi.fn((request: Request) => Response.json({ url: request.url }));
+      const server = mockServer({ config: { runtime: "edge" }, default: handler });
+      const req = mockReq("GET", "/docs", undefined, { host: "example.com" });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/hello", [route("/api/hello")], {
+        basePath: "/docs",
+      });
+
+      expect(JSON.parse(res._body.toString())).toEqual({ url: "http://example.com/docs" });
+    });
+
     it("recognises bare \"export const runtime = 'edge'\" as an edge API route", async () => {
       // Ported from Next.js: packages/next/src/build/analysis/get-page-static-info.ts
       // Both `export const runtime = "edge"` and `export const config = { runtime: "edge" }`

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -1029,6 +1029,35 @@ describe("handleApiRoute", () => {
       });
     });
 
+    it("applies basePath and i18n config to edge API nextUrl", async () => {
+      const handler = vi.fn((request: Request) => {
+        const nextUrl = (
+          request as Request & {
+            nextUrl?: { basePath: string; locale: string; pathname: string };
+          }
+        ).nextUrl;
+        return Response.json({
+          basePath: nextUrl?.basePath,
+          locale: nextUrl?.locale,
+          pathname: nextUrl?.pathname,
+        });
+      });
+      const server = mockServer({ config: { runtime: "edge" }, default: handler });
+      const req = mockReq("GET", "/docs/fr/api/hello?a=b", undefined, { host: "example.com" });
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/fr/api/hello?a=b", [route("/fr/api/hello")], {
+        basePath: "/docs",
+        i18n: { defaultLocale: "en", locales: ["en", "fr"] },
+      });
+
+      expect(JSON.parse(res._body.toString())).toMatchObject({
+        basePath: "/docs",
+        locale: "fr",
+        pathname: "/api/hello",
+      });
+    });
+
     it("recognises bare \"export const runtime = 'edge'\" as an edge API route", async () => {
       // Ported from Next.js: packages/next/src/build/analysis/get-page-static-info.ts
       // Both `export const runtime = "edge"` and `export const config = { runtime: "edge" }`

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -947,17 +947,17 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("runPagesRequest(request, deps)");
   });
 
-  it("handles basePath stripping and creates a new request with stripped URL for middleware", () => {
+  it("handles basePath stripping and clones the request with the stripped URL", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain("basePath");
     expect(content).toContain(
       'import { hasBasePath, stripBasePath } from "vinext/utils/base-path"',
     );
     expect(content).toContain("const stripped = stripBasePath(pathname, basePath);");
-    // After stripping, a new request with the stripped URL must be created
-    // in the adapter so runPagesRequest receives a clean basePath-free request.
+    // After stripping, clone with the stripped URL so runPagesRequest receives
+    // a clean basePath-free request without dropping Worker metadata.
     expect(content).toContain("strippedUrl.pathname = stripped");
-    expect(content).toContain("new Request(strippedUrl, request)");
+    expect(content).toContain("cloneRequestWithUrl(request, strippedUrl.toString())");
   });
 
   it("handles trailing slash normalization", () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -978,6 +978,11 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("runPagesRequest(request, deps)");
   });
 
+  it("preserves request metadata when stripping Pages Router basePath", () => {
+    const content = generatePagesRouterWorkerEntry();
+    expect(content).toContain("cloneRequestWithUrl(request, strippedUrl.toString())");
+  });
+
   it("includes error handling", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain("catch (error)");

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -70,6 +70,14 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(target);
   }
 
+  if (url.pathname.startsWith("/edge-api-rewrite/")) {
+    const id = url.pathname.slice("/edge-api-rewrite/".length);
+    const target = request.nextUrl.clone();
+    target.pathname = `/api/edge-users/${id}`;
+    target.searchParams.set("foo", "bar");
+    return NextResponse.rewrite(target);
+  }
+
   // Issue #1342 / Next.js parity (test/e2e/middleware-rewrites
   //   "should clear query parameters"):
   // when middleware modifies `request.nextUrl.searchParams` (delete keys) and
@@ -262,6 +270,7 @@ export function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     "/api/edge-search-params",
+    "/edge-api-rewrite/:path*",
     "/((?!api|_next|favicon\\.ico|mw-object-gated).*)",
     {
       source: "/mw-object-gated",

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -62,6 +62,14 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(target);
   }
 
+  // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/app/middleware.js
+  if (url.pathname === "/api/edge-search-params") {
+    const target = request.nextUrl.clone();
+    target.searchParams.set("foo", "bar");
+    return NextResponse.rewrite(target);
+  }
+
   // Issue #1342 / Next.js parity (test/e2e/middleware-rewrites
   //   "should clear query parameters"):
   // when middleware modifies `request.nextUrl.searchParams` (delete keys) and
@@ -253,6 +261,7 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/api/edge-search-params",
     "/((?!api|_next|favicon\\.ico|mw-object-gated).*)",
     {
       source: "/mw-object-gated",

--- a/tests/fixtures/pages-basic/pages/api/edge-search-params.ts
+++ b/tests/fixtures/pages-basic/pages/api/edge-search-params.ts
@@ -1,0 +1,12 @@
+// Ported from Next.js:
+// test/e2e/middleware-general/app/pages/api/edge-search-params.js
+// https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/app/pages/api/edge-search-params.js
+export const config = {
+  runtime: "edge",
+};
+
+type NextRequestLike = Request & { nextUrl: { searchParams: URLSearchParams } };
+
+export default function handler(req: NextRequestLike): Response {
+  return Response.json(Object.fromEntries(req.nextUrl.searchParams));
+}

--- a/tests/fixtures/pages-basic/pages/api/edge-users/[id].ts
+++ b/tests/fixtures/pages-basic/pages/api/edge-users/[id].ts
@@ -1,0 +1,12 @@
+export const config = {
+  runtime: "edge",
+};
+
+type NextRequestLike = Request & { nextUrl: URL };
+
+export default function handler(req: NextRequestLike): Response {
+  return Response.json({
+    pathname: req.nextUrl.pathname,
+    query: Object.fromEntries(req.nextUrl.searchParams),
+  });
+}

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -410,6 +410,16 @@ describe("pages api route", () => {
   });
 
   it("preserves edge API request properties when applying the resolved URL", async () => {
+    const request = new Request("https://example.com/api/edge-search-params?a=b", {
+      body: "payload",
+      headers: { "x-test": "1" },
+      method: "POST",
+    });
+    Object.defineProperty(request, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: { country: "US" },
+    });
     const response = await handlePagesApiRoute({
       match: createMatch(
         async (request: Request) => {
@@ -422,22 +432,20 @@ describe("pages api route", () => {
             header: request.headers.get("x-test"),
             method: request.method,
             query: Object.fromEntries(nextUrl.searchParams),
+            cf: Reflect.get(request, "cf"),
           });
         },
         {},
         { runtime: "edge" },
       ),
-      request: new Request("https://example.com/api/edge-search-params?a=b", {
-        body: "payload",
-        headers: { "x-test": "1" },
-        method: "POST",
-      }),
+      request,
       url: "/api/edge-search-params?a=b&foo=bar",
     });
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       body: "payload",
+      cf: { country: "US" },
       header: "1",
       method: "POST",
       query: {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -376,6 +376,39 @@ describe("pages api route", () => {
     });
   });
 
+  it("applies basePath and i18n config to edge API nextUrl", async () => {
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (request: Request) => {
+          const nextUrl = (
+            request as Request & {
+              nextUrl?: { basePath: string; locale: string; pathname: string };
+            }
+          ).nextUrl;
+          return Response.json({
+            basePath: nextUrl?.basePath,
+            locale: nextUrl?.locale,
+            pathname: nextUrl?.pathname,
+          });
+        },
+        {},
+        { runtime: "edge" },
+      ),
+      nextConfig: {
+        basePath: "/docs",
+        i18n: { defaultLocale: "en", locales: ["en", "fr"] },
+      },
+      request: new Request("https://example.com/docs/fr/api/hello?a=b"),
+      url: "/fr/api/hello?a=b",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      basePath: "/docs",
+      locale: "fr",
+      pathname: "/api/hello",
+    });
+  });
+
   it("preserves edge API request properties when applying the resolved URL", async () => {
     const response = await handlePagesApiRoute({
       match: createMatch(

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -314,7 +314,7 @@ describe("pages api route", () => {
     });
   });
 
-  it("passes the middleware-resolved URL to edge API nextUrl.searchParams", async () => {
+  it("passes the resolved query while preserving the original edge API pathname", async () => {
     // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
     //
@@ -328,19 +328,51 @@ describe("pages api route", () => {
           if (!nextUrl) {
             return new Response("missing nextUrl", { status: 500 });
           }
-          return Response.json(Object.fromEntries(nextUrl.searchParams));
+          return Response.json({
+            pathname: nextUrl.pathname,
+            query: Object.fromEntries(nextUrl.searchParams),
+          });
         },
         {},
         { runtime: "edge" },
       ),
-      request: new Request("https://example.com/api/edge-search-params?a=b"),
+      request: new Request("https://example.com/public-edge-path?a=b"),
       url: "/api/edge-search-params?a=b&foo=bar",
     });
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
+      pathname: "/public-edge-path",
+      query: {
+        a: "b",
+        foo: "bar",
+      },
+    });
+  });
+
+  it("includes dynamic route params in edge API nextUrl.searchParams", async () => {
+    // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-pages-support/index.test.ts
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (request: Request) => {
+          const nextUrl = (request as Request & { nextUrl?: URL }).nextUrl;
+          if (!nextUrl) {
+            return new Response("missing nextUrl", { status: 500 });
+          }
+          return Response.json(Object.fromEntries(nextUrl.searchParams));
+        },
+        { id: "id-1" },
+        { runtime: "edge" },
+      ),
+      request: new Request("https://example.com/api/id-1?a=b"),
+      url: "/api/id-1?a=b",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
       a: "b",
-      foo: "bar",
+      id: "id-1",
     });
   });
 

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -314,6 +314,74 @@ describe("pages api route", () => {
     });
   });
 
+  it("passes the middleware-resolved URL to edge API nextUrl.searchParams", async () => {
+    // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+    //
+    // Upstream middleware mutates request.nextUrl.searchParams and rewrites to
+    // the same edge Pages API route. The handler's req.nextUrl must reflect the
+    // resolved rewrite URL, not the original incoming Request URL.
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (request: Request) => {
+          const nextUrl = (request as Request & { nextUrl?: URL }).nextUrl;
+          if (!nextUrl) {
+            return new Response("missing nextUrl", { status: 500 });
+          }
+          return Response.json(Object.fromEntries(nextUrl.searchParams));
+        },
+        {},
+        { runtime: "edge" },
+      ),
+      request: new Request("https://example.com/api/edge-search-params?a=b"),
+      url: "/api/edge-search-params?a=b&foo=bar",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      a: "b",
+      foo: "bar",
+    });
+  });
+
+  it("preserves edge API request properties when applying the resolved URL", async () => {
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        async (request: Request) => {
+          const nextUrl = (request as Request & { nextUrl?: URL }).nextUrl;
+          if (!nextUrl) {
+            return new Response("missing nextUrl", { status: 500 });
+          }
+          return Response.json({
+            body: await request.text(),
+            header: request.headers.get("x-test"),
+            method: request.method,
+            query: Object.fromEntries(nextUrl.searchParams),
+          });
+        },
+        {},
+        { runtime: "edge" },
+      ),
+      request: new Request("https://example.com/api/edge-search-params?a=b", {
+        body: "payload",
+        headers: { "x-test": "1" },
+        method: "POST",
+      }),
+      url: "/api/edge-search-params?a=b&foo=bar",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      body: "payload",
+      header: "1",
+      method: "POST",
+      query: {
+        a: "b",
+        foo: "bar",
+      },
+    });
+  });
+
   it("recognises bare \"export const runtime = 'edge'\" as an edge API route", async () => {
     // Ported from Next.js: packages/next/src/build/analysis/get-page-static-info.ts
     // Both `export const runtime = "edge"` and `export const config = { runtime: "edge" }`

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -956,6 +956,17 @@ describe("Pages Router integration", () => {
     });
   });
 
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("passes middleware rewrite search params to Pages Router edge API nextUrl", async () => {
+    const res = await fetch(`${baseUrl}/api/edge-search-params?a=b`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      a: "b",
+      foo: "bar",
+    });
+  });
+
   // Regression coverage for cloudflare/vinext#1338 — Pages Router OG image
   // routes using `next/og` ImageResponse with `runtime: 'edge'` must execute
   // and return image/png, not 404.
@@ -4197,6 +4208,17 @@ describe("Production server middleware (Pages Router)", () => {
     const res = await fetch(`${prodUrl}/old-page`, { redirect: "manual" });
     expect(res.status).toBe(307);
     expect(res.headers.get("location")).toContain("/about");
+  });
+
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("passes middleware rewrite search params to Pages Router edge API nextUrl in production", async () => {
+    const res = await fetch(`${prodUrl}/api/edge-search-params?a=b`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      a: "b",
+      foo: "bar",
+    });
   });
 
   // Refs #1463: prod-server parity for the dev-server 405 check. POST to a

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -967,6 +967,21 @@ describe("Pages Router integration", () => {
     });
   });
 
+  // Ported from Next.js: test/e2e/edge-pages-support/index.test.ts and
+  // packages/next/src/server/next-server.ts (`runEdgeFunction`).
+  it("preserves the original pathname and adds route params for rewritten edge APIs", async () => {
+    const res = await fetch(`${baseUrl}/edge-api-rewrite/id-1?a=b`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      pathname: "/edge-api-rewrite/id-1",
+      query: {
+        a: "b",
+        foo: "bar",
+        id: "id-1",
+      },
+    });
+  });
+
   // Regression coverage for cloudflare/vinext#1338 — Pages Router OG image
   // routes using `next/og` ImageResponse with `runtime: 'edge'` must execute
   // and return image/png, not 404.
@@ -4218,6 +4233,19 @@ describe("Production server middleware (Pages Router)", () => {
     await expect(res.json()).resolves.toEqual({
       a: "b",
       foo: "bar",
+    });
+  });
+
+  it("preserves the original pathname and adds route params for rewritten edge APIs in production", async () => {
+    const res = await fetch(`${prodUrl}/edge-api-rewrite/id-1?a=b`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      pathname: "/edge-api-rewrite/id-1",
+      query: {
+        a: "b",
+        foo: "bar",
+        id: "id-1",
+      },
     });
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8967,6 +8967,27 @@ describe("NextURL basePath and locale properties", () => {
     expect(url.locale).toBe("fr");
   });
 
+  it("matches domain locale from the detected pathname locale", async () => {
+    // Ported from Next.js: packages/next/src/shared/lib/i18n/detect-domain-locale.ts
+    const { NextURL } = await import("../packages/vinext/src/shims/server.js");
+    const url = new NextURL("https://example.com/fr/about", undefined, {
+      nextConfig: {
+        i18n: {
+          locales: ["en", "fr", "de"],
+          defaultLocale: "en",
+          domains: [
+            { domain: "example.fr", defaultLocale: "fr", locales: ["fr"] },
+            { domain: "example.de", defaultLocale: "de", locales: ["de"] },
+          ],
+        },
+      },
+    });
+    expect(url.domainLocale?.domain).toBe("example.fr");
+    expect(url.defaultLocale).toBe("fr");
+    expect(url.locale).toBe("fr");
+    expect(url.pathname).toBe("/about");
+  });
+
   // --- NextRequest integration ---
 
   it("NextRequest passes basePath and i18n config through to nextUrl", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8728,6 +8728,12 @@ describe("NextURL basePath and locale properties", () => {
     expect(url.clone().href).toBe("https://example.com/api/example");
   });
 
+  it("detects API paths case-insensitively when formatting locale URLs", async () => {
+    const { NextURL } = await import("../packages/vinext/src/shims/server.js");
+    const url = new NextURL("https://example.com/fr/API/example", undefined, i18nConfig);
+    expect(url.href).toBe("https://example.com/API/example");
+  });
+
   it("re-analyzes domain locale after href reassignment", async () => {
     const { NextURL } = await import("../packages/vinext/src/shims/server.js");
     const url = new NextURL("https://example.com/about", undefined, {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8680,6 +8680,56 @@ describe("NextURL basePath and locale properties", () => {
     expect(url.pathname).toBe("/about");
   });
 
+  it("uses the matching domain default locale", async () => {
+    // Ported from Next.js: packages/next/src/server/web/next-url.ts
+    const { NextURL } = await import("../packages/vinext/src/shims/server.js");
+    const url = new NextURL("https://example.fr/about", undefined, {
+      nextConfig: {
+        i18n: {
+          locales: ["en", "fr", "de"],
+          defaultLocale: "en",
+          domains: [{ domain: "example.fr", defaultLocale: "fr", locales: ["fr"] }],
+        },
+      },
+    });
+    expect(url.defaultLocale).toBe("fr");
+    expect(url.locale).toBe("fr");
+    expect(url.pathname).toBe("/about");
+  });
+
+  it("pathname locale overrides the matching domain default locale", async () => {
+    const { NextURL } = await import("../packages/vinext/src/shims/server.js");
+    const url = new NextURL("https://example.fr/de/about", undefined, {
+      nextConfig: {
+        i18n: {
+          locales: ["en", "fr", "de"],
+          defaultLocale: "en",
+          domains: [{ domain: "example.fr", defaultLocale: "fr", locales: ["fr"] }],
+        },
+      },
+    });
+    expect(url.defaultLocale).toBe("fr");
+    expect(url.locale).toBe("de");
+    expect(url.pathname).toBe("/about");
+  });
+
+  it("re-analyzes domain locale after href reassignment", async () => {
+    const { NextURL } = await import("../packages/vinext/src/shims/server.js");
+    const url = new NextURL("https://example.com/about", undefined, {
+      nextConfig: {
+        i18n: {
+          locales: ["en", "fr"],
+          defaultLocale: "en",
+          domains: [{ domain: "example.fr", defaultLocale: "fr", locales: ["fr"] }],
+        },
+      },
+    });
+    expect(url.defaultLocale).toBe("en");
+    url.href = "https://example.fr/about";
+    expect(url.defaultLocale).toBe("fr");
+    expect(url.locale).toBe("fr");
+  });
+
   it("locale detection is case-insensitive", async () => {
     const { NextURL } = await import("../packages/vinext/src/shims/server.js");
     const url = new NextURL("http://localhost/FR/about", undefined, i18nConfig);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8718,6 +8718,16 @@ describe("NextURL basePath and locale properties", () => {
     expect(url.pathname).toBe("/about");
   });
 
+  it("does not add locale prefixes when formatting API paths", async () => {
+    // Ported from Next.js: packages/next/src/shared/lib/router/utils/add-locale.ts
+    const { NextURL } = await import("../packages/vinext/src/shims/server.js");
+    const url = new NextURL("https://example.com/fr/api/example", undefined, i18nConfig);
+    expect(url.locale).toBe("fr");
+    expect(url.pathname).toBe("/api/example");
+    expect(url.href).toBe("https://example.com/api/example");
+    expect(url.clone().href).toBe("https://example.com/api/example");
+  });
+
   it("re-analyzes domain locale after href reassignment", async () => {
     const { NextURL } = await import("../packages/vinext/src/shims/server.js");
     const url = new NextURL("https://example.com/about", undefined, {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8694,6 +8694,11 @@ describe("NextURL basePath and locale properties", () => {
     });
     expect(url.defaultLocale).toBe("fr");
     expect(url.locale).toBe("fr");
+    expect(url.domainLocale).toEqual({
+      domain: "example.fr",
+      defaultLocale: "fr",
+      locales: ["fr"],
+    });
     expect(url.pathname).toBe("/about");
   });
 
@@ -8728,6 +8733,7 @@ describe("NextURL basePath and locale properties", () => {
     url.href = "https://example.fr/about";
     expect(url.defaultLocale).toBe("fr");
     expect(url.locale).toBe("fr");
+    expect(url.domainLocale?.domain).toBe("example.fr");
   });
 
   it("locale detection is case-insensitive", async () => {


### PR DESCRIPTION
## Summary

Fixes a Pages Router edge API parity gap exposed by the upstream Next.js middleware-general suite. When middleware rewrote an edge API request by mutating `request.nextUrl.searchParams`, vinext matched the route using the resolved rewrite URL but still constructed the edge handler's `NextRequest` from the original incoming `Request`. As a result, `req.nextUrl.searchParams` in the edge API handler missed middleware-added query params.

The fix keeps the existing request pipeline boundary intact: `pages-request-pipeline` already passes the middleware-resolved API URL to `handleApiRoute`, and `handlePagesApiRoute` now uses that URL when creating the `NextRequest` for edge API handlers. It preserves the original request method, headers, and body while changing only the URL.

## Upstream parity scope

Scoped from `test/e2e/middleware-general/test/index.test.ts` to the block:

- `passes search params with rewrites`

Relevant Next.js references:

- Upstream assertion: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-general/test/index.test.ts
- Upstream middleware rewrite: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-general/app/middleware.js
- Upstream edge API fixture: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-general/app/pages/api/edge-search-params.js
- Next.js edge request construction: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/web/adapter.ts
- Next.js middleware rewrite routing: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/lib/router-utils/resolve-routes.ts
- Next.js `NextRequest` adapter: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/web/spec-extension/adapters/next-request.ts

## Tests

- `vp test run tests/pages-api-route.test.ts`
- `vp test run tests/pages-router.test.ts -t "passes middleware rewrite search params"`
- `vp test run tests/pages-router.test.ts -t "edge API nextUrl in production"`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/middleware-general/test/index.test.ts`
  - Full upstream file: 40 passed, 26 failed from pre-existing unrelated middleware-general gaps.
  - Scoped assertions passed in both variants:
    - `Middleware Runtime with i18n passes search params with rewrites`
    - `Middleware Runtime without i18n passes search params with rewrites`
