### PR TITLE
perf(app): omit unused metadata route runtime

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -42,6 +42,10 @@ const appRouteHandlerResponsePath = resolveEntryPath(
   "../server/app-route-handler-response.js",
   import.meta.url,
 );
+const metadataRouteResponsePath = resolveEntryPath(
+  "../server/metadata-route-response.js",
+  import.meta.url,
+);
 const appServerActionExecutionPath = resolveEntryPath(
   "../server/app-server-action-execution.js",
   import.meta.url,
@@ -287,6 +291,11 @@ ${
 }
 const __loadAppRouteHandlerDispatch = () => import(${JSON.stringify(appRouteHandlerDispatchPath)});
 const __loadAppServerActionExecution = () => import(${JSON.stringify(appServerActionExecutionPath)});
+${
+  (metadataRoutes?.length ?? 0) > 0
+    ? `const __loadMetadataRouteResponse = () => import(${JSON.stringify(metadataRouteResponsePath)});`
+    : ""
+}
 import {
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from ${JSON.stringify(appRscErrorsPath)};
@@ -1040,9 +1049,20 @@ export default createAppRscHandler({
   i18nConfig: __i18nConfig,
   isMiddlewareProxy: ${JSON.stringify(middlewarePath ? isProxyFile(middlewarePath) : false)},
   ${hasPagesDir ? `loadPrerenderPagesRoutes: __loadPrerenderPagesRoutes,` : ""}
-  makeThenableParams,
+  ${
+    (metadataRoutes?.length ?? 0) > 0
+      ? `async handleMetadataRouteRequest(cleanPathname) {
+    const { handleMetadataRouteRequest: __handleMetadataRouteRequest } =
+      await __loadMetadataRouteResponse();
+    return __handleMetadataRouteRequest({
+      metadataRoutes,
+      cleanPathname,
+      makeThenableParams,
+    });
+  },`
+      : ""
+  }
   matchRoute,
-  metadataRoutes,
   middlewareFilePath: ${middlewarePath ? JSON.stringify(normalizePathSeparators(middlewarePath)) : "null"},
   middlewareModule: ${middlewarePath ? "middlewareModule" : "null"},
   publicFiles: __publicFiles,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -65,10 +65,6 @@ import {
   resolveDevImageRedirect,
   type ImageConfig,
 } from "./image-optimization.js";
-import type {
-  MetadataRouteMakeThenableParams,
-  MetadataRuntimeRoute,
-} from "./metadata-route-response.js";
 import type { MiddlewareModule } from "./middleware-runtime.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
@@ -91,9 +87,7 @@ import {
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
-type MetadataRoutes = readonly MetadataRuntimeRoute[];
 const STATIC_METADATA_CONFIG_HEADER_OVERRIDES = new Set(["cache-control"]);
-type MakeThenableParams = MetadataRouteMakeThenableParams;
 type StaticParamsMap = AppPrerenderStaticParamsMap;
 type RootParamNamesMap = AppPrerenderRootParamNamesMap;
 
@@ -290,6 +284,7 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   handleProgressiveActionRequest: (
     options: HandleProgressiveActionRequestOptions,
   ) => Promise<Response | ProgressiveActionFormStateResult | null>;
+  handleMetadataRouteRequest?: (cleanPathname: string) => Promise<Response | null>;
   handleServerActionRequest: (
     options: HandleServerActionRequestOptions,
   ) => Promise<Response | null>;
@@ -298,9 +293,7 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   isDev: boolean;
   isMiddlewareProxy: boolean;
   loadPrerenderPagesRoutes?: () => Promise<unknown>;
-  makeThenableParams: MakeThenableParams;
   matchRoute: (pathname: string) => AppRscRouteMatch<TRoute> | null;
-  metadataRoutes: MetadataRoutes;
   middlewareFilePath: string | null;
   middlewareModule: MiddlewareModule | null;
   publicFiles: ReadonlySet<string>;
@@ -660,13 +653,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     return Response.redirect(new URL(imageRedirect, url.origin).href, 302);
   }
 
-  if (options.metadataRoutes.length > 0) {
-    const { handleMetadataRouteRequest } = await import("./metadata-route-response.js");
-    const metadataRouteResponse = await handleMetadataRouteRequest({
-      metadataRoutes: options.metadataRoutes,
-      cleanPathname,
-      makeThenableParams: options.makeThenableParams,
-    });
+  if (options.handleMetadataRouteRequest) {
+    const metadataRouteResponse = await options.handleMetadataRouteRequest(cleanPathname);
     if (metadataRouteResponse) {
       applyConfigHeadersToResponse(metadataRouteResponse.headers, {
         basePathState,

--- a/packages/vinext/src/server/metadata-route-response.ts
+++ b/packages/vinext/src/server/metadata-route-response.ts
@@ -13,7 +13,7 @@ import { notFoundResponse } from "./http-error-responses.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type MetadataRouteFunction = (props: Record<string, unknown>) => unknown;
-export type MetadataRouteMakeThenableParams = (params: AppPageParams) => unknown;
+type MetadataRouteMakeThenableParams = (params: AppPageParams) => unknown;
 
 export type MetadataRuntimeRoute = MetadataFileRoute & {
   fileDataBase64?: string;

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -15,6 +15,10 @@ import {
   createClientReusePayloadHash,
 } from "../packages/vinext/src/server/client-reuse-manifest.js";
 import { VINEXT_CLIENT_REUSE_MANIFEST_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  handleMetadataRouteRequest,
+  type MetadataRuntimeRoute,
+} from "../packages/vinext/src/server/metadata-route-response.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 
 type TestRoute = {
@@ -27,6 +31,9 @@ type TestRoute = {
 };
 
 type HandlerOptions = Parameters<typeof createAppRscHandler<TestRoute>>[0];
+type TestHandlerOptions = HandlerOptions & {
+  metadataRoutes?: readonly MetadataRuntimeRoute[];
+};
 type DispatchMatchedRouteHandler = HandlerOptions["dispatchMatchedRouteHandler"];
 
 function createPageRoute(overrides: Partial<TestRoute> = {}): TestRoute {
@@ -39,7 +46,7 @@ function createPageRoute(overrides: Partial<TestRoute> = {}): TestRoute {
   };
 }
 
-function createHandler(overrides: Partial<HandlerOptions> = {}) {
+function createHandler(overrides: Partial<TestHandlerOptions> = {}) {
   const route = createPageRoute();
 
   return createAppRscHandler<TestRoute>({
@@ -66,12 +73,21 @@ function createHandler(overrides: Partial<HandlerOptions> = {}) {
       overrides.dispatchMatchedRouteHandler ?? (async () => new Response("route", { status: 200 })),
     ensureInstrumentation: overrides.ensureInstrumentation,
     handleProgressiveActionRequest: overrides.handleProgressiveActionRequest ?? (async () => null),
+    handleMetadataRouteRequest:
+      overrides.handleMetadataRouteRequest ??
+      (overrides.metadataRoutes?.length
+        ? (cleanPathname) =>
+            handleMetadataRouteRequest({
+              metadataRoutes: overrides.metadataRoutes!,
+              cleanPathname,
+              makeThenableParams,
+            })
+        : undefined),
     handleServerActionRequest: overrides.handleServerActionRequest ?? (async () => null),
     i18nConfig: overrides.i18nConfig ?? null,
     imageConfig: overrides.imageConfig,
     isDev: overrides.isDev ?? true,
     isMiddlewareProxy: overrides.isMiddlewareProxy ?? false,
-    makeThenableParams,
     matchRoute:
       overrides.matchRoute ??
       ((pathname: string) =>
@@ -81,7 +97,6 @@ function createHandler(overrides: Partial<HandlerOptions> = {}) {
               route,
             }
           : null),
-    metadataRoutes: overrides.metadataRoutes ?? [],
     middlewareFilePath: overrides.middlewareFilePath ?? null,
     middlewareModule: overrides.middlewareModule ?? null,
     publicFiles: overrides.publicFiles ?? new Set<string>(),

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -811,6 +811,50 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("computeRscCacheBustingSearchParam(");
   });
 
+  it("generateRscEntry only includes metadata route response handling when routes exist", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-entry-metadata-runtime-"));
+    const filePath = path.join(tmpDir, "sitemap.ts");
+    fs.writeFileSync(filePath, "export default function sitemap() { return []; }");
+
+    try {
+      const withoutMetadataRoutes = generateRscEntry(
+        "/tmp/test/app",
+        minimalAppRoutes,
+        null,
+        [],
+        null,
+        "",
+        false,
+      );
+      const withMetadataRoutes = generateRscEntry(
+        "/tmp/test/app",
+        minimalAppRoutes,
+        null,
+        [
+          {
+            type: "sitemap",
+            isDynamic: true,
+            filePath,
+            routePrefix: "",
+            servedUrl: "/sitemap.xml",
+            contentType: "application/xml",
+          },
+        ],
+        null,
+        "",
+        false,
+      );
+
+      expect(withoutMetadataRoutes).not.toContain("metadata-route-response.js");
+      expect(withoutMetadataRoutes).not.toContain("handleMetadataRouteRequest(cleanPathname)");
+      expect(withMetadataRoutes).toContain("metadata-route-response.js");
+      expect(withMetadataRoutes).toContain("handleMetadataRouteRequest(cleanPathname)");
+      expect(withMetadataRoutes).toContain("await __loadMetadataRouteResponse()");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("generateRscEntry defers route-handler and server-action runtimes", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 


### PR DESCRIPTION
Similar to #2194 but for metadata route runtime. Only load it when files like `sitemap.ts` or `robots.ts` exist so when the runtime is actually needed.