### PR TITLE
fix(image): preserve unoptimized remote URLs

### DIFF
--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -475,6 +475,42 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
         }
       : undefined;
 
+  if (_unoptimized === true) {
+    const sanitizedBlur = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
+    const blurStyle =
+      !blurComplete && placeholder === "blur" && sanitizedBlur
+        ? {
+            backgroundImage: `url(${sanitizedBlur})`,
+            backgroundSize: "cover",
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "center",
+          }
+        : undefined;
+    preloadImageResource({
+      shouldPreload,
+      src,
+      fetchPriority: priorityFetchPriority,
+    });
+    return (
+      <img
+        ref={mergedRef}
+        src={src}
+        alt={alt}
+        width={fill ? undefined : imgWidth}
+        height={fill ? undefined : imgHeight}
+        loading={imageLoading}
+        fetchPriority={priorityFetchPriority}
+        decoding="async"
+        className={className}
+        data-nimg={fill ? "fill" : "1"}
+        onLoad={handleLoad}
+        onError={handleError}
+        style={fill ? getFillStyle(style, blurStyle) : { ...blurStyle, ...style }}
+        {...rest}
+      />
+    );
+  }
+
   // If a custom loader is provided, use basic img with loader URL
   if (loader) {
     const resolvedSrc = loader({ src, width: imgWidth ?? 0, quality: quality ?? 75 });
@@ -532,11 +568,11 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
     const bg = showBlur ? `url(${sanitizedBlur})` : undefined;
 
     if (fill) {
-      const fillSizes = sizes ?? "100vw";
+      const imageSizes = sizes ?? "100vw";
       preloadImageResource({
         shouldPreload,
         src,
-        sizes: fillSizes,
+        sizes: imageSizes,
         fetchPriority: priorityFetchPriority,
       });
       return (
@@ -551,7 +587,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
           loading={imageLoading}
           fetchPriority={priorityFetchPriority}
           decoding="async"
-          sizes={fillSizes}
+          sizes={imageSizes}
           className={className}
           data-nimg="fill"
           onLoad={handleLoad}
@@ -605,7 +641,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   // Next.js behavior where .svg triggers unoptimized=true by default.
   const imgQuality = quality ?? 75;
   const isSvg = isSvgUrl(src);
-  const skipOptimization = _unoptimized === true || (isSvg && !__dangerouslyAllowSVG);
+  const skipOptimization = isSvg && !__dangerouslyAllowSVG;
 
   // Build srcSet for responsive local images (common breakpoints).
   // Each entry points to /_next/image with the appropriate width.
@@ -710,6 +746,34 @@ export function getImageProps(props: ImageProps): {
   } = resolveImageSource({ src: srcProp, width, height, blurDataURL: blurDataURLProp });
   const shouldPreload = _preload === true || priority === true;
 
+  if (_unoptimized === true) {
+    const sanitizedBlurURL = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
+    const blurStyle =
+      placeholder === "blur" && sanitizedBlurURL
+        ? {
+            backgroundImage: `url(${sanitizedBlurURL})`,
+            backgroundSize: "cover",
+            backgroundRepeat: "no-repeat" as const,
+            backgroundPosition: "center" as const,
+          }
+        : undefined;
+    return {
+      props: {
+        src,
+        alt,
+        width: fill ? undefined : imgWidth,
+        height: fill ? undefined : imgHeight,
+        loading: priority ? "eager" : shouldPreload ? loading : (loading ?? "lazy"),
+        fetchPriority: priority ? ("high" as const) : undefined,
+        decoding: "async" as const,
+        className,
+        "data-nimg": fill ? "fill" : "1",
+        style: fill ? getFillStyle(style, blurStyle) : { ...blurStyle, ...style },
+        ...rest,
+      } as React.ImgHTMLAttributes<HTMLImageElement>,
+    };
+  }
+
   // Validate remote URLs against configured patterns
   let blockedInProd = false;
   if (isRemoteUrl(src)) {
@@ -737,11 +801,7 @@ export function getImageProps(props: ImageProps): {
   // SVG sources auto-skip unless dangerouslyAllowSVG is enabled.
   const isSvg = isSvgUrl(resolvedSrc);
   const skipOpt =
-    _unoptimized === true ||
-    (isSvg && !__dangerouslyAllowSVG) ||
-    blockedInProd ||
-    !!loader ||
-    isRemoteUrl(resolvedSrc);
+    (isSvg && !__dangerouslyAllowSVG) || blockedInProd || !!loader || isRemoteUrl(resolvedSrc);
   const optimizedSrc = skipOpt
     ? resolvedSrc
     : imgWidth

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -333,7 +333,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
     onLoadingComplete,
     onError,
     unoptimized: _unoptimized,
-    overrideSrc: _overrideSrc,
+    overrideSrc,
     loading,
     ...rest
   },
@@ -476,6 +476,10 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
       : undefined;
 
   if (_unoptimized === true) {
+    // Unoptimized images are fetched directly by the browser, so intentionally
+    // skip remote URL validation: there is no server-side optimizer fetch and
+    // therefore no SSRF surface. This matches Next.js behavior.
+    const renderedSrc = overrideSrc || src;
     const sanitizedBlur = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
     const blurStyle =
       !blurComplete && placeholder === "blur" && sanitizedBlur
@@ -488,13 +492,13 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
         : undefined;
     preloadImageResource({
       shouldPreload,
-      src,
+      src: renderedSrc,
       fetchPriority: priorityFetchPriority,
     });
     return (
       <img
         ref={mergedRef}
-        src={src}
+        src={renderedSrc}
         alt={alt}
         width={fill ? undefined : imgWidth}
         height={fill ? undefined : imgHeight}
@@ -733,7 +737,7 @@ export function getImageProps(props: ImageProps): {
     onLoad: _onLoad,
     onLoadingComplete: _onLoadingComplete,
     unoptimized: _unoptimized,
-    overrideSrc: _overrideSrc,
+    overrideSrc,
     loading,
     ...rest
   } = props;
@@ -747,6 +751,9 @@ export function getImageProps(props: ImageProps): {
   const shouldPreload = _preload === true || priority === true;
 
   if (_unoptimized === true) {
+    // As in the component path, unoptimized images never reach the server-side
+    // optimizer, so remote URL validation is intentionally unnecessary.
+    const renderedSrc = overrideSrc || src;
     const sanitizedBlurURL = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
     const blurStyle =
       placeholder === "blur" && sanitizedBlurURL
@@ -759,7 +766,7 @@ export function getImageProps(props: ImageProps): {
         : undefined;
     return {
       props: {
-        src,
+        src: renderedSrc,
         alt,
         width: fill ? undefined : imgWidth,
         height: fill ? undefined : imgHeight,

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -758,6 +758,38 @@ describe("unoptimized remote images", () => {
     expect(props.src).toBe(src);
   });
 
+  // Ported from Next.js: test/unit/next-image-get-img-props.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/unit/next-image-get-img-props.test.ts
+  it("honors overrideSrc", () => {
+    const src = "https://imagedelivery.net/accountHash/imageId/public";
+    const overrideSrc = "https://cdn.example.com/original.jpg";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "cloudflare image",
+        src,
+        overrideSrc,
+        width: 100,
+        height: 100,
+        unoptimized: true,
+        priority: true,
+      }),
+    );
+
+    expect(html).toContain(`src="${overrideSrc}"`);
+    expect(html).not.toContain(`src="${src}"`);
+
+    const { props } = getImageProps({
+      alt: "cloudflare image",
+      src,
+      overrideSrc,
+      width: 100,
+      height: 100,
+      unoptimized: true,
+    });
+    expect(props.src).toBe(overrideSrc);
+    expect(props.srcSet).toBeUndefined();
+  });
+
   it("bypasses remote pattern validation in production", async () => {
     vi.stubEnv("NODE_ENV", "production");
     process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -681,6 +681,120 @@ describe("onLoadingComplete prop", () => {
   });
 });
 
+// Ported from Next.js: test/e2e/next-image-new/unoptimized/unoptimized.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/next-image-new/unoptimized/unoptimized.test.ts
+describe("unoptimized remote images", () => {
+  it("preserves a Cloudflare Images variant URL without generating srcSet", () => {
+    const src = "https://imagedelivery.net/accountHash/imageId/public";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "cloudflare image",
+        src,
+        width: 100,
+        height: 100,
+        unoptimized: true,
+        placeholder: "blur",
+        blurDataURL: "data:image/png;base64,test",
+        style: { borderRadius: 8 },
+      }),
+    );
+
+    expect(html).toContain(`src="${src}"`);
+    expect(html).toContain('width="100"');
+    expect(html).toContain('height="100"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('data-nimg="1"');
+    expect(html).toContain("background-image:url(data:image/png;base64,test)");
+    expect(html).toContain("border-radius:8px");
+    expect(html).not.toContain("public=undefined");
+    expect(html).not.toContain("srcSet");
+    expect(html).not.toContain("sizes=");
+
+    const { props } = getImageProps({
+      alt: "cloudflare image",
+      src,
+      width: 100,
+      height: 100,
+      unoptimized: true,
+      placeholder: "blur",
+      blurDataURL: "data:image/png;base64,test",
+      style: { borderRadius: 8 },
+    });
+    expect(props.src).toBe(src);
+    expect(props.srcSet).toBeUndefined();
+    expect(props.sizes).toBeUndefined();
+    expect(props.style).toMatchObject({
+      backgroundImage: "url(data:image/png;base64,test)",
+      borderRadius: 8,
+    });
+  });
+
+  it("does not invoke a custom loader", () => {
+    const loader = vi.fn(() => "https://cdn.example.com/transformed.jpg");
+    const src = "https://imagedelivery.net/accountHash/imageId/public";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "cloudflare image",
+        src,
+        width: 100,
+        height: 100,
+        unoptimized: true,
+        loader,
+      }),
+    );
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(html).toContain(`src="${src}"`);
+
+    const { props } = getImageProps({
+      alt: "cloudflare image",
+      src,
+      width: 100,
+      height: 100,
+      unoptimized: true,
+      loader,
+    });
+    expect(loader).not.toHaveBeenCalled();
+    expect(props.src).toBe(src);
+  });
+
+  it("bypasses remote pattern validation in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([
+      { hostname: "allowed.example.com" },
+    ]);
+
+    vi.resetModules();
+    const { default: UnoptimizedImage, getImageProps: getUnoptimizedImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const src = "https://imagedelivery.net/accountHash/imageId/public";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(UnoptimizedImage, {
+        alt: "cloudflare image",
+        src,
+        width: 100,
+        height: 100,
+        unoptimized: true,
+      }),
+    );
+
+    expect(html).toContain(`src="${src}"`);
+    expect(
+      getUnoptimizedImageProps({
+        alt: "cloudflare image",
+        src,
+        width: 100,
+        height: 100,
+        unoptimized: true,
+      }).props.src,
+    ).toBe(src);
+
+    vi.unstubAllEnvs();
+    delete process.env.__VINEXT_IMAGE_REMOTE_PATTERNS;
+    vi.resetModules();
+  });
+});
+
 // ─── Reproduction: priority prop on remote URL paths ────────────────────
 // Regression tests for:
 //   "Received `true` for a non-boolean attribute `priority`."


### PR DESCRIPTION
## Summary

- render explicitly `unoptimized` images as a plain `<img>` before custom loaders, remote URL validation, or `@unpic/react` transforms
- keep `Image` and `getImageProps()` aligned with Next.js by preserving the original `src` and omitting generated `srcSet`/`sizes`
- add regression coverage for Cloudflare Images named variants, custom loader bypass, remote pattern bypass, and existing image attributes/styles

## Reproduction

Before this change, rendering:

```tsx
<Image
  alt="cloudflare image"
  src="https://imagedelivery.net/accountHash/imageId/public"
  width={100}
  height={100}
  unoptimized
/>
```

produced a malformed URL containing `public=undefined` through `@unpic/react`.

The focused regression reproduced the exact malformed `src` and `srcSet` before the fix.

## Next.js parity

Next.js returns the original `src` before invoking its loader when `unoptimized` is enabled, with no generated `srcSet` or `sizes`:

- `test/e2e/next-image-new/unoptimized/unoptimized.test.ts`
- `packages/next/src/shared/lib/get-img-props.ts` (`generateImgAttrs`)

## Validation

- `vp test run tests/image-component.test.ts tests/shims.test.ts` — 1,197 passed
- `vp check packages/vinext/src/shims/image.tsx tests/image-component.test.ts`
- `vp run vinext#build`
- `git diff --check`
- independent sub-agent review — initial findings addressed; second pass returned `NO FINDINGS`

Fixes #2136

