### PR TITLE
feat(web): show one hundred benchmark runs

### DIFF
--- a/apps/web/app/lib/benchmarks/server.ts
+++ b/apps/web/app/lib/benchmarks/server.ts
@@ -396,7 +396,7 @@ type PerformanceComparisonMeasurementData = Omit<
   profileUrl: string | null;
 };
 
-export async function getPerformanceRuns(limit = 50): Promise<PerformanceRunData[]> {
+export async function getPerformanceRuns(limit = 100): Promise<PerformanceRunData[]> {
   const boundedLimit = Math.max(1, Math.min(limit, 100));
   const db = getD1();
   const { results } = await db


### PR DESCRIPTION
## Summary
- extend the performance dashboard trends and recent-run history from 50 to 100 main commits
- keep the existing query bound of 100 runs

## Validation
- `vp check apps/web/app/lib/benchmarks/server.ts`
- `vp run @apps/web#build:vinext`

The plain Next.js build reaches the existing `cloudflare:workers` runtime import boundary during page-data collection, so the supported vinext production build was used for validation.