### PR TITLE
fix(perf): stabilize stale pull request benchmarks

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -40,13 +40,14 @@ jobs:
     env:
       VINEXT_PERF_RUN_KIND: ${{ github.event_name == 'pull_request' && 'pull_request' || inputs.run_kind || 'main' }}
       VINEXT_PERF_COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.commit_sha || github.sha }}
+      VINEXT_PERF_TARGET_SHA: ${{ github.event_name == 'pull_request' && github.sha || inputs.commit_sha || github.sha }}
       VINEXT_PERF_PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pull_request }}
       VINEXT_PERF_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || inputs.base_sha }}
       VINEXT_PERF_EXECUTION_ID: ${{ github.run_id }}:${{ github.run_attempt }}
       CODSPEED_SKIP_UPLOAD: "true"
       CODSPEED_WALLTIME_PROFILER: samply
       VINEXT_PERF_TARGET_ROOT: ${{ github.workspace }}
-      VINEXT_PERF_TRUSTED_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.base.sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      VINEXT_PERF_TRUSTED_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
     steps:
       - name: Validate run metadata
         run: |
@@ -67,8 +68,8 @@ jobs:
       - name: Checkout code under test
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ env.VINEXT_PERF_COMMIT_SHA }}
+          repository: ${{ github.repository }}
+          ref: ${{ env.VINEXT_PERF_TARGET_SHA }}
           persist-credentials: false
           fetch-depth: 0
 

--- a/apps/web/app/benchmarks/components/profile.ts
+++ b/apps/web/app/benchmarks/components/profile.ts
@@ -17,7 +17,7 @@ type ProfileThread = {
 };
 
 type SamplyProfile = {
-  meta?: { interval?: number };
+  meta?: { interval?: number; vinextBenchmarkRounds?: number };
   shared?: Pick<ProfileThread, "stackTable" | "frameTable" | "funcTable" | "stringArray">;
   threads?: ProfileThread[];
 };
@@ -125,7 +125,8 @@ function serializeTree(node: MutableTraceNode): TraceNode {
 
 export function profileToFlameGraph(profile: SamplyProfile, rounds = 1): TraceNode | null {
   const root: MutableTraceNode = { name: "all samples", value: 0, children: new Map() };
-  const sampleIntervalMs = (Number(profile.meta?.interval ?? 1) || 1) / Math.max(rounds, 1);
+  const profileRounds = Number(profile.meta?.vinextBenchmarkRounds ?? rounds) || 1;
+  const sampleIntervalMs = (Number(profile.meta?.interval ?? 1) || 1) / Math.max(profileRounds, 1);
   for (const thread of profile.threads ?? []) {
     const tables = profile.shared ? { ...thread, ...profile.shared } : thread;
     if (!tables.stackTable || !tables.frameTable || !tables.funcTable || !tables.stringArray) {

--- a/benchmarks/perf/README.md
+++ b/benchmarks/perf/README.md
@@ -60,6 +60,15 @@ VINEXT_PERF_SAMPLES="$PWD/benchmarks/results/perf-samples.jsonl" \
   node benchmarks/perf/run-scenarios.mjs
 ```
 
+CI records five unprofiled timing rounds for every benchmark. Implementations
+marked with `profile: true` then run once more under Samply solely to capture a
+diagnostic profile. The profiled value is discarded and does not contribute to
+the reported timing statistics.
+
+Pull request runs measure GitHub's synthetic merge commit so an out-of-date
+branch is benchmarked as it would land on the current base branch. Results keep
+the pull request head SHA as their identity for dashboard history and comments.
+
 CI sets `CODSPEED_SKIP_UPLOAD=true`. Results and profiles remain local to the
 GitHub runner, are normalized into the owned payload format, and are uploaded
 only to the vinext dashboard.

--- a/benchmarks/perf/normalize-results.mjs
+++ b/benchmarks/perf/normalize-results.mjs
@@ -3,6 +3,11 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import { gzip, gunzip } from "node:zlib";
+
+const gzipAsync = promisify(gzip);
+const gunzipAsync = promisify(gunzip);
 
 const inputPath = resolve(process.argv[2] ?? "benchmarks/results/perf-samples.jsonl");
 const outputPath = resolve(process.argv[3] ?? "benchmarks/results/perf-results.json");
@@ -12,6 +17,10 @@ async function profileFile(benchmarkId) {
   try {
     const profilePath = join(profilesDirectory, benchmarkId, "samply-profile.json.gz");
     await access(profilePath);
+    const profile = JSON.parse((await gunzipAsync(await readFile(profilePath))).toString("utf8"));
+    profile.meta ??= {};
+    profile.meta.vinextBenchmarkRounds = 1;
+    await writeFile(profilePath, await gzipAsync(JSON.stringify(profile)));
     return relative(dirname(outputPath), profilePath);
   } catch {
     return null;
@@ -86,7 +95,7 @@ async function main() {
       unit: group[0].unit,
       lowerIsBetter: group[0].lowerIsBetter,
       samples: summarize(group.map((sample) => sample.value)),
-      profileFile: group[0].profile ? await profileFile(benchmarkId) : null,
+      profileFile: await profileFile(benchmarkId),
     })),
   );
 

--- a/benchmarks/perf/report-sample.mjs
+++ b/benchmarks/perf/report-sample.mjs
@@ -20,8 +20,10 @@ export async function reportPerformanceSample(value) {
     measuredAt: new Date().toISOString(),
   };
 
-  const samplesFile = requiredEnvironment("VINEXT_PERF_SAMPLES");
-  await appendFile(samplesFile, `${JSON.stringify(sample)}\n`);
+  if (process.env.VINEXT_PERF_RECORD_SAMPLE !== "false") {
+    const samplesFile = requiredEnvironment("VINEXT_PERF_SAMPLES");
+    await appendFile(samplesFile, `${JSON.stringify(sample)}\n`);
+  }
   console.log(JSON.stringify(sample));
   return sample;
 }

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -14,7 +14,11 @@ const resultsRoot = process.env.VINEXT_PERF_RESULTS_ROOT ?? join(targetRoot, "be
 const direct = process.argv.includes("--direct");
 const setupOnly = process.argv.includes("--setup-only");
 const roundsArgument = process.argv.find((argument) => argument.startsWith("--rounds="));
-const rounds = Number(roundsArgument?.slice("--rounds=".length) ?? 0);
+const rounds = Number(roundsArgument?.slice("--rounds=".length) ?? 5);
+
+if (!Number.isInteger(rounds) || rounds < 1) {
+  throw new Error(`--rounds must be a positive integer, received ${roundsArgument ?? rounds}`);
+}
 
 function trustedCommand(command) {
   if (command[0] === "vp") return [join(targetRoot, "node_modules/.bin/vp"), ...command.slice(1)];
@@ -96,32 +100,28 @@ for (const scenario of performanceScenarios) {
       VINEXT_PERF_LOWER_IS_BETTER: String(scenario.lowerIsBetter),
       VINEXT_PERF_IMPLEMENTATION_ID: implementation.id,
       VINEXT_PERF_IMPLEMENTATION_LABEL: implementation.label,
-      VINEXT_PERF_PROFILE: String(profile),
+      VINEXT_PERF_PROFILE: "false",
     };
 
     console.log(`\nRunning ${scenario.suite} / ${implementation.label} / ${scenario.label}`);
-    if (direct) {
-      const directRounds = rounds > 0 ? rounds : 1;
-      for (let round = 0; round < directRounds; round++) {
-        const command = trustedCommand(implementation.command);
-        await run(command[0], command.slice(1), env);
-      }
-      continue;
-    }
-
-    const profileArguments = profile
-      ? [
-          "--walltime-profiler",
-          "samply",
-          "--profile-folder",
-          join(resultsRoot, `perf-profiles/${id}`),
-        ]
-      : [];
-    if (profile) await mkdir(join(resultsRoot, `perf-profiles/${id}`), { recursive: true });
     const command = trustedCommand(implementation.command);
+    const timingCommand = targetCommand(command);
+    const timingEnv = { ...env };
+    if (targetUser) delete timingEnv.VINEXT_PERF_TARGET_USER;
+    for (let round = 0; round < rounds; round++) {
+      await run(timingCommand[0], timingCommand.slice(1), timingEnv);
+    }
+    if (direct || !profile) continue;
+
+    await mkdir(join(resultsRoot, `perf-profiles/${id}`), { recursive: true });
     const profiler = profilerCommand();
-    const profilerEnv = { ...env };
+    const profilerEnv = {
+      ...env,
+      VINEXT_PERF_PROFILE: "true",
+      VINEXT_PERF_RECORD_SAMPLE: "false",
+    };
     if (targetUser) delete profilerEnv.VINEXT_PERF_TARGET_USER;
+    console.log(`Profiling one diagnostic round for ${id}`);
     await run(
       profiler[0],
       [
@@ -129,15 +129,18 @@ for (const scenario of performanceScenarios) {
         "exec",
         "--mode",
         "walltime",
-        ...profileArguments,
+        "--walltime-profiler",
+        "samply",
+        "--profile-folder",
+        join(resultsRoot, `perf-profiles/${id}`),
         "--name",
         id,
         "--warmup-time",
         "0s",
         "--min-rounds",
-        String(rounds > 0 ? rounds : 5),
+        "1",
         "--max-rounds",
-        String(rounds > 0 ? rounds : 10),
+        "1",
         "--max-time",
         "3m",
         "--",

--- a/benchmarks/perf/validate-results.mjs
+++ b/benchmarks/perf/validate-results.mjs
@@ -328,10 +328,7 @@ if (sourceEvent === "pull_request") {
 
 let trustedManifestRef;
 if (sourceEvent === "pull_request") {
-  trustedManifestRef =
-    sourcePullRequest.head.repo.full_name === repository
-      ? sourcePullRequest.head.sha
-      : sourcePullRequest.base.sha;
+  trustedManifestRef = sourcePullRequest.base.sha;
 } else if (sourceEvent === "push") {
   trustedManifestRef = sourceRun.head_sha;
 } else if (sourceEvent === "workflow_dispatch") {

--- a/scripts/performance-trace.test.ts
+++ b/scripts/performance-trace.test.ts
@@ -83,19 +83,23 @@ describe("performance traces", () => {
     );
     await writeFile(
       inputPath,
-      `${JSON.stringify({
-        benchmarkId,
-        scenarioId: "dev-start",
-        suite: "Dev server",
-        label: "Dev server cold start",
-        description: "Starts the development server",
-        implementationId: "vinext",
-        implementationLabel: "vinext",
-        unit: "ms",
-        lowerIsBetter: true,
-        value: 1,
-        profile: true,
-      })}\n`,
+      `${[1, 2, 3, 4, 5]
+        .map((value) =>
+          JSON.stringify({
+            benchmarkId,
+            scenarioId: "dev-start",
+            suite: "Dev server",
+            label: "Dev server cold start",
+            description: "Starts the development server",
+            implementationId: "vinext",
+            implementationLabel: "vinext",
+            unit: "ms",
+            lowerIsBetter: true,
+            value,
+            profile: false,
+          }),
+        )
+        .join("\n")}\n`,
     );
 
     await execFileAsync(
@@ -114,13 +118,21 @@ describe("performance traces", () => {
       join("profiles", benchmarkId, "samply-profile.json.gz"),
     );
     expect(result.benchmarks[0]).not.toHaveProperty("flameGraph");
+    expect(result.benchmarks[0].samples.rounds).toBe(5);
+    expect(result.benchmarks[0].samples.mean).toBe(3);
     expect(result.run.commitSha).toBe(commitSha);
     expect(result.run.measuredAt).toBe("2025-04-03T10:34:56.000Z");
 
-    const graph = profileToFlameGraph(profile, 5) as TraceNode;
+    const normalizedProfile = await readGzipProfile(
+      new Response(await readFile(join(profileDirectory, "samply-profile.json.gz")), {
+        headers: { "Content-Type": "application/gzip" },
+      }),
+    );
+    expect(normalizedProfile.meta?.vinextBenchmarkRounds).toBe(1);
+    const graph = profileToFlameGraph(normalizedProfile, 5) as TraceNode;
     expect(flatten(graph).filter((node) => node.name.startsWith("frame-"))).toHaveLength(91);
     expect(maxDepth(graph)).toBe(42);
-    expect(graph.value).toBeCloseTo(10.2);
+    expect(graph.value).toBeCloseTo(51);
     const decodedProfile = await readGzipProfile(
       new Response(await gzipAsync(JSON.stringify(profile)), {
         headers: { "Content-Type": "application/gzip" },


### PR DESCRIPTION
## Summary

- benchmark GitHub's synthetic merge commit for pull requests while retaining the PR head SHA as the result identity
- always load and validate the trusted benchmark harness from the PR base revision
- record five unprofiled timing rounds, then capture one separate Samply diagnostic profile for configured implementations
- annotate profiles with their own round count so old multi-round and new single-round profiles render correctly

## Why

Historical baseline comparisons could report large false regressions when a PR branch was behind `main`, because the workflow measured the stale head directly against a newer base run. Profiling also affected every timing sample for vinext's CPU-heavy scenarios.

## Validation

- `vp test run scripts/performance-trace.test.ts`
- `vp check .github/workflows/perf.yml benchmarks/perf/run-scenarios.mjs benchmarks/perf/report-sample.mjs benchmarks/perf/normalize-results.mjs benchmarks/perf/validate-results.mjs benchmarks/perf/README.md apps/web/app/benchmarks/components/profile.ts scripts/performance-trace.test.ts`
- workflow YAML parse
- `git diff --check`
