### PR TITLE
feat(navigation): promote OperationToken to the eligibility authority (#1790 PR 5)

### DIFF
--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -33,6 +33,7 @@ import {
   type OperationToken,
   type RouteSnapshot,
 } from "./navigation-planner.js";
+import { verifyOperationTokenForCommit, type VerifiedOperationToken } from "./operation-token.js";
 import {
   createSnapshotPathAndSearch,
   type ClientNavigationRenderSnapshot,
@@ -511,18 +512,29 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
   targetHref?: string;
 }): PendingNavigationCommitDispositionDecision {
   const traceFields = createPendingNavigationTraceFields(options);
+  const targetSnapshot = createPendingRouteSnapshot(options.pending);
+  const token = createPendingNavigationOperationToken({
+    pending: options.pending,
+    routeManifest: options.routeManifest ?? null,
+    startedNavigationId: options.startedNavigationId,
+    targetSnapshot,
+  });
 
-  if (
-    options.startedNavigationId !== options.activeNavigationId ||
-    options.pending.action.operation.startedVisibleCommitVersion !==
-      options.currentState.visibleCommitVersion
-  ) {
-    // staleOperation — the navigation that created `pending` started from a
-    // different visibleCommitVersion than the current state. This happens when
-    // a synchronous history snapshot restore (restoreHistoryStateSnapshot, see
+  // OperationToken is the single eligibility authority for commit approval: a
+  // result may enter commit approval only if its token proves it belongs to the
+  // active navigation and the visible commit version it started from is still
+  // current. The token verifies; ApprovedVisibleCommit (downstream) mutates.
+  const verdict = verifyOperationTokenForCommit(token, {
+    activeNavigationId: options.activeNavigationId,
+    visibleCommitVersion: options.currentState.visibleCommitVersion,
+  });
+  if (!verdict.authorized) {
+    // staleOperation — the navigation that created `pending` was superseded, or
+    // visible state advanced after it started. The latter happens when a
+    // synchronous history snapshot restore (restoreHistoryStateSnapshot, see
     // app-browser-entry.ts popstate handler) bumps visibleCommitVersion before
-    // an in-flight async RSC traverse resolves. The snapshot restore is the
-    // authoritative commit; the stale async payload is intentionally discarded.
+    // an in-flight async RSC traverse resolves. The authoritative commit wins;
+    // the stale async payload is intentionally discarded.
     return {
       disposition: "skip",
       preserveElementIds: [],
@@ -536,6 +548,8 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
       pending: options.pending,
       routeManifest: options.routeManifest ?? null,
       targetHref: options.targetHref,
+      targetSnapshot,
+      token: verdict.token,
       traceFields,
     }),
   );
@@ -631,6 +645,7 @@ function createPendingRouteSnapshot(pending: PendingNavigationCommit): RouteSnap
 function createPendingNavigationOperationToken(options: {
   pending: PendingNavigationCommit;
   routeManifest: RouteManifest | null;
+  startedNavigationId: number;
   targetSnapshot: RouteSnapshot;
 }): OperationToken {
   return {
@@ -638,6 +653,10 @@ function createPendingNavigationOperationToken(options: {
     deploymentVersion: null,
     graphVersion: options.routeManifest?.graphVersion ?? null,
     lane: options.pending.action.operation.lane,
+    // The lifecycle navigation id the operation started under. operationId
+    // (renderId) cannot answer "belongs to the active navigation?" because it is
+    // a per-render counter; navigationId carries that lifecycle authority.
+    navigationId: options.startedNavigationId,
     operationId: options.pending.action.operation.id,
     targetSnapshotFingerprint: createRootBoundarySnapshotFingerprint(options.targetSnapshot),
   };
@@ -652,14 +671,14 @@ function planPendingRootBoundaryFlightResponse(options: {
   pending: PendingNavigationCommit;
   routeManifest: RouteManifest | null;
   targetHref?: string;
+  // The token has already passed commit eligibility (verifyOperationTokenForCommit)
+  // in the disposition gate above. Requiring the verified brand here makes that
+  // ordering a compile-time guarantee: the planner cannot be reached with an
+  // unverified token.
+  token: VerifiedOperationToken;
+  targetSnapshot: RouteSnapshot;
   traceFields: NavigationTraceFields;
 }): NavigationDecision {
-  const targetSnapshot = createPendingRouteSnapshot(options.pending);
-  const token = createPendingNavigationOperationToken({
-    pending: options.pending,
-    routeManifest: options.routeManifest,
-    targetSnapshot,
-  });
   const cacheEntryReuseProof = options.pending.cacheEntryReuseProof;
 
   // #726-CORE-07/08 keeps the browser state layer as the lifecycle gate and
@@ -669,7 +688,7 @@ function planPendingRootBoundaryFlightResponse(options: {
   return navigationPlanner.plan({
     routeManifest: options.routeManifest,
     state: {
-      nextOperationToken: token,
+      nextOperationToken: options.token,
       traceFields: options.traceFields,
       visibleCommitVersion: options.currentState.visibleCommitVersion,
       visibleSnapshot: createVisibleRouteSnapshot(options.currentState),
@@ -682,10 +701,10 @@ function planPendingRootBoundaryFlightResponse(options: {
         // planner trace and future hard-nav executor agree with the browser
         // URL. The fallback remains for lower-level tests and direct disposition
         // callers that exercise only snapshot-derived planner semantics.
-        href: options.targetHref ?? targetSnapshot.displayUrl,
-        targetSnapshot,
+        href: options.targetHref ?? options.targetSnapshot.displayUrl,
+        targetSnapshot: options.targetSnapshot,
       },
-      token,
+      token: options.token,
     },
   });
 }

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -32,24 +32,17 @@ import {
   type NavigationTraceFields,
   type NavigationTraceReasonCode,
 } from "./navigation-trace.js";
+import {
+  verifyOperationTokenForCacheReuse,
+  type OperationLane,
+  type OperationToken,
+  type OperationTokenRejectionReason,
+} from "./operation-token.js";
 
-export type OperationLane =
-  | "hmr"
-  | "navigation"
-  | "prefetch"
-  | "refresh"
-  | "server-action"
-  | "traverse";
-
-export type OperationToken = {
-  operationId: number;
-  lane: OperationLane;
-  baseVisibleCommitVersion: number;
-  graphVersion: string | null;
-  deploymentVersion: string | null;
-  targetSnapshotFingerprint: string;
-  cacheVariantFingerprint?: string;
-};
+// OperationToken and OperationLane are owned by ./operation-token.ts, the token
+// authority module. Re-exported here so the planner stays the single import
+// surface for navigation types.
+export type { OperationLane, OperationToken } from "./operation-token.js";
 
 export type RouteSnapshot = {
   interception: InterceptionSnapshot | null;
@@ -125,6 +118,7 @@ type CommitProposal = {
 type NoCommitReason = "prefetchOnly";
 type HardNavigationReason =
   | "cacheProofRejected"
+  | "cacheReuseTokenRejected"
   | "interceptionProofRejected"
   | "rootBoundaryChanged";
 export type RootBoundaryTransition =
@@ -1245,6 +1239,27 @@ function createCacheProofRejectedDecision(options: {
   };
 }
 
+// A proven cache entry rejected by the OperationToken authority (its graph
+// version or variant no longer matches the installed one). Distinct from
+// cacheProofRejected — the cache proof itself authorized reuse; the token did
+// not — so it carries its own reason code and the verdict reason for telemetry.
+function createCacheReuseTokenRejectedDecision(options: {
+  event: Extract<NavigationEvent, { kind: "flightResponseArrived" }>;
+  reason: OperationTokenRejectionReason;
+  traceFields: NavigationTraceFields;
+}): NavigationDecision {
+  return {
+    kind: "hardNavigate",
+    reason: "cacheReuseTokenRejected",
+    token: options.event.token,
+    trace: createNavigationTrace(NavigationTraceReasonCodes.cacheReuseTokenRejected, {
+      ...options.traceFields,
+      cacheReuseTokenReason: options.reason,
+    }),
+    url: options.event.result.href,
+  };
+}
+
 function createAcceptedCacheProofTraceFields(
   traceFields: NavigationTraceFields,
   decision: AcceptedCacheEntryReuseDecision | null,
@@ -1404,6 +1419,29 @@ function planFlightResponseArrived(options: {
     });
   }
   const acceptedCacheEntryDecision = cacheEntryProofEvaluation.decision;
+
+  // Commits and cache reuse share the OperationToken authority. A proven cache
+  // entry may only be reused if its token still matches the installed route graph
+  // and cache variant. Behavior-preserving today — the token's graphVersion is
+  // minted from the same route manifest the planner verifies against — and a real
+  // guard once cross-document or segment reuse (PR 6/7) can carry a token whose
+  // graph version or variant has diverged from the installed one. The installed
+  // cache variant is not yet known to the planner (segment cache, PR 7), so that
+  // dimension stays dormant rather than comparing the token to itself.
+  if (acceptedCacheEntryDecision !== null) {
+    const reuseVerdict = verifyOperationTokenForCacheReuse(options.event.token, {
+      graphVersion: options.routeManifest?.graphVersion ?? null,
+      installedCacheVariantFingerprint: null,
+    });
+    if (!reuseVerdict.authorized) {
+      return createCacheReuseTokenRejectedDecision({
+        event: options.event,
+        reason: reuseVerdict.reason,
+        traceFields,
+      });
+    }
+  }
+
   const commitTraceFields = createAcceptedCacheProofTraceFields(
     traceFields,
     acceptedCacheEntryDecision,

--- a/packages/vinext/src/server/navigation-trace.ts
+++ b/packages/vinext/src/server/navigation-trace.ts
@@ -4,6 +4,7 @@ type NavigationTraceSchemaVersion = 0;
 
 export const NavigationTraceReasonCodes = {
   cacheProofRejected: "NC_CACHE_REJECT",
+  cacheReuseTokenRejected: "NC_CACHE_TOKEN_REJECT",
   commitCurrent: "NC_COMMIT",
   crossDocumentFlight: "NC_CROSS_DOC_FLIGHT",
   fetchFresh: "NC_FETCH_FRESH",
@@ -36,6 +37,7 @@ export const NavigationTraceReasonCodes = {
   visitedResponseReuse: "NC_VISITED_REUSE",
 } satisfies Readonly<{
   cacheProofRejected: "NC_CACHE_REJECT";
+  cacheReuseTokenRejected: "NC_CACHE_TOKEN_REJECT";
   commitCurrent: "NC_COMMIT";
   crossDocumentFlight: "NC_CROSS_DOC_FLIGHT";
   fetchFresh: "NC_FETCH_FRESH";
@@ -92,6 +94,7 @@ type NavigationTraceFieldName =
   | "cacheProofMode"
   | "cacheProofReuseClass"
   | "cacheProofScope"
+  | "cacheReuseTokenReason"
   | "currentRootLayoutTreePath"
   | "currentVisibleCommitVersion"
   | "nextRootLayoutTreePath"

--- a/packages/vinext/src/server/operation-token.ts
+++ b/packages/vinext/src/server/operation-token.ts
@@ -1,0 +1,222 @@
+// OperationToken is the proof-of-eligibility object for App Router navigation.
+// It answers one question at every authority boundary: may this navigation
+// result enter commit approval or cache reuse? The token only *verifies*;
+// `ApprovedVisibleCommit` is the separate proof-of-mutation object that actually
+// advances visible router state. Keep that separation: a verified token never
+// mutates and never substitutes for the approved-commit brand.
+//
+// See issue #1790 (PR 5). The token feeds the active-navigation, visible-commit,
+// graph-version, and cache-variant checks so commits and cache reuse share one
+// authority model instead of deriving eligibility inline in the browser entry.
+
+export type OperationLane =
+  | "hmr"
+  | "navigation"
+  | "prefetch"
+  | "refresh"
+  | "server-action"
+  | "traverse";
+
+export type OperationToken = {
+  // Diagnostic only: the per-render operation id (renderId). Distinct from
+  // navigationId; not a verification dimension.
+  operationId: number;
+  // Execution-lane selector. Drives planner behavior (prefetch no-commit, slot
+  // persistence); not a verification dimension.
+  lane: OperationLane;
+  // Authority — active-navigation dimension. The lifecycle navigation id the
+  // operation started under, verified against the live activeNavigationId.
+  navigationId: number;
+  // Authority — visible-commit dimension. The visibleCommitVersion the operation
+  // started from, verified against the current visibleCommitVersion.
+  baseVisibleCommitVersion: number;
+  // Authority — graph-version dimension. The route graph version the operation
+  // was planned against, verified against the installed graph version.
+  graphVersion: string | null;
+  // Future deployment-compatibility dimension: carried for cross-deployment
+  // reuse authority but not yet verified by any boundary.
+  deploymentVersion: string | null;
+  // Diagnostic / future BFCache identity input (PR 6). Not a commit-authority
+  // check today.
+  targetSnapshotFingerprint: string;
+  // Authority — cache-variant dimension. The cache variant that produced the
+  // result, verified against the installed variant. Populated once segment cache
+  // variant keys exist (PR 7); absent until then.
+  cacheVariantFingerprint?: string;
+};
+
+// A token that has passed `verifyOperationToken`. Boundaries that consume proof
+// (not raw evidence) accept this branded type so an unverified token cannot
+// reach them by construction. Mirrors the ApprovedVisibleCommit brand pattern
+// without collapsing verification and mutation into one object.
+declare const verifiedOperationTokenBrand: unique symbol;
+export type VerifiedOperationToken = OperationToken & {
+  readonly [verifiedOperationTokenBrand]: true;
+};
+
+// The live authority facts a boundary checks the token against. Each field is
+// the *current* installed/active value; the token carries the value it was
+// minted with. graphVersion / installedCacheVariantFingerprint are nullable
+// because low-context paths (absent route manifest, pre-segment-cache reuse) may
+// not carry them.
+export type OperationTokenAuthority = {
+  activeNavigationId: number;
+  visibleCommitVersion: number;
+  graphVersion: string | null;
+  installedCacheVariantFingerprint: string | null;
+};
+
+type OperationTokenDimension = "navigation" | "visibleCommit" | "graphVersion" | "cacheVariant";
+
+export type OperationTokenRejectionReason =
+  | "staleNavigation"
+  | "staleVisibleCommit"
+  | "graphVersionMismatch"
+  | "graphVersionMissing"
+  | "cacheVariantMismatch"
+  | "cacheVariantMissing";
+
+export type OperationTokenVerdict =
+  | { readonly authorized: true; readonly token: VerifiedOperationToken }
+  | { readonly authorized: false; readonly reason: OperationTokenRejectionReason };
+
+// Per-dimension verification policy. `check` is the set of dimensions a boundary
+// evaluates; `require` is the subset whose authority fact must be present.
+//
+// The two-level shape is deliberate, not redundant: a *checked* dimension that
+// is absent is tolerated (low-context paths must keep working), but a *required*
+// dimension that is absent fails closed. Absence must never silently become
+// permission — that is how proof systems rot. Required-but-absent is reserved
+// for the future segment-cache / BFCache write boundaries (PR 6/7), where a
+// forgotten fingerprint must reject.
+export type OperationTokenVerificationPolicy = {
+  check: readonly OperationTokenDimension[];
+  require: readonly OperationTokenDimension[];
+};
+
+// Fixed evaluation order so the reported rejection reason is deterministic
+// regardless of the order a caller lists `check`.
+const DIMENSION_ORDER: readonly OperationTokenDimension[] = [
+  "navigation",
+  "visibleCommit",
+  "graphVersion",
+  "cacheVariant",
+];
+
+type DimensionStatus =
+  | { kind: "satisfied" }
+  | { kind: "mismatch"; reason: OperationTokenRejectionReason }
+  | { kind: "absent"; missingReason: OperationTokenRejectionReason };
+
+function evaluateDimension(
+  dimension: OperationTokenDimension,
+  token: OperationToken,
+  authority: OperationTokenAuthority,
+): DimensionStatus {
+  switch (dimension) {
+    case "navigation":
+      // navigationId is always present (a number), so this dimension is never absent.
+      return token.navigationId === authority.activeNavigationId
+        ? { kind: "satisfied" }
+        : { kind: "mismatch", reason: "staleNavigation" };
+    case "visibleCommit":
+      return token.baseVisibleCommitVersion === authority.visibleCommitVersion
+        ? { kind: "satisfied" }
+        : { kind: "mismatch", reason: "staleVisibleCommit" };
+    case "graphVersion": {
+      if (token.graphVersion === null || authority.graphVersion === null) {
+        return { kind: "absent", missingReason: "graphVersionMissing" };
+      }
+      return token.graphVersion === authority.graphVersion
+        ? { kind: "satisfied" }
+        : { kind: "mismatch", reason: "graphVersionMismatch" };
+    }
+    case "cacheVariant": {
+      const tokenVariant = token.cacheVariantFingerprint;
+      const installedVariant = authority.installedCacheVariantFingerprint;
+      if (tokenVariant === undefined || installedVariant === null) {
+        return { kind: "absent", missingReason: "cacheVariantMissing" };
+      }
+      return tokenVariant === installedVariant
+        ? { kind: "satisfied" }
+        : { kind: "mismatch", reason: "cacheVariantMismatch" };
+    }
+    default: {
+      const _exhaustive: never = dimension;
+      throw new Error("[vinext] Unknown operation-token dimension: " + String(_exhaustive));
+    }
+  }
+}
+
+export function verifyOperationToken(
+  token: OperationToken,
+  authority: OperationTokenAuthority,
+  policy: OperationTokenVerificationPolicy,
+): OperationTokenVerdict {
+  const required = new Set(policy.require);
+  // A required dimension is always evaluated, even if a caller forgot to also
+  // list it in `check`. Requiring a dimension you never evaluate would let its
+  // absence pass silently — the exact failure mode this two-level policy exists
+  // to prevent — so `require` implies evaluation.
+  const evaluated = new Set([...policy.check, ...policy.require]);
+
+  for (const dimension of DIMENSION_ORDER) {
+    if (!evaluated.has(dimension)) continue;
+    const status = evaluateDimension(dimension, token, authority);
+    if (status.kind === "mismatch") {
+      return { authorized: false, reason: status.reason };
+    }
+    if (status.kind === "absent" && required.has(dimension)) {
+      return { authorized: false, reason: status.missingReason };
+    }
+  }
+
+  // The verifier is the only place that mints the verified brand: the raw token
+  // is evidence, the returned token is proof.
+  return { authorized: true, token: token as VerifiedOperationToken };
+}
+
+// Commit eligibility. Commits gate on the lifecycle dimensions the browser owns
+// (which navigation is active, which visible commit it started from). They do
+// not gate on cache variant, and graph-version enforcement for commits remains
+// the RSC artifact-compatibility path's job — so neither is checked here.
+export function verifyOperationTokenForCommit(
+  token: OperationToken,
+  authority: Pick<OperationTokenAuthority, "activeNavigationId" | "visibleCommitVersion">,
+): OperationTokenVerdict {
+  return verifyOperationToken(
+    token,
+    {
+      activeNavigationId: authority.activeNavigationId,
+      visibleCommitVersion: authority.visibleCommitVersion,
+      // Unchecked for commits; echo the token so the facts are consistent.
+      graphVersion: token.graphVersion,
+      installedCacheVariantFingerprint: token.cacheVariantFingerprint ?? null,
+    },
+    { check: ["navigation", "visibleCommit"], require: ["navigation", "visibleCommit"] },
+  );
+}
+
+// Cache-reuse eligibility. Reuse gates on the payload-vs-installed dimensions the
+// planner owns: the graph version the proof was produced under and the cache
+// variant that produced it. Both are tolerated when absent today (the route
+// manifest may be null; segment cache variant keys arrive in PR 7) and reject
+// only on genuine divergence — behavior-preserving for current single-document
+// reuse, a real guard once cross-document/segment reuse can diverge.
+export function verifyOperationTokenForCacheReuse(
+  token: OperationToken,
+  authority: Pick<OperationTokenAuthority, "graphVersion" | "installedCacheVariantFingerprint">,
+): OperationTokenVerdict {
+  return verifyOperationToken(
+    token,
+    {
+      // Unchecked for cache reuse; echo the token so the lifecycle facts are
+      // consistent (the pre-planner commit gate already owns those dimensions).
+      activeNavigationId: token.navigationId,
+      visibleCommitVersion: token.baseVisibleCommitVersion,
+      graphVersion: authority.graphVersion,
+      installedCacheVariantFingerprint: authority.installedCacheVariantFingerprint,
+    },
+    { check: ["graphVersion", "cacheVariant"], require: [] },
+  );
+}

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -288,6 +288,7 @@ function createOperationToken(overrides: Partial<OperationToken> = {}): Operatio
     deploymentVersion: null,
     graphVersion: null,
     lane: "navigation",
+    navigationId: 1,
     operationId: 7,
     targetSnapshotFingerprint: "route:/dashboard|root:/",
     ...overrides,
@@ -429,10 +430,12 @@ function planFlightResponseFromSnapshots(options: {
   lane?: OperationToken["lane"];
   routeManifest?: RouteManifest | null;
   targetSnapshot: RouteSnapshot;
+  tokenGraphVersion?: string | null;
   traceFields?: NavigationPlannerState["traceFields"];
 }): NavigationDecision {
   const token = createOperationToken({
     lane: options.lane ?? "navigation",
+    ...(options.tokenGraphVersion !== undefined ? { graphVersion: options.tokenGraphVersion } : {}),
     targetSnapshotFingerprint: `${options.targetSnapshot.routeId}|root:${
       options.targetSnapshot.rootBoundaryId ?? "unknown"
     }`,
@@ -612,6 +615,76 @@ describe("navigationPlanner root-boundary decisions", () => {
         startedVisibleCommitVersion: 2,
       },
     });
+  });
+
+  it("hard navigates a proven cache entry whose token graph version no longer matches the route graph", () => {
+    // Commits and cache reuse share the OperationToken authority: a proven cache
+    // entry may only be reused under the graph version it was produced for. A
+    // token minted under a stale graph version must not reuse a cache entry
+    // against a newer route graph — it hard navigates and refetches.
+    const currentSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/profile",
+      matchedUrl: "/dashboard/profile",
+      routeId: "route:/dashboard/profile",
+    };
+    const targetSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      cacheEntryReuseProof: createAcceptedStaticLayoutCacheEntryReuseProof(),
+      currentSnapshot,
+      targetSnapshot,
+      // The test manifest declares graphVersion "graph:test".
+      tokenGraphVersion: "graph:stale",
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected a stale-graph cache reuse to hard navigate");
+    }
+    expect(decision.reason).toBe("cacheReuseTokenRejected");
+    expect(decision.url).toBe("https://example.com/dashboard/settings");
+    expect(decision.trace.entries[0]).toEqual({
+      code: NavigationTraceReasonCodes.cacheReuseTokenRejected,
+      fields: {
+        cacheReuseTokenReason: "graphVersionMismatch",
+        currentRootLayoutTreePath: "/",
+        currentVisibleCommitVersion: 2,
+        nextRootLayoutTreePath: "/",
+        startedVisibleCommitVersion: 2,
+      },
+    });
+  });
+
+  it("commits a proven cache entry when its token graph version still matches the route graph", () => {
+    // The cache-reuse token gate must not disturb the normal proven-reuse path:
+    // a token minted under the installed graph version commits as before.
+    const currentSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/profile",
+      matchedUrl: "/dashboard/profile",
+      routeId: "route:/dashboard/profile",
+    };
+    const targetSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot("/"),
+      displayUrl: "https://example.com/dashboard/settings",
+      matchedUrl: "/dashboard/settings",
+      routeId: "route:/dashboard/settings",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      cacheEntryReuseProof: createAcceptedStaticLayoutCacheEntryReuseProof(),
+      currentSnapshot,
+      targetSnapshot,
+      tokenGraphVersion: "graph:test",
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
   });
 
   it("hard-navigates cross-root flight responses", () => {

--- a/tests/operation-token.test.ts
+++ b/tests/operation-token.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  verifyOperationToken,
+  verifyOperationTokenForCacheReuse,
+  verifyOperationTokenForCommit,
+  type OperationToken,
+  type OperationTokenAuthority,
+  type VerifiedOperationToken,
+} from "../packages/vinext/src/server/operation-token.js";
+
+function createToken(overrides: Partial<OperationToken> = {}): OperationToken {
+  return {
+    operationId: 7,
+    lane: "navigation",
+    navigationId: 3,
+    baseVisibleCommitVersion: 2,
+    graphVersion: "graph:test",
+    deploymentVersion: null,
+    targetSnapshotFingerprint: "route:/dashboard|root:/",
+    ...overrides,
+  };
+}
+
+function createAuthority(
+  overrides: Partial<OperationTokenAuthority> = {},
+): OperationTokenAuthority {
+  return {
+    activeNavigationId: 3,
+    visibleCommitVersion: 2,
+    graphVersion: "graph:test",
+    installedCacheVariantFingerprint: null,
+    ...overrides,
+  };
+}
+
+// Compile-time assertion that the verified token narrows to the branded type.
+function consumeVerified(_token: VerifiedOperationToken): void {}
+
+describe("verifyOperationTokenForCommit", () => {
+  it("authorizes when the navigation and visible-commit dimensions match", () => {
+    const token = createToken();
+    const verdict = verifyOperationTokenForCommit(token, createAuthority());
+
+    expect(verdict.authorized).toBe(true);
+    if (verdict.authorized) {
+      // Same evidence object, now carrying the verified brand.
+      expect(verdict.token).toBe(token);
+      consumeVerified(verdict.token);
+    }
+  });
+
+  it("rejects staleNavigation when the token started under a superseded navigation", () => {
+    const verdict = verifyOperationTokenForCommit(
+      createToken({ navigationId: 3 }),
+      createAuthority({ activeNavigationId: 4 }),
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "staleNavigation" });
+  });
+
+  it("rejects staleVisibleCommit when visible state advanced after the operation started", () => {
+    const verdict = verifyOperationTokenForCommit(
+      createToken({ baseVisibleCommitVersion: 2 }),
+      createAuthority({ visibleCommitVersion: 3 }),
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "staleVisibleCommit" });
+  });
+
+  it("reports staleNavigation first when both navigation and visible commit diverge", () => {
+    const verdict = verifyOperationTokenForCommit(
+      createToken({ navigationId: 3, baseVisibleCommitVersion: 2 }),
+      createAuthority({ activeNavigationId: 4, visibleCommitVersion: 3 }),
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "staleNavigation" });
+  });
+
+  it("does not gate commits on the cache-variant or graph-version dimensions", () => {
+    // A commit eligibility check must not reject on cache/graph divergence; that
+    // authority belongs to the cache-reuse boundary and the RSC compatibility path.
+    const verdict = verifyOperationTokenForCommit(
+      createToken({ graphVersion: "graph:stale", cacheVariantFingerprint: "cv:stale" }),
+      createAuthority({
+        graphVersion: "graph:fresh",
+        installedCacheVariantFingerprint: "cv:fresh",
+      }),
+    );
+
+    expect(verdict.authorized).toBe(true);
+  });
+});
+
+describe("verifyOperationTokenForCacheReuse", () => {
+  it("authorizes reuse when the graph version matches the installed graph", () => {
+    const verdict = verifyOperationTokenForCacheReuse(createToken({ graphVersion: "graph:a" }), {
+      graphVersion: "graph:a",
+      installedCacheVariantFingerprint: null,
+    });
+
+    expect(verdict.authorized).toBe(true);
+  });
+
+  it("rejects graphVersionMismatch when the proof was produced under a different graph", () => {
+    const verdict = verifyOperationTokenForCacheReuse(createToken({ graphVersion: "graph:a" }), {
+      graphVersion: "graph:b",
+      installedCacheVariantFingerprint: null,
+    });
+
+    expect(verdict).toEqual({ authorized: false, reason: "graphVersionMismatch" });
+  });
+
+  it("tolerates an absent graph version rather than rejecting low-context reuse", () => {
+    const verdict = verifyOperationTokenForCacheReuse(createToken({ graphVersion: null }), {
+      graphVersion: null,
+      installedCacheVariantFingerprint: null,
+    });
+
+    expect(verdict.authorized).toBe(true);
+  });
+
+  it("rejects cacheVariantMismatch when the installed variant differs from the proof", () => {
+    const verdict = verifyOperationTokenForCacheReuse(
+      createToken({ graphVersion: "graph:a", cacheVariantFingerprint: "cv:a" }),
+      { graphVersion: "graph:a", installedCacheVariantFingerprint: "cv:b" },
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "cacheVariantMismatch" });
+  });
+
+  it("tolerates an absent cache-variant fingerprint until segment cache supplies it", () => {
+    const verdict = verifyOperationTokenForCacheReuse(
+      createToken({ graphVersion: "graph:a", cacheVariantFingerprint: undefined }),
+      { graphVersion: "graph:a", installedCacheVariantFingerprint: "cv:b" },
+    );
+
+    expect(verdict.authorized).toBe(true);
+  });
+
+  it("reports graphVersionMismatch before cacheVariantMismatch when both diverge", () => {
+    const verdict = verifyOperationTokenForCacheReuse(
+      createToken({ graphVersion: "graph:a", cacheVariantFingerprint: "cv:a" }),
+      { graphVersion: "graph:b", installedCacheVariantFingerprint: "cv:b" },
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "graphVersionMismatch" });
+  });
+});
+
+describe("verifyOperationToken required dimensions", () => {
+  it("fails closed when a required dimension's authority fact is absent", () => {
+    // Future segment-cache writes will require the cache-variant dimension. A
+    // forgotten fingerprint must reject, not silently pass: absence is not
+    // permission.
+    const verdict = verifyOperationToken(
+      createToken({ cacheVariantFingerprint: undefined }),
+      createAuthority({ installedCacheVariantFingerprint: null }),
+      { check: ["cacheVariant"], require: ["cacheVariant"] },
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "cacheVariantMissing" });
+  });
+
+  it("rejects a required-but-absent graph version with graphVersionMissing", () => {
+    const verdict = verifyOperationToken(
+      createToken({ graphVersion: null }),
+      createAuthority({ graphVersion: "graph:test" }),
+      { check: ["graphVersion"], require: ["graphVersion"] },
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "graphVersionMissing" });
+  });
+
+  it("skips an unchecked dimension entirely even when it diverges", () => {
+    const verdict = verifyOperationToken(
+      createToken({ graphVersion: "graph:a" }),
+      createAuthority({ graphVersion: "graph:b" }),
+      { check: ["navigation"], require: ["navigation"] },
+    );
+
+    expect(verdict.authorized).toBe(true);
+  });
+
+  it("evaluates a required dimension even when it is omitted from check", () => {
+    // require implies evaluation: a dimension you require but forget to list in
+    // check must still be verified, never silently waved through.
+    const verdict = verifyOperationToken(
+      createToken({ graphVersion: "graph:a" }),
+      createAuthority({ graphVersion: "graph:b" }),
+      { check: ["navigation"], require: ["graphVersion"] },
+    );
+
+    expect(verdict).toEqual({ authorized: false, reason: "graphVersionMismatch" });
+  });
+});


### PR DESCRIPTION
> **Stacked on #2008** (the `V0`-suffix rename). This draft currently shows that rename commit as well; once #2008 merges, this branch rebases onto `main` and the diff becomes logic-only. Review the second commit (`feat(navigation): promote OperationToken…`) for the actual change. Cross-fork PRs can't target a fork branch as base, hence the stack note rather than a base of #2008.

## What this changes

Promotes `OperationToken` from a passively-carried struct into the **single proof-of-eligibility authority** for App Router client navigation. The token now verifies whether a navigation result may enter commit approval or cache reuse; `ApprovedVisibleCommit` remains the separate proof-of-mutation object. This is **PR 5** of the navigation architecture work tracked in #1790.

A new `server/operation-token.ts` module owns the token type and `verifyOperationToken` — a pure verifier over four dimensions (active-navigation, visible-commit, graph-version, cache-variant) returning a branded `VerifiedOperationToken` on success.

## Why

The token threaded through every `NavigationDecision` but only its `lane` field was ever read. The authority it was *meant* to own lived inline elsewhere:

- The commit-staleness gate (`resolvePendingNavigationCommitDispositionDecision`) was a raw boolean — `startedNavigationId !== activeNavigationId || startedVisibleCommitVersion !== visibleCommitVersion` — evaluated *before* the token was even built.
- Cache reuse was gated separately, in its own universe.
- The token carried `operationId` (a per-render counter) but **no navigation id**, so it literally could not answer *"does this result belong to the active navigation?"*

So traversal, refresh, intercepted routes, redirects, and cache reuse did not share one authority model — exactly the split-brain #1790 calls out.

## Approach

- **`navigationId` on the token** (sourced from `startedNavigationId`) supplies the missing active-navigation fact.
- **Commit gate routed through `verifyOperationTokenForCommit`**, inline boolean deleted in the same change. The `staleOperation` skip + trace are byte-identical. `planPendingRootBoundaryFlightResponse` now requires the `VerifiedOperationToken` brand, making *verify-before-plan* a compile-time guarantee rather than a control-flow convention.
- **Cache reuse shares the authority**: `planFlightResponseArrived` gates an *accepted* cache-entry reuse decision through `verifyOperationTokenForCacheReuse`, hard-navigating (`cacheReuseTokenRejected`) when the proof's graph version no longer matches the installed route graph.
- **Absence is not permission**: a *checked* dimension tolerates an absent authority fact (low-context paths keep working), but a *required* one fails closed, and `require` implies evaluation. This is the fail-closed contract segment-cache / BFCache writes need in PR 6/7.

### Scope boundaries (non-goals)

- Behavior-preserving today. The cache-variant dimension ships in the verifier (unit-tested) but its live data feed is **PR 7** (segment cache variant keys); the planner passes `installedCacheVariantFingerprint: null` so that dimension stays dormant rather than comparing the token to itself.
- The graph-version cache-reuse guard cannot reject in the single-document flow (the token's `graphVersion` is minted from the same manifest the planner verifies against). It activates once cross-document / segment reuse (PR 6/7) can carry a diverged graph version.
- BFCache identity consumer is **PR 6**. This PR establishes the authority "before any new cache behavior", per the issue's start-order.

## Validation

- `tests/operation-token.test.ts` (new, 15 tests): every verdict dimension, the `VerifiedOperationToken` brand, the absent-vs-mismatch split, deterministic check order, and the `require ⇒ evaluate` fail-closed contract.
- `tests/navigation-planner.test.ts`: two new tests cover the cache-reuse graph-version seam (stale graph → `cacheReuseTokenRejected`; matching graph → commits unchanged).
- Existing `app-browser-entry.test.ts` (8 `staleOperation` assertions) and the full `navigation-planner` suite stay green, proving the gate refactor preserved behavior.
- `vp check` (format, type-aware lint, knip) green; pre-commit full check + staged tests green.

## Risks / follow-ups

- `cacheReuseTokenRejected` is a new hard-navigation cause that cannot fire in the current single-document flow; first real activation is PR 6/7, which should add cross-document divergence coverage.
- PR 6 (BFCache identity on the route graph) and PR 7 (segment cache) consume this authority: PR 6 supplies the BFCache write boundary, PR 7 supplies the real `cacheVariantFingerprint` + the segment-cache-write boundary (`require: ["cacheVariant"]`).

Refs #1790.