### PR TITLE
fix(build): normalize canonicalized module ids to forward slashes on Windows

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -843,11 +843,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   const shimsDir = path.resolve(__dirname, "shims");
 
   // Shared with the Layer 2 renderChunk hook below. Rolldown stores module
-  // IDs as canonicalized filesystem paths (fs.realpathSync.native), so we must
-  // canonicalize anything we hand to the classifier and anything we ask the
-  // module graph for. The shim files exist in the vinext package before plugin
-  // init, so realpath is safe to evaluate eagerly.
-  const canonicalize = (p: string): string => tryRealpathSync(p) ?? p;
+  // IDs as canonicalized filesystem paths (fs.realpathSync.native) with forward
+  // slashes, so we must canonicalize anything we hand to the classifier and
+  // anything we ask the module graph for — including the separator
+  // normalization, since realpathSync.native keeps backslashes on Windows. The
+  // shim files exist in the vinext package before plugin init, so realpath is
+  // safe to evaluate eagerly.
+  const canonicalize = (p: string): string => normalizePathSeparators(tryRealpathSync(p) ?? p);
   const pageTransformCanonicalPaths = new Map<string, string>();
   const canonicalizePageTransformPath = (modulePath: string): string => {
     const cached = pageTransformCanonicalPaths.get(modulePath);


### PR DESCRIPTION
## What

Makes the `canonicalize` helper used by the build-time layout classifier return forward-slash paths, so its ids match the module graph Rolldown actually keys by on Windows.

## Why

The Layer 2 (module-graph) classifier proves a layout static by walking the RSC module graph for transitive dynamic-shim imports. It looks up modules with `canonicalize(layoutPath)` and compares dynamic-shim ids that were also run through `canonicalize`:

```ts
const canonicalize = (p: string): string => tryRealpathSync(p) ?? p;
```

`tryRealpathSync` is `fs.realpathSync.native`, which keeps backslashes on Windows (`E:\…\app\layout.tsx`). But Rolldown stores module ids as the realpath with **forward** slashes (`E:/…/app/layout.tsx`). So `moduleInfo.getModuleInfo(layoutModuleId)` missed every layout, the injector skipped it (`continue`), and no Layer 2 classification was produced. The root layout — the one Layer 2 is supposed to prove static — got nothing, so `/`'s dispatch table was empty (emitted as a `null` stub) and the debug reasons map had no entry 0.

This is a real Windows build regression, not a test artifact: every layout silently falls back to the Layer 3 runtime probe, losing the build-time static optimization the classifier exists to provide. The function's own doc comment already states its purpose is to "match what Rolldown stores as module IDs" — it was just missing the separator half of that contract.

## How

Wrap `canonicalize` with `normalizePathSeparators`, so it returns the forward-slash realpath that Rolldown's module ids use. All four call sites compare against module-graph ids (the classifier's `dynamicShimPaths` and `canonicalizeLayoutPath`, plus `canonicalizePageTransformPath` / `canonicalPagesDir`), and each compares values that are *both* run through `canonicalize`, so they stay internally consistent — and the page-transform / pages-dir comparisons against Vite's forward-slash transform ids actually get *more* robust on Windows. On POSIX `normalizePathSeparators` is a no-op, so behavior there is unchanged.

## Testing

`vp test run --project unit tests/build-time-classification-integration.test.ts` — 8/8 pass on Windows (previously 2 failed: the `/` dispatch and the force-dyn reasons entry). `tests/layout-classification.test.ts` + `tests/build-report.test.ts` — 108/108, no regression. `vp check` clean.
