### PR TITLE
test(tsconfig-paths): remove temp dir after restoring cwd to avoid EPERM on Windows

### DIFF
--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -6,9 +6,11 @@ import type { Plugin, PluginOption } from "vite-plus";
 import vinext from "../packages/vinext/src/index.js";
 
 const originalCwd = process.cwd();
+let createdRoot: string | undefined;
 
 function setupProject(vitePackageJson: Record<string, unknown>): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-vite-major-"));
+  createdRoot = root;
   fs.mkdirSync(path.join(root, "pages"), { recursive: true });
   fs.mkdirSync(path.join(root, "node_modules", "vite"), { recursive: true });
   fs.writeFileSync(
@@ -35,8 +37,16 @@ function findNamedPlugin(plugins: ReturnType<typeof vinext>, name: string) {
 }
 
 afterEach(() => {
+  // Restore the cwd before removing the temp dir: each test chdir's into
+  // `root`, and Windows refuses to delete a directory that is a process's
+  // current working directory (EPERM). Clean up here, after the chdir, rather
+  // than inside the test body where the cwd is still inside `root`.
   process.chdir(originalCwd);
   vi.restoreAllMocks();
+  if (createdRoot) {
+    fs.rmSync(createdRoot, { recursive: true, force: true });
+    createdRoot = undefined;
+  }
 });
 
 describe("Vite tsconfig paths support", () => {
@@ -47,8 +57,6 @@ describe("Vite tsconfig paths support", () => {
     const plugins = vinext({ appDir: root });
 
     expect(findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it("uses resolve.tsconfigPaths on Vite 8 instead of vite-tsconfig-paths", async () => {
@@ -73,8 +81,6 @@ describe("Vite tsconfig paths support", () => {
     );
 
     expect(resolvedConfig?.resolve?.tsconfigPaths).toBe(true);
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it("materializes simple tsconfig path aliases into resolve.alias on Vite 8", async () => {
@@ -115,8 +121,6 @@ describe("Vite tsconfig paths support", () => {
     expect(alias["@"]).toBeDefined();
     expect(path.isAbsolute(alias["@"])).toBe(true);
     expect(alias["@"].replace(/\\/g, "/")).toContain(root.replace(/\\/g, "/"));
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it("materializes path aliases inherited via tsconfig extends on Vite 8", async () => {
@@ -168,8 +172,6 @@ describe("Vite tsconfig paths support", () => {
         "@": "/src",
       }),
     );
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it("does not override user-defined resolve.tsconfigPaths on Vite 8", async () => {
@@ -191,8 +193,6 @@ describe("Vite tsconfig paths support", () => {
     );
 
     expect(resolvedConfig?.resolve?.tsconfigPaths).toBeUndefined();
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it("uses bundled Vite version from npm alias packages", async () => {
@@ -221,8 +221,6 @@ describe("Vite tsconfig paths support", () => {
     );
 
     expect(resolvedConfig?.resolve?.tsconfigPaths).toBe(true);
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it("falls back to Vite 7 for npm alias packages without bundled versions", async () => {
@@ -240,7 +238,5 @@ describe("Vite tsconfig paths support", () => {
     expect(warn).toHaveBeenCalledWith(
       "[vinext] Could not determine Vite major version from @voidzero-dev/vite-plus-core; assuming Vite 7",
     );
-
-    fs.rmSync(root, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## What

Moves the temp-directory cleanup in `tsconfig-paths-vite8.test.ts` out of each test body and into `afterEach`, after the cwd is restored, so the removal no longer fails on Windows.

## Why

Each test does `process.chdir(root)` into its temp project, then removes it inline with `fs.rmSync(root, { recursive: true, force: true })` while the cwd is still inside `root`. Windows refuses to delete a directory that is a process's current working directory, so every test failed at cleanup with:

```
EPERM, Permission denied: \\?\C:\Users\…\Temp\vinext-vite-major-XXXX
```

The assertions themselves all passed — only the teardown threw. `force: true` doesn't help: it suppresses `ENOENT`, not `EPERM` from the cwd lock. POSIX allows unlinking the cwd, so the tests passed there.

## How

Track the created dir in a module-level `createdRoot`, and remove it in `afterEach` — which already calls `process.chdir(originalCwd)` first, so the cwd lock is released before `rmSync` runs. The seven inline `fs.rmSync(root, …)` calls are deleted. A comment records the Windows cwd-lock reason.

## Testing

`vp test run --project unit tests/tsconfig-paths-vite8.test.ts` — 7/7 pass on Windows (previously all 7 failed in teardown). POSIX behavior is unchanged (cleanup still runs, just from `afterEach`). `vp check` clean.
