### PR TITLE
fix(image-imports): normalize watchChange id so image cache invalidates on Windows

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4450,9 +4450,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       watchChange(id) {
-        imageImportDimCache.delete(id);
-        staticImageAssets.delete(id);
-        staticImageImportsByModule.delete(id);
+        // Rolldown reports the changed file with native separators (backslashes
+        // on Windows), but these caches are keyed by the forward-slash module id
+        // from `load`. Normalize so the invalidation hits on Windows too.
+        const key = normalizePathSeparators(id);
+        imageImportDimCache.delete(key);
+        staticImageAssets.delete(key);
+        staticImageImportsByModule.delete(key);
       },
 
       resolveId: {


### PR DESCRIPTION
## What

Normalizes the file id in the `vinext:image-imports` plugin's `watchChange` hook so that changing a statically-imported image invalidates the plugin's caches during watch rebuilds on Windows.

## Why

The plugin keys three caches — `imageImportDimCache`, `staticImageAssets`, `staticImageImportsByModule` — by the module id seen in `load`, which is Vite/Rolldown's forward-slash id (e.g. `E:/proj/test.png`). But Rolldown calls `watchChange(id)` with the **native** path of the changed file, which uses backslashes on Windows (`E:\proj\test.png`). So every `cache.delete(id)` missed:

```
[watchChange] id = "E:\proj\test.png"   keys = ["E:/proj/test.png"]
```

The stale caches then made the rebuild re-emit the *previous* asset (same content hash and dimensions), so a changed image was never recomputed and a removed import was never dropped. In `vite build --watch` on Windows this means edits to static images silently serve the old asset; the integration test surfaced it as "Timed out waiting for watch rebuild" (the rebuilt output never differed from the first build).

## How

Run the incoming `watchChange` id through `normalizePathSeparators` once and delete by that key, matching the forward-slash space the caches are keyed in. `normalizePathSeparators` is a no-op on POSIX, where the id is already forward-slash, so behavior there is unchanged. The fix is at the consumer boundary (`watchChange`), where the native id enters — the cache keys themselves stay the canonical module-id form produced by `load`.

## Testing

`vp test run --project unit tests/static-image-emission.test.ts` — 4/4 pass on Windows (previously "recomputes changed images and removes deleted imports during watch rebuilds" timed out). The non-watch build tests were already green and stay green. `vp check` clean. Root cause confirmed empirically by logging the `watchChange` id vs the cache keys (backslash vs forward-slash).
