### PR TITLE
perf(app-router): isolate action request detection

### DIFF
--- a/packages/vinext/src/server/app-action-request.ts
+++ b/packages/vinext/src/server/app-action-request.ts
@@ -1,0 +1,17 @@
+import { NEXT_ACTION_HEADER, RSC_ACTION_HEADER } from "./headers.js";
+
+export function isPossibleAppRouteActionRequest(
+  request: Pick<Request, "headers" | "method">,
+): boolean {
+  if (request.method.toUpperCase() !== "POST") return false;
+
+  const contentType = request.headers.get("content-type");
+  return (
+    request.headers.has(RSC_ACTION_HEADER) ||
+    request.headers.has(NEXT_ACTION_HEADER) ||
+    // Next.js uses strict equality here, so charset variants intentionally do
+    // not classify as action requests even though they are valid form posts.
+    contentType === "application/x-www-form-urlencoded" ||
+    contentType?.startsWith("multipart/form-data") === true
+  );
+}

--- a/packages/vinext/src/server/app-page-method.ts
+++ b/packages/vinext/src/server/app-page-method.ts
@@ -1,4 +1,4 @@
-import { isPossibleAppRouteActionRequest } from "./app-route-handler-policy.js";
+import { isPossibleAppRouteActionRequest } from "./app-action-request.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { methodNotAllowedResponse } from "./http-error-responses.js";
 

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -4,8 +4,8 @@ import {
   type RouteHandlerHttpMethod,
   type RouteHandlerModule,
 } from "./app-route-handler-runtime.js";
-import { NEXT_ACTION_HEADER, RSC_ACTION_HEADER } from "./headers.js";
 import { parseNextHttpErrorDigest, parseNextRedirectDigest } from "./next-error-digest.js";
+export { isPossibleAppRouteActionRequest } from "./app-action-request.js";
 
 export type AppRouteHandlerModule = {
   dynamic?: string;
@@ -57,22 +57,6 @@ type AppRouteHandlerSpecialError =
 type AppRouteHandlerSpecialErrorOptions = {
   isAction: boolean;
 };
-
-export function isPossibleAppRouteActionRequest(
-  request: Pick<Request, "headers" | "method">,
-): boolean {
-  if (request.method.toUpperCase() !== "POST") return false;
-
-  const contentType = request.headers.get("content-type");
-  return (
-    request.headers.has(RSC_ACTION_HEADER) ||
-    request.headers.has(NEXT_ACTION_HEADER) ||
-    // Next.js uses strict equality here, so charset variants intentionally do
-    // not classify as action requests even though they are valid form posts.
-    contentType === "application/x-www-form-urlencoded" ||
-    contentType?.startsWith("multipart/form-data") === true
-  );
-}
 
 export function getAppRouteHandlerRevalidateSeconds(
   handler: Pick<AppRouteHandlerModule, "revalidate">,


### PR DESCRIPTION
Extracts `action-request` detection into a lightweight standalone module while keeping behavior as is. This avoids loading the broader route-handler policy module for regular App Router page requests.

Ideally this gives us a faster first-request and total startup times.