### PR TITLE
refactor(plugin): build removeConsole exclude set only after the bail-out checks

### DIFF
--- a/packages/vinext/src/plugins/remove-console.ts
+++ b/packages/vinext/src/plugins/remove-console.ts
@@ -50,11 +50,6 @@ export function removeConsoleCalls(
 ): RemoveConsoleResult | null {
   if (config === false) return null;
 
-  const excluded =
-    typeof config === "object"
-      ? new Set(config.exclude.map((s) => s.toLowerCase()))
-      : new Set<string>();
-
   // Fast path: if there's no bare "console" reference, skip parsing.
   // This avoids the parse cost for the vast majority of modules.
   const consoleMatch = code.match(/\bconsole\b/);
@@ -67,6 +62,11 @@ export function removeConsoleCalls(
     // If parsing fails (shouldn't happen post-transform), bail out
     return null;
   }
+
+  const excluded =
+    typeof config === "object"
+      ? new Set(config.exclude.map((s) => s.toLowerCase()))
+      : new Set<string>();
 
   // Collect shadowing scopes: tracks whether there's a local binding named
   // "console" in the current or any parent scope. We do a simple top-down


### PR DESCRIPTION
`removeConsoleCalls` runs once per transformed module. It built the lowercased `exclude` set up front — before the two early-bail checks that return for the vast majority of modules:

```ts
const excluded =
  typeof config === "object"
    ? new Set(config.exclude.map((s) => s.toLowerCase()))
    : new Set<string>();

// Fast path: no bare "console" reference -> skip parsing (most modules).
const consoleMatch = code.match(/\bconsole\b/);
if (!consoleMatch) return null;

let ast;
try { ast = parseAst(code); } catch { return null; }
```

`excluded` is only read later, in `shouldRemove` during the AST walk, so building it up front is wasted work for every module that has no `console` reference or fails to parse. This moves it past both bail-outs so it's only built when the module is actually going to be walked.

No behavior change.
