### PR TITLE
perf(image-imports): hoist image-extension regex to module scope

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -558,6 +558,9 @@ const RESOLVED_INSTRUMENTATION_CLIENT = `${VIRTUAL_PREFIX}${VIRTUAL_INSTRUMENTAT
 /** Image file extensions handled by the vinext:image-imports plugin.
  *  Shared between the Rolldown hook filter and the transform handler regex. */
 const IMAGE_EXTS = "png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?";
+/** Matches a trailing image extension on an import path. Built once: `IMAGE_EXTS`
+ *  is constant, so there is no need to recompile this per transform invocation. */
+const IMAGE_EXT_RE = new RegExp(`\\.(${IMAGE_EXTS})$`);
 
 function createStaticImageAsset(imagePath: string): { fileName: string; source: Buffer } {
   const source = fs.readFileSync(imagePath);
@@ -4521,7 +4524,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // merely looks like one. Regex-based scanning generated phantom
           // variables for commented-out imports, crashing SSR with
           // `__vinext_img_url_X is not defined`.
-          const imageExtRe = new RegExp(`\\.(${IMAGE_EXTS})$`);
 
           // This plugin uses `enforce: "pre"`, so the handler runs on RAW
           // source — before the JSX/TS transform. `parseAst` defaults to plain
@@ -4563,7 +4565,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
             const importPath = importNode.source?.value;
             if (typeof importPath !== "string") continue;
-            if (!imageExtRe.test(importPath)) continue;
+            if (!IMAGE_EXT_RE.test(importPath)) continue;
 
             // Only handle a single default import (`import X from '...'`),
             // matching the original behavior. Skip named/namespace imports and


### PR DESCRIPTION
## What

Move the trailing-image-extension `RegExp` out of the `vinext:image-imports` transform handler into a module-scope constant `IMAGE_EXT_RE`, built once.

## Why

The handler previously ran `new RegExp(\`\\.(${IMAGE_EXTS})$\`)` on **every invocation** — i.e. for every module whose source matched the image-import `code` filter. `IMAGE_EXTS` is a module-level constant, so the resulting regex is invariant; recompiling it per module is pure redundant work on the dev/build transform path. This mirrors the adjacent `code`-filter regex, which is already built once.

## How

- Add `IMAGE_EXT_RE` next to `IMAGE_EXTS`, compiled once at module load.
- Remove the per-call `const imageExtRe = new RegExp(...)` from the handler.
- Point the single usage site at the shared constant.

Safe to share a single instance: the regex has no `g` flag, so `.test()` carries no `lastIndex` state, and concurrent transforms cannot interfere with each other. The regex value and matching behavior are identical to before — this is a behavior-preserving change.

## Testing

- No behavioral change: the compiled pattern and its single usage are byte-for-byte equivalent to the previous per-call regex; only the allocation site moved.
- The existing `vinext:image-imports` transform tests exercise this path (default image imports, commented-out/string-literal false positives, `.ts` vs `.tsx` parsing).
