### PR TITLE
fix(image): allow any quality 1-100 when images.qualities is unset

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -202,7 +202,7 @@ export type NextConfig = {
     deviceSizes?: number[];
     /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [16, 32, 48, 64, 96, 128, 256, 384] */
     imageSizes?: number[];
-    /** Allowed image qualities. Defaults to Next.js 16's `[75]`. */
+    /** Allowed image qualities. When unset, any quality from 1-100 is permitted (matches Next.js). */
     qualities?: number[];
     /** Allow SVG images through the image optimization endpoint. SVG can contain scripts, so only enable if you trust all image sources. */
     dangerouslyAllowSVG?: boolean;

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -490,7 +490,7 @@ const imageConfig: ImageConfig = {
   imageSizes: JSON.parse(
     process.env.__VINEXT_IMAGE_SIZES ?? JSON.stringify(DEFAULT_IMAGE_SIZES),
   ),
-  qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "[75]"),
+  qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "null") ?? undefined,
   dangerouslyAllowSVG: process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG === "true",
 };
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -32,7 +32,6 @@ import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
 import {
   DEFAULT_DEVICE_SIZES,
-  DEFAULT_IMAGE_QUALITIES,
   DEFAULT_IMAGE_SIZES,
   isImageOptimizationPath,
   resolveDevImageRedirect,
@@ -1355,8 +1354,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             JSON.stringify(deviceSizes),
           );
           defines["process.env.__VINEXT_IMAGE_SIZES"] = JSON.stringify(JSON.stringify(imageSizes));
+          // Emit the configured qualities allowlist, or `null` when unset so the
+          // runtime permits any quality 1-100 (matches Next.js: an unset
+          // `images.qualities` is not restricted to a single value).
           defines["process.env.__VINEXT_IMAGE_QUALITIES"] = JSON.stringify(
-            JSON.stringify(nextConfig.images?.qualities ?? DEFAULT_IMAGE_QUALITIES),
+            JSON.stringify(nextConfig.images?.qualities ?? null),
           );
         }
         // Expose dangerouslyAllowSVG flag for the image shim's auto-skip logic.
@@ -3526,7 +3528,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 const encodedLocation = resolveDevImageRedirect(
                   imageRequestUrl,
                   allowedWidths,
-                  nextConfig.images?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+                  nextConfig.images?.qualities,
                 );
                 if (!encodedLocation) {
                   res.writeHead(400);

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -54,7 +54,6 @@ import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
 import {
   DEFAULT_DEVICE_SIZES,
-  DEFAULT_IMAGE_QUALITIES,
   DEFAULT_IMAGE_SIZES,
   isImageOptimizationPath,
   resolveDevImageRedirect,
@@ -626,7 +625,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         ...(options.imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
         ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ],
-      options.imageConfig?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+      options.imageConfig?.qualities,
       { isDev: options.isDev },
     );
     if (!imageRedirect)

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -44,7 +44,11 @@ export type ImageConfig = {
   deviceSizes?: number[];
   /** Allowed fixed-image widths. Defaults to Next.js image sizes. */
   imageSizes?: number[];
-  /** Allowed output qualities. Defaults to Next.js's `[75]`. */
+  /**
+   * Allowed output qualities. When unset, any quality from 1-100 is permitted
+   * (matches Next.js: an unset `images.qualities` is not restricted to a single
+   * value). When set, only the listed qualities are accepted.
+   */
   qualities?: number[];
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
@@ -71,7 +75,6 @@ export type ImageConfig = {
  */
 export const DEFAULT_DEVICE_SIZES = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 export const DEFAULT_IMAGE_SIZES = [16, 32, 48, 64, 96, 128, 256, 384];
-export const DEFAULT_IMAGE_QUALITIES = [75];
 const DEV_BLUR_MAX_WIDTH = 8;
 const DEV_BLUR_QUALITY = 70;
 
@@ -82,7 +85,7 @@ export type ParseImageParamsOptions = {
 export function resolveDevImageRedirect(
   requestUrl: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
-  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
+  allowedQualities?: number[],
   options: ParseImageParamsOptions = { isDev: true },
 ): string | null {
   const params = parseImageParams(requestUrl, allowedWidths, allowedQualities, options);
@@ -110,7 +113,7 @@ export function resolveDevImageRedirect(
 export function parseImageParams(
   url: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
-  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
+  allowedQualities?: number[],
   options: ParseImageParamsOptions = {},
 ): { imageUrl: string; width: number; quality: number } | null {
   // Intentional hardening divergence from Next.js: reject duplicate and unknown
@@ -137,7 +140,10 @@ export function parseImageParams(
   const isDevBlurWidth = options.isDev && width <= DEV_BLUR_MAX_WIDTH;
   const isDevBlurQuality = options.isDev && quality === DEV_BLUR_QUALITY;
   if (width <= 0 || (!allowedWidths.includes(width) && !isDevBlurWidth)) return null;
-  if (quality < 1 || quality > 100 || (!allowedQualities.includes(quality) && !isDevBlurQuality)) {
+  if (quality < 1 || quality > 100) return null;
+  // Only enforce the quality allowlist when `images.qualities` is configured.
+  // Matches Next.js: an unset `qualities` permits any quality from 1-100.
+  if (allowedQualities && !allowedQualities.includes(quality) && !isDevBlurQuality) {
     return null;
   }
 

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -131,7 +131,10 @@ describe("createAppRscHandler", () => {
   });
 
   it("allows independent Next.js blur width and quality exceptions in pure App Router dev", async () => {
-    const handler = createHandler();
+    // The blur quality exception (q=70) is only observable when `qualities` is
+    // configured — with an unset allowlist any quality 1-100 is permitted, so
+    // pin it to [75] to exercise the dev-only exception itself.
+    const handler = createHandler({ imageConfig: { qualities: [75] } });
     for (const query of ["url=%2Fimg.jpg&w=8&q=75", "url=%2Fimg.jpg&w=640&q=70"]) {
       const response = await handler(
         new Request(`https://example.test/docs/_next/image?${query}`),
@@ -142,7 +145,7 @@ describe("createAppRscHandler", () => {
   });
 
   it("rejects Next.js blur width and quality exceptions in production", async () => {
-    const handler = createHandler({ isDev: false });
+    const handler = createHandler({ isDev: false, imageConfig: { qualities: [75] } });
     for (const query of ["url=%2Fimg.jpg&w=8&q=75", "url=%2Fimg.jpg&w=640&q=70"]) {
       const response = await handler(
         new Request(`https://example.test/docs/_next/image?${query}`),
@@ -150,6 +153,17 @@ describe("createAppRscHandler", () => {
       );
       expect(response.status).toBe(400);
     }
+  });
+
+  it("allows any quality 1-100 in production when images.qualities is unset", async () => {
+    // Matches Next.js: an unset `qualities` is not restricted to a single value,
+    // so q=70 (and any 1-100) is a normal quality even in production.
+    const handler = createHandler({ isDev: false });
+    const response = await handler(
+      new Request("https://example.test/docs/_next/image?url=%2Fimg.jpg&w=640&q=70"),
+      null,
+    );
+    expect(response.status).toBe(302);
   });
 
   it("wraps dispatch responses with request-scoped finalization", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17953,6 +17953,43 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
+  it("parseImageParams permits any quality 1-100 when qualities is unset", async () => {
+    // Matches Next.js: an unset `images.qualities` is not restricted to a single
+    // value. Regression test for non-75 qualities (e.g. `<Image quality={90}>`)
+    // returning 400 from the image optimization endpoint.
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    for (const q of [1, 50, 75, 90, 100]) {
+      const params = parseImageParams(
+        new URL(`http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=${q}`),
+      );
+      expect(params).not.toBeNull();
+      expect(params!.quality).toBe(q);
+    }
+  });
+
+  it("parseImageParams enforces the allowlist only when qualities is configured", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    const allowed = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
+    // Quality in the configured allowlist passes.
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=90"),
+        allowed,
+        [75, 90],
+      ),
+    ).not.toBeNull();
+    // Quality outside the configured allowlist is rejected.
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=50"),
+        allowed,
+        [75, 90],
+      ),
+    ).toBeNull();
+  });
+
   it("parseImageParams blocks backslash-based open redirect (/\\evil.com)", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
@@ -18052,7 +18089,9 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
-  it("parseImageParams defaults allowed qualities to 75", async () => {
+  it("parseImageParams allows any quality 1-100 when qualities is unset", async () => {
+    // Matches Next.js: an unset `images.qualities` does not restrict the quality
+    // to a single value — any integer from 1-100 is accepted.
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
     expect(
@@ -18060,7 +18099,7 @@ describe("image optimization request parsing", () => {
     ).not.toBeNull();
     expect(
       parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=80")),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   it("parseImageParams accepts configured qualities", async () => {


### PR DESCRIPTION
## Problem

The image optimization endpoint returns **400 Bad Request** for any quality other than `75`. For example, the app-router-playground product card uses `<Image quality={90}>`, and the deployed endpoint fails:

```
GET /_next/image?url=%2Fshop%2Ftablet.png&w=750&q=90  ->  400 Bad Request
GET /_next/image?url=%2Fshop%2Ftablet.png&w=640&q=75  ->  200 OK
```

Only `q=75` worked; `q=50`, `q=90`, `q=100` all 400'd regardless of width.

## Root cause

`parseImageParams` defaulted the allowed-quality list to `DEFAULT_IMAGE_QUALITIES = [75]` whenever `images.qualities` was not configured, and the build/runtime plumbing baked `[75]` into the deploy worker (`__VINEXT_IMAGE_QUALITIES ?? "[75]"`).

Next.js only enforces a quality allowlist when `images.qualities` is **explicitly set**. When unset, it permits any integer quality from 1–100 — the allowlist block is skipped entirely:

```js
// next/src/server/image-optimizer.ts — validateParams
const quality = parseInt(q, 10)
if (isNaN(quality) || quality < 1 || quality > 100) { /* reject */ }
if (qualities) {                       // only when configured
  if (isDev) qualities.push(BLUR_QUALITY)
  if (!qualities.includes(quality)) { /* reject */ }
}
```

## Fix

- `parseImageParams` / `resolveDevImageRedirect` take an **optional** `allowedQualities` and only enforce the allowlist when one is provided (still range-checks 1–100 and preserves the dev `BLUR_QUALITY` exception).
- Removed the `[75]` default and the `?? DEFAULT_IMAGE_QUALITIES` / `?? "[75]"` fallbacks; the build now emits `null` when `qualities` is unset so the "allow all" semantics survive into the deploy worker.
- Covers all call paths (app-router, pages-router, dev server, deploy worker) since they all route through the shared `parseImageParams`.

## Tests

- Regression test: any quality 1–100 passes when `qualities` is unset.
- Allowlist is still enforced when `qualities` is configured.
- Updated the prior test that asserted the buggy `[75]`-only behaviour.

## Follow-up

A stacked PR will address the remaining `validateParams` parity gaps (recursive `/_next/image` guard, `localPatterns`, `remotePatterns`, `minimumCacheTTL`).