### PR TITLE
perf(dev-server): memoize the Pages SSR handler across dev requests

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3229,6 +3229,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // fully registered before we inspect them. We prefer "ssr", then any
         // non-"rsc" environment, then whatever is available.
         let pagesRunner: import("vite/module-runner").ModuleRunner | null = null;
+        // Reuse the Pages SSR handler across requests. Every createSSRHandler
+        // input is stable for the dev session (server, runner, config,
+        // middlewarePath) except `routes`, which is the cached pagesRouter array
+        // — a new reference only when the route set changes (invalidateRouteCache
+        // -> re-scan). Keying on `routes` rebuilds exactly then and reuses the
+        // handler otherwise, instead of re-running it for every request.
+        let cachedSSRHandler: {
+          routes: Awaited<ReturnType<typeof pagesRouter>>;
+          handler: ReturnType<typeof createSSRHandler>;
+        } | null = null;
         function getPagesRunner() {
           if (!pagesRunner) {
             const env =
@@ -4200,22 +4210,27 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     return next();
                   }
                 }
-                const handler = createSSRHandler(
-                  server,
-                  getPagesRunner(),
-                  routes,
-                  pagesDir,
-                  nextConfig?.i18n,
-                  fileMatcher,
-                  nextConfig?.basePath ?? "",
-                  nextConfig?.trailingSlash ?? false,
-                  middlewarePath !== null,
-                  (nextConfig?.rewrites.beforeFiles.length ?? 0) > 0 ||
-                    (nextConfig?.rewrites.afterFiles.length ?? 0) > 0 ||
-                    (nextConfig?.rewrites.fallback.length ?? 0) > 0,
-                  nextConfig?.clientTraceMetadata,
-                  nextConfig?.htmlLimitedBots,
-                );
+                if (!cachedSSRHandler || cachedSSRHandler.routes !== routes) {
+                  cachedSSRHandler = {
+                    routes,
+                    handler: createSSRHandler(
+                      server,
+                      getPagesRunner(),
+                      routes,
+                      pagesDir,
+                      nextConfig?.i18n,
+                      fileMatcher,
+                      nextConfig?.basePath ?? "",
+                      nextConfig?.trailingSlash ?? false,
+                      middlewarePath !== null,
+                      (nextConfig?.rewrites.beforeFiles.length ?? 0) > 0 ||
+                        (nextConfig?.rewrites.afterFiles.length ?? 0) > 0 ||
+                        (nextConfig?.rewrites.fallback.length ?? 0) > 0,
+                      nextConfig?.clientTraceMetadata,
+                      nextConfig?.htmlLimitedBots,
+                    ),
+                  };
+                }
                 flushStagedHeaders();
                 flushRequestHeaders();
                 if (pipelineResult.middlewareStatus !== undefined) {
@@ -4223,7 +4238,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 }
                 // Update req.url to the resolved URL so SSR sees the post-mw path
                 req.url = pipelineResult.resolvedUrl;
-                await handler(
+                await cachedSSRHandler.handler(
                   req,
                   res,
                   pipelineResult.resolvedUrl,


### PR DESCRIPTION
The dev middleware rebuilt the Pages SSR handler on **every** request:

```ts
const handler = createSSRHandler(server, getPagesRunner(), routes, pagesDir, ...);
```

`createSSRHandler` runs `routes.map(...)`, kicks off the ALS-registration imports, and allocates the request closure each time. Every input is stable for the dev session — `server`, the runner, config, `middlewarePath` — except `routes`, which is the cached `pagesRouter` array.

`routes` is a new reference only when the route set actually changes: the dev watcher calls `invalidateRouteCache(pagesDir)` on `add`/`unlink` of a page file, so the next `pagesRouter()` re-scans and returns a fresh array. Keying the cached handler on the `routes` reference therefore rebuilds it exactly when routes are added/removed and reuses it otherwise. Editing a route's contents doesn't change the route set — the handler closes over patterns + config, not file contents, and the module is loaded fresh per request via the runner (HMR) — so reuse is correct there too.

`runner.import()` already caches internally, so the ALS-registration imports are unchanged. Behavior-identical; the 316 `pages-router` tests (incl. the dev-server integration tests that render through this middleware) still pass.
