### PR TITLE
fix(shims): guard AsyncLocalStorage construction for browser bundles

### DIFF
--- a/packages/vinext/src/shims/internal/als-registry.ts
+++ b/packages/vinext/src/shims/internal/als-registry.ts
@@ -40,6 +40,36 @@ import { AsyncLocalStorage } from "node:async_hooks";
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 
 /**
+ * No-op AsyncLocalStorage used when the runtime does not provide a usable
+ * `AsyncLocalStorage` constructor.
+ *
+ * In browser/client bundles `node:async_hooks` can resolve to a stub without a
+ * usable constructor (e.g. Vite's `__vite-browser-external`). Constructing such
+ * a value with `new` throws `TypeError: AsyncLocalStorage is not a constructor`
+ * at module-eval time, crashing every client-reachable shim that calls
+ * `getOrCreateAls` on import (request-context, headers, cache, …).
+ *
+ * Mirrors Next.js' `FakeAsyncLocalStorage` (and this repo's
+ * `async-hooks-stub.ts` client virtual module): `getStore()` returns
+ * `undefined` so shims fall back to their non-ALS code path, and the mutating
+ * methods are best-effort no-ops that still invoke the callback.
+ * See: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/async-local-storage.ts
+ */
+class NoopAsyncLocalStorage<T> {
+  getStore(): T | undefined {
+    return undefined;
+  }
+  run<R>(_store: T, fn: (...args: unknown[]) => R, ...args: unknown[]): R {
+    return fn(...args);
+  }
+  exit<R>(fn: (...args: unknown[]) => R, ...args: unknown[]): R {
+    return fn(...args);
+  }
+  enterWith(_store: T): void {}
+  disable(): void {}
+}
+
+/**
  * Get (or lazily create) the AsyncLocalStorage registered on `globalThis`
  * under `Symbol.for(key)`. Multiple callers — including callers in different
  * module instances — that pass the same `key` receive the same ALS instance.
@@ -49,5 +79,8 @@ const _g = globalThis as unknown as Record<PropertyKey, unknown>;
  */
 export function getOrCreateAls<T>(key: string): AsyncLocalStorage<T> {
   const sym = Symbol.for(key);
-  return (_g[sym] ??= new AsyncLocalStorage<T>()) as AsyncLocalStorage<T>;
+  return (_g[sym] ??=
+    typeof AsyncLocalStorage === "function"
+      ? new AsyncLocalStorage<T>()
+      : new NoopAsyncLocalStorage<T>()) as AsyncLocalStorage<T>;
 }

--- a/tests/als-registry.test.ts
+++ b/tests/als-registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+// Simulate a browser/client bundle where `node:async_hooks` resolves to a stub
+// that does NOT expose a usable `AsyncLocalStorage` constructor (e.g. Vite's
+// `__vite-browser-external`). On such a runtime `new AsyncLocalStorage()` would
+// throw `TypeError: AsyncLocalStorage is not a constructor` at module-eval time,
+// crashing every client-reachable shim that calls `getOrCreateAls` on import.
+vi.mock("node:async_hooks", () => ({
+  AsyncLocalStorage: undefined,
+}));
+
+describe("getOrCreateAls — browser-safe fallback", () => {
+  it("does not throw when AsyncLocalStorage is unavailable and returns a no-op store", async () => {
+    const { getOrCreateAls } =
+      await import("../packages/vinext/src/shims/internal/als-registry.js");
+
+    let als: ReturnType<typeof getOrCreateAls<{ value: number }>> | undefined;
+    expect(() => {
+      als = getOrCreateAls<{ value: number }>("vinext.test.als.unavailable");
+    }).not.toThrow();
+
+    // The fallback mirrors Next.js' FakeAsyncLocalStorage: getStore() === undefined
+    // so shims fall back to their non-ALS code path instead of crashing.
+    expect(als).toBeDefined();
+    expect(als!.getStore()).toBeUndefined();
+  });
+
+  it("keeps the global-dedupe behavior: same key returns the same instance", async () => {
+    const { getOrCreateAls } =
+      await import("../packages/vinext/src/shims/internal/als-registry.js");
+
+    const a = getOrCreateAls("vinext.test.als.dedupe");
+    const b = getOrCreateAls("vinext.test.als.dedupe");
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

- Guard the `AsyncLocalStorage` construction in the shared ALS registry so client-reachable shims don't crash when bundled for the browser.
- Falls back to a no-op store (`getStore()` → `undefined`) when no usable `AsyncLocalStorage` constructor is available.

## Root Cause

`getOrCreateAls()` in `shims/internal/als-registry.ts` called `new AsyncLocalStorage()` unconditionally. Many client-reachable shims (`request-context`, `headers`, `cache`, …) call `getOrCreateAls()` at module-evaluation time. In browser bundles, `node:async_hooks` resolves to a stub without a usable constructor, so `new AsyncLocalStorage()` throws `TypeError: AsyncLocalStorage is not a constructor` while the module is evaluating — killing the whole client bundle and breaking hydration.

The fix checks `typeof AsyncLocalStorage === "function"` before constructing and otherwise returns a `NoopAsyncLocalStorage` whose `getStore()` returns `undefined`, so the shims take their existing non-ALS fallback path. The cross-bundle singleton (`Symbol.for` + `??=`) is preserved and no call sites change. This mirrors Next.js' `createAsyncLocalStorage()` / `FakeAsyncLocalStorage` and follows this repo's own `async-hooks-stub.ts` convention (no-op `run` executes the callback rather than throwing).

## References

- Fixes #2015
- Next.js parity: `packages/next/src/server/app-render/async-local-storage.ts` (`createAsyncLocalStorage` / `FakeAsyncLocalStorage`)
- Existing repo convention: `packages/vinext/src/plugins/async-hooks-stub.ts`

## Verification

- `CI=true pnpm test tests/als-registry.test.ts` — new test mocking `node:async_hooks` to an unusable constructor: red before (`TypeError: AsyncLocalStorage is not a constructor`), green after; asserts no throw, `getStore() === undefined`, and the same-key singleton still holds.
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on both changed files.
