### PR TITLE
fix(rsc): resolve the app-rsc-handler shim to a forward-slash id on Windows

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -580,7 +580,7 @@ function createStaticImageAsset(imagePath: string): { fileName: string; source: 
 const _shimsDir = normalizePathSeparators(path.resolve(__dirname, "shims")) + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
 const _appRscHandlerPath = resolveShimModulePath(
-  path.resolve(__dirname, "server"),
+  normalizePathSeparators(path.resolve(__dirname, "server")),
   "app-rsc-handler",
 );
 // Source checkouts resolve to TypeScript and must stay in Vite's graph so tests

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -21374,9 +21374,9 @@ describe("shim alias map .js variants", () => {
       ) => string | { id: string; external: true } | undefined;
     };
     const id = "vinext/server/app-rsc-handler";
-    const expected = path.resolve(
-      import.meta.dirname,
-      "../packages/vinext/src/server/app-rsc-handler.ts",
+    // resolveId returns a forward-slash id (Vite-canonical) on every platform.
+    const expected = normalizePathSeparators(
+      path.resolve(import.meta.dirname, "../packages/vinext/src/server/app-rsc-handler.ts"),
     );
 
     expect(hook.filter.id.test(id)).toBe(true);


### PR DESCRIPTION
## What

Normalizes the base directory used to resolve the `vinext/server/app-rsc-handler` shim so its resolveId result is a forward-slash path on Windows instead of a mixed-separator one.

## Why

`_appRscHandlerPath` is built as `resolveShimModulePath(path.resolve(__dirname, "server"), "app-rsc-handler")`. `resolveShimModulePath` joins with `path.posix.join`, but the base came from a raw `path.resolve`, which is backslashes on Windows. The result mixed separators:

```
E:\shulaoda\vinext\packages\vinext\src\server/app-rsc-handler.ts
```

That mixed id is what the `vinext/server/app-rsc-handler` resolveId hook returns, so Vite carries a non-canonical module id (Vite ids are forward-slash). The sibling `_shimsDir` is already normalized for exactly this reason — its comment notes that a raw `path.resolve` value "has backslashes on Windows and the `id.startsWith(_shimsDir)` checks would never match" — but the app-rsc-handler base was missed.

## How

Wrap the `path.resolve(__dirname, "server")` base in `normalizePathSeparators`, mirroring `_shimsDir`, so `resolveShimModulePath` produces a fully forward-slash id. The test that exercises this resolveId is updated to assert the forward-slash form (the Vite-canonical id) on every platform. On POSIX `normalizePathSeparators` is a no-op, so nothing changes there.

## Testing

`vp test run --project unit tests/shims.test.ts -t "keeps the App Router request handler source-resolved in source checkouts"` — passes on Windows (previously the resolveId returned a mixed-separator path, so the assertion failed). `vp check` clean on both files.
