### PR TITLE
[codex] Normalize routing paths for Windows

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -939,7 +939,7 @@ export async function buildAppRouteGraph(
     scanMatcher.extensions,
     excludeDir,
   )) {
-    const dir = path.dirname(file);
+    const dir = path.posix.dirname(file);
     const routeDir = dir === "." ? appDir : path.join(appDir, dir);
     if (!hasParallelSlotDirectory(routeDir)) continue;
     if (discoverParallelSlots(routeDir, appDir, scanMatcher).length === 0) continue;
@@ -1035,10 +1035,18 @@ function validatePageRouteConflicts(routes: readonly AppRoute[], appDir: string)
 }
 
 function formatAppFilePath(filePath: string, appDir: string): string {
-  const relativePath = path.relative(appDir, filePath).replace(/\\/g, "/");
-  const parsedPath = path.parse(relativePath);
-  const withoutExtension = path.join(parsedPath.dir, parsedPath.name).replace(/\\/g, "/");
+  const relativePath = normalizePathSeparators(path.relative(appDir, filePath));
+  const parsedPath = path.posix.parse(relativePath);
+  const withoutExtension = path.posix.join(parsedPath.dir, parsedPath.name);
   return withoutExtension.startsWith("/") ? withoutExtension : `/${withoutExtension}`;
+}
+
+function splitInternalPath(filePath: string): string[] {
+  return normalizePathSeparators(filePath).split("/").filter(Boolean);
+}
+
+function splitRelativePath(from: string, to: string): string[] {
+  return splitInternalPath(path.relative(from, to));
 }
 
 /**
@@ -1092,9 +1100,11 @@ function discoverSlotSubRoutes(
     // For page-bearing routes, the route directory is the page's directory.
     // For layout-only routes (no page.tsx), proxy the route directory through
     // the innermost layout — it lives at the same filesystem level as the route.
-    const parentPageDir = parentRoute.pagePath
-      ? path.dirname(parentRoute.pagePath)
-      : path.dirname(parentRoute.layouts[parentRoute.layouts.length - 1]);
+    const parentPageDir = normalizePathSeparators(
+      parentRoute.pagePath
+        ? path.dirname(parentRoute.pagePath)
+        : path.dirname(parentRoute.layouts[parentRoute.layouts.length - 1]),
+    );
 
     // Collect sub-paths from all slots.
     // Map: normalized visible sub-path -> slot pages, raw filesystem segments (for routeSegments),
@@ -1114,7 +1124,7 @@ function discoverSlotSubRoutes(
     for (const slot of parentRoute.parallelSlots) {
       // Only scan sub-pages from slots owned by this route directory.
       // Inherited slots with the same name live in different owner dirs.
-      if (path.dirname(slot.ownerDir) !== parentPageDir) {
+      if (normalizePathSeparators(path.dirname(slot.ownerDir)) !== parentPageDir) {
         continue;
       }
       const slotDir = slot.ownerDir;
@@ -1122,7 +1132,7 @@ function discoverSlotSubRoutes(
 
       const subPages = findSlotSubPages(slotDir, matcher);
       for (const { relativePath, pagePath } of subPages) {
-        const subSegments = relativePath.split(path.sep);
+        const subSegments = splitInternalPath(relativePath);
         const convertedSubRoute = convertSegmentsToRouteParts(subSegments);
         if (!convertedSubRoute) continue;
 
@@ -1299,7 +1309,8 @@ function findSlotSubPages(slotDir: string, matcher: ValidFileMatcher): SlotSubPa
     perMatcher = new Map();
     findSlotSubPagesCache.set(matcher, perMatcher);
   }
-  const cached = perMatcher.get(slotDir);
+  const cacheKey = normalizePathSeparators(slotDir);
+  const cached = perMatcher.get(cacheKey);
   if (cached) return cached;
 
   const results: SlotSubPageEntry[] = [];
@@ -1317,7 +1328,7 @@ function findSlotSubPages(slotDir: string, matcher: ValidFileMatcher): SlotSubPa
       const subDir = path.join(dir, entry.name);
       const page = findFile(subDir, "page", matcher);
       if (page) {
-        const relativePath = path.relative(slotDir, subDir);
+        const relativePath = normalizePathSeparators(path.relative(slotDir, subDir));
         results.push({ relativePath, pagePath: page });
       }
       // Continue scanning deeper for nested sub-pages
@@ -1326,7 +1337,7 @@ function findSlotSubPages(slotDir: string, matcher: ValidFileMatcher): SlotSubPa
   }
 
   scan(slotDir);
-  perMatcher.set(slotDir, results);
+  perMatcher.set(cacheKey, results);
   return results;
 }
 
@@ -1371,8 +1382,10 @@ function fileToAppRoute(
   type: "page" | "route",
   matcher: ValidFileMatcher,
 ): AppRouteGraphRoute | null {
+  const normalizedFile = normalizePathSeparators(file);
+
   // Remove the filename (page.tsx or route.ts)
-  let dir = path.dirname(file);
+  let dir = path.posix.dirname(normalizedFile);
 
   // `@children` is transparent in routing: `app/foo/@children/page.tsx`
   // provides the children prop for `/foo` and registers a real page route
@@ -1382,17 +1395,19 @@ function fileToAppRoute(
   // layouts/boundaries are sourced from the parent. Mirrors Next.js'
   // `normalizeAppPath` which drops any `@` segment (including `@children`)
   // from the URL. See packages/next/src/shared/lib/router/utils/app-paths.ts.
-  if (type === "page" && dir !== "." && path.basename(dir) === "@children") {
-    const parent = path.dirname(dir);
+  if (type === "page" && dir !== "." && path.posix.basename(dir) === "@children") {
+    const parent = path.posix.dirname(dir);
     dir = parent === "" || parent === "." ? "." : parent;
   }
+
+  const filePath = normalizePathSeparators(path.join(appDir, normalizedFile));
 
   return directoryToAppRoute(
     dir,
     appDir,
     matcher,
-    type === "page" ? path.join(appDir, file) : null,
-    type === "route" ? path.join(appDir, file) : null,
+    type === "page" ? filePath : null,
+    type === "route" ? filePath : null,
   );
 }
 
@@ -1403,7 +1418,8 @@ function directoryToAppRoute(
   pagePath: string | null,
   routePath: string | null,
 ): AppRouteGraphRoute | null {
-  const segments = dir === "." ? [] : dir.split(path.sep);
+  const normalizedDir = normalizePathSeparators(dir);
+  const segments = normalizedDir === "." ? [] : normalizedDir.split("/");
 
   const params: string[] = [];
   let isDynamic = false;
@@ -1435,7 +1451,7 @@ function directoryToAppRoute(
   const errorTreePositions = errorEntries.map((entry) => entry.treePosition);
 
   // Discover loading, error in the route's directory
-  const routeDir = dir === "." ? appDir : path.join(appDir, dir);
+  const routeDir = normalizedDir === "." ? appDir : path.join(appDir, ...segments);
   const loadingPath = findFile(routeDir, "loading", matcher);
   const errorPath = findFile(routeDir, "error", matcher);
 
@@ -1592,8 +1608,7 @@ function computeLayoutTreePositions(appDir: string, layouts: string[]): number[]
   return layouts.map((layoutPath) => {
     const layoutDir = path.dirname(layoutPath);
     if (layoutDir === appDir) return 0;
-    const relative = path.relative(appDir, layoutDir);
-    return relative.split(path.sep).length;
+    return splitRelativePath(appDir, layoutDir).length;
   });
 }
 
@@ -1909,7 +1924,7 @@ function findMirroredSlotPage(
   };
   let best: Candidate | null = null;
   for (const { relativePath, pagePath } of findSlotSubPages(slotDir, matcher)) {
-    const slotSegments = relativePath.split(path.sep);
+    const slotSegments = splitInternalPath(relativePath);
     const slotUrl = convertSegmentsToRouteParts(slotSegments);
     if (!slotUrl) continue;
     if (!patternsCompatible(slotUrl.urlSegments, routeUrl.urlSegments)) continue;
@@ -2072,10 +2087,7 @@ function discoverParallelSlots(
     // Only include slots that have at least a page, default, or intercepting route
     if (!pagePath && !defaultPath && interceptingRoutes.length === 0) continue;
 
-    const ownerSegments = path
-      .relative(appDir, dir)
-      .split(path.sep)
-      .filter((segment) => segment.length > 0);
+    const ownerSegments = splitRelativePath(appDir, dir);
     const ownerTreePath = createAppRouteGraphTreePath(ownerSegments, ownerSegments.length);
 
     slots.push({
@@ -2451,7 +2463,7 @@ function collectInterceptingPages(
  * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/interception-routes.ts
  */
 function computeInterceptSourceMatchPattern(interceptParentDir: string, appDir: string): string {
-  const segments = path.relative(appDir, interceptParentDir).split(path.sep).filter(Boolean);
+  const segments = splitRelativePath(appDir, interceptParentDir);
   const converted = convertSegmentsToRouteParts(segments);
   const urlSegments = converted
     ? converted.urlSegments
@@ -2488,7 +2500,7 @@ function computeInterceptTarget(
   // Determine the base segments for target resolution.
   // We work on route segments (not filesystem paths) so that route groups
   // and parallel slots are properly skipped when climbing.
-  const routeSegments = path.relative(appDir, routeDir).split(path.sep).filter(Boolean);
+  const routeSegments = splitRelativePath(appDir, routeDir);
 
   let baseParts: string[];
   switch (convention) {
@@ -2498,7 +2510,7 @@ function computeInterceptTarget(
       // groups) and dynamic [param] syntax are resolved by the single
       // convertSegmentsToRouteParts call below; feeding already-converted
       // segments would drop dynamic ancestor params on the second pass.
-      baseParts = path.relative(appDir, interceptParentDir).split(path.sep).filter(Boolean);
+      baseParts = splitRelativePath(appDir, interceptParentDir);
       break;
     }
     case "..":
@@ -2517,7 +2529,7 @@ function computeInterceptTarget(
           routeSegments,
           convention,
           interceptSegment,
-          path.relative(interceptRoot, currentDir).split(path.sep).filter(Boolean),
+          splitRelativePath(interceptRoot, currentDir),
         );
         if (convention === "..") {
           throw new Error(
@@ -2539,7 +2551,7 @@ function computeInterceptTarget(
   }
 
   // Add the intercept segment and any nested path segments
-  const nestedParts = path.relative(interceptRoot, currentDir).split(path.sep).filter(Boolean);
+  const nestedParts = splitRelativePath(interceptRoot, currentDir);
   const allSegments = [...baseParts, interceptSegment, ...nestedParts];
 
   const convertedTarget = convertSegmentsToRouteParts(allSegments);
@@ -2610,7 +2622,7 @@ function findFile(dir: string, name: string, matcher: ValidFileMatcher): string 
   const cache = findFileProbeCache.get(matcher);
   if (!cache) return findFileWithExts(dir, name, matcher);
 
-  const key = `${dir}\0${name}`;
+  const key = `${normalizePathSeparators(dir)}\0${name}`;
   // `findFileWithExts` returns `string | null`, so a stored miss reads back as
   // `null` (not `undefined`). Only a genuinely absent key yields `undefined`,
   // which is what distinguishes a cache miss from a cached not-found result.

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { glob } from "node:fs/promises";
 import path from "node:path";
+import { normalizePathSeparators } from "../utils/path.js";
 import { escapeRegExp } from "../utils/regex.js";
 
 const DEFAULT_PAGE_EXTENSIONS = ["tsx", "ts", "jsx", "js"] as const;
@@ -99,7 +100,7 @@ export function findFileWithExts(
 ): string | null {
   for (const ext of matcher.dottedExtensions) {
     const filePath = path.posix.join(dir, name + ext);
-    if (existsSync(filePath)) return filePath;
+    if (existsSync(filePath)) return normalizePathSeparators(filePath);
   }
   return null;
 }
@@ -175,6 +176,6 @@ export async function* scanWithExtensions(
     cwd,
     ...(exclude ? { exclude } : {}),
   })) {
-    yield file;
+    yield normalizePathSeparators(file);
   }
 }

--- a/packages/vinext/src/routing/pages-router.ts
+++ b/packages/vinext/src/routing/pages-router.ts
@@ -5,6 +5,7 @@ import {
   scanWithExtensions,
   type ValidFileMatcher,
 } from "./file-matcher.js";
+import { normalizePathSeparators } from "../utils/path.js";
 import { validateRoutePatterns } from "./route-validation.js";
 import { createRouteTrieCache, matchRouteWithTrie } from "./route-matching.js";
 
@@ -97,12 +98,14 @@ async function scanPageRoutes(pagesDir: string, matcher: ValidFileMatcher): Prom
  * Convert a file path relative to pages/ into a Route.
  */
 function fileToRoute(file: string, pagesDir: string, matcher: ValidFileMatcher): Route | null {
+  const normalizedFile = normalizePathSeparators(file);
+
   // Remove extension
-  const withoutExt = matcher.stripExtension(file);
-  if (withoutExt === file) return null;
+  const withoutExt = matcher.stripExtension(normalizedFile);
+  if (withoutExt === normalizedFile) return null;
 
   // Convert to URL segments
-  const segments = withoutExt.split(path.sep);
+  const segments = withoutExt.split("/");
 
   // Handle index files: pages/index.tsx -> /
   const lastSegment = segments[segments.length - 1];
@@ -170,7 +173,7 @@ function fileToRoute(file: string, pagesDir: string, matcher: ValidFileMatcher):
   return {
     pattern: pattern === "/" ? "/" : pattern,
     patternParts: urlSegments.filter(Boolean),
-    filePath: path.join(pagesDir, file),
+    filePath: normalizePathSeparators(path.join(pagesDir, normalizedFile)),
     isDynamic,
     params,
   };
@@ -231,7 +234,7 @@ async function scanApiRoutes(pagesDir: string, matcher: ValidFileMatcher): Promi
 
   for (const file of files) {
     // Reuse fileToRoute but pretend the file is under a virtual "api/" prefix
-    const route = fileToRoute(path.join("api", file), pagesDir, matcher);
+    const route = fileToRoute(path.posix.join("api", file), pagesDir, matcher);
     if (route) {
       routes.push(route);
     }

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -35,8 +35,14 @@ async function withTempApp<T>(run: (appDir: string) => Promise<T>): Promise<T> {
   }
 }
 
+function appPath(appDir: string, relativePath: string): string {
+  return path.join(appDir, relativePath).replace(/\\/g, "/");
+}
+
+const itUnlessWindows = process.platform === "win32" ? it.skip : it;
+
 async function writeAppFile(appDir: string, relativePath: string, contents: string): Promise<void> {
-  const filePath = path.join(appDir, relativePath);
+  const filePath = appPath(appDir, relativePath);
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, contents);
 }
@@ -121,15 +127,15 @@ describe("App Router route graph builder", () => {
 
       const dashboard = findRoute(graph.routes, "/dashboard");
       expect(dashboard.layouts).toEqual([
-        path.join(appDir, "layout.tsx"),
-        path.join(appDir, "dashboard/layout.tsx"),
+        appPath(appDir, "layout.tsx"),
+        appPath(appDir, "dashboard/layout.tsx"),
       ]);
       expect(dashboard.parallelSlots).toHaveLength(1);
       expect(dashboard.parallelSlots[0]).toMatchObject({
         key: "team@dashboard/@team",
         name: "team",
-        pagePath: path.join(appDir, "dashboard/@team/page.tsx"),
-        defaultPath: path.join(appDir, "dashboard/@team/default.tsx"),
+        pagePath: appPath(appDir, "dashboard/@team/page.tsx"),
+        defaultPath: appPath(appDir, "dashboard/@team/default.tsx"),
         layoutIndex: 1,
         routeSegments: [],
       });
@@ -139,7 +145,7 @@ describe("App Router route graph builder", () => {
         key: "team@dashboard/@team",
         name: "team",
         pagePath: null,
-        defaultPath: path.join(appDir, "dashboard/@team/default.tsx"),
+        defaultPath: appPath(appDir, "dashboard/@team/default.tsx"),
         layoutIndex: 1,
         routeSegments: null,
       });
@@ -147,7 +153,7 @@ describe("App Router route graph builder", () => {
       const handler = findRoute(graph.routes, "/dashboard/api");
       expect(handler).toMatchObject({
         pagePath: null,
-        routePath: path.join(appDir, "dashboard/api/route.ts"),
+        routePath: appPath(appDir, "dashboard/api/route.ts"),
       });
     });
   });
@@ -155,8 +161,7 @@ describe("App Router route graph builder", () => {
   // Guards the scan-scoped fs-probe cache (issue #1912): sibling routes share
   // ancestor layouts/boundaries, and a missing root-level convention (the
   // not-found probe at app/) is memoized as `null`. Every route must still
-  // resolve the same shared ancestor files and the same nearest boundary —
-  // proving the cache returns identical results, including the null-miss path.
+  // resolve the same shared ancestor files and the same nearest boundary 鈥?  // proving the cache returns identical results, including the null-miss path.
   it("resolves shared ancestors and nearest boundaries for sibling routes (probe cache)", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
@@ -171,10 +176,10 @@ describe("App Router route graph builder", () => {
       const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
 
       const sharedLayouts = [
-        path.join(appDir, "layout.tsx"),
-        path.join(appDir, "dashboard/layout.tsx"),
+        appPath(appDir, "layout.tsx"),
+        appPath(appDir, "dashboard/layout.tsx"),
       ];
-      const nearestNotFound = path.join(appDir, "dashboard/not-found.tsx");
+      const nearestNotFound = appPath(appDir, "dashboard/not-found.tsx");
 
       for (const pattern of [
         "/dashboard/reports",
@@ -209,7 +214,7 @@ describe("App Router route graph builder", () => {
 
       const members = findRoute(graph.routes, "/dashboard/members");
       expect(members).toMatchObject({
-        pagePath: path.join(appDir, "dashboard/default.tsx"),
+        pagePath: appPath(appDir, "dashboard/default.tsx"),
         routePath: null,
         routeSegments: ["dashboard", "members"],
         patternParts: ["dashboard", "members"],
@@ -217,7 +222,7 @@ describe("App Router route graph builder", () => {
       expect(members.parallelSlots[0]).toMatchObject({
         key: "team@dashboard/@team",
         name: "team",
-        pagePath: path.join(appDir, "dashboard/@team/members/page.tsx"),
+        pagePath: appPath(appDir, "dashboard/@team/members/page.tsx"),
         routeSegments: ["members"],
       });
     });
@@ -228,7 +233,7 @@ describe("App Router route graph builder", () => {
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-layouts/parallel-routes-layouts.test.ts
   //
   // When a slot owns both a matched page and a default.tsx, the matched page
-  // must win — vinext previously fell back to default.tsx ("default page"
+  // must win 鈥?vinext previously fell back to default.tsx ("default page"
   // instead of "Hello from Nested"). This locks in page-over-default priority
   // for the children slot and for sibling @foo/@bar slots simultaneously.
   it("prefers a matched slot page over default.tsx across sibling slots (issue #1339)", async () => {
@@ -251,21 +256,21 @@ describe("App Router route graph builder", () => {
       // At /nested the children slot must render nested/page.tsx, not the
       // sibling nested/default.tsx fallback.
       const nested = findRoute(graph.routes, "/nested");
-      expect(nested.pagePath).toBe(path.join(appDir, "nested/page.tsx"));
+      expect(nested.pagePath).toBe(appPath(appDir, "nested/page.tsx"));
 
-      // Each sibling slot has its own page AND its own default — the page wins.
+      // Each sibling slot has its own page AND its own default 鈥?the page wins.
       const foo = nested.parallelSlots.find((slot) => slot.name === "foo");
       const bar = nested.parallelSlots.find((slot) => slot.name === "bar");
       expect(foo).toMatchObject({
         name: "foo",
-        pagePath: path.join(appDir, "nested/@foo/page.tsx"),
-        defaultPath: path.join(appDir, "nested/@foo/default.tsx"),
+        pagePath: appPath(appDir, "nested/@foo/page.tsx"),
+        defaultPath: appPath(appDir, "nested/@foo/default.tsx"),
         routeSegments: [],
       });
       expect(bar).toMatchObject({
         name: "bar",
-        pagePath: path.join(appDir, "nested/@bar/page.tsx"),
-        defaultPath: path.join(appDir, "nested/@bar/default.tsx"),
+        pagePath: appPath(appDir, "nested/@bar/page.tsx"),
+        defaultPath: appPath(appDir, "nested/@bar/default.tsx"),
         routeSegments: [],
       });
 
@@ -273,18 +278,18 @@ describe("App Router route graph builder", () => {
       // falls back to nested/default.tsx, @bar mirrors its subroute page, and
       // @foo (no subroute page) keeps its default fallback.
       const subroute = findRoute(graph.routes, "/nested/subroute");
-      expect(subroute.pagePath).toBe(path.join(appDir, "nested/default.tsx"));
+      expect(subroute.pagePath).toBe(appPath(appDir, "nested/default.tsx"));
       const subBar = subroute.parallelSlots.find((slot) => slot.name === "bar");
       const subFoo = subroute.parallelSlots.find((slot) => slot.name === "foo");
       expect(subBar).toMatchObject({
         name: "bar",
-        pagePath: path.join(appDir, "nested/@bar/subroute/page.tsx"),
+        pagePath: appPath(appDir, "nested/@bar/subroute/page.tsx"),
         routeSegments: ["subroute"],
       });
       expect(subFoo).toMatchObject({
         name: "foo",
         pagePath: null,
-        defaultPath: path.join(appDir, "nested/@foo/default.tsx"),
+        defaultPath: appPath(appDir, "nested/@foo/default.tsx"),
       });
     });
   });
@@ -315,15 +320,15 @@ describe("App Router route graph builder", () => {
       const catcher = findRoute(graph.routes, "/:catcher+");
       // The layout-only ghost parent is not added to routes, but the synthetic
       // sub-route inherits (group-a)'s layout chain.
-      expect(catcher.layouts).toEqual([path.join(appDir, "(group-a)/layout.tsx")]);
+      expect(catcher.layouts).toEqual([appPath(appDir, "(group-a)/layout.tsx")]);
       expect(catcher.parallelSlots).toHaveLength(1);
       expect(catcher.parallelSlots[0]).toMatchObject({
         name: "parallel",
-        pagePath: path.join(appDir, "(group-a)/@parallel/[...catcher]/page.tsx"),
+        pagePath: appPath(appDir, "(group-a)/@parallel/[...catcher]/page.tsx"),
         routeSegments: ["[...catcher]"],
       });
 
-      // The real /foo route belongs to (group-b) only — it must not pick up
+      // The real /foo route belongs to (group-b) only 鈥?it must not pick up
       // slots from the sibling group.
       const foo = findRoute(graph.routes, "/foo");
       expect(foo.parallelSlots).toHaveLength(0);
@@ -333,7 +338,7 @@ describe("App Router route graph builder", () => {
   it("skips synthetic routes that structurally conflict with existing page routes", async () => {
     // A slot sub-page like @feed/[name]/page.tsx under /shop would create /shop/:name,
     // but if /shop/[id]/page.tsx already exists (route /shop/:id), the synthetic route
-    // must be skipped — validateRoutePatterns rejects different slug names at the same
+    // must be skipped 鈥?validateRoutePatterns rejects different slug names at the same
     // dynamic path. The slot content is resolved at render time by findMirroredSlotPage.
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
@@ -428,7 +433,7 @@ describe("App Router route graph builder", () => {
         // The root URL must resolve as a real page, sourced from @children/page.tsx.
         expect(patterns).toContain("/");
         const root = findRoute(graph.routes, "/");
-        expect(root.pagePath).toBe(path.join(appDir, "@children/page.tsx"));
+        expect(root.pagePath).toBe(appPath(appDir, "@children/page.tsx"));
 
         // The catch-all must still cover deeper paths.
         expect(patterns).toContain("/:catchAll+");
@@ -456,7 +461,7 @@ describe("App Router route graph builder", () => {
 
         expect(patterns).toContain("/nested");
         const nested = findRoute(graph.routes, "/nested");
-        expect(nested.pagePath).toBe(path.join(appDir, "nested/@children/page.tsx"));
+        expect(nested.pagePath).toBe(appPath(appDir, "nested/@children/page.tsx"));
       });
     });
   });
@@ -491,13 +496,13 @@ describe("App Router route graph builder", () => {
         expect(patterns).toContain("/baz");
         const baz = findRoute(graph.routes, "/baz");
 
-        // Children fall through to the sibling catch-all (not null → no hang).
-        expect(baz.pagePath).toBe(path.join(appDir, "[...catchAll]/page.tsx"));
+        // Children fall through to the sibling catch-all (not null 鈫?no hang).
+        expect(baz.pagePath).toBe(appPath(appDir, "[...catchAll]/page.tsx"));
 
         // The @slot slot resolves to the explicit @slot/baz page, not the
         // slot's catch-all.
         const slot = baz.parallelSlots.find((s) => s.name === "slot");
-        expect(slot?.pagePath).toBe(path.join(appDir, "@slot/baz/page.tsx"));
+        expect(slot?.pagePath).toBe(appPath(appDir, "@slot/baz/page.tsx"));
 
         // The top-level catch-all is still present for fully-unmatched paths.
         expect(patterns).toContain("/:catchAll+");
@@ -520,8 +525,8 @@ describe("App Router route graph builder", () => {
         const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
         const baz = findRoute(graph.routes, "/baz");
 
-        expect(baz.pagePath).toBe(path.join(appDir, "[...catchAll]/page.tsx"));
-        // Static pattern → no catch-all param captured for the children page.
+        expect(baz.pagePath).toBe(appPath(appDir, "[...catchAll]/page.tsx"));
+        // Static pattern 鈫?no catch-all param captured for the children page.
         expect(baz.isDynamic).toBe(false);
         expect(baz.params).toEqual([]);
         expect(baz.patternParts).toEqual(["baz"]);
@@ -542,7 +547,7 @@ describe("App Router route graph builder", () => {
 
         const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
         const baz = findRoute(graph.routes, "/baz");
-        expect(baz.pagePath).toBe(path.join(appDir, "default.tsx"));
+        expect(baz.pagePath).toBe(appPath(appDir, "default.tsx"));
       });
     });
   });
@@ -550,10 +555,10 @@ describe("App Router route graph builder", () => {
   // Ported from Next.js: test/e2e/app-dir/catchall-parallel-routes-group/
   it("discovers a parallel slot page inside a route group (catchall-parallel-routes-group)", async () => {
     // Fixture mirrors the e2e test:
-    //   app/[...catchAll]/layout.tsx  — layout with `slot` prop
-    //   app/[...catchAll]/page.tsx    — children page
+    //   app/[...catchAll]/layout.tsx  鈥?layout with `slot` prop
+    //   app/[...catchAll]/page.tsx    鈥?children page
     //   app/[...catchAll]/@slot/layout.tsx
-    //   app/[...catchAll]/@slot/(group)/page.tsx  ← page inside route group
+    //   app/[...catchAll]/@slot/(group)/page.tsx  鈫?page inside route group
     //
     // The slot has NO direct page.tsx at the @slot root; the page lives inside
     // a transparent route-group directory. discoverParallelSlots must still
@@ -573,7 +578,7 @@ describe("App Router route graph builder", () => {
       expect(catchAll.parallelSlots).toHaveLength(1);
       expect(catchAll.parallelSlots[0]).toMatchObject({
         name: "slot",
-        pagePath: path.join(appDir, "[...catchAll]/@slot/(group)/page.tsx"),
+        pagePath: appPath(appDir, "[...catchAll]/@slot/(group)/page.tsx"),
         hasPage: true,
         // The route group is transparent in the URL, so routeSegments is empty.
         routeSegments: [],
@@ -596,10 +601,10 @@ describe("App Router route graph builder", () => {
       const route = findRoute(graph.routes, "/group-depth");
       const slot = route.parallelSlots.find((candidate) => candidate.name === "slot");
 
-      expect(route.pagePath).toBe(path.join(appDir, "group-depth/(children)/page.tsx"));
+      expect(route.pagePath).toBe(appPath(appDir, "group-depth/(children)/page.tsx"));
       expect(slot).toMatchObject({
-        pagePath: path.join(appDir, "group-depth/@slot/page.tsx"),
-        layoutPath: path.join(appDir, "group-depth/@slot/layout.tsx"),
+        pagePath: appPath(appDir, "group-depth/@slot/page.tsx"),
+        layoutPath: appPath(appDir, "group-depth/@slot/layout.tsx"),
         routeSegments: [],
       });
     });
@@ -616,7 +621,7 @@ describe("App Router route graph builder", () => {
 
       const about = findRoute(graph.routes, "/about");
       expect(about).toMatchObject({
-        pagePath: path.join(appDir, "(marketing)/about/page.tsx"),
+        pagePath: appPath(appDir, "(marketing)/about/page.tsx"),
         routeSegments: ["(marketing)", "about"],
         patternParts: ["about"],
       });
@@ -638,7 +643,7 @@ describe("App Router route graph builder", () => {
 
       expect(route.layoutTreePositions).toEqual([0]);
       expect(route.layoutErrorPaths).toEqual([null]);
-      expect(route.errorPaths).toEqual([path.join(appDir, "docs/(group)/error.tsx")]);
+      expect(route.errorPaths).toEqual([appPath(appDir, "docs/(group)/error.tsx")]);
       expect(route.errorTreePositions).toEqual([2]);
     });
   });
@@ -1046,8 +1051,8 @@ describe("App Router route graph builder", () => {
       expect(about.parallelSlots).toHaveLength(1);
       expect(about.parallelSlots[0]).toMatchObject({
         name: "breadcrumbs",
-        pagePath: path.join(appDir, "@breadcrumbs/about/page.tsx"),
-        defaultPath: path.join(appDir, "@breadcrumbs/default.tsx"),
+        pagePath: appPath(appDir, "@breadcrumbs/about/page.tsx"),
+        defaultPath: appPath(appDir, "@breadcrumbs/default.tsx"),
         routeSegments: ["about"],
       });
     });
@@ -1064,7 +1069,7 @@ describe("App Router route graph builder", () => {
       const slug = findRoute(graph.routes, "/:slug+");
       expect(slug.parallelSlots[0]).toMatchObject({
         name: "breadcrumbs",
-        pagePath: path.join(appDir, "@breadcrumbs/[...slug]/page.tsx"),
+        pagePath: appPath(appDir, "@breadcrumbs/[...slug]/page.tsx"),
         routeSegments: ["[...slug]"],
       });
     });
@@ -1081,7 +1086,7 @@ describe("App Router route graph builder", () => {
       expect(about.parallelSlots[0]).toMatchObject({
         name: "breadcrumbs",
         pagePath: null,
-        defaultPath: path.join(appDir, "@breadcrumbs/default.tsx"),
+        defaultPath: appPath(appDir, "@breadcrumbs/default.tsx"),
         routeSegments: null,
       });
     });
@@ -1098,8 +1103,8 @@ describe("App Router route graph builder", () => {
       const about = findRoute(graph.routes, "/about");
       expect(about.parallelSlots[0]).toMatchObject({
         name: "breadcrumbs",
-        pagePath: path.join(appDir, "@breadcrumbs/about/page.tsx"),
-        defaultPath: path.join(appDir, "@breadcrumbs/default.tsx"),
+        pagePath: appPath(appDir, "@breadcrumbs/about/page.tsx"),
+        defaultPath: appPath(appDir, "@breadcrumbs/default.tsx"),
         routeSegments: ["about"],
       });
     });
@@ -1115,7 +1120,7 @@ describe("App Router route graph builder", () => {
       const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
       const items = findRoute(graph.routes, "/shop/items");
       expect(items.parallelSlots[0]).toMatchObject({
-        pagePath: path.join(appDir, "@breadcrumbs/shop/items/page.tsx"),
+        pagePath: appPath(appDir, "@breadcrumbs/shop/items/page.tsx"),
         routeSegments: ["shop", "items"],
       });
     });
@@ -1132,7 +1137,7 @@ describe("App Router route graph builder", () => {
       const route = findRoute(graph.routes, "/shop/:id");
       expect(route.parallelSlots[0]).toMatchObject({
         name: "breadcrumbs",
-        pagePath: path.join(appDir, "@breadcrumbs/shop/[name]/page.tsx"),
+        pagePath: appPath(appDir, "@breadcrumbs/shop/[name]/page.tsx"),
         routeSegments: ["shop", "[name]"],
         slotPatternParts: ["shop", ":name"],
         slotParamNames: ["name"],
@@ -1152,7 +1157,7 @@ describe("App Router route graph builder", () => {
       const route = findRoute(graph.routes, "/:teamID/sub/folder");
       expect(route.parallelSlots[0]).toMatchObject({
         name: "slot",
-        pagePath: path.join(appDir, "[teamID]/@slot/[...catchAll]/page.tsx"),
+        pagePath: appPath(appDir, "[teamID]/@slot/[...catchAll]/page.tsx"),
         routeSegments: ["[...catchAll]"],
         slotPatternParts: [":teamID", ":catchAll+"],
         slotParamNames: ["teamID", "catchAll"],
@@ -1172,8 +1177,8 @@ describe("App Router route graph builder", () => {
       const detail = findRoute(graph.routes, "/shop/items/detail");
       expect(detail.parallelSlots[0]).toMatchObject({
         name: "sidebar",
-        pagePath: path.join(appDir, "shop/@sidebar/items/detail/page.tsx"),
-        defaultPath: path.join(appDir, "shop/@sidebar/default.tsx"),
+        pagePath: appPath(appDir, "shop/@sidebar/items/detail/page.tsx"),
+        defaultPath: appPath(appDir, "shop/@sidebar/default.tsx"),
         routeSegments: ["items", "detail"],
         slotPatternParts: ["shop", "items", "detail"],
       });
@@ -1223,23 +1228,26 @@ describe("App Router route graph builder", () => {
     });
   });
 
-  it("skips routes whose param names end in + or * (would collide with internal modifiers)", async () => {
-    // Param names ending in + or * would map to :id+ / :id*, which the trie
-    // matcher interprets as catch-all / optional-catch-all. Skip these routes
-    // entirely to avoid ambiguity.
-    await withTempApp(async (appDir) => {
-      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
-      await writeAppFile(appDir, "[id+]/page.tsx", EMPTY_PAGE);
-      await writeAppFile(appDir, "[id*]/page.tsx", EMPTY_PAGE);
+  itUnlessWindows(
+    "skips routes whose param names end in + or * (would collide with internal modifiers)",
+    async () => {
+      // Param names ending in + or * would map to :id+ / :id*, which the trie
+      // matcher interprets as catch-all / optional-catch-all. Skip these routes
+      // entirely to avoid ambiguity.
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "[id+]/page.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "[id*]/page.tsx", EMPTY_PAGE);
 
-      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
-      const patterns = graph.routes.map((r) => r.pattern);
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((r) => r.pattern);
 
-      expect(patterns).not.toContain("/:id+");
-      expect(patterns).not.toContain("/:id*");
-      expect(patterns).toHaveLength(0);
-    });
-  });
+        expect(patterns).not.toContain("/:id+");
+        expect(patterns).not.toContain("/:id*");
+        expect(patterns).toHaveLength(0);
+      });
+    },
+  );
 
   // Intercepting route source-pattern computation. Mirrors Next.js'
   // `extractInterceptionRouteInformation` which derives the intercepting
@@ -1343,7 +1351,7 @@ describe("App Router route graph builder", () => {
         const intercepts = collectIntercepts(graph.routes);
 
         // sourceMatchPattern derives from interceptParentDir (app/@modal/sub),
-        // stripping the invisible @modal → remaining visible segment "sub" → "/sub".
+        // stripping the invisible @modal 鈫?remaining visible segment "sub" 鈫?"/sub".
         expect(intercepts).toContainEqual(
           expect.objectContaining({
             targetPattern: "/sub/target/:id",
@@ -1449,7 +1457,7 @@ describe("App Router route graph builder", () => {
         const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
         const intercepts = collectIntercepts(graph.routes);
 
-        // (..)(..) target climbs two visible segments from /foo/bar → /,
+        // (..)(..) target climbs two visible segments from /foo/bar 鈫?/,
         // then appends `hoge`. Intercepting route remains /foo/bar.
         expect(intercepts).toContainEqual(
           expect.objectContaining({
@@ -1516,7 +1524,7 @@ describe("App Router route graph builder", () => {
         }
 
         const intercepts = collectSiblingIntercepts(graph.routes);
-        // (..) from templates/ climbs 1 visible segment → target /showcase
+        // (..) from templates/ climbs 1 visible segment 鈫?target /showcase
         expect(intercepts).toContainEqual(
           expect.objectContaining({
             targetPattern: "/showcase",
@@ -1622,13 +1630,13 @@ describe("App Router route graph builder", () => {
         await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
         await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
         await writeAppFile(appDir, "target/page.tsx", EMPTY_PAGE);
-        // Note: no deep/page.tsx or deep/path/page.tsx — both intermediate dirs are empty
+        // Note: no deep/page.tsx or deep/path/page.tsx 鈥?both intermediate dirs are empty
         await writeAppFile(appDir, "deep/path/(...)target/page.tsx", EMPTY_PAGE);
 
         const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
 
         const intercepts = collectSiblingIntercepts(graph.routes);
-        // Must not be dropped — must attach to some route via ancestor walk
+        // Must not be dropped 鈥?must attach to some route via ancestor walk
         expect(intercepts.length).toBeGreaterThan(0);
         const intercept = intercepts.find((ir) => ir.targetPattern === "/target");
         expect(intercept).toBeDefined();
@@ -1657,7 +1665,7 @@ describe("App Router route graph builder", () => {
       ]);
 
       it("terminates the ancestor walk at the forward-slash app root", () => {
-        // deep/path has no route — the walk must stop at appDir and attach to
+        // deep/path has no route 鈥?the walk must stop at appDir and attach to
         // the nearest ancestor route instead of overshooting the app root.
         const owner = findOwnerRouteForDir(
           "C:\\proj\\app\\deep\\path",

--- a/tests/route-sorting.test.ts
+++ b/tests/route-sorting.test.ts
@@ -30,6 +30,10 @@ import { sortRoutes } from "../packages/vinext/src/routing/utils.js";
 const PAGES_DIR = path.resolve(import.meta.dirname, "./fixtures/pages-basic/pages");
 const APP_DIR = path.resolve(import.meta.dirname, "./fixtures/app-basic/app");
 
+function toSlash(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
 async function makeTempDir(prefix: string): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), prefix));
 }
@@ -484,11 +488,11 @@ describe("App Router route sorting (additional)", () => {
 
       expect(membersRoute).toBeDefined();
       expect(membersRoute!.parallelSlots.find((slot) => slot.name === "team")!.pagePath).toContain(
-        path.join("@team", "(a)", "members"),
+        toSlash(path.join("@team", "(a)", "members")),
       );
       expect(
         membersRoute!.parallelSlots.find((slot) => slot.name === "analytics")!.pagePath,
-      ).toContain(path.join("@analytics", "(b)", "members"));
+      ).toContain(toSlash(path.join("@analytics", "(b)", "members")));
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
       invalidateAppRouteCache();
@@ -583,10 +587,10 @@ describe("App Router route sorting (additional)", () => {
 
       expect(teamSlots).toHaveLength(2);
       expect(slotsByOwner.get("dashboard/settings/@team")!.pagePath).toContain(
-        path.join("settings", "@team", "page.tsx"),
+        toSlash(path.join("settings", "@team", "page.tsx")),
       );
       expect(slotsByOwner.get("dashboard/@team")!.pagePath).toContain(
-        path.join("@team", "settings", "page.tsx"),
+        toSlash(path.join("@team", "settings", "page.tsx")),
       );
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
@@ -649,7 +653,7 @@ describe("App Router route sorting (additional)", () => {
 
       expect(teamSlots).toHaveLength(2);
       expect(slotsByOwner.get("dashboard/settings/@team")!.pagePath).toContain(
-        path.join("settings", "@team", "member", "page.tsx"),
+        toSlash(path.join("settings", "@team", "member", "page.tsx")),
       );
       expect(slotsByOwner.get("dashboard/@team")!.pagePath).toBeNull();
     } finally {

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -31,6 +31,12 @@ async function withTempDir<T>(prefix: string, run: (tmpDir: string) => Promise<T
   }
 }
 
+function toSlash(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+const itUnlessWindows = process.platform === "win32" ? it.skip : it;
+
 function makeTestAppRoute(
   pattern: string,
   patternParts: string[],
@@ -379,7 +385,9 @@ describe("apiRouter - route discovery", () => {
       const matchedDocs = matchRoute("/api-docs/first", pages);
       expect(matchedDocs).not.toBeNull();
       expect(matchedDocs!.route.pattern).toBe("/api-docs/:slug+");
-      expect(matchedDocs!.route.filePath).toBe(path.join(pagesDir, "api-docs", "[...slug].tsx"));
+      expect(matchedDocs!.route.filePath).toBe(
+        toSlash(path.join(pagesDir, "api-docs", "[...slug].tsx")),
+      );
 
       const matchedInfo = matchRoute("/api-info", pages);
       expect(matchedInfo).not.toBeNull();
@@ -1364,7 +1372,7 @@ describe("matchAppRoute - URL matching", () => {
       expect(modalSlot!.interceptingRoutes[0]).toMatchObject({
         convention: ".",
         targetPattern: "/explicit-layout/deeper",
-        layoutPaths: [path.join(appDir, "@modal", "(.)explicit-layout", "layout.tsx")],
+        layoutPaths: [toSlash(path.join(appDir, "@modal", "(.)explicit-layout", "layout.tsx"))],
       });
     });
   });
@@ -1400,8 +1408,8 @@ describe("matchAppRoute - URL matching", () => {
       expect(modalSlot).toBeDefined();
       expect(modalSlot!.interceptingRoutes).toHaveLength(1);
       expect(modalSlot!.interceptingRoutes[0]?.layoutPaths).toEqual([
-        path.join(appDir, "@modal", "(.)foo", "layout.tsx"),
-        path.join(appDir, "@modal", "(.)foo", "bar", "layout.tsx"),
+        toSlash(path.join(appDir, "@modal", "(.)foo", "layout.tsx")),
+        toSlash(path.join(appDir, "@modal", "(.)foo", "bar", "layout.tsx")),
       ]);
     });
   });
@@ -1578,7 +1586,7 @@ describe("matchAppRoute - URL matching", () => {
       expect(route!.pagePath).toBeNull();
       expect(route!.parallelSlots.map((slot) => slot.name).sort()).toEqual(["feed", "modal"]);
       expect(route!.parallelSlots.find((slot) => slot.name === "feed")!.pagePath).toContain(
-        path.join("@feed", "page.tsx"),
+        toSlash(path.join("@feed", "page.tsx")),
       );
     });
   });
@@ -1620,7 +1628,9 @@ describe("matchAppRoute - URL matching", () => {
       const nestedRoute = routes.find((r) => r.pattern === "/parallel-nested/home/nested")!;
       expect(nestedRoute.parallelSlots.map((slot) => slot.name).sort()).toEqual(["parallelB"]);
       const parallelBSlot = nestedRoute.parallelSlots.find((slot) => slot.name === "parallelB")!;
-      expect(parallelBSlot.pagePath).toContain(path.join("@parallelB", "nested", "page.tsx"));
+      expect(parallelBSlot.pagePath).toContain(
+        toSlash(path.join("@parallelB", "nested", "page.tsx")),
+      );
     });
   });
 
@@ -1705,7 +1715,7 @@ describe("matchAppRoute - URL matching", () => {
       const homeRoute = routes.find((route) => route.pattern === "/");
 
       expect(homeRoute).toBeDefined();
-      expect(homeRoute!.layouts).toEqual([path.join(appDir, "(group)", "layout.tsx")]);
+      expect(homeRoute!.layouts).toEqual([toSlash(path.join(appDir, "(group)", "layout.tsx"))]);
       expect(homeRoute!.parallelSlots.find((slot) => slot.name === "modal")).toBeUndefined();
     });
   });
@@ -1728,7 +1738,9 @@ describe("matchAppRoute - URL matching", () => {
       expect(modalSlot).toBeDefined();
       expect(modalSlot!.ownerDir).toBe(path.join(appDir, "(group)", "@modal"));
       expect(modalSlot!.layoutIndex).toBe(0);
-      expect(modalSlot!.defaultPath).toBe(path.join(appDir, "(group)", "@modal", "default.tsx"));
+      expect(modalSlot!.defaultPath).toBe(
+        toSlash(path.join(appDir, "(group)", "@modal", "default.tsx")),
+      );
     });
   });
 
@@ -1814,7 +1826,7 @@ describe("pagesRouter - hyphenated param names", () => {
 });
 
 describe("pagesRouter - dotted/colon param names (Next.js parity)", () => {
-  it("discovers dynamic segments with dots and colons", async () => {
+  itUnlessWindows("discovers dynamic segments with dots and colons", async () => {
     await withTempDir("vinext-pages-dotted-param-", async (tmpDir) => {
       const pagesDir = path.join(tmpDir, "pages");
       await mkdir(path.join(pagesDir, "products"), { recursive: true });
@@ -1858,25 +1870,28 @@ describe("pagesRouter - dotted/colon param names (Next.js parity)", () => {
     });
   });
 
-  it("skips routes whose param names end in + or * (would collide with internal modifiers)", async () => {
-    await withTempDir("vinext-pages-skip-plus-", async (tmpDir) => {
-      const pagesDir = path.join(tmpDir, "pages");
-      await mkdir(pagesDir, { recursive: true });
-      await writeFile(
-        path.join(pagesDir, "[id+].tsx"),
-        "export default function Page() { return null; }",
-      );
-      await writeFile(
-        path.join(pagesDir, "[id*].tsx"),
-        "export default function Page() { return null; }",
-      );
+  itUnlessWindows(
+    "skips routes whose param names end in + or * (would collide with internal modifiers)",
+    async () => {
+      await withTempDir("vinext-pages-skip-plus-", async (tmpDir) => {
+        const pagesDir = path.join(tmpDir, "pages");
+        await mkdir(pagesDir, { recursive: true });
+        await writeFile(
+          path.join(pagesDir, "[id+].tsx"),
+          "export default function Page() { return null; }",
+        );
+        await writeFile(
+          path.join(pagesDir, "[id*].tsx"),
+          "export default function Page() { return null; }",
+        );
 
-      invalidateRouteCache(pagesDir);
-      const routes = await pagesRouter(pagesDir);
+        invalidateRouteCache(pagesDir);
+        const routes = await pagesRouter(pagesDir);
 
-      // Skipped entirely to avoid ambiguity with internal :name+ / :name* modifiers
-      expect(routes).toHaveLength(0);
-      invalidateRouteCache(pagesDir);
-    });
-  });
+        // Skipped entirely to avoid ambiguity with internal :name+ / :name* modifiers
+        expect(routes).toHaveLength(0);
+        invalidateRouteCache(pagesDir);
+      });
+    },
+  );
 });

--- a/tests/windows-path-normalization.test.ts
+++ b/tests/windows-path-normalization.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { buildAppRouteGraph } from "../packages/vinext/src/routing/app-route-graph.js";
+import {
+  createValidFileMatcher,
+  scanWithExtensions,
+} from "../packages/vinext/src/routing/file-matcher.js";
+import { invalidateRouteCache, pagesRouter } from "../packages/vinext/src/routing/pages-router.js";
+
+const mockedGlob = vi.hoisted(() => ({
+  entries: new Map<string, string[]>(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    glob: async function* (pattern: string | string[], options?: { cwd?: string }) {
+      const key = `${options?.cwd ?? ""}\0${String(pattern)}`;
+      for (const file of mockedGlob.entries.get(key) ?? []) {
+        yield file;
+      }
+    },
+  };
+});
+
+vi.mock("../packages/vinext/src/utils/path.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../packages/vinext/src/utils/path.js")>();
+  return { ...actual, normalizePathSeparators: (p: string) => p.replace(/\\/g, "/") };
+});
+
+const DEFAULT_PAGE_GLOB = "**/*.{tsx,ts,jsx,js}";
+const DEFAULT_APP_PAGE_GLOB = "**/page.{tsx,ts,jsx,js}";
+const DEFAULT_APP_ROUTE_GLOB = "**/route.{tsx,ts,jsx,js}";
+const DEFAULT_APP_LAYOUT_GLOB = "**/layout.{tsx,ts,jsx,js}";
+const EMPTY_PAGE = "export default function Page() { return null; }\n";
+const EMPTY_LAYOUT = "export default function Layout({ children }) { return children; }\n";
+
+beforeEach(() => {
+  mockedGlob.entries.clear();
+});
+
+function mockGlob(cwd: string, pattern: string, entries: string[]): void {
+  mockedGlob.entries.set(`${cwd}\0${pattern}`, entries);
+}
+
+function toSlash(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+async function withTempDir<T>(prefix: string, run: (tmpDir: string) => Promise<T>): Promise<T> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await run(tmpDir);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe("Windows path normalization", () => {
+  it("normalizes fs.glob results before routing code consumes them", async () => {
+    await withTempDir("vinext-windows-glob-", async (tmpDir) => {
+      mockGlob(tmpDir, "**/*.tsx", ["dashboard\\page.tsx"]);
+
+      const files: string[] = [];
+      for await (const file of scanWithExtensions("**/*", tmpDir, ["tsx"])) {
+        files.push(file);
+      }
+
+      expect(files).toEqual(["dashboard/page.tsx"]);
+    });
+  });
+
+  it("builds Pages Router patterns and file paths from Windows-style scanner output", async () => {
+    await withTempDir("vinext-windows-pages-router-", async (tmpDir) => {
+      const pagesDir = path.join(tmpDir, "pages");
+      await mkdir(pagesDir, { recursive: true });
+      mockGlob(pagesDir, DEFAULT_PAGE_GLOB, ["blog\\[slug].tsx"]);
+      invalidateRouteCache(pagesDir);
+
+      const routes = await pagesRouter(pagesDir);
+
+      expect(routes).toMatchObject([
+        {
+          pattern: "/blog/:slug",
+          patternParts: ["blog", ":slug"],
+          filePath: toSlash(path.join(pagesDir, "blog/[slug].tsx")),
+        },
+      ]);
+    });
+  });
+
+  it("builds App Router routes and graph paths from Windows-style scanner output", async () => {
+    await withTempDir("vinext-windows-app-router-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "dashboard"), { recursive: true });
+      await writeFile(path.join(appDir, "layout.tsx"), EMPTY_LAYOUT);
+      await writeFile(path.join(appDir, "dashboard", "page.tsx"), EMPTY_PAGE);
+      mockGlob(appDir, DEFAULT_APP_PAGE_GLOB, ["dashboard\\page.tsx"]);
+      mockGlob(appDir, DEFAULT_APP_ROUTE_GLOB, []);
+      mockGlob(appDir, DEFAULT_APP_LAYOUT_GLOB, []);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const dashboard = graph.routes.find((route) => route.pattern === "/dashboard");
+
+      expect(dashboard).toBeDefined();
+      expect(dashboard?.routeSegments).toEqual(["dashboard"]);
+      expect(dashboard?.pagePath).toBe(toSlash(path.join(appDir, "dashboard/page.tsx")));
+      expect(dashboard?.layouts).toEqual([toSlash(path.join(appDir, "layout.tsx"))]);
+    });
+  });
+});


### PR DESCRIPTION
﻿## Summary

Part of #1605.

- normalize file scanner and convention-file probe paths to forward slashes for internal routing use
- keep Pages Router and App Router route construction in forward-slash path space on Windows
- update route graph helpers/tests so pagePath, layoutPath, errorPath, slot paths, and scanner output are validated with normalized separators

## Validation

- `corepack pnpm test tests/windows-path-normalization.test.ts tests/app-route-graph.test.ts tests/routing.test.ts tests/route-sorting.test.ts`
- `corepack pnpm run fmt:check`
- `corepack pnpm run check`
