### PR TITLE
fix(app-router): preserve dynamic interception source routes

### DIFF
--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -107,6 +107,7 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
 } {
   const routeTrie = buildRouteTrie(routes);
   const interceptLookup = createInterceptLookup(routes);
+  const routeIndexes = new Map<Route, number>(routes.map((route, index) => [route, index]));
 
   return {
     matchRoute(url) {
@@ -122,6 +123,7 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
 
       const urlParts = appRscPathnameParts(pathname);
       const sourceParts = appRscPathnameParts(sourcePathname);
+      const matchedSourceRoute = trieMatch(routeTrie, sourceParts);
 
       for (const entry of interceptLookup) {
         // Primary gate: when the intercept declares a `sourceMatchPattern`
@@ -134,10 +136,17 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
         const params = matchAppRscRoutePattern(urlParts, entry.targetPatternParts);
         if (params === null) continue;
 
-        const sourceRoute = routes[entry.sourceRouteIndex];
-        const matchedSourceParams = sourceRoute
-          ? matchAppRscRoutePattern(sourceParts, sourceRoute.patternParts)
-          : null;
+        const concreteSourceRouteIndex =
+          matchedSourceRoute && entry.sourceMatchPatternParts !== null
+            ? (routeIndexes.get(matchedSourceRoute.route) ?? entry.sourceRouteIndex)
+            : entry.sourceRouteIndex;
+        const sourceRoute = routes[concreteSourceRouteIndex];
+        const matchedSourceParams =
+          matchedSourceRoute && entry.sourceMatchPatternParts !== null
+            ? matchedSourceRoute.params
+            : sourceRoute
+              ? matchAppRscRoutePattern(sourceParts, sourceRoute.patternParts)
+              : null;
 
         // Secondary gate (from #1249): when the entry has no
         // `sourceMatchPatternParts` declared (older manifest shapes), reject
@@ -152,7 +161,11 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
           continue;
         }
         const sourceParams = matchedSourceParams ?? createRouteParams();
-        return { ...entry, matchedParams: mergeMatchedParams(sourceParams, params) };
+        return {
+          ...entry,
+          sourceRouteIndex: concreteSourceRouteIndex,
+          matchedParams: mergeMatchedParams(sourceParams, params),
+        };
       }
       return null;
     },

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -143,6 +143,26 @@ describe("App RSC route matching", () => {
     expect(matcher.findIntercept("/photos/42", "/gallery")).toBeNull();
   });
 
+  it("does not use an unrelated concrete route for legacy interception entries", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/feed", ["feed"], {
+        modal: {
+          intercepts: [
+            {
+              targetPattern: "/photos/:id",
+              interceptLayouts: ["modal-layout"],
+              page: "photo-page",
+              params: ["id"],
+            },
+          ],
+        },
+      }),
+      route("/gallery", ["gallery"]),
+    ]);
+
+    expect(matcher.findIntercept("/photos/42", "/gallery")).toBeNull();
+  });
+
   it("canonicalizes encoded source path parts for interception params", () => {
     const matcher = createAppRscRouteMatcher([
       route("/_sites/:tenant", ["_sites", ":tenant"], {
@@ -162,6 +182,44 @@ describe("App RSC route matching", () => {
     expect(matcher.findIntercept("/photos/a%2Fb", "/%5Fsites/acme")).toMatchObject({
       targetPattern: "/photos/:id",
       matchedParams: { tenant: "acme", id: "a/b" },
+    });
+  });
+
+  it("renders a root-slot interception from the concrete matched source route", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/", [], {
+        modal: {
+          intercepts: [
+            {
+              sourceMatchPattern: "/",
+              targetPattern: "/org/:orgId/team/:teamId/settings",
+              interceptLayouts: ["modal-layout"],
+              page: "settings-modal",
+              params: ["orgId", "teamId"],
+            },
+          ],
+        },
+      }),
+      route("/org/:orgId/team/:teamId", ["org", ":orgId", "team", ":teamId"], {
+        modal: {
+          intercepts: [
+            {
+              sourceMatchPattern: "/",
+              targetPattern: "/org/:orgId/team/:teamId/settings",
+              interceptLayouts: ["modal-layout"],
+              page: "settings-modal",
+              params: ["orgId", "teamId"],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(
+      matcher.findIntercept("/org/acme/team/engineering/settings", "/org/acme/team/engineering"),
+    ).toMatchObject({
+      sourceRouteIndex: 1,
+      matchedParams: { orgId: "acme", teamId: "engineering" },
     });
   });
 

--- a/tests/e2e/app-router/interception-dynamic-single-segment.spec.ts
+++ b/tests/e2e/app-router/interception-dynamic-single-segment.spec.ts
@@ -69,4 +69,33 @@ test.describe("interception-dynamic-single-segment", () => {
     await page.click("#new-link");
     await expect(page.locator("#modal")).toContainText("Modal: New item for group 456");
   });
+
+  test("preserves a deeply nested dynamic source page", async ({ page }) => {
+    await page.goto(`${BASE}/interception-dyn-single/org/acme/team/engineering`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#settings-link");
+    await expect(page.locator("#modal")).toContainText(
+      "Modal: Settings for Team engineering in Org acme",
+    );
+    await expect(page.locator("#children")).toContainText("Team engineering in Org acme");
+  });
+
+  test("preserves a consecutive dynamic source page", async ({ page }) => {
+    await page.goto(`${BASE}/interception-dyn-single/x/y/z`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#item-link");
+    await expect(page.locator("#modal")).toContainText("Modal: Item for path x/y/z");
+    await expect(page.locator("#children")).toContainText("Path: x/y/z");
+  });
+
+  test("preserves a static multi-segment source page", async ({ page }) => {
+    await page.goto(`${BASE}/interception-dyn-single/admin/dashboard/users`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#new-user-link");
+    await expect(page.locator("#modal")).toContainText("Modal: New User Form");
+    await expect(page.locator("#children")).toContainText("Admin Dashboard - Users");
+  });
 });

--- a/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)[a]/[b]/[c]/item/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)[a]/[b]/[c]/item/page.tsx
@@ -1,0 +1,12 @@
+export default async function ItemModal({
+  params,
+}: {
+  params: Promise<{ a: string; b: string; c: string }>;
+}) {
+  const { a, b, c } = await params;
+  return (
+    <div>
+      Modal: Item for path {a}/{b}/{c}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)admin/dashboard/users/new/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)admin/dashboard/users/new/page.tsx
@@ -1,0 +1,3 @@
+export default function NewUserModal() {
+  return <div>Modal: New User Form</div>;
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)org/[orgId]/team/[teamId]/settings/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)org/[orgId]/team/[teamId]/settings/page.tsx
@@ -1,0 +1,12 @@
+export default async function SettingsModal({
+  params,
+}: {
+  params: Promise<{ orgId: string; teamId: string }>;
+}) {
+  const { orgId, teamId } = await params;
+  return (
+    <div>
+      Modal: Settings for Team {teamId} in Org {orgId}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/[a]/[b]/[c]/item/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/[a]/[b]/[c]/item/page.tsx
@@ -1,0 +1,12 @@
+export default async function ItemPage({
+  params,
+}: {
+  params: Promise<{ a: string; b: string; c: string }>;
+}) {
+  const { a, b, c } = await params;
+  return (
+    <div>
+      Item for path: {a}/{b}/{c}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/[a]/[b]/[c]/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/[a]/[b]/[c]/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default async function ConsecutivePage({
+  params,
+}: {
+  params: Promise<{ a: string; b: string; c: string }>;
+}) {
+  const { a, b, c } = await params;
+  return (
+    <div>
+      <div id="consecutive-page">
+        Path: {a}/{b}/{c}
+      </div>
+      <Link href={`/interception-dyn-single/${a}/${b}/${c}/item`} id="item-link">
+        View Item
+      </Link>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/admin/dashboard/users/new/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/admin/dashboard/users/new/page.tsx
@@ -1,0 +1,3 @@
+export default function NewUserPage() {
+  return <div>New User Form</div>;
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/admin/dashboard/users/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/admin/dashboard/users/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function UsersPage() {
+  return (
+    <div>
+      <div id="users-page">Admin Dashboard - Users</div>
+      <Link href="/interception-dyn-single/admin/dashboard/users/new" id="new-user-link">
+        New User
+      </Link>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/org/[orgId]/team/[teamId]/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/org/[orgId]/team/[teamId]/page.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+export default async function TeamPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; teamId: string }>;
+}) {
+  const { orgId, teamId } = await params;
+  return (
+    <div>
+      <div id="team-page">
+        Team {teamId} in Org {orgId}
+      </div>
+      <Link
+        href={`/interception-dyn-single/org/${orgId}/team/${teamId}/settings`}
+        id="settings-link"
+      >
+        Settings
+      </Link>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/org/[orgId]/team/[teamId]/settings/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/org/[orgId]/team/[teamId]/settings/page.tsx
@@ -1,0 +1,12 @@
+export default async function SettingsPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; teamId: string }>;
+}) {
+  const { orgId, teamId } = await params;
+  return (
+    <div>
+      Settings for Team {teamId} in Org {orgId}
+    </div>
+  );
+}


### PR DESCRIPTION
# Dynamic interception route parity

## Scope

- Source run: `27514800656`
- Next.js suite: `test/e2e/app-dir/interception-dynamic-single-segment/interception-dynamic-single-segment.test.ts`
- Pinned Next.js: `v16.2.6`, commit `ee6e79b1792a4d401ddf2480f40a83549fe8e722`
- Excluded cacheComponents, PPR, fallback-shell, and resume behavior.

## Reproduction

The pinned deploy suite reproduced three failures on `origin/main`:

1. Deep dynamic source `/org/acme/team/engineering`
2. Consecutive dynamic source `/x/y/z`
3. Static multi-segment source `/admin/dashboard/users`

After intercepted navigation, each test expected the original source page in the `children` slot but received the root index page text: `Group 123 Team Consecutive Admin`.

## Root cause

This was a source-route matcher identity bug, not stale slot state or parameter extraction.

Root-owned `@modal` interception entries used the slot owner's route index (`/`) as `sourceRouteIndex`. That is necessary as a fallback for inherited slots when no concrete source page matches, but it is incorrect when the interception context names a real nested source route. The renderer therefore rebuilt the intercepted tree with the root page as `children`.

## Fix

`createAppRscRouteMatcher()` now matches the interception context through the route trie and uses that concrete route as `sourceRouteIndex`. It retains the existing slot-owner index fallback when no concrete source route matches.

Vinext-owned coverage now includes deep nesting, consecutive dynamic segments, and static multi-segment interception in the existing `interception-dyn-single` fixture.

## Validation

- `vp test run tests/app-rsc-route-matching.test.ts`: 18 passed.
- Targeted `vp check`: passed.
- `git diff --check`: passed.
- Exact pinned Next deploy suite after fix: 9 passed, 0 failed, retries 0, concurrency 1, Node 24.
- Final validation-only rerun against exact review-clean commit `49a0030927eed273a67f944dd114a4e46f1b4edf`: deployment succeeded and all 9 assertions passed with retries 0, concurrency 1, Node 24, and `NEXTJS_PREPARE=0`.
- The final rerun rebuilt `@vinext/cloudflare` and `vinext`, served the deployment at `http://127.0.0.1:56542`, reached browser assertions, completed cleanup, and exited with code 0.
- The existing shallow `/groups/[id]` and inherited-slot navigation assertions remained green in the exact suite.
- Local Playwright fixture execution was attempted with one worker. Its shared app-basic web server was blocked before assertions by the unrelated existing `app/nextjs-compat/jsx-in-js/page.js` JSX parser failure; the exact deploy suite covers the same browser behavior and passed.

## Artifacts

- Before fix log: `/tmp/vinext-dynamic-interception-exact.log`
- After fix log: `/tmp/vinext-dynamic-interception-exact-fixed.log`
- Stopped final rerun log: `/tmp/vinext-dynamic-interception-exact-final.log`
- Review-clean exact rerun log: `/tmp/vinext-dynamic-interception-exact-20260615-094556.log`
- Review-clean deploy diagnostics: `/tmp/vinext-dynamic-interception.XzoRZE/vinext/reports/nextjs-deploy-debug/cleanup-1781513198-38484/`
- Worktree: `/tmp/vinext-dynamic-interception.XzoRZE/vinext`
