### PR TITLE
perf(dev): prune NODE_ENV during dependency optimization

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -200,7 +200,11 @@ import fs from "node:fs";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
 import { normalizePathSeparators, stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
-import { getDepOptimizeNodeEnvOptions, getViteMajorVersion } from "./utils/vite-version.js";
+import {
+  getDepOptimizeNodeEnvOptions,
+  getViteMajorVersion,
+  serializeViteDefine,
+} from "./utils/vite-version.js";
 
 // Install the process-level peer-disconnect backstop at module load.
 // Vite plugin lifecycle hooks (config / configureServer) proved
@@ -1312,12 +1316,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
         // Merge env from next.config.js with NEXT_PUBLIC_* env vars
         const defines = getNextPublicEnvDefines();
-        if (
-          !config.define ||
-          typeof config.define !== "object" ||
-          !("process.env.NODE_ENV" in config.define)
-        ) {
-          defines["process.env.NODE_ENV"] = JSON.stringify(resolvedNodeEnv);
+        const userNodeEnvDefine = config.define?.["process.env.NODE_ENV"];
+        const hasUserNodeEnvDefine = Object.hasOwn(config.define ?? {}, "process.env.NODE_ENV");
+        const nodeEnvDefine = hasUserNodeEnvDefine
+          ? serializeViteDefine(userNodeEnvDefine)
+          : JSON.stringify(resolvedNodeEnv);
+        if (!hasUserNodeEnvDefine) {
+          defines["process.env.NODE_ENV"] = nodeEnvDefine;
         }
         for (const [key, value] of Object.entries(nextConfig.env)) {
           // Skip NODE_ENV from next.config.js env — Next.js ignores it too,
@@ -2149,7 +2154,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         };
         const depOptimizeNodeEnvOptions = getDepOptimizeNodeEnvOptions(
           viteMajorVersion,
-          resolvedNodeEnv,
+          nodeEnvDefine,
         );
         viteConfig.optimizeDeps = {
           // @tailwindcss/oxide contains native .node bindings that Rolldown cannot process
@@ -2405,6 +2410,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 // reload the first time a Pages Router page renders an
                 // <Image>.
                 exclude: ["ipaddr.js"],
+                ...depOptimizeNodeEnvOptions,
               },
               build: {
                 outDir: "dist/server",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -200,7 +200,7 @@ import fs from "node:fs";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
 import { normalizePathSeparators, stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
-import { getViteMajorVersion } from "./utils/vite-version.js";
+import { getDepOptimizeNodeEnvOptions, getViteMajorVersion } from "./utils/vite-version.js";
 
 // Install the process-level peer-disconnect backstop at module load.
 // Vite plugin lifecycle hooks (config / configureServer) proved
@@ -2147,13 +2147,21 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             }
           },
         };
+        const depOptimizeNodeEnvOptions = getDepOptimizeNodeEnvOptions(
+          viteMajorVersion,
+          resolvedNodeEnv,
+        );
         viteConfig.optimizeDeps = {
           // @tailwindcss/oxide contains native .node bindings that Rolldown cannot process
           exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE, [
             "@tailwindcss/oxide",
           ]),
           ...(incomingInclude.length > 0 ? { include: incomingInclude } : {}),
-          rolldownOptions: { plugins: [depOptimizeAliasPlugin] },
+          ...depOptimizeNodeEnvOptions,
+          rolldownOptions: {
+            ...depOptimizeNodeEnvOptions.rolldownOptions,
+            plugins: [depOptimizeAliasPlugin],
+          },
         };
         const pagesOptimizeEntries = !hasAppDir
           ? [
@@ -2214,6 +2222,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               optimizeDeps: {
                 exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE),
                 entries: optimizeEntries,
+                ...depOptimizeNodeEnvOptions,
               },
               build: {
                 outDir: options.rscOutDir ?? "dist/server",
@@ -2268,6 +2277,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   userSsrExternal === true ? SSR_EXTERNAL_REACT_ENTRIES : [],
                 ),
                 entries: optimizeEntries,
+                ...depOptimizeNodeEnvOptions,
               },
               build: {
                 outDir: options.ssrOutDir ?? "dist/server/ssr",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2180,6 +2180,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           viteMajorVersion,
           nodeEnvDefine,
         );
+        // Apply the define to the default optimizer and explicitly to server
+        // environments, where Vite's keepProcessEnv default prevents replacement.
         viteConfig.optimizeDeps = {
           // @tailwindcss/oxide contains native .node bindings that Rolldown cannot process
           exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE, [

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -9,6 +9,37 @@
 import path from "node:path";
 import { createRequire } from "node:module";
 
+export function getDepOptimizeNodeEnvOptions(
+  viteMajorVersion: number,
+  nodeEnv: string,
+): {
+  rolldownOptions?: {
+    transform: {
+      define: Record<string, string>;
+    };
+  };
+  esbuildOptions?: {
+    define: Record<string, string>;
+  };
+} {
+  // Vite defaults keepProcessEnv to true for server-consumer environments,
+  // which also disables its built-in optimizer NODE_ENV replacement. Pin the
+  // value explicitly so RSC and SSR dependencies can drop the unused branch.
+  const define = {
+    "process.env.NODE_ENV": JSON.stringify(nodeEnv),
+  };
+
+  return viteMajorVersion >= 8
+    ? {
+        rolldownOptions: {
+          transform: { define },
+        },
+      }
+    : {
+        esbuildOptions: { define },
+      };
+}
+
 /**
  * Detect Vite major version at runtime by resolving from cwd.
  * The plugin may be installed in a workspace root with Vite 7 but used

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -9,9 +9,14 @@
 import path from "node:path";
 import { createRequire } from "node:module";
 
+export function serializeViteDefine(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? "undefined";
+}
+
 export function getDepOptimizeNodeEnvOptions(
   viteMajorVersion: number,
-  nodeEnv: string,
+  nodeEnvDefine: string,
 ): {
   rolldownOptions?: {
     transform: {
@@ -26,7 +31,7 @@ export function getDepOptimizeNodeEnvOptions(
   // which also disables its built-in optimizer NODE_ENV replacement. Pin the
   // value explicitly so RSC and SSR dependencies can drop the unused branch.
   const define = {
-    "process.env.NODE_ENV": JSON.stringify(nodeEnv),
+    "process.env.NODE_ENV": nodeEnvDefine,
   };
 
   return viteMajorVersion >= 8

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -11,6 +11,8 @@ import { createRequire } from "node:module";
 
 export function serializeViteDefine(value: unknown): string {
   if (typeof value === "string") return value;
+  // Vite treats define values as raw expressions, so explicit `undefined`
+  // must become the bare expression rather than the string `"undefined"`.
   return JSON.stringify(value) ?? "undefined";
 }
 

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -1,6 +1,5 @@
 import http from "node:http";
 import fsp from "node:fs/promises";
-import path from "node:path";
 import { type ViteDevServer } from "vite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { APP_FIXTURE_DIR, fetchHtml, startFixtureServer } from "./helpers.js";
@@ -2016,12 +2015,16 @@ describe("App Router integration", () => {
     await response.arrayBuffer();
 
     for (const envName of ["rsc", "ssr"]) {
-      const depsDir = path.join(server.config.cacheDir, `deps_${envName}`);
-      const files = (await fsp.readdir(depsDir)).filter((file) => file.endsWith(".js"));
+      const environment = server.environments[envName];
+      await environment.waitForRequestsIdle();
+
+      const depInfos = environment.depsOptimizer?.metadata.depInfoList ?? [];
+      await Promise.all(depInfos.flatMap((dep) => (dep.processing ? [dep.processing] : [])));
+      const files = [...new Set(depInfos.map((dep) => dep.file))];
       expect(files.length, `${envName} optimized dependencies`).toBeGreaterThan(0);
 
       const optimizedCode = (
-        await Promise.all(files.map((file) => fsp.readFile(path.join(depsDir, file), "utf8")))
+        await Promise.all(files.map((file) => fsp.readFile(file, "utf8")))
       ).join("\n");
       expect(optimizedCode, `${envName} NODE_ENV references`).not.toContain("process.env.NODE_ENV");
       expect(optimizedCode, `${envName} production branches`).not.toMatch(

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -1,4 +1,6 @@
 import http from "node:http";
+import fsp from "node:fs/promises";
+import path from "node:path";
 import { type ViteDevServer } from "vite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { APP_FIXTURE_DIR, fetchHtml, startFixtureServer } from "./helpers.js";
@@ -2003,6 +2005,29 @@ describe("App Router integration", () => {
     expect(clientInclude).toContain("react");
     expect(clientInclude).toContain("react-dom");
     expect(clientInclude).toContain("react-dom/client");
+  });
+
+  it("drops unused NODE_ENV branches from optimized server dependencies", async () => {
+    expect(server.config.environments.rsc?.keepProcessEnv).toBe(true);
+    expect(server.config.environments.ssr?.keepProcessEnv).toBe(true);
+
+    const response = await fetch(`${baseUrl}/`);
+    expect(response.status).toBe(200);
+    await response.arrayBuffer();
+
+    for (const envName of ["rsc", "ssr"]) {
+      const depsDir = path.join(server.config.cacheDir, `deps_${envName}`);
+      const files = (await fsp.readdir(depsDir)).filter((file) => file.endsWith(".js"));
+      expect(files.length, `${envName} optimized dependencies`).toBeGreaterThan(0);
+
+      const optimizedCode = (
+        await Promise.all(files.map((file) => fsp.readFile(path.join(depsDir, file), "utf8")))
+      ).join("\n");
+      expect(optimizedCode, `${envName} NODE_ENV references`).not.toContain("process.env.NODE_ENV");
+      expect(optimizedCode, `${envName} production branches`).not.toMatch(
+        /react(?:-dom|-server-dom-webpack)?[^"\n]*\.production\.js/,
+      );
+    }
   });
 
   // ── CSRF protection for server actions ───────────────────────────────

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -558,6 +558,11 @@ describe("optimizeDeps.exclude for vinext", () => {
 
       const ssrExclude = result.environments?.ssr?.optimizeDeps?.exclude ?? [];
       expect(ssrExclude).toContain("ipaddr.js");
+      expect(
+        result.environments?.ssr?.optimizeDeps?.rolldownOptions?.transform?.define?.[
+          "process.env.NODE_ENV"
+        ],
+      ).toBe(JSON.stringify("development"));
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
@@ -673,6 +678,14 @@ describe("process.env.NODE_ENV define", () => {
 
       // Should NOT override the user's explicit define
       expect(result.define?.["process.env.NODE_ENV"]).toBeUndefined();
+      expect(
+        result.optimizeDeps?.rolldownOptions?.transform?.define?.["process.env.NODE_ENV"],
+      ).toBe(JSON.stringify("staging"));
+      expect(
+        result.environments?.ssr?.optimizeDeps?.rolldownOptions?.transform?.define?.[
+          "process.env.NODE_ENV"
+        ],
+      ).toBe(JSON.stringify("staging"));
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }


### PR DESCRIPTION
This PR improves cold start time by replacing `NODE_ENV` during Rolldown's prebundling step, resulting in less JavaScript dependencies during dev.

Over 10x10 runs:

- main: 1417.5 ms
- new branch: 1309.3 ms
- Difference: **108.2 ms faster**