### PR TITLE
test(e2e): stabilize app router history navigation

### DIFF
--- a/tests/e2e/app-router/instrumentation-client.spec.ts
+++ b/tests/e2e/app-router/instrumentation-client.spec.ts
@@ -12,6 +12,16 @@ function filterNavigationStartLogs(logs: string[]): string[] {
   return logs.filter((message) => message.startsWith("[Router Transition Start]"));
 }
 
+async function ignoreAbortedNavigation(navigate: () => Promise<unknown>): Promise<void> {
+  try {
+    await navigate();
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes("ERR_ABORTED")) {
+      throw error;
+    }
+  }
+}
+
 test.describe.serial("instrumentation-client (App Router)", () => {
   test("executes instrumentation-client before hydration", async ({ page }) => {
     const logs: string[] = [];
@@ -86,11 +96,11 @@ test.describe.serial("instrumentation-client (App Router)", () => {
     await expect(page.locator("#instrumentation-client-some-page")).toBeVisible();
     await waitForAppRouterHydration(page);
 
-    await page.goBack();
+    await ignoreAbortedNavigation(() => page.goBack());
     await expect(page.locator("#instrumentation-client-home")).toBeVisible();
     await waitForAppRouterHydration(page);
 
-    await page.goForward();
+    await ignoreAbortedNavigation(() => page.goForward());
     await expect(page.locator("#instrumentation-client-some-page")).toBeVisible();
     await waitForAppRouterHydration(page);
 

--- a/tests/e2e/app-router/nextjs-compat/client-reference-runtime-map.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-reference-runtime-map.browser.spec.ts
@@ -26,7 +26,7 @@ async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
   await fs.mkdir(targetNodeModules, { recursive: true });
 
   for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
-    if (entry.name === ".vite-temp") continue;
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
 
     await fs.symlink(
       path.join(sourceNodeModules, entry.name),

--- a/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-rsc-requests.browser.spec.ts
@@ -26,7 +26,7 @@ async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
   await fs.mkdir(targetNodeModules, { recursive: true });
 
   for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
-    if (entry.name === ".vite-temp") continue;
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
 
     await fs.symlink(
       path.join(sourceNodeModules, entry.name),

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts
@@ -12,7 +12,7 @@ async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
 
   await fs.mkdir(targetNodeModules, { recursive: true });
   for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
-    if (entry.name === ".vite-temp") continue;
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
 
     await fs.symlink(
       path.join(sourceNodeModules, entry.name),

--- a/tests/e2e/app-router/nextjs-compat/ssr-error-shell-recovery.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/ssr-error-shell-recovery.browser.spec.ts
@@ -46,7 +46,7 @@ async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
   await fs.mkdir(targetNodeModules, { recursive: true });
 
   for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
-    if (entry.name === ".vite-temp") continue;
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
 
     await fs.symlink(
       path.join(sourceNodeModules, entry.name),

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -34,7 +34,7 @@ export async function waitForHydration(page: Page): Promise<void> {
  */
 export async function waitForAppRouterHydration(page: Page): Promise<void> {
   await expect(async () => {
-    const ready = await page.evaluate(() => {
+    const ready = await page.evaluate(async () => {
       const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
       const hasNavigate =
         typeof runtime === "object" &&
@@ -44,20 +44,22 @@ export async function waitForAppRouterHydration(page: Page): Promise<void> {
         runtime.functions !== null &&
         "navigate" in runtime.functions &&
         typeof runtime.functions.navigate === "function";
-      return (
+      const hydrated =
         Boolean(window.__VINEXT_RSC_ROOT__) &&
         hasNavigate &&
-        typeof window.__VINEXT_HYDRATED_AT === "number"
-      );
+        typeof window.__VINEXT_HYDRATED_AT === "number";
+
+      if (!hydrated) {
+        return false;
+      }
+
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      });
+      return true;
     });
     expect(ready).toBe(true);
   }).toPass({ timeout: 10_000 });
-  await page.evaluate(
-    () =>
-      new Promise<void>((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-      }),
-  );
 }
 
 /**


### PR DESCRIPTION
I noticed in https://github.com/cloudflare/vinext/pull/2206 that the e2e tests are flaky.

This PR fixes the flaky App Router E2E test. Cause was that dev-server reloads were racing with browser history navigation.
