### PR TITLE
fix(i18n): match NEXT_LOCALE cookie case-insensitively

### DIFF
--- a/packages/vinext/src/server/pages-i18n.ts
+++ b/packages/vinext/src/server/pages-i18n.ts
@@ -200,8 +200,12 @@ export function parseCookieLocaleFromHeader(
     return null;
   }
 
-  if (i18nConfig.locales.includes(value)) return value;
-  return null;
+  // Match case-insensitively and return the canonical configured locale, so a
+  // cookie like `NEXT_LOCALE=EN-US` resolves to a configured `en-US`. Mirrors
+  // Next.js's `getLocaleFromCookie` (get-locale-redirect.ts), which lowercases
+  // the cookie value and finds the matching configured locale.
+  const lowerValue = value.toLowerCase();
+  return i18nConfig.locales.find((locale) => locale.toLowerCase() === lowerValue) ?? null;
 }
 
 function formatLocalizedRootPath(

--- a/tests/pages-i18n.test.ts
+++ b/tests/pages-i18n.test.ts
@@ -122,6 +122,43 @@ describe("Pages i18n domain helpers", () => {
   });
 });
 
+// Ported from Next.js: test/e2e/i18n-support/shared.ts
+// `addDefaultLocaleCookie` sets `NEXT_LOCALE=EN-US` (uppercase) "to ensure
+// it's case-insensitive". Next.js resolves the cookie case-insensitively and
+// returns the canonical configured locale (get-locale-redirect.ts
+// `getLocaleFromCookie`).
+// https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support/shared.ts
+describe("parseCookieLocaleFromHeader (issue #1969)", () => {
+  let parseCookieLocaleFromHeader: typeof import("../packages/vinext/src/server/pages-i18n.js").parseCookieLocaleFromHeader;
+
+  beforeAll(async () => {
+    ({ parseCookieLocaleFromHeader } = await import("../packages/vinext/src/server/pages-i18n.js"));
+  });
+
+  const i18n = {
+    locales: ["en-US", "fr"],
+    defaultLocale: "en-US",
+    localeDetection: true,
+    domains: [],
+  };
+
+  it("matches an exact-case cookie value", () => {
+    expect(parseCookieLocaleFromHeader("NEXT_LOCALE=en-US", i18n)).toBe("en-US");
+  });
+
+  it("resolves an uppercase cookie to the canonical configured locale", () => {
+    expect(parseCookieLocaleFromHeader("NEXT_LOCALE=EN-US", i18n)).toBe("en-US");
+  });
+
+  it("resolves a mixed-case cookie to the canonical configured locale", () => {
+    expect(parseCookieLocaleFromHeader("NEXT_LOCALE=Fr", i18n)).toBe("fr");
+  });
+
+  it("returns null when the cookie value is not a configured locale", () => {
+    expect(parseCookieLocaleFromHeader("NEXT_LOCALE=de", i18n)).toBeNull();
+  });
+});
+
 // Ported from Next.js: test/e2e/middleware-redirects/test/index.test.ts
 // (the "should redirect to api route with locale" case)
 // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-redirects/test/index.test.ts


### PR DESCRIPTION
## Summary

- Match the `NEXT_LOCALE` cookie against configured locales **case-insensitively**, and return the canonical configured locale.
- Fixes a silently-dropped sticky locale when the cookie case differs from the configured locale (e.g. `NEXT_LOCALE=EN-US` vs configured `en-US`).

## Root Cause

`parseCookieLocaleFromHeader` in `server/pages-i18n.ts` matched the decoded cookie value with a case-**sensitive** `i18nConfig.locales.includes(value)`. A cookie such as `NEXT_LOCALE=EN-US` therefore failed to match a configured `en-US`, the function returned `null`, and locale detection silently fell through to `Accept-Language`/default — the user's sticky locale preference was lost.

Next.js matches this case-insensitively and returns the canonical configured locale: `getLocaleFromCookie` lowercases the cookie (`NEXT_LOCALE?.toLowerCase()`) and does `i18n.locales.find((l) => nextLocale === l.toLowerCase())`. The fix mirrors that — lowercase both sides, `find` the configured locale, and return its canonical casing (`?? null`). Scope is limited to the cookie path: URL-path locale matching stays case-sensitive (correct), and `Accept-Language` parsing was already case-insensitive.

## References

- Fixes #1969
- Next.js parity: `packages/next/src/shared/lib/i18n/get-locale-redirect.ts` (`getLocaleFromCookie`)
- Ported test: `test/e2e/i18n-support/shared.ts` (`addDefaultLocaleCookie` sets `NEXT_LOCALE=EN-US` uppercase to assert case-insensitivity)

## Verification

- `CI=true pnpm test tests/pages-i18n.test.ts` — new cases: exact-case stays matching; `EN-US` → `en-US`; mixed-case `Fr` → `fr`; non-locale → `null`. Red before (the two case-insensitive cases returned `null`), green after (23 passed).
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on both changed files.
