### PR TITLE
perf(server): reuse App SSR bfcache metadata

### DIFF
--- a/packages/vinext/src/server/app-bfcache-identity.ts
+++ b/packages/vinext/src/server/app-bfcache-identity.ts
@@ -7,9 +7,14 @@ import {
 } from "../routing/utils.js";
 import { normalizePath } from "./normalize-path.js";
 import { INITIAL_BFCACHE_ID } from "./app-bfcache-id.js";
-import { isBfcacheSegmentId, type BfcacheIdMap } from "./app-history-state.js";
+import type { BfcacheIdMap } from "./app-history-state.js";
 
 export type BfcacheStateKeyMap = Readonly<Record<string, string>>;
+
+export type InitialBfcacheMaps = Readonly<{
+  bfcacheIds: BfcacheIdMap;
+  stateKeys: BfcacheStateKeyMap;
+}>;
 
 // Monotonic within a single browser document. Full reloads reset the counter,
 // while the document-scoped version gate prevents old history ids from
@@ -49,6 +54,8 @@ function getTreePathIdentityPrefix(pathname: string, treePath: string): string {
 }
 
 type AppElementsMetadata = ReturnType<typeof AppElementsWire.readMetadata>;
+type AppElementsWireElementKey = NonNullable<ReturnType<typeof AppElementsWire.parseElementKey>>;
+type BfcacheSegmentElementKey = Exclude<AppElementsWireElementKey, { kind: "route" }>;
 
 /**
  * Metadata parsed once per element map, with an index that keeps per-slot
@@ -59,6 +66,14 @@ type ParsedAppElementsMetadata = {
   slotBindingsBySlotId: ReadonlyMap<string, AppElementsSlotBinding>;
 };
 
+function indexAppElementsMetadata(metadata: AppElementsMetadata): ParsedAppElementsMetadata {
+  const slotBindingsBySlotId = new Map<string, AppElementsSlotBinding>();
+  for (const binding of metadata.slotBindings) {
+    slotBindingsBySlotId.set(binding.slotId, binding);
+  }
+  return { metadata, slotBindingsBySlotId };
+}
+
 function readAppElementsMetadata(elements: AppElements): ParsedAppElementsMetadata | null {
   let metadata: AppElementsMetadata;
   try {
@@ -67,11 +82,7 @@ function readAppElementsMetadata(elements: AppElements): ParsedAppElementsMetada
     // Some low-level tests pass partial element maps without metadata.
     return null;
   }
-  const slotBindingsBySlotId = new Map<string, AppElementsSlotBinding>();
-  for (const binding of metadata.slotBindings) {
-    slotBindingsBySlotId.set(binding.slotId, binding);
-  }
-  return { metadata, slotBindingsBySlotId };
+  return indexAppElementsMetadata(metadata);
 }
 
 function createActiveSlotIdentity(
@@ -95,11 +106,12 @@ function createActiveSlotIdentity(
  */
 function createBfcacheSegmentIdentity(
   id: string,
-  options: { metadata: ParsedAppElementsMetadata | null; pathname: string },
+  parsed: BfcacheSegmentElementKey,
+  options: {
+    metadata: ParsedAppElementsMetadata | null;
+    pathname: string;
+  },
 ): string | null {
-  const parsed = AppElementsWire.parseElementKey(id);
-  if (!parsed) return null;
-
   if (parsed.kind === "page") {
     return `${id}@${options.pathname}`;
   }
@@ -117,25 +129,32 @@ function createBfcacheSegmentIdentity(
   return null;
 }
 
-function collectBfcacheSegmentIds(
+function collectBfcacheSegmentIdCandidates(
   elements: AppElements,
   parsed?: ParsedAppElementsMetadata | null,
-): string[] {
+): Set<string> {
   const ids = new Set(Object.keys(elements));
   // Reuse parsed metadata when available; initial-map callers can omit it.
   const metadata = parsed === undefined ? readAppElementsMetadata(elements) : parsed;
   for (const layoutId of metadata?.metadata.layoutIds ?? []) {
     ids.add(layoutId);
   }
-  return Array.from(ids).filter(isBfcacheSegmentId);
+  return ids;
+}
+
+function createInitialBfcacheIdMapFromCandidateIds(ids: Iterable<string>): BfcacheIdMap {
+  const bfcacheIds: Record<string, string> = {};
+  for (const id of ids) {
+    const parsed = AppElementsWire.parseElementKey(id);
+    if (parsed === null || parsed.kind === "route") continue;
+    bfcacheIds[id] = INITIAL_BFCACHE_ID;
+  }
+
+  return bfcacheIds;
 }
 
 export function createInitialBfcacheIdMap(elements: AppElements): BfcacheIdMap {
-  const ids: Record<string, string> = {};
-  for (const id of collectBfcacheSegmentIds(elements)) {
-    ids[id] = INITIAL_BFCACHE_ID;
-  }
-  return ids;
+  return createInitialBfcacheIdMapFromCandidateIds(collectBfcacheSegmentIdCandidates(elements));
 }
 
 function normalizeBfcachePathname(pathname: string): string {
@@ -150,15 +169,57 @@ export function createBfcacheSegmentStateKeyMap(options: {
 }): BfcacheStateKeyMap {
   const metadata = readAppElementsMetadata(options.elements);
   const normalizedPathname = normalizeBfcachePathname(options.pathname);
+  const ids = collectBfcacheSegmentIdCandidates(options.elements, metadata);
+  return createBfcacheSegmentStateKeyMapFromCandidateIds({
+    ids,
+    metadata,
+    pathname: normalizedPathname,
+  });
+}
+
+function createBfcacheSegmentStateKeyMapFromCandidateIds(options: {
+  ids: Iterable<string>;
+  metadata: ParsedAppElementsMetadata | null;
+  pathname: string;
+}): BfcacheStateKeyMap {
   const stateKeys: Record<string, string> = {};
-  for (const id of collectBfcacheSegmentIds(options.elements, metadata)) {
-    const stateKey = createBfcacheSegmentIdentity(id, {
+
+  for (const id of options.ids) {
+    const parsed = AppElementsWire.parseElementKey(id);
+    if (parsed === null || parsed.kind === "route") continue;
+    const stateKey = createBfcacheSegmentIdentity(id, parsed, {
+      metadata: options.metadata,
+      pathname: options.pathname,
+    });
+    if (stateKey !== null) stateKeys[id] = stateKey;
+  }
+
+  return stateKeys;
+}
+
+export function createInitialBfcacheMaps(options: {
+  elements: AppElements;
+  metadata: AppElementsMetadata;
+  pathname: string;
+}): InitialBfcacheMaps {
+  const metadata = indexAppElementsMetadata(options.metadata);
+  const ids = collectBfcacheSegmentIdCandidates(options.elements, metadata);
+  const normalizedPathname = normalizeBfcachePathname(options.pathname);
+  const bfcacheIds: Record<string, string> = {};
+  const stateKeys: Record<string, string> = {};
+
+  for (const id of ids) {
+    const parsed = AppElementsWire.parseElementKey(id);
+    if (parsed === null || parsed.kind === "route") continue;
+    bfcacheIds[id] = INITIAL_BFCACHE_ID;
+    const stateKey = createBfcacheSegmentIdentity(id, parsed, {
       metadata,
       pathname: normalizedPathname,
     });
     if (stateKey !== null) stateKeys[id] = stateKey;
   }
-  return stateKeys;
+
+  return { bfcacheIds, stateKeys };
 }
 
 export function createNextBfcacheIdMap(options: {
@@ -179,12 +240,14 @@ export function createNextBfcacheIdMap(options: {
   const currentPathname = normalizeBfcachePathname(options.currentPathname);
   const nextPathname = normalizeBfcachePathname(options.nextPathname);
   const ids: Record<string, string> = {};
-  for (const id of collectBfcacheSegmentIds(options.elements, nextMetadata)) {
-    const currentIdentity = createBfcacheSegmentIdentity(id, {
+  for (const id of collectBfcacheSegmentIdCandidates(options.elements, nextMetadata)) {
+    const parsed = AppElementsWire.parseElementKey(id);
+    if (parsed === null || parsed.kind === "route") continue;
+    const currentIdentity = createBfcacheSegmentIdentity(id, parsed, {
       metadata: currentMetadata,
       pathname: currentPathname,
     });
-    const nextIdentity = createBfcacheSegmentIdentity(id, {
+    const nextIdentity = createBfcacheSegmentIdentity(id, parsed, {
       metadata: nextMetadata,
       pathname: nextPathname,
     });
@@ -195,6 +258,7 @@ export function createNextBfcacheIdMap(options: {
     ids[id] = value;
     rememberBfcacheId(value);
   }
+
   return ids;
 }
 
@@ -204,12 +268,15 @@ export function preserveBfcacheIdsForMergedElements(options: {
   previous: BfcacheIdMap;
 }): BfcacheIdMap {
   const ids: Record<string, string> = {};
-  for (const id of collectBfcacheSegmentIds(options.elements)) {
+  for (const id of collectBfcacheSegmentIdCandidates(options.elements)) {
+    const parsed = AppElementsWire.parseElementKey(id);
+    if (parsed === null || parsed.kind === "route") continue;
     const value = options.next[id] ?? options.previous[id];
     if (value === undefined) continue;
     ids[id] = value;
     // Keep future mints ahead of ids restored by reducer-level preservation.
     rememberBfcacheId(value);
   }
+
   return ids;
 }

--- a/packages/vinext/src/server/app-bfcache-identity.ts
+++ b/packages/vinext/src/server/app-bfcache-identity.ts
@@ -85,6 +85,11 @@ function readAppElementsMetadata(elements: AppElements): ParsedAppElementsMetada
   return indexAppElementsMetadata(metadata);
 }
 
+function parseBfcacheSegmentKey(id: string): BfcacheSegmentElementKey | null {
+  const parsed = AppElementsWire.parseElementKey(id);
+  return parsed !== null && parsed.kind !== "route" ? parsed : null;
+}
+
 function createActiveSlotIdentity(
   id: string,
   parsed: ParsedAppElementsMetadata | null,
@@ -131,30 +136,23 @@ function createBfcacheSegmentIdentity(
 
 function collectBfcacheSegmentIdCandidates(
   elements: AppElements,
-  parsed?: ParsedAppElementsMetadata | null,
+  metadata = readAppElementsMetadata(elements),
 ): Set<string> {
   const ids = new Set(Object.keys(elements));
-  // Reuse parsed metadata when available; initial-map callers can omit it.
-  const metadata = parsed === undefined ? readAppElementsMetadata(elements) : parsed;
   for (const layoutId of metadata?.metadata.layoutIds ?? []) {
     ids.add(layoutId);
   }
   return ids;
 }
 
-function createInitialBfcacheIdMapFromCandidateIds(ids: Iterable<string>): BfcacheIdMap {
-  const bfcacheIds: Record<string, string> = {};
-  for (const id of ids) {
-    const parsed = AppElementsWire.parseElementKey(id);
-    if (parsed === null || parsed.kind === "route") continue;
-    bfcacheIds[id] = INITIAL_BFCACHE_ID;
-  }
-
-  return bfcacheIds;
-}
-
 export function createInitialBfcacheIdMap(elements: AppElements): BfcacheIdMap {
-  return createInitialBfcacheIdMapFromCandidateIds(collectBfcacheSegmentIdCandidates(elements));
+  const bfcacheIds: Record<string, string> = {};
+  for (const id of collectBfcacheSegmentIdCandidates(elements)) {
+    if (parseBfcacheSegmentKey(id) !== null) {
+      bfcacheIds[id] = INITIAL_BFCACHE_ID;
+    }
+  }
+  return bfcacheIds;
 }
 
 function normalizeBfcachePathname(pathname: string): string {
@@ -169,27 +167,14 @@ export function createBfcacheSegmentStateKeyMap(options: {
 }): BfcacheStateKeyMap {
   const metadata = readAppElementsMetadata(options.elements);
   const normalizedPathname = normalizeBfcachePathname(options.pathname);
-  const ids = collectBfcacheSegmentIdCandidates(options.elements, metadata);
-  return createBfcacheSegmentStateKeyMapFromCandidateIds({
-    ids,
-    metadata,
-    pathname: normalizedPathname,
-  });
-}
-
-function createBfcacheSegmentStateKeyMapFromCandidateIds(options: {
-  ids: Iterable<string>;
-  metadata: ParsedAppElementsMetadata | null;
-  pathname: string;
-}): BfcacheStateKeyMap {
   const stateKeys: Record<string, string> = {};
 
-  for (const id of options.ids) {
-    const parsed = AppElementsWire.parseElementKey(id);
-    if (parsed === null || parsed.kind === "route") continue;
+  for (const id of collectBfcacheSegmentIdCandidates(options.elements, metadata)) {
+    const parsed = parseBfcacheSegmentKey(id);
+    if (parsed === null) continue;
     const stateKey = createBfcacheSegmentIdentity(id, parsed, {
-      metadata: options.metadata,
-      pathname: options.pathname,
+      metadata,
+      pathname: normalizedPathname,
     });
     if (stateKey !== null) stateKeys[id] = stateKey;
   }
@@ -209,8 +194,8 @@ export function createInitialBfcacheMaps(options: {
   const stateKeys: Record<string, string> = {};
 
   for (const id of ids) {
-    const parsed = AppElementsWire.parseElementKey(id);
-    if (parsed === null || parsed.kind === "route") continue;
+    const parsed = parseBfcacheSegmentKey(id);
+    if (parsed === null) continue;
     bfcacheIds[id] = INITIAL_BFCACHE_ID;
     const stateKey = createBfcacheSegmentIdentity(id, parsed, {
       metadata,
@@ -241,8 +226,8 @@ export function createNextBfcacheIdMap(options: {
   const nextPathname = normalizeBfcachePathname(options.nextPathname);
   const ids: Record<string, string> = {};
   for (const id of collectBfcacheSegmentIdCandidates(options.elements, nextMetadata)) {
-    const parsed = AppElementsWire.parseElementKey(id);
-    if (parsed === null || parsed.kind === "route") continue;
+    const parsed = parseBfcacheSegmentKey(id);
+    if (parsed === null) continue;
     const currentIdentity = createBfcacheSegmentIdentity(id, parsed, {
       metadata: currentMetadata,
       pathname: currentPathname,
@@ -269,8 +254,7 @@ export function preserveBfcacheIdsForMergedElements(options: {
 }): BfcacheIdMap {
   const ids: Record<string, string> = {};
   for (const id of collectBfcacheSegmentIdCandidates(options.elements)) {
-    const parsed = AppElementsWire.parseElementKey(id);
-    if (parsed === null || parsed.kind === "route") continue;
+    if (parseBfcacheSegmentKey(id) === null) continue;
     const value = options.next[id] ?? options.previous[id];
     if (value === undefined) continue;
     ids[id] = value;

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -269,7 +269,7 @@ export function readHistoryStatePreviousNextUrl(state: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
-export function isBfcacheSegmentId(id: string): boolean {
+function isBfcacheSegmentId(id: string): boolean {
   const parsed = AppElementsWire.parseElementKey(id);
   return (
     parsed?.kind === "layout" ||

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -44,10 +44,7 @@ import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { createInitialDevServerErrorScript } from "./dev-initial-server-error.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { AppElementsWire, type AppWireElements } from "./app-elements.js";
-import {
-  createBfcacheSegmentStateKeyMap,
-  createInitialBfcacheIdMap,
-} from "./app-bfcache-identity.js";
+import { createInitialBfcacheMaps } from "./app-bfcache-identity.js";
 import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/slot";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
@@ -424,6 +421,13 @@ export async function handleSsr(
           const wireElements = use(flightRoot);
           const elements = AppElementsWire.decode(wireElements);
           const metadata = AppElementsWire.readMetadata(elements);
+          const bfcacheMaps = createInitialBfcacheMaps({
+            elements,
+            metadata,
+            // Normalized inside the function to match the client navigation
+            // snapshot pathname (SSR/client Activity key parity).
+            pathname: ssrNavigationContext.pathname,
+          });
           const routeTree = createReactElement(
             ElementsContext.Provider,
             { value: elements },
@@ -431,14 +435,7 @@ export async function handleSsr(
           );
           const stateKeyTree = createReactElement(
             BfcacheStateKeyMapContext.Provider,
-            {
-              value: createBfcacheSegmentStateKeyMap({
-                elements,
-                // Normalized inside the function to match the client navigation
-                // snapshot pathname (SSR/client Activity key parity).
-                pathname: ssrNavigationContext.pathname,
-              }),
-            },
+            { value: bfcacheMaps.stateKeys },
             routeTree,
           );
           // During SSR we only provide the id *map*, seeded entirely with the
@@ -450,7 +447,7 @@ export async function handleSsr(
           return BfcacheIdMapContext
             ? createReactElement(
                 BfcacheIdMapContext.Provider,
-                { value: createInitialBfcacheIdMap(elements) },
+                { value: bfcacheMaps.bfcacheIds },
                 stateKeyTree,
               )
             : stateKeyTree;

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -100,6 +100,7 @@ import {
   type AppRouterState,
   type OperationLane,
 } from "../packages/vinext/src/server/app-browser-state.js";
+import { createInitialBfcacheMaps } from "../packages/vinext/src/server/app-bfcache-identity.js";
 import {
   HistoryStateSnapshotCache,
   RestorableClientStateController,
@@ -5078,6 +5079,24 @@ describe("app browser entry bfcacheId helpers", () => {
       [groupLayoutId]: "0",
       [pageX1Id]: "0",
     });
+  });
+
+  it("builds initial bfcache maps from shared App Elements metadata", () => {
+    const elements = createBfcacheElements(pageX1Id);
+    const metadata = AppElementsWire.readMetadata(elements);
+    const maps = createInitialBfcacheMaps({
+      elements,
+      metadata,
+      pathname: "/x/1",
+    });
+
+    expect(maps.bfcacheIds).toEqual(createInitialBfcacheIdMap(elements));
+    expect(maps.stateKeys).toEqual(
+      createBfcacheSegmentStateKeyMap({
+        elements,
+        pathname: "/x/1",
+      }),
+    );
   });
 
   it("derives page segment state keys from pathname, not history bfcache ids", () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -5099,6 +5099,32 @@ describe("app browser entry bfcacheId helpers", () => {
     );
   });
 
+  it("writes only history-readable bfcache segment ids", () => {
+    const routeId = AppElementsWire.encodeRouteId("/x/1", null);
+    const elements = createResolvedElements(routeId, "/", null, {
+      [routeId]: React.createElement("main", null),
+      [rootLayoutId]: React.createElement("div", null),
+      [pageX1Id]: React.createElement("main", null),
+    });
+    const metadata = AppElementsWire.readMetadata(elements);
+    const maps = createInitialBfcacheMaps({
+      elements,
+      metadata,
+      pathname: "/x/1",
+    });
+    const state = createHistoryStateWithNavigationMetadata(null, {
+      bfcacheIds: maps.bfcacheIds,
+      bfcacheVersion: 1,
+      previousNextUrl: null,
+    });
+
+    expect(maps.bfcacheIds).toEqual({
+      [rootLayoutId]: "0",
+      [pageX1Id]: "0",
+    });
+    expect(readHistoryStateBfcacheIds(state)).toEqual(maps.bfcacheIds);
+  });
+
   it("derives page segment state keys from pathname, not history bfcache ids", () => {
     const dynamicPageId = AppElementsWire.encodePageId("/page/[n]", null);
     const pageOneKeys = createBfcacheSegmentStateKeyMap({


### PR DESCRIPTION
## Summary
- reuse the App Elements metadata already read in `VinextFlightRoot` when building SSR BFCache maps
- build the initial SSR BFCache id map and state-key map from one parsed segment pass
- keep existing browser/navigation helper behavior covered by a focused helper equivalence test

## Profile evidence
Benchmark app: `node benchmarks/generate-app.mjs`, `vp build --sourcemap --minify false`, 1000 warmup + 20000 measured SSR requests to `/`.

Baseline profile: `/tmp/vinext-main-ssr-20000.cpuprofile`
Patched measured-good profile: `/tmp/vinext-bfcache-after2-20000.cpuprofile`

CPU self-time over 20k requests:
- `app-bfcache-identity.ts`: 39.58ms -> 8.84ms
- `app-history-state.ts::isBfcacheSegmentId`: 15.04ms -> 0ms on this SSR path
- `app-ssr-entry.ts`: 72.63ms -> 41.10ms
- `VinextFlightRoot`: 11.29ms -> 2.52ms

HTTP measured window, for context only: 13.58s -> 10.35s.

I also tried a more aggressive follow-up that removed the candidate-id `Set` and pre-split pathnames. The profiler rejected it (`app-bfcache-identity.ts` worsened to 11.05ms and HTTP regressed), so this PR keeps the smaller measured win.

## Verification
- `vp test run tests/app-browser-entry.test.ts`
- `vp run vinext#build`
- pre-commit hook: `vp check --fix`, full check, staged tests, knip

Build warnings were the existing virtual module / sourcemap warnings from the vinext package build and benchmark build.