### PR TITLE
fix(router): treat hash removal as a hash-only navigation

### DIFF
--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -624,7 +624,13 @@ function classifyEarlyNavigationIntent(
   // key order. We intentionally do not sort, since query order can be observable.
   const sameSearch = current.searchParams.toString() === next.searchParams.toString();
 
-  if (samePathname && sameSearch && next.hash !== "") {
+  // A same pathname+search navigation is a same-document scroll whenever either
+  // side carries a hash. This covers adding a hash (/docs → /docs#a), changing
+  // it (/docs#a → /docs#b), and — critically — removing it (/docs#a → /docs),
+  // which is a hash-only change that scrolls to top without an RSC fetch, per
+  // Next.js (#1985). A genuine same-URL reload with no hash on either side still
+  // falls through to a flight navigation.
+  if (samePathname && sameSearch && (next.hash !== "" || current.hash !== "")) {
     return {
       hash: next.hash,
       kind: "sameDocumentScroll",

--- a/packages/vinext/src/shims/url-utils.ts
+++ b/packages/vinext/src/shims/url-utils.ts
@@ -216,7 +216,17 @@ export function isHashOnlyBrowserUrlChange(
     // Keep this raw comparison distinct from the App Router planner's parsed
     // search-param comparison until their separate navigation lifecycles are
     // deliberately unified.
-    return currentPathname === nextPathname && current.search === next.search && next.hash !== "";
+    //
+    // A hash-only change is one where either side carries a hash: adding,
+    // changing, or REMOVING the hash (/page#a → /page). Removal is still a
+    // hash-only navigation (scroll to top) and must not trigger a full page
+    // fetch — Next.js parity (#1985). A same-URL navigation with no hash on
+    // either side is not hash-only.
+    return (
+      currentPathname === nextPathname &&
+      current.search === next.search &&
+      (next.hash !== "" || current.hash !== "")
+    );
   } catch {
     return false;
   }

--- a/tests/navigation-planner-early-intent.test.ts
+++ b/tests/navigation-planner-early-intent.test.ts
@@ -145,10 +145,33 @@ describe("navigationPlanner early navigation intent classification", () => {
     expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
   });
 
-  it("treats hash removal as a flight navigation, not a same-document scroll", () => {
+  it("treats hash removal (/docs#section → /docs) as a same-document scroll to top", () => {
+    // Next.js parity (#1985): same pathname + search with the hash REMOVED is a
+    // hash-only change, so it scrolls (to top, since the target hash is empty)
+    // without an RSC fetch — identical to adding or changing a hash.
     const decision = classify({
       currentHref: "https://example.com/docs#section",
       targetHref: "https://example.com/docs",
+    });
+
+    expect(decision).toEqual({
+      kind: "sameDocumentScroll",
+      hash: "",
+      mode: "push",
+      scroll: true,
+      trace: decision.trace,
+    });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.sameDocumentScroll, {
+      targetHref: "https://example.com/docs",
+    });
+  });
+
+  it("still flights a same-URL navigation with no hash on either side", () => {
+    // Guard: hash removal must not turn a genuine same-URL reload (no hash at all)
+    // into a same-document scroll.
+    const decision = classify({
+      currentHref: "https://example.com/docs?q=1",
+      targetHref: "https://example.com/docs?q=1",
     });
 
     expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -7250,6 +7250,27 @@ describe("middleware matcher patterns", () => {
 });
 
 // ---------------------------------------------------------------------------
+describe("isHashOnlyBrowserUrlChange", () => {
+  it("treats adding, changing, and removing a hash on the same page as hash-only", async () => {
+    const { isHashOnlyBrowserUrlChange } =
+      await import("../packages/vinext/src/shims/url-utils.js");
+    // add
+    expect(isHashOnlyBrowserUrlChange("https://x/docs#a", "https://x/docs")).toBe(true);
+    // change
+    expect(isHashOnlyBrowserUrlChange("https://x/docs#b", "https://x/docs#a")).toBe(true);
+    // remove — Next.js parity (#1985); previously misclassified as a full navigation
+    expect(isHashOnlyBrowserUrlChange("https://x/docs", "https://x/docs#a")).toBe(true);
+  });
+
+  it("is not hash-only with no hash on either side, or when path/search differ", async () => {
+    const { isHashOnlyBrowserUrlChange } =
+      await import("../packages/vinext/src/shims/url-utils.js");
+    expect(isHashOnlyBrowserUrlChange("https://x/docs", "https://x/docs")).toBe(false);
+    expect(isHashOnlyBrowserUrlChange("https://x/other", "https://x/docs#a")).toBe(false);
+    expect(isHashOnlyBrowserUrlChange("https://x/docs?q=2", "https://x/docs?q=1#a")).toBe(false);
+  });
+});
+
 // normalizePath unit tests
 
 describe("normalizePath", () => {


### PR DESCRIPTION
## Summary

- Removing the hash from the URL on the same page (`/page#section` → `/page`) was treated as a full navigation, triggering a needless RSC fetch (App Router) / page load (Pages Router).
- Treat it as a hash-only navigation — scroll to top, no fetch — matching Next.js. A genuine same-URL navigation with no hash on either side still does a full navigation.
- Fixes both routers, which had the identical gate.

## Root Cause

Both routers decided "is this a hash-only / same-document navigation?" by checking that the **target** hash was non-empty:

```ts
// App Router — navigation-planner.ts (classifyEarlyNavigationIntent)
if (samePathname && sameSearch && next.hash !== "") { /* same-document scroll */ }

// Pages Router — shims/url-utils.ts (isHashOnlyBrowserUrlChange)
return currentPathname === nextPathname && current.search === next.search && next.hash !== "";
```

When the hash is **removed**, `next.hash === ""`, so the check is false and the navigation falls through to a full RSC fetch / page navigation — even though only the hash changed. Next.js treats any hash delta on the same pathname+search as a hash-only change (`url.hash !== oldUrl.hash`), including removal, and scrolls (to top, since the target hash is empty) without fetching.

The fix recognises a hash-only change when **either side** carries a hash (`next.hash !== "" || current.hash !== ""`), which adds exactly the removal case and leaves every other classification unchanged. For the App Router, the existing consumer already scrolls to top on an empty hash (`scrollToHashTarget("") → window.scrollTo(0, 0)`). The Pages Router's deliberately separate raw-search comparison is preserved.

## References

- Fixes #1985
- Next.js parity: `onlyHashChange` in `packages/next/src/client/components/segment-cache/navigation.ts` compares `url.hash !== oldUrl.hash`, so hash removal is a same-document change with no fetch.

## Verification

```
pnpm test tests/navigation-planner-early-intent.test.ts   # hash-removal now same-document scroll + same-URL-reload guard
pnpm test tests/shims.test.ts -t isHashOnlyBrowserUrlChange  # add/change/remove hash-only; non-hash-only guards
pnpm test (router/navigation/scroll/link suites)          # 1310 passed
npx vp check (changed files)                              # clean
```
