### PR TITLE
fix(pages): interpolate same-segment rewrite params

### DIFF
--- a/packages/vinext/src/client/pages-router-link-navigation.ts
+++ b/packages/vinext/src/client/pages-router-link-navigation.ts
@@ -5,11 +5,21 @@ type PagesRouterLinkTransitionOptions = {
   scroll?: boolean;
   shallow?: boolean;
   locale?: string | false;
+  _vinextInterpolateDynamicRoute?: boolean;
 };
 
 type PagesRouterLinkRuntime = {
   push(url: string, as?: string, options?: PagesRouterLinkTransitionOptions): Promise<boolean>;
   replace(url: string, as?: string, options?: PagesRouterLinkTransitionOptions): Promise<boolean>;
+};
+
+type PagesRouterLinkNavigation = {
+  href: string;
+  replace: boolean;
+  scroll: boolean;
+  shallow?: boolean;
+  locale?: string | false;
+  interpolateDynamicRoute?: boolean;
 };
 
 export function resolvePagesRouterQueryOnlyHref(
@@ -52,19 +62,46 @@ export async function navigatePagesRouterLink(
     scroll,
     shallow,
     locale,
-  }: {
-    href: string;
-    replace: boolean;
-    scroll: boolean;
-    shallow?: boolean;
-    locale?: string | false;
-  },
+    interpolateDynamicRoute = false,
+  }: PagesRouterLinkNavigation,
 ): Promise<void> {
-  const routerOptions: PagesRouterLinkTransitionOptions = { scroll, locale };
+  const routerOptions: PagesRouterLinkTransitionOptions = {
+    scroll,
+    locale,
+    _vinextInterpolateDynamicRoute: interpolateDynamicRoute,
+  };
   if (shallow !== undefined) routerOptions.shallow = shallow;
   if (replace) {
     await router.replace(href, undefined, routerOptions);
   } else {
     await router.push(href, undefined, routerOptions);
   }
+}
+
+export async function navigatePagesRouterLinkWithFallback({
+  router,
+  loadRouter,
+  navigation,
+  fallback,
+}: {
+  router?: PagesRouterLinkRuntime;
+  loadRouter: () => Promise<PagesRouterLinkRuntime | undefined>;
+  navigation: PagesRouterLinkNavigation;
+  fallback: () => void;
+}): Promise<void> {
+  let pagesRouter = router;
+  if (!pagesRouter) {
+    try {
+      pagesRouter = await loadRouter();
+    } catch {
+      fallback();
+      return;
+    }
+  }
+  if (!pagesRouter) {
+    fallback();
+    return;
+  }
+
+  await navigatePagesRouterLink(pagesRouter, navigation);
 }

--- a/packages/vinext/src/client/pages-router-link-navigation.ts
+++ b/packages/vinext/src/client/pages-router-link-navigation.ts
@@ -68,8 +68,8 @@ export async function navigatePagesRouterLink(
   const routerOptions: PagesRouterLinkTransitionOptions = {
     scroll,
     locale,
-    _vinextInterpolateDynamicRoute: interpolateDynamicRoute,
   };
+  if (interpolateDynamicRoute) routerOptions._vinextInterpolateDynamicRoute = true;
   if (shallow !== undefined) routerOptions.shallow = shallow;
   if (replace) {
     await router.replace(href, undefined, routerOptions);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -63,7 +63,7 @@ import { addLocalePrefix, getDomainLocaleUrl, type DomainLocale } from "../utils
 import { getI18nContext } from "./i18n-context.js";
 import type { VinextLinkPrefetchRoute, VinextNextData } from "../client/vinext-next-data.js";
 import {
-  navigatePagesRouterLink,
+  navigatePagesRouterLinkWithFallback,
   resolvePagesRouterQueryOnlyHref,
 } from "../client/pages-router-link-navigation.js";
 import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
@@ -1071,26 +1071,28 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       // Pages Router still executes instrumentation-client side effects
       // during startup, but it does not invoke the named export on navigation.
       // Pages Router: use the Router singleton
-      try {
-        const Router = window.next?.appDir === true ? undefined : window.next?.router;
-        const pagesRouter =
-          Router && "reload" in Router ? Router : (await import("next/router")).default;
-        await navigatePagesRouterLink(pagesRouter, {
+      const Router = window.next?.appDir === true ? undefined : window.next?.router;
+      const pagesRouter = Router && "reload" in Router ? Router : undefined;
+      await navigatePagesRouterLinkWithFallback({
+        router: pagesRouter,
+        loadRouter: async () => (await import("next/router")).default,
+        navigation: {
           href: pagesNavigateHref,
           replace,
           scroll,
           shallow,
           locale,
-        });
-      } catch {
-        // Fallback to hard navigation if router fails
-        if (replace) {
-          window.history.replaceState({}, "", absoluteFullHref);
-        } else {
-          window.history.pushState({}, "", absoluteFullHref);
-        }
-        window.dispatchEvent(new PopStateEvent("popstate"));
-      }
+          interpolateDynamicRoute: resolvedHref.startsWith("?"),
+        },
+        fallback: () => {
+          if (replace) {
+            window.history.replaceState({}, "", absoluteFullHref);
+          } else {
+            window.history.pushState({}, "", absoluteFullHref);
+          }
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        },
+      });
     }
   };
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -554,7 +554,9 @@ function interpolateCurrentDynamicRoute(resolved: string): string {
     }
     const visiblePath = stripBasePath(window.location.pathname, __basePath);
     const visibleLocale = getLocalePathPrefix(visiblePath, window.__VINEXT_LOCALES__);
-    const routePath = visibleLocale ? visiblePath.slice(visibleLocale.length + 1) || "/" : visiblePath;
+    const routePath = visibleLocale
+      ? visiblePath.slice(visibleLocale.length + 1) || "/"
+      : visiblePath;
     if (extractRouteParamsFromPath(routePattern, routePath) === null) return resolved;
 
     const query = parseQueryString(target.search);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -66,7 +66,11 @@ import {
   type UrlQuery,
   urlQueryToSearchParams,
 } from "../utils/query.js";
-import { matchRoutePattern, routePatternParts } from "../routing/route-pattern.js";
+import {
+  fillRoutePatternSegments,
+  matchRoutePattern,
+  routePatternParts,
+} from "../routing/route-pattern.js";
 import { scrollToHashTarget } from "./hash-scroll.js";
 import {
   installPagesRouterRuntime,
@@ -373,6 +377,7 @@ type TransitionOptions = {
   shallow?: boolean;
   scroll?: boolean;
   locale?: string | false;
+  _vinextInterpolateDynamicRoute?: boolean;
 };
 
 type RouterEvents = {
@@ -527,6 +532,72 @@ function resolveNavigationTarget(
   replaceExistingLocale = false,
 ): string {
   return applyNavigationLocale(as ?? resolveUrl(url), locale, replaceExistingLocale);
+}
+
+class HrefInterpolationError extends Error {}
+
+function interpolateCurrentDynamicRoute(resolved: string): string {
+  if (typeof window === "undefined") return resolved;
+
+  const routePattern = window.__NEXT_DATA__?.page;
+  if (!routePattern || extractRouteParamNames(routePattern).length === 0) return resolved;
+
+  try {
+    const target = new URL(resolved, "http://vinext.local");
+    const currentOrigin = getWindowOrigin();
+    if (
+      currentOrigin &&
+      target.origin !== "http://vinext.local" &&
+      target.origin !== currentOrigin
+    ) {
+      return resolved;
+    }
+    const visiblePath = stripBasePath(window.location.pathname, __basePath);
+    const visibleLocale = getLocalePathPrefix(visiblePath, window.__VINEXT_LOCALES__);
+    const routePath = visibleLocale ? visiblePath.slice(visibleLocale.length + 1) || "/" : visiblePath;
+    if (extractRouteParamsFromPath(routePattern, routePath) === null) return resolved;
+
+    const query = parseQueryString(target.search);
+    const missingParams = routePatternParts(routePattern)
+      .filter((part) => part.startsWith(":") && !part.endsWith("*"))
+      .map((part) => part.slice(1, part.endsWith("+") ? -1 : undefined))
+      .filter((paramName) => {
+        const value = query[paramName];
+        return value === undefined || value === "" || (Array.isArray(value) && value.length === 0);
+      });
+    if (missingParams.length > 0) {
+      const href = `${routePattern}${target.search}${target.hash}`;
+      throw new HrefInterpolationError(
+        `The provided \`href\` (${href}) value is missing query values (${missingParams.join(
+          ", ",
+        )}) to be interpolated properly. Read more: https://nextjs.org/docs/messages/href-interpolation-failed`,
+      );
+    }
+
+    const routeParams = getRouteParamsFromQuery(routePattern, query);
+    if (!routeParams) return resolved;
+
+    const encodedRouteParams = Object.fromEntries(
+      Object.entries(routeParams).map(([key, value]) => [
+        key,
+        Array.isArray(value) ? value.map(encodeURIComponent) : encodeURIComponent(value),
+      ]),
+    );
+    const pathname = fillRoutePatternSegments(routePattern, encodedRouteParams);
+    if (!pathname) return resolved;
+
+    const targetLocale = getLocalePathPrefix(target.pathname, window.__VINEXT_LOCALES__);
+    target.pathname = targetLocale ? `/${targetLocale}${pathname}` : pathname;
+    for (const paramName of extractRouteParamNames(routePattern)) {
+      target.searchParams.delete(paramName);
+    }
+    return target.href.slice(target.origin.length);
+  } catch (error) {
+    if (error instanceof HrefInterpolationError) {
+      throw error;
+    }
+    return resolved;
+  }
 }
 
 function getCurrentUrlLocale(): string | undefined {
@@ -2289,6 +2360,16 @@ async function performNavigation(
       (typeof url.search === "string" && url.search.length > 0) ||
       (typeof url.hash === "string" && url.hash.length > 0));
   let resolved = resolveNavigationTarget(url, as, navigationLocale, replaceInheritedLocale);
+  const inheritsCurrentPath =
+    as === undefined &&
+    ((typeof url === "string" && options?._vinextInterpolateDynamicRoute === true) ||
+      (typeof url !== "string" &&
+        url.pathname === undefined &&
+        ((url.query !== undefined && Object.keys(url.query).length > 0) ||
+          (typeof url.search === "string" && url.search.length > 0))));
+  if (inheritsCurrentPath) {
+    resolved = interpolateCurrentDynamicRoute(resolved);
+  }
 
   // External URLs — delegate to browser (unless same-origin)
   if (isExternalUrl(resolved)) {

--- a/tests/e2e/pages-router/navigation.spec.ts
+++ b/tests/e2e/pages-router/navigation.spec.ts
@@ -145,6 +145,74 @@ test.describe("Client-side navigation", () => {
     );
   });
 
+  test("same-segment rewrite interpolates router.push route params", async ({ page }) => {
+    // Ported from Next.js: test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    await page.goto(`${BASE}/rewrite-navigation-same/0`);
+    await waitForHydration(page);
+    await trackNavigation(page);
+
+    await page.click('[data-testid="router-push"]');
+
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("1");
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation-same/1`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText(
+      "/rewrite-navigation-same/1",
+    );
+    expect(await page.evaluate(() => (window as any).__REWRITE_NAV_HISTORY__.at(-1))).toBe("push");
+    expect(await page.evaluate(() => (window as any).__REWRITE_NAV_EVENTS__)).toEqual([
+      "routeChangeStart:/rewrite-navigation-same/1",
+      "beforeHistoryChange:/rewrite-navigation-same/1",
+      "routeChangeComplete:/rewrite-navigation-same/1",
+    ]);
+  });
+
+  test("same-segment rewrite interpolates router.replace route params", async ({ page }) => {
+    // Ported from Next.js: test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    await page.goto(`${BASE}/rewrite-navigation-same/0`);
+    await waitForHydration(page);
+    await trackNavigation(page);
+
+    await page.click('[data-testid="router-replace"]');
+
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("2");
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation-same/2`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText(
+      "/rewrite-navigation-same/2",
+    );
+    expect(await page.evaluate(() => (window as any).__REWRITE_NAV_HISTORY__.at(-1))).toBe(
+      "replace",
+    );
+    expect(await page.evaluate(() => (window as any).__REWRITE_NAV_EVENTS__)).toEqual([
+      "routeChangeStart:/rewrite-navigation-same/2",
+      "beforeHistoryChange:/rewrite-navigation-same/2",
+      "routeChangeComplete:/rewrite-navigation-same/2",
+    ]);
+  });
+
+  test("same-segment rewrite interpolates Link route params", async ({ page }) => {
+    // Ported from Next.js: test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+    await page.goto(`${BASE}/rewrite-navigation-same/0`);
+    await waitForHydration(page);
+    await trackNavigation(page);
+
+    await page.click('[data-testid="query-link"]');
+
+    await expect(page.locator('[data-testid="query-id"]')).toHaveText("3");
+    await expect(page).toHaveURL(`${BASE}/rewrite-navigation-same/3`);
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText(
+      "/rewrite-navigation-same/3",
+    );
+    expect(await page.evaluate(() => (window as any).__REWRITE_NAV_HISTORY__.at(-1))).toBe("push");
+    expect(await page.evaluate(() => (window as any).__REWRITE_NAV_EVENTS__)).toEqual([
+      "routeChangeStart:/rewrite-navigation-same/3",
+      "beforeHistoryChange:/rewrite-navigation-same/3",
+      "routeChangeComplete:/rewrite-navigation-same/3",
+    ]);
+  });
+
   test("router.push(url, as) uses the masked URL while resolving the real route", async ({
     page,
   }) => {
@@ -261,3 +329,27 @@ test.describe("Client-side navigation", () => {
     );
   });
 });
+
+async function trackNavigation(page: import("@playwright/test").Page) {
+  await page.evaluate(() => {
+    const router = (window as any).next.router;
+    const events: string[] = [];
+    for (const event of ["routeChangeStart", "beforeHistoryChange", "routeChangeComplete"]) {
+      router.events.on(event, (url: string) => events.push(`${event}:${url}`));
+    }
+    (window as any).__REWRITE_NAV_EVENTS__ = events;
+
+    const historyMethods: string[] = [];
+    const pushState = window.history.pushState.bind(window.history);
+    const replaceState = window.history.replaceState.bind(window.history);
+    window.history.pushState = (...args) => {
+      historyMethods.push("push");
+      return pushState(...args);
+    };
+    window.history.replaceState = (...args) => {
+      historyMethods.push("replace");
+      return replaceState(...args);
+    };
+    (window as any).__REWRITE_NAV_HISTORY__ = historyMethods;
+  });
+}

--- a/tests/e2e/pages-router/navigation.spec.ts
+++ b/tests/e2e/pages-router/navigation.spec.ts
@@ -156,9 +156,7 @@ test.describe("Client-side navigation", () => {
 
     await expect(page.locator('[data-testid="query-id"]')).toHaveText("1");
     await expect(page).toHaveURL(`${BASE}/rewrite-navigation-same/1`);
-    await expect(page.locator('[data-testid="as-path"]')).toHaveText(
-      "/rewrite-navigation-same/1",
-    );
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation-same/1");
     expect(await page.evaluate(() => (window as any).__REWRITE_NAV_HISTORY__.at(-1))).toBe("push");
     expect(await page.evaluate(() => (window as any).__REWRITE_NAV_EVENTS__)).toEqual([
       "routeChangeStart:/rewrite-navigation-same/1",
@@ -178,9 +176,7 @@ test.describe("Client-side navigation", () => {
 
     await expect(page.locator('[data-testid="query-id"]')).toHaveText("2");
     await expect(page).toHaveURL(`${BASE}/rewrite-navigation-same/2`);
-    await expect(page.locator('[data-testid="as-path"]')).toHaveText(
-      "/rewrite-navigation-same/2",
-    );
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation-same/2");
     expect(await page.evaluate(() => (window as any).__REWRITE_NAV_HISTORY__.at(-1))).toBe(
       "replace",
     );
@@ -202,9 +198,7 @@ test.describe("Client-side navigation", () => {
 
     await expect(page.locator('[data-testid="query-id"]')).toHaveText("3");
     await expect(page).toHaveURL(`${BASE}/rewrite-navigation-same/3`);
-    await expect(page.locator('[data-testid="as-path"]')).toHaveText(
-      "/rewrite-navigation-same/3",
-    );
+    await expect(page.locator('[data-testid="as-path"]')).toHaveText("/rewrite-navigation-same/3");
     expect(await page.evaluate(() => (window as any).__REWRITE_NAV_HISTORY__.at(-1))).toBe("push");
     expect(await page.evaluate(() => (window as any).__REWRITE_NAV_EVENTS__)).toEqual([
       "routeChangeStart:/rewrite-navigation-same/3",

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -43,6 +43,21 @@ const nextConfig = {
           source: "/rewrite-navigation/:id",
           destination: "/rewrite-navigation/:id/destination",
         },
+        // Ported from Next.js:
+        // test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+        // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+        {
+          source: "/rewrite-navigation-same/1",
+          destination: "/rewrite-navigation-same/001",
+        },
+        {
+          source: "/rewrite-navigation-same/2",
+          destination: "/rewrite-navigation-same/002",
+        },
+        {
+          source: "/rewrite-navigation-same/3",
+          destination: "/rewrite-navigation-same/003",
+        },
         // Used by Vitest: pages-router.test.ts — beforeFiles rewrite gated on
         // a cookie injected by middleware. Middleware injects mw-before-user=1
         // when ?mw-auth is present. The beforeFiles rewrite should see this

--- a/tests/fixtures/pages-basic/pages/rewrite-navigation-same/[id]/index.tsx
+++ b/tests/fixtures/pages-basic/pages/rewrite-navigation-same/[id]/index.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+export default function SameSegmentRewriteNavigationPage() {
+  const router = useRouter();
+
+  return (
+    <main>
+      <p data-testid="query-id">{router.query.id}</p>
+      <p data-testid="as-path">{router.asPath}</p>
+      <button data-testid="router-push" onClick={() => router.push({ query: { id: "1" } })}>
+        Push query
+      </button>
+      <button data-testid="router-replace" onClick={() => router.replace({ query: { id: "2" } })}>
+        Replace query
+      </button>
+      <Link data-testid="query-link" href="?id=3">
+        Link query
+      </Link>
+    </main>
+  );
+}

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -895,16 +895,17 @@ describe("Pages Router Link onClick semantics", () => {
     // and avoids the dynamic-import-into-unknown-module timing pitfall.
     const pagesRouterCalls: { href: string; replace: boolean }[] = [];
     vi.doMock("../packages/vinext/src/client/pages-router-link-navigation.js", () => ({
-      navigatePagesRouterLink: async (
-        _router: unknown,
-        opts: { href: string; replace: boolean },
-      ) => {
-        pagesRouterCalls.push({ href: opts.href, replace: opts.replace });
+      navigatePagesRouterLinkWithFallback: async ({
+        navigation,
+      }: {
+        navigation: { href: string; replace: boolean };
+      }) => {
+        pagesRouterCalls.push({ href: navigation.href, replace: navigation.replace });
       },
     }));
     // The handler still tries `await import("next/router")` before calling
     // navigatePagesRouterLink. Stub it so the import resolves cleanly (the
-    // returned Router is never used because we mocked navigatePagesRouterLink).
+    // returned Router is never used because we mocked the navigation boundary).
     vi.doMock("next/router", () => ({ default: { push() {}, replace() {} } }));
 
     const pushState = vi.fn();

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -23,6 +23,7 @@ import Link, {
 } from "../packages/vinext/src/shims/link.js";
 import {
   navigatePagesRouterLink,
+  navigatePagesRouterLinkWithFallback,
   resolvePagesRouterQueryOnlyHref,
 } from "../packages/vinext/src/client/pages-router-link-navigation.js";
 
@@ -818,6 +819,36 @@ describe("Link locale handling", () => {
 
     expect(push).toHaveBeenCalledWith("/fr/about", undefined, { scroll: true, locale: "fr" });
     expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("rethrows missing-required-param interpolation errors instead of using Link fallback", async () => {
+    const interpolationError = new Error(
+      "The provided `href` (/catalog/[category]/[item]?category=music) value is missing query values (item) to be interpolated properly. Read more: https://nextjs.org/docs/messages/href-interpolation-failed",
+    );
+    const fallback = vi.fn();
+    const loadRouter = vi.fn();
+    const router = {
+      push: vi.fn(async () => {
+        throw interpolationError;
+      }),
+      replace: vi.fn(async () => true),
+    };
+
+    await expect(
+      navigatePagesRouterLinkWithFallback({
+        router,
+        loadRouter,
+        navigation: {
+          href: "/catalog/books/old?category=music",
+          replace: false,
+          scroll: true,
+          interpolateDynamicRoute: true,
+        },
+        fallback,
+      }),
+    ).rejects.toBe(interpolationError);
+    expect(loadRouter).not.toHaveBeenCalled();
+    expect(fallback).not.toHaveBeenCalled();
   });
 
   // Regression for #1332 sub-problem 3: `<Link shallow>` must reach

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14274,6 +14274,203 @@ describe("Pages Router concurrent navigation", () => {
     return { promise, resolve, reject };
   }
 
+  it("preserves cross-origin domain-locale targets during query-only same-segment navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const { win } = createNavWindow();
+    process.env.__NEXT_ROUTER_BASEPATH = "/app";
+    Object.assign(win.location, {
+      pathname: "/app/rewrite-navigation-same/0",
+      href: "https://example.com/app/rewrite-navigation-same/0",
+      hostname: "example.com",
+      origin: "https://example.com",
+    });
+    Object.assign(win, {
+      __VINEXT_LOCALE__: "en",
+      __VINEXT_LOCALES__: ["en", "fr"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/rewrite-navigation-same/[id]",
+        query: { id: "0" },
+        domainLocales: [
+          { domain: "example.com", defaultLocale: "en" },
+          { domain: "example.fr", defaultLocale: "fr", http: true },
+        ],
+      },
+    });
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await Router.push({ query: { id: "1" } }, undefined, { shallow: true, locale: "fr" });
+
+      expect(win.location.assign).toHaveBeenCalledWith(
+        "http://example.fr/app/rewrite-navigation-same/0?id=1",
+      );
+      expect(win.history.pushState).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
+  it("throws href-interpolation-failed when a required same-segment param is missing", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/catalog/books/old",
+      href: "http://localhost/catalog/books/old",
+    });
+    Object.assign(win, {
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/catalog/[category]/[item]",
+        query: { category: "books", item: "old" },
+      },
+    });
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(
+        Router.push({ query: { category: "music" } }, undefined, { shallow: true }),
+      ).rejects.toThrow(
+        "The provided `href` (/catalog/[category]/[item]?category=music) value is missing query values (item) to be interpolated properly. Read more: https://nextjs.org/docs/messages/href-interpolation-failed",
+      );
+      expect(win.history.pushState).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
+  it("allows an omitted optional catch-all during same-segment interpolation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/docs/old",
+      href: "http://localhost/docs/old",
+    });
+    Object.assign(win, {
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/docs/[section]/[[...slug]]",
+        query: { section: "old" },
+      },
+    });
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(
+        Router.push({ query: { section: "guide" } }, undefined, { shallow: true }),
+      ).resolves.toBe(true);
+      expect(win.history.pushState).toHaveBeenCalledWith(
+        expect.objectContaining({ __N: true }),
+        "",
+        "/docs/guide",
+      );
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
+  it("interpolates required catch-all params during same-segment navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/docs/old",
+      href: "http://localhost/docs/old",
+    });
+    Object.assign(win, {
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/docs/[...slug]",
+        query: { slug: ["old"] },
+      },
+    });
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(
+        Router.push({ query: { slug: ["guide", "intro"] } }, undefined, { shallow: true }),
+      ).resolves.toBe(true);
+      expect(win.history.pushState).toHaveBeenCalledWith(
+        expect.objectContaining({ __N: true }),
+        "",
+        "/docs/guide/intro",
+      );
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
+  for (const mode of ["push", "replace"] as const) {
+    it(`keeps hash-only UrlObject ${mode} on the current dynamic route`, async () => {
+      const previousWindow = (globalThis as any).window;
+      const previousDocument = (globalThis as any).document;
+      const originalFetch = globalThis.fetch;
+      const { win } = createNavWindow();
+      Object.assign(win.location, {
+        pathname: "/docs/old",
+        href: "http://localhost/docs/old",
+      });
+      Object.assign(win, {
+        __NEXT_DATA__: {
+          ...win.__NEXT_DATA__,
+          page: "/docs/[id]",
+          query: { id: "old" },
+        },
+      });
+      (globalThis as any).window = win;
+      (globalThis as any).document = {
+        getElementById: vi.fn(() => null),
+        getElementsByName: vi.fn(() => []),
+      };
+      globalThis.fetch = vi.fn(async () => {
+        throw new Error("hash-only dynamic navigation must not fetch page HTML");
+      });
+
+      try {
+        vi.resetModules();
+        const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+        await expect(Router[mode]({ hash: "section" })).resolves.toBe(true);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(win.history[`${mode}State`]).toHaveBeenCalledWith(
+          expect.objectContaining({ __N: true }),
+          "",
+          "/docs/old#section",
+        );
+      } finally {
+        vi.resetModules();
+        if (previousWindow === undefined) delete (globalThis as any).window;
+        else (globalThis as any).window = previousWindow;
+        if (previousDocument === undefined) delete (globalThis as any).document;
+        else (globalThis as any).document = previousDocument;
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
+
   function trackHrefAssignments(win: {
     location: {
       href: string;


### PR DESCRIPTION
## Summary

- interpolate dynamic route parameters for query-only same-segment navigation while preserving the visible rewritten URL
- preserve locale, basePath, encoding, cross-domain locale targets, history mode, and router events
- match Next.js `href-interpolation-failed` behavior for missing required parameters
- keep hash-only navigation out of route interpolation

## Stack

This PR is stacked on #2028 (`codex/fix-pages-rewrites-navigation-20260615`) because it relies on that PR's visible-URL and history handling.

## Next.js parity

Fixes the remaining three same-segment assertions in `test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts`.

## Validation

- pinned Next.js v16.2.6 exact assertions: 3/3 passed
- focused router/Link tests: 43 passed
- vinext build passed
- repeated independent review; no actionable findings remain

Cache Components, PPR, and resume behavior are out of scope.
