### PR TITLE
fix(form): soft-navigate Pages Router submissions

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -621,6 +621,7 @@ ${rootParamNameEntries.join("\n")}
 
 export default __createAppRscHandler({
   basePath: __basePath,
+  buildId: process.env.__VINEXT_BUILD_ID ?? null,
   ensureRouteLoaded: __ensureRouteLoaded,
   clearRequestContext() {
     __clearRequestContext();
@@ -1042,9 +1043,9 @@ export default __createAppRscHandler({
   },
   ${
     hasPagesDir
-      ? `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, isRscRequest, matchKind, middlewareContext, pathname, request, url }) {
+      ? `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url }) {
     return __renderPagesFallback(
-      { allowRscDocumentFallback, appRouteMatch, isRscRequest, matchKind, middlewareContext, pathname, request, url },
+      { allowRscDocumentFallback, appRouteMatch, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url },
       {
         loadPagesEntry() {
           return import.meta.viteRsc.loadModule("ssr", "index");

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -1,5 +1,6 @@
 import type { AppMiddlewareContext } from "./app-middleware.js";
 import { pagesRouteHasPriorityOverAppRoute } from "./hybrid-route-priority.js";
+import { cloneRequestWithHeaders, cloneRequestWithUrl } from "./request-pipeline.js";
 
 export type PagesEntry = {
   handleApiRoute?: (request: Request, url: string) => Promise<Response> | Response;
@@ -11,6 +12,7 @@ export type PagesEntry = {
     query: Record<string, unknown>,
     parsedUrl: unknown,
     middlewareRequestHeaders?: Headers | null,
+    options?: { isDataReq?: boolean },
   ) => Promise<Response> | Response;
 };
 
@@ -60,10 +62,12 @@ type RenderPagesFallbackDependencies = {
 type RenderPagesFallbackOptions = {
   allowRscDocumentFallback?: boolean;
   appRouteMatch?: AppRouteMatch | null;
+  isDataRequest?: boolean;
   isRscRequest: boolean;
   matchKind?: "dynamic" | "static";
   middlewareContext: AppMiddlewareContext;
   pathname?: string;
+  pagesDataRequest?: Request | null;
   request: Request;
   url: URL;
 };
@@ -78,10 +82,12 @@ export async function renderPagesFallback(
   const {
     allowRscDocumentFallback = false,
     appRouteMatch = null,
+    isDataRequest = false,
     isRscRequest,
     matchKind,
     middlewareContext,
     pathname = options.url.pathname,
+    pagesDataRequest = null,
     request,
     url,
   } = options;
@@ -103,15 +109,7 @@ export async function renderPagesFallback(
 
   let pagesRequest = request;
   if (pagesRequestHeaders) {
-    const pagesRequestInit: RequestInit & { duplex?: string } = {
-      method: request.method,
-      headers: pagesRequestHeaders,
-    };
-    if (request.method !== "GET" && request.method !== "HEAD") {
-      pagesRequestInit.body = request.body;
-      pagesRequestInit.duplex = "half";
-    }
-    pagesRequest = new Request(request.url, pagesRequestInit);
+    pagesRequest = cloneRequestWithHeaders(request, pagesRequestHeaders);
   }
 
   const queryIndex = pathname.indexOf("?");
@@ -157,13 +155,25 @@ export async function renderPagesFallback(
   ) {
     return null;
   }
-  const pagesRes = await pagesEntry.renderPage(
-    pagesRequest,
-    pagesUrl,
-    {},
-    undefined,
-    middlewareContext.requestHeaders,
-  );
+  const renderRequest = pagesDataRequest
+    ? cloneRequestWithUrl(pagesRequest, pagesDataRequest.url)
+    : pagesRequest;
+  const pagesRes = isDataRequest
+    ? await pagesEntry.renderPage(
+        renderRequest,
+        pagesUrl,
+        {},
+        undefined,
+        middlewareContext.requestHeaders,
+        { isDataReq: true },
+      )
+    : await pagesEntry.renderPage(
+        renderRequest,
+        pagesUrl,
+        {},
+        undefined,
+        middlewareContext.requestHeaders,
+      );
   if (pagesRes.status === 404 && pageMatch === null) return null;
   return applyDraftModeCookie(pagesRes, getDraftModeCookieHeader());
 }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -32,7 +32,7 @@ import {
 import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/root-params";
 import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
 import { flattenErrorCauses } from "../utils/error-cause.js";
-import { hasBasePath } from "../utils/base-path.js";
+import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { mergeRewriteQuery } from "../utils/query.js";
 import { applyAppMiddleware, type AppMiddlewareContext } from "./app-middleware.js";
 import { mergeMiddlewareResponseHeaders } from "./app-page-response.js";
@@ -47,6 +47,7 @@ import {
 } from "./app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
+import { buildNextDataNotFoundResponse, normalizePagesDataRequest } from "./pages-data-route.js";
 import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { getRenderedConcreteUrlPathsForRoute } from "./pregenerated-concrete-paths.js";
@@ -234,10 +235,12 @@ type RenderNotFoundOptions<TRoute> = {
 type RenderPagesFallbackOptions = {
   allowRscDocumentFallback?: boolean;
   appRouteMatch?: { route: { isDynamic: boolean; pattern: string } } | null;
+  isDataRequest?: boolean;
   isRscRequest: boolean;
   matchKind?: "dynamic" | "static";
   middlewareContext: AppRscMiddlewareContext;
   pathname?: string;
+  pagesDataRequest?: Request | null;
   request: Request;
   url: URL;
 };
@@ -250,6 +253,7 @@ type NavigationContextValue = {
 
 type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   basePath: string;
+  buildId: string | null;
   cacheComponents?: boolean;
   clearRequestContext: () => void;
   configHeaders: NextHeader[];
@@ -446,6 +450,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   request: Request,
   preMiddlewareRequestContext: RequestContext,
   isDataRequest: boolean,
+  pagesDataRequest: Request | null,
 ): Promise<Response> {
   const handlerStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
 
@@ -467,6 +472,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   } = normalized;
   let { pathname, cleanPathname } = normalized;
   let resolvedUrl = cleanPathname + url.search;
+  const originalResolvedUrl = resolvedUrl;
   const getResolvedSearchParams = () => new URL(resolvedUrl, url).searchParams;
   // Canonical (external) pathname the user requested. Middleware rewrites and
   // next.config.js rewrites mutate `cleanPathname` so internal route matching
@@ -534,6 +540,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       isRscRequest && request.headers.get(RSC_HEADER) === "1"
         ? await createRscRedirectLocation(destination, request)
         : preserveRedirectDestinationQuery(destination, url.search);
+    if (isDataRequest) {
+      return new Response(null, {
+        status: 200,
+        headers: { "x-nextjs-redirect": location },
+      });
+    }
     return new Response(null, {
       status: redirect.permanent ? 308 : 307,
       headers: { Location: location },
@@ -729,19 +741,32 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   let match = preActionMatch;
   const renderPagesForMatchKind = async (
     matchKind: "dynamic" | "static",
-  ): Promise<Response | null> =>
-    match === null || match.route.isDynamic
-      ? ((await options.renderPagesFallback?.({
-          appRouteMatch: match ?? null,
-          allowRscDocumentFallback: didMiddlewareRewrite,
-          isRscRequest,
-          matchKind,
-          middlewareContext,
-          pathname: resolvedUrl,
-          request,
-          url,
-        })) ?? null)
-      : null;
+  ): Promise<Response | null> => {
+    const response =
+      match === null || match.route.isDynamic
+        ? ((await options.renderPagesFallback?.({
+            appRouteMatch: match ?? null,
+            allowRscDocumentFallback: didMiddlewareRewrite,
+            isDataRequest,
+            isRscRequest,
+            matchKind,
+            middlewareContext,
+            pathname: resolvedUrl,
+            pagesDataRequest,
+            request,
+            url,
+          })) ?? null)
+        : null;
+    if (!response || !pagesDataRequest || resolvedUrl === originalResolvedUrl) return response;
+
+    const headers = new Headers(response.headers);
+    headers.set("x-nextjs-rewrite", resolvedUrl);
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  };
   const staticPagesFallbackResponse = await renderPagesForMatchKind("static");
   if (staticPagesFallbackResponse) {
     options.clearRequestContext();
@@ -823,6 +848,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       }
       if (match) break;
     }
+  }
+
+  if (pagesDataRequest) {
+    options.clearRequestContext();
+    return buildNextDataNotFoundResponse();
   }
 
   if (!match) {
@@ -1044,7 +1074,24 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     // Capture `x-nextjs-data` before filtering — the middleware redirect
     // protocol needs to know whether the inbound request was a `_next/data`
     // fetch to emit `x-nextjs-redirect` instead of an HTTP redirect.
-    const isDataRequest = rawRequest.headers.get("x-nextjs-data") === "1";
+    const hasDataRequestHeader = rawRequest.headers.get("x-nextjs-data") === "1";
+    const pagesDataUrl = new URL(rawRequest.url);
+    const pagesDataInScope =
+      !options.basePath || hasBasePath(pagesDataUrl.pathname, options.basePath);
+    if (pagesDataInScope) {
+      pagesDataUrl.pathname = stripBasePath(pagesDataUrl.pathname, options.basePath);
+    }
+    const pagesDataCandidate = pagesDataInScope
+      ? cloneRequestWithUrl(rawRequest, pagesDataUrl.toString())
+      : null;
+    const pagesDataNormalization =
+      options.renderPagesFallback && pagesDataCandidate
+        ? normalizePagesDataRequest(pagesDataCandidate, options.buildId)
+        : null;
+    if (pagesDataNormalization?.notFoundResponse) {
+      return pagesDataNormalization.notFoundResponse;
+    }
+    const isDataRequest = hasDataRequestHeader || pagesDataNormalization?.isDataReq === true;
     // Read the trusted prerender route params before filtering strips the
     // route-params header (it IS in VINEXT_INTERNAL_HEADERS), then re-attach the
     // validated value below so the second read in handleAppRscRequest still sees
@@ -1064,7 +1111,16 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     if (prerenderRouteParamsHeader !== null) {
       filteredHeaders.set(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, prerenderRouteParamsHeader);
     }
-    const request = cloneRequestWithHeaders(rawRequest, filteredHeaders);
+    let appRequest = rawRequest;
+    if (pagesDataNormalization?.isDataReq) {
+      const appRequestUrl = new URL(pagesDataNormalization.request.url);
+      appRequestUrl.pathname = addBasePathToPathname(appRequestUrl.pathname, options.basePath);
+      appRequest = cloneRequestWithUrl(pagesDataCandidate!, appRequestUrl.toString());
+    }
+    const request = cloneRequestWithHeaders(appRequest, filteredHeaders);
+    const pagesDataRequest = pagesDataNormalization?.isDataReq
+      ? cloneRequestWithHeaders(pagesDataCandidate!, filteredHeaders)
+      : null;
 
     const executionContext = isExecutionContextLike(ctx)
       ? ctx
@@ -1091,6 +1147,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
               request,
               preMiddlewareRequestContext,
               isDataRequest,
+              pagesDataRequest,
             );
           } catch (error) {
             if (process.env.NODE_ENV !== "production") {

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -68,6 +68,192 @@ describe("renderPagesFallback", () => {
     expect(await response!.text()).toBe("pages");
   });
 
+  it("matches hybrid Pages data requests against their normalized page pathname", async () => {
+    const matchPageRoute = vi.fn(() => ({
+      route: { isDynamic: false, pattern: "/pages-dir/search" },
+    }));
+    let renderedRequestUrl: string | null = null;
+    const renderPage = vi.fn((renderedRequest: Request) => {
+      renderedRequestUrl = renderedRequest.url;
+      return new Response('{"pageProps":{"query":"search"}}', {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const pagesDataRequest = new Request(
+      "http://localhost/_next/data/build-id/pages-dir/search.json?query=search",
+    );
+    const request = new Request("http://localhost/pages-dir/search?query=search");
+
+    const response = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        pagesDataRequest,
+        request,
+        url: new URL(request.url),
+      },
+      {
+        ...defaultDeps,
+        loadPagesEntry: () => ({ matchPageRoute, renderPage }),
+      },
+    );
+
+    expect(matchPageRoute).toHaveBeenCalledWith("/pages-dir/search?query=search", request);
+    expect(renderedRequestUrl).toBe(pagesDataRequest.url);
+    expect(renderPage).toHaveBeenCalledWith(
+      expect.any(Request),
+      "/pages-dir/search?query=search",
+      {},
+      undefined,
+      null,
+    );
+    expect(response?.headers.get("content-type")).toContain("application/json");
+  });
+
+  it("preserves header-recognized Pages data intent after URL normalization", async () => {
+    const renderPage = vi.fn(
+      () =>
+        new Response('{"pageProps":{"query":"search"}}', {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const request = new Request("http://localhost/pages-dir/search?query=search", {
+      headers: { "x-nextjs-data": "1" },
+    });
+
+    await renderPagesFallback(
+      {
+        isDataRequest: true,
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request,
+        url: new URL(request.url),
+      },
+      { ...defaultDeps, loadPagesEntry: () => ({ renderPage }) },
+    );
+
+    expect(renderPage).toHaveBeenCalledWith(
+      request,
+      "/pages-dir/search?query=search",
+      {},
+      undefined,
+      null,
+      { isDataReq: true },
+    );
+  });
+
+  it("forwards the basePath-stripped Pages data request after App pipeline normalization", async () => {
+    const matchPageRoute = vi.fn(() => ({
+      route: { isDynamic: false, pattern: "/pages-dir/search" },
+    }));
+    let renderedRequestUrl: string | null = null;
+    const renderPage = vi.fn((renderedRequest: Request) => {
+      renderedRequestUrl = renderedRequest.url;
+      return new Response("data");
+    });
+    const pagesDataRequest = new Request(
+      "http://localhost/_next/data/build-id/pages-dir/search.json?query=search",
+    );
+    const request = new Request("http://localhost/pages-dir/search?query=search");
+
+    await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        pagesDataRequest,
+        request,
+        url: new URL(request.url),
+      },
+      {
+        ...defaultDeps,
+        loadPagesEntry: () => ({ matchPageRoute, renderPage }),
+      },
+    );
+
+    expect(matchPageRoute).toHaveBeenCalledWith("/pages-dir/search?query=search", request);
+    expect(renderedRequestUrl).toBe(
+      "http://localhost/_next/data/build-id/pages-dir/search.json?query=search",
+    );
+    expect(renderPage).toHaveBeenCalledWith(
+      expect.any(Request),
+      "/pages-dir/search?query=search",
+      {},
+      undefined,
+      null,
+    );
+  });
+
+  it("applies middleware request headers to Pages data renders", async () => {
+    let renderedHeader: string | null = null;
+    let renderedCf: unknown;
+    const renderPage = vi.fn((renderedRequest: Request) => {
+      renderedHeader = renderedRequest.headers.get("x-middleware");
+      renderedCf = (renderedRequest as Request & { cf?: unknown }).cf;
+      return new Response("data");
+    });
+    const pagesDataRequest = new Request(
+      "http://localhost/_next/data/build-id/pages-dir/search.json?query=search",
+    );
+    const request = new Request("http://localhost/pages-dir/search?query=search");
+    const cf = { colo: "LHR" };
+    Object.defineProperty(request, "cf", { value: cf, enumerable: true });
+
+    await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: {
+          headers: null,
+          requestHeaders: new Headers({ "x-middleware": "injected" }),
+          status: null,
+        },
+        pagesDataRequest,
+        request,
+        url: new URL(request.url),
+      },
+      {
+        ...defaultDeps,
+        loadPagesEntry: () => ({ renderPage }),
+      },
+    );
+
+    expect(renderedHeader).toBe("injected");
+    expect(renderedCf).toBe(cf);
+  });
+
+  it("matches rewritten Pages data requests against the rewritten destination", async () => {
+    const matchPageRoute = vi.fn(() => ({
+      route: { isDynamic: false, pattern: "/rewritten-search" },
+    }));
+    const renderPage = vi.fn(() => new Response("rewritten"));
+    const request = new Request(
+      "http://localhost/_next/data/build-id/pages-dir/search.json?query=search",
+    );
+
+    const response = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        pathname: "/rewritten-search?query=search",
+        request,
+        url: new URL(request.url),
+      },
+      {
+        ...defaultDeps,
+        loadPagesEntry: () => ({ matchPageRoute, renderPage }),
+      },
+    );
+
+    expect(matchPageRoute).toHaveBeenCalledWith("/rewritten-search?query=search", request);
+    expect(renderPage).toHaveBeenCalledWith(
+      request,
+      "/rewritten-search?query=search",
+      {},
+      undefined,
+      null,
+    );
+    expect(await response?.text()).toBe("rewritten");
+  });
+
   it("rebuilds request when middleware request headers are present", async () => {
     const handleApiRoute = vi.fn((_req: Request, _url: string) => new Response("api"));
     const deps = {

--- a/tests/app-router-next-config-codegen.test.ts
+++ b/tests/app-router-next-config-codegen.test.ts
@@ -144,10 +144,9 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     expect(code).toContain("renderPagesFallback as __renderPagesFallback");
     expect(code).toContain("server/app-pages-bridge.js");
     expect(code).toContain("return __renderPagesFallback(");
-    expect(code).toContain(
-      "{ allowRscDocumentFallback, appRouteMatch, isRscRequest, matchKind, middlewareContext, pathname, request, url }",
-    );
+    expect(code).toContain("pagesDataRequest");
     expect(code).toContain('return import.meta.viteRsc.loadModule("ssr", "index");');
+    expect(code).toContain("buildId: process.env.__VINEXT_BUILD_ID ?? null");
     expect(code).toContain("buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse");
     expect(code).toContain(
       "applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext",

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -44,6 +44,7 @@ function createHandler(overrides: Partial<HandlerOptions> = {}) {
 
   return createAppRscHandler<TestRoute>({
     basePath: "/docs",
+    buildId: overrides.buildId ?? "build-id",
     clearRequestContext: overrides.clearRequestContext ?? (() => {}),
     configHeaders: overrides.configHeaders ?? [
       {
@@ -541,6 +542,23 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("location")).toBe("/docs/about");
     expect(response.headers.get("x-test-header")).toBeNull();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("uses the soft redirect protocol for config redirects on Pages data requests", async () => {
+    const handler = createHandler({
+      configRedirects: [{ source: "/old-about", destination: "/about", permanent: true }],
+      matchRoute: () => null,
+      renderPagesFallback: async () => new Response("pages-data"),
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/build-id/old-about.json"),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-nextjs-redirect")).toBe("/docs/about");
   });
 
   it("lets middleware redirect headers override earlier matching config headers", async () => {
@@ -1422,6 +1440,166 @@ describe("createAppRscHandler", () => {
         appRouteMatch: expect.objectContaining({ route: dynamicRoute }),
       }),
     );
+  });
+
+  it("normalizes hybrid Pages data requests before middleware", async () => {
+    let middlewarePathname: string | null = null;
+    let middlewareCf: unknown;
+    let pagesDataCf: unknown;
+    let pagesDataUrl: string | null = null;
+    const renderPagesFallback = vi.fn(async (_options: unknown) => new Response("pages-data"));
+    const handler = createHandler({
+      configHeaders: [],
+      matchRoute: () => null,
+      middlewareModule: {
+        default: (request: Request) => {
+          middlewarePathname = new URL(request.url).pathname;
+          middlewareCf = (request as Request & { cf?: unknown }).cf;
+          return new Response(null, { headers: { "x-middleware-next": "1" } });
+        },
+      },
+      renderPagesFallback: async (options) => {
+        pagesDataCf = (options.pagesDataRequest as (Request & { cf?: unknown }) | null)?.cf;
+        pagesDataUrl = options.pagesDataRequest?.url ?? null;
+        return renderPagesFallback(options);
+      },
+    });
+
+    const request = new Request(
+      "https://example.test/docs/_next/data/build-id/form-search.json?query=basic",
+    );
+    const cf = { colo: "LHR" };
+    Object.defineProperty(request, "cf", { value: cf, enumerable: true });
+    const response = await handler(request, null);
+
+    expect(await response.text()).toBe("pages-data");
+    expect(middlewarePathname).toBe("/docs/form-search");
+    expect(middlewareCf).toBe(cf);
+    expect(pagesDataCf).toBe(cf);
+    expect(pagesDataUrl).toBe(
+      "https://example.test/_next/data/build-id/form-search.json?query=basic",
+    );
+    expect(renderPagesFallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: "/form-search?query=basic",
+        pagesDataRequest: expect.any(Request),
+      }),
+    );
+  });
+
+  it("exposes the rewritten route on hybrid Pages data responses", async () => {
+    const renderPagesFallback = vi.fn(
+      async () =>
+        new Response('{"pageProps":{"query":"basic"}}', {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      configRewrites: {
+        beforeFiles: [{ source: "/form-search", destination: "/rewritten-search" }],
+        afterFiles: [],
+        fallback: [],
+      },
+      matchRoute: () => null,
+      renderPagesFallback,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/build-id/form-search.json?query=basic"),
+      null,
+    );
+
+    expect(response.headers.get("x-nextjs-rewrite")).toBe("/rewritten-search?query=basic");
+    expect(renderPagesFallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: "/rewritten-search?query=basic",
+        pagesDataRequest: expect.any(Request),
+      }),
+    );
+  });
+
+  it("uses the soft redirect protocol for URL-recognized Pages data requests", async () => {
+    const handler = createHandler({
+      configHeaders: [],
+      matchRoute: () => null,
+      middlewareModule: {
+        default: () => new Response(null, { status: 307, headers: { Location: "/login" } }),
+      },
+      renderPagesFallback: async () => new Response("pages-data"),
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/build-id/form-search.json"),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-nextjs-redirect")).toBe("/login");
+  });
+
+  it("returns JSON 404 for stale hybrid Pages data requests before middleware", async () => {
+    const middleware = vi.fn(() => new Response(null, { headers: { "x-middleware-next": "1" } }));
+    const renderPagesFallback = vi.fn(async () => new Response("pages-data"));
+    const handler = createHandler({
+      configHeaders: [],
+      matchRoute: () => null,
+      middlewareModule: { default: middleware },
+      renderPagesFallback,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/stale/form-search.json?query=basic"),
+      null,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.text()).toBe("{}");
+    expect(middleware).not.toHaveBeenCalled();
+    expect(renderPagesFallback).not.toHaveBeenCalled();
+  });
+
+  it("does not normalize hybrid Pages data requests outside basePath", async () => {
+    const renderPagesFallback = vi.fn(async () => new Response("pages-data"));
+    const handler = createHandler({
+      configHeaders: [],
+      matchRoute: () => null,
+      renderPagesFallback,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/_next/data/build-id/form-search.json?query=basic"),
+      null,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).not.toContain("application/json");
+    expect(renderPagesFallback).not.toHaveBeenCalled();
+  });
+
+  it("returns JSON 404 when an App route owns a Pages data URL", async () => {
+    const appRoute = createPageRoute({ pattern: "/app-only" });
+    const dispatchMatchedPage = vi.fn(async () => new Response("app-html"));
+    const renderPagesFallback = vi.fn(async () => null);
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchRoute: (pathname) => (pathname === "/app-only" ? { route: appRoute, params: {} } : null),
+      renderPagesFallback,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/build-id/app-only.json"),
+      null,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.text()).toBe("{}");
+    expect(renderPagesFallback).not.toHaveBeenCalled();
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
   it("runs afterFiles rewrites before dynamic Pages route ownership", async () => {

--- a/tests/e2e/use-params-app-pages/pages-form.spec.ts
+++ b/tests/e2e/use-params-app-pages/pages-form.spec.ts
@@ -1,0 +1,65 @@
+// Ported from Next.js: test/e2e/next-form/default/pages-dir.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/next-form/default/pages-dir.test.ts
+import { expect, test } from "@playwright/test";
+
+async function installPageLoadCounter(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    const count = Number(window.sessionStorage.getItem("form-page-loads") ?? "0") + 1;
+    window.sessionStorage.setItem("form-page-loads", String(count));
+  });
+}
+
+test.describe("next/form on a hybrid Pages route", () => {
+  test("soft-navigates a cross-route GSSP submission", async ({ page, baseURL }) => {
+    await installPageLoadCounter(page);
+    await page.goto(`${baseURL}/form-source`);
+    await page.locator("#basic-form button").click();
+
+    await expect(page.locator("#search-query")).toHaveText("basic");
+    await expect(page).toHaveURL(/\/form-search\?query=basic$/);
+    expect(await page.evaluate(() => sessionStorage.getItem("form-page-loads"))).toBe("1");
+  });
+
+  test("honors submitter formAction and name/value", async ({ page, baseURL }) => {
+    await installPageLoadCounter(page);
+    await page.goto(`${baseURL}/form-source`);
+    await page.locator("#submitter-form button").click();
+
+    await expect(page.locator("#search-query")).toHaveText("submitter");
+    await expect(page.locator("#search-source")).toHaveText("button");
+    await expect(page).toHaveURL(/\/form-search\?query=submitter&source=button$/);
+    expect(await page.evaluate(() => sessionStorage.getItem("form-page-loads"))).toBe("1");
+  });
+
+  test("replace preserves history length", async ({ page, baseURL }) => {
+    await installPageLoadCounter(page);
+    await page.goto(`${baseURL}/form-source`);
+    const historyLength = await page.evaluate(() => history.length);
+    await page.locator("#replace-form button").click();
+
+    await expect(page.locator("#search-query")).toHaveText("replace");
+    expect(await page.evaluate(() => history.length)).toBe(historyLength);
+    expect(await page.evaluate(() => sessionStorage.getItem("form-page-loads"))).toBe("1");
+  });
+
+  test("scroll=false preserves scroll position", async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}/form-source`);
+    await page.evaluate(() => window.scrollTo(0, 900));
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+    await page.locator("#no-scroll-form button").click();
+
+    await expect(page.locator("#search-query")).toHaveText("no-scroll");
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  });
+
+  test("unsupported submitter attributes retain native semantics", async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}/form-source`);
+    const url = page.url();
+    await page.locator("#native-form button").click();
+
+    expect(page.url()).toBe(url);
+    expect(
+      await page.evaluate(() => sessionStorage.getItem("native-submit-default-prevented")),
+    ).toBe("false");
+  });
+});

--- a/tests/fixtures/use-params-app-pages/pages/form-search/index.tsx
+++ b/tests/fixtures/use-params-app-pages/pages/form-search/index.tsx
@@ -1,0 +1,24 @@
+export async function getServerSideProps({ req }: { req: { url?: string } }) {
+  const searchParams = new URL(req.url ?? "/", "http://localhost").searchParams;
+  return {
+    props: {
+      query: searchParams.get("query"),
+      source: searchParams.get("source"),
+    },
+  };
+}
+
+export default function FormSearchPage({
+  query,
+  source,
+}: {
+  query: string | null;
+  source: string | null;
+}) {
+  return (
+    <main style={{ minHeight: "200vh" }}>
+      <div id="search-query">{query}</div>
+      <div id="search-source">{source}</div>
+    </main>
+  );
+}

--- a/tests/fixtures/use-params-app-pages/pages/form-source/index.tsx
+++ b/tests/fixtures/use-params-app-pages/pages/form-source/index.tsx
@@ -1,0 +1,48 @@
+import Form from "next/form";
+
+export default function FormSourcePage() {
+  return (
+    <main style={{ minHeight: "200vh", paddingTop: "1200px" }}>
+      <h1>Hybrid Pages Form</h1>
+
+      <Form action="/form-search" id="basic-form">
+        <input name="query" defaultValue="basic" />
+        <button type="submit">Basic submit</button>
+      </Form>
+
+      <Form action="/missing-form-target" id="submitter-form">
+        <input name="query" defaultValue="submitter" />
+        <button type="submit" formAction="/form-search" name="source" value="button">
+          Submitter action
+        </button>
+      </Form>
+
+      <Form action="/form-search" replace id="replace-form">
+        <input name="query" defaultValue="replace" />
+        <button type="submit">Replace submit</button>
+      </Form>
+
+      <Form action="/form-search" scroll={false} id="no-scroll-form">
+        <input name="query" defaultValue="no-scroll" />
+        <button type="submit">No-scroll submit</button>
+      </Form>
+
+      <div
+        id="native-submit-observer"
+        onSubmit={(event) => {
+          window.sessionStorage.setItem(
+            "native-submit-default-prevented",
+            String(event.defaultPrevented),
+          );
+          event.preventDefault();
+        }}
+      >
+        <Form action="/form-search" id="native-form">
+          <button type="submit" formMethod="post">
+            Native submit
+          </button>
+        </Form>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- integrate `next/form` submissions with Pages Router soft navigation
- preserve submitter `formAction`, client actions, `replace`, redirects, rewrites, basePath, history, and scroll behavior
- keep native method/target/external cases on browser form semantics
- add a hybrid Pages Form fixture and focused data-routing coverage

## Next.js parity

Fixes the failing Pages Router matrix in `test/e2e/next-form/default/pages-dir.test.ts`.

## Validation

- pinned Next.js v16.2.6 exact suite: 10/10 passed
- targeted form/link/pages/core tests: 565/565 passed
- vinext-owned Playwright fixture: 5/5 passed
- scoped checks and diff validation passed
- independent review: no actionable findings

Cache Components, PPR, and resume behavior are explicitly out of scope.
