### PR TITLE
perf(server): skip duplicate App RSC vary merge

### DIFF
--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -53,7 +53,12 @@ export function finalizeAppRscResponse(
   }
 
   if (!response.headers.has(VINEXT_STATIC_FILE_HEADER)) {
-    mergeVaryHeader(response.headers, VINEXT_RSC_VARY_HEADER);
+    const varyHeader = response.headers.get("Vary");
+    if (varyHeader === null) {
+      response.headers.set("Vary", VINEXT_RSC_VARY_HEADER);
+    } else if (varyHeader !== VINEXT_RSC_VARY_HEADER) {
+      mergeVaryHeader(response.headers, VINEXT_RSC_VARY_HEADER);
+    }
   }
 
   // The CDN cache adapter owns the *default* Cache-Control. If no route path


### PR DESCRIPTION
## Overview

This PR avoids running the generic `Vary` merge path when App Router response finalization sees the internal RSC `Vary` header is already present, or when the header is missing and can be set directly.

| Area | Change | Impact |
| --- | --- | --- |
| App Router SSR | Fast-path App RSC `Vary` finalization | Removes repeated split, trim, dedupe work from the common page response path |
| Custom `Vary` responses | Keep using `mergeVaryHeader` | Preserves existing wildcard and dedupe semantics |

## Why

App page helpers already stamp `VINEXT_RSC_VARY_HEADER` before `finalizeAppRscResponse()` runs. The finalizer was still calling the generic merge helper, which reparsed and deduped the same known header value on every non-static App Router response.

## Validation

- `vp check tests/app-rsc-response-finalizer.test.ts packages/vinext/src/server/app-rsc-response-finalizer.ts`
- `vp test run tests/app-rsc-response-finalizer.test.ts`
- `vp run vinext#build`

## Perf note

Local 20k warmed SSR profile against the benchmark app showed `mergeVaryHeader` self-time on this path drop from `70.33ms` to `0ms`, with `finalizeAppRscResponse` self-time dropping from `12.29ms` to `5.37ms`.

## Non-goals

This does not change the broader `mergeVaryHeader` helper or optimize route tree construction. Those are separate hot paths.