### PR TITLE
perf(rsc): avoid client decoder in server graph

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -70,6 +70,7 @@ export default {
         "src/server/app-post-middleware-context.ts",
         "src/server/app-request-context.ts",
         "src/server/app-rsc-error-handler.ts",
+        "src/server/app-rsc-runtime.ts",
         "src/server/isr-cache.ts",
         "src/server/rsc-stream-hints.ts",
         // #726-CACHE-01/04 defines the disabled proof boundary before runtime

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -67,6 +67,7 @@ const appRscRouteMatchingPath = resolveEntryPath(
   import.meta.url,
 );
 const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
+const appRscRuntimePath = resolveEntryPath("../server/app-rsc-runtime.js", import.meta.url);
 const isrCachePath = resolveEntryPath("../server/isr-cache.js", import.meta.url);
 const thenableParamsShimPath = resolveEntryPath("../shims/thenable-params.js", import.meta.url);
 const appPageElementBuilderPath = resolveEntryPath(
@@ -177,6 +178,8 @@ type AppRouterConfig = {
   publicFiles?: string[];
   /** Server-only token used to validate the draft-mode bypass cookie. */
   draftModeSecret?: string;
+  /** Use the focused server-only React bridge during development. */
+  serverOnlyRscRuntime?: boolean;
 };
 
 /**
@@ -217,6 +220,9 @@ export function generateRscEntry(
   const hasPagesDir = config?.hasPagesDir ?? false;
   const publicFiles = config?.publicFiles ?? [];
   const draftModeSecret = config?.draftModeSecret ?? randomUUID();
+  const rscRuntimeSpecifier = config?.serverOnlyRscRuntime
+    ? JSON.stringify(appRscRuntimePath)
+    : '"@vitejs/plugin-rsc/rsc"';
   const manifestCode = buildAppRscManifestCode({
     routes,
     metadataRoutes,
@@ -254,7 +260,7 @@ import {
   decodeReply,
   loadServerAction,
   createTemporaryReferenceSet,
-} from "@vitejs/plugin-rsc/rsc";
+} from ${rscRuntimeSpecifier};
 import { createClientManifest as _createClientManifest } from "@vitejs/plugin-rsc/core/rsc";
 import { prerender as _prerender } from "@vitejs/plugin-rsc/vendor/react-server-dom/static.edge";
 import { createRscPrerenderer, createRscRenderer } from ${JSON.stringify(rscStreamHintsPath)};

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -568,6 +568,18 @@ function createStaticImageAsset(imagePath: string): { fileName: string; source: 
  */
 const _shimsDir = normalizePathSeparators(path.resolve(__dirname, "shims")) + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
+const _cacheRuntimeShimPath = normalizePathSeparators(
+  resolveShimModulePath(_shimsDir, "cache-runtime"),
+);
+
+function isCacheRuntimeImporter(importer: string | undefined): boolean {
+  if (!importer) return false;
+  const cleanImporter = normalizePathSeparators(stripViteModuleQuery(importer));
+  return (
+    cleanImporter === _cacheRuntimeShimPath ||
+    cleanImporter === pathToFileURL(_cacheRuntimeShimPath).href
+  );
+}
 
 function isValidExportIdentifier(name: string): boolean {
   return /^[$A-Z_a-z][$\w]*$/.test(name);
@@ -2615,7 +2627,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // direct @vercel/og imports in metadata routes, and \0-prefixed
         // re-imports from @vitejs/plugin-rsc.
         filter: {
-          id: /(?:next\/|vinext\/shims\/|virtual:vinext-|@vercel\/og(?:\.js)?$)/,
+          id: /(?:next\/|vinext\/shims\/|virtual:vinext-|@vercel\/og(?:\.js)?$|@vitejs\/plugin-rsc\/dist\/react\/rsc\.js)/,
         },
         handler(id, importer) {
           // Strip \0 prefix if present — @vitejs/plugin-rsc's generated
@@ -2623,6 +2635,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // ID (with \0 prefix). We need to re-resolve it so the client
           // environment's import-analysis can find it.
           const cleanId = id.startsWith("\0") ? id.slice(1) : id;
+
+          if (
+            this.environment?.name === "rsc" &&
+            this.environment.config?.command === "serve" &&
+            !isCacheRuntimeImporter(importer) &&
+            stripViteModuleQuery(cleanId).endsWith("/@vitejs/plugin-rsc/dist/react/rsc.js")
+          ) {
+            return resolveShimModulePath(path.resolve(__dirname, "server"), "app-rsc-runtime");
+          }
 
           if (isVercelOgImport(cleanId) && !isVinextOgShimImporter(importer)) {
             return resolveShimModulePath(_shimsDir, "og");
@@ -2774,6 +2795,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               publicFiles: scanPublicFileRoutes(root),
               globalNotFoundPath,
               draftModeSecret,
+              serverOnlyRscRuntime: this.environment.config.command === "serve",
             },
             instrumentationPath,
           );

--- a/packages/vinext/src/server/app-rsc-runtime.ts
+++ b/packages/vinext/src/server/app-rsc-runtime.ts
@@ -1,0 +1,72 @@
+import {
+  createClientManifest,
+  createServerManifest,
+  loadServerAction,
+  setRequireModule,
+} from "@vitejs/plugin-rsc/core/rsc";
+import * as ReactServer from "@vitejs/plugin-rsc/vendor/react-server-dom/server.edge";
+import serverReferences from "virtual:vite-rsc/server-references";
+
+type ClientReferenceMetadata = {
+  id: string;
+  name: string;
+};
+
+type RenderExtraOptions = {
+  onClientReference?: (metadata: ClientReferenceMetadata) => void;
+};
+
+function toReferenceValidationVirtual(id: string): string {
+  return `virtual:vite-rsc/reference-validation?type=server&id=${encodeURIComponent(id)}&lang.js`;
+}
+
+setRequireModule({
+  async load(id: string) {
+    if (!import.meta.env.__vite_rsc_build__) {
+      await import(
+        /* @vite-ignore */
+        "/@id/__x00__" + toReferenceValidationVirtual(id)
+      );
+      return import(
+        /* @vite-ignore */
+        id
+      );
+    }
+
+    const importServerReference = serverReferences[id];
+    if (!importServerReference) {
+      throw new Error(`server reference not found '${id}'`);
+    }
+    return importServerReference();
+  },
+});
+
+export function renderToReadableStream(
+  data: unknown,
+  options?: unknown,
+  extraOptions?: RenderExtraOptions,
+): ReadableStream<Uint8Array> {
+  return ReactServer.renderToReadableStream(
+    data,
+    createClientManifest({
+      onClientReference: extraOptions?.onClientReference,
+    }),
+    options,
+  );
+}
+
+export const decodeReply = (body: string | FormData, options?: unknown): Promise<unknown[]> =>
+  ReactServer.decodeReply(body, createServerManifest(), options);
+
+export function decodeAction(body: FormData): Promise<() => Promise<void>> {
+  return ReactServer.decodeAction(body, createServerManifest());
+}
+
+export function decodeFormState(actionResult: unknown, body: FormData): Promise<unknown> {
+  return ReactServer.decodeFormState(actionResult, body, createServerManifest());
+}
+
+export const createTemporaryReferenceSet = ReactServer.createTemporaryReferenceSet;
+export const registerClientReference = ReactServer.registerClientReference;
+export const registerServerReference = ReactServer.registerServerReference;
+export { loadServerAction, setRequireModule };

--- a/packages/vinext/src/vite-rsc-server-runtime.d.ts
+++ b/packages/vinext/src/vite-rsc-server-runtime.d.ts
@@ -1,0 +1,26 @@
+declare module "@vitejs/plugin-rsc/vendor/react-server-dom/server.edge" {
+  export function renderToReadableStream(
+    data: unknown,
+    manifest: unknown,
+    options?: unknown,
+  ): ReadableStream<Uint8Array>;
+  export function decodeReply(
+    body: string | FormData,
+    manifest: unknown,
+    options?: unknown,
+  ): Promise<unknown[]>;
+  export function decodeAction(body: FormData, manifest: unknown): Promise<() => Promise<void>>;
+  export function decodeFormState(
+    actionResult: unknown,
+    body: FormData,
+    manifest: unknown,
+  ): Promise<unknown>;
+  export function createTemporaryReferenceSet(): unknown;
+  export function registerClientReference<T>(proxy: T, id: string, name: string): T;
+  export function registerServerReference<T>(reference: T, id: string, name: string): T;
+}
+
+declare module "virtual:vite-rsc/server-references" {
+  const serverReferences: Record<string, (() => Promise<unknown>) | undefined>;
+  export default serverReferences;
+}

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -147,6 +147,13 @@ describe("App Router integration", () => {
     expect(html).toContain("hello-world");
   });
 
+  it("deduplicates argument-bearing private cache calls within a request", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/use-cache-private-args");
+
+    expect(res.status).toBe(200);
+    expect(textContentByTestId(html, "first")).toBe(textContentByTestId(html, "second"));
+  });
+
   // Ported from Next.js: test/e2e/app-dir/cache-components/cache-components.params.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/cache-components/cache-components.params.test.ts
   it("renders pages with params named then, catch, finally, and status", async () => {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -853,6 +853,26 @@ describe("App Router entry templates", () => {
     );
     expect(code).not.toContain("const _hlFixRe =");
   });
+
+  it("uses the server-only RSC runtime only for development entries", () => {
+    const devCode = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false, {
+      serverOnlyRscRuntime: true,
+    });
+    const buildCode = generateRscEntry(
+      "/tmp/test/app",
+      minimalAppRoutes,
+      null,
+      [],
+      null,
+      "",
+      false,
+    );
+
+    expect(devCode).toContain("/server/app-rsc-runtime.js");
+    expect(devCode).not.toContain('from "@vitejs/plugin-rsc/rsc"');
+    expect(buildCode).toContain('from "@vitejs/plugin-rsc/rsc"');
+    expect(buildCode).not.toContain("/server/app-rsc-runtime.js");
+  });
 });
 
 // ── Pages Router entry template runtime bootstrap ─────────────────────

--- a/tests/fixtures/app-basic/app/use-cache-private-args/page.tsx
+++ b/tests/fixtures/app-basic/app/use-cache-private-args/page.tsx
@@ -1,0 +1,20 @@
+let callCount = 0;
+
+async function getCachedValue(value: string) {
+  "use cache: private";
+
+  callCount++;
+  return `${value}:${callCount}`;
+}
+
+export default async function Page() {
+  const first = await getCachedValue("same");
+  const second = await getCachedValue("same");
+
+  return (
+    <div>
+      <span data-testid="first">{first}</span>
+      <span data-testid="second">{second}</span>
+    </div>
+  );
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { PAGES_FIXTURE_DIR } from "./helpers.js";
 import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/router.js";
 import { extractVinextNextDataJson } from "../packages/vinext/src/client/vinext-next-data.js";
@@ -21322,6 +21323,67 @@ describe("shim alias map .js variants", () => {
     expect(hook.handler.call({ environment: { name: "rsc" } }, "next/error.js")).toBe(
       reactServerShim,
     );
+  });
+
+  it("uses the server-only plugin-rsc runtime only for the dev RSC environment", () => {
+    const plugins = vinext() as Plugin[];
+    const configPlugin = plugins.find((plugin) => plugin.name === "vinext:config");
+    if (!configPlugin?.resolveId || typeof configPlugin.resolveId === "function") {
+      throw new Error("vinext:config resolveId hook not found");
+    }
+
+    const hook = configPlugin.resolveId as {
+      filter: { id: RegExp };
+      handler: (
+        this: {
+          environment?: {
+            name?: string;
+            config: {
+              command: "serve" | "build";
+            };
+          };
+        },
+        id: string,
+        importer?: string,
+      ) => string | undefined;
+    };
+    const runtimeId = path.resolve(
+      import.meta.dirname,
+      "../node_modules/@vitejs/plugin-rsc/dist/react/rsc.js",
+    );
+    const expectedRuntime = path.resolve(
+      import.meta.dirname,
+      "../packages/vinext/src/server/app-rsc-runtime.ts",
+    );
+    const cacheRuntime = path.resolve(
+      import.meta.dirname,
+      "../packages/vinext/src/shims/cache-runtime.ts",
+    );
+
+    expect(hook.filter.id.test(runtimeId)).toBe(true);
+    expect(
+      hook.handler.call({ environment: { name: "rsc", config: { command: "serve" } } }, runtimeId),
+    ).toBe(expectedRuntime);
+    expect(
+      hook.handler.call(
+        { environment: { name: "rsc", config: { command: "serve" } } },
+        runtimeId,
+        cacheRuntime,
+      ),
+    ).toBeUndefined();
+    expect(
+      hook.handler.call(
+        { environment: { name: "rsc", config: { command: "serve" } } },
+        runtimeId,
+        pathToFileURL(cacheRuntime).href,
+      ),
+    ).toBeUndefined();
+    expect(
+      hook.handler.call({ environment: { name: "ssr", config: { command: "serve" } } }, runtimeId),
+    ).toBeUndefined();
+    expect(
+      hook.handler.call({ environment: { name: "rsc", config: { command: "build" } } }, runtimeId),
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
This PR adds a lightweight development RSC runtime that avoids loading the client Flight decoder. The full serialization exports for "use cache" functions is preserved. It also adds a resolver and private-cache deduplication regression coverage.

This reduces the cold start time.