### PR TITLE
fix(build): strip only the matching declarator in combined export const (#1972)

### DIFF
--- a/packages/vinext/src/plugins/strip-server-exports.ts
+++ b/packages/vinext/src/plugins/strip-server-exports.ts
@@ -42,9 +42,18 @@ export function stripServerExports(code: string): string | null {
         );
         changed = true;
       } else if (decl.type === "VariableDeclaration") {
+        // Rewrite only the matching declarator's own range (id = init), not the
+        // whole `export const … ;` statement. Overwriting the full node range per
+        // match would drop sibling declarators (`export const a = 1, gSP = …`
+        // loses `a`) and, with two server exports in one declaration, overwrite
+        // the same range twice — MagicString silently keeps only the last write,
+        // collapsing both to a single stub. Declarator ranges are disjoint and
+        // exclude the `const`/`let`/`var` keyword and the separating commas, so
+        // each match is rewritten independently and siblings (including
+        // destructuring patterns) are preserved. See #1972.
         for (const declarator of decl.declarations) {
           if (declarator.id?.type === "Identifier" && SERVER_EXPORTS.has(declarator.id.name)) {
-            s.overwrite(node.start, node.end, `export const ${declarator.id.name} = undefined;`);
+            s.overwrite(declarator.start, declarator.end, `${declarator.id.name} = undefined`);
             changed = true;
           }
         }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -2772,6 +2772,70 @@ export const getStaticPaths = () => [
     expect(result).toContain("export const getStaticPaths = undefined;");
     expect(result).not.toContain("a;b");
   });
+
+  // Regression test for #1972: a server export sharing a single `export const`
+  // declaration with a sibling binding must strip ONLY the server-export
+  // declarator, preserving the sibling. Ported from Next.js
+  // test/unit/babel-plugin-next-ssg-transform.test.ts ('should not remove extra
+  // named export variable declarations').
+  it("preserves sibling bindings in a combined export const declaration", () => {
+    const code = `
+export default function Page({ foo }) {
+  return foo;
+}
+
+export const foo = 2, getStaticProps = async () => ({ props: { secret: 1 } });
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    // The sibling binding must survive — it was previously deleted.
+    expect(result).toContain("foo = 2");
+    // The server export is stubbed.
+    expect(result).toContain("getStaticProps = undefined");
+    // The server body is gone.
+    expect(result).not.toContain("secret: 1");
+    // The transformed code must be valid JS.
+    expect(() => parseAst(result!)).not.toThrow();
+  });
+
+  // Regression test for #1972: two server exports in a single declaration must
+  // each be stubbed. The old code overwrote the identical node range twice, and
+  // MagicString silently kept only the last write, collapsing them to one stub.
+  it("stubs both server exports declared in a single statement", () => {
+    const code = `
+export default function Page() {
+  return null;
+}
+
+export const getStaticProps = async () => ({ props: {} }), getStaticPaths = async () => ({ paths: ['SECRET_PATH'] });
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    expect(result).toContain("getStaticProps = undefined");
+    expect(result).toContain("getStaticPaths = undefined");
+    expect(result).not.toContain("SECRET_PATH");
+    expect(() => parseAst(result!)).not.toThrow();
+  });
+
+  // Regression test for #1972: a destructuring sibling in the same declaration
+  // must be preserved (its id is an ObjectPattern, not an Identifier).
+  it("preserves a destructuring sibling alongside a server export", () => {
+    const code = `
+const params = { slug: 'a' };
+
+export default function Page({ slug }) {
+  return slug;
+}
+
+export const { slug } = params, getStaticProps = async () => ({ props: { hidden: true } });
+`;
+    const result = _stripServerExports(code);
+    expect(result).not.toBeNull();
+    expect(result).toContain("{ slug } = params");
+    expect(result).toContain("getStaticProps = undefined");
+    expect(result).not.toContain("hidden: true");
+    expect(() => parseAst(result!)).not.toThrow();
+  });
 });
 
 // ─── getClientTreeshakeConfigForVite ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

Fixes #1972.

`stripServerExports` (the client-bundle transform that removes server-only data exports — `getServerSideProps` / `getStaticProps` / `getStaticPaths`) had a correctness bug in its `VariableDeclaration` branch. When a server export was **one declarator inside a multi-declarator** `export const …` statement, the code overwrote the **entire** statement with a single stub. Two failures resulted:

1. **Sibling bindings were deleted.** `export const myData = 42, getStaticProps = …` became `export const getStaticProps = undefined;` — `myData` vanished from the client bundle, producing `myData is not defined` at hydration.
2. **Two server exports in one declaration collapsed to one.** `export const getStaticProps = …, getStaticPaths = …` called `s.overwrite(node.start, node.end, …)` twice on the *identical* range; MagicString 0.30.21 silently keeps only the last write, emitting a single stub.

Next.js handles this correctly — its SWC transform (`next_ssg.rs`) marks only the matched declarator's name as `Pat::Invalid` then prunes it with `decls.retain(...)`, keeping siblings, and the legacy Babel plugin calls per-declarator `d.remove()`. Next.js even ships a dedicated fixture (`should-not-remove-extra-named-export-variable-declarations`). So this was a vinext-only parity defect.

## Fix

Overwrite only the **matched declarator's own range** (`id = init`) instead of the whole statement:

```ts
// before
s.overwrite(node.start, node.end, `export const ${declarator.id.name} = undefined;`);
// after
s.overwrite(declarator.start, declarator.end, `${declarator.id.name} = undefined`);
```

Declarator ranges are disjoint and exclude the `const`/`let`/`var` keyword and the separating commas, so each match is rewritten independently — siblings (including destructuring patterns, whose `id` is not an `Identifier`) are preserved, and two server exports in one declaration each get their own stub with no overlapping write. For the single-declarator case the output is byte-for-byte identical to before, so existing behavior and tests are unchanged. As a bonus the declaration kind is now preserved (`export let getStaticPaths` no longer becomes `const`).

## Tests

Three regression tests added to the `stripServerExports` block in `tests/build-optimization.test.ts` (the first ports Next.js `babel-plugin-next-ssg-transform.test.ts` "should not remove extra named export variable declarations"):

- sibling binding preserved in a combined `export const`
- two server exports in one declaration each stubbed (no collapse)
- destructuring sibling preserved alongside a server export

All confirmed failing before the fix and passing after. Full unit suite passes (`vp test run --project unit`), and `vp run build && vp run check` is clean.
