### PR TITLE
chore(test): keep local deploy-suite output readable

### DIFF
--- a/scripts/run-nextjs-deploy-suite.sh
+++ b/scripts/run-nextjs-deploy-suite.sh
@@ -8,6 +8,8 @@
 #
 # Environment variables:
 #   VINEXT_BUILD=0     Skip building vinext (if already built)
+#   VINEXT_DEPLOY_SUITE_QUIET=0  Disable local output filtering
+#   VINEXT_DEPLOY_SUITE_RAW_LOG=/path/to/log  Override local unfiltered log path
 #   NEXTJS_PREPARE=1   Install + build Next.js and Playwright
 #   NEXTJS_PREPARE_ONLY=1  Prepare Next.js and exit (don't run tests)
 #   NEXT_TEST_GROUP    Shard group (e.g. "1/16")
@@ -107,7 +109,30 @@ if [ "$#" -gt 0 ]; then
   RUN_ARGS+=("$@")
 fi
 
-(
-  cd "${NEXTJS_DIR}"
-  node run-tests.js "${RUN_ARGS[@]}"
-)
+run_nextjs_tests() {
+  (
+    cd "${NEXTJS_DIR}"
+    node run-tests.js "${RUN_ARGS[@]}"
+  )
+}
+
+should_filter_output() {
+  if [ -n "${VINEXT_DEPLOY_SUITE_QUIET:-}" ]; then
+    [ "${VINEXT_DEPLOY_SUITE_QUIET}" != "0" ]
+    return
+  fi
+
+  [ -z "${CI:-}" ]
+}
+
+if should_filter_output; then
+  RAW_LOG="${VINEXT_DEPLOY_SUITE_RAW_LOG:-${TMPDIR:-/tmp}/vinext-nextjs-deploy-suite.$$.log}"
+  echo ">>> writing unfiltered deploy-suite output to ${RAW_LOG}" >&2
+
+  run_nextjs_tests 2>&1 | tee "${RAW_LOG}" | perl -ne '
+    next if /^\[\d{2}:\d{2}:\d{2}\.\d{3}Z\] Browser Log: Failed to load resource:/;
+    print;
+  '
+else
+  run_nextjs_tests
+fi


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Keep local Next.js deploy-suite debug runs readable. |
| Core change | Filter repeated timestamped `Browser Log: Failed to load resource:` lines outside CI by default. |
| Raw logs | Local quiet runs write the unfiltered stream to `${TMPDIR:-/tmp}/vinext-nextjs-deploy-suite.<pid>.log` unless overridden. |
| CI impact | No default CI behavior change because filtering is disabled when `CI` is set. |
| Issue | Closes #2094. |

## Why

The deploy-suite wrapper is the right boundary for local triage noise. Playwright should still collect browser logs internally, and CI should keep raw output by default, but local debug runs should not bury the actionable Jest failure summary under repeated resource-load browser console messages.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Local deploy-suite run | Every timestamped browser resource-load log printed to the terminal. | Those specific lines are filtered from terminal output and preserved in a raw local log. |
| CI deploy-suite run | Raw stream printed directly. | Raw stream still prints directly unless `VINEXT_DEPLOY_SUITE_QUIET=1` is explicitly set. |
| Exit code | `run-tests.js` exit code drives the script. | The pipeline preserves the `run-tests.js` exit code through `pipefail`. |

<details>
<summary>Validation</summary>

- `bash -n scripts/run-nextjs-deploy-suite.sh`
- Fake `run-tests.js` smoke with `VINEXT_BUILD=0 VINEXT_DEPLOY_SUITE_RAW_LOG=/tmp/vinext-quiet-smoke.log ./scripts/run-nextjs-deploy-suite.sh <tmp-nextjs> --debug` verified:
- filtered output kept ordinary browser logs and failure lines
- raw log kept the suppressed resource-load line
- script returned the fake runner exit code `3`

</details>

<details>
<summary>Non-goals</summary>

- Does not change Next.js Playwright browser log collection.
- Does not filter CI logs by default.
- Does not change the deploy-suite test manifest or runner arguments.

</details>
