### PR TITLE
refactor(plugin): iterate SERVER_EXPORTS set instead of spreading to an array

### DIFF
--- a/packages/vinext/src/plugins/strip-server-exports.ts
+++ b/packages/vinext/src/plugins/strip-server-exports.ts
@@ -27,7 +27,10 @@ const EXPORT_ALL_IN_PAGE_ERROR =
   "Using `export * from '...'` in a page is disallowed. Please use `export { default } from '...'` instead.\nRead more: https://nextjs.org/docs/messages/export-all-in-page";
 
 export function hasServerExportCandidate(code: string): boolean {
-  return [...SERVER_EXPORTS].some((name) => code.includes(name));
+  for (const name of SERVER_EXPORTS) {
+    if (code.includes(name)) return true;
+  }
+  return false;
 }
 
 export function hasExportAllCandidate(code: string): boolean {


### PR DESCRIPTION
`hasServerExportCandidate` runs once per transformed module. It spread the module-level `SERVER_EXPORTS` set into a fresh array on every call just to use `.some()`:

```ts
const SERVER_EXPORTS = new Set([
  "getServerSideProps", "getStaticProps", "getStaticPaths",
  "unstable_getServerProps", "unstable_getServerSideProps",
  "unstable_getStaticProps", "unstable_getStaticPaths",
]);

export function hasServerExportCandidate(code: string): boolean {
  return [...SERVER_EXPORTS].some((name) => code.includes(name));
}
```

`Set` is iterable, so iterating it directly avoids the per-call array allocation. `.some()` short-circuits on the first match and the `for...of` early-returns identically, so behavior is unchanged. Every other use of `SERVER_EXPORTS` is already `.has(...)`, so the set form stays.

No behavior change.
