### PR TITLE
refactor(rsc): remove redundant replace in use cache variant parsing

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4811,9 +4811,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // oxlint-disable-next-line typescript/no-explicit-any
             const directiveValue = (cacheDirective as any).expression.value;
             const variant =
-              directiveValue === "use cache"
-                ? ""
-                : directiveValue.replace("use cache:", "").replace("use cache: ", "").trim();
+              directiveValue === "use cache" ? "" : directiveValue.replace("use cache:", "").trim();
 
             // Only skip default export wrapping for layouts and templates —
             // they receive {children} from the framework which requires
@@ -4894,7 +4892,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   const variant =
                     directiveMatch === "use cache"
                       ? ""
-                      : directiveMatch.replace("use cache:", "").replace("use cache: ", "").trim();
+                      : directiveMatch.replace("use cache:", "").trim();
                   return `(await import(${JSON.stringify(runtimeModuleUrl2)})).registerCachedFunction(${value}, ${JSON.stringify(id + ":" + name)}, ${JSON.stringify(variant)})`;
                 },
                 rejectNonAsyncFunction: false,


### PR DESCRIPTION
The `variant` parsing for `"use cache"` directives chained two replaces:

```ts
directive.replace("use cache:", "").replace("use cache: ", "").trim()
```

The second `.replace("use cache: ", "")` is redundant: the first replace already strips the `use cache:` prefix and `.trim()` removes the optional following space, so every `use cache` / `use cache: <profile>` directive yields the same bare profile.

- **Inline (function-level)** directives are matched against `/^use cache(:\s*\w+)?$/`, so a repeated `use cache:` is impossible and the second replace is unreachable.
- **File-level** directives are detected via `startsWith("use cache")`. The second replace only ever produced a different result for malformed inputs containing a repeated `use cache:` (e.g. `"use cache: use cache: x"`), which yield a meaningless profile either way.

No behavior change for any valid directive.
