### PR TITLE
fix(deploy): preserve app module identity with deployment ids

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2000,8 +2000,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           ...(nextConfig.assetPrefix || nextConfig.deploymentId
             ? {
                 experimental: {
-                  renderBuiltUrl: (filename: string) =>
-                    renderVinextBuiltUrl(filename, nextConfig.assetPrefix, nextConfig.deploymentId),
+                  renderBuiltUrl: (filename: string, context) =>
+                    renderVinextBuiltUrl(
+                      filename,
+                      nextConfig.assetPrefix,
+                      nextConfig.deploymentId,
+                      context.hostType,
+                    ),
                 },
               }
             : {}),

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -441,10 +441,14 @@ export async function handleSsr(
         const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent(
           "index",
         );
-        const rawBootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
-        const bootstrapModuleUrl = rawBootstrapModuleUrl
-          ? appendAssetDeploymentIdQuery(rawBootstrapModuleUrl)
-          : undefined;
+        // Keep the bootstrap URL exactly as emitted by plugin-rsc. Appending a
+        // deployment query here happens after Vite has generated the client
+        // module graph, so the bootstrap entry gets a different module identity
+        // from references to the same entry inside that graph. That splits the
+        // React/RSC client singleton state and breaks hydration and server-action
+        // FormData encoding. Normal built assets are versioned earlier through
+        // Vite's renderBuiltUrl hook.
+        const bootstrapModuleUrl = extractBootstrapModuleUrl(bootstrapScriptContent);
         const errorMetaRenderer = createSsrErrorMetaRenderer({
           basePath: options?.basePath,
         });

--- a/packages/vinext/src/shims/dynamic-preload-chunks.tsx
+++ b/packages/vinext/src/shims/dynamic-preload-chunks.tsx
@@ -81,8 +81,8 @@ export function DynamicPreloadChunks(props: { moduleIds?: readonly string[] }) {
   const stylesheets: React.ReactNode[] = [];
   for (const file of files) {
     const assetHref = dynamicPreloadHref(file);
-    const href = appendAssetDeploymentIdQuery(assetHref);
     if (assetHref.endsWith(".css")) {
+      const href = appendAssetDeploymentIdQuery(assetHref);
       stylesheets.push(
         React.createElement("link", {
           key: href,
@@ -103,7 +103,7 @@ export function DynamicPreloadChunks(props: { moduleIds?: readonly string[] }) {
         fetchPriority: "low",
         nonce,
       };
-      ReactDOM.preload(href, preloadOptions);
+      ReactDOM.preload(assetHref, preloadOptions);
     }
   }
 

--- a/packages/vinext/src/utils/built-asset-url.ts
+++ b/packages/vinext/src/utils/built-asset-url.ts
@@ -5,6 +5,7 @@ export function renderVinextBuiltUrl(
   filename: string,
   assetPrefix: string,
   deploymentId?: string,
+  hostType?: "js" | "css" | "html",
 ): string {
   const urlPrefix = resolveAssetUrlPrefix(assetPrefix);
   const onDiskDir = resolveAssetsDir(assetPrefix);
@@ -15,5 +16,10 @@ export function renderVinextBuiltUrl(
       ? filename.slice(ASSET_PREFIX_URL_DIR.length + 1)
       : filename;
 
-  return appendDeploymentIdQuery(urlPrefix + stripped, deploymentId);
+  const url = urlPrefix + stripped;
+  // Native ESM resolves a chunk's imports relative to the importing module URL.
+  // Adding a deployment query to URLs embedded in JavaScript gives the entry a
+  // different module identity while its relative imports remain unversioned,
+  // splitting React/RSC singleton state across duplicate module graphs.
+  return hostType === "js" ? url : appendDeploymentIdQuery(url, deploymentId);
 }

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -117,6 +117,12 @@ describe("renderVinextBuiltUrl", () => {
     );
   });
 
+  it("preserves one native ESM module identity for JavaScript hosts", () => {
+    expect(renderVinextBuiltUrl("_next/static/chunk.js", "", "dpl_123", "js")).toBe(
+      "/_next/static/chunk.js",
+    );
+  });
+
   it("combines path asset prefixes and deployment IDs", () => {
     expect(renderVinextBuiltUrl("cdn/_next/static/chunk.js", "/cdn", "dpl_123")).toBe(
       "/cdn/_next/static/chunk.js?dpl=dpl_123",
@@ -381,7 +387,7 @@ describe("assetPrefix end-to-end build", () => {
 
   // Ported from Next.js: test/production/deployment-id-handling/deployment-id-handling.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/production/deployment-id-handling/deployment-id-handling.test.ts
-  it("deployment ID: emits dpl queries in built output and SSR asset URLs", async () => {
+  it("deployment ID: keeps native ESM URLs on one module identity", async () => {
     const built = await buildFixtureWithConfig(`deploymentId: "dpl_123",`, register);
     const clientDir = path.join(built.outDir, "client");
     const builtFiles: string[] = [];
@@ -394,9 +400,9 @@ describe("assetPrefix end-to-end build", () => {
       }
     };
     collectFiles(clientDir);
-    expect(builtFiles.some((file) => fs.readFileSync(file, "utf8").includes("?dpl=dpl_123"))).toBe(
-      true,
-    );
+    for (const file of builtFiles.filter((file) => /\.[cm]?js$/.test(file))) {
+      expect(fs.readFileSync(file, "utf8"), file).not.toContain("?dpl=dpl_123");
+    }
 
     const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
     const { server } = await startProdServer({
@@ -415,10 +421,12 @@ describe("assetPrefix end-to-end build", () => {
         (match) => match[1],
       );
       expect(assetUrls.length).toBeGreaterThan(0);
-      expect(
-        assetUrls.every((url) => url.includes("dpl=dpl_123")),
-        JSON.stringify(assetUrls),
-      ).toBe(true);
+      const bootstrapModuleUrl = html.match(/<script[^>]+type="module"[^>]+src="([^"]+)"/)?.[1];
+      expect(bootstrapModuleUrl).toBeDefined();
+      expect(bootstrapModuleUrl).not.toContain("dpl=");
+      for (const assetUrl of assetUrls.filter((url) => /\.js(?:[?#]|$)/.test(url))) {
+        expect(assetUrl).not.toContain("dpl=");
+      }
     } finally {
       server.close();
     }


### PR DESCRIPTION
## Summary

- preserve a single native ESM module identity when `deploymentId` is configured
- avoid appending `?dpl=` to URLs embedded in JavaScript or emitted for App Router JS preloads
- keep deployment IDs on request headers and non-JavaScript asset URLs

## Regression

The Next.js deploy suite regressed between:

- baseline run: https://github.com/cloudflare/vinext/actions/runs/27391762001 (`fd102332`)
- regressed run: https://github.com/cloudflare/vinext/actions/runs/27454667309 (`3d963951`)

The report dropped from 2,243 to 2,171 passing tests. A focused `app-action-form-state` canary reproduced two deterministic failures:

- JS `useActionState` submissions decoded an empty `FormData` value (`initial-state:`)
- progressive form responses lost their hydrated form state

The regression first appears in `a155fdf9` (`fix(deploy): improve deployment id parity`). Its `renderBuiltUrl` hook appended `?dpl=` to native ESM URLs embedded in JavaScript, while relative imports inside those modules remained unversioned. Browsers therefore instantiated duplicate React/RSC module graphs, splitting the singleton state used for hydration and server-action encoding.

## Validation

- `vp test run tests/asset-prefix.test.ts -t "deployment ID|native ESM"`
- `vp check tests/asset-prefix.test.ts packages/vinext/src/index.ts packages/vinext/src/server/app-ssr-entry.ts packages/vinext/src/shims/dynamic-preload-chunks.tsx packages/vinext/src/utils/built-asset-url.ts`
- focused Next.js deploy canary: https://github.com/cloudflare/vinext/actions/runs/27464803338
