### PR TITLE
fix(router): share Pages Router context across chunks

### DIFF
--- a/packages/vinext/src/shims/internal/router-context.ts
+++ b/packages/vinext/src/shims/internal/router-context.ts
@@ -4,7 +4,17 @@
  * Used by: some testing utilities and older libraries.
  * Provides the Pages Router context.
  */
-import { createContext } from "react";
+import { createContext, type Context } from "react";
 import type { NextRouter } from "../router";
 
-export const RouterContext = createContext<NextRouter | null>(null);
+const ROUTER_CONTEXT_KEY = Symbol.for("vinext.routerContext");
+
+type RouterContextGlobal = typeof globalThis & {
+  [ROUTER_CONTEXT_KEY]?: Context<NextRouter | null>;
+};
+
+const globalState = globalThis as RouterContextGlobal;
+
+export const RouterContext =
+  globalState[ROUTER_CONTEXT_KEY] ??
+  (globalState[ROUTER_CONTEXT_KEY] = createContext<NextRouter | null>(null));

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -20931,6 +20931,16 @@ describe("default-locale path normalisation (issue #1336, item 4)", () => {
 // runtime object rather than in module-local variables.
 // ---------------------------------------------------------------------------
 describe("Pages Router runtime state sharing", () => {
+  it("shares RouterContext across duplicated next/router module instances", async () => {
+    vi.resetModules();
+    const contextA = await import("../packages/vinext/src/shims/internal/router-context.js");
+
+    vi.resetModules();
+    const contextB = await import("../packages/vinext/src/shims/internal/router-context.js");
+
+    expect(contextB.RouterContext).toBe(contextA.RouterContext);
+  });
+
   it("shares router readiness across duplicated next/router module instances", async () => {
     const previousWindow = (globalThis as any).window;
     const win: any = {


### PR DESCRIPTION
## Summary

- share the Pages Router `RouterContext` across duplicated client-entry/page-chunk module instances
- restore reactive `router.isReady` updates for Pages Router pages rendered through the App Router hooks fixture
- add a focused duplicate-module context identity regression test

## CI regression

This fixes a newly failing deploy-suite delta between:

- good: [Actions run 27465595080](https://github.com/cloudflare/vinext/actions/runs/27465595080), SHA `5ace0db7ac49a3ea3317f682370085fea85e6d37`
- bad: [Actions run 27486658985](https://github.com/cloudflare/vinext/actions/runs/27486658985), SHA `de9d03a84688aebf1ece90a2bc83353960820112`

The affected upstream test is `test/e2e/app-dir/hooks/hooks.test.ts`, specifically the `/adapter-hooks/static` and `/adapter-hooks/1/account` cases timing out while waiting for `#router-ready`.

## Endpoint independence

This failure is unrelated to `next-data-api-endpoint.vercel.app`:

- the complete pinned fixture directory `test/e2e/app-dir/hooks` contains no `next-data-api-endpoint.vercel.app`, `vercel.app`, or HTTP URL references
- the deployment succeeds and the test reaches local browser assertions after hydration
- both failures are local `router.isReady` assertion timeouts, not fetch, deployment, or shared-server cascades

I excluded the middleware method-forwarding and rewrite-body candidates because their fixtures directly call the Vercel endpoint. I also excluded the segment-cache candidate because it failed locally at the declared good SHA.

## Root cause

`4baf85ad` made the Pages Router wrapper component types and readiness state shared across duplicated `next/router` bundles, but `RouterContext` stayed module-local. An HTML-fallback page chunk could therefore read a different context from the shared provider and fall back to the non-reactive singleton. Deferred-ready routes stayed at `isReady=false` even after the shared readiness bit flipped.

This patch gives the Pages Router context the same symbol-keyed shared identity strategy already used by the App Router contexts. It does not change readiness semantics.

## Next.js parity

Verified against pinned Next.js `v16.2.6` / `ee6e79b1792a4d401ddf2480f40a83549fe8e722`:

- [`packages/next/src/shared/lib/router/router.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/shared/lib/router/router.ts#L818-L827) defines the initial `isReady` predicate
- [`test/integration/router-is-ready/test/index.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/integration/router-is-ready/test/index.test.ts#L40-L77) covers immediate GSSP/GSP readiness and delayed GSP readiness with queries
- [`test/e2e/app-dir/hooks/hooks.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/hooks/hooks.test.ts#L8-L30) requires the Pages Router hook to reach ready state

## Local reproduction

Fresh disposable Next.js checkout, Node 24, Next.js pinned to `ee6e79b1792a4d401ddf2480f40a83549fe8e722`:

```bash
env -u VINEXT_BUILD \
  NEXTJS_PREPARE=0 \
  NEXT_TEST_CONCURRENCY=1 \
  vp env exec --node 24 -- \
  ./scripts/run-nextjs-deploy-suite.sh /tmp/nextjs-v16.2.6-20260614-153154 \
  --retries 0 -c 1 --debug \
  test/e2e/app-dir/hooks/hooks.test.ts
```

Results:

- good SHA `5ace0db7`: vinext built, deployment succeeded, 26/26 passed
- bad SHA `de9d03a8`: vinext built, deployment succeeded, 2 failed / 24 passed with matching `#router-ready` timeouts
- boundary: `d1a80cd6` passes; `4baf85ad` fails the same two assertions
- fixed branch: vinext built, deployment succeeded, 26/26 passed

## Validation

```bash
vp check packages/vinext/src/shims/internal/router-context.ts tests/shims.test.ts
vp test run tests/shims.test.ts
```

- scoped format/lint/type checks pass
- 1,086/1,086 shim tests pass
- exact deploy-suite probe passes 26/26
