### PR TITLE
perf(app): omit unused server action runtime

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -156,6 +156,8 @@ type AppRouterConfig = {
   inlineCss?: boolean;
   /** Enables Next.js Cache Components semantics for App Router document HTML. */
   cacheComponents?: boolean;
+  /** Whether the RSC build discovered any server references. Defaults to true. */
+  hasServerActions?: boolean;
   /** Internationalization routing config for middleware matcher locale handling. */
   i18n?: NextI18nConfig | null;
   imageConfig?: ImageConfig;
@@ -217,6 +219,7 @@ export function generateRscEntry(
   const cacheMaxMemorySize = config?.cacheMaxMemorySize;
   const inlineCss = config?.inlineCss === true;
   const cacheComponents = config?.cacheComponents === true;
+  const hasServerActions = config?.hasServerActions !== false;
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
   const publicFiles = config?.publicFiles ?? [];
@@ -253,12 +256,18 @@ async function __loadPrerenderPagesRoutes() {
 import ${JSON.stringify(serverGlobalsPath)};
 import {
   renderToReadableStream as _renderToReadableStream,
-  decodeAction,
+  ${
+    hasServerActions
+      ? `decodeAction,
   decodeFormState,
   decodeReply,
   loadServerAction,
-  createTemporaryReferenceSet,
-} from "@vitejs/plugin-rsc/rsc";
+  createTemporaryReferenceSet,`
+      : ""
+  }
+} from ${JSON.stringify(
+    hasServerActions ? "@vitejs/plugin-rsc/rsc" : "@vitejs/plugin-rsc/react/rsc",
+  )};
 import { createClientManifest as _createClientManifest } from "@vitejs/plugin-rsc/core/rsc";
 import { prerender as _prerender } from "@vitejs/plugin-rsc/vendor/react-server-dom/static.edge";
 import { createRscPrerenderer, createRscRenderer } from ${JSON.stringify(rscStreamHintsPath)};
@@ -296,7 +305,11 @@ ${
     : ""
 }
 const __loadAppRouteHandlerDispatch = () => import(${JSON.stringify(appRouteHandlerDispatchPath)});
-const __loadAppServerActionExecution = () => import(${JSON.stringify(appServerActionExecutionPath)});
+${
+  hasServerActions
+    ? `const __loadAppServerActionExecution = () => import(${JSON.stringify(appServerActionExecutionPath)});`
+    : ""
+}
 ${
   (metadataRoutes?.length ?? 0) > 0
     ? `const __loadMetadataRouteResponse = () => import(${JSON.stringify(metadataRouteResponsePath)});`
@@ -875,6 +888,9 @@ export default createAppRscHandler({
   },`
       : ""
   }
+  ${
+    hasServerActions
+      ? `
   async handleProgressiveActionRequest({
     actionId,
     cleanPathname,
@@ -1052,6 +1068,9 @@ export default createAppRscHandler({
       },
     });
   },
+  `
+      : ""
+  }
   i18nConfig: __i18nConfig,
   ${hasPagesDir ? `loadPrerenderPagesRoutes: __loadPrerenderPagesRoutes,` : ""}
   ${

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -988,6 +988,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let resolvedReactPath: string | null = null;
   let resolvedRscPath: string | null = null;
   let resolvedRscTransformsPath: string | null = null;
+  let rscPluginModulePromise: Promise<typeof import("@vitejs/plugin-rsc")> | null = null;
   // Prefer the user's project graph so vinext shares the app's Vite/plugin
   // instances. In source/workspace development, test fixtures may not declare
   // peer deps explicitly, so fall back to vinext's own install location.
@@ -1012,6 +1013,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       );
     }
     const rscImport = import(pathToFileURL(resolvedRscPath).href);
+    rscPluginModulePromise = rscImport;
     rscPluginPromise = rscImport
       .then((mod) => {
         const rsc = mod.default;
@@ -2817,6 +2819,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         if (id === RESOLVED_RSC_ENTRY && hasAppDir) {
           const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
           const metaRoutes = scanMetadataFiles(appDir);
+          let hasServerActions = true;
+          if (this.environment?.config.command === "build" && rscPluginModulePromise) {
+            const { getPluginApi } = await rscPluginModulePromise;
+            const pluginApi = getPluginApi(this.environment.config);
+            if (pluginApi && !pluginApi.manager.isScanBuild) {
+              hasServerActions = Object.keys(pluginApi.manager.serverReferenceMetaMap).length > 0;
+            }
+          }
           // Check for global-error.tsx at app root
           const globalErrorPath = findFileWithExts(appDir, "global-error", fileMatcher);
           // Check for global-not-found.tsx at app root (Next.js 16+ feature)
@@ -2857,6 +2867,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
               inlineCss: nextConfig?.inlineCss,
               cacheComponents: nextConfig?.cacheComponents,
+              hasServerActions,
               i18n: nextConfig?.i18n,
               imageConfig: {
                 deviceSizes: nextConfig?.images?.deviceSizes,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -83,6 +83,10 @@ import {
   readTrustedPrerenderRouteParams,
   serializePrerenderRouteParamsHeader,
 } from "./prerender-route-params.js";
+import {
+  createServerActionNotFoundResponse,
+  getServerActionNotFoundMessage,
+} from "./server-action-not-found.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
@@ -100,6 +104,8 @@ type RunAppMiddlewareOptions = {
 };
 
 type AppRscHandlerRoute = {
+  __loadPage?: unknown;
+  __loadRouteHandler?: unknown;
   isDynamic: boolean;
   params?: readonly string[];
   page?: unknown;
@@ -287,11 +293,11 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
    * Node server and dev included, not just the Cloudflare worker entry.
    */
   registerCacheAdapters: (env?: Record<string, unknown>) => void;
-  handleProgressiveActionRequest: (
+  handleProgressiveActionRequest?: (
     options: HandleProgressiveActionRequestOptions,
   ) => Promise<Response | ProgressiveActionFormStateResult | null>;
   handleMetadataRouteRequest?: (cleanPathname: string) => Promise<Response | null>;
-  handleServerActionRequest: (
+  handleServerActionRequest?: (
     options: HandleServerActionRequestOptions,
   ) => Promise<Response | null>;
   i18nConfig: NextI18nConfig | null;
@@ -325,6 +331,15 @@ function isEdgeRouteHandler(handler: unknown): boolean {
 function isExecutionContextLike(value: unknown): value is ExecutionContextLike {
   if (!value || typeof value !== "object") return false;
   return hasProperty(value, "waitUntil") && typeof value.waitUntil === "function";
+}
+
+function createMissingServerActionResponse(
+  options: Pick<CreateAppRscHandlerOptions<AppRscHandlerRoute>, "clearRequestContext">,
+  actionId: string | null,
+): Response {
+  console.warn(getServerActionNotFoundMessage(actionId));
+  options.clearRequestContext();
+  return createServerActionNotFoundResponse();
 }
 
 // TODO(#1333): once App Router supports `basePath: false` rules (see
@@ -713,13 +728,17 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   const isPostRequest = request.method.toUpperCase() === "POST";
   let progressiveActionResult: Response | ProgressiveActionFormStateResult | null = null;
   if (isPostRequest && contentType.startsWith("multipart/form-data") && !actionId) {
-    progressiveActionResult = await options.handleProgressiveActionRequest({
-      actionId,
-      cleanPathname,
-      contentType,
-      middlewareContext,
-      request,
-    });
+    if (options.handleProgressiveActionRequest) {
+      progressiveActionResult = await options.handleProgressiveActionRequest({
+        actionId,
+        cleanPathname,
+        contentType,
+        middlewareContext,
+        request,
+      });
+    } else if (preActionMatch?.route.__loadPage && !preActionMatch.route.__loadRouteHandler) {
+      return createMissingServerActionResponse(options, null);
+    }
   }
   if (progressiveActionResult instanceof Response) return progressiveActionResult;
   const progressiveActionFormState =
@@ -734,7 +753,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   const actionError = failedProgressiveActionResult?.actionError;
 
   const serverActionResponse =
-    isPostRequest && actionId
+    isPostRequest && actionId && options.handleServerActionRequest
       ? await options.handleServerActionRequest({
           actionId,
           cleanPathname,
@@ -748,6 +767,9 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         })
       : null;
   if (serverActionResponse) return serverActionResponse;
+  if (isPostRequest && actionId && !options.handleServerActionRequest) {
+    return createMissingServerActionResponse(options, actionId);
+  }
 
   let match = preActionMatch;
   const renderPagesForMatchKind = async (

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -24,6 +24,8 @@ import type { MiddlewareModule } from "../packages/vinext/src/server/middleware-
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 
 type TestRoute = {
+  __loadPage?: unknown;
+  __loadRouteHandler?: unknown;
   isDynamic: boolean;
   page?: { default?: unknown } | null;
   pattern: string;
@@ -43,6 +45,7 @@ type DispatchMatchedRouteHandler = HandlerOptions["dispatchMatchedRouteHandler"]
 
 function createPageRoute(overrides: Partial<TestRoute> = {}): TestRoute {
   return {
+    __loadPage() {},
     isDynamic: false,
     page: { default() {} },
     pattern: "/about",
@@ -77,7 +80,10 @@ function createHandler(overrides: Partial<TestHandlerOptions> = {}) {
     dispatchMatchedRouteHandler:
       overrides.dispatchMatchedRouteHandler ?? (async () => new Response("route", { status: 200 })),
     ensureInstrumentation: overrides.ensureInstrumentation,
-    handleProgressiveActionRequest: overrides.handleProgressiveActionRequest ?? (async () => null),
+    handleProgressiveActionRequest:
+      "handleProgressiveActionRequest" in overrides
+        ? overrides.handleProgressiveActionRequest
+        : async () => null,
     handleMetadataRouteRequest:
       overrides.handleMetadataRouteRequest ??
       (overrides.metadataRoutes
@@ -88,7 +94,10 @@ function createHandler(overrides: Partial<TestHandlerOptions> = {}) {
               makeThenableParams,
             })
         : undefined),
-    handleServerActionRequest: overrides.handleServerActionRequest ?? (async () => null),
+    handleServerActionRequest:
+      "handleServerActionRequest" in overrides
+        ? overrides.handleServerActionRequest
+        : async () => null,
     i18nConfig: overrides.i18nConfig ?? null,
     imageConfig: overrides.imageConfig,
     isDev: overrides.isDev ?? true,
@@ -2009,6 +2018,28 @@ describe("createAppRscHandler", () => {
     expect(handleServerActionRequest).toHaveBeenCalledWith(
       expect.objectContaining({ actionId: "vinext-action" }),
     );
+  });
+
+  it("rejects stale action requests without retaining the action runtime", async () => {
+    const clearRequestContext = vi.fn();
+    const handler = createHandler({
+      clearRequestContext,
+      handleProgressiveActionRequest: undefined,
+      handleServerActionRequest: undefined,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "next-action": "stale-action" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("x-nextjs-action-not-found")).toBe("1");
+    expect(await response.text()).toBe("Server action not found.");
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
   });
 
   it("skips action dispatchers for ordinary page requests", async () => {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -895,6 +895,22 @@ describe("App Router entry templates", () => {
     );
   });
 
+  it("generateRscEntry omits server action imports when no server references were found", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false, {
+      hasServerActions: false,
+    });
+
+    expect(code).toContain('from "@vitejs/plugin-rsc/react/rsc"');
+    expect(code).not.toContain("app-server-action-execution.js");
+    expect(code).not.toContain("decodeAction,");
+    expect(code).not.toContain("decodeFormState,");
+    expect(code).not.toContain("decodeReply,");
+    expect(code).not.toContain("loadServerAction,");
+    expect(code).not.toContain("createTemporaryReferenceSet,");
+    expect(code).not.toContain("handleProgressiveActionRequest({");
+    expect(code).not.toContain("handleServerActionRequest({");
+  });
+
   it("generateRscEntry passes page-slot dynamic stale time config into App page dispatch", () => {
     // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);


### PR DESCRIPTION
This PR detects action-free production builds using the RSC plugin’s server-reference metadata and omits action decoding and execution runtime. 

Stale action requests still return the expected 404 response. 

It reduces the benchmark RSC bundle by about 8.75 KB gzip. That the current bench shows RSC gzip going up is a benchmark artifact that is resolved in #2208 

Follow-up of #2079 