### PR TITLE
perf(build): rely on plugin hook filters

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -184,7 +184,6 @@ import {
 } from "./build/ssr-manifest.js";
 import {
   hasExportAllCandidate,
-  hasServerExportCandidate,
   stripServerExports,
   validatePageExports,
 } from "./plugins/strip-server-exports.js";
@@ -1143,10 +1142,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             transform: {
               filter: { id: /\.m?js(?:\?.*)?$/ },
               async handler(code: string, id: string) {
-                // Only handle .js/.mjs files.
-                // TypeScript (.ts/.tsx/.jsx) files are handled by vite:oxc.
                 const cleanId = id.split("?")[0];
-                if (!/\.(m?js)$/.test(cleanId)) return;
 
                 // Inside node_modules, restrict the JSX transform to files that
                 // carry a React directive. `@vitejs/plugin-rsc` only parses
@@ -3147,25 +3143,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           },
           code: /import\s*\{[^}]*(ViewTransition|addTransitionType)[^}]*\}\s*from\s*['"]react['"]/,
         },
-        handler(code, id) {
-          // Only transform user source files, not node_modules or virtual modules
-          if (id.includes("node_modules")) return null;
-          if (id.startsWith(VIRTUAL_PREFIX)) return null;
-          if (!/\.(tsx?|jsx?|mjs)$/.test(id)) return null;
-
-          // Quick check: does this file reference canary APIs and import from "react"?
-          if (
-            !(code.includes("ViewTransition") || code.includes("addTransitionType")) ||
-            !/from\s+['"]react['"]/.test(code)
-          ) {
-            return null;
-          }
-
-          // Only rewrite if the import actually destructures a canary API
-          const canaryImportRegex =
-            /import\s*\{[^}]*(ViewTransition|addTransitionType)[^}]*\}\s*from\s*['"]react['"]/;
-          if (!canaryImportRegex.test(code)) return null;
-
+        handler(code) {
           // Rewrite all `from "react"` / `from 'react'` to use the canary shim.
           // This is safe because the virtual module re-exports everything from
           // react, so non-canary imports continue to work.
@@ -3173,10 +3151,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             /from\s*['"]react['"]/g,
             'from "virtual:vinext-react-canary"',
           );
-          if (result !== code) {
-            return { code: result, map: null };
-          }
-          return null;
+          return { code: result, map: null };
         },
       },
     },
@@ -4244,7 +4219,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
         handler(code, id) {
           if (this.environment?.name !== "client") return null;
-          if (!hasPagesDir || id.startsWith(VIRTUAL_PREFIX) || !hasExportAllCandidate(code)) {
+          if (!hasPagesDir || !hasExportAllCandidate(code)) {
             return null;
           }
           const modulePath = stripViteModuleQuery(id);
@@ -4275,9 +4250,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
         handler(code, id) {
           if (this.environment?.name !== "client") return null;
-          if (!hasPagesDir || id.startsWith(VIRTUAL_PREFIX) || !hasServerExportCandidate(code)) {
-            return null;
-          }
+          if (!hasPagesDir) return null;
           // Only transform files under the pages/ directory
           const modulePath = stripViteModuleQuery(id);
           if (!isWithinPagesDirectory(modulePath)) return null;
@@ -4306,10 +4279,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     {
       name: "vinext:validate-server-only-client-imports",
       transform: {
-        filter: { id: /\.(tsx?|jsx?|mjs)$/, code: "server-only" },
-        handler(code, id) {
+        filter: {
+          id: {
+            include: /\.(tsx?|jsx?|mjs)$/,
+            exclude: VIRTUAL_MODULE_ID_RE,
+          },
+          code: "server-only",
+        },
+        handler(code) {
           if (this.environment?.name !== "client") return null;
-          if (id.startsWith(VIRTUAL_PREFIX)) return null;
           if (getLeadingReactDirective(code) === "use server") return null;
           if (!hasServerOnlyMarkerImport(code)) return null;
 
@@ -4339,16 +4317,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           },
           code: /\bconsole\b/,
         },
-        handler(code, id) {
+        handler(code) {
           const ssr = this.environment?.name !== "client";
           if (ssr) return null;
           if (!nextConfig.removeConsole) return null;
-          // Skip node_modules to avoid transform overhead on application
-          // dependencies. Next.js applies removeConsole to node_modules too
-          // (the SWC option in getBaseSWCOptions runs on every file the SWC
-          // loader processes); this is a minor divergence in exchange for
-          // faster builds.
-          if (id.includes("/node_modules/")) return null;
 
           const result = removeConsoleCalls(code, nextConfig.removeConsole);
           if (!result) return null;
@@ -4509,16 +4481,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         filter: {
           id: {
             include: /\.(tsx?|jsx?|mjs)$/,
-            exclude: /node_modules/,
+            exclude: [/node_modules/, VIRTUAL_MODULE_ID_RE],
           },
           code: new RegExp(`import\\s+\\w+\\s+from\\s+['"][^'"]+\\.(${IMAGE_EXTS})['"]`),
         },
         async handler(code, id) {
-          // Defensive guard — duplicates filter logic
-          if (id.includes("node_modules")) return null;
-          if (id.startsWith(VIRTUAL_PREFIX)) return null;
-          if (!id.match(/\.(tsx?|jsx?|mjs)$/)) return null;
-
           // The `code` filter above (a regex) only decides whether to invoke
           // this handler; it can fire on text inside comments, strings, or
           // template literals. Scanning must therefore be AST-based so we only
@@ -4681,19 +4648,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         filter: {
           id: {
             include: /\.(tsx?|jsx?|mjs)$/,
-            exclude: /node_modules/,
+            exclude: [/node_modules/, VIRTUAL_MODULE_ID_RE],
           },
           code: "use cache",
         },
         async handler(code, id) {
-          // Defensive guard — duplicates filter logic
-          if (id.includes("node_modules")) return null;
-          if (id.startsWith(VIRTUAL_PREFIX)) return null;
-          if (!id.match(/\.(tsx?|jsx?|mjs)$/)) return null;
-          if (!code.includes("use cache")) return null;
-
           // Parse the AST first to check for actual "use cache" directives before
-          // throwing the missing-RSC error. The fast-path string check above can
+          // throwing the missing-RSC error. The code filter can
           // fire on files that contain "use cache" only in comments or string
           // literals (e.g., in error messages), not as real directives.
           const ast = parseAst(code);
@@ -5413,7 +5374,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       transform: {
         filter: { id: /@vercel\/og.*index\.edge\.js/ },
         handler(code: string, id: string) {
-          if (!id.includes("@vercel/og") || !id.includes("index.edge.js")) return null;
           let result = code;
 
           // ── Yoga WASM: dynamic import + disk-read fallback ──────────────────────────

--- a/packages/vinext/src/plugins/css-data-url.ts
+++ b/packages/vinext/src/plugins/css-data-url.ts
@@ -126,12 +126,6 @@ export function dataUrlCssPlugin(): Plugin {
         code: DATA_URL_HINT,
       },
       handler(code, id) {
-        // Cheap pre-check so we don't run the regex on every module in the
-        // graph. Skip the CSS pipeline itself: synthetic ids round-trip through
-        // `transform`, but their decoded payload never contains a quoted import.
-        if (!code.includes(DATA_URL_HINT)) return null;
-        if (id.startsWith(VIRTUAL_PREFIX)) return null;
-
         let mutated = false;
         const rewritten = code.replace(
           DATA_URL_IMPORT_RE,

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -41,10 +41,7 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
         code: /\bimport\s*\(/,
       },
       handler(code, id) {
-        if (!/\bimport\s*\(/.test(code)) return null;
-        if (isDependencyId(id)) return null;
-        const lang = langForId(id);
-        if (!lang) return null;
+        const lang = langForId(id)!;
 
         let ast: unknown;
         try {
@@ -84,11 +81,6 @@ function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {
   if (ext === ".ts" || ext === ".mts" || ext === ".cts") return "ts";
   if (ext === ".tsx") return "tsx";
   return "jsx";
-}
-
-function isDependencyId(id: string): boolean {
-  const clean = id.split("?", 1)[0].replaceAll("\\", "/");
-  return clean.includes("/node_modules/");
 }
 
 function collectExtensionlessImports(

--- a/packages/vinext/src/plugins/import-meta-url.ts
+++ b/packages/vinext/src/plugins/import-meta-url.ts
@@ -82,7 +82,6 @@ export function createImportMetaUrlPlugin(options: { getRoot: () => string | und
         code: /import\.meta(?:\.|\?\.)url|__filename|__dirname/,
       },
       handler(code, id) {
-        if (!mayContainSourceIdentityToken(code)) return null;
         const paths = getRootPaths();
         if (!paths) return null;
         const cleanId = cleanModuleId(id);
@@ -226,10 +225,6 @@ function mayContainImportMetaUrl(code: string): boolean {
 
 function mayContainServerCjsGlobal(code: string): boolean {
   return code.includes("__filename") || code.includes("__dirname");
-}
-
-function mayContainSourceIdentityToken(code: string): boolean {
-  return mayContainImportMetaUrl(code) || mayContainServerCjsGlobal(code);
 }
 
 function excludedRelativePrefixes(

--- a/packages/vinext/src/plugins/og-assets.ts
+++ b/packages/vinext/src/plugins/og-assets.ts
@@ -85,11 +85,6 @@ export function createOgInlineFetchAssetsPlugin(): Plugin {
     transform: {
       filter: { code: "import.meta.url" },
       async handler(code, id) {
-        // Quick bail-out: only process modules that use new URL(..., import.meta.url)
-        if (!code.includes("import.meta.url")) {
-          return null;
-        }
-
         const useCache = isBuild;
         const moduleDir = path.dirname(id);
         let newCode = code;

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -21,7 +21,7 @@ import type { ResolvedNextConfig } from "../config/next-config.js";
 import { getAstName } from "./ast-utils.js";
 import { normalizePathSeparators } from "../utils/path.js";
 import { escapeRegExp } from "../utils/regex.js";
-import { VIRTUAL_MODULE_ID_RE, VIRTUAL_PREFIX } from "../utils/virtual-module.js";
+import { VIRTUAL_MODULE_ID_RE } from "../utils/virtual-module.js";
 
 /**
  * Read a file's contents, returning null on any error.
@@ -728,7 +728,7 @@ export function createOptimizeImportsPlugin(
         },
         code: /\bimport\b[\s\S]*\bfrom\b/,
       },
-      async handler(code, id) {
+      async handler(code) {
         // Only apply on server environments (RSC/SSR). The client uses Vite's
         // dep optimizer which handles barrel imports correctly.
         const env = (this as PluginCtx).environment;
@@ -736,8 +736,6 @@ export function createOptimizeImportsPlugin(
         // "react-server" export condition should only be preferred in the RSC environment.
         // SSR renders with the full React runtime and must NOT resolve react-server entries.
         const preferReactServer = env?.name === "rsc";
-        // Skip virtual modules
-        if (id.startsWith(VIRTUAL_PREFIX)) return null;
 
         // Quick pre-parse check: only transformable static `import ... from "pkg"`
         // declarations can be rewritten, so skip files that merely mention an

--- a/packages/vinext/src/plugins/require-context.ts
+++ b/packages/vinext/src/plugins/require-context.ts
@@ -61,9 +61,7 @@ export function createRequireContextPlugin(): Plugin {
         code: /\brequire\b[\s\S]*\.context/,
       },
       handler(code, id) {
-        if (!mayContainRequireContext(code)) return null;
-        const lang = langForId(id);
-        if (!lang) return null;
+        const lang = langForId(id)!;
 
         let ast: unknown;
         try {
@@ -87,12 +85,6 @@ export function createRequireContextPlugin(): Plugin {
       },
     },
   };
-}
-
-function mayContainRequireContext(code: string): boolean {
-  // Cheap substring gate: both the `require` token and a `.context` member
-  // access must be present for any genuine call.
-  return code.includes("require") && code.includes(".context");
 }
 
 function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -100,14 +100,14 @@ describe("vinext:extensionless-dynamic-import", () => {
     expect(result).toBeNull();
   });
 
-  it("leaves dependency imports unchanged", () => {
-    const transform = createTransform();
-    const result = transform(
-      "await import(`./${locale}`)",
-      "/app/node_modules/example-package/index.js",
-    );
+  it("filters out dependency imports before invoking the handler", () => {
+    const plugin = createExtensionlessDynamicImportPlugin();
+    if (!plugin.transform || typeof plugin.transform === "function") {
+      throw new Error("filtered transform hook not found");
+    }
+    const idFilter = plugin.transform.filter?.id as { exclude?: RegExp } | undefined;
 
-    expect(result).toBeNull();
+    expect(idFilter?.exclude?.test("/app/node_modules/example-package/index.js")).toBe(true);
   });
 
   it("leaves imports with attributes unchanged", () => {


### PR DESCRIPTION
Follow-up to #2103.

Removes handler guards that duplicate Vite hook filters now that vinext requires Vite 7 or newer. Semantic checks such as environment gating, AST validation, and no-op transform results remain.

Also updates the extensionless dynamic import test to assert dependency exclusion at the filter boundary instead of calling the raw handler with an excluded ID.

Tests:
- `vp check` on changed files
- focused plugin, build optimization, Pages Router, require.context, use cache, and React canary tests