### PR TITLE
test(type-of-window): test the cache-dir exclude filter with POSIX ids

### DIFF
--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -12,6 +12,7 @@ import {
   getTypeofWindowReplacement,
   replaceTypeofWindow,
 } from "../packages/vinext/src/plugins/typeof-window.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -63,9 +64,13 @@ describe("typeof window compilation", () => {
   });
 
   it("configures the hook filter to skip the resolved Vite cache directory", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-filter-"));
+    // Normalize the root to forward slashes up front so everything below stays
+    // in the same POSIX space the plugin's exclude regex (and Vite's ids) use.
+    const root = normalizePathSeparators(
+      await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-filter-")),
+    );
     temporaryDirectories.push(root);
-    const cacheDir = path.join(root, ".vite-cache[custom]");
+    const cacheDir = path.posix.join(root, ".vite-cache[custom]");
     const server = await createServer({
       root,
       cacheDir,
@@ -83,8 +88,8 @@ describe("typeof window compilation", () => {
       }
       const idFilter = plugin.transform.filter?.id as { exclude?: RegExp } | undefined;
       expect(idFilter?.exclude).toBeInstanceOf(RegExp);
-      expect(idFilter?.exclude?.test(path.join(cacheDir, "deps_ssr/react.js"))).toBe(true);
-      expect(idFilter?.exclude?.test(path.join(root, "app/page.js"))).toBe(false);
+      expect(idFilter?.exclude?.test(path.posix.join(cacheDir, "deps_ssr/react.js"))).toBe(true);
+      expect(idFilter?.exclude?.test(path.posix.join(root, "app/page.js"))).toBe(false);
       expect(idFilter?.exclude?.test(`${cacheDir}-other/deps/react.js`)).toBe(false);
     } finally {
       await server.close();


### PR DESCRIPTION
## What

Feeds forward-slash paths to the `vinext:typeof-window` `transform.filter.id.exclude` regex in `tests/type-of-window.test.ts`, so the cache-dir-skip assertion holds on Windows.

## Why

The plugin builds the exclude regex from the cache dir in forward-slash space: `getCacheDirPrefix` runs the cache dir through `normalizePathSeparators`, and the regex is `new RegExp(^${escape(cacheDirPrefix)})`. Vite/Rolldown apply that regex against module **ids**, which are POSIX-normalized, so in production the regex always sees forward slashes.

The test built its probe paths with `path.join(cacheDir, "deps_ssr/react.js")`, which is backslashes on Windows. The forward-slash regex then didn't match, so the "should be excluded" assertion got `false` instead of `true`. The source is correct — its filter regex and its handler (`normalizePathSeparators(id).startsWith(cacheDirPrefix)`) both work in forward-slash space; only the fixture fed an id shape Vite never produces.

## How

Normalize the temp `root` to forward slashes once (right after `fs.mkdtemp`), derive `cacheDir` with `path.posix.join`, and build the three `exclude.test(...)` probe paths with `path.posix.join` — so they mirror the POSIX-normalized ids Vite hands the filter. Passing a forward-slash `root`/`cacheDir` to `createServer` is fine: Vite normalizes config paths internally, and the regex prefix (`getCacheDirPrefix(config.cacheDir)`) is built in that same forward-slash space. On POSIX everything is already forward-slash, so nothing changes there.

## Testing

`vp test run --project unit tests/type-of-window.test.ts` — 8/8 pass on Windows (previously "configures the hook filter to skip the resolved Vite cache directory" failed). `vp check` clean.
