### PR TITLE
fix(build): preserve sibling bindings when stripping server exports

### DIFF
--- a/packages/vinext/src/plugins/strip-server-exports.ts
+++ b/packages/vinext/src/plugins/strip-server-exports.ts
@@ -42,9 +42,15 @@ export function stripServerExports(code: string): string | null {
         );
         changed = true;
       } else if (decl.type === "VariableDeclaration") {
+        // Stub each matched declarator in place rather than overwriting the
+        // whole statement. This preserves any sibling bindings sharing the
+        // declaration (`export const a = 1, getStaticProps = ...`) and avoids
+        // a double-overwrite collapse when two server exports share one
+        // declaration. Matches Next.js's next-ssg, which removes only the
+        // matched declarator and retains the rest.
         for (const declarator of decl.declarations) {
           if (declarator.id?.type === "Identifier" && SERVER_EXPORTS.has(declarator.id.name)) {
-            s.overwrite(node.start, node.end, `export const ${declarator.id.name} = undefined;`);
+            s.overwrite(declarator.start, declarator.end, `${declarator.id.name} = undefined`);
             changed = true;
           }
         }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -2772,6 +2772,48 @@ export const getStaticPaths = () => [
     expect(result).toContain("export const getStaticPaths = undefined;");
     expect(result).not.toContain("a;b");
   });
+
+  // Regression test for #1972: a server export sharing one `const` statement
+  // with a sibling binding must not drop the sibling.
+  // Ported from Next.js: test/unit/babel-plugin-next-ssg-transform.test.ts
+  // "should not remove extra named export variable declarations"
+  // https://github.com/vercel/next.js/blob/canary/test/unit/babel-plugin-next-ssg-transform.test.ts
+  it("preserves sibling bindings sharing a declaration with a server export", () => {
+    const code = `
+export const keep = 1, getStaticProps = () => ({ props: {} });
+
+export default function Page() {
+  return null;
+}
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    // The non-server sibling binding must survive untouched.
+    expect(result).toContain("keep = 1");
+    // The server export is stubbed, not its initializer kept.
+    expect(result).toContain("getStaticProps = undefined");
+    expect(result).not.toContain("props: {}");
+    expect(() => parseAst(result!)).not.toThrow();
+  });
+
+  // Regression test for #1972: two server exports sharing one declaration must
+  // each be stubbed without collapsing the statement (no double-overwrite).
+  it("stubs every server export when several share one declaration", () => {
+    const code = `
+export const getStaticPaths = () => ({ paths: [] }), getStaticProps = () => ({ props: {} });
+
+export default function Page() {
+  return null;
+}
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    expect(result).toContain("getStaticPaths = undefined");
+    expect(result).toContain("getStaticProps = undefined");
+    expect(result).not.toContain("paths: []");
+    expect(result).not.toContain("props: {}");
+    expect(() => parseAst(result!)).not.toThrow();
+  });
 });
 
 // ─── getClientTreeshakeConfigForVite ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Preserve sibling bindings when stripping server-only exports from a combined `export const a = …, getStaticProps = …` declaration.
- Stub each matched server export independently instead of overwriting the whole statement.

## Root Cause

`stripServerExports` (`plugins/strip-server-exports.ts`) handled a `VariableDeclaration` by overwriting the entire statement range (`node.start..node.end`) with a single `export const <name> = undefined;` when any declarator matched a server export. Two failures followed:

1. Sibling bindings sharing the declaration were dropped — `export const keep = 1, getStaticProps = () => {}` became `export const getStaticProps = undefined;`, so `keep` vanished and threw `ReferenceError` at runtime.
2. When several server exports shared one declaration, the same range was overwritten twice (MagicString), collapsing them to a single stub.

The fix overwrites **per declarator** (`declarator.start..declarator.end` → `<name> = undefined`), which preserves the `const`/`let`/`var` keyword, the commas, and every sibling, and touches only disjoint ranges. Non-`Identifier` declarators (destructuring) are still skipped. This matches Next.js' `next-ssg` transforms, which mark/remove only the matched declarator and retain the rest.

## References

- Fixes #1972
- Next.js parity: `crates/next-custom-transforms/src/transforms/next_ssg.rs` and `packages/next/src/build/babel/plugins/next-ssg-transform.ts` (per-declarator removal)
- Ported test: `test/unit/babel-plugin-next-ssg-transform.test.ts` ("should not remove extra named export variable declarations")

## Verification

- `CI=true pnpm test tests/build-optimization.test.ts` — new cases: a sibling binding sharing a declaration with a server export is preserved; multiple server exports in one declaration are each stubbed. Red before, green after; all pre-existing `stripServerExports` tests still pass (115 passed).
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on both changed files.
