### PR TITLE
refactor(build): drop redundant Array.isArray check in prerenderApp

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1227,7 +1227,7 @@ export async function prerenderApp({
             continue;
           }
 
-          if (!Array.isArray(paramSets) || paramSets.length === 0) {
+          if (paramSets.length === 0) {
             // Empty params — skip with warning
             results.push({ route: route.pattern, status: "skipped", reason: "no-static-params" });
             continue;


### PR DESCRIPTION
After the `null` guard, `paramSets` is always an array, so the `!Array.isArray(paramSets)` sub-condition is a redundant no-op.

`paramSets` is typed `Record<string, string | string[]>[] | null` and every assignment produces an array or `null`. The preceding guard handles (and `continue`s on) the `null` case (`prerender.ts` L1216-1230):

```ts
let paramSets: Record<string, string | string[]>[] | null;
// ... assigned to an array or null ...

// null: route has no generateStaticParams (CF Workers Proxy returned null)
if (paramSets === null) {
  // ... push error / skip ...
  continue;
}

if (!Array.isArray(paramSets) || paramSets.length === 0) {  // <- !Array.isArray is always false here
```

By this point TypeScript has already narrowed `paramSets` to the array type, so `!Array.isArray(paramSets)` is both unreachable at runtime and redundant for narrowing. Simplified to `if (paramSets.length === 0)`. No behavior change.
