### PR TITLE
fix(perf): ensure full profiles exist

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -245,6 +245,7 @@ jobs:
               benchmarks/vinext/dist
               benchmarks/vinext/.vite
               benchmarks/vinext/node_modules/.vite
+              benchmarks/vinext/node_modules/.vite-temp
               benchmarks/nextjs/.next
               benchmarks/nextjs/node_modules
             )

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -162,9 +162,35 @@ jobs:
             benchmarks/nextjs
             benchmarks/perf
 
+      - name: Detect Next.js benchmark input changes
+        if: env.VINEXT_PERF_RUN_KIND == 'pull_request'
+        run: |
+          fingerprint_script=".perf-manifests/benchmarks/perf/nextjs-input-fingerprint.mts"
+          base_validator="$VINEXT_PERF_BASE_ROOT/benchmarks/perf/validate-results.mjs"
+          if [ ! -f "$fingerprint_script" ] || \
+            ! grep -q "skippedImplementations" "$base_validator"; then
+            echo "Base publisher does not support skipped implementations yet; keeping Next.js for rollout compatibility."
+            exit 0
+          fi
+          head_fingerprint=$(node "$fingerprint_script" .)
+          base_fingerprint=$(node "$fingerprint_script" "$VINEXT_PERF_BASE_ROOT")
+          if [ "$head_fingerprint" = "$base_fingerprint" ]; then
+            echo "Next.js benchmark inputs are unchanged; skipping Next.js PR benchmarks."
+            echo "VINEXT_PERF_SKIP_IMPLEMENTATIONS=nextjs" >> "$GITHUB_ENV"
+          else
+            if [ "$VINEXT_PERF_TRUSTED_HEAD" != "true" ]; then
+              echo "Fork pull requests may not change Next.js benchmark inputs." >&2
+              exit 1
+            fi
+            echo "Next.js benchmark inputs changed; pairing base and head Next.js benchmarks."
+          fi
+
       - name: Prepare trusted benchmark manifests
         run: |
-          projects=(vinext nextjs)
+          projects=(vinext)
+          if [ "$VINEXT_PERF_RUN_KIND" != "pull_request" ]; then
+            projects+=(nextjs)
+          fi
           for project in "${projects[@]}"; do
             find "benchmarks/$project" -mindepth 1 -maxdepth 1 \
               ! -name app ! -name node_modules ! -name dist ! -name .next -exec rm -rf {} +
@@ -281,7 +307,10 @@ jobs:
             roots+=("$VINEXT_PERF_BASE_ROOT")
           fi
           for root in "${roots[@]}"; do
-            projects=(vinext nextjs)
+            projects=(vinext)
+            if [ "$VINEXT_PERF_RUN_KIND" != "pull_request" ]; then
+              projects+=(nextjs)
+            fi
             for project in "${projects[@]}"; do
               find "$root/benchmarks/$project" -mindepth 1 -maxdepth 1 \
                 ! -name app ! -name node_modules ! -name dist ! -name .next -exec rm -rf {} +
@@ -294,12 +323,18 @@ jobs:
       - name: Prepare performance scenarios
         run: |
           args=(--setup-only)
+          if [ "$VINEXT_PERF_SKIP_IMPLEMENTATIONS" = "nextjs" ]; then
+            args+=(--implementation=vinext)
+          fi
           node "$VINEXT_PERF_HARNESS_ROOT/benchmarks/perf/run-scenarios.mjs" "${args[@]}"
 
       - name: Prepare base performance scenarios
         if: env.VINEXT_PERF_RUN_KIND == 'pull_request'
         run: |
           args=(--setup-only)
+          if [ "$VINEXT_PERF_SKIP_IMPLEMENTATIONS" = "nextjs" ]; then
+            args+=(--implementation=vinext)
+          fi
           VINEXT_PERF_TARGET_ROOT="$VINEXT_PERF_BASE_ROOT" \
             node "$VINEXT_PERF_HARNESS_ROOT/benchmarks/perf/run-scenarios.mjs" "${args[@]}"
 
@@ -314,7 +349,10 @@ jobs:
           for index in "${!roots[@]}"; do
             root="${roots[$index]}"
             user="${users[$index]}"
-            projects=(vinext nextjs)
+            projects=(vinext)
+            if [ "$VINEXT_PERF_RUN_KIND" != "pull_request" ]; then
+              projects+=(nextjs)
+            fi
             for project in "${projects[@]}"; do
               find "$root/benchmarks/$project" -mindepth 1 -maxdepth 1 \
                 ! -name app ! -name node_modules ! -name dist ! -name .next -exec rm -rf {} +

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -162,35 +162,9 @@ jobs:
             benchmarks/nextjs
             benchmarks/perf
 
-      - name: Detect Next.js benchmark input changes
-        if: env.VINEXT_PERF_RUN_KIND == 'pull_request'
-        run: |
-          fingerprint_script=".perf-manifests/benchmarks/perf/nextjs-input-fingerprint.mts"
-          base_validator="$VINEXT_PERF_BASE_ROOT/benchmarks/perf/validate-results.mjs"
-          if [ ! -f "$fingerprint_script" ] || \
-            ! grep -q "skippedImplementations" "$base_validator"; then
-            echo "Base publisher does not support skipped implementations yet; keeping Next.js for rollout compatibility."
-            exit 0
-          fi
-          head_fingerprint=$(node "$fingerprint_script" .)
-          base_fingerprint=$(node "$fingerprint_script" "$VINEXT_PERF_BASE_ROOT")
-          if [ "$head_fingerprint" = "$base_fingerprint" ]; then
-            echo "Next.js benchmark inputs are unchanged; skipping Next.js PR benchmarks."
-            echo "VINEXT_PERF_SKIP_IMPLEMENTATIONS=nextjs" >> "$GITHUB_ENV"
-          else
-            if [ "$VINEXT_PERF_TRUSTED_HEAD" != "true" ]; then
-              echo "Fork pull requests may not change Next.js benchmark inputs." >&2
-              exit 1
-            fi
-            echo "Next.js benchmark inputs changed; pairing base and head Next.js benchmarks."
-          fi
-
       - name: Prepare trusted benchmark manifests
         run: |
-          projects=(vinext)
-          if [ "$VINEXT_PERF_RUN_KIND" != "pull_request" ]; then
-            projects+=(nextjs)
-          fi
+          projects=(vinext nextjs)
           for project in "${projects[@]}"; do
             find "benchmarks/$project" -mindepth 1 -maxdepth 1 \
               ! -name app ! -name node_modules ! -name dist ! -name .next -exec rm -rf {} +
@@ -307,10 +281,7 @@ jobs:
             roots+=("$VINEXT_PERF_BASE_ROOT")
           fi
           for root in "${roots[@]}"; do
-            projects=(vinext)
-            if [ "$VINEXT_PERF_RUN_KIND" != "pull_request" ]; then
-              projects+=(nextjs)
-            fi
+            projects=(vinext nextjs)
             for project in "${projects[@]}"; do
               find "$root/benchmarks/$project" -mindepth 1 -maxdepth 1 \
                 ! -name app ! -name node_modules ! -name dist ! -name .next -exec rm -rf {} +
@@ -323,18 +294,12 @@ jobs:
       - name: Prepare performance scenarios
         run: |
           args=(--setup-only)
-          if [ "$VINEXT_PERF_SKIP_IMPLEMENTATIONS" = "nextjs" ]; then
-            args+=(--implementation=vinext)
-          fi
           node "$VINEXT_PERF_HARNESS_ROOT/benchmarks/perf/run-scenarios.mjs" "${args[@]}"
 
       - name: Prepare base performance scenarios
         if: env.VINEXT_PERF_RUN_KIND == 'pull_request'
         run: |
           args=(--setup-only)
-          if [ "$VINEXT_PERF_SKIP_IMPLEMENTATIONS" = "nextjs" ]; then
-            args+=(--implementation=vinext)
-          fi
           VINEXT_PERF_TARGET_ROOT="$VINEXT_PERF_BASE_ROOT" \
             node "$VINEXT_PERF_HARNESS_ROOT/benchmarks/perf/run-scenarios.mjs" "${args[@]}"
 
@@ -349,10 +314,7 @@ jobs:
           for index in "${!roots[@]}"; do
             root="${roots[$index]}"
             user="${users[$index]}"
-            projects=(vinext)
-            if [ "$VINEXT_PERF_RUN_KIND" != "pull_request" ]; then
-              projects+=(nextjs)
-            fi
+            projects=(vinext nextjs)
             for project in "${projects[@]}"; do
               find "$root/benchmarks/$project" -mindepth 1 -maxdepth 1 \
                 ! -name app ! -name node_modules ! -name dist ! -name .next -exec rm -rf {} +

--- a/benchmarks/perf/cold-start.mjs
+++ b/benchmarks/perf/cold-start.mjs
@@ -118,8 +118,7 @@ async function waitForRoute(url, child, output, getSpawnError) {
 async function stopProcessGroup(child) {
   const processGroupId = child.pid;
   try {
-    if (!profiling && processGroupId) globalThis.process.kill(-processGroupId, "SIGTERM");
-    else if (child.exitCode === null) child.kill("SIGTERM");
+    if (processGroupId) globalThis.process.kill(-processGroupId, "SIGTERM");
   } catch {
     try {
       if (child.exitCode === null) child.kill("SIGTERM");
@@ -135,8 +134,7 @@ async function stopProcessGroup(child) {
 
   if (child.exitCode === null) {
     try {
-      if (!profiling && processGroupId) globalThis.process.kill(-processGroupId, "SIGKILL");
-      else child.kill("SIGKILL");
+      if (processGroupId) globalThis.process.kill(-processGroupId, "SIGKILL");
     } catch {
       // The process exited between the checks.
     }
@@ -155,7 +153,7 @@ async function main() {
   const startedAt = performance.now();
   const child = spawn(command, args, {
     cwd: projectDir,
-    detached: !profiling,
+    detached: true,
     env: targetEnvironment(),
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/benchmarks/perf/cold-start.mjs
+++ b/benchmarks/perf/cold-start.mjs
@@ -9,6 +9,7 @@ import { reportPerformanceSample } from "./report-sample.mjs";
 const repositoryRoot = process.env.VINEXT_PERF_TARGET_ROOT ?? process.cwd();
 const benchmarkDir = join(repositoryRoot, "benchmarks");
 const targetUser = process.env.VINEXT_PERF_TARGET_USER;
+const profiling = process.env.VINEXT_PERF_PROFILE === "true";
 const framework = process.argv[2];
 const route = process.argv[3] ?? "/";
 const expectedText = process.env.VINEXT_PERF_EXPECTED_TEXT ?? "Benchmark App";
@@ -68,10 +69,14 @@ async function clearDirectory(path) {
 function commandFor(port) {
   let command;
   if (framework === "vinext") {
-    const vpPath = execFileSync("which", ["vp"], { encoding: "utf8" }).trim();
+    const vpPath = profiling
+      ? join(projectDir, "node_modules/vite-plus/bin/vp")
+      : execFileSync("which", ["vp"], { encoding: "utf8" }).trim();
     command = {
-      command: vpPath,
-      args: ["dev", "--host", "127.0.0.1", "--port", String(port)],
+      command: profiling ? globalThis.process.execPath : vpPath,
+      args: profiling
+        ? [vpPath, "dev", "--host", "127.0.0.1", "--port", String(port)]
+        : ["dev", "--host", "127.0.0.1", "--port", String(port)],
     };
   } else {
     command = {
@@ -79,7 +84,7 @@ function commandFor(port) {
       args: ["dev", "--turbopack", "-H", "127.0.0.1", "-p", String(port)],
     };
   }
-  return targetUser
+  return targetUser && !profiling
     ? { command: "sudo", args: ["-u", targetUser, "--", command.command, ...command.args] }
     : command;
 }
@@ -113,7 +118,8 @@ async function waitForRoute(url, child, output, getSpawnError) {
 async function stopProcessGroup(child) {
   const processGroupId = child.pid;
   try {
-    if (processGroupId) globalThis.process.kill(-processGroupId, "SIGTERM");
+    if (!profiling && processGroupId) globalThis.process.kill(-processGroupId, "SIGTERM");
+    else if (child.exitCode === null) child.kill("SIGTERM");
   } catch {
     try {
       if (child.exitCode === null) child.kill("SIGTERM");
@@ -129,7 +135,8 @@ async function stopProcessGroup(child) {
 
   if (child.exitCode === null) {
     try {
-      if (processGroupId) globalThis.process.kill(-processGroupId, "SIGKILL");
+      if (!profiling && processGroupId) globalThis.process.kill(-processGroupId, "SIGKILL");
+      else child.kill("SIGKILL");
     } catch {
       // The process exited between the checks.
     }
@@ -148,7 +155,7 @@ async function main() {
   const startedAt = performance.now();
   const child = spawn(command, args, {
     cwd: projectDir,
-    detached: true,
+    detached: !profiling,
     env: targetEnvironment(),
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/benchmarks/perf/validate-profile-traces.mjs
+++ b/benchmarks/perf/validate-profile-traces.mjs
@@ -73,8 +73,11 @@ function profilePath(root, profileFile) {
 async function validateProfile(path, benchmarkId) {
   const profile = JSON.parse((await gunzipAsync(await readFile(path))).toString("utf8"));
   const categories = sampledCategories(profile);
-  console.log(`${benchmarkId}: sampled ${[...categories].join(", ") || "no required"} frames`);
-  return categories;
+  const missing = requiredCategories.filter((category) => !categories.has(category));
+  if (missing.length > 0) {
+    throw new Error(`${benchmarkId} profile is missing sampled ${missing.join(", ")} frames`);
+  }
+  console.log(`${benchmarkId}: sampled ${requiredCategories.join(", ")} frames`);
 }
 
 async function main() {
@@ -85,17 +88,11 @@ async function main() {
   const results = JSON.parse(await readFile(resultsPath, "utf8"));
   const profiles = (results.benchmarks ?? []).filter((benchmark) => benchmark.profileFile);
   if (profiles.length === 0) throw new Error("Performance results contain no diagnostic profiles");
-  const categorySets = await Promise.all(
+  await Promise.all(
     profiles.map((benchmark) =>
       validateProfile(profilePath(artifactRoot, benchmark.profileFile), benchmark.benchmarkId),
     ),
   );
-  const categories = new Set(categorySets.flatMap((categorySet) => [...categorySet]));
-  const missing = requiredCategories.filter((category) => !categories.has(category));
-  if (missing.length > 0) {
-    throw new Error(`Performance profiles are missing sampled ${missing.join(", ")} frames`);
-  }
-  console.log(`Performance profiles sampled ${requiredCategories.join(", ")} frames`);
 }
 
 main().catch((error) => {

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -83,6 +83,7 @@ describe("paired performance benchmarks", () => {
     expect(workflow).toContain('"$root/packages/vinext/dist"');
     expect(workflow).toContain('"$root/packages/cloudflare/dist"');
     expect(workflow).toContain('"$root/node_modules/.vite/task-cache"');
+    expect(workflow).toContain("benchmarks/vinext/node_modules/.vite-temp");
     expect(workflow).toContain('sudo chown -R "$USER":"$USER" "$path"');
     expect(workflow).toContain("benchmarks/perf/validate-profile-traces.mjs");
     expect(workflow).toContain(

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -85,9 +85,6 @@ describe("paired performance benchmarks", () => {
     expect(workflow).toContain('"$root/node_modules/.vite/task-cache"');
     expect(workflow).toContain('sudo chown -R "$USER":"$USER" "$path"');
     expect(workflow).toContain("benchmarks/perf/validate-profile-traces.mjs");
-    expect(workflow).toContain("projects=(vinext nextjs)");
-    expect(workflow).not.toContain("VINEXT_PERF_SKIP_IMPLEMENTATIONS");
-    expect(workflow).not.toContain("Detect Next.js benchmark input changes");
     expect(workflow).toContain(
       "github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.base.sha",
     );
@@ -153,14 +150,25 @@ describe("paired performance benchmarks", () => {
     expect(validation).toContain("Dispatched workflow ref is not the current default branch head");
   });
 
-  it("always pairs Next.js benchmarks for pull requests", () => {
+  it("keeps Next.js enabled until the trusted base supports fingerprinting", () => {
     const workflow = readFileSync(
       join(import.meta.dirname, "../.github/workflows/perf.yml"),
       "utf8",
     );
-    expect(workflow).toContain("projects=(vinext nextjs)");
-    expect(workflow).not.toContain("skipping Next.js PR benchmarks");
-    expect(workflow).not.toContain("--implementation=vinext");
+    const detectionStep = workflow.slice(
+      workflow.indexOf("- name: Detect Next.js benchmark input changes"),
+      workflow.indexOf("- name: Prepare trusted benchmark manifests"),
+    );
+    const compatibilityGuard = detectionStep.indexOf('[ ! -f "$fingerprint_script" ]');
+    const fingerprintInvocation = detectionStep.indexOf(
+      'head_fingerprint=$(node "$fingerprint_script" .)',
+    );
+
+    expect(compatibilityGuard).toBeGreaterThan(-1);
+    expect(detectionStep).toContain('grep -q "skippedImplementations" "$base_validator"');
+    expect(detectionStep).toContain("keeping Next.js for rollout compatibility");
+    expect(detectionStep).toContain("exit 0");
+    expect(fingerprintInvocation).toBeGreaterThan(compatibilityGuard);
   });
 
   it("isolates pull request comment permissions from benchmark publishing", () => {

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -85,6 +85,9 @@ describe("paired performance benchmarks", () => {
     expect(workflow).toContain('"$root/node_modules/.vite/task-cache"');
     expect(workflow).toContain('sudo chown -R "$USER":"$USER" "$path"');
     expect(workflow).toContain("benchmarks/perf/validate-profile-traces.mjs");
+    expect(workflow).toContain("projects=(vinext nextjs)");
+    expect(workflow).not.toContain("VINEXT_PERF_SKIP_IMPLEMENTATIONS");
+    expect(workflow).not.toContain("Detect Next.js benchmark input changes");
     expect(workflow).toContain(
       "github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.base.sha",
     );
@@ -113,6 +116,10 @@ describe("paired performance benchmarks", () => {
     );
     expect(runner).toContain("await runUntrusted(\n    profiler[0]");
     expect(coldStart).toContain('name.startsWith("VINEXT_PERF_")');
+    expect(coldStart).toContain('const profiling = process.env.VINEXT_PERF_PROFILE === "true"');
+    expect(coldStart).toContain('join(projectDir, "node_modules/vite-plus/bin/vp")');
+    expect(coldStart).toContain("detached: !profiling");
+    expect(coldStart).toContain("return targetUser && !profiling");
     expect(coldStart).toContain("await Promise.all(paths.map(clearDirectory))");
     expect(coldStart).toContain("const entries = await readdir(path)");
     expect(buildTime).toContain('name.startsWith("VINEXT_PERF_")');
@@ -146,25 +153,14 @@ describe("paired performance benchmarks", () => {
     expect(validation).toContain("Dispatched workflow ref is not the current default branch head");
   });
 
-  it("keeps Next.js enabled until the trusted base supports fingerprinting", () => {
+  it("always pairs Next.js benchmarks for pull requests", () => {
     const workflow = readFileSync(
       join(import.meta.dirname, "../.github/workflows/perf.yml"),
       "utf8",
     );
-    const detectionStep = workflow.slice(
-      workflow.indexOf("- name: Detect Next.js benchmark input changes"),
-      workflow.indexOf("- name: Prepare trusted benchmark manifests"),
-    );
-    const compatibilityGuard = detectionStep.indexOf('[ ! -f "$fingerprint_script" ]');
-    const fingerprintInvocation = detectionStep.indexOf(
-      'head_fingerprint=$(node "$fingerprint_script" .)',
-    );
-
-    expect(compatibilityGuard).toBeGreaterThan(-1);
-    expect(detectionStep).toContain('grep -q "skippedImplementations" "$base_validator"');
-    expect(detectionStep).toContain("keeping Next.js for rollout compatibility");
-    expect(detectionStep).toContain("exit 0");
-    expect(fingerprintInvocation).toBeGreaterThan(compatibilityGuard);
+    expect(workflow).toContain("projects=(vinext nextjs)");
+    expect(workflow).not.toContain("skipping Next.js PR benchmarks");
+    expect(workflow).not.toContain("--implementation=vinext");
   });
 
   it("isolates pull request comment permissions from benchmark publishing", () => {
@@ -323,7 +319,7 @@ describe("paired performance benchmarks", () => {
     expect(results.benchmarks[0].profileRounds).toBe(1);
   });
 
-  it("accepts required trace categories spread across diagnostic profiles", () => {
+  it("requires every diagnostic profile to contain filterable traces", () => {
     const directory = mkdtempSync(join(tmpdir(), "vinext-perf-traces-"));
     const resultsPath = join(directory, "results.json");
     const firstProfile = "profiles/dev/samply-profile.json.gz";
@@ -353,12 +349,13 @@ describe("paired performance benchmarks", () => {
       }),
     );
 
-    const output = execFileSync(
-      process.execPath,
-      ["benchmarks/perf/validate-profile-traces.mjs", resultsPath, directory],
-      { cwd: join(import.meta.dirname, ".."), encoding: "utf8" },
-    );
-    expect(output).toContain("Performance profiles sampled vinext, vite, rolldown frames");
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        ["benchmarks/perf/validate-profile-traces.mjs", resultsPath, directory],
+        { cwd: join(import.meta.dirname, ".."), encoding: "utf8", stdio: "pipe" },
+      ),
+    ).toThrow("vinext-dev profile is missing sampled vite, rolldown frames");
   });
 
   it("reports unchanged Next.js as skipped", () => {

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -115,7 +115,7 @@ describe("paired performance benchmarks", () => {
     expect(coldStart).toContain('name.startsWith("VINEXT_PERF_")');
     expect(coldStart).toContain('const profiling = process.env.VINEXT_PERF_PROFILE === "true"');
     expect(coldStart).toContain('join(projectDir, "node_modules/vite-plus/bin/vp")');
-    expect(coldStart).toContain("detached: !profiling");
+    expect(coldStart).toContain("detached: true");
     expect(coldStart).toContain("return targetUser && !profiling");
     expect(coldStart).toContain("await Promise.all(paths.map(clearDirectory))");
     expect(coldStart).toContain("const entries = await readdir(path)");
@@ -342,6 +342,7 @@ describe("paired performance benchmarks", () => {
       join(directory, secondProfile),
       gzipSync(
         profileWithSources([
+          "file:///repo/packages/vinext/src/index.ts",
           "file:///repo/node_modules/vite-plus-core/dist/vite/node/index.js",
           "file:///repo/node_modules/rolldown/dist/index.mjs",
         ]),


### PR DESCRIPTION
Fixes diagnostic profile artifacts for PR performance runs.

- Profile the benchmark-local Vite+ dev process instead of only the cold-start adapter
- Avoid nested user switching during diagnostic profiling
- Keep profiled processes attached so Samply follows the actual Vite process tree
- Require every uploaded vinext profile to independently contain vinext, Vite, and Rolldown sampled frames
- Preserve the intentional unchanged-Next.js skip behavior

Acceptance criteria before merge:
- The raw `vinext-dev-cold-start-root` profile contains vinext, Vite, and Rolldown frames
- The raw `vinext-production-build` profile contains vinext, Vite, and Rolldown frames
- Strict trace validation, normalization, and artifact upload pass
- The downloaded artifact is inspected directly, not inferred from workflow status

Auto-merge is not enabled.