### PR TITLE
fix(pages): apply Document renderPage enhancers

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1914,24 +1914,7 @@ async function renderErrorPage(
         }
       }
 
-      let element: React.ReactElement;
-      if (AppComponent) {
-        element = createElement(AppComponent, {
-          Component: ErrorComponent,
-          pageProps: errorProps,
-        });
-      } else {
-        element = createElement(ErrorComponent, errorProps);
-      }
-
-      if (wrapFn) {
-        element = wrapFn(element);
-      }
-
-      const bodyHtml = await renderToStringAsync(element);
-
       // Try custom _document
-      let html: string;
       // oxlint-disable-next-line typescript/no-explicit-any
       let DocumentComponent: any = null;
       const docPathErr = path.join(pagesDir, "_document");
@@ -1944,17 +1927,64 @@ async function renderErrorPage(
         }
       }
 
+      const createErrorElement = (
+        // oxlint-disable-next-line typescript/no-explicit-any
+        FinalApp: any,
+        // oxlint-disable-next-line typescript/no-explicit-any
+        FinalComponent: any,
+      ): React.ReactElement => {
+        let errorElement: React.ReactElement = FinalApp
+          ? createElement(FinalApp, {
+              Component: FinalComponent,
+              pageProps: errorProps,
+            })
+          : createElement(FinalComponent, errorProps);
+        if (wrapFn) errorElement = wrapFn(errorElement);
+        return errorElement;
+      };
+
+      const element = createErrorElement(AppComponent, ErrorComponent);
+      const headShim = await importModule(runner, "next/head");
+      if (typeof headShim.resetSSRHead === "function") headShim.resetSSRHead();
+
       if (DocumentComponent) {
-        const docProps = await loadUserDocumentInitialProps(DocumentComponent);
-        const docElement = docProps
-          ? createElement(DocumentComponent, docProps)
-          : createElement(DocumentComponent);
-        let docHtml = await renderToStringAsync(docElement);
-        docHtml = docHtml.replace("__NEXT_MAIN__", bodyHtml);
-        docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", "");
-        html = docHtml;
+        const errorPathname = candidate === "_error" ? "/_error" : `/${candidate}`;
+        await streamPageToResponse(res, element, {
+          url,
+          server,
+          fontHeadHTML: "",
+          scripts: "",
+          DocumentComponent,
+          statusCode,
+          documentContext: {
+            err,
+            pathname: errorPathname,
+            query: parseQuery(url),
+            asPath: url,
+            req,
+            res,
+          },
+          enhancePageElement: (renderPageOpts) => {
+            let FinalApp = AppComponent;
+            let FinalComponent = ErrorComponent;
+            if (renderPageOpts.enhanceApp && FinalApp) {
+              FinalApp = renderPageOpts.enhanceApp(FinalApp);
+            }
+            if (renderPageOpts.enhanceComponent) {
+              FinalComponent = renderPageOpts.enhanceComponent(FinalComponent);
+            }
+            return createErrorElement(FinalApp, FinalComponent);
+          },
+          getHeadHTML: () =>
+            typeof headShim.getSSRHeadHTML === "function" ? headShim.getSSRHeadHTML() : "",
+          setDocumentInitialHead:
+            typeof headShim.setDocumentInitialHead === "function"
+              ? headShim.setDocumentInitialHead
+              : undefined,
+        });
       } else {
-        html = `<!DOCTYPE html>
+        const bodyHtml = await renderToStringAsync(element);
+        const html = `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8" />
@@ -1964,11 +1994,10 @@ async function renderErrorPage(
   <div id="__next">${bodyHtml}</div>
 </body>
 </html>`;
+        const transformedHtml = await server.transformIndexHtml(url, html);
+        res.writeHead(statusCode, { "Content-Type": "text/html" });
+        res.end(transformedHtml);
       }
-
-      const transformedHtml = await server.transformIndexHtml(url, html);
-      res.writeHead(statusCode, { "Content-Type": "text/html" });
-      res.end(transformedHtml);
       return;
     } catch {
       // This candidate doesn't exist, try next

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -259,7 +259,7 @@ async function streamPageToResponse(
   // Fold any head tags returned by `_document.getInitialProps()` into the same
   // dedupe pipeline as user `next/head` tags. Matches Next.js's `_document`
   // contract. `runDocumentRenderPage` already invokes `getInitialProps` for the
-  // renderPage contract (rendered/consumed), so reuse the head it surfaced
+  // renderPage contract, so reuse the head it surfaced
   // rather than calling it a second time. Only the `skipped` path (no override,
   // or no `enhancePageElement` wired) falls back to the standalone helper, which
   // itself skips the unmodified default from vinext's `next/document` shim —
@@ -283,8 +283,8 @@ async function streamPageToResponse(
   let shellTemplate: string;
 
   if (DocumentComponent) {
-    // When the renderPage path already invoked getInitialProps (rendered or
-    // consumed), reuse its resolved props instead of calling it a second time.
+    // When the renderPage path already invoked getInitialProps, reuse its
+    // resolved props instead of calling it a second time.
     // `skipped` means it was never invoked → fall through to the fast path.
     const docProps =
       documentRenderPage.status === "skipped"

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -207,6 +207,8 @@ async function streamPageToResponse(
      * into `getSSRHeadHTML()`'s output. Called before `getHeadHTML()`.
      */
     setDocumentInitialHead?: (head: React.ReactNode[]) => void;
+    /** Buffer the body before writing headers so error-page fallback remains safe. */
+    bufferBodyBeforeHeaders?: boolean;
   },
 ): Promise<void> {
   const {
@@ -222,6 +224,7 @@ async function streamPageToResponse(
     scriptNonce,
     documentContext,
     setDocumentInitialHead,
+    bufferBodyBeforeHeaders = false,
   } = options;
 
   // Custom `_document.getInitialProps()` may opt in to wrapping the page tree
@@ -328,6 +331,7 @@ async function streamPageToResponse(
   const markerIdx = transformedShell.indexOf(STREAM_BODY_MARKER);
   const prefix = transformedShell.slice(0, markerIdx);
   const suffix = transformedShell.slice(markerIdx + STREAM_BODY_MARKER.length);
+  const bufferedBody = bufferBodyBeforeHeaders ? await new Response(bodyStream).text() : null;
 
   // Send headers and start streaming.
   // Set array-valued headers (e.g. Set-Cookie from gSSP) via setHeader()
@@ -350,6 +354,11 @@ async function streamPageToResponse(
 
   // Write the document prefix (head, opening body)
   res.write(prefix);
+
+  if (bufferedBody !== null) {
+    res.end(bufferedBody + suffix);
+    return;
+  }
 
   // Pipe the React body stream through (Suspense content streams progressively)
   const reader = bodyStream.getReader();
@@ -1759,6 +1768,7 @@ hydrate();
             typeof headShim.setDocumentInitialHead === "function"
               ? headShim.setDocumentInitialHead
               : undefined,
+          bufferBodyBeforeHeaders: true,
         });
         _renderEnd = now();
 
@@ -2000,6 +2010,7 @@ async function renderErrorPage(
       }
       return;
     } catch {
+      if (res.headersSent || res.writableEnded) return;
       // This candidate doesn't exist, try next
       continue;
     }

--- a/packages/vinext/src/server/pages-document-initial-props.ts
+++ b/packages/vinext/src/server/pages-document-initial-props.ts
@@ -138,11 +138,6 @@ type DocumentRenderPageInput = {
  *                  the head nodes returned by `getInitialProps` (forward them to
  *                  `setDocumentInitialHead()` — do NOT call
  *                  `callDocumentGetInitialProps()` as well).
- *   - `consumed` — `getInitialProps` WAS invoked but never called `renderPage`.
- *                  Callers must NOT re-invoke `getInitialProps` (that would
- *                  call it a second time) — render the streaming body, spread
- *                  `docProps` onto `<Document>`, and forward `head` to
- *                  `setDocumentInitialHead()`.
  */
 type RunDocumentRenderPageResult =
   | { status: "skipped" }
@@ -152,8 +147,7 @@ type RunDocumentRenderPageResult =
       stylesHTML: string;
       docProps: Record<string, unknown>;
       head: ReactNode[];
-    }
-  | { status: "consumed"; docProps: Record<string, unknown>; head: ReactNode[] };
+    };
 
 /**
  * Run a user `_document.getInitialProps()` with a `ctx.renderPage()` that
@@ -165,10 +159,10 @@ type RunDocumentRenderPageResult =
  * prod (`pages-page-response.ts`) and dev (`dev-server.ts`) SSR pipelines so
  * the `getInitialProps` + `renderPage` contract lives in one place.
  *
- * `getInitialProps` is invoked at most once here. When this returns `consumed`
- * or `rendered`, callers MUST treat that as the single invocation and must not
- * call `loadUserDocumentInitialProps` again. Errors intentionally propagate to
- * the Pages Router's normal error-page pipeline, matching Next.js.
+ * `getInitialProps` is invoked at most once here. When this returns `rendered`,
+ * callers MUST treat that as the single invocation and must not call
+ * `loadUserDocumentInitialProps` again. Errors intentionally propagate to the
+ * Pages Router's normal error-page pipeline, matching Next.js.
  *
  * @see .nextjs-ref/packages/next/src/server/render.tsx (search `renderPage`)
  */
@@ -190,11 +184,9 @@ export async function runDocumentRenderPage(
   if (!input.enhancePageElement) return { status: "skipped" };
   const enhancePageElement = input.enhancePageElement;
 
-  let renderPageCalled = false;
   const renderPage = async (
     opts: RenderPageEnhancer = {},
   ): Promise<{ html: string; head: ReactNode[] }> => {
-    renderPageCalled = true;
     const enhancers: RenderPageEnhancers =
       typeof opts === "function" ? { enhanceComponent: opts } : opts;
     const enhancedElement = enhancePageElement(enhancers);
@@ -240,11 +232,6 @@ export async function runDocumentRenderPage(
       `"${DocCtor.displayName ?? DocCtor.name ?? "Document"}.getInitialProps()" should resolve to an object with a "html" prop set with a valid html string`,
     );
   }
-
-  // If the user implemented getInitialProps but never invoked renderPage
-  // (uncommon — but possible if they only return head/styles), fall back to
-  // the streaming render so the body content is produced normally.
-  if (!renderPageCalled) return { status: "consumed", docProps, head };
 
   // Render `styles` returned by `getInitialProps()` (e.g. collected
   // styled-components / emotion <style> tags) to a string ready for the SSR

--- a/packages/vinext/src/server/pages-document-initial-props.ts
+++ b/packages/vinext/src/server/pages-document-initial-props.ts
@@ -14,19 +14,19 @@
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx
  * (search for `loadDocumentInitialProps` and `documentElement`).
  *
- * vinext only forwards `docProps`. The full `DocumentContext`
- * (`renderPage`, `defaultGetInitialProps`, `pathname`, `query`, `req`, `res`,
- * `err`, `asPath`) is not yet plumbed through. The common upstream pattern
+ * `runDocumentRenderPage()` supplies `renderPage`, `defaultGetInitialProps`,
+ * and the request pathname/query/asPath fields needed by the common upstream
+ * pattern:
  *
  *   static async getInitialProps(ctx) {
  *     const initialProps = await Document.getInitialProps(ctx)
  *     return { ...initialProps, docValue }
  *   }
  *
- * works because the base `Document.getInitialProps` shim in
- * `shims/document.tsx` returns `{ html: "" }` and ignores `ctx`. User
- * overrides that *only* read `ctx` will see `undefined` fields — that is a
- * separate gap tracked alongside the shim TODO.
+ * The standalone `loadUserDocumentInitialProps()` compatibility path supplies
+ * an empty default render result because it is only used after the body has
+ * already been produced. Request-only fields such as req/res remain outside
+ * that compatibility helper.
  *
  * Returns `null` when the user did not override the base shim (the static
  * `getInitialProps` reference still points at the shim's stub) so callers
@@ -69,11 +69,12 @@ export async function loadUserDocumentInitialProps(
   // fast path keeps the same number of awaits as before this helper landed.
   if (getInitialProps === BASE_GET_INITIAL_PROPS) return null;
 
-  // Pass ctx as `{}`. Most upstream overrides only use ctx to delegate
-  // back to `Document.getInitialProps`, which the shim ignores. Errors
-  // propagate — matching Next.js's `loadGetInitialProps`, which has no
-  // catch and surfaces user bugs as 500s.
-  const result = await getInitialProps({});
+  // This compatibility path renders an already-produced body, so provide the
+  // base Document delegation with an empty shell. The full Pages render path
+  // uses `runDocumentRenderPage()` and supplies the real render callback.
+  const result = await getInitialProps({
+    defaultGetInitialProps: async () => ({ html: "" }),
+  });
   return result && typeof result === "object" ? (result as Record<string, unknown>) : null;
 }
 
@@ -211,12 +212,11 @@ export async function runDocumentRenderPage(
     // `ctx.renderPage` (the styled-components / emotion pattern) work
     // without those fields.
     renderPage,
-    defaultGetInitialProps: async (ctx: { renderPage?: typeof renderPage }) => {
+    defaultGetInitialProps: async (ctx: { renderPage: typeof renderPage }) => {
       // Mirrors Next.js's `ctx.defaultGetInitialProps`: wrap App in an
       // identity enhancer so renderPage is still invoked even when a user
       // doesn't pass any enhancers themselves.
-      const inner = ctx.renderPage ?? renderPage;
-      const result = await inner({
+      const result = await ctx.renderPage({
         // oxlint-disable-next-line @typescript-eslint/no-explicit-any
         enhanceApp: (App) => (props: any) => React.createElement(App, props),
       });
@@ -235,31 +235,25 @@ export async function runDocumentRenderPage(
   const { html: _html, head: rawHead, styles: _styles, ...docProps } = docInitialProps ?? {};
   const head: ReactNode[] = Array.isArray(rawHead) ? (rawHead as ReactNode[]) : [];
 
+  if (!docInitialProps || typeof docInitialProps.html !== "string") {
+    throw new Error(
+      `"${DocCtor.displayName ?? DocCtor.name ?? "Document"}.getInitialProps()" should resolve to an object with a "html" prop set with a valid html string`,
+    );
+  }
+
   // If the user implemented getInitialProps but never invoked renderPage
   // (uncommon — but possible if they only return head/styles), fall back to
   // the streaming render so the body content is produced normally.
   if (!renderPageCalled) return { status: "consumed", docProps, head };
 
-  if (!docInitialProps || typeof docInitialProps.html !== "string") {
-    console.error(
-      `[vinext] "${DocCtor.displayName ?? DocCtor.name ?? "Document"}.getInitialProps()" did not return an object with a string "html" prop`,
-    );
-    return { status: "consumed", docProps, head };
-  }
-
   // Render `styles` returned by `getInitialProps()` (e.g. collected
   // styled-components / emotion <style> tags) to a string ready for the SSR
   // head. Matches Next.js's render.tsx where `styles` flows into the head.
-  // Failures are swallowed so a buggy styles element doesn't crash the render.
   let stylesHTML = "";
   if (docInitialProps.styles != null) {
-    try {
-      stylesHTML = await input.renderStylesToString(
-        React.createElement(React.Fragment, null, docInitialProps.styles),
-      );
-    } catch (err) {
-      console.error("[vinext] Failed to render _document.getInitialProps() styles:", err);
-    }
+    stylesHTML = await input.renderStylesToString(
+      React.createElement(React.Fragment, null, docInitialProps.styles),
+    );
   }
 
   return { status: "rendered", bodyHtml: docInitialProps.html, stylesHTML, docProps, head };

--- a/packages/vinext/src/server/pages-document-initial-props.ts
+++ b/packages/vinext/src/server/pages-document-initial-props.ts
@@ -137,12 +137,11 @@ type DocumentRenderPageInput = {
  *                  the head nodes returned by `getInitialProps` (forward them to
  *                  `setDocumentInitialHead()` — do NOT call
  *                  `callDocumentGetInitialProps()` as well).
- *   - `consumed` — `getInitialProps` WAS invoked but no body was produced
- *                  (it never called `renderPage`, returned no `{ html }`, or
- *                  threw). Callers must NOT re-invoke `getInitialProps` (that
- *                  would call it a second time) — render the streaming body,
- *                  spread `docProps` (possibly empty) onto `<Document>`, and
- *                  forward `head` to `setDocumentInitialHead()`.
+ *   - `consumed` — `getInitialProps` WAS invoked but never called `renderPage`.
+ *                  Callers must NOT re-invoke `getInitialProps` (that would
+ *                  call it a second time) — render the streaming body, spread
+ *                  `docProps` onto `<Document>`, and forward `head` to
+ *                  `setDocumentInitialHead()`.
  */
 type RunDocumentRenderPageResult =
   | { status: "skipped" }
@@ -167,9 +166,8 @@ type RunDocumentRenderPageResult =
  *
  * `getInitialProps` is invoked at most once here. When this returns `consumed`
  * or `rendered`, callers MUST treat that as the single invocation and must not
- * call `loadUserDocumentInitialProps` (which would invoke it again — and, for a
- * throwing override, surface the error as a 500 rather than the clean fallback
- * this contract guarantees).
+ * call `loadUserDocumentInitialProps` again. Errors intentionally propagate to
+ * the Pages Router's normal error-page pipeline, matching Next.js.
  *
  * @see .nextjs-ref/packages/next/src/server/render.tsx (search `renderPage`)
  */
@@ -207,33 +205,25 @@ export async function runDocumentRenderPage(
     return { html, head: [] };
   };
 
-  let docInitialProps: DocumentInitialProps;
-  try {
-    docInitialProps = await DocCtor.getInitialProps({
-      // Minimal `DocumentContext` shim — vinext does not yet thread the full
-      // context (req/res/AppTree/locale). Subclasses that just forward to
-      // `ctx.renderPage` (the styled-components / emotion pattern) work
-      // without those fields.
-      renderPage,
-      defaultGetInitialProps: async (ctx: { renderPage?: typeof renderPage }) => {
-        // Mirrors Next.js's `ctx.defaultGetInitialProps`: wrap App in an
-        // identity enhancer so renderPage is still invoked even when a user
-        // doesn't pass any enhancers themselves.
-        const inner = ctx.renderPage ?? renderPage;
-        const result = await inner({
-          // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-          enhanceApp: (App) => (props: any) => React.createElement(App, props),
-        });
-        return { html: result.html, head: result.head ?? [], styles: undefined };
-      },
-      ...input.context,
-    });
-  } catch (err) {
-    // Falls back cleanly: render the streaming body and a bare Document.
-    // `getInitialProps` was already invoked, so the caller must not re-call it.
-    console.error("[vinext] _document.getInitialProps() threw:", err);
-    return { status: "consumed", docProps: {}, head: [] };
-  }
+  const docInitialProps = await DocCtor.getInitialProps({
+    // Minimal `DocumentContext` shim — vinext does not yet thread the full
+    // context (req/res/AppTree/locale). Subclasses that just forward to
+    // `ctx.renderPage` (the styled-components / emotion pattern) work
+    // without those fields.
+    renderPage,
+    defaultGetInitialProps: async (ctx: { renderPage?: typeof renderPage }) => {
+      // Mirrors Next.js's `ctx.defaultGetInitialProps`: wrap App in an
+      // identity enhancer so renderPage is still invoked even when a user
+      // doesn't pass any enhancers themselves.
+      const inner = ctx.renderPage ?? renderPage;
+      const result = await inner({
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        enhanceApp: (App) => (props: any) => React.createElement(App, props),
+      });
+      return { html: result.html, head: result.head ?? [], styles: undefined };
+    },
+    ...input.context,
+  });
 
   // Strip the contract fields the pipeline consumes itself so the rest can be
   // spread onto `<Document>` like Next.js does. `html` is the body; `head`/

--- a/packages/vinext/src/server/pages-document-initial-props.ts
+++ b/packages/vinext/src/server/pages-document-initial-props.ts
@@ -86,7 +86,7 @@ export type RenderPageEnhancers = {
   enhanceComponent?: (Comp: ComponentType<unknown>) => any;
 };
 
-export type RenderPageEnhancer =
+type RenderPageEnhancer =
   | RenderPageEnhancers
   | ((Comp: ComponentType<unknown>) => ComponentType<unknown>);
 

--- a/packages/vinext/src/server/pages-document-initial-props.ts
+++ b/packages/vinext/src/server/pages-document-initial-props.ts
@@ -85,6 +85,10 @@ export type RenderPageEnhancers = {
   enhanceComponent?: (Comp: ComponentType<unknown>) => any;
 };
 
+export type RenderPageEnhancer =
+  | RenderPageEnhancers
+  | ((Comp: ComponentType<unknown>) => ComponentType<unknown>);
+
 type DocumentInitialProps = {
   html: string;
   head?: ReactNode[];
@@ -189,10 +193,12 @@ export async function runDocumentRenderPage(
 
   let renderPageCalled = false;
   const renderPage = async (
-    opts: RenderPageEnhancers = {},
+    opts: RenderPageEnhancer = {},
   ): Promise<{ html: string; head: ReactNode[] }> => {
     renderPageCalled = true;
-    const enhancedElement = enhancePageElement(opts);
+    const enhancers: RenderPageEnhancers =
+      typeof opts === "function" ? { enhanceComponent: opts } : opts;
+    const enhancedElement = enhancePageElement(enhancers);
     // Nonce responsibility lives here so prod and dev produce identical
     // output — callers' `enhancePageElement` must not apply it themselves.
     const wrapped = withScriptNonce(enhancedElement as React.ReactElement, input.scriptNonce);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -744,6 +744,7 @@ export function createPagesPageHandler(
           pageProps,
           props: renderProps,
           params,
+          query,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -539,7 +539,7 @@ export function createPagesPageHandler(
 
         const pageDataResult = await resolvePagesPageData({
           isDataReq,
-          err,
+          err: err instanceof Error ? err : undefined,
           applyRequestContexts: applySSRContext,
           buildId,
           deploymentId: process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
@@ -727,6 +727,7 @@ export function createPagesPageHandler(
             return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
           },
           DocumentComponent,
+          err: err instanceof Error ? err : undefined,
           flushPreloads: typeof flushPreloads === "function" ? flushPreloads : undefined,
           fontLinkHeader,
           fontPreloads: allFontPreloads,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -185,6 +185,7 @@ type RenderPagesPageResponseOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  query?: Record<string, unknown>;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -520,7 +521,7 @@ export async function renderPagesPageResponse(
     scriptNonce: options.scriptNonce,
     context: {
       pathname: options.routePattern,
-      query: options.params,
+      query: options.query ?? options.params,
       asPath: options.routeUrl,
     },
   });

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -150,6 +150,7 @@ type RenderPagesPageResponseOptions = {
    */
   enhancePageElement?: ((opts: RenderPageEnhancers) => ReactNode) | undefined;
   DocumentComponent: ComponentType | null;
+  err?: Error;
   flushPreloads?: (() => Promise<void> | void) | undefined;
   fontLinkHeader: string;
   fontPreloads: PagesFontPreload[];
@@ -520,6 +521,7 @@ export async function renderPagesPageResponse(
       readStreamAsText(await options.renderToReadableStream(element)),
     scriptNonce: options.scriptNonce,
     context: {
+      err: options.err,
       pathname: options.routePattern,
       query: options.query ?? options.params,
       asPath: options.routeUrl,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -556,7 +556,7 @@ export async function renderPagesPageResponse(
   // Fold any head tags returned by `_document.getInitialProps()` into the
   // dedupe pipeline before getSSRHeadHTML serialises the final <head>. Mirrors
   // Next.js's `_document` contract. `runDocumentRenderPage` already invokes
-  // `getInitialProps` for the renderPage contract (rendered/consumed), so reuse
+  // `getInitialProps` for the renderPage contract, so reuse
   // the head it surfaced rather than calling it a second time. Only the
   // `skipped` path (no override, or no `enhancePageElement` wired) falls back to
   // the standalone helper — which itself skips the unmodified default shim.
@@ -585,8 +585,8 @@ export async function renderPagesPageResponse(
     DocumentComponent: options.DocumentComponent,
     renderDocumentToString: options.renderDocumentToString,
     ssrHeadHTML,
-    // When the renderPage path already invoked getInitialProps (rendered or
-    // consumed), reuse its resolved props instead of calling it a second time.
+    // When the renderPage path already invoked getInitialProps, reuse its
+    // resolved props instead of calling it a second time.
     // `skipped` means it was never invoked → fall through to the fast path.
     resolvedDocProps: documentRenderPage.status === "skipped" ? null : documentRenderPage.docProps,
   });

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -62,7 +62,7 @@ export type DocumentContext = {
   // and the inherited `NextPageContext` (`pathname`, `query`, `req`, `res`,
   // `err`, `asPath`, ...). They're declared as optional because the dev error
   // renderer and compatibility paths may provide only a partial context.
-  renderPage?: (
+  renderPage: (
     options?:
       | {
           enhanceApp?: (
@@ -72,7 +72,7 @@ export type DocumentContext = {
         }
       | ((Comp: React.ComponentType<unknown>) => React.ComponentType<unknown>),
   ) => DocumentInitialProps | Promise<DocumentInitialProps>;
-  defaultGetInitialProps?: (
+  defaultGetInitialProps: (
     ctx: DocumentContext,
     options?: { nonce?: string },
   ) => Promise<DocumentInitialProps>;
@@ -106,13 +106,12 @@ export type DocumentInitialProps = {
 // oxlint-disable-next-line @typescript-eslint/no-empty-object-type
 export default class Document<P = {}> extends React.Component<P & { children?: React.ReactNode }> {
   /**
-   * `getInitialProps` is invoked by the SSR pipeline. The default implementation
-   * returns an empty shell because the runtime-provided
-   * `ctx.defaultGetInitialProps()` owns the actual page render and style
-   * collection when custom Documents delegate through it.
+   * `getInitialProps` is invoked by the SSR pipeline. The runtime-provided
+   * `ctx.defaultGetInitialProps()` owns the page render and style collection,
+   * matching Next.js's canonical CSS-in-JS integration path.
    */
-  static async getInitialProps(_ctx: DocumentContext): Promise<DocumentInitialProps> {
-    return { html: "" };
+  static getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    return ctx.defaultGetInitialProps(ctx);
   }
 
   render(): React.ReactNode {

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -50,24 +50,28 @@ export function NextScript() {
 }
 
 /**
- * Loose stand-ins for Next.js's `DocumentContext` / `DocumentInitialProps`.
- * The shim doesn't currently invoke `getInitialProps` on user `_document.tsx`
- * files (separate gap), but the signatures here match Next.js's so subclasses
- * that delegate via `await Document.getInitialProps(ctx)` typecheck against
- * the same shape they'd see under real Next.js.
+ * Stand-ins for Next.js's `DocumentContext` / `DocumentInitialProps`.
+ * The signatures match Next.js so custom `_document.tsx` subclasses can use
+ * `ctx.renderPage()` enhancers and delegate through
+ * `await Document.getInitialProps(ctx)` with the expected public types.
  *
  * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/utils.ts
  */
 export type DocumentContext = {
   // The full `DocumentContext` includes `renderPage`, `defaultGetInitialProps`,
   // and the inherited `NextPageContext` (`pathname`, `query`, `req`, `res`,
-  // `err`, `asPath`, ...). They're declared as optional here because vinext
-  // does not yet plumb them through; widening to optional avoids forcing user
-  // code to assert their presence.
-  renderPage?: (options?: {
-    enhanceApp?: (App: React.ComponentType<{ children?: React.ReactNode }>) => unknown;
-    enhanceComponent?: (Comp: React.ComponentType<unknown>) => unknown;
-  }) => { html: string; head?: ReadonlyArray<React.ReactElement> };
+  // `err`, `asPath`, ...). They're declared as optional because the dev error
+  // renderer and compatibility paths may provide only a partial context.
+  renderPage?: (
+    options?:
+      | {
+          enhanceApp?: (
+            App: React.ComponentType<{ children?: React.ReactNode }>,
+          ) => React.ComponentType<{ children?: React.ReactNode }>;
+          enhanceComponent?: (Comp: React.ComponentType<unknown>) => React.ComponentType<unknown>;
+        }
+      | ((Comp: React.ComponentType<unknown>) => React.ComponentType<unknown>),
+  ) => DocumentInitialProps | Promise<DocumentInitialProps>;
   defaultGetInitialProps?: (
     ctx: DocumentContext,
     options?: { nonce?: string },
@@ -103,11 +107,9 @@ export type DocumentInitialProps = {
 export default class Document<P = {}> extends React.Component<P & { children?: React.ReactNode }> {
   /**
    * `getInitialProps` is invoked by the SSR pipeline. The default implementation
-   * is a stub: vinext does not yet plumb the Pages Router `renderPage` /
-   * `defaultGetInitialProps` chain into the SSR entry, so subclasses that
-   * delegate via `await Document.getInitialProps(ctx)` receive an empty shell
-   * (`html: ""`). This matches the runtime contract user code expects without
-   * pretending the chain is wired up.
+   * returns an empty shell because the runtime-provided
+   * `ctx.defaultGetInitialProps()` owns the actual page render and style
+   * collection when custom Documents delegate through it.
    */
   static async getInitialProps(_ctx: DocumentContext): Promise<DocumentInitialProps> {
     return { html: "" };

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -66,7 +66,7 @@ declare module "next/document" {
     styles?: ReactElement[] | Iterable<ReactNode> | ReactElement;
   };
   export type DocumentContext = {
-    renderPage?: (
+    renderPage: (
       options?:
         | {
             enhanceApp?: (
@@ -76,7 +76,7 @@ declare module "next/document" {
           }
         | ((Comp: ComponentType<unknown>) => ComponentType<unknown>),
     ) => DocumentInitialProps | Promise<DocumentInitialProps>;
-    defaultGetInitialProps?: (
+    defaultGetInitialProps: (
       ctx: DocumentContext,
       options?: { nonce?: string },
     ) => Promise<DocumentInitialProps>;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -66,10 +66,16 @@ declare module "next/document" {
     styles?: ReactElement[] | Iterable<ReactNode> | ReactElement;
   };
   export type DocumentContext = {
-    renderPage?: (options?: {
-      enhanceApp?: (App: ComponentType<{ children?: ReactNode }>) => unknown;
-      enhanceComponent?: (Comp: ComponentType<unknown>) => unknown;
-    }) => { html: string; head?: ReadonlyArray<ReactElement> };
+    renderPage?: (
+      options?:
+        | {
+            enhanceApp?: (
+              App: ComponentType<{ children?: ReactNode }>,
+            ) => ComponentType<{ children?: ReactNode }>;
+            enhanceComponent?: (Comp: ComponentType<unknown>) => ComponentType<unknown>;
+          }
+        | ((Comp: ComponentType<unknown>) => ComponentType<unknown>),
+    ) => DocumentInitialProps | Promise<DocumentInitialProps>;
     defaultGetInitialProps?: (
       ctx: DocumentContext,
       options?: { nonce?: string },

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -132,14 +132,12 @@ describe("Document base class", () => {
     expect(html).toContain("__NEXT_SCRIPTS__");
   });
 
-  it("exposes a static getInitialProps that resolves to a DocumentInitialProps-shaped value", async () => {
-    // The runtime contract: subclasses commonly delegate via
-    // `await Document.getInitialProps(ctx)` and destructure `html` from the
-    // result. The stub returns an empty html shell — the test pins the shape
-    // so wiring up the full Pages Router renderPage flow later doesn't
-    // silently regress consumers that destructure `html`.
-    const result = await Document.getInitialProps({});
-    expect(typeof result.html).toBe("string");
+  it("delegates static getInitialProps to ctx.defaultGetInitialProps", async () => {
+    const defaultGetInitialProps = async () => ({ html: "<main>page</main>" });
+    const context = { defaultGetInitialProps } as never;
+    await expect(Document.getInitialProps(context)).resolves.toEqual({
+      html: "<main>page</main>",
+    });
   });
 });
 
@@ -164,12 +162,7 @@ describe("loadUserDocumentInitialProps", () => {
     const props = await loadUserDocumentInitialProps(MyDocument as React.ComponentType);
     expect(props).not.toBeNull();
     expect(props!.docValue).toBe("doc value");
-    // The base Document.getInitialProps contract is to return { html: "" } so
-    // `await Document.getInitialProps(ctx)` spreads `{ html: "" }` into the
-    // resulting props. This pins that contract — the dev-server / prod
-    // response builder render `<Document {...docProps} />` and consumers may
-    // read either field.
-    expect(typeof props!.html).toBe("string");
+    expect(props!.html).toBe("");
   });
 
   it("returns null when the user did not override the base getInitialProps", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -607,6 +607,43 @@ describe("pages page response", () => {
     expect(html).toContain("<p>page</p>");
   });
 
+  it("uses custom document html and styles without calling renderPage", async () => {
+    const common = createCommonOptions();
+
+    function MyDocument() {
+      return null;
+    }
+    (MyDocument as unknown as { getInitialProps: unknown }).getInitialProps = async () => ({
+      html: '<article id="manual-document-html">MANUAL</article>',
+      styles: React.createElement(
+        "style",
+        { "data-manual-document-style": true },
+        ".manual{color:blue}",
+      ),
+    });
+
+    const enhancePageElement = vi.fn(() => React.createElement("p", null, "page"));
+    const reactDomServer = await import("react-dom/server.edge");
+    const renderToReadableStream = vi.fn(async (element: React.ReactNode) =>
+      reactDomServer.renderToReadableStream(element as React.ReactElement),
+    );
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      DocumentComponent: MyDocument as unknown as React.ComponentType,
+      enhancePageElement,
+      renderToReadableStream,
+    });
+    const html = await response.text();
+
+    expect(html).toContain('id="manual-document-html">MANUAL');
+    expect(html).toContain("data-manual-document-style");
+    expect(html).toContain(".manual{color:blue}");
+    expect(html).not.toContain("live-body");
+    expect(enhancePageElement).not.toHaveBeenCalled();
+    expect(renderToReadableStream).toHaveBeenCalledTimes(1);
+  });
+
   it("propagates _document.getInitialProps errors without rendering the page", async () => {
     const common = createCommonOptions();
 

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -630,33 +630,62 @@ describe("pages page response", () => {
     expect(enhancePageElement).not.toHaveBeenCalled();
   });
 
-  // Edge case: a user `getInitialProps` that never calls `renderPage` (it only
-  // returns head/styles) must fall back to the normal streaming render so the
-  // body content is still produced.
-  it("falls back to streaming render when getInitialProps never calls renderPage", async () => {
+  it.each([undefined, null, 42, {}])(
+    "rejects invalid _document html %j without rendering the page",
+    async (html) => {
+      const common = createCommonOptions();
+
+      function MyDocument() {
+        return null;
+      }
+      (MyDocument as unknown as { getInitialProps: unknown }).getInitialProps = async () => ({
+        html,
+      });
+
+      const enhancePageElement = vi.fn(() => React.createElement("p", null, "enhanced"));
+      const renderToReadableStream = vi.fn(common.options.renderToReadableStream);
+
+      await expect(
+        renderPagesPageResponse({
+          ...common.options,
+          DocumentComponent: MyDocument as unknown as React.ComponentType,
+          enhancePageElement,
+          renderToReadableStream,
+        }),
+      ).rejects.toThrow('should resolve to an object with a "html" prop');
+
+      expect(enhancePageElement).not.toHaveBeenCalled();
+      expect(renderToReadableStream).not.toHaveBeenCalled();
+    },
+  );
+
+  it("propagates _document style serialization errors", async () => {
     const common = createCommonOptions();
 
     function MyDocument() {
       return null;
     }
-    // Returns props without ever invoking ctx.renderPage.
-    (MyDocument as unknown as { getInitialProps: unknown }).getInitialProps = async () => ({
-      custom: "value",
-    });
+    (MyDocument as unknown as { getInitialProps: unknown }).getInitialProps = async (ctx: {
+      renderPage: () => Promise<{ html: string }>;
+    }) => ({ ...(await ctx.renderPage()), styles: React.createElement("style") });
 
     const enhancePageElement = vi.fn(() => React.createElement("p", null, "enhanced"));
-
-    const response = await renderPagesPageResponse({
-      ...common.options,
-      DocumentComponent: MyDocument as unknown as React.ComponentType,
-      enhancePageElement,
+    const renderToReadableStream = vi.fn(async () => {
+      if (renderToReadableStream.mock.calls.length === 1) return createStream(["enhanced"]);
+      throw new Error("style serialization failed");
     });
 
-    const html = await response.text();
-    // Body came from the streaming fallback, not renderPage.
-    expect(html).toContain("live-body");
-    expect(html).not.toContain("enhanced");
-    expect(enhancePageElement).not.toHaveBeenCalled();
+    await expect(
+      renderPagesPageResponse({
+        ...common.options,
+        DocumentComponent: MyDocument as unknown as React.ComponentType,
+        enhancePageElement,
+        renderToReadableStream,
+      }),
+    ).rejects.toThrow("style serialization failed");
+
+    expect(enhancePageElement).toHaveBeenCalledTimes(1);
+    expect(renderToReadableStream).toHaveBeenCalledTimes(2);
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -607,11 +607,8 @@ describe("pages page response", () => {
     expect(html).toContain("<p>page</p>");
   });
 
-  // Edge case: a user `getInitialProps` that throws must not crash the render —
-  // the pipeline logs and falls back to the normal streaming page render.
-  it("falls back to streaming render when _document.getInitialProps throws", async () => {
+  it("propagates _document.getInitialProps errors without rendering the page", async () => {
     const common = createCommonOptions();
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     function MyDocument() {
       return null;
@@ -622,24 +619,15 @@ describe("pages page response", () => {
 
     const enhancePageElement = vi.fn(() => React.createElement("p", null, "enhanced"));
 
-    const response = await renderPagesPageResponse({
-      ...common.options,
-      DocumentComponent: MyDocument as unknown as React.ComponentType,
-      enhancePageElement,
-    });
+    await expect(
+      renderPagesPageResponse({
+        ...common.options,
+        DocumentComponent: MyDocument as unknown as React.ComponentType,
+        enhancePageElement,
+      }),
+    ).rejects.toThrow("boom");
 
-    const html = await response.text();
-    // Fell back to the default streaming render (the common mock body), not
-    // the enhanced renderPage output.
-    expect(html).toContain("live-body");
-    expect(html).not.toContain("enhanced");
-    // enhancePageElement is only reached inside renderPage, which never ran.
     expect(enhancePageElement).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(
-      "[vinext] _document.getInitialProps() threw:",
-      expect.any(Error),
-    );
-    errorSpy.mockRestore();
   });
 
   // Edge case: a user `getInitialProps` that never calls `renderPage` (it only
@@ -1263,12 +1251,8 @@ describe("pages page response", () => {
     }
   });
 
-  // Edge case: `renderPage` is called but the underlying stream render throws.
-  // The error propagates out of `getInitialProps`, is caught by the shared
-  // helper, and the pipeline falls back to the normal streaming render.
-  it("falls back to streaming render when renderPage's stream render throws", async () => {
+  it("propagates renderPage errors without a fallback render", async () => {
     const common = createCommonOptions();
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     function MyDocument() {
       return null;
@@ -1284,30 +1268,90 @@ describe("pages page response", () => {
 
     const enhancePageElement = vi.fn(() => React.createElement("p", null, "enhanced"));
 
-    let renderCall = 0;
-    const response = await renderPagesPageResponse({
-      ...common.options,
-      DocumentComponent: MyDocument as unknown as React.ComponentType,
-      enhancePageElement,
-      renderToReadableStream: vi.fn(async () => {
-        renderCall += 1;
-        // First call is renderPage's render (throw); a later fallback call must
-        // succeed so the page still renders.
-        if (renderCall === 1) throw new Error("stream render failed");
-        return createStream(["<div>live-body</div>"]);
-      }),
+    const renderToReadableStream = vi.fn(async () => {
+      throw new Error("stream render failed");
     });
+    await expect(
+      renderPagesPageResponse({
+        ...common.options,
+        DocumentComponent: MyDocument as unknown as React.ComponentType,
+        enhancePageElement,
+        renderToReadableStream,
+      }),
+    ).rejects.toThrow("stream render failed");
 
-    const html = await response.text();
-    // renderPage was reached (enhancePageElement ran) but the throw bubbled up
-    // and the pipeline fell back to the normal streaming render.
     expect(enhancePageElement).toHaveBeenCalledTimes(1);
-    expect(html).toContain("live-body");
-    expect(html).not.toContain("enhanced");
-    expect(errorSpy).toHaveBeenCalledWith(
-      "[vinext] _document.getInitialProps() threw:",
-      expect.any(Error),
+    expect(renderToReadableStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a throwing enhancer without rendering the page", async () => {
+    const common = createCommonOptions();
+
+    function MyDocument() {
+      return null;
+    }
+    (MyDocument as unknown as { getInitialProps: unknown }).getInitialProps = async (ctx: {
+      renderPage: (enhancer: (Comp: React.ComponentType) => React.ComponentType) => Promise<{
+        html: string;
+      }>;
+    }) =>
+      ctx.renderPage(() => {
+        throw new Error("enhancer failed");
+      });
+
+    const enhancePageElement = vi.fn(
+      (opts: {
+        enhanceApp?: (App: React.ComponentType<{ children?: React.ReactNode }>) => unknown;
+        enhanceComponent?: (Comp: React.ComponentType<unknown>) => unknown;
+      }) => {
+        opts.enhanceComponent?.(() => null);
+        return React.createElement("p", null, "unreachable");
+      },
     );
-    errorSpy.mockRestore();
+    const renderToReadableStream = vi.fn(async () => createStream(["unreachable"]));
+
+    await expect(
+      renderPagesPageResponse({
+        ...common.options,
+        DocumentComponent: MyDocument as unknown as React.ComponentType,
+        enhancePageElement,
+        renderToReadableStream,
+      }),
+    ).rejects.toThrow("enhancer failed");
+
+    expect(enhancePageElement).toHaveBeenCalledTimes(1);
+    expect(renderToReadableStream).not.toHaveBeenCalled();
+  });
+
+  it("propagates a throwing page after one renderer invocation", async () => {
+    const common = createCommonOptions();
+
+    function MyDocument() {
+      return null;
+    }
+    (MyDocument as unknown as { getInitialProps: unknown }).getInitialProps = async (ctx: {
+      renderPage: () => Promise<{ html: string }>;
+    }) => ctx.renderPage();
+
+    function ThrowingPage(): React.ReactNode {
+      throw new Error("page failed");
+    }
+    const enhancePageElement = vi.fn(() => React.createElement(ThrowingPage));
+    const reactDomServer = await import("react-dom/server.edge");
+    const renderToReadableStream = vi.fn(async (element: React.ReactNode) =>
+      reactDomServer.renderToReadableStream(element as React.ReactElement),
+    );
+
+    await expect(
+      renderPagesPageResponse({
+        ...common.options,
+        DocumentComponent: MyDocument as unknown as React.ComponentType,
+        enhancePageElement,
+        renderToReadableStream,
+      }),
+    ).rejects.toThrow("page failed");
+
+    expect(enhancePageElement).toHaveBeenCalledTimes(1);
+    expect(renderToReadableStream).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5279,6 +5279,126 @@ describe("Production server middleware (Pages Router)", () => {
   });
 });
 
+describe("Pages _document renderPage enhancers", () => {
+  let fixtureRoot: string;
+  let devServer: ViteDevServer;
+  let devUrl: string;
+  let prodServer: import("node:http").Server;
+  let prodUrl: string;
+  let outDir: string;
+
+  const enhancerCases = [
+    ["withEnhancer=true", ["render-page-enhance-component"]],
+    ["withEnhanceComponent=true", ["render-page-enhance-component"]],
+    ["withEnhanceApp=true", ["render-page-enhance-app"]],
+    [
+      "withEnhanceComponent=true&withEnhanceApp=true",
+      ["render-page-enhance-component", "render-page-enhance-app"],
+    ],
+  ] as const;
+
+  beforeAll(async () => {
+    fixtureRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-"));
+    outDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-out-"));
+    await fsp.symlink(
+      path.resolve(import.meta.dirname, "../node_modules"),
+      path.join(fixtureRoot, "node_modules"),
+      "junction",
+    );
+    await fsp.symlink(
+      path.resolve(import.meta.dirname, "../node_modules"),
+      path.join(outDir, "node_modules"),
+      "junction",
+    );
+    await fsp.mkdir(path.join(fixtureRoot, "pages"), { recursive: true });
+    await fsp.writeFile(
+      path.join(fixtureRoot, "package.json"),
+      JSON.stringify({ private: true, dependencies: { next: "*", react: "*", "react-dom": "*" } }),
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "_app.tsx"),
+      `export default function App({ Component, pageProps }: any) {
+  return <main id="app-shell"><Component {...pageProps} /></main>;
+}
+`,
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "index.tsx"),
+      `export default function Page() {
+  return <p id="page-content">PAGE</p>;
+}
+`,
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "_document.tsx"),
+      `import Document, { Html, Head, Main, NextScript } from "next/document";
+export default class CustomDocument extends Document {
+  static async getInitialProps(ctx: any) {
+    const enhanceComponent = (Component: any) => (props: any) => (
+      <div><span id="render-page-enhance-component">RENDERED</span><Component {...props} /></div>
+    );
+    const enhanceApp = (App: any) => (props: any) => (
+      <div><span id="render-page-enhance-app">RENDERED</span><App {...props} /></div>
+    );
+    let options;
+    if (ctx.query.withEnhancer) {
+      options = enhanceComponent;
+    } else if (ctx.query.withEnhanceComponent || ctx.query.withEnhanceApp) {
+      options = {
+        enhanceComponent: ctx.query.withEnhanceComponent ? enhanceComponent : undefined,
+        enhanceApp: ctx.query.withEnhanceApp ? enhanceApp : undefined,
+      };
+    }
+    return { ...(await ctx.renderPage(options)), documentProp: "DOCUMENT" };
+  }
+  render() {
+    return (
+      <Html><Head /><body><p id="document-prop">{(this.props as any).documentProp}</p><Main /><NextScript /></body></Html>
+    );
+  }
+}
+`,
+    );
+
+    const dev = await startFixtureServer(fixtureRoot);
+    devServer = dev.server;
+    devUrl = dev.baseUrl;
+
+    await buildPagesFixtureToOutDir(fixtureRoot, outDir);
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    prodServer = unwrapStartedProdServer(
+      await startProdServer({ port: 0, host: "127.0.0.1", outDir }),
+    );
+    const address = prodServer.address() as { port: number };
+    prodUrl = `http://127.0.0.1:${address.port}`;
+  }, 120000);
+
+  afterAll(async () => {
+    await devServer?.close();
+    if (prodServer) await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+    if (fixtureRoot) fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    if (outDir) fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  // Ported from Next.js: test/e2e/app-document/rendering.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-document/rendering.test.ts
+  it.each(["dev", "prod"] as const)("applies all renderPage enhancer forms in %s", async (mode) => {
+    const url = mode === "dev" ? devUrl : prodUrl;
+    for (const [query, expectedIds] of enhancerCases) {
+      const response = await fetch(`${url}/?${query}`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain('id="document-prop">DOCUMENT');
+      expect(html).toContain('id="page-content">PAGE');
+      expect(html.match(/id="page-content"/g)).toHaveLength(1);
+      for (const id of expectedIds) {
+        expect(html).toContain(`id="${id}">RENDERED`);
+        expect(html.match(new RegExp(`id="${id}"`, "g"))).toHaveLength(1);
+      }
+    }
+  });
+});
+
 describe("Production Pages Router SSR streaming", () => {
   let outDir: string;
   let prodServer: import("node:http").Server;

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5323,27 +5323,68 @@ describe("Pages _document renderPage enhancers", () => {
 `,
     );
     await fsp.writeFile(
+      path.join(fixtureRoot, "render-counts.ts"),
+      `export const renderCounts = { enhancer: 0, page: 0 };
+`,
+    );
+    await fsp.writeFile(
       path.join(fixtureRoot, "pages", "index.tsx"),
-      `export default function Page() {
+      `import { renderCounts } from "../render-counts";
+export function getServerSideProps({ query }: any) {
+  renderCounts.enhancer = 0;
+  renderCounts.page = 0;
+  return { props: { throwPage: query.throwPage === "true" } };
+}
+export default function Page({ throwPage }: { throwPage: boolean }) {
+  if (throwPage) {
+    renderCounts.page += 1;
+    throw new Error("page render failed");
+  }
   return <p id="page-content">PAGE</p>;
 }
 `,
     );
     await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "_error.tsx"),
+      `import { renderCounts } from "../render-counts";
+function ErrorPage({ message }: { message: string }) {
+  return (
+    <div id="error-page">
+      <p id="error-message">{message}</p>
+      <p id="enhancer-render-count">{renderCounts.enhancer}</p>
+      <p id="page-render-count">{renderCounts.page}</p>
+    </div>
+  );
+}
+ErrorPage.getInitialProps = ({ err }: any) => ({
+  message: err instanceof Error ? err.message : String(err),
+});
+export default ErrorPage;
+`,
+    );
+    await fsp.writeFile(
       path.join(fixtureRoot, "pages", "_document.tsx"),
       `import Document, { Html, Head, Main, NextScript } from "next/document";
+import { renderCounts } from "../render-counts";
 export default class CustomDocument extends Document {
   static async getInitialProps(ctx: any) {
+    if (!ctx.renderPage) return Document.getInitialProps(ctx);
     const enhanceComponent = (Component: any) => (props: any) => (
       <div><span id="render-page-enhance-component">RENDERED</span><Component {...props} /></div>
     );
     const enhanceApp = (App: any) => (props: any) => (
       <div><span id="render-page-enhance-app">RENDERED</span><App {...props} /></div>
     );
+    const throwEnhancer = (_Component: any) => {
+      renderCounts.enhancer += 1;
+      throw new Error("enhancer render failed");
+    };
     let options;
-    if (ctx.query.withEnhancer) {
+    if (ctx.pathname !== "/_error" && ctx.query?.throwEnhancer) {
+      options = throwEnhancer;
+    } else if (ctx.query?.withEnhancer) {
       options = enhanceComponent;
-    } else if (ctx.query.withEnhanceComponent || ctx.query.withEnhanceApp) {
+    } else if (ctx.query?.withEnhanceComponent || ctx.query?.withEnhanceApp) {
       options = {
         enhanceComponent: ctx.query.withEnhanceComponent ? enhanceComponent : undefined,
         enhanceApp: ctx.query.withEnhanceApp ? enhanceApp : undefined,
@@ -5397,6 +5438,35 @@ export default class CustomDocument extends Document {
       }
     }
   });
+
+  it.each(["dev", "prod"] as const)(
+    "routes throwing renderPage enhancers through the error page once in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/?throwEnhancer=true`);
+      expect(response.status).toBe(500);
+      const html = await response.text();
+      expect(html).toContain('id="error-page"');
+      expect(html).toContain('id="error-message">enhancer render failed');
+      expect(html).toContain('id="enhancer-render-count">1');
+      expect(html).toContain('id="page-render-count">0');
+      expect(html).not.toContain('id="page-content"');
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "routes throwing page renders through the error page once in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/?throwPage=true`);
+      expect(response.status).toBe(500);
+      const html = await response.text();
+      expect(html).toContain('id="error-page"');
+      expect(html).toContain('id="error-message">page render failed');
+      expect(html).toContain('id="enhancer-render-count">0');
+      expect(html).not.toContain('id="page-content"');
+    },
+  );
 });
 
 describe("Production Pages Router SSR streaming", () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5379,6 +5379,9 @@ export default class CustomDocument extends Document {
       renderCounts.enhancer += 1;
       throw new Error("enhancer render failed");
     };
+    const ThrowingStyle = () => {
+      throw new Error("style serialization failed");
+    };
     let options;
     if (ctx.pathname !== "/_error" && ctx.query?.throwEnhancer) {
       options = throwEnhancer;
@@ -5390,7 +5393,18 @@ export default class CustomDocument extends Document {
         enhanceApp: ctx.query.withEnhanceApp ? enhanceApp : undefined,
       };
     }
-    return { ...(await ctx.renderPage(options)), documentProp: "DOCUMENT" };
+    if (ctx.pathname !== "/_error" && ctx.query?.invalidDocumentHtml) return { html: null };
+    const originalRenderPage = ctx.renderPage;
+    ctx.renderPage = () => originalRenderPage(options);
+    const initialProps = await Document.getInitialProps(ctx);
+    return {
+      ...initialProps,
+      styles:
+        ctx.pathname !== "/_error" && ctx.query?.throwStyles
+          ? <ThrowingStyle />
+          : initialProps.styles,
+      documentProp: "DOCUMENT",
+    };
   }
   render() {
     return (
@@ -5464,6 +5478,32 @@ export default class CustomDocument extends Document {
       expect(html).toContain('id="error-page"');
       expect(html).toContain('id="error-message">page render failed');
       expect(html).toContain('id="enhancer-render-count">0');
+      expect(html).not.toContain('id="page-content"');
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "routes invalid document html through the error page in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/?invalidDocumentHtml=true`);
+      expect(response.status).toBe(500);
+      const html = await response.text();
+      expect(html).toContain('id="error-page"');
+      expect(html).toContain("should resolve to an object with a");
+      expect(html).not.toContain('id="page-content"');
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "routes document style serialization failures through the error page in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/?throwStyles=true`);
+      expect(response.status).toBe(500);
+      const html = await response.text();
+      expect(html).toContain('id="error-page"');
+      expect(html).toContain('id="error-message">style serialization failed');
       expect(html).not.toContain('id="page-content"');
     },
   );

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5418,6 +5418,14 @@ export default class CustomDocument extends Document {
       };
     }
     if (ctx.pathname !== "/_error" && ctx.query?.invalidDocumentHtml) return { html: null };
+    if (ctx.query?.manualDocumentHtml) {
+      return {
+        html: '<article id="manual-document-html">MANUAL</article>',
+        styles: <style data-manual-document-style>{".manual{color:blue}"}</style>,
+        documentProp: "DOCUMENT",
+        documentErrorContext: "",
+      };
+    }
     const originalRenderPage = ctx.renderPage;
     ctx.renderPage = () =>
       originalRenderPage(
@@ -5485,6 +5493,21 @@ export default class CustomDocument extends Document {
       }
     }
   });
+
+  it.each(["dev", "prod"] as const)(
+    "uses direct document html and styles without rendering the page in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/?manualDocumentHtml=true`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain('id="manual-document-html">MANUAL');
+      expect(html).toContain("data-manual-document-style");
+      expect(html).toContain(".manual{color:blue}");
+      expect(html).not.toContain('id="page-content"');
+      expect(html).not.toContain('id="app-shell"');
+    },
+  );
 
   it.each(["dev", "prod"] as const)(
     "routes throwing renderPage enhancers through the error page once in %s",

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5297,6 +5297,25 @@ describe("Pages _document renderPage enhancers", () => {
     ],
   ] as const;
 
+  function expectErrorDocument(
+    html: string,
+    expectedMessage: string | RegExp,
+    expectedQueryKey: string,
+  ): void {
+    expect(html).toContain('id="error-page"');
+    if (typeof expectedMessage === "string") {
+      expect(html).toContain(`id="error-message">${expectedMessage}`);
+    } else {
+      expect(html).toMatch(expectedMessage);
+    }
+    expect(html).toContain(`id="document-error-context">/_error|${expectedQueryKey}|`);
+    expect(html.match(/id="document-error-enhancer"/g)).toHaveLength(1);
+    expect(html.match(/data-error-document-style/g)).toHaveLength(1);
+    expect(html).toContain(".error-document{color:red}");
+    expect(html).toContain('id="error-render-count">1');
+    expect(html).not.toContain('id="page-content"');
+  }
+
   beforeAll(async () => {
     fixtureRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-"));
     outDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-out-"));
@@ -5324,7 +5343,7 @@ describe("Pages _document renderPage enhancers", () => {
     );
     await fsp.writeFile(
       path.join(fixtureRoot, "render-counts.ts"),
-      `export const renderCounts = { enhancer: 0, page: 0 };
+      `export const renderCounts = { enhancer: 0, page: 0, error: 0 };
 `,
     );
     await fsp.writeFile(
@@ -5333,6 +5352,7 @@ describe("Pages _document renderPage enhancers", () => {
 export function getServerSideProps({ query }: any) {
   renderCounts.enhancer = 0;
   renderCounts.page = 0;
+  renderCounts.error = 0;
   return { props: { throwPage: query.throwPage === "true" } };
 }
 export default function Page({ throwPage }: { throwPage: boolean }) {
@@ -5348,11 +5368,13 @@ export default function Page({ throwPage }: { throwPage: boolean }) {
       path.join(fixtureRoot, "pages", "_error.tsx"),
       `import { renderCounts } from "../render-counts";
 function ErrorPage({ message }: { message: string }) {
+  renderCounts.error += 1;
   return (
     <div id="error-page">
       <p id="error-message">{message}</p>
       <p id="enhancer-render-count">{renderCounts.enhancer}</p>
       <p id="page-render-count">{renderCounts.page}</p>
+      <p id="error-render-count">{renderCounts.error}</p>
     </div>
   );
 }
@@ -5368,7 +5390,6 @@ export default ErrorPage;
 import { renderCounts } from "../render-counts";
 export default class CustomDocument extends Document {
   static async getInitialProps(ctx: any) {
-    if (!ctx.renderPage) return Document.getInitialProps(ctx);
     const enhanceComponent = (Component: any) => (props: any) => (
       <div><span id="render-page-enhance-component">RENDERED</span><Component {...props} /></div>
     );
@@ -5382,6 +5403,9 @@ export default class CustomDocument extends Document {
     const ThrowingStyle = () => {
       throw new Error("style serialization failed");
     };
+    const enhanceErrorComponent = (Component: any) => (props: any) => (
+      <div id="document-error-enhancer"><Component {...props} /></div>
+    );
     let options;
     if (ctx.pathname !== "/_error" && ctx.query?.throwEnhancer) {
       options = throwEnhancer;
@@ -5395,20 +5419,29 @@ export default class CustomDocument extends Document {
     }
     if (ctx.pathname !== "/_error" && ctx.query?.invalidDocumentHtml) return { html: null };
     const originalRenderPage = ctx.renderPage;
-    ctx.renderPage = () => originalRenderPage(options);
+    ctx.renderPage = () =>
+      originalRenderPage(
+        ctx.pathname === "/_error" ? { enhanceComponent: enhanceErrorComponent } : options,
+      );
     const initialProps = await Document.getInitialProps(ctx);
     return {
       ...initialProps,
       styles:
-        ctx.pathname !== "/_error" && ctx.query?.throwStyles
-          ? <ThrowingStyle />
-          : initialProps.styles,
+        ctx.pathname === "/_error"
+          ? <style data-error-document-style>{".error-document{color:red}"}</style>
+          : ctx.query?.throwStyles
+            ? <ThrowingStyle />
+            : initialProps.styles,
       documentProp: "DOCUMENT",
+      documentErrorContext:
+        ctx.pathname === "/_error"
+          ? [ctx.pathname, Object.keys(ctx.query ?? {})[0] ?? "", ctx.err?.message ?? ""].join("|")
+          : "",
     };
   }
   render() {
     return (
-      <Html><Head /><body><p id="document-prop">{(this.props as any).documentProp}</p><Main /><NextScript /></body></Html>
+      <Html><Head /><body><p id="document-prop">{(this.props as any).documentProp}</p><p id="document-error-context">{(this.props as any).documentErrorContext}</p><Main /><NextScript /></body></Html>
     );
   }
 }
@@ -5460,11 +5493,9 @@ export default class CustomDocument extends Document {
       const response = await fetch(`${url}/?throwEnhancer=true`);
       expect(response.status).toBe(500);
       const html = await response.text();
-      expect(html).toContain('id="error-page"');
-      expect(html).toContain('id="error-message">enhancer render failed');
+      expectErrorDocument(html, "enhancer render failed", "throwEnhancer");
       expect(html).toContain('id="enhancer-render-count">1');
       expect(html).toContain('id="page-render-count">0');
-      expect(html).not.toContain('id="page-content"');
     },
   );
 
@@ -5475,10 +5506,8 @@ export default class CustomDocument extends Document {
       const response = await fetch(`${url}/?throwPage=true`);
       expect(response.status).toBe(500);
       const html = await response.text();
-      expect(html).toContain('id="error-page"');
-      expect(html).toContain('id="error-message">page render failed');
+      expectErrorDocument(html, "page render failed", "throwPage");
       expect(html).toContain('id="enhancer-render-count">0');
-      expect(html).not.toContain('id="page-content"');
     },
   );
 
@@ -5489,9 +5518,11 @@ export default class CustomDocument extends Document {
       const response = await fetch(`${url}/?invalidDocumentHtml=true`);
       expect(response.status).toBe(500);
       const html = await response.text();
-      expect(html).toContain('id="error-page"');
-      expect(html).toContain("should resolve to an object with a");
-      expect(html).not.toContain('id="page-content"');
+      expectErrorDocument(
+        html,
+        /id="error-message">(?:&quot;|").+?\.getInitialProps\(\)(?:&quot;|") should resolve to an object with a (?:&quot;|")html(?:&quot;|") prop set with a valid html string/,
+        "invalidDocumentHtml",
+      );
     },
   );
 
@@ -5502,9 +5533,7 @@ export default class CustomDocument extends Document {
       const response = await fetch(`${url}/?throwStyles=true`);
       expect(response.status).toBe(500);
       const html = await response.text();
-      expect(html).toContain('id="error-page"');
-      expect(html).toContain('id="error-message">style serialization failed');
-      expect(html).not.toContain('id="page-content"');
+      expectErrorDocument(html, "style serialization failed", "throwStyles");
     },
   );
 });


### PR DESCRIPTION
## Summary

- support object and legacy function forms of `ctx.renderPage` enhancers
- make base `Document.getInitialProps(ctx)` delegate to `ctx.defaultGetInitialProps(ctx)` for canonical CSS-in-JS integrations
- preserve custom Document HTML/styles when `renderPage` is intentionally skipped
- propagate enhancer/document/style errors through the normal error-page pipeline
- align dev and production error Document context and prevent fallback/double renders
- update public Document typings

## Next.js parity

Fixes the `_document.getInitialProps().renderPage()` enhancer parity failures and supports documented styled-components/emotion integration patterns.

## Validation

- 364 document/pages response/router tests passed
- dev and production integration cases passed
- full `vp check` and vinext build passed
- repeated independent review; no actionable findings remain

Cache Components, PPR, and resume behavior are out of scope.
