### PR TITLE
test(e2e): quiet local Playwright server output

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from "@playwright/test";
 
+if (process.env.FORCE_COLOR) {
+  delete process.env.NO_COLOR;
+}
+
+if (!process.env.CI && process.env.VINEXT_E2E_NODE_WARNINGS !== "1") {
+  process.env.NODE_OPTIONS = [process.env.NODE_OPTIONS, "--no-warnings"].filter(Boolean).join(" ");
+}
+
 const appRouterBrowserSpecificTests = "**/app-router/**/*.browser.spec.ts";
 const appRouterServer = {
   command: "npx vp dev --port 4174",
@@ -280,6 +288,8 @@ const projectServers = {
 type ProjectName = keyof typeof projectServers;
 
 const selected = process.env.PLAYWRIGHT_PROJECT;
+const webServerOutput: "pipe" | "ignore" =
+  process.env.CI || process.env.VINEXT_E2E_WEB_SERVER_LOGS === "1" ? "pipe" : "ignore";
 
 if (selected && !(selected in projectServers)) {
   throw new Error(
@@ -321,7 +331,14 @@ export default defineConfig({
           (server): server is NonNullable<(typeof projectServers)[ProjectName]["server"]> =>
             server !== null,
         )
-        .map((server) => [server.port, server]),
+        .map((server) => [
+          server.port,
+          {
+            ...server,
+            stdout: webServerOutput,
+            stderr: webServerOutput,
+          },
+        ]),
     ).values(),
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig } from "@playwright/test";
 
-if (process.env.FORCE_COLOR) {
+// Playwright sets FORCE_COLOR when writing to a TTY. Clear a conflicting NO_COLOR so worker
+// processes inherit color, but treat FORCE_COLOR=0/false as "disable color" (npm/Playwright
+// convention) and leave NO_COLOR in place for those.
+const forceColor = process.env.FORCE_COLOR;
+if (forceColor && forceColor !== "0" && forceColor !== "false") {
   delete process.env.NO_COLOR;
 }
 
 if (!process.env.CI && process.env.VINEXT_E2E_NODE_WARNINGS !== "1") {
-  process.env.NODE_OPTIONS = [process.env.NODE_OPTIONS, "--no-warnings"].filter(Boolean).join(" ");
+  const nodeOptions = process.env.NODE_OPTIONS ?? "";
+  // Guard against duplicating the flag when NODE_OPTIONS already carries it.
+  if (!/(?:^|\s)--no-warnings(?:\s|$)/.test(nodeOptions)) {
+    process.env.NODE_OPTIONS = [nodeOptions, "--no-warnings"].filter(Boolean).join(" ");
+  }
 }
 
 const appRouterBrowserSpecificTests = "**/app-router/**/*.browser.spec.ts";
@@ -288,8 +296,12 @@ const projectServers = {
 type ProjectName = keyof typeof projectServers;
 
 const selected = process.env.PLAYWRIGHT_PROJECT;
-const webServerOutput: "pipe" | "ignore" =
-  process.env.CI || process.env.VINEXT_E2E_WEB_SERVER_LOGS === "1" ? "pipe" : "ignore";
+
+// Preserve Playwright's defaults in CI (stdout "ignore", stderr "pipe") so CI diagnostics are
+// unchanged; locally suppress both unless VINEXT_E2E_WEB_SERVER_LOGS opts back in.
+const wantWebServerLogs = process.env.VINEXT_E2E_WEB_SERVER_LOGS === "1";
+const webServerStdout: "pipe" | "ignore" = wantWebServerLogs ? "pipe" : "ignore";
+const webServerStderr: "pipe" | "ignore" = process.env.CI || wantWebServerLogs ? "pipe" : "ignore";
 
 if (selected && !(selected in projectServers)) {
   throw new Error(
@@ -335,8 +347,8 @@ export default defineConfig({
           server.port,
           {
             ...server,
-            stdout: webServerOutput,
-            stderr: webServerOutput,
+            stdout: webServerStdout,
+            stderr: webServerStderr,
           },
         ]),
     ).values(),


### PR DESCRIPTION
## What this changes
Local Playwright e2e runs now suppress fixture web-server stdout and stderr by default, while CI continues to pipe server output for diagnostics. Developers can opt back into local web-server logs with `VINEXT_E2E_WEB_SERVER_LOGS=1`.

The config also normalizes `NO_COLOR` when Playwright has set `FORCE_COLOR`, and suppresses local child Node warnings unless `VINEXT_E2E_NODE_WARNINGS=1` is set.

## Why
Narrow e2e runs can start several fixture servers. Their Vite, Vite+, and fixture startup warnings currently dominate the terminal output and make the actual failing Playwright assertion hard to find.

## Approach
- Keep CI server output unchanged by using `pipe` in CI.
- Use Playwright webServer `stdout` and `stderr` controls to ignore local server output by default.
- Preserve local debug escape hatches for server logs and child Node warnings.

## Validation
- `vp check`
- `NODE_OPTIONS=--no-warnings PLAYWRIGHT_PROJECT=app-router pnpm exec playwright test tests/e2e/app-router/scroll-restoration.spec.ts`

## Risks / follow-ups
Local server startup logs are hidden by default, so debugging a fixture boot failure may require rerunning with `VINEXT_E2E_WEB_SERVER_LOGS=1`. CI still captures the full server output.