### PR TITLE
fix(perf): allow publisher PR comments

### DIFF
--- a/.github/workflows/perf-publish.yml
+++ b/.github/workflows/perf-publish.yml
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: read
-      issues: write
+      pull-requests: write
     steps:
       - name: Download rendered comment
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -178,12 +178,12 @@ describe("paired performance benchmarks", () => {
     );
     const commentJob = workflow.slice(workflow.indexOf("  comment:"));
 
-    expect(workflow).not.toContain("pull-requests: write");
     expect(publishJob).toContain("actions: read");
     expect(publishJob).toContain("contents: read");
     expect(publishJob).not.toContain("issues: write");
     expect(commentJob).toContain("actions: read");
-    expect(commentJob).toContain("issues: write");
+    expect(commentJob).toContain("pull-requests: write");
+    expect(commentJob).not.toContain("issues: write");
     expect(commentJob).not.toContain("secrets.");
     expect(commentJob).not.toContain("actions/checkout");
     expect(commentJob).not.toContain("performance-artifact");


### PR DESCRIPTION
Fixes the trusted performance publisher comment job after benchmark uploads.

- Use `pull-requests: write` for comments attached to pull requests
- Keep artifact publishing isolated from all comment write permissions
- Update the focused workflow regression test

Evidence:
- Publisher run `27811633765` successfully created the same Issue Comments API comment with an effective `PullRequests: write` token.
- After the privilege split changed the isolated comment job to `Issues: write`, runs `27820091264` and `27820596969` consistently received `403 Resource not accessible by integration`.
- The failing run was a same-repository PR by an organization member, so fork restrictions were not involved.

Auto-merge is not enabled.