### PR TITLE
fix(router): dedupe gssp data navigations

### DIFF
--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -148,20 +148,14 @@ export function hasNamedExport(code: string, name: string): boolean {
 export function hasExportedName(code: string, name: string): boolean {
   const program = parseRouteModule(code);
   if (!program) return false;
-
-  for (const node of program.body) {
-    if (node.type !== "ExportNamedDeclaration") continue;
-    if (node.exportKind === "type") continue;
-    if (declarationHasBindingName(node.declaration, name)) return true;
-    for (const specifier of node.specifiers) {
-      if (specifier.exportKind === "type") continue;
-      if (moduleExportNameValue(specifier.local) === name) return true;
-    }
-  }
-  return false;
+  return hasNamedExportInProgram(program, name);
 }
 
-function hasNamedExportInProgram(program: Program, name: string): boolean {
+function hasNamedExportInProgram(
+  program: Program,
+  name: string,
+  which: "local" | "exported" = "local",
+): boolean {
   for (const node of program.body) {
     if (node.type !== "ExportNamedDeclaration") continue;
     if (node.exportKind === "type") continue;
@@ -171,7 +165,7 @@ function hasNamedExportInProgram(program: Program, name: string): boolean {
     for (const specifier of node.specifiers) {
       if (specifier.exportKind === "type") continue;
 
-      if (moduleExportNameValue(specifier.local) === name) {
+      if (moduleExportNameValue(specifier[which]) === name) {
         return true;
       }
     }
@@ -193,24 +187,7 @@ function hasNamedExportInProgram(program: Program, name: string): boolean {
 export function hasPublicExportedName(code: string, name: string): boolean {
   const program = parseRouteModule(code);
   if (!program) return false;
-  return hasPublicExportedNameInProgram(program, name);
-}
-
-function hasPublicExportedNameInProgram(program: Program, name: string): boolean {
-  for (const node of program.body) {
-    if (node.type !== "ExportNamedDeclaration") continue;
-    if (node.exportKind === "type") continue;
-
-    if (declarationHasBindingName(node.declaration, name)) return true;
-
-    for (const specifier of node.specifiers) {
-      if (specifier.exportKind === "type") continue;
-      if (moduleExportNameValue(specifier.exported) === name) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return hasNamedExportInProgram(program, name, "exported");
 }
 
 function unwrapStaticExpression(expression: Expression): Expression {

--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -176,6 +176,40 @@ function hasNamedExportInProgram(program: Program, name: string): boolean {
   return false;
 }
 
+/**
+ * Returns true if the source code exports the given public name.
+ *
+ * Differs from `hasNamedExport` and `hasExportedName` for re-export specifiers:
+ *   export { gsp as getStaticProps } -> true for name "getStaticProps"
+ *   export { getStaticProps as gsp } -> false for name "getStaticProps"
+ *
+ * Use this when the runtime contract is "does this module expose name X?",
+ * rather than Next.js' static-analyzer convention of tracking the original
+ * local binding name.
+ */
+export function hasPublicExportedName(code: string, name: string): boolean {
+  const program = parseRouteModule(code);
+  if (!program) return false;
+  return hasPublicExportedNameInProgram(program, name);
+}
+
+function hasPublicExportedNameInProgram(program: Program, name: string): boolean {
+  for (const node of program.body) {
+    if (node.type !== "ExportNamedDeclaration") continue;
+    if (node.exportKind === "type") continue;
+
+    if (declarationHasBindingName(node.declaration, name)) return true;
+
+    for (const specifier of node.specifiers) {
+      if (specifier.exportKind === "type") continue;
+      if (moduleExportNameValue(specifier.exported) === name) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function unwrapStaticExpression(expression: Expression): Expression {
   let current = expression;
   while (

--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -164,10 +164,13 @@ export function hasExportedName(code: string, name: string): boolean {
 function hasNamedExportInProgram(program: Program, name: string): boolean {
   for (const node of program.body) {
     if (node.type !== "ExportNamedDeclaration") continue;
+    if (node.exportKind === "type") continue;
 
     if (declarationHasBindingName(node.declaration, name)) return true;
 
     for (const specifier of node.specifiers) {
+      if (specifier.exportKind === "type") continue;
+
       if (moduleExportNameValue(specifier.local) === name) {
         return true;
       }

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -24,7 +24,7 @@ import type {
 } from "../client/vinext-next-data.js";
 import { findFileWithExts } from "./pages-entry-helpers.js";
 import { normalizePathSeparators } from "../utils/path.js";
-import { hasExportedName, type StaticMiddlewareMatcher } from "../build/report.js";
+import { hasPublicExportedName, type StaticMiddlewareMatcher } from "../build/report.js";
 
 /**
  * Project a Pages `Route` down to the public `VinextPagesLinkPrefetchRoute`
@@ -43,11 +43,11 @@ function toPagesLinkPrefetchRoute(route: Route): VinextPagesLinkPrefetchRoute {
 }
 
 async function hasGetStaticPropsExport(filePath: string): Promise<boolean> {
-  return hasExportedName(await readFile(filePath, "utf8"), "getStaticProps");
+  return hasPublicExportedName(await readFile(filePath, "utf8"), "getStaticProps");
 }
 
 async function hasGetServerSidePropsExport(filePath: string): Promise<boolean> {
-  return hasExportedName(await readFile(filePath, "utf8"), "getServerSideProps");
+  return hasPublicExportedName(await readFile(filePath, "utf8"), "getServerSideProps");
 }
 
 export async function generateClientEntry(

--- a/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
+++ b/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
@@ -35,7 +35,9 @@ import { getDeploymentId } from "../../utils/deployment-id.js";
 
 type InflightEntry = {
   controller: AbortController;
+  deleteOnSettle: boolean;
   promise: Promise<BufferedResponse>;
+  settled: boolean;
 };
 
 type BufferedResponse = {
@@ -127,10 +129,17 @@ export function fetchStaticPagesData(dataHref: string, init?: RequestInit): Prom
 }
 
 export function evictPagesDataCache(dataHref: string): void {
-  const key = getStaticDataKey(dataHref);
-  delete staticDataCache[key];
-  staticDataSources.delete(key);
-  inflight.delete(getInflightKey(dataHref));
+  const staticKey = getStaticDataKey(dataHref);
+  delete staticDataCache[staticKey];
+  staticDataSources.delete(staticKey);
+  const inflightKey = getInflightKey(dataHref);
+  const entry = inflight.get(inflightKey);
+  if (!entry) return;
+  if (entry.settled) {
+    inflight.delete(inflightKey);
+  } else {
+    entry.deleteOnSettle = true;
+  }
 }
 
 function getInflightKey(dataHref: string): string {
@@ -205,18 +214,25 @@ export function dedupedPagesDataFetch(
           status: response.status,
           statusText: response.statusText,
         };
-        if ((!persist || !response.ok) && inflight.get(key) === currentEntry) {
+        currentEntry.settled = true;
+        if (
+          (!persist || !response.ok || currentEntry.deleteOnSettle) &&
+          inflight.get(key) === currentEntry
+        ) {
           inflight.delete(key);
         }
         return buffered;
       })
       .catch((error: unknown) => {
+        currentEntry.settled = true;
         if (inflight.get(key) === currentEntry) inflight.delete(key);
         throw error;
       });
     currentEntry = {
       controller,
+      deleteOnSettle: false,
       promise,
+      settled: false,
     };
     inflight.set(key, currentEntry);
     entry = currentEntry;

--- a/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
+++ b/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
@@ -12,16 +12,15 @@
  * Ported from Next.js: `fetchNextData()` in
  * `packages/next/src/shared/lib/router/router.ts`. Next.js maintains an
  * `inflightCache` (keyed by the resolved data URL) and reuses the existing
- * Promise when a concurrent caller asks for the same URL. The entry is
- * dropped once the fetch settles (success or rejection) so the next
- * navigation re-fetches fresh.
+ * Promise when a concurrent caller asks for the same URL. Production prefetch
+ * entries stay cached until a real `__N_SSP` navigation consumes them; failed
+ * or uncached requests self-evict when they settle.
  *
  * Design notes:
  *
- * - Callers receive a cloned Response, so each can independently consume the
- *   body (`.json()`, `.text()`, etc.). The originating Response is never read
- *   directly by anyone, which keeps subsequent clones legal even after one
- *   caller has consumed its copy.
+ * - The shared fetch is buffered once, and callers receive a fresh `Response`
+ *   over those bytes. This mirrors Next.js' text-buffered `fetchNextData()`
+ *   cache while avoiding unread prefetch streams.
  *
  * - Each caller owns one waiter. Cancelling a waiter rejects only that caller;
  *   the shared request continues and self-evicts when it settles. This mirrors
@@ -36,9 +35,18 @@ import { getDeploymentId, NEXT_DEPLOYMENT_ID_HEADER } from "../../utils/deployme
 
 type InflightEntry = {
   controller: AbortController;
-  promise: Promise<Response>;
-  settled: boolean;
-  waiters: number;
+  promise: Promise<BufferedResponse>;
+};
+
+type BufferedResponse = {
+  body: ArrayBuffer;
+  headers: [string, string][];
+  status: number;
+  statusText: string;
+};
+
+export type PagesDataFetchInit = RequestInit & {
+  persist?: boolean;
 };
 
 /** Inflight fetch entries keyed by the resolved data request identity. */
@@ -118,13 +126,14 @@ export function fetchStaticPagesData(dataHref: string, init?: RequestInit): Prom
   return fetchCachedPagesData(dataHref, init);
 }
 
-export function evictPagesDataCache(dataHref: string): void {
+export function evictPagesDataCache(dataHref: string, init?: PagesDataFetchInit): void {
   const key = getStaticDataKey(dataHref);
   delete staticDataCache[key];
   staticDataSources.delete(key);
+  inflight.delete(getInflightKey(dataHref, init));
 }
 
-function getInflightKey(dataHref: string, init?: RequestInit): string {
+function getInflightKey(dataHref: string, init?: PagesDataFetchInit): string {
   let resolvedHref = dataHref;
   if (typeof window !== "undefined") {
     try {
@@ -136,34 +145,27 @@ function getInflightKey(dataHref: string, init?: RequestInit): string {
   return `${resolvedHref}\n${deploymentId}`;
 }
 
-function cloneSharedResponse(
-  key: string,
-  entry: InflightEntry,
-  signal?: AbortSignal,
-): Promise<Response> {
-  entry.waiters += 1;
+function responseFromBuffered(buffered: BufferedResponse): Response {
+  return new Response(buffered.body.byteLength === 0 ? undefined : buffered.body.slice(0), {
+    headers: buffered.headers,
+    status: buffered.status,
+    statusText: buffered.statusText,
+  });
+}
 
+function cloneSharedResponse(entry: InflightEntry, signal?: AbortSignal): Promise<Response> {
   return new Promise<Response>((resolve, reject) => {
-    let released = false;
-    const release = () => {
-      if (released) return;
-      released = true;
-      entry.waiters -= 1;
-    };
     const abort = () => {
-      release();
       reject(new DOMException("Aborted", "AbortError"));
     };
     signal?.addEventListener("abort", abort, { once: true });
     entry.promise.then(
-      (response) => {
+      (buffered) => {
         signal?.removeEventListener("abort", abort);
-        release();
-        resolve(response.clone());
+        resolve(responseFromBuffered(buffered));
       },
       (error: unknown) => {
         signal?.removeEventListener("abort", abort);
-        release();
         reject(error);
       },
     );
@@ -171,18 +173,22 @@ function cloneSharedResponse(
 }
 
 /**
- * Dedupe a `fetch()` against the `_next/data` endpoint. Multiple concurrent
- * callers for the same resolved URL and deployment ID share one underlying
- * network request.
+ * Dedupe a `fetch()` against the `_next/data` endpoint. Multiple callers for
+ * the same resolved URL and deployment ID share one underlying network
+ * request, including a navigation racing a completed prefetch.
  *
- * Each call returns a freshly-cloned `Response` so consumers can read the
- * body independently. Once the in-flight Promise settles (resolve or reject)
- * the entry is removed, and the next call will hit the network again.
+ * Each call returns a fresh `Response` so consumers can read the body
+ * independently. Non-persistent entries are removed once the fetch settles.
+ * Persistent entries model Next.js' `sdc` cache and should be cleared by the
+ * navigation path after consuming an `__N_SSP` response.
  *
- * Errors propagate to every concurrent caller — the in-flight entry is
- * dropped on failure so the next navigation can retry.
+ * Errors and non-OK responses propagate to every concurrent caller, but are
+ * dropped from cache so the next navigation can retry.
  */
-export function dedupedPagesDataFetch(dataHref: string, init?: RequestInit): Promise<Response> {
+export function dedupedPagesDataFetch(
+  dataHref: string,
+  init?: PagesDataFetchInit,
+): Promise<Response> {
   const key = getInflightKey(dataHref, init);
   const signal = init?.signal ?? undefined;
   if (signal?.aborted) return Promise.reject(new DOMException("Aborted", "AbortError"));
@@ -191,20 +197,32 @@ export function dedupedPagesDataFetch(dataHref: string, init?: RequestInit): Pro
   if (!entry) {
     const controller = new AbortController();
     let currentEntry: InflightEntry;
-    const promise = fetch(dataHref, { ...init, signal: controller.signal }).finally(() => {
-      currentEntry.settled = true;
-      if (inflight.get(key) === currentEntry) inflight.delete(key);
-    });
+    const { persist = false, signal: _signal, ...fetchInit } = init ?? {};
+    const promise = fetch(dataHref, { ...fetchInit, signal: controller.signal })
+      .then(async (response) => {
+        const buffered: BufferedResponse = {
+          body: await response.arrayBuffer(),
+          headers: Array.from(response.headers.entries()),
+          status: response.status,
+          statusText: response.statusText,
+        };
+        if ((!persist || !response.ok) && inflight.get(key) === currentEntry) {
+          inflight.delete(key);
+        }
+        return buffered;
+      })
+      .catch((error: unknown) => {
+        if (inflight.get(key) === currentEntry) inflight.delete(key);
+        throw error;
+      });
     currentEntry = {
       controller,
       promise,
-      settled: false,
-      waiters: 0,
     };
     inflight.set(key, currentEntry);
     entry = currentEntry;
   }
-  return cloneSharedResponse(key, entry, signal);
+  return cloneSharedResponse(entry, signal);
 }
 
 /**

--- a/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
+++ b/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
@@ -31,7 +31,7 @@
  *   browser only, so a single `Map` is sufficient.
  */
 
-import { getDeploymentId, NEXT_DEPLOYMENT_ID_HEADER } from "../../utils/deployment-id.js";
+import { getDeploymentId } from "../../utils/deployment-id.js";
 
 type InflightEntry = {
   controller: AbortController;
@@ -126,14 +126,14 @@ export function fetchStaticPagesData(dataHref: string, init?: RequestInit): Prom
   return fetchCachedPagesData(dataHref, init);
 }
 
-export function evictPagesDataCache(dataHref: string, init?: PagesDataFetchInit): void {
+export function evictPagesDataCache(dataHref: string): void {
   const key = getStaticDataKey(dataHref);
   delete staticDataCache[key];
   staticDataSources.delete(key);
-  inflight.delete(getInflightKey(dataHref, init));
+  inflight.delete(getInflightKey(dataHref));
 }
 
-function getInflightKey(dataHref: string, init?: PagesDataFetchInit): string {
+function getInflightKey(dataHref: string): string {
   let resolvedHref = dataHref;
   if (typeof window !== "undefined") {
     try {
@@ -141,12 +141,11 @@ function getInflightKey(dataHref: string, init?: PagesDataFetchInit): string {
     } catch {}
   }
 
-  const deploymentId = new Headers(init?.headers).get(NEXT_DEPLOYMENT_ID_HEADER) ?? "";
-  return `${resolvedHref}\n${deploymentId}`;
+  return `${resolvedHref}\n${getDeploymentId() ?? ""}`;
 }
 
 function responseFromBuffered(buffered: BufferedResponse): Response {
-  return new Response(buffered.body.byteLength === 0 ? undefined : buffered.body.slice(0), {
+  return new Response(buffered.body, {
     headers: buffered.headers,
     status: buffered.status,
     statusText: buffered.statusText,
@@ -189,7 +188,7 @@ export function dedupedPagesDataFetch(
   dataHref: string,
   init?: PagesDataFetchInit,
 ): Promise<Response> {
-  const key = getInflightKey(dataHref, init);
+  const key = getInflightKey(dataHref);
   const signal = init?.signal ?? undefined;
   if (signal?.aborted) return Promise.reject(new DOMException("Aborted", "AbortError"));
 

--- a/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
+++ b/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
@@ -227,7 +227,8 @@ export function dedupedPagesDataFetch(
 
 /**
  * Drop every cached in-flight entry. Intended for tests; production code
- * does not need to call this because entries self-evict on settle.
+ * does not need to call this because non-persisted entries self-evict on
+ * settle, while persisted entries are retained intentionally.
  */
 export function clearPagesDataInflight(): void {
   for (const entry of inflight.values()) entry.controller.abort();

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2109,12 +2109,11 @@ async function navigateClientData(
 
   // Fetch the page-data JSON.
   //
-  // We dedupe by URL: concurrent `Router.push` calls (or back-to-back link
-  // clicks) for the same destination share a single underlying request.
-  // The shared fetch uses `controller.signal` to release this caller's waiter.
-  // The network request stays alive while another identical navigation is
-  // waiting, and aborts once the final waiter cancels. This matches Next.js's
-  // combination of in-flight reuse and per-navigation cancellation.
+  // We dedupe by URL: a prefetched response, concurrent `Router.push` calls,
+  // and back-to-back link clicks for the same destination all share the same
+  // data promise. This matches Next.js' `sdc` cache; after consuming an
+  // `__N_SSP` payload below, or after handling a soft redirect, we delete the
+  // entry so the next navigation fetches fresh data.
   //
   // Pre-await abort still throws so callers see the documented cancellation
   // surface when supersession happened before the fetch was even attempted.
@@ -2163,6 +2162,9 @@ async function navigateClientData(
   // when middleware (or gSSP/gSP) chose a redirect for this URL.
   const softRedirect = res.headers.get("x-nextjs-redirect");
   if (softRedirect) {
+    // A redirect response must not be retained in the data cache: the
+    // redirect may be conditional on request state, and replaying it on a
+    // later navigation would skip the server decision.
     evictPagesDataCache(initialTarget.dataHref, { headers: dataFetchHeaders });
     const redirectedUrl = resolveLocalRedirectUrl(softRedirect);
     if (!redirectedUrl) {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2122,6 +2122,7 @@ async function navigateClientData(
     throw new NavigationCancelledError(url);
   }
   let res = prefetchedResponse;
+  let dataFetchHeaders: Record<string, string> | undefined;
   if (!res) {
     try {
       const headers: Record<string, string> = {
@@ -2130,12 +2131,19 @@ async function navigateClientData(
       };
       const deploymentId = getDeploymentId();
       if (deploymentId) headers[NEXT_DEPLOYMENT_ID_HEADER] = deploymentId;
-      const dataFetch =
-        initialTarget.dataKind === "static" ? fetchStaticPagesData : dedupedPagesDataFetch;
-      res = await dataFetch(initialTarget.dataHref, {
-        headers,
-        signal: controller.signal,
-      });
+      if (initialTarget.dataKind === "static") {
+        res = await fetchStaticPagesData(initialTarget.dataHref, {
+          headers,
+          signal: controller.signal,
+        });
+      } else {
+        dataFetchHeaders = headers;
+        res = await dedupedPagesDataFetch(initialTarget.dataHref, {
+          headers,
+          persist: true,
+          signal: controller.signal,
+        });
+      }
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") {
         throw new NavigationCancelledError(url);
@@ -2155,6 +2163,7 @@ async function navigateClientData(
   // when middleware (or gSSP/gSP) chose a redirect for this URL.
   const softRedirect = res.headers.get("x-nextjs-redirect");
   if (softRedirect) {
+    evictPagesDataCache(initialTarget.dataHref, { headers: dataFetchHeaders });
     const redirectedUrl = resolveLocalRedirectUrl(softRedirect);
     if (!redirectedUrl) {
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
@@ -2190,6 +2199,7 @@ async function navigateClientData(
   try {
     body = (await res.json()) as PagesDataResponse;
   } catch {
+    evictPagesDataCache(initialTarget.dataHref, { headers: dataFetchHeaders });
     scheduleHardNavigationAndThrow(url, "Data navigation failed: invalid JSON response");
   }
   assertStillCurrent();
@@ -2197,8 +2207,8 @@ async function navigateClientData(
   const props: Record<string, unknown> = isUnknownRecord(body) ? body : {};
   const rawPageProps = props.pageProps;
   const pageProps: Record<string, unknown> = isUnknownRecord(rawPageProps) ? rawPageProps : {};
-  if (initialTarget.dataKind === "server") {
-    evictPagesDataCache(initialTarget.dataHref);
+  if (initialTarget.dataKind === "server" || (isUnknownRecord(body) && body.__N_SSP === true)) {
+    evictPagesDataCache(initialTarget.dataHref, { headers: dataFetchHeaders });
   }
 
   // gSSP/gSP redirect marker. When getServerSideProps/getStaticProps returns

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2121,7 +2121,6 @@ async function navigateClientData(
     throw new NavigationCancelledError(url);
   }
   let res = prefetchedResponse;
-  let dataFetchHeaders: Record<string, string> | undefined;
   if (!res) {
     try {
       const headers: Record<string, string> = {
@@ -2136,7 +2135,6 @@ async function navigateClientData(
           signal: controller.signal,
         });
       } else {
-        dataFetchHeaders = headers;
         res = await dedupedPagesDataFetch(initialTarget.dataHref, {
           headers,
           persist: true,
@@ -2165,7 +2163,7 @@ async function navigateClientData(
     // A redirect response must not be retained in the data cache: the
     // redirect may be conditional on request state, and replaying it on a
     // later navigation would skip the server decision.
-    evictPagesDataCache(initialTarget.dataHref, { headers: dataFetchHeaders });
+    evictPagesDataCache(initialTarget.dataHref);
     const redirectedUrl = resolveLocalRedirectUrl(softRedirect);
     if (!redirectedUrl) {
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
@@ -2201,7 +2199,7 @@ async function navigateClientData(
   try {
     body = (await res.json()) as PagesDataResponse;
   } catch {
-    evictPagesDataCache(initialTarget.dataHref, { headers: dataFetchHeaders });
+    evictPagesDataCache(initialTarget.dataHref);
     scheduleHardNavigationAndThrow(url, "Data navigation failed: invalid JSON response");
   }
   assertStillCurrent();
@@ -2210,7 +2208,7 @@ async function navigateClientData(
   const rawPageProps = props.pageProps;
   const pageProps: Record<string, unknown> = isUnknownRecord(rawPageProps) ? rawPageProps : {};
   if (initialTarget.dataKind === "server" || (isUnknownRecord(body) && body.__N_SSP === true)) {
-    evictPagesDataCache(initialTarget.dataHref, { headers: dataFetchHeaders });
+    evictPagesDataCache(initialTarget.dataHref);
   }
 
   // gSSP/gSP redirect marker. When getServerSideProps/getStaticProps returns

--- a/tests/build-report.test.ts
+++ b/tests/build-report.test.ts
@@ -92,6 +92,15 @@ describe("hasNamedExport", () => {
     );
   });
 
+  it("ignores type-only export specifiers", () => {
+    expect(
+      hasNamedExport(
+        "export type { getStaticProps } from './types';\nexport default function Page() { return null; }",
+        "getStaticProps",
+      ),
+    ).toBe(false);
+  });
+
   it("detects export on a line following other code", () => {
     const code = `const x = 1;\nexport async function getStaticProps() {}`;
     expect(hasNamedExport(code, "getStaticProps")).toBe(true);
@@ -141,6 +150,15 @@ describe("hasPublicExportedName", () => {
     expect(hasPublicExportedName("export { getStaticProps as gsp };", "getStaticProps")).toBe(
       false,
     );
+  });
+
+  it("ignores type-only export specifiers", () => {
+    expect(
+      hasPublicExportedName(
+        "export type { getStaticProps } from './types';\nexport default function Page() { return null; }",
+        "getStaticProps",
+      ),
+    ).toBe(false);
   });
 
   it("returns false when export is absent", () => {

--- a/tests/build-report.test.ts
+++ b/tests/build-report.test.ts
@@ -12,6 +12,7 @@ import fs from "node:fs/promises";
 import {
   hasExportedName,
   hasNamedExport,
+  hasPublicExportedName,
   extractExportConstString,
   extractExportConstNumber,
   extractGetStaticPropsRevalidate,
@@ -105,6 +106,47 @@ describe("hasNamedExport", () => {
 export function getServerSideProps() {}
 */`;
     expect(hasNamedExport(code, "getServerSideProps")).toBe(false);
+  });
+});
+
+// ─── hasPublicExportedName ────────────────────────────────────────────────────
+
+describe("hasPublicExportedName", () => {
+  it("detects direct function declaration export", () => {
+    expect(
+      hasPublicExportedName("export async function getStaticProps() {}", "getStaticProps"),
+    ).toBe(true);
+  });
+
+  it("detects direct const declaration export", () => {
+    expect(
+      hasPublicExportedName("export const getStaticProps = async () => ({});", "getStaticProps"),
+    ).toBe(true);
+  });
+
+  it("detects re-export specifier", () => {
+    expect(hasPublicExportedName("export { getStaticProps, foo };", "getStaticProps")).toBe(true);
+  });
+
+  it("detects aliased local binding exported under the searched name", () => {
+    expect(
+      hasPublicExportedName(
+        "const gsp = async () => ({ props: {} });\nexport { gsp as getStaticProps };",
+        "getStaticProps",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not detect alias exported under a different name", () => {
+    expect(hasPublicExportedName("export { getStaticProps as gsp };", "getStaticProps")).toBe(
+      false,
+    );
+  });
+
+  it("returns false when export is absent", () => {
+    expect(hasPublicExportedName("export default function Page() {}", "getStaticProps")).toBe(
+      false,
+    );
   });
 });
 

--- a/tests/e2e/pages-router-prod/gssp-data-dedup.spec.ts
+++ b/tests/e2e/pages-router-prod/gssp-data-dedup.spec.ts
@@ -3,11 +3,30 @@ import { waitForHydration } from "../helpers";
 
 // Ported from Next.js: test/e2e/getserversideprops/test/index.test.ts
 // https://github.com/vercel/next.js/blob/canary/test/e2e/getserversideprops/test/index.test.ts
-// Covers "should dedupe server data requests" and cancellation without errors.
 
 const BASE = "http://localhost:4175";
 
 test.describe("Pages Router concurrent gSSP data navigation", () => {
+  test("repeated Link clicks share one in-flight server data request", async ({ page }) => {
+    await page.goto(`${BASE}/gssp-dedup-test?reset=1`);
+    await waitForHydration(page);
+
+    const slow = page.getByTestId("slow");
+    await slow.click();
+    await slow.click();
+    await slow.click();
+    await slow.click();
+
+    await expect(page.getByRole("heading", { name: "a slow page" })).toBeVisible();
+    await expect(page.getByTestId("hit")).toHaveText("hit: 1");
+
+    await page.goto(`${BASE}/gssp-dedup-test`);
+    await waitForHydration(page);
+    await page.getByTestId("slow").click();
+    await expect(page.getByRole("heading", { name: "a slow page" })).toBeVisible();
+    await expect(page.getByTestId("hit")).toHaveText("hit: 2");
+  });
+
   test("identical pushes share one request and a superseded request stays silent", async ({
     page,
     consoleErrors,
@@ -20,7 +39,7 @@ test.describe("Pages Router concurrent gSSP data navigation", () => {
       }
     });
 
-    await page.goto(`${BASE}/gssp-dedup-test`);
+    await page.goto(`${BASE}/gssp-dedup-test?reset=1`);
     await waitForHydration(page);
 
     await page.getByTestId("push-identical").click();
@@ -28,14 +47,14 @@ test.describe("Pages Router concurrent gSSP data navigation", () => {
     await expect(page.getByTestId("key")).toHaveText("key: same");
     expect(dataRequests.filter((url) => url.endsWith("?key=same"))).toHaveLength(1);
 
-    await page.goto(`${BASE}/gssp-dedup-test`);
+    await page.goto(`${BASE}/gssp-dedup-test?reset=1`);
     await waitForHydration(page);
     await page.getByTestId("push-distinct-query").click();
     await expect(page.getByTestId("key")).toHaveText("key: query-two");
     expect(dataRequests.filter((url) => url.endsWith("?key=query-one"))).toHaveLength(1);
     expect(dataRequests.filter((url) => url.endsWith("?key=query-two"))).toHaveLength(1);
 
-    await page.goto(`${BASE}/gssp-dedup-test`);
+    await page.goto(`${BASE}/gssp-dedup-test?reset=1`);
     await waitForHydration(page);
     await page.getByTestId("push-cancelled").click();
     await expect(page.getByTestId("normal-text")).toHaveText("a normal page");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1200,6 +1200,10 @@ describe("Pages Router entry template", () => {
         path.join(pagesDir, "local-alias.tsx"),
         "const getStaticProps = () => ({ props: {} }); export { getStaticProps as loader }; export default function Page() { return null; }",
       );
+      fs.writeFileSync(
+        path.join(pagesDir, "type-only.tsx"),
+        "export type { getStaticProps } from './types';\nexport default function Page() { return null; }",
+      );
 
       const code = await generateClientEntry(
         pagesDir,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1389,5 +1389,4 @@ describe("Pages Router entry template", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
-
 });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1207,7 +1207,7 @@ describe("Pages Router entry template", () => {
         createValidFileMatcher(),
       );
 
-      expect(code).toContain('window.__VINEXT_PAGES_SSG_PATTERNS__ = ["/local-alias","/ssg"]');
+      expect(code).toContain('window.__VINEXT_PAGES_SSG_PATTERNS__ = ["/public-alias","/ssg"]');
       expect(code).toContain('window.__VINEXT_PAGES_SSP_PATTERNS__ = ["/dynamic"]');
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -1385,4 +1385,5 @@ describe("Pages Router entry template", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
 });

--- a/tests/fixtures/pages-basic/pages/gssp-dedup-test.tsx
+++ b/tests/fixtures/pages-basic/pages/gssp-dedup-test.tsx
@@ -1,4 +1,5 @@
 import Router from "next/router";
+import Link from "next/link";
 
 const COUNTER_KEY = Symbol.for("vinext.tests.gsspDedupCounter");
 
@@ -6,6 +7,9 @@ export default function GsspDedupTest() {
   return (
     <main>
       <h1>gSSP Dedup Test</h1>
+      <Link href="/gssp-dedup-slow?key=same" data-testid="slow">
+        to slow
+      </Link>
       <button
         data-testid="push-identical"
         onClick={() => {
@@ -41,7 +45,9 @@ export default function GsspDedupTest() {
   );
 }
 
-export function getServerSideProps() {
-  (globalThis as typeof globalThis & { [COUNTER_KEY]?: number })[COUNTER_KEY] = 0;
+export function getServerSideProps({ query }: { query: Record<string, string | string[]> }) {
+  if (query.reset) {
+    (globalThis as typeof globalThis & { [COUNTER_KEY]?: number })[COUNTER_KEY] = 0;
+  }
   return { props: {} };
 }

--- a/tests/pages-data-fetch-dedup.test.ts
+++ b/tests/pages-data-fetch-dedup.test.ts
@@ -114,34 +114,23 @@ describe("dedupedPagesDataFetch", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps locale, basePath, deployment, and query request identities distinct", async () => {
-    let resolveFetch: (response: Response) => void = () => {};
-    const fetchPromise = new Promise<Response>((resolve) => {
-      resolveFetch = resolve;
-    });
-    const fetchSpy = vi.fn(() => fetchPromise);
+  it("keeps locale, basePath, and query request identities distinct", async () => {
+    const fetchSpy = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolve(new Response(JSON.stringify({ pageProps: {} })));
+        }),
+    );
     (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
 
     const requests = [
-      dedupedPagesDataFetch("/_next/data/id/about.json?tab=one", {
-        headers: { "x-deployment-id": "deployment-a" },
-      }),
-      dedupedPagesDataFetch("/_next/data/id/fr/about.json?tab=one", {
-        headers: { "x-deployment-id": "deployment-a" },
-      }),
-      dedupedPagesDataFetch("/docs/_next/data/id/about.json?tab=one", {
-        headers: { "x-deployment-id": "deployment-a" },
-      }),
-      dedupedPagesDataFetch("/_next/data/id/about.json?tab=two", {
-        headers: { "x-deployment-id": "deployment-a" },
-      }),
-      dedupedPagesDataFetch("/_next/data/id/about.json?tab=one", {
-        headers: { "x-deployment-id": "deployment-b" },
-      }),
+      dedupedPagesDataFetch("/_next/data/id/about.json?tab=one"),
+      dedupedPagesDataFetch("/_next/data/id/fr/about.json?tab=one"),
+      dedupedPagesDataFetch("/docs/_next/data/id/about.json?tab=one"),
+      dedupedPagesDataFetch("/_next/data/id/about.json?tab=two"),
     ];
 
-    expect(fetchSpy).toHaveBeenCalledTimes(5);
-    resolveFetch(new Response(JSON.stringify({ pageProps: {} })));
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
     await Promise.all(requests);
   });
 
@@ -257,7 +246,7 @@ describe("dedupedPagesDataFetch", () => {
     expect(await second.json()).toEqual({ pageProps: { count: 1 } });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-    evictPagesDataCache(url, init);
+    evictPagesDataCache(url);
     const afterEvict = await dedupedPagesDataFetch(url, { ...init, persist: true });
     expect(await afterEvict.json()).toEqual({ pageProps: { count: 2 } });
     expect(fetchSpy).toHaveBeenCalledTimes(2);

--- a/tests/pages-data-fetch-dedup.test.ts
+++ b/tests/pages-data-fetch-dedup.test.ts
@@ -12,8 +12,9 @@
  * `packages/next/src/shared/lib/router/router.ts` and the `inflightCache`
  * parameter. The first call seeds `inflightCache[cacheKey]` with the fetch
  * Promise; subsequent concurrent calls for the same key reuse that Promise
- * instead of starting a new network request. The entry is dropped once the
- * fetch settles (success or failure) so the next navigation re-fetches fresh.
+ * instead of starting a new network request. The normal navigation path drops
+ * gSSP (`__N_SSP`) entries after consuming them, while SSG prefetch entries
+ * can persist like Next.js' `sdc` cache.
  *
  * This file pins the parity fix at the helper level: concurrent calls to
  * `dedupedPagesDataFetch()` for the same URL must share a single `fetch()`
@@ -23,12 +24,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test"
 
 let dedupedPagesDataFetch: (typeof import("../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js"))["dedupedPagesDataFetch"];
 let clearPagesDataInflight: (typeof import("../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js"))["clearPagesDataInflight"];
+let evictPagesDataCache: (typeof import("../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js"))["evictPagesDataCache"];
 
 beforeEach(async () => {
   vi.resetModules();
   const mod = await import("../packages/vinext/src/shims/internal/pages-data-fetch-dedup.js");
   dedupedPagesDataFetch = mod.dedupedPagesDataFetch;
   clearPagesDataInflight = mod.clearPagesDataInflight;
+  evictPagesDataCache = mod.evictPagesDataCache;
   clearPagesDataInflight();
 });
 
@@ -230,6 +233,33 @@ describe("dedupedPagesDataFetch", () => {
 
     const res = await dedupedPagesDataFetch(url);
     expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts a persisted OK entry by request identity", async () => {
+    let fetchCount = 0;
+    const fetchSpy = vi.fn(() => {
+      fetchCount += 1;
+      return Promise.resolve(
+        new Response(JSON.stringify({ pageProps: { count: fetchCount } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const url = "/_next/data/build-id/persist.json";
+    const init = { headers: { Accept: "application/json", "x-deployment-id": "deployment-a" } };
+    const first = await dedupedPagesDataFetch(url, { ...init, persist: true });
+    const second = await dedupedPagesDataFetch(url, { ...init, persist: true });
+    expect(await first.json()).toEqual({ pageProps: { count: 1 } });
+    expect(await second.json()).toEqual({ pageProps: { count: 1 } });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    evictPagesDataCache(url, init);
+    const afterEvict = await dedupedPagesDataFetch(url, { ...init, persist: true });
+    expect(await afterEvict.json()).toEqual({ pageProps: { count: 2 } });
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/pages-data-fetch-dedup.test.ts
+++ b/tests/pages-data-fetch-dedup.test.ts
@@ -251,4 +251,46 @@ describe("dedupedPagesDataFetch", () => {
     expect(await afterEvict.json()).toEqual({ pageProps: { count: 2 } });
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps an evicted in-flight entry joinable until it settles", async () => {
+    let resolveFetch: (response: Response) => void = () => {};
+    let fetchCount = 0;
+    const fetchSpy = vi.fn(() => {
+      fetchCount += 1;
+      if (fetchCount === 1) {
+        return new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        });
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ pageProps: { attempt: fetchCount } }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const url = "/_next/data/build-id/slow.json";
+    const first = dedupedPagesDataFetch(url, { persist: true });
+    evictPagesDataCache(url);
+    const second = dedupedPagesDataFetch(url, { persist: true });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    resolveFetch(
+      new Response(JSON.stringify({ pageProps: { attempt: 1 } }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(first.then((response) => response.json())).resolves.toEqual({
+      pageProps: { attempt: 1 },
+    });
+    await expect(second.then((response) => response.json())).resolves.toEqual({
+      pageProps: { attempt: 1 },
+    });
+
+    const afterSettle = await dedupedPagesDataFetch(url, { persist: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(await afterSettle.json()).toEqual({ pageProps: { attempt: 2 } });
+  });
 });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18857,6 +18857,76 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  it("does not cache x-nextjs-redirect responses for later navigations", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+
+    const aboutLoader = vi.fn(async () => makePageModule("about"));
+    const { win, buildId } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/about": aboutLoader,
+        "/login": vi.fn(async () => makePageModule("login")),
+      },
+    });
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    function buildNavHtmlWithBuildId(page: string, pageModuleUrl: string): string {
+      const nextData = {
+        props: { pageProps: {} },
+        page,
+        query: {},
+        buildId,
+        isFallback: false,
+        __vinext: { pageModuleUrl },
+      };
+      return `<html><head></head><body><script>window.__NEXT_DATA__ = ${JSON.stringify(nextData)}</script></body></html>`;
+    }
+
+    let dataFetchCount = 0;
+    globalThis.fetch = vi.fn(async (url: any) => {
+      const urlString = String(url);
+      if (urlString.includes("/_next/data/")) {
+        dataFetchCount += 1;
+        if (dataFetchCount === 1) {
+          return new Response("{}", {
+            status: 200,
+            headers: { "Content-Type": "application/json", "x-nextjs-redirect": "/login" },
+          });
+        }
+        return new Response(JSON.stringify({ pageProps: { ok: true } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // HTML fetch for the redirect target.
+      return new Response(buildNavHtmlWithBuildId("/login", "/@fs/pages/login.js"), {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      });
+    }) as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      await Router.push("/about");
+      expect(dataFetchCount).toBe(1);
+
+      await Router.push("/about");
+      // The second navigation must perform a fresh data fetch instead of
+      // replaying the cached redirect response.
+      expect(dataFetchCount).toBe(2);
+      expect(aboutLoader).toHaveBeenCalled();
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("falls back to the HTML path when no loader is registered for the target route", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Overview

| Area | Summary |
| --- | --- |
| Goal | Match Next.js Pages Router behavior for rapid getServerSideProps client navigations. |
| Core change | Share buffered `_next/data` responses across concurrent navigations, keep cancelled requests joinable, and gate data prefetch to SSG routes. |
| Review path | `pages-data-fetch-dedup.ts` -> `pages-data-target.ts` -> `router.ts` -> tests. |
| Impact | Repeated clicks to the same gSSP Link run one server data request; later navigation fetches fresh props. |

## Why

Pages Router data navigation has two distinct contracts in Next.js: `fetchNextData()` dedupes by data URL, and `Router.prefetch()` fetches `_next/data` only for SSG pages. gSSP pages should not eagerly consume server data during prefetch, but concurrent navigations to the same gSSP URL should still share the active request.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Rapid repeated gSSP Link clicks | Multiple `_next/data` fetches could call gSSP repeatedly. | Concurrent callers share one buffered data request. |
| Cancelled data navigation | Cancelling waiters could abandon the shared request shape. | Cancellation rejects that caller while the shared request remains joinable. |
| Pages Link prefetch | gSSP routes could prefetch data too early. | Only routes exporting `getStaticProps` prefetch data; all Pages routes still warm the chunk. |
| Completed gSSP navigation | Cache lifetime did not match Next's `__N_SSP` clearing point. | `__N_SSP` entries clear after successful consumption so the next navigation fetches fresh props. |

<details>
<summary>Validation</summary>

- `vp test run tests/pages-data-fetch-dedup.test.ts tests/pages-data-prefetch.test.ts`
- `CI=1 PLAYWRIGHT_PROJECT=pages-router-prod vp env exec --node 24 pnpm run test:e2e tests/e2e/pages-router-prod/gssp-data-dedup.spec.ts`
- `vp check`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/getserversideprops/test/index.test.ts`
  - Selected block now passes: `should not trigger an error when a data request is cancelled due to another navigation`, `should dedupe server data requests`.
  - Remaining failures are out of scope: 404 client-transition visibility, non-GSSP `__NEXT_DATA__.gssp`, invalid JSON GSSP handling.
- Pre-commit: `tests/entry-templates.test.ts`, staged checks, full check, staged tests, knip.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js gSSP e2e test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/getserversideprops/test/index.test.ts) | Source behavior for repeated `#slow` clicks and expected `hit: 1` then `hit: 2`. |
| [Next.js `fetchNextData`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts#L465-L603) | Defines the in-flight data cache and cancellation-independent fetch promise. |
| [Next.js `Router.prefetch`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts#L2183-L2350) | Shows data prefetch is gated on SSG via `pageLoader._isSsg(route)`. |
