### PR TITLE
fix(perf): trace sandboxed benchmark processes

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -159,6 +159,7 @@ jobs:
           tar -xzf /tmp/perf-runner.tar.gz -C /tmp
           install -m 0755 /tmp/codspeed-runner-x86_64-unknown-linux-musl/codspeed "$HOME/.local/bin/codspeed"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "VINEXT_PERF_PROFILER_BIN=$HOME/.local/bin/codspeed" >> "$GITHUB_ENV"
 
       - name: Measure performance scenarios
         run: node "$VINEXT_PERF_HARNESS_ROOT/benchmarks/perf/run-scenarios.mjs"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -140,6 +140,8 @@ jobs:
           rm -rf "$VINEXT_PERF_RESULTS_ROOT"
           mkdir -p "$VINEXT_PERF_RESULTS_ROOT"
           chmod 700 "$VINEXT_PERF_RESULTS_ROOT"
+          sudo setfacl -m u:vinext-perf:rwx "$VINEXT_PERF_RESULTS_ROOT"
+          sudo setfacl -d -m u:vinext-perf:rwX,u:"$USER":rwX "$VINEXT_PERF_RESULTS_ROOT"
           for project in vinext nextjs; do
             find "benchmarks/$project" -mindepth 1 -maxdepth 1 \
               ! -name app ! -name node_modules ! -name dist ! -name .next -exec rm -rf {} +

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -155,6 +155,8 @@ jobs:
 
       - name: Install pinned performance runner
         run: |
+          sudo sysctl -w kernel.kptr_restrict=0
+          sudo sysctl -w kernel.perf_event_paranoid=-1
           curl -fsSL https://github.com/CodSpeedHQ/codspeed/releases/download/v4.17.5/codspeed-runner-x86_64-unknown-linux-musl.tar.gz -o /tmp/perf-runner.tar.gz
           echo "88be40970bbe409192dec6f6242489ee916a4b2d8c4138b42b796853111c9b15  /tmp/perf-runner.tar.gz" | sha256sum -c
           mkdir -p "$HOME/.local/bin"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -170,6 +170,7 @@ jobs:
             "$VINEXT_PERF_RESULTS_ROOT/perf-samples.jsonl" \
             "$VINEXT_PERF_RESULTS_ROOT/perf-results.json" \
             "$VINEXT_PERF_RESULTS_ROOT/perf-profiles"
+          sudo chmod -R a+rX "$VINEXT_PERF_RESULTS_ROOT"
 
       - name: Upload performance artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -32,7 +32,11 @@ function targetCommand(command) {
 }
 
 function profilerCommand() {
-  return targetUser ? ["sudo", "-E", "--", profilerBin] : [profilerBin];
+  if (!targetUser) return [profilerBin];
+  const preservedEnvironment = ["HOME", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"].flatMap((name) =>
+    process.env[name] ? [`${name}=${process.env[name]}`] : [],
+  );
+  return ["sudo", "-E", "--", "env", ...preservedEnvironment, profilerBin];
 }
 
 function run(command, args, env, cwd = targetRoot) {

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -33,8 +33,8 @@ function targetCommand(command) {
 
 function profilerCommand() {
   if (!targetUser) return [profilerBin];
-  const preservedEnvironment = ["HOME", "PATH", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"].flatMap((name) =>
-    process.env[name] ? [`${name}=${process.env[name]}`] : [],
+  const preservedEnvironment = ["HOME", "PATH", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"].flatMap(
+    (name) => (process.env[name] ? [`${name}=${process.env[name]}`] : []),
   );
   return ["sudo", "-E", "--", "env", ...preservedEnvironment, profilerBin];
 }

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -32,19 +32,27 @@ function targetCommand(command) {
 }
 
 function profilerCommand() {
-  return targetUser
-    ? [
-        "sudo",
-        "-E",
-        "-H",
-        "-u",
-        targetUser,
-        "--",
-        "env",
-        `PATH=/home/${targetUser}/.local/bin:${process.env.PATH}`,
-        profilerBin,
-      ]
-    : [profilerBin];
+  if (!targetUser) return [profilerBin];
+  const targetHome = `/home/${targetUser}`;
+  return [
+    "sudo",
+    "-E",
+    "-H",
+    "-u",
+    targetUser,
+    "--",
+    "env",
+    "-u",
+    "GITHUB_ENV",
+    "-u",
+    "GITHUB_PATH",
+    `HOME=${targetHome}`,
+    `CARGO_HOME=${targetHome}/.cargo`,
+    `XDG_CACHE_HOME=${targetHome}/.cache`,
+    `XDG_CONFIG_HOME=${targetHome}/.config`,
+    `PATH=${targetHome}/.cargo/bin:${targetHome}/.local/bin:${process.env.PATH}`,
+    profilerBin,
+  ];
 }
 
 function run(command, args, env, cwd = targetRoot) {

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -9,6 +9,7 @@ import { performanceScenarios, performanceSetup, benchmarkId } from "./scenarios
 const harnessRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const targetRoot = process.env.VINEXT_PERF_TARGET_ROOT ?? process.cwd();
 const targetUser = process.env.VINEXT_PERF_TARGET_USER;
+const profilerBin = process.env.VINEXT_PERF_PROFILER_BIN ?? "codspeed";
 const resultsRoot = process.env.VINEXT_PERF_RESULTS_ROOT ?? join(targetRoot, "benchmarks/results");
 const direct = process.argv.includes("--direct");
 const setupOnly = process.argv.includes("--setup-only");
@@ -28,6 +29,10 @@ function trustedCommand(command) {
 function targetCommand(command) {
   if (!targetUser) return command;
   return ["sudo", "-E", "-H", "-u", targetUser, "--", ...command];
+}
+
+function profilerCommand() {
+  return targetUser ? ["sudo", "-E", "--", profilerBin] : [profilerBin];
 }
 
 function run(command, args, env, cwd = targetRoot) {
@@ -94,9 +99,11 @@ for (const scenario of performanceScenarios) {
       : [];
     if (profile) await mkdir(join(resultsRoot, `perf-profiles/${id}`), { recursive: true });
     const command = trustedCommand(implementation.command);
+    const profiler = profilerCommand();
     await run(
-      "codspeed",
+      profiler[0],
       [
+        ...profiler.slice(1),
         "exec",
         "--mode",
         "walltime",

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -32,11 +32,19 @@ function targetCommand(command) {
 }
 
 function profilerCommand() {
-  if (!targetUser) return [profilerBin];
-  const preservedEnvironment = ["HOME", "PATH", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"].flatMap(
-    (name) => (process.env[name] ? [`${name}=${process.env[name]}`] : []),
-  );
-  return ["sudo", "-E", "--", "env", ...preservedEnvironment, profilerBin];
+  return targetUser
+    ? [
+        "sudo",
+        "-E",
+        "-H",
+        "-u",
+        targetUser,
+        "--",
+        "env",
+        `PATH=/home/${targetUser}/.local/bin:${process.env.PATH}`,
+        profilerBin,
+      ]
+    : [profilerBin];
 }
 
 function run(command, args, env, cwd = targetRoot) {
@@ -104,6 +112,8 @@ for (const scenario of performanceScenarios) {
     if (profile) await mkdir(join(resultsRoot, `perf-profiles/${id}`), { recursive: true });
     const command = trustedCommand(implementation.command);
     const profiler = profilerCommand();
+    const profilerEnv = { ...env };
+    if (targetUser) delete profilerEnv.VINEXT_PERF_TARGET_USER;
     await run(
       profiler[0],
       [
@@ -125,7 +135,7 @@ for (const scenario of performanceScenarios) {
         "--",
         ...command,
       ],
-      env,
+      profilerEnv,
       targetRoot,
     );
   }

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -33,7 +33,7 @@ function targetCommand(command) {
 
 function profilerCommand() {
   if (!targetUser) return [profilerBin];
-  const preservedEnvironment = ["HOME", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"].flatMap((name) =>
+  const preservedEnvironment = ["HOME", "PATH", "XDG_CACHE_HOME", "XDG_CONFIG_HOME"].flatMap((name) =>
     process.env[name] ? [`${name}=${process.env[name]}`] : [],
   );
   return ["sudo", "-E", "--", "env", ...preservedEnvironment, profilerBin];


### PR DESCRIPTION
## Summary
- run the pinned trusted wall-time profiler with enough privilege to follow the sandboxed benchmark process tree
- keep the actual vinext/Next.js commands running as the isolated `vinext-perf` user
- pass the absolute pinned profiler path through the trusted harness

## Regression
The isolation hardening moved benchmark commands behind a cross-user `sudo` boundary. Samply continued profiling the runner-owned adapter but no longer captured the vinext/Vite/Rolldown child process, leaving only ~226 ms of samples for a ~2.74 s cold start.

## Validation
- `vp check benchmarks/perf/run-scenarios.mjs`
- `vp test run scripts/performance-trace.test.ts`
- `actionlint .github/workflows/perf.yml`
- `zizmor --format plain .github/workflows/perf.yml`
- `vp run knip`
- `git diff --check`

I will verify the generated raw profile artifact on this PR before marking it ready.