### PR TITLE
fix(perf): keep main benchmark runs queued

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -30,7 +30,7 @@ permissions:
 
 concurrency:
   group: performance-${{ github.event_name == 'workflow_dispatch' && inputs.commit_sha || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
 
 jobs:
   benchmarks:


### PR DESCRIPTION
## Summary
- stop newer pushes to `main` from cancelling in-progress performance benchmark runs
- preserve cancellation for pull request and manual benchmark runs

## Validation
- `actionlint .github/workflows/perf.yml`
- `vp fmt --check .github/workflows/perf.yml`
- `git diff --check`