### PR TITLE
test(shims): normalize expected og shim path for Windows

### DIFF
--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15,6 +15,7 @@ import type {
   CacheHandlerValue,
   IncrementalCacheValue,
 } from "../packages/vinext/src/shims/cache.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.ts";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
 describe("vinext next data client helpers", () => {
@@ -18898,7 +18899,10 @@ describe("@vercel/og compatibility resolution", () => {
 
   it("routes direct @vercel/og app imports through the Next-compatible ImageResponse shim", () => {
     const hook = getResolveIdHook();
-    const expectedShim = path.resolve(import.meta.dirname, "../packages/vinext/src/shims/og.tsx");
+    // resolveId returns Vite-style ids: forward slashes on every platform.
+    const expectedShim = normalizePathSeparators(
+      path.resolve(import.meta.dirname, "../packages/vinext/src/shims/og.tsx"),
+    );
 
     expect(hook.filter.id.test("@vercel/og")).toBe(true);
     expect(hook.filter.id.test("@vercel/og.js")).toBe(true);


### PR DESCRIPTION
## What

Normalizes the expected shim path in the `@vercel/og compatibility resolution` test (`tests/shims.test.ts`) so it matches the forward-slash id that `vinext:config`'s `resolveId` returns.

## Why

The test asserts that `resolveId("@vercel/og", importer)` returns the path to `src/shims/og.tsx`. The hook produces a Vite-style id — forward slashes on every platform — but the expected value was built with `path.resolve`, which uses native separators. On Windows that compared `E:/.../og.tsx` (received) against `E:\...\og.tsx` (expected) and failed; on POSIX the two forms are identical, so the test passed there.

The fix wraps the expected value in `normalizePathSeparators`, the codebase-standard helper. No source change — `resolveId` already returns the correct forward-slash id.

## Testing

`vp test run --project unit tests/shims.test.ts` — passes on Windows (this test previously failed); no behavior change on POSIX, where `normalizePathSeparators` is a no-op. `vp check` clean.