### PR TITLE
test(oxlint-prefer-shared-utils): remove dir-symlink fixtures on Windows

### DIFF
--- a/tests/oxlint-prefer-shared-utils.test.ts
+++ b/tests/oxlint-prefer-shared-utils.test.ts
@@ -52,12 +52,15 @@ function runLint(files: readonly string[]): { status: number | null; output: str
 }
 
 afterEach(() => {
+  // Windows treats a directory symlink as a directory, so rmSync needs
+  // `recursive` to unlink it; on a symlink it removes only the link, not the
+  // target (fixtureDir is removed separately below).
   if (fixtureLinkDir) {
-    fs.rmSync(fixtureLinkDir, { force: true });
+    fs.rmSync(fixtureLinkDir, { recursive: true, force: true });
     fixtureLinkDir = undefined;
   }
   if (testFixtureLinkDir) {
-    fs.rmSync(testFixtureLinkDir, { force: true });
+    fs.rmSync(testFixtureLinkDir, { recursive: true, force: true });
     testFixtureLinkDir = undefined;
   }
   if (!fixtureDir) return;


### PR DESCRIPTION
## What

Makes `tests/oxlint-prefer-shared-utils.test.ts` clean up its directory-symlink fixtures on Windows by using `fs.rmSync(link, { recursive: true, force: true })`. Test-only — no source change.

## Why

The tests create directory symlinks (`fs.symlinkSync(fixtureDir, link, "dir")`) inside `packages/vinext/src/` and `tests/` so the `vp lint` run treats the temp fixtures as in-repo files. The `afterEach` removed those links with `fs.rmSync(link, { force: true })`:

- On POSIX this unlinks the symlink and succeeds.
- On Windows a directory symlink is treated as a directory, and `fs.rmSync` without `recursive` throws `ERR_FS_EISDIR` ("Path is a directory").

Because all three tests share the same `afterEach`, every one failed at cleanup (not on any assertion), and the symlinks were left behind, leaking `__lint_rule_fixtures__-*` entries into `src/` and `tests/` in the working tree.

## How

Add `recursive: true` to the two symlink removals, matching the `fixtureDir` removal immediately below. Empirically verified on Windows and POSIX that `rmSync(recursive, force)` on a symlink removes only the link and leaves the target intact (the real `fixtureDir` is still removed separately), so no fixture data is double-deleted. A short comment notes the Windows reason since `recursive` on a symlink looks unusual.

`fs.rmdirSync` was rejected as an alternative because it throws `ENOTDIR` on a POSIX symlink-to-dir.

## Testing

`vp test run --project unit tests/oxlint-prefer-shared-utils.test.ts` — 3/3 pass on Windows (previously 3 failed); no leftover symlinks in the working tree. POSIX behavior is unchanged. `vp check` clean.
