### PR TITLE
perf(og): use MagicString positional overwrites instead of repeated replaceAll

### DIFF
--- a/packages/vinext/src/plugins/og-assets.ts
+++ b/packages/vinext/src/plugins/og-assets.ts
@@ -102,7 +102,7 @@ export function createOgInlineFetchAssetsPlugin(): Plugin {
         const boundary = await ownership.resolveModuleBoundary(id);
         if (boundary === null) return null;
         const { assetRoot, moduleDir } = boundary;
-        let newCode = code;
+        const s = new MagicString(code);
         let didReplace = false;
 
         // Read a file from disk and return its base64 encoding, using the build
@@ -163,7 +163,7 @@ export function createOgInlineFetchAssetsPlugin(): Plugin {
               `})()`,
             ].join("");
 
-            newCode = newCode.replaceAll(fullMatch, inlined);
+            s.overwrite(match.index, match.index + fullMatch.length, inlined);
             didReplace = true;
           }
         }
@@ -176,7 +176,7 @@ export function createOgInlineFetchAssetsPlugin(): Plugin {
           const readFilePattern =
             /[a-zA-Z_$][a-zA-Z0-9_$]*\.readFileSync\(\s*(?:[a-zA-Z_$][a-zA-Z0-9_$]*\.)?fileURLToPath\(\s*new URL\(\s*(["'])(\.[^"']+)\1\s*,\s*import\.meta\.url\s*\)\s*\)\s*\)/g;
 
-          for (const match of newCode.matchAll(readFilePattern)) {
+          for (const match of code.matchAll(readFilePattern)) {
             const fullMatch = match[0];
             const relPath = match[2]; // e.g. "./noto-sans-v27-latin-regular.ttf"
             const absPath = path.resolve(moduleDir, relPath);
@@ -188,13 +188,13 @@ export function createOgInlineFetchAssetsPlugin(): Plugin {
             // Buffer is always available in Node.js and in the vinext SSR/RSC environments.
             const inlined = `Buffer.from(${JSON.stringify(fileBase64)},"base64")`;
 
-            newCode = newCode.replaceAll(fullMatch, inlined);
+            s.overwrite(match.index, match.index + fullMatch.length, inlined);
             didReplace = true;
           }
         }
 
         if (!didReplace) return null;
-        return { code: newCode, map: null };
+        return { code: s.toString(), map: s.generateMap({ hires: "boundary" }) };
       },
     },
   } satisfies Plugin;


### PR DESCRIPTION
The OG asset inliner rewrote each matched `fetch(new URL(...))` / `readFileSync(...)` via `newCode.replaceAll(fullMatch, inlined)`. Each replacement injects a large base64 IIFE, so `newCode` grows with every match and `replaceAll` re-scans the whole (growing) string per match — O(matches × len(newCode)).

This switches to MagicString positional overwrites — the same approach the sibling `createOgAssetsPlugin` hook in this file already uses — with a single `s.overwrite(match.index, match.index + fullMatch.length, inlined)` per match:

```ts
const s = new MagicString(code);
// ...
s.overwrite(match.index, match.index + fullMatch.length, inlined);
```

- Pattern 2 (`readFileSync`) now matches the original `code` rather than the post-Pattern-1 string. The `fetch` and `readFileSync` patterns are disjoint, so the matches — and the output — are unchanged.
- As a bonus, the handler now returns a real source map (`s.generateMap`) instead of `map: null`, since MagicString tracks the edit offsets.

Output code is identical; the 57 `og-inline` / `og-assets` tests still pass.
