### PR TITLE
feat(benchmarks): track eager client entry size

### DIFF
--- a/benchmarks/perf/bundle-size.mjs
+++ b/benchmarks/perf/bundle-size.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { lstat, readdir, readFile, realpath } from "node:fs/promises";
-import { isAbsolute, join, relative } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { gzipSync } from "node:zlib";
 import { reportPerformanceSample } from "./report-sample.mjs";
 
@@ -12,12 +12,12 @@ const target = process.argv[3] ?? "client";
 
 if (framework !== "vinext" && framework !== "nextjs") {
   console.error(
-    "Usage: node benchmarks/perf/bundle-size.mjs <vinext|nextjs> [client|rsc-entry|server]",
+    "Usage: node benchmarks/perf/bundle-size.mjs <vinext|nextjs> [client|client-entry|rsc-entry|server]",
   );
   process.exit(1);
 }
 
-if (!["client", "rsc-entry", "server"].includes(target)) {
+if (!["client", "client-entry", "rsc-entry", "server"].includes(target)) {
   throw new Error(`Unknown bundle target: ${target}`);
 }
 if (framework === "nextjs" && target !== "client") {
@@ -27,7 +27,7 @@ if (framework === "nextjs" && target !== "client") {
 const outputPath =
   framework === "nextjs"
     ? join(benchmarkDir, "nextjs", ".next", "static")
-    : target === "client"
+    : target === "client" || target === "client-entry"
       ? join(benchmarkDir, "vinext", "dist", "client")
       : target === "rsc-entry"
         ? join(benchmarkDir, "vinext", "dist", "server", "index.js")
@@ -52,6 +52,61 @@ async function gzipBundleSize(directory) {
   }
 
   return { gzipBytes, fileCount };
+}
+
+async function gzipClientEntryClosure(clientOutputPath) {
+  const manifestPath = join(clientOutputPath, ".vite", "manifest.json");
+  const resolvedClientOutputPath = await realpath(clientOutputPath);
+  const manifestOutput = await lstat(manifestPath);
+  if (!manifestOutput.isFile() || manifestOutput.isSymbolicLink()) {
+    throw new Error(`Client manifest must be a regular file: ${manifestPath}`);
+  }
+  const resolvedManifestPath = await realpath(manifestPath);
+  const manifestRelativePath = relative(resolvedClientOutputPath, resolvedManifestPath);
+  if (manifestRelativePath.startsWith("..") || isAbsolute(manifestRelativePath)) {
+    throw new Error(`Client manifest escapes the output directory: ${manifestPath}`);
+  }
+  const manifest = JSON.parse(await readFile(resolvedManifestPath, "utf8"));
+  const entryKeys = Object.keys(manifest).filter((key) => manifest[key]?.isEntry === true);
+  if (entryKeys.length !== 1) {
+    throw new Error(`Expected one client entry in ${manifestPath}, found ${entryKeys.length}`);
+  }
+
+  let gzipBytes = 0;
+  const visited = new Set();
+
+  async function visit(key) {
+    if (visited.has(key)) return;
+    visited.add(key);
+
+    const chunk = manifest[key];
+    if (!chunk || typeof chunk.file !== "string") {
+      throw new Error(`Client manifest entry ${JSON.stringify(key)} has no output file`);
+    }
+
+    const filePath = resolve(clientOutputPath, chunk.file);
+    const relativePath = relative(clientOutputPath, filePath);
+    if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+      throw new Error(`Client manifest file escapes the output directory: ${chunk.file}`);
+    }
+    const output = await lstat(filePath);
+    if (!output.isFile() || output.isSymbolicLink()) {
+      throw new Error(`Client entry output must be a regular file: ${filePath}`);
+    }
+    const resolvedFilePath = await realpath(filePath);
+    const resolvedRelativePath = relative(resolvedClientOutputPath, resolvedFilePath);
+    if (resolvedRelativePath.startsWith("..") || isAbsolute(resolvedRelativePath)) {
+      throw new Error(`Client entry output escapes the output directory: ${chunk.file}`);
+    }
+    gzipBytes += gzipSync(await readFile(resolvedFilePath)).length;
+
+    for (const importedKey of chunk.imports ?? []) {
+      await visit(importedKey);
+    }
+  }
+
+  await visit(entryKeys[0]);
+  return { gzipBytes, fileCount: visited.size };
 }
 
 async function main() {
@@ -79,7 +134,9 @@ async function main() {
   const { gzipBytes, fileCount } =
     target === "rsc-entry"
       ? { gzipBytes: gzipSync(await readFile(outputPath)).length, fileCount: 1 }
-      : await gzipBundleSize(outputPath);
+      : target === "client-entry"
+        ? await gzipClientEntryClosure(outputPath)
+        : await gzipBundleSize(outputPath);
   if (fileCount === 0) throw new Error(`No JavaScript or CSS found in ${outputPath}`);
   await reportPerformanceSample(gzipBytes);
 }

--- a/benchmarks/perf/scenarios.json
+++ b/benchmarks/perf/scenarios.json
@@ -82,6 +82,23 @@
       ]
     },
     {
+      "id": "client-entry-gzip",
+      "suite": "Build",
+      "label": "Client entry size (gzip)",
+      "description": "Total gzip size of the production browser entry and its eager static JavaScript imports.",
+      "unit": "bytes",
+      "lowerIsBetter": true,
+      "implementations": [
+        {
+          "id": "vinext",
+          "label": "vinext",
+          "profile": false,
+          "compareBase": true,
+          "command": ["node", "benchmarks/perf/bundle-size.mjs", "vinext", "client-entry"]
+        }
+      ]
+    },
+    {
       "id": "rsc-entry-gzip",
       "suite": "Build",
       "label": "RSC entry size (gzip)",

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -312,6 +312,62 @@ describe("paired performance benchmarks", () => {
     ]);
   });
 
+  it("measures only the eager client entry closure", () => {
+    const directory = mkdtempSync(join(tmpdir(), "vinext-perf-client-entry-"));
+    const clientDirectory = join(directory, "benchmarks/vinext/dist/client");
+    const chunksDirectory = join(clientDirectory, "assets");
+    const manifestDirectory = join(clientDirectory, ".vite");
+    const samplesPath = join(directory, "samples.jsonl");
+    const entry = "import './shared.js'; console.log('entry');";
+    const shared = "export const shared = 'shared';";
+    const lazy = "export const lazy = 'lazy';";
+    mkdirSync(chunksDirectory, { recursive: true });
+    mkdirSync(manifestDirectory, { recursive: true });
+    writeFileSync(join(chunksDirectory, "entry.js"), entry);
+    writeFileSync(join(chunksDirectory, "shared.js"), shared);
+    writeFileSync(join(chunksDirectory, "lazy.js"), lazy);
+    writeFileSync(
+      join(manifestDirectory, "manifest.json"),
+      JSON.stringify({
+        "virtual:entry": {
+          file: "assets/entry.js",
+          isEntry: true,
+          imports: ["shared"],
+          dynamicImports: ["lazy"],
+        },
+        shared: {
+          file: "assets/shared.js",
+          imports: ["virtual:entry"],
+        },
+        lazy: {
+          file: "assets/lazy.js",
+          isDynamicEntry: true,
+        },
+      }),
+    );
+
+    execFileSync(process.execPath, ["benchmarks/perf/bundle-size.mjs", "vinext", "client-entry"], {
+      cwd: join(import.meta.dirname, ".."),
+      env: {
+        ...process.env,
+        VINEXT_PERF_TARGET_ROOT: directory,
+        VINEXT_PERF_SAMPLES: samplesPath,
+        VINEXT_PERF_BENCHMARK_ID: "vinext-client-entry-gzip",
+        VINEXT_PERF_SCENARIO_ID: "client-entry-gzip",
+        VINEXT_PERF_SUITE: "Build",
+        VINEXT_PERF_LABEL: "Client entry size",
+        VINEXT_PERF_IMPLEMENTATION_ID: "vinext",
+        VINEXT_PERF_IMPLEMENTATION_LABEL: "vinext",
+        VINEXT_PERF_UNIT: "bytes",
+        VINEXT_PERF_LOWER_IS_BETTER: "true",
+        VINEXT_PERF_REVISION: "head",
+      },
+    });
+
+    const sample = JSON.parse(readFileSync(samplesPath, "utf8"));
+    expect(sample.value).toBe(gzipSync(entry).length + gzipSync(shared).length);
+  });
+
   it("normalizes same-run baseline samples separately from head samples", () => {
     const directory = mkdtempSync(join(tmpdir(), "vinext-perf-"));
     const samplesPath = join(directory, "samples.jsonl");


### PR DESCRIPTION
Another scenario to track is how much JS is loaded eagerly. We only capture the full gzip size which is somewhat misleading given that we add more JS that is loaded lazily.

See e.g. #2189 