### PR TITLE
fix(transforms): emit sourcemaps from strip-server-exports and remove-console

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4286,9 +4286,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (isApiPage(canonicalId)) return null;
           if (/^\/(?:_app|_document|_error)(?:\.[^/]*)?$/.test(relativePath)) return null;
 
-          const result = stripServerExports(code);
-          if (!result) return null;
-          return { code: result, map: null };
+          // stripServerExports returns { code, map }; thread the map through so
+          // line shifts from removed exports stay debuggable in client builds.
+          return stripServerExports(code);
         },
       },
     },
@@ -4346,9 +4346,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (ssr) return null;
           if (!nextConfig.removeConsole) return null;
 
-          const result = removeConsoleCalls(code, nextConfig.removeConsole);
-          if (!result) return null;
-          return { code: result, map: null };
+          // removeConsoleCalls returns { code, map }; thread the map through so
+          // stripped console calls don't desync client-build sourcemaps.
+          return removeConsoleCalls(code, nextConfig.removeConsole);
         },
       },
     },

--- a/packages/vinext/src/plugins/remove-console.ts
+++ b/packages/vinext/src/plugins/remove-console.ts
@@ -22,6 +22,11 @@ type BindingNode = Extract<ASTNode, { type: string }>;
 
 type RemoveConsoleConfig = boolean | { exclude: string[] };
 
+type RemoveConsoleResult = {
+  code: string;
+  map: ReturnType<MagicString["generateMap"]>;
+};
+
 // Node types that introduce a new function-style scope. Hoisted to a module-
 // level Set so the membership check in walk() is O(1) and doesn't allocate
 // per recursive call.
@@ -39,7 +44,10 @@ const SCOPE_ENTERING_TYPES = new Set([
  *
  * Returns `null` if no console calls are removed.
  */
-export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): string | null {
+export function removeConsoleCalls(
+  code: string,
+  config: RemoveConsoleConfig,
+): RemoveConsoleResult | null {
   if (config === false) return null;
 
   const excluded =
@@ -300,5 +308,7 @@ export function removeConsoleCalls(code: string, config: RemoveConsoleConfig): s
   }
 
   if (!changed) return null;
-  return s.toString();
+  // Emit the MagicString sourcemap rather than dropping it: stripped calls and
+  // statements shift positions, so a null map would break client-build debugging.
+  return { code: s.toString(), map: s.generateMap({ hires: "boundary" }) };
 }

--- a/packages/vinext/src/plugins/strip-server-exports.ts
+++ b/packages/vinext/src/plugins/strip-server-exports.ts
@@ -345,6 +345,11 @@ export function validatePageExports(code: string): void {
   }
 }
 
+type StripServerExportsResult = {
+  code: string;
+  map: ReturnType<MagicString["generateMap"]>;
+};
+
 /**
  * Strip server-only Pages Router data-fetching exports and their unique
  * dependency graph from browser bundles.
@@ -353,7 +358,7 @@ export function validatePageExports(code: string): void {
  * - test/unit/babel-plugin-next-ssg-transform.test.ts
  * - crates/next-custom-transforms/src/transforms/strip_page_exports.rs
  */
-export function stripServerExports(code: string): string | null {
+export function stripServerExports(code: string): StripServerExportsResult | null {
   if (!hasServerExportCandidate(code) && !hasExportAllCandidate(code)) {
     return null;
   }
@@ -752,5 +757,8 @@ export function stripServerExports(code: string): string | null {
     string.overwrite(edit.start, edit.end, edit.replacement);
     lastStart = edit.start;
   }
-  return string.toString();
+  // The MagicString already tracks every overwrite, so emit its sourcemap
+  // instead of dropping it — removing whole statements shifts line numbers for
+  // the rest of the module, which would otherwise break client-build debugging.
+  return { code: string.toString(), map: string.generateMap({ hires: "boundary" }) };
 }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -14,7 +14,7 @@ import { augmentSsrManifestFromBundle as _augmentSsrManifestFromBundle } from ".
 import {
   hasExportAllCandidate as _hasExportAllCandidate,
   hasServerExportCandidate as _hasServerExportCandidate,
-  stripServerExports as _stripServerExports,
+  stripServerExports as _stripServerExportsImpl,
   validatePageExports as _validatePageExports,
 } from "../packages/vinext/src/plugins/strip-server-exports.js";
 import {
@@ -34,6 +34,11 @@ import { collectAssetTags } from "../packages/vinext/src/server/pages-asset-tags
 import { computeClientRuntimeMetadata } from "../packages/vinext/src/utils/client-runtime-metadata.js";
 import { manifestFileWithBase } from "../packages/vinext/src/utils/manifest-paths.js";
 import { asyncHooksStubPlugin as _asyncHooksStubPlugin } from "../packages/vinext/src/plugins/async-hooks-stub.js";
+
+// `stripServerExports` returns `{ code, map }`; these tests assert on the
+// transformed source, so unwrap to the code string (null is preserved).
+const _stripServerExports = (code: string): string | null =>
+  _stripServerExportsImpl(code)?.code ?? null;
 
 // Create a clientManualChunks instance with a test shims directory.
 // The exact path doesn't matter for the node_modules-focused tests;

--- a/tests/remove-console.test.ts
+++ b/tests/remove-console.test.ts
@@ -9,7 +9,14 @@
  * - Only strips the global `console` object
  */
 import { describe, it, expect } from "vite-plus/test";
-import { removeConsoleCalls } from "../packages/vinext/src/plugins/remove-console.js";
+import { removeConsoleCalls as _removeConsoleCallsImpl } from "../packages/vinext/src/plugins/remove-console.js";
+
+// `removeConsoleCalls` returns `{ code, map }`; these tests assert on the
+// transformed source, so unwrap to the code string (null is preserved).
+const removeConsoleCalls = (
+  code: string,
+  config: Parameters<typeof _removeConsoleCallsImpl>[1],
+): string | null => _removeConsoleCallsImpl(code, config)?.code ?? null;
 
 describe("removeConsoleCalls", () => {
   it("returns null when code has no console calls", () => {


### PR DESCRIPTION
## What

Emit the MagicString sourcemap from the `vinext:strip-server-exports` and `vinext:remove-console` client-build transforms instead of returning `map: null`.

## Why

Both helpers already build a `MagicString` and apply surgical `.overwrite()` edits — the whole reason to use MagicString over plain string surgery is to produce an accurate sourcemap — yet each discarded it (`return s.toString()`, then the caller wrapped it as `{ code, map: null }`). `strip-server-exports` removes entire statements and `remove-console` removes calls/statements, so both shift line and column positions for the rest of the module. A null map breaks the sourcemap chain from that point, desyncing stack traces and breakpoints in client builds that emit sourcemaps. Wiring up the already-computed map matches the convention every other source-mutating transform in the package follows (`generateMap({ hires: "boundary" })`).

## How

- `stripServerExports` / `removeConsoleCalls` now return `{ code, map } | null`, generating the map via `generateMap({ hires: "boundary" })`.
- The two `index.ts` transform handlers return the result directly instead of re-wrapping it with `map: null`.
- Both unit tests assert on the transformed source as a string, so each gets a one-line adapter that unwraps `.code` (null preserved) — the ~140 existing assertions are untouched.

## Scope note

`vinext:react-canary` is deliberately left as-is: it rewrites only the `from "react"` specifier via a newline-free string replace, so line numbers are preserved and only import-line columns shift. The sourcemap impact is negligible and a correct map would require a from-scratch MagicString conversion for ~zero benefit.

## Testing

- `remove-console` and `build-optimization` unit suites pass (180 tests) with the existing assertions unchanged.
- `vp check` is clean for all changed files; the only remaining type errors are pre-existing and unrelated (apps/web, benchmarks).
