### PR TITLE
fix(pages-router): cancel deduped GSSP data waits

### DIFF
--- a/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
+++ b/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
@@ -23,23 +23,81 @@
  *   directly by anyone, which keeps subsequent clones legal even after one
  *   caller has consumed its copy.
  *
- * - No `AbortSignal` is honored at the shared layer. Each `Router.push` cycle
- *   has its own AbortController that supersedes prior navigations via
- *   `_navigationId`; aborting the shared fetch on behalf of one caller would
- *   destroy the dedup gain for every other concurrent caller. Cancellation is
- *   handled by the caller's `assertStillCurrent()` checkpoints after `await`,
- *   not by abort propagation.
+ * - Each caller owns one waiter. Cancelling a waiter leaves the shared request
+ *   alive while another waiter remains; cancelling the final waiter aborts the
+ *   underlying fetch and evicts the entry immediately so a replacement caller
+ *   can retry without joining a doomed request.
  *
  * - The map is module-scoped (one per realm). The Pages Router runs in the
  *   browser only, so a single `Map` is sufficient.
  */
 
-/** Inflight fetch promises keyed by the resolved data URL. */
-const inflight = new Map<string, Promise<Response>>();
+import { NEXT_DEPLOYMENT_ID_HEADER } from "../../utils/deployment-id.js";
+
+type InflightEntry = {
+  controller: AbortController;
+  promise: Promise<Response>;
+  settled: boolean;
+  waiters: number;
+};
+
+/** Inflight fetch entries keyed by the resolved data request identity. */
+const inflight = new Map<string, InflightEntry>();
+
+function getInflightKey(dataHref: string, init?: RequestInit): string {
+  let resolvedHref = dataHref;
+  if (typeof window !== "undefined") {
+    try {
+      resolvedHref = new URL(dataHref, window.location.href).href;
+    } catch {}
+  }
+
+  const deploymentId = new Headers(init?.headers).get(NEXT_DEPLOYMENT_ID_HEADER) ?? "";
+  return `${resolvedHref}\n${deploymentId}`;
+}
+
+function cloneSharedResponse(
+  key: string,
+  entry: InflightEntry,
+  signal?: AbortSignal,
+): Promise<Response> {
+  entry.waiters += 1;
+
+  return new Promise<Response>((resolve, reject) => {
+    let released = false;
+    const release = (cancelled: boolean) => {
+      if (released) return;
+      released = true;
+      entry.waiters -= 1;
+      if (cancelled && entry.waiters === 0 && !entry.settled) {
+        if (inflight.get(key) === entry) inflight.delete(key);
+        entry.controller.abort();
+      }
+    };
+    const abort = () => {
+      release(true);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    entry.promise.then(
+      (response) => {
+        signal?.removeEventListener("abort", abort);
+        release(false);
+        resolve(response.clone());
+      },
+      (error: unknown) => {
+        signal?.removeEventListener("abort", abort);
+        release(false);
+        reject(error);
+      },
+    );
+  });
+}
 
 /**
  * Dedupe a `fetch()` against the `_next/data` endpoint. Multiple concurrent
- * callers for the same `dataHref` share one underlying network request.
+ * callers for the same resolved URL and deployment ID share one underlying
+ * network request.
  *
  * Each call returns a freshly-cloned `Response` so consumers can read the
  * body independently. Once the in-flight Promise settles (resolve or reject)
@@ -49,20 +107,28 @@ const inflight = new Map<string, Promise<Response>>();
  * dropped on failure so the next navigation can retry.
  */
 export function dedupedPagesDataFetch(dataHref: string, init?: RequestInit): Promise<Response> {
-  let entry = inflight.get(dataHref);
+  const key = getInflightKey(dataHref, init);
+  const signal = init?.signal ?? undefined;
+  if (signal?.aborted) return Promise.reject(new DOMException("Aborted", "AbortError"));
+
+  let entry = inflight.get(key);
   if (!entry) {
-    entry = fetch(dataHref, init).finally(() => {
-      // Only drop the entry if it still matches the one we set. A racing
-      // caller could in principle overwrite, but inflight is keyed by URL
-      // and we never overwrite on a hit, so this check is defensive.
-      if (inflight.get(dataHref) === entry) inflight.delete(dataHref);
+    const controller = new AbortController();
+    let currentEntry: InflightEntry;
+    const promise = fetch(dataHref, { ...init, signal: controller.signal }).finally(() => {
+      currentEntry.settled = true;
+      if (inflight.get(key) === currentEntry) inflight.delete(key);
     });
-    inflight.set(dataHref, entry);
+    currentEntry = {
+      controller,
+      promise,
+      settled: false,
+      waiters: 0,
+    };
+    inflight.set(key, currentEntry);
+    entry = currentEntry;
   }
-  // Always return a clone so each consumer gets an independently-readable
-  // body. The original `entry` Response is never consumed directly, so
-  // cloning remains valid for every caller (including the first).
-  return entry.then((res) => res.clone());
+  return cloneSharedResponse(key, entry, signal);
 }
 
 /**
@@ -70,5 +136,6 @@ export function dedupedPagesDataFetch(dataHref: string, init?: RequestInit): Pro
  * does not need to call this because entries self-evict on settle.
  */
 export function clearPagesDataInflight(): void {
+  for (const entry of inflight.values()) entry.controller.abort();
   inflight.clear();
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1416,10 +1416,9 @@ async function resolveMiddlewareDataEffect(
   const dataUrl = getMiddlewarePagesDataFetchUrl(browserUrl);
   if (!dataUrl) return null;
 
-  // We deliberately do NOT thread `signal` into the shared fetch — see the
-  // dedup helper for why. Stale callers bail out via `assertStillCurrent()`
-  // after the await; we still surface a pre-await abort via this check so
-  // callers see the documented AbortError on supersession.
+  // The dedup helper uses `signal` to release this caller's waiter. It keeps
+  // the shared request alive for any identical waiter, and aborts only when
+  // this was the final waiter.
   if (signal.aborted) {
     throw new DOMException("Aborted", "AbortError");
   }
@@ -1430,6 +1429,7 @@ async function resolveMiddlewareDataEffect(
         Accept: "application/json",
         "x-nextjs-data": "1",
       },
+      signal,
     });
     return {
       redirectLocation: res.headers.get("x-nextjs-redirect"),
@@ -1506,11 +1506,10 @@ async function navigateClientData(
   //
   // We dedupe by URL: concurrent `Router.push` calls (or back-to-back link
   // clicks) for the same destination share a single underlying request.
-  // The shared fetch deliberately ignores `controller.signal` — each caller
-  // still bails out of their navigation via `assertStillCurrent()` after the
-  // await, but the shared network request itself runs to completion so other
-  // racing callers still benefit. This matches Next.js's `inflightCache`
-  // semantics in `fetchNextData()`.
+  // The shared fetch uses `controller.signal` to release this caller's waiter.
+  // The network request stays alive while another identical navigation is
+  // waiting, and aborts once the final waiter cancels. This matches Next.js's
+  // combination of in-flight reuse and per-navigation cancellation.
   //
   // Pre-await abort still throws so callers see the documented cancellation
   // surface when supersession happened before the fetch was even attempted.
@@ -1526,7 +1525,10 @@ async function navigateClientData(
       };
       const deploymentId = getDeploymentId();
       if (deploymentId) headers[NEXT_DEPLOYMENT_ID_HEADER] = deploymentId;
-      res = await dedupedPagesDataFetch(initialTarget.dataHref, { headers });
+      res = await dedupedPagesDataFetch(initialTarget.dataHref, {
+        headers,
+        signal: controller.signal,
+      });
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") {
         throw new NavigationCancelledError(url);
@@ -1897,8 +1899,12 @@ async function navigateClient(
 ): Promise<void> {
   if (typeof window === "undefined") return;
 
-  // Cancel any in-flight navigation (abort its fetch, settle its render-commit wait)
-  routerRuntimeState.activeAbortController?.abort();
+  // Supersede the prior navigation immediately via navigationId below, but
+  // defer its AbortSignal by one microtask. A synchronous identical push can
+  // then join the shared _next/data fetch before the prior waiter releases;
+  // different destinations still abort the abandoned request in this turn.
+  const previousAbortController = routerRuntimeState.activeAbortController;
+  if (previousAbortController) queueMicrotask(() => previousAbortController.abort());
   cancelPreviousRenderCommit();
   const controller = new AbortController();
   routerRuntimeState.activeAbortController = controller;

--- a/tests/e2e/pages-router-prod/gssp-data-dedup.spec.ts
+++ b/tests/e2e/pages-router-prod/gssp-data-dedup.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "../fixtures";
+import { waitForHydration } from "../helpers";
+
+// Ported from Next.js: test/e2e/getserversideprops/test/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/test/index.test.ts
+// Covers "should dedupe server data requests" and cancellation without errors.
+
+const BASE = "http://localhost:4175";
+
+test.describe("Pages Router concurrent gSSP data navigation", () => {
+  test("identical pushes share one request and a superseded request stays silent", async ({
+    page,
+    consoleErrors,
+  }) => {
+    const dataRequests: string[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (url.pathname.includes("/_next/data/") && url.pathname.endsWith("/gssp-dedup-slow.json")) {
+        dataRequests.push(url.pathname + url.search);
+      }
+    });
+
+    await page.goto(`${BASE}/gssp-dedup-test`);
+    await waitForHydration(page);
+
+    await page.getByTestId("push-identical").click();
+    await expect(page.getByTestId("hit")).toHaveText("hit: 1");
+    await expect(page.getByTestId("key")).toHaveText("key: same");
+    expect(dataRequests.filter((url) => url.endsWith("?key=same"))).toHaveLength(1);
+
+    await page.goto(`${BASE}/gssp-dedup-test`);
+    await waitForHydration(page);
+    await page.getByTestId("push-distinct-query").click();
+    await expect(page.getByTestId("key")).toHaveText("key: query-two");
+    expect(dataRequests.filter((url) => url.endsWith("?key=query-one"))).toHaveLength(1);
+    expect(dataRequests.filter((url) => url.endsWith("?key=query-two"))).toHaveLength(1);
+
+    await page.goto(`${BASE}/gssp-dedup-test`);
+    await waitForHydration(page);
+    await page.getByTestId("push-cancelled").click();
+    await expect(page.getByTestId("normal-text")).toHaveText("a normal page");
+    expect(dataRequests.filter((url) => url.endsWith("?key=cancelled"))).toHaveLength(1);
+
+    void consoleErrors;
+  });
+});

--- a/tests/fixtures/pages-basic/pages/gssp-dedup-slow.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-dedup-slow.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from "next/router";
+
+type Props = {
+  hit: number;
+};
+
+const COUNTER_KEY = Symbol.for("vinext.tests.gsspDedupCounter");
+
+type CounterGlobal = typeof globalThis & {
+  [COUNTER_KEY]?: number;
+};
+
+export default function GsspDedupSlow({ hit }: Props) {
+  const router = useRouter();
+  return (
+    <main>
+      <h1>a slow page</h1>
+      <p data-testid="hit">hit: {hit}</p>
+      <p data-testid="key">key: {String(router.query.key ?? "")}</p>
+    </main>
+  );
+}
+
+export async function getServerSideProps() {
+  const counterGlobal = globalThis as CounterGlobal;
+  counterGlobal[COUNTER_KEY] = (counterGlobal[COUNTER_KEY] ?? 0) + 1;
+  const hit = counterGlobal[COUNTER_KEY];
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  return {
+    props: {
+      hit,
+    },
+  };
+}

--- a/tests/fixtures/pages-basic/pages/gssp-dedup-test.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-dedup-test.tsx
@@ -1,0 +1,47 @@
+import Router from "next/router";
+
+const COUNTER_KEY = Symbol.for("vinext.tests.gsspDedupCounter");
+
+export default function GsspDedupTest() {
+  return (
+    <main>
+      <h1>gSSP Dedup Test</h1>
+      <button
+        data-testid="push-identical"
+        onClick={() => {
+          void Promise.all([
+            Router.push("/gssp-dedup-slow?key=same"),
+            Router.push("/gssp-dedup-slow?key=same"),
+            Router.push("/gssp-dedup-slow?key=same"),
+            Router.push("/gssp-dedup-slow?key=same"),
+          ]);
+        }}
+      >
+        Push identical
+      </button>
+      <button
+        data-testid="push-cancelled"
+        onClick={() => {
+          void Router.push("/gssp-dedup-slow?key=cancelled");
+          void Router.push("/gssp-redirect-target");
+        }}
+      >
+        Cancel slow request
+      </button>
+      <button
+        data-testid="push-distinct-query"
+        onClick={() => {
+          void Router.push("/gssp-dedup-slow?key=query-one");
+          void Router.push("/gssp-dedup-slow?key=query-two");
+        }}
+      >
+        Push distinct queries
+      </button>
+    </main>
+  );
+}
+
+export function getServerSideProps() {
+  (globalThis as typeof globalThis & { [COUNTER_KEY]?: number })[COUNTER_KEY] = 0;
+  return { props: {} };
+}

--- a/tests/pages-data-fetch-dedup.test.ts
+++ b/tests/pages-data-fetch-dedup.test.ts
@@ -111,6 +111,115 @@ describe("dedupedPagesDataFetch", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps locale, basePath, deployment, and query request identities distinct", async () => {
+    let resolveFetch: (response: Response) => void = () => {};
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchSpy = vi.fn(() => fetchPromise);
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const requests = [
+      dedupedPagesDataFetch("/_next/data/id/about.json?tab=one", {
+        headers: { "x-deployment-id": "deployment-a" },
+      }),
+      dedupedPagesDataFetch("/_next/data/id/fr/about.json?tab=one", {
+        headers: { "x-deployment-id": "deployment-a" },
+      }),
+      dedupedPagesDataFetch("/docs/_next/data/id/about.json?tab=one", {
+        headers: { "x-deployment-id": "deployment-a" },
+      }),
+      dedupedPagesDataFetch("/_next/data/id/about.json?tab=two", {
+        headers: { "x-deployment-id": "deployment-a" },
+      }),
+      dedupedPagesDataFetch("/_next/data/id/about.json?tab=one", {
+        headers: { "x-deployment-id": "deployment-b" },
+      }),
+    ];
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    resolveFetch(new Response(JSON.stringify({ pageProps: {} })));
+    await Promise.all(requests);
+  });
+
+  it("cancels one caller without aborting the shared request", async () => {
+    let resolveFetch: (response: Response) => void = () => {};
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchSpy = vi.fn(() => fetchPromise);
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const controller = new AbortController();
+    const cancelled = dedupedPagesDataFetch("/_next/data/id/slow.json", {
+      signal: controller.signal,
+    });
+    const active = dedupedPagesDataFetch("/_next/data/id/slow.json");
+    controller.abort();
+
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    resolveFetch(new Response(JSON.stringify({ pageProps: { ok: true } })));
+    await expect(active.then((response) => response.json())).resolves.toEqual({
+      pageProps: { ok: true },
+    });
+  });
+
+  it("aborts and evicts when all callers cancel, then lets a replacement succeed", async () => {
+    const fetchSignals: AbortSignal[] = [];
+    let rejectAbortedFetch: (error: unknown) => void = () => {};
+    let resolveReplacement: (response: Response) => void = () => {};
+    const fetchSpy = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("missing shared abort signal");
+      fetchSignals.push(signal);
+
+      if (fetchSignals.length === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          rejectAbortedFetch = reject;
+        });
+      }
+
+      return new Promise<Response>((resolve) => {
+        resolveReplacement = resolve;
+      });
+    });
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const url = "/_next/data/id/all-cancel.json";
+    const first = dedupedPagesDataFetch(url, { signal: firstController.signal });
+    const second = dedupedPagesDataFetch(url, { signal: secondController.signal });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    firstController.abort();
+    expect(fetchSignals[0].aborted).toBe(false);
+    secondController.abort();
+    expect(fetchSignals[0].aborted).toBe(true);
+
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+    await expect(second).rejects.toMatchObject({ name: "AbortError" });
+
+    const replacement = dedupedPagesDataFetch(url);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSignals[1].aborted).toBe(false);
+
+    rejectAbortedFetch(new DOMException("Aborted", "AbortError"));
+    await Promise.resolve();
+
+    const replacementJoiner = dedupedPagesDataFetch(url);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    resolveReplacement(new Response(JSON.stringify({ pageProps: { attempt: 2 } })));
+    await expect(
+      Promise.all([replacement, replacementJoiner]).then((responses) =>
+        Promise.all(responses.map((response) => response.json())),
+      ),
+    ).resolves.toEqual([{ pageProps: { attempt: 2 } }, { pageProps: { attempt: 2 } }]);
+  });
+
   it("evicts the inflight entry on fetch rejection so the next call retries", async () => {
     let attempt = 0;
     const fetchSpy = vi.fn(() => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16643,6 +16643,64 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  it("dedupes deferred identical pushes while cancelling only the stale navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+
+    const slowLoader = vi.fn(async () => makePageModule("slow"));
+    const { win, render, pushState } = createDataNavWindow({
+      loaders: { "/": vi.fn(async () => makePageModule("home")), "/slow": slowLoader },
+    });
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    let resolveFetch: (response: Response) => void = () => {};
+    const deferredResponse = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn(() => deferredResponse);
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      const routeChangeErrors: unknown[] = [];
+      const routeChangeComplete = vi.fn();
+      Router.events.on("routeChangeError", (error) => routeChangeErrors.push(error));
+      Router.events.on("routeChangeComplete", routeChangeComplete);
+
+      const firstPush = Router.push("/slow?value=one");
+      const secondPush = Router.push("/slow?value=one");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledTimes(2);
+
+      resolveFetch(
+        new Response(JSON.stringify({ pageProps: { hit: 1 } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(Promise.all([firstPush, secondPush])).resolves.toEqual([true, true]);
+      expect(routeChangeErrors).toHaveLength(1);
+      expect(routeChangeErrors[0]).toMatchObject({ cancelled: true });
+      expect(routeChangeComplete).toHaveBeenCalledTimes(1);
+      expect(slowLoader).toHaveBeenCalledTimes(1);
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(win.__NEXT_DATA__).toMatchObject({
+        page: "/slow",
+        query: { value: "one" },
+        props: { pageProps: { hit: 1 } },
+      });
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("threads full Pages props through _app during data navigation", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -16987,6 +17045,7 @@ describe("Pages Router _next/data client navigation", () => {
           purpose: "prefetch",
           "x-nextjs-data": "1",
         },
+        signal: expect.any(AbortSignal),
       });
       expect(appendedLinks).toEqual([]);
       // The loader was warmed (chunk fetch kicked off).


### PR DESCRIPTION
# vinext parity: concurrent Pages gSSP data navigation dedup and cancellation

Date: 2026-06-15
Branch: `codex/wave2-pages-gssp-dedup`
Base: `origin/main` at `a3d2f921` (`fix(router): honor hybrid pages route priority (#1997)`)

## Scope

- Pages Router `getServerSideProps` client data navigation only.
- Excludes cacheComponents, PPR, and resume behavior.
- Adds in-flight `/_next/data` request identity, waiter-aware shared cancellation, and stale-response protection.

## Upstream Next.js references

- Test: `.nextjs-ref/test/e2e/getserversideprops/test/index.test.ts`
  - `should not trigger an error when a data request is cancelled due to another navigation`
  - `should dedupe server data requests`
- Implementation: `.nextjs-ref/packages/next/src/shared/lib/router/router.ts`
  - `fetchNextData()` resolves `dataHref` against `window.location.href` and keys `inflightCache` by the resolved URL.
  - Router cancellation uses the active cancellation callback and emits a cancelled error without committing stale route data.

## Implementation

- `packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts`
  - Keys in-flight requests by resolved data URL plus `x-deployment-id`.
  - URL identity naturally keeps locale path, basePath, and query-string variants distinct.
  - Stores a shared `AbortController`, promise, settlement flag, and active waiter count per key.
  - Each caller releases exactly one waiter on response, rejection, or cancellation.
  - Cancelling one caller keeps the fetch alive while another waiter remains.
  - Cancelling the final waiter immediately evicts and aborts the shared fetch.
  - Both cancellation and settlement use entry identity checks, so an old finalizer cannot evict a replacement request.
- `packages/vinext/src/shims/router.ts`
  - Threads each navigation's abort signal into shared Pages data fetches and middleware data probes.
  - Defers superseded-navigation abort by one microtask so synchronous identical pushes can join the shared request before the prior waiter releases.
  - Navigation IDs still supersede stale work immediately; existing events, history writes, and stale-response checks remain intact.

## Coverage

- Helper tests:
  - identical concurrent URLs share one fetch;
  - locale/basePath/query/deployment variants remain distinct;
  - one cancelled caller does not abort the shared fetch;
  - all callers cancelling aborts the underlying fetch and evicts immediately;
  - a later identical caller starts and successfully consumes a replacement request;
  - the aborted old request settling after replacement does not evict that replacement;
  - settled/rejected requests evict and retry.
- Deferred router test:
  - repeated identical `Router.push()` calls issue one fetch;
  - stale navigation emits one `{ cancelled: true }` route error;
  - only the latest navigation completes, loads, renders, and commits `__NEXT_DATA__`;
  - both pushes keep their existing history/event return behavior.
- Production browser fixture:
  - four identical pushes produce one `/_next/data/...gssp-dedup-slow.json?key=same` request and server hit `1`;
  - different query keys produce distinct data requests;
  - a superseded slow request lands on the newer route with no console/page errors.

## Validation

Passed:

- `vp test run tests/pages-data-fetch-dedup.test.ts tests/pages-data-prefetch.test.ts tests/shims.test.ts -t "Pages Router _next/data client navigation|dedupedPagesDataFetch|prefetchPagesData"`
  - 21 passed, 1089 skipped by the targeted name filter.
- `PLAYWRIGHT_PROJECT=pages-router-prod npx playwright test tests/e2e/pages-router-prod/gssp-data-dedup.spec.ts --project=pages-router-prod`
  - 1 passed; the project command rebuilt `vinext`, built the Pages fixture, and ran it with `vinext start`.
- `vp check <changed files>`
  - formatting, lint, and type checks clean.
- `git diff --check`
  - clean.

## Review notes

- Review finding addressed: final-waiter cancellation now aborts the underlying fetch and permits immediate replacement.
- Self-review specifically checked waiter underflow, cancel/settle races, stale finalizer eviction, and synchronous identical-push ordering.
- No cacheComponents/PPR/resume files or behavior touched.
- No server-side request cache introduced; dedup is browser-realm and in-flight only.
- No push or PR created. Commit remains local for clean review.
