### PR TITLE
perf(rsc): prebundle static renderer entry

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2253,6 +2253,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               optimizeDeps: {
                 exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE),
                 entries: optimizeEntries,
+                // plugin-rsc pre-includes server.edge, but not its vendored
+                // static.edge import, which it rewrites to this package specifier.
+                // Prebundle both so they share the large development renderer
+                // instead of transforming its raw CJS source on the first request.
+                include: [...new Set([...incomingInclude, "react-server-dom-webpack/static.edge"])],
                 ...depOptimizeNodeEnvOptions,
               },
               build: {

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -2033,6 +2033,15 @@ describe("App Router integration", () => {
     }
   });
 
+  it("includes the static RSC renderer in startup dependency optimization", async () => {
+    const rscEnvironment = server.environments.rsc;
+    await rscEnvironment.waitForRequestsIdle();
+
+    const optimizedDependencies =
+      rscEnvironment.depsOptimizer?.metadata.depInfoList.map((dep) => dep.id) ?? [];
+    expect(optimizedDependencies).toContain("react-server-dom-webpack/static.edge");
+  });
+
   // ── CSRF protection for server actions ───────────────────────────────
   it("rejects server action POST with mismatched Origin header (CSRF protection)", async () => {
     const res = await fetch(`${baseUrl}/actions.rsc`, {


### PR DESCRIPTION
This PR prebundles `react-server-dom-webpack/static.edge` during RSC dependency optimization when an RSC env is detected

This avoids transforming its large CommonJS renderer on the first request.
In turn, cold start is improved by ± 90ms (mainly the first request is sped up through this change).