### PR TITLE
fix(routing): keep static routes ahead of infix-dynamic routes in linear scan

### DIFF
--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -19,11 +19,22 @@
  *     penalties (1000+) are not swamped, preserving their relative ordering.
  *     E.g. /:locale/blog/:path+ (with infix "blog") correctly beats /:locale/:path+
  *     even when both share the same "locale-test" static prefix.
- *   - Note: dynamic routes CAN score negative (e.g. /a/:b/c/:d = -346), but
- *     this is harmless because the trie matcher (route-trie.ts) checks static
- *     children before dynamic children at each node, so purely-static routes
- *     still win at request time regardless of sort-order score.
+ *   - Infix-static and static-prefix bonuses can drive a dynamic route's raw
+ *     score below zero (e.g. /:id/b = -400). The trie matcher (route-trie.ts)
+ *     is unaffected (it checks static children before dynamic ones per node),
+ *     but linear-scan consumers of this order — e.g.
+ *     findRouteManifestRouteByMatchedUrl in navigation-planner.ts — return the
+ *     first matching route, so a negative-scoring dynamic route would shadow a
+ *     purely-static one (#1964). To prevent that, every dynamic route is lifted
+ *     by a uniform offset (DYNAMIC_PRECEDENCE_OFFSET) so the whole dynamic band
+ *     sits strictly above static routes (score 0), while the offset preserves
+ *     the exact relative ordering among dynamic routes.
  */
+// Uniform offset applied to every dynamic route's precedence. Large enough to
+// clear any infix-driven negative for realistic route depths, so static routes
+// (score 0) always sort before dynamic ones in linear-scan matchers.
+const DYNAMIC_PRECEDENCE_OFFSET = 1_000_000;
+
 function routePrecedence(pattern: string): number {
   const parts = pattern.split("/").filter(Boolean);
   let score = 0;
@@ -56,16 +67,22 @@ function routePrecedence(pattern: string): number {
 
   // Apply a small reduction per static-prefix segment for routes that also
   // contain dynamic segments. This ensures /_sites/:subdomain sorts above
-  // /:subdomain, and /_sites/:slug* sorts above /:slug*, while keeping the
-  // final score positive (so purely-static routes at score=0 always win).
+  // /:subdomain, and /_sites/:slug* sorts above /:slug*.
   //
   // 50 is deliberately smaller than the dynamic-segment penalty (100) so
   // one static prefix segment is enough to beat one bare dynamic segment,
   // and smaller than the infix-static bonus (500) so that infix ordering is
   // not disturbed between two routes that share the same prefix.
   const isDynamic = parts.some((p) => p.startsWith(":") || p.endsWith("+") || p.endsWith("*"));
-  if (isDynamic && staticPrefixCount > 0) {
-    score -= staticPrefixCount * 50;
+  if (isDynamic) {
+    if (staticPrefixCount > 0) {
+      score -= staticPrefixCount * 50;
+    }
+    // Lift the whole dynamic band above purely-static routes (score 0). The
+    // offset is uniform, so relative ordering among dynamic routes (including
+    // negative infix-static scores) is preserved exactly while no dynamic route
+    // can ever sort before a static one in a linear scan (#1964).
+    score += DYNAMIC_PRECEDENCE_OFFSET;
   }
 
   return score;

--- a/tests/route-sorting.test.ts
+++ b/tests/route-sorting.test.ts
@@ -705,6 +705,27 @@ describe("sortRoutes", () => {
     ]);
   });
 
+  it("prefers a static route over a dynamic route with infix-static segments", () => {
+    // Regression for #1964: a dynamic route whose infix-static bonus drives its
+    // raw precedence negative (e.g. /:id/b = -400) must NOT sort before a purely
+    // static route (/x/b = 0). The manifest linear scanner
+    // (findRouteManifestRouteByMatchedUrl) returns the first matching route in
+    // this order, so a negative-scoring dynamic route would shadow the static one.
+    expect(order(["/:id/b", "/x/b"])).toEqual(["/x/b", "/:id/b"]);
+    expect(order(["/:a/x/y/:b", "/p/x/y/q"])).toEqual(["/p/x/y/q", "/:a/x/y/:b"]);
+  });
+
+  it("preserves specificity ordering among infix dynamic routes (more infixes win)", () => {
+    // Must-not-break guard alongside #1964: lifting the dynamic band above 0 has
+    // to keep the documented intra-dynamic ordering — more static infixes = more
+    // specific = higher priority (sorts first).
+    expect(order(["/:a/:b+", "/:a/x/:b+", "/:a/x/y/:b+"])).toEqual([
+      "/:a/x/y/:b+",
+      "/:a/x/:b+",
+      "/:a/:b+",
+    ]);
+  });
+
   it("breaks ties lexicographically for a deterministic total order", () => {
     expect(order(["/zebra", "/apple", "/mango"])).toEqual(["/apple", "/mango", "/zebra"]);
   });


### PR DESCRIPTION
## Summary

- A dynamic route whose precedence score is driven negative by infix-static bonuses (e.g. `/:id/b` scores `-400`) could sort **ahead** of a purely-static route (`/x/b` scores `0`).
- Lift every dynamic route by a uniform offset so the whole dynamic band sits strictly above static routes (score `0`), while preserving the exact relative ordering among dynamic routes.
- Adds a regression test plus a guard test asserting intra-dynamic (infix) ordering is unchanged.

## Root Cause

`routePrecedence()` in `routing/utils.ts` assigns each route an additive score (lower = higher priority). Infix-static segments subtract `500` each and a static prefix subtracts `50` each, which can push a dynamic route's score **below zero** — below the `0` that purely-static routes always score.

The trie matcher (`route-trie.ts`) is unaffected because it checks static children before dynamic children at each node. But linear-scan consumers of `sortRoutes()` order return the **first** matching route in that order:

```ts
// navigation-planner.ts — findRouteManifestRouteByMatchedUrl
for (const route of routeManifest.segmentGraph.routes.values()) {
  if (matchRoutePattern(urlParts, route.patternParts) !== null) {
    return route; // first match in sortRoutes() order wins
  }
}
```

So for URL `/x/b`, with both `/x/b` (static, `0`) and `/:id/b` (dynamic, `-400`) present, the dynamic route — sorted first — shadows the static one. This path is reachable from `findRouteManifestRouteForSnapshot` (navigation planning) via the stale-/mismatched-`routeId` fallback.

The previous code comment asserted negative scores were "harmless because the trie matcher checks static children first" — true for the trie, but not for the linear scan. The fix restores the function's documented contract (follow static → dynamic → catch-all precedence) for that path.

## References

- Fixes #1964
- Next.js orders static segments before dynamic ones at each level via the trie-based `getSortedRoutes` comparator (`packages/next/src/shared/lib/router/utils/sorted-routes.ts`); vinext's additive heuristic must produce the same static-before-dynamic ordering. Mirrors the spirit of `test/unit/page-route-sorter.test.ts`.

## Verification

```
pnpm test tests/route-sorting.test.ts          # 49 passed (new regression + guard)
pnpm test tests/routing.test.ts tests/route-trie.test.ts \
          tests/hybrid-route-priority.test.ts tests/route-pattern.test.ts  # 224 passed
npx vp check packages/vinext/src/routing/utils.ts tests/route-sorting.test.ts  # format + lint + types clean
```
