### PR TITLE
perf(server): cache App Router route wiring plans

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -257,18 +257,18 @@ type AppPageRouteWiringPlan<
 > = {
   defaultSourcePage: string;
   errorEntries: readonly AppPageErrorEntry<TErrorModule>[];
-  errorEntriesByTreePosition: ReadonlyMap<number, AppPageErrorEntry<TErrorModule>>;
+  errorEntriesByTreePosition: readonly (AppPageErrorEntry<TErrorModule> | undefined)[];
   layoutEntries: readonly AppPageLayoutEntry<TModule, TErrorModule>[];
-  layoutEntriesByTreePosition: ReadonlyMap<number, AppPageLayoutEntry<TModule, TErrorModule>>;
+  layoutEntriesByTreePosition: readonly (AppPageLayoutEntry<TModule, TErrorModule> | undefined)[];
   layoutIds: readonly string[];
-  layoutIndicesByTreePosition: ReadonlyMap<number, number>;
+  layoutIndicesByTreePosition: readonly (number | undefined)[];
   orderedTreePositions: readonly number[];
   rootLayoutTreePath: string | null;
   routeSegments: readonly string[];
   slotEntries: readonly AppPageSlotEntry<TModule, TErrorModule>[];
   slotNameCounts: ReadonlyMap<string, number> | null;
   templateEntries: readonly AppPageTemplateEntry<TModule>[];
-  templateEntriesByTreePosition: ReadonlyMap<number, AppPageTemplateEntry<TModule>>;
+  templateEntriesByTreePosition: readonly (AppPageTemplateEntry<TModule> | undefined)[];
 };
 
 const appPageRouteWiringPlanCache = new WeakMap<
@@ -459,21 +459,21 @@ function createAppPageRouteWiringPlan<
   const layoutEntries = createAppPageLayoutEntries(route);
   const templateEntries = createAppPageTemplateEntries(route);
   const errorEntries = createAppPageErrorEntries(route);
-  const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
-  const templateEntriesByTreePosition = new Map<number, AppPageTemplateEntry<TModule>>();
-  const errorEntriesByTreePosition = new Map<number, AppPageErrorEntry<TErrorModule>>();
-  const layoutIndicesByTreePosition = new Map<number, number>();
+  const layoutEntriesByTreePosition: (AppPageLayoutEntry<TModule, TErrorModule> | undefined)[] = [];
+  const templateEntriesByTreePosition: (AppPageTemplateEntry<TModule> | undefined)[] = [];
+  const errorEntriesByTreePosition: (AppPageErrorEntry<TErrorModule> | undefined)[] = [];
+  const layoutIndicesByTreePosition: (number | undefined)[] = [];
 
   for (let index = 0; index < layoutEntries.length; index++) {
     const layoutEntry = layoutEntries[index];
-    layoutEntriesByTreePosition.set(layoutEntry.treePosition, layoutEntry);
-    layoutIndicesByTreePosition.set(layoutEntry.treePosition, index);
+    layoutEntriesByTreePosition[layoutEntry.treePosition] = layoutEntry;
+    layoutIndicesByTreePosition[layoutEntry.treePosition] = index;
   }
   for (const templateEntry of templateEntries) {
-    templateEntriesByTreePosition.set(templateEntry.treePosition, templateEntry);
+    templateEntriesByTreePosition[templateEntry.treePosition] = templateEntry;
   }
   for (const errorEntry of errorEntries) {
-    errorEntriesByTreePosition.set(errorEntry.treePosition, errorEntry);
+    errorEntriesByTreePosition[errorEntry.treePosition] = errorEntry;
   }
 
   const slotEntries: AppPageSlotEntry<TModule, TErrorModule>[] = route.slots
@@ -591,12 +591,6 @@ function resolveAppPageSlotBindingState(
   return "unmatched";
 }
 
-function resolveEmptyAppPageSlotOverride<TModule extends AppPageModule>():
-  | AppPageSlotOverride<TModule>
-  | undefined {
-  return undefined;
-}
-
 function createAppPageSlotBindings<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
@@ -712,15 +706,12 @@ export function buildAppPageElements<
   const layoutIndicesByTreePosition = routePlan.layoutIndicesByTreePosition;
   const slotEntries = routePlan.slotEntries;
   const hasSlots = slotEntries.length > 0;
-  const hasTemplates = templateEntries.length > 0;
   const layoutDependenciesByIndex: AppRenderDependency[] = [];
   const renderDependenciesByElementId = new Map<string, AppRenderDependency>();
   const layoutDependenciesBefore: Array<readonly AppRenderDependency[]> = [];
   const slotDependenciesByLayoutIndex: Array<readonly AppRenderDependency[]> = [];
-  const templateDependenciesById = hasTemplates ? new Map<string, AppRenderDependency>() : null;
-  const templateDependenciesBeforeById = hasTemplates
-    ? new Map<string, readonly AppRenderDependency[]>()
-    : null;
+  const templateDependenciesById = new Map<string, AppRenderDependency>();
+  const templateDependenciesBeforeById = new Map<string, readonly AppRenderDependency[]>();
   const pageDependencies: AppRenderDependency[] = [];
   const rootLayoutTreePath = routePlan.rootLayoutTreePath;
   const slotNameCounts = routePlan.slotNameCounts;
@@ -743,7 +734,7 @@ export function buildAppPageElements<
 
         return undefined;
       }
-    : resolveEmptyAppPageSlotOverride;
+    : () => undefined;
   const elements: Record<
     string,
     | ReactNode
@@ -785,11 +776,12 @@ export function buildAppPageElements<
     resolveSlotOverride?.(slotKey, slotName)?.params ?? options.matchedParams;
 
   for (const treePosition of orderedTreePositions) {
-    const layoutIndex = layoutIndicesByTreePosition.get(treePosition);
+    const layoutIndex = layoutIndicesByTreePosition[treePosition];
     if (layoutIndex !== undefined) {
       const layoutEntry = layoutEntries[layoutIndex];
-      layoutDependenciesBefore[layoutIndex] =
+      const deps =
         pageDependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...pageDependencies];
+      layoutDependenciesBefore[layoutIndex] = deps;
       if (getDefaultExport(layoutEntry.layoutModule)) {
         const layoutDependency = createAppRenderDependency();
         layoutDependenciesByIndex[layoutIndex] = layoutDependency;
@@ -797,17 +789,12 @@ export function buildAppPageElements<
         pageDependencies.push(layoutDependency);
       }
       if (hasSlots) {
-        slotDependenciesByLayoutIndex[layoutIndex] =
-          pageDependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...pageDependencies];
+        slotDependenciesByLayoutIndex[layoutIndex] = deps;
       }
     }
 
-    if (hasTemplates && templateDependenciesById && templateDependenciesBeforeById) {
-      const templateEntry = templateEntriesByTreePosition.get(treePosition);
-      if (!templateEntry || !getDefaultExport(templateEntry.templateModule)) {
-        continue;
-      }
-
+    const templateEntry = templateEntriesByTreePosition[treePosition];
+    if (templateEntry && getDefaultExport(templateEntry.templateModule)) {
       const templateDependency = createAppRenderDependency();
       templateDependenciesById.set(templateEntry.id, templateDependency);
       templateDependenciesBeforeById.set(
@@ -839,7 +826,7 @@ export function buildAppPageElements<
       continue;
     }
     const TemplateComponent = templateComponent;
-    const templateDependency = templateDependenciesById?.get(templateEntry.id);
+    const templateDependency = templateDependenciesById.get(templateEntry.id);
     const templateElement = templateDependency ? (
       renderWithAppDependencyBarrier(
         <TemplateComponent>
@@ -854,7 +841,7 @@ export function buildAppPageElements<
     );
     elements[templateEntry.id] = renderAfterAppDependencies(
       templateElement,
-      templateDependenciesBeforeById?.get(templateEntry.id) ?? EMPTY_APP_RENDER_DEPENDENCIES,
+      templateDependenciesBeforeById.get(templateEntry.id) ?? EMPTY_APP_RENDER_DEPENDENCIES,
     );
   }
 
@@ -1171,9 +1158,9 @@ export function buildAppPageElements<
       options.matchedParams,
     );
     let segmentChildren: ReactNode = routeChildren;
-    const layoutEntry = layoutEntriesByTreePosition.get(treePosition);
-    const templateEntry = templateEntriesByTreePosition.get(treePosition);
-    const errorEntry = errorEntriesByTreePosition.get(treePosition);
+    const layoutEntry = layoutEntriesByTreePosition[treePosition];
+    const templateEntry = templateEntriesByTreePosition[treePosition];
+    const errorEntry = errorEntriesByTreePosition[treePosition];
 
     // Next.js nesting per segment (outer to inner): Layout > Template > Error > Unauthorized > Forbidden > NotFound > children.
     // Building bottom-up means NotFoundBoundary must wrap the leaf subtree first,
@@ -1237,7 +1224,7 @@ export function buildAppPageElements<
       continue;
     }
     const layoutHasElement = getDefaultExport(layoutEntry.layoutModule) !== null;
-    const layoutIndex = layoutIndicesByTreePosition.get(treePosition) ?? -1;
+    const layoutIndex = layoutIndicesByTreePosition[treePosition] ?? -1;
     const segmentMap: { children: string[] } & Record<string, string[]> = {
       children: resolveAppPageLayoutSegmentProviderSegments(
         options.route.childrenRouteSegments ?? routeSegments,

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -81,6 +81,12 @@ function resolveSlotLayoutParams(
   return resolveAppPageBranchParams(routeSegments, treePosition, params);
 }
 
+function snapshotAppRenderDependencies(
+  dependencies: readonly AppRenderDependency[],
+): readonly AppRenderDependency[] {
+  return dependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...dependencies];
+}
+
 export type AppPageModule = Record<string, unknown> & {
   default?: AppPageComponent | null | undefined;
 };
@@ -779,9 +785,7 @@ export function buildAppPageElements<
     const layoutIndex = layoutIndicesByTreePosition[treePosition];
     if (layoutIndex !== undefined) {
       const layoutEntry = layoutEntries[layoutIndex];
-      const deps =
-        pageDependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...pageDependencies];
-      layoutDependenciesBefore[layoutIndex] = deps;
+      layoutDependenciesBefore[layoutIndex] = snapshotAppRenderDependencies(pageDependencies);
       if (getDefaultExport(layoutEntry.layoutModule)) {
         const layoutDependency = createAppRenderDependency();
         layoutDependenciesByIndex[layoutIndex] = layoutDependency;
@@ -789,7 +793,8 @@ export function buildAppPageElements<
         pageDependencies.push(layoutDependency);
       }
       if (hasSlots) {
-        slotDependenciesByLayoutIndex[layoutIndex] = deps;
+        slotDependenciesByLayoutIndex[layoutIndex] =
+          snapshotAppRenderDependencies(pageDependencies);
       }
     }
 
@@ -799,7 +804,7 @@ export function buildAppPageElements<
       templateDependenciesById.set(templateEntry.id, templateDependency);
       templateDependenciesBeforeById.set(
         templateEntry.id,
-        pageDependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...pageDependencies],
+        snapshotAppRenderDependencies(pageDependencies),
       );
       pageDependencies.push(templateDependency);
     }

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -71,6 +71,7 @@ type AppPageComponent = ComponentType<AppPageComponentProps>;
 type AppPageErrorComponent = ComponentType<{ error: unknown; reset: () => void }>;
 const APP_PAGE_LAYOUT_PROBE_CHILD = <Fragment />;
 const DEFAULT_GLOBAL_ERROR_COMPONENT = DefaultGlobalError as AppPageErrorComponent;
+const EMPTY_APP_RENDER_DEPENDENCIES: readonly AppRenderDependency[] = [];
 
 function resolveSlotLayoutParams(
   routeSegments: readonly string[],
@@ -245,6 +246,36 @@ type AppPageErrorEntry<TErrorModule extends AppPageErrorModule = AppPageErrorMod
   treePosition: number;
 };
 
+type AppPageSlotEntry<
+  TModule extends AppPageModule = AppPageModule,
+  TErrorModule extends AppPageErrorModule = AppPageErrorModule,
+> = readonly [string, AppPageRouteWiringSlot<TModule, TErrorModule>];
+
+type AppPageRouteWiringPlan<
+  TModule extends AppPageModule = AppPageModule,
+  TErrorModule extends AppPageErrorModule = AppPageErrorModule,
+> = {
+  defaultSourcePage: string;
+  errorEntries: readonly AppPageErrorEntry<TErrorModule>[];
+  errorEntriesByTreePosition: ReadonlyMap<number, AppPageErrorEntry<TErrorModule>>;
+  layoutEntries: readonly AppPageLayoutEntry<TModule, TErrorModule>[];
+  layoutEntriesByTreePosition: ReadonlyMap<number, AppPageLayoutEntry<TModule, TErrorModule>>;
+  layoutIds: readonly string[];
+  layoutIndicesByTreePosition: ReadonlyMap<number, number>;
+  orderedTreePositions: readonly number[];
+  rootLayoutTreePath: string | null;
+  routeSegments: readonly string[];
+  slotEntries: readonly AppPageSlotEntry<TModule, TErrorModule>[];
+  slotNameCounts: ReadonlyMap<string, number> | null;
+  templateEntries: readonly AppPageTemplateEntry<TModule>[];
+  templateEntriesByTreePosition: ReadonlyMap<number, AppPageTemplateEntry<TModule>>;
+};
+
+const appPageRouteWiringPlanCache = new WeakMap<
+  object,
+  AppPageRouteWiringPlan<AppPageModule, AppPageErrorModule>
+>();
+
 function getDefaultExport<TModule extends AppPageModule>(
   module: TModule | null | undefined,
 ): AppPageComponent | null {
@@ -418,13 +449,94 @@ function createAppPageErrorEntries<TErrorModule extends AppPageErrorModule>(
   });
 }
 
+function createAppPageRouteWiringPlan<
+  TModule extends AppPageModule,
+  TErrorModule extends AppPageErrorModule,
+>(
+  route: AppPageRouteWiringRoute<TModule, TErrorModule>,
+): AppPageRouteWiringPlan<TModule, TErrorModule> {
+  const routeSegments = route.routeSegments ?? [];
+  const layoutEntries = createAppPageLayoutEntries(route);
+  const templateEntries = createAppPageTemplateEntries(route);
+  const errorEntries = createAppPageErrorEntries(route);
+  const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
+  const templateEntriesByTreePosition = new Map<number, AppPageTemplateEntry<TModule>>();
+  const errorEntriesByTreePosition = new Map<number, AppPageErrorEntry<TErrorModule>>();
+  const layoutIndicesByTreePosition = new Map<number, number>();
+
+  for (let index = 0; index < layoutEntries.length; index++) {
+    const layoutEntry = layoutEntries[index];
+    layoutEntriesByTreePosition.set(layoutEntry.treePosition, layoutEntry);
+    layoutIndicesByTreePosition.set(layoutEntry.treePosition, index);
+  }
+  for (const templateEntry of templateEntries) {
+    templateEntriesByTreePosition.set(templateEntry.treePosition, templateEntry);
+  }
+  for (const errorEntry of errorEntries) {
+    errorEntriesByTreePosition.set(errorEntry.treePosition, errorEntry);
+  }
+
+  const slotEntries: AppPageSlotEntry<TModule, TErrorModule>[] = route.slots
+    ? Object.entries(route.slots)
+    : [];
+  let slotNameCounts: Map<string, number> | null = null;
+  if (slotEntries.length > 0) {
+    slotNameCounts = new Map();
+    for (const [, slot] of slotEntries) {
+      slotNameCounts.set(slot.name, (slotNameCounts.get(slot.name) ?? 0) + 1);
+    }
+  }
+
+  return {
+    defaultSourcePage: createAppPageSourcePage(routeSegments),
+    errorEntries,
+    errorEntriesByTreePosition,
+    layoutEntries,
+    layoutEntriesByTreePosition,
+    layoutIds: route.ids?.layouts ?? layoutEntries.map((entry) => entry.id),
+    layoutIndicesByTreePosition,
+    orderedTreePositions: Array.from(
+      new Set<number>([
+        ...layoutEntries.map((entry) => entry.treePosition),
+        ...templateEntries.map((entry) => entry.treePosition),
+        ...errorEntries.map((entry) => entry.treePosition),
+      ]),
+    ).sort((left, right) => left - right),
+    rootLayoutTreePath: layoutEntries[0]?.treePath ?? null,
+    routeSegments,
+    slotEntries,
+    slotNameCounts,
+    templateEntries,
+    templateEntriesByTreePosition,
+  };
+}
+
+function getAppPageRouteWiringPlan<
+  TModule extends AppPageModule,
+  TErrorModule extends AppPageErrorModule,
+>(
+  route: AppPageRouteWiringRoute<TModule, TErrorModule>,
+): AppPageRouteWiringPlan<TModule, TErrorModule> {
+  const cached = appPageRouteWiringPlanCache.get(route);
+  if (cached) {
+    return cached as unknown as AppPageRouteWiringPlan<TModule, TErrorModule>;
+  }
+
+  const plan = createAppPageRouteWiringPlan(route);
+  appPageRouteWiringPlanCache.set(
+    route,
+    plan as unknown as AppPageRouteWiringPlan<AppPageModule, AppPageErrorModule>,
+  );
+  return plan;
+}
+
 function createAppPageParallelSlotEntries<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
 >(
   layoutIndex: number,
   layoutEntries: readonly AppPageLayoutEntry<TModule, TErrorModule>[],
-  route: AppPageRouteWiringRoute<TModule, TErrorModule>,
+  slotEntries: readonly AppPageSlotEntry<TModule, TErrorModule>[],
   getEffectiveSlotParams: (slotKey: string, slotName: string) => AppPageParams,
   resolveSlotOverride: (
     slotKey: string,
@@ -433,7 +545,7 @@ function createAppPageParallelSlotEntries<
 ): Readonly<Record<string, ReactNode>> | undefined {
   const parallelSlots: Record<string, ReactNode> = {};
 
-  for (const [slotKey, slot] of Object.entries(route.slots ?? {})) {
+  for (const [slotKey, slot] of slotEntries) {
     const slotName = slot.name;
     const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
     if (targetIndex !== layoutIndex) {
@@ -479,11 +591,18 @@ function resolveAppPageSlotBindingState(
   return "unmatched";
 }
 
+function resolveEmptyAppPageSlotOverride<TModule extends AppPageModule>():
+  | AppPageSlotOverride<TModule>
+  | undefined {
+  return undefined;
+}
+
 function createAppPageSlotBindings<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
 >(
   route: AppPageRouteWiringRoute<TModule, TErrorModule>,
+  slotEntries: readonly AppPageSlotEntry<TModule, TErrorModule>[],
   layoutEntries: readonly AppPageLayoutEntry<TModule, TErrorModule>[],
   resolveSlotOverride: (
     slotKey: string,
@@ -506,7 +625,7 @@ function createAppPageSlotBindings<
       state: route.childrenSlot.state,
     });
   }
-  for (const [slotKey, slot] of Object.entries(route.slots ?? {})) {
+  for (const [slotKey, slot] of slotEntries) {
     const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
     const layoutEntry = layoutEntries[targetIndex] ?? null;
     const ownerLayoutId = layoutEntry?.id ?? null;
@@ -574,7 +693,8 @@ export function buildAppPageElements<
   const interceptionContext =
     renderIdentity?.interceptionContext ?? options.interceptionContext ?? null;
   const renderMode = options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION;
-  const routeSegments = options.route.routeSegments ?? [];
+  const routePlan = getAppPageRouteWiringPlan(options.route);
+  const routeSegments = routePlan.routeSegments;
   const routeResetKey = resolveAppPageRouteStateKey(routeSegments, options.matchedParams);
   const routeId =
     renderIdentity?.routeId ??
@@ -582,60 +702,48 @@ export function buildAppPageElements<
   const pageId =
     renderIdentity?.pageId ?? AppElementsWire.encodePageId(options.routePath, interceptionContext);
   const pageElementId = options.route.childrenSlot?.id ?? pageId;
-  const layoutEntries = createAppPageLayoutEntries(options.route);
-  const templateEntries = createAppPageTemplateEntries(options.route);
-  const errorEntries = createAppPageErrorEntries(options.route);
+  const layoutEntries = routePlan.layoutEntries;
+  const templateEntries = routePlan.templateEntries;
+  const errorEntries = routePlan.errorEntries;
   const metadataPlacement = options.metadataPlacement ?? "head";
-  const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
-  const templateEntriesByTreePosition = new Map<number, AppPageTemplateEntry<TModule>>();
-  const errorEntriesByTreePosition = new Map<number, AppPageErrorEntry<TErrorModule>>();
-  for (const layoutEntry of layoutEntries) {
-    layoutEntriesByTreePosition.set(layoutEntry.treePosition, layoutEntry);
-  }
-  for (const templateEntry of templateEntries) {
-    templateEntriesByTreePosition.set(templateEntry.treePosition, templateEntry);
-  }
-  for (const errorEntry of errorEntries) {
-    errorEntriesByTreePosition.set(errorEntry.treePosition, errorEntry);
-  }
-  const layoutIndicesByTreePosition = new Map<number, number>();
-  for (let index = 0; index < layoutEntries.length; index++) {
-    layoutIndicesByTreePosition.set(layoutEntries[index].treePosition, index);
-  }
-  const layoutDependenciesByIndex = new Map<number, AppRenderDependency>();
+  const layoutEntriesByTreePosition = routePlan.layoutEntriesByTreePosition;
+  const templateEntriesByTreePosition = routePlan.templateEntriesByTreePosition;
+  const errorEntriesByTreePosition = routePlan.errorEntriesByTreePosition;
+  const layoutIndicesByTreePosition = routePlan.layoutIndicesByTreePosition;
+  const slotEntries = routePlan.slotEntries;
+  const hasSlots = slotEntries.length > 0;
+  const hasTemplates = templateEntries.length > 0;
+  const layoutDependenciesByIndex: AppRenderDependency[] = [];
   const renderDependenciesByElementId = new Map<string, AppRenderDependency>();
-  const layoutDependenciesBefore: AppRenderDependency[][] = [];
-  const slotDependenciesByLayoutIndex: AppRenderDependency[][] = [];
-  const templateDependenciesById = new Map<string, AppRenderDependency>();
-  const templateDependenciesBeforeById = new Map<string, AppRenderDependency[]>();
+  const layoutDependenciesBefore: Array<readonly AppRenderDependency[]> = [];
+  const slotDependenciesByLayoutIndex: Array<readonly AppRenderDependency[]> = [];
+  const templateDependenciesById = hasTemplates ? new Map<string, AppRenderDependency>() : null;
+  const templateDependenciesBeforeById = hasTemplates
+    ? new Map<string, readonly AppRenderDependency[]>()
+    : null;
   const pageDependencies: AppRenderDependency[] = [];
-  const rootLayoutTreePath = layoutEntries[0]?.treePath ?? null;
-  const slotNameCounts = new Map<string, number>();
-  for (const slot of Object.values(options.route.slots ?? {})) {
-    const slotName = slot.name;
-    slotNameCounts.set(slotName, (slotNameCounts.get(slotName) ?? 0) + 1);
-  }
-  const orderedTreePositions = Array.from(
-    new Set<number>([
-      ...layoutEntries.map((entry) => entry.treePosition),
-      ...templateEntries.map((entry) => entry.treePosition),
-      ...errorEntries.map((entry) => entry.treePosition),
-    ]),
-  ).sort((left, right) => left - right);
-  const resolveSlotOverride = (slotKey: string, slotName: string) => {
-    const overrideByKey = options.slotOverrides?.[slotKey];
-    if (overrideByKey) {
-      return overrideByKey;
-    }
+  const rootLayoutTreePath = routePlan.rootLayoutTreePath;
+  const slotNameCounts = routePlan.slotNameCounts;
+  const orderedTreePositions = routePlan.orderedTreePositions;
+  const resolveSlotOverride: (
+    slotKey: string,
+    slotName: string,
+  ) => AppPageSlotOverride<TModule> | undefined = hasSlots
+    ? (slotKey, slotName) => {
+        const overrideByKey = options.slotOverrides?.[slotKey];
+        if (overrideByKey) {
+          return overrideByKey;
+        }
 
-    // Legacy callers may still provide overrides by slot prop name.
-    // Only allow that fallback when it is unambiguous.
-    if (slotKey === slotName || (slotNameCounts.get(slotName) ?? 0) === 1) {
-      return options.slotOverrides?.[slotName];
-    }
+        // Legacy callers may still provide overrides by slot prop name.
+        // Only allow that fallback when it is unambiguous.
+        if (slotKey === slotName || (slotNameCounts?.get(slotName) ?? 0) === 1) {
+          return options.slotOverrides?.[slotName];
+        }
 
-    return undefined;
-  };
+        return undefined;
+      }
+    : resolveEmptyAppPageSlotOverride;
   const elements: Record<
     string,
     | ReactNode
@@ -648,15 +756,20 @@ export function buildAppPageElements<
     ...AppElementsWire.createMetadataEntries({
       interception: renderIdentity?.interception ?? options.interception ?? null,
       interceptionContext,
-      layoutIds: options.route.ids?.layouts ?? layoutEntries.map((entry) => entry.id),
+      layoutIds: routePlan.layoutIds,
       rootLayoutTreePath,
       routeId,
-      sourcePage: createAppPageSourcePage(options.sourcePageSegments ?? routeSegments),
-      slotBindings: createAppPageSlotBindings(options.route, layoutEntries, resolveSlotOverride, {
-        interception: renderIdentity?.interception ?? options.interception ?? null,
-        interceptionContext,
-        routePath: options.routePath,
-      }),
+      sourcePage: options.sourcePageSegments
+        ? createAppPageSourcePage(options.sourcePageSegments)
+        : routePlan.defaultSourcePage,
+      slotBindings:
+        hasSlots || options.route.childrenSlot
+          ? createAppPageSlotBindings(options.route, slotEntries, layoutEntries, resolveSlotOverride, {
+            interception: renderIdentity?.interception ?? options.interception ?? null,
+            interceptionContext,
+            routePath: options.routePath,
+            })
+          : undefined,
     }),
   };
   // Surface static-sibling info on the wire so the client router can decide
@@ -669,31 +782,40 @@ export function buildAppPageElements<
     elements[APP_STATIC_SIBLINGS_KEY] = options.route.staticSiblings;
   }
   const getEffectiveSlotParams = (slotKey: string, slotName: string): AppPageParams =>
-    resolveSlotOverride(slotKey, slotName)?.params ?? options.matchedParams;
+    resolveSlotOverride?.(slotKey, slotName)?.params ?? options.matchedParams;
 
   for (const treePosition of orderedTreePositions) {
     const layoutIndex = layoutIndicesByTreePosition.get(treePosition);
     if (layoutIndex !== undefined) {
       const layoutEntry = layoutEntries[layoutIndex];
-      layoutDependenciesBefore[layoutIndex] = [...pageDependencies];
+      layoutDependenciesBefore[layoutIndex] =
+        pageDependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...pageDependencies];
       if (getDefaultExport(layoutEntry.layoutModule)) {
         const layoutDependency = createAppRenderDependency();
-        layoutDependenciesByIndex.set(layoutIndex, layoutDependency);
+        layoutDependenciesByIndex[layoutIndex] = layoutDependency;
         renderDependenciesByElementId.set(layoutEntry.id, layoutDependency);
         pageDependencies.push(layoutDependency);
       }
-      slotDependenciesByLayoutIndex[layoutIndex] = [...pageDependencies];
+      if (hasSlots) {
+        slotDependenciesByLayoutIndex[layoutIndex] =
+          pageDependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...pageDependencies];
+      }
     }
 
-    const templateEntry = templateEntriesByTreePosition.get(treePosition);
-    if (!templateEntry || !getDefaultExport(templateEntry.templateModule)) {
-      continue;
-    }
+    if (hasTemplates && templateDependenciesById && templateDependenciesBeforeById) {
+      const templateEntry = templateEntriesByTreePosition.get(treePosition);
+      if (!templateEntry || !getDefaultExport(templateEntry.templateModule)) {
+        continue;
+      }
 
-    const templateDependency = createAppRenderDependency();
-    templateDependenciesById.set(templateEntry.id, templateDependency);
-    templateDependenciesBeforeById.set(templateEntry.id, [...pageDependencies]);
-    pageDependencies.push(templateDependency);
+      const templateDependency = createAppRenderDependency();
+      templateDependenciesById.set(templateEntry.id, templateDependency);
+      templateDependenciesBeforeById.set(
+        templateEntry.id,
+        pageDependencies.length === 0 ? EMPTY_APP_RENDER_DEPENDENCIES : [...pageDependencies],
+      );
+      pageDependencies.push(templateDependency);
+    }
   }
 
   const routeLoadingComponent = getDefaultExport(options.route.loading);
@@ -717,7 +839,7 @@ export function buildAppPageElements<
       continue;
     }
     const TemplateComponent = templateComponent;
-    const templateDependency = templateDependenciesById.get(templateEntry.id);
+    const templateDependency = templateDependenciesById?.get(templateEntry.id);
     const templateElement = templateDependency ? (
       renderWithAppDependencyBarrier(
         <TemplateComponent>
@@ -732,7 +854,7 @@ export function buildAppPageElements<
     );
     elements[templateEntry.id] = renderAfterAppDependencies(
       templateElement,
-      templateDependenciesBeforeById.get(templateEntry.id) ?? [],
+      templateDependenciesBeforeById?.get(templateEntry.id) ?? EMPTY_APP_RENDER_DEPENDENCIES,
     );
   }
 
@@ -762,17 +884,19 @@ export function buildAppPageElements<
       ),
     };
 
-    for (const slot of Object.values(options.route.slots ?? {})) {
-      const slotName = slot.name;
-      const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
-      if (targetIndex !== index) {
-        continue;
+    if (hasSlots) {
+      for (const [, slot] of slotEntries) {
+        const slotName = slot.name;
+        const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
+        if (targetIndex !== index) {
+          continue;
+        }
+        layoutProps[slotName] = <ParallelSlot name={slotName} />;
       }
-      layoutProps[slotName] = <ParallelSlot name={slotName} />;
     }
 
     const LayoutComponent = layoutComponent;
-    const layoutDependency = layoutDependenciesByIndex.get(index);
+    const layoutDependency = layoutDependenciesByIndex[index];
     const layoutElement = layoutDependency ? (
       renderWithAppDependencyBarrier(
         <LayoutComponent {...layoutProps}>
@@ -791,7 +915,7 @@ export function buildAppPageElements<
     );
   }
 
-  for (const [slotKey, slot] of Object.entries(options.route.slots ?? {})) {
+  for (const [slotKey, slot] of slotEntries) {
     const slotName = slot.name;
     const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
     const treePath = layoutEntries[targetIndex]?.treePath ?? "/";
@@ -1121,7 +1245,7 @@ export function buildAppPageElements<
         options.matchedParams,
       ),
     };
-    for (const [slotKey, slot] of Object.entries(options.route.slots ?? {})) {
+    for (const [slotKey, slot] of slotEntries) {
       const slotName = slot.name;
       const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
       if (targetIndex !== layoutIndex) {
@@ -1149,13 +1273,17 @@ export function buildAppPageElements<
         {layoutHasElement ? (
           <Slot
             id={layoutEntry.id}
-            parallelSlots={createAppPageParallelSlotEntries(
-              layoutIndex,
-              layoutEntries,
-              options.route,
-              getEffectiveSlotParams,
-              resolveSlotOverride,
-            )}
+            parallelSlots={
+              hasSlots
+                ? createAppPageParallelSlotEntries(
+                    layoutIndex,
+                    layoutEntries,
+                    slotEntries,
+                    getEffectiveSlotParams,
+                    resolveSlotOverride,
+                  )
+                : undefined
+            }
           >
             {segmentChildren}
           </Slot>

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -72,6 +72,7 @@ type AppPageErrorComponent = ComponentType<{ error: unknown; reset: () => void }
 const APP_PAGE_LAYOUT_PROBE_CHILD = <Fragment />;
 const DEFAULT_GLOBAL_ERROR_COMPONENT = DefaultGlobalError as AppPageErrorComponent;
 const EMPTY_APP_RENDER_DEPENDENCIES: readonly AppRenderDependency[] = [];
+const EMPTY_APP_PAGE_SLOT_ENTRIES: readonly AppPageSlotEntry[] = [];
 
 function resolveSlotLayoutParams(
   routeSegments: readonly string[],
@@ -272,6 +273,10 @@ type AppPageRouteWiringPlan<
   rootLayoutTreePath: string | null;
   routeSegments: readonly string[];
   slotEntries: readonly AppPageSlotEntry<TModule, TErrorModule>[];
+  slotEntriesByLayoutIndex: readonly (
+    | readonly AppPageSlotEntry<TModule, TErrorModule>[]
+    | undefined
+  )[];
   slotNameCounts: ReadonlyMap<string, number> | null;
   templateEntries: readonly AppPageTemplateEntry<TModule>[];
   templateEntriesByTreePosition: readonly (AppPageTemplateEntry<TModule> | undefined)[];
@@ -485,11 +490,17 @@ function createAppPageRouteWiringPlan<
   const slotEntries: AppPageSlotEntry<TModule, TErrorModule>[] = route.slots
     ? Object.entries(route.slots)
     : [];
+  const slotEntriesByLayoutIndex: AppPageSlotEntry<TModule, TErrorModule>[][] = [];
   let slotNameCounts: Map<string, number> | null = null;
   if (slotEntries.length > 0) {
     slotNameCounts = new Map();
-    for (const [, slot] of slotEntries) {
+    for (const slotEntry of slotEntries) {
+      const [, slot] = slotEntry;
       slotNameCounts.set(slot.name, (slotNameCounts.get(slot.name) ?? 0) + 1);
+      const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
+      if (targetIndex >= 0) {
+        (slotEntriesByLayoutIndex[targetIndex] ??= []).push(slotEntry);
+      }
     }
   }
 
@@ -511,6 +522,7 @@ function createAppPageRouteWiringPlan<
     rootLayoutTreePath: layoutEntries[0]?.treePath ?? null,
     routeSegments,
     slotEntries,
+    slotEntriesByLayoutIndex,
     slotNameCounts,
     templateEntries,
     templateEntriesByTreePosition,
@@ -540,8 +552,7 @@ function createAppPageParallelSlotEntries<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
 >(
-  layoutIndex: number,
-  layoutEntries: readonly AppPageLayoutEntry<TModule, TErrorModule>[],
+  layoutTreePath: string,
   slotEntries: readonly AppPageSlotEntry<TModule, TErrorModule>[],
   getEffectiveSlotParams: (slotKey: string, slotName: string) => AppPageParams,
   resolveSlotOverride: (
@@ -549,18 +560,15 @@ function createAppPageParallelSlotEntries<
     slotName: string,
   ) => AppPageSlotOverride<TModule> | undefined,
 ): Readonly<Record<string, ReactNode>> | undefined {
+  if (slotEntries.length === 0) {
+    return undefined;
+  }
+
   const parallelSlots: Record<string, ReactNode> = {};
 
   for (const [slotKey, slot] of slotEntries) {
     const slotName = slot.name;
-    const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
-    if (targetIndex !== layoutIndex) {
-      continue;
-    }
-
-    const layoutEntry = layoutEntries[targetIndex];
-    const treePath = layoutEntry?.treePath ?? "/";
-    const slotId = resolveAppPageSlotId(slot, treePath);
+    const slotId = resolveAppPageSlotId(slot, layoutTreePath);
     const slotParams = getEffectiveSlotParams(slotKey, slotName);
     const routeSegments =
       resolveSlotOverride(slotKey, slotName)?.routeSegments ?? slot.routeSegments;
@@ -574,7 +582,7 @@ function createAppPageParallelSlotEntries<
     );
   }
 
-  return Object.keys(parallelSlots).length > 0 ? parallelSlots : undefined;
+  return parallelSlots;
 }
 
 function resolveAppPageSlotId(slot: AppPageRouteWiringSlot, treePath: string): string {
@@ -711,6 +719,7 @@ export function buildAppPageElements<
   const errorEntriesByTreePosition = routePlan.errorEntriesByTreePosition;
   const layoutIndicesByTreePosition = routePlan.layoutIndicesByTreePosition;
   const slotEntries = routePlan.slotEntries;
+  const slotEntriesByLayoutIndex = routePlan.slotEntriesByLayoutIndex;
   const hasSlots = slotEntries.length > 0;
   const layoutDependenciesByIndex: AppRenderDependency[] = [];
   const renderDependenciesByElementId = new Map<string, AppRenderDependency>();
@@ -761,11 +770,17 @@ export function buildAppPageElements<
         : routePlan.defaultSourcePage,
       slotBindings:
         hasSlots || options.route.childrenSlot
-          ? createAppPageSlotBindings(options.route, slotEntries, layoutEntries, resolveSlotOverride, {
-            interception: renderIdentity?.interception ?? options.interception ?? null,
-            interceptionContext,
-            routePath: options.routePath,
-            })
+          ? createAppPageSlotBindings(
+              options.route,
+              slotEntries,
+              layoutEntries,
+              resolveSlotOverride,
+              {
+                interception: renderIdentity?.interception ?? options.interception ?? null,
+                interceptionContext,
+                routePath: options.routePath,
+              },
+            )
           : undefined,
     }),
   };
@@ -779,7 +794,7 @@ export function buildAppPageElements<
     elements[APP_STATIC_SIBLINGS_KEY] = options.route.staticSiblings;
   }
   const getEffectiveSlotParams = (slotKey: string, slotName: string): AppPageParams =>
-    resolveSlotOverride?.(slotKey, slotName)?.params ?? options.matchedParams;
+    resolveSlotOverride(slotKey, slotName)?.params ?? options.matchedParams;
 
   for (const treePosition of orderedTreePositions) {
     const layoutIndex = layoutIndicesByTreePosition[treePosition];
@@ -877,12 +892,8 @@ export function buildAppPageElements<
     };
 
     if (hasSlots) {
-      for (const [, slot] of slotEntries) {
+      for (const [, slot] of slotEntriesByLayoutIndex[index] ?? []) {
         const slotName = slot.name;
-        const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
-        if (targetIndex !== index) {
-          continue;
-        }
         layoutProps[slotName] = <ParallelSlot name={slotName} />;
       }
     }
@@ -1230,6 +1241,10 @@ export function buildAppPageElements<
     }
     const layoutHasElement = getDefaultExport(layoutEntry.layoutModule) !== null;
     const layoutIndex = layoutIndicesByTreePosition[treePosition] ?? -1;
+    const layoutSlotEntries =
+      layoutIndex >= 0
+        ? (slotEntriesByLayoutIndex[layoutIndex] ?? EMPTY_APP_PAGE_SLOT_ENTRIES)
+        : EMPTY_APP_PAGE_SLOT_ENTRIES;
     const segmentMap: { children: string[] } & Record<string, string[]> = {
       children: resolveAppPageLayoutSegmentProviderSegments(
         options.route.childrenRouteSegments ?? routeSegments,
@@ -1237,12 +1252,8 @@ export function buildAppPageElements<
         options.matchedParams,
       ),
     };
-    for (const [slotKey, slot] of slotEntries) {
+    for (const [slotKey, slot] of layoutSlotEntries) {
       const slotName = slot.name;
-      const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
-      if (targetIndex !== layoutIndex) {
-        continue;
-      }
       const slotParams = getEffectiveSlotParams(slotKey, slotName);
       const slotOverride = resolveSlotOverride(slotKey, slotName);
       const hasActiveSlotPage =
@@ -1266,11 +1277,10 @@ export function buildAppPageElements<
           <Slot
             id={layoutEntry.id}
             parallelSlots={
-              hasSlots
+              layoutSlotEntries.length > 0
                 ? createAppPageParallelSlotEntries(
-                    layoutIndex,
-                    layoutEntries,
-                    slotEntries,
+                    layoutEntry.treePath,
+                    layoutSlotEntries,
                     getEffectiveSlotParams,
                     resolveSlotOverride,
                   )

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -1606,6 +1606,77 @@ describe("app page route wiring helpers", () => {
     expect(body).not.toContain("page:en");
   });
 
+  it("waits for the owning layout before serializing parallel slot entries", async () => {
+    let activeLocale = "en";
+
+    async function LocaleLayout(props: Record<string, unknown>) {
+      await Promise.resolve();
+      activeLocale = "de";
+      return createElement(
+        "div",
+        { "data-layout": "locale" },
+        readChildren(props.sidebar),
+        readChildren(props.children),
+      );
+    }
+
+    function LocaleSlotPage() {
+      return createElement("aside", null, `slot:${activeLocale}`);
+    }
+
+    function LocalePage() {
+      return createElement("main", null, "page");
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(LocalePage),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: LocaleLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["locale"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: 0,
+            loading: null,
+            name: "sidebar",
+            page: { default: LocaleSlotPage },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/locale",
+      rootNotFoundModule: null,
+    });
+
+    const body = await renderHtml(
+      createElement(
+        Fragment,
+        null,
+        readChildren(elements["layout:/"]),
+        readChildren(elements["slot:sidebar:/"]),
+      ),
+    );
+
+    expect(body).toContain("slot:de");
+    expect(body).not.toContain("slot:en");
+  });
+
   it("releases skipped layout dependencies before serializing retained child entries", async () => {
     let activeLocale = "en";
 


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Reduce App Router SSR route wiring overhead shown in CPU profiles. |
| Core change | Cache route-invariant App Router wiring plans in a `WeakMap` keyed by the generated route object. |
| Main boundary | Keep params, dependency barriers, and React element creation per request while hoisting stable layout/template/error/slot derivations. |
| Primary file | `packages/vinext/src/server/app-page-route-wiring.tsx` |
| Expected impact | Lower `buildAppPageElements` self-time on warm SSR requests. |

## Why

Generated App Router route objects are stable for the server process, but the SSR path rebuilt derived layout, template, error, tree-position, and slot metadata for every request. Those derivations are route-invariant, while params and render dependencies remain request-scoped.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Route wiring | Generated route structure is stable after startup. | Adds a per-route cached wiring plan for derived entries, maps, ids, slot entries, and source page data. |
| Request render state | Params, dependency barriers, and React elements are request-scoped. | Leaves these on the request path. |
| Slots/templates | Empty feature sets should not allocate support structures per request. | Avoids slot dependency snapshots and template maps when the matched route does not use them. |

## Profiling

Warm SSR profile of `benchmarks/vinext` at `/`, built with `--sourcemap --minify false`, using 1000 warmup requests plus 20000 measured requests.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| `buildAppPageElements` self-time | 85.83ms | 38.75ms | -54.9% |
| `app-page-route-wiring` source self-time | 104.88ms | 48.62ms | -53.6% |
| 20k measured HTTP wall time | 13.49s | 10.62s | -21.3% |

CPU self-time is the primary signal here. HTTP timing is included as supporting context only.

## Validation

<details>
<summary>Commands run</summary>

```bash
vp check tests/app-page-route-wiring.test.ts tests/app-page-element-builder.test.ts tests/app-static-siblings.test.ts
vp test run tests/app-page-route-wiring.test.ts tests/app-page-element-builder.test.ts tests/app-static-siblings.test.ts
vp run vinext#build
node benchmarks/generate-app.mjs
cd benchmarks/vinext && vp build --sourcemap --minify false
```

The final pre-commit hook also ran staged `vp check --fix`, full check, and knip.

</details>

## Risk / Compatibility

<details>
<summary>Notes</summary>

- Runtime behaviour should be unchanged. The cache stores only route-invariant structure derived from the generated route object.
- The cache is a `WeakMap`, so route objects can still be collected if a dev/runtime graph drops them.
- Per-request state remains per request: matched params, slot override params, render dependencies, search params, and React elements are not cached.
- This does not include the separate safe JSON or Vary optimizations from PRs #2176 and #2177.

</details>
