### PR TITLE
perf(client): preserve App Router route chunk boundaries

### DIFF
--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -16,6 +16,17 @@ type RscFrameworkManualChunksMeta = {
   getModuleInfo(id: string): RscFrameworkModuleInfo | null;
 };
 
+const ROUTE_OWNED_CLIENT_SHIMS = new Set([
+  "dynamic-preload-chunks",
+  "form",
+  "image",
+  "layout-segment-context",
+  "link",
+  "offline",
+  "router",
+  "script",
+]);
+
 // Next.js emits CSS under `static/css/` and CSS url() dependencies (images,
 // fonts, …) under `static/media/`, both with an 8-char content hash. Mirror
 // that layout so migrated apps keep stable, Next-shaped asset URLs.
@@ -81,12 +92,10 @@ function getPackageName(id: string): string | null {
  *
  * Splits the client bundle into:
  * - "framework" — React, ReactDOM, and scheduler (loaded on every page)
- * - "vinext"    — vinext shims (router, head, link, etc.)
+ * - "vinext"    — shared vinext runtime shims
  *
- * All other vendor code is left to Rollup's default chunk-splitting
- * algorithm. Rollup automatically deduplicates shared modules into
- * common chunks based on the import graph — no manual intervention
- * needed.
+ * Route-owned client shims and all other vendor code are left to the bundler's
+ * graph-based chunking so they stay behind their client-reference boundaries.
  *
  * Why not split every npm package into its own chunk?
  * - Per-package splitting (`vendor-X`) creates 50-200+ chunks for a
@@ -103,7 +112,7 @@ function getPackageName(id: string): string | null {
  *   well: shared dependencies between routes get their own chunks,
  *   and route-specific code stays in route chunks.
  */
-export function createClientManualChunks(shimsDir: string) {
+export function createClientManualChunks(shimsDir: string, preserveRouteBoundaries = false) {
   return function clientManualChunks(id: string): string | undefined {
     // React framework — always loaded, shared across all pages.
     // Isolating React into its own chunk is the single highest-value
@@ -122,10 +131,11 @@ export function createClientManualChunks(shimsDir: string) {
       return undefined;
     }
 
-    // vinext shims — small runtime, shared across all pages.
-    // Use the absolute shims directory path to avoid matching user files
-    // that happen to have "/shims/" in their path.
     if (id.startsWith(shimsDir)) {
+      const relativeId = id.slice(shimsDir.length).split("?", 1)[0] ?? "";
+      const extensionIndex = relativeId.lastIndexOf(".");
+      const shimName = extensionIndex === -1 ? relativeId : relativeId.slice(0, extensionIndex);
+      if (preserveRouteBoundaries && ROUTE_OWNED_CLIENT_SHIMS.has(shimName)) return undefined;
       return "vinext";
     }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -695,15 +695,25 @@ const _reactServerShims = new Map<string, string>([
 
 const clientManualChunks = createClientManualChunks(_shimsDir);
 const clientCodeSplittingConfig = createClientCodeSplittingConfig(clientManualChunks);
+const appClientManualChunks = createClientManualChunks(_shimsDir, true);
+const appClientCodeSplittingConfig = createClientCodeSplittingConfig(appClientManualChunks);
 
-function getClientOutputConfigForVite(viteMajorVersion: number, assetsDir: string) {
+function getClientOutputConfigForVite(
+  viteMajorVersion: number,
+  assetsDir: string,
+  preserveAppRouteBoundaries = false,
+) {
+  const manualChunks = preserveAppRouteBoundaries ? appClientManualChunks : clientManualChunks;
+  const codeSplitting = preserveAppRouteBoundaries
+    ? appClientCodeSplittingConfig
+    : clientCodeSplittingConfig;
   return viteMajorVersion >= 8
     ? {
         ...createClientFileNameConfig(assetsDir),
         assetFileNames: createClientAssetFileNames(assetsDir),
-        codeSplitting: clientCodeSplittingConfig,
+        codeSplitting,
       }
-    : createClientOutputConfig(clientManualChunks, assetsDir);
+    : createClientOutputConfig(manualChunks, assetsDir);
 }
 
 export type VinextOptions = {
@@ -2425,7 +2435,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 assetsInlineLimit: clientAssetsInlineLimit,
                 ...withBuildBundlerOptions(viteMajorVersion, {
                   input: appClientInput,
-                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
+                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir, true),
                   treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
                 }),
               },

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -9,6 +9,13 @@ import { APP_FIXTURE_DIR } from "./helpers.js";
 
 type BuiltAppHandler = (request: Request) => Promise<Response | string | null | undefined>;
 
+type ClientManifestEntry = {
+  imports?: string[];
+  isEntry?: boolean;
+  name?: string;
+  src?: string;
+};
+
 function isBuiltAppHandler(value: unknown): value is BuiltAppHandler {
   return typeof value === "function";
 }
@@ -51,6 +58,38 @@ describe("App Router Production build", () => {
     // directory.
     const clientAssets = fs.readdirSync(path.join(outDir, "client", "_next", "static", "chunks"));
     expect(clientAssets.some((f: string) => f.endsWith(".js"))).toBe(true);
+
+    // Ported from the client-reference chunk ownership covered by Next.js:
+    // test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
+    //
+    // `next/link` is a client reference used by selected routes. It must remain
+    // a lazy chunk instead of being pulled into the eager App Router bootstrap
+    // by vinext's manual chunk policy.
+    const clientManifest = JSON.parse(
+      fs.readFileSync(path.join(outDir, "client", ".vite", "manifest.json"), "utf-8"),
+    ) as Record<string, ClientManifestEntry>;
+    const browserEntryKey = Object.keys(clientManifest).find(
+      (key) => clientManifest[key]?.isEntry === true,
+    );
+    const linkEntryKey = Object.keys(clientManifest).find((key) => {
+      const entry = clientManifest[key];
+      const source = entry?.src?.replaceAll("\\", "/") ?? key.replaceAll("\\", "/");
+      return entry?.name === "link" || /\/shims\/link\.(?:js|tsx)$/.test(source);
+    });
+    expect(browserEntryKey).toBeDefined();
+    expect(linkEntryKey).toBeDefined();
+
+    const eagerKeys = new Set<string>();
+    const visitEagerImports = (key: string): void => {
+      if (eagerKeys.has(key)) return;
+      eagerKeys.add(key);
+      for (const importedKey of clientManifest[key]?.imports ?? []) {
+        visitEagerImports(importedKey);
+      }
+    };
+    if (browserEntryKey) visitEagerImports(browserEntryKey);
+    expect(linkEntryKey ? eagerKeys.has(linkEntryKey) : true).toBe(false);
 
     // RSC bundle should contain route handling code
     const rscEntry = fs.readFileSync(path.join(outDir, "server", "index.js"), "utf-8");

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -44,6 +44,7 @@ const _stripServerExports = (code: string): string | null =>
 // The exact path doesn't matter for the node_modules-focused tests;
 // shims-chunk tests would need a real path.
 const clientManualChunks = createClientManualChunks("/vinext/shims/");
+const appClientManualChunks = createClientManualChunks("/vinext/shims/", true);
 
 // The vinext config hook mutates process.env.NODE_ENV as a side effect (matching
 // Next.js behavior). Save/restore globally so tests that call config() don't
@@ -115,6 +116,19 @@ describe("clientManualChunks", () => {
   it("returns undefined for user source files", () => {
     expect(clientManualChunks("/src/components/App.tsx")).toBeUndefined();
     expect(clientManualChunks("/src/pages/index.tsx")).toBeUndefined();
+  });
+
+  it("keeps shared vinext shims in the runtime chunk", () => {
+    expect(clientManualChunks("/vinext/shims/link.js")).toBe("vinext");
+    expect(clientManualChunks("/vinext/shims/navigation.js")).toBe("vinext");
+    expect(appClientManualChunks("/vinext/shims/navigation.js")).toBe("vinext");
+  });
+
+  it("leaves App Router route-owned client shims behind their dynamic boundaries", () => {
+    expect(appClientManualChunks("/vinext/shims/link.js")).toBeUndefined();
+    expect(appClientManualChunks("/vinext/shims/router.ts")).toBeUndefined();
+    expect(appClientManualChunks("/vinext/shims/image.tsx?client")).toBeUndefined();
+    expect(appClientManualChunks("/vinext/shims/layout-segment-context.js")).toBeUndefined();
   });
 
   it("handles pnpm-style nested node_modules paths", () => {


### PR DESCRIPTION
This PR preserves App Router route chunk boundaries instead of eagerly bundling route-owned `vinext` shims.

This should reduce initial JavaScript by 6–10 KB (gzipped) with no measurable performance regression, at the cost of 1 to 2 additional requests in case the shims are necessary.  These occur only when a route actually needs one of the separated shims, such as `next/link` or `next/image`.