### PR TITLE
refactor(build): drop unreachable fsRoute lookup in prerenderPages

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -710,12 +710,6 @@ export async function prerenderPages({
       // that non-2xx response as a prerender failure.
       if (route.pattern === "/404") continue;
 
-      // Cross-reference with file-system route scan.
-      const fsRoute = routes.find(
-        (r) => r.filePath === route.filePath || r.pattern === route.pattern,
-      );
-      if (!fsRoute) continue;
-
       const { type, revalidate: classifiedRevalidate } = classifyPagesRoute(route.filePath);
 
       // Route type detection uses static file analysis (classifyPagesRoute).


### PR DESCRIPTION
`prerenderPages` cross-referenced each iterated route back to the FS route scan. This is an unreachable no-op, removed in this PR.

`bundlePageRoutes` is built **1:1** from `routes` — each entry's `pattern`/`filePath` is copied straight from a `routes` entry (`prerender.ts` L654):

```ts
const bundlePageRoutes: BundleRoute[] = routes.map((r) => ({
  pattern: r.pattern,
  isDynamic: r.isDynamic ?? false,
  params: {},
  filePath: r.filePath,
  module: { /* ... */ },
}));
```

So in the render loop (L705-717), the removed lookup always matched the origin entry:

```ts
for (const route of bundlePageRoutes) {
  if (BLOCKED_PAGES.includes(route.pattern)) continue;
  if (route.pattern === "/404") continue;

  // removed — route.{pattern,filePath} always equals the routes entry it was
  // mapped from, so find() always matches: fsRoute is never undefined, the
  // continue never fires, and fsRoute is used nowhere else.
  const fsRoute = routes.find(
    (r) => r.filePath === route.filePath || r.pattern === route.pattern,
  );
  if (!fsRoute) continue;

  const { type, revalidate: classifiedRevalidate } = classifyPagesRoute(route.filePath);
  // ...
}
```

No behavior change.
