### PR TITLE
fix(pages): preserve middleware response metadata in hybrid routes

### DIFF
--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -1,6 +1,7 @@
 import type { AppMiddlewareContext } from "./app-middleware.js";
 import { pagesRouteHasPriorityOverAppRoute } from "./hybrid-route-priority.js";
 import { cloneRequestWithHeaders, cloneRequestWithUrl } from "./request-pipeline.js";
+import { mergeHeaders } from "./worker-utils.js";
 
 export type PagesEntry = {
   handleApiRoute?: (request: Request, url: string) => Promise<Response> | Response;
@@ -176,9 +177,27 @@ export async function renderPagesFallback(
       );
   if (pagesRes.status === 404 && pageMatch === null) return null;
   return applyDraftModeCookie(
-    applyRouteHandlerMiddlewareContext(pagesRes, middlewareContext),
+    mergePagesResponseWithMiddleware(pagesRes, middlewareContext),
     getDraftModeCookieHeader(),
   );
+}
+
+export function mergePagesResponseWithMiddleware(
+  response: Response,
+  middlewareContext: Pick<AppMiddlewareContext, "headers" | "status">,
+): Response {
+  if (!middlewareContext.headers && middlewareContext.status == null) return response;
+
+  const middlewareHeaders: Record<string, string | string[]> = {};
+  if (middlewareContext.headers) {
+    middlewareContext.headers.forEach((value, key) => {
+      if (key !== "set-cookie") middlewareHeaders[key] = value;
+    });
+    const cookies = middlewareContext.headers.getSetCookie?.() ?? [];
+    if (cookies.length > 0) middlewareHeaders["set-cookie"] = cookies;
+  }
+
+  return mergeHeaders(response, middlewareHeaders, middlewareContext.status ?? undefined);
 }
 
 /**

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -175,7 +175,10 @@ export async function renderPagesFallback(
         middlewareContext.requestHeaders,
       );
   if (pagesRes.status === 404 && pageMatch === null) return null;
-  return applyDraftModeCookie(pagesRes, getDraftModeCookieHeader());
+  return applyDraftModeCookie(
+    applyRouteHandlerMiddlewareContext(pagesRes, middlewareContext),
+    getDraftModeCookieHeader(),
+  );
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,6 +1449,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/og-font-package: {}
+
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -1,9 +1,100 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  mergePagesResponseWithMiddleware,
   renderPagesFallback,
   type PagesEntry,
 } from "../packages/vinext/src/server/app-pages-bridge.js";
 import type { AppMiddlewareContext } from "../packages/vinext/src/server/app-middleware.js";
+
+describe("mergePagesResponseWithMiddleware", () => {
+  it("lets the page response win singular header conflicts", () => {
+    const merged = mergePagesResponseWithMiddleware(
+      new Response("page", {
+        headers: {
+          "cache-control": "private, no-store",
+          "content-type": "text/html; charset=utf-8",
+          "x-shared": "page",
+        },
+      }),
+      {
+        headers: new Headers({
+          "cache-control": "public, max-age=60",
+          "content-type": "application/json",
+          "x-middleware": "present",
+          "x-shared": "middleware",
+        }),
+        status: null,
+      },
+    );
+
+    expect(merged.headers.get("cache-control")).toBe("private, no-store");
+    expect(merged.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(merged.headers.get("x-shared")).toBe("page");
+    expect(merged.headers.get("x-middleware")).toBe("present");
+  });
+
+  it("preserves page and middleware Set-Cookie headers", () => {
+    const responseHeaders = new Headers();
+    responseHeaders.append("set-cookie", "page=1; Path=/");
+    responseHeaders.append("set-cookie", "page-two=2; Path=/");
+    const middlewareHeaders = new Headers();
+    middlewareHeaders.append("set-cookie", "middleware=1; Path=/");
+    middlewareHeaders.append("set-cookie", "middleware-two=2; Path=/");
+
+    const merged = mergePagesResponseWithMiddleware(
+      new Response("page", { headers: responseHeaders }),
+      { headers: middlewareHeaders, status: null },
+    );
+
+    expect(merged.headers.getSetCookie()).toEqual([
+      "middleware=1; Path=/",
+      "middleware-two=2; Path=/",
+      "page=1; Path=/",
+      "page-two=2; Path=/",
+    ]);
+  });
+
+  it("uses middleware status while preserving a normal page body", async () => {
+    const merged = mergePagesResponseWithMiddleware(new Response("page", { status: 200 }), {
+      headers: null,
+      status: 202,
+    });
+
+    expect(merged.status).toBe(202);
+    expect(await merged.text()).toBe("page");
+  });
+
+  it("preserves page redirects and errors without a middleware status override", async () => {
+    const redirect = mergePagesResponseWithMiddleware(
+      new Response(null, { status: 307, headers: { location: "/page" } }),
+      { headers: new Headers({ location: "/middleware" }), status: null },
+    );
+    const error = mergePagesResponseWithMiddleware(
+      new Response("page error", { status: 500, headers: { "content-type": "text/plain" } }),
+      { headers: new Headers({ "x-middleware": "present" }), status: null },
+    );
+
+    expect(redirect.status).toBe(307);
+    expect(redirect.headers.get("location")).toBe("/page");
+    expect(error.status).toBe(500);
+    expect(await error.text()).toBe("page error");
+  });
+
+  it("drops the page body for a no-body middleware status", async () => {
+    const merged = mergePagesResponseWithMiddleware(
+      new Response("page", {
+        headers: { "content-type": "text/html", "content-length": "4" },
+      }),
+      { headers: new Headers({ "x-middleware": "present" }), status: 204 },
+    );
+
+    expect(merged.status).toBe(204);
+    expect(merged.body).toBeNull();
+    expect(merged.headers.get("content-type")).toBeNull();
+    expect(merged.headers.get("content-length")).toBeNull();
+    expect(await merged.text()).toBe("");
+  });
+});
 
 describe("renderPagesFallback", () => {
   const defaultDeps = {
@@ -404,40 +495,43 @@ describe("renderPagesFallback", () => {
     expect(await res!.text()).toBe("page-response");
   });
 
-  it("applies middleware response headers to Pages fallback page responses", async () => {
-    const renderPage = vi.fn(
-      () =>
-        new Response("page-response", {
-          headers: { "x-page-header": "page" },
-        }),
-    );
-    const middlewareHeaders = new Headers({
-      "set-cookie": "middleware=1; Path=/",
-      "x-from-middleware": "present",
+  it("uses Pages merge semantics in the production fallback bridge", async () => {
+    const applyRouteHandlerMiddlewareContext = vi.fn(() => {
+      throw new Error("Pages responses must not use App Route merge semantics");
     });
+    const responseHeaders = new Headers({ location: "/page", "x-shared": "page" });
+    responseHeaders.append("set-cookie", "page=1; Path=/");
+    const middlewareHeaders = new Headers({
+      location: "/middleware",
+      "x-middleware": "present",
+      "x-shared": "middleware",
+    });
+    middlewareHeaders.append("set-cookie", "middleware=1; Path=/");
 
     const res = await renderPagesFallback(
       {
         isRscRequest: false,
-        middlewareContext: {
-          headers: middlewareHeaders,
-          requestHeaders: null,
-          status: 202,
-        },
-        request: new Request("http://localhost/pages/middleware-headers-node"),
-        url: new URL("http://localhost/pages/middleware-headers-node"),
+        middlewareContext: { headers: middlewareHeaders, requestHeaders: null, status: null },
+        request: new Request("http://localhost/page"),
+        url: new URL("http://localhost/page"),
       },
       {
         ...defaultDeps,
-        loadPagesEntry: () => ({ renderPage }),
+        applyRouteHandlerMiddlewareContext,
+        loadPagesEntry: () => ({
+          matchPageRoute: () => ({ route: { isDynamic: false, pattern: "/page" } }),
+          renderPage: () => new Response(null, { status: 307, headers: responseHeaders }),
+        }),
       },
     );
 
     expect(res).not.toBeNull();
-    expect(res!.status).toBe(202);
-    expect(res!.headers.get("x-page-header")).toBe("page");
-    expect(res!.headers.get("x-from-middleware")).toBe("present");
-    expect(res!.headers.getSetCookie()).toContain("middleware=1; Path=/");
+    expect(res!.status).toBe(307);
+    expect(res!.headers.get("location")).toBe("/page");
+    expect(res!.headers.get("x-shared")).toBe("page");
+    expect(res!.headers.get("x-middleware")).toBe("present");
+    expect(res!.headers.getSetCookie()).toEqual(["middleware=1; Path=/", "page=1; Path=/"]);
+    expect(applyRouteHandlerMiddlewareContext).not.toHaveBeenCalled();
   });
 
   it("filters static and dynamic Pages matches by ownership phase", async () => {

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -404,6 +404,42 @@ describe("renderPagesFallback", () => {
     expect(await res!.text()).toBe("page-response");
   });
 
+  it("applies middleware response headers to Pages fallback page responses", async () => {
+    const renderPage = vi.fn(
+      () =>
+        new Response("page-response", {
+          headers: { "x-page-header": "page" },
+        }),
+    );
+    const middlewareHeaders = new Headers({
+      "set-cookie": "middleware=1; Path=/",
+      "x-from-middleware": "present",
+    });
+
+    const res = await renderPagesFallback(
+      {
+        isRscRequest: false,
+        middlewareContext: {
+          headers: middlewareHeaders,
+          requestHeaders: null,
+          status: 202,
+        },
+        request: new Request("http://localhost/pages/middleware-headers-node"),
+        url: new URL("http://localhost/pages/middleware-headers-node"),
+      },
+      {
+        ...defaultDeps,
+        loadPagesEntry: () => ({ renderPage }),
+      },
+    );
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(202);
+    expect(res!.headers.get("x-page-header")).toBe("page");
+    expect(res!.headers.get("x-from-middleware")).toBe("present");
+    expect(res!.headers.getSetCookie()).toContain("middleware=1; Path=/");
+  });
+
   it("filters static and dynamic Pages matches by ownership phase", async () => {
     const renderPage = vi.fn(() => new Response("page"));
     const request = new Request("http://localhost/blog/hello");

--- a/tests/e2e/app-router/headers-cookies.spec.ts
+++ b/tests/e2e/app-router/headers-cookies.spec.ts
@@ -150,6 +150,18 @@ test.describe("Middleware header/cookie behavior (OpenNext compat)", () => {
     expect(apiRes.headers()["x-mw-ran"]).toBeUndefined();
   });
 
+  test("middleware response headers reach hybrid Pages Router pages", async ({ request }) => {
+    // Ported from Next.js: test/e2e/import-conditions/import-conditions.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/import-conditions/import-conditions.test.ts
+    for (const pathname of ["/pages/middleware-headers-node", "/pages/middleware-headers-edge"]) {
+      const response = await request.get(`${BASE}${pathname}`);
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()["x-mw-ran"]).toBe("true");
+      expect(response.headers()["x-mw-pathname"]).toBe(pathname);
+    }
+  });
+
   test("request headers available in server component RSC rendering", async ({ request }) => {
     // Ref: opennextjs-cloudflare headers.test.ts "Request header should be available in RSC"
     const res = await request.get(`${BASE}/headers-test`, {

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -363,6 +363,8 @@ export const config = {
     "/api/pages-og",
     "/header-override-after-prior-access",
     "/pages-header-override-delete",
+    "/pages/middleware-headers-node",
+    "/pages/middleware-headers-edge",
     "/revalidate-test",
     "/script-nonce/:path*",
     "/script-manual-nonce",

--- a/tests/fixtures/app-basic/pages/pages/middleware-headers-edge.tsx
+++ b/tests/fixtures/app-basic/pages/pages/middleware-headers-edge.tsx
@@ -1,0 +1,7 @@
+export const config = {
+  runtime: "experimental-edge",
+};
+
+export default function PagesMiddlewareHeadersEdge() {
+  return <h1>Pages middleware headers edge</h1>;
+}

--- a/tests/fixtures/app-basic/pages/pages/middleware-headers-node.tsx
+++ b/tests/fixtures/app-basic/pages/pages/middleware-headers-node.tsx
@@ -1,0 +1,7 @@
+export const config = {
+  runtime: "nodejs",
+};
+
+export default function PagesMiddlewareHeadersNode() {
+  return <h1>Pages middleware headers node</h1>;
+}


### PR DESCRIPTION
## Summary

- preserve middleware-only headers and status on Pages routes rendered through the App/Pages bridge
- let page-owned headers win conflicts while keeping cookies additive
- cover node and edge hybrid Pages routes plus production merge semantics

## Next.js parity

Addresses the Pages Router middleware-header failures exposed by `test/e2e/import-conditions/import-conditions.test.ts`. The export-condition failures themselves are covered separately by #2035.

## Validation

- `vp test run tests/app-pages-bridge.test.ts` — 26 passed
- focused hybrid Pages Playwright assertion — passed with one worker
- targeted format, lint, and type checks
- independent review loop — clean

Full suites are deferred to CI.