### PR TITLE
test(next-config): build the cacheHandler file:// fixture with pathToFileURL

### DIFF
--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi, beforeEach } from "vite-plus/test"
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   detectNextIntlConfig,
   lightningCssFeatureNamesToMask,
@@ -2423,10 +2424,15 @@ describe("resolveNextConfig rootParams deprecation warning", () => {
 
 describe("resolveNextConfig cacheHandler", () => {
   it("resolves file:// URLs to filesystem paths", async () => {
+    // Build the URL with pathToFileURL so it is valid on Windows too, where a
+    // file:// URL must carry a drive letter (a drive-less file:///… throws in
+    // fileURLToPath). In production the URL comes from import.meta.resolve, so
+    // it is always platform-valid.
+    const handlerPath = path.resolve("/absolute/path/to/handler.js");
     const resolved = await resolveNextConfig({
-      cacheHandler: "file:///absolute/path/to/handler.js",
+      cacheHandler: pathToFileURL(handlerPath).href,
     });
-    expect(resolved.cacheHandler).toBe("/absolute/path/to/handler.js");
+    expect(resolved.cacheHandler).toBe(handlerPath);
   });
 
   it("passes through absolute paths unchanged", async () => {


### PR DESCRIPTION
## What

Fixes the `resolveNextConfig cacheHandler` test "resolves file:// URLs to filesystem paths" so it uses a platform-valid `file://` URL, letting it pass on Windows.

## Why

`resolveCacheHandlerPathToFilesystem` turns a `file://` cache-handler URL into a filesystem path via `fileURLToPath`. The fixture passed a drive-less URL, `file:///absolute/path/to/handler.js`. On Windows that is not a valid file URL — `fileURLToPath` throws `TypeError: File URL path must be absolute` because a Windows file URL must carry a drive letter — so the test errored before reaching its assertion. On POSIX the drive-less URL is fine, so it passed there.

The source is correct: in production the cache-handler URL comes from `import.meta.resolve`, which always yields a platform-valid (drive-qualified on Windows) `file://` URL. Only the fixture's hand-written URL was unportable.

## How

Build the URL the same way production does — `pathToFileURL(path.resolve("/absolute/path/to/handler.js")).href` — so it carries a drive letter on Windows and stays `file:///absolute/...` on POSIX, then assert against the round-tripped `path.resolve(...)` target. On POSIX this is identical to the old literal; on Windows both sides become the drive-qualified path `fileURLToPath` produces.

## Testing

`vp test run --project unit tests/next-config.test.ts` — 201/201 pass on Windows (previously this one test threw `File URL path must be absolute`). POSIX behavior is unchanged. `vp check` clean.
