### PR TITLE
fix(pages): honor basePath in dev module loaders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,10 @@ jobs:
             label: pages-router
             shardIndex: 1
             shardTotal: 1
+          - project: pages-router-basepath-dev
+            label: pages-router-basepath-dev
+            shardIndex: 1
+            shardTotal: 1
           - project: app-router
             label: app-router 1/3
             shardIndex: 1

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1209,11 +1209,7 @@ export function createSSRHandler(
                         viteBase,
                       );
                       const regenAppUrl = RegenApp
-                        ? createPagesDevModuleUrl(
-                            viteRoot,
-                            path.join(pagesDir, "_app"),
-                            viteBase,
-                          )
+                        ? createPagesDevModuleUrl(viteRoot, path.join(pagesDir, "_app"), viteBase)
                         : null;
                       const freshPagesNextData = {
                         ...pagesNextData,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1201,14 +1201,19 @@ export function createSSRHandler(
                       // Rebuild __NEXT_DATA__ with fresh props. The hydration
                       // script (module URLs) is stable across regenerations —
                       // extract it from the cached HTML to avoid duplication.
-                      const viteRoot = server.config?.root;
-                      const regenPageUrl = viteRoot
-                        ? "/" + path.relative(viteRoot, route.filePath)
-                        : route.filePath;
+                      const viteRoot = server.config.root;
+                      const viteBase = server.config.base;
+                      const regenPageUrl = createPagesDevModuleUrl(
+                        viteRoot,
+                        route.filePath,
+                        viteBase,
+                      );
                       const regenAppUrl = RegenApp
-                        ? viteRoot
-                          ? "/" + path.relative(viteRoot, path.join(pagesDir, "_app"))
-                          : path.join(pagesDir, "_app")
+                        ? createPagesDevModuleUrl(
+                            viteRoot,
+                            path.join(pagesDir, "_app"),
+                            viteBase,
+                          )
                         : null;
                       const freshPagesNextData = {
                         ...pagesNextData,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -58,6 +58,7 @@ import {
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
+import { createPagesDevModuleUrl } from "./pages-dev-module-url.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 import {
   loadUserDocumentInitialProps,
@@ -1542,11 +1543,18 @@ export function createSSRHandler(
           fontHeadHTML += `<style data-vinext-fonts${nonceAttr}>${allFontStyles.join("\n")}</style>\n  `;
         }
 
-        // Convert absolute file paths to Vite-servable URLs (relative to root)
+        // Convert absolute file paths to Vite-servable URLs under the dev
+        // server's configured base. Vite rejects root-relative module requests
+        // when basePath config sets server.config.base to a non-root pathname.
         const viteRoot = server.config.root;
-        const pageModuleUrl = "/" + path.relative(viteRoot, route.filePath);
+        const viteBase = server.config.base;
+        const pageModuleUrl = createPagesDevModuleUrl(viteRoot, route.filePath, viteBase);
+        const pageModuleSource = createPagesDevModuleUrl(viteRoot, route.filePath, "/");
         const appModuleUrl = AppComponent
-          ? "/" + path.relative(viteRoot, path.join(pagesDir, "_app"))
+          ? createPagesDevModuleUrl(viteRoot, path.join(pagesDir, "_app"), viteBase)
+          : null;
+        const appModuleSource = AppComponent
+          ? createPagesDevModuleUrl(viteRoot, path.join(pagesDir, "_app"), "/")
           : null;
         const serializedPagesNextData = {
           ...pagesNextData,
@@ -1571,8 +1579,8 @@ const nextData = window.__NEXT_DATA__;
 const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};
 const rawPageProps = props.pageProps;
 const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};
-window.__VINEXT_PAGE_LOADERS__ = { [nextData.page]: () => import("${pageModuleUrl}") };
-window.__VINEXT_APP_LOADER__ = ${appModuleUrl ? `() => import("${appModuleUrl}")` : "undefined"};
+window.__VINEXT_PAGE_LOADERS__ = { [nextData.page]: () => import("${pageModuleSource}") };
+window.__VINEXT_APP_LOADER__ = ${appModuleSource ? `() => import("${appModuleSource}")` : "undefined"};
 
 async function hydrate() {
   let hydrateRootOptions;
@@ -1587,13 +1595,13 @@ async function hydrate() {
     };
   }
 
-  const pageModule = await import("${pageModuleUrl}");
+  const pageModule = await import("${pageModuleSource}");
   const PageComponent = pageModule.default;
   let element;
   ${
-    appModuleUrl
+    appModuleSource
       ? `
-  const appModule = await import("${appModuleUrl}");
+  const appModule = await import("${appModuleSource}");
   const AppComponent = appModule.default;
   window.__VINEXT_APP__ = AppComponent;
   element = React.createElement(AppComponent, {

--- a/packages/vinext/src/server/pages-dev-module-url.ts
+++ b/packages/vinext/src/server/pages-dev-module-url.ts
@@ -6,7 +6,11 @@ function normalizeBase(base: string): string {
 }
 
 function encodeModulePath(modulePath: string): string {
-  return encodeURI(modulePath).replace(/\?/g, "%3F").replace(/#/g, "%23");
+  return encodeURI(modulePath)
+    .replace(/%5B/gi, "[")
+    .replace(/%5D/gi, "]")
+    .replace(/\?/g, "%3F")
+    .replace(/#/g, "%23");
 }
 
 export function createPagesDevModuleUrl(

--- a/packages/vinext/src/server/pages-dev-module-url.ts
+++ b/packages/vinext/src/server/pages-dev-module-url.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+
+function normalizeBase(base: string): string {
+  if (!base || base === "/") return "/";
+  return `/${base.replace(/^\/+|\/+$/g, "")}/`;
+}
+
+function encodeModulePath(modulePath: string): string {
+  return encodeURI(modulePath).replace(/\?/g, "%3F").replace(/#/g, "%23");
+}
+
+export function createPagesDevModuleUrl(
+  viteRoot: string,
+  moduleFilePath: string,
+  viteBase: string,
+): string {
+  const pathImpl = /^[A-Za-z]:[\\/]/.test(viteRoot) ? path.win32 : path;
+  const relativePath = pathImpl.relative(viteRoot, moduleFilePath).replace(/\\/g, "/");
+  return normalizeBase(viteBase) + encodeModulePath(relativePath);
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -263,6 +263,18 @@ const projectServers = {
       timeout: 60_000,
     },
   },
+  "pages-router-basepath-dev": {
+    testDir: "./tests/e2e/pages-router-basepath-dev",
+    use: { baseURL: "http://localhost:4189" },
+    server: {
+      command:
+        "(test -e node_modules || test -L node_modules || ln -s ../pages-basic/node_modules node_modules) && npx vp dev --port 4189",
+      cwd: "./tests/fixtures/pages-basepath-dev",
+      port: 4189,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+  },
 };
 
 type ProjectName = keyof typeof projectServers;

--- a/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
+++ b/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
@@ -32,3 +32,59 @@ test("loads the target page module through the dev server basePath", async ({ pa
   expect(moduleRequests).not.toContain("/pages/about.tsx?import");
   expect(moduleRequests.every((request) => request.startsWith("/docs/"))).toBe(true);
 });
+
+test("soft navigates with basePath module URLs after ISR regeneration", async ({
+  page,
+  request,
+}) => {
+  const firstResponse = await request.get("/docs/isr-basepath");
+  expect(firstResponse.ok()).toBe(true);
+  const firstHtml = await firstResponse.text();
+  const firstGeneratedAt = firstHtml.match(/data-testid="generated-at">(\d+)</)?.[1];
+  expect(firstGeneratedAt).toBeDefined();
+
+  await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+  const staleResponse = await request.get("/docs/isr-basepath");
+  expect(staleResponse.headers()["x-vinext-cache"]).toBe("STALE");
+
+  let regeneratedHtml = "";
+  await expect
+    .poll(async () => {
+      const response = await request.get("/docs/isr-basepath");
+      regeneratedHtml = await response.text();
+      return {
+        cache: response.headers()["x-vinext-cache"],
+        changed:
+          regeneratedHtml.match(/data-testid="generated-at">(\d+)</)?.[1] !== firstGeneratedAt,
+      };
+    })
+    .toEqual({ cache: "HIT", changed: true });
+
+  const regeneratedAt = regeneratedHtml.match(/data-testid="generated-at">(\d+)</)?.[1];
+  expect(regeneratedAt).toBeDefined();
+
+  const moduleRequests: string[] = [];
+  page.on("request", (moduleRequest) => {
+    const url = new URL(moduleRequest.url());
+    if (url.pathname.endsWith("/pages/isr-basepath.tsx")) {
+      moduleRequests.push(url.pathname + url.search);
+    }
+  });
+
+  await page.goto("/docs/");
+  await page.waitForFunction(() => Boolean((window as any).__VINEXT_ROOT__));
+  await page.evaluate(() => {
+    (window as any).__VINEXT_SOFT_NAV_MARKER__ = true;
+  });
+
+  await page.getByRole("link", { name: "ISR" }).click();
+
+  await expect(page.getByRole("heading", { name: "ISR BasePath" })).toBeVisible();
+  await expect(page.getByTestId("generated-at")).toHaveText(regeneratedAt!);
+  await expect(page).toHaveURL(/\/docs\/isr-basepath$/);
+  expect(await page.evaluate(() => (window as any).__VINEXT_SOFT_NAV_MARKER__)).toBe(true);
+  expect(moduleRequests).toContain("/docs/pages/isr-basepath.tsx?import");
+  expect(moduleRequests).not.toContain("/pages/isr-basepath.tsx?import");
+  expect(moduleRequests.every((moduleRequest) => moduleRequest.startsWith("/docs/"))).toBe(true);
+});

--- a/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
+++ b/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+// Ported from Next.js: test/e2e/basepath/router-events.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
+test("loads the target page module through the dev server basePath", async ({ page }) => {
+  const moduleRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname.endsWith("/pages/about.tsx")) {
+      moduleRequests.push(url.pathname + url.search);
+    }
+  });
+
+  await page.goto("/docs/");
+  await page.waitForFunction(() => Boolean((window as any).__VINEXT_ROOT__));
+  await page.evaluate(() => {
+    (window as any).__VINEXT_SOFT_NAV_MARKER__ = true;
+  });
+
+  const initialNavigationEntries = await page.evaluate(
+    () => performance.getEntriesByType("navigation").length,
+  );
+  await page.getByRole("link", { name: "About" }).click();
+
+  await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
+  await expect(page).toHaveURL(/\/docs\/about$/);
+  expect(await page.evaluate(() => performance.getEntriesByType("navigation").length)).toBe(
+    initialNavigationEntries,
+  );
+  expect(await page.evaluate(() => (window as any).__VINEXT_SOFT_NAV_MARKER__)).toBe(true);
+  expect(moduleRequests).toContain("/docs/pages/about.tsx?import");
+  expect(moduleRequests).not.toContain("/pages/about.tsx?import");
+  expect(moduleRequests.every((request) => request.startsWith("/docs/"))).toBe(true);
+});

--- a/tests/fixtures/pages-basepath-dev/next.config.mjs
+++ b/tests/fixtures/pages-basepath-dev/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  basePath: "/docs",
+  assetPrefix: "/assets",
+};
+
+export default nextConfig;

--- a/tests/fixtures/pages-basepath-dev/pages/about.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/about.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <h1>About</h1>;
+}

--- a/tests/fixtures/pages-basepath-dev/pages/index.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/index.tsx
@@ -5,6 +5,7 @@ export default function Home() {
     <main>
       <h1>Home</h1>
       <Link href="/about">About</Link>
+      <Link href="/isr-basepath">ISR</Link>
     </main>
   );
 }

--- a/tests/fixtures/pages-basepath-dev/pages/index.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/index.tsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/about">About</Link>
+    </main>
+  );
+}

--- a/tests/fixtures/pages-basepath-dev/pages/isr-basepath.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/isr-basepath.tsx
@@ -1,0 +1,19 @@
+interface IsrBasePathProps {
+  generatedAt: number;
+}
+
+export default function IsrBasePath({ generatedAt }: IsrBasePathProps) {
+  return (
+    <main>
+      <h1>ISR BasePath</h1>
+      <p data-testid="generated-at">{generatedAt}</p>
+    </main>
+  );
+}
+
+export function getStaticProps() {
+  return {
+    props: { generatedAt: Date.now() },
+    revalidate: 1,
+  };
+}

--- a/tests/fixtures/pages-basepath-dev/vite.config.mts
+++ b/tests/fixtures/pages-basepath-dev/vite.config.mts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite-plus";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext()],
+});

--- a/tests/pages-dev-module-url.test.ts
+++ b/tests/pages-dev-module-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createPagesDevModuleUrl } from "../packages/vinext/src/server/pages-dev-module-url.js";
+
+describe("createPagesDevModuleUrl", () => {
+  it("uses Vite's configured base without applying assetPrefix", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/")).toBe(
+      "/docs/pages/about.tsx",
+    );
+  });
+
+  it("preserves root-base behavior", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/")).toBe(
+      "/pages/about.tsx",
+    );
+  });
+
+  it("normalizes Windows paths", () => {
+    expect(
+      createPagesDevModuleUrl("C:\\repo", "C:\\repo\\pages\\about.tsx", "/docs/"),
+    ).toBe("/docs/pages/about.tsx");
+  });
+
+  it("encodes path query and fragment delimiters", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/what?#.tsx", "/docs/"))
+      .toBe("/docs/pages/what%3F%23.tsx");
+  });
+
+  it("returns a stable URL for Vite HMR module identity", () => {
+    const first = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");
+    const second = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");
+    expect(second).toBe(first);
+  });
+});

--- a/tests/pages-dev-module-url.test.ts
+++ b/tests/pages-dev-module-url.test.ts
@@ -24,6 +24,12 @@ describe("createPagesDevModuleUrl", () => {
     );
   });
 
+  it("preserves dynamic route brackets for Vite module resolution", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/blog/[slug].tsx", "/docs/")).toBe(
+      "/docs/pages/blog/[slug].tsx",
+    );
+  });
+
   it("returns a stable URL for Vite HMR module identity", () => {
     const first = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");
     const second = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");

--- a/tests/pages-dev-module-url.test.ts
+++ b/tests/pages-dev-module-url.test.ts
@@ -9,20 +9,19 @@ describe("createPagesDevModuleUrl", () => {
   });
 
   it("preserves root-base behavior", () => {
-    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/")).toBe(
-      "/pages/about.tsx",
-    );
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/")).toBe("/pages/about.tsx");
   });
 
   it("normalizes Windows paths", () => {
-    expect(
-      createPagesDevModuleUrl("C:\\repo", "C:\\repo\\pages\\about.tsx", "/docs/"),
-    ).toBe("/docs/pages/about.tsx");
+    expect(createPagesDevModuleUrl("C:\\repo", "C:\\repo\\pages\\about.tsx", "/docs/")).toBe(
+      "/docs/pages/about.tsx",
+    );
   });
 
   it("encodes path query and fragment delimiters", () => {
-    expect(createPagesDevModuleUrl("/repo", "/repo/pages/what?#.tsx", "/docs/"))
-      .toBe("/docs/pages/what%3F%23.tsx");
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/what?#.tsx", "/docs/")).toBe(
+      "/docs/pages/what%3F%23.tsx",
+    );
   });
 
   it("returns a stable URL for Vite HMR module identity", () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -6590,6 +6590,10 @@ describe("Pages Router dev ISR regeneration", () => {
         throw new Error(`Unexpected module load: ${id}`);
       };
       const server = {
+        config: {
+          root: FIXTURE_DIR,
+          base: "/docs/",
+        },
         transformIndexHtml: vi.fn(async (_url: string, html: string) => html),
       } as unknown as ViteDevServer;
       const runner = { import: loadModule };
@@ -6671,6 +6675,9 @@ describe("Pages Router dev ISR regeneration", () => {
           },
         },
       });
+      const regeneratedHtml = isrSetSpy.mock.calls[0]?.[1].html as string;
+      expect(regeneratedHtml).toContain('"pageModuleUrl":"/docs/pages/isr-test.tsx"');
+      expect(regeneratedHtml).toContain('"appModuleUrl":"/docs/pages/_app"');
     } finally {
       vi.doUnmock("../packages/vinext/src/server/isr-cache.js");
       vi.resetModules();


### PR DESCRIPTION
## Summary

- generate Pages dev client module URLs through Vite's configured base
- preserve no-basePath, distinct assetPrefix, Windows paths, encoding, and HMR identity
- apply the same URL generation during ISR background regeneration
- add browser coverage for normal and regenerated soft navigation under `/docs`

## Parity impact

Fixes Pages Router client navigation under a configured basePath, including the dev-runtime blocker exposed by the router-events parity suite.

## Validation

- 298 targeted Pages/unit tests passed
- 2 focused browser tests passed, including regenerated ISR navigation
- scoped `vp check`, package build, and diff checks passed
- independent review: functionally clean; formatting finding addressed

Cache Components, PPR, and resume behavior are out of scope.
