### PR TITLE
fix(fonts): parse font transforms with AST

### DIFF
--- a/packages/vinext/src/plugins/ast-utils.ts
+++ b/packages/vinext/src/plugins/ast-utils.ts
@@ -95,8 +95,42 @@ export function collectBindingNames(pattern: unknown, target: Set<string>): void
   }
 }
 
+// `var` is function-scoped: a `var` declared inside nested blocks/loops/switch/
+// catch belongs to the nearest enclosing function (or the module/program), not
+// the block. Collect those hoisted `var` names without crossing into nested
+// function scopes (whose own `var`s belong to them) or claiming block-scoped
+// `let`/`const`/`class`.
+function collectHoistedVars(node: AstRecord, target: Set<string>): void {
+  if (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "ClassDeclaration" ||
+    node.type === "ClassExpression"
+  ) {
+    return;
+  }
+  if (node.type === "VariableDeclaration") {
+    if (node.kind === "var") {
+      for (const decl of nodeArray(node.declarations)) {
+        if (isAstRecord(decl)) collectBindingNames(decl.id, target);
+      }
+    }
+    return;
+  }
+  forEachAstChild(node, (child) => collectHoistedVars(child, target));
+}
+
 export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
   const bindings = new Set<string>();
+
+  // Only function/program scopes own hoisted `var`s. A block scope leaves its
+  // nested `var`s to the enclosing function.
+  const isFunctionScope =
+    scopeNode.type === "FunctionDeclaration" ||
+    scopeNode.type === "FunctionExpression" ||
+    scopeNode.type === "ArrowFunctionExpression" ||
+    scopeNode.type === "Program";
 
   // 1. Collect parameters if scopeNode is a function
   if (
@@ -159,7 +193,10 @@ export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
       return; // Expression bindings do not declare anything in the outer scope.
     }
 
-    // ponytail: nested block scopes, catch, switch, loops are separate lexical scopes, so block-scoped variables (const/let) inside them do not belong to the outer scope
+    // Nested block scopes, catch, switch, and loops are separate lexical scopes:
+    // their `let`/`const`/`class`/function declarations do not belong to the
+    // outer scope. But `var` is function-scoped, so a function/program scope
+    // must still descend to collect hoisted `var`s from them.
     if (
       node.type === "BlockStatement" ||
       node.type === "CatchClause" ||
@@ -168,6 +205,7 @@ export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
       node.type === "ForOfStatement" ||
       node.type === "SwitchStatement"
     ) {
+      if (isFunctionScope) collectHoistedVars(node, bindings);
       return;
     }
 

--- a/packages/vinext/src/plugins/ast-utils.ts
+++ b/packages/vinext/src/plugins/ast-utils.ts
@@ -183,52 +183,17 @@ export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
     forEachAstChild(node, walk);
   }
 
-  if (
-    scopeNode.type === "FunctionDeclaration" ||
-    scopeNode.type === "FunctionExpression" ||
-    scopeNode.type === "ArrowFunctionExpression"
-  ) {
-    if (isAstRecord(scopeNode.body)) {
-      if (scopeNode.body.type === "BlockStatement") {
-        for (const stmt of nodeArray(scopeNode.body.body)) {
-          if (isAstRecord(stmt)) walk(stmt);
-        }
-      } else {
-        walk(scopeNode.body);
-      }
-    }
-  } else if (scopeNode.type === "BlockStatement") {
-    for (const stmt of nodeArray(scopeNode.body)) {
+  const body = scopeNode.body;
+  if (isAstRecord(body) && body.type === "BlockStatement") {
+    for (const stmt of nodeArray(body.body)) {
       if (isAstRecord(stmt)) walk(stmt);
     }
-  } else if (scopeNode.type === "CatchClause") {
-    if (isAstRecord(scopeNode.body)) {
-      if (scopeNode.body.type === "BlockStatement") {
-        for (const stmt of nodeArray(scopeNode.body.body)) {
-          if (isAstRecord(stmt)) walk(stmt);
-        }
-      } else {
-        walk(scopeNode.body);
-      }
-    }
-  } else if (
-    scopeNode.type === "ForStatement" ||
-    scopeNode.type === "ForInStatement" ||
-    scopeNode.type === "ForOfStatement"
-  ) {
-    if (isAstRecord(scopeNode.body)) {
-      if (scopeNode.body.type === "BlockStatement") {
-        for (const stmt of nodeArray(scopeNode.body.body)) {
-          if (isAstRecord(stmt)) walk(stmt);
-        }
-      } else {
-        walk(scopeNode.body);
-      }
-    }
-  } else if (Array.isArray(scopeNode.body)) {
-    for (const stmt of scopeNode.body) {
+  } else if (Array.isArray(body)) {
+    for (const stmt of body) {
       if (isAstRecord(stmt)) walk(stmt);
     }
+  } else if (isAstRecord(body)) {
+    walk(body);
   } else {
     forEachAstChild(scopeNode, walk);
   }

--- a/packages/vinext/src/plugins/ast-utils.ts
+++ b/packages/vinext/src/plugins/ast-utils.ts
@@ -159,12 +159,25 @@ export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
       return; // Expression bindings do not declare anything in the outer scope.
     }
 
+    // ponytail: nested block scopes, catch, switch, loops are separate lexical scopes, so block-scoped variables (const/let) inside them do not belong to the outer scope
+    if (
+      node.type === "BlockStatement" ||
+      node.type === "CatchClause" ||
+      node.type === "ForStatement" ||
+      node.type === "ForInStatement" ||
+      node.type === "ForOfStatement" ||
+      node.type === "SwitchStatement"
+    ) {
+      return;
+    }
+
     if (node.type === "VariableDeclaration") {
       for (const decl of nodeArray(node.declarations)) {
         if (isAstRecord(decl)) {
           collectBindingNames(decl.id, bindings);
         }
       }
+      return;
     }
 
     forEachAstChild(node, walk);
@@ -176,14 +189,46 @@ export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
     scopeNode.type === "ArrowFunctionExpression"
   ) {
     if (isAstRecord(scopeNode.body)) {
-      walk(scopeNode.body);
+      if (scopeNode.body.type === "BlockStatement") {
+        for (const stmt of nodeArray(scopeNode.body.body)) {
+          if (isAstRecord(stmt)) walk(stmt);
+        }
+      } else {
+        walk(scopeNode.body);
+      }
     }
   } else if (scopeNode.type === "BlockStatement") {
     for (const stmt of nodeArray(scopeNode.body)) {
       if (isAstRecord(stmt)) walk(stmt);
     }
   } else if (scopeNode.type === "CatchClause") {
-    if (isAstRecord(scopeNode.body)) walk(scopeNode.body);
+    if (isAstRecord(scopeNode.body)) {
+      if (scopeNode.body.type === "BlockStatement") {
+        for (const stmt of nodeArray(scopeNode.body.body)) {
+          if (isAstRecord(stmt)) walk(stmt);
+        }
+      } else {
+        walk(scopeNode.body);
+      }
+    }
+  } else if (
+    scopeNode.type === "ForStatement" ||
+    scopeNode.type === "ForInStatement" ||
+    scopeNode.type === "ForOfStatement"
+  ) {
+    if (isAstRecord(scopeNode.body)) {
+      if (scopeNode.body.type === "BlockStatement") {
+        for (const stmt of nodeArray(scopeNode.body.body)) {
+          if (isAstRecord(stmt)) walk(stmt);
+        }
+      } else {
+        walk(scopeNode.body);
+      }
+    }
+  } else if (Array.isArray(scopeNode.body)) {
+    for (const stmt of scopeNode.body) {
+      if (isAstRecord(stmt)) walk(stmt);
+    }
   } else {
     forEachAstChild(scopeNode, walk);
   }

--- a/packages/vinext/src/plugins/ast-utils.ts
+++ b/packages/vinext/src/plugins/ast-utils.ts
@@ -94,3 +94,99 @@ export function collectBindingNames(pattern: unknown, target: Set<string>): void
       return;
   }
 }
+
+export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
+  const bindings = new Set<string>();
+
+  // 1. Collect parameters if scopeNode is a function
+  if (
+    scopeNode.type === "FunctionDeclaration" ||
+    scopeNode.type === "FunctionExpression" ||
+    scopeNode.type === "ArrowFunctionExpression"
+  ) {
+    if (scopeNode.id && scopeNode.type === "FunctionExpression") {
+      const name = getAstName(scopeNode.id);
+      if (name) bindings.add(name);
+    }
+    for (const param of nodeArray(scopeNode.params)) {
+      collectBindingNames(param, bindings);
+    }
+  }
+
+  // 2. Collect catch param if scopeNode is a CatchClause
+  if (scopeNode.type === "CatchClause") {
+    if (scopeNode.param) {
+      collectBindingNames(scopeNode.param, bindings);
+    }
+  }
+
+  // 3. Collect loop variables if scopeNode is a loop
+  if (scopeNode.type === "ForStatement") {
+    const init = scopeNode.init as AstRecord | null;
+    if (init && init.type === "VariableDeclaration") {
+      for (const decl of nodeArray(init.declarations)) {
+        if (isAstRecord(decl)) collectBindingNames(decl.id, bindings);
+      }
+    }
+  }
+  if (scopeNode.type === "ForInStatement" || scopeNode.type === "ForOfStatement") {
+    const left = scopeNode.left as AstRecord | null;
+    if (left && left.type === "VariableDeclaration") {
+      for (const decl of nodeArray(left.declarations)) {
+        if (isAstRecord(decl)) collectBindingNames(decl.id, bindings);
+      }
+    }
+  }
+
+  // 4. Traverse the scopeNode's body to collect declared variables/functions/classes,
+  // but do NOT cross nested scope boundaries (like nested functions, classes).
+  function walk(node: AstRecord) {
+    if (node.type === "FunctionDeclaration") {
+      const name = getAstName(node.id);
+      if (name) bindings.add(name);
+      return; // Do not traverse inside nested function
+    }
+    if (node.type === "ClassDeclaration") {
+      const name = getAstName(node.id);
+      if (name) bindings.add(name);
+      return; // Do not traverse inside nested class
+    }
+    if (
+      node.type === "FunctionExpression" ||
+      node.type === "ArrowFunctionExpression" ||
+      node.type === "ClassExpression"
+    ) {
+      return; // Expression bindings do not declare anything in the outer scope.
+    }
+
+    if (node.type === "VariableDeclaration") {
+      for (const decl of nodeArray(node.declarations)) {
+        if (isAstRecord(decl)) {
+          collectBindingNames(decl.id, bindings);
+        }
+      }
+    }
+
+    forEachAstChild(node, walk);
+  }
+
+  if (
+    scopeNode.type === "FunctionDeclaration" ||
+    scopeNode.type === "FunctionExpression" ||
+    scopeNode.type === "ArrowFunctionExpression"
+  ) {
+    if (isAstRecord(scopeNode.body)) {
+      walk(scopeNode.body);
+    }
+  } else if (scopeNode.type === "BlockStatement") {
+    for (const stmt of nodeArray(scopeNode.body)) {
+      if (isAstRecord(stmt)) walk(stmt);
+    }
+  } else if (scopeNode.type === "CatchClause") {
+    if (isAstRecord(scopeNode.body)) walk(scopeNode.body);
+  } else {
+    forEachAstChild(scopeNode, walk);
+  }
+
+  return bindings;
+}

--- a/packages/vinext/src/plugins/ast-utils.ts
+++ b/packages/vinext/src/plugins/ast-utils.ts
@@ -95,30 +95,45 @@ export function collectBindingNames(pattern: unknown, target: Set<string>): void
   }
 }
 
+// Add every name bound by a VariableDeclaration's declarators (handles
+// destructuring patterns) to the target set.
+function addDeclarationBindings(declaration: AstRecord, target: Set<string>): void {
+  for (const decl of nodeArray(declaration.declarations)) {
+    if (isAstRecord(decl)) collectBindingNames(decl.id, target);
+  }
+}
+
+function isFunctionScopeNode(node: AstRecord): boolean {
+  switch (node.type) {
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ArrowFunctionExpression":
+    case "Program":
+      return true;
+    default:
+      return false;
+  }
+}
+
 // `var` is function-scoped: a `var` declared inside nested blocks/loops/switch/
 // catch belongs to the nearest enclosing function (or the module/program), not
 // the block. Collect those hoisted `var` names without crossing into nested
 // function scopes (whose own `var`s belong to them) or claiming block-scoped
 // `let`/`const`/`class`.
 function collectHoistedVars(node: AstRecord, target: Set<string>): void {
-  if (
-    node.type === "FunctionDeclaration" ||
-    node.type === "FunctionExpression" ||
-    node.type === "ArrowFunctionExpression" ||
-    node.type === "ClassDeclaration" ||
-    node.type === "ClassExpression"
-  ) {
-    return;
+  switch (node.type) {
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ArrowFunctionExpression":
+    case "ClassDeclaration":
+    case "ClassExpression":
+      return;
+    case "VariableDeclaration":
+      if (node.kind === "var") addDeclarationBindings(node, target);
+      return;
+    default:
+      forEachAstChild(node, (child) => collectHoistedVars(child, target));
   }
-  if (node.type === "VariableDeclaration") {
-    if (node.kind === "var") {
-      for (const decl of nodeArray(node.declarations)) {
-        if (isAstRecord(decl)) collectBindingNames(decl.id, target);
-      }
-    }
-    return;
-  }
-  forEachAstChild(node, (child) => collectHoistedVars(child, target));
 }
 
 export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
@@ -126,99 +141,71 @@ export function getBindingsInScope(scopeNode: AstRecord): Set<string> {
 
   // Only function/program scopes own hoisted `var`s. A block scope leaves its
   // nested `var`s to the enclosing function.
-  const isFunctionScope =
-    scopeNode.type === "FunctionDeclaration" ||
-    scopeNode.type === "FunctionExpression" ||
-    scopeNode.type === "ArrowFunctionExpression" ||
-    scopeNode.type === "Program";
+  const isFunctionScope = isFunctionScopeNode(scopeNode);
 
-  // 1. Collect parameters if scopeNode is a function
-  if (
-    scopeNode.type === "FunctionDeclaration" ||
-    scopeNode.type === "FunctionExpression" ||
-    scopeNode.type === "ArrowFunctionExpression"
-  ) {
-    if (scopeNode.id && scopeNode.type === "FunctionExpression") {
-      const name = getAstName(scopeNode.id);
-      if (name) bindings.add(name);
-    }
-    for (const param of nodeArray(scopeNode.params)) {
-      collectBindingNames(param, bindings);
-    }
-  }
-
-  // 2. Collect catch param if scopeNode is a CatchClause
-  if (scopeNode.type === "CatchClause") {
-    if (scopeNode.param) {
-      collectBindingNames(scopeNode.param, bindings);
-    }
-  }
-
-  // 3. Collect loop variables if scopeNode is a loop
-  if (scopeNode.type === "ForStatement") {
-    const init = scopeNode.init as AstRecord | null;
-    if (init && init.type === "VariableDeclaration") {
-      for (const decl of nodeArray(init.declarations)) {
-        if (isAstRecord(decl)) collectBindingNames(decl.id, bindings);
+  // 1. Collect the bindings the scope node itself introduces: function params,
+  //    a named function expression, a catch param, or loop-header variables.
+  switch (scopeNode.type) {
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ArrowFunctionExpression": {
+      if (scopeNode.type === "FunctionExpression" && scopeNode.id) {
+        const name = getAstName(scopeNode.id);
+        if (name) bindings.add(name);
       }
-    }
-  }
-  if (scopeNode.type === "ForInStatement" || scopeNode.type === "ForOfStatement") {
-    const left = scopeNode.left as AstRecord | null;
-    if (left && left.type === "VariableDeclaration") {
-      for (const decl of nodeArray(left.declarations)) {
-        if (isAstRecord(decl)) collectBindingNames(decl.id, bindings);
+      for (const param of nodeArray(scopeNode.params)) {
+        collectBindingNames(param, bindings);
       }
+      break;
+    }
+    case "CatchClause":
+      if (scopeNode.param) collectBindingNames(scopeNode.param, bindings);
+      break;
+    case "ForStatement": {
+      const init = scopeNode.init as AstRecord | null;
+      if (init && init.type === "VariableDeclaration") addDeclarationBindings(init, bindings);
+      break;
+    }
+    case "ForInStatement":
+    case "ForOfStatement": {
+      const left = scopeNode.left as AstRecord | null;
+      if (left && left.type === "VariableDeclaration") addDeclarationBindings(left, bindings);
+      break;
     }
   }
 
-  // 4. Traverse the scopeNode's body to collect declared variables/functions/classes,
-  // but do NOT cross nested scope boundaries (like nested functions, classes).
+  // 2. Traverse the scopeNode's body to collect declared variables/functions/
+  //    classes, but do NOT cross nested scope boundaries.
   function walk(node: AstRecord) {
-    if (node.type === "FunctionDeclaration") {
-      const name = getAstName(node.id);
-      if (name) bindings.add(name);
-      return; // Do not traverse inside nested function
-    }
-    if (node.type === "ClassDeclaration") {
-      const name = getAstName(node.id);
-      if (name) bindings.add(name);
-      return; // Do not traverse inside nested class
-    }
-    if (
-      node.type === "FunctionExpression" ||
-      node.type === "ArrowFunctionExpression" ||
-      node.type === "ClassExpression"
-    ) {
-      return; // Expression bindings do not declare anything in the outer scope.
-    }
-
-    // Nested block scopes, catch, switch, and loops are separate lexical scopes:
-    // their `let`/`const`/`class`/function declarations do not belong to the
-    // outer scope. But `var` is function-scoped, so a function/program scope
-    // must still descend to collect hoisted `var`s from them.
-    if (
-      node.type === "BlockStatement" ||
-      node.type === "CatchClause" ||
-      node.type === "ForStatement" ||
-      node.type === "ForInStatement" ||
-      node.type === "ForOfStatement" ||
-      node.type === "SwitchStatement"
-    ) {
-      if (isFunctionScope) collectHoistedVars(node, bindings);
-      return;
-    }
-
-    if (node.type === "VariableDeclaration") {
-      for (const decl of nodeArray(node.declarations)) {
-        if (isAstRecord(decl)) {
-          collectBindingNames(decl.id, bindings);
-        }
+    switch (node.type) {
+      case "FunctionDeclaration":
+      case "ClassDeclaration": {
+        // The name binds the outer scope; the body is a nested scope we skip.
+        const name = getAstName(node.id);
+        if (name) bindings.add(name);
+        return;
       }
-      return;
+      case "FunctionExpression":
+      case "ArrowFunctionExpression":
+      case "ClassExpression":
+        return; // Expression bindings declare nothing in the outer scope.
+      case "BlockStatement":
+      case "CatchClause":
+      case "ForStatement":
+      case "ForInStatement":
+      case "ForOfStatement":
+      case "SwitchStatement":
+        // Separate lexical scopes: their `let`/`const`/`class`/function
+        // declarations stay local. But `var` is function-scoped, so a
+        // function/program scope still hoists nested `var`s out of them.
+        if (isFunctionScope) collectHoistedVars(node, bindings);
+        return;
+      case "VariableDeclaration":
+        addDeclarationBindings(node, bindings);
+        return;
+      default:
+        forEachAstChild(node, walk);
     }
-
-    forEachAstChild(node, walk);
   }
 
   const body = scopeNode.body;

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -483,6 +483,25 @@ function isIdentifierReference(node: unknown, name: string): boolean {
   return isAstRecord(node) && node.type === "Identifier" && node.name === name;
 }
 
+// Node types that open a new scope for shadowing purposes during the font-call
+// traversal. getBindingsInScope is merged into the shadow set when descending
+// into these.
+function isScopeNode(node: AstRecord): boolean {
+  switch (node.type) {
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ArrowFunctionExpression":
+    case "BlockStatement":
+    case "CatchClause":
+    case "ForStatement":
+    case "ForInStatement":
+    case "ForOfStatement":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function collectLocalFontPathLiterals(options: AstRange): Array<{ node: AstRange; path: string }> {
   const paths: Array<{ node: AstRange; path: string }> = [];
 
@@ -576,17 +595,9 @@ function collectLocalFontCalls(
   const calls: LocalFontCallInfo[] = [];
 
   function visit(node: AstRecord, shadowed: Set<string>): void {
-    const isScope =
-      node.type === "FunctionDeclaration" ||
-      node.type === "FunctionExpression" ||
-      node.type === "ArrowFunctionExpression" ||
-      node.type === "BlockStatement" ||
-      node.type === "CatchClause" ||
-      node.type === "ForStatement" ||
-      node.type === "ForInStatement" ||
-      node.type === "ForOfStatement";
-
-    const nextShadowed = isScope ? new Set([...shadowed, ...getBindingsInScope(node)]) : shadowed;
+    const nextShadowed = isScopeNode(node)
+      ? new Set([...shadowed, ...getBindingsInScope(node)])
+      : shadowed;
 
     if (node.type === "VariableDeclarator") {
       if (!nextShadowed.has(localFontIdentifier)) {
@@ -618,12 +629,7 @@ function collectLocalFontCalls(
     forEachAstChild(node, (child) => visit(child, nextShadowed));
   }
 
-  const initialShadowed = new Set<string>();
-  const programBindings = getBindingsInScope(ast as unknown as AstRecord);
-  for (const name of programBindings) {
-    initialShadowed.add(name);
-  }
-
+  const initialShadowed = getBindingsInScope(ast as unknown as AstRecord);
   for (const item of ast.body) {
     visit(item as AstRecord, initialShadowed);
   }
@@ -639,17 +645,9 @@ function collectGoogleFontCalls(
     [];
 
   function visit(node: AstRecord, shadowed: Set<string>): void {
-    const isScope =
-      node.type === "FunctionDeclaration" ||
-      node.type === "FunctionExpression" ||
-      node.type === "ArrowFunctionExpression" ||
-      node.type === "BlockStatement" ||
-      node.type === "CatchClause" ||
-      node.type === "ForStatement" ||
-      node.type === "ForInStatement" ||
-      node.type === "ForOfStatement";
-
-    const nextShadowed = isScope ? new Set([...shadowed, ...getBindingsInScope(node)]) : shadowed;
+    const nextShadowed = isScopeNode(node)
+      ? new Set([...shadowed, ...getBindingsInScope(node)])
+      : shadowed;
 
     if (node.type === "CallExpression" && hasRange(node)) {
       const options = firstObjectArgument(node);
@@ -691,12 +689,7 @@ function collectGoogleFontCalls(
     forEachAstChild(node, (child) => visit(child, nextShadowed));
   }
 
-  const initialShadowed = new Set<string>();
-  const programBindings = getBindingsInScope(ast as unknown as AstRecord);
-  for (const name of programBindings) {
-    initialShadowed.add(name);
-  }
-
+  const initialShadowed = getBindingsInScope(ast as unknown as AstRecord);
   for (const item of ast.body) {
     visit(item as AstRecord, initialShadowed);
   }

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -34,6 +34,7 @@ import {
   type AstRecord,
   forEachAstChild,
   getAstName,
+  getBindingsInScope,
   hasRange,
   isAstRecord,
   nodeArray,
@@ -380,6 +381,78 @@ function getStringProperty(node: AstRecord, key: string): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function reconstructImportClause(node: AstRecord): string {
+  const specifiers = nodeArray(node.specifiers);
+  let defaultImportStr = "";
+  let namespaceImportStr = "";
+  const namedImports: string[] = [];
+
+  for (const specVal of specifiers) {
+    if (!isAstRecord(specVal)) continue;
+    const spec = specVal;
+    if (spec.type === "ImportDefaultSpecifier") {
+      const local = getAstName(spec.local);
+      if (local) defaultImportStr = local;
+    } else if (spec.type === "ImportNamespaceSpecifier") {
+      const local = getAstName(spec.local);
+      if (local) namespaceImportStr = `* as ${local}`;
+    } else if (spec.type === "ImportSpecifier") {
+      const imported = getAstName(spec.imported);
+      const local = getAstName(spec.local);
+      if (!imported || !local) continue;
+
+      const isType = spec.importKind === "type";
+      const typePrefix = isType ? "type " : "";
+
+      if (imported === local) {
+        namedImports.push(`${typePrefix}${imported}`);
+      } else {
+        namedImports.push(`${typePrefix}${imported} as ${local}`);
+      }
+    }
+  }
+
+  const parts: string[] = [];
+  if (defaultImportStr) {
+    parts.push(defaultImportStr);
+  }
+  if (namespaceImportStr) {
+    parts.push(namespaceImportStr);
+  }
+  if (namedImports.length > 0) {
+    const isTypeDecl = node.importKind === "type";
+    const typePrefix = isTypeDecl ? "type " : "";
+    parts.push(`${typePrefix}{ ${namedImports.join(", ")} }`);
+  }
+
+  return parts.join(", ");
+}
+
+function reconstructExportSpecifiers(node: AstRecord): string {
+  const specifiers = nodeArray(node.specifiers);
+  const parts: string[] = [];
+
+  for (const specVal of specifiers) {
+    if (!isAstRecord(specVal) || specVal.type !== "ExportSpecifier") continue;
+    const local = getAstName(specVal.local);
+    const exported = getAstName(specVal.exported) ?? local;
+    if (!local || !exported) continue;
+
+    const isType = specVal.exportKind === "type";
+    const typePrefix = isType ? "type " : "";
+
+    if (local === exported) {
+      parts.push(`${typePrefix}${local}`);
+    } else {
+      parts.push(`${typePrefix}${local} as ${exported}`);
+    }
+  }
+
+  const isTypeDecl = node.exportKind === "type";
+  const typePrefix = isTypeDecl ? "type " : "";
+  return `${typePrefix}{ ${parts.join(", ")} }`;
+}
+
 function getSourceValue(node: AstRecord): string | null {
   const source = node.source;
   if (!isAstRecord(source)) return null;
@@ -395,36 +468,14 @@ function isTypeOnlySpecifier(node: AstRecord, parent: AstRecord): boolean {
   return isTypeOnlyDeclaration(parent) || node.importKind === "type" || node.exportKind === "type";
 }
 
-function importClauseForNode(code: string, node: AstRange): string | null {
-  const source = isAstRecord(node.source) && hasRange(node.source) ? node.source : null;
-  if (!source) return null;
-  const beforeSource = code.slice(node.start, source.start);
-  const fromIndex = beforeSource.lastIndexOf("from");
-  if (fromIndex === -1) return null;
-  return beforeSource.slice("import".length, fromIndex).trim();
-}
-
-function namedBlockForNode(code: string, node: AstRange): string | null {
-  const source = isAstRecord(node.source) && hasRange(node.source) ? node.source : null;
-  if (!source) return null;
-  const beforeSource = code.slice(node.start, source.start);
-  const open = beforeSource.indexOf("{");
-  const close = beforeSource.lastIndexOf("}");
-  if (open === -1 || close === -1 || close < open) return null;
-  return beforeSource.slice(open + 1, close);
-}
-
-function collectGoogleFontImports(
-  ast: ReturnType<typeof parseAst>,
-  code: string,
-): GoogleFontImportInfo[] {
+function collectGoogleFontImports(ast: ReturnType<typeof parseAst>): GoogleFontImportInfo[] {
   const imports: GoogleFontImportInfo[] = [];
   for (const item of ast.body) {
     if (item.type !== "ImportDeclaration") continue;
     const node = item as unknown as AstRecord;
     if (getSourceValue(node) !== "next/font/google") continue;
     if (!hasRange(node)) continue;
-    const clause = importClauseForNode(code, node);
+    const clause = reconstructImportClause(node);
     if (!clause) continue;
 
     let defaultLocal: string | null = null;
@@ -434,23 +485,23 @@ function collectGoogleFontImports(
 
     for (const specifierValue of nodeArray(node.specifiers)) {
       if (!isAstRecord(specifierValue) || !hasRange(specifierValue)) continue;
-      const specifier = specifierValue;
-      if (specifier.type === "ImportDefaultSpecifier") {
-        if (!declarationIsType) defaultLocal = getAstName(specifier.local);
+      const spec = specifierValue;
+      if (spec.type === "ImportDefaultSpecifier") {
+        if (!declarationIsType) defaultLocal = getAstName(spec.local);
         continue;
       }
-      if (specifier.type === "ImportNamespaceSpecifier") {
-        if (!declarationIsType) namespaceLocal = getAstName(specifier.local);
+      if (spec.type === "ImportNamespaceSpecifier") {
+        if (!declarationIsType) namespaceLocal = getAstName(spec.local);
         continue;
       }
-      if (specifier.type !== "ImportSpecifier") continue;
-      const imported = getAstName(specifier.imported) ?? getAstName(specifier.local);
-      const local = getAstName(specifier.local) ?? imported;
+      if (spec.type !== "ImportSpecifier") continue;
+      const imported = getAstName(spec.imported) ?? getAstName(spec.local);
+      const local = getAstName(spec.local) ?? imported;
       if (!imported || !local) continue;
       named.push({
         imported,
         local,
-        isType: isTypeOnlySpecifier(specifier, node),
+        isType: isTypeOnlySpecifier(spec, node),
       });
     }
 
@@ -466,18 +517,14 @@ function collectGoogleFontImports(
   return imports;
 }
 
-function collectGoogleFontExports(
-  ast: ReturnType<typeof parseAst>,
-  code: string,
-): GoogleFontExportInfo[] {
+function collectGoogleFontExports(ast: ReturnType<typeof parseAst>): GoogleFontExportInfo[] {
   const exports: GoogleFontExportInfo[] = [];
   for (const item of ast.body) {
     if (item.type !== "ExportNamedDeclaration") continue;
     const node = item as unknown as AstRecord;
     if (getSourceValue(node) !== "next/font/google") continue;
     if (!hasRange(node)) continue;
-    const specifiers = namedBlockForNode(code, node);
-    if (specifiers === null) continue;
+    const specifiers = reconstructExportSpecifiers(node);
 
     const named: GoogleFontNamedSpecifier[] = [];
     for (const specifierValue of nodeArray(node.specifiers)) {
@@ -507,32 +554,58 @@ function isIdentifierReference(node: unknown, name: string): boolean {
   return isAstRecord(node) && node.type === "Identifier" && node.name === name;
 }
 
-function isFontPathProperty(node: AstRecord): boolean {
-  if (node.type !== "Property" || node.computed) return false;
-  const key = getAstName(node.key);
-  if (key !== "src" && key !== "path") return false;
-  const value = node.value;
-  return (
-    isAstRecord(value) &&
-    hasRange(value) &&
-    value.type === "Literal" &&
-    typeof value.value === "string" &&
-    FONT_FILE_EXTENSION_RE.test(value.value)
-  );
-}
-
 function collectLocalFontPathLiterals(options: AstRange): Array<{ node: AstRange; path: string }> {
   const paths: Array<{ node: AstRange; path: string }> = [];
-  function visit(node: AstRecord): void {
-    if (isFontPathProperty(node)) {
-      const value = node.value;
-      if (isAstRecord(value) && hasRange(value) && typeof value.value === "string") {
+
+  for (const prop of nodeArray(options.properties)) {
+    if (!isAstRecord(prop) || prop.type !== "Property" || prop.computed) continue;
+    if (getAstName(prop.key) !== "src") continue;
+
+    const value = prop.value;
+    if (!isAstRecord(value)) continue;
+
+    if (value.type === "Literal" && typeof value.value === "string" && hasRange(value)) {
+      if (FONT_FILE_EXTENSION_RE.test(value.value)) {
         paths.push({ node: value, path: value.value });
       }
+    } else if (value.type === "ObjectExpression") {
+      for (const subProp of nodeArray(value.properties)) {
+        if (!isAstRecord(subProp) || subProp.type !== "Property" || subProp.computed) continue;
+        if (getAstName(subProp.key) !== "path") continue;
+        const pathVal = subProp.value;
+        if (
+          isAstRecord(pathVal) &&
+          hasRange(pathVal) &&
+          pathVal.type === "Literal" &&
+          typeof pathVal.value === "string"
+        ) {
+          if (FONT_FILE_EXTENSION_RE.test(pathVal.value)) {
+            paths.push({ node: pathVal, path: pathVal.value });
+          }
+        }
+      }
+    } else if (value.type === "ArrayExpression") {
+      for (const elem of nodeArray(value.elements)) {
+        if (!isAstRecord(elem) || elem.type !== "ObjectExpression") continue;
+        for (const subProp of nodeArray(elem.properties)) {
+          if (!isAstRecord(subProp) || subProp.type !== "Property" || subProp.computed) continue;
+          if (getAstName(subProp.key) !== "path") continue;
+          const pathVal = subProp.value;
+          if (
+            isAstRecord(pathVal) &&
+            hasRange(pathVal) &&
+            pathVal.type === "Literal" &&
+            typeof pathVal.value === "string"
+          ) {
+            if (FONT_FILE_EXTENSION_RE.test(pathVal.value)) {
+              paths.push({ node: pathVal, path: pathVal.value });
+            }
+          }
+        }
+      }
     }
-    forEachAstChild(node, visit);
   }
-  visit(options);
+
   return paths;
 }
 
@@ -583,34 +656,59 @@ function collectLocalFontCalls(
   localFontIdentifier: string,
 ): LocalFontCallInfo[] {
   const calls: LocalFontCallInfo[] = [];
-  function visit(node: AstRecord): void {
+
+  function visit(node: AstRecord, shadowed: Set<string>): void {
+    const isScope =
+      node.type === "FunctionDeclaration" ||
+      node.type === "FunctionExpression" ||
+      node.type === "ArrowFunctionExpression" ||
+      node.type === "BlockStatement" ||
+      node.type === "CatchClause" ||
+      node.type === "ForStatement" ||
+      node.type === "ForInStatement" ||
+      node.type === "ForOfStatement";
+
+    const nextShadowed = isScope ? new Set([...shadowed, ...getBindingsInScope(node)]) : shadowed;
+
     if (node.type === "VariableDeclarator") {
-      const localCall = localFontCallFromInitializer(node.init, localFontIdentifier);
-      if (localCall) {
-        calls.push({
-          ...localCall,
-          bindingName: getAstName(node.id),
-        });
+      if (!nextShadowed.has(localFontIdentifier)) {
+        const localCall = localFontCallFromInitializer(node.init, localFontIdentifier);
+        if (localCall) {
+          calls.push({
+            ...localCall,
+            bindingName: getAstName(node.id),
+          });
+        }
       }
+      visit(node.id as AstRecord, nextShadowed);
+      if (node.init) visit(node.init as AstRecord, nextShadowed);
       return;
     }
 
     if (
       node.type === "CallExpression" &&
       hasRange(node) &&
+      !nextShadowed.has(localFontIdentifier) &&
       isIdentifierReference(node.callee, localFontIdentifier)
     ) {
       const options = firstObjectArgument(node);
       if (options) {
         calls.push({ call: node, options, bindingName: null });
       }
-      return;
     }
 
-    forEachAstChild(node, visit);
+    forEachAstChild(node, (child) => visit(child, nextShadowed));
   }
 
-  for (const item of ast.body) visit(item as AstRecord);
+  const initialShadowed = new Set<string>();
+  const programBindings = getBindingsInScope(ast as unknown as AstRecord);
+  for (const name of programBindings) {
+    initialShadowed.add(name);
+  }
+
+  for (const item of ast.body) {
+    visit(item as AstRecord, initialShadowed);
+  }
   return calls;
 }
 
@@ -622,14 +720,26 @@ function collectGoogleFontCalls(
   const calls: Array<{ call: AstRange; options: AstRange; family: string; calleeSource: string }> =
     [];
 
-  function visit(node: AstRecord): void {
+  function visit(node: AstRecord, shadowed: Set<string>): void {
+    const isScope =
+      node.type === "FunctionDeclaration" ||
+      node.type === "FunctionExpression" ||
+      node.type === "ArrowFunctionExpression" ||
+      node.type === "BlockStatement" ||
+      node.type === "CatchClause" ||
+      node.type === "ForStatement" ||
+      node.type === "ForInStatement" ||
+      node.type === "ForOfStatement";
+
+    const nextShadowed = isScope ? new Set([...shadowed, ...getBindingsInScope(node)]) : shadowed;
+
     if (node.type === "CallExpression" && hasRange(node)) {
       const options = firstObjectArgument(node);
       const callee = isAstRecord(node.callee) && hasRange(node.callee) ? node.callee : null;
       if (options && callee?.type === "Identifier") {
         const localName = getStringProperty(callee, "name");
         const importedName = localName ? fontLocals.get(localName) : undefined;
-        if (localName && importedName) {
+        if (localName && importedName && !nextShadowed.has(localName)) {
           calls.push({
             call: node,
             options,
@@ -643,7 +753,12 @@ function collectGoogleFontCalls(
       if (options && callee?.type === "MemberExpression" && !callee.computed) {
         const objectName = getAstName(callee.object);
         const propName = getAstName(callee.property);
-        if (objectName && propName && proxyObjectLocals.has(objectName)) {
+        if (
+          objectName &&
+          propName &&
+          proxyObjectLocals.has(objectName) &&
+          !nextShadowed.has(objectName)
+        ) {
           calls.push({
             call: node,
             options,
@@ -655,10 +770,18 @@ function collectGoogleFontCalls(
       }
     }
 
-    forEachAstChild(node, visit);
+    forEachAstChild(node, (child) => visit(child, nextShadowed));
   }
 
-  for (const item of ast.body) visit(item as AstRecord);
+  const initialShadowed = new Set<string>();
+  const programBindings = getBindingsInScope(ast as unknown as AstRecord);
+  for (const name of programBindings) {
+    initialShadowed.add(name);
+  }
+
+  for (const item of ast.body) {
+    visit(item as AstRecord, initialShadowed);
+  }
   return calls;
 }
 
@@ -990,7 +1113,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         const fontLocals = new Map<string, string>();
         const proxyObjectLocals = new Set<string>();
 
-        for (const parsed of collectGoogleFontImports(ast, code)) {
+        for (const parsed of collectGoogleFontImports(ast)) {
           const utilityImports = parsed.named.filter(
             (spec) => !spec.isType && GOOGLE_FONT_UTILITY_EXPORTS.has(spec.imported),
           );
@@ -1037,7 +1160,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           }
         }
 
-        for (const parsed of collectGoogleFontExports(ast, code)) {
+        for (const parsed of collectGoogleFontExports(ast)) {
           const namedExports = parsed.named;
           const utilityExports = namedExports.filter(
             (spec) => !spec.isType && GOOGLE_FONT_UTILITY_EXPORTS.has(spec.imported),

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -174,7 +174,7 @@ type GoogleFontNamedSpecifier = {
 type GoogleFontImportInfo = {
   start: number;
   end: number;
-  clause: string;
+  source: AstRange;
   defaultLocal: string | null;
   namespaceLocal: string | null;
   named: GoogleFontNamedSpecifier[];
@@ -183,7 +183,7 @@ type GoogleFontImportInfo = {
 type GoogleFontExportInfo = {
   start: number;
   end: number;
-  specifiers: string;
+  source: AstRange;
   named: GoogleFontNamedSpecifier[];
 };
 
@@ -381,78 +381,6 @@ function getStringProperty(node: AstRecord, key: string): string | null {
   return typeof value === "string" ? value : null;
 }
 
-function reconstructImportClause(node: AstRecord): string {
-  const specifiers = nodeArray(node.specifiers);
-  let defaultImportStr = "";
-  let namespaceImportStr = "";
-  const namedImports: string[] = [];
-
-  for (const specVal of specifiers) {
-    if (!isAstRecord(specVal)) continue;
-    const spec = specVal;
-    if (spec.type === "ImportDefaultSpecifier") {
-      const local = getAstName(spec.local);
-      if (local) defaultImportStr = local;
-    } else if (spec.type === "ImportNamespaceSpecifier") {
-      const local = getAstName(spec.local);
-      if (local) namespaceImportStr = `* as ${local}`;
-    } else if (spec.type === "ImportSpecifier") {
-      const imported = getAstName(spec.imported);
-      const local = getAstName(spec.local);
-      if (!imported || !local) continue;
-
-      const isType = spec.importKind === "type";
-      const typePrefix = isType ? "type " : "";
-
-      if (imported === local) {
-        namedImports.push(`${typePrefix}${imported}`);
-      } else {
-        namedImports.push(`${typePrefix}${imported} as ${local}`);
-      }
-    }
-  }
-
-  const parts: string[] = [];
-  if (defaultImportStr) {
-    parts.push(defaultImportStr);
-  }
-  if (namespaceImportStr) {
-    parts.push(namespaceImportStr);
-  }
-  if (namedImports.length > 0) {
-    const isTypeDecl = node.importKind === "type";
-    const typePrefix = isTypeDecl ? "type " : "";
-    parts.push(`${typePrefix}{ ${namedImports.join(", ")} }`);
-  }
-
-  return parts.join(", ");
-}
-
-function reconstructExportSpecifiers(node: AstRecord): string {
-  const specifiers = nodeArray(node.specifiers);
-  const parts: string[] = [];
-
-  for (const specVal of specifiers) {
-    if (!isAstRecord(specVal) || specVal.type !== "ExportSpecifier") continue;
-    const local = getAstName(specVal.local);
-    const exported = getAstName(specVal.exported) ?? local;
-    if (!local || !exported) continue;
-
-    const isType = specVal.exportKind === "type";
-    const typePrefix = isType ? "type " : "";
-
-    if (local === exported) {
-      parts.push(`${typePrefix}${local}`);
-    } else {
-      parts.push(`${typePrefix}${local} as ${exported}`);
-    }
-  }
-
-  const isTypeDecl = node.exportKind === "type";
-  const typePrefix = isTypeDecl ? "type " : "";
-  return `${typePrefix}{ ${parts.join(", ")} }`;
-}
-
 function getSourceValue(node: AstRecord): string | null {
   const source = node.source;
   if (!isAstRecord(source)) return null;
@@ -475,8 +403,8 @@ function collectGoogleFontImports(ast: ReturnType<typeof parseAst>): GoogleFontI
     const node = item as unknown as AstRecord;
     if (getSourceValue(node) !== "next/font/google") continue;
     if (!hasRange(node)) continue;
-    const clause = reconstructImportClause(node);
-    if (!clause) continue;
+    const sourceNode = node.source as AstRecord | null;
+    if (!sourceNode || !hasRange(sourceNode)) continue;
 
     let defaultLocal: string | null = null;
     let namespaceLocal: string | null = null;
@@ -508,7 +436,7 @@ function collectGoogleFontImports(ast: ReturnType<typeof parseAst>): GoogleFontI
     imports.push({
       start: node.start,
       end: node.end,
-      clause,
+      source: sourceNode,
       defaultLocal,
       namespaceLocal,
       named,
@@ -524,7 +452,8 @@ function collectGoogleFontExports(ast: ReturnType<typeof parseAst>): GoogleFontE
     const node = item as unknown as AstRecord;
     if (getSourceValue(node) !== "next/font/google") continue;
     if (!hasRange(node)) continue;
-    const specifiers = reconstructExportSpecifiers(node);
+    const sourceNode = node.source as AstRecord | null;
+    if (!sourceNode || !hasRange(sourceNode)) continue;
 
     const named: GoogleFontNamedSpecifier[] = [];
     for (const specifierValue of nodeArray(node.specifiers)) {
@@ -543,7 +472,7 @@ function collectGoogleFontExports(ast: ReturnType<typeof parseAst>): GoogleFontE
     exports.push({
       start: node.start,
       end: node.end,
-      specifiers,
+      source: sourceNode,
       named,
     });
   }
@@ -568,26 +497,16 @@ function collectLocalFontPathLiterals(options: AstRange): Array<{ node: AstRange
       if (FONT_FILE_EXTENSION_RE.test(value.value)) {
         paths.push({ node: value, path: value.value });
       }
-    } else if (value.type === "ObjectExpression") {
-      for (const subProp of nodeArray(value.properties)) {
-        if (!isAstRecord(subProp) || subProp.type !== "Property" || subProp.computed) continue;
-        if (getAstName(subProp.key) !== "path") continue;
-        const pathVal = subProp.value;
-        if (
-          isAstRecord(pathVal) &&
-          hasRange(pathVal) &&
-          pathVal.type === "Literal" &&
-          typeof pathVal.value === "string"
-        ) {
-          if (FONT_FILE_EXTENSION_RE.test(pathVal.value)) {
-            paths.push({ node: pathVal, path: pathVal.value });
-          }
-        }
-      }
-    } else if (value.type === "ArrayExpression") {
-      for (const elem of nodeArray(value.elements)) {
-        if (!isAstRecord(elem) || elem.type !== "ObjectExpression") continue;
-        for (const subProp of nodeArray(elem.properties)) {
+    } else {
+      const objects =
+        value.type === "ObjectExpression"
+          ? [value]
+          : value.type === "ArrayExpression"
+            ? nodeArray(value.elements).filter(isAstRecord)
+            : [];
+      for (const obj of objects) {
+        if (obj.type !== "ObjectExpression") continue;
+        for (const subProp of nodeArray(obj.properties)) {
           if (!isAstRecord(subProp) || subProp.type !== "Property" || subProp.computed) continue;
           if (getAstName(subProp.key) !== "path") continue;
           const pathVal = subProp.value;
@@ -595,11 +514,10 @@ function collectLocalFontPathLiterals(options: AstRange): Array<{ node: AstRange
             isAstRecord(pathVal) &&
             hasRange(pathVal) &&
             pathVal.type === "Literal" &&
-            typeof pathVal.value === "string"
+            typeof pathVal.value === "string" &&
+            FONT_FILE_EXTENSION_RE.test(pathVal.value)
           ) {
-            if (FONT_FILE_EXTENSION_RE.test(pathVal.value)) {
-              paths.push({ node: pathVal, path: pathVal.value });
-            }
+            paths.push({ node: pathVal, path: pathVal.value });
           }
         }
       }
@@ -1134,11 +1052,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
               fonts: Array.from(new Set(fontImports.map((spec) => spec.imported))),
               utilities: Array.from(new Set(utilityImports.map((spec) => spec.imported))),
             });
-            s.overwrite(
-              parsed.start,
-              parsed.end,
-              `import ${parsed.clause} from ${JSON.stringify(virtualId)};`,
-            );
+            s.overwrite(parsed.source.start, parsed.source.end, JSON.stringify(virtualId));
             overwrittenRanges.push([parsed.start, parsed.end]);
             hasChanges = true;
             continue;
@@ -1175,11 +1089,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
             fonts: Array.from(new Set(fontExports.map((spec) => spec.imported))),
             utilities: Array.from(new Set(utilityExports.map((spec) => spec.imported))),
           });
-          s.overwrite(
-            parsed.start,
-            parsed.end,
-            `export { ${parsed.specifiers.trim()} } from ${JSON.stringify(virtualId)};`,
-          );
+          s.overwrite(parsed.source.start, parsed.source.end, JSON.stringify(virtualId));
           overwrittenRanges.push([parsed.start, parsed.end]);
           hasChanges = true;
         }

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -28,8 +28,16 @@ import type { Plugin } from "vite";
 import { parseAst } from "vite";
 import path from "node:path";
 import fs from "node:fs";
-import { escapeRegExp } from "../utils/regex.js";
 import { lastSignificantChar } from "../utils/has-trailing-comma.js";
+import {
+  type AstRange,
+  type AstRecord,
+  forEachAstChild,
+  getAstName,
+  hasRange,
+  isAstRecord,
+  nodeArray,
+} from "./ast-utils.js";
 import MagicString from "magic-string";
 import {
   buildFallbackFontFace,
@@ -160,8 +168,31 @@ type GoogleFontNamedSpecifier = {
   imported: string;
   local: string;
   isType: boolean;
-  raw: string;
 };
+
+type GoogleFontImportInfo = {
+  start: number;
+  end: number;
+  clause: string;
+  defaultLocal: string | null;
+  namespaceLocal: string | null;
+  named: GoogleFontNamedSpecifier[];
+};
+
+type GoogleFontExportInfo = {
+  start: number;
+  end: number;
+  specifiers: string;
+  named: GoogleFontNamedSpecifier[];
+};
+
+type LocalFontCallInfo = {
+  call: AstRange;
+  options: AstRange;
+  bindingName: string | null;
+};
+
+const FONT_FILE_EXTENSION_RE = /\.(?:woff2?|ttf|otf|eot)$/i;
 
 // ── Helpers shared with index.ts ──────────────────────────────────────────────
 
@@ -331,88 +362,304 @@ export function generateGoogleFontsVirtualModule(
   return lines.join("\n");
 }
 
-// ── Import clause parsers ─────────────────────────────────────────────────────
-
-function parseGoogleFontNamedSpecifiers(
-  specifiersStr: string,
-  forceType = false,
-): GoogleFontNamedSpecifier[] {
-  return specifiersStr
-    .split(",")
-    .map((spec) => spec.trim())
-    .filter(Boolean)
-    .map((raw) => {
-      const isType = forceType || raw.startsWith("type ");
-      const valueSpec = isType ? raw.replace(/^type\s+/, "") : raw;
-      const asParts = valueSpec.split(/\s+as\s+/);
-      const imported = asParts[0]?.trim() ?? "";
-      const local = (asParts[1] || asParts[0] || "").trim();
-      return { imported, local, isType, raw };
-    })
-    .filter((spec) => spec.imported.length > 0 && spec.local.length > 0);
-}
-
-function parseGoogleFontImportClause(clause: string): {
-  defaultLocal: string | null;
-  namespaceLocal: string | null;
-  named: GoogleFontNamedSpecifier[];
-} {
-  const trimmed = clause.trim();
-
-  if (trimmed.startsWith("type ")) {
-    const braceStart = trimmed.indexOf("{");
-    const braceEnd = trimmed.lastIndexOf("}");
-    if (braceStart === -1 || braceEnd === -1) {
-      return { defaultLocal: null, namespaceLocal: null, named: [] };
-    }
-    return {
-      defaultLocal: null,
-      namespaceLocal: null,
-      named: parseGoogleFontNamedSpecifiers(trimmed.slice(braceStart + 1, braceEnd), true),
-    };
-  }
-
-  const braceStart = trimmed.indexOf("{");
-  const braceEnd = trimmed.lastIndexOf("}");
-  if (braceStart !== -1 && braceEnd !== -1) {
-    const beforeNamed = trimmed.slice(0, braceStart).trim().replace(/,\s*$/, "").trim();
-    return {
-      defaultLocal: beforeNamed || null,
-      namespaceLocal: null,
-      named: parseGoogleFontNamedSpecifiers(trimmed.slice(braceStart + 1, braceEnd)),
-    };
-  }
-
-  const commaIndex = trimmed.indexOf(",");
-  if (commaIndex !== -1) {
-    const defaultLocal = trimmed.slice(0, commaIndex).trim() || null;
-    const rest = trimmed.slice(commaIndex + 1).trim();
-    if (rest.startsWith("* as ")) {
-      return {
-        defaultLocal,
-        namespaceLocal: rest.slice("* as ".length).trim() || null,
-        named: [],
-      };
-    }
-  }
-
-  if (trimmed.startsWith("* as ")) {
-    return {
-      defaultLocal: null,
-      namespaceLocal: trimmed.slice("* as ".length).trim() || null,
-      named: [],
-    };
-  }
-
-  return {
-    defaultLocal: trimmed || null,
-    namespaceLocal: null,
-    named: [],
-  };
-}
-
 function propertyNameToGoogleFontFamily(prop: string): string {
   return prop.replace(/_/g, " ").replace(/([a-z])([A-Z])/g, "$1 $2");
+}
+
+function parseTransformAst(code: string, id: string): ReturnType<typeof parseAst> | null {
+  const lang = id.endsWith(".ts") ? "ts" : "tsx";
+  try {
+    return parseAst(code, { lang });
+  } catch {
+    return null;
+  }
+}
+
+function getStringProperty(node: AstRecord, key: string): string | null {
+  const value = node[key];
+  return typeof value === "string" ? value : null;
+}
+
+function getSourceValue(node: AstRecord): string | null {
+  const source = node.source;
+  if (!isAstRecord(source)) return null;
+  const value = source.value;
+  return typeof value === "string" ? value : null;
+}
+
+function isTypeOnlyDeclaration(node: AstRecord): boolean {
+  return node.importKind === "type" || node.exportKind === "type";
+}
+
+function isTypeOnlySpecifier(node: AstRecord, parent: AstRecord): boolean {
+  return isTypeOnlyDeclaration(parent) || node.importKind === "type" || node.exportKind === "type";
+}
+
+function importClauseForNode(code: string, node: AstRange): string | null {
+  const source = isAstRecord(node.source) && hasRange(node.source) ? node.source : null;
+  if (!source) return null;
+  const beforeSource = code.slice(node.start, source.start);
+  const fromIndex = beforeSource.lastIndexOf("from");
+  if (fromIndex === -1) return null;
+  return beforeSource.slice("import".length, fromIndex).trim();
+}
+
+function namedBlockForNode(code: string, node: AstRange): string | null {
+  const source = isAstRecord(node.source) && hasRange(node.source) ? node.source : null;
+  if (!source) return null;
+  const beforeSource = code.slice(node.start, source.start);
+  const open = beforeSource.indexOf("{");
+  const close = beforeSource.lastIndexOf("}");
+  if (open === -1 || close === -1 || close < open) return null;
+  return beforeSource.slice(open + 1, close);
+}
+
+function collectGoogleFontImports(
+  ast: ReturnType<typeof parseAst>,
+  code: string,
+): GoogleFontImportInfo[] {
+  const imports: GoogleFontImportInfo[] = [];
+  for (const item of ast.body) {
+    if (item.type !== "ImportDeclaration") continue;
+    const node = item as unknown as AstRecord;
+    if (getSourceValue(node) !== "next/font/google") continue;
+    if (!hasRange(node)) continue;
+    const clause = importClauseForNode(code, node);
+    if (!clause) continue;
+
+    let defaultLocal: string | null = null;
+    let namespaceLocal: string | null = null;
+    const named: GoogleFontNamedSpecifier[] = [];
+    const declarationIsType = isTypeOnlyDeclaration(node);
+
+    for (const specifierValue of nodeArray(node.specifiers)) {
+      if (!isAstRecord(specifierValue) || !hasRange(specifierValue)) continue;
+      const specifier = specifierValue;
+      if (specifier.type === "ImportDefaultSpecifier") {
+        if (!declarationIsType) defaultLocal = getAstName(specifier.local);
+        continue;
+      }
+      if (specifier.type === "ImportNamespaceSpecifier") {
+        if (!declarationIsType) namespaceLocal = getAstName(specifier.local);
+        continue;
+      }
+      if (specifier.type !== "ImportSpecifier") continue;
+      const imported = getAstName(specifier.imported) ?? getAstName(specifier.local);
+      const local = getAstName(specifier.local) ?? imported;
+      if (!imported || !local) continue;
+      named.push({
+        imported,
+        local,
+        isType: isTypeOnlySpecifier(specifier, node),
+      });
+    }
+
+    imports.push({
+      start: node.start,
+      end: node.end,
+      clause,
+      defaultLocal,
+      namespaceLocal,
+      named,
+    });
+  }
+  return imports;
+}
+
+function collectGoogleFontExports(
+  ast: ReturnType<typeof parseAst>,
+  code: string,
+): GoogleFontExportInfo[] {
+  const exports: GoogleFontExportInfo[] = [];
+  for (const item of ast.body) {
+    if (item.type !== "ExportNamedDeclaration") continue;
+    const node = item as unknown as AstRecord;
+    if (getSourceValue(node) !== "next/font/google") continue;
+    if (!hasRange(node)) continue;
+    const specifiers = namedBlockForNode(code, node);
+    if (specifiers === null) continue;
+
+    const named: GoogleFontNamedSpecifier[] = [];
+    for (const specifierValue of nodeArray(node.specifiers)) {
+      if (!isAstRecord(specifierValue) || !hasRange(specifierValue)) continue;
+      if (specifierValue.type !== "ExportSpecifier") continue;
+      const imported = getAstName(specifierValue.local);
+      const local = getAstName(specifierValue.exported) ?? imported;
+      if (!imported || !local) continue;
+      named.push({
+        imported,
+        local,
+        isType: isTypeOnlySpecifier(specifierValue, node),
+      });
+    }
+
+    exports.push({
+      start: node.start,
+      end: node.end,
+      specifiers,
+      named,
+    });
+  }
+  return exports;
+}
+
+function isIdentifierReference(node: unknown, name: string): boolean {
+  return isAstRecord(node) && node.type === "Identifier" && node.name === name;
+}
+
+function isFontPathProperty(node: AstRecord): boolean {
+  if (node.type !== "Property" || node.computed) return false;
+  const key = getAstName(node.key);
+  if (key !== "src" && key !== "path") return false;
+  const value = node.value;
+  return (
+    isAstRecord(value) &&
+    hasRange(value) &&
+    value.type === "Literal" &&
+    typeof value.value === "string" &&
+    FONT_FILE_EXTENSION_RE.test(value.value)
+  );
+}
+
+function collectLocalFontPathLiterals(options: AstRange): Array<{ node: AstRange; path: string }> {
+  const paths: Array<{ node: AstRange; path: string }> = [];
+  function visit(node: AstRecord): void {
+    if (isFontPathProperty(node)) {
+      const value = node.value;
+      if (isAstRecord(value) && hasRange(value) && typeof value.value === "string") {
+        paths.push({ node: value, path: value.value });
+      }
+    }
+    forEachAstChild(node, visit);
+  }
+  visit(options);
+  return paths;
+}
+
+function objectHasVinextProperty(options: AstRange): boolean {
+  for (const property of nodeArray(options.properties)) {
+    if (!isAstRecord(property) || property.type !== "Property" || property.computed) continue;
+    if (getAstName(property.key) === "_vinext") return true;
+  }
+  return false;
+}
+
+function firstObjectArgument(node: AstRecord): AstRange | null {
+  const args = nodeArray(node.arguments);
+  const firstArg = args[0];
+  if (!isAstRecord(firstArg) || firstArg.type !== "ObjectExpression" || !hasRange(firstArg)) {
+    return null;
+  }
+  return firstArg;
+}
+
+function getLocalFontDefaultImport(ast: ReturnType<typeof parseAst>): string | null {
+  for (const item of ast.body) {
+    if (item.type !== "ImportDeclaration") continue;
+    const node = item as unknown as AstRecord;
+    if (getSourceValue(node) !== "next/font/local") continue;
+    if (isTypeOnlyDeclaration(node)) continue;
+    for (const specifier of nodeArray(node.specifiers)) {
+      if (!isAstRecord(specifier) || specifier.type !== "ImportDefaultSpecifier") continue;
+      return getAstName(specifier.local);
+    }
+  }
+  return null;
+}
+
+function localFontCallFromInitializer(
+  init: unknown,
+  localFontIdentifier: string,
+): { call: AstRange; options: AstRange } | null {
+  if (!isAstRecord(init) || init.type !== "CallExpression" || !hasRange(init)) return null;
+  if (!isIdentifierReference(init.callee, localFontIdentifier)) return null;
+  const options = firstObjectArgument(init);
+  if (!options) return null;
+  return { call: init, options };
+}
+
+function collectLocalFontCalls(
+  ast: ReturnType<typeof parseAst>,
+  localFontIdentifier: string,
+): LocalFontCallInfo[] {
+  const calls: LocalFontCallInfo[] = [];
+  function visit(node: AstRecord): void {
+    if (node.type === "VariableDeclarator") {
+      const localCall = localFontCallFromInitializer(node.init, localFontIdentifier);
+      if (localCall) {
+        calls.push({
+          ...localCall,
+          bindingName: getAstName(node.id),
+        });
+      }
+      return;
+    }
+
+    if (
+      node.type === "CallExpression" &&
+      hasRange(node) &&
+      isIdentifierReference(node.callee, localFontIdentifier)
+    ) {
+      const options = firstObjectArgument(node);
+      if (options) {
+        calls.push({ call: node, options, bindingName: null });
+      }
+      return;
+    }
+
+    forEachAstChild(node, visit);
+  }
+
+  for (const item of ast.body) visit(item as AstRecord);
+  return calls;
+}
+
+function collectGoogleFontCalls(
+  ast: ReturnType<typeof parseAst>,
+  fontLocals: Map<string, string>,
+  proxyObjectLocals: Set<string>,
+): Array<{ call: AstRange; options: AstRange; family: string; calleeSource: string }> {
+  const calls: Array<{ call: AstRange; options: AstRange; family: string; calleeSource: string }> =
+    [];
+
+  function visit(node: AstRecord): void {
+    if (node.type === "CallExpression" && hasRange(node)) {
+      const options = firstObjectArgument(node);
+      const callee = isAstRecord(node.callee) && hasRange(node.callee) ? node.callee : null;
+      if (options && callee?.type === "Identifier") {
+        const localName = getStringProperty(callee, "name");
+        const importedName = localName ? fontLocals.get(localName) : undefined;
+        if (localName && importedName) {
+          calls.push({
+            call: node,
+            options,
+            family: importedName.replace(/_/g, " "),
+            calleeSource: localName,
+          });
+          return;
+        }
+      }
+
+      if (options && callee?.type === "MemberExpression" && !callee.computed) {
+        const objectName = getAstName(callee.object);
+        const propName = getAstName(callee.property);
+        if (objectName && propName && proxyObjectLocals.has(objectName)) {
+          calls.push({
+            call: node,
+            options,
+            family: propertyNameToGoogleFontFamily(propName),
+            calleeSource: `${objectName}.${propName}`,
+          });
+          return;
+        }
+      }
+    }
+
+    forEachAstChild(node, visit);
+  }
+
+  for (const item of ast.body) visit(item as AstRecord);
+  return calls;
 }
 
 // ── Font fetching and caching ─────────────────────────────────────────────────
@@ -725,6 +972,9 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         if (!code.includes("next/font/google")) return null;
         if (id.startsWith(shimsDir)) return null;
 
+        const ast = parseTransformAst(code, id);
+        if (!ast) return null;
+
         // Read the resolved `build.assetsDir` from the current Vite
         // environment so it can be closed over by the inner
         // `injectSelfHostedCss` helper (a plain function declaration
@@ -740,23 +990,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         const fontLocals = new Map<string, string>();
         const proxyObjectLocals = new Set<string>();
 
-        // The clause is a sequence of either a brace block (`\{[^}]*?\}` —
-        // newlines allowed inside, but `[^}]` keeps it from spanning past
-        // the matching close brace) or a single non-`;` non-`\n` char.
-        // Effect: multi-line bracket imports (Prettier wraps past
-        // `printWidth`) match, but a preceding semicolon-less line
-        // (e.g. `import type { Metadata } from 'next'`) can't be swallowed
-        // into the clause via newline crossings. Both shapes used to fail
-        // silently — the rewrite was skipped because the resulting clause
-        // wasn't a valid single import.
-        const importRe =
-          /^[ \t]*import\s+((?:\{[^}]*?\}|[^;\n])+?)\s+from\s*(["'])next\/font\/google\2\s*;?/gm;
-        let importMatch;
-        while ((importMatch = importRe.exec(code)) !== null) {
-          const [fullMatch, clause] = importMatch;
-          const matchStart = importMatch.index;
-          const matchEnd = matchStart + fullMatch.length;
-          const parsed = parseGoogleFontImportClause(clause);
+        for (const parsed of collectGoogleFontImports(ast, code)) {
           const utilityImports = parsed.named.filter(
             (spec) => !spec.isType && GOOGLE_FONT_UTILITY_EXPORTS.has(spec.imported),
           );
@@ -778,11 +1012,11 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
               utilities: Array.from(new Set(utilityImports.map((spec) => spec.imported))),
             });
             s.overwrite(
-              matchStart,
-              matchEnd,
-              `import ${clause} from ${JSON.stringify(virtualId)};`,
+              parsed.start,
+              parsed.end,
+              `import ${parsed.clause} from ${JSON.stringify(virtualId)};`,
             );
-            overwrittenRanges.push([matchStart, matchEnd]);
+            overwrittenRanges.push([parsed.start, parsed.end]);
             hasChanges = true;
             continue;
           }
@@ -796,20 +1030,15 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
               replacementLines.push(`var ${parsed.defaultLocal} = ${proxyImportName};`);
             }
             replacementLines.push(`var ${parsed.namespaceLocal} = ${proxyImportName};`);
-            s.overwrite(matchStart, matchEnd, replacementLines.join("\n"));
-            overwrittenRanges.push([matchStart, matchEnd]);
+            s.overwrite(parsed.start, parsed.end, replacementLines.join("\n"));
+            overwrittenRanges.push([parsed.start, parsed.end]);
             proxyObjectLocals.add(parsed.namespaceLocal);
             hasChanges = true;
           }
         }
 
-        const exportRe = /^[ \t]*export\s*\{([^}]+)\}\s*from\s*(["'])next\/font\/google\2\s*;?/gm;
-        let exportMatch;
-        while ((exportMatch = exportRe.exec(code)) !== null) {
-          const [fullMatch, specifiers] = exportMatch;
-          const matchStart = exportMatch.index;
-          const matchEnd = matchStart + fullMatch.length;
-          const namedExports = parseGoogleFontNamedSpecifiers(specifiers);
+        for (const parsed of collectGoogleFontExports(ast, code)) {
+          const namedExports = parsed.named;
           const utilityExports = namedExports.filter(
             (spec) => !spec.isType && GOOGLE_FONT_UTILITY_EXPORTS.has(spec.imported),
           );
@@ -824,11 +1053,11 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
             utilities: Array.from(new Set(utilityExports.map((spec) => spec.imported))),
           });
           s.overwrite(
-            matchStart,
-            matchEnd,
-            `export { ${specifiers.trim()} } from ${JSON.stringify(virtualId)};`,
+            parsed.start,
+            parsed.end,
+            `export { ${parsed.specifiers.trim()} } from ${JSON.stringify(virtualId)};`,
           );
-          overwrittenRanges.push([matchStart, matchEnd]);
+          overwrittenRanges.push([parsed.start, parsed.end]);
           hasChanges = true;
         }
 
@@ -979,65 +1208,21 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         // against the dev origin; in build, the `writeBundle` hook copies
         // them into the client output directory.
 
-        // Match: Identifier( — where the argument starts with {
-        // The regex intentionally does NOT capture the options object; we use
-        // _findBalancedObject() to handle nested braces correctly.
-        const namedCallRe = /\b([A-Za-z_$][A-Za-z0-9_$]*)\s*\(\s*(?=\{)/g;
-        let namedCallMatch;
-        while ((namedCallMatch = namedCallRe.exec(code)) !== null) {
-          const [fullMatch, localName] = namedCallMatch;
-          const importedName = fontLocals.get(localName);
-          if (!importedName) continue;
-
-          const callStart = namedCallMatch.index;
-          // The regex consumed up to (but not including) the '{' due to the
-          // lookahead — find the balanced object starting at the lookahead pos.
-          const openParenEnd = callStart + fullMatch.length;
-          const objRange = _findBalancedObject(code, openParenEnd);
-          if (!objRange) continue;
-          const optionsStr = code.slice(objRange[0], objRange[1]);
-          const callEnd = _findCallEnd(code, objRange[1]);
-          if (callEnd === null) continue;
-
-          if (overwrittenRanges.some(([start, end]) => callStart < end && callEnd > start)) {
+        for (const fontCall of collectGoogleFontCalls(ast, fontLocals, proxyObjectLocals)) {
+          if (
+            overwrittenRanges.some(
+              ([start, end]) => fontCall.call.start < end && fontCall.call.end > start,
+            )
+          ) {
             continue;
           }
 
           await injectSelfHostedCss(
-            callStart,
-            callEnd,
-            optionsStr,
-            importedName.replace(/_/g, " "),
-            localName,
-          );
-        }
-
-        // Match: Identifier.Identifier( — where the argument starts with {
-        const memberCallRe =
-          /\b([A-Za-z_$][A-Za-z0-9_$]*)\.([A-Za-z_$][A-Za-z0-9_$]*)\s*\(\s*(?=\{)/g;
-        let memberCallMatch;
-        while ((memberCallMatch = memberCallRe.exec(code)) !== null) {
-          const [fullMatch, objectName, propName] = memberCallMatch;
-          if (!proxyObjectLocals.has(objectName)) continue;
-
-          const callStart = memberCallMatch.index;
-          const openParenEnd = callStart + fullMatch.length;
-          const objRange = _findBalancedObject(code, openParenEnd);
-          if (!objRange) continue;
-          const optionsStr = code.slice(objRange[0], objRange[1]);
-          const callEnd = _findCallEnd(code, objRange[1]);
-          if (callEnd === null) continue;
-
-          if (overwrittenRanges.some(([start, end]) => callStart < end && callEnd > start)) {
-            continue;
-          }
-
-          await injectSelfHostedCss(
-            callStart,
-            callEnd,
-            optionsStr,
-            propertyNameToGoogleFontFamily(propName),
-            `${objectName}.${propName}`,
+            fontCall.call.start,
+            fontCall.call.end,
+            code.slice(fontCall.options.start, fontCall.options.end),
+            fontCall.family,
+            fontCall.calleeSource,
           );
         }
 
@@ -1163,61 +1348,52 @@ export function createLocalFontsPlugin(shimsDir: string): Plugin {
         // `font-local` are still transformed. Mirrors `createGoogleFontsPlugin`.
         if (id.startsWith(shimsDir)) return null;
 
-        // Verify there's actually a default import from next/font/local and
-        // remember its local binding so family payloads only attach to real
+        const ast = parseTransformAst(code, id);
+        if (!ast) return null;
+
+        // Verify there's actually a value default import from next/font/local
+        // and remember its local binding so family payloads only attach to real
         // localFont calls.
-        const importMatch =
-          /\bimport\s+([A-Za-z_$][A-Za-z0-9_$]*)\s+from\s*(['"])next\/font\/local\2/.exec(code);
-        if (!importMatch) return null;
-        const localFontIdentifier = importMatch[1];
+        const localFontIdentifier = getLocalFontDefaultImport(ast);
+        if (!localFontIdentifier) return null;
 
         const s = new MagicString(code);
         let hasChanges = false;
         let fontImportCounter = 0;
         const imports: string[] = [];
 
-        // Match font file paths in `path: "..."` or `src: "..."` properties.
-        // Captures: (1) property+colon prefix, (2) quote char, (3) the path.
-        const fontPathRe = /((?:path|src)\s*:\s*)(['"])([^'"]+\.(?:woff2?|ttf|otf|eot))\2/g;
-
-        let match;
-        while ((match = fontPathRe.exec(code)) !== null) {
-          const [fullMatch, prefix, _quote, fontPath] = match;
-          const varName = `__vinext_local_font_${fontImportCounter++}`;
-
-          // Add an import for this font file — Vite resolves it as a static
-          // asset and returns the correct URL for both dev and prod.
-          imports.push(`import ${varName} from ${JSON.stringify(fontPath)};`);
-
-          // Replace: path: "./font.woff2" -> path: __vinext_local_font_0
-          const matchStart = match.index;
-          const matchEnd = matchStart + fullMatch.length;
-          s.overwrite(matchStart, matchEnd, `${prefix}${varName}`);
-          hasChanges = true;
-        }
-
-        const localFontCallRe = new RegExp(
-          String.raw`(?:^|[;{}\n])\s*(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::[^=]+)?=\s*${escapeRegExp(localFontIdentifier)}\s*\(\s*(?=\{)`,
-          "g",
-        );
         const familyPayloadInsertions = new Set<number>();
-        let localFontCallMatch;
-        while ((localFontCallMatch = localFontCallRe.exec(code)) !== null) {
-          const bindingName = localFontCallMatch[1];
-          const objRange = _findBalancedObject(code, localFontCallRe.lastIndex);
-          if (!objRange) continue;
-          if (_findCallEnd(code, objRange[1]) === null) continue;
+        const rewrittenPathRanges = new Set<string>();
+        for (const localFontCall of collectLocalFontCalls(ast, localFontIdentifier)) {
+          for (const fontPathLiteral of collectLocalFontPathLiterals(localFontCall.options)) {
+            const rangeKey = `${fontPathLiteral.node.start}:${fontPathLiteral.node.end}`;
+            if (rewrittenPathRanges.has(rangeKey)) continue;
+            rewrittenPathRanges.add(rangeKey);
 
-          const insertAt = objRange[1] - 1;
+            const varName = `__vinext_local_font_${fontImportCounter++}`;
+
+            // Add an import for this font file — Vite resolves it as a static
+            // asset and returns the correct URL for both dev and prod.
+            imports.push(`import ${varName} from ${JSON.stringify(fontPathLiteral.path)};`);
+
+            // Replace the string literal value:
+            // path: "./font.woff2" -> path: __vinext_local_font_0
+            s.overwrite(fontPathLiteral.node.start, fontPathLiteral.node.end, varName);
+            hasChanges = true;
+          }
+
+          const bindingName = localFontCall.bindingName;
+          if (!bindingName) continue;
+          const insertAt = localFontCall.options.end - 1;
           if (familyPayloadInsertions.has(insertAt)) continue;
-          const optionsStr = code.slice(objRange[0], objRange[1]);
-          if (/(?:^|[,{])\s*_vinext\s*:/.test(optionsStr)) continue;
+          if (objectHasVinextProperty(localFontCall.options)) continue;
 
           // Decide the separator from the last significant character before the
           // closing brace (see injectSelfHostedCss): comment- and
           // string-literal-aware, so a trailing comma hidden behind a comment is
           // honoured and a `//` inside a value (e.g. a path) is not mistaken for
           // a comment that would swallow the real comma → double comma.
+          const optionsStr = code.slice(localFontCall.options.start, localFontCall.options.end);
           const lastChar = lastSignificantChar(optionsStr.slice(0, -1));
           const separator = lastChar === "{" || lastChar === "," ? "" : ", ";
           s.appendLeft(

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -496,6 +496,7 @@ function isScopeNode(node: AstRecord): boolean {
     case "ForStatement":
     case "ForInStatement":
     case "ForOfStatement":
+    case "SwitchStatement":
       return true;
     default:
       return false;

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -933,6 +933,33 @@ describe("vinext:google-fonts plugin", () => {
     }
   });
 
+  it("does not shadow outer scope font imports when redeclared inside nested blocks", async () => {
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-shadow-nested");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `if (process.env.NODE_ENV === "test") {`,
+        `  const Inter = () => null;`,
+        `}`,
+        `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("virtual:vinext-google-fonts?");
+      const matches = result.code.match(/selfHostedCSS/g);
+      expect(matches?.length).toBe(1);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not inject self-host metadata into commented-out font calls", async () => {
     // Next.js discovers next/font calls by walking the SWC AST:
     // crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -1445,6 +1445,42 @@ describe("vinext:google-fonts plugin", () => {
     }
   });
 
+  it("does not rewrite calls shadowed by a var hoisted from a nested block", async () => {
+    // `var` is function-scoped, so a `var Inter` inside an if-block shadows the
+    // imported Google font loader for the whole function body, including calls
+    // that are siblings of the block.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-shadow-var-hoist");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `function render(condition: boolean) {`,
+        `  if (condition) {`,
+        `    var Inter = () => null;`,
+        `  }`,
+        `  return Inter({ weight: '400', subsets: ['latin'] });`,
+        `}`,
+        `const realInter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      // The top-level call is the real import and must be self-hosted.
+      expect(result.code).toContain(
+        "const realInter = Inter({ weight: '400', subsets: ['latin'] , _vinext: {",
+      );
+      // The call inside render is shadowed by the hoisted var and must NOT be rewritten.
+      expect(result.code).toContain("return Inter({ weight: '400', subsets: ['latin'] });");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("handles comments inside import statement containing 'from'", async () => {
     const plugin = getGoogleFontsPlugin();
     const root = path.join(import.meta.dirname, ".test-font-root-import-comment");

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -933,6 +933,62 @@ describe("vinext:google-fonts plugin", () => {
     }
   });
 
+  it("does not inject self-host metadata into commented-out font calls", async () => {
+    // Next.js discovers next/font calls by walking the SWC AST:
+    // crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs
+    // https://github.com/vercel/next.js/blob/canary/crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs
+    // Text in comments is therefore not a font call and must not trigger the
+    // self-hosting rewrite.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-commented-call");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `// const inter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("virtual:vinext-google-fonts?");
+      expect(result.code).not.toContain("selfHostedCSS");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("injects self-host metadata when an options comment contains a brace", async () => {
+    // The AST owns the object range, so braces inside comments cannot make the
+    // font call look prematurely closed.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-comment-brace");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `const inter = Inter({`,
+        `  weight: '400',`,
+        `  subsets: ['latin'], /* } */`,
+        `});`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("selfHostedCSS");
+      expect(result.code).toContain("virtual:vinext-google-fonts?");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not produce double-comma when font options have a trailing comma", async () => {
     // Regression test: Inter({ subsets: ["latin"], }) already has a trailing comma.
     // injectSelfHostedCss must not prepend another ", " making the object literal

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -1387,6 +1387,78 @@ describe("vinext:google-fonts plugin", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("does not rewrite calls to shadowed font identifiers", async () => {
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-shadowed");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `function myComponent(Inter: any) {`,
+        `  return Inter({ weight: '400', subsets: ['latin'] });`,
+        `}`,
+        `const realInter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      // The outer call realInter must be self-hosted
+      expect(result.code).toContain(
+        "const realInter = Inter({ weight: '400', subsets: ['latin'] , _vinext: {",
+      );
+      // The inner call to shadowed Inter must NOT be rewritten
+      expect(result.code).toContain("return Inter({ weight: '400', subsets: ['latin'] });");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("handles comments inside import statement containing 'from'", async () => {
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-import-comment");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [
+        `import { Inter /* comment with from here */ } from 'next/font/google';`,
+        `const inter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("virtual:vinext-google-fonts?");
+      expect(result.code).toContain("selfHostedCSS");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("handles comments inside export statement containing 'from'", async () => {
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-export-comment");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      const code = [`export { Inter /* comment with from */ } from 'next/font/google';`].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain("virtual:vinext-google-fonts?");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── fetchAndCacheFont integration ─────────────────────────────

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -1481,6 +1481,43 @@ describe("vinext:google-fonts plugin", () => {
     }
   });
 
+  it("does not rewrite calls shadowed by a const inside a switch case", async () => {
+    // The switch block is a single lexical scope, so a `const Inter` in any
+    // case shadows the imported loader for the whole switch.
+    const plugin = getGoogleFontsPlugin();
+    const root = path.join(import.meta.dirname, ".test-font-root-shadow-switch");
+    initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS("@font-face { font-family: 'Inter'; src: url(/inter.woff2); }");
+
+    try {
+      const transform = unwrapHook(plugin.transform);
+      // No braces around the case body: the SwitchStatement itself is the only
+      // lexical scope boundary, so this only passes if `switch` is a scope node.
+      const code = [
+        `import { Inter } from 'next/font/google';`,
+        `function render(kind: string) {`,
+        `  switch (kind) {`,
+        `    case "custom":`,
+        `      const Inter = (options: unknown) => options;`,
+        `      return Inter({ weight: '400', subsets: ['latin'] });`,
+        `  }`,
+        `}`,
+        `const realInter = Inter({ weight: '400', subsets: ['latin'] });`,
+      ].join("\n");
+
+      const result = await transform.call(plugin, code, "/app/layout.tsx");
+      expect(result).not.toBeNull();
+      expect(result.code).toContain(
+        "const realInter = Inter({ weight: '400', subsets: ['latin'] , _vinext: {",
+      );
+      // The call inside the switch case is shadowed and must NOT be rewritten.
+      expect(result.code).toContain("return Inter({ weight: '400', subsets: ['latin'] });");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("handles comments inside import statement containing 'from'", async () => {
     const plugin = getGoogleFontsPlugin();
     const root = path.join(import.meta.dirname, ".test-font-root-import-comment");

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -248,6 +248,32 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.code).toContain(`return localFont({ src: "./not-a-next-font.woff2" });`);
   });
 
+  it("does not rewrite localFont calls shadowed by a const inside a switch case", () => {
+    // The switch block is one lexical scope; a `const localFont` in a case
+    // shadows the import for the whole switch. No braces → the SwitchStatement
+    // is the only scope boundary.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `function render(kind: string) {`,
+      `  switch (kind) {`,
+      `    case "custom":`,
+      `      const localFont = (options: unknown) => options;`,
+      `      return localFont({ src: "./not-a-next-font.woff2" });`,
+      `  }`,
+      `}`,
+      `const realFont = localFont({ src: "./real.woff2" });`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./real.woff2");
+    expect(result.code).not.toContain(`from "./not-a-next-font.woff2"`);
+    expect(result.code).toContain(`return localFont({ src: "./not-a-next-font.woff2" });`);
+  });
+
   // ── Helper: assert a font file string was promoted to an ESM import ──
   // The transform's contract is that font path strings get rewritten to ESM
   // imports so Vite can fingerprint and serve them. We don't care about the

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -206,6 +206,23 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.code).toContain(`return localFont({ src: "./not-a-next-font.woff2" });`);
   });
 
+  it("does not shadow outer scope localFont calls when redeclared inside nested blocks", () => {
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `{`,
+      `  const localFont = () => null;`,
+      `}`,
+      `const realFont = localFont({ src: "./real.woff2" });`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./real.woff2");
+  });
+
   // ── Helper: assert a font file string was promoted to an ESM import ──
   // The transform's contract is that font path strings get rewritten to ESM
   // imports so Vite can fingerprint and serve them. We don't care about the

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -223,6 +223,31 @@ describe("vinext:local-fonts plugin", () => {
     expectImported(result.code, "./real.woff2");
   });
 
+  it("does not rewrite localFont calls shadowed by a var hoisted from a nested block", () => {
+    // `var localFont` is function-scoped, so it shadows the import for the whole
+    // function body, including the call that is a sibling of the if-block.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `function render(condition: boolean) {`,
+      `  if (condition) {`,
+      `    var localFont = () => null;`,
+      `  }`,
+      `  return localFont({ src: "./not-a-next-font.woff2" });`,
+      `}`,
+      `const realFont = localFont({ src: "./real.woff2" });`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./real.woff2");
+    // Shadowed by the hoisted var → must not be promoted to an import.
+    expect(result.code).not.toContain(`from "./not-a-next-font.woff2"`);
+    expect(result.code).toContain(`return localFont({ src: "./not-a-next-font.woff2" });`);
+  });
+
   // ── Helper: assert a font file string was promoted to an ESM import ──
   // The transform's contract is that font path strings get rewritten to ESM
   // imports so Vite can fingerprint and serve them. We don't care about the

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -166,6 +166,46 @@ describe("vinext:local-fonts plugin", () => {
     expect(result.code).toContain(`const unrelated = { src: "./unrelated.woff2" };`);
   });
 
+  it("does not rewrite font-looking paths in nested metadata objects", () => {
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `const myFont = localFont({`,
+      `  src: "./real-font.woff2",`,
+      `  metadata: {`,
+      `    path: "./do-not-bundle.woff2",`,
+      `  },`,
+      `});`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./real-font.woff2");
+    expect(result.code).not.toContain(`"./do-not-bundle.woff2";`);
+    expect(result.code).toContain(`path: "./do-not-bundle.woff2"`);
+  });
+
+  it("does not rewrite shadowed local font calls", () => {
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `function render(localFont: any) {`,
+      `  return localFont({ src: "./not-a-next-font.woff2" });`,
+      `}`,
+      `const realFont = localFont({ src: "./real-font.woff2" });`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./real-font.woff2");
+    expect(result.code).not.toContain(`"./not-a-next-font.woff2";`);
+    expect(result.code).toContain(`return localFont({ src: "./not-a-next-font.woff2" });`);
+  });
+
   // ── Helper: assert a font file string was promoted to an ESM import ──
   // The transform's contract is that font path strings get rewritten to ESM
   // imports so Vite can fingerprint and serve them. We don't care about the

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -130,6 +130,42 @@ describe("vinext:local-fonts plugin", () => {
     expect(result).toBeNull();
   });
 
+  it("does not rewrite font-looking paths in comments", () => {
+    // Next.js handles next/font through an AST/SWC transform, so text in
+    // comments is never treated as a local font descriptor. Regex scanning
+    // used to promote this comment into a bogus asset import.
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `// const unused = localFont({ src: "./commented.woff2" });`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).toBeNull();
+  });
+
+  it("only rewrites font paths inside actual localFont calls", () => {
+    // Ported from the shape of Next.js's AST font transform:
+    // crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs
+    // https://github.com/vercel/next.js/blob/canary/crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs
+    const plugin = getLocalFontsPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const code = [
+      `import localFont from 'next/font/local';`,
+      `const unrelated = { src: "./unrelated.woff2" };`,
+      `const myFont = localFont({ src: "./my-font.woff2" });`,
+    ].join("\n");
+
+    const result = transform.call(plugin, code, "/app/layout.tsx");
+
+    expect(result).not.toBeNull();
+    expectImported(result.code, "./my-font.woff2");
+    expect(result.code).not.toContain(`"./unrelated.woff2";`);
+    expect(result.code).toContain(`const unrelated = { src: "./unrelated.woff2" };`);
+  });
+
   // ── Helper: assert a font file string was promoted to an ESM import ──
   // The transform's contract is that font path strings get rewritten to ESM
   // imports so Vite can fingerprint and serve them. We don't care about the


### PR DESCRIPTION
## Summary

- Migrates the remaining `next/font` plugin discovery paths from regex/string scanning to Vite AST traversal.
- Limits local font asset imports to `src` / `path` literals inside actual `localFont(...)` option objects, so comments and unrelated objects no longer create bogus imports.
- Finds Google font loader calls from AST call expressions, so commented-out calls are ignored and comments inside option objects cannot break self-host metadata injection.

Fixes #2056.

## Context

Next.js handles `next/font` in its compiler transform, not by scanning raw source text. The relevant upstream paths are:

- https://github.com/vercel/next.js/blob/canary/crates/next-custom-transforms/src/transforms/fonts/font_functions_collector.rs
- https://github.com/vercel/next.js/blob/canary/crates/next-custom-transforms/src/transforms/fonts/font_imports_generator.rs
- https://github.com/vercel/next.js/blob/canary/crates/next-custom-transforms/src/transforms/fonts/mod.rs

That means text in comments and unrelated object literals should not be interpreted as font declarations. The old vinext regex path could still do that after #2051 fixed the trailing-comma scanner.

## Tests

- `vp test run tests/font-local-transform.test.ts tests/font-google.test.ts`
- `vp check tests/font-local-transform.test.ts tests/font-google.test.ts packages/vinext/src/plugins/fonts.ts`
- pre-commit hook: staged checks, full check, staged unit/integration tests, knip
