### PR TITLE
fix(pages): apply document asset nonce and crossOrigin

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -218,6 +218,8 @@ export type NextConfig = {
   };
   /** Build output mode: 'export' for full static export, 'standalone' for single server */
   output?: "export" | "standalone";
+  /** Adds a CORS mode to generated script and preload tags. */
+  crossOrigin?: "anonymous" | "use-credentials";
   /** File extensions treated as routable pages/routes (Next.js pageExtensions) */
   pageExtensions?: string[];
   /** Turbopack-compatible module resolution options. */
@@ -346,6 +348,8 @@ export type ResolvedNextConfig = {
    * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
    */
   assetPrefix: string;
+  /** Resolved `crossOrigin` from next.config.js for generated script/preload tags. */
+  crossOrigin: "anonymous" | "use-credentials" | undefined;
   trailingSlash: boolean;
   output: "" | "export" | "standalone";
   pageExtensions: string[];
@@ -1116,6 +1120,17 @@ export function normalizeAssetPrefix(value: unknown): string {
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }
 
+function normalizeCrossOrigin(
+  value: NextConfig["crossOrigin"],
+): "anonymous" | "use-credentials" | undefined {
+  if (value === undefined) return undefined;
+  if (value === "anonymous" || value === "use-credentials") return value;
+
+  throw new Error(
+    'Invalid `crossOrigin` configuration: expected "anonymous" or "use-credentials".',
+  );
+}
+
 function resolveDeploymentId(configDeploymentId: unknown): string | undefined {
   const deploymentId =
     configDeploymentId !== undefined ? configDeploymentId : process.env.NEXT_DEPLOYMENT_ID;
@@ -1332,6 +1347,7 @@ export async function resolveNextConfig(
       env: {},
       basePath: "",
       assetPrefix: "",
+      crossOrigin: undefined,
       trailingSlash: false,
       output: "",
       pageExtensions: normalizePageExtensions(),
@@ -1670,6 +1686,7 @@ export async function resolveNextConfig(
     env: config.env ?? {},
     basePath: config.basePath ?? "",
     assetPrefix: normalizeAssetPrefix(config.assetPrefix),
+    crossOrigin: normalizeCrossOrigin(config.crossOrigin),
     trailingSlash: config.trailingSlash ?? false,
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -108,6 +108,7 @@ export async function generateServerEntry(
   const vinextConfigJson = JSON.stringify({
     basePath: nextConfig?.basePath ?? "",
     assetPrefix: nextConfig?.assetPrefix ?? "",
+    crossOrigin: nextConfig?.crossOrigin,
     trailingSlash: nextConfig?.trailingSlash ?? false,
     redirects: nextConfig?.redirects ?? [],
     rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
@@ -356,6 +357,7 @@ const _renderPage = __createPagesPageHandler({
   vinextConfig: {
     basePath: vinextConfig.basePath,
     assetPrefix: vinextConfig.assetPrefix,
+    crossOrigin: vinextConfig.crossOrigin,
     trailingSlash: vinextConfig.trailingSlash,
     expireTime: vinextConfig.expireTime,
     htmlLimitedBots: vinextConfig.htmlLimitedBots,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4519,7 +4519,7 @@ export const loadServerActionClient = ${
                       middlewarePath !== null,
                       (nextConfig?.rewrites.beforeFiles.length ?? 0) > 0 ||
                         (nextConfig?.rewrites.afterFiles.length ?? 0) > 0 ||
-                      (nextConfig?.rewrites.fallback.length ?? 0) > 0,
+                        (nextConfig?.rewrites.fallback.length ?? 0) > 0,
                       nextConfig?.clientTraceMetadata,
                       nextConfig?.htmlLimitedBots,
                       nextConfig?.crossOrigin,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4519,9 +4519,10 @@ export const loadServerActionClient = ${
                       middlewarePath !== null,
                       (nextConfig?.rewrites.beforeFiles.length ?? 0) > 0 ||
                         (nextConfig?.rewrites.afterFiles.length ?? 0) > 0 ||
-                        (nextConfig?.rewrites.fallback.length ?? 0) > 0,
+                      (nextConfig?.rewrites.fallback.length ?? 0) > 0,
                       nextConfig?.clientTraceMetadata,
                       nextConfig?.htmlLimitedBots,
+                      nextConfig?.crossOrigin,
                     ),
                   };
                 }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -73,8 +73,6 @@ import {
   applyPagesDocumentAssetAttributes,
   extractPagesDocumentAssetAttributes,
   mergePagesDocumentAssetAttributes,
-  protectPagesDocumentAssetAttributes,
-  protectPagesDocumentUserContent,
   type PagesDocumentAssetAttributes,
 } from "./pages-document-asset-attributes.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
@@ -302,8 +300,6 @@ async function streamPageToResponse(
 
   // Build the document shell with a placeholder for the body
   let shellTemplate: string;
-  let shellHeadAttrs: PagesDocumentAssetAttributes;
-  let shellNextScriptAttrs: PagesDocumentAssetAttributes;
 
   if (DocumentComponent) {
     // When the renderPage path already invoked getInitialProps, reuse its
@@ -318,20 +314,15 @@ async function streamPageToResponse(
       : React.createElement(DocumentComponent);
     let docHtml = await renderToStringAsync(docElement);
     const extracted = extractPagesDocumentAssetAttributes(docHtml);
-    docHtml = protectPagesDocumentUserContent(extracted.html);
+    docHtml = extracted.html;
     const fallbackAttrs: PagesDocumentAssetAttributes = { nonce: scriptNonce, crossOrigin };
-    const headAttrs = mergePagesDocumentAssetAttributes(extracted.head, fallbackAttrs);
     const nextScriptAttrs = mergePagesDocumentAssetAttributes(extracted.nextScript, fallbackAttrs);
-    shellHeadAttrs = headAttrs;
-    shellNextScriptAttrs = nextScriptAttrs;
-    const protectedFontHead = protectPagesDocumentAssetAttributes(fontHeadHTML);
-    const protectedHead = protectPagesDocumentAssetAttributes(headHTML);
     const scriptsWithAttrs = applyPagesDocumentAssetAttributes(scripts, nextScriptAttrs);
     // Replace __NEXT_MAIN__ with our stream marker
     docHtml = docHtml.replace("__NEXT_MAIN__", STREAM_BODY_MARKER);
     // Inject head tags
-    if (protectedHead || protectedFontHead) {
-      docHtml = docHtml.replace("</head>", `  ${protectedFontHead}${protectedHead}\n</head>`);
+    if (headHTML || fontHeadHTML) {
+      docHtml = docHtml.replace("</head>", `  ${fontHeadHTML}${headHTML}\n</head>`);
     }
     // Inject scripts: replace placeholder or append before </body>
     docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", scriptsWithAttrs);
@@ -341,10 +332,6 @@ async function streamPageToResponse(
     shellTemplate = docHtml;
   } else {
     const fallbackAttrs: PagesDocumentAssetAttributes = { nonce: scriptNonce, crossOrigin };
-    shellHeadAttrs = fallbackAttrs;
-    shellNextScriptAttrs = fallbackAttrs;
-    const protectedFontHead = protectPagesDocumentAssetAttributes(fontHeadHTML);
-    const protectedHead = protectPagesDocumentAssetAttributes(headHTML);
     const scriptsWithAttrs = applyPagesDocumentAssetAttributes(scripts, fallbackAttrs);
     // charset + viewport are emitted via getSSRHeadHTML() (next/head's
     // defaultHead seeds them with data-next-head=""), matching Next.js's
@@ -352,7 +339,7 @@ async function streamPageToResponse(
     shellTemplate = `<!DOCTYPE html>
 <html>
 <head>
-  ${protectedFontHead}${protectedHead}
+  ${fontHeadHTML}${headHTML}
 </head>
 <body>
   <div id="__next">${STREAM_BODY_MARKER}</div>
@@ -365,14 +352,8 @@ async function streamPageToResponse(
   // shell template, then split at the body marker.
   const transformedShell = await server.transformIndexHtml(url, shellTemplate);
   const markerIdx = transformedShell.indexOf(STREAM_BODY_MARKER);
-  const prefix = applyPagesDocumentAssetAttributes(
-    transformedShell.slice(0, markerIdx),
-    shellHeadAttrs,
-  );
-  const suffix = applyPagesDocumentAssetAttributes(
-    transformedShell.slice(markerIdx + STREAM_BODY_MARKER.length),
-    shellNextScriptAttrs,
-  );
+  const prefix = transformedShell.slice(0, markerIdx);
+  const suffix = transformedShell.slice(markerIdx + STREAM_BODY_MARKER.length);
   const bufferedBody = bufferBodyBeforeHeaders ? await new Response(bodyStream).text() : null;
 
   // Send headers and start streaming.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -73,6 +73,8 @@ import {
   applyPagesDocumentAssetAttributes,
   extractPagesDocumentAssetAttributes,
   mergePagesDocumentAssetAttributes,
+  protectPagesDocumentAssetAttributes,
+  protectPagesDocumentUserContent,
   type PagesDocumentAssetAttributes,
 } from "./pages-document-asset-attributes.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
@@ -316,20 +318,20 @@ async function streamPageToResponse(
       : React.createElement(DocumentComponent);
     let docHtml = await renderToStringAsync(docElement);
     const extracted = extractPagesDocumentAssetAttributes(docHtml);
-    docHtml = extracted.html;
+    docHtml = protectPagesDocumentUserContent(extracted.html);
     const fallbackAttrs: PagesDocumentAssetAttributes = { nonce: scriptNonce, crossOrigin };
     const headAttrs = mergePagesDocumentAssetAttributes(extracted.head, fallbackAttrs);
     const nextScriptAttrs = mergePagesDocumentAssetAttributes(extracted.nextScript, fallbackAttrs);
     shellHeadAttrs = headAttrs;
     shellNextScriptAttrs = nextScriptAttrs;
-    const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, headAttrs);
-    const headWithAttrs = applyPagesDocumentAssetAttributes(headHTML, headAttrs);
+    const protectedFontHead = protectPagesDocumentAssetAttributes(fontHeadHTML);
+    const protectedHead = protectPagesDocumentAssetAttributes(headHTML);
     const scriptsWithAttrs = applyPagesDocumentAssetAttributes(scripts, nextScriptAttrs);
     // Replace __NEXT_MAIN__ with our stream marker
     docHtml = docHtml.replace("__NEXT_MAIN__", STREAM_BODY_MARKER);
     // Inject head tags
-    if (headWithAttrs || fontHeadWithAttrs) {
-      docHtml = docHtml.replace("</head>", `  ${fontHeadWithAttrs}${headWithAttrs}\n</head>`);
+    if (protectedHead || protectedFontHead) {
+      docHtml = docHtml.replace("</head>", `  ${protectedFontHead}${protectedHead}\n</head>`);
     }
     // Inject scripts: replace placeholder or append before </body>
     docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", scriptsWithAttrs);
@@ -341,8 +343,8 @@ async function streamPageToResponse(
     const fallbackAttrs: PagesDocumentAssetAttributes = { nonce: scriptNonce, crossOrigin };
     shellHeadAttrs = fallbackAttrs;
     shellNextScriptAttrs = fallbackAttrs;
-    const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, fallbackAttrs);
-    const headWithAttrs = applyPagesDocumentAssetAttributes(headHTML, fallbackAttrs);
+    const protectedFontHead = protectPagesDocumentAssetAttributes(fontHeadHTML);
+    const protectedHead = protectPagesDocumentAssetAttributes(headHTML);
     const scriptsWithAttrs = applyPagesDocumentAssetAttributes(scripts, fallbackAttrs);
     // charset + viewport are emitted via getSSRHeadHTML() (next/head's
     // defaultHead seeds them with data-next-head=""), matching Next.js's
@@ -350,7 +352,7 @@ async function streamPageToResponse(
     shellTemplate = `<!DOCTYPE html>
 <html>
 <head>
-  ${fontHeadWithAttrs}${headWithAttrs}
+  ${protectedFontHead}${protectedHead}
 </head>
 <body>
   <div id="__next">${STREAM_BODY_MARKER}</div>

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -69,6 +69,12 @@ import {
   type RenderPageEnhancers,
   runDocumentRenderPage,
 } from "./pages-document-initial-props.js";
+import {
+  applyPagesDocumentAssetAttributes,
+  extractPagesDocumentAssetAttributes,
+  mergePagesDocumentAssetAttributes,
+  type PagesDocumentAssetAttributes,
+} from "./pages-document-asset-attributes.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import {
   hasPagesGetInitialProps,
@@ -202,6 +208,8 @@ async function streamPageToResponse(
     enhancePageElement?: ((opts: RenderPageEnhancers) => React.ReactElement) | undefined;
     /** Per-request CSP nonce forwarded to the shared renderPage helper. */
     scriptNonce?: string | undefined;
+    /** Configured Next.js crossOrigin mode for generated scripts/preloads. */
+    crossOrigin?: "anonymous" | "use-credentials" | undefined;
     /**
      * Minimal `DocumentContext` fields (`pathname`/`query`/`asPath`) forwarded
      * to `getInitialProps`. Mirrors the prod pipeline for parity.
@@ -228,6 +236,7 @@ async function streamPageToResponse(
     getHeadHTML,
     enhancePageElement,
     scriptNonce,
+    crossOrigin,
     documentContext,
     setDocumentInitialHead,
     bufferBodyBeforeHeaders = false,
@@ -291,6 +300,8 @@ async function streamPageToResponse(
 
   // Build the document shell with a placeholder for the body
   let shellTemplate: string;
+  let shellHeadAttrs: PagesDocumentAssetAttributes;
+  let shellNextScriptAttrs: PagesDocumentAssetAttributes;
 
   if (DocumentComponent) {
     // When the renderPage path already invoked getInitialProps, reuse its
@@ -304,30 +315,46 @@ async function streamPageToResponse(
       ? React.createElement(DocumentComponent, docProps)
       : React.createElement(DocumentComponent);
     let docHtml = await renderToStringAsync(docElement);
+    const extracted = extractPagesDocumentAssetAttributes(docHtml);
+    docHtml = extracted.html;
+    const fallbackAttrs: PagesDocumentAssetAttributes = { nonce: scriptNonce, crossOrigin };
+    const headAttrs = mergePagesDocumentAssetAttributes(extracted.head, fallbackAttrs);
+    const nextScriptAttrs = mergePagesDocumentAssetAttributes(extracted.nextScript, fallbackAttrs);
+    shellHeadAttrs = headAttrs;
+    shellNextScriptAttrs = nextScriptAttrs;
+    const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, headAttrs);
+    const headWithAttrs = applyPagesDocumentAssetAttributes(headHTML, headAttrs);
+    const scriptsWithAttrs = applyPagesDocumentAssetAttributes(scripts, nextScriptAttrs);
     // Replace __NEXT_MAIN__ with our stream marker
     docHtml = docHtml.replace("__NEXT_MAIN__", STREAM_BODY_MARKER);
     // Inject head tags
-    if (headHTML || fontHeadHTML) {
-      docHtml = docHtml.replace("</head>", `  ${fontHeadHTML}${headHTML}\n</head>`);
+    if (headWithAttrs || fontHeadWithAttrs) {
+      docHtml = docHtml.replace("</head>", `  ${fontHeadWithAttrs}${headWithAttrs}\n</head>`);
     }
     // Inject scripts: replace placeholder or append before </body>
-    docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", scripts);
+    docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", scriptsWithAttrs);
     if (!docHtml.includes("__NEXT_DATA__")) {
-      docHtml = docHtml.replace("</body>", `  ${scripts}\n</body>`);
+      docHtml = docHtml.replace("</body>", `  ${scriptsWithAttrs}\n</body>`);
     }
     shellTemplate = docHtml;
   } else {
+    const fallbackAttrs: PagesDocumentAssetAttributes = { nonce: scriptNonce, crossOrigin };
+    shellHeadAttrs = fallbackAttrs;
+    shellNextScriptAttrs = fallbackAttrs;
+    const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, fallbackAttrs);
+    const headWithAttrs = applyPagesDocumentAssetAttributes(headHTML, fallbackAttrs);
+    const scriptsWithAttrs = applyPagesDocumentAssetAttributes(scripts, fallbackAttrs);
     // charset + viewport are emitted via getSSRHeadHTML() (next/head's
     // defaultHead seeds them with data-next-head=""), matching Next.js's
     // canonical ordering. Don't duplicate them here.
     shellTemplate = `<!DOCTYPE html>
 <html>
 <head>
-  ${fontHeadHTML}${headHTML}
+  ${fontHeadWithAttrs}${headWithAttrs}
 </head>
 <body>
   <div id="__next">${STREAM_BODY_MARKER}</div>
-  ${scripts}
+  ${scriptsWithAttrs}
 </body>
 </html>`;
   }
@@ -336,8 +363,14 @@ async function streamPageToResponse(
   // shell template, then split at the body marker.
   const transformedShell = await server.transformIndexHtml(url, shellTemplate);
   const markerIdx = transformedShell.indexOf(STREAM_BODY_MARKER);
-  const prefix = transformedShell.slice(0, markerIdx);
-  const suffix = transformedShell.slice(markerIdx + STREAM_BODY_MARKER.length);
+  const prefix = applyPagesDocumentAssetAttributes(
+    transformedShell.slice(0, markerIdx),
+    shellHeadAttrs,
+  );
+  const suffix = applyPagesDocumentAssetAttributes(
+    transformedShell.slice(markerIdx + STREAM_BODY_MARKER.length),
+    shellNextScriptAttrs,
+  );
   const bufferedBody = bufferBodyBeforeHeaders ? await new Response(bodyStream).text() : null;
 
   // Send headers and start streaming.
@@ -442,6 +475,7 @@ export function createSSRHandler(
    */
   clientTraceMetadata?: readonly string[],
   htmlLimitedBots?: string,
+  crossOrigin?: "anonymous" | "use-credentials",
 ) {
   const matcher = fileMatcher ?? createValidFileMatcher();
 
@@ -1727,6 +1761,7 @@ hydrate();
           // Forward the per-request nonce so the shared renderPage helper can
           // apply `withScriptNonce` once (it owns that responsibility).
           scriptNonce,
+          crossOrigin,
           // DocumentContext for `getInitialProps`, matching prod parity.
           documentContext: {
             pathname: patternToNextFormat(route.pattern),

--- a/packages/vinext/src/server/html.ts
+++ b/packages/vinext/src/server/html.ts
@@ -53,6 +53,18 @@ export function createNonceAttribute(nonce?: string): string {
   return ` nonce="${escapeHtmlAttr(nonce)}"`;
 }
 
-export function createInlineScriptTag(content: string, nonce?: string): string {
-  return `<script${createNonceAttribute(nonce)}>${content}</script>`;
+export function createCrossOriginAttribute(crossOrigin?: string): string {
+  if (crossOrigin === undefined) {
+    return "";
+  }
+
+  return ` crossorigin="${escapeHtmlAttr(crossOrigin)}"`;
+}
+
+export function createInlineScriptTag(
+  content: string,
+  nonce?: string,
+  options?: { crossOrigin?: string },
+): string {
+  return `<script${createNonceAttribute(nonce)}${createCrossOriginAttribute(options?.crossOrigin)}>${content}</script>`;
 }

--- a/packages/vinext/src/server/pages-asset-tags.ts
+++ b/packages/vinext/src/server/pages-asset-tags.ts
@@ -9,7 +9,7 @@
  * template string.
  */
 
-import { createNonceAttribute } from "./html.js";
+import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
 import { assetServingUrlFromBaseAnchored } from "../utils/manifest-paths.js";
 import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
 import { getPagesClientAssets } from "./pages-client-assets.js";
@@ -94,6 +94,8 @@ type CollectAssetTagsOptions = {
   moduleIds: (string | null | undefined)[];
   /** Script nonce for CSP. */
   scriptNonce?: string;
+  /** Configured Next.js crossOrigin mode for generated scripts/preloads. */
+  crossOrigin?: "anonymous" | "use-credentials";
   /**
    * When `false` (default), page scripts are emitted with the `defer`
    * attribute mirroring Next.js's `experimental.disableOptimizedLoading`
@@ -129,6 +131,14 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   const tags: string[] = [];
   const seen = new Set<string>();
   const nonceAttr = createNonceAttribute(options.scriptNonce);
+  const crossOriginAttr =
+    options.crossOrigin === undefined
+      ? " crossorigin"
+      : ` crossorigin="${escapeHtmlAttr(options.crossOrigin)}"`;
+  const modulePreloadCrossOriginAttr =
+    options.crossOrigin === undefined
+      ? ""
+      : ` crossorigin="${escapeHtmlAttr(options.crossOrigin)}"`;
   // Mirrors Next.js `_document` behaviour: when `experimental.disableOptimizedLoading`
   // is false (the default), page scripts are emitted with `defer` in <head>. See
   // .nextjs-ref/packages/next/src/pages/_document.tsx getScripts().
@@ -165,14 +175,23 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   const clientEntry = runtimeAssets.clientEntry;
   if (clientEntry) {
     seen.add(clientEntry);
-    tags.push('<link rel="modulepreload"' + nonceAttr + ' href="' + href(clientEntry) + '" />');
+    tags.push(
+      '<link rel="modulepreload"' +
+        nonceAttr +
+        modulePreloadCrossOriginAttr +
+        ' href="' +
+        href(clientEntry) +
+        '" />',
+    );
     tags.push(
       '<script type="module"' +
         deferAttr +
         nonceAttr +
         ' src="' +
         href(clientEntry) +
-        '" crossorigin></script>',
+        '"' +
+        crossOriginAttr +
+        "></script>",
     );
   }
 
@@ -237,14 +256,23 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
         // Membership test uses the base-anchored `tf` (same key-space as
         // lazy chunk registry), NOT the re-anchored href.
         if (lazySet && lazySet.has(tf)) continue;
-        tags.push('<link rel="modulepreload"' + nonceAttr + ' href="' + href(tf) + '" />');
+        tags.push(
+          '<link rel="modulepreload"' +
+            nonceAttr +
+            modulePreloadCrossOriginAttr +
+            ' href="' +
+            href(tf) +
+            '" />',
+        );
         tags.push(
           '<script type="module"' +
             deferAttr +
             nonceAttr +
             ' src="' +
             href(tf) +
-            '" crossorigin></script>',
+            '"' +
+            crossOriginAttr +
+            "></script>",
         );
       }
     }

--- a/packages/vinext/src/server/pages-document-asset-attributes.ts
+++ b/packages/vinext/src/server/pages-document-asset-attributes.ts
@@ -12,7 +12,13 @@ const HEAD_CROSS_ORIGIN_ATTR = "data-vinext-document-head-crossorigin";
 const NEXT_SCRIPT_MARKER_ATTR = "data-vinext-next-script";
 const NEXT_SCRIPT_NONCE_ATTR = "data-vinext-next-script-nonce";
 const NEXT_SCRIPT_CROSS_ORIGIN_ATTR = "data-vinext-next-script-crossorigin";
+const NEXT_MAIN_PLACEHOLDER = "__NEXT_MAIN__";
 const NEXT_SCRIPT_PLACEHOLDER = "<!-- __NEXT_SCRIPTS__ -->";
+const PROTECTED_ASSET_ATTRS_START = "<!--VINEXT_DOCUMENT_ASSET_ATTRS_PROTECTED_START-->";
+const PROTECTED_ASSET_ATTRS_END = "<!--VINEXT_DOCUMENT_ASSET_ATTRS_PROTECTED_END-->";
+const BODY_PLACEHOLDER_PATTERN = new RegExp(
+  `(${escapeRegExp(NEXT_MAIN_PLACEHOLDER)}|${escapeRegExp(NEXT_SCRIPT_PLACEHOLDER)})`,
+);
 const NEXT_SCRIPT_MARKER_PATTERN = new RegExp(
   `<span\\b(?=[^>]*\\b${escapeRegExp(NEXT_SCRIPT_MARKER_ATTR)}(?:\\s|=|>|\\/))[^>]*>\\s*${escapeRegExp(NEXT_SCRIPT_PLACEHOLDER)}\\s*<\\/span>`,
   "i",
@@ -89,6 +95,46 @@ function cleanMarkerAttributes(tag: string, names: string[]): string {
   return names.reduce((current, name) => removeHtmlAttribute(current, name), tag);
 }
 
+export function protectPagesDocumentAssetAttributes(html: string): string {
+  if (!html) return html;
+  return `${PROTECTED_ASSET_ATTRS_START}${html}${PROTECTED_ASSET_ATTRS_END}`;
+}
+
+function protectPagesDocumentHeadContent(html: string): string {
+  return html.replace(
+    /(<head\b[^>]*>)([\s\S]*?)(<\/head>)/i,
+    (_match: string, open: string, content: string, close: string) => {
+      if (!content) return `${open}${close}`;
+      return `${open}${protectPagesDocumentAssetAttributes(content)}${close}`;
+    },
+  );
+}
+
+function protectPagesDocumentBodyContent(html: string): string {
+  return html.replace(
+    /(<body\b[^>]*>)([\s\S]*?)(<\/body>)/i,
+    (_match: string, open: string, content: string, close: string) => {
+      const parts = content.split(BODY_PLACEHOLDER_PATTERN);
+      const protectedContent = parts
+        .map((part) =>
+          part === NEXT_MAIN_PLACEHOLDER || part === NEXT_SCRIPT_PLACEHOLDER
+            ? part
+            : protectPagesDocumentAssetAttributes(part),
+        )
+        .join("");
+      return `${open}${protectedContent}${close}`;
+    },
+  );
+}
+
+export function protectPagesDocumentUserContent(html: string): string {
+  return protectPagesDocumentBodyContent(protectPagesDocumentHeadContent(html));
+}
+
+function stripPagesDocumentAssetAttributeProtection(html: string): string {
+  return html.replaceAll(PROTECTED_ASSET_ATTRS_START, "").replaceAll(PROTECTED_ASSET_ATTRS_END, "");
+}
+
 export function extractPagesDocumentAssetAttributes(html: string): {
   html: string;
   head: PagesDocumentAssetAttributes;
@@ -126,23 +172,49 @@ export function applyPagesDocumentAssetAttributes(
   html: string,
   attrs: PagesDocumentAssetAttributes,
 ): string {
-  if (!attrs.nonce && attrs.crossOrigin === undefined) return html;
+  if (!attrs.nonce && attrs.crossOrigin === undefined) {
+    return stripPagesDocumentAssetAttributeProtection(html);
+  }
 
-  return html.replace(/<(script|link)\b[^>]*>/gi, (tag, tagName: string) => {
-    if (tagName.toLowerCase() === "link") {
-      const rel = getHtmlAttribute(tag, "rel")?.toLowerCase();
-      if (rel !== "preload" && rel !== "modulepreload" && rel !== "stylesheet") {
-        return tag;
+  const applyToSegment = (segment: string) =>
+    segment.replace(/<(script|link)\b[^>]*>/gi, (tag, tagName: string) => {
+      if (tagName.toLowerCase() === "link") {
+        const rel = getHtmlAttribute(tag, "rel")?.toLowerCase();
+        if (rel !== "preload" && rel !== "modulepreload" && rel !== "stylesheet") {
+          return tag;
+        }
       }
+
+      let next = tag;
+      if (attrs.nonce) {
+        next = setHtmlAttribute(next, "nonce", attrs.nonce);
+      }
+      if (attrs.crossOrigin !== undefined) {
+        next = setHtmlAttribute(next, "crossorigin", attrs.crossOrigin);
+      }
+      return next;
+    });
+
+  let output = "";
+  let index = 0;
+  for (;;) {
+    const start = html.indexOf(PROTECTED_ASSET_ATTRS_START, index);
+    if (start === -1) {
+      output += applyToSegment(html.slice(index));
+      break;
     }
 
-    let next = tag;
-    if (attrs.nonce) {
-      next = setHtmlAttribute(next, "nonce", attrs.nonce);
+    output += applyToSegment(html.slice(index, start));
+    const protectedStart = start + PROTECTED_ASSET_ATTRS_START.length;
+    const end = html.indexOf(PROTECTED_ASSET_ATTRS_END, protectedStart);
+    if (end === -1) {
+      output += stripPagesDocumentAssetAttributeProtection(html.slice(start));
+      break;
     }
-    if (attrs.crossOrigin !== undefined) {
-      next = setHtmlAttribute(next, "crossorigin", attrs.crossOrigin);
-    }
-    return next;
-  });
+
+    output += html.slice(protectedStart, end);
+    index = end + PROTECTED_ASSET_ATTRS_END.length;
+  }
+
+  return output;
 }

--- a/packages/vinext/src/server/pages-document-asset-attributes.ts
+++ b/packages/vinext/src/server/pages-document-asset-attributes.ts
@@ -1,0 +1,148 @@
+import { escapeRegExp } from "../utils/regex.js";
+import { escapeHtmlAttr } from "./html.js";
+
+export type PagesDocumentAssetAttributes = {
+  nonce?: string;
+  crossOrigin?: string;
+};
+
+const HEAD_MARKER_ATTR = "data-vinext-document-head";
+const HEAD_NONCE_ATTR = "data-vinext-document-head-nonce";
+const HEAD_CROSS_ORIGIN_ATTR = "data-vinext-document-head-crossorigin";
+const NEXT_SCRIPT_MARKER_ATTR = "data-vinext-next-script";
+const NEXT_SCRIPT_NONCE_ATTR = "data-vinext-next-script-nonce";
+const NEXT_SCRIPT_CROSS_ORIGIN_ATTR = "data-vinext-next-script-crossorigin";
+const NEXT_SCRIPT_PLACEHOLDER = "<!-- __NEXT_SCRIPTS__ -->";
+const NEXT_SCRIPT_MARKER_PATTERN = new RegExp(
+  `<span\\b(?=[^>]*\\b${escapeRegExp(NEXT_SCRIPT_MARKER_ATTR)}(?:\\s|=|>|\\/))[^>]*>\\s*${escapeRegExp(NEXT_SCRIPT_PLACEHOLDER)}\\s*<\\/span>`,
+  "i",
+);
+
+function getHtmlAttribute(tag: string, name: string): string | undefined {
+  const pattern = new RegExp(
+    `\\s${escapeRegExp(name)}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`,
+    "i",
+  );
+  const match = tag.match(pattern);
+  const value = match?.[1] ?? match?.[2] ?? match?.[3];
+  return value === undefined ? undefined : decodeHtmlAttribute(value);
+}
+
+function hasHtmlAttribute(tag: string, name: string): boolean {
+  return new RegExp(
+    `\\s${escapeRegExp(name)}(?:\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+))?(?=\\s|/?>)`,
+    "i",
+  ).test(tag);
+}
+
+function removeHtmlAttribute(tag: string, name: string): string {
+  return tag.replace(
+    new RegExp(
+      `\\s${escapeRegExp(name)}(?=\\s*=|\\s|/?>)(?:\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+))?`,
+      "gi",
+    ),
+    "",
+  );
+}
+
+function setHtmlAttribute(tag: string, name: string, value: string): string {
+  const withoutExisting = removeHtmlAttribute(tag, name);
+  const attr = ` ${name}="${escapeHtmlAttr(value)}"`;
+  return withoutExisting.replace(/\s*\/?>$/, (closing) =>
+    closing.endsWith("/>") ? `${attr} />` : `${attr}>`,
+  );
+}
+
+function decodeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#34;/g, '"')
+    .replace(/&#x22;/gi, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&#60;/g, "<")
+    .replace(/&#x3c;/gi, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#62;/g, ">")
+    .replace(/&#x3e;/gi, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function normalizeCrossOrigin(value: string | undefined): string | undefined {
+  return value === "anonymous" || value === "use-credentials" ? value : undefined;
+}
+
+function readAssetAttributes(
+  tag: string,
+  nonceAttr: string,
+  crossOriginAttr: string,
+): PagesDocumentAssetAttributes {
+  return {
+    nonce: getHtmlAttribute(tag, nonceAttr),
+    crossOrigin: normalizeCrossOrigin(getHtmlAttribute(tag, crossOriginAttr)),
+  };
+}
+
+function cleanMarkerAttributes(tag: string, names: string[]): string {
+  return names.reduce((current, name) => removeHtmlAttribute(current, name), tag);
+}
+
+export function extractPagesDocumentAssetAttributes(html: string): {
+  html: string;
+  head: PagesDocumentAssetAttributes;
+  nextScript: PagesDocumentAssetAttributes;
+} {
+  let head: PagesDocumentAssetAttributes = {};
+  let nextScript: PagesDocumentAssetAttributes = {};
+
+  let cleaned = html.replace(/<head\b[^>]*>/i, (tag) => {
+    if (!hasHtmlAttribute(tag, HEAD_MARKER_ATTR)) return tag;
+
+    head = readAssetAttributes(tag, HEAD_NONCE_ATTR, HEAD_CROSS_ORIGIN_ATTR);
+    return cleanMarkerAttributes(tag, [HEAD_MARKER_ATTR, HEAD_NONCE_ATTR, HEAD_CROSS_ORIGIN_ATTR]);
+  });
+
+  cleaned = cleaned.replace(NEXT_SCRIPT_MARKER_PATTERN, (tag) => {
+    nextScript = readAssetAttributes(tag, NEXT_SCRIPT_NONCE_ATTR, NEXT_SCRIPT_CROSS_ORIGIN_ATTR);
+    return NEXT_SCRIPT_PLACEHOLDER;
+  });
+
+  return { html: cleaned, head, nextScript };
+}
+
+export function mergePagesDocumentAssetAttributes(
+  documentAttrs: PagesDocumentAssetAttributes,
+  fallbackAttrs: PagesDocumentAssetAttributes,
+): PagesDocumentAssetAttributes {
+  return {
+    nonce: documentAttrs.nonce ?? fallbackAttrs.nonce,
+    crossOrigin: documentAttrs.crossOrigin ?? fallbackAttrs.crossOrigin,
+  };
+}
+
+export function applyPagesDocumentAssetAttributes(
+  html: string,
+  attrs: PagesDocumentAssetAttributes,
+): string {
+  if (!attrs.nonce && attrs.crossOrigin === undefined) return html;
+
+  return html.replace(/<(script|link)\b[^>]*>/gi, (tag, tagName: string) => {
+    if (tagName.toLowerCase() === "link") {
+      const rel = getHtmlAttribute(tag, "rel")?.toLowerCase();
+      if (rel !== "preload" && rel !== "modulepreload" && rel !== "stylesheet") {
+        return tag;
+      }
+    }
+
+    let next = tag;
+    if (attrs.nonce) {
+      next = setHtmlAttribute(next, "nonce", attrs.nonce);
+    }
+    if (attrs.crossOrigin !== undefined) {
+      next = setHtmlAttribute(next, "crossorigin", attrs.crossOrigin);
+    }
+    return next;
+  });
+}

--- a/packages/vinext/src/server/pages-document-asset-attributes.ts
+++ b/packages/vinext/src/server/pages-document-asset-attributes.ts
@@ -12,13 +12,7 @@ const HEAD_CROSS_ORIGIN_ATTR = "data-vinext-document-head-crossorigin";
 const NEXT_SCRIPT_MARKER_ATTR = "data-vinext-next-script";
 const NEXT_SCRIPT_NONCE_ATTR = "data-vinext-next-script-nonce";
 const NEXT_SCRIPT_CROSS_ORIGIN_ATTR = "data-vinext-next-script-crossorigin";
-const NEXT_MAIN_PLACEHOLDER = "__NEXT_MAIN__";
 const NEXT_SCRIPT_PLACEHOLDER = "<!-- __NEXT_SCRIPTS__ -->";
-const PROTECTED_ASSET_ATTRS_START = "<!--VINEXT_DOCUMENT_ASSET_ATTRS_PROTECTED_START-->";
-const PROTECTED_ASSET_ATTRS_END = "<!--VINEXT_DOCUMENT_ASSET_ATTRS_PROTECTED_END-->";
-const BODY_PLACEHOLDER_PATTERN = new RegExp(
-  `(${escapeRegExp(NEXT_MAIN_PLACEHOLDER)}|${escapeRegExp(NEXT_SCRIPT_PLACEHOLDER)})`,
-);
 const NEXT_SCRIPT_MARKER_PATTERN = new RegExp(
   `<span\\b(?=[^>]*\\b${escapeRegExp(NEXT_SCRIPT_MARKER_ATTR)}(?:\\s|=|>|\\/))[^>]*>\\s*${escapeRegExp(NEXT_SCRIPT_PLACEHOLDER)}\\s*<\\/span>`,
   "i",
@@ -95,46 +89,6 @@ function cleanMarkerAttributes(tag: string, names: string[]): string {
   return names.reduce((current, name) => removeHtmlAttribute(current, name), tag);
 }
 
-export function protectPagesDocumentAssetAttributes(html: string): string {
-  if (!html) return html;
-  return `${PROTECTED_ASSET_ATTRS_START}${html}${PROTECTED_ASSET_ATTRS_END}`;
-}
-
-function protectPagesDocumentHeadContent(html: string): string {
-  return html.replace(
-    /(<head\b[^>]*>)([\s\S]*?)(<\/head>)/i,
-    (_match: string, open: string, content: string, close: string) => {
-      if (!content) return `${open}${close}`;
-      return `${open}${protectPagesDocumentAssetAttributes(content)}${close}`;
-    },
-  );
-}
-
-function protectPagesDocumentBodyContent(html: string): string {
-  return html.replace(
-    /(<body\b[^>]*>)([\s\S]*?)(<\/body>)/i,
-    (_match: string, open: string, content: string, close: string) => {
-      const parts = content.split(BODY_PLACEHOLDER_PATTERN);
-      const protectedContent = parts
-        .map((part) =>
-          part === NEXT_MAIN_PLACEHOLDER || part === NEXT_SCRIPT_PLACEHOLDER
-            ? part
-            : protectPagesDocumentAssetAttributes(part),
-        )
-        .join("");
-      return `${open}${protectedContent}${close}`;
-    },
-  );
-}
-
-export function protectPagesDocumentUserContent(html: string): string {
-  return protectPagesDocumentBodyContent(protectPagesDocumentHeadContent(html));
-}
-
-function stripPagesDocumentAssetAttributeProtection(html: string): string {
-  return html.replaceAll(PROTECTED_ASSET_ATTRS_START, "").replaceAll(PROTECTED_ASSET_ATTRS_END, "");
-}
-
 export function extractPagesDocumentAssetAttributes(html: string): {
   html: string;
   head: PagesDocumentAssetAttributes;
@@ -172,49 +126,23 @@ export function applyPagesDocumentAssetAttributes(
   html: string,
   attrs: PagesDocumentAssetAttributes,
 ): string {
-  if (!attrs.nonce && attrs.crossOrigin === undefined) {
-    return stripPagesDocumentAssetAttributeProtection(html);
-  }
+  if (!attrs.nonce && attrs.crossOrigin === undefined) return html;
 
-  const applyToSegment = (segment: string) =>
-    segment.replace(/<(script|link)\b[^>]*>/gi, (tag, tagName: string) => {
-      if (tagName.toLowerCase() === "link") {
-        const rel = getHtmlAttribute(tag, "rel")?.toLowerCase();
-        if (rel !== "preload" && rel !== "modulepreload" && rel !== "stylesheet") {
-          return tag;
-        }
+  return html.replace(/<(script|link)\b[^>]*>/gi, (tag, tagName: string) => {
+    if (tagName.toLowerCase() === "link") {
+      const rel = getHtmlAttribute(tag, "rel")?.toLowerCase();
+      if (rel !== "preload" && rel !== "modulepreload" && rel !== "stylesheet") {
+        return tag;
       }
-
-      let next = tag;
-      if (attrs.nonce) {
-        next = setHtmlAttribute(next, "nonce", attrs.nonce);
-      }
-      if (attrs.crossOrigin !== undefined) {
-        next = setHtmlAttribute(next, "crossorigin", attrs.crossOrigin);
-      }
-      return next;
-    });
-
-  let output = "";
-  let index = 0;
-  for (;;) {
-    const start = html.indexOf(PROTECTED_ASSET_ATTRS_START, index);
-    if (start === -1) {
-      output += applyToSegment(html.slice(index));
-      break;
     }
 
-    output += applyToSegment(html.slice(index, start));
-    const protectedStart = start + PROTECTED_ASSET_ATTRS_START.length;
-    const end = html.indexOf(PROTECTED_ASSET_ATTRS_END, protectedStart);
-    if (end === -1) {
-      output += stripPagesDocumentAssetAttributeProtection(html.slice(start));
-      break;
+    let next = tag;
+    if (attrs.nonce) {
+      next = setHtmlAttribute(next, "nonce", attrs.nonce);
     }
-
-    output += html.slice(protectedStart, end);
-    index = end + PROTECTED_ASSET_ATTRS_END.length;
-  }
-
-  return output;
+    if (attrs.crossOrigin !== undefined) {
+      next = setHtmlAttribute(next, "crossorigin", attrs.crossOrigin);
+    }
+    return next;
+  });
 }

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -83,6 +83,7 @@ type I18nConfig = {
 type VinextConfigSubset = {
   basePath: string;
   assetPrefix: string;
+  crossOrigin?: "anonymous" | "use-credentials";
   trailingSlash: boolean;
   expireTime?: number;
   htmlLimitedBots?: string;
@@ -720,6 +721,7 @@ export function createPagesPageHandler(
           manifest,
           moduleIds: pageModuleIds,
           scriptNonce,
+          crossOrigin: vinextConfig.crossOrigin,
           disableOptimizedLoading: vinextConfig.disableOptimizedLoading,
           basePath: vinextConfig.basePath,
           assetPrefix: vinextConfig.assetPrefix,
@@ -774,6 +776,7 @@ export function createPagesPageHandler(
           routeUrl,
           safeJsonStringify,
           scriptNonce,
+          crossOrigin: vinextConfig.crossOrigin,
           statusCode: renderStatusCode,
           nextData: serializedPagesNextData,
           userAgent: request.headers.get("user-agent") ?? undefined,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -346,8 +346,6 @@ async function buildPagesShellHtml(
     };
     const headAttrs = mergePagesDocumentAssetAttributes(extracted.head, fallbackAttrs);
     const nextScriptAttrs = mergePagesDocumentAssetAttributes(extracted.nextScript, fallbackAttrs);
-    const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, headAttrs);
-    const ssrHeadWithAttrs = applyPagesDocumentAssetAttributes(options.ssrHeadHTML, headAttrs);
     const assetTagsWithAttrs = applyPagesDocumentAssetAttributes(options.assetTags, headAttrs);
     const nextDataScriptWithAttrs = applyPagesDocumentAssetAttributes(
       nextDataScript,
@@ -355,10 +353,10 @@ async function buildPagesShellHtml(
     );
 
     html = html.replace("__NEXT_MAIN__", bodyMarker);
-    if (ssrHeadWithAttrs || assetTagsWithAttrs || fontHeadWithAttrs) {
+    if (options.ssrHeadHTML || assetTagsWithAttrs || fontHeadHTML) {
       html = html.replace(
         "</head>",
-        `  ${fontHeadWithAttrs}${ssrHeadWithAttrs}\n  ${assetTagsWithAttrs}\n</head>`,
+        `  ${fontHeadHTML}${options.ssrHeadHTML}\n  ${assetTagsWithAttrs}\n</head>`,
       );
     }
     html = html.replace("<!-- __NEXT_SCRIPTS__ -->", nextDataScriptWithAttrs);
@@ -372,8 +370,6 @@ async function buildPagesShellHtml(
     nonce: options.scriptNonce,
     crossOrigin: options.crossOrigin,
   };
-  const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, fallbackAttrs);
-  const ssrHeadWithAttrs = applyPagesDocumentAssetAttributes(options.ssrHeadHTML, fallbackAttrs);
   const assetTagsWithAttrs = applyPagesDocumentAssetAttributes(options.assetTags, fallbackAttrs);
   const nextDataScriptWithAttrs = applyPagesDocumentAssetAttributes(nextDataScript, fallbackAttrs);
 
@@ -382,7 +378,7 @@ async function buildPagesShellHtml(
   // canonical ordering. Don't duplicate them here.
   return (
     "<!DOCTYPE html>\n<html>\n<head>\n" +
-    `  ${fontHeadWithAttrs}${ssrHeadWithAttrs}\n` +
+    `  ${fontHeadHTML}${options.ssrHeadHTML}\n` +
     `  ${assetTagsWithAttrs}\n` +
     "</head>\n<body>\n" +
     `  <div id="__next">${bodyMarker}</div>\n` +

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -11,7 +11,7 @@ import {
 } from "./isr-decision.js";
 import { encodeCacheTag } from "../utils/encode-cache-tag.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
-import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
+import { createCrossOriginAttribute, createNonceAttribute, escapeHtmlAttr } from "./html.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { reportRequestError } from "./instrumentation.js";
 import {
@@ -23,6 +23,12 @@ import { fnv1a52 } from "../utils/hash.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
+import {
+  applyPagesDocumentAssetAttributes,
+  extractPagesDocumentAssetAttributes,
+  mergePagesDocumentAssetAttributes,
+  type PagesDocumentAssetAttributes,
+} from "./pages-document-asset-attributes.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
@@ -202,6 +208,7 @@ type RenderPagesPageResponseOptions = {
   routeUrl: string;
   safeJsonStringify: (value: unknown) => string;
   scriptNonce?: string;
+  crossOrigin?: "anonymous" | "use-credentials";
   statusCode?: number;
   vinext?: VinextNextData["__vinext"];
   nextData?: PagesNextDataExtras;
@@ -265,6 +272,7 @@ export function buildPagesNextDataScript(
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
+    | "crossOrigin"
     | "nextData"
   > & {
     vinext?: VinextNextData["__vinext"];
@@ -300,7 +308,7 @@ export function buildPagesNextDataScript(
     };
   }
 
-  return `<script id="__NEXT_DATA__" type="application/json"${createNonceAttribute(options.scriptNonce)}>${options.safeJsonStringify(nextDataPayload)}</script>`;
+  return `<script id="__NEXT_DATA__" type="application/json"${createNonceAttribute(options.scriptNonce)}${createCrossOriginAttribute(options.crossOrigin)}>${options.safeJsonStringify(nextDataPayload)}</script>`;
 }
 
 async function buildPagesShellHtml(
@@ -312,6 +320,8 @@ async function buildPagesShellHtml(
     "assetTags" | "DocumentComponent" | "renderDocumentToString"
   > & {
     ssrHeadHTML: string;
+    scriptNonce?: string | undefined;
+    crossOrigin?: "anonymous" | "use-credentials" | undefined;
     /**
      * Document props already resolved by `runDocumentRenderPage`. When set,
      * `getInitialProps` was consumed by the renderPage path and must not be
@@ -328,30 +338,55 @@ async function buildPagesShellHtml(
       ? React.createElement(options.DocumentComponent, docProps)
       : React.createElement(options.DocumentComponent);
     let html = await options.renderDocumentToString(docElement);
+    const extracted = extractPagesDocumentAssetAttributes(html);
+    html = extracted.html;
+    const fallbackAttrs: PagesDocumentAssetAttributes = {
+      nonce: options.scriptNonce,
+      crossOrigin: options.crossOrigin,
+    };
+    const headAttrs = mergePagesDocumentAssetAttributes(extracted.head, fallbackAttrs);
+    const nextScriptAttrs = mergePagesDocumentAssetAttributes(extracted.nextScript, fallbackAttrs);
+    const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, headAttrs);
+    const ssrHeadWithAttrs = applyPagesDocumentAssetAttributes(options.ssrHeadHTML, headAttrs);
+    const assetTagsWithAttrs = applyPagesDocumentAssetAttributes(options.assetTags, headAttrs);
+    const nextDataScriptWithAttrs = applyPagesDocumentAssetAttributes(
+      nextDataScript,
+      nextScriptAttrs,
+    );
+
     html = html.replace("__NEXT_MAIN__", bodyMarker);
-    if (options.ssrHeadHTML || options.assetTags || fontHeadHTML) {
+    if (ssrHeadWithAttrs || assetTagsWithAttrs || fontHeadWithAttrs) {
       html = html.replace(
         "</head>",
-        `  ${fontHeadHTML}${options.ssrHeadHTML}\n  ${options.assetTags}\n</head>`,
+        `  ${fontHeadWithAttrs}${ssrHeadWithAttrs}\n  ${assetTagsWithAttrs}\n</head>`,
       );
     }
-    html = html.replace("<!-- __NEXT_SCRIPTS__ -->", nextDataScript);
+    html = html.replace("<!-- __NEXT_SCRIPTS__ -->", nextDataScriptWithAttrs);
     if (!html.includes("__NEXT_DATA__")) {
-      html = html.replace("</body>", `  ${nextDataScript}\n</body>`);
+      html = html.replace("</body>", `  ${nextDataScriptWithAttrs}\n</body>`);
     }
     return html;
   }
+
+  const fallbackAttrs: PagesDocumentAssetAttributes = {
+    nonce: options.scriptNonce,
+    crossOrigin: options.crossOrigin,
+  };
+  const fontHeadWithAttrs = applyPagesDocumentAssetAttributes(fontHeadHTML, fallbackAttrs);
+  const ssrHeadWithAttrs = applyPagesDocumentAssetAttributes(options.ssrHeadHTML, fallbackAttrs);
+  const assetTagsWithAttrs = applyPagesDocumentAssetAttributes(options.assetTags, fallbackAttrs);
+  const nextDataScriptWithAttrs = applyPagesDocumentAssetAttributes(nextDataScript, fallbackAttrs);
 
   // charset + viewport are emitted via getSSRHeadHTML() (next/head's
   // defaultHead seeds them with data-next-head=""), matching Next.js's
   // canonical ordering. Don't duplicate them here.
   return (
     "<!DOCTYPE html>\n<html>\n<head>\n" +
-    `  ${fontHeadHTML}${options.ssrHeadHTML}\n` +
-    `  ${options.assetTags}\n` +
+    `  ${fontHeadWithAttrs}${ssrHeadWithAttrs}\n` +
+    `  ${assetTagsWithAttrs}\n` +
     "</head>\n<body>\n" +
     `  <div id="__next">${bodyMarker}</div>\n` +
-    `  ${nextDataScript}\n` +
+    `  ${nextDataScriptWithAttrs}\n` +
     "</body>\n</html>"
   );
 }
@@ -494,6 +529,7 @@ export async function renderPagesPageResponse(
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,
+    crossOrigin: options.crossOrigin,
     nextData: options.nextData,
     vinext: options.vinext,
   });
@@ -589,6 +625,8 @@ export async function renderPagesPageResponse(
     DocumentComponent: options.DocumentComponent,
     renderDocumentToString: options.renderDocumentToString,
     ssrHeadHTML,
+    scriptNonce: options.scriptNonce,
+    crossOrigin: options.crossOrigin,
     // When the renderPage path already invoked getInitialProps, reuse its
     // resolved props instead of calling it a second time.
     // `skipped` means it was never invoked → fall through to the fast path.

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -7,6 +7,11 @@
  */
 import React from "react";
 
+type OriginProps = {
+  nonce?: string;
+  crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+};
+
 export function Html({
   children,
   lang,
@@ -29,8 +34,26 @@ export function Html({
  * ordering (`<meta charset>` first, then `<meta viewport>`, then user tags,
  * all with `data-next-head=""`). See `test/e2e/next-head/index.test.ts`.
  */
-export function Head({ children }: { children?: React.ReactNode }) {
-  return <head>{children}</head>;
+export function Head({
+  children,
+  nonce,
+  crossOrigin,
+  ...props
+}: React.HTMLAttributes<HTMLHeadElement> &
+  OriginProps & {
+    children?: React.ReactNode;
+  }) {
+  const markerProps: Record<string, string> = { "data-vinext-document-head": "" };
+  if (typeof nonce === "string") markerProps["data-vinext-document-head-nonce"] = nonce;
+  if (typeof crossOrigin === "string") {
+    markerProps["data-vinext-document-head-crossorigin"] = crossOrigin;
+  }
+
+  return (
+    <head {...props} {...markerProps}>
+      {children}
+    </head>
+  );
 }
 
 /**
@@ -45,8 +68,16 @@ export function Main() {
  * actual hydration scripts (__NEXT_DATA__ + entry module).
  * Uses dangerouslySetInnerHTML so the HTML comment survives renderToString.
  */
-export function NextScript() {
-  return <span dangerouslySetInnerHTML={{ __html: "<!-- __NEXT_SCRIPTS__ -->" }} />;
+export function NextScript({ nonce, crossOrigin }: OriginProps) {
+  const markerProps: Record<string, string> = { "data-vinext-next-script": "" };
+  if (typeof nonce === "string") markerProps["data-vinext-next-script-nonce"] = nonce;
+  if (typeof crossOrigin === "string") {
+    markerProps["data-vinext-next-script-crossorigin"] = crossOrigin;
+  }
+
+  return (
+    <span {...markerProps} dangerouslySetInnerHTML={{ __html: "<!-- __NEXT_SCRIPTS__ -->" }} />
+  );
 }
 
 /**

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -29,6 +29,15 @@ describe("NextScript", () => {
     // Dev-server replaces this HTML comment with __NEXT_DATA__ + module script tags
     expect(html).toContain("<!-- __NEXT_SCRIPTS__ -->");
   });
+
+  it("serializes nonce and crossOrigin markers for generated script tags", () => {
+    const html = render(
+      React.createElement(NextScript, { nonce: "test-nonce", crossOrigin: "anonymous" }),
+    );
+    expect(html).toContain('data-vinext-next-script=""');
+    expect(html).toContain('data-vinext-next-script-nonce="test-nonce"');
+    expect(html).toContain('data-vinext-next-script-crossorigin="anonymous"');
+  });
 });
 
 describe("Head", () => {
@@ -39,7 +48,16 @@ describe("Head", () => {
   // flow through the same `data-next-head=""` dedupe step as user tags.
   it("renders an empty <head> when given no children (defaults flow via next/head)", () => {
     const html = render(React.createElement(Head));
-    expect(html).toBe("<head></head>");
+    expect(html).toBe('<head data-vinext-document-head=""></head>');
+  });
+
+  it("serializes nonce and crossOrigin markers for generated head asset tags", () => {
+    const html = render(
+      React.createElement(Head, { nonce: "test-nonce", crossOrigin: "anonymous" }),
+    );
+    expect(html).toContain('data-vinext-document-head=""');
+    expect(html).toContain('data-vinext-document-head-nonce="test-nonce"');
+    expect(html).toContain('data-vinext-document-head-crossorigin="anonymous"');
   });
 
   it("renders only user-provided children — defaults are not duplicated here", () => {
@@ -62,7 +80,7 @@ describe("Default Document", () => {
 
     // The dev-server does string replacement on this output.
     // If the nesting order breaks, SSR output will be malformed.
-    const headOpen = html.indexOf("<head>");
+    const headOpen = html.indexOf("<head");
     const bodyOpen = html.indexOf("<body>");
     const mainDiv = html.indexOf('id="__next"');
     const placeholder = html.indexOf("__NEXT_MAIN__");

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1999,6 +1999,7 @@ describe("detectNextIntlConfig", () => {
       env: {},
       assetPrefix: "",
       basePath: "",
+      crossOrigin: undefined,
       trailingSlash: false,
       output: "",
       pageExtensions: ["tsx", "ts", "jsx", "js"],

--- a/tests/pages-asset-tags.test.ts
+++ b/tests/pages-asset-tags.test.ts
@@ -165,6 +165,22 @@ describe("collectAssetTags", () => {
     expect(result).toContain('src="/page.js"');
   });
 
+  it("applies configured crossOrigin to modulepreload and script tags", () => {
+    const manifest = makeManifest({ "page.tsx": ["page.js"] });
+    const result = collectAssetTags({
+      manifest,
+      moduleIds: ["page.tsx"],
+      disableOptimizedLoading: true,
+      crossOrigin: "anonymous",
+    });
+    expect(result).toContain(
+      '<link rel="modulepreload" crossorigin="anonymous" href="/page.js" />',
+    );
+    expect(result).toContain(
+      '<script type="module" src="/page.js" crossorigin="anonymous"></script>',
+    );
+  });
+
   it("adds defer attribute when disableOptimizedLoading is false", () => {
     const manifest = makeManifest({ "page.tsx": ["page.js"] });
     const result = collectAssetTags({

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -45,6 +45,12 @@ async function settleMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+function expectHtmlTag(html: string, pattern: RegExp): string {
+  const match = html.match(pattern);
+  expect(match).not.toBeNull();
+  return match?.[0] ?? "";
+}
+
 function createCommonOptions() {
   const clearSsrContext = vi.fn();
   const createPageElement = vi.fn((pageProps: Record<string, unknown>) =>
@@ -339,12 +345,19 @@ describe("pages page response", () => {
       async () =>
         '<!DOCTYPE html><html><head data-vinext-document-head="" data-vinext-document-head-nonce="head-nonce" data-vinext-document-head-crossorigin="anonymous"><style>body { margin: 0 }</style></head><body><div id="__next">__NEXT_MAIN__</div><span data-vinext-next-script="" data-vinext-next-script-nonce="script-nonce" data-vinext-next-script-crossorigin="use-credentials"><!-- __NEXT_SCRIPTS__ --></span></body></html>',
     );
+    const getSSRHeadHTML = vi.fn(
+      () =>
+        '<script src="https://example.com/user.js"></script>\n' +
+        '<link rel="stylesheet" href="https://example.com/user.css" />\n' +
+        '<link rel="preload" href="/user-preload.js" as="script" />',
+    );
 
     const response = await renderPagesPageResponse({
       ...common.options,
       assetTags:
         '<link rel="modulepreload" href="/entry.js" />\n' +
         '<script type="module" src="/entry.js"></script>',
+      getSSRHeadHTML,
       renderDocumentToString,
     });
 
@@ -362,6 +375,25 @@ describe("pages page response", () => {
     expect(html).toMatch(
       /<script\b(?=[^>]*id="__NEXT_DATA__")(?=[^>]*nonce="script-nonce")(?=[^>]*crossorigin="use-credentials")[^>]*>/,
     );
+
+    const userScript = expectHtmlTag(
+      html,
+      /<script\b(?=[^>]*src="https:\/\/example\.com\/user\.js")[^>]*>/,
+    );
+    expect(userScript).not.toContain("nonce=");
+    expect(userScript).not.toContain("crossorigin");
+    const userStylesheet = expectHtmlTag(
+      html,
+      /<link\b(?=[^>]*rel="stylesheet")(?=[^>]*href="https:\/\/example\.com\/user\.css")[^>]*>/,
+    );
+    expect(userStylesheet).not.toContain("nonce=");
+    expect(userStylesheet).not.toContain("crossorigin");
+    const userPreload = expectHtmlTag(
+      html,
+      /<link\b(?=[^>]*rel="preload")(?=[^>]*href="\/user-preload\.js")[^>]*>/,
+    );
+    expect(userPreload).not.toContain("nonce=");
+    expect(userPreload).not.toContain("crossorigin");
   });
 
   it("falls back to configured crossOrigin when Document passes an empty value", async () => {
@@ -385,6 +417,33 @@ describe("pages page response", () => {
     expect(html).toMatch(
       /<script\b(?=[^>]*id="__NEXT_DATA__")(?=[^>]*crossorigin="anonymous")[^>]*>/,
     );
+  });
+
+  it("does not apply Document or config crossOrigin to font preloads", async () => {
+    const common = createCommonOptions();
+    const renderDocumentToString = vi.fn(
+      async () =>
+        '<!DOCTYPE html><html><head data-vinext-document-head="" data-vinext-document-head-nonce="head-nonce" data-vinext-document-head-crossorigin="use-credentials"></head><body><div id="__next">__NEXT_MAIN__</div><!-- __NEXT_SCRIPTS__ --></body></html>',
+    );
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      assetTags: '<link rel="modulepreload" href="/entry.js" />',
+      crossOrigin: "use-credentials",
+      renderDocumentToString,
+    });
+
+    const html = await response.text();
+    expect(html).toMatch(
+      /<link\b(?=[^>]*rel="modulepreload")(?=[^>]*href="\/entry\.js")(?=[^>]*nonce="head-nonce")(?=[^>]*crossorigin="use-credentials")[^>]*>/,
+    );
+    const fontPreload = expectHtmlTag(
+      html,
+      /<link\b(?=[^>]*rel="preload")(?=[^>]*href="\/font\.woff2")[^>]*>/,
+    );
+    expect(fontPreload).toContain("crossorigin");
+    expect(fontPreload).not.toContain('crossorigin="use-credentials"');
+    expect(fontPreload).not.toContain('nonce="head-nonce"');
   });
 
   it("renders page before collecting SSR head HTML to prevent style race conditions", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -321,13 +321,69 @@ describe("pages page response", () => {
     expect(html).toContain(
       '<script id="__NEXT_DATA__" type="application/json" nonce="pages-test-nonce">',
     );
-    expect(html).toContain('<link rel="stylesheet" nonce="pages-test-nonce" href="/font.css" />');
-    expect(html).toContain(
-      '<link rel="preload" nonce="pages-test-nonce" href="/font.woff2" as="font" type="font/woff2" crossorigin />',
+    expect(html).toMatch(
+      /<link\b(?=[^>]*rel="stylesheet")(?=[^>]*href="\/font\.css")(?=[^>]*nonce="pages-test-nonce")[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<link\b(?=[^>]*rel="preload")(?=[^>]*href="\/font\.woff2")(?=[^>]*as="font")(?=[^>]*type="font\/woff2")(?=[^>]*crossorigin)(?=[^>]*nonce="pages-test-nonce")[^>]*>/,
     );
     expect(html).toContain('<style data-vinext-fonts nonce="pages-test-nonce">');
-    expect(html).toContain(
-      '<script type="module" nonce="pages-test-nonce" src="/entry.js" crossorigin></script>',
+    expect(html).toMatch(
+      /<script\b(?=[^>]*type="module")(?=[^>]*src="\/entry\.js")(?=[^>]*crossorigin)(?=[^>]*nonce="pages-test-nonce")[^>]*>/,
+    );
+  });
+
+  it("applies custom Document Head and NextScript attributes to generated assets", async () => {
+    const common = createCommonOptions();
+    const renderDocumentToString = vi.fn(
+      async () =>
+        '<!DOCTYPE html><html><head data-vinext-document-head="" data-vinext-document-head-nonce="head-nonce" data-vinext-document-head-crossorigin="anonymous"><style>body { margin: 0 }</style></head><body><div id="__next">__NEXT_MAIN__</div><span data-vinext-next-script="" data-vinext-next-script-nonce="script-nonce" data-vinext-next-script-crossorigin="use-credentials"><!-- __NEXT_SCRIPTS__ --></span></body></html>',
+    );
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      assetTags:
+        '<link rel="modulepreload" href="/entry.js" />\n' +
+        '<script type="module" src="/entry.js"></script>',
+      renderDocumentToString,
+    });
+
+    const html = await response.text();
+    expect(html).not.toContain("data-vinext-document-head");
+    expect(html).not.toContain("data-vinext-next-script");
+    expect(html).not.toContain("<head-nonce");
+    expect(html).toContain("<head><style>body { margin: 0 }</style>");
+    expect(html).toMatch(
+      /<link\b(?=[^>]*rel="modulepreload")(?=[^>]*href="\/entry\.js")(?=[^>]*nonce="head-nonce")(?=[^>]*crossorigin="anonymous")[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<script\b(?=[^>]*type="module")(?=[^>]*src="\/entry\.js")(?=[^>]*nonce="head-nonce")(?=[^>]*crossorigin="anonymous")[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<script\b(?=[^>]*id="__NEXT_DATA__")(?=[^>]*nonce="script-nonce")(?=[^>]*crossorigin="use-credentials")[^>]*>/,
+    );
+  });
+
+  it("falls back to configured crossOrigin when Document passes an empty value", async () => {
+    const common = createCommonOptions();
+    const renderDocumentToString = vi.fn(
+      async () =>
+        '<!DOCTYPE html><html><head data-vinext-document-head="" data-vinext-document-head-crossorigin=""></head><body><div id="__next">__NEXT_MAIN__</div><span data-vinext-next-script="" data-vinext-next-script-crossorigin=""><!-- __NEXT_SCRIPTS__ --></span></body></html>',
+    );
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      assetTags: '<script type="module" src="/entry.js"></script>',
+      crossOrigin: "anonymous",
+      renderDocumentToString,
+    });
+
+    const html = await response.text();
+    expect(html).toMatch(
+      /<script\b(?=[^>]*type="module")(?=[^>]*src="\/entry\.js")(?=[^>]*crossorigin="anonymous")[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<script\b(?=[^>]*id="__NEXT_DATA__")(?=[^>]*crossorigin="anonymous")[^>]*>/,
     );
   });
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5028,8 +5028,12 @@ describe("Production server middleware (Pages Router)", () => {
     expect(html).toContain(
       '<script id="__NEXT_DATA__" type="application/json" nonce="pages-prod">',
     );
-    expect(html).toMatch(/<script type="module" defer nonce="pages-prod" src="\/[^"]+"/);
-    expect(html).toMatch(/<link rel="modulepreload" nonce="pages-prod" href="\/[^"]+"/);
+    expect(html).toMatch(
+      /<script\b(?=[^>]*type="module")(?=[^>]*defer)(?=[^>]*nonce="pages-prod")(?=[^>]*src="\/[^"]+")[^>]*>/,
+    );
+    expect(html).toMatch(
+      /<link\b(?=[^>]*rel="modulepreload")(?=[^>]*nonce="pages-prod")(?=[^>]*href="\/[^"]+")[^>]*>/,
+    );
   });
 
   // Ported from Next.js: test/e2e/optimized-loading/test/index.test.ts
@@ -5698,6 +5702,11 @@ describe("Pages _document renderPage enhancers", () => {
       JSON.stringify({ private: true, dependencies: { next: "*", react: "*", "react-dom": "*" } }),
     );
     await fsp.writeFile(
+      path.join(fixtureRoot, "next.config.js"),
+      `module.exports = { crossOrigin: "anonymous" };
+`,
+    );
+    await fsp.writeFile(
       path.join(fixtureRoot, "pages", "_app.tsx"),
       `export default function App({ Component, pageProps }: any) {
   return <main id="app-shell"><Component {...pageProps} /></main>;
@@ -5854,7 +5863,7 @@ export default class CustomDocument extends Document {
   }
   render() {
     return (
-      <Html><Head /><body><p id="document-prop">{(this.props as any).documentProp}</p><p id="document-request-context">{(this.props as any).documentRequestContext}</p><p id="document-error-context">{(this.props as any).documentErrorContext}</p><Main /><NextScript /></body></Html>
+      <Html><Head nonce="test-nonce"><style>{\`body { margin: 0 } /* custom! */\`}</style></Head><body><p id="document-prop">{(this.props as any).documentProp}</p><p id="document-request-context">{(this.props as any).documentRequestContext}</p><p id="document-error-context">{(this.props as any).documentErrorContext}</p><Main /><NextScript nonce="test-nonce" /></body></Html>
     );
   }
 }
@@ -5883,6 +5892,40 @@ export default class CustomDocument extends Document {
 
   // Ported from Next.js: test/e2e/app-document/rendering.test.ts
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-document/rendering.test.ts
+  it.each(["dev", "prod"] as const)(
+    "preserves custom Document Head children in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      expect(html).toContain("body { margin: 0 }");
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "adds nonces and crossOrigin to all scripts and preload links in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      // Next.js emits JavaScript preloads as `link[rel=preload]`; vinext's Vite
+      // ESM build emits the equivalent entries as `link[rel=modulepreload]`.
+      const targetTags = Array.from(html.matchAll(/<(script|link)\b[^>]*>/g))
+        .map((match) => match[0])
+        .filter(
+          (tag) => tag.startsWith("<script") || /\srel=["'](?:preload|modulepreload)["']/.test(tag),
+        );
+
+      expect(targetTags.length).toBeGreaterThan(0);
+      for (const tag of targetTags) {
+        expect(tag).toContain('nonce="test-nonce"');
+        expect(tag).toContain('crossorigin="anonymous"');
+      }
+    },
+  );
+
   it.each(["dev", "prod"] as const)("applies all renderPage enhancer forms in %s", async (mode) => {
     const url = mode === "dev" ? devUrl : prodUrl;
     for (const [query, expectedIds] of enhancerCases) {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5689,6 +5689,21 @@ describe("Pages _document renderPage enhancers", () => {
     return match?.[0] ?? "";
   }
 
+  function isVinextOwnedDocumentAssetTag(tag: string): boolean {
+    if (tag.includes('id="__NEXT_DATA__"')) return true;
+
+    if (tag.startsWith("<script")) {
+      if (/\ssrc=["']\/(?:@id|@vite)\//.test(tag)) return false;
+      if (!/\ssrc=/.test(tag)) return false;
+      return /\ssrc=["']\/(?:_next|assets)\//.test(tag);
+    }
+
+    return (
+      /\srel=["'](?:preload|modulepreload)["']/.test(tag) &&
+      /\shref=["']\/(?:_next|assets)\//.test(tag)
+    );
+  }
+
   beforeAll(async () => {
     fixtureRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-"));
     outDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-out-"));
@@ -5927,7 +5942,7 @@ export default class CustomDocument extends Document {
   );
 
   it.each(["dev", "prod"] as const)(
-    "adds nonces and crossOrigin to all scripts and preload links in %s",
+    "adds nonces and crossOrigin to owned generated scripts and preload links in %s",
     async (mode) => {
       const url = mode === "dev" ? devUrl : prodUrl;
       const response = await fetch(`${url}/`);
@@ -5937,9 +5952,7 @@ export default class CustomDocument extends Document {
       // ESM build emits the equivalent entries as `link[rel=modulepreload]`.
       const targetTags = Array.from(html.matchAll(/<(script|link)\b[^>]*>/g))
         .map((match) => match[0])
-        .filter(
-          (tag) => tag.startsWith("<script") || /\srel=["'](?:preload|modulepreload)["']/.test(tag),
-        );
+        .filter(isVinextOwnedDocumentAssetTag);
 
       expect(targetTags.length).toBeGreaterThan(0);
       for (const tag of targetTags) {
@@ -5980,13 +5993,7 @@ export default class CustomDocument extends Document {
 
       const generatedTags = Array.from(html.matchAll(/<(script|link)\b[^>]*>/g))
         .map((match) => match[0])
-        .filter(
-          (tag) =>
-            (tag.startsWith("<script") || /\srel=["'](?:preload|modulepreload)["']/.test(tag)) &&
-            !tag.includes("https://example.com/user.js") &&
-            !tag.includes("https://example.com/user.css") &&
-            !tag.includes("/user-preload.js"),
-        );
+        .filter(isVinextOwnedDocumentAssetTag);
 
       expect(generatedTags.length).toBeGreaterThan(0);
       for (const tag of generatedTags) {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5683,6 +5683,12 @@ describe("Pages _document renderPage enhancers", () => {
     expect(html).not.toContain('id="page-content"');
   }
 
+  function expectHtmlTag(html: string, pattern: RegExp): string {
+    const match = html.match(pattern);
+    expect(match).not.toBeNull();
+    return match?.[0] ?? "";
+  }
+
   beforeAll(async () => {
     fixtureRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-"));
     outDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-enhancers-out-"));
@@ -5750,6 +5756,23 @@ export default function Page({ throwPage }: { throwPage: boolean }) {
 }
 export default function StaticGspPage() {
   return <p id="static-gsp-page-content">STATIC GSP</p>;
+}
+`,
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "head-assets.tsx"),
+      `import Head from "next/head";
+export default function HeadAssetsPage() {
+  return (
+    <>
+      <Head>
+        <script src="https://example.com/user.js" />
+        <link rel="stylesheet" href="https://example.com/user.css" />
+        <link rel="preload" href="/user-preload.js" as="script" />
+      </Head>
+      <p id="head-assets-page">HEAD ASSETS</p>
+    </>
+  );
 }
 `,
     );
@@ -5920,6 +5943,53 @@ export default class CustomDocument extends Document {
 
       expect(targetTags.length).toBeGreaterThan(0);
       for (const tag of targetTags) {
+        expect(tag).toContain('nonce="test-nonce"');
+        expect(tag).toContain('crossorigin="anonymous"');
+      }
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "does not apply Document asset attributes to user-authored next/head tags in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/head-assets`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+
+      const userScript = expectHtmlTag(
+        html,
+        /<script\b(?=[^>]*src="https:\/\/example\.com\/user\.js")[^>]*>/,
+      );
+      expect(userScript).not.toContain("nonce=");
+      expect(userScript).not.toContain("crossorigin");
+
+      const userStylesheet = expectHtmlTag(
+        html,
+        /<link\b(?=[^>]*rel="stylesheet")(?=[^>]*href="https:\/\/example\.com\/user\.css")[^>]*>/,
+      );
+      expect(userStylesheet).not.toContain("nonce=");
+      expect(userStylesheet).not.toContain("crossorigin");
+
+      const userPreload = expectHtmlTag(
+        html,
+        /<link\b(?=[^>]*rel="preload")(?=[^>]*href="\/user-preload\.js")[^>]*>/,
+      );
+      expect(userPreload).not.toContain("nonce=");
+      expect(userPreload).not.toContain("crossorigin");
+
+      const generatedTags = Array.from(html.matchAll(/<(script|link)\b[^>]*>/g))
+        .map((match) => match[0])
+        .filter(
+          (tag) =>
+            (tag.startsWith("<script") || /\srel=["'](?:preload|modulepreload)["']/.test(tag)) &&
+            !tag.includes("https://example.com/user.js") &&
+            !tag.includes("https://example.com/user.css") &&
+            !tag.includes("/user-preload.js"),
+        );
+
+      expect(generatedTags.length).toBeGreaterThan(0);
+      for (const tag of generatedTags) {
         expect(tag).toContain('nonce="test-nonce"');
         expect(tag).toContain('crossorigin="anonymous"');
       }


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js Pages `_document` rendering for custom `Head` and `NextScript` asset attributes. |
| Core change | Capture `_document` `Head` and `NextScript` `nonce` and `crossOrigin` props in private server-only markers, strip those markers after document render, and apply the resolved attrs only to vinext-owned generated fragments. |
| Main boundary | Never run a document asset-attribute rewriter over mixed-ownership HTML. |
| Primary files | `packages/vinext/src/shims/document.tsx`, `packages/vinext/src/server/pages-document-asset-attributes.ts`, `packages/vinext/src/server/pages-page-response.ts`, `packages/vinext/src/server/dev-server.ts`, `packages/vinext/src/server/pages-asset-tags.ts` |
| Expected impact | Pages Router output preserves custom document head children, leaves user-authored head tags unchanged, and applies Next.js-compatible nonce/crossOrigin attrs to generated assets in dev, production, and deploy-suite fixtures. |

## Why

Next.js lets `_document` own attributes for generated document assets: `Head nonce` controls generated head assets and `NextScript nonce` controls `__NEXT_DATA__` and generated scripts. `next.config.js` `crossOrigin` is the fallback when a document component does not pass a truthy prop. User-authored `next/head` tags are not part of that generated-asset surface, so vinext must carry document attributes across the shell boundary without rewriting arbitrary page head HTML.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| `_document` shim | `Head` and `NextScript` props are observable by server asset generation. | Adds private marker attributes for `nonce` and `crossOrigin`, preserving children exactly. |
| Production Pages renderer | Generated asset fragments have known provenance, mixed `ssrHeadHTML` does not. | Applies `Head` attrs only to `options.assetTags`, and applies `NextScript` attrs only to `__NEXT_DATA__`. |
| Dev Pages renderer | Vite transforms the complete shell, so post-transform rewrites see mixed ownership. | Applies attrs only to vinext-generated scripts before insertion, then runs `server.transformIndexHtml()`, then splits the shell without further mutation. |
| User head output | Page-owned `next/head` tags are user HTML, not generated framework assets. | Does not apply document asset attrs to `ssrHeadHTML`, custom document head children, or user-authored head tags. |
| Font output | Next font preloads use their own fixed crossorigin semantics. | Leaves font fragments out of the generic document/config crossOrigin rewriter. |
| Config | `next.config.js` `crossOrigin` is parsed once and carried as a typed value. | Adds `crossOrigin` to `ResolvedNextConfig` and threads it into Pages server entry/dev server wiring. |
| Marker cleanup | Internal markers must not leak or corrupt user HTML. | Uses boundary-aware attr removal and covers the previous malformed `<head-nonce>` failure. |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| `<Head nonce="test-nonce">` with custom children | Generated assets did not inherit the document nonce, and marker stripping could corrupt the opening head tag. | Custom head children remain in `<head>`, internal markers are stripped, and generated head assets receive the nonce where vinext owns that fragment. |
| `<NextScript nonce="test-nonce" />` | `__NEXT_DATA__` and generated scripts only saw request-level nonce behavior. | NextScript attrs apply to `__NEXT_DATA__` and generated script tags. |
| `crossOrigin: "anonymous"` in config | Config was not parsed or threaded into Pages asset generation. | Generated scripts and preload/modulepreload links receive `crossorigin="anonymous"` when configured. |
| User-authored `next/head` script/link/preload tags | The initial implementation could rewrite them with document asset attrs. | They remain unchanged while generated tags still receive nonce/crossOrigin. |
| Vite dev HTML transforms | Dev rewrote the transformed shell and needed sentinel comments to skip user regions. | Dev no longer rewrites transformed HTML. Vite-injected dev client tags intentionally do not inherit `_document` attrs. |
| Existing middleware CSP nonce output | Test assumed serializer order. | Assertion now checks the same nonce contract without depending on attr order. |

<details>
<summary>Maintainer Review Path</summary>

1. `packages/vinext/src/shims/document.tsx`: inspect the private marker attrs emitted by `Head` and `NextScript`.
2. `packages/vinext/src/server/pages-document-asset-attributes.ts`: inspect marker extraction, marker stripping, attr merging, and the now-simple fragment-local attr replacement.
3. `packages/vinext/src/server/pages-page-response.ts`: inspect production scoping to `options.assetTags` and `__NEXT_DATA__`, with `ssrHeadHTML` and font fragments left unmodified.
4. `packages/vinext/src/server/dev-server.ts`: inspect dev scoping to generated scripts before `server.transformIndexHtml()` and the lack of post-transform mutation.
5. `packages/vinext/src/config/next-config.ts`, `packages/vinext/src/entries/pages-server-entry.ts`, `packages/vinext/src/index.ts`, `packages/vinext/src/server/pages-page-handler.ts`: inspect `crossOrigin` config threading.
6. `tests/pages-router.test.ts` and `tests/pages-page-response.test.ts`: inspect the ported behavior, malformed-head regression, user-authored head regression, owned-generated-tag assertions, and font crossOrigin boundary coverage.

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/pages-router.test.ts -t "Pages _document renderPage enhancers"`
- `vp check packages/vinext/src/server/dev-server.ts packages/vinext/src/server/pages-document-asset-attributes.ts packages/vinext/src/server/pages-page-response.ts tests/pages-page-response.test.ts tests/pages-router.test.ts`
- `vp test run tests/document.test.ts tests/pages-asset-tags.test.ts tests/pages-page-response.test.ts`
- `vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/nathan/Projects/vinext/.refs/nextjs-v16.2.6 --retries 0 -c 1 --debug test/e2e/app-document/rendering.test.ts`
- `git diff --check`
- Commit hook: full check, staged unit/integration tests, and knip passed before commit.

</details>

<details>
<summary>Risk / Compatibility</summary>

- Public API: adds support for existing Next.js `crossOrigin` config and existing `_document` props.
- Runtime: marker attrs are private to server-rendered document output and stripped before final HTML.
- User HTML: page-authored `next/head` scripts, stylesheets, and preloads are not rewritten with generated-asset attrs.
- Font output: font preloads keep their existing crossorigin behavior instead of inheriting document/config `crossOrigin` values.
- Dev parity: Vite-injected HMR/client tags are not owned by vinext document generation and do not receive `_document` attrs.
- HTML serialization: tag assertions are order-insensitive where behavior does not require ordering.
- Compatibility: vinext emits Vite ESM `modulepreload` entries where Next.js emits JS `preload` entries, so the port checks both while preserving the same observable asset-attribute contract.

</details>

<details>
<summary>Non-goals</summary>

- This does not implement all deprecated `_document` `crossOrigin` warning behavior from Next.js.
- This does not change App Router asset generation.
- This does not change Pages Router CSP policy generation, only the generated tag attributes.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js upstream rendering test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-document/rendering.test.ts#L10-L48) | Defines the required custom head child, nonce, and crossOrigin assertions. |
| [Next.js app-document `_document` fixture](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-document/pages/_document.js#L63-L74) | Shows `<Head nonce="test-nonce">` and `<NextScript nonce="test-nonce" />` in the fixture this PR ports. |
| [Next.js app-document config](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-document/next.config.js#L1) | Provides `crossOrigin: "anonymous"` for the upstream behavior. |
| [Next.js page head cloning](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/pages/_document.tsx#L532-L560) | Shows page-owned head children are cloned as head entries rather than treated as generated document assets. |
| [Next.js font preload implementation](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/pages/_document.tsx#L300-L327) | Shows next/font preloads hardcode `crossOrigin="anonymous"`. |
| [Next.js Head preload implementation](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/pages/_document.tsx#L450-L458) | Applies `nonce` and `crossOrigin={this.props.crossOrigin || crossOrigin}` to generated preload links. |
| [Next.js NextScript implementation](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/pages/_document.tsx#L792-L810) | Applies `nonce` and `crossOrigin={this.props.crossOrigin || crossOrigin}` to generated scripts and `__NEXT_DATA__`. |
| [Next.js render context crossOrigin](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/render.tsx#L1413-L1435) | Threads `renderOpts.crossOrigin` into the document HTML context. |
| [Next.js base server crossOrigin option](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/base-server.ts#L504) | Sources the document context `crossOrigin` from `nextConfig.crossOrigin`. |
| [Next.js crossOrigin docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/crossOrigin) | Documents the public config option this PR now parses and threads. |
