### PR TITLE
perf(dev): externalize App Router request handler

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -57,6 +57,10 @@
       "types": "./dist/server/app-router-entry.d.ts",
       "import": "./dist/server/app-router-entry.js"
     },
+    "./server/app-rsc-handler": {
+      "types": "./dist/server/app-rsc-handler.d.ts",
+      "import": "./dist/server/app-rsc-handler.js"
+    },
     "./config/config-matchers": {
       "types": "./dist/config/config-matchers.d.ts",
       "import": "./dist/config/config-matchers.js"

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -34,7 +34,6 @@ const middlewareRequestHeadersPath = resolveEntryPath(
   import.meta.url,
 );
 const normalizePathModulePath = resolveEntryPath("../server/normalize-path.js", import.meta.url);
-const appRscHandlerPath = resolveEntryPath("../server/app-rsc-handler.js", import.meta.url);
 const appRouteHandlerDispatchPath = resolveEntryPath(
   "../server/app-route-handler-dispatch.js",
   import.meta.url,
@@ -275,7 +274,7 @@ ${
 import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(instrumentationRuntimePath)};`
     : ""
 }
-import { createAppRscHandler as __createAppRscHandler } from ${JSON.stringify(appRscHandlerPath)};
+import { createAppRscHandler } from "vinext/server/app-rsc-handler";
 import { registerConfiguredCacheAdapters as __registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
 import { decodePathParams as __decodePathParams } from ${JSON.stringify(normalizePathModulePath)};
 import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
@@ -619,7 +618,7 @@ const rootParamNamesMap = {
 ${rootParamNameEntries.join("\n")}
 };
 
-export default __createAppRscHandler({
+export default createAppRscHandler({
   basePath: __basePath,
   buildId: process.env.__VINEXT_BUILD_ID ?? null,
   ensureRouteLoaded: __ensureRouteLoaded,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -568,6 +568,14 @@ function createStaticImageAsset(imagePath: string): { fileName: string; source: 
  */
 const _shimsDir = normalizePathSeparators(path.resolve(__dirname, "shims")) + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
+const _appRscHandlerPath = resolveShimModulePath(
+  path.resolve(__dirname, "server"),
+  "app-rsc-handler",
+);
+// Source checkouts resolve to TypeScript and must stay in Vite's graph so tests
+// do not execute a stale dist build. Published packages resolve to emitted JS,
+// which Node can load natively outside the RSC transform graph.
+const _canExternalizeAppRscHandler = _appRscHandlerPath.endsWith(".js");
 
 function isValidExportIdentifier(name: string): boolean {
   return /^[$A-Z_a-z][$\w]*$/.test(name);
@@ -2240,7 +2248,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                       external:
                         userSsrExternal === true
                           ? true
-                          : ["satori", "@resvg/resvg-js", "yoga-wasm-web", ...userSsrExternal],
+                          : [
+                              "satori",
+                              "@resvg/resvg-js",
+                              "yoga-wasm-web",
+                              ...(env?.command === "serve" && _canExternalizeAppRscHandler
+                                ? ["vinext/server/app-rsc-handler"]
+                                : []),
+                              ...userSsrExternal,
+                            ],
                       // Force all node_modules through Vite's transform pipeline
                       // so non-JS imports (CSS, images) don't hit Node's native
                       // ESM loader. Matches Next.js behavior of bundling everything.
@@ -2615,7 +2631,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // direct @vercel/og imports in metadata routes, and \0-prefixed
         // re-imports from @vitejs/plugin-rsc.
         filter: {
-          id: /(?:next\/|vinext\/shims\/|virtual:vinext-|@vercel\/og(?:\.js)?$)/,
+          id: /(?:next\/|vinext\/(?:shims\/|server\/app-rsc-handler)|virtual:vinext-|@vercel\/og(?:\.js)?$)/,
         },
         handler(id, importer) {
           // Strip \0 prefix if present — @vitejs/plugin-rsc's generated
@@ -2623,6 +2639,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // ID (with \0 prefix). We need to re-resolve it so the client
           // environment's import-analysis can find it.
           const cleanId = id.startsWith("\0") ? id.slice(1) : id;
+
+          if (cleanId === "vinext/server/app-rsc-handler") {
+            if (
+              _canExternalizeAppRscHandler &&
+              this.environment?.name === "rsc" &&
+              this.environment.config?.command === "serve"
+            ) {
+              return { id: _appRscHandlerPath, external: true };
+            }
+            return _appRscHandlerPath;
+          }
 
           if (isVercelOgImport(cleanId) && !isVinextOgShimImporter(importer)) {
             return resolveShimModulePath(_shimsDir, "og");

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -87,6 +87,17 @@ describe("App Router integration", () => {
     expect(html).toContain("Server Component");
   });
 
+  it("loads the current source App Router request handler in source-checkout tests", async () => {
+    const response = await fetch(`${baseUrl}/`);
+    expect(response.status).toBe(200);
+    await response.arrayBuffer();
+
+    const rscModuleIds = server.environments.rsc.moduleGraph.idToModuleMap.keys();
+    const handlerIds = [...rscModuleIds].filter((id) => id.includes("app-rsc-handler"));
+    expect(handlerIds.some((id) => id.includes("/src/server/app-rsc-handler.ts"))).toBe(true);
+    expect(handlerIds.some((id) => id.includes("/dist/server/app-rsc-handler.js"))).toBe(false);
+  });
+
   it("renders the about page", async () => {
     const res = await fetch(`${baseUrl}/about`);
     expect(res.status).toBe(200);

--- a/tests/app-router-isr-codegen.test.ts
+++ b/tests/app-router-isr-codegen.test.ts
@@ -35,7 +35,7 @@ describe("generateRscEntry ISR code generation", () => {
   it("generated handler delegates request and ctx handling to createAppRscHandler", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes);
     expect(code).toContain("createAppRscHandler");
-    expect(code).toContain("export default __createAppRscHandler({");
+    expect(code).toContain("export default createAppRscHandler({");
   });
 
   it("generated code stores root layout params separately from leaf params", () => {

--- a/tests/app-router-next-config-codegen.test.ts
+++ b/tests/app-router-next-config-codegen.test.ts
@@ -197,7 +197,7 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
     const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
       redirects: [{ source: "/old", destination: "/new", permanent: true }],
     });
-    expect(code).toContain("export default __createAppRscHandler({");
+    expect(code).toContain("export default createAppRscHandler({");
     expect(code).toContain("configRedirects: __configRedirects");
     expect(code).toContain("dispatchMatchedPage({");
     expect(code).toContain("    clientReuseManifest,");

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -306,6 +306,39 @@ describe("optimizeDeps.exclude for vinext", () => {
     }
   }, 15000);
 
+  it("does not externalize the built App Router request handler from a source checkout", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const mainPlugin = vinext().find(
+      (plugin: any) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-rsc-handler-source-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "page.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+
+    try {
+      const devConfig = await (mainPlugin as any).config(
+        { root: tmpDir, build: {}, plugins: [] },
+        { command: "serve" },
+      );
+      expect(devConfig.environments.rsc.resolve.external).not.toContain(
+        "vinext/server/app-rsc-handler",
+      );
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
   // Regression for #1103: when the user sets `ssr.external: true`, plugin-rsc's
   // crawlFrameworkPkgs adds React to environments.ssr.optimizeDeps.include and
   // Vite pre-bundles a second React copy into deps_ssr/. Externalized callers

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -798,8 +798,8 @@ describe("App Router entry templates", () => {
   it("generateRscEntry delegates App Router request handling to the typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain("app-rsc-handler.js");
-    expect(code).toContain("export default __createAppRscHandler({");
+    expect(code).toContain('import { createAppRscHandler } from "vinext/server/app-rsc-handler";');
+    expect(code).toContain("export default createAppRscHandler({");
     expect(code).not.toContain("computeRscCacheBustingSearchParam(");
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -21323,6 +21323,45 @@ describe("shim alias map .js variants", () => {
       reactServerShim,
     );
   });
+
+  it("keeps the App Router request handler source-resolved in source checkouts", () => {
+    const plugins = vinext() as Plugin[];
+    const configPlugin = plugins.find((plugin) => plugin.name === "vinext:config");
+    if (!configPlugin?.resolveId || typeof configPlugin.resolveId === "function") {
+      throw new Error("vinext:config resolveId hook not found");
+    }
+
+    const hook = configPlugin.resolveId as {
+      filter: { id: RegExp };
+      handler: (
+        this: {
+          environment?: {
+            name?: string;
+            config: {
+              command: "serve" | "build";
+            };
+          };
+        },
+        id: string,
+      ) => string | { id: string; external: true } | undefined;
+    };
+    const id = "vinext/server/app-rsc-handler";
+    const expected = path.resolve(
+      import.meta.dirname,
+      "../packages/vinext/src/server/app-rsc-handler.ts",
+    );
+
+    expect(hook.filter.id.test(id)).toBe(true);
+    expect(
+      hook.handler.call({ environment: { name: "rsc", config: { command: "serve" } } }, id),
+    ).toBe(expected);
+    expect(
+      hook.handler.call({ environment: { name: "rsc", config: { command: "build" } } }, id),
+    ).toBe(expected);
+    expect(
+      hook.handler.call({ environment: { name: "ssr", config: { command: "serve" } } }, id),
+    ).toBe(expected);
+  });
 });
 
 describe("@vercel/og compatibility resolution", () => {


### PR DESCRIPTION
This PR externalizes the App Router RSC request handler from Vite’s dev module graph for built packages, reducing cold-start time further for vinext "consumers".

Local measures:

  - 50.4 ms faster total
  - 35.2 ms faster first request
  - 0.5 ms faster readiness