### PR TITLE
feat(web): show fifty benchmark runs

### DIFF
--- a/apps/web/app/benchmarks/page.tsx
+++ b/apps/web/app/benchmarks/page.tsx
@@ -8,7 +8,7 @@ export const revalidate = 300;
  * The interactive dashboard (tabs, charts, data fetching) is a client component.
  */
 export default async function HomePage() {
-  const runs = await getPerformanceRuns(20);
+  const runs = await getPerformanceRuns();
 
   return (
     <div className="mx-auto w-full max-w-6xl px-6 py-8">

--- a/apps/web/app/lib/benchmarks/server.ts
+++ b/apps/web/app/lib/benchmarks/server.ts
@@ -304,7 +304,7 @@ type PerformanceComparisonMeasurementData = Omit<
   profileUrl: string | null;
 };
 
-export async function getPerformanceRuns(limit = 20): Promise<PerformanceRunData[]> {
+export async function getPerformanceRuns(limit = 50): Promise<PerformanceRunData[]> {
   const boundedLimit = Math.max(1, Math.min(limit, 100));
   const db = getD1();
   const { results } = await db

--- a/benchmarks/perf/scenarios.json
+++ b/benchmarks/perf/scenarios.json
@@ -14,16 +14,16 @@
       "lowerIsBetter": true,
       "implementations": [
         {
-          "id": "vinext",
-          "label": "vinext",
-          "profile": true,
-          "command": ["node", "benchmarks/perf/cold-start.mjs", "vinext", "/"]
-        },
-        {
           "id": "nextjs",
           "label": "Next.js",
           "profile": false,
           "command": ["node", "benchmarks/perf/cold-start.mjs", "nextjs", "/"]
+        },
+        {
+          "id": "vinext",
+          "label": "vinext",
+          "profile": true,
+          "command": ["node", "benchmarks/perf/cold-start.mjs", "vinext", "/"]
         }
       ]
     },
@@ -36,16 +36,16 @@
       "lowerIsBetter": true,
       "implementations": [
         {
-          "id": "vinext",
-          "label": "vinext",
-          "profile": true,
-          "command": ["node", "benchmarks/perf/build-time.mjs", "vinext"]
-        },
-        {
           "id": "nextjs",
           "label": "Next.js",
           "profile": false,
           "command": ["node", "benchmarks/perf/build-time.mjs", "nextjs"]
+        },
+        {
+          "id": "vinext",
+          "label": "vinext",
+          "profile": true,
+          "command": ["node", "benchmarks/perf/build-time.mjs", "vinext"]
         }
       ]
     },
@@ -58,16 +58,16 @@
       "lowerIsBetter": true,
       "implementations": [
         {
-          "id": "vinext",
-          "label": "vinext",
-          "profile": false,
-          "command": ["node", "benchmarks/perf/bundle-size.mjs", "vinext"]
-        },
-        {
           "id": "nextjs",
           "label": "Next.js",
           "profile": false,
           "command": ["node", "benchmarks/perf/bundle-size.mjs", "nextjs"]
+        },
+        {
+          "id": "vinext",
+          "label": "vinext",
+          "profile": false,
+          "command": ["node", "benchmarks/perf/bundle-size.mjs", "vinext"]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- show the latest 50 main-branch performance runs by default
- keep the default in the shared server query helper

## Validation
- `vp check apps/web/app/benchmarks/page.tsx apps/web/app/lib/benchmarks/server.ts`
- `vp run knip`
- `git diff --check`