### PR TITLE
fix(router): ignore superseded page loader failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,10 @@ jobs:
             label: pages-router
             shardIndex: 1
             shardTotal: 1
+          - project: pages-router-basepath-dev
+            label: pages-router-basepath-dev
+            shardIndex: 1
+            shardTotal: 1
           - project: app-router
             label: app-router 1/3
             shardIndex: 1

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1209,11 +1209,7 @@ export function createSSRHandler(
                         viteBase,
                       );
                       const regenAppUrl = RegenApp
-                        ? createPagesDevModuleUrl(
-                            viteRoot,
-                            path.join(pagesDir, "_app"),
-                            viteBase,
-                          )
+                        ? createPagesDevModuleUrl(viteRoot, path.join(pagesDir, "_app"), viteBase)
                         : null;
                       const freshPagesNextData = {
                         ...pagesNextData,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1201,14 +1201,19 @@ export function createSSRHandler(
                       // Rebuild __NEXT_DATA__ with fresh props. The hydration
                       // script (module URLs) is stable across regenerations —
                       // extract it from the cached HTML to avoid duplication.
-                      const viteRoot = server.config?.root;
-                      const regenPageUrl = viteRoot
-                        ? "/" + path.relative(viteRoot, route.filePath)
-                        : route.filePath;
+                      const viteRoot = server.config.root;
+                      const viteBase = server.config.base;
+                      const regenPageUrl = createPagesDevModuleUrl(
+                        viteRoot,
+                        route.filePath,
+                        viteBase,
+                      );
                       const regenAppUrl = RegenApp
-                        ? viteRoot
-                          ? "/" + path.relative(viteRoot, path.join(pagesDir, "_app"))
-                          : path.join(pagesDir, "_app")
+                        ? createPagesDevModuleUrl(
+                            viteRoot,
+                            path.join(pagesDir, "_app"),
+                            viteBase,
+                          )
                         : null;
                       const freshPagesNextData = {
                         ...pagesNextData,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -58,6 +58,7 @@ import {
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
+import { createPagesDevModuleUrl } from "./pages-dev-module-url.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 import {
   loadUserDocumentInitialProps,
@@ -1542,11 +1543,18 @@ export function createSSRHandler(
           fontHeadHTML += `<style data-vinext-fonts${nonceAttr}>${allFontStyles.join("\n")}</style>\n  `;
         }
 
-        // Convert absolute file paths to Vite-servable URLs (relative to root)
+        // Convert absolute file paths to Vite-servable URLs under the dev
+        // server's configured base. Vite rejects root-relative module requests
+        // when basePath config sets server.config.base to a non-root pathname.
         const viteRoot = server.config.root;
-        const pageModuleUrl = "/" + path.relative(viteRoot, route.filePath);
+        const viteBase = server.config.base;
+        const pageModuleUrl = createPagesDevModuleUrl(viteRoot, route.filePath, viteBase);
+        const pageModuleSource = createPagesDevModuleUrl(viteRoot, route.filePath, "/");
         const appModuleUrl = AppComponent
-          ? "/" + path.relative(viteRoot, path.join(pagesDir, "_app"))
+          ? createPagesDevModuleUrl(viteRoot, path.join(pagesDir, "_app"), viteBase)
+          : null;
+        const appModuleSource = AppComponent
+          ? createPagesDevModuleUrl(viteRoot, path.join(pagesDir, "_app"), "/")
           : null;
         const serializedPagesNextData = {
           ...pagesNextData,
@@ -1571,8 +1579,8 @@ const nextData = window.__NEXT_DATA__;
 const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};
 const rawPageProps = props.pageProps;
 const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};
-window.__VINEXT_PAGE_LOADERS__ = { [nextData.page]: () => import("${pageModuleUrl}") };
-window.__VINEXT_APP_LOADER__ = ${appModuleUrl ? `() => import("${appModuleUrl}")` : "undefined"};
+window.__VINEXT_PAGE_LOADERS__ = { [nextData.page]: () => import("${pageModuleSource}") };
+window.__VINEXT_APP_LOADER__ = ${appModuleSource ? `() => import("${appModuleSource}")` : "undefined"};
 
 async function hydrate() {
   let hydrateRootOptions;
@@ -1587,13 +1595,13 @@ async function hydrate() {
     };
   }
 
-  const pageModule = await import("${pageModuleUrl}");
+  const pageModule = await import("${pageModuleSource}");
   const PageComponent = pageModule.default;
   let element;
   ${
-    appModuleUrl
+    appModuleSource
       ? `
-  const appModule = await import("${appModuleUrl}");
+  const appModule = await import("${appModuleSource}");
   const AppComponent = appModule.default;
   window.__VINEXT_APP__ = AppComponent;
   element = React.createElement(AppComponent, {

--- a/packages/vinext/src/server/pages-dev-module-url.ts
+++ b/packages/vinext/src/server/pages-dev-module-url.ts
@@ -6,7 +6,11 @@ function normalizeBase(base: string): string {
 }
 
 function encodeModulePath(modulePath: string): string {
-  return encodeURI(modulePath).replace(/\?/g, "%3F").replace(/#/g, "%23");
+  return encodeURI(modulePath)
+    .replace(/%5B/gi, "[")
+    .replace(/%5D/gi, "]")
+    .replace(/\?/g, "%3F")
+    .replace(/#/g, "%23");
 }
 
 export function createPagesDevModuleUrl(

--- a/packages/vinext/src/server/pages-dev-module-url.ts
+++ b/packages/vinext/src/server/pages-dev-module-url.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+
+function normalizeBase(base: string): string {
+  if (!base || base === "/") return "/";
+  return `/${base.replace(/^\/+|\/+$/g, "")}/`;
+}
+
+function encodeModulePath(modulePath: string): string {
+  return encodeURI(modulePath).replace(/\?/g, "%3F").replace(/#/g, "%23");
+}
+
+export function createPagesDevModuleUrl(
+  viteRoot: string,
+  moduleFilePath: string,
+  viteBase: string,
+): string {
+  const pathImpl = /^[A-Za-z]:[\\/]/.test(viteRoot) ? path.win32 : path;
+  const relativePath = pathImpl.relative(viteRoot, moduleFilePath).replace(/\\/g, "/");
+  return normalizeBase(viteBase) + encodeModulePath(relativePath);
+}

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -146,7 +146,7 @@ function renderPagesRouterElement(
       if (routerRuntimeState.cancelPendingRenderCommit === cancel) {
         routerRuntimeState.cancelPendingRenderCommit = null;
       }
-      reject(new NavigationCancelledError("superseded"));
+      reject(new NavigationCancelledError());
     };
     routerRuntimeState.cancelPendingRenderCommit = cancel;
 
@@ -403,6 +403,8 @@ type PagesRouterRuntimeState = {
   historyKeyCounter: number;
   navigationId: number;
   activeAbortController: AbortController | null;
+  activeNavigationEventUrl: string | null;
+  cancellationEventEmittedControllers: WeakSet<AbortController>;
   cancelPendingRenderCommit: (() => void) | null;
   beforePopStateCb?: BeforePopStateCallback;
   lastPathnameAndSearch: string;
@@ -430,6 +432,8 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
     historyKeyCounter: 0,
     navigationId: 0,
     activeAbortController: null,
+    activeNavigationEventUrl: null,
+    cancellationEventEmittedControllers: new WeakSet(),
     cancelPendingRenderCommit: null,
     lastPathnameAndSearch:
       typeof window !== "undefined" ? window.location.pathname + window.location.search : "",
@@ -643,15 +647,13 @@ export function isExternalUrl(url: string): boolean {
   return isAbsoluteOrProtocolRelativeUrl(url);
 }
 
-/** Resolve a hash URL to a basePath-stripped app URL for event payloads */
+/** Resolve a hash URL to the browser-facing URL used by router event payloads. */
 function resolveHashUrl(url: string): string {
   if (typeof window === "undefined") return url;
-  if (url.startsWith("#"))
-    return stripBasePath(window.location.pathname, __basePath) + window.location.search + url;
-  // Full-path hash URL — strip basePath for consistency with other events
+  if (url.startsWith("#")) return window.location.pathname + window.location.search + url;
   try {
     const parsed = new URL(url, window.location.href);
-    return stripBasePath(parsed.pathname, __basePath) + parsed.search + parsed.hash;
+    return parsed.pathname + parsed.search + parsed.hash;
   } catch {
     return url;
   }
@@ -1258,8 +1260,9 @@ function notifyNextNavigationPagesContext(): void {
  */
 class NavigationCancelledError extends Error {
   cancelled = true;
-  constructor(route: string) {
-    super(`Abort fetching component for route: "${route}"`);
+  eventEmitted = false;
+  constructor() {
+    super("Route Cancelled");
     this.name = "NavigationCancelledError";
   }
 }
@@ -1281,6 +1284,23 @@ function cancelPreviousRenderCommit(): void {
   routerRuntimeState.cancelPendingRenderCommit = null;
 }
 
+function cancelActiveNavigation(): void {
+  const cancelledEventUrl = routerRuntimeState.activeNavigationEventUrl;
+  const controller = routerRuntimeState.activeAbortController;
+  if (!controller || !cancelledEventUrl) return;
+
+  controller.abort();
+  cancelPreviousRenderCommit();
+  routerRuntimeState.navigationId += 1;
+  routerRuntimeState.activeAbortController = null;
+  routerRuntimeState.activeNavigationEventUrl = null;
+
+  routerRuntimeState.cancellationEventEmittedControllers.add(controller);
+  routerEvents.emit("routeChangeError", new NavigationCancelledError(), cancelledEventUrl, {
+    shallow: false,
+  });
+}
+
 function scheduleHardNavigationAndThrow(url: string, message: string): never {
   if (typeof window === "undefined") {
     throw new HardNavigationScheduledError(message);
@@ -1291,6 +1311,7 @@ function scheduleHardNavigationAndThrow(url: string, message: string): never {
 
 type NavigateClientOptions = {
   allowNotFoundResponse?: boolean;
+  commitNavigation?: (browserUrl: string) => void;
   /**
    * The history mode of the originating navigation. Used when a gSSP/gSP data
    * response carries a `__N_REDIRECT` marker so the re-entrant navigation to
@@ -1515,7 +1536,7 @@ async function navigateClientData(
   // Pre-await abort still throws so callers see the documented cancellation
   // surface when supersession happened before the fetch was even attempted.
   if (controller.signal.aborted) {
-    throw new NavigationCancelledError(url);
+    throw new NavigationCancelledError();
   }
   let res = prefetchedResponse;
   if (!res) {
@@ -1529,7 +1550,7 @@ async function navigateClientData(
       res = await dedupedPagesDataFetch(initialTarget.dataHref, { headers });
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") {
-        throw new NavigationCancelledError(url);
+        throw new NavigationCancelledError();
       }
       throw err;
     }
@@ -1545,9 +1566,14 @@ async function navigateClientData(
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
     }
 
-    window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    await navigateClientHtml(redirectedUrl, redirectedUrl, controller, navId, assertStillCurrent);
+    await navigateClientHtml(
+      redirectedUrl,
+      redirectedUrl,
+      controller,
+      navId,
+      assertStillCurrent,
+      options,
+    );
     return;
   }
 
@@ -1556,7 +1582,7 @@ async function navigateClientData(
     // reload to land on the new build's HTML. Any other non-OK status is
     // treated the same way per the user-configured "always hard reload"
     // fallback policy.
-    scheduleHardNavigationAndThrow(url, `Data navigation failed: ${res.status} ${res.statusText}`);
+    scheduleHardNavigationAndThrow(url, "Failed to load static props");
   }
 
   const rewriteTarget = res.headers.get("x-nextjs-rewrite");
@@ -1593,7 +1619,7 @@ async function navigateClientData(
   const redirectDestination = pageProps.__N_REDIRECT;
   if (typeof redirectDestination === "string") {
     handleDataRedirect(redirectDestination, pageProps.__N_REDIRECT_BASE_PATH, options.mode);
-    throw new NavigationCancelledError(url);
+    throw new NavigationCancelledError();
   }
 
   // Load the page module via the registered code-split loader. Vite has
@@ -1692,6 +1718,7 @@ async function navigateClientData(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
+  options.commitNavigation?.(url);
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
@@ -1717,7 +1744,6 @@ async function navigateClientHtml(
   options: NavigateClientOptions = {},
 ): Promise<void> {
   let browserUrl = url;
-  let pendingRedirectHistoryUrl: string | null = fetchUrl === url ? null : url;
   const root = window.__VINEXT_ROOT__;
   if (!root) {
     // No React root yet — fall back to hard navigation
@@ -1735,7 +1761,7 @@ async function navigateClientHtml(
   } catch (err: unknown) {
     // AbortError means a newer navigation cancelled this fetch
     if (err instanceof DOMException && err.name === "AbortError") {
-      throw new NavigationCancelledError(url);
+      throw new NavigationCancelledError();
     }
     throw err;
   }
@@ -1745,7 +1771,6 @@ async function navigateClientHtml(
     const redirectedUrl = resolveSameOriginRedirectedUrl(res.url);
     if (redirectedUrl) {
       browserUrl = redirectedUrl;
-      pendingRedirectHistoryUrl = redirectedUrl;
     }
   }
 
@@ -1759,10 +1784,7 @@ async function navigateClientHtml(
     // must NOT schedule a second hard navigation — this assignment already queues
     // the browser fallback, and the helper-level HardNavigationScheduledError
     // makes that contract explicit to callers.
-    scheduleHardNavigationAndThrow(
-      browserUrl,
-      `Navigation failed: ${res.status} ${res.statusText}`,
-    );
+    scheduleHardNavigationAndThrow(browserUrl, "Failed to load static props");
   }
 
   const html = await res.text();
@@ -1866,10 +1888,7 @@ async function navigateClientHtml(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
-  if (pendingRedirectHistoryUrl) {
-    window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-  }
+  options.commitNavigation?.(browserUrl);
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
@@ -1897,18 +1916,20 @@ async function navigateClient(
 ): Promise<void> {
   if (typeof window === "undefined") return;
 
-  // Cancel any in-flight navigation (abort its fetch, settle its render-commit wait)
-  routerRuntimeState.activeAbortController?.abort();
-  cancelPreviousRenderCommit();
+  // performNavigation cancels before emitting routeChangeStart so event order
+  // matches Next.js. Keep the shared entry-point guard for popstate and any
+  // future callers that invoke navigateClient without going through it.
+  cancelActiveNavigation();
   const controller = new AbortController();
   routerRuntimeState.activeAbortController = controller;
+  routerRuntimeState.activeNavigationEventUrl = url;
 
   const navId = ++routerRuntimeState.navigationId;
 
   /** Check if this navigation is still the active one. If not, throw. */
   function assertStillCurrent(): void {
     if (navId !== routerRuntimeState.navigationId) {
-      throw new NavigationCancelledError(url);
+      throw new NavigationCancelledError();
     }
   }
 
@@ -1931,7 +1952,7 @@ async function navigateClient(
           middlewareEffect = await resolveMiddlewareDataEffect(browserUrl, controller.signal);
         } catch (err: unknown) {
           if (err instanceof DOMException && err.name === "AbortError") {
-            throw new NavigationCancelledError(browserUrl);
+            throw new NavigationCancelledError();
           }
           throw err;
         }
@@ -1942,9 +1963,6 @@ async function navigateClient(
           if (!redirectedUrl) {
             scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
           }
-          window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-          routerRuntimeState.lastPathnameAndSearch =
-            window.location.pathname + window.location.search;
           browserUrl = redirectedUrl;
           htmlFetchUrl = redirectedUrl;
         } else if (middlewareEffect?.rewriteTarget) {
@@ -1974,10 +1992,19 @@ async function navigateClient(
         );
       }
     }
+  } catch (err: unknown) {
+    if (
+      err instanceof NavigationCancelledError &&
+      routerRuntimeState.cancellationEventEmittedControllers.delete(controller)
+    ) {
+      err.eventEmitted = true;
+    }
+    throw err;
   } finally {
     // Clean up the abort controller if this navigation is still the active one
     if (navId === routerRuntimeState.navigationId) {
       routerRuntimeState.activeAbortController = null;
+      routerRuntimeState.activeNavigationEventUrl = null;
     }
   }
 }
@@ -2004,7 +2031,10 @@ async function runNavigateClient(
     await navigateClient(fullUrl, fetchUrl, options);
     return "completed";
   } catch (err: unknown) {
-    routerEvents.emit("routeChangeError", err, resolvedUrl, { shallow: false });
+    const cancellationAlreadyEmitted = err instanceof NavigationCancelledError && err.eventEmitted;
+    if (!cancellationAlreadyEmitted) {
+      routerEvents.emit("routeChangeError", err, resolvedUrl, { shallow: false });
+    }
     if (err instanceof NavigationCancelledError) {
       return "cancelled";
     }
@@ -2259,6 +2289,7 @@ async function performNavigation(
 
   // Hash-only change — no page fetch needed
   if (options?._h !== 1 && isHashOnlyChange(full)) {
+    cancelActiveNavigation();
     // Snapshot the outgoing entry's scroll before updateHistory mints a new
     // key, so a later back-popstate restores the position the user had
     // reached here rather than {x: 0, y: 0}. Upstream snapshots inside
@@ -2300,6 +2331,7 @@ async function performNavigation(
     (appPathEntry !== undefined && "__appRouter" in appPathEntry && appPathEntry.__appRouter) ||
     ["app", "document"].includes(resolveHybridClientRouteOwner(resolved, __basePath) ?? "");
   if (appRouteDetected) {
+    cancelActiveNavigation();
     if (mode === "push") window.location.assign(full);
     else window.location.replace(full);
     return new Promise<boolean>(() => {});
@@ -2307,16 +2339,23 @@ async function performNavigation(
 
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
+  cancelActiveNavigation();
   if (!isQueryUpdating) {
-    routerEvents.emit("routeChangeStart", resolved, { shallow });
+    routerEvents.emit("routeChangeStart", full, { shallow });
   }
-  routerEvents.emit("beforeHistoryChange", resolved, { shallow });
-  updateHistory(mode, full, navState);
   if (!shallow) {
-    const result = await runNavigateClient(full, resolved, htmlFetchUrl, navigateOptions);
+    const result = await runNavigateClient(full, full, htmlFetchUrl, {
+      ...navigateOptions,
+      commitNavigation(browserUrl) {
+        routerEvents.emit("beforeHistoryChange", browserUrl, { shallow });
+        updateHistory(mode, browserUrl, navState);
+      },
+    });
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {
+    routerEvents.emit("beforeHistoryChange", full, { shallow });
+    updateHistory(mode, full, navState);
     // Shallow navigations skip the render-commit path, so apply the scroll
     // reset synchronously here — before routeChangeComplete. This matches the
     // non-shallow path, where the x/y reset runs inside the render-commit
@@ -2329,7 +2368,7 @@ async function performNavigation(
   }
   onStateUpdate?.();
   if (!isQueryUpdating) {
-    routerEvents.emit("routeChangeComplete", resolved, { shallow });
+    routerEvents.emit("routeChangeComplete", full, { shallow });
   }
   // Hash scrolling after routeChangeComplete, matching Next.js ordering:
   // x/y restoration happens during the render commit, then hash scrolling
@@ -2617,17 +2656,16 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     if (!shouldContinue) return;
   }
 
-  // Update trackers only after beforePopState confirms navigation proceeds.
-  // If beforePopState cancels, the app stays on the previous history entry,
-  // so both must retain their previous values: `lastPathnameAndSearch` so the
-  // next popstate compares against the correct baseline, and `currentHistoryKey`
-  // so subsequent scroll bookkeeping keys off the entry the app is actually on.
-  if (targetKey !== undefined) {
-    routerRuntimeState.currentHistoryKey = targetKey;
-  }
-  routerRuntimeState.lastPathnameAndSearch = browserUrl;
+  const adoptPopState = () => {
+    if (targetKey !== undefined) {
+      routerRuntimeState.currentHistoryKey = targetKey;
+    }
+    routerRuntimeState.lastPathnameAndSearch = browserUrl;
+  };
 
   if (isHashOnly) {
+    cancelActiveNavigation();
+    adoptPopState();
     // Hash-only back/forward — no page fetch needed.
     //
     // `forcedScroll` is intentionally discarded here: only the hash anchor is
@@ -2639,7 +2677,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     // path (.nextjs-ref/packages/next/src/shared/lib/router/router.ts around
     // L1381-1403 and L1780). The snapshot stays in sessionStorage, so a later
     // non-hash popstate to this entry still restores the saved position.
-    const hashUrl = appUrl + window.location.hash;
+    const hashUrl = browserUrl + window.location.hash;
     routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
     scrollToHashTarget(window.location.hash);
     routerEvents.emit("hashChangeComplete", hashUrl, { shallow: false });
@@ -2653,14 +2691,9 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   const stateLocale = isNextRouterState(state) ? state.options?.locale : undefined;
   const effectiveLocale = stateLocale ?? window.__VINEXT_LOCALE__;
 
-  const fullAppUrl = appUrl + window.location.hash;
-  routerEvents.emit("routeChangeStart", fullAppUrl, { shallow: false });
-  // Note: The browser has already updated window.location by the time popstate
-  // fires, so this is not truly "before" the URL change. In Next.js the popstate
-  // handler calls replaceState to store history metadata — beforeHistoryChange
-  // precedes that call, not the URL change itself. We emit it here for API
-  // compatibility.
-  routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow: false });
+  const fullBrowserUrl = browserUrl + window.location.hash;
+  cancelActiveNavigation();
+  routerEvents.emit("routeChangeStart", fullBrowserUrl, { shallow: false });
   void (async () => {
     // When manual scroll restoration is enabled we drive the position from the
     // sessionStorage snapshot keyed by history key. When it is disabled we
@@ -2679,12 +2712,18 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
       : readScrollPosition(state);
     const result = await runNavigateClient(
       browserUrl,
-      fullAppUrl,
+      fullBrowserUrl,
       getPagesHtmlFetchUrl(browserUrl, effectiveLocale),
-      { scroll: scrollTarget },
+      {
+        scroll: scrollTarget,
+        commitNavigation() {
+          routerEvents.emit("beforeHistoryChange", fullBrowserUrl, { shallow: false });
+          adoptPopState();
+        },
+      },
     );
     if (result === "completed") {
-      routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: false });
+      routerEvents.emit("routeChangeComplete", fullBrowserUrl, { shallow: false });
       dispatchNavigateEvent();
     }
     // "cancelled": superseded by a newer navigation, so this popstate no longer wins.

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1646,6 +1646,8 @@ async function navigateClientData(
     );
   }
 
+  options.commitNavigation?.(url);
+
   // Lazy-load `_app` if we have an app loader and haven't cached it yet.
   let AppComponent = window.__VINEXT_APP__;
   if (!AppComponent && typeof window.__VINEXT_APP_LOADER__ === "function") {
@@ -1722,7 +1724,6 @@ async function navigateClientData(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
-  options.commitNavigation?.(url);
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
@@ -1851,6 +1852,8 @@ async function navigateClientHtml(
     );
   }
 
+  options.commitNavigation?.(browserUrl);
+
   // Import React for createElement
   const React = (await import("react")).default;
   assertStillCurrent();
@@ -1892,7 +1895,6 @@ async function navigateClientHtml(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
-  options.commitNavigation?.(browserUrl);
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
@@ -2350,26 +2352,19 @@ async function performNavigation(
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", full, { shallow });
   }
-  if (isQueryOnlyNavigation) {
-    routerEvents.emit("beforeHistoryChange", full, { shallow });
-    updateHistory(mode, full, navState);
-  }
   if (!shallow) {
     const result = await runNavigateClient(full, full, htmlFetchUrl, {
       ...navigateOptions,
       commitNavigation(browserUrl) {
-        completedBrowserUrl = browserUrl;
-        if (isQueryOnlyNavigation) {
-          if (browserUrl !== full) updateHistory("replace", browserUrl, navState);
-        } else {
-          routerEvents.emit("beforeHistoryChange", browserUrl, { shallow });
-          updateHistory(mode, browserUrl, navState);
-        }
+        const historyUrl = isQueryOnlyNavigation ? full : browserUrl;
+        completedBrowserUrl = historyUrl;
+        routerEvents.emit("beforeHistoryChange", historyUrl, { shallow });
+        updateHistory(mode, historyUrl, navState);
       },
     });
     if (result === "cancelled") return true;
     if (result === "failed") return false;
-  } else if (!isQueryOnlyNavigation) {
+  } else {
     routerEvents.emit("beforeHistoryChange", full, { shallow });
     updateHistory(mode, full, navState);
     // Shallow navigations skip the render-commit path, so apply the scroll

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1284,7 +1284,7 @@ function cancelPreviousRenderCommit(): void {
   routerRuntimeState.cancelPendingRenderCommit = null;
 }
 
-function cancelActiveNavigation(): void {
+function cancelActiveNavigation(shallow = false): void {
   const cancelledEventUrl = routerRuntimeState.activeNavigationEventUrl;
   const controller = routerRuntimeState.activeAbortController;
   if (!controller || !cancelledEventUrl) return;
@@ -1297,7 +1297,7 @@ function cancelActiveNavigation(): void {
 
   routerRuntimeState.cancellationEventEmittedControllers.add(controller);
   routerEvents.emit("routeChangeError", new NavigationCancelledError(), cancelledEventUrl, {
-    shallow: false,
+    shallow,
   });
 }
 
@@ -2289,7 +2289,7 @@ async function performNavigation(
 
   // Hash-only change — no page fetch needed
   if (options?._h !== 1 && isHashOnlyChange(full)) {
-    cancelActiveNavigation();
+    cancelActiveNavigation(shallow);
     // Snapshot the outgoing entry's scroll before updateHistory mints a new
     // key, so a later back-popstate restores the position the user had
     // reached here rather than {x: 0, y: 0}. Upstream snapshots inside
@@ -2331,7 +2331,7 @@ async function performNavigation(
     (appPathEntry !== undefined && "__appRouter" in appPathEntry && appPathEntry.__appRouter) ||
     ["app", "document"].includes(resolveHybridClientRouteOwner(resolved, __basePath) ?? "");
   if (appRouteDetected) {
-    cancelActiveNavigation();
+    cancelActiveNavigation(shallow);
     if (mode === "push") window.location.assign(full);
     else window.location.replace(full);
     return new Promise<boolean>(() => {});
@@ -2339,7 +2339,7 @@ async function performNavigation(
 
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
-  cancelActiveNavigation();
+  cancelActiveNavigation(shallow);
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", full, { shallow });
   }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2339,6 +2339,7 @@ async function performNavigation(
 
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
+  let completedBrowserUrl = full;
   cancelActiveNavigation(shallow);
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", full, { shallow });
@@ -2347,6 +2348,7 @@ async function performNavigation(
     const result = await runNavigateClient(full, full, htmlFetchUrl, {
       ...navigateOptions,
       commitNavigation(browserUrl) {
+        completedBrowserUrl = browserUrl;
         routerEvents.emit("beforeHistoryChange", browserUrl, { shallow });
         updateHistory(mode, browserUrl, navState);
       },
@@ -2368,13 +2370,14 @@ async function performNavigation(
   }
   onStateUpdate?.();
   if (!isQueryUpdating) {
-    routerEvents.emit("routeChangeComplete", full, { shallow });
+    routerEvents.emit("routeChangeComplete", completedBrowserUrl, { shallow });
   }
   // Hash scrolling after routeChangeComplete, matching Next.js ordering:
   // x/y restoration happens during the render commit, then hash scrolling
   // happens after the completion event.
-  if (doScroll && hash && !shallow) {
-    scrollToHashTarget(hash);
+  if (doScroll && !shallow) {
+    const completedHash = extractHash(completedBrowserUrl);
+    if (completedHash) scrollToHashTarget(completedHash);
   }
   dispatchNavigateEvent();
   return true;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1633,6 +1633,7 @@ async function navigateClientData(
   try {
     pageModule = await target.loader();
   } catch (err) {
+    assertStillCurrent();
     console.error("[vinext] Page loader threw during navigation:", err);
     scheduleHardNavigationAndThrow(url, "Data navigation failed: page loader threw");
   }
@@ -1828,7 +1829,12 @@ async function navigateClientHtml(
     // React component identity stable for same-route param changes. Importing
     // the extracted chunk URL directly can evaluate a duplicate module when
     // the router runtime is split across entry and page chunks.
-    pageModule = await loader();
+    try {
+      pageModule = await loader();
+    } catch (err) {
+      assertStillCurrent();
+      throw err;
+    }
   } else if (!pageModuleUrl) {
     scheduleHardNavigationAndThrow(browserUrl, "Navigation failed: no page module URL found");
   } else {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -485,7 +485,11 @@ function getPagesRouterRuntimeComponents(): PagesRouterRuntimeComponents {
 
 function resolveUrl(url: string | UrlObject): string {
   if (typeof url === "string") return url;
-  let result = url.pathname ?? "/";
+  let result =
+    url.pathname ??
+    (typeof window === "undefined"
+      ? "/"
+      : stripBasePath(window.location.pathname, __basePath) || "/");
   if (url.query) {
     const params = urlQueryToSearchParams(url.query);
     result = appendSearchParamsToUrl(result, params);
@@ -2340,22 +2344,32 @@ async function performNavigation(
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
   let completedBrowserUrl = full;
+  const isQueryOnlyNavigation =
+    typeof url !== "string" && url.pathname === undefined && as === undefined;
   cancelActiveNavigation(shallow);
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", full, { shallow });
+  }
+  if (isQueryOnlyNavigation) {
+    routerEvents.emit("beforeHistoryChange", full, { shallow });
+    updateHistory(mode, full, navState);
   }
   if (!shallow) {
     const result = await runNavigateClient(full, full, htmlFetchUrl, {
       ...navigateOptions,
       commitNavigation(browserUrl) {
         completedBrowserUrl = browserUrl;
-        routerEvents.emit("beforeHistoryChange", browserUrl, { shallow });
-        updateHistory(mode, browserUrl, navState);
+        if (isQueryOnlyNavigation) {
+          if (browserUrl !== full) updateHistory("replace", browserUrl, navState);
+        } else {
+          routerEvents.emit("beforeHistoryChange", browserUrl, { shallow });
+          updateHistory(mode, browserUrl, navState);
+        }
       },
     });
     if (result === "cancelled") return true;
     if (result === "failed") return false;
-  } else {
+  } else if (!isQueryOnlyNavigation) {
     routerEvents.emit("beforeHistoryChange", full, { shallow });
     updateHistory(mode, full, navState);
     // Shallow navigations skip the render-commit path, so apply the scroll

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -263,6 +263,18 @@ const projectServers = {
       timeout: 60_000,
     },
   },
+  "pages-router-basepath-dev": {
+    testDir: "./tests/e2e/pages-router-basepath-dev",
+    use: { baseURL: "http://localhost:4189" },
+    server: {
+      command:
+        "(test -e node_modules || test -L node_modules || ln -s ../pages-basic/node_modules node_modules) && npx vp dev --port 4189",
+      cwd: "./tests/fixtures/pages-basepath-dev",
+      port: 4189,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+  },
 };
 
 type ProjectName = keyof typeof projectServers;

--- a/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
+++ b/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
@@ -1,5 +1,13 @@
 import { expect, test } from "@playwright/test";
 
+const basePath = "/docs";
+
+async function openRouterEventsPage(page: import("@playwright/test").Page) {
+  await page.goto(`${basePath}/hello`);
+  await page.waitForFunction(() => Boolean((window as any).__VINEXT_ROOT__));
+  await page.evaluate(() => (window as any)._clearEventLog());
+}
+
 // Ported from Next.js: test/e2e/basepath/router-events.test.ts
 // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
 test("loads the target page module through the dev server basePath", async ({ page }) => {
@@ -87,4 +95,65 @@ test("soft navigates with basePath module URLs after ISR regeneration", async ({
   expect(moduleRequests).toContain("/docs/pages/isr-basepath.tsx?import");
   expect(moduleRequests).not.toContain("/pages/isr-basepath.tsx?import");
   expect(moduleRequests.every((moduleRequest) => moduleRequest.startsWith("/docs/"))).toBe(true);
+});
+
+// Ported from Next.js: test/e2e/basepath/router-events.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
+test.describe("basePath router events", () => {
+  test("uses basePath URLs for successful route changes", async ({ page }) => {
+    await openRouterEventsPage(page);
+    await page.locator("#other-page-link").click();
+    await expect(page.locator("#other-page-title")).toBeVisible();
+
+    expect(await page.evaluate(() => (window as any)._getEventLog())).toEqual([
+      ["routeChangeStart", `${basePath}/about`, { shallow: false }],
+      ["beforeHistoryChange", `${basePath}/about`, { shallow: false }],
+      ["routeChangeComplete", `${basePath}/about`, { shallow: false }],
+    ]);
+  });
+
+  test("uses basePath URLs for hash changes", async ({ page }) => {
+    await openRouterEventsPage(page);
+    await page.locator("#hash-change").click();
+
+    await expect
+      .poll(() => page.evaluate(() => (window as any)._getEventLog()))
+      .toEqual([
+        ["hashChangeStart", `${basePath}/hello#some-hash`, { shallow: false }],
+        ["hashChangeComplete", `${basePath}/hello#some-hash`, { shallow: false }],
+      ]);
+  });
+
+  test("uses basePath URLs for cancelled route changes", async ({ page }) => {
+    await openRouterEventsPage(page);
+    await page.locator("#slow-route").click();
+    await page.locator("#other-page-link").click();
+    await expect(page.locator("#other-page-title")).toBeVisible();
+
+    expect(await page.evaluate(() => (window as any)._getEventLog())).toEqual([
+      ["routeChangeStart", `${basePath}/slow-route`, { shallow: false }],
+      ["routeChangeError", "Route Cancelled", true, `${basePath}/slow-route`, { shallow: false }],
+      ["routeChangeStart", `${basePath}/about`, { shallow: false }],
+      ["beforeHistoryChange", `${basePath}/about`, { shallow: false }],
+      ["routeChangeComplete", `${basePath}/about`, { shallow: false }],
+    ]);
+  });
+
+  test("uses basePath URLs for failed route changes", async ({ page }) => {
+    await openRouterEventsPage(page);
+    await page.locator("#error-route").click();
+
+    await expect
+      .poll(() => page.evaluate(() => (window as any)._getEventLog()))
+      .toEqual([
+        ["routeChangeStart", `${basePath}/error-route`, { shallow: false }],
+        [
+          "routeChangeError",
+          "Failed to load static props",
+          null,
+          `${basePath}/error-route`,
+          { shallow: false },
+        ],
+      ]);
+  });
 });

--- a/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
+++ b/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
@@ -144,7 +144,12 @@ test.describe("basePath router events", () => {
     await page.locator("#error-route").click();
 
     await expect
-      .poll(() => page.evaluate(() => (window as any)._getEventLog()))
+      .poll(() =>
+        page.evaluate(() => {
+          const data = sessionStorage.getItem("router-event-log");
+          return data ? JSON.parse(data) : [];
+        }),
+      )
       .toEqual([
         ["routeChangeStart", `${basePath}/error-route`, { shallow: false }],
         [

--- a/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
+++ b/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
@@ -32,3 +32,59 @@ test("loads the target page module through the dev server basePath", async ({ pa
   expect(moduleRequests).not.toContain("/pages/about.tsx?import");
   expect(moduleRequests.every((request) => request.startsWith("/docs/"))).toBe(true);
 });
+
+test("soft navigates with basePath module URLs after ISR regeneration", async ({
+  page,
+  request,
+}) => {
+  const firstResponse = await request.get("/docs/isr-basepath");
+  expect(firstResponse.ok()).toBe(true);
+  const firstHtml = await firstResponse.text();
+  const firstGeneratedAt = firstHtml.match(/data-testid="generated-at">(\d+)</)?.[1];
+  expect(firstGeneratedAt).toBeDefined();
+
+  await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+  const staleResponse = await request.get("/docs/isr-basepath");
+  expect(staleResponse.headers()["x-vinext-cache"]).toBe("STALE");
+
+  let regeneratedHtml = "";
+  await expect
+    .poll(async () => {
+      const response = await request.get("/docs/isr-basepath");
+      regeneratedHtml = await response.text();
+      return {
+        cache: response.headers()["x-vinext-cache"],
+        changed:
+          regeneratedHtml.match(/data-testid="generated-at">(\d+)</)?.[1] !== firstGeneratedAt,
+      };
+    })
+    .toEqual({ cache: "HIT", changed: true });
+
+  const regeneratedAt = regeneratedHtml.match(/data-testid="generated-at">(\d+)</)?.[1];
+  expect(regeneratedAt).toBeDefined();
+
+  const moduleRequests: string[] = [];
+  page.on("request", (moduleRequest) => {
+    const url = new URL(moduleRequest.url());
+    if (url.pathname.endsWith("/pages/isr-basepath.tsx")) {
+      moduleRequests.push(url.pathname + url.search);
+    }
+  });
+
+  await page.goto("/docs/");
+  await page.waitForFunction(() => Boolean((window as any).__VINEXT_ROOT__));
+  await page.evaluate(() => {
+    (window as any).__VINEXT_SOFT_NAV_MARKER__ = true;
+  });
+
+  await page.getByRole("link", { name: "ISR" }).click();
+
+  await expect(page.getByRole("heading", { name: "ISR BasePath" })).toBeVisible();
+  await expect(page.getByTestId("generated-at")).toHaveText(regeneratedAt!);
+  await expect(page).toHaveURL(/\/docs\/isr-basepath$/);
+  expect(await page.evaluate(() => (window as any).__VINEXT_SOFT_NAV_MARKER__)).toBe(true);
+  expect(moduleRequests).toContain("/docs/pages/isr-basepath.tsx?import");
+  expect(moduleRequests).not.toContain("/pages/isr-basepath.tsx?import");
+  expect(moduleRequests.every((moduleRequest) => moduleRequest.startsWith("/docs/"))).toBe(true);
+});

--- a/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
+++ b/tests/e2e/pages-router-basepath-dev/navigation.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+// Ported from Next.js: test/e2e/basepath/router-events.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
+test("loads the target page module through the dev server basePath", async ({ page }) => {
+  const moduleRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname.endsWith("/pages/about.tsx")) {
+      moduleRequests.push(url.pathname + url.search);
+    }
+  });
+
+  await page.goto("/docs/");
+  await page.waitForFunction(() => Boolean((window as any).__VINEXT_ROOT__));
+  await page.evaluate(() => {
+    (window as any).__VINEXT_SOFT_NAV_MARKER__ = true;
+  });
+
+  const initialNavigationEntries = await page.evaluate(
+    () => performance.getEntriesByType("navigation").length,
+  );
+  await page.getByRole("link", { name: "About" }).click();
+
+  await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
+  await expect(page).toHaveURL(/\/docs\/about$/);
+  expect(await page.evaluate(() => performance.getEntriesByType("navigation").length)).toBe(
+    initialNavigationEntries,
+  );
+  expect(await page.evaluate(() => (window as any).__VINEXT_SOFT_NAV_MARKER__)).toBe(true);
+  expect(moduleRequests).toContain("/docs/pages/about.tsx?import");
+  expect(moduleRequests).not.toContain("/pages/about.tsx?import");
+  expect(moduleRequests.every((request) => request.startsWith("/docs/"))).toBe(true);
+});

--- a/tests/fixtures/pages-basepath-dev/next.config.mjs
+++ b/tests/fixtures/pages-basepath-dev/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  basePath: "/docs",
+  assetPrefix: "/assets",
+};
+
+export default nextConfig;

--- a/tests/fixtures/pages-basepath-dev/pages/_app.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/_app.tsx
@@ -1,0 +1,66 @@
+import type { AppProps } from "next/app";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+const EVENT_LOG_KEY = "router-event-log";
+
+declare global {
+  interface Window {
+    _clearEventLog(): void;
+    _getEventLog(): unknown[][];
+  }
+}
+
+function getEventLog(): unknown[][] {
+  const data = sessionStorage.getItem(EVENT_LOG_KEY);
+  return data ? JSON.parse(data) : [];
+}
+
+function addEvent(event: unknown[]) {
+  sessionStorage.setItem(EVENT_LOG_KEY, JSON.stringify([...getEventLog(), event]));
+}
+
+if (typeof window !== "undefined") {
+  window._clearEventLog = () => sessionStorage.removeItem(EVENT_LOG_KEY);
+  window._getEventLog = getEventLog;
+}
+
+export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const onRouteChangeStart = (url: string, properties: { shallow: boolean }) =>
+      addEvent(["routeChangeStart", url, properties]);
+    const onBeforeHistoryChange = (url: string, properties: { shallow: boolean }) =>
+      addEvent(["beforeHistoryChange", url, properties]);
+    const onRouteChangeComplete = (url: string, properties: { shallow: boolean }) =>
+      addEvent(["routeChangeComplete", url, properties]);
+    const onRouteChangeError = (
+      error: Error & { cancelled?: boolean },
+      url: string,
+      properties: { shallow: boolean },
+    ) => addEvent(["routeChangeError", error.message, error.cancelled ?? null, url, properties]);
+    const onHashChangeStart = (url: string, properties: { shallow: boolean }) =>
+      addEvent(["hashChangeStart", url, properties]);
+    const onHashChangeComplete = (url: string, properties: { shallow: boolean }) =>
+      addEvent(["hashChangeComplete", url, properties]);
+
+    router.events.on("routeChangeStart", onRouteChangeStart);
+    router.events.on("beforeHistoryChange", onBeforeHistoryChange);
+    router.events.on("routeChangeComplete", onRouteChangeComplete);
+    router.events.on("routeChangeError", onRouteChangeError);
+    router.events.on("hashChangeStart", onHashChangeStart);
+    router.events.on("hashChangeComplete", onHashChangeComplete);
+
+    return () => {
+      router.events.off("routeChangeStart", onRouteChangeStart);
+      router.events.off("beforeHistoryChange", onBeforeHistoryChange);
+      router.events.off("routeChangeComplete", onRouteChangeComplete);
+      router.events.off("routeChangeError", onRouteChangeError);
+      router.events.off("hashChangeStart", onHashChangeStart);
+      router.events.off("hashChangeComplete", onHashChangeComplete);
+    };
+  }, [router.events]);
+
+  return <Component {...pageProps} />;
+}

--- a/tests/fixtures/pages-basepath-dev/pages/about.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/about.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <h1>About</h1>;
+}

--- a/tests/fixtures/pages-basepath-dev/pages/about.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/about.tsx
@@ -1,3 +1,3 @@
 export default function About() {
-  return <h1>About</h1>;
+  return <h1 id="other-page-title">About</h1>;
 }

--- a/tests/fixtures/pages-basepath-dev/pages/error-route.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/error-route.tsx
@@ -1,0 +1,7 @@
+export async function getServerSideProps() {
+  throw new Error("KABOOM!");
+}
+
+export default function ErrorRoute() {
+  return null;
+}

--- a/tests/fixtures/pages-basepath-dev/pages/hello.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/hello.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default function Hello() {
+  return (
+    <main>
+      <h1>Hello</h1>
+      <Link href="/about" id="other-page-link">
+        About
+      </Link>
+      <Link href="/slow-route" id="slow-route">
+        Slow route
+      </Link>
+      <Link href="/error-route" id="error-route">
+        Error route
+      </Link>
+      <Link href="/hello#some-hash" id="hash-change">
+        Hash change
+      </Link>
+    </main>
+  );
+}

--- a/tests/fixtures/pages-basepath-dev/pages/index.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/index.tsx
@@ -5,6 +5,7 @@ export default function Home() {
     <main>
       <h1>Home</h1>
       <Link href="/about">About</Link>
+      <Link href="/isr-basepath">ISR</Link>
     </main>
   );
 }

--- a/tests/fixtures/pages-basepath-dev/pages/index.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/index.tsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/about">About</Link>
+    </main>
+  );
+}

--- a/tests/fixtures/pages-basepath-dev/pages/isr-basepath.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/isr-basepath.tsx
@@ -1,0 +1,19 @@
+interface IsrBasePathProps {
+  generatedAt: number;
+}
+
+export default function IsrBasePath({ generatedAt }: IsrBasePathProps) {
+  return (
+    <main>
+      <h1>ISR BasePath</h1>
+      <p data-testid="generated-at">{generatedAt}</p>
+    </main>
+  );
+}
+
+export function getStaticProps() {
+  return {
+    props: { generatedAt: Date.now() },
+    revalidate: 1,
+  };
+}

--- a/tests/fixtures/pages-basepath-dev/pages/slow-route.tsx
+++ b/tests/fixtures/pages-basepath-dev/pages/slow-route.tsx
@@ -1,0 +1,8 @@
+export async function getServerSideProps() {
+  await new Promise((resolve) => setTimeout(resolve, 1_000));
+  return { props: {} };
+}
+
+export default function SlowRoute() {
+  return <h1>Slow route</h1>;
+}

--- a/tests/fixtures/pages-basepath-dev/vite.config.mts
+++ b/tests/fixtures/pages-basepath-dev/vite.config.mts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite-plus";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext()],
+});

--- a/tests/pages-dev-module-url.test.ts
+++ b/tests/pages-dev-module-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createPagesDevModuleUrl } from "../packages/vinext/src/server/pages-dev-module-url.js";
+
+describe("createPagesDevModuleUrl", () => {
+  it("uses Vite's configured base without applying assetPrefix", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/")).toBe(
+      "/docs/pages/about.tsx",
+    );
+  });
+
+  it("preserves root-base behavior", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/")).toBe(
+      "/pages/about.tsx",
+    );
+  });
+
+  it("normalizes Windows paths", () => {
+    expect(
+      createPagesDevModuleUrl("C:\\repo", "C:\\repo\\pages\\about.tsx", "/docs/"),
+    ).toBe("/docs/pages/about.tsx");
+  });
+
+  it("encodes path query and fragment delimiters", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/what?#.tsx", "/docs/"))
+      .toBe("/docs/pages/what%3F%23.tsx");
+  });
+
+  it("returns a stable URL for Vite HMR module identity", () => {
+    const first = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");
+    const second = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");
+    expect(second).toBe(first);
+  });
+});

--- a/tests/pages-dev-module-url.test.ts
+++ b/tests/pages-dev-module-url.test.ts
@@ -24,6 +24,12 @@ describe("createPagesDevModuleUrl", () => {
     );
   });
 
+  it("preserves dynamic route brackets for Vite module resolution", () => {
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/blog/[slug].tsx", "/docs/")).toBe(
+      "/docs/pages/blog/[slug].tsx",
+    );
+  });
+
   it("returns a stable URL for Vite HMR module identity", () => {
     const first = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");
     const second = createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/docs/");

--- a/tests/pages-dev-module-url.test.ts
+++ b/tests/pages-dev-module-url.test.ts
@@ -9,20 +9,19 @@ describe("createPagesDevModuleUrl", () => {
   });
 
   it("preserves root-base behavior", () => {
-    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/")).toBe(
-      "/pages/about.tsx",
-    );
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/")).toBe("/pages/about.tsx");
   });
 
   it("normalizes Windows paths", () => {
-    expect(
-      createPagesDevModuleUrl("C:\\repo", "C:\\repo\\pages\\about.tsx", "/docs/"),
-    ).toBe("/docs/pages/about.tsx");
+    expect(createPagesDevModuleUrl("C:\\repo", "C:\\repo\\pages\\about.tsx", "/docs/")).toBe(
+      "/docs/pages/about.tsx",
+    );
   });
 
   it("encodes path query and fragment delimiters", () => {
-    expect(createPagesDevModuleUrl("/repo", "/repo/pages/what?#.tsx", "/docs/"))
-      .toBe("/docs/pages/what%3F%23.tsx");
+    expect(createPagesDevModuleUrl("/repo", "/repo/pages/what?#.tsx", "/docs/")).toBe(
+      "/docs/pages/what%3F%23.tsx",
+    );
   });
 
   it("returns a stable URL for Vite HMR module identity", () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -6590,6 +6590,10 @@ describe("Pages Router dev ISR regeneration", () => {
         throw new Error(`Unexpected module load: ${id}`);
       };
       const server = {
+        config: {
+          root: FIXTURE_DIR,
+          base: "/docs/",
+        },
         transformIndexHtml: vi.fn(async (_url: string, html: string) => html),
       } as unknown as ViteDevServer;
       const runner = { import: loadModule };
@@ -6671,6 +6675,9 @@ describe("Pages Router dev ISR regeneration", () => {
           },
         },
       });
+      const regeneratedHtml = isrSetSpy.mock.calls[0]?.[1].html as string;
+      expect(regeneratedHtml).toContain('"pageModuleUrl":"/docs/pages/isr-test.tsx"');
+      expect(regeneratedHtml).toContain('"appModuleUrl":"/docs/pages/_app"');
     } finally {
       vi.doUnmock("../packages/vinext/src/server/isr-cache.js");
       vi.resetModules();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14244,11 +14244,16 @@ describe("Pages Router concurrent navigation", () => {
     try {
       vi.resetModules();
       const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      const routeChangeErrors: unknown[][] = [];
+      Router.events.on("routeChangeError", (...args: unknown[]) => routeChangeErrors.push(args));
 
       const slowNavigation = Router.push("/slow-route");
       await Promise.resolve();
       await expect(Router.push("/?tab=next", undefined, { shallow: true })).resolves.toBe(true);
       expect(slowSignal?.aborted).toBe(true);
+      expect(routeChangeErrors).toHaveLength(1);
+      expect((routeChangeErrors[0]![0] as Error & { cancelled?: boolean }).cancelled).toBe(true);
+      expect(routeChangeErrors[0]!.slice(1)).toEqual(["/slow-route", { shallow: true }]);
 
       slowResponse.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
       await expect(slowNavigation).resolves.toBe(true);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15920,6 +15920,14 @@ describe("Pages Router concurrent navigation", () => {
       vi.resetModules();
       const routerModule = await import("../packages/vinext/src/shims/router.js");
       const Router = routerModule.default;
+      const events: string[] = [];
+      Router.events.on("routeChangeStart", (url: unknown) => events.push(`start:${String(url)}`));
+      Router.events.on("beforeHistoryChange", (url: unknown) =>
+        events.push(`before:${String(url)}`),
+      );
+      Router.events.on("routeChangeComplete", (url: unknown) =>
+        events.push(`complete:${String(url)}`),
+      );
 
       const result = await Router.push("/old-home");
 
@@ -15939,6 +15947,11 @@ describe("Pages Router concurrent navigation", () => {
         "/docs/new-home",
       );
       expect(win.location.href).toBe("http://localhost/docs/new-home");
+      expect(events).toEqual([
+        "start:/docs/old-home",
+        "before:/docs/new-home",
+        "complete:/docs/new-home",
+      ]);
       expect(render).toHaveBeenCalled();
     } finally {
       vi.resetModules();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13965,6 +13965,376 @@ describe("Pages Router concurrent navigation", () => {
     return assignments;
   }
 
+  // Ported from Next.js: test/e2e/basepath/router-events.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
+  it("Pages Router events include basePath for successful navigations", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    win.location.pathname = "/docs/hello";
+    win.location.href = "http://localhost/docs/hello";
+    (globalThis as any).window = win;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    globalThis.fetch = vi.fn(async () => new Response(buildNavHtml("/other-page", pageModuleUrl)));
+    const events: unknown[][] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      for (const event of ["routeChangeStart", "beforeHistoryChange", "routeChangeComplete"]) {
+        Router.events.on(event, (...args: unknown[]) => events.push([event, ...args]));
+      }
+
+      await expect(Router.push("/other-page")).resolves.toBe(true);
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/other-page", { shallow: false }],
+        ["beforeHistoryChange", "/docs/other-page", { shallow: false }],
+        ["routeChangeComplete", "/docs/other-page", { shallow: false }],
+      ]);
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("Pages Router hash events include basePath", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    win.location.pathname = "/docs/hello";
+    win.location.href = "http://localhost/docs/hello";
+    (globalThis as any).window = win;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("hash-only navigation must not fetch");
+    });
+    const events: unknown[][] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      for (const event of ["hashChangeStart", "hashChangeComplete"]) {
+        Router.events.on(event, (...args: unknown[]) => events.push([event, ...args]));
+      }
+
+      await expect(Router.push("/hello#some-hash", undefined, { scroll: false })).resolves.toBe(
+        true,
+      );
+      expect(events).toEqual([
+        ["hashChangeStart", "/docs/hello#some-hash", { shallow: false }],
+        ["hashChangeComplete", "/docs/hello#some-hash", { shallow: false }],
+      ]);
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("Pages Router cancelled events match Next basePath, shape, and timing", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const slowResponse = createDeferred<Response>();
+    win.location.pathname = "/docs/hello";
+    win.location.href = "http://localhost/docs/hello";
+    (globalThis as any).window = win;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementationOnce(() => slowResponse.promise)
+      .mockResolvedValueOnce(new Response(buildNavHtml("/other-page", pageModuleUrl)));
+    const events: unknown[][] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.on("routeChangeStart", (...args: unknown[]) =>
+        events.push(["routeChangeStart", ...args]),
+      );
+      Router.events.on("beforeHistoryChange", (...args: unknown[]) =>
+        events.push(["beforeHistoryChange", ...args]),
+      );
+      Router.events.on("routeChangeComplete", (...args: unknown[]) =>
+        events.push(["routeChangeComplete", ...args]),
+      );
+      Router.events.on("routeChangeError", (error: unknown, ...args: unknown[]) => {
+        const routeError = error as Error & { cancelled?: boolean };
+        events.push(["routeChangeError", routeError.message, routeError.cancelled, ...args]);
+      });
+
+      const slowNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      const completedNavigation = Router.push("/other-page");
+      slowResponse.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
+      await Promise.all([slowNavigation, completedNavigation]);
+
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/slow-route", { shallow: false }],
+        ["routeChangeError", "Route Cancelled", true, "/docs/slow-route", { shallow: false }],
+        ["routeChangeStart", "/docs/other-page", { shallow: false }],
+        ["beforeHistoryChange", "/docs/other-page", { shallow: false }],
+        ["routeChangeComplete", "/docs/other-page", { shallow: false }],
+      ]);
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("Pages Router failed events match Next basePath, shape, and timing", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    win.location.pathname = "/docs/hello";
+    win.location.href = "http://localhost/docs/hello";
+    Object.assign(win as unknown as Window, {
+      __NEXT_DATA__: { ...win.__NEXT_DATA__, buildId: "test-build" },
+      __VINEXT_PAGE_LOADERS__: {
+        "/error-route": vi.fn(async () => ({ default: () => null })),
+      },
+      __VINEXT_PAGE_PATTERNS__: ["/error-route"],
+    });
+    (globalThis as any).window = win;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    globalThis.fetch = vi.fn(async () => new Response("KABOOM!", { status: 500 }));
+    const events: unknown[][] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.on("routeChangeStart", (...args: unknown[]) =>
+        events.push(["routeChangeStart", ...args]),
+      );
+      Router.events.on("beforeHistoryChange", (...args: unknown[]) =>
+        events.push(["beforeHistoryChange", ...args]),
+      );
+      Router.events.on("routeChangeError", (error: unknown, ...args: unknown[]) => {
+        const routeError = error as Error & { cancelled?: boolean };
+        events.push([
+          "routeChangeError",
+          routeError.message,
+          routeError.cancelled ?? null,
+          ...args,
+        ]);
+      });
+
+      await expect(Router.push("/error-route")).resolves.toBe(false);
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/error-route", { shallow: false }],
+        [
+          "routeChangeError",
+          "Failed to load static props",
+          null,
+          "/docs/error-route",
+          { shallow: false },
+        ],
+      ]);
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("does not mutate history for failed or cancelled route loads", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, pushState } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const slowResponse = createDeferred<Response>();
+    (globalThis as any).window = win;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementationOnce(() => slowResponse.promise)
+      .mockResolvedValueOnce(new Response("KABOOM!", { status: 500 }));
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+
+      const cancelledNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      const failedNavigation = Router.push("/error-route");
+      slowResponse.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
+
+      await expect(cancelledNavigation).resolves.toBe(true);
+      await expect(failedNavigation).resolves.toBe(false);
+      expect(pushState).not.toHaveBeenCalled();
+      expect(win.location.pathname).toBe("/");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("hash-only navigation cancels a pending route before it can commit", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const slowResponse = createDeferred<Response>();
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      getElementById: vi.fn(() => null),
+      getElementsByName: vi.fn(() => []),
+    };
+    globalThis.fetch = vi.fn(() => slowResponse.promise);
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+
+      const slowNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      await expect(Router.push("#section", undefined, { scroll: false })).resolves.toBe(true);
+      slowResponse.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
+      await expect(slowNavigation).resolves.toBe(true);
+
+      expect(win.location.pathname).toBe("/");
+      expect(win.location.hash).toBe("#section");
+      expect(win.__NEXT_DATA__.page).toBe("/");
+      expect(render).not.toHaveBeenCalled();
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("shallow navigation aborts and invalidates a pending route load", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const slowResponse = createDeferred<Response>();
+    let slowSignal: AbortSignal | undefined;
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      slowSignal = init?.signal ?? undefined;
+      return slowResponse.promise;
+    });
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+
+      const slowNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      await expect(Router.push("/?tab=next", undefined, { shallow: true })).resolves.toBe(true);
+      expect(slowSignal?.aborted).toBe(true);
+
+      slowResponse.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
+      await expect(slowNavigation).resolves.toBe(true);
+      expect(win.location.pathname).toBe("/");
+      expect(win.location.search).toBe("?tab=next");
+      expect(win.__NEXT_DATA__.page).toBe("/");
+      expect(render).not.toHaveBeenCalled();
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("App Router handoff cancels a pending Pages route load", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const slowResponse = createDeferred<Response>();
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(() => slowResponse.promise);
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.components["/app-target"] = { __appRouter: true };
+
+      const slowNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      const appNavigation = Router.push("/app-target");
+
+      expect(win.location.assign).toHaveBeenCalledWith("/app-target");
+      slowResponse.resolve(new Response("stale"));
+      await expect(slowNavigation).resolves.toBe(true);
+      expect(win.__NEXT_DATA__.page).toBe("/");
+      void appNavigation;
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("emits beforeHistoryChange immediately before the successful history write", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, pushState } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => new Response(buildNavHtml("/other-page", pageModuleUrl)));
+    const observations: string[] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.on("routeChangeStart", () => {
+        observations.push(`start:${win.location.pathname}`);
+      });
+      Router.events.on("beforeHistoryChange", () => {
+        observations.push(`before:${win.location.pathname}`);
+      });
+      pushState.mockImplementationOnce((...args: unknown[]) => {
+        observations.push(`write:${win.location.pathname}`);
+        const url = String(args[2]);
+        const parsed = new URL(url, "http://localhost");
+        win.location.pathname = parsed.pathname;
+        win.location.search = parsed.search;
+        win.location.hash = parsed.hash;
+        win.location.href = parsed.href;
+      });
+      Router.events.on("routeChangeComplete", () => {
+        observations.push(`complete:${win.location.pathname}`);
+      });
+
+      await expect(Router.push("/other-page")).resolves.toBe(true);
+      expect(observations).toEqual(["start:/", "before:/", "write:/", "complete:/other-page"]);
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   async function expectPagesRouterPushTrailingSlashNormalization({
     target,
     expectedBrowserUrl,
@@ -14542,20 +14912,12 @@ describe("Pages Router concurrent navigation", () => {
       const Router = routerModule.default;
 
       const result = await Router.push("/failing-page");
-      // Distinguish the history update from the hard-navigation fallback:
-      // pushState writes the absolute browser URL, while the fallback helper
-      // writes the raw app-relative URL. The guard is correct only if each
-      // happens exactly once.
       const fallbackAssignments = hrefAssignments.filter((value) => value === "/failing-page");
-      const pushStateAssignments = hrefAssignments.filter(
-        (value) => value === "http://localhost/failing-page",
-      );
 
       expect(result).toBe(false);
       expect(fallbackAssignments).toHaveLength(1);
-      expect(pushStateAssignments).toHaveLength(1);
-      // Catch-all: exactly one history write plus exactly one hard-nav fallback.
-      expect(hrefAssignments).toHaveLength(2);
+      // Failed route loads must not mutate history before the hard fallback.
+      expect(hrefAssignments).toEqual(["/failing-page"]);
     } finally {
       if (previousWindow === undefined) {
         delete (globalThis as any).window;
@@ -15314,7 +15676,7 @@ describe("Pages Router concurrent navigation", () => {
   it("handles Pages Router middleware internal redirects as client-side redirects", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
-    const { win, replaceState, render } = createNavWindow();
+    const { win, render } = createNavWindow();
     const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
     Object.assign(win.location, { origin: "http://localhost" });
     Object.assign(win, {
@@ -15364,7 +15726,11 @@ describe("Pages Router concurrent navigation", () => {
         }),
       );
       expect(fetch).toHaveBeenNthCalledWith(2, "/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/new-home");
+      expect(win.history.pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ __N: true }),
+        "",
+        "/new-home",
+      );
       expect(win.location.pathname).toBe("/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -15511,7 +15877,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
-    const { win, replaceState, render } = createNavWindow();
+    const { win, render } = createNavWindow();
     const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
     Object.assign(win.location, {
       origin: "http://localhost",
@@ -15562,7 +15928,11 @@ describe("Pages Router concurrent navigation", () => {
       );
       expect(fetch).toHaveBeenNthCalledWith(2, "/docs/new-home", expect.any(Object));
       expect(fetch).not.toHaveBeenCalledWith("/docs/docs/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/docs/new-home");
+      expect(win.history.pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ __N: true }),
+        "",
+        "/docs/new-home",
+      );
       expect(win.location.href).toBe("http://localhost/docs/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -15634,6 +16004,52 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("does not expose an internal redirect URL when the redirected route fails", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, pushState, replaceState } = createNavWindow();
+    Object.assign(win.location, { origin: "http://localhost" });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    Object.assign(win, {
+      __VINEXT_PAGE_LOADERS__: {
+        "/new-home": async () => ({ default: () => null }),
+      },
+    });
+    (globalThis as any).window = win;
+
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/_next/data/build-1/old-home.json") {
+        return new Response("{}", {
+          headers: { "x-nextjs-redirect": "/new-home" },
+          status: 200,
+        });
+      }
+      if (href === "/new-home") {
+        return new Response("KABOOM!", { status: 500 });
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+
+      await expect(Router.push("/old-home")).resolves.toBe(false);
+      expect(pushState).not.toHaveBeenCalled();
+      expect(replaceState).not.toHaveBeenCalledWith(expect.anything(), "", "/new-home");
+      expect(win.location.pathname).toBe("/");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("hard-navigates to the final middleware redirect URL when it is not a page", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -15679,8 +16095,8 @@ describe("Pages Router concurrent navigation", () => {
           headers: expect.objectContaining({ "x-nextjs-data": "1" }),
         }),
       );
-      expect(hrefAssignments).toContain("http://localhost/nl/to?pathname=/api/ok");
       expect(hrefAssignments).toContain("/api/ok");
+      expect(hrefAssignments).not.toContain("http://localhost/nl/to?pathname=/api/ok");
       expect(hrefAssignments).not.toContain("/nl/api/ok");
     } finally {
       vi.resetModules();
@@ -15785,7 +16201,7 @@ describe("Pages Router concurrent navigation", () => {
       browserPath: "/app/router-events-test",
       target: "/router-events-test#section-1",
       expectedBrowserUrl: "/app/router-events-test#section-1",
-      expectedEventUrl: "/router-events-test#section-1",
+      expectedEventUrl: "/app/router-events-test#section-1",
     });
   });
 
@@ -15920,7 +16336,7 @@ describe("Pages Router concurrent navigation", () => {
       browserPath: "/app/app/foo",
       target: "/app/foo#section-1",
       expectedBrowserUrl: "/app/app/foo#section-1",
-      expectedEventUrl: "/app/foo#section-1",
+      expectedEventUrl: "/app/app/foo#section-1",
     });
   });
 
@@ -15972,6 +16388,241 @@ describe("Pages Router concurrent navigation", () => {
       }
       globalThis.fetch = originalFetch;
       (globalThis as any).CustomEvent = originalCustomEvent;
+    }
+  });
+
+  it("hash-only popstate cancels a pending route and uses the browser basePath URL", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win, render } = createNavWindow();
+    const slowResponse = createDeferred<Response>();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    win.location.pathname = "/docs/current";
+    win.location.href = "http://localhost/docs/current";
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      getElementById: vi.fn(() => null),
+      getElementsByName: vi.fn(() => []),
+    };
+    globalThis.fetch = vi.fn(() => slowResponse.promise);
+    const events: unknown[][] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      Router.events.on("routeChangeError", (error: unknown, url: unknown) => {
+        events.push(["error", (error as Error).message, url]);
+      });
+      Router.events.on("hashChangeStart", (url: unknown) => events.push(["hashStart", url]));
+      Router.events.on("hashChangeComplete", (url: unknown) => events.push(["hashComplete", url]));
+
+      const slowNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      win.location.hash = "#section";
+      win.location.href = "http://localhost/docs/current#section";
+      listeners.get("popstate")!({ state: null });
+
+      expect(events).toEqual([
+        ["error", "Route Cancelled", "/docs/slow-route"],
+        ["hashStart", "/docs/current#section"],
+        ["hashComplete", "/docs/current#section"],
+      ]);
+      slowResponse.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
+      await expect(slowNavigation).resolves.toBe(true);
+      expect(win.__NEXT_DATA__.page).toBe("/");
+      expect(render).not.toHaveBeenCalled();
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("full-route popstate cancels before start and delays adoption until load success", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    const slowResponse = createDeferred<Response>();
+    const popResponse = createDeferred<Response>();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    win.location.pathname = "/docs/current";
+    win.location.href = "http://localhost/docs/current";
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementationOnce(() => slowResponse.promise)
+      .mockImplementationOnce(() => popResponse.promise);
+    const events: string[] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      Router.events.on("routeChangeError", (error: unknown, url: unknown) =>
+        events.push(`error:${String(url)}:${(error as Error).message}`),
+      );
+      Router.events.on("routeChangeStart", (url: unknown) => events.push(`start:${String(url)}`));
+      Router.events.on("beforeHistoryChange", (url: unknown) =>
+        events.push(`before:${String(url)}`),
+      );
+      Router.events.on("routeChangeComplete", (url: unknown) =>
+        events.push(`complete:${String(url)}`),
+      );
+
+      const slowNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      win.location.pathname = "/docs/next";
+      win.location.href = "http://localhost/docs/next";
+      listeners.get("popstate")!({
+        state: { __N: true, as: "/next", url: "/next", key: "next-key" },
+      });
+
+      expect(events).toEqual([
+        "start:/docs/slow-route",
+        "error:/docs/slow-route:Route Cancelled",
+        "start:/docs/next",
+      ]);
+      popResponse.resolve(new Response(buildNavHtml("/next", pageModuleUrl)));
+      await vi.waitFor(() => expect(events).toContain("complete:/docs/next"));
+      expect(events).toEqual([
+        "start:/docs/slow-route",
+        "error:/docs/slow-route:Route Cancelled",
+        "start:/docs/next",
+        "before:/docs/next",
+        "complete:/docs/next",
+      ]);
+      slowResponse.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
+      await expect(slowNavigation).resolves.toBe(true);
+      expect(win.__NEXT_DATA__.page).toBe("/next");
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("failed popstate emits no beforeHistoryChange or completion", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    win.location.pathname = "/docs/current";
+    win.location.href = "http://localhost/docs/current";
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => new Response("KABOOM!", { status: 500 }));
+    const events: string[] = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      for (const event of [
+        "routeChangeStart",
+        "beforeHistoryChange",
+        "routeChangeComplete",
+        "routeChangeError",
+      ]) {
+        Router.events.on(event, (...args: unknown[]) => {
+          const url = event === "routeChangeError" ? args[1] : args[0];
+          events.push(`${event}:${String(url)}`);
+        });
+      }
+
+      win.location.pathname = "/docs/failing";
+      win.location.href = "http://localhost/docs/failing";
+      listeners.get("popstate")!({
+        state: { __N: true, as: "/failing", url: "/failing", key: "fail-key" },
+      });
+      await vi.waitFor(() => expect(events).toContain("routeChangeError:/docs/failing"));
+
+      expect(events).toEqual(["routeChangeStart:/docs/failing", "routeChangeError:/docs/failing"]);
+    } finally {
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("a stale popstate load cannot commit after a newer popstate wins", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win, render } = createNavWindow();
+    const firstResponse = createDeferred<Response>();
+    const secondResponse = createDeferred<Response>();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementationOnce(() => firstResponse.promise)
+      .mockImplementationOnce(() => secondResponse.promise);
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      win.location.pathname = "/first";
+      win.location.href = "http://localhost/first";
+      listeners.get("popstate")!({ state: { __N: true, as: "/first", url: "/first" } });
+      await Promise.resolve();
+      win.location.pathname = "/second";
+      win.location.href = "http://localhost/second";
+      listeners.get("popstate")!({ state: { __N: true, as: "/second", url: "/second" } });
+
+      secondResponse.resolve(new Response(buildNavHtml("/second", pageModuleUrl)));
+      await vi.waitFor(() => expect(win.__NEXT_DATA__.page).toBe("/second"));
+      firstResponse.resolve(new Response(buildNavHtml("/first", pageModuleUrl)));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(win.__NEXT_DATA__.page).toBe("/second");
+      expect(render).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
     }
   });
 
@@ -16315,12 +16966,9 @@ describe("Pages Router concurrent navigation", () => {
     (globalThis as any).window = win;
     vi.resetModules();
 
-    // Capture router state mid-navigation, after pushState has updated
-    // window.location but before navigateClient's dynamic import runs (which
-    // would fail in this test env). useRouter() reads from window.location
-    // and window.__NEXT_DATA__ at provider-mount time, so rendering a Probe
-    // inside the mocked fetch handler observes the post-pushState state —
-    // exactly the code path that #1196 corrupts in Next.js.
+    // Capture router state after the route has loaded and history has committed.
+    // Failed or pending loads must leave the old location visible, so observing
+    // the destination during fetch is no longer a valid contract.
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const routerModule = await import("../packages/vinext/src/shims/router.js");
@@ -16331,26 +16979,18 @@ describe("Pages Router concurrent navigation", () => {
       return React.createElement("span", null, "ok");
     }
 
-    globalThis.fetch = async (_url: any, _init: any) => {
-      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
-      // Return HTML containing the destination's __NEXT_DATA__. The dynamic
-      // import of the page module fails in this test env, which is fine — the
-      // assertion above has already captured router.query.
-      return new Response(
-        buildNavHtml("/[...path]", "/@fs/pages/catchall.js", { path: ["second"] }),
-      );
-    };
-
-    // Silence the expected routeChangeError from the page-module import failure.
-    const onRouteChangeError = vi.fn();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    globalThis.fetch = async () =>
+      new Response(buildNavHtml("/[...path]", pageModuleUrl, { path: ["second"] }));
 
     try {
       const Router = routerModule.default;
-      Router.events.on("routeChangeError", onRouteChangeError);
 
       // Router.push() takes an app-relative path; basePath is added internally
-      // by performNavigation → toBrowserNavigationHref before pushState.
-      await Router.push("/second");
+      // by performNavigation → toBrowserNavigationHref when the loaded route
+      // commits successfully.
+      await expect(Router.push("/second")).resolves.toBe(true);
+      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
 
       // pushState has fired, so location.pathname is "/docs/second".
       // stripBasePath() removes "/docs", and the catch-all pattern
@@ -16363,7 +17003,6 @@ describe("Pages Router concurrent navigation", () => {
       expect(capturedRouter.query.path).not.toContain("_next");
       expect(capturedRouter.query.path).not.toContain("data");
     } finally {
-      routerModule.default.events.off("routeChangeError", onRouteChangeError);
       globalThis.fetch = originalFetch;
       if (previousBasePath === undefined) {
         delete process.env.__NEXT_ROUTER_BASEPATH;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15886,7 +15886,7 @@ describe("Pages Router concurrent navigation", () => {
     ["push", "/source/0", "/source/0?param=1"],
     ["replace", "/source/0", "/source/0?param=1"],
   ] as const)(
-    "%s preserves the current pathname and visible query while a rewrite resolves",
+    "%s preserves the current pathname and commits the visible query after a rewrite resolves",
     async (method, pathname, expectedUrl) => {
       const previousWindow = (globalThis as any).window;
       const originalFetch = globalThis.fetch;
@@ -15916,16 +15916,14 @@ describe("Pages Router concurrent navigation", () => {
         vi.resetModules();
         const routerModule = await import("../packages/vinext/src/shims/router.js");
         const Router = routerModule.default;
+        pushState.mockClear();
+        replaceState.mockClear();
 
         const navigation = Router[method]({ query: { param: 1 } });
 
         const historyMutation = method === "push" ? pushState : replaceState;
-        expect(historyMutation).toHaveBeenLastCalledWith(
-          expect.objectContaining({ __N: true }),
-          "",
-          expectedUrl,
-        );
-        expect(win.location.pathname + win.location.search).toBe(expectedUrl);
+        expect(historyMutation.mock.calls.filter((call) => call[2] !== undefined)).toHaveLength(0);
+        expect(win.location.pathname + win.location.search).toBe(pathname);
 
         response.resolve(
           new Response(JSON.stringify({ pageProps: {} }), {
@@ -15938,8 +15936,141 @@ describe("Pages Router concurrent navigation", () => {
         const result = await navigation;
 
         expect(result).toBe(true);
+        expect(historyMutation).toHaveBeenLastCalledWith(
+          expect.objectContaining({ __N: true }),
+          "",
+          expectedUrl,
+        );
         expect(win.location.pathname + win.location.search).toBe(expectedUrl);
         expect(destinationLoader).toHaveBeenCalledOnce();
+      } finally {
+        vi.resetModules();
+        if (previousWindow === undefined) {
+          delete (globalThis as any).window;
+        } else {
+          (globalThis as any).window = previousWindow;
+        }
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
+
+  it.each(["push", "replace"] as const)(
+    "%s does not commit a failed query-only navigation",
+    async (method) => {
+      const previousWindow = (globalThis as any).window;
+      const originalFetch = globalThis.fetch;
+      const { win, pushState, replaceState } = createNavWindow();
+      Object.assign(win.location, {
+        origin: "http://localhost",
+        pathname: "/source/0",
+        href: "http://localhost/source/0",
+      });
+      Object.assign(win.__NEXT_DATA__, {
+        buildId: "build-1",
+        __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+      });
+      (globalThis as any).window = win;
+      globalThis.fetch = vi.fn(async () => {
+        throw new Error("route resolution failed");
+      });
+
+      try {
+        vi.resetModules();
+        const routerModule = await import("../packages/vinext/src/shims/router.js");
+        const Router = routerModule.default;
+        pushState.mockClear();
+        replaceState.mockClear();
+
+        const result = await Router[method]({ query: { param: 1 } });
+
+        expect(result).toBe(false);
+        expect(pushState.mock.calls.filter((call) => call[2] !== undefined)).toHaveLength(0);
+        expect(replaceState.mock.calls.filter((call) => call[2] !== undefined)).toHaveLength(0);
+        expect(win.location.pathname + win.location.search).toBe("/source/0");
+      } finally {
+        vi.resetModules();
+        if (previousWindow === undefined) {
+          delete (globalThis as any).window;
+        } else {
+          (globalThis as any).window = previousWindow;
+        }
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
+
+  it.each(["push", "replace"] as const)(
+    "%s does not commit a superseded query-only navigation",
+    async (method) => {
+      const previousWindow = (globalThis as any).window;
+      const originalFetch = globalThis.fetch;
+      const { win, pushState, replaceState } = createNavWindow();
+      const destinationLoader = vi.fn(async () => ({ default: () => null }));
+      Object.assign(win.location, {
+        origin: "http://localhost",
+        pathname: "/source/0",
+        href: "http://localhost/source/0",
+      });
+      Object.assign(win.__NEXT_DATA__, {
+        buildId: "build-1",
+        __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+      });
+      Object.assign(win, {
+        __VINEXT_PAGE_PATTERNS__: ["/destination"],
+        __VINEXT_PAGE_LOADERS__: { "/destination": destinationLoader },
+      });
+      (globalThis as any).window = win;
+
+      const firstResponse = createDeferred<Response>();
+      const secondResponse = createDeferred<Response>();
+      globalThis.fetch = vi
+        .fn()
+        .mockImplementationOnce(() => firstResponse.promise)
+        .mockImplementationOnce(() => secondResponse.promise);
+
+      try {
+        vi.resetModules();
+        const routerModule = await import("../packages/vinext/src/shims/router.js");
+        const Router = routerModule.default;
+        pushState.mockClear();
+        replaceState.mockClear();
+
+        const firstNavigation = Router[method]({ query: { param: 1 } });
+        const secondNavigation = Router[method]({ query: { param: 2 } });
+
+        expect(pushState.mock.calls.filter((call) => call[2] !== undefined)).toHaveLength(0);
+        expect(replaceState.mock.calls.filter((call) => call[2] !== undefined)).toHaveLength(0);
+        expect(win.location.pathname + win.location.search).toBe("/source/0");
+
+        secondResponse.resolve(
+          new Response(JSON.stringify({ pageProps: {} }), {
+            headers: {
+              "content-type": "application/json",
+              "x-nextjs-rewrite": "/destination",
+            },
+          }),
+        );
+        expect(await secondNavigation).toBe(true);
+
+        firstResponse.resolve(
+          new Response(JSON.stringify({ pageProps: {} }), {
+            headers: {
+              "content-type": "application/json",
+              "x-nextjs-rewrite": "/destination",
+            },
+          }),
+        );
+        expect(await firstNavigation).toBe(true);
+
+        const historyMutation = method === "push" ? pushState : replaceState;
+        expect(historyMutation).toHaveBeenCalledTimes(1);
+        expect(historyMutation).toHaveBeenLastCalledWith(
+          expect.objectContaining({ __N: true }),
+          "",
+          "/source/0?param=2",
+        );
+        expect(win.location.pathname + win.location.search).toBe("/source/0?param=2");
       } finally {
         vi.resetModules();
         if (previousWindow === undefined) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14933,6 +14933,136 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("superseded JSON page loader failures do not hard-navigate or emit a second error", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const hrefAssignments = trackHrefAssignments(win);
+    const loaderA = createDeferred<{ default: () => null }>();
+    const pageALoader = vi.fn(() => loaderA.promise);
+    Object.assign(win.location, { origin: "http://localhost" });
+    Object.assign(win as unknown as Window, {
+      __NEXT_DATA__: { ...win.__NEXT_DATA__, buildId: "test-build" },
+      __VINEXT_PAGE_LOADERS__: {
+        "/page-a": pageALoader,
+        "/page-b": vi.fn(async () => ({ default: () => null })),
+      },
+      __VINEXT_PAGE_PATTERNS__: ["/page-a", "/page-b"],
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pageProps: {} }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const errors: Array<{ error: Error & { cancelled?: boolean }; url: string }> = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.on("routeChangeError", (error: unknown, url: unknown) => {
+        errors.push({ error: error as Error & { cancelled?: boolean }, url: String(url) });
+      });
+
+      const navigationA = Router.push("/page-a");
+      await vi.waitFor(() => expect(pageALoader).toHaveBeenCalled());
+      await expect(Router.push("/page-b")).resolves.toBe(true);
+      hrefAssignments.length = 0;
+      loaderA.reject(new Error("stale chunk failed"));
+      await expect(navigationA).resolves.toBe(true);
+
+      expect(win.location.pathname).toBe("/page-b");
+      expect(hrefAssignments).toEqual([]);
+      expect(errors.filter(({ url }) => url === "/page-a")).toHaveLength(1);
+      expect(errors[0]?.error).toHaveProperty("cancelled", true);
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("superseded HTML page loader failures do not hard-navigate or emit a second error", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const hrefAssignments = trackHrefAssignments(win);
+    const loaderA = createDeferred<{ default: () => null }>();
+    const pageALoader = vi.fn(() => loaderA.promise);
+    Object.assign(win as unknown as Window, {
+      __VINEXT_PAGE_LOADERS__: {
+        "/page-a": pageALoader,
+        "/page-b": vi.fn(async () => ({ default: () => null })),
+      },
+      __VINEXT_PAGE_PATTERNS__: [],
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+      const pathname = new URL(getFetchHref(url), "http://localhost").pathname;
+      return new Response(buildNavHtml(pathname, `/@fs/pages${pathname}.js`));
+    });
+    const errors: Array<{ error: Error & { cancelled?: boolean }; url: string }> = [];
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.on("routeChangeError", (error: unknown, url: unknown) => {
+        errors.push({ error: error as Error & { cancelled?: boolean }, url: String(url) });
+      });
+
+      const navigationA = Router.push("/page-a");
+      await vi.waitFor(() => expect(pageALoader).toHaveBeenCalled());
+      await expect(Router.push("/page-b")).resolves.toBe(true);
+      hrefAssignments.length = 0;
+      loaderA.reject(new Error("stale chunk failed"));
+      await expect(navigationA).resolves.toBe(true);
+
+      expect(win.location.pathname).toBe("/page-b");
+      expect(hrefAssignments).toEqual([]);
+      expect(errors.filter(({ url }) => url === "/page-a")).toHaveLength(1);
+      expect(errors[0]?.error).toHaveProperty("cancelled", true);
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("active HTML page loader failures still hard-navigate", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const hrefAssignments = trackHrefAssignments(win);
+    Object.assign(win as unknown as Window, {
+      __VINEXT_PAGE_LOADERS__: {
+        "/failing-page": vi.fn(async () => {
+          throw new Error("chunk failed");
+        }),
+      },
+      __VINEXT_PAGE_PATTERNS__: [],
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(
+      async () => new Response(buildNavHtml("/failing-page", "/@fs/pages/failing-page.js")),
+    );
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+
+      await expect(Router.push("/failing-page")).resolves.toBe(false);
+      expect(hrefAssignments).toEqual(["/failing-page"]);
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("fetches default-locale root through a locale-qualified URL without changing the browser URL", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15878,6 +15878,80 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+  it.each([
+    ["push", "/", "/?param=1"],
+    ["replace", "/", "/?param=1"],
+    ["push", "/source/0", "/source/0?param=1"],
+    ["replace", "/source/0", "/source/0?param=1"],
+  ] as const)(
+    "%s preserves the current pathname and visible query while a rewrite resolves",
+    async (method, pathname, expectedUrl) => {
+      const previousWindow = (globalThis as any).window;
+      const originalFetch = globalThis.fetch;
+      const { win, pushState, replaceState } = createNavWindow();
+      const destinationLoader = vi.fn(async () => ({ default: () => null }));
+      Object.assign(win.location, {
+        origin: "http://localhost",
+        pathname,
+        href: `http://localhost${pathname}`,
+      });
+      Object.assign(win.__NEXT_DATA__, {
+        buildId: "build-1",
+        __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+      });
+      Object.assign(win, {
+        __VINEXT_PAGE_PATTERNS__: ["/destination"],
+        __VINEXT_PAGE_LOADERS__: {
+          "/destination": destinationLoader,
+        },
+      });
+      (globalThis as any).window = win;
+
+      const response = createDeferred<Response>();
+      globalThis.fetch = vi.fn(() => response.promise);
+
+      try {
+        vi.resetModules();
+        const routerModule = await import("../packages/vinext/src/shims/router.js");
+        const Router = routerModule.default;
+
+        const navigation = Router[method]({ query: { param: 1 } });
+
+        const historyMutation = method === "push" ? pushState : replaceState;
+        expect(historyMutation).toHaveBeenLastCalledWith(
+          expect.objectContaining({ __N: true }),
+          "",
+          expectedUrl,
+        );
+        expect(win.location.pathname + win.location.search).toBe(expectedUrl);
+
+        response.resolve(
+          new Response(JSON.stringify({ pageProps: {} }), {
+            headers: {
+              "content-type": "application/json",
+              "x-nextjs-rewrite": "/destination",
+            },
+          }),
+        );
+        const result = await navigation;
+
+        expect(result).toBe(true);
+        expect(win.location.pathname + win.location.search).toBe(expectedUrl);
+        expect(destinationLoader).toHaveBeenCalledOnce();
+      } finally {
+        vi.resetModules();
+        if (previousWindow === undefined) {
+          delete (globalThis as any).window;
+        } else {
+          (globalThis as any).window = previousWindow;
+        }
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
+
   it("does not double-prefix basePath for middleware data redirects", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

- keep the current page mounted when a Pages route-data request returns an HTTP 5xx
- emit `routeChangeError` instead of hard-navigating for route-data server failures
- preserve hard navigation for deploy-skew 404s, malformed payloads, missing modules, and active chunk-loader failures
- ignore late loader failures from superseded navigations so they cannot override a winning route

## Stack

Stacked on #2036, which is stacked on #2033.

## Next.js parity

Completes the failed-route assertion in `test/e2e/basepath/router-events.test.ts`.

## Validation

- exact Next success, hash, cancellation, and failed-route assertions: 4/4 passed
- focused stale-loader and active-failure controls passed
- targeted `vp check` passed
- independent cumulative review: clean
