### PR TITLE
fix(init): ignore vinext output directory

### DIFF
--- a/.agents/skills/migrate-to-vinext/SKILL.md
+++ b/.agents/skills/migrate-to-vinext/SKILL.md
@@ -49,6 +49,7 @@ Run `vinext init`. This command:
 4. Renames CJS config files (e.g., `postcss.config.js` → `.cjs`) to avoid ESM conflicts
 5. Adds `dev:vinext` and `build:vinext` scripts to package.json
 6. Generates a minimal `vite.config.ts`
+7. Adds `/dist/` and `.vinext/` to `.gitignore`
 
 This is non-destructive — the existing Next.js setup continues to work alongside vinext. Use the `dev:vinext` script to test before fully switching over.
 
@@ -113,6 +114,15 @@ export default defineConfig({ plugins: [vinext()] });
 ```
 
 vinext auto-registers `@vitejs/plugin-rsc` for App Router when the `rsc` option is not explicitly `false`. No manual RSC plugin config needed for local development.
+
+### 3e. Update .gitignore
+
+Ensure vinext-generated output and caches are ignored:
+
+```gitignore
+/dist/
+.vinext/
+```
 
 ## Phase 4: Deployment (Optional)
 

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -9,7 +9,7 @@
  *   4. Rename CJS config files to .cjs
  *   5. Add vinext scripts to package.json
  *   6. Generate vite.config.ts
- *   7. Update .gitignore to include /dist/
+ *   7. Update .gitignore to include /dist/ and .vinext/
  *   8. Print summary
  *
  * Non-destructive: does NOT modify next.config, tsconfig, or source files.
@@ -58,7 +58,7 @@ type InitResult = {
   generatedViteConfig: boolean;
   /** Whether vite.config.ts generation was skipped (already exists) */
   skippedViteConfig: boolean;
-  /** Whether .gitignore was updated to include /dist/ */
+  /** Whether .gitignore was updated to include vinext-generated output */
   updatedGitignore: boolean;
 };
 
@@ -226,27 +226,41 @@ function installDeps(
 // ─── .gitignore Update ───────────────────────────────────────────────────────
 
 /**
- * Ensure /dist/ is listed in .gitignore. Creates the file if it doesn't exist.
- * Returns true if the file was modified (or created), false if /dist/ was already present.
+ * Ensure vinext-generated output directories are listed in .gitignore.
+ * Creates the file if it doesn't exist. Returns true if the file was modified
+ * (or created), false if all entries were already present.
  */
 export function updateGitignore(root: string): boolean {
   const gitignorePath = path.join(root, ".gitignore");
-  const exactEntry = "/dist/";
+  const entries = [
+    {
+      entry: "/dist/",
+      coveredBy: new Set(["/dist/", "/dist", "dist/", "dist"]),
+    },
+    {
+      entry: ".vinext/",
+      coveredBy: new Set(["/.vinext/", "/.vinext", ".vinext/", ".vinext"]),
+    },
+  ];
 
   let content = "";
+  let lines: string[] = [];
   if (fs.existsSync(gitignorePath)) {
     content = fs.readFileSync(gitignorePath, "utf-8");
-
-    // Check if dist is already covered — match /dist/, dist/, or dist (all common variants)
-    const lines = content.split("\n").map((l) => l.trim());
-    if (lines.includes(exactEntry) || lines.includes("dist/") || lines.includes("dist")) {
-      return false;
-    }
+    lines = content.split("\n").map((l) => l.trim());
   }
 
-  // Append /dist/ with a trailing newline, ensuring we don't merge with an existing last line
+  const missingEntries = entries
+    .filter(({ coveredBy }) => !lines.some((line) => coveredBy.has(line)))
+    .map(({ entry }) => entry);
+
+  if (missingEntries.length === 0) {
+    return false;
+  }
+
+  // Append entries with a trailing newline, ensuring we don't merge with an existing last line
   const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
-  fs.writeFileSync(gitignorePath, content + separator + exactEntry + "\n", "utf-8");
+  fs.writeFileSync(gitignorePath, content + separator + missingEntries.join("\n") + "\n", "utf-8");
   return true;
 }
 
@@ -359,7 +373,7 @@ export async function init(options: InitOptions): Promise<InitResult> {
     console.log(`    - Skipped vite.config.ts (already exists, use --force to overwrite)`);
   }
   if (updatedGitignore) {
-    console.log(`    \u2713 Added /dist/ to .gitignore`);
+    console.log(`    \u2713 Added vinext output directories to .gitignore`);
   }
 
   console.log(`

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -797,32 +797,42 @@ describe("init — non-destructive", () => {
 // ─── Unit Tests: updateGitignore ─────────────────────────────────────────────
 
 describe("updateGitignore", () => {
-  it("creates .gitignore with /dist/ when file does not exist", () => {
+  it("creates .gitignore with vinext output directories when file does not exist", () => {
     const result = updateGitignore(tmpDir);
 
     expect(result).toBe(true);
     const content = readFile(tmpDir, ".gitignore");
-    expect(content).toBe("/dist/\n");
+    expect(content).toBe("/dist/\n.vinext/\n");
   });
 
-  it("appends /dist/ to existing .gitignore", () => {
+  it("appends vinext output directories to existing .gitignore", () => {
     writeFile(tmpDir, ".gitignore", "node_modules/\n.env\n");
 
     const result = updateGitignore(tmpDir);
 
     expect(result).toBe(true);
     const content = readFile(tmpDir, ".gitignore");
-    expect(content).toBe("node_modules/\n.env\n/dist/\n");
+    expect(content).toBe("node_modules/\n.env\n/dist/\n.vinext/\n");
   });
 
-  it("does not duplicate /dist/ when already present", () => {
+  it("appends only .vinext/ when /dist/ is already present", () => {
     writeFile(tmpDir, ".gitignore", "node_modules/\n/dist/\n");
+
+    const result = updateGitignore(tmpDir);
+
+    expect(result).toBe(true);
+    const content = readFile(tmpDir, ".gitignore");
+    expect(content).toBe("node_modules/\n/dist/\n.vinext/\n");
+  });
+
+  it("does not duplicate entries when already present", () => {
+    writeFile(tmpDir, ".gitignore", "node_modules/\n/dist/\n.vinext/\n");
 
     const result = updateGitignore(tmpDir);
 
     expect(result).toBe(false);
     const content = readFile(tmpDir, ".gitignore");
-    expect(content).toBe("node_modules/\n/dist/\n");
+    expect(content).toBe("node_modules/\n/dist/\n.vinext/\n");
   });
 
   it("handles .gitignore without trailing newline", () => {
@@ -832,11 +842,11 @@ describe("updateGitignore", () => {
 
     expect(result).toBe(true);
     const content = readFile(tmpDir, ".gitignore");
-    expect(content).toBe("node_modules/\n/dist/\n");
+    expect(content).toBe("node_modules/\n/dist/\n.vinext/\n");
   });
 
-  it("handles /dist/ with surrounding whitespace in existing file", () => {
-    writeFile(tmpDir, ".gitignore", "node_modules/\n  /dist/  \n");
+  it("handles existing entries with surrounding whitespace", () => {
+    writeFile(tmpDir, ".gitignore", "node_modules/\n  /dist/  \n  .vinext/  \n");
 
     const result = updateGitignore(tmpDir);
 
@@ -844,30 +854,40 @@ describe("updateGitignore", () => {
   });
 
   it("does not add /dist/ when dist/ (without leading slash) is already present", () => {
-    writeFile(tmpDir, ".gitignore", "node_modules/\ndist/\n");
+    writeFile(tmpDir, ".gitignore", "node_modules/\ndist/\n.vinext/\n");
 
     const result = updateGitignore(tmpDir);
 
     expect(result).toBe(false);
     const content = readFile(tmpDir, ".gitignore");
-    expect(content).toBe("node_modules/\ndist/\n");
+    expect(content).toBe("node_modules/\ndist/\n.vinext/\n");
   });
 
   it("does not add /dist/ when bare dist is already present", () => {
-    writeFile(tmpDir, ".gitignore", "node_modules/\ndist\n");
+    writeFile(tmpDir, ".gitignore", "node_modules/\ndist\n.vinext/\n");
 
     const result = updateGitignore(tmpDir);
 
     expect(result).toBe(false);
     const content = readFile(tmpDir, ".gitignore");
-    expect(content).toBe("node_modules/\ndist\n");
+    expect(content).toBe("node_modules/\ndist\n.vinext/\n");
+  });
+
+  it("does not add .vinext/ when anchored variant is already present", () => {
+    writeFile(tmpDir, ".gitignore", "node_modules/\n/dist/\n/.vinext/\n");
+
+    const result = updateGitignore(tmpDir);
+
+    expect(result).toBe(false);
+    const content = readFile(tmpDir, ".gitignore");
+    expect(content).toBe("node_modules/\n/dist/\n/.vinext/\n");
   });
 });
 
 // ─── Integration: init updates .gitignore ────────────────────────────────────
 
 describe("init — .gitignore", () => {
-  it("adds /dist/ to .gitignore during init", async () => {
+  it("adds vinext output directories to .gitignore during init", async () => {
     setupProject(tmpDir, { router: "app" });
 
     const { result } = await runInit(tmpDir);
@@ -875,11 +895,12 @@ describe("init — .gitignore", () => {
     expect(result.updatedGitignore).toBe(true);
     const content = readFile(tmpDir, ".gitignore");
     expect(content).toContain("/dist/");
+    expect(content).toContain(".vinext/");
   });
 
-  it("does not duplicate /dist/ if already in .gitignore", async () => {
+  it("does not duplicate entries if already in .gitignore", async () => {
     setupProject(tmpDir, { router: "app" });
-    writeFile(tmpDir, ".gitignore", "node_modules/\n/dist/\n");
+    writeFile(tmpDir, ".gitignore", "node_modules/\n/dist/\n.vinext/\n");
 
     const { result } = await runInit(tmpDir);
 
@@ -888,9 +909,11 @@ describe("init — .gitignore", () => {
     const content = readFile(tmpDir, ".gitignore");
     const matches = content.split("\n").filter((l: string) => l.trim() === "/dist/");
     expect(matches.length).toBe(1);
+    const vinextMatches = content.split("\n").filter((l: string) => l.trim() === ".vinext/");
+    expect(vinextMatches.length).toBe(1);
   });
 
-  it("preserves existing .gitignore entries when adding /dist/", async () => {
+  it("preserves existing .gitignore entries when adding vinext output directories", async () => {
     setupProject(tmpDir, { router: "app" });
     writeFile(tmpDir, ".gitignore", "node_modules/\n.env\n.next/\n");
 
@@ -902,5 +925,6 @@ describe("init — .gitignore", () => {
     expect(content).toContain(".env");
     expect(content).toContain(".next/");
     expect(content).toContain("/dist/");
+    expect(content).toContain(".vinext/");
   });
 });


### PR DESCRIPTION
## Summary
- update `vinext init` to add `.vinext/` alongside `/dist/` to `.gitignore`
- avoid duplicating existing `.vinext` ignore variants
- document the ignore entry in the migrate-to-vinext agent skill

## Tests
- `pnpm test tests/init.test.ts`
- `pnpm exec vp fmt --check packages/vinext/src/init.ts tests/init.test.ts .agents/skills/migrate-to-vinext/SKILL.md`