### PR TITLE
fix(image): emit static imports as managed assets

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -198,7 +198,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 import fs from "node:fs";
-import { randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
 import { normalizePathSeparators, stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
 import { getViteMajorVersion } from "./utils/vite-version.js";
@@ -962,6 +962,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   }
 
   const imageImportDimCache = new Map<string, { width: number; height: number }>();
+  const staticImageAssets = new Map<string, { fileName: string; source: Buffer }>();
 
   // Shared state for the MDX proxy plugin. We auto-inject @mdx-js/rollup when
   // MDX is detected in app/pages during config(), and lazily on first plain
@@ -4176,16 +4177,43 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       _dimCache: imageImportDimCache,
 
       resolveId: {
-        filter: { id: /\?vinext-meta$/ },
+        filter: { id: /\?vinext-(?:image-url|meta)$/ },
         handler(source, _importer) {
-          if (!source.endsWith("?vinext-meta")) return null;
-          // Resolve the real image path from the importer
-          const realPath = source.replace("?vinext-meta", "");
-          return `\0vinext-image-meta:${realPath}`;
+          if (source.endsWith("?vinext-image-url")) {
+            return `\0vinext-image-url:${source.slice(0, -"?vinext-image-url".length)}`;
+          }
+          if (source.endsWith("?vinext-meta")) {
+            return `\0vinext-image-meta:${source.slice(0, -"?vinext-meta".length)}`;
+          }
+          return null;
         },
       },
 
       async load(id) {
+        if (id.startsWith("\0vinext-image-url:")) {
+          const imagePath = id.replace("\0vinext-image-url:", "");
+          if (this.environment.config.command === "serve") {
+            return `import url from ${JSON.stringify(imagePath + "?url")}; export default url;`;
+          }
+
+          let asset = staticImageAssets.get(imagePath);
+          if (!asset) {
+            const source = fs.readFileSync(imagePath);
+            const extension = path.extname(imagePath);
+            const name = path.basename(imagePath, extension);
+            const hash = createHash("sha256").update(source).digest("hex").slice(0, 8);
+            asset = {
+              fileName: `media/${name}.${hash}${extension}`,
+              source,
+            };
+            staticImageAssets.set(imagePath, asset);
+          }
+
+          const builtFileName = `${resolveAssetsDir(nextConfig.assetPrefix)}/${asset.fileName}`;
+          return `export default ${JSON.stringify(
+            renderVinextBuiltUrl(builtFileName, nextConfig.assetPrefix, nextConfig.deploymentId),
+          )};`;
+        }
         if (!id.startsWith("\0vinext-image-meta:")) return null;
         const imagePath = id.replace("\0vinext-image-meta:", "");
 
@@ -4293,13 +4321,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             if (!fs.existsSync(absImagePath)) continue;
 
             // Replace the single import with two:
-            // 1. Original import (Vite gives us the URL string)
+            // 1. URL module. In dev it delegates to Vite's asset server; in a
+            //    production build it returns a stable Next-shaped URL and the
+            //    client build writes the registered source under static/media.
             // 2. Meta import (we provide { width, height })
             // Combined into a StaticImageData object
             const urlVar = `__vinext_img_url_${varName}`;
             const metaVar = `__vinext_img_meta_${varName}`;
             const replacement =
-              `import ${urlVar} from ${JSON.stringify(importPath)};\n` +
+              `import ${urlVar} from ${JSON.stringify(absImagePath + "?vinext-image-url")};\n` +
               `import ${metaVar} from ${JSON.stringify(absImagePath + "?vinext-meta")};\n` +
               `const ${varName} = { src: ${urlVar}, width: ${metaVar}.width, height: ${metaVar}.height };`;
 
@@ -4313,6 +4343,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             code: s.toString(),
             map: s.generateMap({ hires: "boundary" }),
           };
+        },
+      },
+
+      writeBundle: {
+        sequential: true,
+        order: "post",
+        handler(outputOptions) {
+          if (this.environment?.name !== "client") return;
+          const clientOutDir = outputOptions.dir
+            ? path.resolve(root, outputOptions.dir)
+            : path.resolve(root, options.clientOutDir ?? "dist/client");
+          const assetsDir = resolveAssetsDir(nextConfig.assetPrefix);
+          for (const asset of staticImageAssets.values()) {
+            const outputPath = path.join(clientOutDir, assetsDir, asset.fileName);
+            fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+            fs.writeFileSync(outputPath, asset.source);
+          }
         },
       },
     } as Plugin & { _dimCache: Map<string, { width: number; height: number }> },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -525,6 +525,14 @@ const RESOLVED_INSTRUMENTATION_CLIENT = `\0${VIRTUAL_INSTRUMENTATION_CLIENT}.mjs
  *  Shared between the Rolldown hook filter and the transform handler regex. */
 const IMAGE_EXTS = "png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?";
 
+function createStaticImageAsset(imagePath: string): { fileName: string; source: Buffer } {
+  const source = fs.readFileSync(imagePath);
+  const extension = path.extname(imagePath);
+  const name = path.basename(imagePath, extension);
+  const hash = createHash("sha256").update(source).digest("hex").slice(0, 8);
+  return { fileName: `media/${name}.${hash}${extension}`, source };
+}
+
 /**
  * Absolute path to vinext's shims directory, with a trailing slash. Normalized
  * to forward slashes because it is prefix-matched against Vite module ids (which
@@ -963,6 +971,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
   const imageImportDimCache = new Map<string, { width: number; height: number }>();
   const staticImageAssets = new Map<string, { fileName: string; source: Buffer }>();
+  const staticImageImportsByModule = new Map<string, Set<string>>();
+  const writtenStaticImageFiles = new Set<string>();
 
   // Shared state for the MDX proxy plugin. We auto-inject @mdx-js/rollup when
   // MDX is detected in app/pages during config(), and lazily on first plain
@@ -4176,6 +4186,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       // Cache of image dimensions to avoid re-reading files
       _dimCache: imageImportDimCache,
 
+      buildStart() {
+        imageImportDimCache.clear();
+        staticImageAssets.clear();
+      },
+
+      watchChange(id) {
+        imageImportDimCache.delete(id);
+        staticImageAssets.delete(id);
+        staticImageImportsByModule.delete(id);
+      },
+
       resolveId: {
         filter: { id: /\?vinext-(?:image-url|meta)$/ },
         handler(source, _importer) {
@@ -4192,22 +4213,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       async load(id) {
         if (id.startsWith("\0vinext-image-url:")) {
           const imagePath = id.replace("\0vinext-image-url:", "");
+          this.addWatchFile(imagePath);
           if (this.environment.config.command === "serve") {
             return `import url from ${JSON.stringify(imagePath + "?url")}; export default url;`;
           }
 
-          let asset = staticImageAssets.get(imagePath);
-          if (!asset) {
-            const source = fs.readFileSync(imagePath);
-            const extension = path.extname(imagePath);
-            const name = path.basename(imagePath, extension);
-            const hash = createHash("sha256").update(source).digest("hex").slice(0, 8);
-            asset = {
-              fileName: `media/${name}.${hash}${extension}`,
-              source,
-            };
-            staticImageAssets.set(imagePath, asset);
-          }
+          const asset = createStaticImageAsset(imagePath);
+          staticImageAssets.set(imagePath, asset);
 
           const builtFileName = `${resolveAssetsDir(nextConfig.assetPrefix)}/${asset.fileName}`;
           return `export default ${JSON.stringify(
@@ -4216,6 +4228,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
         if (!id.startsWith("\0vinext-image-meta:")) return null;
         const imagePath = id.replace("\0vinext-image-meta:", "");
+        this.addWatchFile(imagePath);
 
         // Read from cache first
         const cache = imageImportDimCache;
@@ -4286,6 +4299,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
           const s = new MagicString(code);
           let hasChanges = false;
+          const imageImports = new Set<string>();
 
           for (const node of ast.body) {
             if (node.type !== "ImportDeclaration") continue;
@@ -4319,6 +4333,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             const absImagePath = normalizePathSeparators(path.resolve(dir, importPath));
 
             if (!fs.existsSync(absImagePath)) continue;
+            imageImports.add(absImagePath);
 
             // Replace the single import with two:
             // 1. URL module. In dev it delegates to Vite's asset server; in a
@@ -4337,7 +4352,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             hasChanges = true;
           }
 
-          if (!hasChanges) return null;
+          if (!hasChanges) {
+            staticImageImportsByModule.delete(id);
+            return null;
+          }
+          staticImageImportsByModule.set(id, imageImports);
 
           return {
             code: s.toString(),
@@ -4355,11 +4374,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             ? path.resolve(root, outputOptions.dir)
             : path.resolve(root, options.clientOutDir ?? "dist/client");
           const assetsDir = resolveAssetsDir(nextConfig.assetPrefix);
-          for (const asset of staticImageAssets.values()) {
+          const activeImagePaths = new Set(
+            Array.from(staticImageImportsByModule.values()).flatMap((imports) => [...imports]),
+          );
+          const nextWrittenFiles = new Set<string>();
+          for (const imagePath of activeImagePaths) {
+            if (!fs.existsSync(imagePath)) continue;
+            const asset = staticImageAssets.get(imagePath) ?? createStaticImageAsset(imagePath);
             const outputPath = path.join(clientOutDir, assetsDir, asset.fileName);
             fs.mkdirSync(path.dirname(outputPath), { recursive: true });
             fs.writeFileSync(outputPath, asset.source);
+            nextWrittenFiles.add(outputPath);
           }
+          for (const outputPath of writtenStaticImageFiles) {
+            if (!nextWrittenFiles.has(outputPath)) fs.rmSync(outputPath, { force: true });
+          }
+          writtenStaticImageFiles.clear();
+          for (const outputPath of nextWrittenFiles) writtenStaticImageFiles.add(outputPath);
         },
       },
     } as Plugin & { _dimCache: Map<string, { width: number; height: number }> },

--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -264,13 +264,25 @@ export class StaticFileCache {
 export function etagFromFilenameHash(relativePath: string, ext: string): string | null {
   const basename = path.basename(relativePath, ext);
   const lastDash = basename.lastIndexOf("-");
-  if (lastDash === -1 || lastDash === basename.length - 1) return null;
-  const suffix = basename.slice(lastDash + 1);
-  // Vite emits 8-char base64url hashes; allow 6-12 for other bundlers.
-  // If Rolldown changes its hash length, update this range.
-  return suffix.length >= 6 && suffix.length <= 12 && /^[A-Za-z0-9_-]+$/.test(suffix)
-    ? `W/"${suffix}"`
-    : null;
+  if (lastDash !== -1 && lastDash !== basename.length - 1) {
+    const suffix = basename.slice(lastDash + 1);
+    // Vite emits 8-char base64url hashes; allow 6-12 for other bundlers.
+    // If Rolldown changes its hash length, update this range.
+    if (suffix.length >= 6 && suffix.length <= 12 && /^[A-Za-z0-9_-]+$/.test(suffix)) {
+      return `W/"${suffix}"`;
+    }
+  }
+
+  // vinext-managed static image imports use Next-shaped dot-delimited names:
+  // `media/name.<sha256-8>.<ext>`. Restrict this alternate form to exactly
+  // eight lowercase hex characters so semantic versions and ordinary dotted
+  // filenames can never be mistaken for stable content hashes.
+  const lastDot = basename.lastIndexOf(".");
+  if (lastDot !== -1) {
+    const suffix = basename.slice(lastDot + 1);
+    if (/^[0-9a-f]{8}$/.test(suffix)) return `W/"${suffix}"`;
+  }
+  return null;
 }
 
 function buildVariant(

--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -274,13 +274,20 @@ export function etagFromFilenameHash(relativePath: string, ext: string): string 
   }
 
   // vinext-managed static image imports use Next-shaped dot-delimited names:
-  // `media/name.<sha256-8>.<ext>`. Restrict this alternate form to exactly
-  // eight lowercase hex characters so semantic versions and ordinary dotted
-  // filenames can never be mistaken for stable content hashes.
-  const lastDot = basename.lastIndexOf(".");
-  if (lastDot !== -1) {
-    const suffix = basename.slice(lastDot + 1);
-    if (/^[0-9a-f]{8}$/.test(suffix)) return `W/"${suffix}"`;
+  // `_next/static/media/name.<sha256-8>.<ext>`. Restrict this alternate form
+  // to that managed directory so arbitrary static files such as
+  // `_next/static/config.deadbeef.json` cannot receive a stale hash ETag.
+  const normalizedPath = normalizePathSeparators(relativePath);
+  const managedMediaSegment = `${ASSET_PREFIX_URL_DIR}/media/`;
+  const isManagedMedia =
+    normalizedPath.startsWith(managedMediaSegment) ||
+    normalizedPath.includes(`/${managedMediaSegment}`);
+  if (isManagedMedia) {
+    const lastDot = basename.lastIndexOf(".");
+    if (lastDot !== -1) {
+      const suffix = basename.slice(lastDot + 1);
+      if (/^[0-9a-f]{8}$/.test(suffix)) return `W/"${suffix}"`;
+    }
   }
   return null;
 }

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -223,6 +223,14 @@ function isRemoteUrl(src: string): boolean {
   return src.startsWith("http://") || src.startsWith("https://") || src.startsWith("//");
 }
 
+function isSvgUrl(src: string): boolean {
+  try {
+    return new URL(src, "http://vinext.local").pathname.toLowerCase().endsWith(".svg");
+  } catch {
+    return false;
+  }
+}
+
 function getFillStyle(
   style?: React.CSSProperties,
   backgroundStyle?: React.CSSProperties,
@@ -596,7 +604,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   // SVG sources auto-skip unless dangerouslyAllowSVG is enabled, matching
   // Next.js behavior where .svg triggers unoptimized=true by default.
   const imgQuality = quality ?? 75;
-  const isSvg = src.endsWith(".svg");
+  const isSvg = isSvgUrl(src);
   const skipOptimization = _unoptimized === true || (isSvg && !__dangerouslyAllowSVG);
 
   // Build srcSet for responsive local images (common breakpoints).
@@ -727,7 +735,7 @@ export function getImageProps(props: ImageProps): {
   // For local images (no loader, not remote), route through optimization endpoint.
   // When `unoptimized` is true, bypass the endpoint entirely (Next.js compat).
   // SVG sources auto-skip unless dangerouslyAllowSVG is enabled.
-  const isSvg = resolvedSrc.endsWith(".svg");
+  const isSvg = isSvgUrl(resolvedSrc);
   const skipOpt =
     _unoptimized === true ||
     (isSvg && !__dangerouslyAllowSVG) ||

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -230,8 +230,8 @@ describe("Image SSR rendering", () => {
       }),
     );
 
-    expect(html).toContain(`src="${src.replace("&", "&amp;")}"`);
-    expect(html).toContain(`srcSet="${src.replace("&", "&amp;")}`);
+    expect(html).toContain(`src="${src.replaceAll("&", "&amp;")}"`);
+    expect(html).toContain(`srcSet="${src.replaceAll("&", "&amp;")}`);
     expect(html).not.toContain("/_next/image?");
   });
 

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -221,6 +221,20 @@ describe("Image SSR rendering", () => {
     expect(html).toContain("data:image/png;base64,xyz");
   });
 
+  it("bypasses optimization for deployment-tagged SVG static imports", () => {
+    const src = "/_next/static/media/icon.0123abcd.svg?dpl=deployment-1";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "static svg",
+        src: { src, width: 32, height: 32 },
+      }),
+    );
+
+    expect(html).toContain(`src="${src.replace("&", "&amp;")}"`);
+    expect(html).toContain(`srcSet="${src.replace("&", "&amp;")}`);
+    expect(html).not.toContain("/_next/image?");
+  });
+
   it("applies className and custom style", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
@@ -442,6 +456,17 @@ describe("getImageProps", () => {
     expect(props.src).toBe(optUrl("/static/photo.png", 1920));
     expect(props.width).toBe(1920);
     expect(props.height).toBe(1080);
+  });
+
+  it("getImageProps bypasses optimization for deployment-tagged SVG imports", () => {
+    const src = "/_next/static/media/icon.0123abcd.svg?dpl=deployment-1";
+    const { props } = getImageProps({
+      alt: "static svg",
+      src: { src, width: 32, height: 32 },
+    });
+
+    expect(props.src).toBe(src);
+    expect(props.srcSet).toBeUndefined();
   });
 
   it("generates srcSet for local images", () => {

--- a/tests/image-imports.test.ts
+++ b/tests/image-imports.test.ts
@@ -42,10 +42,25 @@ describe("vinext:image-imports — resolveId", () => {
 
 // ── load ──────────────────────────────────────────────────────
 describe("vinext:image-imports — load", () => {
+  function createLoadContext(plugin: Plugin) {
+    const watched: string[] = [];
+    return {
+      context: Object.assign(Object.create(plugin), {
+        addWatchFile(filePath: string) {
+          watched.push(filePath);
+        },
+        environment: { config: { command: "build" } },
+      }),
+      watched,
+    };
+  }
+
   it("returns dimensions for a PNG file", async () => {
     const plugin = getImagePlugin();
     const load = plugin.load as Function;
-    const result = await load.call(plugin, `\0vinext-image-meta:${PNG_PATH}`);
+    const { context, watched } = createLoadContext(plugin);
+    const result = await load.call(context, `\0vinext-image-meta:${PNG_PATH}`);
+    expect(watched).toEqual([PNG_PATH]);
     expect(result).toContain("export default");
     const json = result.replace("export default ", "").replace(";", "");
     const dims = JSON.parse(json);
@@ -56,7 +71,9 @@ describe("vinext:image-imports — load", () => {
   it("returns dimensions for a JPEG file", async () => {
     const plugin = getImagePlugin();
     const load = plugin.load as Function;
-    const result = await load.call(plugin, `\0vinext-image-meta:${JPG_PATH}`);
+    const { context, watched } = createLoadContext(plugin);
+    const result = await load.call(context, `\0vinext-image-meta:${JPG_PATH}`);
+    expect(watched).toEqual([JPG_PATH]);
     const json = result.replace("export default ", "").replace(";", "");
     const dims = JSON.parse(json);
     expect(dims.width).toBe(8);
@@ -66,7 +83,9 @@ describe("vinext:image-imports — load", () => {
   it("returns 0x0 for non-existent file", async () => {
     const plugin = getImagePlugin();
     const load = plugin.load as Function;
-    const result = await load.call(plugin, "\0vinext-image-meta:/no/such/file.png");
+    const { context, watched } = createLoadContext(plugin);
+    const result = await load.call(context, "\0vinext-image-meta:/no/such/file.png");
+    expect(watched).toEqual(["/no/such/file.png"]);
     const json = result.replace("export default ", "").replace(";", "");
     const dims = JSON.parse(json);
     expect(dims.width).toBe(0);
@@ -84,10 +103,11 @@ describe("vinext:image-imports — load", () => {
     const plugin = getImagePlugin();
     plugin._dimCache.clear();
     const load = plugin.load as Function;
-    await load.call(plugin, `\0vinext-image-meta:${PNG_PATH}`);
+    const { context } = createLoadContext(plugin);
+    await load.call(context, `\0vinext-image-meta:${PNG_PATH}`);
     expect(plugin._dimCache.has(PNG_PATH)).toBe(true);
     // Second call uses cache (no way to verify directly, but should not throw)
-    const result = await load.call(plugin, `\0vinext-image-meta:${PNG_PATH}`);
+    const result = await load.call(context, `\0vinext-image-meta:${PNG_PATH}`);
     expect(result).toContain('"width":4');
   });
 });

--- a/tests/image-imports.test.ts
+++ b/tests/image-imports.test.ts
@@ -106,6 +106,8 @@ describe("vinext:image-imports — transform", () => {
   function expectImageBinding(code: string, name: string, fileBasename: string) {
     expect(code).not.toMatch(new RegExp(`import\\s+${name}\\s+from`));
     expect(code).toMatch(new RegExp(`const\\s+${name}\\s*=\\s*\\{[^}]*src\\s*:`));
+    const urlSpecifier = normalizePathSeparators(path.join(IMAGES_DIR, fileBasename));
+    expect(code).toContain(urlSpecifier + "?vinext-image-url");
     // The meta import specifier uses forward slashes — the transform normalizes
     // the resolved path so generated output is consistent across platforms.
     const metaSpecifier = normalizePathSeparators(path.join(IMAGES_DIR, fileBasename));

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -778,6 +778,28 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(captured.headers["Cache-Control"]).toBe("public, max-age=31536000, immutable");
   });
 
+  it("slow path returns 304 for managed image with matching dot-hash ETag", async () => {
+    await writeFile(clientDir, "_next/static/media/photo.0123abcd.png", "image content");
+
+    const req = mockReq(undefined, { "if-none-match": 'W/"0123abcd"' });
+    const { res, captured } = mockRes();
+
+    const served = await tryServeStatic(
+      req,
+      res,
+      clientDir,
+      "/_next/static/media/photo.0123abcd.png",
+      false,
+    );
+
+    await captured.ended;
+    expect(served).toBe(true);
+    expect(captured.status).toBe(304);
+    expect(captured.body.length).toBe(0);
+    expect(captured.headers["ETag"]).toBe('W/"0123abcd"');
+    expect(captured.headers["Cache-Control"]).toBe("public, max-age=31536000, immutable");
+  });
+
   it("slow path returns 200 when ETag does not match", async () => {
     await writeFile(clientDir, "_next/static/etag-slow-miss-xyz999.js", "fresh content");
 

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -800,6 +800,32 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(captured.headers["Cache-Control"]).toBe("public, max-age=31536000, immutable");
   });
 
+  it("slow path does not reuse dot-hash ETags for arbitrary static files", async () => {
+    const relativePath = "_next/static/config.deadbeef.json";
+    await writeFile(clientDir, relativePath, '{"version":1}');
+
+    const firstReq = mockReq();
+    const { res: firstRes, captured: firstCaptured } = mockRes();
+    await tryServeStatic(firstReq, firstRes, clientDir, `/${relativePath}`, false);
+    await firstCaptured.ended;
+
+    const firstEtag = firstCaptured.headers["ETag"] as string;
+    expect(firstCaptured.status).toBe(200);
+    expect(firstCaptured.body.toString()).toBe('{"version":1}');
+    expect(firstEtag).not.toBe('W/"deadbeef"');
+
+    await writeFile(clientDir, relativePath, '{"version":200}');
+
+    const secondReq = mockReq(undefined, { "if-none-match": firstEtag });
+    const { res: secondRes, captured: secondCaptured } = mockRes();
+    await tryServeStatic(secondReq, secondRes, clientDir, `/${relativePath}`, false);
+    await secondCaptured.ended;
+
+    expect(secondCaptured.status).toBe(200);
+    expect(secondCaptured.body.toString()).toBe('{"version":200}');
+    expect(secondCaptured.headers["ETag"]).not.toBe(firstEtag);
+  });
+
   it("slow path returns 200 when ETag does not match", async () => {
     await writeFile(clientDir, "_next/static/etag-slow-miss-xyz999.js", "fresh content");
 

--- a/tests/static-file-cache.test.ts
+++ b/tests/static-file-cache.test.ts
@@ -114,6 +114,15 @@ describe("StaticFileCache", () => {
     expect(entry!.etag).toBe('W/"abc123"');
   });
 
+  it("generates stable weak etag for dot-delimited managed image hashes", async () => {
+    await writeFile(clientDir, "_next/static/media/photo.0123abcd.png", "image bytes");
+
+    const cache = await StaticFileCache.create(clientDir);
+    const entry = cache.lookup("/_next/static/media/photo.0123abcd.png");
+
+    expect(entry!.etag).toBe('W/"0123abcd"');
+  });
+
   it("falls back to mtime etag for non-hashed files", async () => {
     await writeFile(clientDir, "favicon.ico", "icon");
 
@@ -138,6 +147,15 @@ describe("StaticFileCache", () => {
 
     const cache = await StaticFileCache.create(clientDir);
     const entry = cache.lookup("/_next/static/my-library-v2.0.0.js");
+
+    expect(entry!.etag).toMatch(/^W\/"\d+-\d+"$/);
+  });
+
+  it("does not treat arbitrary dot suffixes as managed image hashes", async () => {
+    await writeFile(clientDir, "_next/static/media/photo.deadbeefg.png", "image bytes");
+
+    const cache = await StaticFileCache.create(clientDir);
+    const entry = cache.lookup("/_next/static/media/photo.deadbeefg.png");
 
     expect(entry!.etag).toMatch(/^W\/"\d+-\d+"$/);
   });

--- a/tests/static-file-cache.test.ts
+++ b/tests/static-file-cache.test.ts
@@ -160,6 +160,17 @@ describe("StaticFileCache", () => {
     expect(entry!.etag).toMatch(/^W\/"\d+-\d+"$/);
   });
 
+  it("does not trust exact dot-hash suffixes outside managed media", async () => {
+    await writeFile(clientDir, "_next/static/config.deadbeef.json", '{"version":1}');
+
+    const cache = await StaticFileCache.create(clientDir);
+    const entry = cache.lookup("/_next/static/config.deadbeef.json");
+
+    expect(entry!.etag).toMatch(/^W\/"\d+-\d+"$/);
+    expect(entry!.etag).not.toBe('W/"deadbeef"');
+    expect(entry!.original.headers["Cache-Control"]).toBe("public, max-age=31536000, immutable");
+  });
+
   // ── Precompressed variants ─────────────────────────────────────
 
   it("detects brotli precompressed variant", async () => {

--- a/tests/static-image-emission.test.ts
+++ b/tests/static-image-emission.test.ts
@@ -11,6 +11,8 @@ const PNG_1X1 = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+X8n26QAAAABJRU5ErkJggg==",
   "base64",
 );
+const PNG_4X3 = fs.readFileSync(path.join(import.meta.dirname, "fixtures/images/test-4x3.png"));
+const SVG_2X3 = `<svg xmlns="http://www.w3.org/2000/svg" width="2" height="3"></svg>`;
 
 const tempDirs: string[] = [];
 const servers: Server[] = [];
@@ -45,6 +47,7 @@ async function createFixture(
     JSON.stringify({ name: `vinext-${router}-static-image`, private: true, type: "module" }),
   );
   writeFixtureFile(root, "test.png", PNG_1X1);
+  writeFixtureFile(root, "test.svg", SVG_2X3);
   writeFixtureFile(root, "tiny.png", PNG_1X1);
   if (options.basePath || options.assetPrefix || options.deploymentId) {
     writeFixtureFile(root, "next.config.mjs", `export default ${JSON.stringify(options)};\n`);
@@ -52,6 +55,7 @@ async function createFixture(
 
   const imageMarkup = `
       <Image id="static-image" alt="static import" src={staticImage} quality={85} />
+      <Image id="static-svg" alt="static svg import" src={staticSvg} />
       <img id="ordinary-asset" alt="ordinary asset" src={tinyUrl} />`;
 
   if (router === "app") {
@@ -82,6 +86,7 @@ export default function ClientImage() {
       "app/page.tsx",
       `import Image from "next/image";
 import staticImage from "../test.png";
+import staticSvg from "../test.svg";
 import tinyUrl from "../tiny.png?url";
 import ClientImage from "./client-image";
 
@@ -96,6 +101,7 @@ export default function Page() {
       "pages/index.tsx",
       `import Image from "next/image";
 import staticImage from "../test.png";
+import staticSvg from "../test.svg";
 import tinyUrl from "../tiny.png?url";
 
 export default function Page() {
@@ -155,6 +161,39 @@ async function buildFixture(root: string, router: "app" | "pages"): Promise<void
   });
 }
 
+type BuildWatcher = {
+  on(event: "event", callback: (event: { code: string; error?: Error }) => void): void;
+  close(): Promise<void>;
+};
+
+function waitForWatchBuild(watcher: BuildWatcher): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("Timed out waiting for watch rebuild")),
+      20_000,
+    );
+    watcher.on("event", (event) => {
+      if (event.code === "ERROR") {
+        clearTimeout(timeout);
+        reject(event.error ?? new Error("Watch build failed"));
+      } else if (event.code === "END") {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+  });
+}
+
+async function readBuiltJavaScript(outDir: string): Promise<string> {
+  const chunks: string[] = [];
+  for (const entry of await readdir(outDir, { withFileTypes: true })) {
+    const entryPath = path.join(outDir, entry.name);
+    if (entry.isDirectory()) chunks.push(await readBuiltJavaScript(entryPath));
+    else if (entry.name.endsWith(".js")) chunks.push(await readFile(entryPath, "utf8"));
+  }
+  return chunks.join("\n");
+}
+
 function getAttribute(html: string, id: string, attribute: string): string {
   const tag = html.match(new RegExp(`<img\\b[^>]*\\bid="${id}"[^>]*>`))?.[0];
   const value = tag?.match(new RegExp(`\\b${attribute}="([^"]+)"`, "i"))?.[1];
@@ -162,15 +201,24 @@ function getAttribute(html: string, id: string, attribute: string): string {
   return value.replaceAll("&amp;", "&");
 }
 
-async function findEmittedImage(root: string, assetPrefix = ""): Promise<string> {
+async function findEmittedAsset(
+  root: string,
+  assetPrefix: string,
+  extension: string,
+): Promise<string> {
   const prefixPath = assetPrefix.startsWith("http")
     ? ""
     : assetPrefix.split("/").filter(Boolean).join("/");
   const mediaDir = path.join(root, "dist/client", prefixPath, "_next/static/media");
   const files = await readdir(mediaDir);
-  const image = files.find((file) => /^test\.[\w-]{8}\.png$/.test(file));
-  if (!image) throw new Error(`Missing emitted test image in ${mediaDir}: ${files.join(", ")}`);
-  return image;
+  const asset = files.find((file) => new RegExp(`^test\\.[\\w-]{8}\\.${extension}$`).test(file));
+  if (!asset)
+    throw new Error(`Missing emitted test.${extension} in ${mediaDir}: ${files.join(", ")}`);
+  return asset;
+}
+
+async function findEmittedImage(root: string, assetPrefix = ""): Promise<string> {
+  return findEmittedAsset(root, assetPrefix, "png");
 }
 
 async function assertStaticImageProductionParity(
@@ -181,6 +229,7 @@ async function assertStaticImageProductionParity(
   await buildFixture(root, router);
   const effectiveAssetPrefix = options.assetPrefix ?? options.basePath ?? "";
   const emittedImage = await findEmittedImage(root, effectiveAssetPrefix);
+  const emittedSvg = await findEmittedAsset(root, effectiveAssetPrefix, "svg");
   const prefixPath = effectiveAssetPrefix.split("/").filter(Boolean).join("/");
   expect(
     await readFile(path.join(root, "dist/client", prefixPath, "_next/static/media", emittedImage)),
@@ -213,11 +262,27 @@ async function assertStaticImageProductionParity(
   }
 
   expect(getAttribute(html, "ordinary-asset", "src")).toMatch(/^data:image\/png/);
+  const managedSvgUrl = `${effectiveAssetPrefix}/_next/static/media/${emittedSvg}${
+    options.deploymentId ? `?dpl=${options.deploymentId}` : ""
+  }`;
+  expect(getAttribute(html, "static-svg", "src")).toBe(managedSvgUrl);
+  expect(getAttribute(html, "static-svg", "src")).not.toContain("/_next/image?");
   const assetResponse = await fetch(
     `http://127.0.0.1:${address.port}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
   );
   expect(assetResponse.status).toBe(200);
+  expect(assetResponse.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+  const etag = assetResponse.headers.get("etag");
+  expect(etag).toMatch(/^W\/"[0-9a-f]{8}"$/);
   expect(Buffer.from(await assetResponse.arrayBuffer())).toEqual(PNG_1X1);
+
+  const conditionalResponse = await fetch(
+    `http://127.0.0.1:${address.port}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
+    { headers: { "if-none-match": etag! } },
+  );
+  expect(conditionalResponse.status).toBe(304);
+  expect(conditionalResponse.headers.get("etag")).toBe(etag);
+  expect(await conditionalResponse.text()).toBe("");
 }
 
 describe("static image import production emission", () => {
@@ -244,5 +309,54 @@ describe("static image import production emission", () => {
       assetPrefix: "/cdn",
       deploymentId: "static-image-test",
     });
+  }, 60_000);
+
+  it("recomputes changed images and removes deleted imports during watch rebuilds", async () => {
+    const root = await mkdtemp(path.join(import.meta.dirname, ".tmp-static-image-watch-"));
+    tempDirs.push(root);
+    const outDir = path.join(root, "dist/client");
+    const imagePath = path.join(root, "test.png");
+    const entryPath = path.join(root, "entry.ts");
+    writeFixtureFile(root, "test.png", PNG_1X1);
+    writeFixtureFile(root, "entry.ts", `import image from "./test.png"; console.log(image.src);\n`);
+
+    const watcher = (await build({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [vinext()],
+      build: {
+        outDir,
+        emptyOutDir: true,
+        watch: {},
+        rolldownOptions: { input: entryPath },
+      },
+    })) as BuildWatcher;
+
+    try {
+      await waitForWatchBuild(watcher);
+      const firstImage = await findEmittedImage(root);
+      expect(await readFile(path.join(outDir, "_next/static/media", firstImage))).toEqual(PNG_1X1);
+
+      const changedBuild = waitForWatchBuild(watcher);
+      await fs.promises.writeFile(imagePath, PNG_4X3);
+      await changedBuild;
+      const secondImage = await findEmittedImage(root);
+      expect(secondImage).not.toBe(firstImage);
+      expect(await readFile(path.join(outDir, "_next/static/media", secondImage))).toEqual(PNG_4X3);
+      expect(fs.existsSync(path.join(outDir, "_next/static/media", firstImage))).toBe(false);
+      const changedJavaScript = await readBuiltJavaScript(outDir);
+      expect(changedJavaScript).toContain(secondImage);
+      expect(changedJavaScript).toMatch(/width:4[,}]|"width":4/);
+      expect(changedJavaScript).toMatch(/height:3[,}]|"height":3/);
+
+      const removedBuild = waitForWatchBuild(watcher);
+      await fs.promises.writeFile(entryPath, `console.log("no image");\n`);
+      await removedBuild;
+      expect(fs.existsSync(path.join(outDir, "_next/static/media", secondImage))).toBe(false);
+      expect(await readBuiltJavaScript(outDir)).not.toContain(secondImage);
+    } finally {
+      await watcher.close();
+    }
   }, 60_000);
 });

--- a/tests/static-image-emission.test.ts
+++ b/tests/static-image-emission.test.ts
@@ -1,0 +1,248 @@
+import fs from "node:fs";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import type { Server } from "node:http";
+import path from "node:path";
+import { build, createBuilder } from "vite";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { startProdServer } from "../packages/vinext/src/server/prod-server.js";
+
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+X8n26QAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const tempDirs: string[] = [];
+const servers: Server[] = [];
+
+function writeFixtureFile(root: string, filePath: string, content: string | Buffer): void {
+  const absolutePath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+}
+
+type FixtureOptions = {
+  basePath?: string;
+  assetPrefix?: string;
+  deploymentId?: string;
+};
+
+async function createFixture(
+  router: "app" | "pages",
+  options: FixtureOptions = {},
+): Promise<string> {
+  const root = await mkdtemp(path.join(import.meta.dirname, `.tmp-${router}-static-image-`));
+  tempDirs.push(root);
+  fs.mkdirSync(path.join(root, "node_modules"));
+  fs.symlinkSync(
+    path.resolve(import.meta.dirname, "../packages/vinext/node_modules/ipaddr.js"),
+    path.join(root, "node_modules/ipaddr.js"),
+    "junction",
+  );
+  writeFixtureFile(
+    root,
+    "package.json",
+    JSON.stringify({ name: `vinext-${router}-static-image`, private: true, type: "module" }),
+  );
+  writeFixtureFile(root, "test.png", PNG_1X1);
+  writeFixtureFile(root, "tiny.png", PNG_1X1);
+  if (options.basePath || options.assetPrefix || options.deploymentId) {
+    writeFixtureFile(root, "next.config.mjs", `export default ${JSON.stringify(options)};\n`);
+  }
+
+  const imageMarkup = `
+      <Image id="static-image" alt="static import" src={staticImage} quality={85} />
+      <img id="ordinary-asset" alt="ordinary asset" src={tinyUrl} />`;
+
+  if (router === "app") {
+    writeFixtureFile(
+      root,
+      "app/layout.tsx",
+      `import type { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+    );
+    writeFixtureFile(
+      root,
+      "app/client-image.tsx",
+      `"use client";
+import Image from "next/image";
+import staticImage from "../test.png";
+
+export default function ClientImage() {
+  return <Image id="client-static-image" alt="client static import" src={staticImage} quality={85} />;
+}
+`,
+    );
+    writeFixtureFile(
+      root,
+      "app/page.tsx",
+      `import Image from "next/image";
+import staticImage from "../test.png";
+import tinyUrl from "../tiny.png?url";
+import ClientImage from "./client-image";
+
+export default function Page() {
+  return <main>${imageMarkup}<ClientImage /></main>;
+}
+`,
+    );
+  } else {
+    writeFixtureFile(
+      root,
+      "pages/index.tsx",
+      `import Image from "next/image";
+import staticImage from "../test.png";
+import tinyUrl from "../tiny.png?url";
+
+export default function Page() {
+  return <main>${imageMarkup}</main>;
+}
+`,
+    );
+  }
+
+  return root;
+}
+
+async function buildFixture(root: string, router: "app" | "pages"): Promise<void> {
+  const commonConfig = {
+    root,
+    configFile: false as const,
+    logLevel: "silent" as const,
+    build: { assetsInlineLimit: 100_000 },
+  };
+
+  if (router === "app") {
+    const builder = await createBuilder({
+      ...commonConfig,
+      plugins: [
+        vinext({
+          appDir: root,
+          rscOutDir: path.join(root, "dist/server"),
+          ssrOutDir: path.join(root, "dist/server/ssr"),
+          clientOutDir: path.join(root, "dist/client"),
+        }),
+      ],
+    });
+    await builder.buildApp();
+    return;
+  }
+
+  await build({
+    ...commonConfig,
+    plugins: [vinext()],
+    build: {
+      ...commonConfig.build,
+      outDir: path.join(root, "dist/server"),
+      ssr: "virtual:vinext-server-entry",
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
+    },
+  });
+  await build({
+    ...commonConfig,
+    plugins: [vinext()],
+    build: {
+      ...commonConfig.build,
+      outDir: path.join(root, "dist/client"),
+      manifest: true,
+      ssrManifest: true,
+      rolldownOptions: { input: "virtual:vinext-client-entry" },
+    },
+  });
+}
+
+function getAttribute(html: string, id: string, attribute: string): string {
+  const tag = html.match(new RegExp(`<img\\b[^>]*\\bid="${id}"[^>]*>`))?.[0];
+  const value = tag?.match(new RegExp(`\\b${attribute}="([^"]+)"`, "i"))?.[1];
+  if (!value) throw new Error(`Missing ${attribute} on image #${id}`);
+  return value.replaceAll("&amp;", "&");
+}
+
+async function findEmittedImage(root: string, assetPrefix = ""): Promise<string> {
+  const prefixPath = assetPrefix.startsWith("http")
+    ? ""
+    : assetPrefix.split("/").filter(Boolean).join("/");
+  const mediaDir = path.join(root, "dist/client", prefixPath, "_next/static/media");
+  const files = await readdir(mediaDir);
+  const image = files.find((file) => /^test\.[\w-]{8}\.png$/.test(file));
+  if (!image) throw new Error(`Missing emitted test image in ${mediaDir}: ${files.join(", ")}`);
+  return image;
+}
+
+async function assertStaticImageProductionParity(
+  router: "app" | "pages",
+  options: FixtureOptions = {},
+): Promise<void> {
+  const root = await createFixture(router, options);
+  await buildFixture(root, router);
+  const effectiveAssetPrefix = options.assetPrefix ?? options.basePath ?? "";
+  const emittedImage = await findEmittedImage(root, effectiveAssetPrefix);
+  const prefixPath = effectiveAssetPrefix.split("/").filter(Boolean).join("/");
+  expect(
+    await readFile(path.join(root, "dist/client", prefixPath, "_next/static/media", emittedImage)),
+  ).toEqual(PNG_1X1);
+
+  const started = await startProdServer({
+    port: 0,
+    host: "127.0.0.1",
+    outDir: path.join(root, "dist"),
+  });
+  servers.push(started.server);
+  const address = started.server.address();
+  if (!address || typeof address === "string") throw new Error("Production server did not bind");
+  const response = await fetch(`http://127.0.0.1:${address.port}${options.basePath ?? ""}/`);
+  const html = await response.text();
+  expect(response.status, html).toBe(200);
+
+  for (const id of router === "app" ? ["static-image", "client-static-image"] : ["static-image"]) {
+    const src = getAttribute(html, id, "src");
+    const srcset = getAttribute(html, id, "srcset");
+    const managedUrl = `${effectiveAssetPrefix}/_next/static/media/${emittedImage}`;
+    const managedSourceUrl = options.deploymentId
+      ? `${managedUrl}?dpl=${options.deploymentId}`
+      : managedUrl;
+    expect(new URL(src, "http://vinext.test").searchParams.get("url")).toBe(managedSourceUrl);
+    expect(src).toContain("q=85");
+    expect(src).not.toContain("data%3Aimage");
+    expect(srcset).toContain(`url=${encodeURIComponent(managedSourceUrl)}`);
+    expect(srcset).not.toContain("data%3Aimage");
+  }
+
+  expect(getAttribute(html, "ordinary-asset", "src")).toMatch(/^data:image\/png/);
+  const assetResponse = await fetch(
+    `http://127.0.0.1:${address.port}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
+  );
+  expect(assetResponse.status).toBe(200);
+  expect(Buffer.from(await assetResponse.arrayBuffer())).toEqual(PNG_1X1);
+}
+
+describe("static image import production emission", () => {
+  afterAll(async () => {
+    await Promise.all(
+      servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+    );
+    await Promise.all(tempDirs.map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/next-image/next-image.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-image/next-image.test.ts
+  it("emits App Router static imports while preserving ordinary asset thresholds", async () => {
+    await assertStaticImageProductionParity("app");
+  }, 60_000);
+
+  it("emits Pages Router static imports while preserving ordinary asset thresholds", async () => {
+    await assertStaticImageProductionParity("pages");
+  }, 60_000);
+
+  it("preserves managed image URLs under basePath and assetPrefix", async () => {
+    await assertStaticImageProductionParity("app", {
+      basePath: "/docs",
+      assetPrefix: "/cdn",
+      deploymentId: "static-image-test",
+    });
+  }, 60_000);
+});


### PR DESCRIPTION
# vinext parity: static image import emission

## Source evidence

- Wave2 report: `/tmp/vinext-e2e-27514800656-backlog-wave2.md`
- Source deploy-suite run: `27514800656`
- Source main commit: `10b5086f4d96a7f2054cbc9c6c239aa16a1d6dd8` (June 14, 2026)
- Exact suite: `test/e2e/app-dir/next-image/next-image.test.ts`
- Exact direct assertions:
  - browser: `should render images nested under page dir on /nested route`
  - SSR: `should render images on /client route`
  - SSR root image assertion crashed because the expected static-media attribute was absent
- Exact symptom: expected an optimizer URL whose `url=` was `/_next/static/media/test.HASH.png` and whose selected width was `828`; received an optimizer URL whose `url=` was a large `data:image/png;base64,...` and whose width was `400`.
- Downstream failures: optimizer fetches returned 400/500 because the optimizer received embedded data URLs instead of managed static asset URLs.
- Explicitly excluded from this candidate: cacheComponents, PPR, resume, and fallback-shell work.

## Upstream and bundler semantics

- Next.js `next-image-loader` always emits imported image content and returns `StaticImageData` with a URL under `/static/media/[name].[hash:8].[ext]`; it does not apply a general inline threshold to static image imports.
- Next.js webpack CSS handling similarly uses `asset/resource` where managed asset URLs are required, specifically to avoid data-URI inlining.
- Vite normally applies `build.assetsInlineLimit` independently in each build environment. In App Router builds, RSC can therefore inline a source even when the client environment emits it, producing different `StaticImageData.src` values across environments.
- App Router production build order is RSC scan, SSR scan, RSC build, client build, SSR build. A plugin-instance registry can therefore collect server-only image imports before the client output is written.

## Reproduction added

`tests/static-image-emission.test.ts` production-builds small real fixtures with `build.assetsInlineLimit: 100_000` so the images would inline without an explicit framework override.

Coverage:

- App Router server component static import.
- App Router client component static import.
- Pages Router static import.
- Emitted file under `dist/client/.../_next/static/media/` with original bytes.
- Rendered optimizer `src` and `srcSet` point to the same managed media URL and never contain `data:image`.
- Direct fetch of the managed asset returns 200 and the original bytes.
- A separate ordinary `?url` import remains a data URL, proving the user's inline threshold is preserved for unrelated assets.
- `basePath`, path `assetPrefix`, and `deploymentId` URL/on-disk behavior.

## Implementation

- Static image transforms now import an internal absolute-path `?vinext-image-url` virtual module plus the existing metadata module.
- In dev, the URL module delegates to Vite's normal `?url` handling.
- In production, the URL module:
  - reads the image once,
  - computes a deterministic 8-character SHA-256 content hash,
  - registers `media/[name].[hash][ext]`,
  - returns the existing vinext managed asset URL shaped by `assetPrefix` and `deploymentId`.
- The client environment's post-write hook writes all registered image bytes into its actual output directory. This covers server-only RSC imports while keeping one public asset location for Node and Cloudflare static serving.
- Existing dimension extraction and `StaticImageData` shape are unchanged.
- No global `assetsInlineLimit` override was added; public files, CSS assets, ordinary Vite imports, and explicit user thresholds retain their existing behavior.
- SVG bytes are emitted unchanged; existing image optimizer SVG/security configuration remains authoritative.

## Validation

Branch base: current `origin/main` at `a3d2f921520ff140a826224616df5e0db4ed0186` on June 15, 2026.

Passed:

- `vp test run tests/image-imports.test.ts tests/image-component.test.ts tests/image-optimization-parity.test.ts tests/static-image-emission.test.ts`
  - 4 files, 92 tests.
- `vp check`
  - all 1953 files formatted;
  - no warnings, lint errors, or type errors in 899 files.
- `vp run vinext#build`
  - package build completed successfully.
- `git diff --check`
  - clean.

## Exact assertion disposition

The local production assertion corresponding to the wave2 failure now observes:

- optimizer `url=` resolving to a managed `/_next/static/media/<name>.<8-char-hash>.png` URL;
- generated `srcSet` candidates using that managed URL;
- no embedded `data:image` source;
- a directly fetchable emitted asset.

The full upstream Next.js deploy suite was not rerun locally; the focused vinext-owned production fixture exercises the same failing contract without cacheComponents/PPR/resume scope.

## Review follow-up — 4225b4cfd705a12b71079e7499b7c0a384a2f606

All static-image review findings were addressed in commit `4225b4cfd705a12b71079e7499b7c0a384a2f606`:

- Production/watch builds call `addWatchFile` for image URL and metadata modules.
- Per-build image bytes/dimensions are cleared and recomputed; importer dependencies are tracked so changed images receive new hashes/dimensions and removed imports delete stale emitted files.
- SVG classification inspects the parsed URL pathname, so managed `.svg?dpl=...` sources bypass the image optimizer unless SVG optimization is explicitly allowed.
- Static-file ETag recognition safely accepts vinext's exact dot-delimited eight-lowercase-hex image hash format while rejecting arbitrary dotted suffixes.
- Production direct requests assert immutable caching, stable filename-derived ETags, and matching `If-None-Match` responses returning 304 with no body.

Review validation completed June 15, 2026:

- `vp test run tests/static-image-emission.test.ts tests/image-component.test.ts tests/static-file-cache.test.ts tests/serve-static.test.ts tests/image-imports.test.ts` — 5 files, 151 tests passed.
- Earlier scoped image optimizer parity run in this review cycle — 6 tests passed.
- `vp check` — all 1953 files formatted; no warnings, lint errors, or type errors in 899 files.
- `vp run vinext#build` — package build completed successfully.
- `git diff --check` — clean before commit.

No upstream deploy suite was started. Nothing was pushed and no PR was opened.

## Independent review follow-up — managed media ETag scope

The independent P2 review finding was addressed by restricting vinext's dot-delimited eight-character image hash ETag format to files under `_next/static/media/`, including path-prefixed layouts. Dash-delimited Vite asset hashes remain unchanged.

Focused regression coverage now verifies:

- an arbitrary `_next/static/config.deadbeef.json` file does not receive `W/"deadbeef"`;
- changing that file's content produces a different validator and a conditional request returns `200` with the new content rather than an incorrect `304`;
- managed `_next/static/media/photo.0123abcd.png` files retain the stable filename-derived ETag, immutable cache control, and matching conditional `304` behavior.

Validation completed June 15, 2026:

- `vp test run tests/static-file-cache.test.ts tests/serve-static.test.ts` — 2 files, 64 tests passed.
- `vp check --fix packages/vinext/src/server/static-file-cache.ts tests/static-file-cache.test.ts tests/serve-static.test.ts` — formatting completed; no warnings, lint errors, or type errors in 3 files.
- `git diff --check` — clean.
