### PR TITLE
fix(middleware): normalize trailing slash before matching

### DIFF
--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -124,21 +124,21 @@ function stripLocalePrefix(pathname: string, i18nConfig: NextI18nConfig): string
     return null;
   }
 
-  const stripped = "/" + segments.slice(2).join("/");
-  return removeTrailingSlash(stripped);
+  return "/" + segments.slice(2).join("/");
 }
 
 export function matchPattern(pathname: string, pattern: string): boolean {
-  const normalizedPathname = removeTrailingSlash(pathname);
-  const normalizedPattern = removeTrailingSlash(pattern);
+  const hasPatternSyntax = /[\\():*+?]/.test(pattern);
+  const normalizedPattern = hasPatternSyntax ? pattern : removeTrailingSlash(pattern);
   let cached = _mwPatternCache.get(normalizedPattern);
   if (cached === undefined) {
     cached = compileMatcherPattern(normalizedPattern);
     _mwPatternCache.set(normalizedPattern, cached);
   }
   if (cached === UNSAFE_MATCHER_PATTERN) return true;
-  if (cached === null) return normalizedPathname === normalizedPattern;
-  return cached.test(normalizedPathname);
+  if (cached === null) return removeTrailingSlash(pathname) === normalizedPattern;
+  if (cached.test(pathname)) return true;
+  return pathname.endsWith("/") && cached.test(removeTrailingSlash(pathname));
 }
 
 function extractConstraint(str: string, re: RegExp): string | null {

--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -129,6 +129,7 @@ function stripLocalePrefix(pathname: string, i18nConfig: NextI18nConfig): string
 }
 
 export function matchPattern(pathname: string, pattern: string): boolean {
+  const normalizedPathname = removeTrailingSlash(pathname);
   const normalizedPattern = removeTrailingSlash(pattern);
   let cached = _mwPatternCache.get(normalizedPattern);
   if (cached === undefined) {
@@ -136,8 +137,8 @@ export function matchPattern(pathname: string, pattern: string): boolean {
     _mwPatternCache.set(normalizedPattern, cached);
   }
   if (cached === UNSAFE_MATCHER_PATTERN) return true;
-  if (cached === null) return pathname === normalizedPattern;
-  return cached.test(pathname);
+  if (cached === null) return normalizedPathname === normalizedPattern;
+  return cached.test(normalizedPathname);
 }
 
 function extractConstraint(str: string, re: RegExp): string | null {

--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -129,13 +129,14 @@ function stripLocalePrefix(pathname: string, i18nConfig: NextI18nConfig): string
 }
 
 export function matchPattern(pathname: string, pattern: string): boolean {
-  let cached = _mwPatternCache.get(pattern);
+  const normalizedPattern = removeTrailingSlash(pattern);
+  let cached = _mwPatternCache.get(normalizedPattern);
   if (cached === undefined) {
-    cached = compileMatcherPattern(pattern);
-    _mwPatternCache.set(pattern, cached);
+    cached = compileMatcherPattern(normalizedPattern);
+    _mwPatternCache.set(normalizedPattern, cached);
   }
   if (cached === UNSAFE_MATCHER_PATTERN) return true;
-  if (cached === null) return pathname === pattern;
+  if (cached === null) return pathname === normalizedPattern;
   return cached.test(pathname);
 }
 

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -17,7 +17,12 @@ import { MatcherConfig, matchesMiddleware } from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "./middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 import { badRequestResponse, internalServerErrorResponse } from "./http-error-responses.js";
-import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
+import {
+  addBasePathToPathname,
+  hasBasePath,
+  removeTrailingSlash,
+  stripBasePath,
+} from "../utils/base-path.js";
 
 export type MiddlewareModule = Record<string, unknown>;
 
@@ -274,9 +279,10 @@ export async function executeMiddleware(
   // stripBasePath is a no-op. When it is auto-derived from the request URL and the
   // URL carries the basePath (because the adapter passed the original URL), we must
   // strip before matching so patterns like "/about" fire correctly.
-  const matchPathname = options.basePath
+  const basePathStrippedPathname = options.basePath
     ? stripBasePath(normalizedPathname, options.basePath)
     : normalizedPathname;
+  const matchPathname = removeTrailingSlash(basePathStrippedPathname);
 
   if (
     !matchesMiddleware(

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -282,7 +282,7 @@ export async function executeMiddleware(
   const basePathStrippedPathname = options.basePath
     ? stripBasePath(normalizedPathname, options.basePath)
     : normalizedPathname;
-  const matchPathname = removeTrailingSlash(basePathStrippedPathname);
+  const matchPathname = basePathStrippedPathname;
 
   if (
     !matchesMiddleware(
@@ -303,7 +303,7 @@ export async function executeMiddleware(
     options.trailingSlash,
     hadBasePath,
   );
-  const fetchEvent = new NextFetchEvent({ page: matchPathname });
+  const fetchEvent = new NextFetchEvent({ page: removeTrailingSlash(matchPathname) });
 
   let response: Response | undefined | void;
   try {

--- a/tests/app-router-middleware-next-request.test.ts
+++ b/tests/app-router-middleware-next-request.test.ts
@@ -44,12 +44,11 @@ describe("App Router middleware with NextRequest", () => {
   });
 
   it("runs an exact API middleware matcher for a trailing-slash request", async () => {
-    const res = await fetch(`${baseUrl}/api/hello/`);
+    const res = await fetch(`${baseUrl}/api/header-override-delete/`);
 
     expect(res.status).toBe(200);
     expect(res.headers.get("x-mw-ran")).toBe("true");
-    expect(res.headers.get("x-mw-pathname")).toBe("/api/hello/");
-    await expect(res.json()).resolves.toEqual({ message: "Hello from App Router API" });
+    expect(res.headers.get("x-mw-pathname")).toBe("/api/header-override-delete/");
   });
 
   it("object-form matcher requires has and missing conditions", async () => {

--- a/tests/app-router-middleware-next-request.test.ts
+++ b/tests/app-router-middleware-next-request.test.ts
@@ -43,6 +43,15 @@ describe("App Router middleware with NextRequest", () => {
     expect(res.headers.get("x-mw-has-session")).toBe("true");
   });
 
+  it("runs an exact API middleware matcher for a trailing-slash request", async () => {
+    const res = await fetch(`${baseUrl}/api/hello/`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-mw-ran")).toBe("true");
+    expect(res.headers.get("x-mw-pathname")).toBe("/api/hello/");
+    await expect(res.json()).resolves.toEqual({ message: "Hello from App Router API" });
+  });
+
   it("object-form matcher requires has and missing conditions", async () => {
     const noHeaderRes = await fetch(`${baseUrl}/mw-object-gated`);
     expect(noHeaderRes.status).toBe(200);

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -790,12 +790,11 @@ describe("App Router Production server (startProdServer)", () => {
   });
 
   it("runs an exact API middleware matcher for a trailing-slash route handler request", async () => {
-    const res = await fetch(`${baseUrl}/api/hello/`);
+    const res = await fetch(`${baseUrl}/api/header-override-delete/`);
 
     expect(res.status).toBe(200);
     expect(res.headers.get("x-mw-ran")).toBe("true");
-    expect(res.headers.get("x-mw-pathname")).toBe("/api/hello/");
-    await expect(res.json()).resolves.toEqual({ message: "Hello from App Router API" });
+    expect(res.headers.get("x-mw-pathname")).toBe("/api/header-override-delete/");
   });
 
   it("returns 404 for nonexistent routes", async () => {

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -789,6 +789,15 @@ describe("App Router Production server (startProdServer)", () => {
     expect(json).toHaveProperty("message");
   });
 
+  it("runs an exact API middleware matcher for a trailing-slash route handler request", async () => {
+    const res = await fetch(`${baseUrl}/api/hello/`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-mw-ran")).toBe("true");
+    expect(res.headers.get("x-mw-pathname")).toBe("/api/hello/");
+    await expect(res.json()).resolves.toEqual({ message: "Hello from App Router API" });
+  });
+
   it("returns 404 for nonexistent routes", async () => {
     const res = await fetch(`${baseUrl}/no-such-page`);
     expect(res.status).toBe(404);

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -360,6 +360,7 @@ export const config = {
     "/headers/override-from-middleware",
     "/header-override-delete",
     "/api/header-override-delete",
+    "/api/hello",
     "/api/pages-og",
     "/header-override-after-prior-access",
     "/pages-header-override-delete",

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -360,7 +360,6 @@ export const config = {
     "/headers/override-from-middleware",
     "/header-override-delete",
     "/api/header-override-delete",
-    "/api/hello",
     "/api/pages-og",
     "/header-override-after-prior-access",
     "/pages-header-override-delete",

--- a/tests/middleware-runtime-trailing-slash.test.ts
+++ b/tests/middleware-runtime-trailing-slash.test.ts
@@ -174,3 +174,38 @@ describe("executeMiddleware propagates trailingSlash to NextURL", () => {
     expect(new URL(result.redirectUrl!, "http://localhost").pathname).toBe("/file.css/");
   });
 });
+
+describe("executeMiddleware normalizes trailing slashes for matcher evaluation", () => {
+  const protectedApiMiddleware = (observedPathnames: string[] = []) => ({
+    config: { matcher: ["/api/admin"] },
+    middleware: (request: { nextUrl: { pathname: string } }) => {
+      observedPathnames.push(request.nextUrl.pathname);
+      return new Response("unauthorized", { status: 401 });
+    },
+  });
+
+  it("matches an exact API pathname when the request URL has a trailing slash", async () => {
+    const result = await executeMiddleware({
+      isProxy: false,
+      module: protectedApiMiddleware(),
+      request: new Request("http://localhost/api/admin/"),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.response?.status).toBe(401);
+  });
+
+  it("matches an exact API pathname when an adapter provides a trailing-slash pathname", async () => {
+    const observedPathnames: string[] = [];
+    const result = await executeMiddleware({
+      isProxy: false,
+      module: protectedApiMiddleware(observedPathnames),
+      normalizedPathname: "/api/admin/",
+      request: new Request("http://localhost/api/admin/"),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.response?.status).toBe(401);
+    expect(observedPathnames).toEqual(["/api/admin/"]);
+  });
+});

--- a/tests/middleware-runtime-trailing-slash.test.ts
+++ b/tests/middleware-runtime-trailing-slash.test.ts
@@ -208,4 +208,18 @@ describe("executeMiddleware normalizes trailing slashes for matcher evaluation",
     expect(result.response?.status).toBe(401);
     expect(observedPathnames).toEqual(["/api/admin/"]);
   });
+
+  it("matches a canonical API pathname when the matcher source has a trailing slash", async () => {
+    const result = await executeMiddleware({
+      isProxy: false,
+      module: {
+        config: { matcher: ["/api/admin/"] },
+        middleware: () => new Response("unauthorized", { status: 401 }),
+      },
+      request: new Request("http://localhost/api/admin"),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.response?.status).toBe(401);
+  });
 });

--- a/tests/middleware-runtime-trailing-slash.test.ts
+++ b/tests/middleware-runtime-trailing-slash.test.ts
@@ -222,4 +222,46 @@ describe("executeMiddleware normalizes trailing slashes for matcher evaluation",
     expect(result.continue).toBe(false);
     expect(result.response?.status).toBe(401);
   });
+
+  it("preserves an escaped terminal slash matcher", async () => {
+    const module = {
+      config: { matcher: ["/api/admin\\/"] },
+      middleware: () => new Response("unauthorized", { status: 401 }),
+    };
+    const matchingResult = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost/api/admin/"),
+    });
+    const nonMatchingResult = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost/api/admin"),
+    });
+
+    expect(matchingResult.continue).toBe(false);
+    expect(matchingResult.response?.status).toBe(401);
+    expect(nonMatchingResult).toEqual({ continue: true });
+  });
+
+  it("preserves a custom constraint that requires a terminal slash", async () => {
+    const module = {
+      config: { matcher: ["/:path(.*\\/)"] },
+      middleware: () => new Response("unauthorized", { status: 401 }),
+    };
+    const matchingResult = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost/foo/"),
+    });
+    const nonMatchingResult = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost/foo"),
+    });
+
+    expect(matchingResult.continue).toBe(false);
+    expect(matchingResult.response?.status).toBe(401);
+    expect(nonMatchingResult).toEqual({ continue: true });
+  });
 });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -7139,9 +7139,24 @@ describe("middleware matcher patterns", () => {
     // Next.js compiles middleware sources with an optional terminal delimiter.
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/analysis/get-page-static-info.ts
     expect(matchPattern("/api/admin/", "/api/admin/")).toBe(true);
+    expect(matchPattern("/api/admin/", "/api/admin\\/")).toBe(true);
+    expect(matchPattern("/api/admin", "/api/admin\\/")).toBe(false);
+    expect(matchPattern("/blog/post/", "/(.*)/")).toBe(true);
+    expect(matchPattern("/blog/post", "/(.*)/")).toBe(false);
+    expect(matchPattern("/api/123/", "/api/:id")).toBe(true);
+    expect(matchPattern("/api/123/", "/api/:id/")).toBe(true);
+    expect(matchPattern("/api/123", "/api/:id/")).toBe(false);
+    expect(matchPattern("/foo/", "/:path(.*\\/)")).toBe(true);
+    expect(matchPattern("/foo", "/:path(.*\\/)")).toBe(false);
     expect(matchesMiddleware("/api/admin", "/api/admin/")).toBe(true);
     expect(matchesMiddleware("/api/admin", ["/api/admin/"])).toBe(true);
     expect(matchesMiddleware("/api/admin", [{ source: "/api/admin/" }])).toBe(true);
+    expect(
+      matchesMiddleware("/fr/api/admin/", "/api/admin\\/", undefined, {
+        locales: ["en", "fr"],
+        defaultLocale: "en",
+      }),
+    ).toBe(true);
     expect(matchesMiddleware("/", "/")).toBe(true);
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -7133,10 +7133,12 @@ describe("middleware matcher patterns", () => {
   });
 
   it("matchesMiddleware: trailing slashes in matcher sources are optional", async () => {
-    const { matchesMiddleware } = await import("../packages/vinext/src/server/middleware.js");
+    const { matchPattern, matchesMiddleware } =
+      await import("../packages/vinext/src/server/middleware.js");
 
     // Next.js compiles middleware sources with an optional terminal delimiter.
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/analysis/get-page-static-info.ts
+    expect(matchPattern("/api/admin/", "/api/admin/")).toBe(true);
     expect(matchesMiddleware("/api/admin", "/api/admin/")).toBe(true);
     expect(matchesMiddleware("/api/admin", ["/api/admin/"])).toBe(true);
     expect(matchesMiddleware("/api/admin", [{ source: "/api/admin/" }])).toBe(true);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -7132,6 +7132,17 @@ describe("middleware matcher patterns", () => {
     expect(matchesMiddleware("/other", matcher)).toBe(false);
   });
 
+  it("matchesMiddleware: trailing slashes in matcher sources are optional", async () => {
+    const { matchesMiddleware } = await import("../packages/vinext/src/server/middleware.js");
+
+    // Next.js compiles middleware sources with an optional terminal delimiter.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/analysis/get-page-static-info.ts
+    expect(matchesMiddleware("/api/admin", "/api/admin/")).toBe(true);
+    expect(matchesMiddleware("/api/admin", ["/api/admin/"])).toBe(true);
+    expect(matchesMiddleware("/api/admin", [{ source: "/api/admin/" }])).toBe(true);
+    expect(matchesMiddleware("/", "/")).toBe(true);
+  });
+
   it("matchesMiddleware: array of object matchers with source", async () => {
     const { matchesMiddleware } = await import("../packages/vinext/src/server/middleware.js");
     const matcher = [{ source: "/about" }, { source: "/dashboard/:path*" }];


### PR DESCRIPTION
## Summary

- normalize the pathname used for middleware matcher evaluation by removing trailing slashes
- preserve the original request URL exposed through `request.nextUrl`
- cover exact API matchers in the shared runtime and App Router dev/production servers

## Next.js parity

Next.js removes the trailing slash from the normalized pathname before evaluating middleware matchers:

- https://github.com/vercel/next.js/blob/canary/packages/next/src/server/next-server.ts

## Validation

- `vp check`
- `vp test run tests/middleware-runtime-trailing-slash.test.ts tests/app-router-middleware-next-request.test.ts`
- `vp test run tests/app-router-production-server.test.ts -t "trailing-slash route handler request"`
