### PR TITLE
fix(app-router): settle superseded link navigations

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1686,6 +1686,8 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
   }
   markInitialAppRouterBootstrapHydrated();
 
+  let activeNavigationAbortController: AbortController | null = null;
+
   const navigateRsc: NavigationRuntimeNavigate = async function navigateRsc(
     href: string,
     redirectDepth = 0,
@@ -1697,6 +1699,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     scrollIntent?: AppRouterScrollIntent | null,
     visibleCommitMode: NavigationRuntimeVisibleCommitMode = "transition",
   ): Promise<void> {
+    activeNavigationAbortController?.abort();
+    const navigationAbortController = new AbortController();
+    activeNavigationAbortController = navigationAbortController;
     let pendingRouterState: PendingBrowserRouterState | null = null;
     // Hoist navId above try so the catch and finally blocks can reference it.
     const navId = browserNavigationController.beginNavigation();
@@ -2062,6 +2067,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           navResponse = await fetch(rscUrl, {
             headers: requestHeaders,
             credentials: "include",
+            signal: navigationAbortController.signal,
           });
         }
 
@@ -2147,6 +2153,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           headers: navResponse.headers,
         });
         const cacheBufferPromise = new Response(cacheBranch).arrayBuffer();
+        void cacheBufferPromise.catch(() => {});
 
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 
@@ -2225,6 +2232,9 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       });
       performHardNavigationForScrollIntent(errorDecision.url);
     } finally {
+      if (activeNavigationAbortController === navigationAbortController) {
+        activeNavigationAbortController = null;
+      }
       // Single settlement site: covers normal return, early returns on stale-id
       // checks, and error paths. The finally runs even when the catch returns.
       // settlePendingBrowserRouterState is idempotent via the settled flag.

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1974,6 +1974,10 @@ const _appRouter: AppRouterInstance = {
   push(href: string, options?: { scroll?: boolean }): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
+    // An imperative navigation supersedes any <Link>-owned pending state.
+    // Clear it before entering the navigation transition so React does not
+    // defer the idle update behind the suspended destination render.
+    getNavigationRuntime()?.functions.notifyLinkNavigationStart?.();
     const releaseNavigation = trackScheduledAppRouterNavigation();
     try {
       React.startTransition(() => {
@@ -1988,6 +1992,7 @@ const _appRouter: AppRouterInstance = {
   replace(href: string, options?: { scroll?: boolean }): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
+    getNavigationRuntime()?.functions.notifyLinkNavigationStart?.();
     const releaseNavigation = trackScheduledAppRouterNavigation();
     try {
       React.startTransition(() => {

--- a/tests/e2e/app-router/nextjs-compat/use-link-status.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/use-link-status.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+
+test.describe("useLinkStatus navigation ownership", () => {
+  test("imperative navigation clears link-owned pending state", async ({ page }) => {
+    // Ported from Next.js: test/e2e/use-link-status/index.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/use-link-status/index.test.ts
+    await page.goto(`${BASE}/nextjs-compat/use-link-status`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#post-1-link").click({ noWaitAfter: true });
+    await expect(page.locator("#post-1-loading")).toHaveText("(Loading)");
+
+    await page.locator("#router-push-2-btn").click({ noWaitAfter: true });
+    await expect(page.locator("#post-1-loading")).toHaveCount(0);
+    await expect(page.locator("#post-2-page")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("only the last rapidly clicked link stays pending and settles", async ({ page }) => {
+    // Ported from Next.js: test/e2e/use-link-status/index.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/use-link-status/index.test.ts
+    await page.goto(`${BASE}/nextjs-compat/use-link-status`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#post-1-link").click({ noWaitAfter: true });
+    await expect(page.locator("#post-1-loading")).toHaveText("(Loading)");
+    await page.locator("#post-2-link").click({ noWaitAfter: true });
+
+    await expect(page.locator("#post-1-loading")).toHaveCount(0);
+    await expect(page.locator("#post-2-loading")).toHaveText("(Loading)");
+    await expect(page.locator("#post-2-page")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/layout.tsx
@@ -1,0 +1,10 @@
+import NavBar from "./nav-bar";
+
+export default function UseLinkStatusLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <main>
+      <NavBar />
+      {children}
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/nav-bar.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/nav-bar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link, { useLinkStatus } from "next/link";
+import { useRouter } from "next/navigation";
+
+function LoadingIndicator({ id }: { id: string }) {
+  const { pending } = useLinkStatus();
+  return pending ? <span id={`${id}-loading`}>(Loading)</span> : null;
+}
+
+export default function NavBar() {
+  const router = useRouter();
+
+  return (
+    <nav>
+      <Link href="/nextjs-compat/use-link-status/post/1" prefetch={false} id="post-1-link">
+        Post 1 <LoadingIndicator id="post-1" />
+      </Link>
+      <Link href="/nextjs-compat/use-link-status/post/2" prefetch={false} id="post-2-link">
+        Post 2 <LoadingIndicator id="post-2" />
+      </Link>
+      <button
+        id="router-push-2-btn"
+        onClick={() => router.push("/nextjs-compat/use-link-status/post/2")}
+      >
+        Router push to post 2
+      </button>
+    </nav>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/page.tsx
@@ -1,0 +1,3 @@
+export default function UseLinkStatusPage() {
+  return <h1 id="use-link-status-home">Use link status</h1>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/post/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/use-link-status/post/[id]/page.tsx
@@ -1,0 +1,5 @@
+export default async function PostPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  await new Promise((resolve) => setTimeout(resolve, 1_500));
+  return <h1 id={`post-${id}-page`}>Post {id}</h1>;
+}


### PR DESCRIPTION
## Summary

- clear link-owned pending state when imperative `router.push` or `router.replace` supersedes a link navigation
- abort superseded live RSC requests and prevent stale commits/cache writes
- add vinext-owned rapid-click and imperative-navigation coverage

## Next.js parity

Fixes failures from `test/e2e/use-link-status/index.test.ts`, including pending state surviving `router.push` and rapid overlapping navigations.

## Validation

- pinned Next.js v16.2.6 deploy suite: 6/6 passed
- focused unit tests: 324 passed
- new Playwright fixture: 2 passed
- adjacent navigation tests: 16 passed
- scoped `vp check` and vinext build
- two review passes; no actionable findings remain
