### PR TITLE
fix(pages): emit canonical __NEXT_DATA__ JSON

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -55,6 +55,12 @@ type VinextLocaleGlobalTarget = {
 };
 
 export function extractVinextNextDataJson(html: string): string | null {
+  const canonical =
+    /<script\b(?=[^>]*\bid=["']__NEXT_DATA__["'])(?=[^>]*\btype=["']application\/json["'])[^>]*>([\s\S]*?)<\/script>/.exec(
+      html,
+    );
+  if (canonical) return canonical[1];
+
   const assignment = /<script(?:\s[^>]*)?>\s*window\.__NEXT_DATA__\s*=\s*/.exec(html);
   if (!assignment || assignment.index === undefined) return null;
 

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -160,14 +160,14 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
 
-_initializePagesRouterReadyFromNextData(window.__NEXT_DATA__);
-
 async function hydrate() {
   const nextData = window.__NEXT_DATA__;
   if (!nextData) {
     console.error("[vinext] No __NEXT_DATA__ found");
     return;
   }
+
+  _initializePagesRouterReadyFromNextData(nextData);
 
   let hydrateRootOptions;
   if (import.meta.env.DEV) {

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -97,6 +97,10 @@ export async function generateClientEntry(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
+import Router, {
+  wrapWithRouterContext,
+  _initializePagesRouterReadyFromNextData,
+} from "next/router";
 
 const pageLoaders = {
 ${loaderEntries.join(",\n")}
@@ -156,10 +160,6 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
 
-// The router reads __NEXT_DATA__ while initializing its readiness state, so
-// canonical JSON must be parsed before this module executes.
-const { default: Router, wrapWithRouterContext, _initializePagesRouterReadyFromNextData } =
-  await import("next/router");
 _initializePagesRouterReadyFromNextData(window.__NEXT_DATA__);
 
 async function hydrate() {

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -97,19 +97,6 @@ export async function generateClientEntry(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
-// Statically import next/router as the very first vinext shim so that
-// (a) installWindowNext runs at top-level — \`window.next.router\` is
-//     available to test harnesses and third-party scripts BEFORE
-//     hydrate() resolves (see .nextjs-ref/packages/next/src/client/next.ts
-//     line 13, which also sets window.next as a top-level side effect),
-// and (b) the popstate handler is registered before
-//     installPagesRouterRuntime() runs, removing the race window where a
-//     popstate event could fire between hydration and runtime install.
-//
-// Mirrors Next.js's bootstrap order: client/next.ts statically imports
-// from './' before calling initialize/hydrate, so window.next is set up
-// before any async work.
-import Router, { wrapWithRouterContext } from "next/router";
 
 const pageLoaders = {
 ${loaderEntries.join(",\n")}
@@ -168,6 +155,12 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
+
+// The router reads __NEXT_DATA__ while initializing its readiness state, so
+// canonical JSON must be parsed before this module executes.
+const { default: Router, wrapWithRouterContext, _initializePagesRouterReadyFromNextData } =
+  await import("next/router");
+_initializePagesRouterReadyFromNextData(window.__NEXT_DATA__);
 
 async function hydrate() {
   const nextData = window.__NEXT_DATA__;

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -161,6 +161,14 @@ window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(appPrefetchRoutes)};
 window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(pagesPrefetchRoutes)};
 window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(nextConfig.rewrites)};
 
+const nextDataElement = document.getElementById("__NEXT_DATA__");
+if (nextDataElement?.textContent) {
+  window.__NEXT_DATA__ = JSON.parse(nextDataElement.textContent);
+  window.__VINEXT_LOCALE__ = window.__NEXT_DATA__.locale;
+  window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
+  window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
+}
+
 async function hydrate() {
   const nextData = window.__NEXT_DATA__;
   if (!nextData) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1567,6 +1567,7 @@ export function createSSRHandler(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
+import Router, { wrapWithRouterContext, _initializePagesRouterReadyFromNextData } from "next/router";
 
 const nextDataElement = document.getElementById("__NEXT_DATA__");
 if (nextDataElement?.textContent) {
@@ -1575,7 +1576,6 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
-const { default: Router, wrapWithRouterContext, _initializePagesRouterReadyFromNextData } = await import("next/router");
 const nextData = window.__NEXT_DATA__;
 _initializePagesRouterReadyFromNextData(nextData);
 const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1567,7 +1567,6 @@ export function createSSRHandler(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
-import Router, { wrapWithRouterContext } from "next/router";
 
 const nextDataElement = document.getElementById("__NEXT_DATA__");
 if (nextDataElement?.textContent) {
@@ -1576,7 +1575,9 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
+const { default: Router, wrapWithRouterContext, _initializePagesRouterReadyFromNextData } = await import("next/router");
 const nextData = window.__NEXT_DATA__;
+_initializePagesRouterReadyFromNextData(nextData);
 const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};
 const rawPageProps = props.pageProps;
 const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1219,18 +1219,20 @@ export function createSSRHandler(
                         },
                       };
 
-                      const freshNextData = `<script>window.__NEXT_DATA__ = ${safeJsonStringify({
-                        props: freshRenderProps,
-                        page: patternToNextFormat(route.pattern),
-                        query: params,
-                        buildId: process.env.__VINEXT_BUILD_ID,
-                        isFallback: false,
-                        locale: locale ?? currentDefaultLocale,
-                        locales: i18nConfig?.locales,
-                        defaultLocale: currentDefaultLocale,
-                        domainLocales,
-                        ...freshPagesNextData,
-                      })}${i18nConfig ? `;window.__VINEXT_LOCALE__=${safeJsonStringify(locale ?? currentDefaultLocale)};window.__VINEXT_LOCALES__=${safeJsonStringify(i18nConfig.locales)};window.__VINEXT_DEFAULT_LOCALE__=${safeJsonStringify(currentDefaultLocale)}` : ""}</script>`;
+                      const freshNextData = `<script id="__NEXT_DATA__" type="application/json">${safeJsonStringify(
+                        {
+                          props: freshRenderProps,
+                          page: patternToNextFormat(route.pattern),
+                          query: params,
+                          buildId: process.env.__VINEXT_BUILD_ID,
+                          isFallback: false,
+                          locale: locale ?? currentDefaultLocale,
+                          locales: i18nConfig?.locales,
+                          defaultLocale: currentDefaultLocale,
+                          domainLocales,
+                          ...freshPagesNextData,
+                        },
+                      )}</script>`;
 
                       const hydrationMatch = cachedHtml.match(
                         /<script type="module">[\s\S]*?<\/script>/,
@@ -1567,6 +1569,13 @@ import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import Router, { wrapWithRouterContext } from "next/router";
 
+const nextDataElement = document.getElementById("__NEXT_DATA__");
+if (nextDataElement?.textContent) {
+  window.__NEXT_DATA__ = JSON.parse(nextDataElement.textContent);
+  window.__VINEXT_LOCALE__ = window.__NEXT_DATA__.locale;
+  window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
+  window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
+}
 const nextData = window.__NEXT_DATA__;
 const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};
 const rawPageProps = props.pageProps;
@@ -1625,8 +1634,8 @@ async function hydrate() {
 hydrate();
 </script>`;
 
-        const nextDataScript = createInlineScriptTag(
-          `window.__NEXT_DATA__ = ${safeJsonStringify({
+        const nextDataScript = `<script id="__NEXT_DATA__" type="application/json"${nonceAttr}>${safeJsonStringify(
+          {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
             query: params,
@@ -1637,9 +1646,8 @@ hydrate();
             defaultLocale: currentDefaultLocale,
             domainLocales,
             ...serializedPagesNextData,
-          })}${i18nConfig ? `;window.__VINEXT_LOCALE__=${safeJsonStringify(locale ?? currentDefaultLocale)};window.__VINEXT_LOCALES__=${safeJsonStringify(i18nConfig.locales)};window.__VINEXT_DEFAULT_LOCALE__=${safeJsonStringify(currentDefaultLocale)}` : ""}`,
-          scriptNonce,
-        );
+          },
+        )}</script>`;
 
         // Try to load custom _document.tsx
         const docPath = path.join(pagesDir, "_document");

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -551,11 +551,11 @@ function rewritePagesCachedHtml(
   const bodyMarker = '<div id="__next">';
   const bodyStart = cachedHtml.indexOf(bodyMarker);
   const contentStart = bodyStart >= 0 ? bodyStart + bodyMarker.length : -1;
-  // This intentionally looks for the bare inline __NEXT_DATA__ marker.
-  // Pages responses with scriptNonce are excluded from ISR writes, so cached
-  // HTML should never contain nonce-prefixed __NEXT_DATA__ scripts here.
-  const nextDataMarker = "<script>window.__NEXT_DATA__";
-  const nextDataStart = cachedHtml.indexOf(nextDataMarker);
+  const canonicalNextDataStart = cachedHtml.search(
+    /<script\b(?=[^>]*\bid=["']__NEXT_DATA__["'])(?=[^>]*\btype=["']application\/json["'])[^>]*>/,
+  );
+  const legacyNextDataStart = cachedHtml.indexOf("<script>window.__NEXT_DATA__");
+  const nextDataStart = canonicalNextDataStart >= 0 ? canonicalNextDataStart : legacyNextDataStart;
 
   if (contentStart >= 0 && nextDataStart >= 0) {
     const region = cachedHtml.slice(contentStart, nextDataStart);

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -11,7 +11,7 @@ import {
 } from "./isr-decision.js";
 import { encodeCacheTag } from "../utils/encode-cache-tag.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
-import { createInlineScriptTag, createNonceAttribute, escapeHtmlAttr } from "./html.js";
+import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { reportRequestError } from "./instrumentation.js";
 import {
@@ -290,16 +290,7 @@ export function buildPagesNextDataScript(
     };
   }
 
-  const localeGlobals = options.i18n.locales
-    ? `;window.__VINEXT_LOCALE__=${options.safeJsonStringify(options.i18n.locale)}` +
-      `;window.__VINEXT_LOCALES__=${options.safeJsonStringify(options.i18n.locales)}` +
-      `;window.__VINEXT_DEFAULT_LOCALE__=${options.safeJsonStringify(options.i18n.defaultLocale)}`
-    : "";
-
-  return createInlineScriptTag(
-    `window.__NEXT_DATA__ = ${options.safeJsonStringify(nextDataPayload)}${localeGlobals}`,
-    options.scriptNonce,
-  );
+  return `<script id="__NEXT_DATA__" type="application/json"${createNonceAttribute(options.scriptNonce)}>${options.safeJsonStringify(nextDataPayload)}</script>`;
 }
 
 async function buildPagesShellHtml(

--- a/packages/vinext/src/server/pages-readiness.ts
+++ b/packages/vinext/src/server/pages-readiness.ts
@@ -42,7 +42,7 @@ export function buildPagesReadinessNextData(options: {
   const hasAppGip = typeof options.appComponent?.getInitialProps === "function";
   return {
     gssp: hasPageGssp,
-    gsp: hasPageGsp,
+    gsp: hasPageGsp ? true : undefined,
     gip: hasPageGip,
     appGip: hasAppGip,
     autoExport: !hasPageGssp && !hasPageGsp && !hasPageGip && !hasAppGip,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1214,6 +1214,15 @@ function markPagesRouterReady(): boolean {
   return true;
 }
 
+function initializePagesRouterReadyFromNextData(nextData: VinextNextData): void {
+  if (typeof window === "undefined") return;
+  routerRuntimeState.pagesRouterReady = getPagesNavigationIsReadyFromSerializedState(
+    nextData.page,
+    window.location.search,
+    nextData,
+  );
+}
+
 function markPagesRouterHydrated(): void {
   if (typeof window === "undefined" || window.__NEXT_HYDRATED === true) return;
 
@@ -3064,5 +3073,6 @@ const _PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
 // Internal export for unit tests that need to drive the readiness transition
 // without relying on React effect timing in a Node test environment.
 export { markPagesRouterReady as _markPagesRouterReady };
+export { initializePagesRouterReadyFromNextData as _initializePagesRouterReadyFromNextData };
 
 export default Router;

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -7,6 +7,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
+import vm from "node:vm";
 import { describe, it, expect } from "vite-plus/test";
 import { generateBrowserEntry } from "../packages/vinext/src/entries/app-browser-entry.js";
 import { buildAppRscManifestCode } from "../packages/vinext/src/entries/app-rsc-manifest.js";
@@ -995,7 +996,7 @@ describe("Pages Router entry template", () => {
       expect(code).toContain("wrapWithRouterContext,");
       expect(code).toContain("_initializePagesRouterReadyFromNextData,");
       expect(code).toContain('} from "next/router";');
-      expect(code).toContain("_initializePagesRouterReadyFromNextData(window.__NEXT_DATA__);");
+      expect(code).toContain("_initializePagesRouterReadyFromNextData(nextData);");
       expect(code).toContain("router: Router,");
       expect(code).toContain("pageProps: rawPageProps,");
       expect(code).toContain("element = wrapWithRouterContext(element, resolveHydrationCommit);");
@@ -1006,6 +1007,44 @@ describe("Pages Router entry template", () => {
       expect(code).not.toContain("function VinextHydrationMarker");
       expect(code).not.toContain("React.createElement(VinextHydrationMarker");
       expect(code).toContain("hydrateRoot(container, element, hydrateRootOptions)");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("gracefully skips Pages Router initialization without __NEXT_DATA__", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-no-data-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      const code = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({}),
+        createValidFileMatcher(),
+      );
+      const initializationStart = code.indexOf(
+        'const nextDataElement = document.getElementById("__NEXT_DATA__");',
+      );
+      const initializationEnd = code.indexOf("  let hydrateRootOptions;", initializationStart);
+      const initializationCode = code.slice(initializationStart, initializationEnd);
+      const errors: string[] = [];
+      await expect(
+        vm.runInNewContext(`(async () => {${initializationCode}\n}\nawait hydrate();})()`, {
+          window: {},
+          document: { getElementById: () => null },
+          console: { error: (message: string) => errors.push(message) },
+          _initializePagesRouterReadyFromNextData: () => {
+            throw new Error("router readiness must not initialize without __NEXT_DATA__");
+          },
+        }),
+      ).resolves.toBeUndefined();
+      expect(errors).toEqual(["[vinext] No __NEXT_DATA__ found"]);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -991,7 +991,11 @@ describe("Pages Router entry template", () => {
       expect(code).toContain(
         'const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};',
       );
-      expect(code).toContain('import Router, { wrapWithRouterContext } from "next/router";');
+      expect(code).toContain("import Router, {");
+      expect(code).toContain("wrapWithRouterContext,");
+      expect(code).toContain("_initializePagesRouterReadyFromNextData,");
+      expect(code).toContain('} from "next/router";');
+      expect(code).toContain("_initializePagesRouterReadyFromNextData(window.__NEXT_DATA__);");
       expect(code).toContain("router: Router,");
       expect(code).toContain("pageProps: rawPageProps,");
       expect(code).toContain("element = wrapWithRouterContext(element, resolveHydrationCommit);");

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -677,7 +677,7 @@ describe("ISR (Pages Router)", () => {
     // __NEXT_DATA__ must also contain the fresh timestamp, proving both the
     // server-rendered HTML and the hydration data are in sync.
     const nextDataMatch = hitHtml.match(
-      /window\.__NEXT_DATA__\s*=\s*(\{[\s\S]*?\})(?:;|<\/script>)/,
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
     );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]);
@@ -1213,7 +1213,9 @@ export default function About({ locale, locales, defaultLocale }) {
     const res = await fetch(`${i18nBaseUrl}/fr/about`);
     const html = await res.text();
     // Extract the JSON object from __NEXT_DATA__ (handles nested braces)
-    const dataMatch = html.match(/__NEXT_DATA__\s*=\s*(\{[^<]+\})/);
+    const dataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(dataMatch).not.toBeNull();
     const data = JSON.parse(dataMatch![1]);
     expect(data.locale).toBe("fr");
@@ -1224,7 +1226,9 @@ export default function About({ locale, locales, defaultLocale }) {
   it("includes locale info in __NEXT_DATA__ for default locale", async () => {
     const res = await fetch(`${i18nBaseUrl}/about`);
     const html = await res.text();
-    const dataMatch = html.match(/__NEXT_DATA__\s*=\s*(\{[^<]+\})/);
+    const dataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(dataMatch).not.toBeNull();
     const data = JSON.parse(dataMatch![1]);
     expect(data.locale).toBe("en");
@@ -4718,7 +4722,9 @@ describe("Next.js edge cases", () => {
     expect(html).toMatch(/Article ID:.*1/);
     // Query params should NOT affect the rendered page content (they may appear in Vite module URLs)
     // Check the __NEXT_DATA__ doesn't leak query params into getStaticProps
-    const dataMatch = html.match(/__NEXT_DATA__\s*=\s*(\{[^<]+\})/);
+    const dataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(dataMatch).not.toBeNull();
     const data = JSON.parse(dataMatch![1]);
     expect(data.props.pageProps.id).toBe("1");
@@ -4731,7 +4737,9 @@ describe("Next.js edge cases", () => {
   it("__NEXT_DATA__ query contains dynamic params for static pages", async () => {
     const res = await fetch(`${edgeBaseUrl}/articles/2?extra=value`);
     const html = await res.text();
-    const dataMatch = html.match(/__NEXT_DATA__\s*=\s*(\{[^<]+\})/);
+    const dataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(dataMatch).not.toBeNull();
     const data = JSON.parse(dataMatch![1]);
     // query should contain the dynamic segment
@@ -5748,7 +5756,9 @@ export default function NestedProps({ user }) {
     const res = await fetch(`${edgeBaseUrl}/nested-props`);
     const html = await res.text();
     // __NEXT_DATA__ is injected as: <script>window.__NEXT_DATA__ = {...}</script>
-    const match = html.match(/window\.__NEXT_DATA__\s*=\s*(\{[\s\S]*?\})(?:;|<)/);
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(match).not.toBeNull();
     const data = JSON.parse(match![1]);
     expect(data.props.pageProps.user.name).toBe("Alice");

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -178,8 +178,16 @@ describe("pages page response", () => {
     expect(html).toContain("<div>live-body</div>");
     expect(html).toContain('<meta name="test-head" content="1" />');
     expect(html).toContain('<link rel="stylesheet" href="/font.css" />');
-    expect(html).toContain("window.__NEXT_DATA__");
-    expect(html).toContain("__VINEXT_LOCALE__");
+    expect(html).toContain('<script id="__NEXT_DATA__" type="application/json">');
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).not.toBeNull();
+    expect(JSON.parse(nextDataMatch![1]!)).toMatchObject({
+      locale: "en",
+      locales: ["en", "fr"],
+      defaultLocale: "en",
+    });
 
     expect(common.clearSsrContext).toHaveBeenCalledTimes(1);
     expect(common.renderDocumentToString).toHaveBeenCalledTimes(1);
@@ -703,7 +711,7 @@ describe("pages page response", () => {
 
     const html = await response.text();
     expect(html).toContain("live-body");
-    expect(html).toContain("window.__NEXT_DATA__");
+    expect(html).toContain('<script id="__NEXT_DATA__" type="application/json">');
   });
 
   it("buffers the response for Google-PageRenderer and attaches an ETag", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -310,7 +310,9 @@ describe("pages page response", () => {
     });
 
     const html = await response.text();
-    expect(html).toContain('<script nonce="pages-test-nonce">window.__NEXT_DATA__ = ');
+    expect(html).toContain(
+      '<script id="__NEXT_DATA__" type="application/json" nonce="pages-test-nonce">',
+    );
     expect(html).toContain('<link rel="stylesheet" nonce="pages-test-nonce" href="/font.css" />');
     expect(html).toContain(
       '<link rel="preload" nonce="pages-test-nonce" href="/font.woff2" as="font" type="font/woff2" crossorigin />',

--- a/tests/pages-router-concurrency.test.ts
+++ b/tests/pages-router-concurrency.test.ts
@@ -75,7 +75,9 @@ describe("Pages Router dev concurrency isolation", () => {
       expect(ssrPathname, `response ${i} ssr-pathname`).toBe("/concurrent-router");
       expect(routerPathname, `response ${i} router-pathname`).toBe("/concurrent-router");
 
-      const nextData = htmlResults[i].match(/__NEXT_DATA__\s*=\s*(\{[^<]+\})/);
+      const nextData = htmlResults[i].match(
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+      );
       if (!nextData) throw new Error(`no __NEXT_DATA__ found in response ${i}`);
       const data = JSON.parse(nextData[1]);
       expect(data.props.pageProps.ssrQuery.id, `response ${i} ssrQuery.id`).toBe(String(i));
@@ -156,7 +158,9 @@ describe("Pages Router prod concurrency isolation", () => {
       const bodyReqId = extractTestId(htmlResults[i], "req-id");
       expect(bodyReqId, `response ${i} should contain its own req-id`).toBe(String(i));
 
-      const nextData = htmlResults[i].match(/__NEXT_DATA__\s*=\s*(\{[^<]+\})/);
+      const nextData = htmlResults[i].match(
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+      );
       if (!nextData) throw new Error(`no __NEXT_DATA__ found in response ${i}`);
       const data = JSON.parse(nextData[1]);
       expect(data.props.pageProps.reqId, `response ${i} pageProps.reqId`).toBe(String(i));
@@ -171,7 +175,9 @@ describe("Pages Router prod concurrency isolation", () => {
       const ssrPathname = extractTestId(htmlResults[i], "ssr-pathname");
       expect(ssrPathname, `response ${i} ssr-pathname`).toBe("/concurrent-router");
 
-      const nextData = htmlResults[i].match(/__NEXT_DATA__\s*=\s*(\{[^<]+\})/);
+      const nextData = htmlResults[i].match(
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+      );
       if (!nextData) throw new Error(`no __NEXT_DATA__ found in response ${i}`);
       const data = JSON.parse(nextData[1]);
       expect(data.props.pageProps.ssrQuery.id, `response ${i} ssrQuery.id`).toBe(String(i));

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1549,7 +1549,7 @@ describe("Pages Router integration", () => {
       expectElementText(dynamicHtml, "resolved-url", "/blog/post-1");
       expectElementText(dynamicHtml, "as-path", "/blog/post-1");
       const dynamicNextDataMatch = dynamicHtml.match(
-        /<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/,
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
       );
       expect(dynamicNextDataMatch).toBeTruthy();
       const dynamicNextData = JSON.parse(dynamicNextDataMatch![1]!);
@@ -1656,7 +1656,9 @@ describe("Pages Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("SSR Query");
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({ hello: "world" });
@@ -1667,7 +1669,9 @@ describe("Pages Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toMatch(/Post:\s*(<!--\s*-->)?\s*first/);
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
@@ -1679,7 +1683,9 @@ describe("Pages Router integration", () => {
     const res = await fetch(`${baseUrl}/mw-rewrite-merge-query?hello=world&other=keep`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({
@@ -1693,7 +1699,9 @@ describe("Pages Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("SSR Query");
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toEqual({});
@@ -1709,7 +1717,9 @@ describe("Pages Router integration", () => {
     const res = await fetch(`${baseUrl}/mw-clear-query-params?a=1&b=2&foo=bar&allowed=kept`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toEqual({ allowed: "kept" });
@@ -1864,7 +1874,9 @@ describe("Pages Router integration", () => {
     expect(html).toContain("Loading product...");
     // The full-content branch must NOT render — getStaticProps was skipped.
     expect(html).not.toMatch(/Product ID:.*unknown/);
-    const match = html.match(/__NEXT_DATA__\s*=\s*(\{.*?\})\s*[;<]/);
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(match).toBeTruthy();
     const nextData = JSON.parse(match![1]);
     expect(nextData.isFallback).toBe(true);
@@ -1924,7 +1936,9 @@ describe("Pages Router integration", () => {
       // Bot should see the real rendered page, not the loading shell.
       expect(html, `UA: ${userAgent}`).not.toContain("Loading product...");
       expect(html, `UA: ${userAgent}`).toMatch(new RegExp(`Product ID:.*${slug}`));
-      const match = html.match(/__NEXT_DATA__\s*=\s*(\{.*?\})\s*[;<]/);
+      const match = html.match(
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+      );
       expect(match, `UA: ${userAgent}`).toBeTruthy();
       const nextData = JSON.parse(match![1]);
       expect(nextData.isFallback, `UA: ${userAgent}`).toBe(false);
@@ -1944,7 +1958,9 @@ describe("Pages Router integration", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("Loading product...");
-    const match = html.match(/__NEXT_DATA__\s*=\s*(\{.*?\})\s*[;<]/);
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(match).toBeTruthy();
     const nextData = JSON.parse(match![1]);
     expect(nextData.isFallback).toBe(true);
@@ -1953,7 +1969,9 @@ describe("Pages Router integration", () => {
   it("includes isFallback: false in __NEXT_DATA__", async () => {
     const res = await fetch(`${baseUrl}/products/widget`);
     const html = await res.text();
-    const match = html.match(/__NEXT_DATA__\s*=\s*(\{.*?\})\s*[;<]/);
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(match).toBeTruthy();
     const nextData = JSON.parse(match![1]);
     expect(nextData.isFallback).toBe(false);
@@ -4770,7 +4788,9 @@ describe("Production server middleware (Pages Router)", () => {
     expect(html).toContain("Loading product...");
     // Full-data branch must not have rendered — getStaticProps was skipped.
     expect(html).not.toMatch(/Product ID:.*never-built/);
-    const match = html.match(/__NEXT_DATA__\s*=\s*(\{.*?\})\s*[;<]/);
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(match).toBeTruthy();
     const nextData = JSON.parse(match![1]);
     expect(nextData.isFallback).toBe(true);
@@ -4922,7 +4942,9 @@ describe("Production server middleware (Pages Router)", () => {
     const res = await fetch(`${prodUrl}/mw-rewrite-query?hello=world`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({ hello: "world" });
@@ -4932,7 +4954,9 @@ describe("Production server middleware (Pages Router)", () => {
     const res = await fetch(`${prodUrl}/mw-rewrite-dynamic-query?hello=world`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
@@ -4950,7 +4974,9 @@ describe("Production server middleware (Pages Router)", () => {
     const res = await fetch(`${prodUrl}/mw-clear-query-params?a=1&b=2&foo=bar&allowed=kept`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const nextDataMatch = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toEqual({ allowed: "kept" });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -6344,6 +6344,14 @@ describe("router __NEXT_DATA__ correctness (Pages Router)", () => {
   let routerServer: ViteDevServer;
   let routerBaseUrl: string;
 
+  function readNextData(html: string) {
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json"(?: nonce="[^"]+")?>([\s\S]*?)<\/script>/,
+    );
+    expect(match).toBeTruthy();
+    return JSON.parse(match![1]);
+  }
+
   beforeAll(async () => {
     ({ server: routerServer, baseUrl: routerBaseUrl } = await startFixtureServer(FIXTURE_DIR));
   });
@@ -6356,9 +6364,7 @@ describe("router __NEXT_DATA__ correctness (Pages Router)", () => {
     const res = await fetch(`${routerBaseUrl}/blog/hello-world`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
-    expect(match).toBeTruthy();
-    const nextData = JSON.parse(match![1]);
+    const nextData = readNextData(html);
     expect(nextData.query).toEqual({ slug: "hello-world" });
     expect(nextData.page).toBe("/blog/[slug]");
   });
@@ -6367,8 +6373,7 @@ describe("router __NEXT_DATA__ correctness (Pages Router)", () => {
     const res = await fetch(`${routerBaseUrl}/posts/hello-world`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
-    const nextData = JSON.parse(match![1]);
+    const nextData = readNextData(html);
     expect(nextData.page).toBe("/posts/[id]");
     expect(nextData.query.id).toBe("hello-world");
   });
@@ -6377,33 +6382,38 @@ describe("router __NEXT_DATA__ correctness (Pages Router)", () => {
     const res = await fetch(`${routerBaseUrl}/docs/a/b/c`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
-    const nextData = JSON.parse(match![1]);
+    const nextData = readNextData(html);
     expect(nextData.page).toBe("/docs/[...slug]");
   });
 
   it("__NEXT_DATA__ includes isFallback: false", async () => {
     const res = await fetch(`${routerBaseUrl}/blog/hello-world`);
     const html = await res.text();
-    const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
-    const nextData = JSON.parse(match![1]);
+    const nextData = readNextData(html);
     expect(nextData.isFallback).toBe(false);
   });
 
   it("static page __NEXT_DATA__.page is the pathname", async () => {
     const res = await fetch(`${routerBaseUrl}/about`);
     const html = await res.text();
-    const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
-    const nextData = JSON.parse(match![1]);
+    const nextData = readNextData(html);
     expect(nextData.page).toBe("/about");
+  });
+
+  // Ported from Next.js: test/e2e/prerender.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/prerender.test.ts
+  it("omits gsp from __NEXT_DATA__ for non-GSP pages", async () => {
+    const res = await fetch(`${routerBaseUrl}/about`);
+    const html = await res.text();
+    const nextData = readNextData(html);
+    expect("gsp" in nextData).toBe(false);
   });
 
   it("shallow-test page returns correct __NEXT_DATA__ with GSSP props", async () => {
     const res = await fetch(`${routerBaseUrl}/shallow-test`);
     expect(res.status).toBe(200);
     const html = await res.text();
-    const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
-    const nextData = JSON.parse(match![1]);
+    const nextData = readNextData(html);
     expect(nextData.page).toBe("/shallow-test");
     expect(nextData.props.pageProps.gsspCallId).toBeGreaterThan(0);
   });
@@ -6464,9 +6474,7 @@ export default function middleware() {
         const res = await fetch(`${baseUrl}/docs/first`);
         expect(res.status).toBe(200);
         const html = await res.text();
-        const match = html.match(/<script>window\.__NEXT_DATA__\s*=\s*({.*?})<\/script>/);
-        expect(match).toBeTruthy();
-        const nextData = JSON.parse(match![1]);
+        const nextData = readNextData(html);
         expect(nextData.page).toBe("/[...path]");
         expect(nextData.query).toEqual({ path: ["first"] });
         expect(html).toContain("CatchAll");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -569,7 +569,9 @@ describe("Pages Router integration", () => {
     );
 
     const html = await res.text();
-    expect(html).toContain('<script nonce="pages-response">window.__NEXT_DATA__ = ');
+    expect(html).toContain(
+      '<script id="__NEXT_DATA__" type="application/json" nonce="pages-response">',
+    );
   });
 
   it("does not serve cached Pages ISR HTML to CSP nonce requests", async () => {
@@ -594,7 +596,9 @@ describe("Pages Router integration", () => {
     expect(second.headers.get("cache-control")).toBe("no-store, must-revalidate");
     expect(second.headers.get("x-vinext-cache")).toBeNull();
     const secondHtml = await second.text();
-    expect(secondHtml).toContain('<script nonce="pages-isr">window.__NEXT_DATA__ = ');
+    expect(secondHtml).toContain(
+      '<script id="__NEXT_DATA__" type="application/json" nonce="pages-isr">',
+    );
   });
 
   it("renders the SSR page with getServerSideProps data", async () => {
@@ -4694,7 +4698,9 @@ describe("Production server middleware (Pages Router)", () => {
     );
 
     const html = await res.text();
-    expect(html).toContain('<script nonce="pages-prod">window.__NEXT_DATA__ = ');
+    expect(html).toContain(
+      '<script id="__NEXT_DATA__" type="application/json" nonce="pages-prod">',
+    );
     expect(html).toMatch(/<script type="module" defer nonce="pages-prod" src="\/[^"]+"/);
     expect(html).toMatch(/<link rel="modulepreload" nonce="pages-prod" href="\/[^"]+"/);
   });
@@ -4740,7 +4746,9 @@ describe("Production server middleware (Pages Router)", () => {
     expect(second.headers.get("cache-control")).toBe("no-store, must-revalidate");
     expect(second.headers.get("x-vinext-cache")).toBeNull();
     const secondHtml = await second.text();
-    expect(secondHtml).toContain('<script nonce="pages-prod-isr">window.__NEXT_DATA__ = ');
+    expect(secondHtml).toContain(
+      '<script id="__NEXT_DATA__" type="application/json" nonce="pages-prod-isr">',
+    );
   });
 
   it("rewrites /rewritten to render /ssr content", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -29,6 +29,16 @@ function commitRenderedPagesRouterElement(element: unknown): void {
 }
 
 describe("vinext next data client helpers", () => {
+  it("extracts Next.js-compatible application/json data scripts", () => {
+    const json = '{"props":{"pageProps":{"nested":{"value":"}"}}},"page":"/","query":{}}';
+
+    expect(
+      extractVinextNextDataJson(
+        `<script id="__NEXT_DATA__" type="application/json">${json}</script>`,
+      ),
+    ).toBe(json);
+  });
+
   it("extracts __NEXT_DATA__ after carriage-return whitespace", () => {
     const json = '{"props":{},"page":"/","query":{}}';
 

--- a/tests/static-export.test.ts
+++ b/tests/static-export.test.ts
@@ -180,7 +180,9 @@ describe("Static export — Pages Router (served via HTTP)", () => {
     const html = await res.text();
     expect(html).toContain("__NEXT_DATA__");
     // Verify it's valid JSON inside the script tag
-    const match = html.match(/window\.__NEXT_DATA__\s*=\s*({[^<]+})/);
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(match).toBeTruthy();
     const data = JSON.parse(match![1]);
     expect(data.props).toBeDefined();
@@ -202,7 +204,9 @@ describe("Static export — Pages Router (served via HTTP)", () => {
   it("getStaticProps pages have correct data in __NEXT_DATA__", async () => {
     const res = await fetch(`${baseUrl}/blog/hello-world`);
     const html = await res.text();
-    const match = html.match(/window\.__NEXT_DATA__\s*=\s*({[^<]+})/);
+    const match = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
     expect(match).toBeTruthy();
     const data = JSON.parse(match![1]);
     expect(data.props.pageProps).toBeDefined();


### PR DESCRIPTION
# Prerender canonical `__NEXT_DATA__` parity

## Source and scope

- Source run: GitHub Actions `27514800656`, `test/e2e/prerender.test.ts` (20 failed records).
- Base: `origin/main` at `a3d2f921520ff140a826224616df5e0db4ed0186`.
- Next.js reference: v16.2.6, commit/build commit `ee6e79b1792a4d401ddf2480f40a83549fe8e722`.
- Focused root cause: Pages Router HTML used executable `<script>window.__NEXT_DATA__ = ...</script>` rather than Next.js-compatible `<script id="__NEXT_DATA__" type="application/json">...</script>`.
- Included related payload correction: omit `gsp` when the page does not export `getStaticProps`; Next.js does not serialize `gsp: false`.
- Explicitly excluded: query propagation, mismatched href/as `_next/data`, fallback rewrites, caching headers, invalid JSON behavior, navigation failures, no-revalidate behavior, preview/on-demand ISR, and all PR #2027 scope.

## Original failure classification

The cohesive cluster contained eight assertions:

1. `should SSR incremental page correctly`
2. `should SSR blocking path correctly (blocking)`
3. `should SSR blocking path correctly (pre-rendered)`
4. `should have gsp in __NEXT_DATA__`
5. `should not have gsp in __NEXT_DATA__ for non-GSP page`
6. `should support prerendered catchall route`
7. `should support prerendered catchall-explicit route (nested)`
8. `should support prerendered catchall-explicit route (single)`

Seven initially failed with `Unexpected end of JSON input` because the upstream tests read `script#__NEXT_DATA__.text()`. After canonical markup, the eighth reached its real payload assertion and showed that vinext serialized `gsp: false` instead of omitting the field.

The other 12 records were classified as separate product gaps or cascade symptoms and were not changed in this work.

## Implementation

- Emit canonical JSON `__NEXT_DATA__` markup in Pages dev and production responses, including nonce support.
- Initialize `window.__NEXT_DATA__` and locale globals explicitly from the JSON element before hydration.
- Parse both canonical JSON and legacy assignment markup during client navigation for compatibility.
- Replace canonical or legacy `__NEXT_DATA__` blocks during cached Pages regeneration.
- Omit `gsp` when false while preserving `gsp: true` readiness behavior.

## Local validation

Passed:

- `tests/shims.test.ts`: 3 targeted tests.
- `tests/pages-page-response.test.ts`: 3 targeted tests.
- `tests/pages-page-data.test.ts`: 9 targeted tests.
- `tests/entry-templates.test.ts`: 27 tests.
- `tests/pages-router.test.ts`: 8 targeted integration tests.
- Scoped `vp check`: formatting, lint, and type checks passed for all nine changed source/test files.
- `git diff --check` passed.

Independent review found four stale CSP integration assertions that still expected the former executable assignment markup. They now assert the canonical nonced JSON element while preserving the existing cache, preload, and content checks.

Review-fix validation passed:

- `tests/pages-router.test.ts`: 4 exact CSP/nonced `__NEXT_DATA__` tests.
- `tests/shims.test.ts`: 2 `vinext next data client helpers` tests.
- `tests/pages-page-response.test.ts`: 3 targeted nonce/cache/HTML recording tests.
- `tests/pages-page-data.test.ts`: 43 tests.
- `tests/entry-templates.test.ts`: 27 tests.
- Scoped `vp check tests/pages-router.test.ts` passed.
- `git diff --check` passed.

The initial frozen `vp install` populated dependencies and built the core packages; an unrelated Fumadocs example postinstall failed once. A subsequent wrapper install completed successfully.

## Exact Next.js deploy validation

Command:

```bash
NEXTJS_PREPARE=0 NEXT_TEST_CONCURRENCY=1 \
  vp env exec --node 24 \
  ./scripts/run-nextjs-deploy-suite.sh \
  /Users/jamesanderson/Developer/vinext/.nextjs-ref \
  --retries 0 -c 1 --debug \
  test/e2e/prerender.test.ts
```

The wrapper does not forward a Jest name filter, so the single targeted file ran in full. Deployment succeeded and assertions were reached.

Scoped final results:

- PASS — `should SSR incremental page correctly`
- PASS — `should SSR blocking path correctly (blocking)`
- PASS — `should SSR blocking path correctly (pre-rendered)`
- PASS — `should have gsp in __NEXT_DATA__`
- PASS — `should not have gsp in __NEXT_DATA__ for non-GSP page`
- PASS — `should support prerendered catchall route`
- PASS — `should support prerendered catchall-explicit route (nested)`
- PASS — `should support prerendered catchall-explicit route (single)`

The full file remains red only for out-of-scope query, rewrite, `_next/data`, caching, navigation, invalid-JSON, and ISR assertions.
