### PR TITLE
fix(config): support tsconfig extends array form

### DIFF
--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -49,6 +49,22 @@ function resolveTsconfigPathCandidate(candidate: string): string | null {
   return null;
 }
 
+/**
+ * Normalize a tsconfig `extends` field into a list of specifier strings.
+ *
+ * TypeScript 5.0+ allows `extends` to be either a string or an array of
+ * strings. Matches Next.js's handling in
+ * packages/next/src/build/next-config-ts/transpile-config.ts, where parents
+ * are iterated in order and later entries override earlier ones.
+ */
+function normalizeExtends(extendsField: unknown): string[] {
+  if (typeof extendsField === "string") return [extendsField];
+  if (Array.isArray(extendsField)) {
+    return extendsField.filter((value): value is string => typeof value === "string");
+  }
+  return [];
+}
+
 function resolveTsconfigExtends(configPath: string, specifier: string): string | null {
   const fromDir = path.dirname(configPath);
   if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("\\")) {
@@ -122,7 +138,9 @@ function loadResolutionFromTsconfigFile(
   if (!parsed) return emptyResolution();
 
   let resolution = emptyResolution();
-  const extendsList = typeof parsed.extends === "string" ? [parsed.extends] : [];
+  // TypeScript 5.0+ allows `extends` to be an array of specifiers (later
+  // entries override earlier ones). Normalize both forms to a string list.
+  const extendsList = normalizeExtends(parsed.extends);
 
   for (const extendsSpecifier of extendsList) {
     const extendedPath = resolveTsconfigExtends(configPath, extendsSpecifier);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -337,6 +337,22 @@ function resolveTsconfigPathCandidate(candidate: string): string | null {
   return null;
 }
 
+/**
+ * Normalize a tsconfig `extends` field into a list of specifier strings.
+ *
+ * TypeScript 5.0+ allows `extends` to be either a string or an array of
+ * strings. Matches Next.js's handling in
+ * packages/next/src/build/next-config-ts/transpile-config.ts, where parents
+ * are iterated in order and later entries override earlier ones.
+ */
+function normalizeTsconfigExtends(extendsField: unknown): string[] {
+  if (typeof extendsField === "string") return [extendsField];
+  if (Array.isArray(extendsField)) {
+    return extendsField.filter((value): value is string => typeof value === "string");
+  }
+  return [];
+}
+
 function resolveTsconfigExtends(configPath: string, specifier: string): string | null {
   const fromDir = path.dirname(configPath);
   if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("\\")) {
@@ -431,10 +447,12 @@ function loadTsconfigPathAliases(
   if (!parsed) return {};
 
   let aliases: Record<string, string> = {};
-  if (typeof parsed.extends === "string") {
-    const extendedPath = resolveTsconfigExtends(normalizedPath, parsed.extends);
+  // `extends` may be a string or (TypeScript 5.0+) an array; iterate parents in
+  // order so later entries override earlier ones (matching Next.js).
+  for (const extendsSpecifier of normalizeTsconfigExtends(parsed.extends)) {
+    const extendedPath = resolveTsconfigExtends(normalizedPath, extendsSpecifier);
     if (extendedPath) {
-      aliases = loadTsconfigPathAliases(extendedPath, projectRoot, seen);
+      aliases = { ...aliases, ...loadTsconfigPathAliases(extendedPath, projectRoot, seen) };
     }
   }
 

--- a/tests/tsconfig-paths-config-loader.test.ts
+++ b/tests/tsconfig-paths-config-loader.test.ts
@@ -89,6 +89,68 @@ describe("loadTsconfigPathAliasesForRoot", () => {
     expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
   });
 
+  // Ported from Next.js: packages/next/src/build/next-config-ts/transpile-config.ts (array extends)
+  it("follows array-form 'extends' for inherited paths", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.base.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@/*": ["./lib/*"] } },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({ extends: ["./tsconfig.base.json"] }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "lib"));
+  });
+
+  // Ported from Next.js: packages/next/src/build/next-config-ts/transpile-config.ts (array extends)
+  it("array-form 'extends': later entries override earlier ones", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.first.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@/*": ["./first/*"] } },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.second.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@/*": ["./second/*"] } },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({ extends: ["./tsconfig.first.json", "./tsconfig.second.json"] }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "second"));
+  });
+
+  it("child paths override array-form extended paths", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.base.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@/*": ["./lib/*"] } },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        extends: ["./tsconfig.base.json"],
+        compilerOptions: { paths: { "@/*": ["./src/*"] } },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
+  });
+
   it("supports non-wildcard exact alias", () => {
     tmpDir = makeTempDir();
     fs.writeFileSync(


### PR DESCRIPTION
## Summary

- Support the TypeScript 5.0+ array form of `extends` (`"extends": ["./a.json", "./b.json"]`) when loading tsconfig path aliases.
- Previously only the string form was handled, so array-form `extends` was silently ignored and inherited `paths`/`baseUrl` were dropped.

## Root Cause

Two sites resolved `extends` as a string only:

- `config/tsconfig-paths.ts`: `const extendsList = typeof parsed.extends === "string" ? [parsed.extends] : [];`
- `index.ts`: `if (typeof parsed.extends === "string") { … }`

When a project used `extends: [...]` (common in monorepos with shared base configs), both produced an empty parent list, so path aliases / `baseUrl` defined in the extended configs were never loaded — and `next.config.ts` imports through those aliases failed at config-load time.

The fix normalizes `extends` (`string | string[] | undefined`) into an ordered list at both sites and iterates the parents, merging so that later array entries override earlier ones and the child config overrides all parents — matching Next.js' `loadTsConfigFile`. The shared `seen` set is threaded through every entry so cyclic `extends` can't loop, and each parent's aliases continue to resolve relative to its own directory. Non-string array entries are filtered out; the single-string form is unchanged.

## References

- Fixes #1974
- Next.js parity: `packages/next/src/build/next-config-ts/transpile-config.ts` (`Array.isArray(config.extends) ? config.extends : [config.extends]`, parents merged in order)

## Verification

- `CI=true pnpm test tests/tsconfig-paths-config-loader.test.ts` — new cases (ported from Next.js): array-form `extends` resolves inherited paths; later array entries override earlier; child overrides array-extended paths. Red before, green after; single-string regression and child-override tests still pass (12 passed).
- `CI=true pnpm test tests/tsconfig-path-alias-build.test.ts tests/tsconfig-paths-vite8.test.ts` — the `index.ts` call-site suites pass (no regression).
- `CI=true pnpm test` — full battery green (only the pre-existing env flakes `deploy.test.ts > resolveWranglerBin` and `oxlint-prefer-shared-utils`, reproduced identically on `origin/main`).
- `CI=true npx vp check` — clean on all changed files.
