### PR TITLE
refactor(instrumentation): drop redundant normalizePath on instrumentation-client path

### DIFF
--- a/packages/vinext/src/plugins/instrumentation-client.ts
+++ b/packages/vinext/src/plugins/instrumentation-client.ts
@@ -12,8 +12,10 @@ export function createInstrumentationClientTransformPlugin(
       const instrumentationClientPath = getInstrumentationClientPath();
       if (!instrumentationClientPath) return null;
 
+      // findInstrumentationClientFile already returns a POSIX path, so only the
+      // incoming id needs normalizing before the comparison.
       const normalizedId = normalizePath(id.split("?", 1)[0]);
-      if (normalizedId !== normalizePath(instrumentationClientPath)) return null;
+      if (normalizedId !== instrumentationClientPath) return null;
       if (code.includes("__vinextInstrumentationClientStart")) return null;
 
       const ast = parseAst(code);


### PR DESCRIPTION
## What

Removes the `normalizePath(...)` call applied to `instrumentationClientPath` in `createInstrumentationClientTransformPlugin`'s id comparison. Follow-up to #2128.

## Why

Since #2128, `findInstrumentationClientFile` builds its result with `path.posix.join`, so `instrumentationClientPath` is already a forward-slash, POSIX-normalized path. Vite's `normalizePath` only converts separators and runs `path.posix.normalize`, so on an already-normalized POSIX path it is a no-op — verified for Windows-drive, `src/`, and POSIX inputs (`normalizePath(p) === p` for each).

The comparison was:

```ts
const normalizedId = normalizePath(id.split("?", 1)[0]);
if (normalizedId !== normalizePath(instrumentationClientPath)) return null;
```

The right-hand `normalizePath` is now dead weight. Only the incoming `id` still needs normalizing (it is an arbitrary transform id), so the left side stays and the `normalizePath` import remains.

## How

Drop `normalizePath` on `instrumentationClientPath`, comparing the normalized id directly against it, with a comment noting the path already arrives POSIX-normalized. Behavior-preserving: the compared value is byte-identical (the removed call was a proven no-op), so the comparison result is unchanged on every platform.

## Testing

`vp test run --project unit tests/instrumentation.test.ts` — 33/33. `vp check` clean. The transform's timing injection is covered by `tests/e2e/app-router/instrumentation-client.spec.ts`; since the removed `normalizePath` was a no-op, the comparison value (and therefore that behavior) is unchanged.
