### PR TITLE
fix(pages): align on-demand ISR regeneration semantics

### DIFF
--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -341,9 +341,14 @@ export class KVCacheHandler implements CacheHandler {
 
     // Resolve effective revalidate — data overrides ctx.
     // revalidate: 0 means "don't cache", so skip storage entirely.
-    let effectiveRevalidate: number | undefined;
+    let effectiveRevalidate: number | false | undefined;
     let effectiveExpire: number | undefined;
     effectiveRevalidate = readCacheControlNumberField(ctx, "revalidate");
+    if (ctx?.cacheControl && (ctx.cacheControl as Record<string, unknown>).revalidate === false) {
+      effectiveRevalidate = false;
+    } else if (ctx?.revalidate === false) {
+      effectiveRevalidate = false;
+    }
     effectiveExpire = readCacheControlNumberField(ctx, "expire");
     if (data && "revalidate" in data && typeof data.revalidate === "number") {
       effectiveRevalidate = data.revalidate;
@@ -359,8 +364,8 @@ export class KVCacheHandler implements CacheHandler {
       typeof effectiveExpire === "number" && effectiveExpire > 0
         ? now + effectiveExpire * 1000
         : null;
-    const cacheControl =
-      typeof effectiveRevalidate === "number"
+    const cacheControl: CacheControlMetadata | undefined =
+      typeof effectiveRevalidate === "number" || effectiveRevalidate === false
         ? effectiveExpire === undefined
           ? { revalidate: effectiveRevalidate }
           : { revalidate: effectiveRevalidate, expire: effectiveExpire }
@@ -550,7 +555,9 @@ function validateCacheEntry(raw: unknown): KVCacheEntry | null {
   }
   if (obj.cacheControl !== undefined) {
     if (!isUnknownRecord(obj.cacheControl)) return null;
-    if (typeof obj.cacheControl.revalidate !== "number") return null;
+    if (typeof obj.cacheControl.revalidate !== "number" && obj.cacheControl.revalidate !== false) {
+      return null;
+    }
     if (obj.cacheControl.expire !== undefined && typeof obj.cacheControl.expire !== "number") {
       return null;
     }

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -479,8 +479,11 @@ export async function readAppPageCacheResponse(
       // the stale payload and will fall through to a fresh render.
       options.scheduleBackgroundRegeneration(regenerationKey, async () => {
         const revalidatedPage = await options.renderFreshPageForCache();
+        const revalidatedPageRevalidate = revalidatedPage.cacheControl?.revalidate;
         const revalidateSeconds =
-          revalidatedPage.cacheControl?.revalidate ?? options.revalidateSeconds;
+          revalidatedPageRevalidate === false
+            ? Infinity
+            : (revalidatedPageRevalidate ?? options.revalidateSeconds);
         const expireSeconds = revalidatedPage.cacheControl?.expire ?? options.expireSeconds;
         const writes = [
           options.isrSet(

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -22,6 +22,7 @@ import {
   beginPagesIsrGeneration,
   cancelPagesIsrGeneration,
   commitPagesIsrGeneration,
+  waitForPagesIsrGeneration,
   triggerBackgroundRegeneration,
   setRevalidateDuration,
   getRevalidateDuration,
@@ -575,6 +576,7 @@ export function createSSRHandler(
     const requestContext = createRequestContext();
     return runWithRequestContext(requestContext, async () => {
       ensureFetchPatch();
+      let pagesIsrGeneration: ReturnType<typeof beginPagesIsrGeneration> | null = null;
       try {
         await _alsRegistration;
 
@@ -696,7 +698,6 @@ export function createSSRHandler(
         let pageProps: Record<string, unknown> = {};
         let renderProps: Record<string, unknown> = { pageProps };
         let isrRevalidateSeconds: number | false | null = null;
-        let pagesIsrGeneration: ReturnType<typeof beginPagesIsrGeneration> | null = null;
         // Set when `getStaticPaths: { fallback: true }` is configured and the
         // requested path is NOT in the pre-rendered list. Triggers the loading
         // shell render below: `getStaticProps`/`getServerSideProps` are skipped
@@ -1005,6 +1006,21 @@ export function createSSRHandler(
           );
           if (isOnDemandRevalidate) {
             pagesIsrGeneration = beginPagesIsrGeneration(cacheKey, "on-demand");
+            await waitForPagesIsrGeneration(pagesIsrGeneration);
+          }
+
+          if (!isOnDemandRevalidate && cached && !cached.isStale && cached.value.value === null) {
+            await renderErrorPage(
+              server,
+              runner,
+              req,
+              res,
+              url,
+              pagesDir,
+              404,
+              routerShim.wrapWithRouterContext,
+            );
+            return;
           }
 
           if (
@@ -1334,6 +1350,15 @@ export function createSSRHandler(
             return;
           }
           if (result && "notFound" in result && result.notFound) {
+            if (isOnDemandRevalidate) {
+              const revalidateSeconds =
+                typeof result.revalidate === "number" && result.revalidate > 0
+                  ? result.revalidate
+                  : false;
+              await commitPagesIsrGeneration(pagesIsrGeneration, () =>
+                isrSet(cacheKey, null, revalidateSeconds),
+              );
+            }
             if (isDataReq) {
               // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
               // `_next/data` notFound exits for deployment-skew protection. Fixes #1829.
@@ -1819,6 +1844,7 @@ hydrate();
           }
         }
       } catch (e) {
+        cancelPagesIsrGeneration(pagesIsrGeneration, e);
         // ssrFixStacktrace() is specific to ssrLoadModule and is not applicable
         // when using ModuleRunner — no stack trace fixup is needed here.
         console.error(e);
@@ -1866,7 +1892,7 @@ hydrate();
           res.end(`Internal Server Error: ${(fallbackErr as Error).message}`);
         }
       } finally {
-        // Cleanup is handled by unified ALS scope unwinding.
+        cancelPagesIsrGeneration(pagesIsrGeneration);
       }
     });
   };

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -19,6 +19,8 @@ import {
   isrSet,
   isrCacheKey,
   buildPagesCacheValue,
+  beginPagesIsrGeneration,
+  commitPagesIsrGeneration,
   triggerBackgroundRegeneration,
   setRevalidateDuration,
   getRevalidateDuration,
@@ -692,7 +694,8 @@ export function createSSRHandler(
         // Collect page props via data fetching methods
         let pageProps: Record<string, unknown> = {};
         let renderProps: Record<string, unknown> = { pageProps };
-        let isrRevalidateSeconds: number | null = null;
+        let isrRevalidateSeconds: number | false | null = null;
+        let pagesIsrGeneration: ReturnType<typeof beginPagesIsrGeneration> | null = null;
         // Set when `getStaticPaths: { fallback: true }` is configured and the
         // requested path is NOT in the pre-rendered list. Triggers the loading
         // shell render below: `getStaticProps`/`getServerSideProps` are skipped
@@ -999,6 +1002,9 @@ export function createSSRHandler(
           const isOnDemandRevalidate = isOnDemandRevalidateRequest(
             req.headers[PRERENDER_REVALIDATE_HEADER],
           );
+          if (isOnDemandRevalidate) {
+            pagesIsrGeneration = beginPagesIsrGeneration(cacheKey);
+          }
 
           if (
             !isOnDemandRevalidate &&
@@ -1049,6 +1055,7 @@ export function createSSRHandler(
             triggerBackgroundRegeneration(
               cacheKey,
               async () => {
+                const generation = beginPagesIsrGeneration(cacheKey);
                 const regenContext = createRequestContext({
                   // Dev never has a Workers ExecutionContext. Set it
                   // explicitly so background regeneration cannot inherit
@@ -1238,10 +1245,12 @@ export function createSSRHandler(
                       const hydrationScript = hydrationMatch?.[0] ?? "";
 
                       const freshHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${freshBody}</div>${freshNextData}\n  ${hydrationScript}</body></html>`;
-                      await isrSet(
-                        cacheKey,
-                        buildPagesCacheValue(freshHtml, freshRenderProps),
-                        revalidate,
+                      await commitPagesIsrGeneration(generation, () =>
+                        isrSet(
+                          cacheKey,
+                          buildPagesCacheValue(freshHtml, freshRenderProps),
+                          revalidate,
+                        ),
                       );
                       setRevalidateDuration(cacheKey, revalidate);
                     }
@@ -1358,6 +1367,8 @@ export function createSSRHandler(
           // Extract revalidate period for ISR caching after render
           if (typeof result?.revalidate === "number" && result.revalidate > 0) {
             isrRevalidateSeconds = result.revalidate;
+          } else if (isOnDemandRevalidate) {
+            isrRevalidateSeconds = false;
           } else if (
             cached?.value.value?.kind === "PAGES" &&
             cached.value.value.generatedFromDataRequest
@@ -1412,19 +1423,24 @@ export function createSSRHandler(
           if (shouldPersistFallbackData) {
             const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
             const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
-            await isrSet(
-              cacheKey,
-              {
-                kind: "PAGES",
-                html: "",
-                pageData: renderProps,
-                generatedFromDataRequest: true,
-                headers: undefined,
-                status: undefined,
-              },
-              revalidateSeconds,
+            const generation = beginPagesIsrGeneration(cacheKey);
+            await commitPagesIsrGeneration(generation, () =>
+              isrSet(
+                cacheKey,
+                {
+                  kind: "PAGES",
+                  html: "",
+                  pageData: renderProps,
+                  generatedFromDataRequest: true,
+                  headers: undefined,
+                  status: undefined,
+                },
+                revalidateSeconds,
+              ),
             );
-            setRevalidateDuration(cacheKey, revalidateSeconds);
+            if (typeof revalidateSeconds === "number") {
+              setRevalidateDuration(cacheKey, revalidateSeconds);
+            }
           }
           const dataHeaders: Record<string, string | string[] | number> = {
             "Content-Type": "application/json",
@@ -1671,11 +1687,13 @@ hydrate();
         const extraHeaders: Record<string, string | string[]> = {
           ...gsspExtraHeaders,
         };
-        if (isrRevalidateSeconds) {
+        if (isrRevalidateSeconds !== null) {
           if (scriptNonce) {
             extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
           } else {
-            extraHeaders["Cache-Control"] = buildMissIsrCacheControl(isrRevalidateSeconds);
+            extraHeaders["Cache-Control"] = buildMissIsrCacheControl(
+              isrRevalidateSeconds === false ? 31_536_000 : isrRevalidateSeconds,
+            );
             Object.assign(extraHeaders, buildCacheStateHeaders("MISS"));
           }
         }
@@ -1770,7 +1788,7 @@ hydrate();
         // If ISR is enabled, we need the full HTML for caching.
         // For ISR, re-render synchronously to get the complete HTML string.
         // This runs after the stream is already sent, so it doesn't affect TTFB.
-        if (!scriptNonce && isrRevalidateSeconds !== null && isrRevalidateSeconds > 0) {
+        if (!scriptNonce && isrRevalidateSeconds !== null) {
           let isrElement = AppComponent
             ? createElement(AppComponent, {
                 ...renderProps,
@@ -1786,8 +1804,13 @@ hydrate();
           );
           const isrHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${isrBodyHtml}</div>${allScripts}</body></html>`;
           const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
-          await isrSet(cacheKey, buildPagesCacheValue(isrHtml, pageProps), isrRevalidateSeconds);
-          setRevalidateDuration(cacheKey, isrRevalidateSeconds);
+          const generation = pagesIsrGeneration ?? beginPagesIsrGeneration(cacheKey);
+          await commitPagesIsrGeneration(generation, () =>
+            isrSet(cacheKey, buildPagesCacheValue(isrHtml, pageProps), isrRevalidateSeconds),
+          );
+          if (typeof isrRevalidateSeconds === "number") {
+            setRevalidateDuration(cacheKey, isrRevalidateSeconds);
+          }
         }
       } catch (e) {
         // ssrFixStacktrace() is specific to ssrLoadModule and is not applicable

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -20,6 +20,7 @@ import {
   isrCacheKey,
   buildPagesCacheValue,
   beginPagesIsrGeneration,
+  cancelPagesIsrGeneration,
   commitPagesIsrGeneration,
   triggerBackgroundRegeneration,
   setRevalidateDuration,
@@ -1003,7 +1004,7 @@ export function createSSRHandler(
             req.headers[PRERENDER_REVALIDATE_HEADER],
           );
           if (isOnDemandRevalidate) {
-            pagesIsrGeneration = beginPagesIsrGeneration(cacheKey);
+            pagesIsrGeneration = beginPagesIsrGeneration(cacheKey, "on-demand");
           }
 
           if (
@@ -1055,7 +1056,8 @@ export function createSSRHandler(
             triggerBackgroundRegeneration(
               cacheKey,
               async () => {
-                const generation = beginPagesIsrGeneration(cacheKey);
+                const generation = beginPagesIsrGeneration(cacheKey, "stale");
+                if (!generation) return;
                 const regenContext = createRequestContext({
                   // Dev never has a Workers ExecutionContext. Set it
                   // explicitly so background regeneration cannot inherit
@@ -1080,182 +1082,186 @@ export function createSSRHandler(
                       }
                     : null,
                 });
-                return runWithRequestContext(regenContext, async () => {
-                  ensureFetchPatch();
-                  let freshPageProps: Record<string, unknown> = {};
-                  let freshRenderProps: Record<string, unknown> = { pageProps: freshPageProps };
+                try {
+                  await runWithRequestContext(regenContext, async () => {
+                    ensureFetchPatch();
+                    let freshPageProps: Record<string, unknown> = {};
+                    let freshRenderProps: Record<string, unknown> = { pageProps: freshPageProps };
 
-                  // oxlint-disable-next-line typescript/no-explicit-any
-                  let RegenApp: any = null;
-                  const appPath = path.join(pagesDir, "_app");
-                  if (findFileWithExtensions(appPath, matcher)) {
-                    try {
-                      const appMod = (await runner.import(appPath)) as Record<string, unknown>;
-                      RegenApp = appMod.default ?? null;
-                    } catch {
-                      // _app failed to load
+                    // oxlint-disable-next-line typescript/no-explicit-any
+                    let RegenApp: any = null;
+                    const appPath = path.join(pagesDir, "_app");
+                    if (findFileWithExtensions(appPath, matcher)) {
+                      try {
+                        const appMod = (await runner.import(appPath)) as Record<string, unknown>;
+                        RegenApp = appMod.default ?? null;
+                      } catch {
+                        // _app failed to load
+                      }
                     }
-                  }
 
-                  if (RegenApp && hasPagesGetInitialProps(RegenApp)) {
-                    const regenReq = { url: req.url, headers: req.headers, method: req.method };
-                    const regenRes = {
-                      headersSent: false,
-                      writableEnded: false,
-                      statusCode: 200,
-                      getHeaders() {
-                        return {};
-                      },
-                    };
-                    const initialProps = await loadPagesGetInitialProps(RegenApp, {
-                      AppTree: (appTreeProps: Record<string, unknown>) => {
-                        const appTree = React.createElement(RegenApp, {
-                          ...appTreeProps,
-                          Component: pageModule.default,
-                          pageProps: appTreeProps.pageProps,
-                          router: routerShim.default,
-                        });
-                        return typeof routerShim.wrapWithRouterContext === "function"
-                          ? routerShim.wrapWithRouterContext(appTree)
-                          : appTree;
-                      },
-                      Component: pageModule.default,
-                      router: {
-                        pathname: patternToNextFormat(route.pattern),
-                        query,
-                        asPath: requestAsPath,
-                      },
-                      ctx: {
-                        req: regenReq,
-                        res: regenRes,
-                        pathname: patternToNextFormat(route.pattern),
-                        query,
-                        asPath: requestAsPath,
-                        locale: locale ?? currentDefaultLocale,
-                        locales: i18nConfig?.locales,
-                        defaultLocale: currentDefaultLocale,
-                      },
-                    });
-                    if (regenRes.headersSent || regenRes.writableEnded) return;
-                    if (initialProps) {
-                      freshRenderProps = initialProps;
-                      freshPageProps = isUnknownRecord(initialProps.pageProps)
-                        ? initialProps.pageProps
-                        : {};
-                    }
-                  }
-
-                  const freshResult = await pageModule.getStaticProps({
-                    params: userFacingParams,
-                    locale: locale ?? currentDefaultLocale,
-                    locales: i18nConfig?.locales,
-                    defaultLocale: currentDefaultLocale,
-                    // Stale-while-revalidate background regeneration — mirrors
-                    // Next.js `render.tsx`'s `revalidateReason` resolution.
-                    revalidateReason: "stale",
-                  });
-                  if (freshResult && "props" in freshResult) {
-                    const revalidate =
-                      typeof freshResult.revalidate === "number"
-                        ? freshResult.revalidate
-                        : (cached.value.cacheControl?.revalidate ?? 0);
-                    if (revalidate > 0) {
-                      freshPageProps = { ...freshPageProps, ...freshResult.props };
-                      freshRenderProps = { ...freshRenderProps, pageProps: freshPageProps };
-
-                      if (typeof routerShim.setSSRContext === "function") {
-                        routerShim.setSSRContext({
+                    if (RegenApp && hasPagesGetInitialProps(RegenApp)) {
+                      const regenReq = { url: req.url, headers: req.headers, method: req.method };
+                      const regenRes = {
+                        headersSent: false,
+                        writableEnded: false,
+                        statusCode: 200,
+                        getHeaders() {
+                          return {};
+                        },
+                      };
+                      const initialProps = await loadPagesGetInitialProps(RegenApp, {
+                        AppTree: (appTreeProps: Record<string, unknown>) => {
+                          const appTree = React.createElement(RegenApp, {
+                            ...appTreeProps,
+                            Component: pageModule.default,
+                            pageProps: appTreeProps.pageProps,
+                            router: routerShim.default,
+                          });
+                          return typeof routerShim.wrapWithRouterContext === "function"
+                            ? routerShim.wrapWithRouterContext(appTree)
+                            : appTree;
+                        },
+                        Component: pageModule.default,
+                        router: {
                           pathname: patternToNextFormat(route.pattern),
                           query,
                           asPath: requestAsPath,
-                          navigationIsReady,
+                        },
+                        ctx: {
+                          req: regenReq,
+                          res: regenRes,
+                          pathname: patternToNextFormat(route.pattern),
+                          query,
+                          asPath: requestAsPath,
+                          locale: locale ?? currentDefaultLocale,
+                          locales: i18nConfig?.locales,
+                          defaultLocale: currentDefaultLocale,
+                        },
+                      });
+                      if (regenRes.headersSent || regenRes.writableEnded) return;
+                      if (initialProps) {
+                        freshRenderProps = initialProps;
+                        freshPageProps = isUnknownRecord(initialProps.pageProps)
+                          ? initialProps.pageProps
+                          : {};
+                      }
+                    }
+
+                    const freshResult = await pageModule.getStaticProps({
+                      params: userFacingParams,
+                      locale: locale ?? currentDefaultLocale,
+                      locales: i18nConfig?.locales,
+                      defaultLocale: currentDefaultLocale,
+                      // Stale-while-revalidate background regeneration — mirrors
+                      // Next.js `render.tsx`'s `revalidateReason` resolution.
+                      revalidateReason: "stale",
+                    });
+                    if (freshResult && "props" in freshResult) {
+                      const revalidate =
+                        typeof freshResult.revalidate === "number"
+                          ? freshResult.revalidate
+                          : (cached.value.cacheControl?.revalidate ?? 0);
+                      if (revalidate > 0) {
+                        freshPageProps = { ...freshPageProps, ...freshResult.props };
+                        freshRenderProps = { ...freshRenderProps, pageProps: freshPageProps };
+
+                        if (typeof routerShim.setSSRContext === "function") {
+                          routerShim.setSSRContext({
+                            pathname: patternToNextFormat(route.pattern),
+                            query,
+                            asPath: requestAsPath,
+                            navigationIsReady,
+                            locale: locale ?? currentDefaultLocale,
+                            locales: i18nConfig?.locales,
+                            defaultLocale: currentDefaultLocale,
+                            domainLocales,
+                          });
+                        }
+                        if (i18nConfig) {
+                          await runner.import("vinext/i18n-state");
+                          const i18nCtx = await importModule(runner, "vinext/i18n-context");
+                          if (typeof i18nCtx.setI18nContext === "function") {
+                            i18nCtx.setI18nContext({
+                              locale: locale ?? currentDefaultLocale,
+                              locales: i18nConfig.locales,
+                              defaultLocale: currentDefaultLocale,
+                              domainLocales,
+                              hostname: req.headers.host?.split(":", 1)[0],
+                            });
+                          }
+                        }
+
+                        let el = RegenApp
+                          ? React.createElement(RegenApp, {
+                              ...freshRenderProps,
+                              Component: pageModule.default,
+                              pageProps: freshRenderProps.pageProps,
+                              router: routerShim.default,
+                            })
+                          : React.createElement(pageModule.default, freshPageProps);
+                        if (routerShim.wrapWithRouterContext) {
+                          el = routerShim.wrapWithRouterContext(el);
+                        }
+                        const freshBody = await renderIsrPassToStringAsync(
+                          withScriptNonce(el, scriptNonce),
+                        );
+
+                        // Rebuild __NEXT_DATA__ with fresh props. The hydration
+                        // script (module URLs) is stable across regenerations —
+                        // extract it from the cached HTML to avoid duplication.
+                        const viteRoot = server.config?.root;
+                        const regenPageUrl = viteRoot
+                          ? "/" + path.relative(viteRoot, route.filePath)
+                          : route.filePath;
+                        const regenAppUrl = RegenApp
+                          ? viteRoot
+                            ? "/" + path.relative(viteRoot, path.join(pagesDir, "_app"))
+                            : path.join(pagesDir, "_app")
+                          : null;
+                        const freshPagesNextData = {
+                          ...pagesNextData,
+                          __vinext: {
+                            ...pagesNextData.__vinext,
+                            pageModuleUrl: regenPageUrl,
+                            appModuleUrl: regenAppUrl,
+                            hasMiddleware,
+                          },
+                        };
+
+                        const freshNextData = `<script>window.__NEXT_DATA__ = ${safeJsonStringify({
+                          props: freshRenderProps,
+                          page: patternToNextFormat(route.pattern),
+                          query: params,
+                          buildId: process.env.__VINEXT_BUILD_ID,
+                          isFallback: false,
                           locale: locale ?? currentDefaultLocale,
                           locales: i18nConfig?.locales,
                           defaultLocale: currentDefaultLocale,
                           domainLocales,
-                        });
+                          ...freshPagesNextData,
+                        })}${i18nConfig ? `;window.__VINEXT_LOCALE__=${safeJsonStringify(locale ?? currentDefaultLocale)};window.__VINEXT_LOCALES__=${safeJsonStringify(i18nConfig.locales)};window.__VINEXT_DEFAULT_LOCALE__=${safeJsonStringify(currentDefaultLocale)}` : ""}</script>`;
+
+                        const hydrationMatch = cachedHtml.match(
+                          /<script type="module">[\s\S]*?<\/script>/,
+                        );
+                        const hydrationScript = hydrationMatch?.[0] ?? "";
+
+                        const freshHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${freshBody}</div>${freshNextData}\n  ${hydrationScript}</body></html>`;
+                        await commitPagesIsrGeneration(generation, () =>
+                          isrSet(
+                            cacheKey,
+                            buildPagesCacheValue(freshHtml, freshRenderProps),
+                            revalidate,
+                          ),
+                        );
+                        setRevalidateDuration(cacheKey, revalidate);
                       }
-                      if (i18nConfig) {
-                        await runner.import("vinext/i18n-state");
-                        const i18nCtx = await importModule(runner, "vinext/i18n-context");
-                        if (typeof i18nCtx.setI18nContext === "function") {
-                          i18nCtx.setI18nContext({
-                            locale: locale ?? currentDefaultLocale,
-                            locales: i18nConfig.locales,
-                            defaultLocale: currentDefaultLocale,
-                            domainLocales,
-                            hostname: req.headers.host?.split(":", 1)[0],
-                          });
-                        }
-                      }
-
-                      let el = RegenApp
-                        ? React.createElement(RegenApp, {
-                            ...freshRenderProps,
-                            Component: pageModule.default,
-                            pageProps: freshRenderProps.pageProps,
-                            router: routerShim.default,
-                          })
-                        : React.createElement(pageModule.default, freshPageProps);
-                      if (routerShim.wrapWithRouterContext) {
-                        el = routerShim.wrapWithRouterContext(el);
-                      }
-                      const freshBody = await renderIsrPassToStringAsync(
-                        withScriptNonce(el, scriptNonce),
-                      );
-
-                      // Rebuild __NEXT_DATA__ with fresh props. The hydration
-                      // script (module URLs) is stable across regenerations —
-                      // extract it from the cached HTML to avoid duplication.
-                      const viteRoot = server.config?.root;
-                      const regenPageUrl = viteRoot
-                        ? "/" + path.relative(viteRoot, route.filePath)
-                        : route.filePath;
-                      const regenAppUrl = RegenApp
-                        ? viteRoot
-                          ? "/" + path.relative(viteRoot, path.join(pagesDir, "_app"))
-                          : path.join(pagesDir, "_app")
-                        : null;
-                      const freshPagesNextData = {
-                        ...pagesNextData,
-                        __vinext: {
-                          ...pagesNextData.__vinext,
-                          pageModuleUrl: regenPageUrl,
-                          appModuleUrl: regenAppUrl,
-                          hasMiddleware,
-                        },
-                      };
-
-                      const freshNextData = `<script>window.__NEXT_DATA__ = ${safeJsonStringify({
-                        props: freshRenderProps,
-                        page: patternToNextFormat(route.pattern),
-                        query: params,
-                        buildId: process.env.__VINEXT_BUILD_ID,
-                        isFallback: false,
-                        locale: locale ?? currentDefaultLocale,
-                        locales: i18nConfig?.locales,
-                        defaultLocale: currentDefaultLocale,
-                        domainLocales,
-                        ...freshPagesNextData,
-                      })}${i18nConfig ? `;window.__VINEXT_LOCALE__=${safeJsonStringify(locale ?? currentDefaultLocale)};window.__VINEXT_LOCALES__=${safeJsonStringify(i18nConfig.locales)};window.__VINEXT_DEFAULT_LOCALE__=${safeJsonStringify(currentDefaultLocale)}` : ""}</script>`;
-
-                      const hydrationMatch = cachedHtml.match(
-                        /<script type="module">[\s\S]*?<\/script>/,
-                      );
-                      const hydrationScript = hydrationMatch?.[0] ?? "";
-
-                      const freshHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${freshBody}</div>${freshNextData}\n  ${hydrationScript}</body></html>`;
-                      await commitPagesIsrGeneration(generation, () =>
-                        isrSet(
-                          cacheKey,
-                          buildPagesCacheValue(freshHtml, freshRenderProps),
-                          revalidate,
-                        ),
-                      );
-                      setRevalidateDuration(cacheKey, revalidate);
                     }
-                  }
-                });
+                  });
+                } finally {
+                  cancelPagesIsrGeneration(generation);
+                }
               },
               {
                 routerKind: "Pages Router",
@@ -1423,7 +1429,7 @@ export function createSSRHandler(
           if (shouldPersistFallbackData) {
             const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
             const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
-            const generation = beginPagesIsrGeneration(cacheKey);
+            const generation = beginPagesIsrGeneration(cacheKey, "ordinary");
             await commitPagesIsrGeneration(generation, () =>
               isrSet(
                 cacheKey,
@@ -1804,7 +1810,7 @@ hydrate();
           );
           const isrHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${isrBodyHtml}</div>${allScripts}</body></html>`;
           const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
-          const generation = pagesIsrGeneration ?? beginPagesIsrGeneration(cacheKey);
+          const generation = pagesIsrGeneration ?? beginPagesIsrGeneration(cacheKey, "ordinary");
           await commitPagesIsrGeneration(generation, () =>
             isrSet(cacheKey, buildPagesCacheValue(isrHtml, pageProps), isrRevalidateSeconds),
           );

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -153,7 +153,7 @@ export async function isrGet(key: string): Promise<ISRCacheEntry | null> {
   // Page-level reads go through the CDN cache adapter. The default adapter
   // reads the data cache; an edge adapter may return null so the CDN serves.
   const result = await getCdnCacheAdapter().get(key);
-  if (!result || !result.value) return null;
+  if (!result) return null;
   // Built-in handlers hard-delete expired entries and return null, but custom
   // CacheHandler implementations may surface expiry explicitly.
   if (result.cacheState === "expired") return null;
@@ -169,7 +169,7 @@ export async function isrGet(key: string): Promise<ISRCacheEntry | null> {
  */
 export async function isrSet(
   key: string,
-  data: IncrementalCacheValue,
+  data: IncrementalCacheValue | null,
   revalidateSeconds: number | false,
   tags?: string[],
   expireSeconds?: number,
@@ -191,6 +191,9 @@ export type PagesIsrGeneration = {
   kind: "on-demand" | "ordinary" | "stale";
   version: number;
   finished: boolean;
+  authoritativeTurn: Promise<void>;
+  resolveAuthoritative: (() => void) | null;
+  rejectAuthoritative: ((error: unknown) => void) | null;
 };
 
 type PagesIsrCoordinationState = {
@@ -199,6 +202,7 @@ type PagesIsrCoordinationState = {
   authoritativeVersion: number;
   version: number;
   commitTail: Promise<void>;
+  authoritativeTail: Promise<void>;
 };
 
 const _PAGES_ISR_COORDINATION_KEY = Symbol.for("vinext.pagesIsr.coordination");
@@ -218,6 +222,7 @@ export function beginPagesIsrGeneration(
     authoritativeVersion: 0,
     version: 0,
     commitTail: Promise.resolve(),
+    authoritativeTail: Promise.resolve(),
   };
   if (kind !== "on-demand" && state.authoritativeInFlight > 0) return null;
   state.version += 1;
@@ -226,18 +231,47 @@ export function beginPagesIsrGeneration(
     state.authoritativeInFlight += 1;
     state.authoritativeVersion = state.version;
   }
+  const authoritativeTurn = kind === "on-demand" ? state.authoritativeTail : Promise.resolve();
+  let resolveAuthoritative: (() => void) | null = null;
+  let rejectAuthoritative: ((error: unknown) => void) | null = null;
+  if (kind === "on-demand") {
+    const authoritativeResult = new Promise<void>((resolve, reject) => {
+      resolveAuthoritative = resolve;
+      rejectAuthoritative = reject;
+    });
+    state.authoritativeTail = authoritativeTurn.catch(() => {}).then(() => authoritativeResult);
+    void state.authoritativeTail.catch(() => {});
+  }
   pagesIsrCoordination.set(key, state);
-  return { key, kind, version: state.version, finished: false };
+  return {
+    key,
+    kind,
+    version: state.version,
+    finished: false,
+    authoritativeTurn,
+    resolveAuthoritative,
+    rejectAuthoritative,
+  };
+}
+
+export async function waitForPagesIsrGeneration(generation: PagesIsrGeneration | null) {
+  await generation?.authoritativeTurn;
 }
 
 function finishPagesIsrGeneration(
   generation: PagesIsrGeneration,
   state: PagesIsrCoordinationState,
+  error?: unknown,
 ): void {
   if (generation.finished) return;
   generation.finished = true;
   state.active -= 1;
-  if (generation.kind === "on-demand") state.authoritativeInFlight -= 1;
+  if (generation.kind === "on-demand") {
+    state.authoritativeInFlight -= 1;
+    if (error === undefined) generation.resolveAuthoritative?.();
+    else generation.rejectAuthoritative?.(error);
+    if (state.authoritativeInFlight === 0) state.authoritativeTail = Promise.resolve();
+  }
   const cleanupTail = state.commitTail;
   void cleanupTail.then(() => {
     if (
@@ -250,11 +284,14 @@ function finishPagesIsrGeneration(
   });
 }
 
-export function cancelPagesIsrGeneration(generation: PagesIsrGeneration | null): void {
+export function cancelPagesIsrGeneration(
+  generation: PagesIsrGeneration | null,
+  error?: unknown,
+): void {
   if (!generation) return;
   const state = pagesIsrCoordination.get(generation.key);
   if (!state) return;
-  finishPagesIsrGeneration(generation, state);
+  finishPagesIsrGeneration(generation, state, error);
 }
 
 export function commitPagesIsrGeneration(
@@ -271,13 +308,19 @@ export function commitPagesIsrGeneration(
       if (generation.kind !== "on-demand" && state.authoritativeVersion > generation.version) {
         return false;
       }
-      if (generation.kind === "on-demand" && state.authoritativeVersion !== generation.version) {
-        return false;
-      }
       await write();
       return true;
     })
-    .finally(() => finishPagesIsrGeneration(generation, state));
+    .then(
+      (result) => {
+        finishPagesIsrGeneration(generation, state);
+        return result;
+      },
+      (error) => {
+        finishPagesIsrGeneration(generation, state, error);
+        throw error;
+      },
+    );
   state.commitTail = commit.then(
     () => {},
     () => {},

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -170,7 +170,7 @@ export async function isrGet(key: string): Promise<ISRCacheEntry | null> {
 export async function isrSet(
   key: string,
   data: IncrementalCacheValue,
-  revalidateSeconds: number,
+  revalidateSeconds: number | false,
   tags?: string[],
   expireSeconds?: number,
 ): Promise<void> {
@@ -184,6 +184,54 @@ export async function isrSet(
     revalidate: revalidateSeconds,
     tags: tags ?? [],
   });
+}
+
+export type PagesIsrGeneration = {
+  key: string;
+  version: number;
+};
+
+type PagesIsrCoordinationState = {
+  version: number;
+  commitTail: Promise<void>;
+};
+
+const _PAGES_ISR_COORDINATION_KEY = Symbol.for("vinext.pagesIsr.coordination");
+const _pagesIsrGlobal = globalThis as unknown as Record<PropertyKey, unknown>;
+const pagesIsrCoordination = (_pagesIsrGlobal[_PAGES_ISR_COORDINATION_KEY] ??= new Map<
+  string,
+  PagesIsrCoordinationState
+>()) as Map<string, PagesIsrCoordinationState>;
+
+export function beginPagesIsrGeneration(key: string): PagesIsrGeneration {
+  const state = pagesIsrCoordination.get(key) ?? {
+    version: 0,
+    commitTail: Promise.resolve(),
+  };
+  state.version += 1;
+  pagesIsrCoordination.set(key, state);
+  return { key, version: state.version };
+}
+
+export function commitPagesIsrGeneration(
+  generation: PagesIsrGeneration,
+  write: () => Promise<void>,
+): Promise<boolean> {
+  const state = pagesIsrCoordination.get(generation.key);
+  if (!state) return Promise.resolve(false);
+
+  const commit = state.commitTail
+    .catch(() => {})
+    .then(async () => {
+      if (state.version !== generation.version) return false;
+      await write();
+      return true;
+    });
+  state.commitTail = commit.then(
+    () => {},
+    () => {},
+  );
+  return commit;
 }
 
 export async function isrSetPrerenderedAppPage(

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -188,10 +188,15 @@ export async function isrSet(
 
 export type PagesIsrGeneration = {
   key: string;
+  kind: "on-demand" | "ordinary" | "stale";
   version: number;
+  finished: boolean;
 };
 
 type PagesIsrCoordinationState = {
+  active: number;
+  authoritativeInFlight: number;
+  authoritativeVersion: number;
   version: number;
   commitTail: Promise<void>;
 };
@@ -203,30 +208,76 @@ const pagesIsrCoordination = (_pagesIsrGlobal[_PAGES_ISR_COORDINATION_KEY] ??= n
   PagesIsrCoordinationState
 >()) as Map<string, PagesIsrCoordinationState>;
 
-export function beginPagesIsrGeneration(key: string): PagesIsrGeneration {
+export function beginPagesIsrGeneration(
+  key: string,
+  kind: PagesIsrGeneration["kind"] = "ordinary",
+): PagesIsrGeneration | null {
   const state = pagesIsrCoordination.get(key) ?? {
+    active: 0,
+    authoritativeInFlight: 0,
+    authoritativeVersion: 0,
     version: 0,
     commitTail: Promise.resolve(),
   };
+  if (kind !== "on-demand" && state.authoritativeInFlight > 0) return null;
   state.version += 1;
+  state.active += 1;
+  if (kind === "on-demand") {
+    state.authoritativeInFlight += 1;
+    state.authoritativeVersion = state.version;
+  }
   pagesIsrCoordination.set(key, state);
-  return { key, version: state.version };
+  return { key, kind, version: state.version, finished: false };
+}
+
+function finishPagesIsrGeneration(
+  generation: PagesIsrGeneration,
+  state: PagesIsrCoordinationState,
+): void {
+  if (generation.finished) return;
+  generation.finished = true;
+  state.active -= 1;
+  if (generation.kind === "on-demand") state.authoritativeInFlight -= 1;
+  const cleanupTail = state.commitTail;
+  void cleanupTail.then(() => {
+    if (
+      state.active === 0 &&
+      state.commitTail === cleanupTail &&
+      pagesIsrCoordination.get(generation.key) === state
+    ) {
+      pagesIsrCoordination.delete(generation.key);
+    }
+  });
+}
+
+export function cancelPagesIsrGeneration(generation: PagesIsrGeneration | null): void {
+  if (!generation) return;
+  const state = pagesIsrCoordination.get(generation.key);
+  if (!state) return;
+  finishPagesIsrGeneration(generation, state);
 }
 
 export function commitPagesIsrGeneration(
-  generation: PagesIsrGeneration,
+  generation: PagesIsrGeneration | null,
   write: () => Promise<void>,
 ): Promise<boolean> {
+  if (!generation) return Promise.resolve(false);
   const state = pagesIsrCoordination.get(generation.key);
   if (!state) return Promise.resolve(false);
 
   const commit = state.commitTail
     .catch(() => {})
     .then(async () => {
-      if (state.version !== generation.version) return false;
+      if (generation.kind !== "on-demand" && state.authoritativeVersion > generation.version) {
+        return false;
+      }
+      if (generation.kind === "on-demand" && state.authoritativeVersion !== generation.version) {
+        return false;
+      }
       await write();
       return true;
-    });
+    })
+    .finally(() => finishPagesIsrGeneration(generation, state));
   state.commitTail = commit.then(
     () => {},
     () => {},

--- a/packages/vinext/src/server/isr-decision.ts
+++ b/packages/vinext/src/server/isr-decision.ts
@@ -72,7 +72,7 @@ type DecideIsrOptions = {
 
 /** Resolve effective revalidate/expire, preferring per-entry metadata. */
 function resolveRevalidate(options: DecideIsrOptions): {
-  effectiveRevalidate: number;
+  effectiveRevalidate: number | false;
   effectiveExpire: number | undefined;
 } {
   const effectiveRevalidate = options.cacheControlMeta?.revalidate ?? options.revalidateSeconds;
@@ -95,9 +95,10 @@ function resolveRevalidate(options: DecideIsrOptions): {
 function buildCacheControl(
   disposition: "HIT" | "STALE",
   kind: IsrPolicyKind,
-  revalidate: number,
+  revalidate: number | false,
   expire: number | undefined,
 ): string {
+  if (revalidate === false) return STATIC_CACHE_CONTROL;
   if (kind === "app-route") {
     if (revalidate === 0) return NEVER_CACHE_CONTROL;
     if (revalidate === Infinity) return STATIC_CACHE_CONTROL;

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -6,7 +6,13 @@ import type { CachedPagesValue, CacheControlMetadata } from "vinext/shims/cache"
 import { applyCdnResponseHeaders } from "./cache-control.js";
 import { decideIsr } from "./isr-decision.js";
 import { buildCacheStateHeaders } from "./cache-headers.js";
-import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
+import {
+  beginPagesIsrGeneration,
+  buildPagesCacheValue,
+  commitPagesIsrGeneration,
+  type ISRCacheEntry,
+  type PagesIsrGeneration,
+} from "./isr-cache.js";
 import {
   buildPagesNextDataScript,
   etagMatches,
@@ -154,7 +160,7 @@ export type ResolvePagesPageDataOptions = {
   isrSet: (
     key: string,
     data: CachedPagesValue,
-    revalidateSeconds: number,
+    revalidateSeconds: number | false,
     tags?: string[],
     expireSeconds?: number,
   ) => Promise<void>;
@@ -240,7 +246,8 @@ export type ResolvePagesPageDataOptions = {
 type ResolvePagesPageDataRenderResult = {
   kind: "render";
   gsspRes: PagesGsspResponse | null;
-  isrRevalidateSeconds: number | null;
+  isrRevalidateSeconds: number | false | null;
+  isrGeneration: PagesIsrGeneration | null;
   pageProps: Record<string, unknown>;
   props: PagesRenderProps;
   /**
@@ -686,6 +693,7 @@ export async function resolvePagesPageData(
         kind: "render",
         gsspRes: null,
         isrRevalidateSeconds: null,
+        isrGeneration: null,
         pageProps,
         props: renderProps,
         isFallback: true,
@@ -756,11 +764,15 @@ export async function resolvePagesPageData(
     gsspRes = res;
   }
 
-  let isrRevalidateSeconds: number | null = null;
+  let isrRevalidateSeconds: number | false | null = null;
+  let isrGeneration: PagesIsrGeneration | null = null;
 
   if (typeof options.pageModule.getStaticProps === "function") {
     const pathname = options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", pathname);
+    if (options.isOnDemandRevalidate) {
+      isrGeneration = beginPagesIsrGeneration(cacheKey);
+    }
     const cached = await options.isrGet(cacheKey);
     const cachedValue = cached?.value.value;
 
@@ -812,6 +824,7 @@ export async function resolvePagesPageData(
       options.triggerBackgroundRegeneration(
         cacheKey,
         async function () {
+          const generation = beginPagesIsrGeneration(cacheKey);
           return options.runInFreshUnifiedContext(async () => {
             options.applyRequestContexts();
             // Rebuild the full App render props before re-running getStaticProps
@@ -849,9 +862,9 @@ export async function resolvePagesPageData(
             const freshRevalidateSeconds =
               typeof freshResult?.revalidate === "number" && freshResult.revalidate > 0
                 ? freshResult.revalidate
-                : cached.value.cacheControl?.revalidate;
+                : false;
 
-            if (freshResult?.props && freshRevalidateSeconds && freshRevalidateSeconds > 0) {
+            if (freshResult?.props) {
               const freshHtml = await renderPagesIsrHtml({
                 buildId: options.buildId,
                 cachedHtml: cachedValue.html,
@@ -867,12 +880,14 @@ export async function resolvePagesPageData(
                 vinext: options.vinext,
               });
 
-              await options.isrSet(
-                cacheKey,
-                buildPagesCacheValue(freshHtml, freshRenderProps, options.statusCode),
-                freshRevalidateSeconds,
-                undefined,
-                options.expireSeconds,
+              await commitPagesIsrGeneration(generation, () =>
+                options.isrSet(
+                  cacheKey,
+                  buildPagesCacheValue(freshHtml, freshRenderProps, options.statusCode),
+                  freshRevalidateSeconds,
+                  undefined,
+                  options.expireSeconds,
+                ),
               );
             }
           });
@@ -911,6 +926,7 @@ export async function resolvePagesPageData(
       isUnknownRecord(cachedValue.pageData)
         ? cachedValue.pageData
         : null;
+    isrGeneration ??= beginPagesIsrGeneration(cacheKey);
     if (!generatedPageData) {
       const shortCircuit = await loadForegroundAppInitialRenderProps();
       if (shortCircuit) return shortCircuit;
@@ -965,26 +981,28 @@ export async function resolvePagesPageData(
     if (typeof result?.revalidate === "number" && result.revalidate > 0) {
       isrRevalidateSeconds = result.revalidate;
     } else if (options.isOnDemandRevalidate) {
-      isrRevalidateSeconds = cached?.value.cacheControl?.revalidate ?? 31_536_000;
+      isrRevalidateSeconds = false;
     } else if (cachedValue?.kind === "PAGES" && cachedValue.generatedFromDataRequest) {
       isrRevalidateSeconds = cached?.value.cacheControl?.revalidate ?? 31_536_000;
     }
 
     if (shouldPersistFallbackData) {
       const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
-      await options.isrSet(
-        cacheKey,
-        {
-          kind: "PAGES",
-          html: "",
-          pageData: renderProps,
-          generatedFromDataRequest: true,
-          headers: undefined,
-          status: undefined,
-        },
-        revalidateSeconds,
-        undefined,
-        options.expireSeconds,
+      await commitPagesIsrGeneration(isrGeneration, () =>
+        options.isrSet(
+          cacheKey,
+          {
+            kind: "PAGES",
+            html: "",
+            pageData: renderProps,
+            generatedFromDataRequest: true,
+            headers: undefined,
+            status: undefined,
+          },
+          revalidateSeconds,
+          undefined,
+          options.expireSeconds,
+        ),
       );
     }
   }
@@ -1036,6 +1054,7 @@ export async function resolvePagesPageData(
     kind: "render",
     gsspRes,
     isrRevalidateSeconds,
+    isrGeneration,
     pageProps,
     props: renderProps,
     isFallback: false,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -964,6 +964,8 @@ export async function resolvePagesPageData(
 
     if (typeof result?.revalidate === "number" && result.revalidate > 0) {
       isrRevalidateSeconds = result.revalidate;
+    } else if (options.isOnDemandRevalidate) {
+      isrRevalidateSeconds = cached?.value.cacheControl?.revalidate ?? 31_536_000;
     } else if (cachedValue?.kind === "PAGES" && cachedValue.generatedFromDataRequest) {
       isrRevalidateSeconds = cached?.value.cacheControl?.revalidate ?? 31_536_000;
     }

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -11,6 +11,7 @@ import {
   buildPagesCacheValue,
   cancelPagesIsrGeneration,
   commitPagesIsrGeneration,
+  waitForPagesIsrGeneration,
   type ISRCacheEntry,
   type PagesIsrGeneration,
 } from "./isr-cache.js";
@@ -160,7 +161,7 @@ export type ResolvePagesPageDataOptions = {
   isrGet: (key: string) => Promise<ISRCacheEntry | null>;
   isrSet: (
     key: string,
-    data: CachedPagesValue,
+    data: CachedPagesValue | null,
     revalidateSeconds: number | false,
     tags?: string[],
     expireSeconds?: number,
@@ -773,9 +774,25 @@ export async function resolvePagesPageData(
     const cacheKey = options.isrCacheKey("pages", pathname);
     if (options.isOnDemandRevalidate) {
       isrGeneration = beginPagesIsrGeneration(cacheKey, "on-demand");
+      try {
+        await waitForPagesIsrGeneration(isrGeneration);
+      } catch (error) {
+        cancelPagesIsrGeneration(isrGeneration, error);
+        throw error;
+      }
     }
-    const cached = await options.isrGet(cacheKey);
+    let cached: ISRCacheEntry | null;
+    try {
+      cached = await options.isrGet(cacheKey);
+    } catch (error) {
+      cancelPagesIsrGeneration(isrGeneration, error);
+      throw error;
+    }
     const cachedValue = cached?.value.value;
+
+    if (!options.isOnDemandRevalidate && cached && !cached.isStale && cachedValue === null) {
+      return buildPagesNotFoundResult(options);
+    }
 
     // On-demand revalidation (`res.revalidate()`) must regenerate the entry
     // synchronously with `revalidateReason: "on-demand"`, so the fresh/stale
@@ -970,7 +987,7 @@ export async function resolvePagesPageData(
                 : "stale",
           });
     } catch (error) {
-      cancelPagesIsrGeneration(isrGeneration);
+      cancelPagesIsrGeneration(isrGeneration, error);
       throw error;
     }
 
@@ -993,7 +1010,17 @@ export async function resolvePagesPageData(
     }
 
     if (result?.notFound) {
-      cancelPagesIsrGeneration(isrGeneration);
+      if (options.isOnDemandRevalidate) {
+        const revalidateSeconds =
+          typeof result.revalidate === "number" && result.revalidate > 0
+            ? result.revalidate
+            : false;
+        await commitPagesIsrGeneration(isrGeneration, () =>
+          options.isrSet(cacheKey, null, revalidateSeconds, undefined, options.expireSeconds),
+        );
+      } else {
+        cancelPagesIsrGeneration(isrGeneration);
+      }
       return buildPagesNotFoundResult(options);
     }
 
@@ -1006,7 +1033,12 @@ export async function resolvePagesPageData(
     // .nextjs-ref/packages/next/src/lib/is-serializable-props.ts. Tracked in
     // vinext#1478.
     if (result?.props !== undefined) {
-      isSerializableProps(options.routePattern, "getStaticProps", pageProps);
+      try {
+        isSerializableProps(options.routePattern, "getStaticProps", pageProps);
+      } catch (error) {
+        cancelPagesIsrGeneration(isrGeneration, error);
+        throw error;
+      }
     }
 
     if (typeof result?.revalidate === "number" && result.revalidate > 0) {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -9,6 +9,7 @@ import { buildCacheStateHeaders } from "./cache-headers.js";
 import {
   beginPagesIsrGeneration,
   buildPagesCacheValue,
+  cancelPagesIsrGeneration,
   commitPagesIsrGeneration,
   type ISRCacheEntry,
   type PagesIsrGeneration,
@@ -771,7 +772,7 @@ export async function resolvePagesPageData(
     const pathname = options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", pathname);
     if (options.isOnDemandRevalidate) {
-      isrGeneration = beginPagesIsrGeneration(cacheKey);
+      isrGeneration = beginPagesIsrGeneration(cacheKey, "on-demand");
     }
     const cached = await options.isrGet(cacheKey);
     const cachedValue = cached?.value.value;
@@ -821,76 +822,95 @@ export async function resolvePagesPageData(
       !options.scriptNonce &&
       !options.isDataReq
     ) {
+      const staleEntryLastModified = cached.value.lastModified;
       options.triggerBackgroundRegeneration(
         cacheKey,
         async function () {
-          const generation = beginPagesIsrGeneration(cacheKey);
-          return options.runInFreshUnifiedContext(async () => {
-            options.applyRequestContexts();
-            // Rebuild the full App render props before re-running getStaticProps
-            // so the regenerated HTML / __NEXT_DATA__ still contains app-level
-            // props from _app.getInitialProps. Mirrors the foreground path.
-            const freshAppResult = await loadPagesAppInitialRenderProps(options, () =>
-              options.createGsspReqRes(),
-            );
-            if (freshAppResult.kind === "response") {
-              // _app.getInitialProps short-circuited the request during background
-              // regeneration. We cannot turn that into an HTTP response here, so
-              // skip the cache write and let the stale entry remain.
-              return;
-            }
-            let freshPageProps = freshAppResult.pageProps;
-            let freshRenderProps = freshAppResult.renderProps;
+          const generation = beginPagesIsrGeneration(cacheKey, "stale");
+          if (!generation) return;
+          try {
+            await options.runInFreshUnifiedContext(async () => {
+              options.applyRequestContexts();
+              // Rebuild the full App render props before re-running getStaticProps
+              // so the regenerated HTML / __NEXT_DATA__ still contains app-level
+              // props from _app.getInitialProps. Mirrors the foreground path.
+              const freshAppResult = await loadPagesAppInitialRenderProps(options, () =>
+                options.createGsspReqRes(),
+              );
+              if (freshAppResult.kind === "response") {
+                // _app.getInitialProps short-circuited the request during background
+                // regeneration. We cannot turn that into an HTTP response here, so
+                // skip the cache write and let the stale entry remain.
+                return;
+              }
+              let freshPageProps = freshAppResult.pageProps;
+              let freshRenderProps = freshAppResult.renderProps;
 
-            const freshResult = await options.pageModule.getStaticProps?.({
-              params: userFacingParams,
-              locale: options.i18n.locale,
-              locales: options.i18n.locales,
-              defaultLocale: options.i18n.defaultLocale,
-              // Background regeneration for an entry that is already in the
-              // cache is always a stale-while-revalidate refresh — mirrors
-              // Next.js `render.tsx` (`isBuildTimeSSG ? "build" : "stale"`,
-              // and we're not at build time here).
-              revalidateReason: "stale",
-            });
-
-            if (freshResult?.props) {
-              freshPageProps = { ...freshPageProps, ...freshResult.props };
-              freshRenderProps = { ...freshRenderProps, pageProps: freshPageProps };
-            }
-
-            const freshRevalidateSeconds =
-              typeof freshResult?.revalidate === "number" && freshResult.revalidate > 0
-                ? freshResult.revalidate
-                : false;
-
-            if (freshResult?.props) {
-              const freshHtml = await renderPagesIsrHtml({
-                buildId: options.buildId,
-                cachedHtml: cachedValue.html,
-                createPageElement: options.createPageElement,
-                i18n: options.i18n,
-                pageProps: freshPageProps,
-                props: freshRenderProps,
-                params: options.params,
-                renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
-                routePattern: options.routePattern,
-                safeJsonStringify: options.safeJsonStringify,
-                nextData: options.nextData,
-                vinext: options.vinext,
+              const freshResult = await options.pageModule.getStaticProps?.({
+                params: userFacingParams,
+                locale: options.i18n.locale,
+                locales: options.i18n.locales,
+                defaultLocale: options.i18n.defaultLocale,
+                // Background regeneration for an entry that is already in the
+                // cache is always a stale-while-revalidate refresh — mirrors
+                // Next.js `render.tsx` (`isBuildTimeSSG ? "build" : "stale"`,
+                // and we're not at build time here).
+                revalidateReason: "stale",
               });
 
-              await commitPagesIsrGeneration(generation, () =>
-                options.isrSet(
-                  cacheKey,
-                  buildPagesCacheValue(freshHtml, freshRenderProps, options.statusCode),
-                  freshRevalidateSeconds,
-                  undefined,
-                  options.expireSeconds,
-                ),
-              );
-            }
-          });
+              if (freshResult?.props) {
+                freshPageProps = { ...freshPageProps, ...freshResult.props };
+                freshRenderProps = { ...freshRenderProps, pageProps: freshPageProps };
+              }
+
+              const freshRevalidateSeconds =
+                typeof freshResult?.revalidate === "number" && freshResult.revalidate > 0
+                  ? freshResult.revalidate
+                  : false;
+
+              if (freshResult?.props) {
+                const freshHtml = await renderPagesIsrHtml({
+                  buildId: options.buildId,
+                  cachedHtml: cachedValue.html,
+                  createPageElement: options.createPageElement,
+                  i18n: options.i18n,
+                  pageProps: freshPageProps,
+                  props: freshRenderProps,
+                  params: options.params,
+                  renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
+                  routePattern: options.routePattern,
+                  safeJsonStringify: options.safeJsonStringify,
+                  nextData: options.nextData,
+                  vinext: options.vinext,
+                });
+
+                await commitPagesIsrGeneration(generation, async () => {
+                  // This re-read prevents a stale renderer in another isolate
+                  // from overwriting an on-demand result that is already
+                  // visible through the configured cache backend. The check
+                  // and write are not atomic: CacheHandler/CdnCacheAdapter do
+                  // not currently expose CAS or conditional-set primitives,
+                  // so cross-isolate ordering cannot be guaranteed here.
+                  const current = await options.isrGet(cacheKey);
+                  if (
+                    current?.value.lastModified !== undefined &&
+                    current.value.lastModified > staleEntryLastModified
+                  ) {
+                    return;
+                  }
+                  await options.isrSet(
+                    cacheKey,
+                    buildPagesCacheValue(freshHtml, freshRenderProps, options.statusCode),
+                    freshRevalidateSeconds,
+                    undefined,
+                    options.expireSeconds,
+                  );
+                });
+              }
+            });
+          } finally {
+            cancelPagesIsrGeneration(generation);
+          }
         },
         {
           routerKind: "Pages Router",
@@ -927,23 +947,32 @@ export async function resolvePagesPageData(
         ? cachedValue.pageData
         : null;
     isrGeneration ??= beginPagesIsrGeneration(cacheKey);
-    if (!generatedPageData) {
-      const shortCircuit = await loadForegroundAppInitialRenderProps();
-      if (shortCircuit) return shortCircuit;
+    let result: Awaited<ReturnType<NonNullable<PagesPageModule["getStaticProps"]>>> | null;
+    try {
+      if (!generatedPageData) {
+        const shortCircuit = await loadForegroundAppInitialRenderProps();
+        if (shortCircuit) {
+          cancelPagesIsrGeneration(isrGeneration);
+          return shortCircuit;
+        }
+      }
+      result = generatedPageData
+        ? null
+        : await options.pageModule.getStaticProps({
+            params: userFacingParams,
+            locale: options.i18n.locale,
+            locales: options.i18n.locales,
+            defaultLocale: options.i18n.defaultLocale,
+            revalidateReason: options.isOnDemandRevalidate
+              ? "on-demand"
+              : options.isBuildTimePrerendering
+                ? "build"
+                : "stale",
+          });
+    } catch (error) {
+      cancelPagesIsrGeneration(isrGeneration);
+      throw error;
     }
-    const result = generatedPageData
-      ? null
-      : await options.pageModule.getStaticProps({
-          params: userFacingParams,
-          locale: options.i18n.locale,
-          locales: options.i18n.locales,
-          defaultLocale: options.i18n.defaultLocale,
-          revalidateReason: options.isOnDemandRevalidate
-            ? "on-demand"
-            : options.isBuildTimePrerendering
-              ? "build"
-              : "stale",
-        });
 
     if (generatedPageData) {
       renderProps = generatedPageData as PagesRenderProps;
@@ -956,6 +985,7 @@ export async function resolvePagesPageData(
     }
 
     if (result?.redirect) {
+      cancelPagesIsrGeneration(isrGeneration);
       return {
         kind: "response",
         response: buildPagesRedirectResponse(result.redirect, options, renderProps),
@@ -963,6 +993,7 @@ export async function resolvePagesPageData(
     }
 
     if (result?.notFound) {
+      cancelPagesIsrGeneration(isrGeneration);
       return buildPagesNotFoundResult(options);
     }
 

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -751,18 +751,6 @@ export async function resolvePagesPageData(
       return buildPagesNotFoundResult(options);
     }
 
-    // Mirrors Next.js render.tsx's `isSerializableProps(pathname, "getServerSideProps", data.props)`
-    // check, gated on `!metadata.isRedirect && !metadata.isNotFound` (both
-    // short-circuit above). Throws a friendly `SerializableError` so the
-    // caller's existing try/catch surfaces a clear 500 instead of rendering
-    // an empty page. See
-    // .nextjs-ref/packages/next/src/server/render.tsx (~line 1200) and
-    // .nextjs-ref/packages/next/src/lib/is-serializable-props.ts. Tracked in
-    // vinext#1478.
-    if (result?.props !== undefined) {
-      isSerializableProps(options.routePattern, "getServerSideProps", pageProps);
-    }
-
     gsspRes = res;
   }
 
@@ -1032,7 +1020,7 @@ export async function resolvePagesPageData(
     // .nextjs-ref/packages/next/src/server/render.tsx (~line 982) and
     // .nextjs-ref/packages/next/src/lib/is-serializable-props.ts. Tracked in
     // vinext#1478.
-    if (result?.props !== undefined) {
+    if (options.isBuildTimePrerendering && result?.props !== undefined) {
       try {
         isSerializableProps(options.routePattern, "getStaticProps", pageProps);
       } catch (error) {

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -536,6 +536,9 @@ export function createPagesPageHandler(
         const parsedRouteUrl = new URL(routeUrl, originalRequestUrl);
         const routePathname = parsedRouteUrl.pathname || "/";
         const pagesResolvedUrl = routePathname + originalRequestUrl.search;
+        const isOnDemandRevalidate = isOnDemandRevalidateRequest(
+          request.headers.get(PRERENDER_REVALIDATE_HEADER),
+        );
 
         const pageDataResult = await resolvePagesPageData({
           isDataReq,
@@ -577,9 +580,7 @@ export function createPagesPageHandler(
           // mirrors Next.js's `checkIsOnDemandRevalidate`, preventing an
           // external client from forcing synchronous regeneration via an
           // arbitrary header value (cache-stampede/DoS vector).
-          isOnDemandRevalidate: isOnDemandRevalidateRequest(
-            request.headers.get(PRERENDER_REVALIDATE_HEADER),
-          ),
+          isOnDemandRevalidate,
           pageModule,
           AppComponent,
           params,
@@ -714,6 +715,7 @@ export function createPagesPageHandler(
 
         return await renderPagesPageResponse({
           assetTags,
+          awaitIsrCacheWrite: isOnDemandRevalidate,
           buildId,
           clearSsrContext() {
             if (typeof setSSRContext === "function") setSSRContext(null);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -636,6 +636,7 @@ export function createPagesPageHandler(
         }
         const gsspRes = pageDataResult.gsspRes;
         const isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
+        const isrGeneration = pageDataResult.isrGeneration;
         const isFallbackRender = pageDataResult.isFallback === true;
 
         // Republish SSR context with isFallback flipped on so `useRouter().isFallback`
@@ -740,6 +741,7 @@ export function createPagesPageHandler(
           isrCacheKey: pageIsrCacheKey,
           expireSeconds: vinextConfig.expireTime,
           isrRevalidateSeconds,
+          isrGeneration,
           isrSet,
           i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
           isFallback: isFallbackRender,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -35,9 +35,11 @@ import {
   isrGet,
   isrSet,
   isrCacheKey,
+  cancelPagesIsrGeneration,
   triggerBackgroundRegeneration,
   PRERENDER_REVALIDATE_HEADER,
   isOnDemandRevalidateRequest,
+  type PagesIsrGeneration,
 } from "./isr-cache.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { reportRequestError } from "./instrumentation.js";
@@ -414,6 +416,8 @@ export function createPagesPageHandler(
 
     return runWithRequestContext(uCtx, async () => {
       ensureFetchPatch();
+      let ownedIsrGeneration: PagesIsrGeneration | null = null;
+      let renderFailure: unknown;
       try {
         const routePattern = patternToNextFormat(route.pattern);
         const renderStatusCode =
@@ -643,6 +647,7 @@ export function createPagesPageHandler(
         const gsspRes = pageDataResult.gsspRes;
         const isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
         const isrGeneration = pageDataResult.isrGeneration;
+        ownedIsrGeneration = isrGeneration;
         const isFallbackRender = pageDataResult.isFallback === true;
 
         // Republish SSR context with isFallback flipped on so `useRouter().isFallback`
@@ -722,8 +727,12 @@ export function createPagesPageHandler(
           deploymentId: process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
         });
 
-        return finalizePagesResponse(
-          await renderPagesPageResponse({
+        const responseOwnsIsrGeneration =
+          !scriptNonce && isrRevalidateSeconds !== null && isrGeneration !== null;
+        if (responseOwnsIsrGeneration) ownedIsrGeneration = null;
+        let renderedResponse: Response;
+        try {
+          renderedResponse = await renderPagesPageResponse({
             assetTags,
             awaitIsrCacheWrite: isOnDemandRevalidate,
             buildId,
@@ -778,9 +787,14 @@ export function createPagesPageHandler(
             userAgent: request.headers.get("user-agent") ?? undefined,
             ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
             requestCacheControl: request.headers.get("cache-control") ?? undefined,
-          }),
-        );
+          });
+        } catch (error) {
+          cancelPagesIsrGeneration(isrGeneration, error);
+          throw error;
+        }
+        return finalizePagesResponse(renderedResponse);
       } catch (e) {
+        renderFailure = e;
         console.error("[vinext] SSR error:", e);
         reportRequestError(
           e instanceof Error ? e : new Error(String(e)),
@@ -828,6 +842,8 @@ export function createPagesPageHandler(
           }
         }
         return new Response("Internal Server Error", { status: 500 });
+      } finally {
+        cancelPagesIsrGeneration(ownedIsrGeneration, renderFailure);
       }
     });
   }

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -45,7 +45,7 @@ import { createRequestContext, runWithRequestContext } from "vinext/shims/unifie
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { ensureFetchPatch } from "vinext/shims/fetch-cache";
 import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js";
-import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
+import { NEXTJS_CACHE_HEADER, NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 
@@ -539,6 +539,10 @@ export function createPagesPageHandler(
         const isOnDemandRevalidate = isOnDemandRevalidateRequest(
           request.headers.get(PRERENDER_REVALIDATE_HEADER),
         );
+        const finalizePagesResponse = (response: Response): Response => {
+          if (isOnDemandRevalidate) response.headers.set(NEXTJS_CACHE_HEADER, "REVALIDATED");
+          return response;
+        };
 
         const pageDataResult = await resolvePagesPageData({
           isDataReq,
@@ -615,17 +619,19 @@ export function createPagesPageHandler(
         if (pageDataResult.kind === "notFound") {
           const notFoundRoute = findNotFoundRoute();
           if (notFoundRoute && routePattern !== "/404" && routePattern !== "/_error") {
-            return renderPage(request, url, manifest, middlewareHeaders, {
-              statusCode: 404,
-              asPath: renderAsPath ?? routeUrl,
-              renderErrorPageOnMiss: false,
-              __forcedRoute: notFoundRoute,
-            });
+            return finalizePagesResponse(
+              await renderPage(request, url, manifest, middlewareHeaders, {
+                statusCode: 404,
+                asPath: renderAsPath ?? routeUrl,
+                renderErrorPageOnMiss: false,
+                __forcedRoute: notFoundRoute,
+              }),
+            );
           }
-          return buildDefaultPagesNotFoundResponse();
+          return finalizePagesResponse(buildDefaultPagesNotFoundResponse());
         }
         if (pageDataResult.kind === "response") {
-          return pageDataResult.response;
+          return finalizePagesResponse(pageDataResult.response);
         }
 
         let pageProps = pageDataResult.pageProps;
@@ -695,7 +701,9 @@ export function createPagesPageHandler(
               init.headers[NEXTJS_DEPLOYMENT_ID_HEADER] = deploymentId;
             }
           }
-          return buildNextDataPropsJsonResponse(renderProps, safeJsonStringify, init);
+          return finalizePagesResponse(
+            buildNextDataPropsJsonResponse(renderProps, safeJsonStringify, init),
+          );
         }
 
         // Include both the matched page module and the global _app module.
@@ -714,57 +722,64 @@ export function createPagesPageHandler(
           deploymentId: process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
         });
 
-        return await renderPagesPageResponse({
-          assetTags,
-          awaitIsrCacheWrite: isOnDemandRevalidate,
-          buildId,
-          clearSsrContext() {
-            if (typeof setSSRContext === "function") setSSRContext(null);
-          },
-          createPageElement(currentProps) {
-            const el = createPageElement(PageComponent, AppComponent, currentProps);
-            return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
-          },
-          enhancePageElement(renderPageOpts) {
-            const el = enhancePageElement(PageComponent, AppComponent, renderProps, renderPageOpts);
-            return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
-          },
-          DocumentComponent,
-          flushPreloads: typeof flushPreloads === "function" ? flushPreloads : undefined,
-          fontLinkHeader,
-          fontPreloads: allFontPreloads,
-          getFontLinks,
-          getFontStyles,
-          getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
-          clientTraceMetadata: vinextConfig.clientTraceMetadata,
-          gsspRes,
-          isrCacheKey: pageIsrCacheKey,
-          expireSeconds: vinextConfig.expireTime,
-          isrRevalidateSeconds,
-          isrGeneration,
-          isrSet,
-          i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
-          isFallback: isFallbackRender,
-          pageProps,
-          props: renderProps,
-          params,
-          renderDocumentToString(element) {
-            return renderToStringAsync(element);
-          },
-          renderToReadableStream,
-          resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
-          setDocumentInitialHead:
-            typeof setDocumentInitialHead === "function" ? setDocumentInitialHead : undefined,
-          routePattern,
-          routeUrl,
-          safeJsonStringify,
-          scriptNonce,
-          statusCode: renderStatusCode,
-          nextData: serializedPagesNextData,
-          userAgent: request.headers.get("user-agent") ?? undefined,
-          ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
-          requestCacheControl: request.headers.get("cache-control") ?? undefined,
-        });
+        return finalizePagesResponse(
+          await renderPagesPageResponse({
+            assetTags,
+            awaitIsrCacheWrite: isOnDemandRevalidate,
+            buildId,
+            clearSsrContext() {
+              if (typeof setSSRContext === "function") setSSRContext(null);
+            },
+            createPageElement(currentProps) {
+              const el = createPageElement(PageComponent, AppComponent, currentProps);
+              return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
+            },
+            enhancePageElement(renderPageOpts) {
+              const el = enhancePageElement(
+                PageComponent,
+                AppComponent,
+                renderProps,
+                renderPageOpts,
+              );
+              return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
+            },
+            DocumentComponent,
+            flushPreloads: typeof flushPreloads === "function" ? flushPreloads : undefined,
+            fontLinkHeader,
+            fontPreloads: allFontPreloads,
+            getFontLinks,
+            getFontStyles,
+            getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
+            clientTraceMetadata: vinextConfig.clientTraceMetadata,
+            gsspRes,
+            isrCacheKey: pageIsrCacheKey,
+            expireSeconds: vinextConfig.expireTime,
+            isrRevalidateSeconds,
+            isrGeneration,
+            isrSet,
+            i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
+            isFallback: isFallbackRender,
+            pageProps,
+            props: renderProps,
+            params,
+            renderDocumentToString(element) {
+              return renderToStringAsync(element);
+            },
+            renderToReadableStream,
+            resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
+            setDocumentInitialHead:
+              typeof setDocumentInitialHead === "function" ? setDocumentInitialHead : undefined,
+            routePattern,
+            routeUrl,
+            safeJsonStringify,
+            scriptNonce,
+            statusCode: renderStatusCode,
+            nextData: serializedPagesNextData,
+            userAgent: request.headers.get("user-agent") ?? undefined,
+            ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
+            requestCacheControl: request.headers.get("cache-control") ?? undefined,
+          }),
+        );
       } catch (e) {
         console.error("[vinext] SSR error:", e);
         reportRequestError(

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -167,6 +167,7 @@ type RenderPagesPageResponseOptions = {
   isrCacheKey: (router: string, pathname: string) => string;
   expireSeconds?: number;
   isrRevalidateSeconds: number | null;
+  awaitIsrCacheWrite?: boolean;
   isrSet: (
     key: string,
     data: CachedPagesValue,
@@ -404,6 +405,8 @@ async function reportPagesIsrCacheWriteError(
   }
 }
 
+const pendingPagesIsrCacheWrites = new Map<string, Promise<void>>();
+
 function schedulePagesIsrCacheWrite(options: {
   cacheKey: string;
   expireSeconds?: number;
@@ -415,9 +418,11 @@ function schedulePagesIsrCacheWrite(options: {
   status: number;
   stream: ReadableStream<Uint8Array>;
   setCache: RenderPagesPageResponseOptions["isrSet"];
-}): void {
-  const cacheWritePromise = readStreamAsText(options.stream)
-    .then((bodyHtml) =>
+}): Promise<void> {
+  const bodyHtmlPromise = readStreamAsText(options.stream);
+  const previousWrite = pendingPagesIsrCacheWrites.get(options.cacheKey) ?? Promise.resolve();
+  const cacheWritePromise = Promise.all([previousWrite, bodyHtmlPromise])
+    .then(([, bodyHtml]) =>
       options.setCache(
         options.cacheKey,
         {
@@ -434,9 +439,16 @@ function schedulePagesIsrCacheWrite(options: {
     )
     .catch((error: unknown) =>
       reportPagesIsrCacheWriteError(error, options.cacheKey, options.routePattern),
-    );
+    )
+    .finally(() => {
+      if (pendingPagesIsrCacheWrites.get(options.cacheKey) === cacheWritePromise) {
+        pendingPagesIsrCacheWrites.delete(options.cacheKey);
+      }
+    });
 
+  pendingPagesIsrCacheWrites.set(options.cacheKey, cacheWritePromise);
   getRequestExecutionContext()?.waitUntil(cacheWritePromise);
+  return cacheWritePromise;
 }
 
 function applyGsspHeaders(
@@ -610,7 +622,7 @@ export async function renderPagesPageResponse(
     const isrPathname = options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", isrPathname);
 
-    schedulePagesIsrCacheWrite({
+    const cacheWritePromise = schedulePagesIsrCacheWrite({
       cacheKey,
       expireSeconds: options.expireSeconds,
       pageData: options.pageProps,
@@ -622,6 +634,9 @@ export async function renderPagesPageResponse(
       status: finalStatus,
       stream: cacheBodyStream,
     });
+    if (options.awaitIsrCacheWrite) {
+      await cacheWritePromise;
+    }
   }
 
   const compositeStream = await buildPagesCompositeStream(

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -614,26 +614,29 @@ export async function renderPagesPageResponse(
     const isrPathname = options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", isrPathname);
 
-    const cacheWritePromise = schedulePagesIsrCacheWrite({
-      cacheKey,
-      expireSeconds: options.expireSeconds,
-      pageData: options.pageProps,
-      revalidateSeconds: options.isrRevalidateSeconds,
-      generation: options.isrGeneration ?? beginPagesIsrGeneration(cacheKey),
-      routePattern: options.routePattern,
-      setCache: options.isrSet,
-      shellPrefix,
-      shellSuffix,
-      status: finalStatus,
-      stream: cacheBodyStream,
-    });
-    if (options.awaitIsrCacheWrite) {
-      await cacheWritePromise;
-    } else {
-      const backgroundCacheWrite = cacheWritePromise.catch((error: unknown) =>
-        reportPagesIsrCacheWriteError(error, cacheKey, options.routePattern),
-      );
-      getRequestExecutionContext()?.waitUntil(backgroundCacheWrite);
+    const generation = options.isrGeneration ?? beginPagesIsrGeneration(cacheKey, "ordinary");
+    if (generation) {
+      const cacheWritePromise = schedulePagesIsrCacheWrite({
+        cacheKey,
+        expireSeconds: options.expireSeconds,
+        pageData: options.pageProps,
+        revalidateSeconds: options.isrRevalidateSeconds,
+        generation,
+        routePattern: options.routePattern,
+        setCache: options.isrSet,
+        shellPrefix,
+        shellSuffix,
+        status: finalStatus,
+        stream: cacheBodyStream,
+      });
+      if (options.awaitIsrCacheWrite) {
+        await cacheWritePromise;
+      } else {
+        const backgroundCacheWrite = cacheWritePromise.catch((error: unknown) =>
+          reportPagesIsrCacheWriteError(error, cacheKey, options.routePattern),
+        );
+        getRequestExecutionContext()?.waitUntil(backgroundCacheWrite);
+      }
     }
   }
 

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -23,6 +23,11 @@ import { fnv1a52 } from "../utils/hash.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
+import {
+  beginPagesIsrGeneration,
+  commitPagesIsrGeneration,
+  type PagesIsrGeneration,
+} from "./isr-cache.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
@@ -166,12 +171,13 @@ type RenderPagesPageResponseOptions = {
   gsspRes: PagesGsspResponse | null;
   isrCacheKey: (router: string, pathname: string) => string;
   expireSeconds?: number;
-  isrRevalidateSeconds: number | null;
+  isrRevalidateSeconds: number | false | null;
+  isrGeneration?: PagesIsrGeneration | null;
   awaitIsrCacheWrite?: boolean;
   isrSet: (
     key: string,
     data: CachedPagesValue,
-    revalidateSeconds: number,
+    revalidateSeconds: number | false,
     tags?: string[],
     expireSeconds?: number,
   ) => Promise<void>;
@@ -405,13 +411,12 @@ async function reportPagesIsrCacheWriteError(
   }
 }
 
-const pendingPagesIsrCacheWrites = new Map<string, Promise<void>>();
-
 function schedulePagesIsrCacheWrite(options: {
   cacheKey: string;
   expireSeconds?: number;
   pageData: Record<string, unknown>;
-  revalidateSeconds: number;
+  revalidateSeconds: number | false;
+  generation: PagesIsrGeneration;
   routePattern: string;
   shellPrefix: string;
   shellSuffix: string;
@@ -419,10 +424,8 @@ function schedulePagesIsrCacheWrite(options: {
   stream: ReadableStream<Uint8Array>;
   setCache: RenderPagesPageResponseOptions["isrSet"];
 }): Promise<void> {
-  const bodyHtmlPromise = readStreamAsText(options.stream);
-  const previousWrite = pendingPagesIsrCacheWrites.get(options.cacheKey) ?? Promise.resolve();
-  const cacheWritePromise = Promise.all([previousWrite, bodyHtmlPromise])
-    .then(([, bodyHtml]) =>
+  return readStreamAsText(options.stream).then((bodyHtml) =>
+    commitPagesIsrGeneration(options.generation, () =>
       options.setCache(
         options.cacheKey,
         {
@@ -436,19 +439,8 @@ function schedulePagesIsrCacheWrite(options: {
         undefined,
         options.expireSeconds,
       ),
-    )
-    .catch((error: unknown) =>
-      reportPagesIsrCacheWriteError(error, options.cacheKey, options.routePattern),
-    )
-    .finally(() => {
-      if (pendingPagesIsrCacheWrites.get(options.cacheKey) === cacheWritePromise) {
-        pendingPagesIsrCacheWrites.delete(options.cacheKey);
-      }
-    });
-
-  pendingPagesIsrCacheWrites.set(options.cacheKey, cacheWritePromise);
-  getRequestExecutionContext()?.waitUntil(cacheWritePromise);
-  return cacheWritePromise;
+    ).then(() => {}),
+  );
 }
 
 function applyGsspHeaders(
@@ -614,7 +606,7 @@ export async function renderPagesPageResponse(
     // later matches the cached __NEXT_DATA__ block via a bare <script> marker.
     !options.scriptNonce &&
     options.isrRevalidateSeconds !== null &&
-    options.isrRevalidateSeconds > 0
+    options.isrGeneration !== null
   ) {
     const cacheBodyStreamPair = bodyStream.tee();
     responseBodyStream = cacheBodyStreamPair[0];
@@ -627,6 +619,7 @@ export async function renderPagesPageResponse(
       expireSeconds: options.expireSeconds,
       pageData: options.pageProps,
       revalidateSeconds: options.isrRevalidateSeconds,
+      generation: options.isrGeneration ?? beginPagesIsrGeneration(cacheKey),
       routePattern: options.routePattern,
       setCache: options.isrSet,
       shellPrefix,
@@ -636,6 +629,11 @@ export async function renderPagesPageResponse(
     });
     if (options.awaitIsrCacheWrite) {
       await cacheWritePromise;
+    } else {
+      const backgroundCacheWrite = cacheWritePromise.catch((error: unknown) =>
+        reportPagesIsrCacheWriteError(error, cacheKey, options.routePattern),
+      );
+      getRequestExecutionContext()?.waitUntil(backgroundCacheWrite);
     }
   }
 
@@ -656,14 +654,17 @@ export async function renderPagesPageResponse(
 
   if (options.scriptNonce) {
     responseHeaders.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
-  } else if (options.isrRevalidateSeconds) {
+  } else if (options.isrRevalidateSeconds !== null) {
     // Fresh ISR (MISS) response: route through the CDN adapter so edge adapters
     // emit CDN-Cache-Control + a path-based Cache-Tag (matching revalidatePath,
     // which Pages Router invalidation uses) while the default emits Cache-Control.
     const isrPathname = options.routeUrl.split("?")[0];
     const stem = isrPathname.endsWith("/") ? isrPathname.slice(0, -1) : isrPathname;
     applyCdnResponseHeaders(responseHeaders, {
-      cacheControl: buildMissIsrCacheControl(options.isrRevalidateSeconds, options.expireSeconds),
+      cacheControl: buildMissIsrCacheControl(
+        options.isrRevalidateSeconds === false ? 31_536_000 : options.isrRevalidateSeconds,
+        options.expireSeconds,
+      ),
       tags: [encodeCacheTag(`_N_T_${stem || "/"}`)],
     });
     setCacheStateHeaders(responseHeaders, "MISS");

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -176,7 +176,7 @@ type RenderPagesPageResponseOptions = {
   awaitIsrCacheWrite?: boolean;
   isrSet: (
     key: string,
-    data: CachedPagesValue,
+    data: CachedPagesValue | null,
     revalidateSeconds: number | false,
     tags?: string[],
     expireSeconds?: number,

--- a/packages/vinext/src/server/pages-revalidate.ts
+++ b/packages/vinext/src/server/pages-revalidate.ts
@@ -63,10 +63,6 @@ export async function performOnDemandRevalidate(
   // the cache header reports REVALIDATED, the status is 200, or the path was
   // not generated and the caller opted into `unstable_onlyGenerated`.
   //
-  // NOTE: vinext's Pages ISR path only ever emits HIT/MISS/STALE on
-  // `x-nextjs-cache`, never REVALIDATED, so in practice the happy path is the
-  // 200 branch. The REVALIDATED branch is kept for parity with Next.js and to
-  // stay correct if that header is emitted in the future.
   const cacheHeader = res.headers.get(NEXTJS_CACHE_HEADER);
   const ok =
     cacheHeader?.toUpperCase() === "REVALIDATED" ||

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -657,7 +657,7 @@ function throwPrivateUseCacheInsidePublicUseCacheError(): never {
 function recordRequestScopedCacheControl(cacheControl: CacheControlMetadata | undefined): void {
   if (cacheControl === undefined) return;
   _setRequestScopedCacheLife({
-    revalidate: cacheControl.revalidate,
+    revalidate: typeof cacheControl.revalidate === "number" ? cacheControl.revalidate : undefined,
     expire: cacheControl.expire,
   });
 }

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -73,7 +73,7 @@ export type CacheHandlerValue = {
 };
 
 export type CacheControlMetadata = {
-  revalidate: number;
+  revalidate: number | false;
   expire?: number;
 };
 
@@ -374,9 +374,14 @@ export class MemoryCacheHandler implements CacheHandler {
 
     // Resolve effective revalidate — data overrides ctx.
     // revalidate: 0 means "don't cache", so skip storage entirely.
-    let effectiveRevalidate: number | undefined;
+    let effectiveRevalidate: number | false | undefined;
     let effectiveExpire: number | undefined;
     effectiveRevalidate = readCacheControlNumberField(ctx, "revalidate");
+    if (ctx?.cacheControl && (ctx.cacheControl as Record<string, unknown>).revalidate === false) {
+      effectiveRevalidate = false;
+    } else if (ctx?.revalidate === false) {
+      effectiveRevalidate = false;
+    }
     effectiveExpire = readCacheControlNumberField(ctx, "expire");
     if (data && "revalidate" in data && typeof data.revalidate === "number") {
       effectiveRevalidate = data.revalidate;
@@ -392,8 +397,8 @@ export class MemoryCacheHandler implements CacheHandler {
       typeof effectiveExpire === "number" && effectiveExpire > 0
         ? now + effectiveExpire * 1000
         : null;
-    const cacheControl =
-      typeof effectiveRevalidate === "number"
+    const cacheControl: CacheControlMetadata | undefined =
+      typeof effectiveRevalidate === "number" || effectiveRevalidate === false
         ? effectiveExpire === undefined
           ? { revalidate: effectiveRevalidate }
           : { revalidate: effectiveRevalidate, expire: effectiveExpire }

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -686,6 +686,45 @@ describe("app page cache helpers", () => {
     ]);
   });
 
+  it("normalizes static cache metadata during stale regeneration", async () => {
+    const scheduledRegenerations: Array<() => Promise<void>> = [];
+    const revalidateSeconds: number[] = [];
+    const rscData = new TextEncoder().encode("fresh-flight").buffer;
+
+    await readAppPageCacheResponse({
+      cleanPathname: "/static",
+      clearRequestContext() {},
+      isRscRequest: false,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedAppPageValue("<h1>stale</h1>"), true);
+      },
+      isrHtmlKey(pathname) {
+        return "html:" + pathname;
+      },
+      isrRscKey(pathname) {
+        return "rsc:" + pathname;
+      },
+      async isrSet(_key, _data, revalidate) {
+        revalidateSeconds.push(revalidate);
+      },
+      revalidateSeconds: 60,
+      async renderFreshPageForCache() {
+        return {
+          cacheControl: { revalidate: false },
+          html: "<h1>fresh</h1>",
+          rscData,
+          tags: ["/static", "_N_T_/static"],
+        };
+      },
+      scheduleBackgroundRegeneration(_key, renderFn) {
+        scheduledRegenerations.push(renderFn);
+      },
+    });
+
+    await scheduledRegenerations[0]();
+    expect(revalidateSeconds).toEqual([Infinity, Infinity]);
+  });
+
   it("serves stale static fallback shells without regenerating the shared shell key", async () => {
     const debugCalls: Array<[string, string]> = [];
 

--- a/tests/e2e/pages-router-prod/production.spec.ts
+++ b/tests/e2e/pages-router-prod/production.spec.ts
@@ -32,6 +32,16 @@ test.describe("Pages Router Production Build", () => {
     );
   });
 
+  test("client navigation renders non-JSON getServerSideProps values", async ({ page }) => {
+    // Ported from Next.js: test/e2e/getserversideprops/test/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/test/index.test.ts
+    await page.goto(`${BASE}/`);
+    await page.locator('[data-testid="gssp-non-json-link"]').click();
+
+    await expect(page.locator('[data-testid="gssp-non-json"]')).toContainText("hello ");
+    expect(page.url()).toBe(`${BASE}/gssp-non-json`);
+  });
+
   test("__NEXT_DATA__ is present with page props", async ({ page }) => {
     await page.goto(`${BASE}/ssr`);
     const nextData = await page.evaluate(() => (window as any).__NEXT_DATA__);

--- a/tests/fixtures/pages-basic/pages/gssp-non-json.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-non-json.tsx
@@ -1,0 +1,9 @@
+export default function GsspNonJsonPage({ time }: { time: Date }) {
+  return <p data-testid="gssp-non-json">hello {time.toString()}</p>;
+}
+
+export async function getServerSideProps() {
+  return {
+    props: { time: new Date(0) },
+  };
+}

--- a/tests/fixtures/pages-basic/pages/index.tsx
+++ b/tests/fixtures/pages-basic/pages/index.tsx
@@ -10,6 +10,9 @@ export default function Home() {
       <h1>Hello, vinext!</h1>
       <p>This is a Pages Router app running on Vite.</p>
       <Link href="/about">Go to About</Link>
+      <Link href="/gssp-non-json" data-testid="gssp-non-json-link">
+        Go to non-JSON GSSP
+      </Link>
     </div>
   );
 }

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -17,6 +17,8 @@ import {
   isrGet,
   isrSet,
   buildPagesCacheValue,
+  beginPagesIsrGeneration,
+  commitPagesIsrGeneration,
   buildAppPageCacheValue,
   normalizeMountedSlotsHeader,
   setRevalidateDuration,
@@ -423,6 +425,49 @@ describe("ISR expire ceiling", () => {
     });
 
     await expect(isrGet("expired-handler-entry")).resolves.toBeNull();
+  });
+
+  it("replaces a prior numeric TTL with never-revalidate metadata", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(1_000);
+
+    await isrSet("ttl-transition", buildPagesCacheValue("<html>numeric</html>", {}), 1);
+    await isrSet("ttl-transition", buildPagesCacheValue("<html>static</html>", {}), false);
+
+    vi.setSystemTime(10_000);
+    const entry = await isrGet("ttl-transition");
+    expect(entry?.isStale).toBe(false);
+    expect(entry?.value.cacheControl?.revalidate).toBe(false);
+    expect(entry?.value.value).toEqual(
+      expect.objectContaining({ kind: "PAGES", html: "<html>static</html>" }),
+    );
+  });
+});
+
+describe("Pages ISR generation coordination", () => {
+  it("skips a stale write when a later on-demand generation finishes first", async () => {
+    const key = "pages:coordination-stale-first";
+    const writes: string[] = [];
+    const staleGeneration = beginPagesIsrGeneration(key);
+    let finishStaleRender: (() => void) | undefined;
+    const staleRender = new Promise<void>((resolve) => {
+      finishStaleRender = resolve;
+    });
+
+    const staleCommit = staleRender.then(() =>
+      commitPagesIsrGeneration(staleGeneration, async () => {
+        writes.push("stale");
+      }),
+    );
+
+    const onDemandGeneration = beginPagesIsrGeneration(key);
+    await commitPagesIsrGeneration(onDemandGeneration, async () => {
+      writes.push("on-demand");
+    });
+    finishStaleRender?.();
+
+    await expect(staleCommit).resolves.toBe(false);
+    expect(writes).toEqual(["on-demand"]);
   });
 });
 

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -18,6 +18,7 @@ import {
   isrSet,
   buildPagesCacheValue,
   beginPagesIsrGeneration,
+  cancelPagesIsrGeneration,
   commitPagesIsrGeneration,
   buildAppPageCacheValue,
   normalizeMountedSlotsHeader,
@@ -448,7 +449,7 @@ describe("Pages ISR generation coordination", () => {
   it("skips a stale write when a later on-demand generation finishes first", async () => {
     const key = "pages:coordination-stale-first";
     const writes: string[] = [];
-    const staleGeneration = beginPagesIsrGeneration(key);
+    const staleGeneration = beginPagesIsrGeneration(key, "stale");
     let finishStaleRender: (() => void) | undefined;
     const staleRender = new Promise<void>((resolve) => {
       finishStaleRender = resolve;
@@ -460,7 +461,7 @@ describe("Pages ISR generation coordination", () => {
       }),
     );
 
-    const onDemandGeneration = beginPagesIsrGeneration(key);
+    const onDemandGeneration = beginPagesIsrGeneration(key, "on-demand");
     await commitPagesIsrGeneration(onDemandGeneration, async () => {
       writes.push("on-demand");
     });
@@ -468,6 +469,52 @@ describe("Pages ISR generation coordination", () => {
 
     await expect(staleCommit).resolves.toBe(false);
     expect(writes).toEqual(["on-demand"]);
+  });
+
+  it("does not start stale work after on-demand generation begins", async () => {
+    const key = "pages:coordination-on-demand-first";
+    const onDemandGeneration = beginPagesIsrGeneration(key, "on-demand");
+
+    expect(beginPagesIsrGeneration(key, "stale")).toBeNull();
+
+    await expect(commitPagesIsrGeneration(onDemandGeneration, async () => {})).resolves.toBe(true);
+  });
+
+  it("cleans failed and cancelled generations without retaining priority state", async () => {
+    const failedKey = "pages:coordination-failed-cleanup";
+    const failedGeneration = beginPagesIsrGeneration(failedKey, "on-demand");
+    await expect(
+      commitPagesIsrGeneration(failedGeneration, async () => {
+        throw new Error("cache write failed");
+      }),
+    ).rejects.toThrow("cache write failed");
+    await Promise.resolve();
+
+    const afterFailure = beginPagesIsrGeneration(failedKey, "stale");
+    expect(afterFailure).toMatchObject({ version: 1, kind: "stale" });
+    cancelPagesIsrGeneration(afterFailure);
+
+    const cancelledKey = "pages:coordination-cancelled-cleanup";
+    const cancelledGeneration = beginPagesIsrGeneration(cancelledKey, "on-demand");
+    cancelPagesIsrGeneration(cancelledGeneration);
+    await Promise.resolve();
+
+    const afterCancellation = beginPagesIsrGeneration(cancelledKey, "stale");
+    expect(afterCancellation).toMatchObject({ version: 1, kind: "stale" });
+    cancelPagesIsrGeneration(afterCancellation);
+  });
+
+  it("does not delete a newer generation during older-tail cleanup", async () => {
+    const key = "pages:coordination-cleanup-race";
+    const first = beginPagesIsrGeneration(key, "ordinary");
+    let second: ReturnType<typeof beginPagesIsrGeneration> = null;
+
+    await commitPagesIsrGeneration(first, async () => {
+      second = beginPagesIsrGeneration(key, "ordinary");
+    });
+    await Promise.resolve();
+
+    await expect(commitPagesIsrGeneration(second, async () => {})).resolves.toBe(true);
   });
 });
 

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -20,6 +20,7 @@ import {
   beginPagesIsrGeneration,
   cancelPagesIsrGeneration,
   commitPagesIsrGeneration,
+  waitForPagesIsrGeneration,
   buildAppPageCacheValue,
   normalizeMountedSlotsHeader,
   setRevalidateDuration,
@@ -443,6 +444,19 @@ describe("ISR expire ceiling", () => {
       expect.objectContaining({ kind: "PAGES", html: "<html>static</html>" }),
     );
   });
+
+  it("round-trips a Pages notFound tombstone", async () => {
+    await isrSet("pages:not-found-tombstone", null, false);
+
+    const entry = await isrGet("pages:not-found-tombstone");
+    expect(entry).toMatchObject({
+      isStale: false,
+      value: {
+        value: null,
+        cacheControl: { revalidate: false },
+      },
+    });
+  });
 });
 
 describe("Pages ISR generation coordination", () => {
@@ -478,6 +492,51 @@ describe("Pages ISR generation coordination", () => {
     expect(beginPagesIsrGeneration(key, "stale")).toBeNull();
 
     await expect(commitPagesIsrGeneration(onDemandGeneration, async () => {})).resolves.toBe(true);
+  });
+
+  it("serializes concurrent on-demand generations and preserves both results", async () => {
+    const key = "pages:coordination-concurrent-on-demand";
+    const writes: string[] = [];
+    const first = beginPagesIsrGeneration(key, "on-demand");
+    const second = beginPagesIsrGeneration(key, "on-demand");
+    let secondStarted = false;
+
+    const secondRun = (async () => {
+      await waitForPagesIsrGeneration(second);
+      secondStarted = true;
+      return commitPagesIsrGeneration(second, async () => {
+        writes.push("second");
+      });
+    })();
+
+    await Promise.resolve();
+    expect(secondStarted).toBe(false);
+    await expect(
+      commitPagesIsrGeneration(first, async () => {
+        writes.push("first");
+      }),
+    ).resolves.toBe(true);
+    await expect(secondRun).resolves.toBe(true);
+    expect(writes).toEqual(["first", "second"]);
+  });
+
+  it("propagates an authoritative failure to a queued on-demand generation", async () => {
+    const key = "pages:coordination-on-demand-failure";
+    const first = beginPagesIsrGeneration(key, "on-demand");
+    const second = beginPagesIsrGeneration(key, "on-demand");
+    const secondTurn = waitForPagesIsrGeneration(second);
+
+    await expect(
+      commitPagesIsrGeneration(first, async () => {
+        throw new Error("authoritative write failed");
+      }),
+    ).rejects.toThrow("authoritative write failed");
+    await expect(secondTurn).rejects.toThrow("authoritative write failed");
+    cancelPagesIsrGeneration(second, new Error("authoritative write failed"));
+
+    const later = beginPagesIsrGeneration(key, "on-demand");
+    await expect(waitForPagesIsrGeneration(later)).resolves.toBeUndefined();
+    cancelPagesIsrGeneration(later);
   });
 
   it("cleans failed and cancelled generations without retaining priority state", async () => {

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -416,6 +416,24 @@ describe("KVCacheHandler", () => {
       expect((result!.value as any).html).toBe("<div>hi</div>");
     });
 
+    it("round-trips never-revalidate cache metadata", async () => {
+      await handler.set(
+        "pages-static",
+        {
+          kind: "PAGES",
+          html: "<html>static</html>",
+          pageData: {},
+          headers: undefined,
+          status: undefined,
+        },
+        { cacheControl: { revalidate: false }, revalidate: false },
+      );
+
+      const result = await handler.get("pages-static");
+      expect(result?.cacheControl?.revalidate).toBe(false);
+      expect(result?.cacheState).toBeUndefined();
+    });
+
     it("preserves slash-based path tags for Workers invalidation", async () => {
       await handler.set(
         "rt-path-tags",

--- a/tests/nextjs-compat/revalidate-reason.test.ts
+++ b/tests/nextjs-compat/revalidate-reason.test.ts
@@ -18,6 +18,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import vinext from "../../packages/vinext/src/index.js";
+import { PRERENDER_REVALIDATE_HEADER } from "../../packages/vinext/src/server/isr-cache.js";
 import { startFixtureServer, PAGES_FIXTURE_DIR, type TestServerResult } from "../helpers.js";
 
 let ctx: TestServerResult;
@@ -92,12 +93,16 @@ describe("Next.js compat: revalidate-reason (Pages Router)", () => {
 });
 
 describe("Next.js compat: revalidate-reason (Pages Router production)", () => {
+  const revalidateSecret = "vinext-revalidate-reason-test-secret";
+  let previousRevalidateSecret: string | undefined;
   let tmpRoot: string;
   let outDir: string;
   let server: import("node:http").Server;
   let baseUrl: string;
 
   beforeAll(async () => {
+    previousRevalidateSecret = process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
+    process.env.__VINEXT_SHARED_REVALIDATE_SECRET = revalidateSecret;
     tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-revalidate-reason-"));
     outDir = path.join(tmpRoot, "dist");
 
@@ -124,6 +129,15 @@ export async function getStaticProps({ revalidateReason }) {
       `export default async function handler(_req, res) {
   await res.revalidate("/");
   res.status(200).json({ revalidated: true });
+}
+`,
+    );
+    await fs.writeFile(
+      path.join(tmpRoot, "pages", "not-found.tsx"),
+      `export default function Page() { return null; }
+
+export async function getStaticProps() {
+  return { notFound: true };
 }
 `,
     );
@@ -162,6 +176,11 @@ export async function getStaticProps({ revalidateReason }) {
   }, 60_000);
 
   afterAll(async () => {
+    if (previousRevalidateSecret === undefined) {
+      delete process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
+    } else {
+      process.env.__VINEXT_SHARED_REVALIDATE_SECRET = previousRevalidateSecret;
+    }
     if (server) {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
@@ -182,5 +201,17 @@ export async function getStaticProps({ revalidateReason }) {
     const regenerated = await fetch(baseUrl);
     expect(regenerated.status).toBe(200);
     expect(reasonFromHtml(await regenerated.text())).toBe("on-demand");
+  });
+
+  it("emits REVALIDATED for authenticated on-demand success and notFound", async () => {
+    const headers = { [PRERENDER_REVALIDATE_HEADER]: revalidateSecret };
+
+    const success = await fetch(baseUrl, { method: "HEAD", headers });
+    expect(success.status).toBe(200);
+    expect(success.headers.get("x-nextjs-cache")).toBe("REVALIDATED");
+
+    const notFound = await fetch(`${baseUrl}/not-found`, { method: "HEAD", headers });
+    expect(notFound.status).toBe(404);
+    expect(notFound.headers.get("x-nextjs-cache")).toBe("REVALIDATED");
   });
 });

--- a/tests/nextjs-compat/revalidate-reason.test.ts
+++ b/tests/nextjs-compat/revalidate-reason.test.ts
@@ -134,10 +134,32 @@ export async function getStaticProps({ revalidateReason }) {
     );
     await fs.writeFile(
       path.join(tmpRoot, "pages", "not-found.tsx"),
-      `export default function Page() { return null; }
+      `let calls = 0;
+
+export default function Page() { return null; }
 
 export async function getStaticProps() {
+  calls += 1;
+  if (calls > 1) throw new Error("notFound tombstone was not reused");
   return { notFound: true };
+}
+`,
+    );
+    await fs.writeFile(
+      path.join(tmpRoot, "pages", "concurrent-failure.tsx"),
+      `let onDemandCalls = 0;
+
+export default function Page({ calls }) {
+  return <p id="calls">{calls}</p>;
+}
+
+export async function getStaticProps({ revalidateReason }) {
+  if (revalidateReason === "on-demand") {
+    onDemandCalls += 1;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    if (onDemandCalls === 1) throw new Error("first authoritative generation failed");
+  }
+  return { props: { calls: onDemandCalls }, revalidate: 60 };
 }
 `,
     );
@@ -213,5 +235,25 @@ export async function getStaticProps() {
     const notFound = await fetch(`${baseUrl}/not-found`, { method: "HEAD", headers });
     expect(notFound.status).toBe(404);
     expect(notFound.headers.get("x-nextjs-cache")).toBe("REVALIDATED");
+
+    const cachedNotFound = await fetch(`${baseUrl}/not-found`);
+    expect(cachedNotFound.status).toBe(404);
+  });
+
+  it("propagates a failed authoritative result to concurrent on-demand callers", async () => {
+    const headers = { [PRERENDER_REVALIDATE_HEADER]: revalidateSecret };
+    const [first, second] = await Promise.all([
+      fetch(`${baseUrl}/concurrent-failure`, { method: "HEAD", headers }),
+      fetch(`${baseUrl}/concurrent-failure`, { method: "HEAD", headers }),
+    ]);
+
+    expect(first.status).toBe(500);
+    expect(second.status).toBe(500);
+    expect(first.headers.get("x-nextjs-cache")).not.toBe("REVALIDATED");
+    expect(second.headers.get("x-nextjs-cache")).not.toBe("REVALIDATED");
+
+    const recovered = await fetch(`${baseUrl}/concurrent-failure`, { method: "HEAD", headers });
+    expect(recovered.status).toBe(200);
+    expect(recovered.headers.get("x-nextjs-cache")).toBe("REVALIDATED");
   });
 });

--- a/tests/nextjs-compat/revalidate-reason.test.ts
+++ b/tests/nextjs-compat/revalidate-reason.test.ts
@@ -13,6 +13,11 @@
  * Tracks vinext#1462.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import { build } from "vite-plus";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vinext from "../../packages/vinext/src/index.js";
 import { startFixtureServer, PAGES_FIXTURE_DIR, type TestServerResult } from "../helpers.js";
 
 let ctx: TestServerResult;
@@ -83,5 +88,99 @@ describe("Next.js compat: revalidate-reason (Pages Router)", () => {
     const res = await fetch(`${ctx.baseUrl}/revalidate-reason`);
     expect(res.status).toBe(200);
     expect(reasonFromHtml(await res.text())).toBe("on-demand");
+  });
+});
+
+describe("Next.js compat: revalidate-reason (Pages Router production)", () => {
+  let tmpRoot: string;
+  let outDir: string;
+  let server: import("node:http").Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-revalidate-reason-"));
+    outDir = path.join(tmpRoot, "dist");
+
+    await fs.symlink(
+      path.resolve(import.meta.dirname, "../../node_modules"),
+      path.join(tmpRoot, "node_modules"),
+      "junction",
+    );
+    await fs.mkdir(path.join(tmpRoot, "pages", "api"), { recursive: true });
+    await fs.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ type: "module" }));
+    await fs.writeFile(
+      path.join(tmpRoot, "pages", "index.tsx"),
+      `export default function Page({ reason }) {
+  return <p id="reason">revalidate reason: {reason}</p>;
+}
+
+export async function getStaticProps({ revalidateReason }) {
+  return { props: { reason: revalidateReason } };
+}
+`,
+    );
+    await fs.writeFile(
+      path.join(tmpRoot, "pages", "api", "revalidate.ts"),
+      `export default async function handler(_req, res) {
+  await res.revalidate("/");
+  res.status(200).json({ revalidated: true });
+}
+`,
+    );
+
+    await build({
+      root: tmpRoot,
+      configFile: false,
+      plugins: [vinext({ disableAppRouter: true })],
+      logLevel: "silent",
+      build: {
+        outDir: path.join(outDir, "server"),
+        ssr: "virtual:vinext-server-entry",
+        rolldownOptions: { output: { entryFileNames: "entry.js" } },
+      },
+    });
+    await build({
+      root: tmpRoot,
+      configFile: false,
+      plugins: [vinext({ disableAppRouter: true })],
+      logLevel: "silent",
+      build: {
+        outDir: path.join(outDir, "client"),
+        manifest: true,
+        ssrManifest: true,
+        rolldownOptions: { input: "virtual:vinext-client-entry" },
+      },
+    });
+
+    const { startProdServer } = await import("../../packages/vinext/src/server/prod-server.js");
+    const started = await startProdServer({ port: 0, host: "127.0.0.1", outDir });
+    server = "server" in started ? started.server : started;
+    const address = server.address();
+    if (!address || typeof address === "string")
+      throw new Error("Production server did not listen");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('persists revalidateReason: "on-demand" before res.revalidate resolves', async () => {
+    const prime = await fetch(baseUrl);
+    expect(prime.status).toBe(200);
+    expect(reasonFromHtml(await prime.text())).toBe("stale");
+
+    const revalidate = await fetch(`${baseUrl}/api/revalidate`);
+    expect(revalidate.status).toBe(200);
+    expect(await revalidate.json()).toEqual({ revalidated: true });
+
+    const regenerated = await fetch(baseUrl);
+    expect(regenerated.status).toBe(200);
+    expect(reasonFromHtml(await regenerated.text())).toBe("on-demand");
   });
 });

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -1,10 +1,16 @@
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   renderPagesIsrHtml,
   resolvePagesPageData,
   type ResolvePagesPageDataOptions,
 } from "../packages/vinext/src/server/pages-page-data.js";
+import { commitPagesIsrGeneration } from "../packages/vinext/src/server/isr-cache.js";
+
+afterEach(() => {
+  const coordination = Reflect.get(globalThis, Symbol.for("vinext.pagesIsr.coordination"));
+  if (coordination instanceof Map) coordination.clear();
+});
 
 function createOptions(
   overrides: Partial<ResolvePagesPageDataOptions> = {},
@@ -837,9 +843,59 @@ describe("pages page data", () => {
       }),
     );
     expect(onDemandResult.kind).toBe("render");
+    if (onDemandResult.kind !== "render") throw new Error("expected render result");
+    await commitPagesIsrGeneration(onDemandResult.isrGeneration, async () => {});
 
     finishStaleRender?.();
     await staleRegeneration;
+    expect(isrSet).not.toHaveBeenCalled();
+  });
+
+  it("skips a stale write when the backend entry advanced in another isolate", async () => {
+    let staleRegeneration: Promise<void> | undefined;
+    const isrSet = vi.fn(async () => {});
+    const staleCacheEntry = {
+      isStale: true,
+      value: {
+        lastModified: 1,
+        cacheState: "stale",
+        cacheControl: { revalidate: 5 },
+        value: {
+          kind: "PAGES" as const,
+          html: "<html>stale</html>",
+          pageData: { reason: "build" },
+          headers: undefined,
+          status: undefined,
+        },
+      },
+    };
+    const advancedCacheEntry = {
+      ...staleCacheEntry,
+      isStale: false,
+      value: { ...staleCacheEntry.value, lastModified: 2, cacheState: "fresh" },
+    };
+    const isrGet = vi
+      .fn<ResolvePagesPageDataOptions["isrGet"]>()
+      .mockResolvedValueOnce(staleCacheEntry)
+      .mockResolvedValueOnce(advancedCacheEntry);
+
+    await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        isrSet,
+        pageModule: {
+          async getStaticProps() {
+            return { props: { reason: "stale" }, revalidate: 5 };
+          },
+        },
+        triggerBackgroundRegeneration: vi.fn((_key, renderFn) => {
+          staleRegeneration = renderFn();
+        }),
+      }),
+    );
+
+    await staleRegeneration;
+    expect(isrGet).toHaveBeenCalledTimes(2);
     expect(isrSet).not.toHaveBeenCalled();
   });
 

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -1469,6 +1469,7 @@ describe("pages page data", () => {
     await expect(
       resolvePagesPageData(
         createOptions({
+          isBuildTimePrerendering: true,
           pageModule: {
             async getStaticProps() {
               return { props: { date: new Date(0) } };
@@ -1483,22 +1484,46 @@ describe("pages page data", () => {
     );
   });
 
-  it("throws a Next.js-style error when getServerSideProps returns non-serializable props", async () => {
-    await expect(
-      resolvePagesPageData(
-        createOptions({
-          pageModule: {
-            async getServerSideProps() {
-              return { props: { fn: () => "nope" } };
-            },
+  it("allows non-serializable getServerSideProps values in production", async () => {
+    const date = new Date(0);
+    const result = await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getServerSideProps() {
+            return { props: { date } };
           },
-          routePattern: "/gssp-bad",
-          routeUrl: "/gssp-bad",
-        }),
-      ),
-    ).rejects.toThrow(
-      /Error serializing `\.fn` returned from `getServerSideProps` in "\/gssp-bad"\.\s*Reason: `function` cannot be serialized as JSON/,
+        },
+        routePattern: "/non-json",
+        routeUrl: "/non-json",
+      }),
     );
+
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { date },
+      props: { __N_SSP: true, pageProps: { date } },
+    });
+  });
+
+  it("allows non-serializable getStaticProps values during runtime regeneration", async () => {
+    const date = new Date(0);
+    const result = await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getStaticProps() {
+            return { props: { date } };
+          },
+        },
+        routePattern: "/non-json",
+        routeUrl: "/non-json",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { date },
+      props: { pageProps: { date } },
+    });
   });
 
   // ── x-nextjs-deployment-id header ─────────────────────────────────────────

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -761,7 +761,7 @@ describe("pages page data", () => {
         html: expect.stringContaining("<div>fresh-body</div>"),
         pageData: { pageProps: { title: "fresh" } },
       }),
-      15,
+      false,
       undefined,
       300,
     );
@@ -772,10 +772,75 @@ describe("pages page data", () => {
         html: expect.stringContaining('"__vinext":{"hasMiddleware":true}'),
         pageData: { pageProps: { title: "fresh" } },
       }),
-      15,
+      false,
       undefined,
       300,
     );
+  });
+
+  it("does not let stale regeneration overwrite a later on-demand generation", async () => {
+    let staleRenderStarted: (() => void) | undefined;
+    let finishStaleRender: (() => void) | undefined;
+    const staleStarted = new Promise<void>((resolve) => {
+      staleRenderStarted = resolve;
+    });
+    const staleMayFinish = new Promise<void>((resolve) => {
+      finishStaleRender = resolve;
+    });
+    let staleRegeneration: Promise<void> | undefined;
+    const isrSet = vi.fn(async () => {});
+    const triggerBackgroundRegeneration = vi.fn((_key: string, renderFn: () => Promise<void>) => {
+      staleRegeneration = renderFn();
+    });
+    const staleCacheEntry = {
+      isStale: true,
+      value: {
+        lastModified: 1,
+        cacheState: "stale",
+        cacheControl: { revalidate: 5 },
+        value: {
+          kind: "PAGES" as const,
+          html: "<html>stale</html>",
+          pageData: { reason: "build" },
+          headers: undefined,
+          status: undefined,
+        },
+      },
+    };
+
+    await resolvePagesPageData(
+      createOptions({
+        isrGet: vi.fn().mockResolvedValue(staleCacheEntry),
+        isrSet,
+        pageModule: {
+          async getStaticProps() {
+            staleRenderStarted?.();
+            await staleMayFinish;
+            return { props: { reason: "stale" }, revalidate: 5 };
+          },
+        },
+        triggerBackgroundRegeneration,
+      }),
+    );
+    await staleStarted;
+
+    const onDemandResult = await resolvePagesPageData(
+      createOptions({
+        isOnDemandRevalidate: true,
+        isrGet: vi.fn().mockResolvedValue(staleCacheEntry),
+        isrSet,
+        pageModule: {
+          async getStaticProps() {
+            return { props: { reason: "on-demand" } };
+          },
+        },
+      }),
+    );
+    expect(onDemandResult.kind).toBe("render");
+
+    finishStaleRender?.();
+    await staleRegeneration;
+    expect(isrSet).not.toHaveBeenCalled();
   });
 
   it("preserves _app.getInitialProps app-level props during stale ISR regeneration", async () => {
@@ -1115,6 +1180,7 @@ describe("pages page data", () => {
       kind: "render",
       gsspRes: null,
       isrRevalidateSeconds: 30,
+      isrGeneration: expect.objectContaining({ key: "pages:/posts/post" }),
       pageProps: { title: "hello" },
       props: { pageProps: { title: "hello" } },
       isFallback: false,
@@ -1219,7 +1285,7 @@ describe("pages page data", () => {
 
     expect(result.kind).toBe("render");
     if (result.kind !== "render") throw new Error("expected render result");
-    expect(result.isrRevalidateSeconds).toBe(31_536_000);
+    expect(result.isrRevalidateSeconds).toBe(false);
   });
 
   it("passes revalidateReason: 'stale' to getStaticProps for runtime cache-miss requests", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -379,6 +379,56 @@ describe("pages page data", () => {
     await expect(result.response.text()).resolves.toBe("{}");
   });
 
+  it("persists and awaits an on-demand notFound tombstone", async () => {
+    let releaseWrite: (() => void) | undefined;
+    const writePending = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    const isrSet = vi.fn(async () => writePending);
+    let settled = false;
+    const resultPromise = resolvePagesPageData(
+      createOptions({
+        isOnDemandRevalidate: true,
+        isrSet,
+        pageModule: {
+          async getStaticProps() {
+            return { notFound: true };
+          },
+        },
+      }),
+    ).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.waitFor(() => expect(isrSet).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    expect(isrSet).toHaveBeenCalledWith("pages:/posts/post", null, false, undefined, 300);
+    releaseWrite?.();
+
+    await expect(resultPromise).resolves.toEqual({ kind: "notFound" });
+  });
+
+  it("serves a persisted notFound tombstone without rerunning getStaticProps", async () => {
+    const getStaticProps = vi.fn(async () => ({ props: {} }));
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet: vi.fn().mockResolvedValue({
+          isStale: false,
+          value: {
+            lastModified: 1,
+            cacheControl: { revalidate: false },
+            value: null,
+          },
+        }),
+        pageModule: { getStaticProps },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "notFound" });
+    expect(getStaticProps).not.toHaveBeenCalled();
+  });
+
   it("returns JSON 404 envelope for data requests when getServerSideProps returns notFound", async () => {
     const result = await resolvePagesPageData(
       createOptions({

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -1205,6 +1205,23 @@ describe("pages page data", () => {
     expect(received).toBe("on-demand");
   });
 
+  it("persists on-demand output for static pages without an explicit revalidate value", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        isOnDemandRevalidate: true,
+        pageModule: {
+          async getStaticProps() {
+            return { props: { reason: "on-demand" } };
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("render");
+    if (result.kind !== "render") throw new Error("expected render result");
+    expect(result.isrRevalidateSeconds).toBe(31_536_000);
+  });
+
   it("passes revalidateReason: 'stale' to getStaticProps for runtime cache-miss requests", async () => {
     let received: unknown = "untouched";
     await resolvePagesPageData(

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -601,3 +601,77 @@ describe("createPagesPageHandler — x-nextjs-deployment-id", () => {
     }
   });
 });
+
+describe("createPagesPageHandler — on-demand ISR lifecycle", () => {
+  it("releases authoritative generation when a nonce disables the cache write", async () => {
+    const {
+      beginPagesIsrGeneration,
+      cancelPagesIsrGeneration,
+      getRevalidateSecret,
+      PRERENDER_REVALIDATE_HEADER,
+    } = await import("../packages/vinext/src/server/isr-cache.js");
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute(
+            "/",
+            makePageModule({
+              async getStaticProps() {
+                return { props: { ok: true }, revalidate: 60 };
+              },
+            }),
+          ),
+        ],
+      }),
+    );
+    const request = new Request("http://localhost/", {
+      headers: {
+        [PRERENDER_REVALIDATE_HEADER]: getRevalidateSecret(),
+        "content-security-policy": "script-src 'nonce-lifecycle-test'",
+      },
+    });
+
+    const response = await handler(request, "/", null, null, null);
+    expect(response.status).toBe(200);
+
+    const stale = beginPagesIsrGeneration("pages:/", "stale");
+    expect(stale).not.toBeNull();
+    cancelPagesIsrGeneration(stale);
+  });
+
+  it("releases authoritative generation when rendering throws", async () => {
+    const {
+      beginPagesIsrGeneration,
+      cancelPagesIsrGeneration,
+      getRevalidateSecret,
+      PRERENDER_REVALIDATE_HEADER,
+    } = await import("../packages/vinext/src/server/isr-cache.js");
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute(
+            "/",
+            makePageModule({
+              async getStaticProps() {
+                return { props: { ok: true }, revalidate: 60 };
+              },
+            }),
+          ),
+        ],
+        renderToReadableStream: async () => {
+          throw new Error("render lifecycle failure");
+        },
+      }),
+    );
+    const request = new Request("http://localhost/", {
+      headers: { [PRERENDER_REVALIDATE_HEADER]: getRevalidateSecret() },
+    });
+
+    const response = await handler(request, "/", null, null, null);
+    expect(response.status).toBe(500);
+
+    const stale = beginPagesIsrGeneration("pages:/", "stale");
+    expect(stale).not.toBeNull();
+    cancelPagesIsrGeneration(stale);
+  });
+});

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -56,7 +56,7 @@ function createCommonOptions() {
   const isrSet = vi.fn(
     async (
       _key: string,
-      _data: CachedPagesValue,
+      _data: CachedPagesValue | null,
       _revalidateSeconds: number | false,
       _tags?: string[],
       _expireSeconds?: number,
@@ -318,6 +318,7 @@ describe("pages page response", () => {
     let finishFirstWrite: (() => void) | undefined;
     const writes: string[] = [];
     common.isrSet.mockImplementation(async (_key, value) => {
+      if (!value) throw new Error("expected Pages cache value");
       const pageData = value.pageData as Record<string, unknown>;
       const title = String(pageData.title);
       writes.push(title);

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -57,7 +57,7 @@ function createCommonOptions() {
     async (
       _key: string,
       _data: CachedPagesValue,
-      _revalidateSeconds: number,
+      _revalidateSeconds: number | false,
       _tags?: string[],
       _expireSeconds?: number,
     ) => {},
@@ -278,6 +278,39 @@ describe("pages page response", () => {
     const response = await responsePromise;
     expect(settled).toBe(true);
     await expect(response.text()).resolves.toContain("<div>live-body</div>");
+  });
+
+  it("propagates awaited on-demand ISR cache write failures", async () => {
+    const common = createCommonOptions();
+    common.isrSet.mockRejectedValue(new Error("cache write failed"));
+
+    await expect(
+      renderPagesPageResponse({
+        ...common.options,
+        awaitIsrCacheWrite: true,
+        isrRevalidateSeconds: 60,
+      }),
+    ).rejects.toThrow("cache write failed");
+  });
+
+  it("uses one-year cache-control compatibility for false revalidate metadata", async () => {
+    const common = createCommonOptions();
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      awaitIsrCacheWrite: true,
+      isrRevalidateSeconds: false,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    await response.text();
+    expect(common.isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post",
+      expect.any(Object),
+      false,
+      undefined,
+      undefined,
+    );
   });
 
   it("orders an on-demand cache write after an earlier asynchronous write", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -7,6 +7,7 @@ import {
   etagMatches,
 } from "../packages/vinext/src/server/pages-page-response.js";
 import { resolvePagesPageData } from "../packages/vinext/src/server/pages-page-data.js";
+import type { CachedPagesValue } from "../packages/vinext/src/shims/cache.js";
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -52,7 +53,15 @@ function createCommonOptions() {
       "data-page": typeof pageProps.title === "string" ? pageProps.title : "",
     }),
   );
-  const isrSet = vi.fn(async () => {});
+  const isrSet = vi.fn(
+    async (
+      _key: string,
+      _data: CachedPagesValue,
+      _revalidateSeconds: number,
+      _tags?: string[],
+      _expireSeconds?: number,
+    ) => {},
+  );
   const renderDocumentToString = vi.fn(
     async () =>
       '<!DOCTYPE html><html><head></head><body><div id="__next">__NEXT_MAIN__</div><!-- __NEXT_SCRIPTS__ --></body></html>',
@@ -240,6 +249,79 @@ describe("pages page response", () => {
       undefined,
       300,
     );
+  });
+
+  it("awaits the ISR cache write for synchronous on-demand revalidation", async () => {
+    const common = createCommonOptions();
+    let finishCacheWrite: (() => void) | undefined;
+    common.isrSet.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCacheWrite = resolve;
+        }),
+    );
+
+    let settled = false;
+    const responsePromise = renderPagesPageResponse({
+      ...common.options,
+      awaitIsrCacheWrite: true,
+      isrRevalidateSeconds: 60,
+    }).then((response) => {
+      settled = true;
+      return response;
+    });
+
+    await vi.waitFor(() => expect(common.isrSet).toHaveBeenCalledTimes(1));
+    expect(settled).toBe(false);
+
+    finishCacheWrite?.();
+    const response = await responsePromise;
+    expect(settled).toBe(true);
+    await expect(response.text()).resolves.toContain("<div>live-body</div>");
+  });
+
+  it("orders an on-demand cache write after an earlier asynchronous write", async () => {
+    const common = createCommonOptions();
+    let finishFirstWrite: (() => void) | undefined;
+    const writes: string[] = [];
+    common.isrSet.mockImplementation(async (_key, value) => {
+      const pageData = value.pageData as Record<string, unknown>;
+      const title = String(pageData.title);
+      writes.push(title);
+      if (title === "stale") {
+        await new Promise<void>((resolve) => {
+          finishFirstWrite = resolve;
+        });
+      }
+    });
+
+    const staleResponse = await renderPagesPageResponse({
+      ...common.options,
+      isrRevalidateSeconds: 60,
+      pageProps: { title: "stale" },
+    });
+    await staleResponse.text();
+    await vi.waitFor(() => expect(writes).toEqual(["stale"]));
+
+    let onDemandSettled = false;
+    const onDemandResponsePromise = renderPagesPageResponse({
+      ...common.options,
+      awaitIsrCacheWrite: true,
+      isrRevalidateSeconds: 60,
+      pageProps: { title: "on-demand" },
+    }).then((response) => {
+      onDemandSettled = true;
+      return response;
+    });
+
+    await settleMicrotasks();
+    expect(writes).toEqual(["stale"]);
+    expect(onDemandSettled).toBe(false);
+
+    finishFirstWrite?.();
+    const onDemandResponse = await onDemandResponsePromise;
+    expect(writes).toEqual(["stale", "on-demand"]);
+    await expect(onDemandResponse.text()).resolves.toContain("<div>live-body</div>");
   });
 
   it("records split UTF-8 chunks without corrupting cached ISR HTML", async () => {


### PR DESCRIPTION
## Summary

- persist and await Pages Router on-demand regeneration output
- distinguish build, stale, and on-demand revalidation reasons
- coordinate same-isolate ISR writes so stale work cannot overwrite authoritative on-demand output
- propagate awaited backend failures, persist notFound tombstones, emit `x-nextjs-cache: REVALIDATED`, and preserve `revalidate: false`
- safely finalize and clean generation state on every exit path

## Next.js parity

Fixes `test/e2e/revalidate-reason/revalidate-reason.test.ts`, where on-demand regeneration was reported as `stale`.

## Validation

- pinned Next.js v16.2.6 exact suite: build/on-demand/stale all passed
- focused Pages/cache tests: 550 passed
- scoped format/lint/type checks and vinext build passed
- repeated independent reviews; no actionable findings remain

Cross-isolate ordering remains best-effort for custom distributed cache adapters because the current interface has no atomic CAS/conditional-set primitive; the patch performs a backend freshness re-read before stale writes.
