### PR TITLE
fix(pages): re-enter filesystem routes after rewrites

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1104,6 +1104,26 @@ export function matchRewrite(
 }
 
 /**
+ * Check whether a rewrite source can match a pathname without evaluating its
+ * request-dependent `has` / `missing` conditions.
+ *
+ * Dev uses this only as a conservative preflight before middleware runs. The
+ * conditions may become true after middleware overrides request headers, so
+ * evaluating them against the original request would incorrectly skip the
+ * Pages request pipeline for file-looking paths.
+ */
+export function matchesRewriteSource(
+  pathname: string,
+  rewrite: NextRewrite,
+  basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
+): boolean {
+  return (
+    shouldEvaluateRule(rewrite.basePath, basePathState) &&
+    matchConfigPattern(pathname, rewrite.source) !== null
+  );
+}
+
+/**
  * Substitute all matched route params into a redirect/rewrite destination.
  *
  * Handles repeated params (e.g. `/api/:id/:id`) and catch-all suffix forms

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -112,11 +112,7 @@ import {
   pagesRouteHasPriorityOverAppRoute,
   validateHybridRouteConflicts,
 } from "./server/hybrid-route-priority.js";
-import {
-  matchRewrite,
-  proxyExternalRequest,
-  requestContextFromRequest,
-} from "./config/config-matchers.js";
+import { matchesRewriteSource, proxyExternalRequest } from "./config/config-matchers.js";
 import { detectPackageManager } from "./utils/project.js";
 import { isUnknownRecord as isRecord } from "./utils/record.js";
 import { ASSET_PREFIX_URL_DIR, resolveAssetsDir } from "./utils/asset-prefix.js";
@@ -3756,32 +3752,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // Skip requests for files with extensions (static assets) after
               // trailing-slash canonicalization so file-looking dynamic routes
               // like /catch-all/hello.world/ still get the Next.js redirect.
-              const rewriteContextHeaders = new Headers();
-              for (const [key, value] of Object.entries(req.headers)) {
-                if (value === undefined || key.startsWith(":")) continue;
-                if (Array.isArray(value)) {
-                  for (const item of value) rewriteContextHeaders.append(key, item);
-                } else {
-                  rewriteContextHeaders.set(key, value);
-                }
-              }
-              const rewriteContextRequest = new Request(
-                new URL(url, `http://${req.headers.host ?? "localhost"}`),
-                {
-                  headers: rewriteContextHeaders,
-                },
-              );
-              const rewriteRequestContext = requestContextFromRequest(rewriteContextRequest);
               const filePathMatchesRewrite = [
                 ...(nextConfig?.rewrites.beforeFiles ?? []),
                 ...(nextConfig?.rewrites.afterFiles ?? []),
                 ...(nextConfig?.rewrites.fallback ?? []),
-              ].some(
-                (rewrite) =>
-                  matchRewrite(pathname, [rewrite], rewriteRequestContext, {
-                    basePath: bp,
-                    hadBasePath: true,
-                  }) !== null,
+              ].some((rewrite) =>
+                matchesRewriteSource(pathname, rewrite, {
+                  basePath: bp,
+                  hadBasePath: true,
+                }),
               );
               if (
                 pathname.includes(".") &&

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3962,8 +3962,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 return next();
               }
 
-              // The dev static adapter returns a Response rather than writing directly,
-              // so `handled` remains a Node-production-only result here.
+              // `handled` means an adapter wrote the response directly, including
+              // Vite's filesystem middleware for rewritten public/static files.
               if (pipelineResult.type === "handled") {
                 return;
               }

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2202,6 +2202,90 @@ describe("Pages Router integration", () => {
   });
 });
 
+describe("Pages Router dev dot-path rewrite preflight", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-dot-path-rewrite-"));
+    await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fsp.mkdir(path.join(tmpDir, "public"), { recursive: true });
+    await fsp.symlink(
+      path.resolve(import.meta.dirname, "../node_modules"),
+      path.join(tmpDir, "node_modules"),
+      "junction",
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "pages", "about.tsx"),
+      `export default function About() { return <div>rewritten download page</div>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "public", "unrelated.txt"), "unrelated asset");
+    await fsp.writeFile(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default {
+  async rewrites() {
+    return {
+      beforeFiles: [{
+        source: "/download.txt",
+        has: [{ type: "header", key: "x-download-rewrite", value: "enabled" }],
+        destination: "/about",
+      }],
+      afterFiles: [],
+      fallback: [],
+    };
+  },
+};
+`,
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "middleware.ts"),
+      `import { NextResponse } from "next/server";
+
+export default function middleware(request) {
+  if (new URL(request.url).searchParams.has("rewrite")) {
+    const headers = new Headers(request.headers);
+    headers.set("x-download-rewrite", "enabled");
+    return NextResponse.next({ request: { headers } });
+  }
+  return NextResponse.next();
+}
+
+export const config = { matcher: "/download.txt" };
+`,
+    );
+
+    ({ server, baseUrl } = await startFixtureServer(tmpDir));
+  }, 30000);
+
+  afterAll(async () => {
+    await server?.close();
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("runs middleware before evaluating has conditions for dot-path rewrites", async () => {
+    const response = await fetch(`${baseUrl}/download.txt?rewrite`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(await response.text()).toContain("rewritten download page");
+  });
+
+  it("does not apply the rewrite when the post-middleware condition is false", async () => {
+    const response = await fetch(`${baseUrl}/download.txt`);
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).not.toContain("rewritten download page");
+  });
+
+  it("does not route unrelated dot-path assets through rewrite handling", async () => {
+    const response = await fetch(`${baseUrl}/unrelated.txt`);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("unrelated asset");
+  });
+});
+
 describe("Pages Router dev server origin check", () => {
   let server: ViteDevServer;
   let baseUrl: string;


### PR DESCRIPTION
# `locale: false` public rewrite parity investigation

## Outcome

Confirmed and fixed a real vinext parity gap from Actions run `27514800656`.

Next.js re-enters filesystem routing after config rewrites. Vinext applied the
rewrite destination to page/API dispatch, but only probed public and built
static files before rewrites. Consequently, a `locale: false` rewrite from a
localized source to `/file.txt` or `/_next/static/...` returned 404.

## Baseline

- Vinext base: `a3d2f921520ff140a826224616df5e0db4ed0186`
- Next.js reference tag: `v16.2.6`
- Next.js source/build commit: `ee6e79b1792a4d401ddf2480f40a83549fe8e722`
- Worktree: `/tmp/vinext-locale-false-public.MmAbBc/vinext`
- Branch: `codex/fix-locale-false-public-rewrites`

## Exact upstream assertions

Suite:
`test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts`

The source config uses a `beforeFiles` rewrite:

```js
{
  source: '/:locale/rewrite-files/:path*',
  destination: '/:path*',
  locale: false,
}
```

The deploy run `27514800656` failed the public-file assertion for `/`, `/nl`,
and `/sv`, returning Next 404 HTML instead of `hello from file.txt`. The suite's
API rewrite was the control and showed that rewrite matching itself worked.

## Local reproduction on unmodified main

Added a vinext Pages fixture with locales `en`, `sv`, and `nl`, a public text
file, a page, an API route, and rewrite destinations for public, built-static,
page, and API routes.

Targeted command:

```sh
vp test run tests/pages-i18n-public-rewrite.test.ts
```

Baseline result: 5/5 failed. Both default-locale (`/en`) and non-default-locale
(`/sv`) public rewrites returned 404 in development and production. The API and
page controls passed, while the rewritten built-static destination also
returned 404.

## Fix

- Replaced the Node-only direct static callback with a runtime-supplied
  filesystem-route callback.
- Re-entered filesystem resolution after successful `beforeFiles`,
  `afterFiles`, and `fallback` rewrites, matching Next.js routing order.
- Preserved direct public/build-static precedence before `afterFiles` and
  `fallback` rewrites.
- Re-dispatched API routes after rewritten filesystem misses.
- Used Vite's serving pipeline in development so rewritten files preserve HEAD,
  range, MIME, ETag, and conditional-request behavior.
- Used the production static-file cache in the Node production server.
- Added Worker generated-entry support using `env.ASSETS.fetch`, only for
  rewritten GET/HEAD non-API destinations.

The fix is not specific to locale parsing. `locale: false` matching already
produced the correct destination; the missing behavior was post-rewrite
filesystem re-entry.

### Independent review follow-up: dev dot-path preflight

Independent review found a separate dev-only gap in the early static-asset
preflight. For file-looking paths such as `/download.txt`, dev decided whether
to enter the Pages pipeline by fully evaluating rewrite `has` / `missing`
conditions against the original request. That skipped middleware entirely when
middleware was responsible for adding the header that enabled the rewrite.

The preflight now checks only whether a rewrite's source pattern can match the
pathname. Request-dependent conditions remain deferred to the Pages pipeline,
after middleware request-header overrides have been applied. Paths that do not
match any rewrite source still bypass Pages handling, so unrelated static
assets continue through Vite's normal filesystem middleware.

Focused dev coverage verifies:

- `/download.txt?rewrite` reaches middleware, receives an injected request
  header, and rewrites to a Pages route.
- `/download.txt` remains unmatched when middleware does not inject the header.
- An unrelated real public asset remains served by Vite.

Node production and Worker routing do not have the dev-only file-extension
preflight. Both already enter `runPagesRequest`, run middleware, apply request
header overrides, and evaluate config rewrites using the post-middleware
request context, so no runtime changes were required there.

## Targeted validation

```sh
vp test run \
  tests/pages-i18n-public-rewrite.test.ts \
  tests/pages-request-pipeline.test.ts \
  tests/deploy.test.ts
```

Result: 349 tests passed.

Coverage includes default/non-default locales, dev/prod public files,
built-static assets, API/page controls, `beforeFiles`/`afterFiles`/`fallback`
ordering, Worker asset fetch generation, HEAD/range/ETag behavior, and misses.

```sh
vp check \
  packages/vinext/src/deploy.ts \
  packages/vinext/src/index.ts \
  packages/vinext/src/server/pages-request-pipeline.ts \
  packages/vinext/src/server/prod-server.ts \
  packages/vinext/src/server/static-file-cache.ts \
  tests/deploy.test.ts \
  tests/pages-i18n-public-rewrite.test.ts \
  tests/pages-request-pipeline.test.ts
```

Result: formatting, lint, and type checks passed. `git diff --check` passed.

Independent review follow-up validation:

```sh
vp test run tests/pages-router.test.ts \
  -t "Pages Router dev dot-path rewrite preflight"

vp check \
  packages/vinext/src/config/config-matchers.ts \
  packages/vinext/src/index.ts \
  tests/pages-router.test.ts
```

Result: 3 focused integration tests passed; scoped formatting, lint, and type
checks passed; `git diff --check` passed. The upstream deploy suite was not
rerun for this dev-only follow-up.

## Exact pinned Next.js deploy validation

```sh
NEXTJS_PREPARE=0 \
NEXT_TEST_CONCURRENCY=1 \
vp env exec --node 24 \
  ./scripts/run-nextjs-deploy-suite.sh \
  /Users/jamesanderson/Developer/vinext/.nextjs-ref \
  --retries 0 -c 1 --debug \
  test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
```

The custom deployment succeeded at a local URL and reached assertions.

Result: 8/8 passed:

- Public-file rewrites: empty/default path, `/en`, `/sv`, `/nl`
- API rewrite controls: empty/default path, `/en`, `/sv`, `/nl`

## Scope

No `cacheComponents`, `use cache`, PPR shell, or resume code was changed. No
lockfile change was made. The branch was not pushed and no PR was opened.
