### PR TITLE
fix(routing): match routes inside dot-directories

### DIFF
--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -1,5 +1,5 @@
-import { existsSync } from "node:fs";
-import { glob } from "node:fs/promises";
+import { existsSync, type Dirent } from "node:fs";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { escapeRegExp } from "../utils/regex.js";
 
@@ -15,13 +15,6 @@ export function normalizePageExtensions(pageExtensions?: readonly string[] | nul
     .map((ext) => ext.trim().replace(/^\.+/, ""))
     .filter((ext) => ext.length > 0);
   return filtered.length > 0 ? [...filtered] : [...DEFAULT_PAGE_EXTENSIONS];
-}
-
-function buildExtensionGlob(stem: string, extensions: readonly string[]): string {
-  if (extensions.length === 1) {
-    return `${stem}.${extensions[0]}`;
-  }
-  return `${stem}.{${extensions.join(",")}}`;
 }
 
 export type ValidFileMatcher = {
@@ -162,7 +155,23 @@ export function normalizeViteResolveExtensions(extensions: readonly string[]): s
 }
 
 /**
- * Use function-form exclude for Node < 22.14 compatibility.
+ * Recursively scan `cwd` for files matching `stem.{extensions}`.
+ *
+ * `stem` is always a recursive glob (a leading globstar joined to a leaf), where
+ * the leaf is either a literal basename (`page`, `route`, `layout`, …) or `*`
+ * (any basename). The leading globstar means the leaf may live at any depth.
+ *
+ * This mirrors Next.js route discovery (`recursiveReadDir`), which walks the
+ * directory tree itself and only skips directories the caller asks it to. Unlike
+ * Node's `glob`, `**` there does NOT skip dot-prefixed directories — Next.js only
+ * ignores path parts starting with `_` (and the caller supplies that filter via
+ * `exclude`). Using `glob` here silently dropped routes inside dot-directories
+ * such as `app/.well-known/openid-configuration/route.ts` (cloudflare/vinext#2014).
+ *
+ * The `exclude` callback receives the base name of each entry (with extension for
+ * files) and, when it returns true, prunes that directory (or skips that file),
+ * matching the previous `glob` `exclude` semantics. Yielded paths are relative to
+ * `cwd` and use the platform path separator, as `glob` did.
  */
 export async function* scanWithExtensions(
   stem: string,
@@ -170,11 +179,50 @@ export async function* scanWithExtensions(
   extensions: readonly string[],
   exclude?: (name: string) => boolean,
 ): AsyncGenerator<string> {
-  const pattern = buildExtensionGlob(stem, extensions);
-  for await (const file of glob(pattern, {
-    cwd,
-    ...(exclude ? { exclude } : {}),
-  })) {
-    yield file;
+  const leaf = stem.slice(stem.lastIndexOf("/") + 1);
+  // Compare against each full extension (not just the substring after the last
+  // dot) so multi-dot pageExtensions like "platform.tsx" still match a file
+  // named `page.platform.tsx`, exactly as the previous `{a,b}` glob brace did.
+  const suffixes = extensions.map((ext) => `.${ext}`);
+  const matchesLeaf = (fileName: string): boolean =>
+    suffixes.some((suffix) =>
+      leaf === "*"
+        ? fileName.length > suffix.length && fileName.endsWith(suffix)
+        : fileName === `${leaf}${suffix}`,
+    );
+
+  yield* scanDirectory(cwd, "", matchesLeaf, exclude);
+}
+
+async function* scanDirectory(
+  absoluteDir: string,
+  relativeDir: string,
+  matchesLeaf: (fileName: string) => boolean,
+  exclude: ((name: string) => boolean) | undefined,
+): AsyncGenerator<string> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(absoluteDir, { withFileTypes: true });
+  } catch {
+    // Directory removed between readdir calls (or unreadable): abandon it.
+    return;
+  }
+
+  // Sort for deterministic discovery order regardless of filesystem ordering.
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  for (const entry of entries) {
+    const name = entry.name;
+    if (exclude?.(name)) continue;
+    const childRelative = relativeDir ? path.join(relativeDir, name) : name;
+    // `isDirectory()` is false for symlinks-to-directories, so we don't recurse
+    // into them. This is an intentional, conservative divergence from Next.js'
+    // `recursiveReadDir` (which follows symlinks): route trees almost never use
+    // symlinked directories, and not following them avoids symlink cycles.
+    if (entry.isDirectory()) {
+      yield* scanDirectory(path.join(absoluteDir, name), childRelative, matchesLeaf, exclude);
+    } else if (matchesLeaf(name)) {
+      yield childRelative;
+    }
   }
 }

--- a/packages/vinext/src/routing/pages-router.ts
+++ b/packages/vinext/src/routing/pages-router.ts
@@ -72,9 +72,12 @@ async function scanPageRoutes(pagesDir: string, matcher: ValidFileMatcher): Prom
   const routes: Route[] = [];
 
   // Use function form of exclude for Node < 22.14 compatibility (string arrays require >= 22.14).
-  // The `RESERVED_PAGE_NAMES` check here is a directory-traversal optimization only — glob's
-  // exclude callback fires on directory names, not file names, so root-level files like
-  // `_app.tsx` still get yielded and are filtered by the guard in `fileToRoute()` below.
+  // The exclude predicate fires on every scanned entry — both directory names AND file names.
+  // For directories it prunes traversal (`api`, reserved folders). For files it matches against
+  // extensionless basenames: `RESERVED_PAGE_NAMES` stores `_app`/`_document`, so `exclude("_app.tsx")`
+  // is false and root-level reserved files are still yielded, then filtered by the guard in
+  // `fileToRoute()` below. So this check is a traversal optimization; the authoritative
+  // reserved-file filtering lives in `fileToRoute()`.
   for await (const file of scanWithExtensions(
     "**/*",
     pagesDir,

--- a/tests/file-matcher.test.ts
+++ b/tests/file-matcher.test.ts
@@ -1,9 +1,26 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import {
   createValidFileMatcher,
   normalizePageExtensions,
+  scanWithExtensions,
 } from "../packages/vinext/src/routing/file-matcher.js";
 import { shouldInvalidateAppRouteFile } from "../packages/vinext/src/server/dev-route-files.js";
+
+async function collectScan(
+  stem: string,
+  cwd: string,
+  extensions: readonly string[],
+  exclude?: (name: string) => boolean,
+): Promise<string[]> {
+  const out: string[] = [];
+  for await (const file of scanWithExtensions(stem, cwd, extensions, exclude)) {
+    out.push(file.split(path.sep).join("/"));
+  }
+  return out.sort();
+}
 
 describe("file matcher", () => {
   it("normalizes pageExtensions with defaults and preserves configured values", () => {
@@ -82,5 +99,81 @@ describe("file matcher", () => {
     expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/robots.ts", matcher)).toBe(
       false,
     );
+  });
+});
+
+describe("scanWithExtensions directory traversal", () => {
+  it("discovers route files inside dot-directories at any depth", async () => {
+    // Next.js discovers app routes via recursiveReadDir, which only ignores
+    // path parts starting with "_" (private folders) — NOT dot-directories.
+    // See packages/next/src/build/route-discovery.ts (ignorePartFilter:
+    // (part) => part.startsWith('_')) and packages/next/src/lib/recursive-readdir.ts.
+    // So app/.well-known/openid-configuration/route.ts MUST be matched.
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "vinext-scan-dot-"));
+    try {
+      const write = async (rel: string) => {
+        const filePath = path.join(tmpDir, rel);
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, "export const GET = () => new Response();\n");
+      };
+
+      await write("foo/route.ts");
+      await write(".well-known/openid-configuration/route.ts");
+      await write("nested/.hidden/deep/route.ts");
+
+      const found = await collectScan("**/route", tmpDir, ["ts", "tsx"]);
+
+      expect(found).toEqual([
+        ".well-known/openid-configuration/route.ts",
+        "foo/route.ts",
+        "nested/.hidden/deep/route.ts",
+      ]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still prunes excluded directories while traversing dot-directories", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "vinext-scan-exclude-"));
+    try {
+      const write = async (rel: string) => {
+        const filePath = path.join(tmpDir, rel);
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, "export default function Page() { return null; }\n");
+      };
+
+      await write("blog/page.tsx");
+      await write(".well-known/page.tsx");
+      await write("_private/page.tsx");
+
+      const found = await collectScan("**/page", tmpDir, ["tsx"], (name) => name.startsWith("_"));
+
+      expect(found).toEqual([".well-known/page.tsx", "blog/page.tsx"]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches multi-dot page extensions like the previous brace-expansion glob", async () => {
+    // pageExtensions can carry compound suffixes, e.g. ["platform.tsx", "tsx"]
+    // from the Next.js resolve-extensions fixture (see buildViteResolveExtensions).
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "vinext-scan-ext-"));
+    try {
+      const write = async (rel: string) => {
+        const filePath = path.join(tmpDir, rel);
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, "export default function Page() { return null; }\n");
+      };
+
+      await write("a/page.platform.tsx");
+      await write("b/page.tsx");
+      await write("c/page.module.css");
+
+      const found = await collectScan("**/page", tmpDir, ["platform.tsx", "tsx"]);
+
+      expect(found).toEqual(["a/page.platform.tsx", "b/page.tsx"]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Discover route files inside dot-directories (e.g. `app/.well-known/…/route.ts`), which were previously never matched.
- Replaces the glob-based route scan with a recursive directory walk that descends into dot-directories, preserving the existing exclude and multi-extension semantics.

## Root Cause

`scanWithExtensions` in `routing/file-matcher.ts` discovered routes with Node's `fs/promises` `glob` using `**/`-prefixed patterns. Node's `glob` never descends into dot-prefixed directories via `**` — and `{ dot: true }` does not change this for `**` traversal — so any route under `.well-known/`, `. well-known/`-style folders, etc. was silently dropped: the route 404s with no build error.

Next.js discovers routes with its own `recursiveReadDir` (`packages/next/src/lib/recursive-readdir.ts`, driven from `route-discovery.ts`), which walks the tree itself and only ignores `_`-prefixed parts — **not** dot-directories. The fix replaces the glob with an equivalent recursive `readdir` walk that: descends every directory including dot-directories, applies the existing `exclude(name)` predicate to each entry (so `_private`/etc. pruning is unchanged), matches leaves against the full `.ext` suffixes (preserving multi-dot `pageExtensions` like `page.platform.tsx`), and yields native-separator relative paths in sorted (deterministic) order. No call sites changed.

Symlinked directories are intentionally not followed (a conservative divergence from Next.js, documented inline) to avoid symlink cycles; route trees effectively never rely on symlinked directories.

## References

- Fixes #2014
- Next.js parity: `packages/next/src/lib/recursive-readdir.ts` + `route-discovery.ts` (`ignorePartFilter: (part) => part.startsWith('_')`)
- No dedicated Next.js test asserts dot-directory route discovery, so there was none to port; behavior is anchored to the `recursive-readdir` source and covered by new unit tests.

## Verification

- `CI=true pnpm test tests/file-matcher.test.ts` — new tests: a `.well-known/…/route` at depth is discovered (red before, green after); excluded directories are still pruned while traversing dot-directories; multi-dot extensions still match like the old brace-expansion glob.
- `CI=true pnpm test tests/app-route-graph.test.ts tests/pages-router.test.ts` — both route-discovery call-site suites pass (no regression).
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on the changed file.
