### PR TITLE
fix(pages): preserve module identity with deployment ids

### DIFF
--- a/packages/vinext/src/server/pages-asset-tags.ts
+++ b/packages/vinext/src/server/pages-asset-tags.ts
@@ -65,17 +65,14 @@ export function resolveClientModuleUrl(
   moduleId: string | null | undefined,
   basePath = "",
   assetPrefix = "",
-  deploymentId?: string,
+  _deploymentId?: string,
 ): string | undefined {
   const files = getManifestFilesForModule(resolveSsrManifest(manifest), moduleId);
   if (!files) return undefined;
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     if (!file || !file.endsWith(".js")) continue;
-    return appendDeploymentIdQuery(
-      assetServingUrlFromBaseAnchored(file, basePath, assetPrefix),
-      deploymentId,
-    );
+    return assetServingUrlFromBaseAnchored(file, basePath, assetPrefix);
   }
   return undefined;
 }
@@ -148,11 +145,14 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   // no assetPrefix this is the legacy `"/" + value`.
   const basePath = options.basePath ?? "";
   const assetPrefix = options.assetPrefix ?? "";
-  const href = (value: string): string =>
-    appendDeploymentIdQuery(
-      assetServingUrlFromBaseAnchored(value, basePath, assetPrefix),
-      options.deploymentId,
-    );
+  const href = (value: string): string => {
+    const url = assetServingUrlFromBaseAnchored(value, basePath, assetPrefix);
+    // Native ESM resolves relative imports without inheriting the importing
+    // module's query string. Querying Pages JavaScript entries therefore gives
+    // the entry and its imports different module identities, which can execute
+    // the hydration bootstrap twice when a lazy page chunk imports shared code.
+    return value.endsWith(".js") ? url : appendDeploymentIdQuery(url, options.deploymentId);
+  };
 
   // Load the set of lazy chunk filenames (only reachable via dynamic imports).
   // These should NOT get <link rel="modulepreload"> or <script type="module">

--- a/tests/pages-asset-tags.test.ts
+++ b/tests/pages-asset-tags.test.ts
@@ -110,9 +110,9 @@ describe("resolveClientModuleUrl", () => {
     expect(resolveClientModuleUrl(m, "page.tsx")).toBeUndefined();
   });
 
-  it("appends the deployment ID to client module URLs", () => {
+  it("preserves native ESM identity for client module URLs", () => {
     const m = makeManifest({ "page.tsx": ["page.js"] });
-    expect(resolveClientModuleUrl(m, "page.tsx", "", "", "dpl_123")).toBe("/page.js?dpl=dpl_123");
+    expect(resolveClientModuleUrl(m, "page.tsx", "", "", "dpl_123")).toBe("/page.js");
   });
 });
 
@@ -147,7 +147,7 @@ describe("collectAssetTags", () => {
 
   // Ported from Next.js: test/production/deployment-id-handling/deployment-id-handling.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/production/deployment-id-handling/deployment-id-handling.test.ts
-  it("appends the deployment ID to managed script and stylesheet URLs", () => {
+  it("keeps JavaScript unqueried while tagging managed stylesheets", () => {
     const result = collectAssetTags({
       manifest: makeManifest({ "page.tsx": ["style.css", "page.js"] }),
       moduleIds: ["page.tsx"],
@@ -156,8 +156,9 @@ describe("collectAssetTags", () => {
     });
 
     expect(result).toContain('href="/style.css?dpl=dpl_123"');
-    expect(result).toContain('href="/page.js?dpl=dpl_123"');
-    expect(result).toContain('src="/page.js?dpl=dpl_123"');
+    expect(result).toContain('href="/page.js"');
+    expect(result).toContain('src="/page.js"');
+    expect(result).not.toContain("page.js?dpl=");
   });
 
   it("emits modulepreload + script for js files", () => {


### PR DESCRIPTION
## Summary

- keep Pages Router JavaScript bootstrap, preload, page, and `_app` URLs on one native ESM identity when a deployment ID is configured
- retain `?dpl=` tagging for managed non-JavaScript assets such as CSS
- fix the pinned Next.js `middleware-general` client transition where a second queried client-entry module created a second React root and restored the old page after the destination committed

## Root cause

Instrumentation showed the destination `/blog/[slug]` component rendered and committed successfully on the original root. About 6 ms later, the Pages client entry evaluated again as the queried URL `index-*.js?dpl=...`, called `hydrateRoot` a second time on the same `#__next` container, overwrote `window.__VINEXT_ROOT__`, and rendered the original `/[id]` page.

The initial document bootstrap was unqueried while Pages page/module URLs were deployment-queried. Native ESM does not inherit query strings across relative imports, so queried and unqueried URLs formed duplicate module graphs. This applies PR #2005's existing module-identity rule to Pages Router asset tags.

## Validation

- pinned Next.js v16.2.6 `middleware-general/test/index.test.ts`, exact assertion only: with i18n PASS; without i18n PASS
- pinned Next.js v16.2.6 `middleware-general/test/node-runtime.test.ts`, exact assertion only: with i18n PASS; without i18n PASS
- `vp test run tests/pages-asset-tags.test.ts tests/build-optimization.test.ts tests/asset-prefix.test.ts`
- `vp test run tests/shims.test.ts -t "shares RouterContext across duplicated next/router module instances"`
- focused PR #1999 scroll traversal tests
- `vp run vinext#build`
- scoped `vp check`
