### PR TITLE
perf(client): preserve additional route-owned shims

### DIFF
--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -17,14 +17,18 @@ type RscFrameworkManualChunksMeta = {
 };
 
 const ROUTE_OWNED_CLIENT_SHIMS = new Set([
+  "compat-router",
+  "dynamic",
   "dynamic-preload-chunks",
   "form",
   "image",
   "layout-segment-context",
+  "legacy-image",
   "link",
   "offline",
   "router",
   "script",
+  "web-vitals",
 ]);
 
 // Next.js emits CSS under `static/css/` and CSS url() dependencies (images,
@@ -132,10 +136,12 @@ export function createClientManualChunks(shimsDir: string, preserveRouteBoundari
     }
 
     if (id.startsWith(shimsDir)) {
-      const relativeId = id.slice(shimsDir.length).split("?", 1)[0] ?? "";
-      const extensionIndex = relativeId.lastIndexOf(".");
-      const shimName = extensionIndex === -1 ? relativeId : relativeId.slice(0, extensionIndex);
-      if (preserveRouteBoundaries && ROUTE_OWNED_CLIENT_SHIMS.has(shimName)) return undefined;
+      if (preserveRouteBoundaries) {
+        const relativeId = id.slice(shimsDir.length).split("?", 1)[0] ?? "";
+        const extensionIndex = relativeId.lastIndexOf(".");
+        const shimName = extensionIndex === -1 ? relativeId : relativeId.slice(0, extensionIndex);
+        if (ROUTE_OWNED_CLIENT_SHIMS.has(shimName)) return undefined;
+      }
       return "vinext";
     }
 

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -125,10 +125,14 @@ describe("clientManualChunks", () => {
   });
 
   it("leaves App Router route-owned client shims behind their dynamic boundaries", () => {
+    expect(appClientManualChunks("/vinext/shims/compat-router.js")).toBeUndefined();
+    expect(appClientManualChunks("/vinext/shims/dynamic.js")).toBeUndefined();
     expect(appClientManualChunks("/vinext/shims/link.js")).toBeUndefined();
     expect(appClientManualChunks("/vinext/shims/router.ts")).toBeUndefined();
     expect(appClientManualChunks("/vinext/shims/image.tsx?client")).toBeUndefined();
+    expect(appClientManualChunks("/vinext/shims/legacy-image.tsx")).toBeUndefined();
     expect(appClientManualChunks("/vinext/shims/layout-segment-context.js")).toBeUndefined();
+    expect(appClientManualChunks("/vinext/shims/web-vitals.ts")).toBeUndefined();
   });
 
   it("handles pnpm-style nested node_modules paths", () => {


### PR DESCRIPTION
Follow-up to #2189 addressing the post-merge review remarks.

* Keep `next/compat/router`, `next/dynamic`, `next/legacy/image`, and `next/web-vitals` behind App Router route boundaries
* Avoid parsing shim names unless route-boundary preservation is enabled
* Add focused manual-chunk coverage for the additional shims