### PR TITLE
fix(metadata): gate twitter app and player tags on card type

### DIFF
--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -1103,7 +1103,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
       }
     }
     // Twitter player cards
-    if (tw.players) {
+    if (tw.card === "player" && tw.players) {
       const players = Array.isArray(tw.players) ? tw.players : [tw.players];
       for (const player of players) {
         const playerUrl = player.playerUrl.toString();
@@ -1121,7 +1121,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
       }
     }
     // Twitter app cards
-    if (tw.app) {
+    if (tw.card === "app" && tw.app) {
       const { app } = tw;
       for (const platform of ["iphone", "ipad", "googleplay"] as const) {
         if (app.name) {
@@ -1129,7 +1129,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
             <meta key={key++} name={`twitter:app:name:${platform}`} content={app.name} />,
           );
         }
-        if (app.id[platform] !== undefined) {
+        if (app.id[platform]) {
           elements.push(
             <meta
               key={key++}
@@ -1138,7 +1138,7 @@ export function MetadataHead({ metadata, pathname = "/", trailingSlash }: Metada
             />,
           );
         }
-        if (app.url?.[platform] !== undefined) {
+        if (app.url?.[platform]) {
           const appUrl = app.url[platform]!.toString();
           elements.push(
             <meta key={key++} name={`twitter:app:url:${platform}`} content={resolveUrl(appUrl)} />,

--- a/tests/file-based-metadata.test.ts
+++ b/tests/file-based-metadata.test.ts
@@ -847,3 +847,81 @@ describe("applyFileBasedMetadata", () => {
     expect(html).not.toContain("https://mydomain.com/dynamic/big");
   });
 });
+
+// Regression for cloudflare/vinext#1968 — twitter:app:* tags must only be
+// emitted when the resolved card type is exactly "app", and individual id/url
+// tags must use truthy (not !== undefined) checks so falsy ids/urls (0, "")
+// are skipped.
+// Ported from Next.js: packages/next/src/lib/metadata/metadata.tsx
+describe("twitter app card gating (#1968)", () => {
+  it("does not emit twitter:app:* tags when card type is not 'app'", () => {
+    const metadata: Metadata = {
+      twitter: {
+        // No `card` set -> not an app card, so no app:* tags.
+        app: {
+          name: "My App",
+          id: { iphone: "id123", ipad: "id123", googleplay: "com.example.app" },
+          url: {
+            iphone: "https://example.com/iphone",
+            ipad: "https://example.com/ipad",
+            googleplay: "https://example.com/android",
+          },
+        },
+      },
+    };
+    const html = renderToStaticMarkup(createElement(MetadataHead, { metadata }));
+    expect(html).not.toContain("twitter:app:name");
+    expect(html).not.toContain("twitter:app:id");
+    expect(html).not.toContain("twitter:app:url");
+  });
+
+  it("skips falsy app ids but emits truthy ones when card is 'app'", () => {
+    const metadata: Metadata = {
+      twitter: {
+        card: "app",
+        app: {
+          name: "My App",
+          id: { iphone: 0, ipad: "", googleplay: "999" },
+        },
+      },
+    };
+    const html = renderToStaticMarkup(createElement(MetadataHead, { metadata }));
+    expect(html).toContain('name="twitter:card" content="app"');
+    expect(html).not.toContain("twitter:app:id:iphone");
+    expect(html).not.toContain("twitter:app:id:ipad");
+    expect(html).toContain('name="twitter:app:id:googleplay" content="999"');
+  });
+
+  it("does not emit twitter:player:* tags when card type is not 'player'", () => {
+    const metadata: Metadata = {
+      twitter: {
+        // No `card` set -> not a player card, so no player:* tags.
+        players: {
+          playerUrl: "https://example.com/player",
+          streamUrl: "https://example.com/stream",
+          width: 640,
+          height: 480,
+        },
+      },
+    };
+    const html = renderToStaticMarkup(createElement(MetadataHead, { metadata }));
+    expect(html).not.toContain("twitter:player");
+  });
+
+  it("emits twitter:player:* tags when card is 'player'", () => {
+    const metadata: Metadata = {
+      twitter: {
+        card: "player",
+        players: {
+          playerUrl: "https://example.com/player",
+          streamUrl: "https://example.com/stream",
+          width: 640,
+          height: 480,
+        },
+      },
+    };
+    const html = renderToStaticMarkup(createElement(MetadataHead, { metadata }));
+    expect(html).toContain('name="twitter:card" content="player"');
+    expect(html).toContain("twitter:player:stream");
+  });
+});


### PR DESCRIPTION
## Summary

- Gate `twitter:app:*` tags on `card === "app"` and `twitter:player:*` tags on `card === "player"`, instead of emitting them whenever a `twitter.app` / `twitter.players` object exists.
- Skip falsy `twitter:app:id` / `twitter:app:url` values (`0`, `""`).

## Root Cause

The Twitter metadata renderer (`shims/metadata.tsx`) gated the app block on `if (tw.app)` and the player block on `if (tw.players)` — purely on object presence, not on the resolved card type. So a user who set `twitter: { app: {...} }` while the card defaulted to `summary` still got `twitter:app:*` tags (and the analogous problem for player cards). It also emitted `twitter:app:id`/`twitter:app:url` for falsy values because it tested `!== undefined`.

Next.js gates each sub-block on the resolved card (`if (card === 'app')`, `if (card === 'player')`) and uses truthy checks for app id/url. The fix mirrors that: gate app on `card === "app"`, player on `card === "player"`, and use truthy checks. The card is already defaulted in `postProcessMetadata` (`summary_large_image` when images are present, else `summary`), matching Next.js' `resolve-opengraph` defaulting, so the gate always compares against a resolved value.

## References

- Fixes #1968
- Next.js parity: `packages/next/src/lib/metadata/metadata.tsx` (`if (card === 'app')` / `if (card === 'player')`, truthy id/url) and `resolvers/resolve-opengraph.ts` (card defaulting)

## Verification

- `CI=true pnpm test tests/file-based-metadata.test.ts tests/nextjs-compat/metadata.test.ts` — new cases: no `twitter:app:*` when card isn't `app`; falsy app ids skipped while truthy ones emit; no `twitter:player:*` when card isn't `player`; player tags emit when card is `player`. Red before, green after; existing twitter card tests still pass (71 passed).
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on both changed files.
