### PR TITLE
fix(fonts): detect trailing comma past comments when injecting font options

### DIFF
--- a/packages/vinext/src/plugins/dynamic-preload-metadata.ts
+++ b/packages/vinext/src/plugins/dynamic-preload-metadata.ts
@@ -3,6 +3,7 @@ import { parseAst } from "vite";
 import MagicString from "magic-string";
 import path from "node:path";
 import { isUnknownRecord as isRecord } from "../utils/record.js";
+import { hasTrailingComma } from "../utils/has-trailing-comma.js";
 import { relativeWithinRoot, tryRealpathSync } from "../build/ssr-manifest.js";
 
 type AstRecord = Record<string, unknown>;
@@ -438,10 +439,6 @@ function appendObjectProperty(
   return true;
 }
 
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
-}
-
 function insertSecondOptionsArgument(
   output: MagicString,
   code: string,
@@ -461,14 +458,14 @@ function insertSecondOptionsArgument(
   // dropping it. The call's close paren is always past the whole argument list.
   const closeParen = callEnd - 1;
 
-  // Decide the separator with a COMMENT-AWARE trailing-comma check: strip
-  // comments from the gap between the first argument and the close paren, then
-  // look for a real trailing comma. A pre-existing trailing comma
-  // (`dynamic(loader,)`) must NOT get a second one (`,,` is a syntax error), and
-  // a comma living inside a comment must NOT be mistaken for a real one (the old
-  // substring scan overwrote — and thus ate — such comments).
-  const between = stripComments(code.slice(firstArgEnd, closeParen)).trimEnd();
-  const separator = between.endsWith(",") ? " " : ", ";
+  // Decide the separator with a COMMENT-AWARE trailing-comma check:
+  // `hasTrailingComma` inspects only the gap between the first argument and the
+  // close paren, ignoring trailing whitespace/comments (and never treating a
+  // `//`/`/*` inside a string literal as a comment). A pre-existing trailing
+  // comma (`dynamic(loader,)`) must NOT get a second one (`,,` is a syntax
+  // error), and a comma living inside a comment must NOT be mistaken for a real
+  // one (the old substring scan overwrote — and thus ate — such comments).
+  const separator = hasTrailingComma(code.slice(firstArgEnd, closeParen)) ? " " : ", ";
   output.appendLeft(closeParen, `${separator}${optionsLiteral}`);
   return true;
 }

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -29,6 +29,7 @@ import { parseAst } from "vite";
 import path from "node:path";
 import fs from "node:fs";
 import { escapeRegExp } from "../utils/regex.js";
+import { lastSignificantChar } from "../utils/has-trailing-comma.js";
 import MagicString from "magic-string";
 import {
   buildFallbackFontFace,
@@ -949,12 +950,17 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
             `_vinext: { font: { ${internalFontProperties.join(", ")} } }`,
           ];
           const closingBrace = optionsStr.lastIndexOf("}");
-          const beforeBrace = optionsStr.slice(0, closingBrace).trim();
-          // Determine the separator to insert before the new property:
-          //   - Empty string if the object is empty ({ is the last non-whitespace char)
+          // Decide the separator from the last significant character before the
+          // closing brace. `lastSignificantChar` skips whitespace AND comments
+          // without being fooled by `//`/`/*` inside string literals (e.g. a URL
+          // or a path with a double slash), so a trailing comma hidden behind a
+          // comment is honoured and a `//` inside a value can never eat the real
+          // comma. Determine the separator to insert before the new property:
+          //   - Empty string if the object is empty ({ is the last significant char)
           //   - Empty string if there's already a trailing comma (avoid double comma)
           //   - ", " otherwise (before the new property)
-          const separator = beforeBrace.endsWith("{") || beforeBrace.endsWith(",") ? "" : ", ";
+          const lastChar = lastSignificantChar(optionsStr.slice(0, closingBrace));
+          const separator = lastChar === "{" || lastChar === "," ? "" : ", ";
           const optionsWithCSS =
             optionsStr.slice(0, closingBrace) +
             separator +
@@ -1207,9 +1213,13 @@ export function createLocalFontsPlugin(shimsDir: string): Plugin {
           const optionsStr = code.slice(objRange[0], objRange[1]);
           if (/(?:^|[,{])\s*_vinext\s*:/.test(optionsStr)) continue;
 
-          const beforeClosingBrace = optionsStr.slice(0, -1).trim();
-          const separator =
-            beforeClosingBrace.endsWith("{") || beforeClosingBrace.endsWith(",") ? "" : ", ";
+          // Decide the separator from the last significant character before the
+          // closing brace (see injectSelfHostedCss): comment- and
+          // string-literal-aware, so a trailing comma hidden behind a comment is
+          // honoured and a `//` inside a value (e.g. a path) is not mistaken for
+          // a comment that would swallow the real comma → double comma.
+          const lastChar = lastSignificantChar(optionsStr.slice(0, -1));
+          const separator = lastChar === "{" || lastChar === "," ? "" : ", ";
           s.appendLeft(
             insertAt,
             `${separator}_vinext: { font: { family: ${JSON.stringify(bindingName)} } }`,

--- a/packages/vinext/src/utils/has-trailing-comma.ts
+++ b/packages/vinext/src/utils/has-trailing-comma.ts
@@ -1,0 +1,65 @@
+/**
+ * Return the last syntactically significant character of a JS source fragment,
+ * skipping whitespace and comments. A forward scan tracks string and comment
+ * state so that `//` or `/*` sequences appearing INSIDE a string literal (e.g. a
+ * URL such as `"https://example.com"` or a path with a double slash) are NOT
+ * mistaken for comments.
+ *
+ * This is deliberately stricter than a whole-string comment strip: stripping
+ * every `//...`/`/* ... *\/` would also delete those sequences from inside
+ * string literals, which can swallow the real trailing comma that follows them
+ * and corrupt the trailing-comma / empty-object detection this feeds.
+ *
+ * Returns "" for an empty / whitespace-only / comment-only fragment.
+ */
+export function lastSignificantChar(source: string): string {
+  let last = "";
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+    // Line comment: skip to the end of the line.
+    if (c === "/" && next === "/") {
+      i += 2;
+      while (i < n && source[i] !== "\n") i += 1;
+      continue;
+    }
+    // Block comment: skip to the closing `*/`.
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) i += 1;
+      i += 2;
+      continue;
+    }
+    // String / template literal: skip to the matching unescaped quote. The
+    // literal counts as significant content (its closing quote is the token).
+    if (c === '"' || c === "'" || c === "`") {
+      i += 1;
+      while (i < n && source[i] !== c) {
+        if (source[i] === "\\") i += 1;
+        i += 1;
+      }
+      last = c;
+      i += 1;
+      continue;
+    }
+    // Whitespace is not significant.
+    if (/\s/.test(c)) {
+      i += 1;
+      continue;
+    }
+    last = c;
+    i += 1;
+  }
+  return last;
+}
+
+/**
+ * True when `source` ends — ignoring trailing whitespace and comments — with a
+ * real trailing comma. Used to avoid splicing a second comma (`,,` is a syntax
+ * error) when injecting a property or argument into existing source.
+ */
+export function hasTrailingComma(source: string): boolean {
+  return lastSignificantChar(source) === ",";
+}

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -965,6 +965,95 @@ describe("vinext:google-fonts plugin", () => {
     }
   });
 
+  it("does not produce double-comma when a trailing comma is hidden behind a block comment", async () => {
+    // Regression for #1973: `.trim()` strips whitespace but not comments, so a
+    // trailing comma followed by a block comment, e.g. Inter({ subsets: ["latin"], /* c */ }),
+    // was not detected and a second ", " was inserted → `, /* c */ , _vinext` (invalid JS).
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-block-comment");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `const inter = Inter({`,
+        `  subsets: ["latin"], /* c */`,
+        `});`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("selfHostedCSS");
+      // No comma must be inserted right after the block comment's close.
+      expect(result.code).not.toMatch(/\*\/\s*,/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not produce double-comma when a trailing comma is hidden behind a line comment", async () => {
+    // Regression for #1973: a trailing comma followed by a `// line comment`
+    // also escaped detection → a second comma was inserted on the next line.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-line-comment");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `const inter = Inter({`,
+        `  subsets: ["latin"], // c`,
+        `});`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("selfHostedCSS");
+      // No comma must be inserted on the line following the line comment.
+      expect(result.code).not.toMatch(/\/\/ c\n\s*,/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not produce double-comma when a string option value contains `//` before a trailing comma", async () => {
+    // Hardening for #1973: a whole-slice comment strip also deletes the `//`
+    // inside a string literal (e.g. Inter({ variable: "--font//x", })) and the
+    // rest of that line — swallowing the REAL trailing comma and injecting a
+    // second one (`, , selfHostedCSS` → invalid JS). The string-aware, end-only
+    // scan is not fooled by the in-string `//`.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-string-slashes");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `const inter = Inter({`,
+        `  subsets: ["latin"],`,
+        `  variable: "--font//x",`,
+        `});`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("selfHostedCSS");
+      // The real trailing comma must be detected → no double comma injected.
+      expect(result.code).not.toMatch(/,\s*,/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("self-hosts font calls with nested-brace options (e.g. axes: { wght: 400 })", async () => {
     // Regression: namedCallRe used \{[^}]*\} which stopped at the first '}'
     // inside a nested object, so calls with nested braces were silently skipped.

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -199,6 +199,66 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.code).toContain(`_vinext: { font: { family: "myFont" } }`);
   });
 
+  it("does not produce double-comma when a trailing comma is hidden behind a block comment", () => {
+    // Regression for #1973: `.trim()` strips whitespace but not comments, so a
+    // trailing comma followed by a block comment escaped the trailing-comma
+    // check and a second comma was inserted before the `_vinext` payload.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `const myFont = localFont({`,
+      `  src: "./my-font.woff2", /* c */`,
+      `});`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expect(result.code).toContain(`_vinext: { font: { family: "myFont" } }`);
+    expect(result.code).not.toMatch(/\*\/\s*,/);
+  });
+
+  it("does not produce double-comma when a trailing comma is hidden behind a line comment", () => {
+    // Regression for #1973: a trailing comma followed by a `// line comment`.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `const myFont = localFont({`,
+      `  src: "./my-font.woff2", // c`,
+      `});`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expect(result.code).toContain(`_vinext: { font: { family: "myFont" } }`);
+    expect(result.code).not.toMatch(/\/\/ c\n\s*,/);
+  });
+
+  it("does not produce double-comma when a string value contains `//` before a trailing comma", () => {
+    // Hardening for #1973: a whole-slice comment strip also deletes the `//`
+    // inside a string literal (e.g. a path with a double slash) and everything
+    // after it on that line — swallowing the REAL trailing comma and causing a
+    // second comma to be injected. The string-aware, end-only scan is not fooled.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `const myFont = localFont({`,
+      `  src: "./fonts//my-font.woff2",`,
+      `});`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expect(result.code).toContain(`_vinext: { font: { family: "myFont" } }`);
+    // The real trailing comma must be detected → no double comma injected.
+    expect(result.code).not.toMatch(/,\s*,/);
+  });
+
   // ── Object src with path property ────────────────────────────
 
   it("transforms a single source object with path property", () => {


### PR DESCRIPTION
## Summary

- Fix a build-breaking `,,` produced when a `next/font` options object has a trailing comma hidden behind a comment, e.g. `Inter({ subsets: ["latin"], /* note */ })`.
- Detect the trailing comma with a shared, **string-aware** scanner instead of a naive comment strip, so a `//` inside a string literal (a URL) can never be mistaken for a comment.

## Root Cause

The font plugins inject an extra option into the user's `next/font` call by string-splicing before the closing `}`, choosing the separator (`""` vs `", "`) by testing whether the text before `}` ends with `,`. That test ran on raw source, so a trailing comment masked a real trailing comma:

```
Inter({ weight: "400", /* x */ })
  → { weight: "400", /* x */, _vinext: {…} }   // double comma → SyntaxError → build fails
```

Both font sites (`plugins/fonts.ts`, Google self-host + local transform) and `plugins/dynamic-preload-metadata.ts` (which kept a private comment-stripper) had this shape. The fix adds a shared `utils/has-trailing-comma.ts` exposing `lastSignificantChar` / `hasTrailingComma`, which **forward-scans tracking string and comment state** and returns the last meaningful character. This is used to pick the separator at all three sites.

A stateful scan is required rather than a regex comment-strip: a regex cannot distinguish a `//` that opens a comment from a `//` inside a string literal (e.g. `src: "https://…"`), and stripping the latter would corrupt the trailing-comma decision. Consolidating into one shared util also satisfies the repo's `prefer-shared-utils` lint (no duplicated private helper).

## References

- Fixes #1973
- No Next.js test to port: Next.js parses font calls to an AST and never re-serializes user source (`crates/next-custom-transforms/.../fonts`), so this class of bug can't occur there — the behavior is anchored to vinext's string-splice path and covered by new unit tests.

## Verification

- `CI=true pnpm test tests/font-google.test.ts tests/font-local-transform.test.ts tests/build-optimization.test.ts` — new cases for both font sites: trailing comma behind a block comment and a line comment, plus a value containing `//` (URL) that must not be misread. Red before, green after (269 passed).
- `node -e` checks on the scanner: 18 cases incl. `{ url: "http://x.com", }` → has-trailing-comma `true`, `{ url: "http://x.com", b: 2 }` → `false`.
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on all changed files; `prefer-shared-utils` satisfied.
