### PR TITLE
perf(app-router): gate cache-proof observation producers

### DIFF
--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -1,5 +1,6 @@
 import { isValidElement, type ReactNode } from "react";
 import {
+  ARTIFACT_COMPATIBILITY_PROOF_FIELDS,
   createArtifactCompatibilityEnvelope,
   parseArtifactCompatibilityEnvelope,
   type ArtifactCompatibilityEnvelope,
@@ -9,7 +10,6 @@ import type {
   CacheProofBreakerFallbackMode,
   CacheProofFallbackScope,
   CacheProofRejectionCode,
-  RenderObservation,
 } from "./cache-proof.js";
 import type { ClientReuseManifestSkipDisposition } from "./client-reuse-manifest.js";
 import { isInterceptionMatchedUrlPath } from "./normalize-path.js";
@@ -244,7 +244,6 @@ export type AppOutgoingElements = Readonly<
     | ArtifactCompatibilityEnvelope
     | CacheEntryReuseProof
     | AppElementsInterception
-    | RenderObservation
     | readonly string[]
     | readonly AppElementsSlotBinding[]
   >
@@ -277,7 +276,6 @@ type AppElementsWireCodec = {
     artifactCompatibility?: ArtifactCompatibilityEnvelope;
     cacheEntryReuseProof?: CacheEntryReuseProof;
     layoutFlags: LayoutFlags;
-    renderObservation?: RenderObservation;
     skipDisposition?: ClientReuseManifestSkipDisposition;
   }): ReactNode | AppOutgoingElements;
   encodePageId(routePath: string, interceptionContext: string | null): string;
@@ -636,12 +634,21 @@ export function withLayoutFlags<T extends Record<string, unknown>>(
   return { ...elements, [APP_LAYOUT_FLAGS_KEY]: layoutFlags };
 }
 
+const DEFAULT_ARTIFACT_COMPATIBILITY_ENVELOPE = createArtifactCompatibilityEnvelope();
+
+function isDefaultArtifactCompatibilityEnvelope(
+  artifactCompatibility: ArtifactCompatibilityEnvelope,
+): boolean {
+  return ARTIFACT_COMPATIBILITY_PROOF_FIELDS.every(
+    (field) => artifactCompatibility[field] === DEFAULT_ARTIFACT_COMPATIBILITY_ENVELOPE[field],
+  );
+}
+
 export function buildOutgoingAppPayload(input: {
   element: ReactNode | AppElements;
   artifactCompatibility?: ArtifactCompatibilityEnvelope;
   cacheEntryReuseProof?: CacheEntryReuseProof;
   layoutFlags: LayoutFlags;
-  renderObservation?: RenderObservation;
   skipDisposition?: ClientReuseManifestSkipDisposition;
 }): ReactNode | AppOutgoingElements {
   if (!isAppElementsRecord(input.element)) {
@@ -655,7 +662,6 @@ export function buildOutgoingAppPayload(input: {
     | ArtifactCompatibilityEnvelope
     | CacheEntryReuseProof
     | AppElementsInterception
-    | RenderObservation
     | readonly string[]
     | readonly AppElementsSlotBinding[]
   > = {};
@@ -666,17 +672,19 @@ export function buildOutgoingAppPayload(input: {
     }
     payload[key] = value === UNMATCHED_SLOT ? APP_UNMATCHED_SLOT_WIRE_VALUE : value;
   }
-  payload[APP_LAYOUT_FLAGS_KEY] = input.layoutFlags;
+  if (Object.keys(input.layoutFlags).length > 0) {
+    payload[APP_LAYOUT_FLAGS_KEY] = input.layoutFlags;
+  }
   if (skippedLayoutIds.size > 0) {
     payload[APP_SKIPPED_LAYOUT_IDS_KEY] = [...skippedLayoutIds];
   }
-  payload[APP_ARTIFACT_COMPATIBILITY_KEY] =
-    input.artifactCompatibility ?? createArtifactCompatibilityEnvelope();
+  const artifactCompatibility =
+    input.artifactCompatibility ?? DEFAULT_ARTIFACT_COMPATIBILITY_ENVELOPE;
+  if (!isDefaultArtifactCompatibilityEnvelope(artifactCompatibility)) {
+    payload[APP_ARTIFACT_COMPATIBILITY_KEY] = artifactCompatibility;
+  }
   if (input.cacheEntryReuseProof) {
     payload[APP_CACHE_ENTRY_REUSE_PROOF_KEY] = input.cacheEntryReuseProof;
-  }
-  if (input.renderObservation) {
-    payload[APP_RENDER_OBSERVATION_KEY] = input.renderObservation;
   }
   return payload;
 }

--- a/packages/vinext/src/server/app-page-cache-proof-gating.ts
+++ b/packages/vinext/src/server/app-page-cache-proof-gating.ts
@@ -1,0 +1,58 @@
+import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
+
+type AppPageCacheProofConsumerInput = Readonly<{
+  clientReuseManifest?: ClientReuseManifestParseResult;
+  debugClassification?: boolean;
+  isDraftMode: boolean;
+  isForceDynamic: boolean;
+  isPrerender?: boolean;
+  isProduction: boolean;
+  isProgressiveActionRender?: boolean;
+  isRscRequest: boolean;
+  revalidateSeconds: number | null;
+}>;
+
+function hasIncomingStaticLayoutReuseConsumer(
+  clientReuseManifest: ClientReuseManifestParseResult | undefined,
+): boolean {
+  return clientReuseManifest?.kind === "parsed" && clientReuseManifest.manifest.entries.length > 0;
+}
+
+function isKnownNoStoreAppPageRender(input: {
+  isDraftMode: boolean;
+  isForceDynamic: boolean;
+  isProgressiveActionRender?: boolean;
+  revalidateSeconds: number | null;
+}): boolean {
+  return (
+    input.isDraftMode ||
+    input.isForceDynamic ||
+    input.isProgressiveActionRender === true ||
+    (input.revalidateSeconds !== null && input.revalidateSeconds <= 0)
+  );
+}
+
+export function shouldTrackRenderObservation(input: AppPageCacheProofConsumerInput): boolean {
+  if (isKnownNoStoreAppPageRender(input)) {
+    return false;
+  }
+
+  return input.isProduction || input.isPrerender === true;
+}
+
+export function shouldCollectCacheProof(input: AppPageCacheProofConsumerInput): boolean {
+  if (input.debugClassification === true) {
+    return true;
+  }
+  if (!input.isProduction && input.isPrerender !== true) {
+    return true;
+  }
+  if (isKnownNoStoreAppPageRender(input)) {
+    return false;
+  }
+  if (input.isRscRequest && hasIncomingStaticLayoutReuseConsumer(input.clientReuseManifest)) {
+    return true;
+  }
+
+  return shouldTrackRenderObservation(input);
+}

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -87,6 +87,7 @@ import {
   isAppLayoutObservationUnsafeForStaticReuse,
   type AppLayoutParamAccessTracker,
 } from "./app-layout-param-observation.js";
+import { shouldCollectCacheProof } from "./app-page-cache-proof-gating.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type AppPageElement = ReactNode | Readonly<Record<string, ReactNode>>;
@@ -649,7 +650,18 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const isDynamicError = dynamicConfig === "error";
   const isForceDynamic = dynamicConfig === "force-dynamic";
   const isDraftMode = isDraftModeRequest(options.request, options.draftModeSecret);
-  const layoutParamAccess = createAppLayoutParamAccessTracker();
+  const collectCacheProof = shouldCollectCacheProof({
+    clientReuseManifest: options.clientReuseManifest,
+    debugClassification: options.debugClassification !== undefined,
+    isDraftMode,
+    isForceDynamic,
+    isProduction: options.isProduction,
+    isProgressiveActionRender: options.isProgressiveActionRender,
+    isPrerender: process.env.VINEXT_PRERENDER === "1",
+    isRscRequest: options.isRscRequest,
+    revalidateSeconds: currentRevalidateSeconds,
+  });
+  const layoutParamAccess = collectCacheProof ? createAppLayoutParamAccessTracker() : undefined;
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
   setCurrentFetchCacheMode(options.fetchCache ?? null);
@@ -1089,33 +1101,36 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     probePage() {
       return options.probePage();
     },
-    classification: {
-      getLayoutId(index) {
-        const treePosition = route.layoutTreePositions?.[index] ?? 0;
-        return AppElementsWire.encodeLayoutId(
-          createAppPageTreePath([...route.routeSegments], treePosition),
-        );
-      },
-      buildTimeClassifications: layoutClassifications.buildTimeClassifications,
-      buildTimeReasons: layoutClassifications.buildTimeReasons,
-      debugClassification: options.debugClassification,
-      isLayoutObservationDynamic(layoutId) {
-        return isAppLayoutObservationUnsafeForStaticReuse(
-          layoutParamAccess.getLayoutObservation(layoutId),
-        );
-      },
-      async runWithIsolatedDynamicScope(fn) {
-        const priorDynamic = consumeDynamicUsage();
-        try {
-          const result = await fn();
-          const dynamicDetected = consumeDynamicUsage();
-          return { result, dynamicDetected };
-        } finally {
-          consumeDynamicUsage();
-          if (priorDynamic) markDynamicUsage();
+    classification: collectCacheProof
+      ? {
+          getLayoutId(index) {
+            const treePosition = route.layoutTreePositions?.[index] ?? 0;
+            return AppElementsWire.encodeLayoutId(
+              createAppPageTreePath([...route.routeSegments], treePosition),
+            );
+          },
+          buildTimeClassifications: layoutClassifications.buildTimeClassifications,
+          buildTimeReasons: layoutClassifications.buildTimeReasons,
+          debugClassification: options.debugClassification,
+          isLayoutObservationDynamic(layoutId) {
+            if (!layoutParamAccess) return false;
+            return isAppLayoutObservationUnsafeForStaticReuse(
+              layoutParamAccess.getLayoutObservation(layoutId),
+            );
+          },
+          async runWithIsolatedDynamicScope(fn) {
+            const priorDynamic = consumeDynamicUsage();
+            try {
+              const result = await fn();
+              const dynamicDetected = consumeDynamicUsage();
+              return { result, dynamicDetected };
+            } finally {
+              consumeDynamicUsage();
+              if (priorDynamic) markDynamicUsage();
+            }
+          },
         }
-      },
-    },
+      : null,
     dynamicStaleTimeSeconds: options.dynamicStaleTimeSeconds,
     revalidateSeconds: currentRevalidateSeconds,
     mountedSlotsHeader: options.mountedSlotsHeader,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -15,7 +15,6 @@ import {
   getDraftModeCookieHeader,
   isDraftModeRequest,
   markDynamicUsage,
-  peekRenderRequestApiUsage,
   setHeadersContext,
 } from "vinext/shims/headers";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
@@ -30,7 +29,6 @@ import {
   ensureFetchPatch,
   type FetchCacheMode,
   getCollectedFetchTags,
-  peekDynamicFetchObservations,
   runWithFetchDedupe,
   setCurrentFetchCacheMode,
   setCurrentForceDynamicFetchDefault,
@@ -1085,12 +1083,6 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       : undefined,
     layoutParamAccess,
     rootParams: options.rootParams,
-    peekRenderObservationState() {
-      return {
-        dynamicFetches: peekDynamicFetchObservations(),
-        requestApis: peekRenderRequestApiUsage(),
-      };
-    },
     probeLayoutAt(layoutIndex) {
       return options.probeLayoutAt(layoutIndex, layoutParamAccess);
     },

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -73,7 +73,6 @@ import {
   createAppPageHtmlOutputScope,
   createAppPageRenderObservation,
   createAppPageRscOutputScope,
-  createEmptyAppPageRenderObservationState,
   type AppPageRenderObservationState,
 } from "./app-page-render-observation.js";
 import type {
@@ -162,7 +161,6 @@ type RenderAppPageLifecycleOptions = {
   pprFallbackShellReactSignal?: AbortSignal;
   abortPprFallbackShell?: () => void;
   rootParams?: RootParams;
-  peekRenderObservationState?: () => AppPageRenderObservationState;
   probeLayoutAt: (layoutIndex: number) => unknown;
   probePage: () => unknown;
   expireSeconds?: number;
@@ -633,19 +631,6 @@ export async function renderAppPageLifecycle(
     rootBoundaryId,
     routePattern: options.routePattern,
   });
-  // Partial payload metadata is a pre-stream snapshot. Fetch tags may still
-  // accumulate while the RSC/HTML streams are consumed; complete cache artifact
-  // observations below rebuild this field after the stream drains.
-  const payloadRenderObservation = createAppPageRenderObservation({
-    boundaryOutcome: { kind: "unknown" },
-    cacheability: "unknown",
-    cacheTags: options.getPageTags(),
-    cleanPathname: options.cleanPathname,
-    completeness: "partial",
-    output: rscOutputScope,
-    params: options.navigationParams,
-    state: options.peekRenderObservationState?.() ?? createEmptyAppPageRenderObservationState(),
-  });
   const skipDisposition =
     options.skipDisposition ??
     createRenderLifecycleSkipDisposition({
@@ -663,7 +648,6 @@ export async function renderAppPageLifecycle(
     element: options.element,
     layoutFlags,
     ...(artifactCompatibility ? { artifactCompatibility } : {}),
-    renderObservation: payloadRenderObservation,
     skipDisposition: options.isRscRequest ? skipDisposition : undefined,
   });
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -10,6 +10,7 @@ import {
   finalizeAppPageHtmlCacheResponse,
   finalizeAppPageRscCacheResponse,
 } from "./app-page-cache-finalizer.js";
+import { shouldTrackRenderObservation } from "./app-page-cache-proof-gating.js";
 import {
   buildAppPageFontLinkHeader,
   readAppPageBinaryStream,
@@ -686,6 +687,16 @@ export async function renderAppPageLifecycle(
 
   let revalidateSeconds = options.revalidateSeconds;
   let expireSeconds = options.expireSeconds;
+  const trackRenderObservation = shouldTrackRenderObservation({
+    clientReuseManifest: options.clientReuseManifest,
+    isDraftMode: options.isDraftMode,
+    isForceDynamic: options.isForceDynamic,
+    isProduction: options.isProduction,
+    isProgressiveActionRender: options.isProgressiveActionRender,
+    isPrerender: options.isPrerender,
+    isRscRequest: options.isRscRequest,
+    revalidateSeconds,
+  });
   const shouldCaptureRscForCacheMetadata =
     options.isProgressiveActionRender !== true &&
     (options.isProduction || options.isPrerender === true) &&
@@ -800,19 +811,23 @@ export async function renderAppPageLifecycle(
         options.isProduction && shouldCaptureRscForCacheMetadata ? capturedRscDataRef.value : null,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,
-      consumeRenderObservationState: options.consumeRenderObservationState,
-      createRscRenderObservation(input) {
-        return createAppPageRenderObservation({
-          boundaryOutcome: { kind: "success" },
-          cacheability: "public",
-          cacheTags: input.cacheTags,
-          cleanPathname: options.cleanPathname,
-          completeness: "complete",
-          output: rscOutputScope,
-          params: options.navigationParams,
-          state: input.state,
-        });
-      },
+      ...(trackRenderObservation
+        ? {
+            consumeRenderObservationState: options.consumeRenderObservationState,
+            createRscRenderObservation(input) {
+              return createAppPageRenderObservation({
+                boundaryOutcome: { kind: "success" },
+                cacheability: "public",
+                cacheTags: input.cacheTags,
+                cleanPathname: options.cleanPathname,
+                completeness: "complete",
+                output: rscOutputScope,
+                params: options.navigationParams,
+                state: input.state,
+              });
+            },
+          }
+        : {}),
       dynamicUsedDuringBuild,
       getPageTags() {
         return options.getPageTags();
@@ -1012,31 +1027,35 @@ export async function renderAppPageLifecycle(
       capturedRscDataPromise: capturedRscDataRef.value,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,
-      consumeRenderObservationState: options.consumeRenderObservationState,
-      createHtmlRenderObservation(input) {
-        return createAppPageRenderObservation({
-          boundaryOutcome: { kind: "success" },
-          cacheability: "public",
-          cacheTags: input.cacheTags,
-          cleanPathname: options.cleanPathname,
-          completeness: "complete",
-          output: htmlOutputScope,
-          params: options.navigationParams,
-          state: input.state,
-        });
-      },
-      createRscRenderObservation(input) {
-        return createAppPageRenderObservation({
-          boundaryOutcome: { kind: "success" },
-          cacheability: "public",
-          cacheTags: input.cacheTags,
-          cleanPathname: options.cleanPathname,
-          completeness: "complete",
-          output: rscOutputScope,
-          params: options.navigationParams,
-          state: input.state,
-        });
-      },
+      ...(trackRenderObservation
+        ? {
+            consumeRenderObservationState: options.consumeRenderObservationState,
+            createHtmlRenderObservation(input) {
+              return createAppPageRenderObservation({
+                boundaryOutcome: { kind: "success" },
+                cacheability: "public",
+                cacheTags: input.cacheTags,
+                cleanPathname: options.cleanPathname,
+                completeness: "complete",
+                output: htmlOutputScope,
+                params: options.navigationParams,
+                state: input.state,
+              });
+            },
+            createRscRenderObservation(input) {
+              return createAppPageRenderObservation({
+                boundaryOutcome: { kind: "success" },
+                cacheability: "public",
+                cacheTags: input.cacheTags,
+                cleanPathname: options.cleanPathname,
+                completeness: "complete",
+                output: rscOutputScope,
+                params: options.navigationParams,
+                state: input.state,
+              });
+            },
+          }
+        : {}),
       getPageTags() {
         return options.getPageTags();
       },

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -11,7 +11,6 @@ import {
   APP_INTERCEPTION_CONTEXT_KEY,
   APP_LAYOUT_IDS_KEY,
   APP_LAYOUT_FLAGS_KEY,
-  APP_RENDER_OBSERVATION_KEY,
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   APP_SKIPPED_LAYOUT_IDS_KEY,
@@ -32,10 +31,7 @@ import {
   evaluateArtifactCompatibility,
   RSC_PAYLOAD_SCHEMA_VERSION,
 } from "../packages/vinext/src/server/artifact-compatibility.js";
-import {
-  buildRenderObservation,
-  createCacheEntryReuseProof,
-} from "../packages/vinext/src/server/cache-proof.js";
+import { createCacheEntryReuseProof } from "../packages/vinext/src/server/cache-proof.js";
 
 describe("AppElementsWire", () => {
   it("encodes outgoing record payloads without mutating caller-owned records", () => {
@@ -55,7 +51,6 @@ describe("AppElementsWire", () => {
       expect(encoded).toEqual({
         "layout:/": "root-layout",
         "page:/blog": "blog-page",
-        [APP_ARTIFACT_COMPATIBILITY_KEY]: createArtifactCompatibilityEnvelope(),
         [APP_LAYOUT_FLAGS_KEY]: { "layout:/": "s" },
       });
     }
@@ -838,6 +833,10 @@ describe("buildOutgoingAppPayload", () => {
       layoutFlags: {},
     });
     expect(result).not.toBe(element);
+    expect(isAppElementsRecord(result)).toBe(true);
+    if (isAppElementsRecord(result)) {
+      expect(result).toEqual({ "page:/": "page" });
+    }
   });
 
   it("does not mutate the input record", () => {
@@ -866,6 +865,18 @@ describe("buildOutgoingAppPayload", () => {
     expect(isAppElementsRecord(result)).toBe(true);
     if (isAppElementsRecord(result)) {
       expect(result[APP_LAYOUT_FLAGS_KEY]).toEqual({ "layout:/": "s" });
+    }
+  });
+
+  it("omits default artifact compatibility on the returned record", () => {
+    const result = buildOutgoingAppPayload({
+      element: { "page:/": "page" },
+      layoutFlags: { "layout:/": "s" },
+      artifactCompatibility: createArtifactCompatibilityEnvelope(),
+    });
+    expect(isAppElementsRecord(result)).toBe(true);
+    if (isAppElementsRecord(result)) {
+      expect(APP_ARTIFACT_COMPATIBILITY_KEY in result).toBe(false);
     }
   });
 
@@ -911,40 +922,6 @@ describe("buildOutgoingAppPayload", () => {
       expect(AppElementsWire.readMetadata(result).cacheEntryReuseProof).toEqual(
         cacheEntryReuseProof,
       );
-    }
-  });
-
-  it("attaches render observation metadata on the returned record when provided", () => {
-    const renderObservation = buildRenderObservation({
-      boundaryOutcome: { kind: "success" },
-      cacheability: "public",
-      cacheTags: ["posts"],
-      completeness: "complete",
-      dynamicFetches: ["https://api.example.test/posts?token=secret"],
-      output: {
-        kind: "app-rsc",
-        mountedSlotsFingerprint: null,
-        renderEpoch: null,
-        rootBoundaryId: "layout:/",
-        routeId: "route:/posts",
-      },
-      pathTags: ["/posts"],
-      requestApis: [
-        { kind: "headers", status: "notObserved" },
-        { kind: "cookies", status: "notObserved" },
-      ],
-    });
-
-    const result = buildOutgoingAppPayload({
-      element: { "page:/posts": "posts-page" },
-      layoutFlags: { "layout:/": "s" },
-      renderObservation,
-    });
-
-    expect(isAppElementsRecord(result)).toBe(true);
-    if (isAppElementsRecord(result)) {
-      expect(result[APP_RENDER_OBSERVATION_KEY]).toEqual(renderObservation);
-      expect(JSON.stringify(result[APP_RENDER_OBSERVATION_KEY])).not.toContain("secret");
     }
   });
 

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
+  APP_LAYOUT_FLAGS_KEY,
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   AppElementsWire,
@@ -1059,6 +1060,120 @@ describe("app page dispatch", () => {
         process.env.__VINEXT_BUILD_ID = originalBuildId;
       }
     }
+  });
+
+  it.each([
+    {
+      name: "draft mode",
+      overrides: {
+        request: new Request("https://example.test/posts/hello", {
+          headers: { Cookie: "__prerender_bypass=draft-secret" },
+        }),
+        revalidateSeconds: 60,
+      },
+    },
+    {
+      name: "force-dynamic",
+      overrides: {
+        dynamicConfig: "force-dynamic" as const,
+        revalidateSeconds: 60,
+      },
+    },
+    {
+      name: "revalidate=0 no-store",
+      overrides: {
+        revalidateSeconds: 0,
+      },
+    },
+  ])("skips cache-proof layout observation collection for $name renders", async ({ overrides }) => {
+    const seenTrackers: unknown[] = [];
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const layoutId = AppElementsWire.encodeLayoutId("/");
+    const route = createRoute({
+      layoutTreePositions: [0],
+      layouts: [{ default() {} }],
+      pattern: "/posts/[slug]",
+      routeSegments: ["posts", "[slug]"],
+    });
+    const { options } = createDispatchOptions({
+      buildPageElement: async () => ({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/posts/[slug]",
+        [layoutId]: "root-layout",
+        [AppElementsWire.encodePageId("/posts/[slug]", null)]: "post-page",
+      }),
+      isProduction: true,
+      isRscRequest: true,
+      route,
+      ...overrides,
+      probeLayoutAt(_layoutIndex, layoutParamAccess) {
+        seenTrackers.push(layoutParamAccess);
+        return null;
+      },
+      renderToReadableStream(payload) {
+        capturedPayloads.push(captureRecord(payload));
+        return createStream(["flight"]);
+      },
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("flight");
+    expect(seenTrackers).toEqual([undefined]);
+    expect(capturedPayloads).toHaveLength(1);
+    expect(Object.hasOwn(capturedPayloads[0], APP_LAYOUT_FLAGS_KEY)).toBe(false);
+  });
+
+  it("keeps cache-proof layout observation collection for cacheable static-layout reuse renders", async () => {
+    const seenTrackers: unknown[] = [];
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const layoutId = AppElementsWire.encodeLayoutId("/");
+    const route = createRoute({
+      __buildTimeClassifications: new Map([[0, "static"]]),
+      layoutTreePositions: [0],
+      layouts: [{ default() {} }],
+      params: [],
+      pattern: "/",
+      routeSegments: [],
+    });
+    const probeLayout = createLayoutParamProbe(route, {}, []);
+    const { options } = createDispatchOptions({
+      buildPageElement: async () => ({
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_ROUTE_KEY]: "route:/",
+        [layoutId]: "root-layout",
+        [AppElementsWire.encodePageId("/", null)]: "home-page",
+      }),
+      cleanPathname: "/",
+      isProduction: true,
+      isRscRequest: true,
+      params: {},
+      revalidateSeconds: 60,
+      route,
+      probeLayoutAt(_layoutIndex, layoutParamAccess) {
+        seenTrackers.push(layoutParamAccess);
+        return probeLayout(_layoutIndex, layoutParamAccess);
+      },
+      renderToReadableStream(payload) {
+        capturedPayloads.push(captureRecord(payload));
+        return createStream(["flight"]);
+      },
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("flight");
+    expect(seenTrackers).toHaveLength(1);
+    expect(seenTrackers[0]).toEqual(
+      expect.objectContaining({
+        getLayoutObservation: expect.any(Function),
+        runLayoutProbe: expect.any(Function),
+      }),
+    );
+    expect(capturedPayloads).toHaveLength(1);
+    expect(capturedPayloads[0][APP_LAYOUT_FLAGS_KEY]).toEqual({ [layoutId]: "s" });
   });
 
   it("returns not found for dynamicParams=false paths outside generated params", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -476,6 +476,40 @@ describe("app page render lifecycle", () => {
     expect(consumeDynamicUsage).toHaveBeenCalledTimes(2);
   });
 
+  it.each([
+    {
+      name: "draft mode",
+      overrides: { isDraftMode: true, revalidateSeconds: 60 },
+    },
+    {
+      name: "force-dynamic",
+      overrides: { isForceDynamic: true, revalidateSeconds: 60 },
+    },
+    {
+      name: "revalidate=0 no-store",
+      overrides: { revalidateSeconds: 0 },
+    },
+  ])("skips render observation collection for $name RSC renders", async ({ overrides }) => {
+    const common = createCommonOptions();
+    const consumeRenderObservationState = vi.fn(() => {
+      throw new Error("render observation state should not be consumed");
+    });
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      ...overrides,
+      consumeRenderObservationState,
+      isProduction: true,
+      isRscRequest: true,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("flight-data");
+    expect(common.waitUntilPromises).toHaveLength(0);
+    expect(common.isrSet).not.toHaveBeenCalled();
+    expect(consumeRenderObservationState).not.toHaveBeenCalled();
+  });
+
   it("does not cache RSC responses when skip transport omits layout records", async () => {
     const common = createCommonOptions();
     const isrDebug = vi.fn();

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1279,7 +1279,7 @@ describe("layoutFlags injection into RSC payload", () => {
     expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({ "layout:/": "d" });
   });
 
-  it("injects empty __layoutFlags when classification is not provided (backward compat)", async () => {
+  it("omits empty __layoutFlags when classification is not provided", async () => {
     const { options, getCapturedElement } = createRscOptions({
       element: { "layout:/": "root-layout", "page:/test": "test-page" },
       layoutCount: 1,
@@ -1287,7 +1287,7 @@ describe("layoutFlags injection into RSC payload", () => {
     });
 
     await renderAppPageLifecycle(options);
-    expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({});
+    expect(APP_LAYOUT_FLAGS_KEY in getCapturedElement()).toBe(false);
   });
 
   it("injects concrete artifact compatibility metadata from the render boundary", async () => {
@@ -1325,7 +1325,7 @@ describe("layoutFlags injection into RSC payload", () => {
     });
   });
 
-  it("injects partial render observation metadata into outgoing AppElements payloads", async () => {
+  it("omits partial render observation metadata from outgoing AppElements payloads", async () => {
     const { options, getCapturedElement } = createRscOptions({
       element: {
         [APP_ROOT_LAYOUT_KEY]: "/",
@@ -1333,38 +1333,13 @@ describe("layoutFlags injection into RSC payload", () => {
         "page:/test": "test-page",
       },
     });
-
     await renderAppPageLifecycle({
       ...options,
       navigationParams: { id: "123" },
       params: { id: "123" },
-      peekRenderObservationState() {
-        return {
-          dynamicFetches: ["https://api.example.test/posts?token=secret"],
-          requestApis: ["headers"],
-        };
-      },
     });
 
-    const renderObservation = getCapturedElement()[APP_RENDER_OBSERVATION_KEY];
-
-    expect(renderObservation).toMatchObject({
-      boundaryOutcome: { kind: "unknown" },
-      cacheability: "unknown",
-      completeness: "partial",
-      output: {
-        kind: "app-rsc",
-        mountedSlotsFingerprint: null,
-        renderEpoch: null,
-        rootBoundaryId: "/",
-        routeId: "route:/test",
-      },
-      requestApis: expect.arrayContaining([
-        { kind: "headers", status: "observed" },
-        { kind: "params", status: "observed" },
-      ]),
-    });
-    expect(JSON.stringify(renderObservation)).not.toContain("secret");
+    expect(APP_RENDER_OBSERVATION_KEY in getCapturedElement()).toBe(false);
   });
 
   it("injects __layoutFlags for multiple independently classified layouts", async () => {


### PR DESCRIPTION
## Summary

Reworks the old fixed-slot cache-proof micro-optimization into producer-side gating for App Router cache-proof work. This keeps #2176's Flight payload trimming contract and moves the remaining optimization upstream: when a render is known to have no cache/reuse/finalization consumer, vinext skips creating layout proof trackers, layout classifications, and render-observation finalizer callbacks.

Concretely this adds a shared App Page decision helper for:

- `shouldCollectCacheProof`: controls layout/static-reuse proof collection near dispatch.
- `shouldTrackRenderObservation`: controls render-observation cache finalizer wiring.

Known no-store paths now skip proof collection in production/prerender contexts:

- draft mode
- `force-dynamic`
- progressive action renders
- `revalidate = 0`

Development/debug classification stays conservative. Cacheable production/prerender/static-layout reuse paths continue collecting proof metadata.

## Realistic scenario

This PR represents uncached App Router request paths: dynamic dashboards, account/admin surfaces, draft preview, server-action result renders, or explicit `revalidate = 0`/`force-dynamic` pages with shared layouts. In those cases the response cannot be written to the app-page cache or reused as static-layout proof, so collecting layout/cache-proof observations is dead producer work.

It does not represent build-time optimization, client bundle optimization, or cached/static-route optimization. Those should be neutral apart from the small server-side code-size cost of the gating helper.

## Tests

- `vp check packages/vinext/src/server/app-page-cache-proof-gating.ts packages/vinext/src/server/app-page-dispatch.ts packages/vinext/src/server/app-page-render.ts tests/app-page-dispatch.test.ts tests/app-page-render.test.ts`
- `vp test run tests/app-page-dispatch.test.ts tests/app-page-render.test.ts tests/app-layout-param-observation.test.ts tests/cache-proof.test.ts tests/skip-cache-proof.test.ts`
- commit hook also ran staged checks/full check/staged unit+integration tests/knip

## Benchmark

Compared #2176 (`e9122499`) against this PR (`ea2326c7`).

Repo perf harness, vinext-only, paired base/head mode, 3 alternating rounds:

```
VINEXT_PERF_RUN_KIND=pull_request \
VINEXT_PERF_BASE_ROOT=/Users/nathan/Projects/vinext/.worktrees/bench-pr2181-base \
VINEXT_PERF_SKIP_IMPLEMENTATIONS=nextjs \
VINEXT_PERF_PROFILER_BIN=true \
VINEXT_PERF_SAMPLES=/tmp/pr2181-paired-samples.jsonl \
node benchmarks/perf/run-scenarios.mjs --rounds=3
```

Medians:

| Scenario | #2176 | This PR | Delta |
| --- | ---: | ---: | ---: |
| Dev server cold start | 861.65 ms | 862.16 ms | +0.06% |
| Production build time | 982.37 ms | 997.46 ms | +1.54% |
| Client bundle gzip | 132,974 B | 132,973 B | -1 B |
| RSC entry gzip | 65,833 B | 66,054 B | +221 B |
| Server bundle gzip | 188,197 B | 188,419 B | +222 B |

Interpretation: standard repo benchmarks are neutral-to-slightly-costly, as expected for a request-path server gating change. The measurable build artifact cost is about +222 B gzip server-side.

Focused request-path profiler workload for the intended scenario, 50k repeated force-dynamic App Router dispatches:

- #2176: `PROFILE_LAYOUT_TRACKERS=50000`, `PROFILE_LAYOUT_PROBES=50000`
- This PR: `PROFILE_LAYOUT_TRACKERS=0`, `PROFILE_LAYOUT_PROBES=0`

Named V8 CPU-profile frames present in #2176 and absent in this PR for that workload:

- `createAppLayoutParamAccessTracker`
- `recordProbeDependencies`
- `getLayoutObservation`
- `isAppLayoutObservationUnsafeForStaticReuse`

So the real win is less per-request proof producer work on uncached dynamic App Router renders, not a broad benchmark improvement.

Depends on #2176 for the Flight payload metadata trimming baseline.
