### PR TITLE
fix(router): align Pages middleware data rewrites

### DIFF
--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -137,6 +137,28 @@ function declarationHasBindingName(declaration: Statement | null, name: string):
  *   export function foo() {}
  *   export const foo = ...
  *   export { foo }
+ *
+ * Recognised shapes (covered by tests/build-report.test.ts):
+ *   - `export function foo() {}` / `export async function foo() {}`
+ *   - `export const foo = ...` / `export let foo = ...` (with TS annotations)
+ *   - `export { foo }` and `export { foo as bar }` (alias under the new name)
+ *   - `export { foo, bar }` (multi-specifier, any matching local)
+ *
+ * Intentionally NOT recognised (so a page is treated as non-SSG / non-static):
+ *   - `export * from "./other"` (no explicit specifier to inspect)
+ *   - `export * as ns from "./other"` (namespace re-export, not a top-level binding)
+ *   - `export { default }` or `export { default as foo }` (the local is the
+ *     `default` keyword, not the string "foo")
+ *   - Dynamically-constructed exports (string concatenation, indirect specifiers)
+ *   - Exports hidden behind wrapper modules that re-export from another file
+ *     with a renamed binding
+ *
+ * When a page that should be SSG falls into one of these gaps, the manifest
+ * omits it: the runtime still works (data prefetch is best-effort and the
+ * loader map still resolves the chunk), but `router.sdc` will not warm a JSON
+ * payload for that page during hover/viewport prefetch. See
+ * tests/build-report.test.ts → "hasNamedExport" for the full supported-shape
+ * contract.
  */
 export function hasNamedExport(code: string, name: string): boolean {
   const program = parseRouteModule(code);

--- a/packages/vinext/src/client/window-next.ts
+++ b/packages/vinext/src/client/window-next.ts
@@ -92,7 +92,10 @@ export type PagesRouterPublicInstance = {
    * See: `packages/next/src/shared/lib/router/router.ts:2525`.
    */
   components: Record<string, unknown>;
-  /** Persistent Pages Router static-data cache, matching Next.js `Router.sdc`. */
+  /**
+   * Mirrors Next.js's `Router.sdc`, the SSG data cache populated by Pages
+   * Router prefetches and inspected by the upstream deploy suite.
+   */
   sdc: Record<string, Promise<Response>>;
 };
 

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -13,6 +13,7 @@ import type {
   HasCondition,
 } from "./next-config.js";
 import {
+  MIDDLEWARE_CACHE_HEADER,
   MIDDLEWARE_HEADER_PREFIX,
   VINEXT_MW_CTX_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
@@ -563,8 +564,10 @@ export function normalizeHost(hostHeader: string | null, fallbackHostname: strin
 
 /**
  * Unpack `x-middleware-request-*` headers from the collected middleware
- * response headers into the actual request, and strip all `x-middleware-*`
- * internal signals so they never reach clients.
+ * response headers into the actual request, and strip internal
+ * `x-middleware-*` signals that should never reach clients. The public
+ * `x-middleware-cache` Pages Router cache-policy signal is preserved in
+ * `middlewareHeaders` for response staging.
  *
  * `middlewareHeaders` is mutated in-place (matching keys are deleted).
  * Returns a (possibly cloned) `Request` with the unpacked headers applied,
@@ -590,7 +593,7 @@ export function applyMiddlewareRequestHeaders(
   );
 
   for (const key of Object.keys(middlewareHeaders)) {
-    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
+    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key !== MIDDLEWARE_CACHE_HEADER) {
       delete middlewareHeaders[key];
     }
   }

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -178,6 +178,7 @@ export async function runMiddleware(request, ctx, options) {
     i18nConfig,
     isDataRequest: options?.isDataRequest === true,
     isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
+    localeOverride: options?.dataRequestLocale ?? null,
     module: middlewareModule,
     request,
     trailingSlash: vinextConfig.trailingSlash,
@@ -238,7 +239,7 @@ const i18nConfig = ${i18nConfigJson};
 // to load next.config.js at runtime.
 export const buildId = ${buildIdJson};
 export function normalizeDataRequest(request) {
-  return __normalizePagesDataRequest(request, buildId);
+  return __normalizePagesDataRequest(request, buildId, "", i18nConfig);
 }
 export const hasMiddleware = ${JSON.stringify(Boolean(middlewarePath))};
 

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -124,6 +124,14 @@ declare global {
     __VINEXT_MIDDLEWARE_MATCHER__: unknown;
 
     /**
+     * Pages Router route patterns that export `getStaticProps`, in the same
+     * Next.js bracket format as `__VINEXT_PAGE_PATTERNS__`. Mirrors Next.js's
+     * client `_ssgManifest`, letting Pages Router prefetch fetch JSON only for
+     * SSG routes while still warming chunks for non-SSG routes.
+     */
+    __VINEXT_PAGES_SSG_PATTERNS__: string[] | undefined;
+
+    /**
      * Pages Router `_app` loader. Dynamic `import()` thunk for the user's
      * `pages/_app.tsx` module, or `undefined` when the app has no `_app`.
      * Set by the generated client entry; read by `shims/router.ts`

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -76,10 +76,13 @@ import {
   type NextConfigInput,
   type ResolvedNextConfig,
 } from "./config/next-config.js";
-import { mergeServerExternalPackages } from "./config/server-external-packages.js";
-
 import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
-import { isNextDataPathname, parseNextDataPathname } from "./server/pages-data-route.js";
+import { mergeServerExternalPackages } from "./config/server-external-packages.js";
+import {
+  isNextDataPathname,
+  normalizePagesDataRouteInfo,
+  parseNextDataPathname,
+} from "./server/pages-data-route.js";
 import { resolvePagesI18nRequest } from "./server/pages-i18n.js";
 import {
   MIDDLEWARE_NEXT_HEADER,
@@ -4133,6 +4136,7 @@ export const loadServerActionClient = ${
               // accept the request; if it is present and wrong, fall through
               // to the dot-extension skip below which returns 404.
               let isDataReq = false;
+              let dataRequestLocale: string | null = null;
               if (isNextDataPathname(pathname)) {
                 // Use the plugin's resolved buildId so a user-supplied
                 // `generateBuildId` in next.config.mjs is honored in dev —
@@ -4145,8 +4149,14 @@ export const loadServerActionClient = ${
                 if (dataMatch) {
                   isDataReq = true;
                   const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-                  url = dataMatch.pagePathname + qs;
-                  pathname = dataMatch.pagePathname;
+                  const dataRouteInfo = normalizePagesDataRouteInfo(
+                    dataMatch.pagePathname,
+                    nextConfig?.i18n ?? null,
+                  );
+                  const middlewarePathname = dataRouteInfo.middlewarePathname;
+                  dataRequestLocale = dataRouteInfo.locale;
+                  url = middlewarePathname + qs;
+                  pathname = middlewarePathname;
                   // Rewrite req.url so downstream middleware sees the page
                   // path, not the raw _next/data URL.
                   req.url = url;
@@ -4273,6 +4283,7 @@ export const loadServerActionClient = ${
                         nextConfig?.basePath,
                         nextConfig?.trailingSlash,
                         opts.isDataRequest,
+                        opts.dataRequestLocale,
                       );
 
                       // Forward middleware context to the RSC entry so it can
@@ -4323,6 +4334,7 @@ export const loadServerActionClient = ${
                 hadBasePath: true, // Vite strips basePath before our middleware sees the request
                 isDataReq,
                 isDataRequest,
+                dataRequestLocale,
                 hasMiddleware: capturedMiddlewarePath !== null,
                 // Raw query so redirect Locations aren't re-encoded by URL parsing.
                 rawSearch: url.includes("?") ? url.slice(url.indexOf("?")) : "",
@@ -4539,6 +4551,7 @@ export const loadServerActionClient = ${
                   req.__vinextMiddlewareStatus,
                   pipelineResult.isDataReq,
                   originalRequestUrl,
+                  dataRequestLocale,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1173,7 +1173,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       : null;
     const pagesDataNormalization =
       options.renderPagesFallback && pagesDataCandidate
-        ? normalizePagesDataRequest(pagesDataCandidate, options.buildId)
+        ? normalizePagesDataRequest(pagesDataCandidate, options.buildId, "", options.i18nConfig)
         : null;
     if (pagesDataNormalization?.notFoundResponse) {
       return pagesDataNormalization.notFoundResponse;

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -55,6 +55,7 @@ import {
   resolvePagesI18nRequest,
 } from "./pages-i18n.js";
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
+import { buildStaticPageNextDataQuery } from "./pages-next-data-query.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import {
@@ -480,6 +481,7 @@ export function createSSRHandler(
      */
     isDataReq: boolean = false,
     originalUrl: string = url,
+    dataRequestLocale: string | null = null,
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -533,10 +535,11 @@ export function createSSRHandler(
       }
     }
 
+    const activeLocale = isDataReq && dataRequestLocale ? dataRequestLocale : locale;
     const i18nCacheVariant = i18nConfig
       ? currentDomainLocaleDomain
         ? "domain:" + currentDomainLocaleDomain.toLowerCase()
-        : "locale:" + String(locale)
+        : "locale:" + String(activeLocale)
       : null;
     const pagesIsrCacheKey = i18nCacheVariant
       ? (pathname: string) =>
@@ -560,7 +563,7 @@ export function createSSRHandler(
         const notFoundHeaders: Record<string, string> = { "Content-Type": "application/json" };
         if (hasMiddleware) {
           notFoundHeaders["x-nextjs-matched-path"] =
-            `${locale ? `/${locale}` : ""}${localeStrippedUrl}`;
+            `${activeLocale ? `/${activeLocale}` : ""}${localeStrippedUrl}`;
         }
         if (deploymentId) notFoundHeaders[NEXTJS_DEPLOYMENT_ID_HEADER] = deploymentId;
         res.writeHead(hasMiddleware ? 200 : 404, notFoundHeaders);
@@ -648,6 +651,11 @@ export function createSSRHandler(
           appComponent: AppComponent,
           hasRewrites,
         });
+        const nextDataQuery =
+          typeof pageModule.getStaticProps === "function" &&
+          typeof pageModule.getServerSideProps !== "function"
+            ? buildStaticPageNextDataQuery(params, localeStrippedUrl, originalRequestSearch)
+            : query;
         const navigationIsReady =
           typeof routerShim.getPagesNavigationIsReadyFromSerializedState === "function"
             ? routerShim.getPagesNavigationIsReadyFromSerializedState(
@@ -1228,7 +1236,7 @@ export function createSSRHandler(
                         {
                           props: freshRenderProps,
                           page: patternToNextFormat(route.pattern),
-                          query: params,
+                          query: nextDataQuery,
                           buildId: process.env.__VINEXT_BUILD_ID,
                           isFallback: false,
                           locale: locale ?? currentDefaultLocale,
@@ -1437,7 +1445,7 @@ export function createSSRHandler(
             "Content-Type": "application/json",
           };
           if ((statusCode ?? 200) === 200) {
-            const matchedPathname = `${locale ? `/${locale}` : ""}${patternToNextFormat(route.pattern)}`;
+            const matchedPathname = `${activeLocale ? `/${activeLocale}` : ""}${patternToNextFormat(route.pattern)}`;
             dataHeaders["x-nextjs-matched-path"] = matchedPathname;
           }
           if (gsspExtraHeaders) {
@@ -1655,7 +1663,7 @@ hydrate();
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: params,
+            query: nextDataQuery,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -133,6 +133,7 @@ export const ACTION_REDIRECT_STATUS_HEADER = "x-action-redirect-status";
 // ---------------------------------------------------------------------------
 
 export {
+  MIDDLEWARE_CACHE_HEADER,
   MIDDLEWARE_HEADER_PREFIX,
   MIDDLEWARE_SET_COOKIE_HEADER,
 } from "../utils/protocol-headers.js";

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -24,6 +24,7 @@ import {
   removeTrailingSlash,
   stripBasePath,
 } from "../utils/base-path.js";
+import { addLocalePrefix } from "../utils/domain-locale.js";
 
 export type MiddlewareModule = Record<string, unknown>;
 
@@ -73,6 +74,12 @@ type ExecuteMiddlewareOptions = {
    */
   isDataRequest?: boolean;
   isProxy: boolean;
+  /**
+   * Locale carried by a trusted `_next/data` URL. Data requests are normalized
+   * to the route pathname before middleware runs, but Next.js still exposes the
+   * encoded data locale through `request.nextUrl.locale`.
+   */
+  localeOverride?: string | null;
   module: MiddlewareModule;
   normalizedPathname?: string;
   request: Request;
@@ -222,6 +229,10 @@ function resolveMiddlewarePathname(request: Request): string | Response {
   }
 }
 
+function isApiRoutePathname(pathname: string): boolean {
+  return pathname === "/api" || pathname.startsWith("/api/");
+}
+
 function createNextRequest(
   request: Request,
   normalizedPathname: string,
@@ -229,6 +240,7 @@ function createNextRequest(
   basePath?: string,
   trailingSlash?: boolean,
   hadBasePath?: boolean,
+  localeOverride?: string | null,
 ): NextRequest {
   const url = new URL(request.url);
   // Middleware gets an isolated body branch; downstream routing keeps owning
@@ -244,10 +256,12 @@ function createNextRequest(
   // configured value. Out-of-basePath ("absolute path") requests must stay
   // un-prefixed so the middleware observes nextUrl.basePath === "" (Next.js
   // getNextPathnameInfo semantics).
+  let nextUrlPathname = normalizedPathname;
+  if (i18nConfig && localeOverride && !isApiRoutePathname(normalizedPathname)) {
+    nextUrlPathname = addLocalePrefix(normalizedPathname, localeOverride, "");
+  }
   const mwPathname =
-    basePath && hadBasePath
-      ? addBasePathToPathname(normalizedPathname, basePath)
-      : normalizedPathname;
+    basePath && hadBasePath ? addBasePathToPathname(nextUrlPathname, basePath) : nextUrlPathname;
   if (mwPathname !== url.pathname) {
     const mwUrl = new URL(url);
     mwUrl.pathname = mwPathname;
@@ -320,6 +334,7 @@ export async function executeMiddleware(
     options.basePath,
     options.trailingSlash,
     hadBasePath,
+    options.localeOverride,
   );
   if (options.isDataRequest) {
     Object.defineProperty(nextRequest, "__isData", {

--- a/packages/vinext/src/server/middleware.ts
+++ b/packages/vinext/src/server/middleware.ts
@@ -158,6 +158,7 @@ export async function runMiddleware(
   basePath?: string,
   trailingSlash?: boolean,
   isDataRequest?: boolean,
+  dataRequestLocale?: string | null,
 ): Promise<MiddlewareResult> {
   // Load the middleware module via the direct-call ModuleRunner.
   // This bypasses the hot channel entirely and is safe with all Vite plugin
@@ -179,6 +180,7 @@ export async function runMiddleware(
     includeErrorDetails: process.env.NODE_ENV !== "production",
     isDataRequest,
     isProxy: isProxyFile(middlewarePath),
+    localeOverride: dataRequestLocale ?? null,
     module: mod,
     request,
     trailingSlash,

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -20,6 +20,8 @@
 
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
+import type { NextI18nConfig } from "../config/next-config.js";
+import { extractLocaleFromUrl } from "./pages-i18n.js";
 
 const NEXT_DATA_PREFIX = "/_next/data/";
 const NEXT_DATA_SUFFIX = ".json";
@@ -172,10 +174,39 @@ type NormalizePagesDataRequestResult =
   | {
       isDataReq: true;
       request: Request;
+      /**
+       * The locale-stripped page pathname used for middleware/routing. The
+       * data endpoint keeps the locale segment in the wire URL, but Next.js
+       * middleware observes the route pathname without that locale prefix.
+       */
+      middlewarePathname: string;
+      /**
+       * The parsed data page pathname, locale segment included when present.
+       * Renderers use this to preserve the data request's asPath/envelope.
+       */
       normalizedPathname: string;
+      /**
+       * The locale encoded in the data URL, or the configured default locale
+       * when i18n is enabled and the data URL is unprefixed. Middleware gets
+       * the locale-stripped route pathname but `request.nextUrl.locale` must
+       * still reflect the data URL's active locale.
+       */
+      locale: string | null;
       search: string;
       notFoundResponse: null;
     };
+
+export function normalizePagesDataRouteInfo(
+  pagePathname: string,
+  i18nConfig?: NextI18nConfig | null,
+): { middlewarePathname: string; locale: string | null } {
+  if (!i18nConfig) return { middlewarePathname: pagePathname, locale: null };
+  const localeInfo = extractLocaleFromUrl(pagePathname, i18nConfig);
+  return {
+    middlewarePathname: localeInfo.hadPrefix ? localeInfo.url : pagePathname,
+    locale: localeInfo.locale,
+  };
+}
 
 /**
  * Detect and normalize `/_next/data/<buildId>/<page>.json` requests in one
@@ -199,6 +230,7 @@ export function normalizePagesDataRequest(
   request: Request,
   buildId: string | null,
   basePath = "",
+  i18nConfig?: NextI18nConfig | null,
 ): NormalizePagesDataRequestResult {
   const reqUrl = new URL(request.url);
   const hadBasePath = !!basePath && hasBasePath(reqUrl.pathname, basePath);
@@ -223,13 +255,16 @@ export function normalizePagesDataRequest(
     };
   }
   const normalizedUrl = new URL(reqUrl);
+  const routeInfo = normalizePagesDataRouteInfo(dataMatch.pagePathname, i18nConfig);
   normalizedUrl.pathname = hadBasePath
-    ? addBasePathToPathname(dataMatch.pagePathname, basePath)
-    : dataMatch.pagePathname;
+    ? addBasePathToPathname(routeInfo.middlewarePathname, basePath)
+    : routeInfo.middlewarePathname;
   return {
     isDataReq: true,
     request: new Request(normalizedUrl, request),
+    middlewarePathname: routeInfo.middlewarePathname,
     normalizedPathname: dataMatch.pagePathname,
+    locale: routeInfo.locale,
     search: reqUrl.search,
     notFoundResponse: null,
   };

--- a/packages/vinext/src/server/pages-next-data-query.ts
+++ b/packages/vinext/src/server/pages-next-data-query.ts
@@ -1,0 +1,39 @@
+import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
+
+function queryValuesEqual(
+  left: string | string[] | undefined,
+  right: string | string[] | undefined,
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  const leftValues = Array.isArray(left) ? left : [left];
+  const rightValues = Array.isArray(right) ? right : [right];
+  if (leftValues.length !== rightValues.length) return false;
+  return leftValues.every((value, index) => value === rightValues[index]);
+}
+
+function getRewriteDerivedQuery(
+  routeUrl: string,
+  originalRequestSearch: string,
+): Record<string, string | string[]> {
+  const destinationQuery = parseQuery(routeUrl);
+  if (Object.keys(destinationQuery).length === 0) return {};
+
+  const originalQuery = parseQuery(originalRequestSearch);
+  const rewriteQuery: Record<string, string | string[]> = {};
+
+  for (const [key, value] of Object.entries(destinationQuery)) {
+    if (!queryValuesEqual(value, originalQuery[key])) {
+      rewriteQuery[key] = Array.isArray(value) ? [...value] : value;
+    }
+  }
+
+  return rewriteQuery;
+}
+
+export function buildStaticPageNextDataQuery(
+  params: Record<string, string | string[]>,
+  routeUrl: string,
+  originalRequestSearch: string,
+): Record<string, string | string[]> {
+  return mergeRouteParamsIntoQuery(getRewriteDerivedQuery(routeUrl, originalRequestSearch), params);
+}

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -21,6 +21,7 @@ import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { renderPagesPageResponse } from "./pages-page-response.js";
+import { buildStaticPageNextDataQuery } from "./pages-next-data-query.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
@@ -310,7 +311,7 @@ export function createPagesPageHandler(
     const originalRequestPathAndSearch = originalRequestUrl.pathname + originalRequestUrl.search;
     let dataRequestPathname: string | null = null;
     let dataRequestSearch = "";
-    const initialDataNorm = normalizePagesDataRequest(request, buildId);
+    const initialDataNorm = normalizePagesDataRequest(request, buildId, "", i18nConfig);
 
     // Auto-detect /_next/data/... requests by inspecting the incoming URL.
     // When the worker pipeline forwards an unrewritten data URL as the `url`
@@ -323,7 +324,7 @@ export function createPagesPageHandler(
         dataRequestSearch = initialDataNorm.search;
         if (url && url.startsWith("/_next/data/")) {
           const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-          url = initialDataNorm.normalizedPathname + qs;
+          url = initialDataNorm.middlewarePathname + qs;
         }
       }
     } else if (initialDataNorm.isDataReq) {
@@ -418,6 +419,7 @@ export function createPagesPageHandler(
     }
 
     const { route, params } = match;
+    const pageModule = route.module;
     const uCtx = createRequestContext({
       executionContext: getRequestExecutionContext(),
     });
@@ -430,11 +432,16 @@ export function createPagesPageHandler(
           renderStatusCodeOverride ?? (routePattern === "/404" ? 404 : undefined);
         const query = mergeRouteParamsIntoQuery(parseQuery(routeUrl), params);
 
+        const nextDataQuery =
+          typeof pageModule.getStaticProps === "function" &&
+          typeof pageModule.getServerSideProps !== "function"
+            ? buildStaticPageNextDataQuery(params, routeUrl, originalRequestUrl.search)
+            : query;
+
         // Model Pages Router readiness for `next/navigation` compat hooks. The
         // serialized `__NEXT_DATA__` flags (gssp/gsp/gip/appGip/autoExport) plus
         // the configured-rewrites flag decide the initial `router.isReady` value,
         // mirroring Next.js's Pages adapter. See server/render.tsx readiness rule.
-        const pageModule = route.module;
         const pagesNextData = buildPagesReadinessNextData({
           pageModule,
           appComponent: AppComponent as { getInitialProps?: unknown } | null,
@@ -763,6 +770,7 @@ export function createPagesPageHandler(
           props: renderProps,
           params,
           query,
+          nextDataQuery,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -195,6 +195,7 @@ type RenderPagesPageResponseOptions = {
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
   query?: Record<string, unknown>;
+  nextDataQuery?: Record<string, unknown>;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -262,6 +263,8 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "query"
+    | "nextDataQuery"
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
@@ -273,7 +276,7 @@ export function buildPagesNextDataScript(
   const nextDataPayload: Record<string, unknown> = {
     props: options.props ?? { pageProps: options.pageProps },
     page: options.routePattern,
-    query: options.params,
+    query: options.nextDataQuery ?? options.query ?? options.params,
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -491,6 +494,8 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.query,
+    nextDataQuery: options.nextDataQuery,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -101,6 +101,7 @@ export type PagesPipelineDeps = {
   hadBasePath: boolean; // adapter computes: !basePath || hasBasePath(originalPathname, basePath)
   isDataReq: boolean; // true if this was a /_next/data/ request (already normalized by adapter)
   isDataRequest: boolean; // trusted data classification for middleware protocol handling
+  dataRequestLocale?: string | null; // trusted locale parsed from the _next/data path
   hasMiddleware: boolean; // true only when the app defines middleware/proxy
   ctx?: unknown; // Cloudflare ExecutionContext or undefined (for Node)
   // Raw, un-re-encoded query string (incl. leading "?") for building redirect Location
@@ -120,7 +121,7 @@ export type PagesPipelineDeps = {
     | ((
         request: Request,
         ctx: unknown,
-        opts: { isDataRequest: boolean },
+        opts: { isDataRequest: boolean; dataRequestLocale?: string | null },
       ) => Promise<MiddlewareResult>)
     | null;
   renderPage?:
@@ -327,7 +328,10 @@ export async function runPagesRequest(
   };
 
   if (typeof deps.runMiddleware === "function") {
-    const result = await deps.runMiddleware(request, deps.ctx ?? null, { isDataRequest });
+    const result = await deps.runMiddleware(request, deps.ctx ?? null, {
+      dataRequestLocale: deps.dataRequestLocale,
+      isDataRequest,
+    });
 
     // Bubble waitUntil promises
     if (result.waitUntilPromises && result.waitUntilPromises.length > 0) {
@@ -420,18 +424,30 @@ export async function runPagesRequest(
   });
   let resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
 
-  const matchResolvedPathname = (p: string): string =>
-    i18nConfig ? normalizeDefaultLocalePathname(p, i18nConfig, { hostname: requestHostname }) : p;
+  const dataMatchedPathLocale =
+    i18nConfig && (isDataReq || isDataRequest) && deps.dataRequestLocale
+      ? deps.dataRequestLocale
+      : null;
+  const localePrefixPathname = (p: string, locale: string): string =>
+    p === "/" ? `/${locale}` : `/${locale}${p}`;
+  const matchResolvedPathname = (p: string, localeOverride?: string | null): string => {
+    if (!i18nConfig) return p;
+    if (localeOverride) {
+      const existingLocale = p.split("/", 3)[1];
+      return existingLocale && i18nConfig.locales.includes(existingLocale)
+        ? p
+        : localePrefixPathname(p, localeOverride);
+    }
+    return normalizeDefaultLocalePathname(p, i18nConfig, { hostname: requestHostname });
+  };
   const matchedPathnameForRoute = (routePattern: string | undefined): string => {
     const matchedPathname = routePattern ? patternToNextFormat(routePattern) : resolvedPathname;
     if (!i18nConfig) return matchedPathname;
     const resolvedLocale = resolvedPathname.split("/", 3)[1];
     if (resolvedLocale && i18nConfig.locales.includes(resolvedLocale)) {
-      return matchedPathname === "/"
-        ? `/${resolvedLocale}`
-        : `/${resolvedLocale}${matchedPathname}`;
+      return localePrefixPathname(matchedPathname, resolvedLocale);
     }
-    return matchResolvedPathname(matchedPathname);
+    return matchResolvedPathname(matchedPathname, dataMatchedPathLocale);
   };
 
   // Step 7: Config headers staging
@@ -696,7 +712,7 @@ export async function runPagesRequest(
     ) {
       const headers = new Headers(response.headers);
       headers.set("content-type", "application/json");
-      headers.set("x-nextjs-matched-path", matchResolvedPathname(pathname));
+      headers.set("x-nextjs-matched-path", matchResolvedPathname(pathname, dataMatchedPathLocale));
       const notFoundResponse = new Response("{}", { status: 200, headers });
       return {
         type: "response",

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -48,6 +48,7 @@ import {
   isNextDataPathname,
   parseNextDataPathname,
   buildNextDataNotFoundResponse,
+  normalizePagesDataRouteInfo,
 } from "./pages-data-route.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import {
@@ -1752,6 +1753,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       // here — stale clients can fall back to a hard navigation without
       // accidentally triggering middleware/SSR on a bogus path.
       let isDataReq = false;
+      let dataRequestLocale: string | null = null;
       const originalRenderUrl = url;
       if (isNextDataPathname(pathname)) {
         const dataMatch = pagesBuildId ? parseNextDataPathname(pathname, pagesBuildId) : null;
@@ -1764,8 +1766,11 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         }
         isDataReq = true;
         const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-        url = dataMatch.pagePathname + qs;
-        pathname = dataMatch.pagePathname;
+        const dataRouteInfo = normalizePagesDataRouteInfo(dataMatch.pagePathname, i18nConfig);
+        const middlewarePathname = dataRouteInfo.middlewarePathname;
+        dataRequestLocale = dataRouteInfo.locale;
+        url = middlewarePathname + qs;
+        pathname = middlewarePathname;
       }
 
       // Convert Node.js req to Web Request for the server entry
@@ -1800,6 +1805,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         hadBasePath,
         isDataReq,
         isDataRequest,
+        dataRequestLocale,
         hasMiddleware,
         ctx: undefined, // Node has no ExecutionContext
         // Raw query from req.url so redirect Locations aren't re-encoded by URL parsing.

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -4,6 +4,7 @@ import type { BasePathMatchState, RequestContext } from "../config/config-matche
 import { matchHeaders } from "../config/config-matchers.js";
 import {
   INTERNAL_HEADERS,
+  MIDDLEWARE_CACHE_HEADER,
   MIDDLEWARE_HEADER_PREFIX,
   VINEXT_INTERNAL_HEADERS,
   VINEXT_STATIC_FILE_HEADER,
@@ -544,7 +545,9 @@ export function isOriginAllowed(origin: string, allowed: string[]): boolean {
  *
  * Middleware uses `x-middleware-*` headers as internal signals (e.g.
  * `x-middleware-next`, `x-middleware-rewrite`, `x-middleware-request-*`).
- * These must be removed before sending the response to the client.
+ * These must be removed before sending the response to the client. The one
+ * exception is `x-middleware-cache`, which Next.js exposes to the Pages Router
+ * client so it can evict prefetch data when middleware opts out of caching.
  *
  * @param headers - The Headers object to modify in place
  */
@@ -552,7 +555,7 @@ export function processMiddlewareHeaders(headers: Headers): void {
   const keysToDelete: string[] = [];
 
   for (const key of headers.keys()) {
-    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
+    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key !== MIDDLEWARE_CACHE_HEADER) {
       keysToDelete.push(key);
     }
   }

--- a/packages/vinext/src/shims/internal/pages-data-target.ts
+++ b/packages/vinext/src/shims/internal/pages-data-target.ts
@@ -35,13 +35,51 @@ export type PagesDataTarget = {
   /** URL search string including the leading `?`. */
   search: string;
   /**
-   * Locale prefix detected on the URL, or `undefined` when the URL is
-   * unprefixed (default locale, or no i18n configured). Lets the caller refresh
-   * locale state on locale transitions, which the data JSON envelope itself
-   * does not carry.
+   * Active locale for this data request. Locale-prefixed browser URLs use the
+   * URL prefix; unprefixed i18n URLs use the current/default locale because
+   * Next.js still includes that segment in `/_next/data` paths.
    */
   locale: string | undefined;
 };
+
+type PagesDataLocalePath = {
+  dataPagePath: string;
+  locale: string | undefined;
+};
+
+function prefixPagesDataPathWithLocale(pagePath: string, locale: string): string {
+  return pagePath === "/" ? `/${locale}` : `/${locale}${pagePath}`;
+}
+
+export function resolvePagesDataLocalePath(
+  pagePath: string,
+  locales: readonly string[] | undefined,
+  currentLocale: string | undefined,
+  defaultLocale: string | undefined,
+): PagesDataLocalePath {
+  if (!locales || locales.length === 0) {
+    return { dataPagePath: pagePath, locale: undefined };
+  }
+
+  const pathLocale = getLocalePathPrefix(pagePath, locales);
+  if (pathLocale) {
+    return { dataPagePath: pagePath, locale: pathLocale };
+  }
+
+  const activeLocale = currentLocale ?? defaultLocale;
+  if (!activeLocale || !locales.includes(activeLocale)) {
+    return { dataPagePath: pagePath, locale: undefined };
+  }
+
+  if (activeLocale === defaultLocale) {
+    return { dataPagePath: pagePath, locale: activeLocale };
+  }
+
+  return {
+    dataPagePath: prefixPagesDataPathWithLocale(pagePath, activeLocale),
+    locale: activeLocale,
+  };
+}
 
 type ClientMiddlewareMatcherObject = {
   source: string;
@@ -124,7 +162,11 @@ function clientMiddlewareMatcherMatches(pathname: string, matcher: unknown): boo
   return false;
 }
 
-export function getPagesMiddlewareDataHref(browserUrl: string, basePath: string): string | null {
+export function getPagesMiddlewareDataHref(
+  browserUrl: string,
+  basePath: string,
+  activeLocaleOverride?: string,
+): string | null {
   const nextData = window.__NEXT_DATA__;
   if (!nextData || !hasVinextMiddleware(nextData)) return null;
   const buildId = nextData.buildId;
@@ -138,12 +180,18 @@ export function getPagesMiddlewareDataHref(browserUrl: string, basePath: string)
   }
   if (parsed.origin !== window.location.origin) return null;
 
-  const pathname = stripBasePath(parsed.pathname, basePath);
-  if (!clientMiddlewareMatcherMatches(pathname, window.__VINEXT_MIDDLEWARE_MATCHER__)) {
+  const pagePath = stripBasePath(parsed.pathname, basePath);
+  if (!clientMiddlewareMatcherMatches(pagePath, window.__VINEXT_MIDDLEWARE_MATCHER__)) {
     return null;
   }
 
-  return buildPagesDataHref(basePath, buildId, pathname, parsed.search);
+  const { dataPagePath } = resolvePagesDataLocalePath(
+    pagePath,
+    window.__VINEXT_LOCALES__,
+    activeLocaleOverride ?? window.__VINEXT_LOCALE__,
+    window.__VINEXT_DEFAULT_LOCALE__,
+  );
+  return buildPagesDataHref(basePath, buildId, dataPagePath, parsed.search);
 }
 
 /**
@@ -172,6 +220,7 @@ export function getPagesMiddlewareDataHref(browserUrl: string, basePath: string)
 export function resolvePagesDataNavigationTarget(
   browserUrl: string,
   basePath: string,
+  activeLocaleOverride?: string,
 ): PagesDataTarget | null {
   if (typeof window === "undefined") return null;
 
@@ -191,10 +240,10 @@ export function resolvePagesDataNavigationTarget(
   if (parsed.origin !== window.location.origin) return null;
 
   const pagePath = stripBasePath(parsed.pathname, basePath);
-  const locale = getLocalePathPrefix(pagePath, window.__VINEXT_LOCALES__);
-  // `locale.length + 1` skips the `/<locale>` segment. If only the locale was
-  // present (`/fr`) the remainder is empty, which normalises to `/` (root).
-  const pathForMatch = locale ? pagePath.slice(locale.length + 1) || "/" : pagePath;
+  const pathLocale = getLocalePathPrefix(pagePath, window.__VINEXT_LOCALES__);
+  // `pathLocale.length + 1` skips the `/<locale>` segment. If only the locale
+  // was present (`/fr`) the remainder is empty, which normalises to `/` (root).
+  const pathForMatch = pathLocale ? pagePath.slice(pathLocale.length + 1) || "/" : pagePath;
 
   const match = matchPagesPattern(pathForMatch, patterns);
   if (!match) return null;
@@ -214,13 +263,21 @@ export function resolvePagesDataNavigationTarget(
         ? "server"
         : "none";
 
+  const { dataPagePath, locale } = resolvePagesDataLocalePath(
+    pagePath,
+    window.__VINEXT_LOCALES__,
+    activeLocaleOverride ?? window.__VINEXT_LOCALE__,
+    window.__VINEXT_DEFAULT_LOCALE__,
+  );
+
   return {
-    dataHref: buildPagesDataHref(basePath, buildId, pagePath, parsed.search),
+    dataHref: buildPagesDataHref(basePath, buildId, dataPagePath, parsed.search),
     pattern: match.pattern,
     params: match.params,
     loader,
     dataKind,
-    middlewareDataHref: getPagesMiddlewareDataHref(browserUrl, basePath) ?? undefined,
+    middlewareDataHref:
+      getPagesMiddlewareDataHref(browserUrl, basePath, activeLocaleOverride) ?? undefined,
     buildId,
     pagePath,
     search: parsed.search,

--- a/packages/vinext/src/shims/internal/pages-data-url.ts
+++ b/packages/vinext/src/shims/internal/pages-data-url.ts
@@ -78,26 +78,71 @@ type PagesPatternMatch = {
   params: Record<string, string | string[]>;
 };
 
+function routePartRank(part: string): number {
+  if (part.startsWith(":") && part.endsWith("*")) return 3;
+  if (part.startsWith(":") && part.endsWith("+")) return 2;
+  if (part.startsWith(":")) return 1;
+  return 0;
+}
+
+function comparePagesPatternSpecificity(left: string, right: string): number {
+  const leftParts = routePatternParts(left);
+  const rightParts = routePatternParts(right);
+  const maxLength = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < maxLength; index++) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+
+    const leftRank = routePartRank(leftPart);
+    const rightRank = routePartRank(rightPart);
+    if (leftRank !== rightRank) return leftRank - rightRank;
+
+    if (leftRank === 0 && leftPart !== rightPart) {
+      return leftPart.localeCompare(rightPart);
+    }
+  }
+
+  return left.localeCompare(right);
+}
+
 /**
  * Find the route pattern (Next.js bracket format) that matches `pathname`.
  *
- * Patterns are tried in `patterns` order — callers should pre-sort so more
- * specific patterns come before catch-alls. Returns `null` when no pattern
- * matches, so the caller can fall back to a hard navigation (this is how
- * vinext handles routes that exist on the server but are not in the
- * client-side loader map, e.g. dev-only pages).
+ * Next.js resolves all matching page routes with sorted-routes specificity:
+ * static segments beat dynamic segments, dynamic beats catch-all, and optional
+ * catch-all comes last. Do that here instead of trusting global manifest order;
+ * middleware rewrites can turn a dynamic visible URL into a static destination
+ * such as `/about`, and the client must import the destination page module.
+ *
+ * Ported from Next.js:
+ * `packages/next/src/shared/lib/router/router.ts` (`resolveDynamicRoute`) and
+ * `packages/next/src/shared/lib/router/utils/sorted-routes.ts`.
+ *
+ * Returns `null` when no pattern matches, so the caller can fall back to a hard
+ * navigation (this is how vinext handles routes that exist on the server but
+ * are not in the client-side loader map, e.g. dev-only pages).
  */
 export function matchPagesPattern(
   pathname: string,
   patterns: readonly string[],
 ): PagesPatternMatch | null {
   const urlParts = pathname.split("/").filter(Boolean);
+  let bestMatch: PagesPatternMatch | null = null;
   for (const pattern of patterns) {
     const patternParts = routePatternParts(pattern);
     const params = matchRoutePattern(urlParts, patternParts);
     if (params !== null) {
-      return { pattern, params };
+      const match = { pattern, params };
+      if (
+        bestMatch === null ||
+        comparePagesPatternSpecificity(match.pattern, bestMatch.pattern) < 0
+      ) {
+        bestMatch = match;
+      }
     }
   }
-  return null;
+  return bestMatch;
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -148,6 +148,7 @@ function PagesRouterCommitBoundaryHelper({
 function renderPagesRouterElement(
   element: ReactElement,
   scroll?: ScrollPosition | null,
+  onCommit?: () => void,
 ): Promise<void> {
   const root = window.__VINEXT_ROOT__;
   if (!root) {
@@ -189,6 +190,7 @@ function renderPagesRouterElement(
             if (!isCurrent()) return;
 
             try {
+              onCommit?.();
               await scrollHandler();
               if (!isCurrent()) return;
               clearIfCurrent();
@@ -205,9 +207,20 @@ function renderPagesRouterElement(
         },
       ),
     );
-    if (!hasBrowserDocument()) {
+    if (!onCommit && !scroll) {
       clearIfCurrent();
       resolve();
+      return;
+    }
+    if (!hasBrowserDocument()) {
+      try {
+        onCommit?.();
+        clearIfCurrent();
+        resolve();
+      } catch (err) {
+        clearIfCurrent();
+        reject(err);
+      }
     }
   });
 }
@@ -1452,10 +1465,30 @@ function scheduleHardNavigationAndThrow(url: string, message: string): never {
 type NavigateClientOptions = {
   allowNotFoundResponse?: boolean;
   /**
-   * The history mode of the originating navigation. Used when a gSSP/gSP data
-   * response carries a `__N_REDIRECT` marker so the re-entrant navigation to
-   * the redirect destination preserves push-vs-replace semantics, matching
-   * Next.js's `this.change(method, ...)` re-dispatch.
+   * Set by `navigateClientData` after a `__N_REDIRECT` data response has
+   * chained a `performNavigation` to the redirect destination. The outer
+   * `performNavigation` reads this to skip its own `routeChangeComplete`
+   * event — the destination navigation has already produced completion for
+   * the destination URL. Mirrors Next.js's
+   * `return this.change(method, newUrl, newAs, options)` chain in
+   * `pageProps.__N_REDIRECT` handling.
+   */
+  consumedByRedirect?: boolean;
+  /**
+   * The boolean the chained destination `performNavigation` resolved to,
+   * recorded alongside `consumedByRedirect`. The outer `performNavigation`
+   * returns this instead of a hardcoded `true` so a failed destination
+   * navigation (e.g. deploy-skew 404 → hard reload) propagates `false` to
+   * the originating `Router.push()`, matching Next.js's recursive
+   * `return this.change(...)` which yields the destination navigation's
+   * result.
+   */
+  redirectResult?: boolean;
+  dataLocale?: string;
+  /**
+   * The history mode of the originating navigation. Used when a gSSP/gSP
+   * data response carries a `__N_REDIRECT` marker so the re-entrant
+   * navigation preserves push-vs-replace semantics.
    */
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
@@ -1795,8 +1828,11 @@ async function resolveClientConfigRewrite(
   return matched ? { href: currentHref, kind: "rewrite" } : null;
 }
 
-function getMiddlewarePagesDataFetchUrl(browserUrl: string): string | null {
-  return getPagesMiddlewareDataHref(browserUrl, __basePath);
+function getMiddlewarePagesDataFetchUrl(
+  browserUrl: string,
+  activeLocaleOverride?: string,
+): string | null {
+  return getPagesMiddlewareDataHref(browserUrl, __basePath, activeLocaleOverride);
 }
 
 function getPagesDataCacheHref(dataHref: string): string {
@@ -1824,8 +1860,9 @@ function shouldEvictMiddlewareDataCache(
 async function resolveMiddlewareDataEffect(
   browserUrl: string,
   signal: AbortSignal,
+  activeLocaleOverride?: string,
 ): Promise<MiddlewareDataEffect | null> {
-  const dataUrl = getMiddlewarePagesDataFetchUrl(browserUrl);
+  const dataUrl = getMiddlewarePagesDataFetchUrl(browserUrl, activeLocaleOverride);
   if (!dataUrl) return null;
 
   // Middleware probes use the Pages data cache so a Link prefetch can be reused
@@ -1860,20 +1897,28 @@ async function resolveMiddlewareDataEffect(
  *
  * Internal destinations (absolute paths, unless the redirect opted out of
  * basePath via `__N_REDIRECT_BASE_PATH === false`) are followed with a fresh
- * client-side navigation that preserves the originating push/replace mode. The
- * fresh navigation increments the navigation id, so the navigation that
+ * client-side navigation that preserves the originating push/replace mode.
+ * The fresh navigation increments the navigation id, so the navigation that
  * produced this redirect is superseded and never commits the intermediate
- * page. External (or non-absolute) destinations fall back to a hard navigation.
+ * page. External (or non-absolute) destinations fall back to a hard
+ * navigation.
+ *
+ * The destination navigation is **awaited** so the userland `router.push()`
+ * promise resolves only after the redirect destination has finished. This
+ * matches Next.js's `return this.change(method, newUrl, newAs, options)`
+ * in `pageProps.__N_REDIRECT` handling (packages/next/src/shared/lib/
+ * router/router.ts:1725), where the recursive `change` chains into the
+ * source navigation's promise.
  *
  * Ported from Next.js: packages/next/src/shared/lib/router/router.ts
  * (`pageProps.__N_REDIRECT` handling — internal `this.change` vs
  * `handleHardNavigation`).
  */
-function handleDataRedirect(
+async function handleDataRedirect(
   destination: string,
   redirectBasePath: unknown,
   mode: "push" | "replace" = "push",
-): void {
+): Promise<boolean> {
   const isInternal = destination.startsWith("/") && redirectBasePath !== false;
   if (!isInternal) {
     // External or basePath-less redirect — hard navigate to the redirect
@@ -1881,9 +1926,9 @@ function handleDataRedirect(
     scheduleHardNavigationAndThrow(destination, "Navigation redirected externally");
   }
 
-  // Re-dispatch as a fresh navigation. `locale: false` matches Next.js, which
-  // does not re-apply the locale prefix to a redirect destination.
-  void performNavigation(destination, undefined, { locale: false }, mode);
+  // Re-dispatch as a chained navigation. `locale: false` matches Next.js,
+  // which does not re-apply the locale prefix to a redirect destination.
+  return performNavigation(destination, undefined, { locale: false }, mode);
 }
 
 async function loadTargetPageModule(
@@ -2123,13 +2168,13 @@ async function navigateClientData(
   }
   let res = prefetchedResponse;
   if (!res) {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      "x-nextjs-data": "1",
+    };
+    const deploymentId = getDeploymentId();
+    if (deploymentId) headers[NEXT_DEPLOYMENT_ID_HEADER] = deploymentId;
     try {
-      const headers: Record<string, string> = {
-        Accept: "application/json",
-        "x-nextjs-data": "1",
-      };
-      const deploymentId = getDeploymentId();
-      if (deploymentId) headers[NEXT_DEPLOYMENT_ID_HEADER] = deploymentId;
       const dataFetch =
         initialTarget.dataKind === "static" ? fetchStaticPagesData : dedupedPagesDataFetch;
       res = await dataFetch(initialTarget.dataHref, {
@@ -2160,10 +2205,14 @@ async function navigateClientData(
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
     }
 
-    window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-    await navigateClientHtml(redirectedUrl, redirectedUrl, controller, navId, assertStillCurrent);
+    await navigateClientHtml(
+      redirectedUrl,
+      redirectedUrl,
+      controller,
+      navId,
+      assertStillCurrent,
+      options,
+    );
     return;
   }
 
@@ -2177,7 +2226,7 @@ async function navigateClientData(
 
   const rewriteTarget = res.headers.get("x-nextjs-rewrite");
   const target = rewriteTarget
-    ? resolvePagesDataNavigationTarget(rewriteTarget, __basePath)
+    ? resolvePagesDataNavigationTarget(rewriteTarget, __basePath, options.dataLocale)
     : initialTarget;
   if (!target) {
     scheduleHardNavigationAndThrow(
@@ -2201,18 +2250,27 @@ async function navigateClientData(
     evictPagesDataCache(initialTarget.dataHref);
   }
 
-  // gSSP/gSP redirect marker. When getServerSideProps/getStaticProps returns
-  // `{ redirect }`, the data endpoint replies 200 with `__N_REDIRECT` /
-  // `__N_REDIRECT_STATUS` inside pageProps (rather than an HTTP redirect, which
-  // fetch would transparently follow to non-JSON HTML). Re-enter a fresh
-  // navigation to the destination — this increments the navigation id, which
-  // supersedes (cancels) the current navigation so the intermediate page is
-  // never committed. Mirrors Next.js's `pageProps.__N_REDIRECT` handling in
-  // packages/next/src/shared/lib/router/router.ts (`this.change(method, ...)`).
+  // gSSP/gSP redirect marker. When getServerSideProps/getStaticProps
+  // returns `{ redirect }`, the data endpoint replies 200 with
+  // `__N_REDIRECT` / `__N_REDIRECT_STATUS` inside pageProps (rather than
+  // an HTTP redirect, which fetch would transparently follow to non-JSON
+  // HTML). Chain into a fresh navigation to the destination and await it
+  // so the userland `router.push()` promise resolves only after the
+  // redirect has committed. Mirrors Next.js's
+  // `return this.change(method, newUrl, newAs, options)` in
+  // packages/next/src/shared/lib/router/router.ts:1725. The
+  // `consumedByRedirect` flag tells the source `performNavigation` to
+  // skip its own `commitHistory` write and `routeChangeComplete` event
+  // because the destination has already produced both.
   const redirectDestination = pageProps.__N_REDIRECT;
   if (typeof redirectDestination === "string") {
-    handleDataRedirect(redirectDestination, pageProps.__N_REDIRECT_BASE_PATH, options.mode);
-    throw new NavigationCancelledError(url);
+    options.consumedByRedirect = true;
+    options.redirectResult = await handleDataRedirect(
+      redirectDestination,
+      pageProps.__N_REDIRECT_BASE_PATH,
+      options.mode,
+    );
+    return;
   }
 
   await renderPagesNavigationTarget(url, target, props, options, assertStillCurrent);
@@ -2386,11 +2444,6 @@ async function navigateClientHtml(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
-  if (pendingRedirectHistoryUrl) {
-    window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-  }
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
@@ -2495,11 +2548,18 @@ async function navigateClient(
       // `_next/data/<id>/something-else.json` (the page that actually renders)
       // rather than `_next/data/<id>/hello.json` (the masked address). When
       // routeUrl === url (no mask), behaviour is unchanged.
-      let dataTarget = resolvePagesDataNavigationTarget(routeLookupUrl, __basePath);
+      let dataTarget = resolvePagesDataNavigationTarget(
+        routeLookupUrl,
+        __basePath,
+        options.dataLocale,
+      );
       let middlewareDataResponse: Response | undefined;
       let middlewareEffect: MiddlewareDataEffect | null = null;
       let middlewareRewrittenTarget: PagesDataTarget | null | undefined;
-      const middlewareProbeDataHref = getMiddlewarePagesDataFetchUrl(browserUrl);
+      const middlewareProbeDataHref = getMiddlewarePagesDataFetchUrl(
+        browserUrl,
+        options.dataLocale,
+      );
       if (middlewareProbeDataHref !== null) {
         // If this navigation is superseded before middleware responds, we do
         // not yet know whether middleware would redirect/rewrite away from a
@@ -2508,7 +2568,11 @@ async function navigateClient(
         // target is cacheable static data.
         middlewareDataCacheEvictHref = getPagesDataCacheHref(middlewareProbeDataHref);
         try {
-          middlewareEffect = await resolveMiddlewareDataEffect(browserUrl, controller.signal);
+          middlewareEffect = await resolveMiddlewareDataEffect(
+            browserUrl,
+            controller.signal,
+            options.dataLocale,
+          );
         } catch (err: unknown) {
           if (err instanceof DOMException && err.name === "AbortError") {
             throw new NavigationCancelledError(browserUrl);
@@ -2519,6 +2583,7 @@ async function navigateClient(
           middlewareRewrittenTarget = resolvePagesDataNavigationTarget(
             middlewareEffect.rewriteTarget,
             __basePath,
+            options.dataLocale,
           );
         }
         if (middlewareEffect) {
@@ -2544,6 +2609,8 @@ async function navigateClient(
         routerRuntimeState.lastHash = window.location.hash;
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
+        options.consumedByRedirect = true;
+        options.redirectResult = true;
       } else if (middlewareEffect) {
         // A masked navigation probes middleware using the browser-visible URL but must fetch page
         // data using the route URL. Without a rewrite header those are different requests, so do
@@ -2554,7 +2621,11 @@ async function navigateClient(
         if (middlewareEffect.rewriteTarget) {
           const rewrittenTarget =
             middlewareRewrittenTarget ??
-            resolvePagesDataNavigationTarget(middlewareEffect.rewriteTarget, __basePath);
+            resolvePagesDataNavigationTarget(
+              middlewareEffect.rewriteTarget,
+              __basePath,
+              options.dataLocale,
+            );
           if (!rewrittenTarget) {
             scheduleHardNavigationAndThrow(browserUrl, "Navigation rewritten to a non-Pages route");
           }
@@ -2755,6 +2826,22 @@ function updateHistory(
   routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
   routerRuntimeState.lastHash = window.location.hash;
   routerRuntimeState.routerDidNavigate = true;
+}
+
+function buildNavigationHistoryState(
+  historyUrl: string,
+  options: { locale?: string; shallow: boolean },
+): { url: string; as: string; options: { locale?: string; shallow: boolean } } {
+  try {
+    const parsed = new URL(historyUrl, window.location.href);
+    const hashlessHistoryUrl = stripHash(historyUrl);
+    const search = parsed.search || (hashlessHistoryUrl.endsWith("?") ? "?" : "");
+    const appPath = stripBasePath(parsed.pathname, __basePath) + search;
+    return { url: appPath, as: appPath, options };
+  } catch {
+    const appPath = stripHash(historyUrl);
+    return { url: appPath, as: appPath, options };
+  }
 }
 
 /**
@@ -2972,8 +3059,8 @@ async function performNavigation(
   // scroll after completion.
   const scrollTarget = doScroll ? { x: 0, y: 0 } : null;
   const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
-    ? { allowNotFoundResponse: true, mode, scroll: scrollTarget }
-    : { mode, scroll: scrollTarget };
+    ? { allowNotFoundResponse: true, dataLocale: navigationLocale, mode, scroll: scrollTarget }
+    : { dataLocale: navigationLocale, mode, scroll: scrollTarget };
 
   // Next.js push→replace coercion (narrowed): when the display URL (asPath)
   // doesn't change AND the route URL DOES change AND the locale doesn't
@@ -3096,11 +3183,20 @@ async function performNavigation(
   routerEvents.emit("beforeHistoryChange", resolved, { shallow });
   updateHistory(mode, full, navState);
   if (!shallow) {
+    // Spread into a new object so navigateClientData can mark recursive
+    // redirects as consumed without mutating the caller's options object.
+    // The reference is retained so the outer `performNavigation` can observe
+    // `consumedByRedirect`, which `navigateClientData` sets when a
+    // `__N_REDIRECT` gSSP/gSP marker chains a destination navigation into
+    // this one's promise.
+    const navigateClientOptions: NavigateClientOptions = {
+      ...navigateOptions,
+    };
     const result = await runNavigateClient(
       full,
       resolved,
       htmlFetchUrl,
-      navigateOptions,
+      navigateClientOptions,
       // When href and as differ, the data fetch must target the route URL
       // (the module that actually renders), not the masked display URL.
       // fullRouteUrl === full when there is no mask, so this is a no-op
@@ -3109,6 +3205,15 @@ async function performNavigation(
     );
     if (result === "cancelled") return true;
     if (result === "failed") return false;
+    if (navigateClientOptions.consumedByRedirect) {
+      // Destination navigation already produced beforeHistoryChange +
+      // routeChangeComplete for the destination URL; suppress the source
+      // URL's completion event so listeners see a single transition. Return
+      // the destination navigation's own boolean so a failed redirect target
+      // reports `false` to `Router.push()`, matching Next.js's recursive
+      // `return this.change(...)`.
+      return navigateClientOptions.redirectResult ?? true;
+    }
   } else {
     // Shallow navigations skip the render-commit path, so apply the scroll
     // reset synchronously here — before routeChangeComplete. This matches the

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -1,4 +1,5 @@
 import {
+  MIDDLEWARE_CACHE_HEADER,
   MIDDLEWARE_OVERRIDE_HEADERS,
   MIDDLEWARE_REQUEST_HEADER_PREFIX,
   MIDDLEWARE_SET_COOKIE_HEADER,
@@ -116,6 +117,7 @@ export function buildRequestHeadersFromMiddlewareResponse(
 
 export function shouldKeepMiddlewareHeader(key: string): boolean {
   return (
+    key === MIDDLEWARE_CACHE_HEADER ||
     key === MIDDLEWARE_OVERRIDE_HEADERS ||
     key === MIDDLEWARE_SET_COOKIE_HEADER ||
     key.startsWith(MIDDLEWARE_REQUEST_HEADER_PREFIX)

--- a/packages/vinext/src/utils/protocol-headers.ts
+++ b/packages/vinext/src/utils/protocol-headers.ts
@@ -18,3 +18,6 @@ export const MIDDLEWARE_SET_COOKIE_HEADER = "x-middleware-set-cookie";
 
 /** Generic prefix for all middleware internal headers. */
 export const MIDDLEWARE_HEADER_PREFIX = "x-middleware-";
+
+/** Public cache-policy signal consumed by the Pages Router client. */
+export const MIDDLEWARE_CACHE_HEADER = "x-middleware-cache";

--- a/tests/build-report.test.ts
+++ b/tests/build-report.test.ts
@@ -106,6 +106,41 @@ export function getServerSideProps() {}
 */`;
     expect(hasNamedExport(code, "getServerSideProps")).toBe(false);
   });
+
+  // The following tests document the SHAPES hasNamedExport intentionally does
+  // NOT recognise. They are negative contracts: each one is a real export
+  // shape that the analyzer cannot resolve to the searched name. Pages using
+  // these shapes are treated as non-SSG by the client prefetch manifest
+  // emitted from packages/vinext/src/entries/pages-client-entry.ts. The
+  // runtime still works (data prefetch is best-effort; the chunk loader map
+  // resolves the page module), but `router.sdc` will not warm a JSON payload
+  // for the page during hover/viewport prefetch. See the long-form note on
+  // `hasNamedExport` in packages/vinext/src/build/report.ts.
+
+  it("does not recognise namespace re-exports (export * as ...)", () => {
+    expect(hasNamedExport("export * as gsp from './gsp';", "gsp")).toBe(false);
+    expect(hasNamedExport("export * as gsp from './gsp';", "getStaticProps")).toBe(false);
+  });
+
+  it("does not recognise wildcard re-exports (export * from ...)", () => {
+    expect(hasNamedExport("export * from './gsp';", "getStaticProps")).toBe(false);
+  });
+
+  it("does not follow re-exports through renamed source bindings", () => {
+    // Source: getStaticProps is exported as `gsp` from another file, then this
+    // file re-exports `gsp` under a different alias. The static analyzer
+    // matches the LOCAL name, not the source module's name, so this resolves
+    // to false.
+    expect(hasNamedExport("export { gsp as getStaticProps } from './gsp';", "getStaticProps")).toBe(
+      false,
+    );
+  });
+
+  it("does not recognise re-exports of `default`", () => {
+    expect(
+      hasNamedExport("export { default as getStaticProps } from './gsp';", "getStaticProps"),
+    ).toBe(false);
+  });
 });
 
 // ─── extractExportConstString ─────────────────────────────────────────────────

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { executeMiddleware } from "../packages/vinext/src/server/middleware-runtime.js";
-import type { NextRequest } from "../packages/vinext/src/shims/server.js";
+import { NextResponse, type NextRequest } from "../packages/vinext/src/shims/server.js";
 
 // Tests for the redirect protocol implemented in `executeMiddleware`. These
 // fixtures mirror the behaviour Next.js's edge adapter applies after a
@@ -199,6 +199,84 @@ describe("middleware redirect protocol", () => {
     expect(result.redirectUrl).toBe("/new-home");
     expect(result.response?.status).toBe(307);
     expect(result.response?.headers.get("x-nextjs-redirect")).toBeNull();
+  });
+});
+
+// Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts
+describe("middleware _next/data locale normalization", () => {
+  const i18nConfig = {
+    locales: ["ja", "en", "fr", "es"],
+    defaultLocale: "en",
+  };
+
+  it("exposes the data URL locale while middleware matches the stripped pathname", async () => {
+    const captured: { pathname?: string; locale?: string; urlPathname?: string } = {};
+    const module = {
+      default: (req: NextRequest) => {
+        captured.pathname = req.nextUrl.pathname;
+        captured.locale = req.nextUrl.locale;
+        captured.urlPathname = new URL(req.url).pathname;
+
+        const rewriteUrl = req.nextUrl.clone();
+        rewriteUrl.searchParams.set("locale", req.nextUrl.locale);
+        return NextResponse.rewrite(rewriteUrl);
+      },
+    };
+
+    const result = await executeMiddleware({
+      i18nConfig,
+      isDataRequest: true,
+      isProxy: false,
+      localeOverride: "ja",
+      module,
+      normalizedPathname: "/i18n",
+      request: new Request("http://localhost:3000/i18n"),
+    });
+
+    expect(captured.pathname).toBe("/i18n");
+    expect(captured.locale).toBe("ja");
+    expect(captured.urlPathname).toBe("/ja/i18n");
+    expect(result.continue).toBe(true);
+    expect(result.rewriteUrl).toBe("/ja/i18n?locale=ja");
+  });
+
+  it("preserves x-middleware-cache on data rewrites that opt out of prefetch caching", async () => {
+    const captured: { pathname?: string; locale?: string } = {};
+    const module = {
+      default: (req: NextRequest) => {
+        captured.pathname = req.nextUrl.pathname;
+        captured.locale = req.nextUrl.locale;
+
+        if (
+          req.nextUrl.pathname === "/dynamic-no-cache/1" &&
+          req.headers.get("purpose") === "prefetch"
+        ) {
+          return NextResponse.rewrite(req.nextUrl, {
+            headers: { "x-middleware-cache": "no-cache" },
+          });
+        }
+        return undefined;
+      },
+    };
+
+    const result = await executeMiddleware({
+      i18nConfig,
+      isDataRequest: true,
+      isProxy: false,
+      localeOverride: "en",
+      module,
+      normalizedPathname: "/dynamic-no-cache/1",
+      request: new Request("http://localhost:3000/dynamic-no-cache/1", {
+        headers: { purpose: "prefetch" },
+      }),
+    });
+
+    expect(captured.pathname).toBe("/dynamic-no-cache/1");
+    expect(captured.locale).toBe("en");
+    expect(result.continue).toBe(true);
+    expect(result.rewriteUrl).toBe("/dynamic-no-cache/1");
+    expect(result.responseHeaders?.get("x-middleware-cache")).toBe("no-cache");
   });
 });
 

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -112,6 +112,28 @@ describe("pages-data-route", () => {
       expect(result.normalizedPathname).toBe("/about");
       expect(result.request.url).toBe("http://localhost/about?x=1");
     });
+
+    // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts
+    it("strips the locale segment before middleware while preserving the data page pathname", () => {
+      const buildId = "abc123";
+      const req = new Request(
+        `http://localhost/_next/data/${buildId}/en/dynamic-no-cache/1.json?x=1`,
+      );
+      const result = normalizePagesDataRequest(req, buildId, "", {
+        locales: ["ja", "en", "fr", "es"],
+        defaultLocale: "en",
+      });
+
+      expect(result.isDataReq).toBe(true);
+      if (!result.isDataReq) throw new Error("expected data request normalization");
+      expect(result.normalizedPathname).toBe("/en/dynamic-no-cache/1");
+      expect(result.middlewarePathname).toBe("/dynamic-no-cache/1");
+      expect(result.locale).toBe("en");
+      expect(result.search).toBe("?x=1");
+      expect(result.request.url).toBe("http://localhost/dynamic-no-cache/1?x=1");
+      expect(result.notFoundResponse).toBeNull();
+    });
   });
 
   describe("buildNextDataNotFoundResponse", () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -193,6 +193,30 @@ describe("pages page response", () => {
     expect(common.renderDocumentToString).toHaveBeenCalledTimes(1);
   });
 
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts
+  it("serializes rewrite-derived query params into __NEXT_DATA__", async () => {
+    const common = createCommonOptions();
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      params: {},
+      query: { rewriteSlug: "post-2" },
+      routePattern: "/ssg",
+      routeUrl: "/config-rewrite-to-dynamic-static/post-2",
+    });
+
+    const html = await response.text();
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).not.toBeNull();
+    expect(JSON.parse(nextDataMatch![1]!)).toMatchObject({
+      page: "/ssg",
+      query: { rewriteSlug: "post-2" },
+    });
+  });
+
   it("preserves array-valued non-set-cookie headers from gSSP responses", async () => {
     const common = createCommonOptions();
 

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -38,7 +38,7 @@ function makeMiddleware(result: Partial<MiddlewareResult>) {
 
 function makeRenderPage(status = 200, body = "ok") {
   return vi.fn(
-    async (_req: Request, _url: string, _opts?: PagesRenderOptions) =>
+    async (_req: Request, _url: string, _opts?: PagesRenderOptions, _stagedHeaders?: Headers) =>
       new Response(body, { status }),
   );
 }
@@ -205,6 +205,27 @@ describe("middleware", () => {
     expect(result.response.headers.get("x-nextjs-matched-path")).toBe("/fr/blog/[slug]");
   });
 
+  it("uses the trusted data URL locale for locale-stripped dynamic data responses", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/source"),
+      baseDeps({
+        i18nConfig: { locales: ["en", "fr"], defaultLocale: "en" },
+        isDataReq: true,
+        isDataRequest: true,
+        dataRequestLocale: "fr",
+        runMiddleware: makeMiddleware({ continue: true }),
+        matchPageRoute: vi
+          .fn()
+          .mockReturnValue({ route: { isDynamic: true, pattern: "/blog/:slug" } }),
+        renderPage: makeRenderPage(),
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.headers.get("x-nextjs-matched-path")).toBe("/fr/blog/[slug]");
+  });
+
   it("does not add matched-path routing metadata to HTML responses", async () => {
     const result = await runPagesRequest(
       makeRequest("/ssr-page"),
@@ -238,6 +259,28 @@ describe("middleware", () => {
     expect(result.response.status).toBe(200);
     expect(result.response.headers.get("content-type")).toContain("application/json");
     expect(result.response.headers.get("x-nextjs-matched-path")).toBe("/unknown");
+    expect(await result.response.text()).toBe("{}");
+  });
+
+  it("uses the trusted data URL locale for locale-stripped data misses", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/unknown"),
+      baseDeps({
+        i18nConfig: { locales: ["en", "fr"], defaultLocale: "en" },
+        isDataReq: true,
+        isDataRequest: true,
+        dataRequestLocale: "fr",
+        hasMiddleware: true,
+        runMiddleware: makeMiddleware({ continue: true }),
+        matchPageRoute: vi.fn().mockReturnValue(null),
+        renderPage: makeRenderPage(404, "not found"),
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.status).toBe(200);
+    expect(result.response.headers.get("x-nextjs-matched-path")).toBe("/fr/unknown");
     expect(await result.response.text()).toBe("{}");
   });
 
@@ -398,6 +441,47 @@ describe("middleware", () => {
       undefined,
       expect.any(Headers),
     );
+  });
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // ("should opt out of prefetch caching for dynamic routes")
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("preserves x-middleware-cache from data-request middleware rewrites", async () => {
+    const renderPage = makeRenderPage(200, '{"pageProps":{"id":"1"}}');
+    const runMiddleware = vi.fn(async () => ({
+      continue: true,
+      rewriteUrl: "/dynamic-no-cache/1",
+      responseHeaders: new Headers({ "x-middleware-cache": "no-cache" }),
+    }));
+
+    const result = await runPagesRequest(
+      makeRequest("/dynamic-no-cache/1", {
+        purpose: "prefetch",
+        "x-nextjs-data": "1",
+        "x-middleware-prefetch": "1",
+      }),
+      baseDeps({
+        isDataReq: true,
+        isDataRequest: true,
+        runMiddleware,
+        renderPage,
+      }),
+    );
+
+    expect(runMiddleware).toHaveBeenCalledWith(expect.any(Request), null, {
+      isDataRequest: true,
+    });
+    expect(renderPage).toHaveBeenCalledWith(
+      expect.any(Request),
+      "/dynamic-no-cache/1",
+      { isDataReq: true },
+      expect.any(Headers),
+    );
+    const stagedHeaders = renderPage.mock.calls[0]?.[3];
+    expect(stagedHeaders?.get("x-middleware-cache")).toBe("no-cache");
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.headers.get("x-middleware-cache")).toBe("no-cache");
   });
 
   it.each([

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -718,6 +718,20 @@ describe("processMiddlewareHeaders", () => {
     expect(headers.get("content-type")).toBe("text/html");
   });
 
+  // Ported from Next.js: packages/next/src/shared/lib/router/router.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts
+  it("preserves x-middleware-cache for Pages Router prefetch cache policy", () => {
+    const headers = new Headers({
+      "x-middleware-cache": "no-cache",
+      "x-middleware-next": "1",
+      "content-type": "application/json",
+    });
+    processMiddlewareHeaders(headers);
+    expect(headers.get("x-middleware-cache")).toBe("no-cache");
+    expect(headers.has("x-middleware-next")).toBe(false);
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
   it("is a no-op when no x-middleware-* headers are present", () => {
     const headers = new Headers({
       "content-type": "text/html",

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16599,6 +16599,168 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts
+  it("resolves the destination route after a middleware rewrite from a dynamic visible URL", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const sourceLoader = vi.fn(async () => ({ default: () => null }));
+    const aboutLoader = vi.fn(async () => ({ default: () => null }));
+    Object.assign(win.location, { origin: "http://localhost" });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      locale: "en",
+      locales: ["en", "fr"],
+      defaultLocale: "en",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    Object.assign(win, {
+      __VINEXT_LOCALE__: "en",
+      __VINEXT_LOCALES__: ["en", "fr"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+      __VINEXT_PAGE_PATTERNS__: ["/fallback-true-blog/[slug]", "/about"],
+      __VINEXT_PAGE_LOADERS__: {
+        "/fallback-true-blog/[slug]": sourceLoader,
+        "/about": aboutLoader,
+      },
+    });
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/_next/data/build-1/fr/fallback-true-blog/rewritten.json") {
+        return new Response(JSON.stringify({ pageProps: { from: "about" } }), {
+          headers: {
+            "content-type": "application/json",
+            "x-nextjs-rewrite": "/about",
+          },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/fallback-true-blog/rewritten", undefined, {
+        locale: "fr",
+      });
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith(
+        "/_next/data/build-1/fr/fallback-true-blog/rewritten.json",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "x-nextjs-data": "1" }),
+        }),
+      );
+      expect(sourceLoader).not.toHaveBeenCalled();
+      expect(aboutLoader).toHaveBeenCalledOnce();
+      expect(win.location.pathname).toBe("/fr/fallback-true-blog/rewritten");
+      expect(win.__NEXT_DATA__).toMatchObject({
+        page: "/about",
+        query: {},
+        props: { pageProps: { from: "about" } },
+        locale: "fr",
+      });
+      expect(Router.pathname).toBe("/about");
+      expect(Router.query).toEqual({});
+      expect(win.__VINEXT_LOCALE__).toBe("fr");
+      expect(render).toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts#L398-L410
+  it("renders the destination page for recursive middleware data rewrites", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const sourceLoader = vi.fn(async () => ({ default: () => null }));
+    const aboutLoader = vi.fn(async () => ({ default: () => null }));
+    Object.assign(win.location, { origin: "http://localhost" });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      locale: "en",
+      locales: ["ja", "en", "fr", "es"],
+      defaultLocale: "en",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    Object.assign(win, {
+      __VINEXT_LOCALE__: "en",
+      __VINEXT_LOCALES__: ["ja", "en", "fr", "es"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+      __VINEXT_PAGE_PATTERNS__: ["/[param]", "/about"],
+      __VINEXT_PAGE_LOADERS__: {
+        "/[param]": sourceLoader,
+        "/about": aboutLoader,
+      },
+    });
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/_next/data/build-1/rewrite-me-to-about.json?override=internal") {
+        return new Response(JSON.stringify({ pageProps: { message: "about" } }), {
+          headers: {
+            "content-type": "application/json",
+            "x-nextjs-rewrite": "/about?override=internal",
+          },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/rewrite-me-to-about?override=internal");
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenCalledWith(
+        "/_next/data/build-1/rewrite-me-to-about.json?override=internal",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "x-nextjs-data": "1" }),
+        }),
+      );
+      expect(sourceLoader).not.toHaveBeenCalled();
+      expect(aboutLoader).toHaveBeenCalledOnce();
+      expect(win.location.pathname).toBe("/rewrite-me-to-about");
+      expect(win.location.search).toBe("?override=internal");
+      expect(win.__NEXT_DATA__).toMatchObject({
+        page: "/about",
+        query: { override: "internal" },
+        props: { pageProps: { message: "about" } },
+        locale: "en",
+      });
+      expect(Router.pathname).toBe("/about");
+      expect(Router.query).toEqual({ override: "internal" });
+      expect(render).toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("hard-navigates when middleware rewrites an existing Pages path to App Router", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| goal | Match Next.js Pages Router middleware rewrite behaviour for `_next/data` deploy tests. |
| core change | Preserve the Pages data navigation protocol across SSG prefetch, middleware cache opt-out, i18n data URLs, rewrite target route matching, and history commit timing. |
| primary files | `packages/vinext/src/shims/router.ts`, `packages/vinext/src/shims/internal/pages-data-*.ts`, `packages/vinext/src/server/pages-data-route.ts`, `packages/vinext/src/server/pages-request-pipeline.ts`, `tests/shims.test.ts` |
| expected impact | The upstream `test/e2e/middleware-rewrites/test/index.test.ts` deploy suite now passes against vinext. |

## Why

Pages Router `_next/data` navigation is not just a JSON shortcut. It is the observable routing protocol for middleware rewrites, redirects, SSG prefetch cache reuse, i18n locale routing, and client history timing. Vinext was treating those pieces independently, which let the browser URL, rendered route, middleware cache policy, and data locale diverge from Next.js.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| SSG data prefetch | Next.js only fetches data during prefetch for SSG pages and stores it in `router.sdc`. | Emits a Pages SSG manifest, exposes `router.sdc`, reuses cached data for navigation, and evicts on `x-middleware-cache: no-cache`. |
| Data request normalization | Middleware should observe the normalized page pathname while preserving the active data locale. | Normalizes `_next/data` routes with separate middleware pathname, render pathname, and locale across dev, prod, Worker, and app fallback paths. |
| Client navigation commit | The browser URL should not advance before the destination page has committed or a hard navigation has been scheduled. | Defers non-shallow history writes to the Pages render commit and forwards that commit path through data rewrites and redirects. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| SSG prefetch | Any route with a loader could issue data prefetches. | Only SSG routes prefetch JSON data, matching Next.js `_isSsg(route)`. |
| Middleware no-cache prefetch | `x-middleware-cache` was stripped before the client could use it. | The header is preserved as the Pages Router cache policy signal and evicts `router.sdc`. |
| Recursive middleware rewrite | A rewritten destination could be resolved through a less-specific source route. | Route matching now picks the most specific matching Pages route for data rewrite targets. |
| Locale data URLs | Default-locale data URLs could drop the locale segment and middleware could lose `nextUrl.locale`. | Data URLs preserve the active locale segment, while middleware receives the locale-stripped route pathname and correct locale metadata. |
| Redirect/rewrite history | Client history could update before the destination tree rendered. | History writes now happen at render commit or hard-navigation fallback. |
| gSSP/gSP redirect (`__N_REDIRECT`) | A `{ redirect }` data response committed source history eagerly and reported success regardless of the destination's outcome. | The destination navigation is chained into the source `Router.push()` promise (mirrors Next's recursive `return this.change(...)`); the source suppresses its own `commitHistory`/`routeChangeComplete` and resolves the destination's own boolean, so a failed redirect target reports `false`. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/internal/pages-data-target.ts` and `packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts`: SSG detection, data href construction, `router.sdc`, and no-cache eviction.
2. `packages/vinext/src/server/pages-data-route.ts`, `packages/vinext/src/server/pages-request-pipeline.ts`, and adapters: trusted `_next/data` normalization and data locale plumbing.
3. `packages/vinext/src/shims/router.ts`: rewrite target route selection, soft redirect handling, and deferred history commit.
4. `tests/shims.test.ts` plus the small pipeline tests: ported behaviours and focused regression checks.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/shims.test.ts -t "renderable x-nextjs-redirect|hard-reloads to the redirect target|middleware internal redirects as client-side redirects|recursive middleware data rewrites"`
- `vp test run tests/shims.test.ts -t "__N_REDIRECT"` — gSSP/gSP redirect chaining: happy path resolves `true`; failed destination (404 → hard reload) resolves `false` while suppressing source `commitHistory`/`routeChangeComplete`
- `vp test run tests/shims.test.ts` — full file (1149) green after merging `main` (#2076 `as`-mask); deferred `commitHistory` reconciled with the mask-aware `navState` so masked-locale history (`url=route, as=display`) and redirect tests both pass
- `vp test run tests/entry-templates.test.ts tests/pages-data-prefetch.test.ts tests/pages-data-route.test.ts tests/middleware-runtime.test.ts tests/request-pipeline.test.ts tests/pages-request-pipeline.test.ts tests/pages-page-response.test.ts tests/shims.test.ts tests/pages-router-i18n-sticky-locale.test.ts`
- `git diff --check`
- `vp check`
- `vp run vinext#build`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/middleware-rewrites/test/index.test.ts`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: adds the already-Next-shaped `window.next.router.sdc` cache surface for Pages Router.
- Runtime: touches Pages Router client navigation and Pages request pipelines. The new tests cover data prefetch reuse, no-cache eviction, redirect commit ordering, i18n data normalization, and rewrite-specific route matching.
- Build output: Pages client entry now scans page files for `getStaticProps` so it can emit the SSG pattern manifest.
- Intentional divergence: none. This follows the Next.js contract tested by the v16.2.6 deploy suite.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js middleware rewrites deploy test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts) | Upstream observable contract ported and verified here. |
| [Next.js middleware rewrite fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/app/middleware.js) | Defines recursive rewrites, no-cache middleware prefetch, locale rewrites, and redirect cases. |
| [Next.js Pages Router implementation](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts) | Source for `fetchNextData`, `router.sdc`, middleware data effects, route resolution, and history ordering. |
| [Next.js Link](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/link.tsx) and [page loader](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/page-loader.ts) | Source for Pages prefetch behaviour and data href construction. |
| [Next.js server render](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/render.tsx) and [base server](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/base-server.ts) | Source for `_next/data` response shape and request normalization. |
| [Next.js sorted routes](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/utils/sorted-routes.ts) | Route specificity reference for resolving rewritten destinations. |
| [Middleware matching docs](https://nextjs.org/docs/app/building-your-application/routing/middleware#matching-paths) | Documents middleware order relative to rewrites and filesystem routing. |

