### PR TITLE
perf(mdx): gate the MDX transform handler behind a native id filter

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3124,27 +3124,30 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         const fn = typeof hook === "function" ? hook : hook.handler;
         return fn.call(this, config, env);
       },
-      async transform(code, id, options) {
-        // Skip ?raw and other query imports — @mdx-js/rollup ignores the query
-        // and would compile the file as MDX instead of returning raw text.
-        if (id.includes("?")) return;
-        // Case-insensitive extension check for cross-platform compatibility
-        // (Windows/macOS case-insensitive, Linux case-sensitive)
-        if (!id.toLowerCase().endsWith(".mdx")) return;
+      transform: {
+        // Native id filter so the JS handler only runs for `.mdx` files instead
+        // of being invoked for every module in the graph just to bail. The
+        // case-insensitive `\.mdx$` include covers cross-platform extension
+        // casing; `exclude: /\?/` skips query imports like `foo.mdx?raw`
+        // (@mdx-js/rollup ignores the query and would compile them as MDX) —
+        // including the `foo.mdx?something.mdx` edge case where the id still
+        // ends in `.mdx`.
+        filter: { id: { include: /\.mdx$/i, exclude: /\?/ } },
+        async handler(code, id, options) {
+          const delegate = mdxDelegate ?? (await ensureMdxDelegate("on-demand"));
+          if (delegate?.transform) {
+            const hook = delegate.transform;
+            const transform = typeof hook === "function" ? hook : hook.handler;
+            return transform.call(this, code, id, options);
+          }
 
-        const delegate = mdxDelegate ?? (await ensureMdxDelegate("on-demand"));
-        if (delegate?.transform) {
-          const hook = delegate.transform;
-          const transform = typeof hook === "function" ? hook : hook.handler;
-          return transform.call(this, code, id, options);
-        }
-
-        if (!hasUserMdxPlugin) {
-          throw new Error(
-            `[vinext] Encountered MDX module ${id} but no MDX plugin is configured. ` +
-              `Install @mdx-js/rollup or register an MDX plugin manually.`,
-          );
-        }
+          if (!hasUserMdxPlugin) {
+            throw new Error(
+              `[vinext] Encountered MDX module ${id} but no MDX plugin is configured. ` +
+                `Install @mdx-js/rollup or register an MDX plugin manually.`,
+            );
+          }
+        },
       },
     },
     // Shim React canary/experimental APIs (ViewTransition, addTransitionType)

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2977,34 +2977,37 @@ describe("Plugin config", () => {
     expect(mdxProxy.enforce).toBe("pre");
     // Proxy forwards config and transform to the delegate (@mdx-js/rollup)
     expect(typeof mdxProxy.config).toBe("function");
-    expect(typeof mdxProxy.transform).toBe("function");
-    // Proxy should be inert when no MDX files are detected (mdxDelegate is null)
+    // transform is an object-form hook: a native id filter gates the JS handler
+    // so it only runs for .mdx files instead of every module in the graph.
+    expect(typeof mdxProxy.transform).toBe("object");
+    expect(typeof mdxProxy.transform.handler).toBe("function");
+    const { include, exclude } = mdxProxy.transform.filter.id;
+    expect(include.test("/app/page.mdx") && !exclude.test("/app/page.mdx")).toBe(true);
+    expect(include.test("./foo.ts")).toBe(false);
+    // Proxy config is inert when no MDX files are detected (mdxDelegate is null)
     expect(mdxProxy.config({}, { command: "build", mode: "production" })).toBeUndefined();
-    await expect(mdxProxy.transform("code", "./foo.ts", {})).resolves.toBeUndefined();
   });
 
-  it("vinext:mdx transform skips ids that contain a query string (regression: ?raw)", async () => {
-    // @mdx-js/rollup strips the query before matching the file extension, so
-    // it would compile "foo.mdx?raw" as MDX and return compiled JSX instead of
-    // raw text. The proxy must short-circuit on any id that contains "?".
+  it("vinext:mdx filter skips ids that contain a query string (regression: ?raw)", () => {
+    // @mdx-js/rollup strips the query before matching the file extension, so it
+    // would compile "foo.mdx?raw" as MDX and return compiled JSX instead of raw
+    // text. The id filter must exclude any id with a "?" so the handler never
+    // runs for query imports.
     const plugins = vinext() as any[];
     const mdxProxy = plugins.find((p: any) => p.name === "vinext:mdx");
+    const { include, exclude } = mdxProxy.transform.filter.id;
+    const matches = (id: string) => include.test(id) && !exclude.test(id);
 
     // Common query-param import patterns that must be skipped
-    await expect(
-      mdxProxy.transform("# hello", "/app/content.mdx?raw", {}),
-    ).resolves.toBeUndefined();
-    await expect(mdxProxy.transform("# hello", "/app/page.mdx?url", {})).resolves.toBeUndefined();
-    await expect(
-      mdxProxy.transform("# hello", "/app/page.mdx?inline", {}),
-    ).resolves.toBeUndefined();
-    // Additional query variations
-    await expect(mdxProxy.transform("# hello", "/app/page.mdx?v=123", {})).resolves.toBeUndefined();
-    await expect(mdxProxy.transform("# hello", "/app/page.mdx?mdx", {})).resolves.toBeUndefined();
+    expect(matches("/app/content.mdx?raw")).toBe(false);
+    expect(matches("/app/page.mdx?url")).toBe(false);
+    expect(matches("/app/page.mdx?inline")).toBe(false);
+    expect(matches("/app/page.mdx?v=123")).toBe(false);
+    expect(matches("/app/page.mdx?mdx")).toBe(false);
     // Edge case: query value contains .mdx but isn't the extension
-    await expect(
-      mdxProxy.transform("# hello", "/app/page.mdx?something.mdx", {}),
-    ).resolves.toBeUndefined();
+    expect(matches("/app/page.mdx?something.mdx")).toBe(false);
+    // Plain .mdx still matches the filter
+    expect(matches("/app/page.mdx")).toBe(true);
   });
 
   it("vinext:mdx lazily compiles plain .mdx imports that were not pre-detected", async () => {
@@ -3025,7 +3028,8 @@ describe("Plugin config", () => {
         { command: "build", mode: "production" },
       );
 
-      const result = await mdxProxy.transform(
+      const result = await mdxProxy.transform.handler.call(
+        mdxProxy,
         `---
 title: "Second Post"
 ---


### PR DESCRIPTION
The `vinext:mdx` plugin's `transform` hook ran its JS handler for **every** module in the graph, only to bail on the first two lines:

```ts
async transform(code, id, options) {
  if (id.includes("?")) return;
  if (!id.toLowerCase().endsWith(".mdx")) return;
  // ...only .mdx files reach here...
}
```

This converts it to the object-form hook with a native `id` filter, so the handler is only invoked for `.mdx` files — the same pattern used by `import-meta-url`, `extensionless-dynamic-import`, etc., per the project's "filter Vite hooks before JS runs" guidance:

```ts
transform: {
  filter: { id: { include: /\.mdx$/i, exclude: /\?/ } },
  async handler(code, id, options) { ... },
}
```

`exclude: /\?/` preserves the `?raw` skip — including the `foo.mdx?something.mdx` edge case where the id still ends in `.mdx` but is a query import (a naive `/\.mdx$/` would wrongly match it).

The two redundant in-handler guards are removed (the filter now enforces them). The existing `vinext:mdx` unit tests are updated to assert the filter regex directly / call `transform.handler`. No behavior change.
