### PR TITLE
fix(perf): resolve Vite from benchmark target root

### DIFF
--- a/benchmarks/perf/bundle-size.mjs
+++ b/benchmarks/perf/bundle-size.mjs
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 
 import { lstat, readdir, readFile, realpath } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { gzipSync } from "node:zlib";
-import { parseAst } from "vite";
 import { reportPerformanceSample } from "./report-sample.mjs";
 
 const repositoryRoot = process.env.VINEXT_PERF_TARGET_ROOT ?? process.cwd();
 const benchmarkDir = join(repositoryRoot, "benchmarks");
+const requireFromRepositoryRoot = createRequire(join(repositoryRoot, "package.json"));
 const framework = process.argv[2];
 const target = process.argv[3] ?? "client";
+let parseAstPromise;
 
 if (framework !== "vinext" && framework !== "nextjs") {
   console.error(
@@ -23,6 +25,12 @@ if (!["client", "client-entry", "rsc-entry", "server"].includes(target)) {
 }
 if (framework === "nextjs" && target !== "client") {
   throw new Error(`Bundle target ${target} is only defined for vinext`);
+}
+
+async function parseJavaScriptAst(source) {
+  parseAstPromise ??= import(requireFromRepositoryRoot.resolve("vite")).then((mod) => mod.parseAst);
+  const parseAst = await parseAstPromise;
+  return parseAst(source);
 }
 
 const outputPath =
@@ -131,7 +139,7 @@ async function gzipStaticEntryClosure(entryPath) {
 
     const source = await readFile(resolvedFilePath, "utf8");
     gzipBytes += gzipSync(source).length;
-    const ast = parseAst(source);
+    const ast = await parseJavaScriptAst(source);
     for (const statement of ast.body) {
       if (
         statement.type !== "ImportDeclaration" &&


### PR DESCRIPTION
## Summary

- resolve `vite` for the bundle-size benchmark from `VINEXT_PERF_TARGET_ROOT` instead of the copied harness directory
- lazily load `parseAst` only for the RSC static entry closure path
- keep the trusted temp harness runnable without its own `node_modules`

## Why

Fork PR performance runs execute benchmark scripts from `$RUNNER_TEMP/vinext-perf-harness` while measuring a separate target checkout through `VINEXT_PERF_TARGET_ROOT`. `bundle-size.mjs` had a top-level `import { parseAst } from "vite"`, so Node tried to resolve `vite` from the temp harness copy and failed before the bundle-size scenario could run.

This is currently blocking the Performance scenarios check on #2209 with:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite' imported from .../_temp/vinext-perf-harness/benchmarks/perf/bundle-size.mjs
```

## Verification

- `vp check benchmarks/perf/bundle-size.mjs`
- copied `benchmarks/perf/bundle-size.mjs` and `report-sample.mjs` to a temp directory with no local `node_modules`, then ran:
  - `node $tmpdir/benchmarks/perf/bundle-size.mjs vinext client` with `VINEXT_PERF_TARGET_ROOT=$PWD` and required perf env vars: emitted a client gzip sample
  - `node $tmpdir/benchmarks/perf/bundle-size.mjs vinext rsc-entry` with `VINEXT_PERF_TARGET_ROOT=$PWD` and required perf env vars: emitted an RSC entry gzip sample

## Note

Because this changes trusted perf harness code from a fork, this PR may still be subject to the fork benchmark-input guard until a maintainer lands or reruns it from a trusted branch. Once this is on `main`, #2209 can be rerun against a base harness that resolves dependencies correctly.
