### PR TITLE
test(fixture-dev-server): wait for child exit by exit/signal code, not killed

### DIFF
--- a/tests/fixture-dev-server.test.ts
+++ b/tests/fixture-dev-server.test.ts
@@ -38,7 +38,11 @@ describe("fixture dev server helper", () => {
     ).rejects.toThrow(/Fixture "never-ready" did not start within 100ms: .*never listened/s);
 
     expect(fixtureProcess).toBeDefined();
-    if (fixtureProcess && fixtureProcess.exitCode == null && !fixtureProcess.killed) {
+    // Wait until the child has actually exited. `killed` only means a signal was
+    // sent, not that the process is gone — on Windows `stopFixtureDevServer`
+    // calls `proc.kill()`, which sets `killed` synchronously while exit is still
+    // pending, so gating on `!killed` would skip the wait and read a null code.
+    if (fixtureProcess && fixtureProcess.exitCode == null && fixtureProcess.signalCode == null) {
       await once(fixtureProcess, "exit");
     }
 


### PR DESCRIPTION
## What

Fixes the `terminates the child process when startup readiness times out` test so it waits for the child to actually exit before asserting on its exit/signal code.

## Why

After the startup timeout rejects, `stopFixtureDevServer` terminates the child, and the test then waits for the process to exit before checking `signalCode ?? exitCode`:

```ts
if (fixtureProcess && fixtureProcess.exitCode == null && !fixtureProcess.killed) {
  await once(fixtureProcess, "exit");
}
```

`proc.killed` only means a signal was *sent*, not that the process has exited. On Windows `stopFixtureDevServer` terminates via `proc.kill("SIGTERM")` (the method), which sets `proc.killed = true` synchronously while the actual exit is still pending. So `!killed` was false, the `await once(..., "exit")` was skipped, and the immediately-following assertion read a still-null `signalCode`/`exitCode` and failed.

On POSIX the test happened to pass only because `stopFixtureDevServer` there kills the process group via the global `process.kill(-pid, …)`, which does not set `proc.killed`, so the guard awaited as intended.

## How

Gate the wait on whether the process has actually exited — `exitCode == null && signalCode == null` — instead of `!killed`. A process has exited iff one of those codes is set, so this awaits exactly when an exit is still pending and skips the wait (avoiding a hang on an already-emitted `exit`) once it has. POSIX behavior is unchanged: both codes are null at that point there too, so it still awaits.

## Testing

`vp test run --project unit tests/fixture-dev-server.test.ts` — 2/2 pass on Windows (previously 1 failed). `vp check` clean.
