### PR TITLE
perf(app-page-cache): reuse the ISR cache key on the stale-regeneration path

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -465,31 +465,31 @@ export async function readAppPageCacheResponse(
     }
 
     if (cached?.isStale && cachedValue) {
-      const regenerationKey = options.isRscRequest
-        ? options.isrRscKey(
-            options.cleanPathname,
-            options.mountedSlotsHeader,
-            options.renderMode,
-            options.interceptionContext,
-          )
-        : options.isrHtmlKey(options.cleanPathname);
-
       // Preserve the legacy behavior from the inline generator: stale entries
       // still trigger background regeneration even if this request cannot use
       // the stale payload and will fall through to a fresh render.
-      options.scheduleBackgroundRegeneration(regenerationKey, async () => {
+      //
+      // The regeneration key is derived from exactly the same inputs as `isrKey`
+      // above (the RSC variant when `isRscRequest`, the HTML key otherwise), so
+      // reuse it instead of recomputing the hash.
+      options.scheduleBackgroundRegeneration(isrKey, async () => {
         const revalidatedPage = await options.renderFreshPageForCache();
         const revalidateSeconds =
           revalidatedPage.cacheControl?.revalidate ?? options.revalidateSeconds;
         const expireSeconds = revalidatedPage.cacheControl?.expire ?? options.expireSeconds;
         const writes = [
           options.isrSet(
-            options.isrRscKey(
-              options.cleanPathname,
-              options.mountedSlotsHeader,
-              options.renderMode,
-              options.interceptionContext,
-            ),
+            // For an RSC request `isrKey` is already the RSC variant key, so
+            // reuse it; an HTML-triggered regen still needs the RSC key here,
+            // computed lazily so a deduped (skipped) regen pays nothing.
+            options.isRscRequest
+              ? isrKey
+              : options.isrRscKey(
+                  options.cleanPathname,
+                  options.mountedSlotsHeader,
+                  options.renderMode,
+                  options.interceptionContext,
+                ),
             buildAppPageCacheValue(
               "",
               revalidatedPage.rscData,


### PR DESCRIPTION
## What

Deduplicate ISR cache-key derivation in `readAppPageCacheResponse` on the stale-entry regeneration path.

## Why

When a cache entry is stale, the same key was derived up to three times: once for the lookup (`isrKey`), again as `regenerationKey` passed to `scheduleBackgroundRegeneration`, and a third time inside the regeneration closure's RSC write. Each derivation runs slot/interception normalization plus `fnv1a64` hashing (two full passes over the slots header, interception context, and pathname). For a stale RSC request all three produce the identical key, so two of them are pure redundant work — concentrated on exactly the popular stale pages that the background-regen dedup exists to cheapen.

## How

- Pass `isrKey` directly to `scheduleBackgroundRegeneration`: the regeneration key is computed from the same inputs as `isrKey` in both the RSC and HTML branches, so it is provably equal.
- In the regeneration closure's RSC write, reuse `isrKey` when the request is an RSC request (there `isrKey` is already the RSC-variant key). An HTML-triggered regen still derives the RSC key, kept lazy inside the ternary so a deduped/skipped regen pays nothing.
- The closure's HTML write (only on HTML-triggered regens, the coldest path) is left unchanged.

Subtlety worth flagging: naively reusing `isrKey` for the closure's RSC write would be a bug, because for an HTML request `isrKey` is the *HTML* key while that write needs the *RSC* variant key. The fix only substitutes `isrKey` where it is provably the RSC key.

## Net effect

- Stale RSC request: RSC key derived 1× (was 3×).
- Stale HTML request: HTML key derived 1× (was 2×); RSC key still derived once, lazily — unchanged.

## Testing

- Behavior-preserving: the scheduling/dedup key and every written cache key are byte-identical to before; only the redundant re-derivations were removed.
- The existing app-page ISR cache tests exercise the stale HIT → background-regeneration path for both RSC and HTML requests.
