### PR TITLE
fix(css): keep module hashes stable with url assets

### DIFF
--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -13,12 +13,14 @@ import type { Rolldown } from "vite";
  * vitejs/vite#8632). The one native escape hatch is `this.emitFile({ fileName })`:
  * assets emitted with an explicit `fileName` are *never* deduped. So we:
  *
- *   1. mark — during the client CSS transform, tag each relative asset `url()`
- *      with a private `?vinext_css_url_asset=<source-basename>` query. This is
- *      the only durable carrier of per-reference provenance: once Rolldown
- *      dedupes, the emitted bundle cannot tell which `url()` came from which
- *      source, and the bundle metadata (`originalFileNames`) records the set of
- *      sources but not the mapping per reference.
+ *   1. mark — during every production CSS transform, tag each relative asset
+ *      `url()` with a private `?vinext_css_url_asset=<source-basename>` query.
+ *      Using identical transformed CSS in server and client environments is
+ *      required because the default CSS Modules scoped name hashes the full CSS
+ *      text. In the client build, the marker is also the only durable carrier
+ *      of per-reference provenance: once Rolldown dedupes, the emitted bundle
+ *      cannot tell which `url()` came from which source, and bundle metadata
+ *      records the source set but not the mapping per reference.
  *
  *   2. restore — at `generateBundle`, read each marked reference's source
  *      basename back out. When it differs from the deduped output's basename,
@@ -149,7 +151,7 @@ function rewriteCssUrls(code: string, replace: (rawUrl: string) => string | null
 /**
  * Append the private provenance marker to each relative asset `url()` in a CSS
  * source. Idempotent and side-effect free (only adds a query param), so it is
- * safe to run on every client-environment stylesheet, vendored CSS included.
+ * safe to run on every build-environment stylesheet, vendored CSS included.
  */
 export function markCssUrlAssetReferences(code: string, id: string): string | null {
   if (!isCssRequest(id) || !code.includes("url(")) return null;

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -17,10 +17,10 @@ import type { Rolldown } from "vite";
  *      `url()` with a private `?vinext_css_url_asset=<source-basename>` query.
  *      Using identical transformed CSS in server and client environments is
  *      required because the default CSS Modules scoped name hashes the full CSS
- *      text. In the client build, the marker is also the only durable carrier
- *      of per-reference provenance: once Rolldown dedupes, the emitted bundle
- *      cannot tell which `url()` came from which source, and bundle metadata
- *      records the source set but not the mapping per reference.
+ *      text. The marker is also the only durable carrier of per-reference
+ *      provenance: once Rolldown dedupes, the emitted bundle cannot tell which
+ *      `url()` came from which source, and bundle metadata records the source
+ *      set but not the mapping per reference.
  *
  *   2. restore — at `generateBundle`, read each marked reference's source
  *      basename back out. When it differs from the deduped output's basename,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2955,7 +2955,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // CSS url() asset parity with Next.js. Build-only: dev CSS is untouched.
     // Apply the transient marker in every environment so CSS Modules receives
     // identical source text and generates identical class names for server and
-    // client builds. Only the client restore phase emits deduped media siblings.
+    // client builds. Restore it in every output so server-emitted CSS also keeps
+    // distinct asset filenames and never exposes the private marker.
     {
       name: "vinext:css-url-assets-mark",
       enforce: "pre",
@@ -3024,7 +3025,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       apply: "build",
 
       generateBundle(_options, bundle) {
-        if (this.environment?.name !== "client") return;
         restoreDedupedCssAssetReferences(bundle, (asset) => {
           this.emitFile({ type: "asset", fileName: asset.fileName, source: asset.source });
         });

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2952,8 +2952,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
       },
     },
-    // CSS url() asset parity with Next.js. Build-only and client-scoped: dev CSS
-    // is untouched, and server environments keep Vite's default asset handling.
+    // CSS url() asset parity with Next.js. Build-only: dev CSS is untouched.
+    // Apply the transient marker in every environment so CSS Modules receives
+    // identical source text and generates identical class names for server and
+    // client builds. Only the client restore phase emits deduped media siblings.
     {
       name: "vinext:css-url-assets-mark",
       enforce: "pre",
@@ -2965,7 +2967,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           code: "url(",
         },
         handler(code, id) {
-          if (this.environment?.name !== "client") return null;
           const marked = markCssUrlAssetReferences(code, id);
           if (marked === null) return null;
           // No source map: the marker is transient — it's stripped before final

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -73,6 +73,10 @@ function svgUrls(css: string): string[] {
   return extractCssUrls(css).filter((url) => url.includes(".svg"));
 }
 
+function extractRedTextClassNames(code: string): string[] {
+  return [...new Set(code.match(/_redText_[A-Za-z0-9_-]+_\d+/g) ?? [])];
+}
+
 async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     server.close((err) => (err ? reject(err) : resolve()));
@@ -281,6 +285,7 @@ describe("Pages Router CSS url() asset emission", () => {
 describe("App Router CSS url() asset emission", () => {
   let tmpDir: string;
   let clientDir: string;
+  let serverDir: string;
 
   beforeAll(async () => {
     // Build an isolated copy so the client output (which vinext writes to
@@ -301,6 +306,7 @@ describe("App Router CSS url() asset emission", () => {
     });
     await builder.buildApp();
     clientDir = path.join(tmpDir, "dist", "client");
+    serverDir = path.join(tmpDir, "dist", "server");
   }, 180_000);
 
   afterAll(async () => {
@@ -333,5 +339,32 @@ describe("App Router CSS url() asset emission", () => {
       const stat = await fs.stat(path.join(clientDir, assetUrl));
       expect(stat.isFile(), `expected emitted asset ${assetUrl}`).toBe(true);
     }
+  });
+
+  it("uses the same CSS Module class name in server, client JS, and client CSS", async () => {
+    const serverFiles = (await listFiles(serverDir)).filter((file) => file.endsWith(".js"));
+    const clientFiles = (await listFiles(clientDir)).filter((file) => file.endsWith(".js"));
+    const cssFiles = (await listFiles(clientDir)).filter((file) => file.endsWith(".css"));
+
+    const serverCode = (
+      await Promise.all(serverFiles.map((file) => fs.readFile(file, "utf-8")))
+    ).join("\n");
+    const clientCode = (
+      await Promise.all(clientFiles.map((file) => fs.readFile(file, "utf-8")))
+    ).join("\n");
+    const clientCss = (await Promise.all(cssFiles.map((file) => fs.readFile(file, "utf-8")))).join(
+      "\n",
+    );
+
+    const serverClassNames = extractRedTextClassNames(serverCode);
+    const clientClassNames = extractRedTextClassNames(clientCode);
+    const cssClassNames = extractRedTextClassNames(clientCss);
+
+    expect(serverClassNames).toHaveLength(1);
+    expect(clientClassNames).toEqual(serverClassNames);
+    expect(cssClassNames).toEqual(serverClassNames);
+    expect(serverCode).not.toContain("vinext_css_url_asset");
+    expect(clientCode).not.toContain("vinext_css_url_asset");
+    expect(clientCss).not.toContain("vinext_css_url_asset");
   });
 });

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -303,6 +303,7 @@ describe("App Router CSS url() asset emission", () => {
       configFile: false,
       plugins: [vinext({ appDir: tmpDir })],
       logLevel: "silent",
+      build: { assetsInlineLimit: 0 },
     });
     await builder.buildApp();
     clientDir = path.join(tmpDir, "dist", "client");
@@ -343,11 +344,15 @@ describe("App Router CSS url() asset emission", () => {
 
   it("uses the same CSS Module class name in server, client JS, and client CSS", async () => {
     const serverFiles = (await listFiles(serverDir)).filter((file) => file.endsWith(".js"));
+    const serverCssFiles = (await listFiles(serverDir)).filter((file) => file.endsWith(".css"));
     const clientFiles = (await listFiles(clientDir)).filter((file) => file.endsWith(".js"));
     const cssFiles = (await listFiles(clientDir)).filter((file) => file.endsWith(".css"));
 
     const serverCode = (
       await Promise.all(serverFiles.map((file) => fs.readFile(file, "utf-8")))
+    ).join("\n");
+    const serverCss = (
+      await Promise.all(serverCssFiles.map((file) => fs.readFile(file, "utf-8")))
     ).join("\n");
     const clientCode = (
       await Promise.all(clientFiles.map((file) => fs.readFile(file, "utf-8")))
@@ -364,7 +369,13 @@ describe("App Router CSS url() asset emission", () => {
     expect(clientClassNames).toEqual(serverClassNames);
     expect(cssClassNames).toEqual(serverClassNames);
     expect(serverCode).not.toContain("vinext_css_url_asset");
+    expect(serverCss).not.toContain("vinext_css_url_asset");
     expect(clientCode).not.toContain("vinext_css_url_asset");
     expect(clientCss).not.toContain("vinext_css_url_asset");
+
+    const serverAssetUrls = svgUrls(serverCss);
+    expect(serverAssetUrls).toHaveLength(2);
+    expect(serverAssetUrls[0]).toMatch(/\/dark[.-][A-Za-z0-9_-]+\.svg$/);
+    expect(serverAssetUrls[1]).toMatch(/\/dark2[.-][A-Za-z0-9_-]+\.svg$/);
   });
 });


### PR DESCRIPTION
## Summary

- apply the temporary CSS URL provenance marker consistently across production build environments
- keep CSS Module hash input identical between RSC/SSR and client builds
- retain client-only restoration of distinct media filenames
- add regression coverage comparing server JS, client JS, and emitted client CSS class names

## Root cause

The CSS URL asset repair added `?vinext_css_url_asset=...` only during the client CSS transform. Vite's default CSS Modules scoped name hashes the full CSS text, so App Router server builds and client builds generated different class maps for modules containing relative `url(...)` references.

The marker is now added in every production build environment. The client restore phase remains responsible for emitting deduplicated sibling assets and removing the marker from final output.

## Validation

- `vp test run tests/css-url-assets.test.ts tests/ssr-css-assets.test.ts`
- `vp test run tests/build-optimization.test.ts -t "multi-env build scopes treeshake"`
- `vp check packages/vinext/src/index.ts packages/vinext/src/build/css-url-assets.ts tests/css-url-assets.test.ts`

Fixes #2111