### PR TITLE
refactor(project): unify directory detection into a shared findDir helper

### DIFF
--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -20,11 +20,11 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 import { parseSync } from "vite";
 import type { ESTree } from "vite";
 import type { Route } from "../routing/pages-router.js";
 import type { AppRoute } from "../routing/app-router.js";
+import { findDir } from "../utils/project.js";
 import type { LayoutBuildClassification } from "./layout-classification-types.js";
 import type { PrerenderResult } from "./prerender.js";
 
@@ -745,20 +745,6 @@ export function formatBuildReport(rows: RouteRow[], routerLabel = "app"): string
   }
 
   return lines.join("\n");
-}
-
-// ─── Directory detection ──────────────────────────────────────────────────────
-
-export function findDir(root: string, ...candidates: string[]): string | null {
-  for (const candidate of candidates) {
-    const full = path.join(root, candidate);
-    try {
-      if (fs.statSync(full).isDirectory()) return full;
-    } catch {
-      // not found or not a directory — try next candidate
-    }
-  }
-  return null;
 }
 
 // ─── Main entry point ─────────────────────────────────────────────────────────

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -32,7 +32,7 @@ import { loadNextConfig, resolveNextConfig } from "../config/next-config.js";
 import { pagesRouter, apiRouter } from "../routing/pages-router.js";
 import { appRouter } from "../routing/app-router.js";
 import { scanMetadataFiles } from "../server/metadata-routes.js";
-import { findDir } from "./report.js";
+import { findDir } from "../utils/project.js";
 import { startProdServer } from "../server/prod-server.js";
 
 // ─── Progress UI ──────────────────────────────────────────────────────────────

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -5,7 +5,7 @@
  * showing what will work, what needs changes, and an overall score.
  */
 
-import { detectPackageManager } from "./utils/project.js";
+import { detectPackageManager, findDir } from "./utils/project.js";
 import { normalizePathSeparators } from "./utils/path.js";
 import { parseAst, type ESTree } from "vite";
 import fs from "node:fs";
@@ -932,16 +932,8 @@ export function checkConventions(root: string): CheckItem[] {
   const items: CheckItem[] = [];
 
   // Check for pages/ and app/ at root level, then fall back to src/
-  const pagesDir = fs.existsSync(path.join(root, "pages"))
-    ? path.join(root, "pages")
-    : fs.existsSync(path.join(root, "src", "pages"))
-      ? path.join(root, "src", "pages")
-      : null;
-  const appDirPath = fs.existsSync(path.join(root, "app"))
-    ? path.join(root, "app")
-    : fs.existsSync(path.join(root, "src", "app"))
-      ? path.join(root, "src", "app")
-      : null;
+  const pagesDir = findDir(root, "pages", path.join("src", "pages"));
+  const appDirPath = findDir(root, "app", path.join("src", "app"));
 
   const hasPages = pagesDir !== null;
   const hasApp = appDirPath !== null;

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -25,6 +25,8 @@ import {
   renameCJSConfigs as _renameCJSConfigs,
   detectPackageManager as _detectPackageManager,
   findInNodeModules as _findInNodeModules,
+  findDir,
+  hasAppDir,
 } from "./utils/project.js";
 import { getReactUpgradeDeps } from "./init.js";
 import { runTPR } from "./cloudflare/tpr.js";
@@ -182,10 +184,8 @@ export function formatMissingCloudflarePluginError(options: {
 }
 
 export function detectProject(root: string): ProjectInfo {
-  const hasApp =
-    fs.existsSync(path.join(root, "app")) || fs.existsSync(path.join(root, "src", "app"));
-  const hasPages =
-    fs.existsSync(path.join(root, "pages")) || fs.existsSync(path.join(root, "src", "pages"));
+  const hasApp = hasAppDir(root);
+  const hasPages = findDir(root, "pages", path.join("src", "pages")) !== null;
 
   // Prefer App Router if both exist
   const isAppRouter = hasApp;

--- a/packages/vinext/src/typegen.ts
+++ b/packages/vinext/src/typegen.ts
@@ -5,6 +5,7 @@ import { appRouteGraph } from "./routing/app-router.js";
 import { patternToNextFormat } from "./routing/route-validation.js";
 import { decodeRouteSegment } from "./routing/utils.js";
 import { compareStrings } from "./utils/compare.js";
+import { findDir } from "./utils/project.js";
 
 type GenerateRouteTypesOptions = {
   root: string;
@@ -24,7 +25,9 @@ import "./.next/types/routes.d.ts";
 
 export async function generateRouteTypes(options: GenerateRouteTypesOptions): Promise<string> {
   const root = path.resolve(options.root);
-  const appDir = options.appDir ? path.resolve(options.appDir) : await findAppDir(root);
+  const appDir = options.appDir
+    ? path.resolve(options.appDir)
+    : findDir(root, "app", path.join("src", "app"));
   const outPath = path.join(root, ".next", "types", "routes.d.ts");
 
   const content = appDir
@@ -136,19 +139,6 @@ async function collectRouteTypeModel(
   for (const slotNames of model.layoutSlots.values()) slotNames.sort(compareStrings);
 
   return model;
-}
-
-async function findAppDir(root: string): Promise<string | null> {
-  for (const rel of ["app", path.join("src", "app")]) {
-    const candidate = path.join(root, rel);
-    try {
-      const stat = await fs.stat(candidate);
-      if (stat.isDirectory()) return candidate;
-    } catch {
-      // Try the next conventional app directory.
-    }
-  }
-  return null;
 }
 
 function renderRouteTypes(model: RouteTypeModel): string {

--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -269,8 +269,25 @@ export function hasViteConfig(root: string): boolean {
 }
 
 /**
+ * Return the first candidate directory (resolved against `root`) that exists,
+ * or null. Used to locate conventional `app`/`pages` directories that may live
+ * at the root or under `src/`.
+ */
+export function findDir(root: string, ...candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    const full = path.join(root, candidate);
+    try {
+      if (fs.statSync(full).isDirectory()) return full;
+    } catch {
+      // not found or not a directory — try next candidate
+    }
+  }
+  return null;
+}
+
+/**
  * Check if the project uses App Router (has an app/ directory).
  */
 export function hasAppDir(root: string): boolean {
-  return fs.existsSync(path.join(root, "app")) || fs.existsSync(path.join(root, "src", "app"));
+  return findDir(root, "app", path.join("src", "app")) !== null;
 }


### PR DESCRIPTION
## What

Extracts a single `findDir(root, ...candidates)` helper into `utils/project.ts` and routes every duplicated "find the conventional `app`/`pages` directory" site through it. Behavior-preserving dedup — no functional change.

## Why

The same "return the first candidate directory under `root` that exists" logic was copied across the codebase:

- `build/report.ts` defined and exported `findDir` (used there and re-imported by `build/run-prerender.ts`).
- `typegen.ts` had its own `findAppDir` — an async re-implementation of `findDir(root, "app", "src/app")`.
- `check.ts` inlined the same lookup as nested `fs.existsSync(...)` ternaries.
- `deploy.ts` open-coded `existsSync(app) || existsSync(src/app)` — which is exactly the existing `hasAppDir` it didn't use.

Five copies of one idea, in three slightly different shapes (sync vs async, returns-path vs returns-boolean).

## How

- Add `findDir` to `utils/project.ts` (the home of the other project-layout helpers like `hasAppDir`, `findInNodeModules`, `hasViteConfig`); rewrite `hasAppDir` to call it.
- `build/report.ts`: delete the local `findDir`, import it from utils; drop the now-unused `path` import.
- `build/run-prerender.ts`: import `findDir` from utils instead of from `report.js`.
- `typegen.ts`: delete the async `findAppDir`; call the sync `findDir(root, "app", "src/app")` directly (it runs at CLI time, so sync `statSync` is fine).
- `check.ts`: replace the inline `existsSync` ternaries with `findDir`.
- `deploy.ts`: use the existing `hasAppDir` and `findDir` instead of the open-coded checks.

One intentional semantic tightening: the inlined sites in `check.ts`/`deploy.ts` used `fs.existsSync` (matches a file too), while `findDir` uses `statSync(...).isDirectory()`. For the `app`/`pages` conventions that must be directories this is more correct, and identical in practice — all affected tests still pass.

The forward-slash behavior of these paths is left unchanged here and handled separately.

## Testing

`vp check` clean across all six files. `tests/check.test.ts` 140/140, `tests/typegen.test.ts` 8/8, `tests/build-report.test.ts` 95/95, `tests/deploy.test.ts` 280/281 — the one failure (`returns a clear fallback path when Wrangler is missing`) is a pre-existing, unrelated Wrangler-resolution issue.
