### PR TITLE
fix(middleware): classify Pages data requests by URL

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -562,7 +562,7 @@ import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix
 import { hasBasePath, stripBasePath } from "vinext/utils/base-path";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
-import { renderPage, handleApiRoute, runMiddleware, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
+import { renderPage, handleApiRoute, runMiddleware, normalizeDataRequest, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
 
@@ -626,11 +626,6 @@ export default {
         return notFoundStaticAssetResponse();
       }
 
-      // Capture x-nextjs-data before filterInternalHeaders strips it -- the
-      // middleware redirect protocol needs to know whether the inbound request
-      // was a _next/data fetch to emit x-nextjs-redirect instead of a 3xx.
-      const isDataRequest = request.headers.get("x-nextjs-data") === "1";
-
       // Strip internal headers from inbound requests so they cannot be
       // forged to influence routing or impersonate internal state.
       // Request.headers is immutable in Workers, so build a clean copy.
@@ -652,6 +647,14 @@ export default {
           request = cloneRequestWithUrl(request, strippedUrl.toString());
           pathname = stripped;
         }
+      }
+
+      const dataNorm = normalizeDataRequest(request);
+      if (dataNorm.notFoundResponse) return dataNorm.notFoundResponse;
+      const isDataReq = dataNorm.isDataReq;
+      if (isDataReq) {
+        request = dataNorm.request;
+        pathname = dataNorm.normalizedPathname;
       }
 
       // ── Image optimization via Cloudflare Images binding ──────────
@@ -682,12 +685,8 @@ export default {
         configRewrites,
         configHeaders,
         hadBasePath,
-        // The worker adapter does not do _next/data URL normalization (no
-        // buildId available at request time). isDataReq is used by the pipeline
-        // only for renderPage options and shouldDeferErrorPageOnMiss -- false
-        // is correct here.
-        isDataReq: false,
-        isDataRequest,
+        isDataReq,
+        isDataRequest: isDataReq,
         ctx,
         matchPageRoute: typeof matchPageRoute === "function" ? matchPageRoute : null,
         // Pass the original (pre-basePath-stripping) URL to middleware so that

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -171,43 +171,20 @@ if (typeof _instrumentation.onRequestError === "function") {
   const middlewareExportCode = middlewarePath
     ? `
 export async function runMiddleware(request, ctx, options) {
-  // Auto-detect /_next/data/<buildId>/<page>.json requests so user-written
-  // worker entries don't need to know about the data endpoint protocol.
-  // Mismatched buildId → JSON 404 short-circuit. Matched → middleware sees
-  // the normalized page path via the request URL, and the worker sees the
-  // normalized URL via result.rewriteUrl (if middleware didn't already
-  // rewrite to something else).
-  const __dataNorm = __normalizePagesDataRequest(request, buildId);
-  if (__dataNorm.notFoundResponse) {
-    return { continue: false, response: __dataNorm.notFoundResponse };
-  }
-  const __result = await __runGeneratedMiddleware({
+  return __runGeneratedMiddleware({
     basePath: vinextConfig.basePath,
     ctx,
     i18nConfig,
-    isDataRequest: options?.isDataRequest === true || __dataNorm.isDataReq,
+    isDataRequest: options?.isDataRequest === true,
     isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
     module: middlewareModule,
-    request: __dataNorm.request,
+    request,
     trailingSlash: vinextConfig.trailingSlash,
   });
-  if (__dataNorm.isDataReq && __result.continue && !__result.rewriteUrl && !__result.redirectUrl) {
-    return { ...__result, rewriteUrl: __dataNorm.normalizedPathname + __dataNorm.search };
-  }
-  return __result;
 }
 `
     : `
 export async function runMiddleware(request) {
-  // Even without user middleware, the data-endpoint URL must be normalized so
-  // the worker pipeline sees the page path. Mismatched buildId → JSON 404.
-  const __dataNorm = __normalizePagesDataRequest(request, buildId);
-  if (__dataNorm.notFoundResponse) {
-    return { continue: false, response: __dataNorm.notFoundResponse };
-  }
-  if (__dataNorm.isDataReq) {
-    return { continue: true, rewriteUrl: __dataNorm.normalizedPathname + __dataNorm.search };
-  }
   return { continue: true };
 }
 `;
@@ -256,6 +233,9 @@ const i18nConfig = ${i18nConfigJson};
 // match _next/data requests against the embedded buildId without needing
 // to load next.config.js at runtime.
 export const buildId = ${buildIdJson};
+export function normalizeDataRequest(request) {
+  return __normalizePagesDataRequest(request, buildId);
+}
 const __hasMiddleware = ${JSON.stringify(Boolean(middlewarePath))};
 
 // Full resolved config for production server (embedded at build time)

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3616,6 +3616,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 }
               }
 
+              // When @cloudflare/vite-plugin is present, delegate the entire
+              // Pages Router request pipeline to the Worker/miniflare side
+              // before mutating _next/data URLs. The generated Worker entry
+              // owns build-ID-aware data normalization and trusted protocol
+              // classification.
+              if (hasCloudflarePlugin) return next();
+
               // ── `_next/data` normalization (Pages Router) ──────────────
               // Client-side navigations in the Pages Router fetch
               // `/_next/data/<buildId>/<page>.json`. Normalize the URL to the
@@ -3667,13 +3674,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 return next();
               }
 
-              // When @cloudflare/vite-plugin is present, delegate the entire
-              // Pages Router request pipeline to the Worker/miniflare side.
-              // That keeps middleware, headers, redirects, rewrites, API
-              // routes, and rendering in one place instead of mutating the
-              // host request and forwarding post-middleware state downstream.
-              if (hasCloudflarePlugin) return next();
-
               // Snapshot of req.headers before middleware runs. Used for both
               // preMiddlewareReqCtx and the middleware Request itself. Intentionally
               // captured once here — applyRequestHeadersToNodeRequest() mutates
@@ -3689,11 +3689,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     .map(([k, v]) => [k, Array.isArray(v) ? v.join(", ") : String(v)]),
                 ),
               );
-              // Capture `x-nextjs-data` before filterInternalHeaders strips it
-              // — the middleware redirect protocol needs to know whether the
-              // inbound request was a `_next/data` fetch to emit
-              // `x-nextjs-redirect` instead of a 3xx.
-              const isDataRequest = rawHeaders.get("x-nextjs-data") === "1";
+              // Only a successfully parsed `/_next/data/...json` URL is a data
+              // request. The inbound x-nextjs-data header is internal and must
+              // not let callers opt normal URLs into the data redirect protocol.
+              const isDataRequest = isDataReq;
               // Strip internal headers from inbound requests so they cannot be
               // forged to influence routing or impersonate internal state.
               // Both the middleware Request (built below) and the SSR handler

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -61,10 +61,9 @@ type ExecuteMiddlewareOptions = {
   i18nConfig?: NextI18nConfig | null;
   includeErrorDetails?: boolean;
   /**
-   * Whether the incoming request was a Next.js `_next/data` fetch (carried
-   * `x-nextjs-data: 1`). The header itself is stripped by `filterInternalHeaders`
-   * before the middleware request is constructed, so callers must capture this
-   * flag from the raw incoming headers and forward it explicitly.
+   * Whether the incoming request was recognized as a Next.js `_next/data`
+   * fetch. Internal headers are stripped before middleware runs, so adapters
+   * must derive and forward this from trusted URL normalization.
    */
   isDataRequest?: boolean;
   isProxy: boolean;
@@ -371,9 +370,8 @@ export async function executeMiddleware(
       // For `_next/data` requests, translate the HTTP redirect into the
       // `x-nextjs-redirect` soft-redirect protocol so the client router can
       // perform the navigation without tripping CORS on cross-origin targets.
-      // `x-nextjs-data` lives in INTERNAL_HEADERS and is stripped before the
-      // middleware request is constructed, so the flag is threaded in from the
-      // caller (which sees the raw incoming headers).
+      // Internal data headers are stripped before middleware runs, so this
+      // protocol is gated on trusted classification threaded by the caller.
       if (options.isDataRequest) {
         return {
           continue: false,

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -19,6 +19,7 @@
  */
 
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
+import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
 
 const NEXT_DATA_PREFIX = "/_next/data/";
 const NEXT_DATA_SUFFIX = ".json";
@@ -197,9 +198,12 @@ type NormalizePagesDataRequestResult =
 export function normalizePagesDataRequest(
   request: Request,
   buildId: string | null,
+  basePath = "",
 ): NormalizePagesDataRequestResult {
   const reqUrl = new URL(request.url);
-  if (!isNextDataPathname(reqUrl.pathname)) {
+  const hadBasePath = !!basePath && hasBasePath(reqUrl.pathname, basePath);
+  const dataPathname = basePath ? stripBasePath(reqUrl.pathname, basePath) : reqUrl.pathname;
+  if (!isNextDataPathname(dataPathname)) {
     return {
       isDataReq: false,
       request,
@@ -208,7 +212,7 @@ export function normalizePagesDataRequest(
       notFoundResponse: null,
     };
   }
-  const dataMatch = buildId ? parseNextDataPathname(reqUrl.pathname, buildId) : null;
+  const dataMatch = buildId ? parseNextDataPathname(dataPathname, buildId) : null;
   if (!dataMatch) {
     return {
       isDataReq: false,
@@ -219,7 +223,9 @@ export function normalizePagesDataRequest(
     };
   }
   const normalizedUrl = new URL(reqUrl);
-  normalizedUrl.pathname = dataMatch.pagePathname;
+  normalizedUrl.pathname = hadBasePath
+    ? addBasePathToPathname(dataMatch.pagePathname, basePath)
+    : dataMatch.pagePathname;
   return {
     isDataReq: true,
     request: new Request(normalizedUrl, request),

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -76,7 +76,7 @@ export type PagesPipelineDeps = {
   // Pre-computed per-request values (adapter sets these)
   hadBasePath: boolean; // adapter computes: !basePath || hasBasePath(originalPathname, basePath)
   isDataReq: boolean; // true if this was a /_next/data/ request (already normalized by adapter)
-  isDataRequest: boolean; // true if x-nextjs-data: 1 header was present (for middleware opts)
+  isDataRequest: boolean; // trusted data classification for middleware protocol handling
   ctx?: unknown; // Cloudflare ExecutionContext or undefined (for Node)
   // Raw, un-re-encoded query string (incl. leading "?") for building redirect Location
   // headers. Node adapters that build the Web Request from a raw req.url string should
@@ -548,11 +548,7 @@ export async function runPagesRequest(
       }
     }
     // A data request must not defer-render the error page or run fallback rewrites.
-    // Node/dev signal this via `isDataReq` (set when a `/_next/data/` path is
-    // normalized); the worker never normalizes those paths (no buildId at request
-    // scope), so it relies on the `x-nextjs-data: 1` header captured as `isDataRequest`.
-    // Gate on both so the worker matches the pre-refactor behavior (it previously gated
-    // on the header). No-op for Node/dev, where a data request already has isDataReq=true.
+    // All adapters normalize real `/_next/data/` URLs before this point.
     const shouldDeferErrorPageOnMiss =
       !isDataReq && !isDataRequest && !!deps.matchPageRoute && !renderPageMatch;
     const initialRenderOptions: PagesRenderOptions | undefined = shouldDeferErrorPageOnMiss

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1707,10 +1707,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       const protocol = resolveRequestProtocol(req);
       const hostHeader = resolveHost(req, `${host}:${port}`);
       const rawReqHeaders = nodeHeadersToWebHeaders(req.headers);
-      // Capture `x-nextjs-data` before filterInternalHeaders strips it — the
-      // middleware redirect protocol needs to know whether the inbound request
-      // was a `_next/data` fetch to emit `x-nextjs-redirect` instead of a 3xx.
-      const isDataRequest = rawReqHeaders.get("x-nextjs-data") === "1";
+      // Only a successfully parsed `/_next/data/...json` URL is a data
+      // request. The inbound x-nextjs-data header is internal and must not let
+      // callers opt normal URLs into the data redirect protocol.
+      const isDataRequest = isDataReq;
       // Strip internal headers from inbound requests before any handler or
       // middleware sees them.
       const reqHeaders = filterInternalHeaders(rawReqHeaders);

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -853,6 +853,21 @@ describe("scanPublicFileRoutes", () => {
 });
 
 describe("generatePagesRouterWorkerEntry", () => {
+  it("keeps Cloudflare dev _next/data URLs intact for Worker normalization", () => {
+    const indexSource = fs.readFileSync(
+      path.join(import.meta.dirname, "../packages/vinext/src/index.ts"),
+      "utf8",
+    );
+    const delegation = indexSource.indexOf("if (hasCloudflarePlugin) return next();");
+    const dataNormalization = indexSource.indexOf(
+      "// ── `_next/data` normalization (Pages Router) ──────────────",
+    );
+
+    expect(delegation).toBeGreaterThanOrEqual(0);
+    expect(dataNormalization).toBeGreaterThanOrEqual(0);
+    expect(delegation).toBeLessThan(dataNormalization);
+  });
+
   it("generates valid TypeScript", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain("export default");
@@ -869,6 +884,8 @@ describe("generatePagesRouterWorkerEntry", () => {
     // runPagesRequest.
     expect(content).toContain('typeof runMiddleware === "function"');
     expect(content).toContain("wrapMiddlewareWithBasePath(runMiddleware, basePath, hadBasePath)");
+    expect(content).toContain("const dataNorm = normalizeDataRequest(request)");
+    expect(content).toContain("isDataRequest: isDataReq");
     expect(content).toContain("runPagesRequest(request, deps)");
   });
 
@@ -1250,9 +1267,10 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("does not defer error page rendering for data requests", () => {
     const content = generatePagesRouterWorkerEntry();
     // shouldDeferErrorPageOnMiss logic is now inside runPagesRequest.
-    // The worker passes isDataReq: false (no buildId normalization) and
-    // matchPageRoute dep so the pipeline computes the right behavior.
-    expect(content).toContain("isDataReq: false,");
+    // The worker normalizes the build-ID-aware URL before the pipeline and
+    // passes the trusted classification alongside matchPageRoute.
+    expect(content).toContain("isDataReq,");
+    expect(content).toContain("isDataRequest: isDataReq");
     expect(content).toContain(
       'matchPageRoute: typeof matchPageRoute === "function" ? matchPageRoute : null',
     );

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -857,6 +857,41 @@ describe("App Router entry templates", () => {
 // ── Pages Router entry template runtime bootstrap ─────────────────────
 
 describe("Pages Router entry template", () => {
+  it("reports trusted _next/data classification from URL normalization", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-data-entry-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    const middlewarePath = path.join(tmpDir, "middleware.ts");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+      fs.writeFileSync(
+        middlewarePath,
+        'export function middleware() { return new Response(null, { headers: { "x-middleware-next": "1" } }); }',
+      );
+
+      const code = await generateServerEntry(
+        pagesDir,
+        await resolveNextConfig({
+          basePath: "/root",
+          generateBuildId: () => "test-build-id",
+        }),
+        createValidFileMatcher(),
+        middlewarePath,
+        null,
+      );
+
+      expect(code).toContain("export function normalizeDataRequest(request)");
+      expect(code).toContain("return __normalizePagesDataRequest(request, buildId)");
+      expect(code).not.toContain('request.headers.get("x-nextjs-data")');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("installs server globals before Pages Router user modules are imported", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-entry-"));
     const pagesDir = path.join(tmpDir, "pages");

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -90,6 +90,30 @@ describe("pages-data-route", () => {
     });
   });
 
+  describe("normalizePagesDataRequest", () => {
+    it("recognizes a data URL under basePath while preserving basePath for middleware", () => {
+      const buildId = "abc123";
+      const req = new Request(`http://localhost/root/_next/data/${buildId}/about.json?x=1`);
+      const result = normalizePagesDataRequest(req, buildId, "/root");
+
+      expect(result.isDataReq).toBe(true);
+      expect(result.normalizedPathname).toBe("/about");
+      expect(result.search).toBe("?x=1");
+      expect(result.request.url).toBe("http://localhost/root/about?x=1");
+      expect(result.notFoundResponse).toBeNull();
+    });
+
+    it("preserves an absolute data URL outside the configured basePath", () => {
+      const buildId = "abc123";
+      const req = new Request(`http://localhost/_next/data/${buildId}/about.json?x=1`);
+      const result = normalizePagesDataRequest(req, buildId, "/root");
+
+      expect(result.isDataReq).toBe(true);
+      expect(result.normalizedPathname).toBe("/about");
+      expect(result.request.url).toBe("http://localhost/about?x=1");
+    });
+  });
+
   describe("buildNextDataNotFoundResponse", () => {
     it("returns a 404 JSON response with empty body", async () => {
       const res = buildNextDataNotFoundResponse();

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -141,6 +141,30 @@ describe("middleware", () => {
     expect(result.response.status).toBe(307);
   });
 
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("does not classify a normal request as data from x-nextjs-data alone", async () => {
+    const runMiddleware = vi.fn(async () => ({
+      continue: false,
+      redirectUrl: "http://localhost/somewhere",
+      redirectStatus: 307,
+    }));
+
+    const result = await runPagesRequest(
+      makeRequest("/redirect-to-somewhere", { "x-nextjs-data": "1" }),
+      baseDeps({ runMiddleware }),
+    );
+
+    expect(runMiddleware).toHaveBeenCalledWith(expect.any(Request), null, {
+      isDataRequest: false,
+    });
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.status).toBe(307);
+    expect(result.response.headers.get("Location")).toBe("http://localhost/somewhere");
+    expect(result.response.headers.get("x-nextjs-redirect")).toBeNull();
+  });
+
   // 5. Middleware rewrite: resolvedUrl changes, pipeline continues
   it("middleware rewrite changes resolved URL, pipeline continues to render", async () => {
     const renderPage = makeRenderPage(200, "rewrite target");
@@ -164,23 +188,36 @@ describe("middleware", () => {
     );
   });
 
-  it("exposes the middleware rewrite target on Pages data responses", async () => {
-    const result = await runPagesRequest(
-      makeRequest("/to-blog/post"),
-      baseDeps({
-        isDataRequest: true,
-        runMiddleware: makeMiddleware({
-          continue: true,
-          rewriteUrl: "/fallback-true-blog/post",
+  it.each([
+    { i18nConfig: null, requestPath: "/ssr-page", rewritePath: "/ssr-page-2" },
+    {
+      i18nConfig: { locales: ["en", "fr"], defaultLocale: "en" },
+      requestPath: "/en/ssr-page",
+      rewritePath: "/en/ssr-page-2",
+    },
+  ])(
+    "exposes the middleware rewrite target on real Pages data responses ($requestPath)",
+    async ({ i18nConfig, requestPath, rewritePath }) => {
+      const result = await runPagesRequest(
+        makeRequest(requestPath),
+        baseDeps({
+          isDataReq: true,
+          isDataRequest: true,
+          i18nConfig,
+          runMiddleware: makeMiddleware({
+            continue: true,
+            rewriteUrl: rewritePath,
+          }),
+          renderPage: makeRenderPage(200, '{"pageProps":{"message":"Bye Cruel World"}}'),
         }),
-        renderPage: makeRenderPage(200, '{"pageProps":{"slug":"post"}}'),
-      }),
-    );
+      );
 
-    expect(result.type).toBe("response");
-    if (result.type !== "response") return;
-    expect(result.response.headers.get("x-nextjs-rewrite")).toBe("/fallback-true-blog/post");
-  });
+      expect(result.type).toBe("response");
+      if (result.type !== "response") return;
+      expect(result.response.headers.get("x-nextjs-rewrite")).toBe(rewritePath);
+      expect(result.response.headers.get("x-middleware-rewrite")).toBeNull();
+    },
+  );
 
   it("does not expose the middleware rewrite target on HTML responses", async () => {
     const result = await runPagesRequest(

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2027,6 +2027,25 @@ describe("Pages Router integration", () => {
     // value matches the prod-server's embedded buildId.
     const BUILD_ID = "test-build-id";
 
+    // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+    it("does not treat a normal URL as a data request from x-nextjs-data alone", async () => {
+      const res = await fetch(`${baseUrl}/old-page`, {
+        redirect: "manual",
+        headers: { "x-nextjs-data": "1" },
+      });
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/about");
+      expect(res.headers.get("x-nextjs-redirect")).toBeNull();
+    });
+
+    it("adds x-nextjs-rewrite for a real data URL rewritten by middleware", async () => {
+      const res = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/rewritten.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-nextjs-rewrite")).toBe("/ssr");
+      expect(res.headers.get("x-middleware-rewrite")).toBeNull();
+    });
+
     it("returns { pageProps } JSON for a getServerSideProps page", async () => {
       const res = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/ssr.json`);
       expect(res.status).toBe(200);
@@ -5229,6 +5248,25 @@ describe("Production server middleware (Pages Router)", () => {
   describe("/_next/data JSON endpoint", () => {
     // pages-basic's next.config.mjs pins the build id to "test-build-id".
     const BUILD_ID = "test-build-id";
+
+    // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+    it("does not treat a normal URL as a data request from x-nextjs-data alone", async () => {
+      const res = await fetch(`${prodUrl}/old-page`, {
+        redirect: "manual",
+        headers: { "x-nextjs-data": "1" },
+      });
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toContain("/about");
+      expect(res.headers.get("x-nextjs-redirect")).toBeNull();
+    });
+
+    it("adds x-nextjs-rewrite for a real data URL rewritten by middleware", async () => {
+      const res = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/rewritten.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-nextjs-rewrite")).toBe("/ssr");
+      expect(res.headers.get("x-middleware-rewrite")).toBeNull();
+    });
 
     it("returns { pageProps } JSON for a getServerSideProps page", async () => {
       const res = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/ssr.json`);


### PR DESCRIPTION
# vinext parity: Pages middleware data requests

Date: 2026-06-15
Worktree: `/Users/jamesanderson/.codex/worktrees/wave2-middleware-data-requests/vinext`
Branch: `codex/wave2-middleware-data-requests`
Base: `origin/main` at `a3d2f921`
Scope: wave2 candidate 2 only; cacheComponents/PPR/resume excluded.

## Next.js reference

Ported exact behavior from:

- `test/e2e/middleware-general/test/index.test.ts`
  - `should not treat as _next/data request with just header`
  - `should add a rewrite header on data requests for rewrites`
  - i18n enabled and disabled matrix
- `test/e2e/middleware-general/app/middleware.js`
  - normal redirect behavior
  - `/ssr-page` rewrite to `/ssr-page-2`

## Reproduction on origin/main

A disposable detached worktree at `a3d2f921` ran the header-only redirect assertion against the existing Pages middleware fixture.

```text
Pages Router integration: expected 307, received 200
Production server middleware: expected 307, received 200
```

The inbound `x-nextjs-data: 1` header incorrectly opted an ordinary URL into the data soft-redirect protocol.

## Final implementation

- Dev and Node production classify data requests only after successful build-ID-aware `/_next/data/...json` URL parsing.
- The Worker adapter imports a generated `normalizeDataRequest()` helper and normalizes before `runPagesRequest`, preserving config redirect/header ordering and stale-build-ID JSON 404 behavior.
- Cloudflare Vite dev delegates before the host mutates `/_next/data` URLs, so the Worker receives the original trusted URL.
- Worker basePath normalization preserves whether the incoming data URL actually carried basePath, including absolute out-of-basePath requests.
- The shared pipeline emits `x-nextjs-rewrite` only for trusted real data rewrites.
- Internal `x-middleware-rewrite` and forged `x-nextjs-data` values are not exposed or trusted.

## Independent review

Multiple independent `codex review --uncommitted` passes identified and drove fixes for:

1. Worker data classification with basePath.
2. Absolute out-of-basePath data URLs.
3. Cloudflare Vite-dev handoff after host URL mutation.
4. Config redirect/header ordering when Worker normalization occurred too late.

Final architecture moves Worker data normalization before the shared request pipeline, resolving all four findings.

## Exact validations

Green final gate:

```bash
vp check packages/vinext/src/deploy.ts packages/vinext/src/entries/pages-server-entry.ts packages/vinext/src/index.ts packages/vinext/src/server/middleware-runtime.ts packages/vinext/src/server/pages-data-route.ts packages/vinext/src/server/pages-request-pipeline.ts packages/vinext/src/server/prod-server.ts tests/deploy.test.ts tests/entry-templates.test.ts tests/pages-data-route.test.ts tests/pages-request-pipeline.test.ts tests/pages-router.test.ts

vp test run tests/deploy.test.ts -t "keeps Cloudflare dev _next/data URLs intact|runs middleware before routing|does not defer error page rendering for data requests"
# 3 passed

vp test run tests/pages-data-route.test.ts tests/middleware-runtime.test.ts tests/pages-request-pipeline.test.ts
# 83 passed

vp test run tests/pages-router.test.ts -t "does not treat a normal URL as a data request|adds x-nextjs-rewrite for a real data URL"
# 4 passed

vp test run tests/entry-templates.test.ts -t "trusted _next/data classification"
# 1 passed

git diff --check
# clean
```

Also completed successfully before finalization:

```bash
vp run vinext#build
```

The package build completed with its existing unresolved virtual/private import warnings treated as externals.
