### PR TITLE
fix(pages): preserve rewritten URLs during navigation

### DIFF
--- a/packages/vinext/src/client/pages-router-link-navigation.ts
+++ b/packages/vinext/src/client/pages-router-link-navigation.ts
@@ -1,3 +1,6 @@
+import { stripBasePath } from "../utils/base-path.js";
+import { getLocalePathPrefix } from "../utils/domain-locale.js";
+
 type PagesRouterLinkTransitionOptions = {
   scroll?: boolean;
   shallow?: boolean;
@@ -8,6 +11,38 @@ type PagesRouterLinkRuntime = {
   push(url: string, as?: string, options?: PagesRouterLinkTransitionOptions): Promise<boolean>;
   replace(url: string, as?: string, options?: PagesRouterLinkTransitionOptions): Promise<boolean>;
 };
+
+export function resolvePagesRouterQueryOnlyHref(
+  href: string,
+  {
+    asPath,
+    basePath,
+    fallbackHref,
+    locales,
+  }: {
+    asPath?: string;
+    basePath: string;
+    fallbackHref: string;
+    locales?: readonly string[];
+  },
+): string {
+  if (!href.startsWith("?")) return href;
+
+  try {
+    const fallbackUrl = new URL(fallbackHref);
+    const base = new URL(
+      asPath ??
+        `${stripBasePath(fallbackUrl.pathname, basePath)}${fallbackUrl.search}${fallbackUrl.hash}`,
+      "http://vinext.local",
+    );
+    const locale = getLocalePathPrefix(base.pathname, locales);
+    if (locale) base.pathname = base.pathname.slice(locale.length + 1) || "/";
+    const resolved = new URL(href, base);
+    return resolved.href.slice(resolved.origin.length);
+  } catch {
+    return href;
+  }
+}
 
 export async function navigatePagesRouterLink(
   router: PagesRouterLinkRuntime,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -963,6 +963,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       window.location.href,
       __basePath,
     );
+    const pagesNavigateHref = navigateHref.startsWith("?")
+      ? (toSameOriginAppPath(absoluteFullHref, __basePath) ?? navigateHref)
+      : navigateHref;
 
     // Call onNavigate callback if provided (Next.js 16 View Transitions support)
     if (onNavigate) {
@@ -1037,10 +1040,11 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       // during startup, but it does not invoke the named export on navigation.
       // Pages Router: use the Router singleton
       try {
-        const routerModule = await import("next/router");
-        const Router = routerModule.default;
-        await navigatePagesRouterLink(Router, {
-          href: navigateHref,
+        const Router = window.next?.appDir === true ? undefined : window.next?.router;
+        const pagesRouter =
+          Router && "reload" in Router ? Router : (await import("next/router")).default;
+        await navigatePagesRouterLink(pagesRouter, {
+          href: pagesNavigateHref,
           replace,
           scroll,
           shallow,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -62,7 +62,10 @@ import { appendSearchParamsToUrl, type UrlQuery, urlQueryToSearchParams } from "
 import { addLocalePrefix, getDomainLocaleUrl, type DomainLocale } from "../utils/domain-locale.js";
 import { getI18nContext } from "./i18n-context.js";
 import type { VinextLinkPrefetchRoute, VinextNextData } from "../client/vinext-next-data.js";
-import { navigatePagesRouterLink } from "../client/pages-router-link-navigation.js";
+import {
+  navigatePagesRouterLink,
+  resolvePagesRouterQueryOnlyHref,
+} from "../client/pages-router-link-navigation.js";
 import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
 import { stripBasePath } from "../utils/base-path.js";
 import {
@@ -191,6 +194,32 @@ function resolveHref(href: LinkProps["href"]): string {
     url = appendSearchParamsToUrl(url, params);
   }
   return url;
+}
+
+function resolvePagesQueryOnlyHref(href: string): string {
+  if (!href.startsWith("?") || typeof window === "undefined") return href;
+
+  const pagesRouter = window.next?.appDir === true ? undefined : window.next?.router;
+  const visibleHref =
+    pagesRouter &&
+    "reload" in pagesRouter &&
+    "asPath" in pagesRouter &&
+    typeof pagesRouter.asPath === "string"
+      ? pagesRouter.asPath
+      : undefined;
+  return resolvePagesRouterQueryOnlyHref(href, {
+    asPath: visibleHref,
+    basePath: __basePath,
+    fallbackHref: window.location.href,
+    locales: window.__VINEXT_LOCALES__,
+  });
+}
+
+function resolvePagesLinkNavigationHref(href: string, locale: string | false | undefined): string {
+  return normalizePathTrailingSlash(
+    applyLocaleToHref(resolvePagesQueryOnlyHref(href), locale),
+    __trailingSlash,
+  );
 }
 
 /**
@@ -957,15 +986,18 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
     e.preventDefault();
 
+    const hasAppNavigationRuntime = Boolean(getNavigationRuntime()?.functions.navigate);
+    const pagesNavigateHref = resolvedHref.startsWith("?")
+      ? resolvePagesLinkNavigationHref(resolvedHref, locale)
+      : navigateHref;
     // Resolve relative hrefs (#hash, ?query) for onNavigate and the hard-navigation fallback.
+    // Pages query-only links must use the rewrite-aware target resolved above,
+    // so callbacks and router-error fallback agree with the actual navigation.
     const absoluteFullHref = toBrowserNavigationHref(
-      navigateHref,
+      hasAppNavigationRuntime ? navigateHref : pagesNavigateHref,
       window.location.href,
       __basePath,
     );
-    const pagesNavigateHref = navigateHref.startsWith("?")
-      ? (toSameOriginAppPath(absoluteFullHref, __basePath) ?? navigateHref)
-      : navigateHref;
 
     // Call onNavigate callback if provided (Next.js 16 View Transitions support)
     if (onNavigate) {
@@ -1005,7 +1037,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // (`setPending`, `setLinkForCurrentNavigation`) would be a no-op at best
     // and a stale `useLinkStatus` indicator at worst.
     if (
-      getNavigationRuntime()?.functions.navigate &&
+      hasAppNavigationRuntime &&
       ["pages", "document"].includes(resolveHybridClientRouteOwner(navigateHref, __basePath) ?? "")
     ) {
       if (replace) {
@@ -1018,7 +1050,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
     // App Router: delegate to navigateClientSide which handles scroll save,
     // hash-only changes, RSC fetch, and two-phase URL commit.
-    if (getNavigationRuntime()?.functions.navigate) {
+    if (hasAppNavigationRuntime) {
       const setter = setPendingRef.current;
       // Register this link as the one driving the current navigation. This
       // resets any previously-pending link (e.g. a different link clicked

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -481,7 +481,9 @@ function getPagesRouterRuntimeComponents(): PagesRouterRuntimeComponents {
 
 function resolveUrl(url: string | UrlObject): string {
   if (typeof url === "string") return url;
-  let result = url.pathname ?? "/";
+  let result =
+    url.pathname ??
+    (typeof window !== "undefined" ? stripBasePath(window.location.pathname, __basePath) : "/");
   if (url.query) {
     const params = urlQueryToSearchParams(url.query);
     result = appendSearchParamsToUrl(result, params);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -495,7 +495,7 @@ function resolveUrl(url: string | UrlObject): string {
         : (window.__NEXT_DATA__?.page ?? stripBasePath(window.location.pathname, __basePath))
       : "/");
   if (hasSearch) {
-    result = appendSearchParamsToUrl(result, new URLSearchParams(url.search));
+    result += url.search!.startsWith("?") ? url.search : `?${url.search}`;
   } else if (hasQuery) {
     const params = urlQueryToSearchParams(url.query!);
     result = appendSearchParamsToUrl(result, params);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -496,7 +496,7 @@ function resolveUrl(url: string | UrlObject): string {
       : "/");
   if (hasSearch) {
     const search = url.search!.startsWith("?") ? url.search! : `?${url.search}`;
-    result += search.replace("#", "%23");
+    result += search.replaceAll("#", "%23");
   } else if (hasQuery) {
     const params = urlQueryToSearchParams(url.query!);
     result = appendSearchParamsToUrl(result, params);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -496,7 +496,9 @@ function resolveUrl(url: string | UrlObject): string {
       : "/");
   if (hasSearch) {
     const search = url.search!.startsWith("?") ? url.search! : `?${url.search}`;
-    result += search.replaceAll("#", "%23");
+    const hashIndex = search.indexOf("#");
+    result +=
+      hashIndex === -1 ? search : `${search.slice(0, hashIndex)}%23${search.slice(hashIndex + 1)}`;
   } else if (hasQuery) {
     const params = urlQueryToSearchParams(url.query!);
     result = appendSearchParamsToUrl(result, params);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -495,7 +495,8 @@ function resolveUrl(url: string | UrlObject): string {
         : (window.__NEXT_DATA__?.page ?? stripBasePath(window.location.pathname, __basePath))
       : "/");
   if (hasSearch) {
-    result += url.search!.startsWith("?") ? url.search : `?${url.search}`;
+    const search = url.search!.startsWith("?") ? url.search! : `?${url.search}`;
+    result += search.replace("#", "%23");
   } else if (hasQuery) {
     const params = urlQueryToSearchParams(url.query!);
     result = appendSearchParamsToUrl(result, params);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -364,6 +364,8 @@ export type NextRouter = {
 type UrlObject = {
   pathname?: string;
   query?: UrlQuery;
+  search?: string;
+  hash?: string;
 };
 
 type TransitionOptions = {
@@ -481,12 +483,27 @@ function getPagesRouterRuntimeComponents(): PagesRouterRuntimeComponents {
 
 function resolveUrl(url: string | UrlObject): string {
   if (typeof url === "string") return url;
+  const hasQuery = url.query !== undefined && Object.keys(url.query).length > 0;
+  const hasSearch = typeof url.search === "string" && url.search.length > 0;
+  const hasHash = typeof url.hash === "string" && url.hash.length > 0;
+  const inheritsVisiblePath = url.pathname === undefined && (hasQuery || hasSearch || hasHash);
   let result =
     url.pathname ??
-    (typeof window !== "undefined" ? stripBasePath(window.location.pathname, __basePath) : "/");
-  if (url.query) {
-    const params = urlQueryToSearchParams(url.query);
+    (typeof window !== "undefined"
+      ? inheritsVisiblePath
+        ? stripBasePath(window.location.pathname, __basePath)
+        : (window.__NEXT_DATA__?.page ?? stripBasePath(window.location.pathname, __basePath))
+      : "/");
+  if (hasSearch) {
+    result = appendSearchParamsToUrl(result, new URLSearchParams(url.search));
+  } else if (hasQuery) {
+    const params = urlQueryToSearchParams(url.query!);
     result = appendSearchParamsToUrl(result, params);
+  } else if (hasHash && typeof window !== "undefined") {
+    result += window.location.search;
+  }
+  if (hasHash) {
+    result += url.hash!.startsWith("#") ? url.hash : `#${url.hash}`;
   }
   return result;
 }
@@ -504,8 +521,9 @@ function resolveNavigationTarget(
   url: string | UrlObject,
   as: string | undefined,
   locale: string | undefined,
+  replaceExistingLocale = false,
 ): string {
-  return applyNavigationLocale(as ?? resolveUrl(url), locale);
+  return applyNavigationLocale(as ?? resolveUrl(url), locale, replaceExistingLocale);
 }
 
 function getCurrentUrlLocale(): string | undefined {
@@ -590,21 +608,41 @@ function getDomainLocalePath(url: string, locale: string): string | undefined {
  * Apply locale prefix to a URL for client-side navigation.
  * Same logic as Link's applyLocaleToHref but reads from window globals.
  */
-export function applyNavigationLocale(url: string, locale?: string): string {
+export function applyNavigationLocale(
+  url: string,
+  locale?: string,
+  replaceExistingLocale = false,
+): string {
   if (!locale || typeof window === "undefined") return url;
   // Absolute and protocol-relative URLs must not be prefixed — locale
   // only applies to local paths.
   if (isAbsoluteOrProtocolRelativeUrl(url)) {
     return url;
   }
-  if (getLocalePathPrefix(url, window.__VINEXT_LOCALES__)) {
+  if (!replaceExistingLocale && getLocalePathPrefix(url, window.__VINEXT_LOCALES__)) {
     return url;
   }
+  const normalizedUrl = replaceExistingLocale ? removeNavigationLocalePrefix(url) : url;
 
-  const domainLocalePath = getDomainLocalePath(url, locale);
+  const domainLocalePath = getDomainLocalePath(normalizedUrl, locale);
   if (domainLocalePath) return domainLocalePath;
 
-  return addLocalePrefix(url, locale, window.__VINEXT_DEFAULT_LOCALE__ ?? "");
+  return addLocalePrefix(normalizedUrl, locale, window.__VINEXT_DEFAULT_LOCALE__ ?? "");
+}
+
+function removeNavigationLocalePrefix(url: string): string {
+  const locales = window.__VINEXT_LOCALES__;
+  if (!locales?.length) return url;
+
+  try {
+    const parsed = new URL(url, "http://vinext.local");
+    const locale = getLocalePathPrefix(parsed.pathname, locales);
+    if (!locale) return url;
+    const pathname = parsed.pathname.slice(locale.length + 1) || "/";
+    return `${pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
 }
 
 function isDefaultLocaleRootNavigation(url: string, locale: string | undefined): boolean {
@@ -2217,7 +2255,15 @@ async function performNavigation(
   }
 
   const navigationLocale = resolveTransitionLocale(options?.locale);
-  let resolved = resolveNavigationTarget(url, as, navigationLocale);
+  const replaceInheritedLocale =
+    as === undefined &&
+    options?.locale !== undefined &&
+    typeof url !== "string" &&
+    url.pathname === undefined &&
+    ((url.query !== undefined && Object.keys(url.query).length > 0) ||
+      (typeof url.search === "string" && url.search.length > 0) ||
+      (typeof url.hash === "string" && url.hash.length > 0));
+  let resolved = resolveNavigationTarget(url, as, navigationLocale, replaceInheritedLocale);
 
   // External URLs — delegate to browser (unless same-origin)
   if (isExternalUrl(resolved)) {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1189,8 +1189,30 @@ function getPathnameAndQuery(): {
   }
   const query = { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern
-  const asPath = resolvedPath + window.location.search + window.location.hash;
+  const asPath =
+    getCurrentHistoryAsPath() ?? resolvedPath + window.location.search + window.location.hash;
   return { pathname, query, asPath };
+}
+
+function getCurrentHistoryAsPath(): string | null {
+  const state = window.history?.state;
+  if (!isNextRouterState(state) || typeof state.as !== "string") return null;
+
+  try {
+    const browserUrl = new URL(window.location.href);
+    const stateUrl = new URL(
+      toBrowserNavigationHref(state.as, window.location.href, __basePath),
+      window.location.href,
+    );
+    if (stateUrl.pathname !== browserUrl.pathname || stateUrl.search !== browserUrl.search) {
+      return null;
+    }
+    const stateAs = stripHash(state.as);
+    const visibleAs = `${stripBasePath(window.location.pathname, __basePath)}${window.location.search}`;
+    return `${stateAs || visibleAs}${window.location.hash}`;
+  } catch {
+    return null;
+  }
 }
 
 export function getPagesNavigationIsReadyFromSerializedState(

--- a/tests/e2e/pages-router/navigation.spec.ts
+++ b/tests/e2e/pages-router/navigation.spec.ts
@@ -102,6 +102,20 @@ test.describe("Client-side navigation", () => {
     await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
   });
 
+  test("UrlObject search overrides query and preserves hash on rewritten paths", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/rewrite-navigation/0`);
+    await waitForHydration(page);
+
+    await page.click('[data-testid="search-push"]');
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation/0?id=6#result`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText(
+      "/rewrite-navigation/0?id=6#result",
+    );
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
+  });
+
   test("router.push(url, as) uses the masked URL while resolving the real route", async ({
     page,
   }) => {

--- a/tests/e2e/pages-router/navigation.spec.ts
+++ b/tests/e2e/pages-router/navigation.spec.ts
@@ -62,6 +62,46 @@ test.describe("Client-side navigation", () => {
     expect(page.url()).toBe(`${BASE}/about`);
   });
 
+  test("query-only navigation preserves the visible dynamic rewrite path", async ({ page }) => {
+    // Ported from Next.js: test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    await page.goto(`${BASE}/rewrite-navigation/0`);
+    await waitForHydration(page);
+    await expect(page.locator("h1")).toHaveText("Rewrite Navigation Destination");
+    await expect(page.locator('[data-testid="pathname"]')).toHaveText(
+      "/rewrite-navigation/[id]/destination",
+    );
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation/0");
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
+
+    await page.evaluate(() => {
+      window.scrollTo(0, 600);
+      (window as any).__REWRITE_NAV_MARKER__ = true;
+    });
+    await page.click('[data-testid="router-push"]');
+
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation/0?id=1`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation/0?id=1");
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
+    expect(await page.evaluate(() => (window as any).__REWRITE_NAV_MARKER__)).toBe(true);
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+  });
+
+  test("replace and Link preserve the visible dynamic rewrite path", async ({ page }) => {
+    await page.goto(`${BASE}/rewrite-navigation/0`);
+    await waitForHydration(page);
+
+    await page.click('[data-testid="router-replace"]');
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation/0?id=2`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation/0?id=2");
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
+
+    await page.click('[data-testid="query-link"]');
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation/0?id=3`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation/0?id=3");
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
+  });
+
   test("router.push(url, as) uses the masked URL while resolving the real route", async ({
     page,
   }) => {

--- a/tests/e2e/pages-router/navigation.spec.ts
+++ b/tests/e2e/pages-router/navigation.spec.ts
@@ -100,6 +100,9 @@ test.describe("Client-side navigation", () => {
     await expect(page).toHaveURL(`${BASE}/rewrite-navigation/0?id=3`);
     await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation/0?id=3");
     await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
+    await expect(page.locator('[data-testid="navigate-url"]')).toHaveText(
+      "/rewrite-navigation/0?id=3",
+    );
   });
 
   test("UrlObject search overrides query and preserves hash on rewritten paths", async ({
@@ -114,6 +117,32 @@ test.describe("Client-side navigation", () => {
       "/rewrite-navigation/0?id=6#result",
     );
     await expect(page.locator('[data-testid="query-id"]')).toHaveText("0");
+  });
+
+  test("bare UrlObject search remains visible in router.asPath", async ({ page }) => {
+    await page.goto(`${BASE}/rewrite-navigation/0?existing=1`);
+    await waitForHydration(page);
+
+    await page.click('[data-testid="bare-search-push"]');
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation/0?`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation/0?");
+    expect(await page.evaluate(() => window.location.search)).toBe("");
+    expect(await page.evaluate(() => (window as any).next.router.asPath)).toBe(
+      "/rewrite-navigation/0?",
+    );
+  });
+
+  test("bare Link query remains visible in router.asPath", async ({ page }) => {
+    await page.goto(`${BASE}/rewrite-navigation/0?existing=1`);
+    await waitForHydration(page);
+
+    await page.click('[data-testid="bare-query-link"]');
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation/0?`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation/0?");
+    expect(await page.evaluate(() => window.location.search)).toBe("");
+    expect(await page.evaluate(() => (window as any).next.router.asPath)).toBe(
+      "/rewrite-navigation/0?",
+    );
   });
 
   test("router.push(url, as) uses the masked URL while resolving the real route", async ({

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -39,6 +39,10 @@ const nextConfig = {
           source: "/repeat-rewrite/:id",
           destination: "/docs/:id/:id",
         },
+        {
+          source: "/rewrite-navigation/:id",
+          destination: "/rewrite-navigation/:id/destination",
+        },
         // Used by Vitest: pages-router.test.ts — beforeFiles rewrite gated on
         // a cookie injected by middleware. Middleware injects mw-before-user=1
         // when ?mw-auth is present. The beforeFiles rewrite should see this

--- a/tests/fixtures/pages-basic/pages/rewrite-navigation/[id]/destination.tsx
+++ b/tests/fixtures/pages-basic/pages/rewrite-navigation/[id]/destination.tsx
@@ -19,6 +19,13 @@ export default function RewriteNavigationPage() {
       <Link data-testid="query-link" href="?id=3">
         Link query
       </Link>
+      <button
+        data-testid="search-push"
+        onClick={() => router.push({ query: { id: "ignored" }, search: "id=6", hash: "result" })}
+      >
+        Push search and hash
+      </button>
+      <div id="result">Hash result</div>
     </main>
   );
 }

--- a/tests/fixtures/pages-basic/pages/rewrite-navigation/[id]/destination.tsx
+++ b/tests/fixtures/pages-basic/pages/rewrite-navigation/[id]/destination.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+export default function RewriteNavigationPage() {
+  const router = useRouter();
+
+  return (
+    <main style={{ minHeight: "200vh" }}>
+      <h1>Rewrite Navigation Destination</h1>
+      <p data-testid="pathname">{router.pathname}</p>
+      <p data-testid="as-path">{router.asPath}</p>
+      <p data-testid="query-id">{router.query.id}</p>
+      <button data-testid="router-push" onClick={() => router.push({ query: { id: "1" } })}>
+        Push query
+      </button>
+      <button data-testid="router-replace" onClick={() => router.replace({ query: { id: "2" } })}>
+        Replace query
+      </button>
+      <Link data-testid="query-link" href="?id=3">
+        Link query
+      </Link>
+    </main>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/rewrite-navigation/[id]/destination.tsx
+++ b/tests/fixtures/pages-basic/pages/rewrite-navigation/[id]/destination.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useState } from "react";
 
 export default function RewriteNavigationPage() {
   const router = useRouter();
+  const [navigateUrl, setNavigateUrl] = useState("");
 
   return (
     <main style={{ minHeight: "200vh" }}>
@@ -16,15 +18,26 @@ export default function RewriteNavigationPage() {
       <button data-testid="router-replace" onClick={() => router.replace({ query: { id: "2" } })}>
         Replace query
       </button>
-      <Link data-testid="query-link" href="?id=3">
+      <Link
+        data-testid="query-link"
+        href="?id=3"
+        onNavigate={(event) => setNavigateUrl(event.url.pathname + event.url.search)}
+      >
         Link query
       </Link>
+      <p data-testid="navigate-url">{navigateUrl}</p>
       <button
         data-testid="search-push"
         onClick={() => router.push({ query: { id: "ignored" }, search: "id=6", hash: "result" })}
       >
         Push search and hash
       </button>
+      <button data-testid="bare-search-push" onClick={() => router.push({ search: "?" })}>
+        Push bare search
+      </button>
+      <Link data-testid="bare-query-link" href="?">
+        Link bare query
+      </Link>
       <div id="result">Hash result</div>
     </main>
   );

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -21,7 +21,10 @@ import Link, {
   resolveLinkPrefetchMode,
   useLinkStatus,
 } from "../packages/vinext/src/shims/link.js";
-import { navigatePagesRouterLink } from "../packages/vinext/src/client/pages-router-link-navigation.js";
+import {
+  navigatePagesRouterLink,
+  resolvePagesRouterQueryOnlyHref,
+} from "../packages/vinext/src/client/pages-router-link-navigation.js";
 
 // Internal helpers re-exported or accessible via the router shim
 import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/router.js";
@@ -30,6 +33,7 @@ import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/ro
 // rendering occurs (same as dev-server.ts and pages-server-entry.ts do).
 import { runWithI18nState } from "../packages/vinext/src/shims/i18n-state.js";
 import { setI18nContext } from "../packages/vinext/src/shims/i18n-context.js";
+import { addLocalePrefix } from "../packages/vinext/src/utils/domain-locale.js";
 
 import {
   isAbsoluteOrProtocolRelativeUrl,
@@ -446,6 +450,60 @@ describe("Link resolveHref", () => {
       React.createElement(Link, { href: { query: { page: "2", sort: "name" } } }, "x"),
     );
     expect(html).toMatch(/href="\?page=2&(?:amp;)?sort=name"/);
+  });
+
+  it("resolves query-only Pages Links against a rewritten path before locale application", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    (globalThis as any).window = {
+      location: {
+        pathname: "/docs/fr/rewrite-navigation/0",
+        search: "?existing=1",
+        hash: "",
+        href: "http://localhost/docs/fr/rewrite-navigation/0?existing=1",
+        origin: "http://localhost",
+        hostname: "localhost",
+      },
+      history: {
+        state: null,
+        pushState() {},
+        replaceState() {},
+      },
+      addEventListener() {},
+      next: { router: { asPath: "/rewrite-navigation/0?existing=1", reload() {} } },
+      __VINEXT_LOCALE__: "fr",
+      __VINEXT_LOCALES__: ["en", "fr", "de"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+    };
+    try {
+      const resolvedHref = resolvePagesRouterQueryOnlyHref("?id=1", {
+        asPath: "/rewrite-navigation/0?existing=1",
+        basePath: "/docs",
+        fallbackHref: (globalThis as any).window.location.href,
+        locales: ["en", "fr", "de"],
+      });
+      const localizedHref = addLocalePrefix(resolvedHref, "de", "en");
+
+      expect(
+        toBrowserNavigationHref(localizedHref, (globalThis as any).window.location.href, "/docs"),
+      ).toBe("/docs/de/rewrite-navigation/0?id=1");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+    }
+  });
+
+  it("preserves a bare query delimiter when resolving Pages Links", () => {
+    expect(
+      resolvePagesRouterQueryOnlyHref("?", {
+        asPath: "/rewrite-navigation/0?existing=1",
+        basePath: "",
+        fallbackHref: "http://localhost/rewrite-navigation/0?existing=1",
+      }),
+    ).toBe("/rewrite-navigation/0?");
   });
 });
 

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -85,19 +85,15 @@ describe("pagesRouter - route discovery", () => {
     expect(dynamicRoute!.params).toEqual(["id"]);
   });
 
-  it("sorts static routes before dynamic routes", async () => {
+  it("sorts static routes before dynamic routes at the same depth", async () => {
     const routes = await pagesRouter(FIXTURE_DIR);
 
-    const staticRoutes = routes.filter((r) => !r.isDynamic);
-    const dynamicRoutes = routes.filter((r) => r.isDynamic);
+    const aboutIndex = routes.findIndex((route) => route.pattern === "/about");
+    const postIndex = routes.findIndex((route) => route.pattern === "/posts/:id");
 
-    // All static routes should come before dynamic routes
-    const lastStaticIndex = routes.findIndex((r) => r === staticRoutes[staticRoutes.length - 1]);
-    const firstDynamicIndex = routes.findIndex((r) => r === dynamicRoutes[0]);
-
-    if (staticRoutes.length > 0 && dynamicRoutes.length > 0) {
-      expect(lastStaticIndex).toBeLessThan(firstDynamicIndex);
-    }
+    expect(aboutIndex).not.toBe(-1);
+    expect(postIndex).not.toBe(-1);
+    expect(aboutIndex).toBeLessThan(postIndex);
   });
 
   it("ignores _app.tsx and _document.tsx", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2559,9 +2559,21 @@ describe("window.next debug global", () => {
   it.each([
     [{}, "/rewrite-navigation/[id]/destination", "/rewrite-navigation/[id]/destination"],
     [{ query: {} }, "/rewrite-navigation/[id]/destination", "/rewrite-navigation/[id]/destination"],
-    [{ search: "id=2" }, "/rewrite-navigation/0?id=2", "/rewrite-navigation/0?id=2"],
+    [{ search: "flag" }, "/rewrite-navigation/0?flag", "/rewrite-navigation/0?flag"],
+    [{ search: "q=a%20b" }, "/rewrite-navigation/0?q=a%20b", "/rewrite-navigation/0?q=a%20b"],
+    [{ search: "?" }, "/rewrite-navigation/0?", "/rewrite-navigation/0?"],
     [
-      { query: { id: "ignored" }, search: "id=3", hash: "result" },
+      { query: { id: "ignored" }, search: "id=3" },
+      "/rewrite-navigation/0?id=3",
+      "/rewrite-navigation/0?id=3",
+    ],
+    [
+      { search: "q=a%20b", hash: "result" },
+      "/rewrite-navigation/0?q=a%20b#result",
+      "/rewrite-navigation/0?q=a%20b",
+    ],
+    [
+      { query: { id: "ignored" }, search: "?id=3", hash: "#result" },
       "/rewrite-navigation/0?id=3#result",
       "/rewrite-navigation/0?id=3",
     ],

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2637,6 +2637,123 @@ describe("window.next debug global", () => {
     },
   );
 
+  it.each(["push", "replace"] as const)(
+    "preserves a bare trailing question mark in router.asPath after %s",
+    async (method) => {
+      const previousWindow = (globalThis as any).window;
+      const win: any = {
+        location: {
+          pathname: "/rewrite-navigation/0",
+          search: "",
+          hash: "",
+          href: "http://localhost/rewrite-navigation/0",
+          origin: "http://localhost",
+        },
+        history: {
+          state: null as unknown,
+          pushState(state: unknown, _title: string, url: string) {
+            this.state = state;
+            const nextUrl = new URL(url, win.location.href);
+            win.location.pathname = nextUrl.pathname;
+            win.location.search = nextUrl.search;
+            win.location.hash = nextUrl.hash;
+            win.location.href = nextUrl.href;
+          },
+          replaceState(state: unknown, _title: string, url?: string) {
+            this.state = state;
+            if (url === undefined) return;
+            const nextUrl = new URL(url, win.location.href);
+            win.location.pathname = nextUrl.pathname;
+            win.location.search = nextUrl.search;
+            win.location.hash = nextUrl.hash;
+            win.location.href = nextUrl.href;
+          },
+        },
+        addEventListener() {},
+        dispatchEvent() {},
+        scrollTo() {},
+        scrollX: 0,
+        scrollY: 0,
+        __NEXT_DATA__: {
+          page: "/rewrite-navigation/[id]/destination",
+          query: { id: "0" },
+          isFallback: false,
+        },
+      };
+      (globalThis as any).window = win;
+
+      try {
+        vi.resetModules();
+        const routerModule = await import("../packages/vinext/src/shims/router.js");
+        await routerModule.default[method]({ search: "?" }, undefined, { shallow: true });
+
+        expect(win.location.search).toBe("");
+        expect(win.history.state.as).toBe("/rewrite-navigation/0?");
+        expect(routerModule.default.asPath).toBe("/rewrite-navigation/0?");
+      } finally {
+        if (previousWindow === undefined) delete (globalThis as any).window;
+        else (globalThis as any).window = previousWindow;
+        vi.resetModules();
+      }
+    },
+  );
+
+  it.each([
+    ["/", "", "/#section"],
+    ["/posts", "?tab=1", "/posts?tab=1#section"],
+  ])(
+    "preserves the visible path and search in router.asPath after hash-only navigation from %s%s",
+    async (pathname, search, expectedAsPath) => {
+      const previousWindow = (globalThis as any).window;
+      const win: any = {
+        location: {
+          pathname,
+          search,
+          hash: "",
+          href: `http://localhost${pathname}${search}`,
+          origin: "http://localhost",
+        },
+        history: {
+          state: null as unknown,
+          pushState(state: unknown, _title: string, url: string) {
+            this.state = state;
+            const nextUrl = new URL(url, win.location.href);
+            win.location.pathname = nextUrl.pathname;
+            win.location.search = nextUrl.search;
+            win.location.hash = nextUrl.hash;
+            win.location.href = nextUrl.href;
+          },
+          replaceState() {},
+        },
+        addEventListener() {},
+        dispatchEvent() {},
+        scrollTo() {},
+        scrollX: 0,
+        scrollY: 0,
+        __NEXT_DATA__: { page: pathname, query: {}, isFallback: false },
+      };
+      (globalThis as any).window = win;
+      (globalThis as any).document = {
+        getElementById: vi.fn(() => null),
+        getElementsByName: vi.fn(() => []),
+      };
+
+      try {
+        vi.resetModules();
+        const routerModule = await import("../packages/vinext/src/shims/router.js");
+        await routerModule.default.push("#section");
+
+        expect(win.history.state.as).toBe("");
+        expect(routerModule.default.asPath).toBe(expectedAsPath);
+      } finally {
+        if (previousWindow === undefined) delete (globalThis as any).window;
+        else (globalThis as any).window = previousWindow;
+        delete (globalThis as any).document;
+        vi.resetModules();
+      }
+    },
+  );
+
   it("query-only push replaces the current locale under basePath", async () => {
     const previousWindow = (globalThis as any).window;
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2562,6 +2562,11 @@ describe("window.next debug global", () => {
     [{ search: "flag" }, "/rewrite-navigation/0?flag", "/rewrite-navigation/0?flag"],
     [{ search: "q=a%20b" }, "/rewrite-navigation/0?q=a%20b", "/rewrite-navigation/0?q=a%20b"],
     [{ search: "q=a#b" }, "/rewrite-navigation/0?q=a%23b", "/rewrite-navigation/0?q=a%23b"],
+    [
+      { search: "q=a#b#c" },
+      "/rewrite-navigation/0?q=a%23b%23c",
+      "/rewrite-navigation/0?q=a%23b%23c",
+    ],
     [{ search: "?" }, "/rewrite-navigation/0?", "/rewrite-navigation/0?"],
     [
       { query: { id: "ignored" }, search: "id=3" },

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2561,6 +2561,7 @@ describe("window.next debug global", () => {
     [{ query: {} }, "/rewrite-navigation/[id]/destination", "/rewrite-navigation/[id]/destination"],
     [{ search: "flag" }, "/rewrite-navigation/0?flag", "/rewrite-navigation/0?flag"],
     [{ search: "q=a%20b" }, "/rewrite-navigation/0?q=a%20b", "/rewrite-navigation/0?q=a%20b"],
+    [{ search: "q=a#b" }, "/rewrite-navigation/0?q=a%23b", "/rewrite-navigation/0?q=a%23b"],
     [{ search: "?" }, "/rewrite-navigation/0?", "/rewrite-navigation/0?"],
     [
       { query: { id: "ignored" }, search: "id=3" },
@@ -2571,6 +2572,11 @@ describe("window.next debug global", () => {
       { search: "q=a%20b", hash: "result" },
       "/rewrite-navigation/0?q=a%20b#result",
       "/rewrite-navigation/0?q=a%20b",
+    ],
+    [
+      { search: "q=a#b", hash: "result" },
+      "/rewrite-navigation/0?q=a%23b#result",
+      "/rewrite-navigation/0?q=a%23b",
     ],
     [
       { query: { id: "ignored" }, search: "?id=3", hash: "#result" },

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -473,7 +473,7 @@ describe("next/navigation shim", () => {
 
       await navigateClientSide("#content", "push", true, true);
 
-      expect(replaceState).toHaveBeenCalledWith(
+      expect(replaceState).toHaveBeenLastCalledWith(
         expect.objectContaining({ __vinext_scrollX: 12, __vinext_scrollY: 345 }),
         "",
         undefined,
@@ -2551,6 +2551,159 @@ describe("window.next debug global", () => {
         "/rewrite-navigation/0?id=1",
       );
     } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
+  it.each([
+    [{}, "/rewrite-navigation/[id]/destination", "/rewrite-navigation/[id]/destination"],
+    [{ query: {} }, "/rewrite-navigation/[id]/destination", "/rewrite-navigation/[id]/destination"],
+    [{ search: "id=2" }, "/rewrite-navigation/0?id=2", "/rewrite-navigation/0?id=2"],
+    [
+      { query: { id: "ignored" }, search: "id=3", hash: "result" },
+      "/rewrite-navigation/0?id=3#result",
+      "/rewrite-navigation/0?id=3",
+    ],
+    [
+      { hash: "section" },
+      "/rewrite-navigation/0?existing=1#section",
+      "/rewrite-navigation/0?existing=1",
+    ],
+  ])(
+    "formats Pages Router UrlObjects with Next.js semantics: %j",
+    async (url, expected, stateAs) => {
+      const previousWindow = (globalThis as any).window;
+      const previousDocument = (globalThis as any).document;
+      const pushState = vi.fn();
+      const win: any = {
+        location: {
+          pathname: "/rewrite-navigation/0",
+          search: "?existing=1",
+          hash: "",
+          href: "http://localhost/rewrite-navigation/0?existing=1",
+          origin: "http://localhost",
+        },
+        history: { state: null, pushState, replaceState() {} },
+        addEventListener() {},
+        dispatchEvent() {},
+        scrollTo() {},
+        __NEXT_DATA__: {
+          page: "/rewrite-navigation/[id]/destination",
+          query: { id: "0" },
+          isFallback: false,
+        },
+      };
+      (globalThis as any).window = win;
+      (globalThis as any).document = {
+        getElementById: vi.fn(() => null),
+        getElementsByName: vi.fn(() => []),
+      };
+
+      try {
+        vi.resetModules();
+        const routerModule = await import("../packages/vinext/src/shims/router.js");
+        await routerModule.default.push(url, undefined, { shallow: true });
+
+        expect(pushState).toHaveBeenCalledWith(
+          expect.objectContaining({ as: stateAs }),
+          "",
+          expected,
+        );
+      } finally {
+        (globalThis as any).window = previousWindow;
+        if (previousDocument === undefined) delete (globalThis as any).document;
+        else (globalThis as any).document = previousDocument;
+        vi.resetModules();
+      }
+    },
+  );
+
+  it("query-only push replaces the current locale under basePath", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const pushState = vi.fn();
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    const win: any = {
+      location: {
+        pathname: "/docs/fr/rewrite-navigation/0",
+        search: "",
+        hash: "",
+        href: "http://localhost/docs/fr/rewrite-navigation/0",
+        origin: "http://localhost",
+        hostname: "localhost",
+      },
+      history: { state: null, pushState, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+      __VINEXT_LOCALE__: "fr",
+      __VINEXT_LOCALES__: ["en", "fr", "nl"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      await routerModule.default.push({ query: { id: "1" } }, undefined, {
+        locale: "nl",
+        shallow: true,
+      });
+
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({ as: "/nl/rewrite-navigation/0?id=1" }),
+        "",
+        "/docs/nl/rewrite-navigation/0?id=1",
+      );
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
+  it("query-only replace with locale false removes the current locale under basePath", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const replaceState = vi.fn();
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    const win: any = {
+      location: {
+        pathname: "/docs/fr/rewrite-navigation/0",
+        search: "",
+        hash: "",
+        href: "http://localhost/docs/fr/rewrite-navigation/0",
+        origin: "http://localhost",
+        hostname: "localhost",
+      },
+      history: { state: null, pushState() {}, replaceState },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+      __VINEXT_LOCALE__: "fr",
+      __VINEXT_LOCALES__: ["en", "fr"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      await routerModule.default.replace({ search: "id=2" }, undefined, {
+        locale: false,
+        shallow: true,
+      });
+
+      expect(replaceState).toHaveBeenCalledWith(
+        expect.objectContaining({ as: "/rewrite-navigation/0?id=2" }),
+        "",
+        "/docs/rewrite-navigation/0?id=2",
+      );
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
       (globalThis as any).window = previousWindow;
       vi.resetModules();
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2515,6 +2515,47 @@ describe("window.next debug global", () => {
     }
   });
 
+  it("query-only UrlObjects preserve the current visible pathname", async () => {
+    const previousWindow = (globalThis as any).window;
+    const pushState = vi.fn();
+    const win: any = {
+      location: {
+        pathname: "/rewrite-navigation/0",
+        search: "",
+        hash: "",
+        href: "http://localhost/rewrite-navigation/0",
+        origin: "http://localhost",
+      },
+      history: { state: null, pushState, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+
+      const result = await routerModule.default.push({ query: { id: "1" } }, undefined, {
+        shallow: true,
+      });
+
+      expect(result).toBe(true);
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "/rewrite-navigation/0?id=1",
+          as: "/rewrite-navigation/0?id=1",
+        }),
+        "",
+        "/rewrite-navigation/0?id=1",
+      );
+    } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
   // Issue #1522 — shallow `Router.push(url, as, { shallow: true })` must
   // update history to `as` (the visible URL) without fetching the server,
   // even when `as` matches a server-side redirect rule (e.g. `/redirect-1`

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2562,11 +2562,7 @@ describe("window.next debug global", () => {
     [{ search: "flag" }, "/rewrite-navigation/0?flag", "/rewrite-navigation/0?flag"],
     [{ search: "q=a%20b" }, "/rewrite-navigation/0?q=a%20b", "/rewrite-navigation/0?q=a%20b"],
     [{ search: "q=a#b" }, "/rewrite-navigation/0?q=a%23b", "/rewrite-navigation/0?q=a%23b"],
-    [
-      { search: "q=a#b#c" },
-      "/rewrite-navigation/0?q=a%23b%23c",
-      "/rewrite-navigation/0?q=a%23b%23c",
-    ],
+    [{ search: "q=a#b#c" }, "/rewrite-navigation/0?q=a%23b#c", "/rewrite-navigation/0?q=a%23b"],
     [{ search: "?" }, "/rewrite-navigation/0?", "/rewrite-navigation/0?"],
     [
       { query: { id: "ignored" }, search: "id=3" },


### PR DESCRIPTION
## Summary

- resolve query/search/hash-only Pages Router navigation against the browser-visible rewritten URL
- preserve locale and basePath behavior for query-only push, replace, and Link navigation
- retain raw history `asPath`, including a trailing bare `?`
- align `UrlObject` empty/query/search/hash formatting with Next.js
- add dynamic rewrite fixtures and integration coverage

## Next.js parity

Fixes six assertions in `test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts` covering root and cross-segment push/replace/Link navigation. Three same-segment rewrite cases remain separate follow-up scope.

## Validation

- pinned Next.js v16.2.6 targeted assertions: 6/6 passed
- 120 Link tests and 1,119 shim tests passed
- 14 Pages navigation E2E tests, router events, and PR #1999 scroll restoration passed
- full `vp check` and vinext build passed
- repeated independent reviews; no actionable findings remain
