### PR TITLE
fix(cache): decide ISR cache-key hashing on the suffix-free key

### DIFF
--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -349,8 +349,16 @@ function normalizeCachePathname(pathname: string): string {
 function buildCacheKey(prefix: string, pathname: string, suffix?: string): string {
   const normalized = normalizeCachePathname(pathname);
   const suffixPart = suffix ? `:${suffix}` : "";
-  const key = `${prefix}:${normalized}${suffixPart}`;
-  if (key.length <= 200) return key;
+  // Decide hashing on the suffix-free base key, then append the suffix. The hash
+  // decision must not depend on whether the artifact suffix (":html", ":rsc", …)
+  // is passed here or appended by the caller (seed time builds the key as
+  // `isrCacheKey(...) + ":html"`, evaluating the threshold on the unsuffixed
+  // key, while read time calls appIsrHtmlKey() with the suffix). Keying the
+  // threshold off the base makes both paths agree, so a boundary-length
+  // pathname (base <= 200 but base + suffix > 200) is no longer seeded under an
+  // unhashed key but read under a hashed one — a silent cache miss (#1965).
+  const base = `${prefix}:${normalized}`;
+  if (base.length <= 200) return `${base}${suffixPart}`;
   return `${prefix}:__hash:${fnv1a64(normalized)}${suffixPart}`;
 }
 

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -159,6 +159,25 @@ describe("App Router ISR cache key primitives", () => {
     expect(key).toMatch(/^app:__hash:[a-z0-9]+:rsc$/);
   });
 
+  it("decides hashing independently of the artifact suffix (#1965)", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    // Boundary pathname: the suffix-free key is exactly 200 chars, but adding
+    // the ":html" artifact suffix pushes it to 205. Seed time builds the key as
+    // isrCacheKey(...) + ":html" (threshold evaluated on the unsuffixed key);
+    // read time builds appIsrHtmlKey() (threshold evaluated on the suffixed
+    // key). If the hash decision differs, the seeded entry is written under one
+    // key and looked up under another — a silent cache miss.
+    const pathname = "/" + "a".repeat(195); // "app:" + 196 = 200 chars unsuffixed
+    expect(`app:${pathname}`.length).toBe(200);
+
+    const seedKey = isrCacheKey("app", pathname) + ":html";
+    const readKey = appIsrHtmlKey(pathname);
+
+    expect(seedKey).toBe(readKey);
+    expect(seedKey).not.toContain("__hash:"); // 200-char base stays unhashed
+  });
+
   it("keys mounted-slot RSC variants by normalized mounted-slot header", () => {
     delete process.env.__VINEXT_BUILD_ID;
 


### PR DESCRIPTION
## Summary

- The ISR cache-key hashing threshold was evaluated on the **full key including the artifact suffix**, but seed-time and read-time build that key differently, so a boundary-length pathname was seeded under one key and read under another — a silent cache miss.
- Decide hashing on the **suffix-free base key**, then append the suffix, so every construction path agrees.

## Root Cause

`buildCacheKey()` in `server/isr-cache.ts` hashes a pathname into the key once the key exceeds 200 chars (to stay under Cloudflare KV's 512-byte key limit):

```ts
const key = `${prefix}:${normalized}${suffixPart}`;
if (key.length <= 200) return key;
return `${prefix}:__hash:${fnv1a64(normalized)}${suffixPart}`;
```

The threshold was measured on the key **with** the artifact suffix (`:html`, `:rsc`, …). But the two ends construct the key differently:

- **Read time** uses `appIsrHtmlKey()` / `appIsrRscKey()` → `buildCacheKey(prefix, pathname, "html")` — threshold on the **suffixed** key.
- **Seed time** (`cloudflare/tpr.ts`, `server/seed-cache.ts` fallback) builds `isrCacheKey(...) + ":html"` — `isrCacheKey` calls `buildCacheKey` with **no** suffix, so the threshold is on the **unsuffixed** key, and `:html` is appended afterward.

For a boundary-length pathname — unsuffixed base ≤ 200 but base + suffix > 200 — the seed wrote an **unhashed** key (`app:/very/long/path:html`) while the runtime looked up a **hashed** key (`app:__hash:<fnv>:html`). The keys diverge, the pre-rendered entry is never found, and the pre-render work is wasted on every request.

The fix moves the hash decision onto the suffix-free base (`${prefix}:${normalized}`) and appends the suffix in both branches, so `isrCacheKey(...) + ":html"` and `appIsrHtmlKey(...)` always produce the same key. Worst-case key length stays well under the 512-byte KV limit (base ≤ 200 + a short suffix). Pages Router keys (no suffix) are unchanged.

## References

- Fixes #1965
- vinext-specific mechanism: the 200-char threshold and `fnv1a64` fallback exist for Cloudflare KV's 512-byte key limit. Next.js (`FileSystemCache` / `normalizePagePath`) has no equivalent key-hashing step, so there is no upstream test to port.

## Verification

```
pnpm test tests/isr-cache.test.ts            # 65 passed (new boundary regression test)
pnpm test (cache/seed/tpr/prerender suites)  # 687 passed — tpr-kv-keys, seed-cache, kv-cache-handler included
npx vp check packages/vinext/src/server/isr-cache.ts tests/isr-cache.test.ts   # clean
```
