### PR TITLE
perf(app-router): reduce app page probe walker overhead

### DIFF
--- a/packages/vinext/src/server/app-page-probe.ts
+++ b/packages/vinext/src/server/app-page-probe.ts
@@ -1,4 +1,4 @@
-import { Fragment, isValidElement, type ReactElement, type ReactNode } from "react";
+import { Fragment, type ReactElement, type ReactNode } from "react";
 import { markAppPagePropsForUseCache } from "vinext/shims/internal/app-page-props-cache-key";
 import { isNextRouterError } from "vinext/shims/navigation-server";
 import { collectAppPageSearchParams } from "./app-page-head.js";
@@ -14,6 +14,7 @@ import { isPromiseLike } from "../utils/promise.js";
 
 const DEFAULT_SUBTREE_PROBE_MAX_DEPTH = 32;
 const DEFAULT_SUBTREE_PROBE_MAX_NODES = 1000;
+const REACT_ELEMENT_TYPE = Symbol.for("react.transitional.element");
 const REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref");
 const REACT_LAZY_TYPE = Symbol.for("react.lazy");
 const REACT_MEMO_TYPE = Symbol.for("react.memo");
@@ -28,6 +29,8 @@ type ProbeReactElementProps = Readonly<{
 }>;
 
 type UnknownFunction = (...args: unknown[]) => unknown;
+type ProbeVisitResult = void | PromiseLike<void>;
+type ProbeRenderResult = boolean | PromiseLike<boolean>;
 
 type ReactMemoType = Readonly<{
   innerType: unknown;
@@ -63,7 +66,11 @@ function isIterable(value: unknown): value is Iterable<unknown> {
 }
 
 function isProbeReactElement(value: unknown): value is ReactElement<ProbeReactElementProps> {
-  return isValidElement<ProbeReactElementProps>(value);
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { $$typeof?: unknown }).$$typeof === REACT_ELEMENT_TYPE
+  );
 }
 
 function isObjectLike(value: unknown): value is object {
@@ -136,18 +143,36 @@ export async function probeReactServerSubtree(
     }
   };
 
-  const renderElementType = async (
+  const continueArrayProbe = (
+    values: readonly unknown[],
+    startIndex: number,
+    depth: number,
+  ): ProbeVisitResult => {
+    for (let index = startIndex; index < values.length; index += 1) {
+      const childResult = visit(values[index], depth + 1);
+      if (isPromiseLike(childResult)) {
+        return Promise.resolve(childResult).then(() =>
+          continueArrayProbe(values, index + 1, depth),
+        );
+      }
+    }
+  };
+
+  const renderElementType = (
     type: unknown,
     props: ProbeReactElementProps,
     depth: number,
     wrapperDepth = 0,
-  ): Promise<boolean> => {
+  ): ProbeRenderResult => {
     if (wrapperDepth > maxDepth) {
       throw new AppPageSubtreeProbeLimitError("App page layout subtree probe exceeded max depth");
     }
 
     if (isUnknownFunction(type)) {
-      await visit(type(props), depth + 1);
+      const result = visit(type(props), depth + 1);
+      if (isPromiseLike(result)) {
+        return Promise.resolve(result).then(() => true);
+      }
       return true;
     }
 
@@ -158,52 +183,55 @@ export async function probeReactServerSubtree(
 
     const lazyType = readReactLazyType(type);
     if (lazyType) {
-      return renderElementType(
-        await resolveReactLazyType(lazyType),
-        props,
-        depth,
-        wrapperDepth + 1,
+      return resolveReactLazyType(lazyType).then((resolvedType) =>
+        renderElementType(resolvedType, props, depth, wrapperDepth + 1),
       );
     }
 
     const forwardRefRender = readReactForwardRefRender(type);
     if (forwardRefRender) {
-      await visit(forwardRefRender(props, null), depth + 1);
+      const result = visit(forwardRefRender(props, null), depth + 1);
+      if (isPromiseLike(result)) {
+        return Promise.resolve(result).then(() => true);
+      }
       return true;
     }
 
     return false;
   };
 
-  const visit = async (value: unknown, depth: number): Promise<void> => {
+  const visit = (value: unknown, depth: number): ProbeVisitResult => {
     enterProbeNode(depth);
     if (value == null || typeof value === "boolean" || typeof value === "number") return;
     if (typeof value === "string" || typeof value === "bigint") return;
     if (isPromiseLike(value)) {
-      await visit(await value, depth);
-      return;
+      return Promise.resolve(value).then((resolved) => visit(resolved, depth));
     }
     if (Array.isArray(value)) {
-      for (const child of value) {
-        await visit(child, depth + 1);
-      }
-      return;
+      return continueArrayProbe(value, 0, depth);
     }
     if (isIterable(value) && !isProbeReactElement(value)) {
       throw new AppPageSubtreeProbeUnsupportedIterableError();
     }
     if (!isProbeReactElement(value)) return;
 
-    if (value.type === Fragment || typeof value.type === "string") {
-      await visit(value.props.children, depth + 1);
+    const { type, props } = value;
+    if (type === Fragment || typeof type === "string") {
+      return visit(props.children, depth + 1);
+    }
+
+    const renderResult = renderElementType(type, props, depth);
+    if (isPromiseLike(renderResult)) {
+      return Promise.resolve(renderResult).then((didRender) => {
+        if (didRender) return;
+        return visit(props.children, depth + 1);
+      });
+    }
+    if (renderResult) {
       return;
     }
 
-    if (await renderElementType(value.type, value.props, depth)) {
-      return;
-    }
-
-    await visit(value.props.children, depth + 1);
+    return visit(props.children, depth + 1);
   };
 
   await visit(node, 0);
@@ -261,7 +289,7 @@ export function probeAppPage(options: {
       return resolved;
     });
   }
-  if (isValidElement(result) || Array.isArray(result)) {
+  if (isProbeReactElement(result) || Array.isArray(result)) {
     return probeReactServerSubtreeForDynamicUsage(result).then(() => result);
   }
   return result;

--- a/tests/app-page-probe.test.ts
+++ b/tests/app-page-probe.test.ts
@@ -107,6 +107,40 @@ describe("app page probe helpers", () => {
     expect(calls).toEqual(["layout", "lazy"]);
   });
 
+  it("continues probing siblings after an async server component resolves", async () => {
+    const calls: string[] = [];
+
+    function Grandchild() {
+      calls.push("grandchild");
+      return null;
+    }
+
+    async function AsyncChild() {
+      calls.push("async-start");
+      await Promise.resolve();
+      calls.push("async-end");
+      return React.createElement(Grandchild);
+    }
+
+    function Sibling() {
+      calls.push("sibling");
+      return null;
+    }
+
+    function Layout() {
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(AsyncChild),
+        React.createElement(Sibling),
+      );
+    }
+
+    await probeReactServerSubtree(React.createElement(Layout));
+
+    expect(calls).toEqual(["async-start", "async-end", "grandchild", "sibling"]);
+  });
+
   it("enforces subtree depth limits for nested arrays", async () => {
     await expect(
       probeReactServerSubtree([[[React.createElement("span")]]], { maxDepth: 1 }),


### PR DESCRIPTION
## Overview

| Area | Details |
| --- | --- |
| Goal | Reduce App Router page probing overhead on warm SSR requests. |
| Core change | Keep subtree probing synchronous unless the probed value actually becomes thenable. |
| Primary file | `packages/vinext/src/server/app-page-probe.ts` |
| Expected impact | Lower CPU self-time in the app page probe walker without skipping any subtree probing. |

## What changed

`probeReactServerSubtree` no longer allocates promise continuations for every recursive visit in ordinary synchronous React element trees. It now returns synchronously through primitive, array, host, fragment, memo, forwardRef, and function-component paths, and only resumes through promises for thenable children, lazy resolution, or async component results.

The React element predicate also checks React's production element marker directly, matching React's `isValidElement` production contract while avoiding the wrapper call on this hot path.

## Profiling

Benchmark app, `vp build --sourcemap --minify false`, `vp preview` under inspector, 1000 warmup plus 20000 measured requests to `/`, concurrency 50.

| Run | HTTP measured window | `app-page-probe.ts` self-time | Notable probe functions |
| --- | ---: | ---: | --- |
| Baseline from this worktree | 14,289.82ms | 191.42ms | `visit` 100.32ms, `isProbeReactElement` 30.97ms |
| Patched rerun | 11,731.40ms | 87.07ms | `visit` 47.73ms, `probeReactServerSubtree` 11.90ms |

CPU self-time is the primary signal. One intermediate patched run had a slower HTTP measured window, so wall-clock should still be treated as noisy on this workstation. The rerun above was taken after checking no other vinext candidate preview/profiler processes were active.

## Validation

- `vp test run tests/app-page-probe.test.ts tests/app-page-probe-light-runtime.test.ts`
- `git diff --check`
- `vp run vinext#build`
- Pre-commit hook: `vp check --fix`, staged unit/integration checks, `knip`

## Risk

The traversal semantics are intended to remain unchanged: promise, lazy, memo, forwardRef, fragment, host element, unsupported iterable, depth/node limit, redirect/notFound, and dynamic API observation behavior still flow through the same probe boundaries. Added coverage verifies that sibling probing continues after an async server component resolves.
