### PR TITLE
fix(routing): re-encode trailing-slash Location for non-Latin-1 paths

### DIFF
--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -328,9 +328,30 @@ export function normalizeTrailingSlash(
   }
   const normalizedPathname = normalizeTrailingSlashPathname(pathname, trailingSlash);
   if (normalizedPathname === null) return null;
+  // `pathname` arrives segment-wise percent-decoded with path delimiters
+  // already re-encoded (see app-rsc-request-normalization → encodePathDelimiters,
+  // which leaves `%23 %3F %2F %5C` in place). It can still carry raw spaces or
+  // characters above U+00FF (e.g. CJK slugs, emoji). Those must be encoded
+  // before building the Location: an un-encoded space is a malformed redirect
+  // target, and a non-Latin-1 character makes the Headers constructor throw
+  // 'Cannot convert argument to a ByteString' (→ 500 instead of 308).
+  // Percent-encode every character that is not a valid RFC 3986 path character,
+  // i.e. everything outside `pchar`/`/`. We deliberately keep `%` in the safe
+  // set so existing `%xx` escapes are preserved rather than double-encoded
+  // (`encodeURI` would wrongly turn `%23` into `%2523`). Sub-delimiters
+  // (`!$&'()*+,;=`) and `:@` are valid `pchar` and are left raw, matching
+  // Next.js — `+` in particular only carries space semantics in the query
+  // string, which we leave untouched. The `u` flag makes the regex match
+  // astral code points whole, so emoji surrogate pairs aren't split. The query
+  // string comes verbatim from the request URL and is already encoded, so it
+  // must not be re-encoded here. Refs cloudflare/vinext#1979
+  const encodedPathname = normalizedPathname.replace(
+    /[^A-Za-z0-9\-._~!$&'()*+,;=:@/%]/gu,
+    encodeURIComponent,
+  );
   return new Response(null, {
     status: 308,
-    headers: { Location: basePath + normalizedPathname + search },
+    headers: { Location: basePath + encodedPathname + search },
   });
 }
 

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -440,6 +440,56 @@ describe("normalizeTrailingSlash", () => {
     expect(res).not.toBeNull();
     expect(res!.status).toBe(404);
   });
+
+  // Regression coverage for issue #1979 — the Location is built from the
+  // already percent-decoded pathname. A character above U+00FF (e.g. a CJK
+  // slug) makes `new Response(..., { headers: { Location } })` throw
+  // TypeError 'Cannot convert argument to a ByteString' in Workers/undici,
+  // which surfaces as a 500 instead of a 308. Latin-1 chars like spaces do
+  // not throw but emit a malformed, un-percent-encoded Location.
+  // Refs cloudflare/vinext#1979
+  it("percent-encodes non-Latin-1 pathnames in the Location instead of throwing", () => {
+    const res = normalizeTrailingSlash("/日本", "", true, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(308);
+    expect(res!.headers.get("Location")).toBe("/%E6%97%A5%E6%9C%AC/");
+  });
+
+  it("percent-encodes spaces in the redirect Location", () => {
+    const res = normalizeTrailingSlash("/about us", "", true, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(308);
+    expect(res!.headers.get("Location")).toBe("/about%20us/");
+  });
+
+  // The pathname reaches us with path delimiters already re-encoded
+  // (encodePathDelimiters in routing/utils.ts turns `# ? / \` into
+  // `%23 %3F %2F %5C`). The redirect encoder must NOT re-encode the `%`
+  // of those sequences, otherwise `/foo%23bar` becomes `/foo%2523bar`.
+  it("does not double-encode already-encoded delimiters in the Location", () => {
+    const res = normalizeTrailingSlash("/foo%23bar", "", true, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(308);
+    expect(res!.headers.get("Location")).toBe("/foo%23bar/");
+  });
+
+  // Astral characters (emoji) are surrogate pairs in UTF-16; the encoder
+  // must treat them as whole code points, not encode each surrogate half.
+  it("percent-encodes astral characters (emoji) without mangling surrogates", () => {
+    const res = normalizeTrailingSlash("/😀", "", true, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(308);
+    expect(res!.headers.get("Location")).toBe("/%F0%9F%98%80/");
+  });
+
+  // Printable-ASCII characters that RFC 3986 forbids raw in a path (e.g. `<>"`)
+  // must be percent-encoded in the Location, not echoed verbatim.
+  it("percent-encodes reserved ASCII characters that are invalid raw in a path", () => {
+    const res = normalizeTrailingSlash('/a<b>"c', "", true, "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(308);
+    expect(res!.headers.get("Location")).toBe("/a%3Cb%3E%22c/");
+  });
 });
 
 // ── validateCsrfOrigin ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Percent-encode the trailing-slash redirect target before building the `Location` header, so paths containing characters above U+00FF (CJK slugs, emoji) no longer crash the `Headers` constructor.
- Encode every character that is invalid raw in an RFC 3986 path while keeping existing `%xx` escapes and `/` delimiters intact, so already-encoded delimiters such as `%23` are not double-encoded (a naive `encodeURI` would turn `%23` into `%2523`).
- Add unit regression coverage in `tests/request-pipeline.test.ts` for non-Latin-1 slugs, emoji (astral/surrogate pairs), spaces, already-encoded delimiters, and reserved ASCII.

## Root Cause

`normalizeTrailingSlash` built the redirect `Location` as `basePath + normalizedPathname + search`, where `normalizedPathname` arrives **already percent-decoded** (see `app-rsc-request-normalization` → `normalizePathnameForRouteMatchStrict`, which `decodeURIComponent`s each segment and only re-encodes the path delimiters `# ? / \`).

For any path with a character above U+00FF — e.g. `/日本` or an emoji under `trailingSlash: true` — `new Response(null, { headers: { Location: "/日本/" } })` throws `TypeError: Cannot convert argument to a ByteString` in the Workers/undici `Headers` implementation (which only accepts ByteStrings, code points ≤ 0xFF). The throw is caught by the outer handler and surfaces as a **500 Internal Server Error** instead of the expected **308**, making the page unreachable. Latin-1 characters such as spaces did not throw but emitted a malformed, un-percent-encoded `Location` like `/about us/`.

The fix re-encodes the redirect target. `encodeURI` is the wrong tool here because it escapes `%`, double-encoding the delimiter sequences the upstream normalizer deliberately left in place. Instead we encode against an RFC 3986 path allowlist, preserving `%` and `/`:

```ts
normalizedPathname.replace(/[^A-Za-z0-9\-._~!$&'()*+,;=:@/%]/gu, encodeURIComponent)
```

The `u` flag makes the regex match astral code points whole, so emoji surrogate pairs are not split into lone surrogates. Control characters (CR/LF/NUL) fall outside the allowlist and are encoded as well, hardening the redirect against header injection. The query string is taken verbatim from the request URL (already encoded) and is intentionally not re-encoded.

## References

- Issue: https://github.com/cloudflare/vinext/issues/1979
- Next.js trailing-slash behavior (parity reference): https://github.com/vercel/next.js/blob/canary/test/e2e/trailing-slashes/with-trailing-slash.test.ts
- RFC 3986 §3.3 (path `pchar` grammar): https://www.rfc-editor.org/rfc/rfc3986#section-3.3

## Verification

- `pnpm test tests/request-pipeline.test.ts` — 102 passed (5 new regression cases for #1979)
- `npx vp check packages/vinext/src/server/request-pipeline.ts tests/request-pipeline.test.ts` — format, lint, types clean
