### PR TITLE
fix(middleware): fail closed for unsafe matchers

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -383,7 +383,7 @@ export function isSafeRegex(pattern: string): boolean {
 export function safeRegExp(pattern: string, flags?: string): RegExp | null {
   if (!isSafeRegex(pattern)) {
     console.warn(
-      `[vinext] Ignoring potentially unsafe regex pattern (ReDoS risk): ${pattern}\n` +
+      `[vinext] Rejecting potentially unsafe regex pattern (ReDoS risk): ${pattern}\n` +
         `  Patterns with nested quantifiers (e.g. (a+)+) can cause catastrophic backtracking.\n` +
         `  Simplify the pattern to avoid nested repetition.`,
     );

--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -1,5 +1,6 @@
 import {
   checkHasConditions,
+  isSafeRegex,
   requestContextFromRequest,
   safeRegExp,
   type RequestContext,
@@ -23,7 +24,10 @@ const EMPTY_MIDDLEWARE_REQUEST_CONTEXT: RequestContext = {
   host: "",
 };
 
-const _mwPatternCache = new Map<string, RegExp | null>();
+const UNSAFE_MATCHER_PATTERN = Symbol("unsafe matcher pattern");
+type CompiledMatcherPattern = RegExp | null | typeof UNSAFE_MATCHER_PATTERN;
+
+const _mwPatternCache = new Map<string, CompiledMatcherPattern>();
 
 export function matchesMiddleware(
   pathname: string,
@@ -130,6 +134,7 @@ export function matchPattern(pathname: string, pattern: string): boolean {
     cached = compileMatcherPattern(pattern);
     _mwPatternCache.set(pattern, cached);
   }
+  if (cached === UNSAFE_MATCHER_PATTERN) return true;
   if (cached === null) return pathname === pattern;
   return cached.test(pathname);
 }
@@ -149,11 +154,11 @@ function extractConstraint(str: string, re: RegExp): string | null {
   return str.slice(start, i - 1);
 }
 
-function compileMatcherPattern(pattern: string): RegExp | null {
+function compileMatcherPattern(pattern: string): CompiledMatcherPattern {
   const hasConstraints = /:[\w-]+[*+]?\(/.test(pattern);
 
   if (!hasConstraints && (pattern.includes("(") || pattern.includes("\\"))) {
-    return safeRegExp("^" + pattern + "$");
+    return compileMatcherRegExp("^" + pattern + "$", pattern);
   }
 
   let regexStr = "";
@@ -187,5 +192,17 @@ function compileMatcherPattern(pattern: string): RegExp | null {
     }
   }
 
-  return safeRegExp("^" + regexStr + "$");
+  return compileMatcherRegExp("^" + regexStr + "$", pattern);
+}
+
+function compileMatcherRegExp(regexPattern: string, sourcePattern: string): CompiledMatcherPattern {
+  if (!isSafeRegex(regexPattern)) {
+    console.warn(
+      `[vinext] Rejecting potentially unsafe middleware matcher (ReDoS risk): ${sourcePattern}\n` +
+        `  Middleware will run for all paths to avoid bypassing request guards.\n` +
+        `  Simplify the matcher to avoid nested repetition.`,
+    );
+    return UNSAFE_MATCHER_PATTERN;
+  }
+  return safeRegExp(regexPattern);
 }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6633,6 +6633,32 @@ describe("middleware runner", () => {
     }
   });
 
+  it("runs middleware when its matcher is rejected as unsafe", async () => {
+    const { runMiddleware } = await import("../packages/vinext/src/server/middleware.js");
+    let middlewareCalled = false;
+    const mockRunner = {
+      import: async () => ({
+        default: () => {
+          middlewareCalled = true;
+          return new Response("Forbidden", { status: 403 });
+        },
+        // lgtm[js/redos] — deliberate pathological regex to exercise fail-closed behavior
+        config: { matcher: "/(?:[a-z]+/)*admin" },
+      }),
+    };
+
+    const result = await runMiddleware(
+      mockRunner as any,
+      "/fake/middleware.ts",
+      new Request("http://localhost/admin"),
+    );
+
+    expect(middlewareCalled).toBe(true);
+    expect(result.continue).toBe(false);
+    expect(result.response?.status).toBe(403);
+    expect(await result.response?.text()).toBe("Forbidden");
+  });
+
   it("findMiddlewareFile prefers proxy.ts over middleware.ts (Next.js 16)", async () => {
     const fs = await import("node:fs");
     const path = await import("node:path");
@@ -7006,6 +7032,36 @@ describe("middleware matcher patterns", () => {
     expect(matchPattern("/_next/static/chunk.js", "/((?!api|_next|favicon\\.ico).*)")).toBe(false);
   });
 
+  it("fails closed when a middleware matcher is rejected as unsafe", async () => {
+    const { matchPattern, matchesMiddleware } =
+      await import("../packages/vinext/src/server/middleware.js");
+    // Next.js rejects invalid matcher sources during config analysis rather than
+    // silently treating them as non-matches. Vinext additionally rejects unsafe
+    // regexes at runtime, where failing closed avoids bypassing request guards.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/segment-config/middleware/middleware-config.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/invalid-middleware-matchers/invalid-middleware-matchers.test.ts
+    // lgtm[js/redos] — deliberate pathological regex to exercise the safety fallback
+    const unsafePattern = "/(?:[A-Z]+/)*private";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      expect(matchPattern("/private", unsafePattern)).toBe(true);
+      expect(matchesMiddleware("/private", unsafePattern)).toBe(true);
+      expect(matchesMiddleware("/public", [unsafePattern])).toBe(true);
+      expect(matchesMiddleware("/public", [{ source: unsafePattern }])).toBe(true);
+
+      // Repeated calls use the cached rejection, remain fail-closed, and do not
+      // repeatedly warn for the same matcher.
+      expect(matchPattern("/public", unsafePattern)).toBe(true);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Middleware will run for all paths"),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("matchPattern: dots are escaped in paths", async () => {
     const { matchPattern } = await import("../packages/vinext/src/server/middleware.js");
     expect(matchPattern("/files/data.json", "/files/data.json")).toBe(true);
@@ -7176,12 +7232,20 @@ describe("middleware matcher patterns", () => {
     expect(matchesMiddleware("/other", matcher)).toBe(false);
   });
 
-  it("matchPattern: rejects pathological ReDoS patterns", async () => {
+  it("matchPattern: fails closed for pathological ReDoS patterns", async () => {
     const { matchPattern } = await import("../packages/vinext/src/server/middleware.js");
     // Pathological pattern: (a+)+ causes catastrophic backtracking
-    // matchPattern should return false (no match) instead of hanging
+    // matchPattern must avoid evaluating it and run middleware instead of
+    // silently bypassing a potentially security-sensitive request guard.
     // lgtm[js/redos] — deliberate pathological regex to test safeRegExp guard
-    expect(matchPattern("/aaaaaaaaaaaaaaaaaaaac", "(a+)+b")).toBe(false);
+    expect(matchPattern("/aaaaaaaaaaaaaaaaaaaac", "(a+)+b")).toBe(true);
+  });
+
+  it("matchPattern: does not run globally for malformed regex syntax", async () => {
+    const { matchPattern } = await import("../packages/vinext/src/server/middleware.js");
+
+    expect(matchPattern("/public", "/admin(")).toBe(false);
+    expect(matchPattern("/admin(", "/admin(")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- fail closed when a middleware matcher is rejected by the ReDoS safety check
- distinguish unsafe matcher rejection from malformed regex syntax
- warn once that rejected matchers cause middleware to run for all paths
- add regression coverage for direct, cached, array, object, and runtime middleware execution paths

## Why

A matcher rejected as potentially unsafe previously fell back to a literal comparison. For regex-style matcher sources, that comparison could never match the request pathname, so middleware could be skipped entirely.

Rejected unsafe matchers now conservatively execute middleware for every path. Malformed regex syntax retains the existing literal-match fallback, avoiding an unrelated global middleware expansion.

## Testing

- `vp test run tests/shims.test.ts`
- `vp check packages/vinext/src/server/middleware-matcher.ts packages/vinext/src/config/config-matchers.ts tests/shims.test.ts`
- `git diff --check`
