### PR TITLE
fix(router): restore pages scroll traversal state

### DIFF
--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -192,11 +192,6 @@ async function hydrate() {
 
   const root = hydrateRoot(container, element, hydrateRootOptions);
   window.__VINEXT_ROOT__ = root;
-  const hydratedAt = performance.now();
-  window.__VINEXT_HYDRATED_AT = hydratedAt;
-  window.__NEXT_HYDRATED = true;
-  window.__NEXT_HYDRATED_AT = hydratedAt;
-  window.__NEXT_HYDRATED_CB?.();
 }
 
 hydrate();

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -43,8 +43,9 @@ declare global {
 
     /**
      * High-resolution timestamp recorded after client hydration is usable.
-     * Pages Router writes after hydrateRoot() returns; App Router writes after
-     * the first committed tree attaches browser router state.
+     * Pages Router writes from the stable router provider after passive
+     * effects can attach; App Router writes after the first committed tree
+     * attaches browser router state.
      */
     __VINEXT_HYDRATED_AT: number | undefined;
 

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1392,11 +1392,6 @@ async function hydrate() {
   element = wrapWithRouterContext(element);
   const root = hydrateRoot(document.getElementById("__next"), element, hydrateRootOptions);
   window.__VINEXT_ROOT__ = root;
-  const hydratedAt = performance.now();
-  window.__VINEXT_HYDRATED_AT = hydratedAt;
-  window.__NEXT_HYDRATED = true;
-  window.__NEXT_HYDRATED_AT = hydratedAt;
-  window.__NEXT_HYDRATED_CB?.();
 }
 hydrate();
 </script>`;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -210,12 +210,21 @@ async function restorePagesRouterScrollPosition(
   scrollToPagesRouterPosition(scroll);
   if (isAtScrollPosition(scroll)) return;
 
+  let previousScrollY = window.scrollY;
   for (let frame = 0; frame < SCROLL_RESTORE_MAX_FRAMES; frame += 1) {
     await waitForNextAnimationFrame();
     if (!shouldContinue()) return;
 
     scrollToPagesRouterPosition(scroll);
     if (isAtScrollPosition(scroll)) return;
+
+    if (window.scrollY === previousScrollY) {
+      // Scroll target is unreachable (e.g. the restored page is shorter than
+      // the saved position). Stop retrying so routeChangeComplete is not
+      // delayed by the full frame budget.
+      break;
+    }
+    previousScrollY = window.scrollY;
   }
 }
 
@@ -2328,6 +2337,15 @@ export function useRouter(): NextRouter {
     return router;
   }
 
+  // Fallback for the split-chunk compat case: when `useRouter()` is called
+  // outside `PagesRouterProvider` (e.g. from a page chunk that evaluates a
+  // separate `next/router` module before the provider has mounted), return
+  // the module-local Router singleton. This is intentionally non-reactive:
+  // it derives pathname/query from `window.__NEXT_DATA__` and does not
+  // subscribe to `vinext:navigate`, so it won't re-render on navigation.
+  // `wrapWithRouterContext` always provides the reactive context value in
+  // normal usage, so this path only activates in edge cases where the
+  // router module is evaluated outside the provider tree.
   if (typeof window !== "undefined" && window.__VINEXT_PAGE_LOADERS__ !== undefined) {
     return Router;
   }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -395,6 +395,7 @@ type PagesRouterRuntimeState = {
   isFirstPopStateEvent: boolean;
   routerDidNavigate: boolean;
   deprecatedEventBridgeInstalled: boolean;
+  pagesRouterReady: boolean;
   publicRouter?: Record<string, unknown>;
 };
 
@@ -421,6 +422,7 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
     isFirstPopStateEvent: true,
     routerDidNavigate: false,
     deprecatedEventBridgeInstalled: false,
+    pagesRouterReady: typeof window === "undefined" || !shouldDeferInitialPagesRouterReady(),
   };
 }
 
@@ -1165,13 +1167,12 @@ function shouldDeferInitialPagesRouterReady(): boolean {
   );
 }
 
-let _pagesRouterReady =
-  typeof window === "undefined" ? true : !shouldDeferInitialPagesRouterReady();
-
 function isPagesRouterReady(): boolean {
-  // `_pagesRouterReady` initializes to `true` on the server and is only ever
-  // flipped on the client, so this reads correctly in both environments.
-  return _pagesRouterReady;
+  // The ready bit lives in the shared browser runtime state so duplicated
+  // `next/router` module instances (entry + page chunks) observe the same
+  // value. It initialises to `true` on the server, so this reads correctly
+  // in both environments.
+  return routerRuntimeState.pagesRouterReady;
 }
 
 function isPagesRouterDocumentActive(): boolean {
@@ -1183,8 +1184,8 @@ function isPagesRouterDocumentActive(): boolean {
 }
 
 function markPagesRouterReady(): boolean {
-  if (typeof window === "undefined" || _pagesRouterReady) return false;
-  _pagesRouterReady = true;
+  if (typeof window === "undefined" || routerRuntimeState.pagesRouterReady) return false;
+  routerRuntimeState.pagesRouterReady = true;
   return true;
 }
 
@@ -2980,5 +2981,9 @@ const _PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
 );
 (globalThis as Record<PropertyKey, unknown>)[_PAGES_NAVIGATION_ACCESSOR_KEY] =
   getPagesNavigationContext;
+
+// Internal export for unit tests that need to drive the readiness transition
+// without relying on React effect timing in a Node test environment.
+export { markPagesRouterReady as _markPagesRouterReady };
 
 export default Router;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -210,7 +210,7 @@ async function restorePagesRouterScrollPosition(
   scrollToPagesRouterPosition(scroll);
   if (isAtScrollPosition(scroll)) return;
 
-  let previousScrollY = window.scrollY;
+  let previousScrollPosition = getWindowScrollPosition();
   for (let frame = 0; frame < SCROLL_RESTORE_MAX_FRAMES; frame += 1) {
     await waitForNextAnimationFrame();
     if (!shouldContinue()) return;
@@ -218,13 +218,17 @@ async function restorePagesRouterScrollPosition(
     scrollToPagesRouterPosition(scroll);
     if (isAtScrollPosition(scroll)) return;
 
-    if (window.scrollY === previousScrollY) {
+    const currentScrollPosition = getWindowScrollPosition();
+    if (
+      currentScrollPosition.x === previousScrollPosition.x &&
+      currentScrollPosition.y === previousScrollPosition.y
+    ) {
       // Scroll target is unreachable (e.g. the restored page is shorter than
       // the saved position). Stop retrying so routeChangeComplete is not
       // delayed by the full frame budget.
       break;
     }
-    previousScrollY = window.scrollY;
+    previousScrollPosition = currentScrollPosition;
   }
 }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -101,7 +101,6 @@ const useNonWarningLayoutEffect = typeof window === "undefined" ? useEffect : us
 class PagesRouterCommitBoundary extends Component<{
   children?: ReactNode;
   onCommit: () => void;
-  onPassiveCommit: () => void;
   onError: (error: Error) => void;
 }> {
   componentDidCatch(error: Error) {
@@ -111,7 +110,7 @@ class PagesRouterCommitBoundary extends Component<{
   render() {
     return createElement(
       PagesRouterCommitBoundaryHelper,
-      { onCommit: this.props.onCommit, onPassiveCommit: this.props.onPassiveCommit },
+      { onCommit: this.props.onCommit },
       this.props.children,
     );
   }
@@ -120,30 +119,15 @@ class PagesRouterCommitBoundary extends Component<{
 function PagesRouterCommitBoundaryHelper({
   children,
   onCommit,
-  onPassiveCommit,
 }: {
   children?: ReactNode;
   onCommit: () => void;
-  onPassiveCommit: () => void;
 }): ReactElement {
   useNonWarningLayoutEffect(() => {
     onCommit();
   }, [onCommit]);
 
-  return createElement(
-    Fragment,
-    null,
-    children,
-    createElement(PagesRouterPassiveCommitMarker, { onCommit: onPassiveCommit }),
-  );
-}
-
-function PagesRouterPassiveCommitMarker({ onCommit }: { onCommit: () => void }): null {
-  useEffect(() => {
-    onCommit();
-  }, [onCommit]);
-
-  return null;
+  return createElement(Fragment, null, children);
 }
 
 function renderPagesRouterElement(
@@ -158,15 +142,10 @@ function renderPagesRouterElement(
   cancelPreviousRenderCommit();
 
   return new Promise<void>((resolve, reject) => {
-    let resolvePassiveCommit = () => {};
-    const passiveCommitPromise = new Promise<void>((resolve) => {
-      resolvePassiveCommit = resolve;
-    });
     const cancel = () => {
       if (routerRuntimeState.cancelPendingRenderCommit === cancel) {
         routerRuntimeState.cancelPendingRenderCommit = null;
       }
-      resolvePassiveCommit();
       reject(new NavigationCancelledError("superseded"));
     };
     routerRuntimeState.cancelPendingRenderCommit = cancel;
@@ -197,8 +176,6 @@ function renderPagesRouterElement(
             try {
               await scrollHandler();
               if (!isCurrent()) return;
-              await passiveCommitPromise;
-              if (!isCurrent()) return;
               clearIfCurrent();
               resolve();
             } catch (err) {
@@ -208,19 +185,20 @@ function renderPagesRouterElement(
           })();
         },
         (error) => {
-          resolvePassiveCommit();
           clearIfCurrent();
           reject(error);
         },
-        resolvePassiveCommit,
       ),
     );
-    if (typeof document === "undefined") {
-      resolvePassiveCommit();
+    if (!hasBrowserDocument()) {
       clearIfCurrent();
       resolve();
     }
   });
+}
+
+function hasBrowserDocument(): boolean {
+  return typeof document !== "undefined" && document.documentElement !== undefined;
 }
 
 async function restorePagesRouterScrollPosition(
@@ -242,7 +220,7 @@ async function restorePagesRouterScrollPosition(
 }
 
 function scrollToPagesRouterPosition({ x, y }: ScrollPosition): void {
-  if (typeof document === "undefined") {
+  if (!hasBrowserDocument()) {
     window.scrollTo(x, y);
     return;
   }
@@ -406,6 +384,7 @@ function createRouterEvents(): RouterEvents {
 
 type PagesRouterRuntimeState = {
   events: RouterEvents;
+  components?: PagesRouterRuntimeComponents;
   currentHistoryKey?: string;
   historyKeyCounter: number;
   navigationId: number;
@@ -417,6 +396,15 @@ type PagesRouterRuntimeState = {
   routerDidNavigate: boolean;
   deprecatedEventBridgeInstalled: boolean;
   publicRouter?: Record<string, unknown>;
+};
+
+type PagesRouterRuntimeComponents = {
+  CommitBoundary: ComponentType<{
+    children?: ReactNode;
+    onCommit: () => void;
+    onError: (error: Error) => void;
+  }>;
+  Provider: ComponentType<{ children: ReactNode }>;
 };
 
 const PAGES_ROUTER_RUNTIME_STATE_KEY = Symbol.for("vinext.pagesRouter.runtimeState");
@@ -459,6 +447,21 @@ function getPagesRouterRuntimeState(): PagesRouterRuntimeState {
 
 const routerRuntimeState = getPagesRouterRuntimeState();
 const routerEvents = routerRuntimeState.events;
+
+function getPagesRouterRuntimeComponents(): PagesRouterRuntimeComponents {
+  const existing = routerRuntimeState.components;
+  if (existing) return existing;
+
+  // Vite can evaluate next/router in both the client entry and page chunks.
+  // React element types must stay identical across those module instances, or
+  // same-route navigations remount the page and lose Next.js' state continuity.
+  const components: PagesRouterRuntimeComponents = {
+    CommitBoundary: PagesRouterCommitBoundary,
+    Provider: PagesRouterProvider,
+  };
+  routerRuntimeState.components = components;
+  return components;
+}
 
 function resolveUrl(url: string | UrlObject): string {
   if (typeof url === "string") return url;
@@ -1733,12 +1736,16 @@ async function navigateClientHtml(
   }
 
   let pageModule: { default?: unknown; [key: string]: unknown };
-  if (!pageModuleUrl) {
-    const loader = window.__VINEXT_PAGE_LOADERS__?.[nextData.page];
-    if (!loader) {
-      scheduleHardNavigationAndThrow(browserUrl, "Navigation failed: no page module URL found");
-    }
+  const loader = window.__VINEXT_PAGE_LOADERS__?.[nextData.page];
+  if (loader) {
+    // Prefer the generated route loader when it exists, even on the HTML
+    // fallback path. Initial hydration uses the same loader map, so this keeps
+    // React component identity stable for same-route param changes. Importing
+    // the extracted chunk URL directly can evaluate a duplicate module when
+    // the router runtime is split across entry and page chunks.
     pageModule = await loader();
+  } else if (!pageModuleUrl) {
+    scheduleHardNavigationAndThrow(browserUrl, "Navigation failed: no page module URL found");
   } else {
     // Validate the module URL before importing — defense-in-depth against
     // unexpected __NEXT_DATA__ or malformed HTML responses
@@ -2616,9 +2623,9 @@ setPagesRouterPopStateHandler(handlePagesRouterPopState);
  * installing its own global URL-change listener.
  *
  * The PagesRouterCommitBoundary exists for client navigations: its layout
- * callback runs scroll restoration at commit time, its passive callback lets
- * routeChangeComplete wait until remounted page effects can subscribe, and its
- * onError rejection drives the hard-navigation fallback in runNavigateClient.
+ * callback runs scroll restoration at commit time and resolves the navigation
+ * at the same root-commit boundary Next.js awaits before routeChangeComplete.
+ * Its onError rejection drives the hard-navigation fallback in runNavigateClient.
  * The same boundary intentionally also wraps SSR and initial hydration, where
  * callbacks default to noopCommit: a hydration-time render error is caught
  * here (React still console.error's it) instead of propagating, matching the
@@ -2628,12 +2635,12 @@ export function wrapWithRouterContext(
   element: ReactElement,
   onCommit: () => void = noopCommit,
   onError: (error: Error) => void = noopCommit,
-  onPassiveCommit: () => void = noopCommit,
 ): ReactElement {
+  const { CommitBoundary, Provider } = getPagesRouterRuntimeComponents();
   return createElement(
-    PagesRouterCommitBoundary,
-    { onCommit, onError, onPassiveCommit },
-    createElement(PagesRouterProvider, null, element),
+    CommitBoundary,
+    { onCommit, onError },
+    createElement(Provider, null, element),
   );
 }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -86,6 +86,8 @@ const __scrollRestoration: boolean = process.env.__NEXT_SCROLL_RESTORATION === "
 
 type ScrollPosition = { x: number; y: number };
 const noopCommit = (): void => {};
+const SCROLL_RESTORE_MAX_FRAMES = 60;
+const SCROLL_RESTORE_TOLERANCE_PX = 1;
 
 /**
  * A version of useLayoutEffect that doesn't warn during SSR.
@@ -99,6 +101,7 @@ const useNonWarningLayoutEffect = typeof window === "undefined" ? useEffect : us
 class PagesRouterCommitBoundary extends Component<{
   children?: ReactNode;
   onCommit: () => void;
+  onPassiveCommit: () => void;
   onError: (error: Error) => void;
 }> {
   componentDidCatch(error: Error) {
@@ -108,7 +111,7 @@ class PagesRouterCommitBoundary extends Component<{
   render() {
     return createElement(
       PagesRouterCommitBoundaryHelper,
-      { onCommit: this.props.onCommit },
+      { onCommit: this.props.onCommit, onPassiveCommit: this.props.onPassiveCommit },
       this.props.children,
     );
   }
@@ -117,15 +120,30 @@ class PagesRouterCommitBoundary extends Component<{
 function PagesRouterCommitBoundaryHelper({
   children,
   onCommit,
+  onPassiveCommit,
 }: {
   children?: ReactNode;
   onCommit: () => void;
+  onPassiveCommit: () => void;
 }): ReactElement {
   useNonWarningLayoutEffect(() => {
     onCommit();
   }, [onCommit]);
 
-  return createElement(Fragment, null, children);
+  return createElement(
+    Fragment,
+    null,
+    children,
+    createElement(PagesRouterPassiveCommitMarker, { onCommit: onPassiveCommit }),
+  );
+}
+
+function PagesRouterPassiveCommitMarker({ onCommit }: { onCommit: () => void }): null {
+  useEffect(() => {
+    onCommit();
+  }, [onCommit]);
+
+  return null;
 }
 
 function renderPagesRouterElement(
@@ -140,22 +158,32 @@ function renderPagesRouterElement(
   cancelPreviousRenderCommit();
 
   return new Promise<void>((resolve, reject) => {
+    let resolvePassiveCommit = () => {};
+    const passiveCommitPromise = new Promise<void>((resolve) => {
+      resolvePassiveCommit = resolve;
+    });
     const cancel = () => {
-      if (_cancelPendingRenderCommit === cancel) _cancelPendingRenderCommit = null;
+      if (routerRuntimeState.cancelPendingRenderCommit === cancel) {
+        routerRuntimeState.cancelPendingRenderCommit = null;
+      }
+      resolvePassiveCommit();
       reject(new NavigationCancelledError("superseded"));
     };
-    _cancelPendingRenderCommit = cancel;
+    routerRuntimeState.cancelPendingRenderCommit = cancel;
 
-    // Only clear the module-level canceller if it still belongs to this
+    // Only clear the active render canceller if it still belongs to this
     // render; a superseded tree can commit late and must not null out the
     // canceller installed by a newer navigation.
     const clearIfCurrent = () => {
-      if (_cancelPendingRenderCommit === cancel) _cancelPendingRenderCommit = null;
+      if (routerRuntimeState.cancelPendingRenderCommit === cancel) {
+        routerRuntimeState.cancelPendingRenderCommit = null;
+      }
     };
 
-    const scrollHandler = () => {
+    const isCurrent = () => routerRuntimeState.cancelPendingRenderCommit === cancel;
+    const scrollHandler = async () => {
       if (scroll) {
-        window.scrollTo(scroll.x, scroll.y);
+        await restorePagesRouterScrollPosition(scroll, isCurrent);
       }
     };
 
@@ -163,24 +191,92 @@ function renderPagesRouterElement(
       wrapWithRouterContext(
         element,
         () => {
-          clearIfCurrent();
-          try {
-            scrollHandler();
-            resolve();
-          } catch (err) {
-            reject(err);
-          }
+          void (async () => {
+            if (!isCurrent()) return;
+
+            try {
+              await scrollHandler();
+              if (!isCurrent()) return;
+              await passiveCommitPromise;
+              if (!isCurrent()) return;
+              clearIfCurrent();
+              resolve();
+            } catch (err) {
+              clearIfCurrent();
+              reject(err);
+            }
+          })();
         },
         (error) => {
+          resolvePassiveCommit();
           clearIfCurrent();
           reject(error);
         },
+        resolvePassiveCommit,
       ),
     );
     if (typeof document === "undefined") {
+      resolvePassiveCommit();
       clearIfCurrent();
       resolve();
     }
+  });
+}
+
+async function restorePagesRouterScrollPosition(
+  scroll: ScrollPosition,
+  shouldContinue: () => boolean,
+): Promise<void> {
+  if (!shouldContinue()) return;
+
+  scrollToPagesRouterPosition(scroll);
+  if (isAtScrollPosition(scroll)) return;
+
+  for (let frame = 0; frame < SCROLL_RESTORE_MAX_FRAMES; frame += 1) {
+    await waitForNextAnimationFrame();
+    if (!shouldContinue()) return;
+
+    scrollToPagesRouterPosition(scroll);
+    if (isAtScrollPosition(scroll)) return;
+  }
+}
+
+function scrollToPagesRouterPosition({ x, y }: ScrollPosition): void {
+  if (typeof document === "undefined") {
+    window.scrollTo(x, y);
+    return;
+  }
+
+  const htmlElement = document.documentElement;
+  const shouldDisableSmoothScroll = htmlElement.dataset.scrollBehavior === "smooth";
+
+  if (!shouldDisableSmoothScroll) {
+    window.scrollTo(x, y);
+    return;
+  }
+
+  const previousScrollBehavior = htmlElement.style.scrollBehavior;
+  htmlElement.style.scrollBehavior = "auto";
+  htmlElement.getClientRects();
+  window.scrollTo(x, y);
+  htmlElement.style.scrollBehavior = previousScrollBehavior;
+}
+
+function isAtScrollPosition({ x, y }: ScrollPosition): boolean {
+  return (
+    Math.abs(window.scrollX - x) <= SCROLL_RESTORE_TOLERANCE_PX &&
+    Math.abs(window.scrollY - y) <= SCROLL_RESTORE_TOLERANCE_PX
+  );
+}
+
+function waitForNextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+      return;
+    }
+
+    setTimeout(resolve, 16);
   });
 }
 
@@ -308,8 +404,61 @@ function createRouterEvents(): RouterEvents {
   };
 }
 
-// Singleton events instance
-const routerEvents = createRouterEvents();
+type PagesRouterRuntimeState = {
+  events: RouterEvents;
+  currentHistoryKey?: string;
+  historyKeyCounter: number;
+  navigationId: number;
+  activeAbortController: AbortController | null;
+  cancelPendingRenderCommit: (() => void) | null;
+  beforePopStateCb?: BeforePopStateCallback;
+  lastPathnameAndSearch: string;
+  isFirstPopStateEvent: boolean;
+  routerDidNavigate: boolean;
+  deprecatedEventBridgeInstalled: boolean;
+  publicRouter?: Record<string, unknown>;
+};
+
+const PAGES_ROUTER_RUNTIME_STATE_KEY = Symbol.for("vinext.pagesRouter.runtimeState");
+
+function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
+  return {
+    events: createRouterEvents(),
+    historyKeyCounter: 0,
+    navigationId: 0,
+    activeAbortController: null,
+    cancelPendingRenderCommit: null,
+    lastPathnameAndSearch:
+      typeof window !== "undefined" ? window.location.pathname + window.location.search : "",
+    isFirstPopStateEvent: true,
+    routerDidNavigate: false,
+    deprecatedEventBridgeInstalled: false,
+  };
+}
+
+function getPagesRouterRuntimeState(): PagesRouterRuntimeState {
+  // Server-side module instances should stay isolated by normal module scope:
+  // there is no browser history to coordinate, and a process-global state object
+  // would only make test/module resets leak between independent SSR renders.
+  if (typeof window === "undefined") return createPagesRouterRuntimeState();
+
+  // In a real browser `window === globalThis`, so this still deduplicates
+  // independently bundled next/router module instances. In tests, though,
+  // each mocked document gets its own `window`; storing on the process global
+  // would leak router state across independent browser documents.
+  const globalObject = window as Window & {
+    [PAGES_ROUTER_RUNTIME_STATE_KEY]?: PagesRouterRuntimeState;
+  };
+  const existing = globalObject[PAGES_ROUTER_RUNTIME_STATE_KEY];
+  if (existing) return existing;
+
+  const state = createPagesRouterRuntimeState();
+  globalObject[PAGES_ROUTER_RUNTIME_STATE_KEY] = state;
+  return state;
+}
+
+const routerRuntimeState = getPagesRouterRuntimeState();
+const routerEvents = routerRuntimeState.events;
 
 function resolveUrl(url: string | UrlObject): string {
   if (typeof url === "string") return url;
@@ -496,8 +645,6 @@ export function isHashOnlyChange(href: string): boolean {
   return isHashOnlyBrowserUrlChange(href, window.location.href, __basePath);
 }
 
-let _currentHistoryKey: string | undefined;
-
 /**
  * Build router-shaped state for the initial document entry. Captures the
  * active locale (from `window.__VINEXT_LOCALE__`) so a back-navigation
@@ -530,12 +677,13 @@ function stampInitialHistoryState(): void {
 
   const existingState = window.history.state;
   if (existingState !== null && existingState !== undefined) {
-    _currentHistoryKey = getRouterStateKey(existingState) ?? _currentHistoryKey;
+    routerRuntimeState.currentHistoryKey =
+      getRouterStateKey(existingState) ?? routerRuntimeState.currentHistoryKey;
     return;
   }
 
   const initialState = buildInitialRouterState();
-  _currentHistoryKey = initialState.key;
+  routerRuntimeState.currentHistoryKey = initialState.key;
   window.history.replaceState(initialState, "");
 }
 
@@ -558,7 +706,7 @@ function saveScrollPosition(): void {
   const base: Record<string, unknown> = existing ?? buildInitialRouterState();
   const key = getRouterStateKey(base);
   if (key !== undefined) {
-    _currentHistoryKey = key;
+    routerRuntimeState.currentHistoryKey = key;
     saveScrollPositionToSessionStorage(key, position);
   }
   window.history.replaceState({ ...base, ...scroll }, "");
@@ -1037,6 +1185,24 @@ function markPagesRouterReady(): boolean {
   return true;
 }
 
+function markPagesRouterHydrated(): void {
+  if (typeof window === "undefined" || window.__NEXT_HYDRATED === true) return;
+
+  const hydratedAt = performance.now();
+  window.__VINEXT_HYDRATED_AT = hydratedAt;
+  window.__NEXT_HYDRATED = true;
+  window.__NEXT_HYDRATED_AT = hydratedAt;
+  window.__NEXT_HYDRATED_CB?.();
+}
+
+function PagesRouterHydrationMarker(): null {
+  useEffect(() => {
+    markPagesRouterHydrated();
+  }, []);
+
+  return null;
+}
+
 function getRouterSnapshot(): ReturnType<typeof getPathnameAndQuery> & { isReady: boolean } {
   // On the server, derive `router.isReady` from the SSR navigation-readiness
   // context (auto-export dynamic / query-string / rewrite-capable routes are
@@ -1081,32 +1247,9 @@ class HardNavigationScheduledError extends Error {
   }
 }
 
-/**
- * Monotonically increasing ID for tracking the current navigation.
- * Each call to navigateClient() increments this and captures the value.
- * After each async boundary, the navigation checks whether it is still
- * the active one. If a newer navigation has started, the stale one
- * throws NavigationCancelledError so the caller can emit routeChangeError
- * and skip routeChangeComplete.
- *
- * Replaces the old boolean `_navInProgress` guard which silently dropped
- * the second navigation, causing URL/content mismatch.
- */
-let _navigationId = 0;
-
-/** AbortController for the in-flight fetch, so superseded navigations abort network I/O. */
-let _activeAbortController: AbortController | null = null;
-
-/**
- * Pending render-commit rejection, so superseded navigations settle their
- * render-commit Promise instead of hanging when a newer root.render() call
- * starts before the previous tree commits.
- */
-let _cancelPendingRenderCommit: (() => void) | null = null;
-
 function cancelPreviousRenderCommit(): void {
-  _cancelPendingRenderCommit?.();
-  _cancelPendingRenderCommit = null;
+  routerRuntimeState.cancelPendingRenderCommit?.();
+  routerRuntimeState.cancelPendingRenderCommit = null;
 }
 
 function scheduleHardNavigationAndThrow(url: string, message: string): never {
@@ -1358,7 +1501,7 @@ async function navigateClientData(
     }
 
     window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-    _lastPathnameAndSearch = window.location.pathname + window.location.search;
+    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
     await navigateClientHtml(redirectedUrl, redirectedUrl, controller, navId, assertStillCurrent);
     return;
   }
@@ -1658,7 +1801,7 @@ async function navigateClientHtml(
   // Next.js's client Root callback without remounting the page tree.
   if (pendingRedirectHistoryUrl) {
     window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
-    _lastPathnameAndSearch = window.location.pathname + window.location.search;
+    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
   }
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
@@ -1688,16 +1831,16 @@ async function navigateClient(
   if (typeof window === "undefined") return;
 
   // Cancel any in-flight navigation (abort its fetch, settle its render-commit wait)
-  _activeAbortController?.abort();
+  routerRuntimeState.activeAbortController?.abort();
   cancelPreviousRenderCommit();
   const controller = new AbortController();
-  _activeAbortController = controller;
+  routerRuntimeState.activeAbortController = controller;
 
-  const navId = ++_navigationId;
+  const navId = ++routerRuntimeState.navigationId;
 
   /** Check if this navigation is still the active one. If not, throw. */
   function assertStillCurrent(): void {
-    if (navId !== _navigationId) {
+    if (navId !== routerRuntimeState.navigationId) {
       throw new NavigationCancelledError(url);
     }
   }
@@ -1731,7 +1874,8 @@ async function navigateClient(
             scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
           }
           window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-          _lastPathnameAndSearch = window.location.pathname + window.location.search;
+          routerRuntimeState.lastPathnameAndSearch =
+            window.location.pathname + window.location.search;
           browserUrl = redirectedUrl;
           htmlFetchUrl = redirectedUrl;
         }
@@ -1759,8 +1903,8 @@ async function navigateClient(
     }
   } finally {
     // Clean up the abort controller if this navigation is still the active one
-    if (navId === _navigationId) {
-      _activeAbortController = null;
+    if (navId === routerRuntimeState.navigationId) {
+      routerRuntimeState.activeAbortController = null;
     }
   }
 }
@@ -1898,7 +2042,7 @@ function updateHistory(
   const key =
     mode === "push"
       ? createHistoryKey()
-      : (previousKey ?? _currentHistoryKey ?? createHistoryKey());
+      : (previousKey ?? routerRuntimeState.currentHistoryKey ?? createHistoryKey());
   const stateUrl = navState?.url ?? fullUrl;
   const stateAs = navState?.as ?? fullUrl;
   const options = navState?.options ?? {};
@@ -1911,9 +2055,9 @@ function updateHistory(
   };
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
-  _currentHistoryKey = key;
-  _lastPathnameAndSearch = window.location.pathname + window.location.search;
-  _routerDidNavigate = true;
+  routerRuntimeState.currentHistoryKey = key;
+  routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
+  routerRuntimeState.routerDidNavigate = true;
 }
 
 /**
@@ -1928,12 +2072,13 @@ type VinextHistoryState = {
   key: string;
 };
 
-let _historyKeyCounter = 0;
 function createHistoryKey(): string {
-  _historyKeyCounter += 1;
+  routerRuntimeState.historyKeyCounter += 1;
   // Same intent as Next.js's createKey() — opaque, monotonic-ish, fine for
   // identifying history entries client-side.
-  return `vinext_${_historyKeyCounter.toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
+  return `vinext_${routerRuntimeState.historyKeyCounter.toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 9)}`;
 }
 
 /**
@@ -2031,8 +2176,9 @@ async function performNavigation(
 
   // History state metadata — surfaces the active locale to popstate and the
   // Safari-replay filter. `as` is the canonical app-relative path (no
-  // basePath, no hash) so it can be compared against `_lastPathnameAndSearch`
-  // (which is `pathname + search` only) in the popstate handler.
+  // basePath, no hash) so it can be compared against the runtime state's
+  // `lastPathnameAndSearch` (which is `pathname + search` only) in the popstate
+  // handler.
   const navStateOptions: { locale?: string; shallow: boolean } = { shallow };
   if (navigationLocale !== undefined) navStateOptions.locale = navigationLocale;
   const resolvedNoHash = stripHash(resolved);
@@ -2170,13 +2316,17 @@ async function prefetchUrl(url: string): Promise<void> {
  */
 export function useRouter(): NextRouter {
   const router = useContext(RouterContext);
-  if (!router) {
-    throw new Error(
-      "NextRouter was not mounted. https://nextjs.org/docs/messages/next-router-not-mounted",
-    );
+  if (router) {
+    return router;
   }
 
-  return router;
+  if (typeof window !== "undefined" && window.__VINEXT_PAGE_LOADERS__ !== undefined) {
+    return Router;
+  }
+
+  throw new Error(
+    "NextRouter was not mounted. https://nextjs.org/docs/messages/next-router-not-mounted",
+  );
 }
 
 function PagesRouterProvider({ children }: { children: ReactNode }): ReactElement {
@@ -2194,9 +2344,13 @@ function PagesRouterProvider({ children }: { children: ReactNode }): ReactElemen
     window.addEventListener("vinext:navigate", onNavigate);
     let cancelled = false;
     const readyTimer = window.setTimeout(() => {
-      if (cancelled || !markPagesRouterReady()) return;
-      setState(getRouterSnapshot());
-      notifyNextNavigationPagesContext();
+      if (cancelled) return;
+
+      const becameReady = markPagesRouterReady();
+      if (becameReady) {
+        setState(getRouterSnapshot());
+        notifyNextNavigationPagesContext();
+      }
     }, 0);
     return () => {
       cancelled = true;
@@ -2244,38 +2398,27 @@ function PagesRouterProvider({ children }: { children: ReactNode }): ReactElemen
     [],
   );
 
-  const content = createElement(RouterContext.Provider, { value: router }, children);
+  const content = createElement(
+    RouterContext.Provider,
+    { value: router },
+    createElement(Fragment, null, children, createElement(PagesRouterHydrationMarker)),
+  );
   return AppRouterContext
     ? createElement(AppRouterContext.Provider, { value: appRouter }, content)
     : content;
 }
 
-// beforePopState callback: called before handling browser back/forward.
-// If it returns false, the navigation is cancelled.
-let _beforePopStateCb: BeforePopStateCallback | undefined;
-
-// Track pathname+search for detecting hash-only back/forward in the popstate
-// handler. Updated after every pushState/replaceState so that popstate can
-// compare the previous value with the (already-changed) window.location.
-let _lastPathnameAndSearch =
-  typeof window !== "undefined" ? window.location.pathname + window.location.search : "";
-
-// Tracks whether we have observed at least one popstate event in this
-// document. Safari fires a synthetic popstate on tab reopen / restore which
-// must be ignored when the carried state matches the page we're already on.
+// `routerRuntimeState.lastPathnameAndSearch` tracks pathname+search for
+// detecting hash-only back/forward in the popstate handler. It is updated after
+// every pushState/replaceState so popstate can compare the previous value with
+// the already-changed window.location.
 //
-// Ported from Next.js: packages/next/src/shared/lib/router/router.ts
-// (the `isFirstPopStateEvent` flag around the `onPopState` handler, ~L935).
-let _isFirstPopStateEvent = true;
-
-// Tracks whether the router has performed any push/replace in this document.
-// The Safari-replay filter (see below) only fires before any user-initiated
-// navigation — once the user has navigated, a back/forward popstate is by
-// definition a real one and must not be filtered out, even if the carried
-// state happens to compare equal to the live URL on the relevant fields
-// (e.g. a hash-only push followed by goBack carries state.as without a hash,
-// matching `_lastPathnameAndSearch` which is also tracked without a hash).
-let _routerDidNavigate = false;
+// `routerRuntimeState.isFirstPopStateEvent` mirrors Next.js's first-popstate
+// Safari replay filter (packages/next/src/shared/lib/router/router.ts around
+// L935). `routerRuntimeState.routerDidNavigate` disables that filter once the
+// document has performed a user navigation; after that, a back/forward popstate
+// is real even if the carried state compares equal to the tracked URL fields
+// (for example, a hash-only push followed by goBack).
 
 function isNextRouterState(state: unknown): state is {
   url?: string;
@@ -2302,8 +2445,8 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   const appUrl = stripBasePath(window.location.pathname, __basePath) + window.location.search;
 
   const state = e.state as unknown;
-  const wasFirst = _isFirstPopStateEvent;
-  _isFirstPopStateEvent = false;
+  const wasFirst = routerRuntimeState.isFirstPopStateEvent;
+  routerRuntimeState.isFirstPopStateEvent = false;
 
   // History entries written by third-party code (state without `__N: true`)
   // are not owned by the router. Mirror Next.js's `if (!state.__N) return`
@@ -2323,7 +2466,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // for the current entry on tab restore / BFCache. Ignore it when the
   // entry's locale matches the active locale AND the entry's `as` matches
   // the URL the router last actively navigated to. We compare against the
-  // router-internal tracker (`_lastPathnameAndSearch`, browser-shaped, with
+  // router-internal tracker (`lastPathnameAndSearch`, browser-shaped, with
   // basePath) rather than the live `window.location` — after a real
   // back/forward the browser URL has already changed but the router tracker
   // still points at the entry we were on, so a genuine navigation is *not*
@@ -2340,25 +2483,25 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // user has navigated, a popstate is by definition a real back/forward and
   // must not be silently dropped (e.g. a hash-only push then goBack carries
   // state.as without the hash, which would otherwise match
-  // `_lastPathnameAndSearch` and be incorrectly filtered).
-  if (wasFirst && !_routerDidNavigate && isNextRouterState(state)) {
+  // `lastPathnameAndSearch` and be incorrectly filtered).
+  if (wasFirst && !routerRuntimeState.routerDidNavigate && isNextRouterState(state)) {
     const currentLocale = window.__VINEXT_LOCALE__;
     if (
       state.options?.locale === currentLocale &&
       typeof state.as === "string" &&
-      withBasePath(state.as, __basePath) === _lastPathnameAndSearch
+      withBasePath(state.as, __basePath) === routerRuntimeState.lastPathnameAndSearch
     ) {
       return;
     }
   }
 
   // Detect hash-only back/forward: pathname+search unchanged, only hash differs.
-  const isHashOnly = browserUrl === _lastPathnameAndSearch;
+  const isHashOnly = browserUrl === routerRuntimeState.lastPathnameAndSearch;
   const targetKey = getRouterStateKey(state);
   let forcedScroll: ScrollPosition | undefined;
 
   if (manualScrollRestoration) {
-    const currentKey = _currentHistoryKey;
+    const currentKey = routerRuntimeState.currentHistoryKey;
     if (currentKey !== undefined && currentKey !== targetKey) {
       // Reading window scroll here is only correct because manualScrollRestoration
       // implies history.scrollRestoration = "manual", so the browser hasn't yet
@@ -2378,8 +2521,8 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   }
 
   // Check beforePopState callback
-  if (_beforePopStateCb !== undefined) {
-    const shouldContinue = _beforePopStateCb({
+  if (routerRuntimeState.beforePopStateCb !== undefined) {
+    const shouldContinue = routerRuntimeState.beforePopStateCb({
       url: appUrl,
       as: appUrl,
       options: { shallow: false },
@@ -2389,14 +2532,13 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
 
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,
-  // so both must retain their previous values: `_lastPathnameAndSearch` so
-  // the next popstate compares against the correct baseline, and
-  // `_currentHistoryKey` so subsequent scroll bookkeeping keys off the entry
-  // the app is actually on.
+  // so both must retain their previous values: `lastPathnameAndSearch` so the
+  // next popstate compares against the correct baseline, and `currentHistoryKey`
+  // so subsequent scroll bookkeeping keys off the entry the app is actually on.
   if (targetKey !== undefined) {
-    _currentHistoryKey = targetKey;
+    routerRuntimeState.currentHistoryKey = targetKey;
   }
-  _lastPathnameAndSearch = browserUrl;
+  routerRuntimeState.lastPathnameAndSearch = browserUrl;
 
   if (isHashOnly) {
     // Hash-only back/forward — no page fetch needed.
@@ -2473,22 +2615,24 @@ setPagesRouterPopStateHandler(handlePagesRouterPopState);
  * next/compat/router consumers share one context value instead of each hook
  * installing its own global URL-change listener.
  *
- * The PagesRouterCommitBoundary exists for client navigations: its onCommit
- * callback resolves the render-commit promise (so scroll restoration runs at
- * commit time) and its onError rejection drives the hard-navigation fallback
- * in runNavigateClient. The same boundary intentionally also wraps SSR and
- * initial hydration, where both callbacks default to noopCommit: a
- * hydration-time render error is caught here (React still console.error's
- * it) instead of propagating, matching the navigation-path containment.
+ * The PagesRouterCommitBoundary exists for client navigations: its layout
+ * callback runs scroll restoration at commit time, its passive callback lets
+ * routeChangeComplete wait until remounted page effects can subscribe, and its
+ * onError rejection drives the hard-navigation fallback in runNavigateClient.
+ * The same boundary intentionally also wraps SSR and initial hydration, where
+ * callbacks default to noopCommit: a hydration-time render error is caught
+ * here (React still console.error's it) instead of propagating, matching the
+ * navigation-path containment.
  */
 export function wrapWithRouterContext(
   element: ReactElement,
   onCommit: () => void = noopCommit,
   onError: (error: Error) => void = noopCommit,
+  onPassiveCommit: () => void = noopCommit,
 ): ReactElement {
   return createElement(
     PagesRouterCommitBoundary,
-    { onCommit, onError },
+    { onCommit, onError, onPassiveCommit },
     createElement(PagesRouterProvider, null, element),
   );
 }
@@ -2653,7 +2797,7 @@ const RouterMethods = {
   },
   beforePopState: (cb: BeforePopStateCallback) => {
     if (typeof window === "undefined") throwNoRouterInstance();
-    _beforePopStateCb = cb;
+    routerRuntimeState.beforePopStateCb = cb;
   },
   events: routerEvents,
 };
@@ -2719,7 +2863,16 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
     isReady: {
       enumerable: true,
       get(): boolean {
-        return isPagesRouterReady();
+        // `window.next.router.isReady` is used by the Next.js deploy harness as
+        // a post-reload signal before starting client navigations. Keep the
+        // singleton false until the generated Pages client entry's hydration
+        // effect has run, so page-level `useEffect` subscriptions are installed
+        // before tests/userland observe readiness. The provider-backed
+        // `useRouter().isReady` still uses the serialized readiness snapshot to
+        // avoid server/client markup drift during hydration.
+        return (
+          isPagesRouterReady() && (typeof window === "undefined" || window.__NEXT_HYDRATED === true)
+        );
       },
     },
     isPreview: { enumerable: true, value: false, writable: false },
@@ -2732,6 +2885,8 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
     },
   }) as typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods>;
 
+routerRuntimeState.publicRouter = Router as Record<string, unknown>;
+
 // Deprecated event property bridging: when userland code does
 // `Router.onRouteChangeComplete = handler` (the legacy Next.js pattern),
 // the handler must be called whenever the corresponding event fires.
@@ -2741,11 +2896,9 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
 //
 // Ported from Next.js: packages/next/src/client/router.ts (lines 105–124).
 // The reference implementation wraps this in `singletonRouter.ready()` so it
-// runs after the router instance is created; vinext's routerEvents is a module-
-// level singleton that exists from the start, so we can register directly.
-// Registering unconditionally at module load (without a client-only guard) is
-// safe here because every routerEvents.emit() call is already gated behind
-// typeof window checks, so these listeners never fire in SSR contexts.
+// runs after the router instance is created. vinext registers directly against
+// the document-wide events singleton, guarded so duplicate production chunks do
+// not install duplicate bridge handlers.
 const deprecatedRouterEvents = [
   "routeChangeStart",
   "beforeHistoryChange",
@@ -2755,19 +2908,23 @@ const deprecatedRouterEvents = [
   "hashChangeComplete",
 ] as const;
 
-for (const event of deprecatedRouterEvents) {
-  const eventField = `on${event.charAt(0).toUpperCase()}${event.substring(1)}`;
-  routerEvents.on(event, (...args: unknown[]) => {
-    const handler = (Router as Record<string, unknown>)[eventField];
-    if (typeof handler === "function") {
-      try {
-        (handler as (...a: unknown[]) => void)(...args);
-      } catch (err) {
-        console.error(`Error when running the Router event: ${eventField}`);
-        console.error(err instanceof Error ? `${err.message}\n${err.stack}` : String(err));
+if (!routerRuntimeState.deprecatedEventBridgeInstalled) {
+  routerRuntimeState.deprecatedEventBridgeInstalled = true;
+  for (const event of deprecatedRouterEvents) {
+    const eventField = `on${event.charAt(0).toUpperCase()}${event.substring(1)}`;
+    routerEvents.on(event, (...args: unknown[]) => {
+      const routerTarget = routerRuntimeState.publicRouter ?? (Router as Record<string, unknown>);
+      const handler = routerTarget[eventField];
+      if (typeof handler === "function") {
+        try {
+          (handler as (...a: unknown[]) => void)(...args);
+        } catch (err) {
+          console.error(`Error when running the Router event: ${eventField}`);
+          console.error(err instanceof Error ? `${err.message}\n${err.stack}` : String(err));
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 // Expose `window.next.router` for Next.js parity. Pages Router test suites,

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -28,24 +28,8 @@ async function expectScrollPosition(page: Page, expected: ScrollPosition) {
   await expect.poll(() => getScrollPosition(page)).toEqual(expected);
 }
 
-async function expectRouteChangeComplete(page: Page): Promise<void> {
-  // Register a one-shot listener for the next routeChangeComplete event.
-  // MUST be started before the navigation that triggers the event — calling
-  // this after an awaited router.push() will deadlock because the event has
-  // already fired.
-  return page.evaluate(() => {
-    const router = window.next?.router;
-    if (!router || !("events" in router)) {
-      throw new Error("expectRouteChangeComplete: window.next.router.events is not available");
-    }
-    return new Promise<void>((resolve) => {
-      const handler = () => {
-        router.events.off("routeChangeComplete", handler);
-        resolve();
-      };
-      router.events.on("routeChangeComplete", handler);
-    });
-  });
+async function expectPageShowsRouteChangeComplete(page: Page): Promise<void> {
+  await expect(page.locator("html")).toContainText("routeChangeComplete");
 }
 
 async function pushWithPagesRouter(page: Page, href: string): Promise<void> {
@@ -88,18 +72,16 @@ test.describe("reload-scroll-back-restoration", () => {
     scrollPositionMemories.push(await getScrollPosition(page));
     await pushWithPagesRouter(page, "/2");
 
-    const rc1 = expectRouteChangeComplete(page);
     await page.goBack();
-    await rc1;
+    await expectPageShowsRouteChangeComplete(page);
     await expectScrollPosition(page, scrollPositionMemories[1]);
 
     await page.reload();
 
     await expect.poll(() => isPagesRouterReady(page)).toBe(true);
 
-    const rc2 = expectRouteChangeComplete(page);
     await page.goBack();
-    await rc2;
+    await expectPageShowsRouteChangeComplete(page);
     await expectScrollPosition(page, scrollPositionMemories[0]);
   });
 
@@ -126,18 +108,16 @@ test.describe("reload-scroll-back-restoration", () => {
 
     await page.goBack();
     await page.goBack();
-    const rc3 = expectRouteChangeComplete(page);
     await page.goForward();
-    await rc3;
+    await expectPageShowsRouteChangeComplete(page);
     await expectScrollPosition(page, scrollPositionMemories[1]);
 
     await page.reload();
 
     await expect.poll(() => isPagesRouterReady(page)).toBe(true);
 
-    const rc4 = expectRouteChangeComplete(page);
     await page.goForward();
-    await rc4;
+    await expectPageShowsRouteChangeComplete(page);
     await expectScrollPosition(page, scrollPositionMemories[2]);
   });
 
@@ -186,14 +166,12 @@ test.describe("reload-scroll-back-restoration", () => {
       window.isSoftNavigation = true;
     });
 
-    // Push to the page that throws render error
+    // Push to the dynamic page variant that throws during client render.
     await pushWithPagesRouter(page, "/error");
 
     // Since it falls back to hard navigation, the page fully reloads.
     // The reload clears the window context, so `window.isSoftNavigation` will be undefined.
-    // We should wait until the url is "/error" and we are hydrated.
     await expect(page).toHaveURL(`${BASE}/error`);
-    await waitForHydration(page);
 
     // Verify that the window marker is indeed gone (hard navigation occurred)
     const isSoft = await page.evaluate(() => window.isSoftNavigation);

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -29,7 +29,9 @@ async function expectScrollPosition(page: Page, expected: ScrollPosition) {
 }
 
 async function expectPageShowsRouteChangeComplete(page: Page, expectedPath: string): Promise<void> {
-  await expect(page.locator("html")).toContainText(`routeChangeComplete:${expectedPath}`);
+  await expect(
+    page.getByText(`routeChangeComplete:${expectedPath}`, { exact: true }),
+  ).toBeVisible();
 }
 
 async function pushWithPagesRouter(page: Page, href: string): Promise<void> {

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -28,8 +28,8 @@ async function expectScrollPosition(page: Page, expected: ScrollPosition) {
   await expect.poll(() => getScrollPosition(page)).toEqual(expected);
 }
 
-async function expectPageShowsRouteChangeComplete(page: Page): Promise<void> {
-  await expect(page.locator("html")).toContainText("routeChangeComplete");
+async function expectPageShowsRouteChangeComplete(page: Page, expectedPath: string): Promise<void> {
+  await expect(page.locator("html")).toContainText(`routeChangeComplete:${expectedPath}`);
 }
 
 async function pushWithPagesRouter(page: Page, href: string): Promise<void> {
@@ -73,7 +73,7 @@ test.describe("reload-scroll-back-restoration", () => {
     await pushWithPagesRouter(page, "/2");
 
     await page.goBack();
-    await expectPageShowsRouteChangeComplete(page);
+    await expectPageShowsRouteChangeComplete(page, "/1");
     await expectScrollPosition(page, scrollPositionMemories[1]);
 
     await page.reload();
@@ -81,7 +81,7 @@ test.describe("reload-scroll-back-restoration", () => {
     await expect.poll(() => isPagesRouterReady(page)).toBe(true);
 
     await page.goBack();
-    await expectPageShowsRouteChangeComplete(page);
+    await expectPageShowsRouteChangeComplete(page, "/0");
     await expectScrollPosition(page, scrollPositionMemories[0]);
   });
 
@@ -109,7 +109,7 @@ test.describe("reload-scroll-back-restoration", () => {
     await page.goBack();
     await page.goBack();
     await page.goForward();
-    await expectPageShowsRouteChangeComplete(page);
+    await expectPageShowsRouteChangeComplete(page, "/1");
     await expectScrollPosition(page, scrollPositionMemories[1]);
 
     await page.reload();
@@ -117,7 +117,7 @@ test.describe("reload-scroll-back-restoration", () => {
     await expect.poll(() => isPagesRouterReady(page)).toBe(true);
 
     await page.goForward();
-    await expectPageShowsRouteChangeComplete(page);
+    await expectPageShowsRouteChangeComplete(page, "/2");
     await expectScrollPosition(page, scrollPositionMemories[2]);
   });
 

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -952,6 +952,32 @@ describe("Pages Router entry template", () => {
     }
   });
 
+  it("keeps the Pages Router client tree shape stable after hydration", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-hydrated-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      const code = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({}),
+        createValidFileMatcher(),
+      );
+
+      expect(code).not.toContain("function VinextHydrationMarker");
+      expect(code).not.toContain("React.createElement(VinextHydrationMarker");
+      expect(code).toContain("element = wrapWithRouterContext(element);");
+      expect(code).toContain("hydrateRoot(container, element, hydrateRootOptions)");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("installs the dev error overlay before loading Pages Router modules", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-overlay-"));
     const pagesDir = path.join(tmpDir, "pages");

--- a/tests/fixtures/pages-scroll-restoration/pages/[id].js
+++ b/tests/fixtures/pages-scroll-restoration/pages/[id].js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
@@ -11,14 +11,10 @@ const Page = ({ id }) => {
   }
 
   useEffect(() => {
-    const handler = () => {
+    router.events.on("routeChangeComplete", () => {
       setReady(true);
-    };
-    router.events.on("routeChangeComplete", handler);
-    return () => {
-      router.events.off("routeChangeComplete", handler);
-    };
-  }, [router]);
+    });
+  }, [router, ready, setReady]);
 
   return (
     <>
@@ -31,7 +27,7 @@ const Page = ({ id }) => {
       />
       <p>{ready ? "routeChangeComplete" : "loading"}</p>
       <Link
-        href={`/${Number(id) + 1}`}
+        href={`/${id + 1}`}
         id="link"
         style={{
           marginLeft: 5000,
@@ -49,7 +45,7 @@ const Page = ({ id }) => {
 export default Page;
 
 export const getServerSideProps = (context) => {
-  const { id = "0" } = context.query;
+  const { id = 0 } = context.query;
   return {
     props: {
       id,

--- a/tests/fixtures/pages-scroll-restoration/pages/[id].js
+++ b/tests/fixtures/pages-scroll-restoration/pages/[id].js
@@ -1,20 +1,33 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
 const Page = ({ id }) => {
   const router = useRouter();
-  const [ready, setReady] = useState(false);
+  const idRef = useRef(id);
+  idRef.current = id;
+  const [lastEvent, setLastEvent] = useState({ url: null, id });
 
   if (typeof window !== "undefined" && id === "error") {
     throw new Error("Simulated client-side render error");
   }
 
   useEffect(() => {
-    router.events.on("routeChangeComplete", () => {
-      setReady(true);
-    });
-  }, [router, ready, setReady]);
+    // Reset the readiness indicator whenever the page id changes so that
+    // back/forward traversals must emit a fresh routeChangeComplete before
+    // the fixture reports "ready" again.
+    setLastEvent((prev) => (prev.id === idRef.current ? prev : { url: null, id: idRef.current }));
+
+    const handler = (url) => {
+      setLastEvent({ url, id: idRef.current });
+    };
+    router.events.on("routeChangeComplete", handler);
+    return () => {
+      router.events.off("routeChangeComplete", handler);
+    };
+  }, [router]);
+
+  const ready = lastEvent.url !== null && lastEvent.id === id;
 
   return (
     <>
@@ -25,7 +38,7 @@ const Page = ({ id }) => {
           background: "blue",
         }}
       />
-      <p>{ready ? "routeChangeComplete" : "loading"}</p>
+      <p>{ready ? `routeChangeComplete:${lastEvent.url}` : "loading"}</p>
       <Link
         href={`/${id + 1}`}
         id="link"

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -20773,3 +20773,105 @@ describe("default-locale path normalisation (issue #1336, item 4)", () => {
     ).toBe("/sv/new");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Pages Router runtime state sharing
+//
+// Vite can evaluate `next/router` in both the client entry and in page chunks.
+// State that must be consistent across those instances (events, history keys,
+// abort/cancel state, and router readiness) must live on a window-scoped
+// runtime object rather than in module-local variables.
+// ---------------------------------------------------------------------------
+describe("Pages Router runtime state sharing", () => {
+  it("shares router readiness across duplicated next/router module instances", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: {
+        pathname: "/1",
+        search: "",
+        hash: "",
+        href: "http://localhost/1",
+        hostname: "localhost",
+      },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+      __NEXT_DATA__: {
+        page: "/[id]",
+        query: {},
+        autoExport: true,
+        isFallback: false,
+        props: { pageProps: {} },
+      },
+      __VINEXT_PAGE_LOADERS__: {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+
+      // First `next/router` instance: the generated Pages client entry.
+      const routerModuleA = await import("../packages/vinext/src/shims/router.js");
+      const RouterA = routerModuleA.default;
+      const markReadyA = routerModuleA._markPagesRouterReady;
+
+      // Second `next/router` instance: a later page chunk that re-evaluates the
+      // module and overwrites window.next.router.
+      vi.resetModules();
+      const routerModuleB = await import("../packages/vinext/src/shims/router.js");
+      const RouterB = routerModuleB.default;
+      const useRouterB = routerModuleB.useRouter;
+
+      // Both singletons start with the same deferred-ready state.
+      expect(win.next.router).toBe(RouterB);
+      expect(RouterA.isReady).toBe(false);
+      expect(RouterB.isReady).toBe(false);
+
+      // After hydration, the readiness bit still stays false until the provider
+      // publishes it.
+      win.__NEXT_HYDRATED = true;
+      expect(RouterA.isReady).toBe(false);
+      expect(RouterB.isReady).toBe(false);
+
+      // Simulate the provider mounting and flipping the shared ready bit.
+      expect(markReadyA()).toBe(true);
+      expect(markReadyA()).toBe(false);
+
+      // The readiness transition is visible from every module instance and from
+      // the global singleton.
+      expect(RouterA.isReady).toBe(true);
+      expect(RouterB.isReady).toBe(true);
+      expect(win.next.router.isReady).toBe(true);
+
+      // useRouter() backed by the second instance also converges to ready.
+      function ProbeB() {
+        const router = useRouterB();
+        return React.createElement("span", null, router.isReady ? "ready" : "not-ready");
+      }
+      const htmlB = renderToStaticMarkup(
+        routerModuleB.wrapWithRouterContext(React.createElement(ProbeB)),
+      );
+      expect(htmlB).toBe("<span>ready</span>");
+
+      // And a provider-mounted hook from the first instance sees it too.
+      function ProbeA() {
+        const router = routerModuleA.useRouter();
+        return React.createElement("span", null, router.isReady ? "ready" : "not-ready");
+      }
+      const htmlA = renderToStaticMarkup(
+        routerModuleA.wrapWithRouterContext(React.createElement(ProbeA)),
+      );
+      expect(htmlA).toBe("<span>ready</span>");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+});

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13841,6 +13841,58 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("Pages Router HTML fallback prefers the registered route loader", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const LoaderPage = () => null;
+    const loader = vi.fn(async () => ({ default: LoaderPage }));
+    Object.assign(win, {
+      __VINEXT_PAGE_LOADERS__: {
+        "/same": loader,
+      },
+      __VINEXT_PAGE_PATTERNS__: ["/same"],
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      createElement: vi.fn(),
+      head: { appendChild: vi.fn() },
+    };
+
+    const fetch = vi.fn(
+      async () => new Response(buildNavHtml("/same", "javascript:duplicate-or-invalid")),
+    );
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/same");
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith("/same", expect.any(Object));
+      expect(loader).toHaveBeenCalledTimes(1);
+      expect(render).toHaveBeenCalled();
+      expect(win.location.href).toBe("http://localhost/same");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      if (previousDocument === undefined) {
+        delete (globalThis as any).document;
+      } else {
+        (globalThis as any).document = previousDocument;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("last push() wins when two overlap — superseded navigation does not render", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -14419,7 +14471,6 @@ describe("Pages Router concurrent navigation", () => {
       await vi.waitFor(() => expect(render).toHaveBeenCalled());
       const committed = render.mock.calls.at(-1)![0];
       committed.props.onCommit();
-      committed.props.onPassiveCommit();
       await routeChangeComplete;
 
       expect(win.scrollTo).toHaveBeenCalledWith(12, 345);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17,6 +17,16 @@ import type {
 } from "../packages/vinext/src/shims/cache.js";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
+
+function commitRenderedPagesRouterElement(element: unknown): void {
+  if (typeof document === "undefined" || document.documentElement === undefined) return;
+
+  const props = (element as { props?: unknown } | null)?.props;
+  const onCommit =
+    props && typeof props === "object" ? (props as { onCommit?: unknown }).onCommit : undefined;
+  if (typeof onCommit === "function") queueMicrotask(onCommit as () => void);
+}
+
 describe("vinext next data client helpers", () => {
   it("extracts __NEXT_DATA__ after carriage-return whitespace", () => {
     const json = '{"props":{},"page":"/","query":{}}';
@@ -13390,7 +13400,7 @@ describe("Pages Router concurrent navigation", () => {
   function createNavWindow() {
     const pushState = vi.fn();
     const replaceState = vi.fn();
-    const render = vi.fn();
+    const render = vi.fn((element: unknown) => commitRenderedPagesRouterElement(element));
 
     const win = {
       location: {
@@ -14469,7 +14479,7 @@ describe("Pages Router concurrent navigation", () => {
       // The scroll target is applied inside the render-commit callback; the
       // mocked root.render never mounts React, so fire the commit manually.
       await vi.waitFor(() => expect(render).toHaveBeenCalled());
-      const committed = render.mock.calls.at(-1)![0];
+      const committed = render.mock.calls.at(-1)![0] as { props: { onCommit: () => void } };
       committed.props.onCommit();
       await routeChangeComplete;
 
@@ -15960,7 +15970,7 @@ describe("Pages Router _next/data client navigation", () => {
   ) {
     const pushState = vi.fn();
     const replaceState = vi.fn();
-    const render = vi.fn();
+    const render = vi.fn((element: unknown) => commitRenderedPagesRouterElement(element));
     const buildId = opts.buildId ?? "test-build";
 
     const win = {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2658,6 +2658,33 @@ describe("next/router withRouter HOC", () => {
     );
   });
 
+  it("next/router useRouter falls back to the singleton in a Pages Router browser document", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter } = await import("../packages/vinext/src/shims/router.js");
+    const win = (globalThis as { window: Window }).window;
+    const previousPageLoaders = win.__VINEXT_PAGE_LOADERS__;
+
+    try {
+      win.__VINEXT_PAGE_LOADERS__ = {};
+
+      const captured: NextRouter[] = [];
+      function Probe() {
+        captured.push(useRouter());
+        return React.createElement("span", null, "ok");
+      }
+
+      renderToStaticMarkup(React.createElement(Probe));
+
+      const router = captured[0];
+      expect(router).toBeDefined();
+      expect(router?.events).toBeDefined();
+      expect(typeof router?.push).toBe("function");
+    } finally {
+      win.__VINEXT_PAGE_LOADERS__ = previousPageLoaders;
+    }
+  });
+
   it("next/router useRouter does not subscribe once per hook call", async () => {
     const previousWindowForMock = (globalThis as any).window;
     const addEventListener = vi.fn();
@@ -14326,17 +14353,29 @@ describe("Pages Router concurrent navigation", () => {
   // restoration can't position correctly.
   it("popstate restores history-state scroll when manual scroll restoration is off", async () => {
     const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
     const originalFetch = globalThis.fetch;
     const originalCustomEvent = globalThis.CustomEvent;
     const listeners = new Map<string, (event: any) => void>();
     const { win, render } = createNavWindow();
     const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    win.scrollTo.mockImplementation((x: number, y: number) => {
+      win.scrollX = x;
+      win.scrollY = y;
+    });
 
     win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
       listeners.set(type, handler);
     });
 
     (globalThis as any).window = win;
+    (globalThis as any).document = {
+      documentElement: {
+        dataset: {},
+        style: {},
+        getClientRects: vi.fn(),
+      },
+    };
     (globalThis as any).CustomEvent = class CustomEventMock {
       constructor(public type: string) {}
     } as any;
@@ -14374,13 +14413,14 @@ describe("Pages Router concurrent navigation", () => {
           __vinext_scrollY: 345,
         },
       });
-      await routeChangeComplete;
 
       // The scroll target is applied inside the render-commit callback; the
       // mocked root.render never mounts React, so fire the commit manually.
-      expect(render).toHaveBeenCalled();
+      await vi.waitFor(() => expect(render).toHaveBeenCalled());
       const committed = render.mock.calls.at(-1)![0];
       committed.props.onCommit();
+      committed.props.onPassiveCommit();
+      await routeChangeComplete;
 
       expect(win.scrollTo).toHaveBeenCalledWith(12, 345);
     } finally {
@@ -14389,6 +14429,11 @@ describe("Pages Router concurrent navigation", () => {
         delete (globalThis as any).window;
       } else {
         (globalThis as any).window = previousWindow;
+      }
+      if (previousDocument === undefined) {
+        delete (globalThis as any).document;
+      } else {
+        (globalThis as any).document = previousDocument;
       }
       globalThis.fetch = originalFetch;
       (globalThis as any).CustomEvent = originalCustomEvent;


### PR DESCRIPTION
## Summary

- Port the Next.js reload/back/forward scroll-restoration behavior for Pages Router e2e coverage.
- Share Pages Router browser runtime state through the document `window` so production bundles with multiple `next/router` module instances agree on history keys, events, cancellation, and popstate state.
- Move Pages Router hydration readiness into the stable router provider and resolve client navigations after layout scroll restoration plus passive effects, so page-level `routeChangeComplete` subscriptions can observe the event.
- Retry scroll restoration at commit time and temporarily neutralize smooth scrolling when applying a saved scroll target.

## Root Cause

The deploy-suite fixture exposed two coupled production-only problems. First, the entry chunk and a page chunk could evaluate separate `next/router` modules, leaving the popstate listener and `window.next.router` with separate history-key counters/current-key state. After reload plus back/forward traversal, the stale popstate-side key could snapshot the outgoing scroll into the wrong `__next_scroll_<key>` entry and overwrite the position that should be restored later.

Second, vinext emitted `routeChangeComplete` immediately after `root.render()` resolved, before the newly rendered page's passive effects had subscribed to router events. The upstream fixture renders `routeChangeComplete` only from a page-level `useEffect` listener, so the event ordering needed to match the browser-observable Next.js contract more closely.

## References

- Next.js upstream test: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/index.test.ts
- Next.js upstream fixture page: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/pages/%5Bid%5D.js
- Next.js upstream fixture config: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/reload-scroll-backforward-restoration/next.config.js
- Next.js Pages Router scroll/history implementation: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts
- Next.js client hydration/render callback path: https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/index.tsx

## Verification

- `vp test run tests/shims.test.ts`
- `vp test run tests/entry-templates.test.ts -t "keeps the Pages Router client tree shape stable after hydration"`
- `vp test run tests/pages-router.test.ts -t "client entry statically imports next/router|installs the vinext dev error overlay"`
- `vp check`
- `CI=1 PLAYWRIGHT_PROJECT=pages-scroll-restoration pnpm run test:e2e tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts --reporter=line`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/reload-scroll-backforward-restoration/index.test.ts`
