### PR TITLE
perf(dev): externalize SSR React runtime

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2193,6 +2193,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           : config.ssr?.external === true
             ? true
             : nextServerExternal;
+        const externalizeSsrReactInDev =
+          env.command === "serve" && !hasCloudflarePlugin && !hasNitroPlugin;
 
         // Capture top-level optimizeDeps populated by earlier plugins
         // (e.g. @lingui/vite-plugin) so we merge rather than overwrite.
@@ -2331,7 +2333,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ? {}
                 : {
                     resolve: {
-                      external: userSsrExternal === true ? true : [...userSsrExternal, "ipaddr.js"],
+                      external:
+                        userSsrExternal === true
+                          ? true
+                          : [
+                              ...userSsrExternal,
+                              "ipaddr.js",
+                              // Node can load the SSR React runtime natively.
+                              // Keeping it out of Vite's transform graph avoids
+                              // reparsing the large Flight client decoder.
+                              ...(externalizeSsrReactInDev ? SSR_EXTERNAL_REACT_ENTRIES : []),
+                            ],
                       // Force all node_modules through Vite's transform pipeline
                       // so non-JS imports (CSS, images) don't hit Node's native
                       // ESM loader. Matches Next.js behavior of bundling everything.
@@ -2357,11 +2369,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 // bundles it anyway, so excluding it from the dev optimizer
                 // is still correct — it just defers handling to the runtime
                 // resolver instead of the SSR pre-bundle step.
+                //
+                // React is also excluded when Node dev externalizes it above.
+                // This keeps the optimizer from creating a second React copy
+                // while the renderer and client modules use the native one.
                 exclude: mergeOptimizeDepsExclude(
                   incomingExclude,
                   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
                   ["ipaddr.js"],
-                  userSsrExternal === true ? SSR_EXTERNAL_REACT_ENTRIES : [],
+                  userSsrExternal === true || externalizeSsrReactInDev
+                    ? SSR_EXTERNAL_REACT_ENTRIES
+                    : [],
                 ),
                 entries: optimizeEntries,
                 ...depOptimizeNodeEnvOptions,

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -140,7 +140,10 @@ describe("renderVinextBuiltUrl", () => {
       nextConfig: () => ({ deploymentId: "dpl_123" }),
     }) as any[];
     const configPlugin = plugins.find((plugin) => plugin.name === "vinext:config");
-    const config = await configPlugin.config({ root: APP_FIXTURE_DIR, plugins: [] });
+    const config = await configPlugin.config(
+      { root: APP_FIXTURE_DIR, plugins: [] },
+      { command: "build", mode: "production" },
+    );
     const renderBuiltUrl = config.experimental?.renderBuiltUrl;
 
     expect(renderBuiltUrl).toBeTypeOf("function");

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -361,42 +361,46 @@ describe("optimizeDeps.exclude for vinext", () => {
     "react-server-dom-webpack/client.edge",
   ];
 
-  it("excludes React from ssr optimizeDeps when ssr.external: true (App Router)", async () => {
+  async function setupAppRouterConfigTest(prefix: string) {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
-    const plugins = vinext();
-    const mainPlugin = plugins.find(
-      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
+    const mainPlugin = vinext().find(
+      (plugin: any) => plugin.name === "vinext:config" && typeof plugin.config === "function",
     );
     expect(mainPlugin).toBeDefined();
 
-    const os = await import("node:os");
-    const fsp = await import("node:fs/promises");
-    const path = await import("node:path");
-
-    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-ts-test-optdeps-react-true-"));
-    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
-    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
-    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+    await fsp.symlink(
+      path.resolve(import.meta.dirname, "../node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    await fsp.mkdir(path.join(root, "app"), { recursive: true });
     await fsp.writeFile(
-      path.join(tmpDir, "app", "layout.tsx"),
+      path.join(root, "app", "layout.tsx"),
       `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
     );
     await fsp.writeFile(
-      path.join(tmpDir, "app", "page.tsx"),
+      path.join(root, "app", "page.tsx"),
       `export default function Home() { return <h1>Home</h1>; }`,
     );
-    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+    await fsp.writeFile(path.join(root, "next.config.mjs"), `export default {};`);
+
+    return {
+      config(userConfig: Record<string, unknown> = {}, command: "serve" | "build" = "serve") {
+        return (mainPlugin as any).config(
+          { root, build: {}, plugins: [], ...userConfig },
+          { command },
+        );
+      },
+      cleanup: () => fsp.rm(root, { recursive: true, force: true }),
+    };
+  }
+
+  it("excludes React from ssr optimizeDeps when ssr.external: true (App Router)", async () => {
+    const fixture = await setupAppRouterConfigTest("vinext-optdeps-react-true-");
 
     try {
-      const mockConfig = {
-        root: tmpDir,
-        build: {},
-        plugins: [],
-        ssr: { external: true },
-      };
-      const result = await (mainPlugin as any).config(mockConfig, {
-        command: "serve",
-      });
+      const result = await fixture.config({ ssr: { external: true } });
 
       const ssrExclude = result.environments.ssr.optimizeDeps?.exclude ?? [];
       for (const entry of ssrExternalReactEntries) {
@@ -414,101 +418,70 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(result.ssr?.noExternal).toBeUndefined();
       expect(result.ssr?.external).toBe(true);
     } finally {
-      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      await fixture.cleanup();
     }
   }, 15000);
 
-  it("does NOT exclude React from ssr optimizeDeps when ssr.external is unset", async () => {
-    // Default mode (vinext sets noExternal: true on ssr) still pre-bundles
-    // React into deps_ssr — that's the path that already works because
-    // everything is bundled with one React copy.
-    const vinext = (await import("../packages/vinext/src/index.js")).default;
-    const plugins = vinext();
-    const mainPlugin = plugins.find(
-      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
-    );
-    expect(mainPlugin).toBeDefined();
-
-    const os = await import("node:os");
-    const fsp = await import("node:fs/promises");
-    const path = await import("node:path");
-
-    const tmpDir = await fsp.mkdtemp(
-      path.join(os.tmpdir(), "vinext-ts-test-optdeps-react-default-"),
-    );
-    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
-    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
-    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
-    await fsp.writeFile(
-      path.join(tmpDir, "app", "layout.tsx"),
-      `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
-    );
-    await fsp.writeFile(
-      path.join(tmpDir, "app", "page.tsx"),
-      `export default function Home() { return <h1>Home</h1>; }`,
-    );
-    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+  it("externalizes React from the SSR transform graph only in default Node dev", async () => {
+    const fixture = await setupAppRouterConfigTest("vinext-optdeps-react-default-");
 
     try {
-      const mockConfig = { root: tmpDir, build: {}, plugins: [] };
-      const result = await (mainPlugin as any).config(mockConfig, {
-        command: "serve",
+      const devResult = await fixture.config();
+
+      const devExternal = devResult.environments.ssr.resolve.external ?? [];
+      const devExclude = devResult.environments.ssr.optimizeDeps?.exclude ?? [];
+      for (const entry of ssrExternalReactEntries) {
+        expect(devExternal, `dev SSR external should contain ${entry}`).toContain(entry);
+        expect(devExclude, `dev SSR exclude should contain ${entry}`).toContain(entry);
+      }
+
+      const buildResult = await fixture.config({}, "build");
+      const buildExternal = buildResult.environments.ssr.resolve.external ?? [];
+      const buildExclude = buildResult.environments.ssr.optimizeDeps?.exclude ?? [];
+      for (const entry of ssrExternalReactEntries) {
+        expect(buildExternal, `build SSR external should NOT contain ${entry}`).not.toContain(
+          entry,
+        );
+        expect(buildExclude, `build SSR exclude should NOT contain ${entry}`).not.toContain(entry);
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  }, 15000);
+
+  it("does not externalize React from adapter-managed SSR environments", async () => {
+    const fixture = await setupAppRouterConfigTest("vinext-ssr-react-adapter-");
+
+    try {
+      const result = await fixture.config({
+        plugins: [{ name: "vite-plugin-cloudflare" }],
       });
 
       const ssrExclude = result.environments.ssr.optimizeDeps?.exclude ?? [];
       for (const entry of ssrExternalReactEntries) {
-        expect(ssrExclude, `ssr exclude should NOT contain ${entry}`).not.toContain(entry);
+        expect(ssrExclude, `adapter SSR exclude should NOT contain ${entry}`).not.toContain(entry);
       }
+      expect(result.environments.ssr.resolve).toBeUndefined();
     } finally {
-      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      await fixture.cleanup();
     }
   }, 15000);
 
-  it("does NOT exclude React from ssr optimizeDeps when ssr.external is a string array", async () => {
-    // Array form of ssr.external (e.g. ['pg']) should not trigger the
-    // React strip — only the blanket `true` form does.
-    const vinext = (await import("../packages/vinext/src/index.js")).default;
-    const plugins = vinext();
-    const mainPlugin = plugins.find(
-      (p: any) => p.name === "vinext:config" && typeof p.config === "function",
-    );
-    expect(mainPlugin).toBeDefined();
-
-    const os = await import("node:os");
-    const fsp = await import("node:fs/promises");
-    const path = await import("node:path");
-
-    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-ts-test-optdeps-react-array-"));
-    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
-    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
-    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
-    await fsp.writeFile(
-      path.join(tmpDir, "app", "layout.tsx"),
-      `export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }`,
-    );
-    await fsp.writeFile(
-      path.join(tmpDir, "app", "page.tsx"),
-      `export default function Home() { return <h1>Home</h1>; }`,
-    );
-    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+  it("preserves user SSR externals while externalizing React in Node dev", async () => {
+    const fixture = await setupAppRouterConfigTest("vinext-optdeps-react-array-");
 
     try {
-      const mockConfig = {
-        root: tmpDir,
-        build: {},
-        plugins: [],
-        ssr: { external: ["pg"] },
-      };
-      const result = await (mainPlugin as any).config(mockConfig, {
-        command: "serve",
-      });
+      const result = await fixture.config({ ssr: { external: ["pg"] } });
 
+      const ssrExternal = result.environments.ssr.resolve.external ?? [];
       const ssrExclude = result.environments.ssr.optimizeDeps?.exclude ?? [];
+      expect(ssrExternal).toContain("pg");
       for (const entry of ssrExternalReactEntries) {
-        expect(ssrExclude, `ssr exclude should NOT contain ${entry}`).not.toContain(entry);
+        expect(ssrExternal, `ssr external should contain ${entry}`).toContain(entry);
+        expect(ssrExclude, `ssr exclude should contain ${entry}`).toContain(entry);
       }
     } finally {
-      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      await fixture.cleanup();
     }
   }, 15000);
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2812,7 +2812,10 @@ describe("Plugin config", () => {
     expect(configPlugin).toBeDefined();
 
     // Call the config hook with a minimal config
-    const result = await configPlugin.config({ root: FIXTURE_DIR, plugins: [] });
+    const result = await configPlugin.config(
+      { root: FIXTURE_DIR, plugins: [] },
+      { command: "build", mode: "production" },
+    );
 
     expect(result.resolve).toBeDefined();
     expect(result.resolve.dedupe).toBeDefined();
@@ -2827,7 +2830,10 @@ describe("Plugin config", () => {
     const configPlugin = plugins.find((p) => p.name === "vinext:config");
     expect(configPlugin).toBeDefined();
 
-    const result = await configPlugin.config({ root: FIXTURE_DIR, plugins: [] });
+    const result = await configPlugin.config(
+      { root: FIXTURE_DIR, plugins: [] },
+      { command: "build", mode: "production" },
+    );
 
     expect(result.build).toBeDefined();
     const bundlerOptions = getBuildBundlerOptions(result);
@@ -2870,7 +2876,10 @@ describe("Plugin config", () => {
     const configPlugin = plugins.find((p) => p.name === "vinext:config");
     expect(configPlugin).toBeDefined();
 
-    const result = await configPlugin.config({ root: FIXTURE_DIR, plugins: [] });
+    const result = await configPlugin.config(
+      { root: FIXTURE_DIR, plugins: [] },
+      { command: "build", mode: "production" },
+    );
 
     expect(result.build).toBeDefined();
     const bundlerOptions = getBuildBundlerOptions(result);
@@ -2946,11 +2955,14 @@ describe("Plugin config", () => {
     expect(configPlugin).toBeDefined();
 
     const userOnwarn = vi.fn();
-    const result = await configPlugin.config({
-      root: FIXTURE_DIR,
-      plugins: [],
-      build: { rollupOptions: { onwarn: userOnwarn } },
-    });
+    const result = await configPlugin.config(
+      {
+        root: FIXTURE_DIR,
+        plugins: [],
+        build: { rollupOptions: { onwarn: userOnwarn } },
+      },
+      { command: "build", mode: "production" },
+    );
 
     const bundlerOptions = getBuildBundlerOptions(result);
     const defaultHandler = vi.fn();


### PR DESCRIPTION
This PR externalizes React, ReactDOM, and the Flight client runtime from Vite’s SSR transform pipeline during local Node development.

This avoids unnecessary parsing and prebundling, improving App Router dev cold start.

Behavior is unchanged.