### PR TITLE
fix(router): preserve soft history traversal snapshots

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -369,7 +369,7 @@ function restoreHistoryStateSnapshot(historyState: unknown): boolean {
   });
   if (!restored) return false;
 
-  commitClientNavigationState();
+  commitClientNavigationState(navId);
   return true;
 }
 
@@ -2290,39 +2290,38 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       restorePopstateScrollPosition(event.state);
       return;
     }
-    handlePopstate(event);
-    // Synchronous snapshot restore supersedes the in-flight async RSC traverse.
-    //
-    // handlePopstate calls navigate() which starts an async RSC traversal:
-    // renderNavigationPayload captures startedState (visibleCommitVersion N)
-    // and awaits nextElements, yielding at least one microtask.
-    //
-    // restoreHistoryStateSnapshot runs synchronously (flushSync, no await) in
-    // the same task, commits the cached history snapshot, and bumps
-    // visibleCommitVersion to N+1.
-    //
-    // When the async traverse resolves,
-    // resolvePendingNavigationCommitDispositionDecision sees
-    // startedVisibleCommitVersion (N) !== currentState.visibleCommitVersion
-    // (N+1) and returns staleOperation → no-commit, discarding the fresh
-    // RSC payload in favor of the cached client snapshot.
-    //
-    // This matches Next's in-memory bfcache behaviour (no refetch on back).
-    // The ordering is deterministic only because restoreHistoryStateSnapshot
-    // is synchronous while the async traverse always yields.
-    if (restoreHistoryStateSnapshot(event.state)) {
-      restoreSynchronousPopstateScrollPosition(
-        {
-          getActiveNavigationId: () => browserNavigationController.getActiveNavigationId(),
-          isCurrentNavigation: (navId) => browserNavigationController.isCurrentNavigation(navId),
-          markScrollRestoreConsumed: (navId) => {
-            synchronousPopstateScrollRestoreNavigationId = navId;
+    // A restorable history entry already has the exact App Router tree the user
+    // saw at that history index. Consume it synchronously before starting any
+    // RSC traversal. Starting the async traversal first lets it resume after the
+    // snapshot restore, capture the restored tree as its fresh base, and then
+    // overwrite the restored dynamic content with a new server render.
+    const synchronousRestoreNavId = browserNavigationController.beginNavigation();
+    discardedServerActionRefreshScheduler.markNavigationStart();
+    let restoredHistorySnapshot = false;
+    try {
+      restoredHistorySnapshot = restoreHistoryStateSnapshot(event.state);
+      if (restoredHistorySnapshot) {
+        notifyAppRouterTransitionStart(href, "traverse");
+        window.__VINEXT_RSC_PENDING__ = null;
+        restoreSynchronousPopstateScrollPosition(
+          {
+            getActiveNavigationId: () => browserNavigationController.getActiveNavigationId(),
+            isCurrentNavigation: (navId) => browserNavigationController.isCurrentNavigation(navId),
+            markScrollRestoreConsumed: (navId) => {
+              synchronousPopstateScrollRestoreNavigationId = navId;
+            },
+            restorePopstateScrollPosition,
           },
-          restorePopstateScrollPosition,
-        },
-        event.state,
-      );
+          event.state,
+        );
+        browserNavigationController.finalizeNavigation(synchronousRestoreNavId, null);
+        return;
+      }
+    } finally {
+      discardedServerActionRefreshScheduler.markNavigationSettled();
     }
+
+    handlePopstate(event);
   });
 
   if (import.meta.hot) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1688,6 +1688,11 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
 
   let activeNavigationAbortController: AbortController | null = null;
 
+  function abortSupersededNavigation(): void {
+    activeNavigationAbortController?.abort();
+    activeNavigationAbortController = null;
+  }
+
   const navigateRsc: NavigationRuntimeNavigate = async function navigateRsc(
     href: string,
     redirectDepth = 0,
@@ -1699,7 +1704,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     scrollIntent?: AppRouterScrollIntent | null,
     visibleCommitMode: NavigationRuntimeVisibleCommitMode = "transition",
   ): Promise<void> {
-    activeNavigationAbortController?.abort();
+    abortSupersededNavigation();
     const navigationAbortController = new AbortController();
     activeNavigationAbortController = navigationAbortController;
     let pendingRouterState: PendingBrowserRouterState | null = null;
@@ -2301,6 +2306,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     try {
       restoredHistorySnapshot = restoreHistoryStateSnapshot(event.state);
       if (restoredHistorySnapshot) {
+        // The in-flight RSC request (if any) is logically superseded by the
+        // synchronous history restore. Cancel it so the browser does not keep
+        // streaming work that can no longer commit.
+        abortSupersededNavigation();
         notifyAppRouterTransitionStart(href, "traverse");
         window.__VINEXT_RSC_PENDING__ = null;
         restoreSynchronousPopstateScrollPosition(

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -351,7 +351,16 @@ function waitForRscHmrSettle(delayMs = RSC_HMR_SETTLE_DELAY_MS): Promise<void> {
   });
 }
 
-function restoreHistoryStateSnapshot(historyState: unknown): boolean {
+// `onApprovedBeforeCommit` fires inside the restore's `beforeCommit` seam: only
+// once the visible restore is approved, and before the synchronous visible
+// commit. Callers use it to emit the App Router transition-start notification so
+// instrumentation sees "start" before the tree moves — matching the async
+// traverse path (notify before navigate) — without double-firing when a restore
+// is rejected as stale.
+function restoreHistoryStateSnapshot(
+  historyState: unknown,
+  onApprovedBeforeCommit?: () => void,
+): boolean {
   const navId = browserNavigationController.getActiveNavigationId();
   let restored = false;
   flushSync(() => {
@@ -360,7 +369,10 @@ function restoreHistoryStateSnapshot(historyState: unknown): boolean {
       stageClientParams,
       approveVisibleRestore: ({ state, beforeCommit }) =>
         browserNavigationController.restoreHistorySnapshotVisibleState({
-          beforeCommit,
+          beforeCommit: () => {
+            onApprovedBeforeCommit?.();
+            beforeCommit();
+          },
           navId,
           state,
           targetHref: window.location.href,
@@ -2304,13 +2316,18 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     discardedServerActionRefreshScheduler.markNavigationStart();
     let restoredHistorySnapshot = false;
     try {
-      restoredHistorySnapshot = restoreHistoryStateSnapshot(event.state);
+      // Fire transition-start from the restore's approved-before-commit seam so
+      // instrumentation observes "start" before the visible tree moves, mirroring
+      // the async traverse path. Firing it here (after the synchronous restore had
+      // already committed) reported the start late.
+      restoredHistorySnapshot = restoreHistoryStateSnapshot(event.state, () => {
+        notifyAppRouterTransitionStart(href, "traverse");
+      });
       if (restoredHistorySnapshot) {
         // The in-flight RSC request (if any) is logically superseded by the
         // synchronous history restore. Cancel it so the browser does not keep
         // streaming work that can no longer commit.
         abortSupersededNavigation();
-        notifyAppRouterTransitionStart(href, "traverse");
         window.__VINEXT_RSC_PENDING__ = null;
         restoreSynchronousPopstateScrollPosition(
           {

--- a/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/navigation.spec.ts
@@ -208,6 +208,50 @@ test.describe("Next.js compat: navigation (browser)", () => {
     await expect(page.locator("#link-test-page")).toHaveText("Link Test Page", { timeout: 10_000 });
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/index.test.ts
+  test("Link back navigation is soft and restores the server-rendered tree", async ({ page }) => {
+    await page.goto(`${BASE}/with-id`);
+    await waitForAppRouterHydration(page);
+
+    const firstID = await page.locator("#render-id").textContent();
+
+    await page.locator("#link").click();
+    await expect(page.locator("#from-navigation")).toHaveText("hello from /navigation", {
+      timeout: 10_000,
+    });
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/with-id`);
+
+    const secondID = await page.locator("#render-id").textContent();
+    expect(firstID).toBe(secondID);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/index.test.ts
+  test("Link forward navigation is soft and restores the server-rendered tree", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/with-id`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#link").click();
+    await expect(page.locator("#from-navigation")).toHaveText("hello from /navigation", {
+      timeout: 10_000,
+    });
+
+    const firstID = await page.locator("#render-id").textContent();
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${BASE}/with-id`);
+    await page.goForward();
+    await expect(page).toHaveURL(`${BASE}/navigation`);
+
+    const secondID = await page.locator("#render-id").textContent();
+    expect(firstID).toBe(secondID);
+  });
+
   test("Link onNavigate reports the resolved URL for relative query hrefs", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/nav-link-test`);
     await waitForAppRouterHydration(page);

--- a/tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts
@@ -40,6 +40,7 @@ async function writeSoftHistoryFixture(fixtureRoot: string): Promise<void> {
   await linkFixtureNodeModules(fixtureRoot);
   await fs.mkdir(path.join(appDir, "with-id"), { recursive: true });
   await fs.mkdir(path.join(appDir, "navigation"), { recursive: true });
+  await fs.mkdir(path.join(appDir, "slow"), { recursive: true });
   await fs.mkdir(path.join(fixtureRoot, "node_modules", "nanoid"), { recursive: true });
 
   await fs.writeFile(
@@ -103,15 +104,36 @@ export default function Page() {
   );
   await fs.writeFile(
     path.join(appDir, "navigation", "page.tsx"),
-    `import { nanoid } from "nanoid";
+    `import Link from "next/link";
+import { nanoid } from "nanoid";
 
 export default function Page() {
   return (
     <>
       <h1 id="render-id">{nanoid()}</h1>
       <h2 id="from-navigation">hello from /navigation</h2>
+      <Link href="/slow" id="link-to-slow" prefetch={false}>
+        To Slow
+      </Link>
     </>
   );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "slow", "page.tsx"),
+    `export const revalidate = 0;
+
+async function getData() {
+  // Intentionally stall so the RSC request is still in flight when the test
+  // traverses back to the previous history entry.
+  await new Promise((resolve) => setTimeout(resolve, 30_000));
+  return { id: "slow-page" };
+}
+
+export default async function Page() {
+  const { id } = await getData();
+  return <h1 id="render-id">{id}</h1>;
 }
 `,
   );
@@ -228,6 +250,57 @@ test.describe("Next.js compat: production Link history navigation", () => {
 
     const secondID = await page.locator("#render-id").textContent();
     expect(firstID).toBe(secondID);
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("aborts superseded in-flight RSC request on soft back navigation", async ({
+    page,
+    productionApp,
+    consoleErrors,
+  }) => {
+    // Observe the RSC request for /slow so we can detect when it is captured
+    // and when it is later cancelled.
+    let slowRequestCaptured = false;
+    let slowRequestAborted = false;
+    page.on("request", (request) => {
+      if (request.url().includes("/slow")) {
+        slowRequestCaptured = true;
+      }
+    });
+    page.on("requestfailed", (request) => {
+      if (request.url().includes("/slow")) {
+        slowRequestAborted = true;
+      }
+    });
+
+    await page.goto(`${productionApp.baseUrl}/with-id`);
+    await waitForAppRouterHydration(page);
+
+    const firstID = await page.locator("#render-id").textContent();
+
+    // Establish a second history entry so we can traverse back while another
+    // RSC request is still in flight.
+    await page.locator("#link").click();
+    await expect(page.locator("#from-navigation")).toHaveText("hello from /navigation", {
+      timeout: 10_000,
+    });
+
+    // Start navigating to /slow; its RSC response intentionally hangs. The URL
+    // stays on /navigation until the response arrives, so going back returns to
+    // the /with-id history entry.
+    await page.locator("#link-to-slow").click();
+    await expect.poll(() => slowRequestCaptured).toBe(true);
+
+    // Traverse back before the slow response can arrive.
+    await page.goBack();
+    await expect(page).toHaveURL(`${productionApp.baseUrl}/with-id`);
+
+    // The superseded RSC request must be cancelled, not merely prevented from committing.
+    await expect.poll(() => slowRequestAborted).toBe(true);
+
+    // The restored snapshot must still be the original dynamic output.
+    const secondID = await page.locator("#render-id").textContent();
+    expect(secondID).toBe(firstID);
     expect(consoleErrors).toEqual([]);
   });
 });

--- a/tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test as base } from "../../fixtures";
+import { waitForAppRouterHydration } from "../../helpers";
+
+type ProductionApp = {
+  baseUrl: string;
+};
+
+async function closeServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await closed;
+}
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+
+  await fs.mkdir(targetNodeModules, { recursive: true });
+
+  for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+    if (entry.name === ".vite-temp") continue;
+
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+async function writeSoftHistoryFixture(fixtureRoot: string): Promise<void> {
+  const appDir = path.join(fixtureRoot, "app");
+
+  await linkFixtureNodeModules(fixtureRoot);
+  await fs.mkdir(path.join(appDir, "with-id"), { recursive: true });
+  await fs.mkdir(path.join(appDir, "navigation"), { recursive: true });
+  await fs.mkdir(path.join(fixtureRoot, "node_modules", "nanoid"), { recursive: true });
+
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(fixtureRoot, "node_modules", "nanoid", "package.json"),
+    `${JSON.stringify({ name: "nanoid", type: "module", exports: "./index.js" }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(fixtureRoot, "node_modules", "nanoid", "index.js"),
+    `export function nanoid() {
+  return Math.random().toString(36).slice(2);
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "layout.tsx"),
+    `import { use, type ReactNode } from "react";
+
+export const revalidate = 0;
+
+async function getData() {
+  return {
+    world: "world",
+  };
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  const { world } = use(getData());
+
+  return (
+    <html className="this-is-the-document-html">
+      <head>
+        <title>{\`hello \${world}\`}</title>
+        <link rel="icon" href="data:," />
+      </head>
+      <body className="this-is-the-document-body">{children}</body>
+    </html>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "with-id", "page.tsx"),
+    `import Link from "next/link";
+import { nanoid } from "nanoid";
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="render-id">{nanoid()}</h1>
+      <Link href="/navigation" id="link">
+        To Navigation
+      </Link>
+    </>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "navigation", "page.tsx"),
+    `import { nanoid } from "nanoid";
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="render-id">{nanoid()}</h1>
+      <h2 id="from-navigation">hello from /navigation</h2>
+    </>
+  );
+}
+`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});
+`,
+  );
+}
+
+async function buildAndServeSoftHistoryFixture(): Promise<{
+  fixtureRoot: string;
+  server: Server;
+  app: ProductionApp;
+}> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-soft-history-"));
+  await writeSoftHistoryFixture(fixtureRoot);
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const { startProdServer } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/server/prod-server.js")).href
+  );
+  const started = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir: path.join(fixtureRoot, "dist"),
+    noCompression: true,
+  });
+
+  return {
+    fixtureRoot,
+    server: started.server,
+    app: {
+      baseUrl: `http://127.0.0.1:${started.port}`,
+    },
+  };
+}
+
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks -- Playwright fixture `use`, not a React hook */
+const test = base.extend<{ productionApp: ProductionApp }>({
+  productionApp: async ({ page }, use) => {
+    const { fixtureRoot, server, app } = await buildAndServeSoftHistoryFixture();
+
+    try {
+      await use(app);
+    } finally {
+      await page.close();
+      await closeServer(server);
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  },
+});
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
+
+test.setTimeout(90_000);
+
+test.describe("Next.js compat: production Link history navigation", () => {
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/index.test.ts
+  test("should be soft for back navigation", async ({ page, productionApp, consoleErrors }) => {
+    await page.goto(`${productionApp.baseUrl}/with-id`);
+    await waitForAppRouterHydration(page);
+
+    const firstID = await page.locator("#render-id").textContent();
+
+    await page.locator("#link").click();
+    await expect(page.locator("#from-navigation")).toHaveText("hello from /navigation", {
+      timeout: 10_000,
+    });
+    await page.goBack();
+    await expect(page).toHaveURL(`${productionApp.baseUrl}/with-id`);
+
+    const secondID = await page.locator("#render-id").textContent();
+    expect(firstID).toBe(secondID);
+    expect(consoleErrors).toEqual([]);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/index.test.ts
+  test("should be soft for forward navigation", async ({ page, productionApp, consoleErrors }) => {
+    await page.goto(`${productionApp.baseUrl}/with-id`);
+    await waitForAppRouterHydration(page);
+
+    await page.locator("#link").click();
+    await expect(page.locator("#from-navigation")).toHaveText("hello from /navigation", {
+      timeout: 10_000,
+    });
+
+    const firstID = await page.locator("#render-id").textContent();
+
+    await page.goBack();
+    await expect(page).toHaveURL(`${productionApp.baseUrl}/with-id`);
+    await page.goForward();
+    await expect(page).toHaveURL(`${productionApp.baseUrl}/navigation`);
+
+    const secondID = await page.locator("#render-id").textContent();
+    expect(firstID).toBe(secondID);
+    expect(consoleErrors).toEqual([]);
+  });
+});

--- a/tests/fixtures/app-basic/app/navigation/page.tsx
+++ b/tests/fixtures/app-basic/app/navigation/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <>
+      <h1 id="render-id">{Math.random().toString(36).slice(2)}</h1>
+      <h2 id="from-navigation">hello from /navigation</h2>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/with-id/page.tsx
+++ b/tests/fixtures/app-basic/app/with-id/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="render-id">{Math.random().toString(36).slice(2)}</h1>
+      <Link href="/navigation" id="link">
+        To Navigation
+      </Link>
+    </>
+  );
+}


### PR DESCRIPTION
## Overview

| Field | Detail |
| --- | --- |
| Goal | Match Next.js soft back and forward App Router traversal for previously visited server-rendered trees. |
| Core change | Consume restorable vinext history snapshots synchronously before starting an async RSC traversal. |
| Main boundary | Browser App Router `popstate` handling and in-memory history snapshot restoration. |
| Primary files | `packages/vinext/src/server/app-browser-entry.ts`, `tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts` |
| Expected impact | Back and forward navigation restores the original history entry instead of re-rendering dynamic server output. |

## Why

A browser history entry that vinext can restore already contains the exact App Router tree the user saw at that history index. Starting a server traversal before consuming that snapshot lets the traversal resume after the synchronous restore, treat the restored tree as its current base, and overwrite it with a fresh dynamic render.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| App Router history | A restorable history entry owns the visible tree for that traversal. | Restores the snapshot first and skips the async traversal when restore succeeds. |
| Navigation ordering | A navigation id must guard visible commits against older in-flight work. | Gives the synchronous restore its own navigation id and finalizes it. |
| Next.js parity | Back and forward traversal should reuse the history tree when available. | Ports the upstream soft back and forward assertions and adds production coverage for `revalidate = 0`. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `popstate` to a restorable App Router history entry | Started async RSC traversal, then restored the snapshot. Dynamic routes could be overwritten by the later server response. | Attempts snapshot restore first. A successful restore updates scroll and returns without RSC traversal. |
| Failed snapshot restore | Existing async traversal path handled the navigation. | Same fallback path is preserved. |
| Soft back and forward tests | No vinext coverage for the upstream `/with-id` dynamic render-id contract in production. | Adds dev compat coverage plus a production regression fixture that reproduces the deploy-suite failure. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-browser-entry.ts`
   - Review `restoreHistoryStateSnapshot()` and the `popstate` handler ordering.
   - Confirm successful restores own a nav id, clear pending RSC state, restore scroll, finalize, and return.
   - Confirm failed restores still fall through to `handlePopstate(event)`.
2. `tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts`
   - Review the production fixture shape: root layout `revalidate = 0`, nondeterministic `nanoid`, `/with-id`, and `/navigation`.
3. `tests/e2e/app-router/nextjs-compat/navigation.spec.ts`
   - Review the lighter dev browser port of the upstream assertions.

</details>

<details>
<summary>Validation</summary>

- `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific pnpm exec playwright test tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts --retries=0`
  - 2 passed.
- `PLAYWRIGHT_PROJECT=app-router pnpm exec playwright test tests/e2e/app-router/nextjs-compat/navigation.spec.ts -g "Link (back|forward) navigation is soft" --retries=0`
  - 2 passed.
- `vp test run tests/app-browser-history-controller.test.ts tests/app-browser-entry.test.ts -t "history|restore|popstate|bfcache"`
  - 57 passed, 157 skipped.
- `vp check packages/vinext/src/server/app-browser-entry.ts tests/e2e/app-router/nextjs-compat/navigation.spec.ts tests/e2e/app-router/nextjs-compat/soft-history-production.browser.spec.ts tests/fixtures/app-basic/app/navigation/page.tsx tests/fixtures/app-basic/app/with-id/page.tsx`
  - Formatting, lint, and type checks passed for the changed files.
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-dir/app/index.test.ts`
  - The full upstream file still exits nonzero on unrelated existing failures.
  - The candidate cases are now `passed` in `index.test.ts.results.json`:
    - `app dir - basic <Link /> should be soft for back navigation`
    - `app dir - basic <Link /> should be soft for forward navigation`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API impact: none.
- Config impact: none.
- Runtime impact: App Router browser `popstate` now prefers a valid in-memory history snapshot over a fresh RSC traversal, matching the intended soft history semantics.
- RSC/cache impact: failed snapshot restores still use the existing traversal path. Server action revalidation and HMR cache clearing are unchanged.
- Existing app risk: low. The changed path applies only when vinext already has a restorable history snapshot for the target entry.

</details>

<details>
<summary>Non-goals</summary>

- Does not address unrelated upstream deploy-suite failures in `app/index.test.ts`, including same-layout rerender, loading initial HTML, template component, or bootstrap script parity.
- Does not change Pages Router history handling.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js soft back and forward tests](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/index.test.ts#L769-L806) | Source assertions ported by this PR. |
| [Next.js `/with-id` fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/app/with-id/page.js#L1-L13) | Uses nondeterministic server output to prove history restoration instead of re-render. |
| [Next.js root layout uses `revalidate = 0`](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/app/layout.js#L1-L25) | This dynamic layout condition reproduced the deploy-suite failure locally. |
| [Next.js App Router `popstate` restore dispatch](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/app-router.tsx#L350-L371) | Shows App Router history entries dispatch restore/traverse from the stored history state. |
| [Next.js restore reducer uses `FreshnessPolicy.HistoryTraversal`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts#L17-L87) | Confirms history traversal is a distinct freshness mode that restores from existing client state when available. |
