### PR TITLE
fix(middleware): match middleware taint ids by forward-slash on Windows

### DIFF
--- a/packages/vinext/src/plugins/middleware-server-only.ts
+++ b/packages/vinext/src/plugins/middleware-server-only.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from "vite";
+import { normalizePathSeparators } from "../utils/path.js";
 
 /**
  * Allow `import 'server-only'` from middleware (and any module reachable
@@ -59,22 +60,25 @@ export function createMiddlewareServerOnlyPlugin(options: {
   // Rolldown handed us).
   const tainted = new Set<string>();
 
-  function isTainted(id: string | undefined): boolean {
-    if (!id) return false;
-    if (tainted.has(id)) return true;
+  // Canonicalize an id into the space the taint set lives in: forward slashes
+  // (Rolldown ids are POSIX-normalized) with the query suffix stripped. The
+  // seed paths come from `path.join`, which is backslash on Windows, so they
+  // must be normalized to match the importer ids Rolldown passes in.
+  function canonicalizeId(id: string): string {
+    const queryIndex = id.indexOf("?");
     // Strip query string suffix (e.g. ?v=hash, ?rsc, ?used). Rolldown stores
     // module IDs with the query in `importer` strings for HMR / dep optimizer
     // round-trips; the canonical id we tracked doesn't carry one.
-    const queryIndex = id.indexOf("?");
-    if (queryIndex !== -1) {
-      return tainted.has(id.slice(0, queryIndex));
-    }
-    return false;
+    return normalizePathSeparators(queryIndex === -1 ? id : id.slice(0, queryIndex));
+  }
+
+  function isTainted(id: string | undefined): boolean {
+    if (!id) return false;
+    return tainted.has(canonicalizeId(id));
   }
 
   function addTainted(id: string): void {
-    const queryIndex = id.indexOf("?");
-    tainted.add(queryIndex === -1 ? id : id.slice(0, queryIndex));
+    tainted.add(canonicalizeId(id));
   }
 
   return {


### PR DESCRIPTION
## What

Fixes the `vinext:middleware-server-only` plugin so it recognizes the middleware import chain on Windows, letting middleware (and modules it reaches) `import 'server-only'` as intended.

## Why

The plugin allows `server-only` from the middleware chain by taint-tracking: it seeds a set with the middleware path and propagates the taint through `resolveId` to every reachable module, then swaps `server-only` for a no-op shim when a tainted module imports it.

The seed comes from `findMiddlewareFile`, i.e. `path.join(root, …)`. On Windows `path.join` produces backslashes (`E:\…\middleware.ts`) even when `root` is already forward-slash. But Rolldown hands `resolveId` POSIX-normalized importer ids (`E:/…/middleware.ts`), so `tainted.has(importer)` never matched the backslash seed. The taint never propagated, the middleware's transitive `import 'server-only'` (via `lib/auth.ts`) reached `@vitejs/plugin-rsc`'s `rsc:validate-imports`, and the SSR build failed with:

```
'server-only' cannot be imported in client build ('ssr' environment)
```

This is a real Windows build failure, not a test artifact — any project with middleware that imports `server-only` would fail to build on Windows.

## How

The taint set conceptually lives in Rolldown's id space (forward slashes). Collapse `isTainted`/`addTainted` onto a single `canonicalizeId` that strips the query suffix (unchanged) and additionally applies `normalizePathSeparators`, so seeds and importers are compared in the same forward-slash space. The query-stripping logic is preserved exactly; on POSIX `normalizePathSeparators` is a no-op, so behavior there is unchanged. The fix is localized to the plugin and does not touch `middlewarePath`'s other consumers.

Confirmed by experiment: without the `normalizePathSeparators` call the build still fails (the `canonicalizeId` refactor alone is behavior-equivalent to the old code); adding it is what makes the two skipped tests pass.

## Testing

`vp test run --project unit tests/middleware-server-only.test.ts` — 4/4 pass on Windows (previously the `middleware can import server-only` suite failed in `beforeAll`, skipping its 2 tests). POSIX behavior is unchanged (no-op normalize). `vp check` clean.
