### PR TITLE
perf(ssr): isolate open redirect detection

### DIFF
--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -268,7 +268,6 @@ export async function renderAppPageHtmlStream(
  * response body). This is the correct place to clear per-request context,
  * because the RSC/SSR pipeline is lazy — components execute while the stream
  * is being consumed, not when the stream handle is first obtained.
- */
 export async function renderAppPageHtmlResponse(
   options: RenderAppPageHtmlResponseOptions,
 ): Promise<Response> {

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -262,12 +262,6 @@ export async function renderAppPageHtmlStream(
   return normalizeAppSsrRenderResult(rawResult, options.capturedRscDataRef?.value ?? null);
 }
 
-/**
- * Wraps a stream so that `onFlush` is called when the last byte has been read
- * by the downstream consumer (i.e. when the HTTP layer finishes draining the
- * response body). This is the correct place to clear per-request context,
- * because the RSC/SSR pipeline is lazy — components execute while the stream
- * is being consumed, not when the stream handle is first obtained.
 export async function renderAppPageHtmlResponse(
   options: RenderAppPageHtmlResponseOptions,
 ): Promise<Response> {

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -5,6 +5,9 @@ import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import type { RootParams } from "vinext/shims/root-params";
+import { deferUntilStreamConsumed } from "./defer-until-stream-consumed.js";
+
+export { deferUntilStreamConsumed } from "./defer-until-stream-consumed.js";
 
 export type AppPageFontData = {
   links: string[];
@@ -266,54 +269,6 @@ export async function renderAppPageHtmlStream(
  * because the RSC/SSR pipeline is lazy — components execute while the stream
  * is being consumed, not when the stream handle is first obtained.
  */
-export function deferUntilStreamConsumed(
-  stream: ReadableStream<Uint8Array>,
-  onFlush: () => void,
-): ReadableStream<Uint8Array> {
-  let called = false;
-  const once = () => {
-    if (!called) {
-      called = true;
-      onFlush();
-    }
-  };
-
-  const cleanup = new TransformStream<Uint8Array, Uint8Array>({
-    flush() {
-      once();
-    },
-  });
-
-  const piped = stream.pipeThrough(cleanup);
-
-  // Wrap with a ReadableStream so we can intercept cancel() — the TransformStream
-  // Transformer interface does not expose a cancel hook in the Web Streams spec.
-  const reader = piped.getReader();
-  return new ReadableStream<Uint8Array>({
-    pull(controller) {
-      return reader.read().then(
-        ({ done, value }) => {
-          if (done) {
-            controller.close();
-          } else {
-            controller.enqueue(value);
-          }
-        },
-        (error) => {
-          once();
-          controller.error(error);
-        },
-      );
-    },
-    cancel(reason) {
-      // Stream cancelled before fully consumed (e.g. client disconnected).
-      // Still clear per-request context to avoid leaks.
-      once();
-      return reader.cancel(reason);
-    },
-  });
-}
-
 export async function renderAppPageHtmlResponse(
   options: RenderAppPageHtmlResponseOptions,
 ): Promise<Response> {

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -38,7 +38,8 @@ import {
   createRscEmbedTransform,
   createTickBufferedTransform,
 } from "./app-ssr-stream.js";
-import { deferUntilStreamConsumed, type AppSsrRenderResult } from "./app-page-stream.js";
+import type { AppSsrRenderResult } from "./app-page-stream.js";
+import { deferUntilStreamConsumed } from "./defer-until-stream-consumed.js";
 import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { createInitialDevServerErrorScript } from "./dev-initial-server-error.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -19,7 +19,7 @@ import {
 } from "vinext/shims/navigation-server";
 import { runWithNavigationContext } from "vinext/shims/navigation-state";
 import { runWithRootParamsScope, type RootParams } from "vinext/shims/root-params";
-import { isOpenRedirectShaped } from "./request-pipeline.js";
+import { isOpenRedirectShaped } from "./open-redirect.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import {

--- a/packages/vinext/src/server/defer-until-stream-consumed.ts
+++ b/packages/vinext/src/server/defer-until-stream-consumed.ts
@@ -1,0 +1,44 @@
+/**
+ * Defers cleanup until the downstream consumer drains or cancels the stream.
+ */
+export function deferUntilStreamConsumed(
+  stream: ReadableStream<Uint8Array>,
+  onFlush: () => void,
+): ReadableStream<Uint8Array> {
+  let called = false;
+  const once = () => {
+    if (!called) {
+      called = true;
+      onFlush();
+    }
+  };
+
+  const cleanup = new TransformStream<Uint8Array, Uint8Array>({
+    flush() {
+      once();
+    },
+  });
+
+  const reader = stream.pipeThrough(cleanup).getReader();
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      return reader.read().then(
+        ({ done, value }) => {
+          if (done) {
+            controller.close();
+          } else {
+            controller.enqueue(value);
+          }
+        },
+        (error) => {
+          once();
+          controller.error(error);
+        },
+      );
+    },
+    cancel(reason) {
+      once();
+      return reader.cancel(reason);
+    },
+  });
+}

--- a/packages/vinext/src/server/open-redirect.ts
+++ b/packages/vinext/src/server/open-redirect.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns true if a request pathname looks like a protocol-relative open
+ * redirect, in either literal or percent-encoded form.
+ *
+ * A pathname is considered "open redirect shaped" when its first segment,
+ * after decoding backslashes and encoded delimiters, would cause a browser
+ * to resolve a `Location` containing the pathname as protocol-relative.
+ */
+export function isOpenRedirectShaped(rawPathname: string): boolean {
+  if (!rawPathname.startsWith("/")) return false;
+
+  // Browsers treat backslashes as forward slashes in URL paths.
+  const afterSlash = rawPathname.slice(1);
+  if (afterSlash.startsWith("/") || afterSlash.startsWith("\\")) return true;
+
+  // Percent escapes are case-insensitive per RFC 3986 section 2.1.
+  if (afterSlash.length >= 3 && afterSlash[0] === "%") {
+    const encoded = afterSlash.slice(0, 3).toLowerCase();
+    if (encoded === "%5c" || encoded === "%2f") return true;
+  }
+
+  return false;
+}

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -80,7 +80,6 @@ export function guardProtocolRelativeUrl(rawPathname: string): Response | null {
  * pathname — we only examine the leading bytes (up to the second real or
  * encoded delimiter) so malformed suffixes can still reach the normal
  * "400 Bad Request" decode path instead of being masked as "404".
- */
 /**
  * Strip the basePath prefix from a pathname.
  *

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -9,6 +9,9 @@ import {
   VINEXT_STATIC_FILE_HEADER,
 } from "./headers.js";
 import { forbiddenResponse, notFoundResponse } from "./http-error-responses.js";
+import { isOpenRedirectShaped } from "./open-redirect.js";
+
+export { isOpenRedirectShaped } from "./open-redirect.js";
 
 /**
  * Shared request pipeline utilities.
@@ -78,25 +81,6 @@ export function guardProtocolRelativeUrl(rawPathname: string): Response | null {
  * encoded delimiter) so malformed suffixes can still reach the normal
  * "400 Bad Request" decode path instead of being masked as "404".
  */
-export function isOpenRedirectShaped(rawPathname: string): boolean {
-  if (!rawPathname.startsWith("/")) return false;
-
-  // Fast path: literal `//...` or `/\...`. Browsers treat `\` as `/` in
-  // URL paths, so `/\evil.com` is equivalent to `//evil.com`.
-  const afterSlash = rawPathname.slice(1);
-  if (afterSlash.startsWith("/") || afterSlash.startsWith("\\")) return true;
-
-  // Slow path: percent-encoded leading delimiter. We only need to consider
-  // `%5C` (backslash) and `%2F` (forward slash) at position 1. Case-insensitive
-  // per RFC 3986 §2.1.
-  if (afterSlash.length >= 3 && afterSlash[0] === "%") {
-    const encoded = afterSlash.slice(0, 3).toLowerCase();
-    if (encoded === "%5c" || encoded === "%2f") return true;
-  }
-
-  return false;
-}
-
 /**
  * Strip the basePath prefix from a pathname.
  *

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -59,28 +59,6 @@ export function guardProtocolRelativeUrl(rawPathname: string): Response | null {
 }
 
 /**
- * Returns true if a request pathname looks like a protocol-relative open
- * redirect, in either literal or percent-encoded form.
- *
- * Exported for call sites that need to replicate the guard inline (Pages
- * Router worker codegen, Node production server) and for defense-in-depth
- * checks inside redirect emitters.
- *
- * A pathname is considered "open redirect shaped" when its first segment,
- * after decoding backslashes and encoded delimiters, would cause a browser
- * to resolve a `Location` containing the pathname as protocol-relative:
- *
- *   - literal   `//evil.com`
- *   - literal   `/\evil.com`             (browsers normalize `\` to `/`)
- *   - encoded   `/%5Cevil.com`           (`%5C` decodes to `\` in Location)
- *   - encoded   `/%2F/evil.com`          (`%2F` decodes to `/` → `//`)
- *   - mixed     `/%5C%2F`, `/%5C%5C`     (and other combinations)
- *
- * We explicitly do not require a valid percent sequence elsewhere in the
- * pathname — we only examine the leading bytes (up to the second real or
- * encoded delimiter) so malformed suffixes can still reach the normal
- * "400 Bad Request" decode path instead of being masked as "404".
-/**
  * Strip the basePath prefix from a pathname.
  *
  * All internal routing uses basePath-free paths. If the pathname starts

--- a/tests/app-page-stream.test.ts
+++ b/tests/app-page-stream.test.ts
@@ -3,11 +3,11 @@ import {
   buildAppPageLinkHeader,
   createAppPageFontData,
   createAppPageRscErrorTracker,
-  deferUntilStreamConsumed,
   renderAppPageHtmlResponse,
   renderAppPageHtmlStream,
   renderAppPageHtmlStreamWithRecovery,
 } from "../packages/vinext/src/server/app-page-stream.js";
+import { deferUntilStreamConsumed } from "../packages/vinext/src/server/defer-until-stream-consumed.js";
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({


### PR DESCRIPTION
The App Router SSR imported two small helpers from large runtime modules. In turn Vite has to transform the unrelated request, cache, response, and stream code on the first request.

Moving them into dependency-free modules reduces the initial graph and improves cold start times.

(Yes, these are somewhat micro-optimizations but on the plugin level these are worth it IMO. Here we get ~40ms)