### PR TITLE
refactor(dev): defer command and request-path imports

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -655,9 +655,8 @@ async function buildApp() {
     }
   } finally {
     if (pagesClientAssetsBuildSession) {
-      const { clearPagesClientAssetsBuildMetadata } = await import(
-        "./build/pages-client-assets-module.js"
-      );
+      const { clearPagesClientAssetsBuildMetadata } =
+        await import("./build/pages-client-assets-module.js");
       clearPagesClientAssetsBuildMetadata(pagesClientAssetsBuildSession);
       if (
         process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION === pagesClientAssetsBuildSession
@@ -681,9 +680,8 @@ async function buildApp() {
   }
 
   let prerenderResult;
-  const { formatVinextPrerenderLabel, resolveVinextPrerenderDecision } = await import(
-    "./config/prerender.js"
-  );
+  const { formatVinextPrerenderLabel, resolveVinextPrerenderDecision } =
+    await import("./config/prerender.js");
   const prerenderDecision = resolveVinextPrerenderDecision({
     prerenderAllFlag: parsed.prerenderAll,
     vinextPrerenderConfig: buildConfigMetadata.prerenderConfig,
@@ -809,9 +807,7 @@ async function lint() {
 }
 
 async function deployCommand() {
-  const { deploy: runDeploy, parseDeployArgs } = await import(
-    "@vinext/cloudflare/internal/deploy"
-  );
+  const { deploy: runDeploy, parseDeployArgs } = await import("@vinext/cloudflare/internal/deploy");
   const parsed = parseDeployArgs(rawArgs);
   if (parsed.help) {
     printDeployDeprecationWarning();
@@ -892,9 +888,8 @@ async function initCommand() {
   const port = parsed.port ?? 3001;
   const skipCheck = rawArgs.includes("--skip-check");
   const force = rawArgs.includes("--force");
-  const { INIT_PLATFORMS, resolveInitPlatform, resolveInitPrerender } = await import(
-    "./init-platform.js"
-  );
+  const { INIT_PLATFORMS, resolveInitPlatform, resolveInitPrerender } =
+    await import("./init-platform.js");
   const platform = await resolveInitPlatform(rawArgs);
   const platformOptions = await INIT_PLATFORMS[platform].options(rawArgs);
   const prerender = await resolveInitPrerender(rawArgs);

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -14,8 +14,6 @@
  * needed for most Next.js apps.
  */
 
-import vinext from "./index.js";
-import { runPrerender } from "./build/run-prerender.js";
 import path from "node:path";
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -28,21 +26,7 @@ import {
   hasAppDir,
   hasViteConfig,
 } from "./utils/project.js";
-import { deploy as runDeploy, parseDeployArgs } from "@vinext/cloudflare/internal/deploy";
 import { printDeployHelp } from "@vinext/cloudflare/internal/deploy-help";
-import { runCheck, formatReport } from "./check.js";
-import { init as runInit, getReactUpgradeDeps } from "./init.js";
-import { INIT_PLATFORMS, resolveInitPlatform, resolveInitPrerender } from "./init-platform.js";
-import { loadDotenv } from "./config/dotenv.js";
-import {
-  createRscCompatibilityId,
-  loadNextConfig,
-  resolveNextConfig,
-  PHASE_PRODUCTION_BUILD,
-} from "./config/next-config.js";
-import { emitStandaloneOutput } from "./build/standalone.js";
-import { cleanBuildOutput } from "./build/clean-output.js";
-import { clearPagesClientAssetsBuildMetadata } from "./build/pages-client-assets-module.js";
 import { resolveVinextPackageRoot } from "./utils/vinext-root.js";
 import { parseArgs } from "./cli-args.js";
 import {
@@ -50,15 +34,9 @@ import {
   formatAlreadyRunningError,
   tryAcquireLockfile,
 } from "./server/dev-lockfile.js";
-import { generateRouteTypes } from "./typegen.js";
 import { normalizePathSeparators } from "./utils/path.js";
 import { createDevServerConfigPlugin, normalizeDevServerHostname } from "./cli-dev-config.js";
-import {
-  findVinextPrerenderConfigInPlugins,
-  formatVinextPrerenderLabel,
-  resolveVinextPrerenderDecision,
-  type ResolvedVinextPrerenderConfig,
-} from "./config/prerender.js";
+import type { ResolvedVinextPrerenderConfig } from "./config/prerender.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -80,6 +58,7 @@ type ViteModule = {
 };
 
 let _viteModule: ViteModule | null = null;
+let _vinextModulePromise: Promise<typeof import("./index.js").default> | null = null;
 
 /**
  * Dynamically load Vite from the project root. Falls back to the bundled
@@ -113,6 +92,11 @@ async function loadVite(): Promise<ViteModule> {
  */
 function getViteVersion(): string {
   return _viteModule?.version ?? "unknown";
+}
+
+async function loadVinext(): Promise<typeof import("./index.js").default> {
+  _vinextModulePromise ??= import("./index.js").then((module) => module.default);
+  return _vinextModulePromise;
 }
 
 const VERSION = JSON.parse(fs.readFileSync(new URL("../package.json", import.meta.url), "utf-8"))
@@ -245,6 +229,7 @@ async function loadBuildViteConfigMetadata(
     root,
   );
   const emptyOutDir = loaded?.config.build?.emptyOutDir;
+  const { findVinextPrerenderConfigInPlugins } = await import("./config/prerender.js");
   return {
     emptyOutDir: typeof emptyOutDir === "boolean" ? emptyOutDir : undefined,
     prerenderConfig: findVinextPrerenderConfigInPlugins(loaded?.config.plugins),
@@ -256,7 +241,10 @@ async function loadBuildViteConfigMetadata(
  * project, Vite will merge our config with it (theirs takes precedence).
  * If there's no vite.config, this provides everything needed.
  */
-function buildViteConfig(overrides: Record<string, unknown> = {}, logger?: import("vite").Logger) {
+async function buildViteConfig(
+  overrides: Record<string, unknown> = {},
+  logger?: import("vite").Logger,
+) {
   const hasConfig = hasViteConfig(process.cwd());
 
   // If a vite.config exists, let Vite load it — only set root and overrides.
@@ -274,6 +262,7 @@ function buildViteConfig(overrides: Record<string, unknown> = {}, logger?: impor
   // No vite.config — auto-configure everything.
   // vinext() auto-registers @vitejs/plugin-rsc when app/ is detected,
   // so we only need vinext() in the plugins array.
+  const vinext = await loadVinext();
   const config: Record<string, unknown> = {
     root: process.cwd(),
     configFile: false,
@@ -323,6 +312,7 @@ async function dev() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("dev");
 
+  const { loadDotenv } = await import("./config/dotenv.js");
   loadDotenv({
     root: process.cwd(),
     mode: "development",
@@ -383,7 +373,7 @@ async function dev() {
 
   console.log(`\n  vinext dev  (Vite ${getViteVersion()})\n`);
 
-  const config = buildViteConfig();
+  const config = await buildViteConfig();
   const plugins = (config.plugins ??= []) as import("vite").PluginOption[];
   plugins.push(createDevServerConfigPlugin(parsed));
 
@@ -462,15 +452,23 @@ async function buildApp() {
     process.env.VINEXT_PRECOMPRESS = "1";
   }
 
+  const root = process.cwd();
+  const hasUserViteConfig = hasViteConfig(root);
+  const dotenvModulePromise = import("./config/dotenv.js");
+  const nextConfigModulePromise = import("./config/next-config.js");
+  const cleanOutputModulePromise = import("./build/clean-output.js");
+  const vinextModulePromise = hasUserViteConfig ? null : loadVinext();
+
+  const { loadDotenv } = await dotenvModulePromise;
   loadDotenv({
-    root: process.cwd(),
+    root,
     mode: "production",
   });
 
   // Ensure "type": "module" in package.json before Vite loads vite.config.ts.
   // Without this, Vite bundles the config as CJS and tries require() on pure-ESM
   // packages like @cloudflare/vite-plugin, which fails on Node 22.
-  applyViteConfigCompatibility(process.cwd());
+  applyViteConfigCompatibility(root);
 
   const vite = await loadVite();
   const viteMajorVersion = Number.parseInt(vite.version, 10) || 7;
@@ -480,12 +478,15 @@ async function buildApp() {
 
   console.log(`\n  vinext build  (Vite ${getViteVersion()})\n`);
 
-  const root = process.cwd();
   const isApp = hasAppDir(normalizePathSeparators(root));
+  const initModulePromise = isApp ? import("./init.js") : null;
+  const { PHASE_PRODUCTION_BUILD, createRscCompatibilityId, loadNextConfig, resolveNextConfig } =
+    await nextConfigModulePromise;
   const resolvedNextConfig = await resolveNextConfig(
     await loadNextConfig(root, PHASE_PRODUCTION_BUILD),
     root,
   );
+  const reportModulePromise = import("./build/report.js");
 
   // Coordinate a single build ID across every vinext() plugin instance in this
   // build. A hybrid app+pages build runs the App Router multi-environment build
@@ -548,13 +549,14 @@ async function buildApp() {
   // Without this, builds with older React versions can produce a Worker that crashes at
   // runtime with "Cannot read properties of undefined (reading 'moduleMap')".
   if (isApp) {
-    const reactUpgrade = getReactUpgradeDeps(process.cwd());
+    const { getReactUpgradeDeps } = await initModulePromise!;
+    const reactUpgrade = getReactUpgradeDeps(root);
     if (reactUpgrade.length > 0) {
-      const installCmd = detectPackageManager(process.cwd()).replace(/ -D$/, "");
+      const installCmd = detectPackageManager(root).replace(/ -D$/, "");
       const [pm, ...pmArgs] = installCmd.split(" ");
       console.log("  Upgrading React for RSC compatibility...");
       execFileSync(pm, [...pmArgs, ...reactUpgrade], {
-        cwd: process.cwd(),
+        cwd: root,
         stdio: "inherit",
         shell: process.platform === "win32",
       });
@@ -562,7 +564,7 @@ async function buildApp() {
   }
 
   const buildConfigMetadata = await loadBuildViteConfigMetadata(vite, root);
-
+  const { cleanBuildOutput } = await cleanOutputModulePromise;
   cleanBuildOutput({
     root,
     outDir: distDir,
@@ -579,7 +581,7 @@ async function buildApp() {
     process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION = pagesClientAssetsBuildSession;
   }
   try {
-    const config = buildViteConfig({}, logger);
+    const config = await buildViteConfig({}, logger);
     const builder = await vite.createBuilder(config);
     await builder.buildApp();
 
@@ -630,6 +632,7 @@ async function buildApp() {
           );
         }
       }
+      const vinext = await (vinextModulePromise ?? loadVinext());
       await vite.build({
         root,
         configFile: false,
@@ -652,6 +655,9 @@ async function buildApp() {
     }
   } finally {
     if (pagesClientAssetsBuildSession) {
+      const { clearPagesClientAssetsBuildMetadata } = await import(
+        "./build/pages-client-assets-module.js"
+      );
       clearPagesClientAssetsBuildMetadata(pagesClientAssetsBuildSession);
       if (
         process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION === pagesClientAssetsBuildSession
@@ -662,6 +668,7 @@ async function buildApp() {
   }
 
   if (outputMode === "standalone") {
+    const { emitStandaloneOutput } = await import("./build/standalone.js");
     const standalone = emitStandaloneOutput({
       root: process.cwd(),
       outDir: distDir,
@@ -674,6 +681,9 @@ async function buildApp() {
   }
 
   let prerenderResult;
+  const { formatVinextPrerenderLabel, resolveVinextPrerenderDecision } = await import(
+    "./config/prerender.js"
+  );
   const prerenderDecision = resolveVinextPrerenderDecision({
     prerenderAllFlag: parsed.prerenderAll,
     vinextPrerenderConfig: buildConfigMetadata.prerenderConfig,
@@ -690,6 +700,7 @@ async function buildApp() {
     }
     process.stdout.write("\x1b[0m");
     console.log(`  ${formatVinextPrerenderLabel(prerenderDecision)}`);
+    const { runPrerender } = await import("./build/run-prerender.js");
     prerenderResult = await runPrerender({
       root: normalizePathSeparators(process.cwd()),
       concurrency: parsed.prerenderConcurrency,
@@ -700,7 +711,7 @@ async function buildApp() {
   // Opt-in via --precompress CLI flag or `precompress: true` in plugin options.
 
   process.stdout.write("\x1b[0m");
-  const { printBuildReport } = await import("./build/report.js");
+  const { printBuildReport } = await reportModulePromise;
   await printBuildReport({
     root: normalizePathSeparators(process.cwd()),
     pageExtensions: resolvedNextConfig.pageExtensions,
@@ -715,6 +726,7 @@ async function start() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("start");
 
+  const { loadDotenv } = await import("./config/dotenv.js");
   loadDotenv({
     root: process.cwd(),
     mode: "production",
@@ -797,6 +809,9 @@ async function lint() {
 }
 
 async function deployCommand() {
+  const { deploy: runDeploy, parseDeployArgs } = await import(
+    "@vinext/cloudflare/internal/deploy"
+  );
   const parsed = parseDeployArgs(rawArgs);
   if (parsed.help) {
     printDeployDeprecationWarning();
@@ -838,6 +853,7 @@ async function check() {
   console.log(`\n  vinext check\n`);
   console.log("  Scanning project...\n");
 
+  const { runCheck, formatReport } = await import("./check.js");
   const result = runCheck(normalizePathSeparators(process.cwd()));
   console.log(formatReport(result));
 }
@@ -847,14 +863,18 @@ async function typegen() {
   if (parsed.help) return printHelp("typegen");
 
   const root = path.resolve(parsed.positionals?.[0] ?? process.cwd());
+  const { loadDotenv } = await import("./config/dotenv.js");
   loadDotenv({
     root,
     mode: "production",
   });
+  const { PHASE_PRODUCTION_BUILD, loadNextConfig, resolveNextConfig } =
+    await import("./config/next-config.js");
   const resolvedNextConfig = await resolveNextConfig(
     await loadNextConfig(root, PHASE_PRODUCTION_BUILD),
     root,
   );
+  const { generateRouteTypes } = await import("./typegen.js");
   const outputPath = await generateRouteTypes({
     root,
     pageExtensions: resolvedNextConfig.pageExtensions,
@@ -872,10 +892,14 @@ async function initCommand() {
   const port = parsed.port ?? 3001;
   const skipCheck = rawArgs.includes("--skip-check");
   const force = rawArgs.includes("--force");
+  const { INIT_PLATFORMS, resolveInitPlatform, resolveInitPrerender } = await import(
+    "./init-platform.js"
+  );
   const platform = await resolveInitPlatform(rawArgs);
   const platformOptions = await INIT_PLATFORMS[platform].options(rawArgs);
   const prerender = await resolveInitPrerender(rawArgs);
 
+  const { init: runInit } = await import("./init.js");
   await runInit({
     root: process.cwd(),
     port,

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -457,7 +457,7 @@ async function buildApp() {
   const dotenvModulePromise = import("./config/dotenv.js");
   const nextConfigModulePromise = import("./config/next-config.js");
   const cleanOutputModulePromise = import("./build/clean-output.js");
-  const vinextModulePromise = hasUserViteConfig ? null : loadVinext();
+  if (!hasUserViteConfig) void loadVinext();
 
   const { loadDotenv } = await dotenvModulePromise;
   loadDotenv({
@@ -632,7 +632,7 @@ async function buildApp() {
           );
         }
       }
-      const vinext = await (vinextModulePromise ?? loadVinext());
+      const vinext = await loadVinext();
       await vite.build({
         root,
         configFile: false,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -25,6 +25,7 @@ const _pagesApiRoutePath = resolveEntryPath("../server/pages-api-route.js", impo
 const _serverGlobalsPath = resolveEntryPath("../server/server-globals.js", import.meta.url);
 const _queryUtilsPath = resolveEntryPath("../utils/query.js", import.meta.url);
 const _pagesPageHandlerPath = resolveEntryPath("../server/pages-page-handler.js", import.meta.url);
+const _reactRendererEnvPath = resolveEntryPath("../server/react-renderer-env.js", import.meta.url);
 
 /**
  * Generate the virtual SSR server entry module.
@@ -195,7 +196,6 @@ export async function runMiddleware(request) {
   return `
 import ${JSON.stringify(_serverGlobalsPath)};
 import React from "react";
-import { renderToReadableStream } from "react-dom/server.edge";
 import { resetSSRHead, getSSRHeadHTML, setDocumentInitialHead } from "next/head";
 import { flushPreloads } from "next/dynamic";
 import Router, { setSSRContext, wrapWithRouterContext, getPagesNavigationIsReadyFromSerializedState } from "next/router";
@@ -225,6 +225,7 @@ import { handlePagesApiRoute as __handlePagesApiRoute } from ${JSON.stringify(_p
 import { normalizePagesDataRequest as __normalizePagesDataRequest, buildNextDataNotFoundResponse as __buildNextDataNotFoundResponse } from ${JSON.stringify(_pagesDataRoutePath)};
 import { buildDefaultPagesNotFoundResponse as __buildDefaultPagesNotFoundResponse } from ${JSON.stringify(_pagesDefault404Path)};
 import { createPagesPageHandler as __createPagesPageHandler } from ${JSON.stringify(_pagesPageHandlerPath)};
+import { getReactNodeEnv as __getReactNodeEnv, importWithReactNodeEnv as __importWithReactNodeEnv } from ${JSON.stringify(_reactRendererEnvPath)};
 ${instrumentationImportCode}
 ${middlewareImportCode}
 
@@ -256,8 +257,26 @@ __configureMemoryCacheHandler({ cacheMaxMemorySize: vinextConfig.cacheMaxMemoryS
 // by _app are included in every page's <link rel="stylesheet"> set.
 const _appAssetPath = ${appAssetPathJson};
 
+let _reactDomServerEdgePromise = null;
+function _getLoadedReactNodeEnv() {
+  return __getReactNodeEnv(React.createElement);
+}
+
+async function _loadReactDomServerEdge() {
+  if (_reactDomServerEdgePromise) return _reactDomServerEdgePromise;
+  _reactDomServerEdgePromise = __importWithReactNodeEnv(_getLoadedReactNodeEnv(), () =>
+    import("react-dom/server.edge"),
+  );
+  return _reactDomServerEdgePromise;
+}
+
+async function _renderToReadableStream(element) {
+  const { renderToReadableStream } = await _loadReactDomServerEdge();
+  return renderToReadableStream(element);
+}
+
 async function _renderToStringAsync(element) {
-  const stream = await renderToReadableStream(element);
+  const stream = await _renderToReadableStream(element);
   await stream.allReady;
   return new Response(stream).text();
 }
@@ -401,7 +420,7 @@ const _renderPage = __createPagesPageHandler({
       return preloads;
     } catch { return []; }
   },
-  renderToReadableStream,
+  renderToReadableStream: _renderToReadableStream,
   renderIsrPassToStringAsync: _renderIsrPassToStringAsync,
   safeJsonStringify,
   sanitizeDestination: sanitizeDestinationLocal,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -225,7 +225,7 @@ import { handlePagesApiRoute as __handlePagesApiRoute } from ${JSON.stringify(_p
 import { normalizePagesDataRequest as __normalizePagesDataRequest, buildNextDataNotFoundResponse as __buildNextDataNotFoundResponse } from ${JSON.stringify(_pagesDataRoutePath)};
 import { buildDefaultPagesNotFoundResponse as __buildDefaultPagesNotFoundResponse } from ${JSON.stringify(_pagesDefault404Path)};
 import { createPagesPageHandler as __createPagesPageHandler } from ${JSON.stringify(_pagesPageHandlerPath)};
-import { getReactNodeEnv as __getReactNodeEnv, importWithReactNodeEnv as __importWithReactNodeEnv } from ${JSON.stringify(_reactRendererEnvPath)};
+import { getReactNodeEnv as __getReactNodeEnv, importReactDomServerEdge as __importReactDomServerEdge } from ${JSON.stringify(_reactRendererEnvPath)};
 ${instrumentationImportCode}
 ${middlewareImportCode}
 
@@ -260,10 +260,7 @@ const _appAssetPath = ${appAssetPathJson};
 let _reactDomServerEdgePromise = null;
 async function _loadReactDomServerEdge() {
   if (_reactDomServerEdgePromise) return _reactDomServerEdgePromise;
-  _reactDomServerEdgePromise = __importWithReactNodeEnv(
-    __getReactNodeEnv(React.createElement),
-    () => import("react-dom/server.edge"),
-  );
+  _reactDomServerEdgePromise = __importReactDomServerEdge(__getReactNodeEnv(React.createElement));
   return _reactDomServerEdgePromise;
 }
 

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -258,14 +258,11 @@ __configureMemoryCacheHandler({ cacheMaxMemorySize: vinextConfig.cacheMaxMemoryS
 const _appAssetPath = ${appAssetPathJson};
 
 let _reactDomServerEdgePromise = null;
-function _getLoadedReactNodeEnv() {
-  return __getReactNodeEnv(React.createElement);
-}
-
 async function _loadReactDomServerEdge() {
   if (_reactDomServerEdgePromise) return _reactDomServerEdgePromise;
-  _reactDomServerEdgePromise = __importWithReactNodeEnv(_getLoadedReactNodeEnv(), () =>
-    import("react-dom/server.edge"),
+  _reactDomServerEdgePromise = __importWithReactNodeEnv(
+    __getReactNodeEnv(React.createElement),
+    () => import("react-dom/server.edge"),
   );
   return _reactDomServerEdgePromise;
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -237,24 +237,10 @@ function loadMetadataRoutesModule(): Promise<typeof import("./server/metadata-ro
 }
 
 let devServerModulePromise: Promise<typeof import("./server/dev-server.js")> | null = null;
-function loadDevServerModule(): Promise<typeof import("./server/dev-server.js")> {
-  devServerModulePromise ??= import("./server/dev-server.js");
-  return devServerModulePromise;
-}
-
 let apiHandlerModulePromise: Promise<typeof import("./server/api-handler.js")> | null = null;
-function loadApiHandlerModule(): Promise<typeof import("./server/api-handler.js")> {
-  apiHandlerModulePromise ??= import("./server/api-handler.js");
-  return apiHandlerModulePromise;
-}
-
 let imageOptimizationModulePromise: Promise<
   typeof import("./server/image-optimization.js")
 > | null = null;
-function loadImageOptimizationModule(): Promise<typeof import("./server/image-optimization.js")> {
-  imageOptimizationModulePromise ??= import("./server/image-optimization.js");
-  return imageOptimizationModulePromise;
-}
 
 function getCacheDirPrefix(cacheDir: string): string {
   const normalizedCacheDir = normalizePathSeparators(cacheDir);
@@ -4045,7 +4031,8 @@ export const loadServerActionClient = ${
               // its import for non-image dev requests.
               if (requestPathname === "/_next/image" || requestPathname === "/_vinext/image") {
                 const { DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, resolveDevImageRedirect } =
-                  await loadImageOptimizationModule();
+                  await (imageOptimizationModulePromise ??=
+                    import("./server/image-optimization.js"));
                 const imageRequestUrl = new URL(url, `http://${req.headers.host || "localhost"}`);
                 const allowedWidths = [
                   ...(nextConfig.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
@@ -4488,7 +4475,8 @@ export const loadServerActionClient = ${
                 if (pipelineResult.middlewareStatus !== undefined) {
                   req.__vinextMiddlewareStatus = pipelineResult.middlewareStatus;
                 }
-                const { handleApiRoute } = await loadApiHandlerModule();
+                const { handleApiRoute } = await (apiHandlerModulePromise ??=
+                  import("./server/api-handler.js"));
                 const handled = await handleApiRoute(
                   getPagesRunner(),
                   req,
@@ -4540,7 +4528,8 @@ export const loadServerActionClient = ${
                   }
                 }
                 if (!cachedSSRHandler || cachedSSRHandler.routes !== routes) {
-                  const { createSSRHandler } = await loadDevServerModule();
+                  const { createSSRHandler } = await (devServerModulePromise ??=
+                    import("./server/dev-server.js"));
                   cachedSSRHandler = {
                     routes,
                     handler: createSSRHandler(

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2851,8 +2851,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           !hasNitroPlugin &&
           !options.disableAppRouter
         ) {
-          const { hasWranglerConfig, formatMissingCloudflarePluginError } =
-            await import("./deploy.js");
           if (hasWranglerConfig(root)) {
             throw new Error(
               formatMissingCloudflarePluginError({
@@ -5580,9 +5578,8 @@ export const loadServerActionClient = ${
           if (this.environment.name === "client") {
             const buildRoot = envConfig.root ?? process.cwd();
             const clientDir = path.resolve(buildRoot, envConfig.build.outDir);
-            const { computeClientRuntimeMetadata } = await import(
-              "./utils/client-runtime-metadata.js"
-            );
+            const { computeClientRuntimeMetadata } =
+              await import("./utils/client-runtime-metadata.js");
             const runtimeMetadata = computeClientRuntimeMetadata({
               clientDir,
               assetBase: envConfig.base ?? "/",
@@ -5694,95 +5691,7 @@ export const loadServerActionClient = ${
           const envConfig = this.environment?.config;
           if (!envConfig) return;
           const buildRoot = envConfig.root ?? process.cwd();
-          const distDir = path.resolve(buildRoot, "dist");
-          if (!fs.existsSync(distDir)) return;
-
-          const clientDir = path.resolve(buildRoot, "dist", "client");
-          const clientBase = envConfig.base ?? "/";
-
-          const { computeClientRuntimeMetadata, buildRuntimeGlobalsScript } =
-            await import("./utils/client-runtime-metadata.js");
-          // Compute runtime metadata from the client build manifest: lazy
-          // chunks, per-next/dynamic preload files, and (for Pages Router)
-          // the client entry file. This runs for BOTH App Router and Pages
-          // Router — clientEntryFile is only used by the Pages Router path
-          // below (App Router gets its client entry via the RSC plugin).
-          const runtimeMetadata = computeClientRuntimeMetadata({
-            clientDir,
-            assetBase: clientBase,
-            assetPrefix: nextConfig.assetPrefix,
-            includeClientEntry: !hasAppDir ? true : hasPagesDir ? "pages-client-entry" : false,
-          });
-          const lazyChunksData: string[] | null = runtimeMetadata.lazyChunks ?? null;
-          const dynamicPreloadsData: Record<string, string[]> | null =
-            runtimeMetadata.dynamicPreloads ?? null;
-          let clientEntryFile: string | null = runtimeMetadata.clientEntryFile ?? null;
-
-          // Read SSR manifest for per-page CSS/JS injection
-          let ssrManifestData: Record<string, string[]> | null = null;
-          const ssrManifestPath = path.join(clientDir, ".vite", "ssr-manifest.json");
-          if (fs.existsSync(ssrManifestPath)) {
-            try {
-              ssrManifestData = JSON.parse(fs.readFileSync(ssrManifestPath, "utf-8"));
-            } catch {
-              /* ignore parse errors */
-            }
-          }
-
-          if (hasAppDir) {
-            // App Router: the RSC plugin handles the App client bootstrap via
-            // loadBootstrapScriptContent(). In mixed app+pages builds, Pages
-            // fallback routes still render through the Pages entry and need
-            // the Pages client entry global.
-            const workerEntry = path.resolve(distDir, "server", "index.js");
-
-            if (fs.existsSync(workerEntry)) {
-              // `clientEntryFile` is only populated for mixed app+pages builds
-              // (computeClientRuntimeMetadata was asked for "pages-client-entry");
-              // pure App Router gets its client entry via the RSC plugin.
-              const script = buildRuntimeGlobalsScript({
-                clientEntryFile,
-                ssrManifest: ssrManifestData,
-                lazyChunks: lazyChunksData,
-                dynamicPreloads: dynamicPreloadsData,
-              });
-              if (script) {
-                const code = fs.readFileSync(workerEntry, "utf-8");
-                fs.writeFileSync(workerEntry, script + "\n" + code);
-              }
-            }
-          } else {
-            // Pages Router: find worker output by scanning dist/ for a
-            // directory containing wrangler.json (Cloudflare plugin default).
-            let workerOutDir: string | null = null;
-            for (const entry of fs.readdirSync(distDir)) {
-              const candidate = path.join(distDir, entry);
-              if (entry === "client") continue;
-              if (
-                fs.statSync(candidate).isDirectory() &&
-                fs.existsSync(path.join(candidate, "wrangler.json"))
-              ) {
-                workerOutDir = candidate;
-                break;
-              }
-            }
-            if (!workerOutDir) return;
-
-            const workerEntry = path.join(workerOutDir, "index.js");
-            if (!fs.existsSync(workerEntry)) return;
-
-            // Prepend globals to worker entry
-            const script = buildRuntimeGlobalsScript({
-              clientEntryFile,
-              ssrManifest: ssrManifestData,
-              lazyChunks: lazyChunksData,
-              dynamicPreloads: dynamicPreloadsData,
-            });
-            if (script) {
-              const code = fs.readFileSync(workerEntry, "utf-8");
-              fs.writeFileSync(workerEntry, script + "\n" + code);
-            }
-          }
+          const clientDir = path.resolve(buildRoot, envConfig.build.outDir);
 
           // Generate _headers file for Cloudflare Workers static asset caching.
           // Vite outputs content-hashed files (JS, CSS, fonts) to the assetsDir

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -14,8 +14,6 @@ import {
   invalidateRouteCache,
   matchRoute,
 } from "./routing/pages-router.js";
-import { generateServerEntry as _generateServerEntry } from "./entries/pages-server-entry.js";
-import { generateClientEntry as _generateClientEntry } from "./entries/pages-client-entry.js";
 import {
   appRouteGraph,
   appRouter,
@@ -29,15 +27,6 @@ import {
   createValidFileMatcher,
   findFileWithExts,
 } from "./routing/file-matcher.js";
-import { createSSRHandler } from "./server/dev-server.js";
-import { handleApiRoute } from "./server/api-handler.js";
-import {
-  DEFAULT_DEVICE_SIZES,
-  DEFAULT_IMAGE_SIZES,
-  isImageOptimizationPath,
-  resolveDevImageRedirect,
-} from "./server/image-optimization.js";
-
 import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
 import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
@@ -103,14 +92,8 @@ import {
   runInstrumentation,
 } from "./server/instrumentation.js";
 import { PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
-import { precompressAssets } from "./build/precompress.js";
-import { ensureAssetsIgnore } from "./build/assets-ignore.js";
-import { emitNextClientRuntimeManifests } from "./build/next-client-runtime-manifests.js";
-import { collectInlineCssManifest, injectInlineCssManifestGlobal } from "./build/inline-css.js";
 import { validateDevRequest } from "./server/dev-origin-check.js";
 import { installDevStackSourcemapMiddleware } from "./server/dev-stack-sourcemap.js";
-
-import { invalidateMetadataFileCache, scanMetadataFiles } from "./server/metadata-routes.js";
 
 import {
   runPagesRequest,
@@ -146,7 +129,6 @@ import { validateMiddlewareModuleExports } from "./plugins/middleware-export-val
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createDynamicPreloadMetadataPlugin } from "./plugins/dynamic-preload-metadata.js";
 import { createOgInlineFetchAssetsPlugin, createOgAssetsPlugin } from "./plugins/og-assets.js";
-import { generateRouteTypes } from "./typegen.js";
 import {
   mergeOptimizeDepsExclude,
   SSR_EXTERNAL_REACT_ENTRIES,
@@ -161,7 +143,6 @@ import {
   createGoogleFontsPlugin,
   createLocalFontsPlugin,
 } from "./plugins/fonts.js";
-import { computeClientRuntimeMetadata } from "./utils/client-runtime-metadata.js";
 import {
   VINEXT_CLIENT_ENTRY_MANIFEST,
   type ClientEntryManifest,
@@ -244,6 +225,36 @@ import {
 installSocketErrorBackstop();
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
+type CreateSSRHandler = typeof import("./server/dev-server.js").createSSRHandler;
+type StaticExportPages = typeof import("./build/static-export.js").staticExportPages;
+type StaticExportApp = typeof import("./build/static-export.js").staticExportApp;
+
+let metadataRoutesModulePromise: Promise<typeof import("./server/metadata-routes.js")> | null =
+  null;
+function loadMetadataRoutesModule(): Promise<typeof import("./server/metadata-routes.js")> {
+  metadataRoutesModulePromise ??= import("./server/metadata-routes.js");
+  return metadataRoutesModulePromise;
+}
+
+let devServerModulePromise: Promise<typeof import("./server/dev-server.js")> | null = null;
+function loadDevServerModule(): Promise<typeof import("./server/dev-server.js")> {
+  devServerModulePromise ??= import("./server/dev-server.js");
+  return devServerModulePromise;
+}
+
+let apiHandlerModulePromise: Promise<typeof import("./server/api-handler.js")> | null = null;
+function loadApiHandlerModule(): Promise<typeof import("./server/api-handler.js")> {
+  apiHandlerModulePromise ??= import("./server/api-handler.js");
+  return apiHandlerModulePromise;
+}
+
+let imageOptimizationModulePromise: Promise<
+  typeof import("./server/image-optimization.js")
+> | null = null;
+function loadImageOptimizationModule(): Promise<typeof import("./server/image-optimization.js")> {
+  imageOptimizationModulePromise ??= import("./server/image-optimization.js");
+  return imageOptimizationModulePromise;
+}
 
 function getCacheDirPrefix(cacheDir: string): string {
   const normalizedCacheDir = normalizePathSeparators(cacheDir);
@@ -1027,7 +1038,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
    * This is the entry point for `vite build --ssr`.
    */
   async function generateServerEntry(): Promise<string> {
-    return _generateServerEntry(
+    const { generateServerEntry } = await import("./entries/pages-server-entry.js");
+    return generateServerEntry(
       pagesDir,
       nextConfig,
       fileMatcher,
@@ -1055,7 +1067,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           isLinkPrefetchRoute(route) ? toLinkPrefetchRoute(route) : toDocumentOnlyAppRoute(route),
         )
       : [];
-    return _generateClientEntry(pagesDir, nextConfig, fileMatcher, {
+    const { generateClientEntry } = await import("./entries/pages-client-entry.js");
+    return generateClientEntry(pagesDir, nextConfig, fileMatcher, {
       appPrefetchRoutes,
       instrumentationClientPath,
       middlewareMatcher: middlewarePath
@@ -1067,6 +1080,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
   async function writeRouteTypes(): Promise<void> {
     if (!hasAppDir) return;
+    const { generateRouteTypes } = await import("./typegen.js");
     await generateRouteTypes({
       root,
       appDir,
@@ -2843,15 +2857,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           config.command === "build" &&
           !hasCloudflarePlugin &&
           !hasNitroPlugin &&
-          hasWranglerConfig(root) &&
           !options.disableAppRouter
         ) {
-          throw new Error(
-            formatMissingCloudflarePluginError({
-              isAppRouter: hasAppDir,
-              configFile: config.configFile,
-            }),
-          );
+          const { hasWranglerConfig, formatMissingCloudflarePluginError } =
+            await import("./deploy.js");
+          if (hasWranglerConfig(root)) {
+            throw new Error(
+              formatMissingCloudflarePluginError({
+                isAppRouter: hasAppDir,
+                configFile: config.configFile,
+              }),
+            );
+          }
         }
       },
 
@@ -2990,6 +3007,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // App Router virtual modules
         if (id === RESOLVED_RSC_ENTRY && hasAppDir) {
           const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
+          const { scanMetadataFiles } = await loadMetadataRoutesModule();
           const metaRoutes = scanMetadataFiles(appDir);
           const hasServerActions = await resolveHasServerActions(this.environment.config);
           // Check for global-error.tsx at app root
@@ -3517,7 +3535,7 @@ export const loadServerActionClient = ${
         // handler otherwise, instead of re-running it for every request.
         let cachedSSRHandler: {
           routes: Awaited<ReturnType<typeof pagesRouter>>;
-          handler: ReturnType<typeof createSSRHandler>;
+          handler: ReturnType<CreateSSRHandler>;
         } | null = null;
         function getPagesRunner() {
           if (!pagesRunner) {
@@ -3577,7 +3595,11 @@ export const loadServerActionClient = ${
 
         function invalidateAppRoutingModules() {
           invalidateAppRouteCache();
-          invalidateMetadataFileCache();
+          if (metadataRoutesModulePromise) {
+            void loadMetadataRoutesModule().then(({ invalidateMetadataFileCache }) => {
+              invalidateMetadataFileCache();
+            });
+          }
           invalidateRscEntryModule();
           invalidateRootParamsModule();
         }
@@ -4018,7 +4040,12 @@ export const loadServerActionClient = ${
 
               // ── Image optimization passthrough (dev mode) ─────────────
               // In dev, redirect to the original asset URL so Vite serves it.
-              if (isImageOptimizationPath(url.split("?")[0]!)) {
+              const requestPathname = url.split("?")[0]!;
+              // Keep these literals in sync with image-optimization.ts while avoiding
+              // its import for non-image dev requests.
+              if (requestPathname === "/_next/image" || requestPathname === "/_vinext/image") {
+                const { DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, resolveDevImageRedirect } =
+                  await loadImageOptimizationModule();
                 const imageRequestUrl = new URL(url, `http://${req.headers.host || "localhost"}`);
                 const allowedWidths = [
                   ...(nextConfig.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
@@ -4446,13 +4473,22 @@ export const loadServerActionClient = ${
                     return next();
                   }
                 }
-                if (apiMatch) {
-                  flushStagedHeaders();
-                  flushRequestHeaders();
-                  if (pipelineResult.middlewareStatus !== undefined) {
-                    req.__vinextMiddlewareStatus = pipelineResult.middlewareStatus;
-                  }
+                if (!apiMatch) {
+                  // No Pages API route matched — if app dir exists, let the RSC plugin handle it
+                  // (app/api/* route handlers live there). Otherwise hard-404.
+                  if (hasAppDir) return next();
+
+                  res.statusCode = 404;
+                  res.end("404 - API route not found");
+                  return;
                 }
+
+                flushStagedHeaders();
+                flushRequestHeaders();
+                if (pipelineResult.middlewareStatus !== undefined) {
+                  req.__vinextMiddlewareStatus = pipelineResult.middlewareStatus;
+                }
+                const { handleApiRoute } = await loadApiHandlerModule();
                 const handled = await handleApiRoute(
                   getPagesRunner(),
                   req,
@@ -4467,8 +4503,7 @@ export const loadServerActionClient = ${
                 );
                 if (handled) return;
 
-                // No API route matched — if app dir exists, let the RSC plugin handle it
-                // (app/api/* route handlers live there). Otherwise hard-404.
+                // Defensive fallback if the API handler declines a matched route.
                 if (hasAppDir) return next();
 
                 res.statusCode = 404;
@@ -4505,6 +4540,7 @@ export const loadServerActionClient = ${
                   }
                 }
                 if (!cachedSSRHandler || cachedSSRHandler.routes !== routes) {
+                  const { createSSRHandler } = await loadDevServerModule();
                   cachedSSRHandler = {
                     routes,
                     handler: createSSRHandler(
@@ -5418,13 +5454,15 @@ export const loadServerActionClient = ${
       writeBundle: {
         sequential: true,
         order: "post",
-        handler(outputOptions: { dir?: string }) {
+        async handler(outputOptions: { dir?: string }) {
           const clientDir = outputOptions.dir;
           if (!clientDir) return;
 
           const isClientBuild = this.environment?.name === "client";
           if (!isClientBuild) return;
 
+          const { emitNextClientRuntimeManifests } =
+            await import("./build/next-client-runtime-manifests.js");
           emitNextClientRuntimeManifests({
             clientDir,
             assetsSubdir: resolveAssetsDir(nextConfig.assetPrefix),
@@ -5477,6 +5515,7 @@ export const loadServerActionClient = ${
             // the full precompression cost on the critical path of step 4/5.
             pendingPrecompressError = null;
             pendingPrecompress = (async () => {
+              const { precompressAssets } = await import("./build/precompress.js");
               const result = await precompressAssets(outDir, {
                 assetsDir: assetsSubdir,
                 onProgress: (completed, total, file) => {
@@ -5539,11 +5578,14 @@ export const loadServerActionClient = ${
       closeBundle: {
         sequential: true,
         order: "post",
-        handler() {
+        async handler() {
           const envConfig = this.environment.config;
           if (this.environment.name === "client") {
             const buildRoot = envConfig.root ?? process.cwd();
             const clientDir = path.resolve(buildRoot, envConfig.build.outDir);
+            const { computeClientRuntimeMetadata } = await import(
+              "./utils/client-runtime-metadata.js"
+            );
             const runtimeMetadata = computeClientRuntimeMetadata({
               clientDir,
               assetBase: envConfig.base ?? "/",
@@ -5616,13 +5658,15 @@ export const loadServerActionClient = ${
       closeBundle: {
         sequential: true,
         order: "post",
-        handler() {
+        async handler() {
           if (this.environment?.name !== "client") return;
           if (!hasAppDir || nextConfig?.inlineCss !== true) return;
 
           const envConfig = this.environment?.config;
           if (!envConfig) return;
 
+          const { collectInlineCssManifest, injectInlineCssManifestGlobal } =
+            await import("./build/inline-css.js");
           const buildRoot = envConfig.root ?? process.cwd();
           const clientDir = path.resolve(buildRoot, "dist", "client");
           const manifest = collectInlineCssManifest(clientDir, nextConfig.assetPrefix);
@@ -5653,7 +5697,95 @@ export const loadServerActionClient = ${
           const envConfig = this.environment?.config;
           if (!envConfig) return;
           const buildRoot = envConfig.root ?? process.cwd();
-          const clientDir = path.resolve(buildRoot, envConfig.build.outDir);
+          const distDir = path.resolve(buildRoot, "dist");
+          if (!fs.existsSync(distDir)) return;
+
+          const clientDir = path.resolve(buildRoot, "dist", "client");
+          const clientBase = envConfig.base ?? "/";
+
+          const { computeClientRuntimeMetadata, buildRuntimeGlobalsScript } =
+            await import("./utils/client-runtime-metadata.js");
+          // Compute runtime metadata from the client build manifest: lazy
+          // chunks, per-next/dynamic preload files, and (for Pages Router)
+          // the client entry file. This runs for BOTH App Router and Pages
+          // Router — clientEntryFile is only used by the Pages Router path
+          // below (App Router gets its client entry via the RSC plugin).
+          const runtimeMetadata = computeClientRuntimeMetadata({
+            clientDir,
+            assetBase: clientBase,
+            assetPrefix: nextConfig.assetPrefix,
+            includeClientEntry: !hasAppDir ? true : hasPagesDir ? "pages-client-entry" : false,
+          });
+          const lazyChunksData: string[] | null = runtimeMetadata.lazyChunks ?? null;
+          const dynamicPreloadsData: Record<string, string[]> | null =
+            runtimeMetadata.dynamicPreloads ?? null;
+          let clientEntryFile: string | null = runtimeMetadata.clientEntryFile ?? null;
+
+          // Read SSR manifest for per-page CSS/JS injection
+          let ssrManifestData: Record<string, string[]> | null = null;
+          const ssrManifestPath = path.join(clientDir, ".vite", "ssr-manifest.json");
+          if (fs.existsSync(ssrManifestPath)) {
+            try {
+              ssrManifestData = JSON.parse(fs.readFileSync(ssrManifestPath, "utf-8"));
+            } catch {
+              /* ignore parse errors */
+            }
+          }
+
+          if (hasAppDir) {
+            // App Router: the RSC plugin handles the App client bootstrap via
+            // loadBootstrapScriptContent(). In mixed app+pages builds, Pages
+            // fallback routes still render through the Pages entry and need
+            // the Pages client entry global.
+            const workerEntry = path.resolve(distDir, "server", "index.js");
+
+            if (fs.existsSync(workerEntry)) {
+              // `clientEntryFile` is only populated for mixed app+pages builds
+              // (computeClientRuntimeMetadata was asked for "pages-client-entry");
+              // pure App Router gets its client entry via the RSC plugin.
+              const script = buildRuntimeGlobalsScript({
+                clientEntryFile,
+                ssrManifest: ssrManifestData,
+                lazyChunks: lazyChunksData,
+                dynamicPreloads: dynamicPreloadsData,
+              });
+              if (script) {
+                const code = fs.readFileSync(workerEntry, "utf-8");
+                fs.writeFileSync(workerEntry, script + "\n" + code);
+              }
+            }
+          } else {
+            // Pages Router: find worker output by scanning dist/ for a
+            // directory containing wrangler.json (Cloudflare plugin default).
+            let workerOutDir: string | null = null;
+            for (const entry of fs.readdirSync(distDir)) {
+              const candidate = path.join(distDir, entry);
+              if (entry === "client") continue;
+              if (
+                fs.statSync(candidate).isDirectory() &&
+                fs.existsSync(path.join(candidate, "wrangler.json"))
+              ) {
+                workerOutDir = candidate;
+                break;
+              }
+            }
+            if (!workerOutDir) return;
+
+            const workerEntry = path.join(workerOutDir, "index.js");
+            if (!fs.existsSync(workerEntry)) return;
+
+            // Prepend globals to worker entry
+            const script = buildRuntimeGlobalsScript({
+              clientEntryFile,
+              ssrManifest: ssrManifestData,
+              lazyChunks: lazyChunksData,
+              dynamicPreloads: dynamicPreloadsData,
+            });
+            if (script) {
+              const code = fs.readFileSync(workerEntry, "utf-8");
+              fs.writeFileSync(workerEntry, script + "\n" + code);
+            }
+          }
 
           // Generate _headers file for Cloudflare Workers static asset caching.
           // Vite outputs content-hashed files (JS, CSS, fonts) to the assetsDir
@@ -5683,6 +5815,7 @@ export const loadServerActionClient = ${
           // unlinked route paths. The Node prod server blocks `/.vite/` for the
           // same reason (server/static-file-cache.ts); `.assetsignore` is the
           // Cloudflare-side equivalent.
+          const { ensureAssetsIgnore } = await import("./build/assets-ignore.js");
           ensureAssetsIgnore(clientDir);
         },
       },
@@ -5879,7 +6012,20 @@ async function writeWebResponseToNodeRes(
 }
 
 // Public exports for static export
-export { staticExportPages, staticExportApp } from "./build/static-export.js";
+export async function staticExportPages(
+  ...args: Parameters<StaticExportPages>
+): ReturnType<StaticExportPages> {
+  const { staticExportPages } = await import("./build/static-export.js");
+  return staticExportPages(...args);
+}
+
+export async function staticExportApp(
+  ...args: Parameters<StaticExportApp>
+): ReturnType<StaticExportApp> {
+  const { staticExportApp } = await import("./build/static-export.js");
+  return staticExportApp(...args);
+}
+
 export type {
   StaticExportResult,
   StaticExportOptions,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -172,10 +172,6 @@ import {
   withBuildBundlerOptions,
 } from "./build/client-build-config.js";
 import {
-  markCssUrlAssetReferences,
-  restoreDedupedCssAssetReferences,
-} from "./build/css-url-assets.js";
-import {
   augmentSsrManifestFromBundle,
   tryRealpathSync,
   relativeWithinRoot,
@@ -241,6 +237,12 @@ let apiHandlerModulePromise: Promise<typeof import("./server/api-handler.js")> |
 let imageOptimizationModulePromise: Promise<
   typeof import("./server/image-optimization.js")
 > | null = null;
+let cssUrlAssetsModulePromise: Promise<typeof import("./build/css-url-assets.js")> | null = null;
+
+function loadCssUrlAssetsModule(): Promise<typeof import("./build/css-url-assets.js")> {
+  cssUrlAssetsModulePromise ??= import("./build/css-url-assets.js");
+  return cssUrlAssetsModulePromise;
+}
 
 function getCacheDirPrefix(cacheDir: string): string {
   const normalizedCacheDir = normalizePathSeparators(cacheDir);
@@ -3262,7 +3264,8 @@ export const loadServerActionClient = ${
           id: /\.(?:css|scss|sass|less|styl|stylus)(?:\?|$)/i,
           code: "url(",
         },
-        handler(code, id) {
+        async handler(code, id) {
+          const { markCssUrlAssetReferences } = await loadCssUrlAssetsModule();
           const marked = markCssUrlAssetReferences(code, id);
           if (marked === null) return null;
           // No source map: the marker is transient — it's stripped before final
@@ -3336,7 +3339,8 @@ export const loadServerActionClient = ${
       enforce: "post",
       apply: "build",
 
-      generateBundle(_options, bundle) {
+      async generateBundle(_options, bundle) {
+        const { restoreDedupedCssAssetReferences } = await loadCssUrlAssetsModule();
         restoreDedupedCssAssetReferences(bundle, (asset) => {
           this.emitFile({ type: "asset", fileName: asset.fileName, source: asset.source });
         });

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -69,6 +69,12 @@ import { mergeServerExternalPackages } from "./config/server-external-packages.j
 
 import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
 import { isNextDataPathname, parseNextDataPathname } from "./server/pages-data-route.js";
+import { isImageOptimizationPath } from "./server/image-optimization-paths.js";
+import type {
+  StaticExportOptions,
+  AppStaticExportOptions,
+  StaticExportResult,
+} from "./build/static-export.js";
 import { resolvePagesI18nRequest } from "./server/pages-i18n.js";
 import {
   MIDDLEWARE_NEXT_HEADER,
@@ -222,8 +228,6 @@ installSocketErrorBackstop();
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
 type CreateSSRHandler = typeof import("./server/dev-server.js").createSSRHandler;
-type StaticExportPages = typeof import("./build/static-export.js").staticExportPages;
-type StaticExportApp = typeof import("./build/static-export.js").staticExportApp;
 
 let metadataRoutesModulePromise: Promise<typeof import("./server/metadata-routes.js")> | null =
   null;
@@ -4031,9 +4035,9 @@ export const loadServerActionClient = ${
               // ── Image optimization passthrough (dev mode) ─────────────
               // In dev, redirect to the original asset URL so Vite serves it.
               const requestPathname = url.split("?")[0]!;
-              // Keep these literals in sync with image-optimization.ts while avoiding
-              // its import for non-image dev requests.
-              if (requestPathname === "/_next/image" || requestPathname === "/_vinext/image") {
+              // Cheap path predicate — gating here avoids importing the full
+              // image-optimization handler for non-image dev requests.
+              if (isImageOptimizationPath(requestPathname)) {
                 const { DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, resolveDevImageRedirect } =
                   await (imageOptimizationModulePromise ??=
                     import("./server/image-optimization.js"));
@@ -6004,19 +6008,19 @@ async function writeWebResponseToNodeRes(
   }
 }
 
-// Public exports for static export
-export async function staticExportPages(
-  ...args: Parameters<StaticExportPages>
-): ReturnType<StaticExportPages> {
+// Public exports for static export. Thin async wrappers that defer the heavy
+// build/static-export module until a caller actually runs an export, while
+// keeping the underlying single-options signatures intact.
+export async function staticExportPages(options: StaticExportOptions): Promise<StaticExportResult> {
   const { staticExportPages } = await import("./build/static-export.js");
-  return staticExportPages(...args);
+  return staticExportPages(options);
 }
 
 export async function staticExportApp(
-  ...args: Parameters<StaticExportApp>
-): ReturnType<StaticExportApp> {
+  options: AppStaticExportOptions,
+): Promise<StaticExportResult> {
   const { staticExportApp } = await import("./build/static-export.js");
-  return staticExportApp(...args);
+  return staticExportApp(options);
 }
 
 export type {

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -31,15 +31,8 @@ import fs from "node:fs";
 import { escapeRegExp } from "../utils/regex.js";
 import { lastSignificantChar } from "../utils/has-trailing-comma.js";
 import MagicString from "magic-string";
-import {
-  buildFallbackFontFace,
-  getFallbackFontOverrideMetrics,
-} from "../build/google-fonts/fallback-metrics.js";
-import { validateGoogleFontOptions } from "../build/google-fonts/validate.js";
-import { getFontAxes } from "../build/google-fonts/get-axes.js";
 import { buildGoogleFontsUrl } from "../build/google-fonts/build-url.js";
 import { findFontFilesInCss } from "../build/google-fonts/find-font-files-in-css.js";
-import { CONTENT_TYPES } from "../server/static-file-cache.js";
 import { ASSET_PREFIX_URL_DIR } from "../utils/asset-prefix.js";
 
 /**
@@ -95,6 +88,11 @@ const GOOGLE_FONT_UTILITY_EXPORTS = new Set([
  */
 const VINEXT_FONT_URL_NAMESPACE = "_vinext_fonts";
 const MAX_GOOGLE_FONTS_ERROR_BODY_LENGTH = 500;
+const FONT_CONTENT_TYPES: Record<string, string> = {
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".ttf": "font/ttf",
+};
 
 function formatGoogleFontsErrorBody(body: string): string {
   const trimmed = body.trim();
@@ -698,10 +696,10 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         fs.stat(filePath, (err, stat) => {
           if (err || !stat.isFile()) return next();
           const ext = path.extname(filePath).toLowerCase();
-          // CONTENT_TYPES is the same map prod-server uses, so fonts get
-          // identical MIME types in dev and prod. fetchAndCacheFont only
-          // ever writes .woff2/.woff/.ttf, all of which are covered.
-          res.setHeader("Content-Type", CONTENT_TYPES[ext] ?? "application/octet-stream");
+          // Keep this local to avoid importing the production static-file server
+          // on every vinext() plugin load. fetchAndCacheFont only writes these
+          // font extensions, matching prod-server's MIME table for the same files.
+          res.setHeader("Content-Type", FONT_CONTENT_TYPES[ext] ?? "application/octet-stream");
           res.setHeader("Cache-Control", "no-cache");
           res.setHeader("Access-Control-Allow-Origin", "*");
           fs.createReadStream(filePath).pipe(res);
@@ -859,6 +857,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           // See issue #885.
           let validated;
           try {
+            const { validateGoogleFontOptions } = await import("../build/google-fonts/validate.js");
             validated = validateGoogleFontOptions(family, options);
           } catch (err) {
             // Validation errors are programmer errors (unknown family,
@@ -868,6 +867,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
             const message = err instanceof Error ? err.message : String(err);
             throw new Error(`[vinext:google-fonts] ${id}: ${message}`);
           }
+          const { getFontAxes } = await import("../build/google-fonts/get-axes.js");
           const axes = getFontAxes(
             family,
             validated.weights,
@@ -926,13 +926,15 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           )
             .filter((file) => file.preloadFontFile)
             .map((file) => file.googleFontFileUrl);
-          const fallbackMetrics =
-            validated.adjustFontFallback === false
-              ? undefined
-              : getFallbackFontOverrideMetrics(family);
-          const adjustedFallbackCSS = fallbackMetrics
-            ? buildFallbackFontFace(family, fallbackMetrics)
-            : undefined;
+          let adjustedFallbackCSS: string | undefined;
+          if (validated.adjustFontFallback !== false) {
+            const { buildFallbackFontFace, getFallbackFontOverrideMetrics } =
+              await import("../build/google-fonts/fallback-metrics.js");
+            const fallbackMetrics = getFallbackFontOverrideMetrics(family);
+            adjustedFallbackCSS = fallbackMetrics
+              ? buildFallbackFontFace(family, fallbackMetrics)
+              : undefined;
+          }
           const validatedFontWeight =
             validated.weights.length === 1 && validated.weights[0] !== "variable"
               ? Number(validated.weights[0])

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -34,6 +34,7 @@ import MagicString from "magic-string";
 import { buildGoogleFontsUrl } from "../build/google-fonts/build-url.js";
 import { findFontFilesInCss } from "../build/google-fonts/find-font-files-in-css.js";
 import { ASSET_PREFIX_URL_DIR } from "../utils/asset-prefix.js";
+import { CONTENT_TYPES } from "../server/content-types.js";
 
 /**
  * Thrown when Google Fonts returns a non-2xx response. Distinct from a raw
@@ -88,11 +89,6 @@ const GOOGLE_FONT_UTILITY_EXPORTS = new Set([
  */
 const VINEXT_FONT_URL_NAMESPACE = "_vinext_fonts";
 const MAX_GOOGLE_FONTS_ERROR_BODY_LENGTH = 500;
-const FONT_CONTENT_TYPES: Record<string, string> = {
-  ".woff2": "font/woff2",
-  ".woff": "font/woff",
-  ".ttf": "font/ttf",
-};
 
 function formatGoogleFontsErrorBody(body: string): string {
   const trimmed = body.trim();
@@ -696,10 +692,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         fs.stat(filePath, (err, stat) => {
           if (err || !stat.isFile()) return next();
           const ext = path.extname(filePath).toLowerCase();
-          // Keep this local to avoid importing the production static-file server
-          // on every vinext() plugin load. fetchAndCacheFont only writes these
-          // font extensions, matching prod-server's MIME table for the same files.
-          res.setHeader("Content-Type", FONT_CONTENT_TYPES[ext] ?? "application/octet-stream");
+          res.setHeader("Content-Type", CONTENT_TYPES[ext] ?? "application/octet-stream");
           res.setHeader("Cache-Control", "no-cache");
           res.setHeader("Access-Control-Allow-Origin", "*");
           fs.createReadStream(filePath).pipe(res);

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -7,7 +7,6 @@ import { preinitModule } from "react-dom";
 import { Fragment, createElement as createReactElement, use } from "react";
 import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 import type { RenderToReadableStreamOptions } from "react-dom/server";
-import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server.edge";
 import clientReferences from "virtual:vite-rsc/client-references";
 import type { NavigationContext } from "vinext/shims/navigation-server";
 import {
@@ -58,6 +57,7 @@ import { ssrAppRouterInstance } from "./app-ssr-router-instance.js";
 // @ts-expect-error — resolved by the vinext build plugin in SSR environments.
 import pagesClientAssets from "virtual:vinext-pages-client-assets";
 import { setPagesClientAssets, type PagesClientAssets } from "./pages-client-assets.js";
+import { getReactNodeEnv, importWithReactNodeEnv } from "./react-renderer-env.js";
 
 setPagesClientAssets(pagesClientAssets as PagesClientAssets);
 
@@ -69,6 +69,8 @@ setPagesClientAssets(pagesClientAssets as PagesClientAssets);
 type SsrRenderOptions = RenderToReadableStreamOptions & {
   maxHeadersLength?: number;
 };
+type ReactDomServerEdge = typeof import("react-dom/server.edge");
+type RenderToStaticMarkup = ReactDomServerEdge["renderToStaticMarkup"];
 
 /**
  * Default cap for the preload `Link` header, matching Next.js's
@@ -91,14 +93,23 @@ export type FontData = {
 
 type StaticPrerender = typeof import("react-dom/static.edge").prerender;
 
+function getLoadedReactNodeEnv(): "development" | "production" {
+  return getReactNodeEnv(createReactElement);
+}
+
 function isReactDevelopmentRuntime(): boolean {
-  if (process.env.NODE_ENV === "production") {
-    return false;
-  }
-  if (process.env.NODE_ENV === "development") {
-    return true;
-  }
-  return Function.prototype.toString.call(createReactElement).includes("getOwner");
+  return getLoadedReactNodeEnv() === "development";
+}
+
+let reactDomServerEdgePromise: Promise<ReactDomServerEdge> | null = null;
+async function loadReactDomServerEdge(): Promise<ReactDomServerEdge> {
+  if (reactDomServerEdgePromise) return reactDomServerEdgePromise;
+
+  reactDomServerEdgePromise = importWithReactNodeEnv(
+    getLoadedReactNodeEnv(),
+    () => import("react-dom/server.edge"),
+  );
+  return reactDomServerEdgePromise;
 }
 
 function isStaticPrerenderModule(value: unknown): value is { prerender: StaticPrerender } {
@@ -176,6 +187,7 @@ function buildBootstrapModuleScript(bootstrapModuleUrl?: string, nonce?: string)
 }
 
 function renderSsrErrorDocumentShell(
+  renderToStaticMarkup: RenderToStaticMarkup,
   bootstrapModuleUrl?: string,
   nonce?: string,
 ): ReadableStream<Uint8Array> {
@@ -228,7 +240,10 @@ function getErrorMessage(error: unknown): string {
   return Object.prototype.toString.call(error);
 }
 
-function renderInsertedHtml(insertedElements: readonly unknown[]): string {
+function renderInsertedHtml(
+  renderToStaticMarkup: RenderToStaticMarkup,
+  insertedElements: readonly unknown[],
+): string {
   let insertedHTML = "";
 
   for (const element of insertedElements) {
@@ -435,6 +450,7 @@ export async function handleSsr(
         }
 
         let flightRoot: PromiseLike<AppWireElements> | null = null;
+        const { renderToReadableStream, renderToStaticMarkup } = await loadReactDomServerEdge();
 
         function VinextFlightRoot(): ReactNode {
           for (const moduleUrl of pagesClientAssets.appBootstrapPreinitModules ?? []) {
@@ -643,7 +659,11 @@ export async function handleSsr(
               throw error;
             }
             shellErrorRecovered = true;
-            htmlStream = renderSsrErrorDocumentShell(bootstrapModuleUrl, options?.scriptNonce);
+            htmlStream = renderSsrErrorDocumentShell(
+              renderToStaticMarkup,
+              bootstrapModuleUrl,
+              options?.scriptNonce,
+            );
           }
         }
 
@@ -674,7 +694,7 @@ export async function handleSsr(
         };
         let didInjectHeadHTML = false;
         const getInsertedHTML = (): string => {
-          const insertedHTML = renderInsertedHtml(renderServerInsertedHTML());
+          const insertedHTML = renderInsertedHtml(renderToStaticMarkup, renderServerInsertedHTML());
           const errorMetaHTML = errorMetaRenderer.flush();
           const initialDevServerErrorHTML = createInitialDevServerErrorScript(
             options?.initialDevServerError,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -57,7 +57,7 @@ import { ssrAppRouterInstance } from "./app-ssr-router-instance.js";
 // @ts-expect-error — resolved by the vinext build plugin in SSR environments.
 import pagesClientAssets from "virtual:vinext-pages-client-assets";
 import { setPagesClientAssets, type PagesClientAssets } from "./pages-client-assets.js";
-import { getReactNodeEnv, importWithReactNodeEnv } from "./react-renderer-env.js";
+import { getReactNodeEnv, importReactDomServerEdge } from "./react-renderer-env.js";
 
 setPagesClientAssets(pagesClientAssets as PagesClientAssets);
 
@@ -105,10 +105,7 @@ let reactDomServerEdgePromise: Promise<ReactDomServerEdge> | null = null;
 async function loadReactDomServerEdge(): Promise<ReactDomServerEdge> {
   if (reactDomServerEdgePromise) return reactDomServerEdgePromise;
 
-  reactDomServerEdgePromise = importWithReactNodeEnv(
-    getLoadedReactNodeEnv(),
-    () => import("react-dom/server.edge"),
-  );
+  reactDomServerEdgePromise = importReactDomServerEdge(getLoadedReactNodeEnv());
   return reactDomServerEdgePromise;
 }
 

--- a/packages/vinext/src/server/content-types.ts
+++ b/packages/vinext/src/server/content-types.ts
@@ -1,0 +1,35 @@
+/**
+ * Canonical Content-Type lookup for static assets, keyed by lowercase file
+ * extension (with leading dot).
+ *
+ * Split out from `static-file-cache.ts` so consumers that only need the MIME
+ * table — e.g. the font dev-serving middleware in `plugins/fonts.ts` — can
+ * import it without pulling in the production static-file cache, its startup
+ * directory walk, and Node fs/path dependencies. `static-file-cache.ts`
+ * re-exports this so existing importers keep working; this module is the
+ * single source of truth.
+ */
+
+/** Content-type lookup for static assets. */
+export const CONTENT_TYPES: Record<string, string> = {
+  ".js": "application/javascript",
+  ".mjs": "application/javascript",
+  ".css": "text/css",
+  ".html": "text/html",
+  ".json": "application/json",
+  ".txt": "text/plain; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".eot": "application/vnd.ms-fontobject",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".map": "application/json",
+  ".rsc": "text/x-component",
+};

--- a/packages/vinext/src/server/image-optimization-paths.ts
+++ b/packages/vinext/src/server/image-optimization-paths.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical image-optimization endpoint constants and predicate.
+ *
+ * Split out from `image-optimization.ts` so the cheap path facts can be
+ * imported on hot request paths (e.g. the dev-server passthrough in
+ * `index.ts`) without pulling in the full optimization handler, format
+ * negotiation, and security-header machinery. `image-optimization.ts`
+ * re-exports these so existing importers of `vinext/server/image-optimization`
+ * keep working — this module is the single source of truth.
+ */
+
+/** The pathname that triggers image optimization (matches Next.js). */
+export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
+
+/**
+ * Vinext-prefixed alias for the image optimization endpoint. Accepted
+ * alongside IMAGE_OPTIMIZATION_PATH so apps that wire image URLs to the
+ * vinext-prefixed path continue to work; emit IMAGE_OPTIMIZATION_PATH
+ * for any newly generated URLs.
+ */
+export const VINEXT_IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
+
+/** Returns true when `pathname` is either supported image optimization endpoint. */
+export function isImageOptimizationPath(pathname: string): boolean {
+  return pathname === IMAGE_OPTIMIZATION_PATH || pathname === VINEXT_IMAGE_OPTIMIZATION_PATH;
+}

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -19,21 +19,14 @@
 
 import { badRequestResponse } from "./http-error-responses.js";
 
-/** The pathname that triggers image optimization (matches Next.js). */
-export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
-
-/**
- * Vinext-prefixed alias for the image optimization endpoint. Accepted
- * alongside IMAGE_OPTIMIZATION_PATH so apps that wire image URLs to the
- * vinext-prefixed path continue to work; emit IMAGE_OPTIMIZATION_PATH
- * for any newly generated URLs.
- */
-export const VINEXT_IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
-
-/** Returns true when `pathname` is either supported image optimization endpoint. */
-export function isImageOptimizationPath(pathname: string): boolean {
-  return pathname === IMAGE_OPTIMIZATION_PATH || pathname === VINEXT_IMAGE_OPTIMIZATION_PATH;
-}
+// Endpoint constants and predicate live in a tiny standalone module so the
+// dev-server passthrough (and any other hot path) can gate on them without
+// importing this full handler. Re-exported here for existing importers.
+export {
+  IMAGE_OPTIMIZATION_PATH,
+  VINEXT_IMAGE_OPTIMIZATION_PATH,
+  isImageOptimizationPath,
+} from "./image-optimization-paths.js";
 
 /**
  * Image security configuration from next.config.js `images` section.

--- a/packages/vinext/src/server/react-renderer-env.ts
+++ b/packages/vinext/src/server/react-renderer-env.ts
@@ -1,25 +1,63 @@
 export type ReactNodeEnv = "development" | "production";
 
+type ReactDomServerEdge = typeof import("react-dom/server.edge");
+
+/**
+ * Detect whether the *already-loaded* React runtime is a development or
+ * production build by inspecting `createElement`'s source: dev builds carry
+ * owner-tracking (`getOwner`) that production builds strip. This is the source
+ * of truth for which `react-dom/server.edge` flavor must be loaded, because a
+ * bundled React's flavor is fixed at build time and can differ from the
+ * runtime `process.env.NODE_ENV` (e.g. a prod server bundle that externalizes
+ * a development React).
+ */
 export function getReactNodeEnv(createElement: unknown): ReactNodeEnv {
   return Function.prototype.toString.call(createElement).includes("getOwner")
     ? "development"
     : "production";
 }
 
-export async function importWithReactNodeEnv<T>(
+/**
+ * Load `react-dom/server.edge` in the build flavor matching the loaded React
+ * runtime (`reactNodeEnv`, from {@link getReactNodeEnv}). Mismatched flavors
+ * crash at render time (`dispatcher.getOwner is not a function` when a dev
+ * React renders through a prod react-dom), so the two must agree.
+ *
+ * `react-dom/server.edge` is a CommonJS wrapper that selects its development or
+ * production build from `process.env.NODE_ENV` *at module-eval time*. React
+ * exposes no per-flavor entrypoint to import directly — the underlying builds
+ * are absent from the package `exports` map (importing them throws
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED`) — so the only lever is the `NODE_ENV` the
+ * wrapper reads while it evaluates.
+ *
+ * The renderer is loaded via the bundler-visible dynamic `import()` (never a
+ * raw `createRequire`): the app's React lives in the bundle's module graph, and
+ * a `require()` would pull a *separate* react-dom/React copy outside that graph,
+ * reintroducing the dispatcher mismatch this function exists to prevent. That
+ * keeps the load in-graph but also means the wrapper evaluates asynchronously,
+ * so `NODE_ENV` cannot be set purely synchronously around it.
+ *
+ * When the runtime `NODE_ENV` already matches the loaded flavor — the steady
+ * state in dev and in bundled runtimes (Workers) where `NODE_ENV` is fixed at
+ * build time — no swap happens and there is no global side effect. Only on a
+ * genuine mismatch is `NODE_ENV` temporarily realigned for the wrapper and
+ * restored in `finally`. Callers memoize this loader, so any swap occurs at
+ * most once per process, for the duration of a single module evaluation.
+ */
+export async function importReactDomServerEdge(
   reactNodeEnv: ReactNodeEnv,
-  load: () => Promise<T>,
-): Promise<T> {
+): Promise<ReactDomServerEdge> {
   const env = typeof process !== "undefined" && process.env ? process.env : null;
   const previousNodeEnv = env?.NODE_ENV;
-  if (env && previousNodeEnv !== reactNodeEnv) {
+  const mustSwap = env != null && previousNodeEnv !== reactNodeEnv;
+
+  if (mustSwap) {
     env.NODE_ENV = reactNodeEnv;
   }
-
   try {
-    return await load();
+    return await import("react-dom/server.edge");
   } finally {
-    if (env) {
+    if (mustSwap) {
       if (previousNodeEnv === undefined) {
         delete env.NODE_ENV;
       } else {

--- a/packages/vinext/src/server/react-renderer-env.ts
+++ b/packages/vinext/src/server/react-renderer-env.ts
@@ -1,0 +1,30 @@
+export type ReactNodeEnv = "development" | "production";
+
+export function getReactNodeEnv(createElement: unknown): ReactNodeEnv {
+  return Function.prototype.toString.call(createElement).includes("getOwner")
+    ? "development"
+    : "production";
+}
+
+export async function importWithReactNodeEnv<T>(
+  reactNodeEnv: ReactNodeEnv,
+  load: () => Promise<T>,
+): Promise<T> {
+  const env = typeof process !== "undefined" && process.env ? process.env : null;
+  const previousNodeEnv = env?.NODE_ENV;
+  if (env && previousNodeEnv !== reactNodeEnv) {
+    env.NODE_ENV = reactNodeEnv;
+  }
+
+  try {
+    return await load();
+  } finally {
+    if (env) {
+      if (previousNodeEnv === undefined) {
+        delete env.NODE_ENV;
+      } else {
+        env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  }
+}

--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -16,29 +16,11 @@ import path from "node:path";
 import { ASSET_PREFIX_URL_DIR } from "../utils/asset-prefix.js";
 import { normalizePathSeparators } from "../utils/path.js";
 
-/** Content-type lookup for static assets. Shared with prod-server.ts. */
-export const CONTENT_TYPES: Record<string, string> = {
-  ".js": "application/javascript",
-  ".mjs": "application/javascript",
-  ".css": "text/css",
-  ".html": "text/html",
-  ".json": "application/json",
-  ".txt": "text/plain; charset=utf-8",
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".svg": "image/svg+xml",
-  ".ico": "image/x-icon",
-  ".woff": "font/woff",
-  ".woff2": "font/woff2",
-  ".ttf": "font/ttf",
-  ".eot": "application/vnd.ms-fontobject",
-  ".webp": "image/webp",
-  ".avif": "image/avif",
-  ".map": "application/json",
-  ".rsc": "text/x-component",
-};
+// Content-type lookup lives in a tiny standalone module so MIME-only consumers
+// (e.g. the font dev middleware) need not import this cache. Re-exported here
+// for existing importers such as prod-server.ts.
+import { CONTENT_TYPES } from "./content-types.js";
+export { CONTENT_TYPES };
 
 /**
  * Files below this size are buffered in memory at startup for zero-syscall

--- a/tests/react-renderer-env.test.ts
+++ b/tests/react-renderer-env.test.ts
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getReactNodeEnv,
+  importReactDomServerEdge,
+} from "../packages/vinext/src/server/react-renderer-env.js";
+
+describe("getReactNodeEnv", () => {
+  it("classifies a getOwner-carrying createElement as development", () => {
+    expect(getReactNodeEnv(() => "uses getOwner internally")).toBe("development");
+  });
+
+  it("classifies a stripped createElement as production", () => {
+    expect(getReactNodeEnv(() => "no owner tracking")).toBe("production");
+  });
+
+  it("classifies the actually-loaded React runtime", () => {
+    const env = getReactNodeEnv(React.createElement);
+    expect(env === "development" || env === "production").toBe(true);
+  });
+});
+
+describe("importReactDomServerEdge", () => {
+  // `process.env.NODE_ENV` is typed read-only under the test tsconfig; mutate
+  // through a mutable view, the same shape the loader narrows it to.
+  const procEnv = process.env as Record<string, string | undefined>;
+  const original = procEnv.NODE_ENV;
+  afterEach(() => {
+    if (original === undefined) {
+      delete procEnv.NODE_ENV;
+    } else {
+      procEnv.NODE_ENV = original;
+    }
+  });
+
+  it("loads the server renderer", async () => {
+    const mod = await importReactDomServerEdge(getReactNodeEnv(React.createElement));
+    expect(typeof mod.renderToReadableStream).toBe("function");
+  });
+
+  it("leaves NODE_ENV untouched on the fast path (already matching)", async () => {
+    procEnv.NODE_ENV = "production";
+    await importReactDomServerEdge("production");
+    expect(procEnv.NODE_ENV).toBe("production");
+  });
+
+  it("restores a defined NODE_ENV after realigning for a mismatch", async () => {
+    procEnv.NODE_ENV = "renderer-env-sentinel";
+    await importReactDomServerEdge("production");
+    expect(procEnv.NODE_ENV).toBe("renderer-env-sentinel");
+  });
+
+  it("restores NODE_ENV to undefined when it was unset before the mismatch", async () => {
+    delete procEnv.NODE_ENV;
+    await importReactDomServerEdge("production");
+    expect(procEnv.NODE_ENV).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Keep `vinext` CLI/plugin startup from evaluating command-, build-, and request-specific modules before they are needed. |
| Core change | Move heavyweight imports behind cached dynamic imports at command dispatch, Vite hook, or request-branch boundaries. |
| Boundary | This PR is the lazy import-graph cleanup only. The App Router optimizer-entry cold-start optimization is split to #2210. |
| Primary files | `packages/vinext/src/cli.ts`, `packages/vinext/src/index.ts`, `packages/vinext/src/plugins/fonts.ts`, `packages/vinext/src/server/app-ssr-entry.ts`, `packages/vinext/src/entries/pages-server-entry.ts`, `packages/vinext/src/server/react-renderer-env.ts` |

## Why

The CLI and plugin entrypoints sit on the unavoidable startup path. They should not evaluate deploy, build, Pages SSR, API, image, font metadata, typegen, static-export, or build-only CSS asset repair implementations before the selected command, hook, or request path actually needs them.

This cleanup makes those ownership boundaries explicit. It also removes one incidental correctness dependency: SSR/static-export renderer loading now matches the React runtime flavor already loaded in the process instead of relying on an eager dev-server import side effect.

## What changed

| Surface | Before | After |
| --- | --- | --- |
| CLI dispatch | Importing the CLI eagerly pulled in the plugin and most command implementations. | Command modules load only after the command is known; build-only imports are warmed concurrently once `build` is selected. |
| Plugin startup | Dev startup loaded many build-only or request-specific helpers. | Pages entry generation, typegen, deploy checks, image optimization, API handling, SSR dev server creation, static export, build manifests, inline CSS, precompression, and CSS URL asset repair are imported at the hook/request branch that owns them. |
| Font plugin | Registering `next/font/google` support loaded Google font metadata immediately. | Google font validation, axes, and fallback metrics load only when CSS injection needs them. |
| React renderer | Static `react-dom/server.edge` imports masked runtime flavor coupling. | `react-renderer-env` loads the renderer under the already-loaded React dev/prod flavor. |

## Performance

The previous CodSpeed result for this split PR showed this import-graph cleanup is small on the official benchmark by itself: dev cold start moved from `2.39 s` to `2.37 s` (`-0.7%`), below the `1.5%` reporting threshold.

This branch now also defers the build-only CSS URL asset helper from plugin startup. I expect that to be a small incremental improvement, not a headline change. The larger App Router cold-start optimization, focused `optimizeDeps.entries`, is in #2210.

## Validation

- `vp check packages/vinext/src/index.ts`
- `vp check packages/vinext/src/cli.ts packages/vinext/src/index.ts packages/vinext/src/plugins/fonts.ts packages/vinext/src/entries/pages-server-entry.ts packages/vinext/src/server/app-ssr-entry.ts packages/vinext/src/server/react-renderer-env.ts`
- `vp test run tests/cli-args.test.ts tests/entry-templates.test.ts`
- `vp test run tests/css-url-assets.test.ts tests/route-classification-injector.test.ts tests/build-time-classification-integration.test.ts`
- `vp run vinext#build`
- Earlier before the split:
  - `vp test run tests/static-export.test.ts`

## Risk / compatibility

- Public API: no intended API changes.
- Runtime: dynamic imports are cached and remain behind the same observable command, hook, or request branches.
- Build behavior: CSS URL repair still runs only in `apply: "build"` hooks; the implementation module now loads on first matching build hook instead of during dev/plugin startup.
- Dev/prod parity: the renderer helper is the main guard; it prevents prod SSR/static export from depending on an unrelated eager import.
- Review shape: this PR is intentionally separated from #2210 so each optimization can be measured independently.
