### PR TITLE
fix(prerender): surface thrown generateStaticParams/getStaticPaths errors

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -76,6 +76,32 @@ function getErrorMessageWithStack(err: Error): string {
   return err.stack || err.message;
 }
 
+// A user's generateStaticParams/getStaticPaths threw, surfaced by the prerender
+// endpoint as a 500. Distinct from transport/`fetch` failures (a crashed prod
+// server, connection reset) so only genuine user-function errors are marked
+// fatal to the build. Refs cloudflare/vinext#1982
+class PrerenderUserFunctionError extends Error {}
+
+// The prerender static-params / static-paths endpoints return the real error
+// thrown by a user's generateStaticParams/getStaticPaths as `{ error }` in a 500
+// body (app-prerender-endpoints.ts). Extract that message. For our JSON envelope
+// with a missing/empty/non-string `error`, return a generic message rather than
+// echoing the raw `{"error":""}` back; for a non-JSON body, use the raw text.
+// Refs cloudflare/vinext#1982
+function parsePrerenderEndpointError(text: string): string {
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown };
+    if (parsed && typeof parsed === "object" && "error" in parsed) {
+      return typeof parsed.error === "string" && parsed.error.length > 0
+        ? parsed.error
+        : "Unknown prerender endpoint error";
+    }
+  } catch {
+    // Non-JSON body — fall through to the raw text.
+  }
+  return text || "Unknown prerender endpoint error";
+}
+
 // ─── Public Types ─────────────────────────────────────────────────────────────
 
 export type PrerenderResult = {
@@ -113,6 +139,13 @@ export type PrerenderRouteResult =
       route: string;
       status: "error";
       error: string;
+      /**
+       * Set when the error must fail the build in ALL modes (default included),
+       * not just `output: 'export'`. Used for a thrown generateStaticParams /
+       * getStaticPaths, which Next.js treats as a fatal build error rather than a
+       * silently-skipped route. Refs cloudflare/vinext#1982
+       */
+      fatal?: true;
     };
 
 /** Called after each route is resolved (rendered, skipped, or error). */
@@ -639,6 +672,15 @@ export async function prerenderPages({
               );
               const text = await res.text();
               if (!res.ok) {
+                // A 500 carries the real error thrown by the user's getStaticPaths
+                // in the JSON body (app-prerender-endpoints.ts). Surface it so the
+                // route fails with the genuine message, matching Next.js — rather
+                // than swallowing it into a misleading no-static-params skip. Other
+                // statuses (e.g. 404 = disabled/stale secret) keep the warn-and-skip
+                // behavior. Refs cloudflare/vinext#1982
+                if (res.status === 500) {
+                  throw new PrerenderUserFunctionError(parsePrerenderEndpointError(text));
+                }
                 console.warn(
                   `[vinext] Warning: /__vinext/prerender/pages-static-paths returned ${res.status} for ${r.pattern}. ` +
                     `Dynamic paths will be skipped. This may indicate a stale or missing prerender secret.`,
@@ -719,7 +761,23 @@ export async function prerenderPages({
           continue;
         }
 
-        const pathsResult = await route.module.getStaticPaths({ locales: [], defaultLocale: "" });
+        // A throwing getStaticPaths (surfaced as a 500 by the proxy above)
+        // becomes a per-route 'error' with the real message instead of crashing
+        // the whole prerender, matching Next.js. Refs cloudflare/vinext#1982
+        let pathsResult: { paths?: Array<StaticPathsEntry>; fallback?: unknown } | undefined;
+        try {
+          pathsResult = await route.module.getStaticPaths({ locales: [], defaultLocale: "" });
+        } catch (e) {
+          results.push({
+            route: route.pattern,
+            status: "error",
+            error: `Failed to call getStaticPaths(): ${(e as Error).message}`,
+            // Only a thrown user getStaticPaths (a 500 from the endpoint) is fatal
+            // to the build; transport/fetch failures stay non-fatal. #1982
+            ...(e instanceof PrerenderUserFunctionError ? { fatal: true as const } : {}),
+          });
+          continue;
+        }
         const fallback = pathsResult?.fallback ?? false;
 
         if (mode === "export" && fallback !== false) {
@@ -1013,6 +1071,16 @@ export async function prerenderApp({
             });
             const text = await res.text();
             if (!res.ok) {
+              // A 500 carries the real error thrown by the user's
+              // generateStaticParams in the JSON body (app-prerender-endpoints.ts).
+              // Surface it so prerenderApp's catch records a per-route 'error' and
+              // the build fails with the genuine message, matching Next.js — rather
+              // than swallowing it into a misleading no-static-params skip. Other
+              // statuses (e.g. 404 = disabled/stale secret) keep the warn-and-skip
+              // behavior. Refs cloudflare/vinext#1982
+              if (res.status === 500) {
+                throw new PrerenderUserFunctionError(parsePrerenderEndpointError(text));
+              }
               console.warn(
                 `[vinext] Warning: /__vinext/prerender/static-params returned ${res.status} for ${pattern}. ` +
                   `Static params will be skipped. This may indicate a stale or missing prerender secret.`,
@@ -1227,6 +1295,9 @@ export async function prerenderApp({
             route: route.pattern,
             status: "error",
             error: `Failed to call generateStaticParams(): ${detail}`,
+            // Only a thrown user generateStaticParams (a 500 from the endpoint) is
+            // fatal to the build; transport/fetch failures stay non-fatal. #1982
+            ...(e instanceof PrerenderUserFunctionError ? { fatal: true as const } : {}),
           });
         }
       } else if (type === "unknown") {

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -133,6 +133,25 @@ type RunPrerenderOptions = {
  * If a required production bundle does not exist, an error is thrown directing
  * the user to run `vinext build` first.
  */
+/**
+ * Throw if any route is a `fatal` error (a thrown generateStaticParams /
+ * getStaticPaths). These fail the build in ALL modes — default included —
+ * matching `next build`, unlike intentionally-skipped dynamic/SSR routes and
+ * non-fatal errors (e.g. transport failures), which only fail under
+ * `output: 'export'`. Exported for direct unit testing. Refs cloudflare/vinext#1982
+ */
+export function assertNoFatalPrerenderRoutes(routes: readonly PrerenderRouteResult[]): void {
+  const fatalRoutes = routes.filter(
+    (r): r is Extract<PrerenderRouteResult, { status: "error" }> =>
+      r.status === "error" && r.fatal === true,
+  );
+  if (fatalRoutes.length === 0) return;
+  const fatalList = fatalRoutes.map((r) => `  ${r.route}: ${r.error}`).join("\n");
+  throw new Error(
+    `Prerender failed: ${fatalRoutes.length} route${fatalRoutes.length !== 1 ? "s" : ""} errored during static generation.\n${fatalList}`,
+  );
+}
+
 export async function runPrerender(options: RunPrerenderOptions): Promise<PrerenderResult | null> {
   const { root } = options;
 
@@ -337,6 +356,12 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   } finally {
     progress.finish(rendered, skipped, errors);
   }
+
+  // A thrown generateStaticParams/getStaticPaths is a fatal build error in ANY
+  // mode (default included), matching Next.js — unlike intentionally-skipped
+  // dynamic/SSR routes. These are flagged `fatal` by prerenderApp/prerenderPages.
+  // Refs cloudflare/vinext#1982
+  assertNoFatalPrerenderRoutes(allRoutes);
 
   // In export mode, any error route means the build should fail — the app
   // contains dynamic functionality that cannot be statically exported.

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -1072,6 +1072,188 @@ describe("runPrerender — hybrid app+pages (app-basic)", () => {
   });
 });
 
+describe("prerender — generateStaticParams/getStaticPaths errors (#1982)", () => {
+  // Ported from Next.js: test/production/app-dir/generate-static-params-errors/generate-static-params-errors.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/production/app-dir/generate-static-params-errors/generate-static-params-errors.test.ts
+  // Next.js surfaces the real generateStaticParams/getStaticPaths error and fails the build. vinext
+  // must not swallow the 500 returned by the static-params/static-paths endpoint into a misleading
+  // "stale or missing prerender secret" skip — the route must fail with the real error message.
+  //
+  // NOTE: these tests mock the prerender endpoint's HTTP response (the prod server here has no
+  // secret configured), so they exercise the build-side proxy's status branching, not the real
+  // app-prerender-endpoints.ts 500 path end-to-end. The endpoint's own behaviour (throw → 500 with
+  // `{ error }`) is covered by tests/app-prerender-endpoints.test.ts.
+  it("surfaces a thrown generateStaticParams error instead of silently skipping the route", async () => {
+    const root = tmpDir("vinext-prerender-gsp-error-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    const pageDir = path.join(appDir, "blog", "[slug]");
+    fs.mkdirSync(pageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pageDir, "page.tsx"),
+      "export default function Page() { return null; }\n",
+    );
+
+    // The static-params endpoint returns 500 with the real error in the body when
+    // the user's generateStaticParams throws (app-prerender-endpoints.ts).
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/__vinext/prerender/static-params") {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: "Error: boom from generateStaticParams" }));
+        return;
+      }
+      res.setHeader("content-type", "text/html");
+      res.end(
+        "<html><body>" +
+          runtimeRscChunkScript(`0:["$","div",null,{}]\n`) +
+          runtimeRscDoneScript() +
+          "</body></html>",
+      );
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({});
+
+      const result = await prerenderApp({
+        mode: "default",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      const route = result.routes.find((r) => r.route.includes("slug"));
+      // `fatal: true` makes run-prerender fail the build in default mode too,
+      // matching Next.js (not just a visible-but-non-fatal error). #1982
+      expect(route).toMatchObject({ status: "error", fatal: true });
+      if (route?.status !== "error") {
+        throw new Error("expected the throwing generateStaticParams route to fail prerender");
+      }
+      expect(route.error).toContain("boom from generateStaticParams");
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("still warn-skips (does not fail) when the static-params endpoint 404s (disabled/stale secret)", async () => {
+    const root = tmpDir("vinext-prerender-gsp-secret-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    const pageDir = path.join(appDir, "blog", "[slug]");
+    fs.mkdirSync(pageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pageDir, "page.tsx"),
+      "export default function Page() { return null; }\n",
+    );
+
+    // A 404 models the genuine disabled / stale-secret case (notFoundResponse),
+    // which must keep the warn-and-skip behavior rather than failing the build.
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/__vinext/prerender/static-params") {
+        res.statusCode = 404;
+        res.end("not found");
+        return;
+      }
+      res.setHeader("content-type", "text/html");
+      res.end(
+        "<html><body>" +
+          runtimeRscChunkScript(`0:["$","div",null,{}]\n`) +
+          runtimeRscDoneScript() +
+          "</body></html>",
+      );
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({});
+
+      const result = await prerenderApp({
+        mode: "default",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      const route = result.routes.find((r) => r.route.includes("slug"));
+      expect(route).toMatchObject({ status: "skipped", reason: "no-static-params" });
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces a thrown getStaticPaths error instead of silently skipping the route", async () => {
+    const root = tmpDir("vinext-prerender-pages-gsp-error-");
+    const outDir = path.join(root, "out");
+    const pagesDir = path.join(root, "pages");
+    fs.mkdirSync(path.join(pagesDir, "posts"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pagesDir, "posts", "[id].tsx"),
+      "export default function Post() { return null; }\n",
+    );
+
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/__vinext/prerender/pages-static-paths") {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: "Error: boom from getStaticPaths" }));
+        return;
+      }
+      res.setHeader("content-type", "text/html");
+      res.end("<html><body>ok</body></html>");
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderPages } = await import("../packages/vinext/src/build/prerender.js");
+      const { pagesRouter, apiRouter } =
+        await import("../packages/vinext/src/routing/pages-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await pagesRouter(pagesDir);
+      const apiRoutes = await apiRouter(pagesDir);
+      const config = await resolveNextConfig({});
+
+      const result = await prerenderPages({
+        mode: "default",
+        routes,
+        apiRoutes,
+        pagesDir,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      const route = result.routes.find((r) => r.route.includes("posts"));
+      // `fatal: true` makes run-prerender fail the build in default mode too. #1982
+      expect(route).toMatchObject({ status: "error", fatal: true });
+      if (route?.status !== "error") {
+        throw new Error("expected the throwing getStaticPaths route to fail prerender");
+      }
+      expect(route.error).toContain("boom from getStaticPaths");
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("prerenderApp — cacheComponents PPR fallback-shell artifacts", () => {
   async function prerenderDynamicRootParamRoute(
     cacheComponents: boolean,
@@ -1244,6 +1426,38 @@ describe("runPrerender — output: 'export' wiring", () => {
         pagesBundlePath,
       }),
     ).rejects.toThrow(/\/ssr/);
+  });
+});
+
+// ─── run-prerender fatal-route gate (#1982) ───────────────────────────────────
+
+describe("assertNoFatalPrerenderRoutes (#1982)", () => {
+  it("throws (fails the build in default mode) when a route is flagged fatal", async () => {
+    const { assertNoFatalPrerenderRoutes } =
+      await import("../packages/vinext/src/build/run-prerender.js");
+    expect(() =>
+      assertNoFatalPrerenderRoutes([
+        {
+          route: "/blog/:slug",
+          status: "error",
+          error: "Failed to call generateStaticParams(): boom",
+          fatal: true,
+        },
+      ]),
+    ).toThrow(/Prerender failed/);
+  });
+
+  it("does not throw for non-fatal errors or skips (default-mode leniency preserved)", async () => {
+    const { assertNoFatalPrerenderRoutes } =
+      await import("../packages/vinext/src/build/run-prerender.js");
+    // A skipped SSR route and a non-fatal error (e.g. a transport failure) must
+    // NOT fail the default build — only fatal user-function throws do.
+    expect(() =>
+      assertNoFatalPrerenderRoutes([
+        { route: "/ssr", status: "skipped", reason: "ssr" },
+        { route: "/render-fail", status: "error", error: "ECONNREFUSED" },
+      ]),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

- Surface the real error thrown by a user's `generateStaticParams` / `getStaticPaths` during prerender instead of swallowing it. The build-time proxies that fetch the prerender static-params/static-paths endpoints now throw the genuine error message on an HTTP 500, so the route is recorded as a per-route `error` with the real cause (App Router via its existing collector; Pages Router via a new try/catch).
- **Fail the build on these errors in every mode**, not just `output: 'export'`. The per-route error is flagged `fatal`, and `run-prerender` now throws for any `fatal` route regardless of mode — matching `next build`, which fails on a throwing `generateStaticParams`/`getStaticPaths`. Intentionally-skipped dynamic/SSR routes are unaffected (they are not `fatal`).
- Keep the genuine disabled / stale-secret case (HTTP 404 / 403) on the existing warn-and-skip path — only a `500` (which carries the user error in its JSON body) is treated as a real failure.
- Add a `parsePrerenderEndpointError` helper that extracts the `{ error }` message from the 500 body, falling back to the raw text.

## Root Cause

Both build-time proxies (`packages/vinext/src/build/prerender.ts`) that fetch `/__vinext/prerender/static-params` (App Router) and `/__vinext/prerender/pages-static-paths` (Pages Router) treated **any** `!res.ok` response identically: they logged `"… This may indicate a stale or missing prerender secret."` and returned the no-params sentinel (`null` / `{ paths: [], fallback: false }`), **discarding the response body**.

But the endpoint (`packages/vinext/src/server/app-prerender-endpoints.ts`) returns two very different non-ok responses:

- `notFoundResponse()` → **404** for the genuine disabled / stale-secret case;
- `jsonResponse({ error: String(error) }, 500)` → **500** when the user's `generateStaticParams` / `getStaticPaths` *throws*, with the real error in the body.

Because the proxy swallowed the 500, a throwing `generateStaticParams` was mis-reported as "no static params", the route was silently dropped from prerendering, and the **only** console output blamed a non-existent secret problem — while the default-mode build still "succeeded" and shipped an app missing pre-rendered pages. In `output: 'export'` it failed with the misleading `Dynamic route requires generateStaticParams()` instead of the user's error.

The fix branches on status: a `500` throws `parsePrerenderEndpointError(text)`. For App Router that throw is caught by the existing per-route collector (`Failed to call generateStaticParams(): …`); for Pages Router the `getStaticPaths` consumption is now wrapped to produce the same per-route `error`. Non-500 responses keep the warn-and-skip behavior, so the legitimate secret/disabled path is unchanged.

This matches Next.js, which invokes the user function directly with no swallowing wrapper and fails the build with the real error/stack.

## References

- Issue: https://github.com/cloudflare/vinext/issues/1982
- Next.js parity — `generateStaticParams` errors fail the build with the real message: https://github.com/vercel/next.js/blob/canary/test/production/app-dir/generate-static-params-errors/generate-static-params-errors.test.ts
- Next.js source (no swallowing wrapper): `packages/next/src/build/static-paths/app.ts`, `packages/next/src/build/static-paths/pages.ts`

## Verification

- `pnpm test tests/prerender.test.ts tests/run-prerender-concurrency.test.ts` — green (3 new prerender cases: App Router throw flagged `fatal`, Pages Router throw flagged `fatal`, 404/secret still warn-skips)
- The endpoint's own throw→500 path is covered by `tests/app-prerender-endpoints.test.ts`
- `pnpm test` — full Vitest suite green (only pre-existing local-env flakes unrelated to this change)
- `npx vp check` on the touched files — format, lint, types clean
