### PR TITLE
fix(app-router): render parallel slots through route groups

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1807,14 +1807,15 @@ function discoverInheritedParallelSlots(
     // Layout-less routes keep their legacy slot metadata here; validation is separate.
     if (lvlLayoutIdx < 0 && routeHasLayout) continue;
 
-    const isOwnDir = dir === routeDir;
     const slotLayoutIdx = Math.max(lvlLayoutIdx, 0);
     const slotsAtLevel = discoverParallelSlots(dir, appDir, matcher);
     const segmentsBelow = segments.slice(segmentIndex);
+    const isActiveUrlLevel = dir === routeDir || segmentsBelow.every(isInvisibleSegment);
 
     for (const slot of slotsAtLevel) {
-      if (isOwnDir) {
-        // At the route's own directory: use page.tsx (normal behavior)
+      if (isActiveUrlLevel) {
+        // Use the slot's root page at its active URL level. Route groups below
+        // the slot owner are transparent, so they do not make the slot inherited.
         slot.layoutIndex = slotLayoutIdx;
         slotMap.set(slot.key, slot);
       } else {

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -581,6 +581,30 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  // Ported from Next.js: test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
+  it("keeps a sibling slot active when children are inside a route group", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "group-depth/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "group-depth/(children)/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "group-depth/(children)/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "group-depth/@slot/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "group-depth/@slot/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const route = findRoute(graph.routes, "/group-depth");
+      const slot = route.parallelSlots.find((candidate) => candidate.name === "slot");
+
+      expect(route.pagePath).toBe(path.join(appDir, "group-depth/(children)/page.tsx"));
+      expect(slot).toMatchObject({
+        pagePath: path.join(appDir, "group-depth/@slot/page.tsx"),
+        layoutPath: path.join(appDir, "group-depth/@slot/layout.tsx"),
+        routeSegments: [],
+      });
+    });
+  });
+
   it("keeps route groups transparent in materialized URL patterns", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -497,6 +497,20 @@ describe("App Router integration", () => {
     expect(html).toContain('data-testid="slot-collision-page"');
   });
 
+  // Ported from Next.js: test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
+  it("renders a sibling parallel slot when children are inside a route group", async () => {
+    const res = await fetch(`${baseUrl}/parallel-route-group-depth`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('data-testid="parallel-route-group-depth-layout"');
+    expect(html).toContain('data-testid="parallel-route-group-depth-slot-layout"');
+    expect(html).toContain('data-testid="parallel-route-group-depth-slot-page"');
+    expect(html).toContain('data-testid="parallel-route-group-depth-children-layout"');
+    expect(html).toContain('data-testid="parallel-route-group-depth-children-page"');
+  });
+
   it("parallel slots do not affect URL routing", async () => {
     // @team and @analytics should NOT be accessible as direct routes
     const teamRes = await fetch(`${baseUrl}/dashboard/team`);

--- a/tests/fixtures/app-basic/app/parallel-route-group-depth/(children)/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-route-group-depth/(children)/layout.tsx
@@ -1,0 +1,3 @@
+export default function ChildrenGroupLayout({ children }: { children: React.ReactNode }) {
+  return <div data-testid="parallel-route-group-depth-children-layout">{children}</div>;
+}

--- a/tests/fixtures/app-basic/app/parallel-route-group-depth/(children)/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-route-group-depth/(children)/page.tsx
@@ -1,0 +1,3 @@
+export default function ChildrenGroupPage() {
+  return <p data-testid="parallel-route-group-depth-children-page">Children route group page</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-route-group-depth/@slot/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-route-group-depth/@slot/layout.tsx
@@ -1,0 +1,3 @@
+export default function SlotLayout({ children }: { children: React.ReactNode }) {
+  return <div data-testid="parallel-route-group-depth-slot-layout">{children}</div>;
+}

--- a/tests/fixtures/app-basic/app/parallel-route-group-depth/@slot/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-route-group-depth/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function SlotPage() {
+  return <p data-testid="parallel-route-group-depth-slot-page">Slot Page</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-route-group-depth/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-route-group-depth/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode;
+  slot: React.ReactNode;
+}) {
+  return (
+    <section data-testid="parallel-route-group-depth-layout">
+      <div data-testid="parallel-route-group-depth-slot">{slot}</div>
+      <div data-testid="parallel-route-group-depth-children">{children}</div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- preserve a parallel slot's root page when only URL-transparent route groups remain beneath the slot owner
- add a focused route-graph regression test
- add a vinext fixture reproducing the upstream Next.js route-group depth behavior

## Next.js parity

Ported from:

- `test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts`

Before the fix, the slot rendered an empty value instead of `Slot Page`. The exact pinned Next.js v16.2.6 suite now passes.

## Validation

- exact Next.js deploy-suite test: 1/1 passed
- route graph/routing tests: 168 passed
- App Router integration tests: 166 passed
- scoped `vp check`
- vinext build
- independent review: no actionable findings
