### PR TITLE
refactor(instrumentation): resolve instrumentation hook files in forward-slash space

### DIFF
--- a/packages/vinext/src/server/instrumentation.ts
+++ b/packages/vinext/src/server/instrumentation.ts
@@ -74,7 +74,10 @@ function findInstrumentationHookFile(
 ): string | null {
   for (const dir of INSTRUMENTATION_LOCATIONS) {
     for (const ext of fileMatcher.dottedExtensions) {
-      const fullPath = path.join(root, dir, `${basename}${ext}`);
+      // `root` is normalized to forward slashes by the config hook before it
+      // reaches here, so keep the result forward-slash with path.posix.join
+      // instead of letting win32 path.join reintroduce backslashes.
+      const fullPath = path.posix.join(root, dir, `${basename}${ext}`);
       if (fs.existsSync(fullPath)) {
         return fullPath;
       }

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./helpers.js";
 import { withEnvVar } from "./env-test-helpers.js";
 import { createValidFileMatcher } from "../packages/vinext/src/routing/file-matcher.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
 
@@ -3849,15 +3850,17 @@ describe("instrumentation.ts support", () => {
     const fs = await import("node:fs");
     const path = await import("node:path");
 
-    // Create a temp directory with an instrumentation.ts file
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-inst-"));
+    // Create a temp directory with an instrumentation.ts file. Production
+    // always passes a forward-slash root (the config hook normalizes it), so
+    // mirror that — findInstrumentationFile returns forward-slash paths.
+    const tmpDir = normalizePathSeparators(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-inst-")));
     fs.writeFileSync(
       path.join(tmpDir, "instrumentation.ts"),
       'export function register() { console.log("registered"); }',
     );
 
     const result = findInstrumentationFile(tmpDir, createValidFileMatcher());
-    expect(result).toBe(path.join(tmpDir, "instrumentation.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "instrumentation.ts"));
 
     // Cleanup
     fs.rmSync(tmpDir, { recursive: true });
@@ -3870,7 +3873,7 @@ describe("instrumentation.ts support", () => {
     const fs = await import("node:fs");
     const path = await import("node:path");
 
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-inst-"));
+    const tmpDir = normalizePathSeparators(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-inst-")));
     fs.mkdirSync(path.join(tmpDir, "src"));
     fs.writeFileSync(
       path.join(tmpDir, "src", "instrumentation.ts"),
@@ -3878,7 +3881,7 @@ describe("instrumentation.ts support", () => {
     );
 
     const result = findInstrumentationFile(tmpDir, createValidFileMatcher());
-    expect(result).toBe(path.join(tmpDir, "src", "instrumentation.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "src", "instrumentation.ts"));
 
     fs.rmSync(tmpDir, { recursive: true });
   });

--- a/tests/instrumentation.test.ts
+++ b/tests/instrumentation.test.ts
@@ -9,6 +9,7 @@ import {
   findInstrumentationClientFile,
   findInstrumentationFile,
 } from "../packages/vinext/src/server/instrumentation.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 import { generateInstrumentationClientInjectModule } from "../packages/vinext/src/client/instrumentation-client-inject.js";
 import { createValidFileMatcher } from "../packages/vinext/src/routing/file-matcher.js";
 
@@ -94,7 +95,10 @@ describe("findInstrumentationFile", () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-instr-"));
+    // Production always passes a forward-slash root (the config hook normalizes
+    // it), so mirror that here — findInstrumentationFile now returns
+    // forward-slash paths via path.posix.join.
+    tmpDir = normalizePathSeparators(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-instr-")));
   });
 
   afterEach(() => {
@@ -106,7 +110,7 @@ describe("findInstrumentationFile", () => {
 
     const result = findInstrumentationFile(tmpDir, createValidFileMatcher());
 
-    expect(result).toBe(path.join(tmpDir, "instrumentation.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "instrumentation.ts"));
   });
 
   it("prefers root over src/ directory (priority order)", () => {
@@ -118,7 +122,7 @@ describe("findInstrumentationFile", () => {
     const result = findInstrumentationFile(tmpDir, createValidFileMatcher());
 
     // Root files come first in INSTRUMENTATION_FILES, so root wins
-    expect(result).toBe(path.join(tmpDir, "instrumentation.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "instrumentation.ts"));
   });
 
   it("falls back to src/ directory", () => {
@@ -127,7 +131,7 @@ describe("findInstrumentationFile", () => {
 
     const result = findInstrumentationFile(tmpDir, createValidFileMatcher());
 
-    expect(result).toBe(path.join(tmpDir, "src", "instrumentation.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "src", "instrumentation.ts"));
   });
 
   it("returns null when no instrumentation file exists", () => {
@@ -141,7 +145,9 @@ describe("findInstrumentationClientFile", () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-instr-client-"));
+    tmpDir = normalizePathSeparators(
+      fs.mkdtempSync(path.join(os.tmpdir(), "vinext-instr-client-")),
+    );
   });
 
   afterEach(() => {
@@ -153,7 +159,7 @@ describe("findInstrumentationClientFile", () => {
 
     const result = findInstrumentationClientFile(tmpDir, createValidFileMatcher());
 
-    expect(result).toBe(path.join(tmpDir, "instrumentation-client.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "instrumentation-client.ts"));
   });
 
   it("prefers root over src/ directory (priority order)", () => {
@@ -163,7 +169,7 @@ describe("findInstrumentationClientFile", () => {
 
     const result = findInstrumentationClientFile(tmpDir, createValidFileMatcher());
 
-    expect(result).toBe(path.join(tmpDir, "instrumentation-client.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "instrumentation-client.ts"));
   });
 
   it("falls back to src/ directory", () => {
@@ -172,7 +178,7 @@ describe("findInstrumentationClientFile", () => {
 
     const result = findInstrumentationClientFile(tmpDir, createValidFileMatcher());
 
-    expect(result).toBe(path.join(tmpDir, "src", "instrumentation-client.ts"));
+    expect(result).toBe(path.posix.join(tmpDir, "src", "instrumentation-client.ts"));
   });
 
   it("returns null when no instrumentation-client file exists", () => {


### PR DESCRIPTION
## What

Builds the path in `findInstrumentationHookFile` with `path.posix.join` instead of `path.join`, so `findInstrumentationFile` / `findInstrumentationClientFile` return forward-slash paths on Windows. Updates the two unit fixtures that passed a native-separator root to mirror production.

## Why

`root` reaches this helper already normalized to forward slashes: the only production callers are `index.ts:1355-1356`, both inside the `vinext:config` hook after `root = normalizePathSeparators(config.root ?? process.cwd())` (verified upward). With `path.join`, win32 re-introduced backslashes into the returned path, leaving it inconsistent with the forward-slash module-id space the rest of the route graph uses. `path.posix.join` keeps the result forward-slash (and `existsSync` accepts forward slashes on Windows).

This is behavior-preserving, hence `refactor` not `fix`: every place that embeds `instrumentationPath` into generated code already wraps it in `normalizePathSeparators` (`pages-server-entry.ts:145`, `pages-client-entry.ts:93`, `app-rsc-entry.ts:273`), and the dev compare site (`instrumentation-client.ts:16`) normalizes too, so the emitted imports are byte-identical before and after. Pushing the normalization to the producer makes those downstream wrappers redundant — they can be dropped in a follow-up (the #1896 "normalize at the source, drop downstream workarounds" pattern). On POSIX `path.posix.join` ≡ `path.join`, so nothing changes there.

## How

- `findInstrumentationHookFile`: `path.join(root, dir, …)` → `path.posix.join(root, dir, …)`, with a comment noting `root` is already forward-slash.
- `tests/instrumentation.test.ts` + `tests/features.test.ts`: the fixtures passed `fs.mkdtempSync(...)` (native backslash) as the root and asserted the backslash result — an input production never produces. Normalize the temp root with `normalizePathSeparators` (mirroring production) and assert with `path.posix.join`.

## Testing

`vp test run --project unit tests/instrumentation.test.ts` — 33/33. `vp test run --project integration tests/features.test.ts -t "findInstrumentation"` — 4/4. Both previously failed on Windows once the source returned forward-slash but the fixtures still expected backslash. `vp check` clean on all three files.
