### PR TITLE
fix(csp): match script-src-elem/attr when extracting script nonce

### DIFF
--- a/packages/vinext/src/server/csp.ts
+++ b/packages/vinext/src/server/csp.ts
@@ -3,10 +3,6 @@ import type { IncomingHttpHeaders, OutgoingHttpHeaders } from "node:http";
 const ESCAPE_REGEX = /[&><\u2028\u2029]/;
 type NodeHeaders = IncomingHttpHeaders | OutgoingHttpHeaders;
 
-function matchesDirectiveName(directive: string, name: string): boolean {
-  return directive === name || directive.startsWith(`${name} `);
-}
-
 function getNodeHeaderValue(
   headers: NodeHeaders | null | undefined,
   key: "content-security-policy" | "content-security-policy-report-only",
@@ -24,9 +20,13 @@ function getNodeHeaderValue(
 export function getScriptNonceFromHeader(cspHeaderValue: string): string | undefined {
   const directives = cspHeaderValue.split(";").map((directive) => directive.trim());
 
+  // First try to find the directive for 'script-src', otherwise fall back to
+  // 'default-src'. Matches Next.js (get-script-nonce-from-header.tsx), which
+  // uses startsWith so the script-src-elem/script-src-attr variants are also
+  // matched.
   const directive =
-    directives.find((value) => matchesDirectiveName(value, "script-src")) ??
-    directives.find((value) => matchesDirectiveName(value, "default-src"));
+    directives.find((value) => value.startsWith("script-src")) ??
+    directives.find((value) => value.startsWith("default-src"));
 
   if (!directive) {
     return undefined;

--- a/tests/csp.test.ts
+++ b/tests/csp.test.ts
@@ -25,20 +25,39 @@ describe("CSP nonce helpers", () => {
     ).toBe("script");
   });
 
-  it("does not match script-src-* directives when resolving the script nonce", () => {
+  it("extracts the nonce from script-src-elem when no plain script-src is present", () => {
+    expect(getScriptNonceFromHeader("script-src-elem 'nonce-abc'; default-src 'self'")).toBe("abc");
+  });
+
+  it("extracts the nonce from script-src-attr when no plain script-src is present", () => {
+    expect(getScriptNonceFromHeader("script-src-attr 'nonce-attr'; default-src 'self'")).toBe(
+      "attr",
+    );
+  });
+
+  it("matches the first script-src* directive (Next.js startsWith parity)", () => {
     expect(
       getScriptNonceFromHeader(
         "script-src-elem 'nonce-element'; script-src-attr 'nonce-attr'; script-src 'nonce-script'",
       ),
-    ).toBe("script");
+    ).toBe("element");
   });
 
-  it("does not match default-src-* directives when falling back to default-src", () => {
+  it("matches the first default-src* directive when falling back (Next.js startsWith parity)", () => {
     expect(
       getScriptNonceFromHeader(
         "default-src-elem 'nonce-element'; default-src-attr 'nonce-attr'; default-src 'nonce-default'",
       ),
-    ).toBe("default");
+    ).toBe("element");
+  });
+
+  it("only reads the first script-src* directive and does not scan later script-src directives", () => {
+    // Next.js selects a single directive via find(startsWith('script-src')) and
+    // extracts the nonce only from that directive, so a nonce on a later plain
+    // script-src is not used.
+    expect(
+      getScriptNonceFromHeader("script-src-elem 'self'; script-src 'nonce-x'"),
+    ).toBeUndefined();
   });
 
   it("parses the first matching nonce across extra whitespace and additional nonces", () => {


### PR DESCRIPTION
## Problem

Next.js's `get-script-nonce-from-header.tsx` selects the nonce directive with `dir.startsWith('script-src')`, which also matches `script-src-elem` and `script-src-attr`. vinext used an exact-match predicate (`matchesDirectiveName`) that required `directive === "script-src"` or a `script-src ` prefix, so a CSP declaring the nonce only on `script-src-elem` (with no plain `script-src`) was skipped. vinext then fell through to `default-src` (or found no nonce), and SSR scripts could be emitted without the expected nonce and get blocked by the browser CSP.

Fixes #1989.

## Fix

Select the directive via `startsWith("script-src")` then `startsWith("default-src")`, matching Next.js exactly. The existing nonce-source parsing (slice + `ESCAPE_REGEX` guard) is unchanged. This is the single directive matcher in the repo, so App Router (`app-rsc-handler.ts`), Pages Router (`pages-page-handler.ts`), and dev (`dev-server.ts`) are all fixed together. The now-unused `matchesDirectiveName` helper was removed.

### Next.js parity notes

- Verified against canary `packages/next/src/server/app-render/get-script-nonce-from-header.tsx`, which uses `directives.find(dir => dir.startsWith('script-src')) || directives.find(dir => dir.startsWith('default-src'))`.
- No false-positive risk: only `script-src`, `script-src-elem`, `script-src-attr` start with `script-src` (all script-related); only `default-src` starts with `default-src`.
- Faithful to Next.js's single-directive semantics: the nonce is extracted only from the **first** matching `script-src*` directive, so a nonce on a later plain `script-src` is not used.

## Tests

Updated `tests/csp.test.ts` (the two prior tests encoded the old buggy behavior). Added coverage for:

- `script-src-elem 'nonce-abc'` / `script-src-attr 'nonce-attr'` with no plain `script-src` → nonce extracted
- First `script-src*` / `default-src*` directive selected when multiple exist
- Edge case: nonce extracted only from the first `script-src*` directive (`script-src-elem 'self'; script-src 'nonce-x'` → `undefined`)

## Validation

- `vp test run tests/csp.test.ts` — 15 passed
- `vp test run tests/nextjs-compat/script-nonce.test.ts` — 4 passed (no SSR regression)
- `vp check` — format, lint, typecheck clean