### PR TITLE
fix(script): register src beforeInteractive scripts and mark hoisted output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ result-*
 
 .vinext
 next-env.d.ts
+
+# Leaked temp fixtures from the oxlint prefer-shared-utils rule test
+# (normally cleaned up in afterEach; ignore so a crashed run can't commit them).
+__lint_rule_fixtures__-*

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -33,6 +33,7 @@ import {
   escapeHtmlAttr,
   safeJsonStringify,
 } from "./html.js";
+import { renderBeforeInteractiveInlineScripts } from "./before-interactive-head.js";
 import {
   createNavigationRuntimeRscMetadataScript,
   createRscEmbedTransform,
@@ -189,54 +190,6 @@ function renderInsertedHtml(insertedElements: readonly unknown[]): string {
   }
 
   return insertedHTML;
-}
-
-/**
- * Render captured `<Script strategy="beforeInteractive">` inline scripts to
- * HTML, ready to splice immediately after `<head ...>` opens. Each entry has
- * already had its inline content escaped via `escapeInlineContent(..., "script")`
- * inside the Script shim, so this function only quotes the attributes that
- * actually go on the tag (id, nonce, plus the residual passthroughs).
- *
- * Keeping this function colocated with the rest of the head-injection
- * helpers makes it obvious where the boundary is: anything passed through
- * here is being concatenated directly into HTML; treat the inputs
- * accordingly.
- */
-// Conservative subset of the HTML attribute-name grammar. Must start with a
-// letter and contain only letters, digits, underscores, hyphens, or dots —
-// enough to round-trip data-* and standard attributes (`async`, `defer`,
-// `type`, `crossorigin`, etc.) without ever splicing a `"`/`>`/whitespace
-// into the unquoted *name* position where escaping wouldn't help.
-const VALID_ATTR_NAME = /^[a-zA-Z][\w.-]*$/;
-
-function renderBeforeInteractiveInlineScripts(
-  scripts: readonly BeforeInteractiveInlineScript[],
-): string {
-  if (scripts.length === 0) return "";
-  let html = "";
-  for (const script of scripts) {
-    let attrs = "";
-    if (script.id) {
-      attrs += ` id="${escapeHtmlAttr(script.id)}"`;
-    }
-    attrs += createNonceAttribute(script.nonce);
-    if (script.attributes) {
-      for (const [key, value] of Object.entries(script.attributes)) {
-        // Attribute *values* go through escapeHtmlAttr below. The *name*
-        // can't be escaped — a malformed key would break the tag — so we
-        // gate at the boundary instead of trying to neutralise it.
-        if (!VALID_ATTR_NAME.test(key)) continue;
-        if (value === true) {
-          attrs += ` ${key}`;
-        } else if (typeof value === "string") {
-          attrs += ` ${key}="${escapeHtmlAttr(value)}"`;
-        }
-      }
-    }
-    html += `<script${attrs}>${script.innerHTML}</script>`;
-  }
-  return html;
 }
 
 function renderFontHtml(

--- a/packages/vinext/src/server/before-interactive-head.ts
+++ b/packages/vinext/src/server/before-interactive-head.ts
@@ -1,0 +1,64 @@
+import type { BeforeInteractiveInlineScript } from "vinext/shims/before-interactive-context";
+import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
+
+// Conservative subset of the HTML attribute-name grammar. Must start with a
+// letter and contain only letters, digits, underscores, hyphens, or dots —
+// enough to round-trip data-* and standard attributes (`async`, `defer`,
+// `type`, `crossorigin`, etc.) without ever splicing a `"`/`>`/whitespace
+// into the unquoted *name* position where escaping wouldn't help.
+const VALID_ATTR_NAME = /^[a-zA-Z][\w.-]*$/;
+
+/**
+ * Render captured `<Script strategy="beforeInteractive">` scripts to HTML,
+ * ready to splice immediately after `<head ...>` opens. Each entry has already
+ * had its inline content escaped via `escapeInlineContent(..., "script")`
+ * inside the Script shim, so this function only quotes the attributes that
+ * actually go on the tag (id, src, nonce, plus the residual passthroughs).
+ *
+ * Keeping this function in its own module makes the boundary obvious: anything
+ * passed through here is being concatenated directly into HTML; treat the
+ * inputs accordingly.
+ */
+export function renderBeforeInteractiveInlineScripts(
+  scripts: readonly BeforeInteractiveInlineScript[],
+): string {
+  if (scripts.length === 0) return "";
+  let html = "";
+  for (const script of scripts) {
+    let attrs = "";
+    if (script.id) {
+      attrs += ` id="${escapeHtmlAttr(script.id)}"`;
+    }
+    if (script.src) {
+      attrs += ` src="${escapeHtmlAttr(script.src)}"`;
+    }
+    attrs += createNonceAttribute(script.nonce);
+    if (script.attributes) {
+      for (const [key, value] of Object.entries(script.attributes)) {
+        // Attribute *values* go through escapeHtmlAttr below. The *name*
+        // can't be escaped — a malformed key would break the tag — so we
+        // gate at the boundary instead of trying to neutralise it.
+        if (!VALID_ATTR_NAME.test(key)) continue;
+        // We emit the `data-nscript` marker ourselves below; drop any
+        // user-supplied one so the tag never carries a duplicate attribute.
+        if (key === "data-nscript") continue;
+        if (value === true) {
+          attrs += ` ${key}`;
+        } else if (typeof value === "string") {
+          attrs += ` ${key}="${escapeHtmlAttr(value)}"`;
+        }
+      }
+    }
+    // Tag every hoisted script with Next.js's `data-nscript` marker. Next.js
+    // applies `data-nscript="beforeInteractive"` to server-rendered
+    // beforeInteractive scripts and the client dedupes against it
+    // (.nextjs-ref/packages/next/src/client/script.tsx — `data-nscript` and
+    // `addBeforeInteractiveToCache`). Emitting it keeps vinext's hoisted output
+    // consistent with that DOM contract.
+    attrs += ` data-nscript="beforeInteractive"`;
+    // `innerHTML` is pre-escaped inline content; src scripts have none, so the
+    // tag body is empty.
+    html += `<script${attrs}>${script.innerHTML ?? ""}</script>`;
+  }
+  return html;
+}

--- a/packages/vinext/src/shims/before-interactive-context.tsx
+++ b/packages/vinext/src/shims/before-interactive-context.tsx
@@ -1,19 +1,30 @@
 import React from "react";
 
 /**
- * Inline `<Script strategy="beforeInteractive">` content captured during SSR.
+ * A `<Script strategy="beforeInteractive">` captured during SSR.
  *
  * The Script shim hands these records to the SSR pipeline through
  * `BeforeInteractiveContext` instead of rendering the `<script>` tag inline.
  * The pipeline then emits the captured tag immediately after `<head>` opens,
  * so the script runs before any React-hoisted stylesheets or modulepreload
  * links. Matches the standard no-flash dark-mode pattern.
+ *
+ * Both inline (`children`/`dangerouslySetInnerHTML`) and external (`src`)
+ * beforeInteractive scripts flow through here, mirroring Next.js which registers
+ * inline and src beforeInteractive scripts equally in the App Router runtime
+ * (`(self.__next_s=...).push(...)`). An entry has `src` set for external
+ * scripts and `innerHTML` set for inline scripts (never both).
  */
 export type BeforeInteractiveInlineScript = {
   /** Optional id attribute. */
   id?: string;
-  /** Pre-escaped inline content (already passed through `escapeInlineContent`). */
-  innerHTML: string;
+  /** External script URL. Set for src beforeInteractive scripts. */
+  src?: string;
+  /**
+   * Pre-escaped inline content (already passed through `escapeInlineContent`).
+   * Set for inline beforeInteractive scripts; omitted for src scripts.
+   */
+  innerHTML?: string;
   /** Nonce to emit on the `<script>` tag, when CSP is enabled. */
   nonce?: string;
   /**

--- a/packages/vinext/src/shims/script.tsx
+++ b/packages/vinext/src/shims/script.tsx
@@ -221,8 +221,10 @@ function extractBeforeInteractiveInlineContent(
 const REACT_TO_HTML_ATTR: Record<string, string> = {
   acceptCharset: "accept-charset",
   className: "class",
+  crossOrigin: "crossorigin",
   htmlFor: "for",
   httpEquiv: "http-equiv",
+  referrerPolicy: "referrerpolicy",
 };
 
 /**
@@ -579,28 +581,37 @@ function Script(props: ScriptProps): React.ReactElement | null {
     }
 
     if (strategy === "beforeInteractive") {
-      // Inline beforeInteractive scripts (no src) need to run BEFORE any
-      // stylesheets, modulepreload links, or other resource hints React Float
-      // hoists into <head>. React Fizz emits user-rendered head children
-      // AFTER the hoisted resources, so leaving the script in source order
-      // breaks the no-flash dark-mode pattern. We instead capture the inline
-      // content through BeforeInteractiveContext and the SSR pipeline emits
-      // it immediately after `<head>` opens — guaranteeing it precedes every
-      // React-emitted hint in the streamed HTML.
+      // beforeInteractive scripts need to run BEFORE any stylesheets,
+      // modulepreload links, or other resource hints React Float hoists into
+      // <head>. React Fizz emits user-rendered head children AFTER the hoisted
+      // resources, so leaving the script in source order breaks the no-flash
+      // dark-mode pattern. We instead capture the script through
+      // BeforeInteractiveContext and the SSR pipeline emits it immediately
+      // after `<head>` opens — guaranteeing it precedes every React-emitted
+      // hint in the streamed HTML.
+      //
+      // Both inline (children/dangerouslySetInnerHTML) and external (src)
+      // scripts are registered, mirroring Next.js which routes inline and src
+      // beforeInteractive scripts equally through the App Router runtime
+      // (.nextjs-ref/packages/next/src/client/script.tsx — the `(self.__next_s=
+      // ...).push([0|src, …])` branch).
       const inlineContent = src
         ? null
         : extractBeforeInteractiveInlineContent(children, dangerouslySetInnerHTML);
-      if (inlineContent !== null && registerBeforeInteractive) {
-        const inline: BeforeInteractiveInlineScript = {
+      if ((src || inlineContent !== null) && registerBeforeInteractive) {
+        const registered: BeforeInteractiveInlineScript = {
           id,
+          src: src ?? undefined,
           // Escape `</script>` sequences exactly as the inline render path does
           // (see buildBeforeInteractiveScriptProps); keep the escape colocated
-          // with the emit boundary so it never gets accidentally skipped.
-          innerHTML: escapeInlineContent(inlineContent, "script"),
+          // with the emit boundary so it never gets accidentally skipped. src
+          // scripts have no inline body.
+          innerHTML:
+            inlineContent !== null ? escapeInlineContent(inlineContent, "script") : undefined,
           nonce: resolvedNonce,
           attributes: collectBeforeInteractiveAttributes(rest),
         };
-        registerBeforeInteractive(inline);
+        registerBeforeInteractive(registered);
         return null;
       }
 
@@ -621,11 +632,12 @@ function Script(props: ScriptProps): React.ReactElement | null {
   }
 
   if (strategy === "beforeInteractive") {
-    // On the client, only suppress the `<script>` render for inline
-    // beforeInteractive Scripts in App Router pages. The pre-head splice
-    // in app-ssr-entry/app-ssr-stream already put the tag in the DOM, so
-    // rendering it again would either duplicate the script (for Scripts
-    // outside `<head>`) or cause a hydration mismatch (positions differ).
+    // On the client, suppress the `<script>` render for any beforeInteractive
+    // Script in App Router pages — inline AND external `src`. The pre-head
+    // splice in app-ssr-entry/app-ssr-stream already put the tag in the DOM
+    // (the SSR registration condition above mirrors this exactly), so rendering
+    // it again would duplicate the script (double execution) or cause a
+    // hydration mismatch (positions differ).
     //
     // For Pages Router and any other SSR path that didn't run through
     // app-ssr-entry, the server rendered the `<script>` inline in source
@@ -633,14 +645,10 @@ function Script(props: ScriptProps): React.ReactElement | null {
     // navigation runtime that the App Router bootstrap installs before
     // calling hydrateRoot — it is the most reliable runtime signal we
     // can read from inside a `"use client"` shim.
-    //
-    // External-`src` beforeInteractive scripts always keep rendering
-    // inline. They are not captured by the pre-head splice and must mount
-    // through React so their `src` attribute is fetched on the client.
     const inlineContent = src
       ? null
       : extractBeforeInteractiveInlineContent(children, dangerouslySetInnerHTML);
-    if (inlineContent !== null && hasAppNavigationRuntimeBootstrap()) {
+    if ((src || inlineContent !== null) && hasAppNavigationRuntimeBootstrap()) {
       return null;
     }
 

--- a/tests/script-head-ordering.test.ts
+++ b/tests/script-head-ordering.test.ts
@@ -160,11 +160,23 @@ describe("inline beforeInteractive head ordering", () => {
     expect(tagMatch?.[0]).toContain('nonce="ordering-nonce"');
   });
 
-  it("does not affect external src beforeInteractive scripts", async () => {
-    // The existing /script-nonce page uses external src beforeInteractive
-    // (Script src="/test2.js"). This must keep rendering as an inline
-    // <script src> tag — only the no-src inline form is hoisted.
+  it("hoists external src beforeInteractive scripts into <head> with the data-nscript marker", async () => {
+    // Regression for cloudflare/vinext#2016: external src beforeInteractive
+    // scripts (the /script-nonce page renders Script src="/test2.js") are now
+    // registered through BeforeInteractiveContext and hoisted into <head> just
+    // like the inline form, mirroring Next.js which routes inline and src
+    // beforeInteractive scripts equally through the App Router runtime. The
+    // hoisted tag carries Next.js's `data-nscript="beforeInteractive"` marker.
     const { html } = await fetchHtml(baseUrl, "/script-nonce");
-    expect(html).toMatch(/<script\b[^>]*src="\/test2\.js"/);
+    const head = extractHeadHtml(html);
+    const tagMatch = /<script\b[^>]*src="\/test2\.js"[^>]*>/.exec(head);
+    expect(
+      tagMatch,
+      "expected the src beforeInteractive script to be hoisted into <head>",
+    ).not.toBeNull();
+    expect(tagMatch?.[0]).toContain('data-nscript="beforeInteractive"');
+    // Exactly one tag — the client must not re-render a duplicate.
+    const matches = [...html.matchAll(/<script\b[^>]*src="\/test2\.js"/g)];
+    expect(matches).toHaveLength(1);
   });
 });

--- a/tests/script.test.ts
+++ b/tests/script.test.ts
@@ -18,6 +18,8 @@ import {
   BeforeInteractiveContext,
   type BeforeInteractiveInlineScript,
 } from "../packages/vinext/src/shims/before-interactive-context.js";
+import { renderBeforeInteractiveInlineScripts } from "../packages/vinext/src/server/before-interactive-head.js";
+import { NAVIGATION_RUNTIME_KEY } from "../packages/vinext/src/client/navigation-runtime.js";
 
 const originalDocument = globalThis.document;
 const originalWindow = globalThis.window;
@@ -658,5 +660,137 @@ describe("Script stylesheets prop", () => {
     expect(appendedScripts).toHaveLength(1);
     // The stylesheets prop must never leak onto the <script> attribute list.
     expect(appendedScripts[0]!.attrs).not.toHaveProperty("stylesheets");
+  });
+});
+
+// ─── #2016: src beforeInteractive registration, marker, attr mapping ──────
+//
+// Regression coverage for https://github.com/cloudflare/vinext/issues/2016.
+//
+// Three coupled defects:
+//   1. SSR-hoisted beforeInteractive scripts carried no marker; Next.js tags
+//      server-rendered beforeInteractive scripts with
+//      `data-nscript="beforeInteractive"`
+//      (.nextjs-ref/packages/next/src/client/script.tsx).
+//   2. beforeInteractive scripts with `src` bypassed the server registry, so
+//      they were never hoisted into <head> ahead of interactive. Next.js
+//      treats inline and src beforeInteractive scripts equally in the registry
+//      path (the App Router `(self.__next_s=...).push([src, …])` branch).
+//   3. REACT_TO_HTML_ATTR lacked `crossOrigin`/`referrerPolicy`, so they
+//      round-tripped as camelCase attributes (broken CORS/referrer). Next.js
+//      lowercases these in set-attributes-from-props.ts.
+
+describe("Script beforeInteractive registry (#2016)", () => {
+  it("registers src beforeInteractive scripts so they are hoisted into <head>", () => {
+    const captured: BeforeInteractiveInlineScript[] = [];
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        BeforeInteractiveContext.Provider,
+        { value: (s: BeforeInteractiveInlineScript) => captured.push(s) },
+        React.createElement(Script, {
+          src: "/analytics.js",
+          id: "analytics",
+          strategy: "beforeInteractive",
+        } as ScriptProps),
+      ),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.src).toBe("/analytics.js");
+    expect(captured[0]?.id).toBe("analytics");
+    // The tag is hoisted by the SSR pipeline (returned null from React), so
+    // React itself emits only the preload link, never an inline <script>.
+    expect(html).not.toContain("<script");
+  });
+
+  it("maps crossOrigin/referrerPolicy to HTML attribute names on hoisted src scripts", () => {
+    const captured: BeforeInteractiveInlineScript[] = [];
+    ReactDOMServer.renderToString(
+      React.createElement(
+        BeforeInteractiveContext.Provider,
+        { value: (s: BeforeInteractiveInlineScript) => captured.push(s) },
+        React.createElement(Script, {
+          src: "/cdn.js",
+          strategy: "beforeInteractive",
+          crossOrigin: "anonymous",
+          referrerPolicy: "no-referrer",
+        } as ScriptProps),
+      ),
+    );
+
+    expect(captured).toHaveLength(1);
+    const attrs = captured[0]?.attributes ?? {};
+    expect(attrs).toMatchObject({
+      crossorigin: "anonymous",
+      referrerpolicy: "no-referrer",
+    });
+    expect(attrs).not.toHaveProperty("crossOrigin");
+    expect(attrs).not.toHaveProperty("referrerPolicy");
+  });
+
+  it("does not re-render a hoisted src beforeInteractive script on the client", () => {
+    // With the App Router runtime installed on `window`, the SSR pipeline has
+    // already hoisted the script's tag into <head>. The client component must
+    // return null for both inline AND src beforeInteractive scripts so React
+    // does not duplicate the tag (duplicate execution / hydration mismatch).
+    setGlobalValue("window", {
+      [NAVIGATION_RUNTIME_KEY]: {
+        bootstrap: { routeManifest: null, rsc: undefined },
+        functions: {},
+      },
+    });
+    setGlobalValue("document", { querySelector: () => null });
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Script, {
+        src: "/dedupe.js",
+        strategy: "beforeInteractive",
+      } as ScriptProps),
+    );
+
+    expect(html).toBe("");
+  });
+});
+
+describe("renderBeforeInteractiveInlineScripts (#2016)", () => {
+  it('marks every hoisted script with data-nscript="beforeInteractive"', () => {
+    const html = renderBeforeInteractiveInlineScripts([{ id: "x", innerHTML: "console.log(1)" }]);
+    expect(html).toContain('data-nscript="beforeInteractive"');
+    expect(html).toContain('id="x"');
+    expect(html).toContain("console.log(1)");
+  });
+
+  it("emits a <script src> tag (with no body) for registered src scripts", () => {
+    const html = renderBeforeInteractiveInlineScripts([
+      {
+        id: "a",
+        src: "/a.js",
+        attributes: { crossorigin: "anonymous", defer: true },
+      },
+    ]);
+    expect(html).toMatch(/<script\b[^>]*src="\/a\.js"/);
+    expect(html).toContain('crossorigin="anonymous"');
+    expect(html).toContain(" defer");
+    expect(html).toContain('data-nscript="beforeInteractive"');
+    // src-only scripts have no inline body.
+    expect(html).toMatch(/<script[^>]*><\/script>/);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts
+  // (the "/multiple" route asserting multiple beforeInteractive scripts each
+  // render with the correct `class` attribute, never `classname`).
+  it("renders multiple hoisted beforeInteractive scripts with correct class attributes", () => {
+    const html = renderBeforeInteractiveInlineScripts([
+      { id: "first", innerHTML: "1", attributes: { class: "first-script" } },
+      { id: "second", src: "/second.js", attributes: { class: "second-script" } },
+    ]);
+    expect(html).toContain('class="first-script"');
+    expect(html).toContain('class="second-script"');
+    expect(html).not.toContain('classname="first-script"');
+    expect(html).not.toContain('classname="second-script"');
+    // Both are tagged and emitted in registration order.
+    expect((html.match(/data-nscript="beforeInteractive"/g) ?? []).length).toBe(2);
+    expect(html.indexOf("first-script")).toBeLessThan(html.indexOf("second-script"));
   });
 });


### PR DESCRIPTION
## Summary

- Register `src` `beforeInteractive` `next/script`s (not just inline ones) so they are hoisted into `<head>` server-side, matching inline behavior.
- Mark every hoisted `beforeInteractive` script with `data-nscript="beforeInteractive"` and suppress the duplicate client render for both inline and `src` scripts, preventing double execution / hydration mismatch.
- Map `crossOrigin` → `crossorigin` and `referrerPolicy` → `referrerpolicy` when serializing hoisted script attributes.

## Root Cause

Three defects in App Router `beforeInteractive` handling:

1. **`src` scripts bypassed the server registry.** In `shims/script.tsx` the SSR branch computed `inlineContent = src ? null : …` and only registered when `inlineContent !== null`, so external `src` scripts were never captured and never hoisted into `<head>` before interactive — they stayed in source order behind React's resource hints. The condition now registers when `src` is present too.
2. **No hydration marker → duplicate execution.** Hoisted scripts carried no marker, so the client React render of the same `<Script>` produced a second `<script>` node (double execution / hydration mismatch). Next.js marks server-rendered `beforeInteractive` scripts with `data-nscript="beforeInteractive"` and dedupes on the client; we now emit the same marker and return `null` on the client for both inline and `src` `beforeInteractive` scripts in App Router (afterInteractive/lazyOnload paths are unchanged).
3. **Attribute name mismatch.** `REACT_TO_HTML_ATTR` lacked `crossOrigin`/`referrerPolicy`, so they round-tripped as camelCase; added the lowercase mappings to match Next.js' attribute serialization.

For testability the pure emit logic (`renderBeforeInteractiveInlineScripts`) was extracted from the virtual-import-heavy `app-ssr-entry.ts` into a new `server/before-interactive-head.ts`; attribute values are HTML-escaped at that boundary.

## References

- Fixes #2016
- Next.js parity: `packages/next/src/client/script.tsx` (`data-nscript` marker + `addBeforeInteractiveToCache` dedupe on `id || src`)
- Ported test: `test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts` (the multiple-scripts case)

## Verification

- `CI=true pnpm test tests/script.test.ts tests/script-head-ordering.test.ts` — new tests cover: `src` `beforeInteractive` hoisted into `<head>`; `crossOrigin`/`referrerPolicy` lowercased on hoisted tags; client does not re-render a hoisted `src` script; every hoisted script carries `data-nscript`; multiple hoisted scripts (ported from Next.js). All green (red first).
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on all changed files.
