### PR TITLE
test(font-local): normalize the shim path fixture so the skip guard matches on Windows

### DIFF
--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vite-plus/test";
 import path from "node:path";
 import vinext from "../packages/vinext/src/index.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 import localFont, { getSSRFontStyles } from "../packages/vinext/src/shims/font-local.js";
 import type { Plugin } from "vite-plus";
 
@@ -9,9 +10,10 @@ import type { Plugin } from "vite-plus";
 // Absolute path to vinext's own font-local shim — the plugin guards against
 // rewriting any file under its shims directory via a prefix check, so tests
 // that exercise the guard must use the real resolved path.
-const FONT_LOCAL_SHIM_PATH = path.resolve(
-  import.meta.dirname,
-  "../packages/vinext/src/shims/font-local.ts",
+// Vite hands the transform hook POSIX-normalized ids, and the plugin's guard
+// prefix-checks against the (forward-slash) shims dir — so normalize here too.
+const FONT_LOCAL_SHIM_PATH = normalizePathSeparators(
+  path.resolve(import.meta.dirname, "../packages/vinext/src/shims/font-local.ts"),
 );
 
 /** Unwrap a Vite plugin hook that may use the object-with-filter format */


### PR DESCRIPTION
## What

Normalizes `FONT_LOCAL_SHIM_PATH` in `tests/font-local-transform.test.ts` to forward slashes so the "skips vinext's own font-local shim" test exercises the plugin's guard correctly on Windows.

## Why

`createLocalFontsPlugin` refuses to rewrite its own shim with a prefix check, `id.startsWith(shimsDir)`, where `shimsDir` is forward-slash. Vite hands `transform` POSIX-normalized ids, so in production the check always sees forward slashes and fires.

The test fed the guard `FONT_LOCAL_SHIM_PATH = path.resolve(import.meta.dirname, ".../font-local.ts")`, which is backslashes on Windows. That backslash id never matched the forward-slash `shimsDir`, so the guard didn't fire, the transform ran, and the test got a rewritten result instead of `null`. On POSIX the path is already forward-slash, so it passed there.

The source is correct — only the fixture handed it an id shape Vite never produces.

## How

Wrap the resolved shim path in `normalizePathSeparators`, mirroring the POSIX-normalized id Vite passes to `transform`. On POSIX it is a no-op; on Windows it converts the `path.resolve` backslashes to the forward-slash form the guard prefix-matches. The const is only used by this one test, so nothing else is affected.

## Testing

`vp test run --project unit tests/font-local-transform.test.ts` — 41/41 pass on Windows (previously "skips vinext's own font-local shim (it has example paths in comments)" failed, getting a transform result instead of `null`). POSIX behavior is unchanged. `vp check` clean.
