### PR TITLE
fix(app-router): block dangerous RSC redirect URLs

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -172,6 +172,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "./app-rsc-render-mode.js";
+import { blockDangerousStreamedRscRedirect } from "./app-browser-rsc-redirect.js";
 import {
   createOptimisticRouteTemplate,
   getOptimisticPrefetchSourceKey,
@@ -2074,6 +2075,10 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 
         const navContentType = navResponse.headers.get("content-type") ?? "";
+        const streamedRedirectTarget = navResponse.headers.get(VINEXT_RSC_REDIRECT_HEADER);
+        if (blockDangerousStreamedRscRedirect(navResponse, streamedRedirectTarget)) {
+          return;
+        }
         const liveFetchDecision = navigationPlanner.classifyRscFetchResult({
           clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
           compatibilityIdHeader: navResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
@@ -2087,7 +2092,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
           responseOk: navResponse.ok,
           responseUrl: navResponseUrl ?? navResponse.url,
           source: "live",
-          streamedRedirectTarget: navResponse.headers.get(VINEXT_RSC_REDIRECT_HEADER),
+          streamedRedirectTarget,
         });
         if (liveFetchDecision.kind === "hardNavigate") {
           if (liveFetchDecision.discardBody) {

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -3,8 +3,22 @@ import {
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
 } from "./app-rsc-cache-busting.js";
+import { DANGEROUS_URL_BLOCK_MESSAGE, isDangerousScheme } from "vinext/shims/url-safety";
 
 const MAX_RSC_REDIRECT_DEPTH = 10;
+
+export function blockDangerousStreamedRscRedirect(
+  response: Response,
+  streamedRedirectTarget: string | null,
+): boolean {
+  if (streamedRedirectTarget === null || !isDangerousScheme(streamedRedirectTarget)) {
+    return false;
+  }
+
+  void response.body?.cancel().catch(() => {});
+  console.error(DANGEROUS_URL_BLOCK_MESSAGE);
+  return true;
+}
 
 type RscRedirectHistoryUpdateMode = "push" | "replace" | undefined;
 

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -3,7 +3,10 @@ import {
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
 } from "./app-rsc-cache-busting.js";
-import { DANGEROUS_URL_BLOCK_MESSAGE, isDangerousScheme } from "vinext/shims/url-safety";
+import {
+  isDangerousScheme,
+  reportBlockedDangerousNavigation,
+} from "vinext/shims/url-safety";
 
 const MAX_RSC_REDIRECT_DEPTH = 10;
 
@@ -16,7 +19,7 @@ export function blockDangerousStreamedRscRedirect(
   }
 
   void response.body?.cancel().catch(() => {});
-  console.error(DANGEROUS_URL_BLOCK_MESSAGE);
+  reportBlockedDangerousNavigation();
   return true;
 }
 

--- a/packages/vinext/src/server/app-browser-rsc-redirect.ts
+++ b/packages/vinext/src/server/app-browser-rsc-redirect.ts
@@ -3,10 +3,7 @@ import {
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
 } from "./app-rsc-cache-busting.js";
-import {
-  isDangerousScheme,
-  reportBlockedDangerousNavigation,
-} from "vinext/shims/url-safety";
+import { isDangerousScheme, reportBlockedDangerousNavigation } from "vinext/shims/url-safety";
 
 const MAX_RSC_REDIRECT_DEPTH = 10;
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -105,6 +105,7 @@ import {
   RestorableClientStateController,
 } from "../packages/vinext/src/server/app-history-state.js";
 import {
+  blockDangerousStreamedRscRedirect,
   resolveRscRedirectLifecycleHop,
   resolveStreamedRscRedirectLifecycleHop,
 } from "../packages/vinext/src/server/app-browser-rsc-redirect.js";
@@ -5984,6 +5985,30 @@ describe("createPopstateRestoreHandler", () => {
 });
 
 describe("app browser RSC redirect lifecycle", () => {
+  it("blocks dangerous streamed redirects before browser navigation", async () => {
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream({ cancel }));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(
+      blockDangerousStreamedRscRedirect(
+        response,
+        "javascript:window.location.assign('/nextjs-compat/javascript-urls/boom')",
+      ),
+    ).toBe(true);
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+    expect(consoleError).toHaveBeenCalledWith(
+      "Next.js has blocked a javascript: URL as a security precaution.",
+    );
+  });
+
+  it("allows safe streamed redirects to reach the navigation planner", () => {
+    const response = new Response("rsc payload");
+
+    expect(blockDangerousStreamedRscRedirect(response, "/dashboard")).toBe(false);
+    expect(response.bodyUsed).toBe(false);
+  });
+
   it("keeps RSC redirect hops in the initiating lifecycle and preserves push history intent", () => {
     const decision = resolveRscRedirectLifecycleHop({
       currentHref: "https://example.com/start",

--- a/tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts
@@ -96,6 +96,25 @@ test.describe("javascript-urls", () => {
     await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
   });
 
+  // Next.js blocks javascript: URLs consumed from redirect errors during
+  // client-side App Router navigation.
+  // Reference implementation: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/navigation.ts
+  test("should prevent javascript URLs in RSC redirects", async ({ page }) => {
+    const { beforePageLoad, getNavigationRequests } = createNavigationInterceptor();
+    beforePageLoad(page);
+
+    await page.goto(`${BASE}/nextjs-compat/javascript-urls/rsc-redirect-trigger`);
+    await waitForAppRouterHydration(page);
+    const initialUrl = page.url();
+
+    await page.locator("#rsc-redirect-link").click();
+
+    await expectJavascriptUrlBlocked(page, initialUrl, getNavigationRequests);
+
+    await page.locator('a[href="/nextjs-compat/javascript-urls/safe"]').click();
+    await expect(page).toHaveURL(`${BASE}/nextjs-compat/javascript-urls/safe`);
+  });
+
   // Next.js keeps user-provided Link onClick handlers on anchors whose href is
   // later blocked by React/Next.js javascript: URL protections.
   // Reference implementation: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/link.tsx

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/rsc-redirect-trigger/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/rsc-redirect-trigger/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <>
+      <Link href="/nextjs-compat/javascript-urls/rsc-redirect" id="rsc-redirect-link">
+        trigger rsc redirect
+      </Link>
+      <Link href="/nextjs-compat/javascript-urls/safe">safe link</Link>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/rsc-redirect/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/rsc-redirect/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+import { DANGEROUS_JAVASCRIPT_URL } from "../bad-url";
+
+export default function Page() {
+  redirect(DANGEROUS_JAVASCRIPT_URL);
+}


### PR DESCRIPTION
## Summary

- block dangerous URL schemes received through App Router RSC redirect headers
- cancel the unused RSC response body and preserve the current router state
- add unit and browser regression coverage, including a follow-up navigation check

## Background

App Router client navigation can receive semantic redirect targets through the RSC response header. Those targets must use the same dangerous-scheme protection as Link, router navigation, and server action redirects before they reach hard-navigation handling.

## Validation

- `vp test run tests/app-browser-entry.test.ts`
- `vp check packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/server/app-browser-rsc-redirect.ts tests/app-browser-entry.test.ts tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts`
- `vp run fmt:check -- packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/server/app-browser-rsc-redirect.ts tests/app-browser-entry.test.ts tests/e2e/app-router/nextjs-compat/javascript-urls.spec.ts tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/rsc-redirect/page.tsx tests/fixtures/app-basic/app/nextjs-compat/javascript-urls/rsc-redirect-trigger/page.tsx`
- `vp run vinext#build`
