### PR TITLE
fix(app-router): settle in-flight navigation when the dev recovery boundary catches

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -934,9 +934,15 @@ function getRequestState(
 // rsc:update fetches the right payload after the bug is fixed.
 function handleDevRecoveryBoundaryCatch(resetKey: number): void {
   // React's onCaughtError option already routes the error to the dev overlay.
-  // Our job here is purely to drive the URL update for the in-flight
-  // navigation that this failed render belonged to.
+  // Drive the URL update for the in-flight navigation that this failed render
+  // belonged to...
   browserNavigationController.drainPrePaintEffects(resetKey);
+  // ...and settle its pending commit. Because the signal never mounted, neither
+  // its useLayoutEffect nor that effect's cleanup runs, so without this the
+  // navigation promise hangs forever and permanently leaks the active-navigation
+  // counter — blocking later server-action refreshes (#1986). This mirrors the
+  // unmount cleanup inside NavigationCommitSignal.
+  browserNavigationController.resolveCommittedNavigations(resetKey);
 }
 
 function isMpaNavigationState(

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -150,6 +150,16 @@ type BrowserNavigationController = {
    * navigation would otherwise be lost.
    */
   drainPrePaintEffects(renderId: number): void;
+  /**
+   * Resolve all pending navigation commits with renderId <= the given id without
+   * waiting for NavigationCommitSignal to commit. The signal's useLayoutEffect
+   * already does this on unmount, but when a render error replaces the subtree
+   * before the signal ever mounts (dev recovery boundary), neither the mount
+   * effect nor its cleanup runs — so the in-flight navigation promise would hang
+   * and leak the active-navigation counter. The recovery path calls this to
+   * settle it (#1986).
+   */
+  resolveCommittedNavigations(renderId: number): void;
   clearCommittedNavigationFailureTargets(renderId: number): void;
   NavigationCommitSignal(
     this: void,
@@ -909,6 +919,7 @@ export function createAppBrowserNavigationController(
     commitSameUrlNavigatePayload,
     hmrReplaceTree,
     drainPrePaintEffects,
+    resolveCommittedNavigations,
     clearCommittedNavigationFailureTargets,
     NavigationCommitSignal,
   };

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -2998,6 +2998,63 @@ describe("app browser navigation controller", () => {
     }
   });
 
+  it("resolveCommittedNavigations settles a pending commit when NavigationCommitSignal never mounts (#1986)", async () => {
+    // Regression for #1986: when a render error makes the dev recovery boundary
+    // replace the subtree, NavigationCommitSignal's useLayoutEffect never fires
+    // (no mount → no cleanup), so the in-flight commit is never resolved and the
+    // navigation promise hangs (leaking activeNavigationCount). The recovery
+    // path must be able to settle the commit directly, mirroring the signal's
+    // unmount cleanup.
+    const { controller, detach, stateRef } = createControllerHarness();
+    const nextElements = Promise.resolve(
+      createResolvedElements("route:/dashboard", "/", null, {
+        "page:/dashboard": React.createElement("main", null, "dashboard"),
+      }),
+    );
+
+    try {
+      const navId = controller.beginNavigation();
+      const renderPromise = controller.renderNavigationPayload({
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+        actionType: "navigate",
+        createNavigationCommitEffect: () => vi.fn(),
+        historyUpdateMode: "push",
+        navigationSnapshot: stateRef.current.navigationSnapshot,
+        nextElements,
+        operationLane: "navigation",
+        params: {},
+        pendingRouterState: null,
+        previousNextUrl: null,
+        targetHref: "https://example.com/dashboard",
+        navId,
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Signal never mounted: the commit is stuck pending.
+      const stuck = await Promise.race([
+        renderPromise.then(() => true),
+        Promise.resolve().then(() => false),
+      ]);
+      expect(stuck).toBe(false);
+
+      // The dev recovery boundary settles it directly.
+      controller.resolveCommittedNavigations(Number.MAX_SAFE_INTEGER);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const settled = await Promise.race([
+        renderPromise.then(() => true),
+        Promise.resolve().then(() => false),
+      ]);
+      expect(settled).toBe(true);
+    } finally {
+      detach();
+    }
+  });
+
   it("does not clear a newer navigation failure target when an older render commits", async () => {
     const { controller, detach, stateRef } = createControllerHarness();
     vi.stubEnv("__NEXT_APP_NAV_FAIL_HANDLING", "true");


### PR DESCRIPTION
## Summary

- In dev, when the recovery boundary catches a render error during a navigation, the in-flight navigation promise hung forever and `activeNavigationCount` leaked permanently — blocking later server-action refreshes.
- The recovery handler now settles the pending commit, mirroring `NavigationCommitSignal`'s unmount cleanup.

## Root Cause

A navigation's promise is resolved by `NavigationCommitSignal`'s `useLayoutEffect` (on commit) or its cleanup (on unmount). When a render error makes `DevRecoveryBoundary` replace the subtree, the signal **never mounts**, so neither its effect nor that effect's cleanup ever runs.

`handleDevRecoveryBoundaryCatch` drained the queued pre-paint effect (so the URL still moves to the target) but never resolved the in-flight navigation's pending commit:

```ts
function handleDevRecoveryBoundaryCatch(resetKey: number): void {
  browserNavigationController.drainPrePaintEffects(resetKey);
  // pendingNavigationCommits[resetKey] was never resolved
}
```

So `renderNavigationPayload`'s promise stayed pending, `navigateRsc` never reached its `finally`, and `markNavigationSettled()` never ran — leaking `activeNavigationCount`. With the counter stuck above zero, `discardedServerActionRefreshScheduler` treats a navigation as perpetually in flight and never flushes discarded server-action refreshes.

The fix exposes `resolveCommittedNavigations` on the navigation controller and calls it from the recovery handler — the same call `NavigationCommitSignal` already makes in its unmount cleanup (`app-browser-navigation-controller.ts`):

```ts
return () => {
  cancelAnimationFrame(frame);
  // Resolve pending commits to prevent callers from hanging if React
  // unmounts this component without committing (e.g., error boundary).
  resolveCommittedNavigations(renderId);
};
```

Resolving the commit unblocks `navigateRsc`, whose `finally` then balances the counter — so no separate counter adjustment is needed (and no risk of a double-decrement).

## References

- Fixes #1986
- Dev-only recovery path; vinext-specific (Next.js has no equivalent dev recovery boundary), so there is no upstream test to port.

## Verification

```
pnpm test tests/app-browser-entry.test.ts   # 202 passed (new #1986 regression + existing "stays pending" guard)
pnpm test tests/app-browser-*.test.ts        # 242 passed
npx vp check <changed files>                 # format + lint + types clean
```
