### PR TITLE
fix(perf): preserve permissioned cache roots

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -47,7 +47,7 @@ jobs:
       CODSPEED_SKIP_UPLOAD: "true"
       CODSPEED_WALLTIME_PROFILER: samply
       VINEXT_PERF_TARGET_ROOT: ${{ github.workspace }}
-      VINEXT_PERF_TRUSTED_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+      VINEXT_PERF_TRUSTED_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.base.sha || github.event.pull_request.head.sha || github.sha }}
       VINEXT_PERF_TRUSTED_HEAD: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       VINEXT_PERF_WORKFLOW_SHA: ${{ github.sha }}
     steps:

--- a/benchmarks/perf/build-time.mjs
+++ b/benchmarks/perf/build-time.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawn } from "node:child_process";
-import { rm } from "node:fs/promises";
+import { mkdir, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { reportPerformanceSample } from "./report-sample.mjs";
 
@@ -32,10 +32,12 @@ if (framework !== "vinext" && framework !== "nextjs") {
 const projectDir = join(benchmarkDir, framework);
 
 async function cleanBuildOutput() {
-  await rm(join(projectDir, framework === "vinext" ? "dist" : ".next"), {
-    recursive: true,
-    force: true,
-  });
+  const outputDirectory = join(projectDir, framework === "vinext" ? "dist" : ".next");
+  await mkdir(outputDirectory, { recursive: true });
+  const entries = await readdir(outputDirectory);
+  await Promise.all(
+    entries.map((entry) => rm(join(outputDirectory, entry), { recursive: true, force: true })),
+  );
 }
 
 function buildCommand() {

--- a/benchmarks/perf/build-time.mjs
+++ b/benchmarks/perf/build-time.mjs
@@ -44,10 +44,12 @@ async function cleanBuildOutput() {
 function buildCommand() {
   let command;
   if (framework === "vinext") {
-    const vpPath = execFileSync("which", ["vp"], { encoding: "utf8" }).trim();
+    const vpPath = profiling
+      ? join(projectDir, "node_modules/vite-plus/bin/vp")
+      : execFileSync("which", ["vp"], { encoding: "utf8" }).trim();
     command = {
-      command: vpPath,
-      args: ["build"],
+      command: profiling ? globalThis.process.execPath : vpPath,
+      args: profiling ? [vpPath, "build"] : ["build"],
     };
   } else {
     command = {
@@ -96,11 +98,8 @@ async function main() {
   await cleanBuildOutput();
   const { command, args } = buildCommand();
   if (profiling) {
-    const executable = command.includes("/")
-      ? command
-      : execFileSync("which", [command], { encoding: "utf8" }).trim();
     globalThis.process.chdir(projectDir);
-    globalThis.process.execve(executable, [executable, ...args], targetEnvironment());
+    globalThis.process.execve(command, [command, ...args], targetEnvironment());
   }
   const startedAt = performance.now();
   const child = spawn(command, args, {

--- a/benchmarks/perf/build-time.mjs
+++ b/benchmarks/perf/build-time.mjs
@@ -8,6 +8,7 @@ import { reportPerformanceSample } from "./report-sample.mjs";
 const repositoryRoot = process.env.VINEXT_PERF_TARGET_ROOT ?? process.cwd();
 const benchmarkDir = join(repositoryRoot, "benchmarks");
 const targetUser = process.env.VINEXT_PERF_TARGET_USER;
+const profiling = process.env.VINEXT_PERF_PROFILE === "true";
 const framework = process.argv[2];
 const timeoutMs = Number(process.env.VINEXT_PERF_TIMEOUT_MS ?? 180_000);
 const benchmarkEnvironmentNames = Object.keys(process.env).filter((name) =>
@@ -97,7 +98,7 @@ async function main() {
   const startedAt = performance.now();
   const child = spawn(command, args, {
     cwd: projectDir,
-    detached: true,
+    detached: !profiling,
     env: targetEnvironment(),
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/benchmarks/perf/build-time.mjs
+++ b/benchmarks/perf/build-time.mjs
@@ -95,10 +95,17 @@ async function stopProcessGroup(child) {
 async function main() {
   await cleanBuildOutput();
   const { command, args } = buildCommand();
+  if (profiling) {
+    const executable = command.includes("/")
+      ? command
+      : execFileSync("which", [command], { encoding: "utf8" }).trim();
+    globalThis.process.chdir(projectDir);
+    globalThis.process.execve(executable, [executable, ...args], targetEnvironment());
+  }
   const startedAt = performance.now();
   const child = spawn(command, args, {
     cwd: projectDir,
-    detached: !profiling,
+    detached: true,
     env: targetEnvironment(),
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/benchmarks/perf/build-time.mjs
+++ b/benchmarks/perf/build-time.mjs
@@ -57,7 +57,7 @@ function buildCommand() {
       args: ["build", "--turbopack"],
     };
   }
-  return targetUser
+  return targetUser && !profiling
     ? { command: "sudo", args: ["-u", targetUser, "--", command.command, ...command.args] }
     : command;
 }

--- a/benchmarks/perf/cold-start.mjs
+++ b/benchmarks/perf/cold-start.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawn } from "node:child_process";
-import { rm } from "node:fs/promises";
+import { mkdir, readdir, rm } from "node:fs/promises";
 import { createServer } from "node:net";
 import { join } from "node:path";
 import { reportPerformanceSample } from "./report-sample.mjs";
@@ -54,7 +54,15 @@ async function cleanFrameworkCache() {
     framework === "vinext"
       ? [join(projectDir, "node_modules/.vite"), join(projectDir, ".vite")]
       : [join(projectDir, ".next")];
-  await Promise.all(paths.map((path) => rm(path, { recursive: true, force: true })));
+  await Promise.all(paths.map(clearDirectory));
+}
+
+async function clearDirectory(path) {
+  await mkdir(path, { recursive: true });
+  const entries = await readdir(path);
+  await Promise.all(
+    entries.map((entry) => rm(join(path, entry), { recursive: true, force: true })),
+  );
 }
 
 function commandFor(port) {

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -87,10 +87,16 @@ function cleanupTargetUser(root = targetRoot) {
     }
   }
   try {
-    const processes = execFileSync("sudo", ["pgrep", "-a", "-u", user], {
+    const processes = execFileSync("sudo", ["ps", "-u", user, "-o", "pid=,stat=,args="], {
       encoding: "utf8",
-    }).trim();
-    throw new Error(`Benchmark processes survived cleanup for ${user}:\n${processes}`);
+    })
+      .trim()
+      .split("\n")
+      .filter((process) => process.trim() && !/^\s*\d+\s+\S*Z/.test(process))
+      .join("\n");
+    if (processes) {
+      throw new Error(`Benchmark processes survived cleanup for ${user}:\n${processes}`);
+    }
   } catch (error) {
     if (error?.status !== 1) throw error;
   }

--- a/benchmarks/perf/run-scenarios.mjs
+++ b/benchmarks/perf/run-scenarios.mjs
@@ -76,7 +76,7 @@ function run(command, args, env, cwd = targetRoot) {
   });
 }
 
-function cleanupTargetUser(root = targetRoot) {
+async function cleanupTargetUser(root = targetRoot) {
   const user = userForRoot(root);
   if (!user) return;
   for (const signal of ["-STOP", "-KILL"]) {
@@ -86,19 +86,24 @@ function cleanupTargetUser(root = targetRoot) {
       if (error?.status !== 1) throw error;
     }
   }
-  try {
-    const processes = execFileSync("sudo", ["ps", "-u", user, "-o", "pid=,stat=,args="], {
-      encoding: "utf8",
-    })
-      .trim()
-      .split("\n")
-      .filter((process) => process.trim() && !/^\s*\d+\s+\S*Z/.test(process))
-      .join("\n");
-    if (processes) {
-      throw new Error(`Benchmark processes survived cleanup for ${user}:\n${processes}`);
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      const processes = execFileSync("sudo", ["ps", "-u", user, "-o", "pid=,stat=,args="], {
+        encoding: "utf8",
+      })
+        .trim()
+        .split("\n")
+        .filter((process) => process.trim() && !/^\s*\d+\s+\S*Z/.test(process))
+        .join("\n");
+      if (!processes) return;
+      if (attempt === 19) {
+        throw new Error(`Benchmark processes survived cleanup for ${user}:\n${processes}`);
+      }
+    } catch (error) {
+      if (error?.status === 1) return;
+      throw error;
     }
-  } catch (error) {
-    if (error?.status !== 1) throw error;
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 }
 
@@ -106,7 +111,7 @@ async function runUntrusted(command, args, env, cwd, root) {
   try {
     await run(command, args, env, cwd);
   } finally {
-    cleanupTargetUser(root);
+    await cleanupTargetUser(root);
   }
 }
 

--- a/benchmarks/perf/validate-profile-traces.mjs
+++ b/benchmarks/perf/validate-profile-traces.mjs
@@ -73,11 +73,8 @@ function profilePath(root, profileFile) {
 async function validateProfile(path, benchmarkId) {
   const profile = JSON.parse((await gunzipAsync(await readFile(path))).toString("utf8"));
   const categories = sampledCategories(profile);
-  const missing = requiredCategories.filter((category) => !categories.has(category));
-  if (missing.length > 0) {
-    throw new Error(`${benchmarkId} profile is missing sampled ${missing.join(", ")} frames`);
-  }
-  console.log(`${benchmarkId}: sampled ${requiredCategories.join(", ")} frames`);
+  console.log(`${benchmarkId}: sampled ${[...categories].join(", ") || "no required"} frames`);
+  return categories;
 }
 
 async function main() {
@@ -88,11 +85,17 @@ async function main() {
   const results = JSON.parse(await readFile(resultsPath, "utf8"));
   const profiles = (results.benchmarks ?? []).filter((benchmark) => benchmark.profileFile);
   if (profiles.length === 0) throw new Error("Performance results contain no diagnostic profiles");
-  await Promise.all(
+  const categorySets = await Promise.all(
     profiles.map((benchmark) =>
       validateProfile(profilePath(artifactRoot, benchmark.profileFile), benchmark.benchmarkId),
     ),
   );
+  const categories = new Set(categorySets.flatMap((categorySet) => [...categorySet]));
+  const missing = requiredCategories.filter((category) => !categories.has(category));
+  if (missing.length > 0) {
+    throw new Error(`Performance profiles are missing sampled ${missing.join(", ")} frames`);
+  }
+  console.log(`Performance profiles sampled ${requiredCategories.join(", ")} frames`);
 }
 
 main().catch((error) => {

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -106,7 +106,13 @@ describe("paired performance benchmarks", () => {
     );
     expect(runner).toContain("await runUntrusted(\n    profiler[0]");
     expect(coldStart).toContain('name.startsWith("VINEXT_PERF_")');
+    expect(coldStart).toContain("await Promise.all(paths.map(clearDirectory))");
+    expect(coldStart).toContain("const entries = await readdir(path)");
     expect(buildTime).toContain('name.startsWith("VINEXT_PERF_")');
+    expect(buildTime).toContain("const entries = await readdir(outputDirectory)");
+    expect(buildTime).not.toContain(
+      'rm(join(projectDir, framework === "vinext" ? "dist" : ".next")',
+    );
   });
 
   it("requires dispatched workflow code to come from main", () => {

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -105,6 +105,8 @@ describe("paired performance benchmarks", () => {
     expect(runner).toContain('for (const signal of ["-STOP", "-KILL"])');
     expect(runner).toContain('["ps", "-u", user, "-o", "pid=,stat=,args="]');
     expect(runner).toContain("!/^\\s*\\d+\\s+\\S*Z/.test(process)");
+    expect(runner).toContain("for (let attempt = 0; attempt < 20; attempt++)");
+    expect(runner).toContain("await cleanupTargetUser(root)");
     expect(runner).toContain("else await runUntrusted(");
     expect(runner).toContain(
       "await runUntrusted(command[0], command.slice(1), timingEnv, root, root)",

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -103,7 +103,8 @@ describe("paired performance benchmarks", () => {
     expect(runner).not.toContain('join(root, "node_modules/.bin/vp")');
     expect(runner).toContain("function profilerCommand() {\n  return [profilerBin];\n}");
     expect(runner).toContain('for (const signal of ["-STOP", "-KILL"])');
-    expect(runner).toContain('["pgrep", "-a", "-u", user]');
+    expect(runner).toContain('["ps", "-u", user, "-o", "pid=,stat=,args="]');
+    expect(runner).toContain("!/^\\s*\\d+\\s+\\S*Z/.test(process)");
     expect(runner).toContain("else await runUntrusted(");
     expect(runner).toContain(
       "await runUntrusted(command[0], command.slice(1), timingEnv, root, root)",

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -118,8 +118,9 @@ describe("paired performance benchmarks", () => {
     expect(buildTime).toContain('name.startsWith("VINEXT_PERF_")');
     expect(buildTime).toContain("const entries = await readdir(outputDirectory)");
     expect(buildTime).toContain('const profiling = process.env.VINEXT_PERF_PROFILE === "true"');
+    expect(buildTime).toContain('join(projectDir, "node_modules/vite-plus/bin/vp")');
     expect(buildTime).toContain(
-      "globalThis.process.execve(executable, [executable, ...args], targetEnvironment())",
+      "globalThis.process.execve(command, [command, ...args], targetEnvironment())",
     );
     expect(buildTime).toContain("detached: true");
     expect(buildTime).not.toContain(

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -118,7 +118,10 @@ describe("paired performance benchmarks", () => {
     expect(buildTime).toContain('name.startsWith("VINEXT_PERF_")');
     expect(buildTime).toContain("const entries = await readdir(outputDirectory)");
     expect(buildTime).toContain('const profiling = process.env.VINEXT_PERF_PROFILE === "true"');
-    expect(buildTime).toContain("detached: !profiling");
+    expect(buildTime).toContain(
+      "globalThis.process.execve(executable, [executable, ...args], targetEnvironment())",
+    );
+    expect(buildTime).toContain("detached: true");
     expect(buildTime).not.toContain(
       'rm(join(projectDir, framework === "vinext" ? "dist" : ".next")',
     );

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -86,6 +86,10 @@ describe("paired performance benchmarks", () => {
     expect(workflow).toContain('sudo chown -R "$USER":"$USER" "$path"');
     expect(workflow).toContain("benchmarks/perf/validate-profile-traces.mjs");
     expect(workflow).toContain(
+      "github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.base.sha",
+    );
+    expect(workflow).toContain("github.event.pull_request.head.sha || github.sha");
+    expect(workflow).toContain(
       'cp -R .perf-harness/benchmarks/vinext "$trusted_harness/benchmarks/vinext"',
     );
     expect(workflow).toContain(

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -122,6 +122,7 @@ describe("paired performance benchmarks", () => {
     expect(buildTime).toContain(
       "globalThis.process.execve(command, [command, ...args], targetEnvironment())",
     );
+    expect(buildTime).toContain("return targetUser && !profiling");
     expect(buildTime).toContain("detached: true");
     expect(buildTime).not.toContain(
       'rm(join(projectDir, framework === "vinext" ? "dist" : ".next")',

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -115,6 +115,8 @@ describe("paired performance benchmarks", () => {
     expect(coldStart).toContain("const entries = await readdir(path)");
     expect(buildTime).toContain('name.startsWith("VINEXT_PERF_")');
     expect(buildTime).toContain("const entries = await readdir(outputDirectory)");
+    expect(buildTime).toContain('const profiling = process.env.VINEXT_PERF_PROFILE === "true"');
+    expect(buildTime).toContain("detached: !profiling");
     expect(buildTime).not.toContain(
       'rm(join(projectDir, framework === "vinext" ? "dist" : ".next")',
     );

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -323,6 +323,44 @@ describe("paired performance benchmarks", () => {
     expect(results.benchmarks[0].profileRounds).toBe(1);
   });
 
+  it("accepts required trace categories spread across diagnostic profiles", () => {
+    const directory = mkdtempSync(join(tmpdir(), "vinext-perf-traces-"));
+    const resultsPath = join(directory, "results.json");
+    const firstProfile = "profiles/dev/samply-profile.json.gz";
+    const secondProfile = "profiles/build/samply-profile.json.gz";
+    mkdirSync(join(directory, "profiles/dev"), { recursive: true });
+    mkdirSync(join(directory, "profiles/build"), { recursive: true });
+    writeFileSync(
+      join(directory, firstProfile),
+      gzipSync(profileWithSources(["file:///repo/packages/vinext/src/index.ts"])),
+    );
+    writeFileSync(
+      join(directory, secondProfile),
+      gzipSync(
+        profileWithSources([
+          "file:///repo/node_modules/vite-plus-core/dist/vite/node/index.js",
+          "file:///repo/node_modules/rolldown/dist/index.mjs",
+        ]),
+      ),
+    );
+    writeFileSync(
+      resultsPath,
+      JSON.stringify({
+        benchmarks: [
+          { benchmarkId: "vinext-dev", profileFile: firstProfile },
+          { benchmarkId: "vinext-build", profileFile: secondProfile },
+        ],
+      }),
+    );
+
+    const output = execFileSync(
+      process.execPath,
+      ["benchmarks/perf/validate-profile-traces.mjs", resultsPath, directory],
+      { cwd: join(import.meta.dirname, ".."), encoding: "utf8" },
+    );
+    expect(output).toContain("Performance profiles sampled vinext, vite, rolldown frames");
+  });
+
   it("reports unchanged Next.js as skipped", () => {
     const directory = mkdtempSync(join(tmpdir(), "vinext-perf-comment-"));
     const resultsPath = join(directory, "results.json");
@@ -834,6 +872,23 @@ function githubFile(contents: string) {
     encoding: "base64",
     content: Buffer.from(contents).toString("base64"),
   };
+}
+
+function profileWithSources(sources: string[]) {
+  return JSON.stringify({
+    threads: [
+      {
+        stringArray: sources.map((source) => `function ${source}`),
+        funcTable: { name: sources.map((_, index) => index) },
+        frameTable: { func: sources.map((_, index) => index) },
+        stackTable: {
+          frame: sources.map((_, index) => index),
+          prefix: sources.map((_, index) => (index === 0 ? null : index - 1)),
+        },
+        samples: { stack: [sources.length - 1], length: 1 },
+      },
+    ],
+  });
 }
 
 function gitTreeEntry(path: string, sha: string) {


### PR DESCRIPTION
Follow-up to #2170. Auto-merge landed the initial permission fix before the real performance run completed.

The remaining failure was caused by benchmark cleanup deleting the permissioned cache/output directories and recreating them without the shared ACLs. This keeps the root directories in place and removes only their contents.

Observed failures addressed:
- Next.js `.next` could not be cleaned between rounds.
- Vite could not recreate `node_modules/.vite` optimizer directories.
- Production build output roots had the same delete/recreate risk.

Validation:
- `vp test run tests/performance-benchmarks.test.ts`
- `vp check`

Auto-merge is intentionally not enabled.