### PR TITLE
fix(build): preserve lazy RSC framework chunks

### DIFF
--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -219,7 +219,13 @@ export function createRscFrameworkChunkOutputConfig(viteMajorVersion: number) {
   if (viteMajorVersion >= 8) {
     return {
       codeSplitting: {
-        groups: [{ name: "framework", test: RSC_FRAMEWORK_CHUNK_TEST }],
+        groups: [
+          {
+            name: "framework",
+            test: RSC_FRAMEWORK_CHUNK_TEST,
+            entriesAware: true,
+          },
+        ],
       },
     };
   }

--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -7,6 +7,15 @@ type ClientAssetFileNameInfo = {
   readonly originalFileNames?: readonly string[];
 };
 
+type RscFrameworkModuleInfo = {
+  importers: string[];
+  isEntry: boolean;
+};
+
+type RscFrameworkManualChunksMeta = {
+  getModuleInfo(id: string): RscFrameworkModuleInfo | null;
+};
+
 // Next.js emits CSS under `static/css/` and CSS url() dependencies (images,
 // fonts, …) under `static/media/`, both with an 8-char content hash. Mirror
 // that layout so migrated apps keep stable, Next-shaped asset URLs.
@@ -208,12 +217,29 @@ export function isRscFrameworkModule(id: string): boolean {
   return pkg !== null && (FRAMEWORK_PACKAGES as readonly string[]).includes(pkg);
 }
 
+function isStaticallyReachableFromEntry(
+  id: string,
+  meta: RscFrameworkManualChunksMeta,
+  visited = new Set<string>(),
+): boolean {
+  if (visited.has(id)) return false;
+  visited.add(id);
+
+  const moduleInfo = meta.getModuleInfo(id);
+  if (!moduleInfo) return false;
+  if (moduleInfo.isEntry) return true;
+  return moduleInfo.importers.some((importer) =>
+    isStaticallyReachableFromEntry(importer, meta, visited),
+  );
+}
+
 /**
  * Output config that isolates React (and the RSC flight runtime) into a
  * dedicated "framework" chunk in the RSC server build. Returns the bundler-
  * appropriate shape: rolldown's `codeSplitting` for Vite 8+, Rollup's
  * `manualChunks` for Vite 7. See {@link RSC_FRAMEWORK_CHUNK_TEST} for the
- * motivation (issue #1549).
+ * motivation (issue #1549). Framework modules that are only reachable through
+ * dynamic imports must stay out of the eager framework chunk (issue #2073).
  */
 export function createRscFrameworkChunkOutputConfig(viteMajorVersion: number) {
   if (viteMajorVersion >= 8) {
@@ -223,6 +249,8 @@ export function createRscFrameworkChunkOutputConfig(viteMajorVersion: number) {
           {
             name: "framework",
             test: RSC_FRAMEWORK_CHUNK_TEST,
+            // Split by the entries that use each module so lazy framework
+            // imports cannot become eager Worker-startup dependencies (#2073).
             entriesAware: true,
           },
         ],
@@ -230,8 +258,10 @@ export function createRscFrameworkChunkOutputConfig(viteMajorVersion: number) {
     };
   }
   return {
-    manualChunks(id: string): string | undefined {
-      return isRscFrameworkModule(id) ? "framework" : undefined;
+    manualChunks(id: string, meta: RscFrameworkManualChunksMeta): string | undefined {
+      return isRscFrameworkModule(id) && isStaticallyReachableFromEntry(id, meta)
+        ? "framework"
+        : undefined;
     },
   };
 }

--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -64,9 +64,10 @@ export function createClientAssetFileNames(assetsDir: string) {
  * (node_modules/.pnpm/pkg@ver/node_modules/pkg).
  */
 function getPackageName(id: string): string | null {
-  const nmIdx = id.lastIndexOf("node_modules/");
+  const normalizedId = id.replaceAll("\\", "/");
+  const nmIdx = normalizedId.lastIndexOf("node_modules/");
   if (nmIdx === -1) return null;
-  const rest = id.slice(nmIdx + "node_modules/".length);
+  const rest = normalizedId.slice(nmIdx + "node_modules/".length);
   if (rest.startsWith("@")) {
     // Scoped package: @org/pkg
     const parts = rest.split("/");

--- a/tests/app-router-global-not-found-css-order.test.ts
+++ b/tests/app-router-global-not-found-css-order.test.ts
@@ -29,10 +29,15 @@
  * Assertions mirror upstream: the 404 document must link ONLY
  * global-not-found's stylesheets, in import order (gnf-a before gnf-b), and
  * must NOT carry the root layout's stylesheet.
+ *
+ * The fixture also includes a lazy `react-dom/server.edge` import for issue
+ * #2073. Importing the production RSC entry must not eagerly evaluate React's
+ * throwing server-component stub.
  */
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { createBuilder, preview } from "vite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import vinext from "../packages/vinext/src/index.js";
@@ -108,6 +113,13 @@ describe("App Router: global-not-found CSS order (production, #1549)", () => {
     // The home page must NOT carry global-not-found's stylesheets.
     expect(css).not.toContain("blue");
     expect(css).not.toContain("red");
+  });
+
+  it("does not eagerly evaluate dynamically imported React server stubs", async () => {
+    const entryUrl = pathToFileURL(path.join(distDir, "server", "index.js"));
+    entryUrl.searchParams.set("test", String(Date.now()));
+
+    await expect(import(entryUrl.href)).resolves.toBeDefined();
   });
 
   it("route-miss 404 serves global-not-found's CSS with red winning, and no layout CSS leak", async () => {

--- a/tests/app-router-global-not-found-css-order.test.ts
+++ b/tests/app-router-global-not-found-css-order.test.ts
@@ -83,7 +83,10 @@ describe("App Router: global-not-found CSS order (production, #1549)", () => {
       logLevel: "silent",
     });
     await builder.buildApp();
+  }, 120_000);
 
+  async function startPreviewServer(): Promise<void> {
+    if (previewServer) return;
     previewServer = await preview({
       root: FIXTURE_DIR,
       configFile: false,
@@ -94,14 +97,22 @@ describe("App Router: global-not-found CSS order (production, #1549)", () => {
     const addr = previewServer.httpServer.address();
     baseUrl = addr && typeof addr === "object" ? `http://localhost:${addr.port}` : "";
     expect(baseUrl).not.toBe("");
-  }, 120_000);
+  }
 
   afterAll(() => {
     previewServer?.httpServer.close();
     fs.rmSync(distDir, { recursive: true, force: true });
   });
 
+  it("does not eagerly evaluate dynamically imported React server stubs", async () => {
+    const entryUrl = pathToFileURL(path.join(distDir, "server", "index.js"));
+    entryUrl.searchParams.set("test", String(Date.now()));
+
+    await expect(import(entryUrl.href)).resolves.toBeDefined();
+  });
+
   it("matched routes serve the root layout's CSS (green wins)", async () => {
+    await startPreviewServer();
     const res = await fetch(`${baseUrl}/`);
     expect(res.status).toBe(200);
     const html = await res.text();
@@ -115,14 +126,8 @@ describe("App Router: global-not-found CSS order (production, #1549)", () => {
     expect(css).not.toContain("red");
   });
 
-  it("does not eagerly evaluate dynamically imported React server stubs", async () => {
-    const entryUrl = pathToFileURL(path.join(distDir, "server", "index.js"));
-    entryUrl.searchParams.set("test", String(Date.now()));
-
-    await expect(import(entryUrl.href)).resolves.toBeDefined();
-  });
-
   it("route-miss 404 serves global-not-found's CSS with red winning, and no layout CSS leak", async () => {
+    await startPreviewServer();
     const res = await fetch(`${baseUrl}/does-not-exist`);
     expect(res.status).toBe(404);
     const html = await res.text();

--- a/tests/app-router-global-not-found-css-order.test.ts
+++ b/tests/app-router-global-not-found-css-order.test.ts
@@ -74,6 +74,7 @@ describe("App Router: global-not-found CSS order (production, #1549)", () => {
   const clientDir = path.join(distDir, "client");
   let previewServer: Awaited<ReturnType<typeof preview>>;
   let baseUrl: string;
+  let startupImportValidated = false;
 
   beforeAll(async () => {
     const builder = await createBuilder({
@@ -86,6 +87,9 @@ describe("App Router: global-not-found CSS order (production, #1549)", () => {
   }, 120_000);
 
   async function startPreviewServer(): Promise<void> {
+    if (!startupImportValidated) {
+      throw new Error("The direct RSC entry import assertion must run before preview startup");
+    }
     if (previewServer) return;
     previewServer = await preview({
       root: FIXTURE_DIR,
@@ -109,6 +113,7 @@ describe("App Router: global-not-found CSS order (production, #1549)", () => {
     entryUrl.searchParams.set("test", String(Date.now()));
 
     await expect(import(entryUrl.href)).resolves.toBeDefined();
+    startupImportValidated = true;
   });
 
   it("matched routes serve the root layout's CSS (green wins)", async () => {

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -2824,8 +2824,12 @@ describe("createRscFrameworkChunkOutputConfig", () => {
     ).manualChunks;
     const moduleInfo = new Map([
       ["/app/src/entry.js", { importers: [], isEntry: true }],
+      ["/app/src/middleman.js", { importers: ["/app/src/entry.js"], isEntry: false }],
       ["/app/src/lazy.js", { importers: [], isEntry: false }],
-      ["/app/node_modules/react/index.js", { importers: ["/app/src/entry.js"], isEntry: false }],
+      [
+        "/app/node_modules/react/index.js",
+        { importers: ["/app/src/middleman.js"], isEntry: false },
+      ],
       [
         "/app/node_modules/react-server-dom-webpack/client.js",
         { importers: ["/app/src/entry.js"], isEntry: false },

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -2812,13 +2812,40 @@ describe("createRscFrameworkChunkOutputConfig", () => {
     const config = createRscFrameworkChunkOutputConfig(7);
     expect(config).not.toHaveProperty("codeSplitting");
     expect(config).toHaveProperty("manualChunks");
-    const manualChunks = (config as { manualChunks: (id: string) => string | undefined })
-      .manualChunks;
-    expect(manualChunks("/app/node_modules/react/index.js")).toBe("framework");
-    expect(manualChunks("/app/node_modules/react-server-dom-webpack/client.js")).toBe("framework");
+    const manualChunks = (
+      config as {
+        manualChunks: (
+          id: string,
+          meta: {
+            getModuleInfo(id: string): { importers: string[]; isEntry: boolean } | null;
+          },
+        ) => string | undefined;
+      }
+    ).manualChunks;
+    const moduleInfo = new Map([
+      ["/app/src/entry.js", { importers: [], isEntry: true }],
+      ["/app/src/lazy.js", { importers: [], isEntry: false }],
+      ["/app/node_modules/react/index.js", { importers: ["/app/src/entry.js"], isEntry: false }],
+      [
+        "/app/node_modules/react-server-dom-webpack/client.js",
+        { importers: ["/app/src/entry.js"], isEntry: false },
+      ],
+      [
+        "/app/node_modules/react-dom/server.react-server.js",
+        { importers: ["/app/src/lazy.js"], isEntry: false },
+      ],
+    ]);
+    const meta = { getModuleInfo: (id: string) => moduleInfo.get(id) ?? null };
+    expect(manualChunks("/app/node_modules/react/index.js", meta)).toBe("framework");
+    expect(manualChunks("/app/node_modules/react-server-dom-webpack/client.js", meta)).toBe(
+      "framework",
+    );
+    expect(
+      manualChunks("/app/node_modules/react-dom/server.react-server.js", meta),
+    ).toBeUndefined();
     // Non-framework node_modules and local files are left to the default algo.
-    expect(manualChunks("/app/node_modules/react-icons/lib/index.js")).toBeUndefined();
-    expect(manualChunks("/app/src/page.tsx")).toBeUndefined();
+    expect(manualChunks("/app/node_modules/react-icons/lib/index.js", meta)).toBeUndefined();
+    expect(manualChunks("/app/src/page.tsx", meta)).toBeUndefined();
   });
 
   it("returns codeSplitting for Vite 8+ (Rolldown), not the deprecated advancedChunks", () => {

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -2893,6 +2893,8 @@ describe("RSC framework package matching", () => {
     "/app/node_modules/react-server-dom-webpack/client.js",
     // pnpm-style nested path.
     "/app/node_modules/.pnpm/react@19.0.0/node_modules/react/index.js",
+    // Windows-style path used by the Vite 7 getPackageName predicate.
+    "C:\\app\\node_modules\\react-dom\\server.js",
   ];
   const notMatching = [
     "/app/node_modules/react-icons/lib/index.js",

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -2827,14 +2827,26 @@ describe("createRscFrameworkChunkOutputConfig", () => {
     expect(config).not.toHaveProperty("manualChunks");
     expect(config).toEqual({
       codeSplitting: {
-        groups: [{ name: "framework", test: RSC_FRAMEWORK_CHUNK_TEST }],
+        groups: [
+          {
+            name: "framework",
+            test: RSC_FRAMEWORK_CHUNK_TEST,
+            entriesAware: true,
+          },
+        ],
       },
     });
 
     // Vite 9+ uses the same Rolldown shape.
     expect(createRscFrameworkChunkOutputConfig(9)).toEqual({
       codeSplitting: {
-        groups: [{ name: "framework", test: RSC_FRAMEWORK_CHUNK_TEST }],
+        groups: [
+          {
+            name: "framework",
+            test: RSC_FRAMEWORK_CHUNK_TEST,
+            entriesAware: true,
+          },
+        ],
       },
     });
   });

--- a/tests/fixtures/global-not-found-css-order/app/page.tsx
+++ b/tests/fixtures/global-not-found-css-order/app/page.tsx
@@ -1,3 +1,7 @@
+Object.assign(globalThis, {
+  __loadReactDomServerForChunkingTest: () => import("react-dom/server.edge"),
+});
+
 export default function Page() {
   return <p>hello world</p>;
 }

--- a/tests/static-image-emission.test.ts
+++ b/tests/static-image-emission.test.ts
@@ -163,24 +163,47 @@ async function buildFixture(root: string, router: "app" | "pages"): Promise<void
 
 type BuildWatcher = {
   on(event: "event", callback: (event: { code: string; error?: Error }) => void): void;
+  off(event: "event", callback: (event: { code: string; error?: Error }) => void): void;
   close(): Promise<void>;
 };
 
-function waitForWatchBuild(watcher: BuildWatcher): Promise<void> {
+function waitForWatchBuild(
+  watcher: BuildWatcher,
+  isExpectedOutput: () => boolean | Promise<boolean> = () => true,
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(
-      () => reject(new Error("Timed out waiting for watch rebuild")),
-      20_000,
-    );
-    watcher.on("event", (event) => {
+    let checkingOutput = false;
+    const cleanup = () => {
+      clearTimeout(timeout);
+      watcher.off("event", onEvent);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for watch rebuild"));
+    }, 20_000);
+    const handleEvent = async (event: { code: string; error?: Error }) => {
       if (event.code === "ERROR") {
-        clearTimeout(timeout);
+        cleanup();
         reject(event.error ?? new Error("Watch build failed"));
-      } else if (event.code === "END") {
-        clearTimeout(timeout);
-        resolve();
+      } else if (event.code === "END" && !checkingOutput) {
+        checkingOutput = true;
+        try {
+          if (await isExpectedOutput()) {
+            cleanup();
+            resolve();
+          }
+        } catch (error) {
+          cleanup();
+          reject(error);
+        } finally {
+          checkingOutput = false;
+        }
       }
-    });
+    };
+    const onEvent = (event: { code: string; error?: Error }) => {
+      void handleEvent(event);
+    };
+    watcher.on("event", onEvent);
   });
 }
 
@@ -338,7 +361,10 @@ describe("static image import production emission", () => {
       const firstImage = await findEmittedImage(root);
       expect(await readFile(path.join(outDir, "_next/static/media", firstImage))).toEqual(PNG_1X1);
 
-      const changedBuild = waitForWatchBuild(watcher);
+      const changedBuild = waitForWatchBuild(watcher, async () => {
+        const emittedImage = await findEmittedImage(root);
+        return emittedImage !== firstImage;
+      });
       await fs.promises.writeFile(imagePath, PNG_4X3);
       await changedBuild;
       const secondImage = await findEmittedImage(root);
@@ -350,7 +376,13 @@ describe("static image import production emission", () => {
       expect(changedJavaScript).toMatch(/width:4[,}]|"width":4/);
       expect(changedJavaScript).toMatch(/height:3[,}]|"height":3/);
 
-      const removedBuild = waitForWatchBuild(watcher);
+      const removedBuild = waitForWatchBuild(watcher, async () => {
+        const builtJavaScript = await readBuiltJavaScript(outDir);
+        return (
+          !fs.existsSync(path.join(outDir, "_next/static/media", secondImage)) &&
+          !builtJavaScript.includes(secondImage)
+        );
+      });
       await fs.promises.writeFile(entryPath, `console.log("no image");\n`);
       await removedBuild;
       expect(fs.existsSync(path.join(outDir, "_next/static/media", secondImage))).toBe(false);


### PR DESCRIPTION
## Summary

- preserve dynamic entry boundaries within the Vite 8/Rolldown RSC framework chunk group
- prevent lazy `react-dom/server.edge` stubs from being evaluated at Worker startup
- retain the framework splitting needed for `global-not-found` CSS ordering
- add production regression coverage for importing the built RSC entry

## Root cause

Rolldown's framework group merged every matching React module into one chunk by default. A lazy `import("react-dom/server.edge")` could therefore place React's throwing `server.react-server.js` stub in the same framework chunk statically imported by the RSC entry.

Setting `entriesAware: true` keeps matching framework modules grouped by the entry points that actually use them. Lazy-only React modules remain behind their dynamic import instead of moving onto the Worker startup path.

## Next.js comparison

Next.js does not create its client-style framework chunk for App Router server builds. It also aliases legacy `react-dom/server.edge` imports in server-component builds. This change addresses vinext's additional eager-chunk regression without attempting to resolve the separate RSC export-condition behavior tracked in #1237 and #1891.

## Validation

- `vp test run tests/build-optimization.test.ts tests/app-router-global-not-found-css-order.test.ts` — 116 tests passed
- `vp check` — formatting, lint, and type checks passed
- rebuilt `vinext` and `examples/fumadocs-docs-template`
- verified the throwing React stub is emitted in a separate lazy framework subgroup
- verified importing `dist/server/index.js` does not throw
- verified `wrangler deploy --dry-run --no-bundle` accepts the Fumadocs artifact

Fixes #2073
