### PR TITLE
test(helpers): link fixture node_modules with a dir symlink, not a junction

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -152,7 +152,21 @@ export async function createIsolatedFixture(
 
   const resolvedNodeModules =
     nodeModulesDir ?? path.resolve(import.meta.dirname, "../node_modules");
-  await fs.symlink(resolvedNodeModules, path.join(tmpDir, "node_modules"), "junction");
+  const nodeModulesLink = path.join(tmpDir, "node_modules");
+  // Prefer a directory symlink over a junction. When the source node_modules
+  // contains pnpm's relative symlinks that climb out of it (e.g. a nested
+  // package's `react` → `../../../../node_modules/.pnpm/...`), Windows resolves
+  // those escaping `..` segments against a junction's mount path — landing
+  // outside the real tree so resolution fails — but against a dir symlink's real
+  // target, which resolves correctly. Fall back to a junction where creating a
+  // symlink isn't permitted (Windows without the privilege); there the escaping
+  // case is unsupported, but the common non-escaping node_modules still works.
+  // On POSIX the type argument is ignored, so this is always a plain symlink.
+  try {
+    await fs.symlink(resolvedNodeModules, nodeModulesLink, "dir");
+  } catch {
+    await fs.symlink(resolvedNodeModules, nodeModulesLink, "junction");
+  }
 
   return tmpDir;
 }


### PR DESCRIPTION
## What

Changes `createIsolatedFixture` to link the fixture's `node_modules` with a directory symlink (falling back to a junction), so pnpm's escaping relative symlinks resolve through it on Windows.

## Why

The App Router CSS-url-assets suite borrows `tests/fixtures/app-basic/node_modules` (it has `react-server-dom-webpack`, which the workspace root node_modules lacks). `app-basic` is a nested package in the pnpm workspace, so its `node_modules/react` is a relative symlink that climbs out of the package to the hoisted store: `..\..\..\..\node_modules\.pnpm\react@…\node_modules\react`.

`createIsolatedFixture` linked `node_modules` into the temp dir with a **junction**. On Windows, traversing a junction and then a child relative symlink resolves the symlink's `..` segments against the junction's mount path, not its real target — so `react`'s `..\..\..\..` climbs out of the temp directory into a non-existent location. `fs.stat`/`existsSync` (and therefore Rolldown's / oxc-resolver's existence probes) fail, so the build dies with:

```
Rolldown failed to resolve import "react/jsx-runtime" from <tmp>/app/layout.tsx
```

Verified directly: through the junction `existsSync(react/jsx-runtime.js)` is `false` while `realpathSync` of the same path succeeds — stat assembles the path against the junction's logical location, realpath resolves against the physical target. The Pages suite is unaffected because it uses the workspace node_modules, whose symlinks stay inside it (no escaping `..`).

## How

Create the `node_modules` link as a `"dir"` symlink, which resolves a child relative symlink's `..` against its real target (climbing correctly to the repo root), and fall back to `"junction"` when symlink creation isn't permitted (Windows without the privilege — the original reason a junction was used). On POSIX the type argument is ignored, so this stays a plain symlink and nothing changes. Non-escaping node_modules (the other callers) resolve identically under both link types, so there is no regression.

## Testing

`vp test run --project unit tests/css-url-assets.test.ts` — 8/8 pass on Windows (previously the App Router suite failed in `beforeAll`). Other unit callers of `createIsolatedFixture` unaffected: `trailing-slash` 6/6, `pages-i18n-public-rewrite` 13/13. `vp check` clean.
