### PR TITLE
perf(app-router): defer prerender endpoint & file metadata runtimes

### DIFF
--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -9,7 +9,6 @@ import {
   type Viewport,
 } from "vinext/shims/metadata";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
-import { applyFileBasedMetadata } from "./file-based-metadata.js";
 import type { AppPageParams } from "./app-page-boundary.js";
 import { tagAppPageMetadataError } from "./app-page-execution.js";
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
@@ -440,26 +439,29 @@ async function resolveAppPageHeadInner<TModule extends AppPageHeadModule>(
   metadataSources.push(...parallelMetadataSources);
   let metadata = resolvedMetadataBase;
 
-  try {
-    metadata = await applyFileBasedMetadata(
-      resolvedMetadataBase,
-      options.routePath,
-      options.params,
-      options.metadataRoutes,
-      {
-        routeSegments,
-        metadataSources,
-        basePath: options.basePath ?? "",
-      },
-    );
-  } catch (error) {
-    if (!options.fallbackOnFileMetadataError) {
-      throw error;
+  if (options.metadataRoutes.length > 0) {
+    try {
+      const { applyFileBasedMetadata } = await import("./file-based-metadata.js");
+      metadata = await applyFileBasedMetadata(
+        resolvedMetadataBase,
+        options.routePath,
+        options.params,
+        options.metadataRoutes,
+        {
+          routeSegments,
+          metadataSources,
+          basePath: options.basePath ?? "",
+        },
+      );
+    } catch (error) {
+      if (!options.fallbackOnFileMetadataError) {
+        throw error;
+      }
+      console.error(
+        `[vinext] File-based metadata resolution failed while rendering error boundary for ${options.routePath}:`,
+        error,
+      );
     }
-    console.error(
-      `[vinext] File-based metadata resolution failed while rendering error boundary for ${options.routePath}:`,
-      error,
-    );
   }
 
   if (metadata) {

--- a/packages/vinext/src/server/app-prerender-endpoints.ts
+++ b/packages/vinext/src/server/app-prerender-endpoints.ts
@@ -1,11 +1,15 @@
 import { callAppPrerenderStaticParams } from "./app-prerender-static-params.js";
+import {
+  VINEXT_PRERENDER_PAGES_STATIC_PATHS_PATH,
+  VINEXT_PRERENDER_STATIC_PARAMS_PATH,
+} from "./headers.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import type { RootParams } from "vinext/shims/root-params";
 
 type GenerateStaticParams = (args: { params: RootParams }) => unknown;
 
-type AppPrerenderStaticParamsMap = Record<string, GenerateStaticParams | null | undefined>;
-type RootParamNamesMap = Record<string, readonly string[] | undefined>;
+export type AppPrerenderStaticParamsMap = Record<string, GenerateStaticParams | null | undefined>;
+export type AppPrerenderRootParamNamesMap = Record<string, readonly string[] | undefined>;
 
 type AppPrerenderPageRoute = {
   pattern: string;
@@ -18,23 +22,21 @@ type HandleAppPrerenderEndpointOptions = {
   isPrerenderEnabled?: () => boolean;
   loadPagesRoutes?: () => Promise<unknown>;
   pathname: string;
-  rootParamNamesByPattern?: RootParamNamesMap;
+  rootParamNamesByPattern?: AppPrerenderRootParamNamesMap;
   staticParamsMap: AppPrerenderStaticParamsMap;
 };
 
-const STATIC_PARAMS_ENDPOINT = "/__vinext/prerender/static-params";
-const PAGES_STATIC_PATHS_ENDPOINT = "/__vinext/prerender/pages-static-paths";
 const JSON_HEADERS = { "content-type": "application/json" };
 
 export async function handleAppPrerenderEndpoint(
   request: Request,
   options: HandleAppPrerenderEndpointOptions,
 ): Promise<Response | null> {
-  if (options.pathname === STATIC_PARAMS_ENDPOINT) {
+  if (options.pathname === VINEXT_PRERENDER_STATIC_PARAMS_PATH) {
     return handleStaticParamsEndpoint(request, options);
   }
 
-  if (options.pathname === PAGES_STATIC_PATHS_ENDPOINT) {
+  if (options.pathname === VINEXT_PRERENDER_PAGES_STATIC_PATHS_PATH) {
     if (!options.loadPagesRoutes) return null;
     return handlePagesStaticPathsEndpoint(request, options);
   }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -65,7 +65,10 @@ import {
   resolveDevImageRedirect,
   type ImageConfig,
 } from "./image-optimization.js";
-import { handleMetadataRouteRequest } from "./metadata-route-response.js";
+import type {
+  MetadataRouteMakeThenableParams,
+  MetadataRuntimeRoute,
+} from "./metadata-route-response.js";
 import type { MiddlewareModule } from "./middleware-runtime.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
@@ -88,9 +91,9 @@ import {
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
-type MetadataRoutes = Parameters<typeof handleMetadataRouteRequest>[0]["metadataRoutes"];
+type MetadataRoutes = readonly MetadataRuntimeRoute[];
 const STATIC_METADATA_CONFIG_HEADER_OVERRIDES = new Set(["cache-control"]);
-type MakeThenableParams = Parameters<typeof handleMetadataRouteRequest>[0]["makeThenableParams"];
+type MakeThenableParams = MetadataRouteMakeThenableParams;
 type StaticParamsMap = AppPrerenderStaticParamsMap;
 type RootParamNamesMap = AppPrerenderRootParamNamesMap;
 
@@ -655,20 +658,23 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     return Response.redirect(new URL(imageRedirect, url.origin).href, 302);
   }
 
-  const metadataRouteResponse = await handleMetadataRouteRequest({
-    metadataRoutes: options.metadataRoutes,
-    cleanPathname,
-    makeThenableParams: options.makeThenableParams,
-  });
-  if (metadataRouteResponse) {
-    applyConfigHeadersToResponse(metadataRouteResponse.headers, {
-      basePathState,
-      configHeaders: options.configHeaders,
-      overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
-      pathname: matchPathname(cleanPathname),
-      requestContext: preMiddlewareRequestContext,
+  if (options.metadataRoutes.length > 0) {
+    const { handleMetadataRouteRequest } = await import("./metadata-route-response.js");
+    const metadataRouteResponse = await handleMetadataRouteRequest({
+      metadataRoutes: options.metadataRoutes,
+      cleanPathname,
+      makeThenableParams: options.makeThenableParams,
     });
-    return applyMiddlewareContextToResponse(metadataRouteResponse, middlewareContext);
+    if (metadataRouteResponse) {
+      applyConfigHeadersToResponse(metadataRouteResponse.headers, {
+        basePathState,
+        configHeaders: options.configHeaders,
+        overwriteExisting: STATIC_METADATA_CONFIG_HEADER_OVERRIDES,
+        pathname: matchPathname(cleanPathname),
+        requestContext: preMiddlewareRequestContext,
+      });
+      return applyMiddlewareContextToResponse(metadataRouteResponse, middlewareContext);
+    }
   }
 
   const publicFileResponse = resolvePublicFileRoute({

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -21,7 +21,9 @@ import {
   RSC_ACTION_HEADER,
   RSC_HEADER,
   VINEXT_MW_CTX_HEADER,
+  VINEXT_PRERENDER_PAGES_STATIC_PATHS_PATH,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+  VINEXT_PRERENDER_STATIC_PARAMS_PATH,
 } from "./headers.js";
 import { ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
@@ -36,7 +38,10 @@ import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base
 import { mergeRewriteQuery } from "../utils/query.js";
 import type { AppMiddlewareContext } from "./app-middleware.js";
 import { mergeMiddlewareResponseHeaders } from "./app-page-response.js";
-import { handleAppPrerenderEndpoint } from "./app-prerender-endpoints.js";
+import type {
+  AppPrerenderRootParamNamesMap,
+  AppPrerenderStaticParamsMap,
+} from "./app-prerender-endpoints.js";
 import {
   createRscRedirectLocation,
   hasRscCacheBustingSearchParam,
@@ -86,10 +91,8 @@ type RequestContext = ReturnType<typeof requestContextFromRequest>;
 type MetadataRoutes = Parameters<typeof handleMetadataRouteRequest>[0]["metadataRoutes"];
 const STATIC_METADATA_CONFIG_HEADER_OVERRIDES = new Set(["cache-control"]);
 type MakeThenableParams = Parameters<typeof handleMetadataRouteRequest>[0]["makeThenableParams"];
-type StaticParamsMap = Parameters<typeof handleAppPrerenderEndpoint>[1]["staticParamsMap"];
-type RootParamNamesMap = Parameters<
-  typeof handleAppPrerenderEndpoint
->[1]["rootParamNamesByPattern"];
+type StaticParamsMap = AppPrerenderStaticParamsMap;
+type RootParamNamesMap = AppPrerenderRootParamNamesMap;
 
 type AppRscMiddlewareContext = AppMiddlewareContext;
 
@@ -489,16 +492,22 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   // issue #1333.
   const basePathState = { basePath: options.basePath, hadBasePath: true };
 
-  const prerenderEndpointResponse = await handleAppPrerenderEndpoint(request, {
-    isPrerenderEnabled() {
-      return process.env.VINEXT_PRERENDER === "1";
-    },
-    loadPagesRoutes: options.loadPrerenderPagesRoutes,
-    pathname,
-    rootParamNamesByPattern: options.rootParamNamesByPattern,
-    staticParamsMap: options.staticParamsMap,
-  });
-  if (prerenderEndpointResponse) return prerenderEndpointResponse;
+  if (
+    pathname === VINEXT_PRERENDER_STATIC_PARAMS_PATH ||
+    pathname === VINEXT_PRERENDER_PAGES_STATIC_PATHS_PATH
+  ) {
+    const { handleAppPrerenderEndpoint } = await import("./app-prerender-endpoints.js");
+    const prerenderEndpointResponse = await handleAppPrerenderEndpoint(request, {
+      isPrerenderEnabled() {
+        return process.env.VINEXT_PRERENDER === "1";
+      },
+      loadPagesRoutes: options.loadPrerenderPagesRoutes,
+      pathname,
+      rootParamNamesByPattern: options.rootParamNamesByPattern,
+      staticParamsMap: options.staticParamsMap,
+    });
+    if (prerenderEndpointResponse) return prerenderEndpointResponse;
+  }
 
   const trailingSlashRedirect = normalizeTrailingSlash(
     pathname,

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -34,6 +34,12 @@ export const VINEXT_PRERENDER_SECRET_HEADER = "x-vinext-prerender-secret";
 /** URL-encoded JSON route params for build-time prerender renders. */
 export const VINEXT_PRERENDER_ROUTE_PARAMS_HEADER = "x-vinext-prerender-route-params";
 
+/** Internal endpoint used to evaluate App Router generateStaticParams exports. */
+export const VINEXT_PRERENDER_STATIC_PARAMS_PATH = "/__vinext/prerender/static-params";
+
+/** Internal endpoint used to evaluate Pages Router getStaticPaths exports. */
+export const VINEXT_PRERENDER_PAGES_STATIC_PATHS_PATH = "/__vinext/prerender/pages-static-paths";
+
 /** TPR (Tailored Per-Request) revalidation interval in seconds. */
 export const VINEXT_REVALIDATE_HEADER = "x-vinext-revalidate";
 

--- a/packages/vinext/src/server/metadata-route-response.ts
+++ b/packages/vinext/src/server/metadata-route-response.ts
@@ -13,16 +13,16 @@ import { notFoundResponse } from "./http-error-responses.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type MetadataRouteFunction = (props: Record<string, unknown>) => unknown;
-type MakeThenableParams = (params: AppPageParams) => unknown;
+export type MetadataRouteMakeThenableParams = (params: AppPageParams) => unknown;
 
-type MetadataRuntimeRoute = MetadataFileRoute & {
+export type MetadataRuntimeRoute = MetadataFileRoute & {
   fileDataBase64?: string;
 };
 
 type MetadataRouteRequestOptions = {
   metadataRoutes: readonly MetadataRuntimeRoute[];
   cleanPathname: string;
-  makeThenableParams: MakeThenableParams;
+  makeThenableParams: MetadataRouteMakeThenableParams;
 };
 
 type MatchedMetadataRoute = {
@@ -263,7 +263,7 @@ function findGeneratedImageId(
 async function callDynamicMetadataRoute(
   route: MetadataRuntimeRoute,
   match: MatchedMetadataRoute,
-  makeThenableParams: MakeThenableParams,
+  makeThenableParams: MetadataRouteMakeThenableParams,
   functions: MetadataRouteFunctions,
 ): Promise<Response> {
   if (!functions.defaultExport) {


### PR DESCRIPTION
Another PR that defers code until it is needed. This time, prerender endpoint and file-based metadata runtimes.

## Why?

Typical App Router page requests do not use these paths.

Loading them lazily reduces development cold-start and first-page compilation work without changing prerender or metadata behavior.

Cold start time got reduced by ~22ms on my machine