### PR TITLE
test(ppr): wait for fallback shell abort signal

### DIFF
--- a/tests/ppr-fallback-shell.test.ts
+++ b/tests/ppr-fallback-shell.test.ts
@@ -14,6 +14,16 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function waitForCondition(predicate: () => boolean, message: string): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > 200) {
+      throw new Error(message);
+    }
+    await delay(1);
+  }
+}
+
 describe("ppr fallback shell cache task tracking", () => {
   it("waits for public cache work before marking warmup cache-ready", async () => {
     const state = createPprFallbackShellState({
@@ -206,11 +216,18 @@ describe("ppr fallback shell render lifecycle", () => {
     runWithPprFallbackShellState(state, () => {
       void createPprFallbackShellSuspensePromise("params");
     });
-    await delay(5);
+
+    await waitForCondition(
+      () => state.pendingCacheReadyCleanup === null,
+      "Timed out waiting for final shell cache-ready scheduling to settle",
+    );
     expect(state.reactAbortController.signal.aborted).toBe(false);
 
     beginPprFallbackShellFinalRender(state);
-    await delay(5);
+    await waitForCondition(
+      () => state.reactAbortController.signal.aborted,
+      "Timed out waiting for final shell abort after React prerender started",
+    );
     expect(state.reactAbortController.signal.aborted).toBe(true);
     expect(state.abortController.signal.aborted).toBe(true);
   });


### PR DESCRIPTION
## Summary

Fixes #2071.

`tests/ppr-fallback-shell.test.ts` had a timing-sensitive assertion that waited a fixed `delay(5)` for the final fallback shell abort path. Under full unit-shard load, that was not always enough for the helper's two-step `setTimeout(..., 0)` scheduling to drain, even though the same test passed in isolation and on rerun.

## What changed

- Added a small condition-based test helper for this file.
- Changed the final-shell lifecycle test to wait until `pendingCacheReadyCleanup` has settled before asserting no pre-start abort.
- Changed the post-`beginPprFallbackShellFinalRender` assertion to wait for the actual `reactAbortController.signal.aborted` condition instead of assuming a 5 ms window.

No runtime code changes.

## Validation

- `vp test run tests/ppr-fallback-shell.test.ts`
- `vp test run --project unit --shard=3/3`
- `vp check`
- Pre-commit hook passed on the final commit, including `vp check --fix`, full check, staged tests, and knip.

## Risk

Low. This only changes a unit test assertion from wall-clock sleep to observable state, preserving the behavior being tested: the final shell should not abort before React prerender starts, and should abort after the final render transition proceeds.
