### PR TITLE
feat(image): recursive-url guard and images.localPatterns parity

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -202,7 +202,7 @@ export type NextConfig = {
     deviceSizes?: number[];
     /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [16, 32, 48, 64, 96, 128, 256, 384] */
     imageSizes?: number[];
-    /** Allowed image qualities. Defaults to Next.js 16's `[75]`. */
+    /** Allowed image qualities. When unset, any quality from 1-100 is permitted (matches Next.js). */
     qualities?: number[];
     /** Allow SVG images through the image optimization endpoint. SVG can contain scripts, so only enable if you trust all image sources. */
     dangerouslyAllowSVG?: boolean;

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -204,6 +204,11 @@ export type NextConfig = {
     imageSizes?: number[];
     /** Allowed image qualities. When unset, any quality from 1-100 is permitted (matches Next.js). */
     qualities?: number[];
+    /**
+     * Restricts which local image paths may be optimized. When unset, any local path is
+     * allowed (matches Next.js). `pathname` is a glob (`*` = one segment, `**` = many).
+     */
+    localPatterns?: Array<{ pathname?: string; search?: string }>;
     /** Allow SVG images through the image optimization endpoint. SVG can contain scripts, so only enable if you trust all image sources. */
     dangerouslyAllowSVG?: boolean;
     /** Allow image optimization for hostnames that resolve to private IP addresses. This is a security risk (SSRF) — only enable for private networks when you understand the risk. */

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -490,7 +490,7 @@ const imageConfig: ImageConfig = {
   imageSizes: JSON.parse(
     process.env.__VINEXT_IMAGE_SIZES ?? JSON.stringify(DEFAULT_IMAGE_SIZES),
   ),
-  qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "[75]"),
+  qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "null") ?? undefined,
   dangerouslyAllowSVG: process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG === "true",
 };
 

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -491,6 +491,7 @@ const imageConfig: ImageConfig = {
     process.env.__VINEXT_IMAGE_SIZES ?? JSON.stringify(DEFAULT_IMAGE_SIZES),
   ),
   qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "null") ?? undefined,
+  localPatterns: JSON.parse(process.env.__VINEXT_IMAGE_LOCAL_PATTERNS ?? "null") ?? undefined,
   dangerouslyAllowSVG: process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG === "true",
 };
 
@@ -592,6 +593,7 @@ const configRewrites = vinextConfig?.rewrites ?? { beforeFiles: [], afterFiles: 
 const configHeaders = vinextConfig?.headers ?? [];
 const imageConfig: ImageConfig | undefined = vinextConfig?.images ? {
   qualities: vinextConfig.images.qualities,
+  localPatterns: vinextConfig.images.localPatterns,
   dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
   dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
   contentDispositionType: vinextConfig.images.contentDispositionType,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -125,6 +125,7 @@ export async function generateServerEntry(
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
       qualities: nextConfig?.images?.qualities,
+      localPatterns: nextConfig?.images?.localPatterns,
       dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
       dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
       contentDispositionType: nextConfig?.images?.contentDispositionType,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -32,7 +32,6 @@ import { createSSRHandler } from "./server/dev-server.js";
 import { handleApiRoute } from "./server/api-handler.js";
 import {
   DEFAULT_DEVICE_SIZES,
-  DEFAULT_IMAGE_QUALITIES,
   DEFAULT_IMAGE_SIZES,
   isImageOptimizationPath,
   resolveDevImageRedirect,
@@ -1355,8 +1354,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             JSON.stringify(deviceSizes),
           );
           defines["process.env.__VINEXT_IMAGE_SIZES"] = JSON.stringify(JSON.stringify(imageSizes));
+          // Emit the configured qualities allowlist, or `null` when unset so the
+          // runtime permits any quality 1-100 (matches Next.js: an unset
+          // `images.qualities` is not restricted to a single value).
           defines["process.env.__VINEXT_IMAGE_QUALITIES"] = JSON.stringify(
-            JSON.stringify(nextConfig.images?.qualities ?? DEFAULT_IMAGE_QUALITIES),
+            JSON.stringify(nextConfig.images?.qualities ?? null),
           );
         }
         // Expose dangerouslyAllowSVG flag for the image shim's auto-skip logic.
@@ -3526,7 +3528,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 const encodedLocation = resolveDevImageRedirect(
                   imageRequestUrl,
                   allowedWidths,
-                  nextConfig.images?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+                  nextConfig.images?.qualities,
                 );
                 if (!encodedLocation) {
                   res.writeHead(400);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1360,6 +1360,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           defines["process.env.__VINEXT_IMAGE_QUALITIES"] = JSON.stringify(
             JSON.stringify(nextConfig.images?.qualities ?? null),
           );
+          // Emit the configured local-path allowlist, or `null` when unset so the
+          // runtime permits any local path (matches Next.js: an unset
+          // `images.localPatterns` does not restrict which local paths optimize).
+          defines["process.env.__VINEXT_IMAGE_LOCAL_PATTERNS"] = JSON.stringify(
+            JSON.stringify(nextConfig.images?.localPatterns ?? null),
+          );
         }
         // Expose dangerouslyAllowSVG flag for the image shim's auto-skip logic.
         // When false (default), .svg sources bypass the optimization endpoint.
@@ -2693,6 +2699,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 deviceSizes: nextConfig?.images?.deviceSizes,
                 imageSizes: nextConfig?.images?.imageSizes,
                 qualities: nextConfig?.images?.qualities,
+                localPatterns: nextConfig?.images?.localPatterns,
               },
               hasPagesDir,
               publicFiles: scanPublicFileRoutes(root),
@@ -3529,6 +3536,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   imageRequestUrl,
                   allowedWidths,
                   nextConfig.images?.qualities,
+                  { isDev: true, localPatterns: nextConfig.images?.localPatterns },
                 );
                 if (!encodedLocation) {
                   res.writeHead(400);
@@ -4596,6 +4604,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             deviceSizes: nextConfig?.images?.deviceSizes,
             imageSizes: nextConfig?.images?.imageSizes,
             qualities: nextConfig?.images?.qualities,
+            localPatterns: nextConfig?.images?.localPatterns,
             dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
             contentDispositionType: nextConfig?.images?.contentDispositionType,
             contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -54,7 +54,6 @@ import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
 import {
   DEFAULT_DEVICE_SIZES,
-  DEFAULT_IMAGE_QUALITIES,
   DEFAULT_IMAGE_SIZES,
   isImageOptimizationPath,
   resolveDevImageRedirect,
@@ -626,7 +625,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         ...(options.imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
         ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ],
-      options.imageConfig?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+      options.imageConfig?.qualities,
       { isDev: options.isDev },
     );
     if (!imageRedirect)

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -626,7 +626,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ],
       options.imageConfig?.qualities,
-      { isDev: options.isDev },
+      { isDev: options.isDev, localPatterns: options.imageConfig?.localPatterns },
     );
     if (!imageRedirect)
       return new Response("Invalid image optimization parameters", { status: 400 });

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -44,7 +44,11 @@ export type ImageConfig = {
   deviceSizes?: number[];
   /** Allowed fixed-image widths. Defaults to Next.js image sizes. */
   imageSizes?: number[];
-  /** Allowed output qualities. Defaults to Next.js's `[75]`. */
+  /**
+   * Allowed output qualities. When unset, any quality from 1-100 is permitted
+   * (matches Next.js: an unset `images.qualities` is not restricted to a single
+   * value). When set, only the listed qualities are accepted.
+   */
   qualities?: number[];
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
@@ -71,7 +75,6 @@ export type ImageConfig = {
  */
 export const DEFAULT_DEVICE_SIZES = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 export const DEFAULT_IMAGE_SIZES = [16, 32, 48, 64, 96, 128, 256, 384];
-export const DEFAULT_IMAGE_QUALITIES = [75];
 const DEV_BLUR_MAX_WIDTH = 8;
 const DEV_BLUR_QUALITY = 70;
 
@@ -82,7 +85,7 @@ export type ParseImageParamsOptions = {
 export function resolveDevImageRedirect(
   requestUrl: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
-  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
+  allowedQualities?: number[],
   options: ParseImageParamsOptions = { isDev: true },
 ): string | null {
   const params = parseImageParams(requestUrl, allowedWidths, allowedQualities, options);
@@ -110,7 +113,7 @@ export function resolveDevImageRedirect(
 export function parseImageParams(
   url: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
-  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
+  allowedQualities?: number[],
   options: ParseImageParamsOptions = {},
 ): { imageUrl: string; width: number; quality: number } | null {
   // Intentional hardening divergence from Next.js: reject duplicate and unknown
@@ -137,7 +140,10 @@ export function parseImageParams(
   const isDevBlurWidth = options.isDev && width <= DEV_BLUR_MAX_WIDTH;
   const isDevBlurQuality = options.isDev && quality === DEV_BLUR_QUALITY;
   if (width <= 0 || (!allowedWidths.includes(width) && !isDevBlurWidth)) return null;
-  if (quality < 1 || quality > 100 || (!allowedQualities.includes(quality) && !isDevBlurQuality)) {
+  if (quality < 1 || quality > 100) return null;
+  // Only enforce the quality allowlist when `images.qualities` is configured.
+  // Matches Next.js: an unset `qualities` permits any quality from 1-100.
+  if (allowedQualities && !allowedQualities.includes(quality) && !isDevBlurQuality) {
     return null;
   }
 

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -18,6 +18,7 @@
  */
 
 import { badRequestResponse } from "./http-error-responses.js";
+import { globToRegex } from "../utils/glob-pattern.js";
 
 /** The pathname that triggers image optimization (matches Next.js). */
 export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
@@ -36,6 +37,17 @@ export function isImageOptimizationPath(pathname: string): boolean {
 }
 
 /**
+ * A single `images.localPatterns` entry. Restricts which local image paths may
+ * be optimized. Mirrors Next.js's `LocalPattern`.
+ */
+export type LocalPattern = {
+  /** Glob pattern matched against the path (`*` = one segment, `**` = many). Defaults to `**`. */
+  pathname?: string;
+  /** Exact query string (including the leading `?`) the request must carry. */
+  search?: string;
+};
+
+/**
  * Image security configuration from next.config.js `images` section.
  * Controls SVG handling and security headers for the image endpoint.
  */
@@ -50,6 +62,12 @@ export type ImageConfig = {
    * value). When set, only the listed qualities are accepted.
    */
   qualities?: number[];
+  /**
+   * Restricts which local image paths may be optimized. When unset, any local
+   * path is allowed (matches Next.js). When set, the request `url` must match
+   * at least one pattern.
+   */
+  localPatterns?: LocalPattern[];
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
   /**
@@ -80,7 +98,26 @@ const DEV_BLUR_QUALITY = 70;
 
 export type ParseImageParamsOptions = {
   isDev?: boolean;
+  /**
+   * When set, the local `url` path must match at least one of these patterns
+   * (matches Next.js `images.localPatterns`). When unset, any local path is allowed.
+   */
+  localPatterns?: LocalPattern[];
 };
+
+/**
+ * Check whether a local image URL matches a single `localPatterns` entry.
+ * Mirrors Next.js's matchLocalPattern().
+ */
+export function matchLocalPattern(pattern: LocalPattern, url: URL): boolean {
+  if (pattern.search !== undefined && pattern.search !== url.search) return false;
+  return globToRegex(pattern.pathname ?? "**", "/").test(url.pathname);
+}
+
+/** Check whether a local image URL matches any configured `localPatterns` entry. */
+export function hasLocalMatch(localPatterns: LocalPattern[], url: URL): boolean {
+  return localPatterns.some((p) => matchLocalPattern(p, url));
+}
 
 export function resolveDevImageRedirect(
   requestUrl: URL,
@@ -159,13 +196,31 @@ export function parseImageParams(
   }
   // Double-check: after URL construction, the origin must not change.
   // This catches any remaining parser differentials.
+  let resolved: URL;
   try {
     const base = "https://localhost";
-    const resolved = new URL(normalizedUrl, base);
+    resolved = new URL(normalizedUrl, base);
     if (resolved.origin !== base) {
       return null;
     }
   } catch {
+    return null;
+  }
+
+  // Reject URLs that point back at the optimization endpoint (matches Next.js:
+  // the `url` parameter "cannot be recursive"). Decode first so an encoded path
+  // (e.g. %2F_next%2Fimage) can't smuggle the endpoint past the check.
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(resolved.pathname);
+  } catch {
+    return null;
+  }
+  if (/\/_(?:next|vinext)\/image(?:$|\/)/.test(decodedPathname)) return null;
+
+  // When `images.localPatterns` is configured, the local path must match at
+  // least one pattern (matches Next.js). Unset => any local path is allowed.
+  if (options.localPatterns && !hasLocalMatch(options.localPatterns, resolved)) {
     return null;
   }
 
@@ -284,7 +339,9 @@ export async function handleImageOptimization(
   imageConfig?: ImageConfig,
 ): Promise<Response> {
   const url = new URL(request.url);
-  const params = parseImageParams(url, allowedWidths, imageConfig?.qualities);
+  const params = parseImageParams(url, allowedWidths, imageConfig?.qualities, {
+    localPatterns: imageConfig?.localPatterns,
+  });
 
   if (!params) {
     return badRequestResponse();

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1292,7 +1292,9 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
         ...(imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
         ...(imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ];
-      const params = parseImageParams(parsedUrl, allowedWidths, imageConfig?.qualities);
+      const params = parseImageParams(parsedUrl, allowedWidths, imageConfig?.qualities, {
+        localPatterns: imageConfig?.localPatterns,
+      });
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");
@@ -1503,6 +1505,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
         dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
         qualities: vinextConfig.images.qualities,
+        localPatterns: vinextConfig.images.localPatterns,
         contentDispositionType: vinextConfig.images.contentDispositionType,
         contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
       }
@@ -1623,7 +1626,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // ── Image optimization passthrough ──────────────────────────────
     if (isImageOptimizationPath(pathname) || isImageOptimizationPath(staticLookupPath)) {
       const parsedUrl = new URL(rawUrl, "http://localhost");
-      const params = parseImageParams(parsedUrl, allowedImageWidths, pagesImageConfig?.qualities);
+      const params = parseImageParams(parsedUrl, allowedImageWidths, pagesImageConfig?.qualities, {
+        localPatterns: pagesImageConfig?.localPatterns,
+      });
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");

--- a/packages/vinext/src/shims/image-config.ts
+++ b/packages/vinext/src/shims/image-config.ts
@@ -1,4 +1,5 @@
 import ipaddr from "ipaddr.js";
+import { globToRegex } from "../utils/glob-pattern.js";
 
 /**
  * Image remote pattern validation.
@@ -21,55 +22,6 @@ export type RemotePattern = {
   pathname?: string;
   search?: string;
 };
-
-// Cache compiled glob regexes — bounded by the number of distinct configured
-// remotePatterns. Key uses \0 as a separator; \0 cannot appear in a valid glob
-// or separator character, so there are no collisions. Compiled regexes are
-// flagless, so sharing via .test() is safe.
-const globRegexCache = new Map<string, RegExp>();
-
-/**
- * Convert a glob pattern (with `*` and `**`) to a RegExp.
- *
- * For hostnames, segments are separated by `.`:
- *   - `*` matches a single segment (no dots): [^.]+
- *   - `**` matches any number of segments: .+
- *
- * For pathnames, segments are separated by `/`:
- *   - `*` matches a single segment (no slashes): [^/]+
- *   - `**` matches any number of segments (including empty): .*
- *
- * Literal characters are escaped for regex safety.
- */
-function globToRegex(pattern: string, separator: "." | "/"): RegExp {
-  const key = `${separator}\0${pattern}`;
-  const cached = globRegexCache.get(key);
-  if (cached !== undefined) return cached;
-  // Split by ** first, then handle * within each part
-  let regexStr = "^";
-  const doubleStar = separator === "." ? ".+" : ".*";
-  const singleStar = separator === "." ? "[^.]+" : "[^/]+";
-
-  const parts = pattern.split("**");
-  for (let i = 0; i < parts.length; i++) {
-    if (i > 0) {
-      regexStr += doubleStar;
-    }
-    // Within each part, split by * and escape the literals
-    const subParts = parts[i].split("*");
-    for (let j = 0; j < subParts.length; j++) {
-      if (j > 0) {
-        regexStr += singleStar;
-      }
-      // Escape regex special chars in the literal portion
-      regexStr += subParts[j].replace(/[.+?^${}()|[\]\\]/g, "\\$&");
-    }
-  }
-  regexStr += "$";
-  const re = new RegExp(regexStr);
-  globRegexCache.set(key, re);
-  return re;
-}
 
 /**
  * Check whether a URL matches a single remote pattern.

--- a/packages/vinext/src/utils/glob-pattern.ts
+++ b/packages/vinext/src/utils/glob-pattern.ts
@@ -1,0 +1,55 @@
+/**
+ * Glob-to-RegExp conversion shared by image remote-pattern (hostname) and
+ * local-pattern (pathname) matching. Follows Next.js semantics:
+ * - `*` matches a single segment (no separator)
+ * - `**` matches any number of segments
+ *
+ * Literal characters are escaped for regex safety.
+ */
+
+// Cache compiled glob regexes — bounded by the number of distinct configured
+// patterns. Key uses \0 as a separator; \0 cannot appear in a valid glob or
+// separator character, so there are no collisions. Compiled regexes are
+// flagless, so sharing via .test() is safe.
+const globRegexCache = new Map<string, RegExp>();
+
+/**
+ * Convert a glob pattern (with `*` and `**`) to a RegExp.
+ *
+ * For hostnames, segments are separated by `.`:
+ *   - `*` matches a single segment (no dots): [^.]+
+ *   - `**` matches any number of segments: .+
+ *
+ * For pathnames, segments are separated by `/`:
+ *   - `*` matches a single segment (no slashes): [^/]+
+ *   - `**` matches any number of segments (including empty): .*
+ */
+export function globToRegex(pattern: string, separator: "." | "/"): RegExp {
+  const key = `${separator}\0${pattern}`;
+  const cached = globRegexCache.get(key);
+  if (cached !== undefined) return cached;
+  // Split by ** first, then handle * within each part
+  let regexStr = "^";
+  const doubleStar = separator === "." ? ".+" : ".*";
+  const singleStar = separator === "." ? "[^.]+" : "[^/]+";
+
+  const parts = pattern.split("**");
+  for (let i = 0; i < parts.length; i++) {
+    if (i > 0) {
+      regexStr += doubleStar;
+    }
+    // Within each part, split by * and escape the literals
+    const subParts = parts[i].split("*");
+    for (let j = 0; j < subParts.length; j++) {
+      if (j > 0) {
+        regexStr += singleStar;
+      }
+      // Escape regex special chars in the literal portion
+      regexStr += subParts[j].replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  regexStr += "$";
+  const re = new RegExp(regexStr);
+  globRegexCache.set(key, re);
+  return re;
+}

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -131,7 +131,10 @@ describe("createAppRscHandler", () => {
   });
 
   it("allows independent Next.js blur width and quality exceptions in pure App Router dev", async () => {
-    const handler = createHandler();
+    // The blur quality exception (q=70) is only observable when `qualities` is
+    // configured — with an unset allowlist any quality 1-100 is permitted, so
+    // pin it to [75] to exercise the dev-only exception itself.
+    const handler = createHandler({ imageConfig: { qualities: [75] } });
     for (const query of ["url=%2Fimg.jpg&w=8&q=75", "url=%2Fimg.jpg&w=640&q=70"]) {
       const response = await handler(
         new Request(`https://example.test/docs/_next/image?${query}`),
@@ -142,7 +145,7 @@ describe("createAppRscHandler", () => {
   });
 
   it("rejects Next.js blur width and quality exceptions in production", async () => {
-    const handler = createHandler({ isDev: false });
+    const handler = createHandler({ isDev: false, imageConfig: { qualities: [75] } });
     for (const query of ["url=%2Fimg.jpg&w=8&q=75", "url=%2Fimg.jpg&w=640&q=70"]) {
       const response = await handler(
         new Request(`https://example.test/docs/_next/image?${query}`),
@@ -150,6 +153,17 @@ describe("createAppRscHandler", () => {
       );
       expect(response.status).toBe(400);
     }
+  });
+
+  it("allows any quality 1-100 in production when images.qualities is unset", async () => {
+    // Matches Next.js: an unset `qualities` is not restricted to a single value,
+    // so q=70 (and any 1-100) is a normal quality even in production.
+    const handler = createHandler({ isDev: false });
+    const response = await handler(
+      new Request("https://example.test/docs/_next/image?url=%2Fimg.jpg&w=640&q=70"),
+      null,
+    );
+    expect(response.status).toBe(302);
   });
 
   it("wraps dispatch responses with request-scoped finalization", async () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -677,6 +677,7 @@ describe("generateAppRouterWorkerEntry", () => {
     expect(content).toContain("process.env.__VINEXT_IMAGE_DEVICE_SIZES");
     expect(content).toContain("process.env.__VINEXT_IMAGE_SIZES");
     expect(content).toContain("process.env.__VINEXT_IMAGE_QUALITIES");
+    expect(content).toContain("process.env.__VINEXT_IMAGE_LOCAL_PATTERNS");
     expect(content).toContain("JSON.stringify(DEFAULT_DEVICE_SIZES)");
     expect(content).toContain("JSON.stringify(DEFAULT_IMAGE_SIZES)");
     expect(content).toContain("}, allowedWidths, imageConfig)");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17953,6 +17953,43 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
+  it("parseImageParams permits any quality 1-100 when qualities is unset", async () => {
+    // Matches Next.js: an unset `images.qualities` is not restricted to a single
+    // value. Regression test for non-75 qualities (e.g. `<Image quality={90}>`)
+    // returning 400 from the image optimization endpoint.
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    for (const q of [1, 50, 75, 90, 100]) {
+      const params = parseImageParams(
+        new URL(`http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=${q}`),
+      );
+      expect(params).not.toBeNull();
+      expect(params!.quality).toBe(q);
+    }
+  });
+
+  it("parseImageParams enforces the allowlist only when qualities is configured", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    const allowed = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
+    // Quality in the configured allowlist passes.
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=90"),
+        allowed,
+        [75, 90],
+      ),
+    ).not.toBeNull();
+    // Quality outside the configured allowlist is rejected.
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=50"),
+        allowed,
+        [75, 90],
+      ),
+    ).toBeNull();
+  });
+
   it("parseImageParams blocks backslash-based open redirect (/\\evil.com)", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
@@ -18052,7 +18089,9 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
-  it("parseImageParams defaults allowed qualities to 75", async () => {
+  it("parseImageParams allows any quality 1-100 when qualities is unset", async () => {
+    // Matches Next.js: an unset `images.qualities` does not restrict the quality
+    // to a single value — any integer from 1-100 is accepted.
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
     expect(
@@ -18060,7 +18099,7 @@ describe("image optimization request parsing", () => {
     ).not.toBeNull();
     expect(
       parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=80")),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   it("parseImageParams accepts configured qualities", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17990,6 +17990,65 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
+  it("parseImageParams rejects url that points back at the optimization endpoint", async () => {
+    // Matches Next.js: the `url` parameter "cannot be recursive".
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    for (const recursive of [
+      "%2F_next%2Fimage",
+      "%2F_next%2Fimage%2Ffoo.png",
+      "%2F_vinext%2Fimage%2Ffoo.png",
+    ]) {
+      expect(
+        parseImageParams(
+          new URL(`http://localhost/_next/image?url=${recursive}&w=640&q=75`),
+        ),
+      ).toBeNull();
+    }
+    // A path that merely starts with the same prefix is not recursive.
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2F_next%2Fimagefoo.png&w=640&q=75"),
+      ),
+    ).not.toBeNull();
+  });
+
+  it("parseImageParams enforces localPatterns only when configured", async () => {
+    // Matches Next.js: an unset `images.localPatterns` allows any local path;
+    // when configured, the `url` path must match at least one pattern.
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    const allowed = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
+    const url = (path: string) =>
+      new URL(`http://localhost/_next/image?url=${encodeURIComponent(path)}&w=640&q=75`);
+
+    // Unset => any local path allowed.
+    expect(parseImageParams(url("/assets/anything.png"))).not.toBeNull();
+
+    // Configured => only matching paths pass.
+    const localPatterns = [{ pathname: "/shop/**" }];
+    expect(parseImageParams(url("/shop/tablet.png"), allowed, undefined, { localPatterns })).not.toBeNull();
+    expect(parseImageParams(url("/shop/a/b/c.png"), allowed, undefined, { localPatterns })).not.toBeNull();
+    expect(parseImageParams(url("/other/x.png"), allowed, undefined, { localPatterns })).toBeNull();
+  });
+
+  it("matchLocalPattern honours pathname globs and exact search", async () => {
+    const { matchLocalPattern } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    // Single-segment `*` does not cross a slash.
+    expect(matchLocalPattern({ pathname: "/img/*" }, new URL("http://n/img/a.png"))).toBe(true);
+    expect(matchLocalPattern({ pathname: "/img/*" }, new URL("http://n/img/a/b.png"))).toBe(false);
+    // `**` crosses slashes.
+    expect(matchLocalPattern({ pathname: "/img/**" }, new URL("http://n/img/a/b.png"))).toBe(true);
+    // Search must match exactly when specified.
+    expect(
+      matchLocalPattern({ pathname: "/img/**", search: "?v=1" }, new URL("http://n/img/a.png?v=1")),
+    ).toBe(true);
+    expect(
+      matchLocalPattern({ pathname: "/img/**", search: "?v=1" }, new URL("http://n/img/a.png?v=2")),
+    ).toBe(false);
+  });
+
   it("parseImageParams blocks backslash-based open redirect (/\\evil.com)", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");


### PR DESCRIPTION
> **Stacked on #2023** (the `images.qualities` parity fix). Review/merge that first — until it lands, this PR's diff against `main` includes its commit. The new work here is the final commit, `feat(image): add recursive-url guard and images.localPatterns parity`.

Follow-up to the quality-validation fix: brings two more `validateParams` branches to parity with Next.js for the `/_next/image` endpoint.

## 1. Recursive-URL guard

Next.js rejects a `url` parameter that points back at the optimizer ("url parameter cannot be recursive"). vinext previously accepted it and 404'd downstream. Now `parseImageParams` rejects a `url` whose **decoded** pathname targets `/_next/image` (or vinext's `/_vinext/image` alias) — decoding first so an encoded path can't smuggle the endpoint past the check.

## 2. `images.localPatterns`

Next.js restricts which local paths may be optimized when `images.localPatterns` is configured (`hasLocalMatch`), and allows any local path when unset. vinext ignored it entirely. Now:

- Added `localPatterns` to the image config types and `matchLocalPattern`/`hasLocalMatch` helpers (Next.js semantics: glob `pathname`, exact `search`).
- Threaded through every path: app router, pages router, dev server, and the deploy worker — via a new `__VINEXT_IMAGE_LOCAL_PATTERNS` build-time define that emits `null` when unset so "allow all" survives into the worker.
- Extracted the existing glob→regex helper (previously private to remote-pattern matching) into `utils/glob-pattern.ts` and reused it for local patterns.

## Deliberately omitted (architectural divergences, not bugs)

- **`remotePatterns` / server-side remote fetch** — vinext serves remote images **client-side** via `@unpic/react`, validated against `remotePatterns`/`domains` in `shims/image-config.ts`. The `/_next/image` endpoint is local-only **by design** (documented in the README, `check.ts`, and the `dangerouslyAllowLocalIP` comment) to avoid the SSRF surface. Implementing server-side remote fetch would reverse that decision.
- **`minimumCacheTTL`** — vinext serves local/static assets with `Cache-Control: ...immutable`, which is exactly Next.js's behaviour for static media. The TTL knob doesn't apply to the local-only model.

## Tests

- Recursive-URL rejection (including the `/_vinext/image` alias and encoded forms; a path that merely shares the prefix is **not** rejected).
- `localPatterns` enforced only when configured; `matchLocalPattern` glob/search semantics.
- Codegen test asserts the new `__VINEXT_IMAGE_LOCAL_PATTERNS` define is threaded into the worker entry.