### PR TITLE
feat(web): link benchmark references to GitHub

### DIFF
--- a/apps/web/app/benchmarks/components/performance-comparison.tsx
+++ b/apps/web/app/benchmarks/components/performance-comparison.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Badge } from "@cloudflare/kumo/components/badge";
 import { Dialog } from "@cloudflare/kumo/components/dialog";
-import { Clock, Flame, MagnifyingGlassPlus, X } from "@phosphor-icons/react";
+import { ArrowSquareOut, Clock, Flame, MagnifyingGlassPlus, X } from "@phosphor-icons/react";
 import type { FlameGraphData, PerformanceComparisonData } from "@/app/lib/benchmarks/server";
 import { formatMs } from "./format";
 import { PerformanceResultsTable, type PerformanceMeasurement } from "./performance-results";
@@ -58,7 +58,18 @@ export function PerformanceComparison({ comparison }: { comparison: Comparison }
                 <Badge variant="secondary">{comparison.badge}</Badge>
                 <span>{hasBaseline ? "Performance comparison" : "Performance results"}</span>
               </div>
-              <h1 className="text-2xl font-bold tracking-tight">{comparison.title}</h1>
+              <h1 className="text-2xl font-bold tracking-tight">
+                <a
+                  href={comparison.githubUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 hover:text-blue-700 hover:underline"
+                >
+                  {comparison.title}
+                  <ArrowSquareOut aria-hidden="true" className="size-5 shrink-0" />
+                  <span className="sr-only"> (opens in a new tab)</span>
+                </a>
+              </h1>
               <p className="mt-2 max-w-2xl text-sm text-gray-500">{comparison.description}</p>
             </div>
           </div>
@@ -68,12 +79,14 @@ export function PerformanceComparison({ comparison }: { comparison: Comparison }
         >
           <RunCard
             label={comparison.currentLabel}
+            fullSha={comparison.head.sha}
             sha={comparison.head.shortSha}
             date={comparison.head.measuredAt}
           />
           {comparison.baseline && (
             <RunCard
               label={comparison.baselineLabel}
+              fullSha={comparison.baseline.sha}
               sha={comparison.baseline.shortSha}
               date={comparison.baseline.measuredAt}
             />
@@ -616,11 +629,30 @@ function TraceFilter({
   );
 }
 
-function RunCard({ label, sha, date }: { label: string; sha: string; date: string | null }) {
+function RunCard({
+  label,
+  fullSha,
+  sha,
+  date,
+}: {
+  label: string;
+  fullSha: string;
+  sha: string;
+  date: string | null;
+}) {
   return (
     <div className="bg-white px-6 py-4">
       <div className="text-xs uppercase tracking-wide text-gray-400">{label}</div>
-      <div className="mt-1 font-mono text-sm font-semibold">{sha}</div>
+      <a
+        href={`https://github.com/cloudflare/vinext/commit/${fullSha}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-1 inline-flex items-center gap-1 font-mono text-sm font-semibold text-blue-700 hover:underline"
+      >
+        {sha}
+        <ArrowSquareOut aria-hidden="true" className="size-3.5 shrink-0" />
+        <span className="sr-only"> (opens in a new tab)</span>
+      </a>
       {date && <div className="mt-1 text-xs text-gray-500">{new Date(date).toLocaleString()}</div>}
     </div>
   );

--- a/apps/web/app/lib/benchmarks/server.ts
+++ b/apps/web/app/lib/benchmarks/server.ts
@@ -442,6 +442,7 @@ export async function getPerformanceRuns(limit = 100): Promise<PerformanceRunDat
 export type PerformanceComparisonData = {
   badge: string;
   title: string;
+  githubUrl: string;
   description: string;
   currentLabel: string;
   head: ReturnType<typeof runReference>;
@@ -494,6 +495,7 @@ export async function getPullComparison(
   return {
     badge: `PR #${pullNumber}`,
     title: `Pull request #${pullNumber}`,
+    githubUrl: `https://github.com/cloudflare/vinext/pull/${pullNumber}`,
     description: comparisonDescription(provenance, "Exact-head measurements."),
     currentLabel: "PR head",
     head: runReference(pullRun),
@@ -564,6 +566,7 @@ export async function getCommitComparison(sha: string): Promise<PerformanceCompa
   return {
     badge: commitSha.slice(0, 7),
     title: `Commit ${commitSha.slice(0, 7)}`,
+    githubUrl: `https://github.com/cloudflare/vinext/commit/${commitSha}`,
     description: isPullRequestRun
       ? comparisonDescription(provenance, "Pull-request measurements.")
       : baselineRun


### PR DESCRIPTION
This PR links benchmark commit headings and run hashes directly to their GitHub commits. Same for pull request comparison headings.

All outbound links are marked with an icon.