### PR TITLE
fix(app-router): preserve max prefetch inlining lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,10 @@ jobs:
             label: app-router-bfcache
             shardIndex: 1
             shardTotal: 1
+          - project: app-prefetch-inlining
+            label: app-prefetch-inlining
+            shardIndex: 1
+            shardTotal: 1
           - project: app-router
             label: app-router 3/3
             shardIndex: 3

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1565,13 +1565,23 @@ async function main(): Promise<void> {
   // helper so the null-branch structurally cannot reach any RSC bootstrap
   // global assignment, even if a future refactor interposes async work here.
   if (rscStream === null) return;
-  const hydrationStream = await preloadInitialClientReferencesFromRscStream(rscStream, {
-    onPreloadError(id, error) {
-      if (import.meta.env.DEV) {
-        console.warn("[vinext] failed to preload initial client ref:", id, error);
-      }
+  // Tee the initial RSC stream and warm up client-reference imports on the side
+  // branch, but hand the render branch to hydration immediately. Blocking
+  // hydration on the warm-up would strand above-the-fold client components until
+  // a slow Suspense boundary at the stream tail settles; the Flight thenable
+  // annotation installed before main() already lets React track in-flight
+  // imports, so the warm-up is an optimization, not a prerequisite.
+  const { stream: hydrationStream, preloaded } = preloadInitialClientReferencesFromRscStream(
+    rscStream,
+    {
+      onPreloadError(id, error) {
+        if (import.meta.env.DEV) {
+          console.warn("[vinext] failed to preload initial client ref:", id, error);
+        }
+      },
     },
-  });
+  );
+  void preloaded.catch(() => {});
   bootstrapHydration(hydrationStream);
 }
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -175,6 +175,10 @@ import {
 } from "./headers.js";
 import { removeStylesheetLinksCoveredByInlineCss } from "./app-inline-css-client.js";
 import { navigationPlanner } from "./navigation-planner.js";
+import {
+  installReactFlightClientReferenceRequire,
+  preloadInitialClientReferencesFromRscStream,
+} from "./app-client-reference-loader.js";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -1561,7 +1565,14 @@ async function main(): Promise<void> {
   // helper so the null-branch structurally cannot reach any RSC bootstrap
   // global assignment, even if a future refactor interposes async work here.
   if (rscStream === null) return;
-  bootstrapHydration(rscStream);
+  const hydrationStream = await preloadInitialClientReferencesFromRscStream(rscStream, {
+    onPreloadError(id, error) {
+      if (import.meta.env.DEV) {
+        console.warn("[vinext] failed to preload initial client ref:", id, error);
+      }
+    },
+  });
+  bootstrapHydration(hydrationStream);
 }
 
 function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
@@ -2281,5 +2292,6 @@ if (typeof document !== "undefined") {
       mpaNavigationScheduler.reset();
     }
   });
+  installReactFlightClientReferenceRequire();
   void main();
 }

--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -46,6 +46,29 @@ function getNavigationRuntimeRscBootstrap(): NavigationRuntimeRscBootstrap | nul
   return getNavigationRuntime()?.bootstrap.rsc ?? null;
 }
 
+function observeDoneMarker(
+  target: object,
+  key: string,
+  initialValue: boolean | undefined,
+  onDone: () => void,
+): void {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key);
+  if (descriptor && !descriptor.configurable) return;
+
+  let value = initialValue;
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: descriptor?.enumerable ?? true,
+    get() {
+      return value;
+    },
+    set(nextValue: boolean | undefined) {
+      value = nextValue;
+      if (nextValue === true) onDone();
+    },
+  });
+}
+
 /**
  * Create a ReadableStream from progressively-embedded RSC chunks.
  *
@@ -97,6 +120,11 @@ export function createProgressiveRscStream(): ReadableStream<Uint8Array> {
       // Capture the bootstrap object before it can be cleared. Inline done
       // scripts mutate this same object, and clearing happens only after the
       // stream has already been consumed or closed.
+      if (liveRuntimeRsc) {
+        observeDoneMarker(liveRuntimeRsc, "done", liveRuntimeRsc.done, closeOnce);
+      } else {
+        observeDoneMarker(vinext, "__VINEXT_RSC_DONE__", vinext.__VINEXT_RSC_DONE__, closeOnce);
+      }
       arr.push = function (...chunks: RscEmbeddedChunk[]): number {
         const length = Array.prototype.push.apply(this, chunks);
 

--- a/packages/vinext/src/server/app-client-reference-loader.ts
+++ b/packages/vinext/src/server/app-client-reference-loader.ts
@@ -82,21 +82,62 @@ async function preloadClientReferenceIds(
   );
 }
 
-export async function preloadInitialClientReferencesFromRscStream(
+export function preloadInitialClientReferencesFromRscStream(
   stream: ReadableStream<Uint8Array>,
   options: {
     clientRequire?: ClientReferenceRequire;
     onPreloadError?: ClientReferencePreloadErrorHandler;
   } = {},
-): Promise<ReadableStream<Uint8Array>> {
+): { stream: ReadableStream<Uint8Array>; preloaded: Promise<void> } {
   const clientRequire = options.clientRequire ?? globalThis.__vite_rsc_client_require__;
-  if (!clientRequire) return stream;
+  if (!clientRequire) return { stream, preloaded: Promise.resolve() };
 
   const [preloadStream, renderStream] = stream.tee();
+  // Warm up the initial client-reference imports on the preload branch while
+  // React consumes the render branch concurrently. This MUST stay off the
+  // hydration critical path: awaiting full-stream consumption would keep
+  // already-rendered, above-the-fold client components non-interactive until
+  // the tail of a streamed RSC payload (e.g. a slow Suspense boundary) settles.
+  // installReactFlightClientReferenceRequire() already annotates every import
+  // thenable so React tracks in-flight modules on its own, so this is a pure
+  // warm-up, not a correctness gate. The returned `preloaded` promise is only
+  // for diagnostics/tests to observe warm-up completion — callers must not gate
+  // hydration on it.
+  const preloaded = drainAndPreloadClientReferences(
+    preloadStream,
+    clientRequire,
+    options.onPreloadError,
+  );
+  return { stream: renderStream, preloaded };
+}
+
+// Reads the tee'd preload branch to completion, kicking off the import for each
+// client reference id as soon as its row is parsed (rather than batching after
+// the stream closes) so the warm-up overlaps the remainder of the stream.
+async function drainAndPreloadClientReferences(
+  preloadStream: ReadableStream<Uint8Array>,
+  clientRequire: ClientReferenceRequire,
+  onPreloadError?: ClientReferencePreloadErrorHandler,
+): Promise<void> {
   const reader = preloadStream.getReader();
   const decoder = new TextDecoder();
-  const referenceIds = new Set<string>();
+  const started = new Set<string>();
+  const imports: Promise<void>[] = [];
   let pendingText = "";
+
+  const preloadFreshIds = (chunkText: string): void => {
+    const ids = new Set<string>();
+    readClientReferenceIdsFromRscText(chunkText, ids);
+    const fresh: string[] = [];
+    for (const id of ids) {
+      if (started.has(id)) continue;
+      started.add(id);
+      fresh.push(id);
+    }
+    if (fresh.length > 0) {
+      imports.push(preloadClientReferenceIds(fresh, clientRequire, onPreloadError));
+    }
+  };
 
   try {
     while (true) {
@@ -106,18 +147,16 @@ export async function preloadInitialClientReferencesFromRscStream(
       const text = pendingText + decoder.decode(value, { stream: true });
       const lines = text.split("\n");
       pendingText = lines.pop() ?? "";
-      readClientReferenceIdsFromRscText(lines.join("\n"), referenceIds);
+      preloadFreshIds(lines.join("\n"));
     }
 
     pendingText += decoder.decode();
     if (pendingText) {
-      readClientReferenceIdsFromRscText(pendingText, referenceIds);
+      preloadFreshIds(pendingText);
     }
 
-    await preloadClientReferenceIds(referenceIds, clientRequire, options.onPreloadError);
+    await Promise.all(imports);
   } finally {
     reader.releaseLock();
   }
-
-  return renderStream;
 }

--- a/packages/vinext/src/server/app-client-reference-loader.ts
+++ b/packages/vinext/src/server/app-client-reference-loader.ts
@@ -1,0 +1,123 @@
+type ReactFlightThenable<T> = Promise<T> & {
+  __vinextReactFlightTracked?: true;
+  reason?: unknown;
+  status?: "fulfilled" | "pending" | "rejected";
+  value?: T;
+};
+
+type ClientReferenceRequire = (id: string) => Promise<unknown>;
+type ClientReferencePreloadErrorHandler = (id: string, error: unknown) => void;
+
+const CLIENT_REFERENCE_REQUIRE_WRAPPED = Symbol.for("vinext.clientReferenceRequireWrapped");
+
+type WrappedClientReferenceRequire = ClientReferenceRequire & {
+  [CLIENT_REFERENCE_REQUIRE_WRAPPED]?: true;
+};
+
+export function annotateReactFlightThenable<T>(promise: Promise<T>): ReactFlightThenable<T> {
+  const thenable = promise as ReactFlightThenable<T>;
+  if (thenable.__vinextReactFlightTracked === true || thenable.status !== undefined) {
+    return thenable;
+  }
+
+  thenable.__vinextReactFlightTracked = true;
+  thenable.status = "pending";
+  thenable.reason = thenable;
+  thenable.then(
+    (value) => {
+      thenable.status = "fulfilled";
+      thenable.value = value;
+      thenable.reason = undefined;
+    },
+    (reason) => {
+      thenable.status = "rejected";
+      thenable.reason = reason;
+    },
+  );
+
+  return thenable;
+}
+
+export function installReactFlightClientReferenceRequire(): void {
+  const existing = globalThis.__vite_rsc_client_require__;
+  if (!existing) return;
+
+  const maybeWrapped = existing as WrappedClientReferenceRequire;
+  if (maybeWrapped[CLIENT_REFERENCE_REQUIRE_WRAPPED] === true) return;
+
+  const wrapped: WrappedClientReferenceRequire = (id) => annotateReactFlightThenable(existing(id));
+  wrapped[CLIENT_REFERENCE_REQUIRE_WRAPPED] = true;
+  globalThis.__vite_rsc_client_require__ = wrapped;
+}
+
+function readClientReferenceIdsFromRscText(text: string, ids: Set<string>): void {
+  for (const line of text.split("\n")) {
+    const payloadStart = line.indexOf(":I[");
+    if (payloadStart === -1) continue;
+
+    try {
+      const row = JSON.parse(line.slice(payloadStart + 2)) as unknown;
+      const referenceId = Array.isArray(row) ? row[0] : undefined;
+      if (typeof referenceId === "string") {
+        ids.add(referenceId);
+      }
+    } catch {
+      // Ignore non-client-reference rows and partial text. React remains the
+      // authoritative RSC parser for the stream passed through the second tee.
+    }
+  }
+}
+
+async function preloadClientReferenceIds(
+  ids: Iterable<string>,
+  clientRequire: ClientReferenceRequire,
+  onPreloadError?: ClientReferencePreloadErrorHandler,
+): Promise<void> {
+  await Promise.all(
+    Array.from(ids, (id) =>
+      annotateReactFlightThenable(clientRequire(id)).catch((error: unknown) => {
+        onPreloadError?.(id, error);
+      }),
+    ),
+  );
+}
+
+export async function preloadInitialClientReferencesFromRscStream(
+  stream: ReadableStream<Uint8Array>,
+  options: {
+    clientRequire?: ClientReferenceRequire;
+    onPreloadError?: ClientReferencePreloadErrorHandler;
+  } = {},
+): Promise<ReadableStream<Uint8Array>> {
+  const clientRequire = options.clientRequire ?? globalThis.__vite_rsc_client_require__;
+  if (!clientRequire) return stream;
+
+  const [preloadStream, renderStream] = stream.tee();
+  const reader = preloadStream.getReader();
+  const decoder = new TextDecoder();
+  const referenceIds = new Set<string>();
+  let pendingText = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const text = pendingText + decoder.decode(value, { stream: true });
+      const lines = text.split("\n");
+      pendingText = lines.pop() ?? "";
+      readClientReferenceIdsFromRscText(lines.join("\n"), referenceIds);
+    }
+
+    pendingText += decoder.decode();
+    if (pendingText) {
+      readClientReferenceIdsFromRscText(pendingText, referenceIds);
+    }
+
+    await preloadClientReferenceIds(referenceIds, clientRequire, options.onPreloadError);
+  } finally {
+    reader.releaseLock();
+  }
+
+  return renderStream;
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -366,7 +366,11 @@ function resolveAutoAppRoutePrefetchForRequest(href: string): AutoAppRoutePrefet
  * For Pages Router: injects a <link rel="prefetch"> for the page module.
  *
  * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
- * the main thread during initial page load.
+ * the main thread during initial page load. The one exception is the App
+ * Router bootstrap window — before the navigate runtime is installed — where
+ * a low-priority prefetch runs immediately so a visible link is not stranded
+ * waiting on idle time while the runtime is still initializing. Once the
+ * runtime is installed, low-priority prefetches yield to idle scheduling again.
  */
 const APP_PREFETCH_RUNTIME_RETRY_LIMIT = 5;
 
@@ -421,8 +425,16 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
     return;
   }
 
+  // Run immediately for high priority, and for the App Router bootstrap retry
+  // window (no `__NEXT_DATA__` and the navigate runtime not yet installed) so a
+  // visible link prefetches without waiting on idle time while the runtime
+  // initializes. Once the runtime is installed, normal low-priority App Router
+  // prefetches fall back to idle scheduling — `__NEXT_DATA__ === undefined`
+  // alone is an App-Router identity check, not a "runtime not ready" signal, so
+  // gating on it without `hasAppNavigationRuntime()` would make every
+  // low-priority prefetch bypass idle scheduling for the page's whole lifetime.
   const schedule =
-    priority === "high" || window.__NEXT_DATA__ === undefined
+    priority === "high" || (window.__NEXT_DATA__ === undefined && !hasAppNavigationRuntime())
       ? (fn: () => void) => {
           fn();
         }
@@ -478,7 +490,17 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
             ) {
               return;
             }
-            if (getPrefetchedUrls().has(fullCacheKey)) return;
+            // For navigation-cacheable entries, freshness is authoritative —
+            // hasPrefetchCacheEntryForNavigation() above already returns true for
+            // a still-pending in-flight prefetch, so it handles concurrent
+            // dedupe. The `prefetchedUrls` marker must NOT gate them: a marker can
+            // outlive its cache entry (e.g. when a prior entry became incompatible
+            // with the current mounted-slot context and was skipped without being
+            // deleted), and letting it block here would suppress a needed
+            // re-prefetch after the cache went stale or missing. The marker is the
+            // sole dedupe signal only for loading-shell entries, which are
+            // invisible to the freshness check (cacheForNavigation === false).
+            if (!autoPrefetch.cacheForNavigation && getPrefetchedUrls().has(fullCacheKey)) return;
 
             getPrefetchedUrls().add(fullCacheKey);
             prefetchRscResponse(

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -172,7 +172,6 @@ if (typeof window !== "undefined") {
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 /** trailingSlash from next.config.js, injected by the plugin at build time */
 const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
-const __prefetchInlining: boolean = process.env.__VINEXT_PREFETCH_INLINING === "true";
 const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
 function resolveHref(href: LinkProps["href"]): string {
@@ -284,14 +283,16 @@ function toSameOriginRouteHref(href: string): string | null {
 }
 
 function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
-  return hasAppNavigationRuntime() ? "app" : "pages";
+  return hasAppLinkPrefetchRuntime() ? "app" : "pages";
 }
 
-function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
+type AutoAppRoutePrefetch = {
   cacheForNavigation: boolean;
-  prefetchShellFirst: boolean;
+  routeIsDynamic: boolean;
   shouldPrefetch: boolean;
-} {
+};
+
+function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): AutoAppRoutePrefetch {
   const hasLoadingShell = route.isDynamic && route.canPrefetchLoadingShell;
   return {
     // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
@@ -299,7 +300,7 @@ function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
     // fallbacks are treated as exact-URL full prefetches. The prefetch cache is
     // keyed by the concrete RSC URL, so this cannot reuse data across params.
     cacheForNavigation: !hasLoadingShell,
-    prefetchShellFirst: !route.isDynamic,
+    routeIsDynamic: route.isDynamic,
     shouldPrefetch: true,
   };
 }
@@ -321,26 +322,33 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
-  prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
+  const result = resolveAutoAppRoutePrefetchForRequest(href);
+  return {
+    cacheForNavigation: result.cacheForNavigation,
+    shouldPrefetch: result.shouldPrefetch,
+  };
+}
+
+function resolveAutoAppRoutePrefetchForRequest(href: string): AutoAppRoutePrefetch {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, routeIsDynamic: false, shouldPrefetch: false };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, routeIsDynamic: false, shouldPrefetch: false };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, routeIsDynamic: false, shouldPrefetch: false };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, routeIsDynamic: false, shouldPrefetch: false };
   }
 
   return resolveMatchedAutoAppRoutePrefetch(match.route);
@@ -360,6 +368,39 @@ export function resolveAutoAppRoutePrefetch(href: string): {
  * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
  * the main thread during initial page load.
  */
+const APP_PREFETCH_RUNTIME_RETRY_LIMIT = 5;
+
+function hasAppLinkPrefetchRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  if (hasAppNavigationRuntime()) return true;
+  return (
+    window.__NEXT_DATA__ === undefined && Array.isArray(window.__VINEXT_LINK_PREFETCH_ROUTES__)
+  );
+}
+
+function isAppMaxPrefetchInliningEnabled(): boolean {
+  return process.env.__VINEXT_PREFETCH_INLINING === "true";
+}
+
+function scheduleAppPrefetchRetry(
+  mode: LinkPrefetchMode,
+  attempt: number,
+  schedulePrefetchAttempt: (nextAttempt: number) => void,
+): boolean {
+  if (
+    mode !== "auto" ||
+    window.__NEXT_DATA__ !== undefined ||
+    attempt >= APP_PREFETCH_RUNTIME_RETRY_LIMIT
+  ) {
+    return false;
+  }
+
+  window.setTimeout(() => {
+    schedulePrefetchAttempt(attempt + 1);
+  }, 16);
+  return true;
+}
+
 function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "high" = "low"): void {
   if (typeof window === "undefined") return;
 
@@ -381,149 +422,206 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
   }
 
   const schedule =
-    priority === "high"
+    priority === "high" || window.__NEXT_DATA__ === undefined
       ? (fn: () => void) => {
           fn();
         }
       : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
 
-  schedule(() => {
-    void (async () => {
-      if (hasAppNavigationRuntime()) {
-        const autoPrefetch =
-          mode === "auto"
-            ? resolveAutoAppRoutePrefetch(prefetchHref)
-            : { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true };
-        if (!autoPrefetch.shouldPrefetch) return;
-
-        const interceptionContext = getPrefetchInterceptionContext(fullHref);
-        const mountedSlotsHeader = getMountedSlotsHeader();
-        const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
-        if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
-        const headers = createRscRequestHeaders({
-          interceptionContext,
-          renderMode: isOptimisticRouteShellPrefetch
-            ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
-            : undefined,
-        });
-        if (mountedSlotsHeader) {
-          headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
-        }
-        // Distinguish the same visible URL when it is prefetched from different
-        // request contexts such as /feed vs /gallery or different mounted slots.
-        const rscUrl = await createRscRequestUrl(fullHref, headers);
-        const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
-        const prefetched = getPrefetchedUrls();
-        if (prefetched.has(cacheKey)) {
-          if (!autoPrefetch.cacheForNavigation) {
+  const schedulePrefetchAttempt = (attempt: number): void => {
+    schedule(() => {
+      void (async () => {
+        if (hasAppLinkPrefetchRuntime()) {
+          const autoPrefetch =
+            mode === "auto"
+              ? resolveAutoAppRoutePrefetchForRequest(prefetchHref)
+              : { cacheForNavigation: true, routeIsDynamic: false, shouldPrefetch: true };
+          if (!autoPrefetch.shouldPrefetch) {
+            scheduleAppPrefetchRetry(mode, attempt, schedulePrefetchAttempt);
             return;
           }
 
-          const existing = getPrefetchCache().get(cacheKey);
-          if (existing?.cacheForNavigation === false) {
-            existing.cacheForNavigation = true;
+          const interceptionContext = getPrefetchInterceptionContext(fullHref);
+          const mountedSlotsHeader = getMountedSlotsHeader();
+          const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+          const useMaxPrefetchInlining =
+            mode === "auto" &&
+            isAppMaxPrefetchInliningEnabled() &&
+            autoPrefetch.cacheForNavigation &&
+            !autoPrefetch.routeIsDynamic;
+          if (
+            (isOptimisticRouteShellPrefetch || useMaxPrefetchInlining) &&
+            interceptionContext !== null
+          ) {
+            return;
           }
-        }
-        // A single freshness-aware gate covers both an exact prior prefetch and
-        // an equivalent `_rsc` variant; the helper also deletes any stale exact
-        // entry, so a stale `prefetched` member is harmlessly re-added below.
-        if (
-          autoPrefetch.cacheForNavigation &&
-          hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)
-        ) {
-          return;
-        }
-        prefetched.add(cacheKey);
-        // Next's `prefetchInlining` Segment Cache path reserves the final
-        // payload while a route-tree request is still pending. Vinext keeps a
-        // unified route payload, so gate that payload behind a loading-shell
-        // request to preserve the same pending/dedup observable contract.
-        const fetchPromise =
-          __prefetchInlining && autoPrefetch.cacheForNavigation && autoPrefetch.prefetchShellFirst
-            ? (async () => {
-                const shellHeaders = createRscRequestHeaders({
-                  interceptionContext,
-                  renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-                });
-                if (mountedSlotsHeader) {
-                  shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
-                }
-                const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
-                const shellResponse = await fetch(shellRscUrl, {
-                  headers: shellHeaders,
-                  credentials: "include",
-                  priority,
-                  // @ts-expect-error — purpose is a valid fetch option in some browsers
-                  purpose: "prefetch",
-                });
-                if (!shellResponse.ok) {
-                  return shellResponse;
-                }
-                await shellResponse.arrayBuffer().catch(() => {});
-                return fetch(rscUrl, {
-                  headers,
-                  credentials: "include",
-                  priority,
-                  // @ts-expect-error — purpose is a valid fetch option in some browsers
-                  purpose: "prefetch",
-                });
-              })()
-            : fetch(rscUrl, {
-                headers,
+          const fullHeaders = createRscRequestHeaders({
+            interceptionContext,
+            renderMode: isOptimisticRouteShellPrefetch
+              ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
+              : undefined,
+          });
+          if (mountedSlotsHeader) {
+            fullHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+          }
+          const fullRscUrl = await createRscRequestUrl(fullHref, fullHeaders);
+          const fullCacheKey = AppElementsWire.encodeCacheKey(fullRscUrl, interceptionContext);
+
+          const startFullRoutePrefetch = (): void => {
+            if (
+              autoPrefetch.cacheForNavigation &&
+              hasPrefetchCacheEntryForNavigation(
+                fullRscUrl,
+                interceptionContext,
+                mountedSlotsHeader,
+              )
+            ) {
+              return;
+            }
+            if (getPrefetchedUrls().has(fullCacheKey)) return;
+
+            getPrefetchedUrls().add(fullCacheKey);
+            prefetchRscResponse(
+              fullRscUrl,
+              fetch(fullRscUrl, {
+                headers: fullHeaders,
                 credentials: "include",
                 priority,
                 // @ts-expect-error — purpose is a valid fetch option in some browsers
                 purpose: "prefetch",
-              });
-        prefetchRscResponse(
-          rscUrl,
-          fetchPromise,
-          interceptionContext,
-          mountedSlotsHeader,
-          undefined,
-          {
-            cacheForNavigation: autoPrefetch.cacheForNavigation,
-            optimisticRouteShell: isOptimisticRouteShellPrefetch,
-          },
-        );
-      } else if (window.__NEXT_DATA__) {
-        // Pages Router prefetch. When a code-split loader is registered for
-        // the target route (prod builds expose them on window via the
-        // generated client entry), prefetch the data JSON + warm the page
-        // chunk in parallel — matching the actual navigation, so the click
-        // is a double cache hit. Otherwise (dev, or unmapped route) fall
-        // back to the legacy `<link rel="prefetch" as="document">` so the
-        // browser still preloads the HTML.
-        //
-        // The decision helper + prefetch action live in shims/internal/ so
-        // this file does not pull in the router shim at module init time,
-        // which would create a circular import and grow the SSR module graph.
-        const dataTarget = resolvePagesDataNavigationTarget(fullHref, __basePath);
-        if (dataTarget) {
-          prefetchPagesData(dataTarget);
-        } else {
-          // The target is not a Pages Router route — mark it on the Pages
-          // Router `components` map if it matches an App Router route in the
-          // shared prefetch manifest. Mirrors Next.js's `_bfl` marker write at
-          // `packages/next/src/shared/lib/router/router.ts:2525`; the Next.js
-          // deploy test reads `window.next.router.components[<path>]` to
-          // assert prefetch detection. See issue #1526.
-          markAppRouteDetectedOnPrefetch(fullHref, __basePath);
+              }),
+              interceptionContext,
+              mountedSlotsHeader,
+              undefined,
+              {
+                cacheForNavigation: autoPrefetch.cacheForNavigation,
+                optimisticRouteShell: isOptimisticRouteShellPrefetch,
+              },
+            );
+          };
 
-          // Legacy fallback: hint the browser to preload the HTML document.
-          // Used in dev (no loader map populated) and for routes not in the
-          // client loader map.
-          const link = document.createElement("link");
-          link.rel = "prefetch";
-          link.href = fullHref;
-          link.as = "document";
-          document.head.appendChild(link);
+          if (useMaxPrefetchInlining) {
+            if (
+              hasPrefetchCacheEntryForNavigation(
+                fullRscUrl,
+                interceptionContext,
+                mountedSlotsHeader,
+              )
+            ) {
+              return;
+            }
+            if (getPrefetchedUrls().has(fullCacheKey)) return;
+
+            const shellHeaders = createRscRequestHeaders({
+              interceptionContext,
+              renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+            });
+            if (mountedSlotsHeader) {
+              shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+            }
+            const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
+            const shellCacheKey = AppElementsWire.encodeCacheKey(shellRscUrl, interceptionContext);
+            const shellEntry = getPrefetchCache().get(shellCacheKey);
+            if (getPrefetchedUrls().has(shellCacheKey)) {
+              if (shellEntry?.outcome === "cache-seeded") {
+                startFullRoutePrefetch();
+              }
+              return;
+            }
+
+            getPrefetchedUrls().add(shellCacheKey);
+            prefetchRscResponse(
+              shellRscUrl,
+              fetch(shellRscUrl, {
+                headers: shellHeaders,
+                credentials: "include",
+                priority,
+                // @ts-expect-error — purpose is a valid fetch option in some browsers
+                purpose: "prefetch",
+              }),
+              interceptionContext,
+              mountedSlotsHeader,
+              undefined,
+              {
+                cacheForNavigation: false,
+                optimisticRouteShell: true,
+              },
+            );
+            const pendingShellEntry = getPrefetchCache().get(shellCacheKey);
+            void pendingShellEntry?.pending?.then(() => {
+              if (getPrefetchCache().get(shellCacheKey)?.outcome === "cache-seeded") {
+                startFullRoutePrefetch();
+              }
+            });
+            return;
+          }
+
+          // Distinguish the same visible URL when it is prefetched from different
+          // request contexts such as /feed vs /gallery or different mounted slots.
+          const prefetched = getPrefetchedUrls();
+          if (prefetched.has(fullCacheKey)) {
+            if (!autoPrefetch.cacheForNavigation) {
+              return;
+            }
+
+            const existing = getPrefetchCache().get(fullCacheKey);
+            if (existing?.cacheForNavigation === false) {
+              existing.cacheForNavigation = true;
+            }
+          }
+          // A single freshness-aware gate covers both an exact prior prefetch and
+          // an equivalent `_rsc` variant; the helper also deletes any stale exact
+          // entry, so a stale `prefetched` member is harmlessly re-added below.
+          if (
+            autoPrefetch.cacheForNavigation &&
+            hasPrefetchCacheEntryForNavigation(fullRscUrl, interceptionContext, mountedSlotsHeader)
+          ) {
+            return;
+          }
+          startFullRoutePrefetch();
+        } else if (window.__NEXT_DATA__) {
+          // Pages Router prefetch. When a code-split loader is registered for
+          // the target route (prod builds expose them on window via the
+          // generated client entry), prefetch the data JSON + warm the page
+          // chunk in parallel — matching the actual navigation, so the click
+          // is a double cache hit. Otherwise (dev, or unmapped route) fall
+          // back to the legacy `<link rel="prefetch" as="document">` so the
+          // browser still preloads the HTML.
+          //
+          // The decision helper + prefetch action live in shims/internal/ so
+          // this file does not pull in the router shim at module init time,
+          // which would create a circular import and grow the SSR module graph.
+          const dataTarget = resolvePagesDataNavigationTarget(fullHref, __basePath);
+          if (dataTarget) {
+            prefetchPagesData(dataTarget);
+          } else {
+            // The target is not a Pages Router route — mark it on the Pages
+            // Router `components` map if it matches an App Router route in the
+            // shared prefetch manifest. Mirrors Next.js's `_bfl` marker write at
+            // `packages/next/src/shared/lib/router/router.ts:2525`; the Next.js
+            // deploy test reads `window.next.router.components[<path>]` to
+            // assert prefetch detection. See issue #1526.
+            markAppRouteDetectedOnPrefetch(fullHref, __basePath);
+
+            // Legacy fallback: hint the browser to preload the HTML document.
+            // Used in dev (no loader map populated) and for routes not in the
+            // client loader map.
+            const link = document.createElement("link");
+            link.rel = "prefetch";
+            link.href = fullHref;
+            link.as = "document";
+            document.head.appendChild(link);
+          }
+        } else if (window.__NEXT_DATA__ === undefined) {
+          scheduleAppPrefetchRetry(mode, attempt, schedulePrefetchAttempt);
         }
-      }
-    })().catch((error) => {
-      console.error("[vinext] RSC prefetch setup error:", error);
+      })().catch((error) => {
+        console.error("[vinext] RSC prefetch setup error:", error);
+      });
     });
-  });
+  };
+
+  schedulePrefetchAttempt(0);
 }
 
 function promotePrefetchEntriesForNavigation(href: string): void {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,15 @@ const appRouterBfcacheServer = {
   timeout: 30_000,
 };
 
+const appPrefetchInliningServer = {
+  command:
+    "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build --prerender-all && node ../../../packages/vinext/dist/cli.js start --port 4186",
+  cwd: "./tests/fixtures/app-prefetch-inlining",
+  port: 4186,
+  reuseExistingServer: !process.env.CI,
+  timeout: 60_000,
+};
+
 /**
  * Each project maps to a single webServer. Some browser-specific projects share
  * a server with the base project, and shared servers are de-duped by port.
@@ -68,6 +77,11 @@ const projectServers = {
     testDir: "./tests/e2e/app-router-bfcache",
     use: { baseURL: "http://localhost:4183" },
     server: appRouterBfcacheServer,
+  },
+  "app-prefetch-inlining": {
+    testDir: "./tests/e2e/app-prefetch-inlining",
+    use: { baseURL: "http://localhost:4186" },
+    server: appPrefetchInliningServer,
   },
   "catch-error": {
     testDir: "./tests/e2e/catch-error",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,6 +1100,8 @@ importers:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.6(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/app-prefetch-inlining: {}
+
   tests/fixtures/app-with-src:
     dependencies:
       '@vitejs/plugin-rsc':

--- a/tests/app-browser-stream.test.ts
+++ b/tests/app-browser-stream.test.ts
@@ -103,12 +103,32 @@ describe("App browser stream helpers", () => {
     vinext.__VINEXT_RSC_CHUNKS__!.push("delta");
     expect(await readText(reader)).toEqual({ done: false, text: "delta" });
 
-    vinext.__VINEXT_RSC_DONE__ = true;
     vinext.__VINEXT_RSC_CHUNKS__!.push("final");
+    vinext.__VINEXT_RSC_DONE__ = true;
     expect(await readText(reader)).toEqual({ done: false, text: "final" });
     expect(await readText(reader)).toEqual({ done: true, text: undefined });
 
     expect(listeners.has("DOMContentLoaded")).toBe(true);
+  });
+
+  it("closes legacy global streams when the done marker is set without another push", async () => {
+    setGlobalDocument({
+      readyState: "loading",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as Document);
+
+    vinext.__VINEXT_RSC_CHUNKS__ = ["shell"];
+    vinext.__VINEXT_RSC_DONE__ = false;
+
+    const reader = createProgressiveRscStream().getReader();
+
+    expect(await readText(reader)).toEqual({ done: false, text: "shell" });
+
+    const pendingRead = readText(reader);
+    vinext.__VINEXT_RSC_DONE__ = true;
+
+    expect(await pendingRead).toEqual({ done: true, text: undefined });
   });
 
   it("streams progressive chunks from the typed navigation runtime", async () => {
@@ -134,11 +154,38 @@ describe("App browser stream helpers", () => {
     runtimeRsc.rsc.push("delta");
     expect(await readText(reader)).toEqual({ done: false, text: "delta" });
 
-    runtimeRsc.done = true;
     runtimeRsc.rsc.push("final");
+    runtimeRsc.done = true;
     expect(await readText(reader)).toEqual({ done: false, text: "final" });
     expect(await readText(reader)).toEqual({ done: true, text: undefined });
 
+    expect(Reflect.has(runtimeWindow, NAVIGATION_RUNTIME_KEY)).toBe(true);
+  });
+
+  it("closes typed navigation runtime streams when the done marker is set without another push", async () => {
+    const runtimeWindow = {};
+    Reflect.set(globalThis, "window", runtimeWindow);
+    setGlobalDocument({
+      readyState: "loading",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as Document);
+
+    registerNavigationRuntimeBootstrap({ rsc: { rsc: ["shell"], done: false } });
+
+    const reader = createProgressiveRscStream().getReader();
+
+    expect(await readText(reader)).toEqual({ done: false, text: "shell" });
+
+    const runtimeRsc = getNavigationRuntime()?.bootstrap.rsc;
+    if (runtimeRsc === undefined) {
+      throw new Error("Expected navigation runtime RSC bootstrap");
+    }
+
+    const pendingRead = readText(reader);
+    runtimeRsc.done = true;
+
+    expect(await pendingRead).toEqual({ done: true, text: undefined });
     expect(Reflect.has(runtimeWindow, NAVIGATION_RUNTIME_KEY)).toBe(true);
   });
 
@@ -158,8 +205,8 @@ describe("App browser stream helpers", () => {
     expect(await readText(reader)).toEqual({ done: false, text: "alpha" });
     expect(await readText(reader)).toEqual({ done: false, text: "beta" });
 
-    vinext.__VINEXT_RSC_DONE__ = true;
     vinext.__VINEXT_RSC_CHUNKS__!.push("omega");
+    vinext.__VINEXT_RSC_DONE__ = true;
     expect(await readText(reader)).toEqual({ done: false, text: "omega" });
     expect(await readText(reader)).toEqual({ done: true, text: undefined });
   });
@@ -181,8 +228,8 @@ describe("App browser stream helpers", () => {
     vinext.__VINEXT_RSC_CHUNKS__!.push([3, "/wABAgM="]);
     expect(await readBytes(reader)).toEqual({ done: false, bytes: [255, 0, 1, 2, 3] });
 
-    vinext.__VINEXT_RSC_DONE__ = true;
     vinext.__VINEXT_RSC_CHUNKS__!.push("final");
+    vinext.__VINEXT_RSC_DONE__ = true;
     expect(await readText(reader)).toEqual({ done: false, text: "final" });
     expect(await readBytes(reader)).toEqual({ done: true, bytes: undefined });
   });
@@ -223,8 +270,8 @@ describe("App browser stream helpers", () => {
     const reader = createProgressiveRscStream().getReader();
     const pendingRead = readText(reader);
 
-    vinext.__VINEXT_RSC_DONE__ = true;
     vinext.__VINEXT_RSC_CHUNKS__!.push("final");
+    vinext.__VINEXT_RSC_DONE__ = true;
 
     expect(await pendingRead).toEqual({ done: false, text: "final" });
     expect(await readText(reader)).toEqual({ done: true, text: undefined });

--- a/tests/app-client-reference-preloader.test.ts
+++ b/tests/app-client-reference-preloader.test.ts
@@ -120,27 +120,81 @@ describe("app client reference preloader", () => {
       '3:I["comp-b",[],"Widget",1]\n' +
       '4:["not a client reference"]\n';
 
-    const preloadPromise = preloadInitialClientReferencesFromRscStream(textStream([sourceText]), {
-      clientRequire(id) {
-        calls.push(id);
-        return id === "comp-a" ? first.promise : second.promise;
+    const { stream: renderStream, preloaded } = preloadInitialClientReferencesFromRscStream(
+      textStream([sourceText]),
+      {
+        clientRequire(id) {
+          calls.push(id);
+          return id === "comp-a" ? first.promise : second.promise;
+        },
       },
-    });
+    );
 
     await expect.poll(() => calls).toEqual(["comp-a", "comp-b"]);
 
     first.resolve(undefined);
     second.resolve(undefined);
 
-    const renderStream = await preloadPromise;
+    await preloaded;
     expect(await readStreamText(renderStream)).toBe(sourceText);
+  });
+
+  it("returns the render stream and warms imports before the RSC stream tail settles", async () => {
+    const calls: string[] = [];
+    const aboveFold = createDeferred<void>();
+    const belowFold = createDeferred<void>();
+    const tail = createDeferred<void>();
+    const encoder = new TextEncoder();
+
+    // The above-the-fold row is available immediately; the tail row does not
+    // arrive until `tail` resolves — modelling a slow Suspense boundary at the
+    // end of a streamed App Router payload. Hydration must not be serialised
+    // behind stream completion.
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('1:I["above-fold",[],"default",1]\n'));
+        void tail.promise.then(() => {
+          controller.enqueue(encoder.encode('2:I["below-fold",[],"default",1]\n'));
+          controller.close();
+        });
+      },
+    });
+
+    const { stream, preloaded } = preloadInitialClientReferencesFromRscStream(source, {
+      clientRequire(id) {
+        calls.push(id);
+        return id === "above-fold" ? aboveFold.promise : belowFold.promise;
+      },
+    });
+
+    // The render branch yields the above-the-fold row without waiting for the
+    // delayed tail. (Destructuring a stream synchronously also proves the call
+    // no longer awaits full-stream consumption before returning.)
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    const firstChunk = await reader.read();
+    expect(decoder.decode(firstChunk.value)).toContain("above-fold");
+
+    // The warm-up has kicked off the above-the-fold import while the tail row is
+    // still outstanding.
+    await expect.poll(() => calls).toEqual(["above-fold"]);
+
+    tail.resolve(undefined);
+    aboveFold.resolve(undefined);
+    belowFold.resolve(undefined);
+    await expect.poll(() => calls).toEqual(["above-fold", "below-fold"]);
+
+    const restChunk = await reader.read();
+    expect(decoder.decode(restChunk.value)).toContain("below-fold");
+    reader.releaseLock();
+    await preloaded;
   });
 
   it("continues initial RSC hydration after client reference preload failures", async () => {
     const reported: Array<{ id: string; error: unknown }> = [];
     const error = new Error("load failed");
 
-    const renderStream = await preloadInitialClientReferencesFromRscStream(
+    const { stream: renderStream, preloaded } = preloadInitialClientReferencesFromRscStream(
       textStream(['1:I["comp-a",[],"default",1]\n']),
       {
         clientRequire() {
@@ -152,6 +206,7 @@ describe("app client reference preloader", () => {
       },
     );
 
+    await preloaded;
     expect(reported).toEqual([{ id: "comp-a", error }]);
     expect(await readStreamText(renderStream)).toBe('1:I["comp-a",[],"default",1]\n');
   });

--- a/tests/app-client-reference-preloader.test.ts
+++ b/tests/app-client-reference-preloader.test.ts
@@ -1,17 +1,161 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  annotateReactFlightThenable,
+  installReactFlightClientReferenceRequire,
+  preloadInitialClientReferencesFromRscStream,
+} from "../packages/vinext/src/server/app-client-reference-loader.js";
 import { createClientReferencePreloader } from "../packages/vinext/src/server/app-client-reference-preloader.js";
 
-function createDeferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolveDeferred: () => void = () => {
+type ReactFlightThenable<T> = Promise<T> & {
+  reason?: unknown;
+  status?: "fulfilled" | "pending" | "rejected";
+  value?: T;
+};
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  reject: (reason: unknown) => void;
+  resolve: (value: T) => void;
+} {
+  let rejectDeferred: (reason: unknown) => void = () => {
     throw new Error("deferred promise was not initialized");
   };
-  const promise = new Promise<void>((resolve) => {
-    resolveDeferred = () => resolve();
+  let resolveDeferred: (value: T) => void = () => {
+    throw new Error("deferred promise was not initialized");
+  };
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectDeferred = reject;
+    resolveDeferred = resolve;
   });
-  return { promise, resolve: resolveDeferred };
+  return { promise, reject: rejectDeferred, resolve: resolveDeferred };
+}
+
+function textStream(chunks: readonly string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function readStreamText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
 }
 
 describe("app client reference preloader", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "__vite_rsc_client_require__");
+  });
+
+  it("marks cold client reference promises as React Flight pending thenables", async () => {
+    const deferred = createDeferred<{ ok: true }>();
+    const tracked = annotateReactFlightThenable(deferred.promise);
+
+    expect(tracked.status).toBe("pending");
+    expect(tracked.reason).toBe(tracked);
+
+    deferred.resolve({ ok: true });
+    await expect(tracked).resolves.toEqual({ ok: true });
+    expect(tracked.status).toBe("fulfilled");
+    expect(tracked.value).toEqual({ ok: true });
+    expect(tracked.reason).toBeUndefined();
+  });
+
+  it("preserves real client reference import failures for React Flight", async () => {
+    const deferred = createDeferred<unknown>();
+    const error = new Error("load failed");
+    const tracked = annotateReactFlightThenable(deferred.promise);
+
+    deferred.reject(error);
+
+    await expect(tracked).rejects.toThrow("load failed");
+    expect(tracked.status).toBe("rejected");
+    expect(tracked.reason).toBe(error);
+  });
+
+  it("wraps the browser client reference require once", async () => {
+    const calls: string[] = [];
+    const deferred = createDeferred<{ name: string }>();
+    globalThis.__vite_rsc_client_require__ = (id) => {
+      calls.push(id);
+      return deferred.promise;
+    };
+
+    installReactFlightClientReferenceRequire();
+    installReactFlightClientReferenceRequire();
+
+    const result = globalThis.__vite_rsc_client_require__("comp-a") as ReactFlightThenable<{
+      name: string;
+    }>;
+
+    expect(calls).toEqual(["comp-a"]);
+    expect(result).toBe(deferred.promise);
+    expect(result.status).toBe("pending");
+    expect(result.reason).toBe(result);
+
+    deferred.resolve({ name: "A" });
+    await expect(result).resolves.toEqual({ name: "A" });
+    expect(result.status).toBe("fulfilled");
+  });
+
+  it("preloads initial RSC client reference rows without consuming the render stream", async () => {
+    const calls: string[] = [];
+    const first = createDeferred<void>();
+    const second = createDeferred<void>();
+    const sourceText =
+      '0:{"children":"shell"}\n' +
+      '2:I["comp-a",[],"default",1]\n' +
+      '3:I["comp-b",[],"Widget",1]\n' +
+      '4:["not a client reference"]\n';
+
+    const preloadPromise = preloadInitialClientReferencesFromRscStream(textStream([sourceText]), {
+      clientRequire(id) {
+        calls.push(id);
+        return id === "comp-a" ? first.promise : second.promise;
+      },
+    });
+
+    await expect.poll(() => calls).toEqual(["comp-a", "comp-b"]);
+
+    first.resolve(undefined);
+    second.resolve(undefined);
+
+    const renderStream = await preloadPromise;
+    expect(await readStreamText(renderStream)).toBe(sourceText);
+  });
+
+  it("continues initial RSC hydration after client reference preload failures", async () => {
+    const reported: Array<{ id: string; error: unknown }> = [];
+    const error = new Error("load failed");
+
+    const renderStream = await preloadInitialClientReferencesFromRscStream(
+      textStream(['1:I["comp-a",[],"default",1]\n']),
+      {
+        clientRequire() {
+          return Promise.reject(error);
+        },
+        onPreloadError(id, preloadError) {
+          reported.push({ id, error: preloadError });
+        },
+      },
+    );
+
+    expect(reported).toEqual([{ id: "comp-a", error }]);
+    expect(await readStreamText(renderStream)).toBe('1:I["comp-a",[],"default",1]\n');
+  });
+
   it("shares one in-flight preload across concurrent cold SSR calls", async () => {
     const refs = { "comp-a": true, "comp-b": true, "comp-c": true };
     const calls: string[] = [];
@@ -33,7 +177,7 @@ describe("app client reference preloader", () => {
     expect(third).toBe(first);
     expect(calls).toEqual(["comp-a", "comp-b", "comp-c"]);
 
-    preloadGate.resolve();
+    preloadGate.resolve(undefined);
     await Promise.all([first, second, third]);
 
     await preloader.preload();
@@ -80,7 +224,7 @@ describe("app client reference preloader", () => {
 
     expect(calls).toEqual(["comp-a", "comp-b", "comp-c"]);
 
-    preloadGate.resolve();
+    preloadGate.resolve(undefined);
     await Promise.all([firstRoute, secondRoute]);
 
     await preloader.preload(["comp-b"]);

--- a/tests/e2e/app-prefetch-inlining/max-prefetch-inlining.spec.ts
+++ b/tests/e2e/app-prefetch-inlining/max-prefetch-inlining.spec.ts
@@ -1,0 +1,102 @@
+import type { Page, Request } from "@playwright/test";
+import { expect, test } from "../fixtures";
+import { waitForAppRouterHydration } from "../helpers";
+
+const BASE = "http://localhost:4186";
+
+function isRscRequest(request: Request, pathname?: string): boolean {
+  const url = new URL(request.url());
+  return request.headers()["rsc"] === "1" && (pathname === undefined || url.pathname === pathname);
+}
+
+async function waitForRscResponseContaining(page: Page, text: string) {
+  return page.waitForResponse(
+    async (response) => {
+      if (!isRscRequest(response.request())) return false;
+      return (await response.text()).includes(text);
+    },
+    { timeout: 10_000 },
+  );
+}
+
+test.describe("max prefetch inlining", () => {
+  // Ported from Next.js:
+  // test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts
+  test("bundles all route data into a bounded number of RSC prefetch requests", async ({
+    page,
+  }) => {
+    let rscRequestCount = 0;
+    page.on("request", (request) => {
+      if (isRscRequest(request)) {
+        rscRequestCount++;
+      }
+    });
+
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+
+    const firstPrefetch = waitForRscResponseContaining(page, "Page C");
+    await page.locator('input[data-link-accordion="/shared/a/b/c"]').click();
+    await firstPrefetch;
+
+    const countBeforeSecondPrefetch = rscRequestCount;
+    const secondPrefetch = waitForRscResponseContaining(page, "Page E");
+    await page.locator('input[data-link-accordion="/shared/a/d/e"]').click();
+    await secondPrefetch;
+
+    const delta = rscRequestCount - countBeforeSecondPrefetch;
+    expect(delta).toBeLessThanOrEqual(2);
+
+    const countBeforeNavigation = rscRequestCount;
+    await page.locator('a[href="/shared/a/d/e"]').click();
+    await expect(page.locator("#page-e")).toHaveText("Page E");
+    expect(rscRequestCount).toBe(countBeforeNavigation);
+  });
+
+  test("works with dynamic routes", async ({ page }) => {
+    await page.goto(`${BASE}/dynamic/hello`);
+    await expect(page.locator("#dynamic-page")).toHaveText("hello");
+  });
+
+  test("deduplicates inlined prefetch requests for the same route", async ({ page }) => {
+    const firstPrefetchBlocker: { release?: () => void } = {};
+    let rscRequestCount = 0;
+
+    await page.route("**/*", async (route) => {
+      const request = route.request();
+      if (isRscRequest(request, "/shared/a/b/c")) {
+        rscRequestCount++;
+        if (firstPrefetchBlocker.release === undefined) {
+          await new Promise<void>((resolve) => {
+            firstPrefetchBlocker.release = resolve;
+          });
+        }
+      }
+      await route.continue();
+    });
+
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+
+    const firstPrefetch = waitForRscResponseContaining(page, "Page C");
+    await page.locator('input[data-link-accordion="/shared/a/b/c"]').click();
+    await expect.poll(() => rscRequestCount).toBe(1);
+
+    await page.locator('input[data-link-accordion="duplicate-a"]').click();
+    await page.waitForTimeout(250);
+    expect(rscRequestCount).toBe(1);
+
+    const release = firstPrefetchBlocker.release;
+    if (release === undefined) {
+      throw new Error("Expected the first prefetch request to be blocked");
+    }
+    release();
+    await firstPrefetch;
+
+    const countBeforeNavigation = rscRequestCount;
+    await page.locator('a[href="/shared/a/b/c"]').first().click();
+    await expect(page.locator("#page-c")).toHaveText("Page C");
+    expect(rscRequestCount).toBe(countBeforeNavigation);
+  });
+});

--- a/tests/fixtures/app-prefetch-inlining/app/dynamic/[slug]/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/dynamic/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from "react";
+
+async function Content({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <p id="dynamic-page">{slug}</p>;
+}
+
+export default function DynamicPage({ params }: { params: Promise<{ slug: string }> }) {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Content params={params} />
+    </Suspense>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/page.tsx
@@ -1,0 +1,28 @@
+// Ported from Next.js:
+// test/e2e/app-dir/segment-cache/max-prefetch-inlining/app/page.tsx
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/max-prefetch-inlining/app/page.tsx
+import { LinkAccordion } from "../components/link-accordion";
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/shared/a/b/c">Route A</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/shared/a/d/e">Route B</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/shared/a/b/c" id="duplicate-a">
+            Route A (duplicate)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/dynamic/hello">Dynamic Route</LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/shared/a/b/c/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/shared/a/b/c/page.tsx
@@ -1,0 +1,3 @@
+export default function PageC() {
+  return <p id="page-c">Page C</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/shared/a/b/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/shared/a/b/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function BLayout({ children }: { children: ReactNode }) {
+  return <div id="b-layout">{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/shared/a/d/e/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/shared/a/d/e/page.tsx
@@ -1,0 +1,3 @@
+export default function PageE() {
+  return <p id="page-e">Page E</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/shared/a/d/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/shared/a/d/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function DLayout({ children }: { children: ReactNode }) {
+  return <div id="d-layout">{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/shared/a/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/shared/a/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function ALayout({ children }: { children: ReactNode }) {
+  return <div id="a-layout">{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/shared/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/shared/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function SharedLayout({ children }: { children: ReactNode }) {
+  return <div id="shared-layout">{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/components/link-accordion.tsx
+++ b/tests/fixtures/app-prefetch-inlining/components/link-accordion.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+// Ported from Next.js:
+// test/e2e/app-dir/segment-cache/max-prefetch-inlining/components/link-accordion.tsx
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/max-prefetch-inlining/components/link-accordion.tsx
+import Link, { type LinkProps } from "next/link";
+import { useState } from "react";
+
+export function LinkAccordion({
+  href,
+  children,
+  id,
+}: {
+  href: LinkProps["href"];
+  children: React.ReactNode;
+  id?: string;
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={id ?? href}
+      />
+      {isVisible ? <Link href={href}>{children}</Link> : `${children} (link is hidden)`}
+    </>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/next.config.ts
+++ b/tests/fixtures/app-prefetch-inlining/next.config.ts
@@ -1,0 +1,16 @@
+import type { NextConfig } from "vinext";
+
+// Ported from Next.js:
+// test/e2e/app-dir/segment-cache/max-prefetch-inlining/next.config.js
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/max-prefetch-inlining/next.config.js
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    prefetchInlining: {
+      maxSize: Infinity,
+      maxBundleSize: Infinity,
+    },
+  },
+};
+
+export default nextConfig;

--- a/tests/fixtures/app-prefetch-inlining/package.json
+++ b/tests/fixtures/app-prefetch-inlining/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app-prefetch-inlining-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/tests/fixtures/app-prefetch-inlining/tsconfig.json
+++ b/tests/fixtures/app-prefetch-inlining/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vite/client", "@vitejs/plugin-rsc/types"]
+  },
+  "include": ["app", "components", "*.ts", "../../../packages/vinext/src/shims/next-shims.d.ts"]
+}

--- a/tests/fixtures/app-prefetch-inlining/vite.config.ts
+++ b/tests/fixtures/app-prefetch-inlining/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "../../../packages/vinext/dist/index.js";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1230,6 +1230,44 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("prefetches App-only visible links before the navigate runtime is installed", async () => {
+    const observer = stubIntersectionObserver();
+    const navigationRuntimeKey = Symbol.for("vinext.navigationRuntime");
+    const requestIdleCallback = vi.fn(() => 1);
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: {
+        [navigationRuntimeKey]: {
+          bootstrap: {
+            routeManifest: null,
+            rsc: undefined,
+          },
+          functions: {},
+        },
+        requestIdleCallback,
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("re-prefetches visible links after the prefetch cache is invalidated", async () => {
     const observer = stubIntersectionObserver();
 
@@ -1580,20 +1618,16 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("gates prefetchInlining full payload behind a loading-shell request", async () => {
+  it("uses the loading shell as the prefetchInlining pending dedupe entry", async () => {
     vi.stubEnv("__VINEXT_PREFETCH_INLINING", "true");
     const observer = stubIntersectionObserver();
     let resolveShell: ((response: Response) => void) | undefined;
-    let releaseShellBody: (() => void) | undefined;
+    let resolveFull: ((response: Response) => void) | undefined;
     const shellPromise = new Promise<Response>((resolve) => {
       resolveShell = resolve;
     });
-    const shellBody = new ReadableStream<Uint8Array>({
-      start(controller) {
-        releaseShellBody = () => {
-          controller.close();
-        };
-      },
+    const fullPromise = new Promise<Response>((resolve) => {
+      resolveFull = resolve;
     });
     const result = await renderIsolatedLink({
       href: "/intent-prefetch-target",
@@ -1602,18 +1636,18 @@ describe("Link prefetch scheduling", () => {
 
     result.fetch
       .mockImplementationOnce(() => shellPromise)
-      .mockImplementationOnce(() => Promise.resolve(new Response("full")));
+      .mockImplementationOnce(() => fullPromise);
 
     try {
       observer.dispatchIntersectingEntry(result.anchor);
       await waitForFetchCalls(result.fetch, 1);
 
-      const firstInit = result.fetch.mock.calls[0]?.[1];
-      expect(firstInit?.headers).toBeInstanceOf(Headers);
-      if (!(firstInit?.headers instanceof Headers)) {
-        throw new Error("Expected prefetch request headers");
+      const shellFetchInit = result.fetch.mock.calls[0]?.[1];
+      expect(shellFetchInit?.headers).toBeInstanceOf(Headers);
+      if (!(shellFetchInit?.headers instanceof Headers)) {
+        throw new Error("Expected shell prefetch request headers");
       }
-      expect(firstInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+      expect(shellFetchInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
         APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
       );
 
@@ -1624,22 +1658,26 @@ describe("Link prefetch scheduling", () => {
       if (resolveShell === undefined) {
         throw new Error("Expected shell prefetch resolver");
       }
-      resolveShell(new Response(shellBody));
-      await flushPrefetchTasks();
-      expect(result.fetch).toHaveBeenCalledTimes(1);
-
-      if (releaseShellBody === undefined) {
-        throw new Error("Expected shell body release");
-      }
-      releaseShellBody();
+      resolveShell(new Response("shell"));
       await waitForFetchCalls(result.fetch, 2);
 
-      const secondInit = result.fetch.mock.calls[1]?.[1];
-      expect(secondInit?.headers).toBeInstanceOf(Headers);
-      if (!(secondInit?.headers instanceof Headers)) {
+      const fullFetchInit = result.fetch.mock.calls[1]?.[1];
+      expect(fullFetchInit?.headers).toBeInstanceOf(Headers);
+      if (!(fullFetchInit?.headers instanceof Headers)) {
         throw new Error("Expected full prefetch request headers");
       }
-      expect(secondInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+      expect(fullFetchInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+
+      if (resolveFull === undefined) {
+        throw new Error("Expected full prefetch resolver");
+      }
+      resolveFull(new Response("full"));
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(2);
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1268,6 +1268,50 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("yields low-priority App Router prefetch to idle scheduling once the navigate runtime is installed", async () => {
+    const observer = stubIntersectionObserver();
+    // Capture the idle callback instead of running it, so a deferred prefetch is
+    // observable as "queued on idle but not yet fired".
+    const idleCallbacks: Array<() => void> = [];
+    const requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+
+    // appNavigation defaults to true → the full navigate runtime is installed,
+    // so this is a normal low-priority prefetch, not the bootstrap retry window.
+    // `__NEXT_DATA__` is undefined (App Router) but must no longer force the
+    // immediate path once the runtime is up.
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+
+      expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      for (const callback of idleCallbacks) {
+        callback();
+      }
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("re-prefetches visible links after the prefetch cache is invalidated", async () => {
     const observer = stubIntersectionObserver();
 
@@ -1613,6 +1657,46 @@ describe("Link prefetch scheduling", () => {
       await flushPrefetchTasks();
 
       expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("re-prefetches a visible navigation-cacheable link when only a stale dedupe marker remains", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { createRscRequestHeaders, createRscRequestUrl } =
+      await import("../packages/vinext/src/server/app-rsc-cache-busting.js");
+    const { getPrefetchCache, getPrefetchedUrls } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const rscUrl = await createRscRequestUrl(
+      "/viewport-prefetch-target",
+      createRscRequestHeaders(),
+    );
+
+    try {
+      // An orphaned dedupe marker with no live cache entry — the state left
+      // behind when a prior entry became incompatible with the current
+      // mounted-slot context and was skipped (not deleted) by the freshness
+      // check. Freshness, not the marker, must decide: the link still has no
+      // usable prefetch data, so a re-prefetch must fire.
+      getPrefetchedUrls().add(rscUrl);
+      expect(getPrefetchCache().has(rscUrl)).toBe(false);
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -319,22 +319,18 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
-        prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
-        prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: true,
-        prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
-        prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       // Ported from Next.js:
@@ -342,12 +338,10 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
-        prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
-        prefetchShellFirst: false,
         shouldPrefetch: false,
       });
     } finally {


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Port and pass Next.js v16.2.6 max-prefetch-inlining behavior in Vinext. |
| Core change | App Router automatic prefetches under `experimental.prefetchInlining` now use a target loading-shell owner request before the cacheable full-route RSC request. |
| Main boundary | Link prefetch lifecycle, RSC prefetch cache pending ownership, initial static hydration. |
| Primary files | `packages/vinext/src/shims/link.tsx`, `packages/vinext/src/server/app-browser-entry.ts`, `packages/vinext/src/server/app-browser-stream.ts`, `tests/e2e/app-prefetch-inlining/*`. |
| Expected impact | Static automatic App Router prefetches match the upstream two-step pending/dedup contract while dynamic routes without loading shells keep direct full-route cache seeding. |

## Why

For this area to match Next.js, a visible Link prefetch must have a stable owner while its route data is pending. Upstream Segment Cache uses a route-tree request followed by inlined segment data when `prefetchInlining` is maximized. Vinext previously collapsed that into one full RSC request, which passed broad request-count checks but failed the duplicate-link blocked-pending contract asserted by upstream.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Link prefetch | Duplicate visible links to the same static route must observe an existing pending owner request. | Static automatic prefetches under `prefetchInlining` seed a non-navigation loading-shell entry, then start the full-route payload when the shell settles. |
| Navigation cache | Only full payloads are consumed for navigation. | Loading-shell entries stay `cacheForNavigation: false`; full payloads retain the existing replay path. |
| Static hydration | Prerendered HTML must hydrate client components before interactive prefetch checks run. | Initial RSC client references are preloaded and Flight import promises are annotated with React Flight status fields. |
| Embedded RSC stream | A done marker can be set without a later chunk push. | The browser stream observes done-marker property writes and closes the stream immediately. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Static automatic Link with max `prefetchInlining` | One full RSC prefetch request owned both pending dedupe and navigation cache. | Loading-shell request owns pending dedupe, then the full RSC request fills the navigation cache. |
| Duplicate static Link revealed while first prefetch is blocked | Vinext did not reproduce the upstream blocked-pending sequence. | No duplicate request is issued, then the inlined full payload is fetched and cached after the shell releases. |
| Dynamic route without loading shell | Full-route automatic prefetch. | Unchanged. |
| Prerendered initial app hydration | Client component boundaries could remain non-interactive under static prerender timing. | Client reference imports are preloaded from the initial RSC stream before hydration consumes the tee'd stream. |

<details>
<summary>Maintainer review path</summary>

1. `tests/e2e/app-prefetch-inlining/max-prefetch-inlining.spec.ts` and `tests/fixtures/app-prefetch-inlining/*`: local port of the upstream fixture and observable behavior.
2. `packages/vinext/src/shims/link.tsx`: two-step static automatic prefetch flow and duplicate dedupe gates.
3. `packages/vinext/src/server/app-client-reference-loader.ts` plus `packages/vinext/src/server/app-browser-entry.ts`: initial client reference preload and Flight promise annotation.
4. `packages/vinext/src/server/app-browser-stream.ts`: done-marker observer for embedded RSC streams.
5. `playwright.config.ts` and `.github/workflows/ci.yml`: dedicated prerendered Playwright project in CI.

</details>

<details>
<summary>Validation</summary>

- `vp check`
- `vp test run tests/link-navigation.test.ts tests/link.test.ts tests/app-client-reference-preloader.test.ts tests/app-browser-stream.test.ts`
- `CI=1 PLAYWRIGHT_PROJECT=app-prefetch-inlining vp exec playwright test tests/e2e/app-prefetch-inlining/max-prefetch-inlining.spec.ts --reporter=list --retries=0`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts`
- Pre-commit hook: staged `vp check --fix`, full check, staged unit/integration tests, knip.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no public API changes.
- Config: consumes existing `process.env.__VINEXT_PREFETCH_INLINING` define already derived from `experimental.prefetchInlining`.
- Runtime: static automatic prefetches with max inlining now issue up to two RSC requests, matching the upstream test's request bound. Dynamic routes without loading shells remain direct full-route prefetches.
- Cache: loading-shell entries are explicitly non-navigation-cacheable and full-route entries retain the existing `consumePrefetchResponseForNavigation` path.
- Hydration: initial RSC stream is tee'd so React still consumes the original bytes; preload failures are reported in dev and do not consume the render branch.

</details>

<details>
<summary>Non-goals</summary>

- This does not implement Next.js's full Segment Cache data model or per-segment layout sharing.
- This does not broaden `experimental.prefetchInlining` threshold support beyond the observable max-inlining behavior covered here.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js max-prefetch-inlining test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/max-prefetch-inlining/max-prefetch-inlining.test.ts) | Authoritative upstream behavior ported in this PR. |
| [Upstream max-prefetch-inlining fixture config](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/max-prefetch-inlining/next.config.js) | Shows `cacheComponents` plus max `prefetchInlining` thresholds. |
| [Next.js `collect-segment-data.tsx`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/app-render/collect-segment-data.tsx) | Server-side source for collected/inlined segment data. |
| [Next.js Link prefetch registration](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/links.ts) | Client-side Link visibility and prefetch scheduling reference. |
| [Next.js Segment Cache scheduler](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/segment-cache/scheduler.ts) | Explains task scheduling around route/tree and segment requests. |
| [Next.js Segment Cache cache](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/segment-cache/cache.ts) | Pending entry and cache-state reference. |
| [Next.js router-act helper](https://github.com/vercel/next.js/blob/v16.2.6/test/lib/router-act.ts) | Defines the nested `block`/`no-requests` semantics that exposed the Vinext mismatch. |