### PR TITLE
fix(middleware): preserve Pages rewrite state and cache isolation

### DIFF
--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -557,7 +557,6 @@ import type { PagesPipelineDeps } from "vinext/server/pages-request-pipeline";
 import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isImageOptimizationPath } from "vinext/server/image-optimization";
 import type { ImageConfig } from "vinext/server/image-optimization";
 import { cloneRequestWithHeaders, cloneRequestWithUrl, filterInternalHeaders, isOpenRedirectShaped } from "vinext/server/request-pipeline";
-import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses";
 import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix";
 import { hasBasePath, stripBasePath } from "vinext/utils/base-path";
 
@@ -622,9 +621,7 @@ export default {
       // by Cloudflare's ASSETS binding BEFORE the worker runs; only misses
       // reach this code. Matches Next.js (#1337):
       //   packages/next/src/server/lib/router-server.ts
-      if (isNextStaticPath(pathname, basePath, assetPathPrefix)) {
-        return notFoundStaticAssetResponse();
-      }
+      const initialStaticAssetMiss = isNextStaticPath(pathname, basePath, assetPathPrefix);
 
       // Strip internal headers from inbound requests so they cannot be
       // forged to influence routing or impersonate internal state.
@@ -685,6 +682,8 @@ export default {
         configRewrites,
         configHeaders,
         hadBasePath,
+        assetPathPrefix,
+        initialStaticAssetMiss,
         isDataReq,
         isDataRequest: isDataReq,
         ctx,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4287,6 +4287,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   req.__vinextMiddlewareStatus,
                   pipelineResult.isDataReq,
                   originalRequestUrl,
+                  pipelineResult.renderOptions?.hasMiddlewareRewrite === true,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -29,6 +29,7 @@ import {
   findFileWithExts,
 } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
+import { getPagesMiddlewareRewriteCacheState } from "./server/pages-middleware-rewrite-cache.js";
 import { handleApiRoute } from "./server/api-handler.js";
 import {
   DEFAULT_DEVICE_SIZES,
@@ -4280,6 +4281,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 }
                 // Update req.url to the resolved URL so SSR sees the post-mw path
                 req.url = pipelineResult.resolvedUrl;
+                const hasMiddlewareRewrite =
+                  pipelineResult.renderOptions?.hasMiddlewareRewrite === true;
                 await cachedSSRHandler.handler(
                   req,
                   res,
@@ -4287,7 +4290,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   req.__vinextMiddlewareStatus,
                   pipelineResult.isDataReq,
                   originalRequestUrl,
-                  pipelineResult.renderOptions?.hasMiddlewareRewrite === true,
+                  hasMiddlewareRewrite
+                    ? getPagesMiddlewareRewriteCacheState(
+                        pipelineResult.resolvedUrl,
+                        hasMiddlewareRewrite,
+                      )
+                    : undefined,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -34,6 +34,7 @@ import {
   findFileWithExts,
 } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
+import { getPagesMiddlewareRewriteCacheState } from "./server/pages-middleware-rewrite-cache.js";
 import { handleApiRoute } from "./server/api-handler.js";
 import {
   DEFAULT_DEVICE_SIZES,
@@ -5528,6 +5529,8 @@ export const loadServerActionClient = ${
                 }
                 // Update req.url to the resolved URL so SSR sees the post-mw path
                 req.url = pipelineResult.resolvedUrl;
+                const hasMiddlewareRewrite =
+                  pipelineResult.renderOptions?.hasMiddlewareRewrite === true;
                 await cachedSSRHandler.handler(
                   req,
                   res,
@@ -5535,6 +5538,12 @@ export const loadServerActionClient = ${
                   req.__vinextMiddlewareStatus,
                   pipelineResult.isDataReq,
                   originalRequestUrl,
+                  hasMiddlewareRewrite
+                    ? getPagesMiddlewareRewriteCacheState(
+                        pipelineResult.resolvedUrl,
+                        hasMiddlewareRewrite,
+                      )
+                    : undefined,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -994,14 +994,13 @@ export function createSSRHandler(
           // Font modules not loaded yet — skip
         }
 
-        if (
-          typeof pageModule.getStaticProps === "function" &&
-          !isFallbackRender &&
-          !hasMiddlewareRewrite
-        ) {
+        if (typeof pageModule.getStaticProps === "function" && !isFallbackRender) {
           // Check ISR cache before calling getStaticProps
           const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
-          const cached = await isrGet(cacheKey);
+          // Next.js dev always executes getStaticProps. Middleware rewrites
+          // additionally bypass vinext's dev ISR cache so query-varying
+          // rewrites cannot reuse or persist another request's page data.
+          const cached = hasMiddlewareRewrite ? null : await isrGet(cacheKey);
 
           // On-demand revalidation request (`res.revalidate()` from an API
           // route sets the `x-prerender-revalidate` header to the process

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -73,6 +73,7 @@ import {
 } from "./pages-get-initial-props.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
+import type { PagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -474,7 +475,7 @@ export function createSSRHandler(
      */
     isDataReq: boolean = false,
     originalUrl: string = url,
-    hasMiddlewareRewrite = false,
+    middlewareRewriteCacheState?: PagesMiddlewareRewriteCacheState,
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -541,6 +542,9 @@ export function createSSRHandler(
           )
       : (pathname: string) => isrCacheKey("pages", pathname, process.env.__VINEXT_BUILD_ID);
 
+    const hasMiddlewareRewrite = middlewareRewriteCacheState !== undefined;
+    const rewriteCachePathname = middlewareRewriteCacheState?.cachePathname ?? url.split("?")[0];
+    const bypassMiddlewareRewriteCache = middlewareRewriteCacheState?.bypassCdnCache === true;
     const match = matchRoute(localeStrippedUrl, routes);
 
     if (!match) {
@@ -785,8 +789,10 @@ export function createSSRHandler(
           const userAgent = Array.isArray(userAgentHeader) ? userAgentHeader[0] : userAgentHeader;
           const isBotRequest = !!userAgent && isBotUserAgent(userAgent, htmlLimitedBots);
           if (fallback === true && !isValidPath && !isDataReq && !isBotRequest) {
-            const fallbackCacheKey = pagesIsrCacheKey(url.split("?")[0]);
-            const generatedEntry = hasMiddlewareRewrite ? null : await isrGet(fallbackCacheKey);
+            const fallbackCacheKey = pagesIsrCacheKey(rewriteCachePathname);
+            const generatedEntry = bypassMiddlewareRewriteCache
+              ? null
+              : await isrGet(fallbackCacheKey);
             isFallbackRender = generatedEntry?.value.value?.kind !== "PAGES";
             if (isFallbackRender && typeof routerShim.setSSRContext === "function") {
               routerShim.setSSRContext({
@@ -996,11 +1002,11 @@ export function createSSRHandler(
 
         if (typeof pageModule.getStaticProps === "function" && !isFallbackRender) {
           // Check ISR cache before calling getStaticProps
-          const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
+          const cacheKey = pagesIsrCacheKey(rewriteCachePathname);
           // Next.js dev always executes getStaticProps. Middleware rewrites
           // additionally bypass vinext's dev ISR cache so query-varying
           // rewrites cannot reuse or persist another request's page data.
-          const cached = hasMiddlewareRewrite ? null : await isrGet(cacheKey);
+          const cached = bypassMiddlewareRewriteCache ? null : await isrGet(cacheKey);
 
           // On-demand revalidation request (`res.revalidate()` from an API
           // route sets the `x-prerender-revalidate` header to the process
@@ -1428,8 +1434,8 @@ export function createSSRHandler(
         // by getServerSideProps (cookies, status codes, etc.) are preserved
         // because we already let gSSP mutate `res` above.
         if (isDataReq) {
-          if (shouldPersistFallbackData && !hasMiddlewareRewrite) {
-            const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
+          if (shouldPersistFallbackData && !bypassMiddlewareRewriteCache) {
+            const cacheKey = pagesIsrCacheKey(rewriteCachePathname);
             const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
             await isrSet(
               cacheKey,
@@ -1453,7 +1459,7 @@ export function createSSRHandler(
               dataHeaders[k] = v;
             }
           }
-          if (hasMiddlewareRewrite && typeof pageModule.getStaticProps === "function") {
+          if (bypassMiddlewareRewriteCache && typeof pageModule.getStaticProps === "function") {
             dataHeaders["Cache-Control"] = "no-cache, must-revalidate";
           }
           // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
@@ -1707,7 +1713,7 @@ hydrate();
         const extraHeaders: Record<string, string | string[]> = {
           ...gsspExtraHeaders,
         };
-        if (hasMiddlewareRewrite && typeof pageModule.getStaticProps === "function") {
+        if (bypassMiddlewareRewriteCache && typeof pageModule.getStaticProps === "function") {
           extraHeaders["Cache-Control"] = "no-cache, must-revalidate";
         } else if (isrRevalidateSeconds) {
           if (scriptNonce) {
@@ -1813,7 +1819,7 @@ hydrate();
           !scriptNonce &&
           isrRevalidateSeconds !== null &&
           isrRevalidateSeconds > 0 &&
-          !hasMiddlewareRewrite
+          !bypassMiddlewareRewriteCache
         ) {
           let isrElement = AppComponent
             ? createElement(AppComponent, {
@@ -1829,7 +1835,7 @@ hydrate();
             withScriptNonce(isrElement, scriptNonce),
           );
           const isrHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${isrBodyHtml}</div>${allScripts}</body></html>`;
-          const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
+          const cacheKey = pagesIsrCacheKey(rewriteCachePathname);
           await isrSet(cacheKey, buildPagesCacheValue(isrHtml, pageProps), isrRevalidateSeconds);
           setRevalidateDuration(cacheKey, isrRevalidateSeconds);
         }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -474,6 +474,7 @@ export function createSSRHandler(
      */
     isDataReq: boolean = false,
     originalUrl: string = url,
+    hasMiddlewareRewrite = false,
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -617,6 +618,8 @@ export function createSSRHandler(
         // Load the page module through Vite's SSR pipeline
         // This gives us HMR and transform support for free
         const pageModule = await importModule(runner, route.filePath);
+        const nextDataQuery =
+          typeof pageModule.getStaticProps === "function" && !hasMiddlewareRewrite ? params : query;
         // Try to load _app.tsx if it exists. This happens before the readiness
         // predicate so app-level getInitialProps participates in the same
         // initial Pages Router state as the client __NEXT_DATA__ payload.
@@ -783,7 +786,7 @@ export function createSSRHandler(
           const isBotRequest = !!userAgent && isBotUserAgent(userAgent, htmlLimitedBots);
           if (fallback === true && !isValidPath && !isDataReq && !isBotRequest) {
             const fallbackCacheKey = pagesIsrCacheKey(url.split("?")[0]);
-            const generatedEntry = await isrGet(fallbackCacheKey);
+            const generatedEntry = hasMiddlewareRewrite ? null : await isrGet(fallbackCacheKey);
             isFallbackRender = generatedEntry?.value.value?.kind !== "PAGES";
             if (isFallbackRender && typeof routerShim.setSSRContext === "function") {
               routerShim.setSSRContext({
@@ -991,7 +994,11 @@ export function createSSRHandler(
           // Font modules not loaded yet — skip
         }
 
-        if (typeof pageModule.getStaticProps === "function" && !isFallbackRender) {
+        if (
+          typeof pageModule.getStaticProps === "function" &&
+          !isFallbackRender &&
+          !hasMiddlewareRewrite
+        ) {
           // Check ISR cache before calling getStaticProps
           const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
           const cached = await isrGet(cacheKey);
@@ -1234,7 +1241,7 @@ export function createSSRHandler(
                         {
                           props: freshRenderProps,
                           page: patternToNextFormat(route.pattern),
-                          query: params,
+                          query: nextDataQuery,
                           buildId: process.env.__VINEXT_BUILD_ID,
                           isFallback: false,
                           locale: locale ?? currentDefaultLocale,
@@ -1422,7 +1429,7 @@ export function createSSRHandler(
         // by getServerSideProps (cookies, status codes, etc.) are preserved
         // because we already let gSSP mutate `res` above.
         if (isDataReq) {
-          if (shouldPersistFallbackData) {
+          if (shouldPersistFallbackData && !hasMiddlewareRewrite) {
             const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
             const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
             await isrSet(
@@ -1657,7 +1664,7 @@ hydrate();
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: params,
+            query: nextDataQuery,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,
@@ -1699,7 +1706,7 @@ hydrate();
           ...gsspExtraHeaders,
         };
         if (isrRevalidateSeconds) {
-          if (scriptNonce) {
+          if (scriptNonce || hasMiddlewareRewrite) {
             extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
           } else {
             extraHeaders["Cache-Control"] = buildMissIsrCacheControl(isrRevalidateSeconds);
@@ -1798,7 +1805,12 @@ hydrate();
         // If ISR is enabled, we need the full HTML for caching.
         // For ISR, re-render synchronously to get the complete HTML string.
         // This runs after the stream is already sent, so it doesn't affect TTFB.
-        if (!scriptNonce && isrRevalidateSeconds !== null && isrRevalidateSeconds > 0) {
+        if (
+          !scriptNonce &&
+          isrRevalidateSeconds !== null &&
+          isrRevalidateSeconds > 0 &&
+          !hasMiddlewareRewrite
+        ) {
           let isrElement = AppComponent
             ? createElement(AppComponent, {
                 ...renderProps,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1453,6 +1453,9 @@ export function createSSRHandler(
               dataHeaders[k] = v;
             }
           }
+          if (hasMiddlewareRewrite && typeof pageModule.getStaticProps === "function") {
+            dataHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
+          }
           // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
           // every _next/data response so the client router can detect a new
           // deployment and trigger a hard navigation (deployment-skew
@@ -1704,8 +1707,10 @@ hydrate();
         const extraHeaders: Record<string, string | string[]> = {
           ...gsspExtraHeaders,
         };
-        if (isrRevalidateSeconds) {
-          if (scriptNonce || hasMiddlewareRewrite) {
+        if (hasMiddlewareRewrite && typeof pageModule.getStaticProps === "function") {
+          extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
+        } else if (isrRevalidateSeconds) {
+          if (scriptNonce) {
             extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
           } else {
             extraHeaders["Cache-Control"] = buildMissIsrCacheControl(isrRevalidateSeconds);

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1454,7 +1454,7 @@ export function createSSRHandler(
             }
           }
           if (hasMiddlewareRewrite && typeof pageModule.getStaticProps === "function") {
-            dataHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
+            dataHeaders["Cache-Control"] = "no-cache, must-revalidate";
           }
           // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
           // every _next/data response so the client router can detect a new
@@ -1708,7 +1708,7 @@ hydrate();
           ...gsspExtraHeaders,
         };
         if (hasMiddlewareRewrite && typeof pageModule.getStaticProps === "function") {
-          extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
+          extraHeaders["Cache-Control"] = "no-cache, must-revalidate";
         } else if (isrRevalidateSeconds) {
           if (scriptNonce) {
             extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -87,6 +87,7 @@ import {
   type PagesPreviewState,
 } from "./pages-preview.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
+import type { PagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -696,6 +697,7 @@ export function createSSRHandler(
      */
     isDataReq: boolean = false,
     originalUrl: string = url,
+    middlewareRewriteCacheState?: PagesMiddlewareRewriteCacheState,
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -865,7 +867,7 @@ export function createSSRHandler(
         const isStaticPropsRender =
           typeof pageModule.getStaticProps === "function" &&
           typeof pageModule.getServerSideProps !== "function";
-        if (isStaticPropsRender) {
+        if (isStaticPropsRender && !middlewareRewriteCacheState) {
           // Match Next.js's Pages handler: getStaticProps renders receive only
           // route params and a resolved asPath without request search state.
           query = mergeRouteParamsIntoQuery({}, params);
@@ -1589,7 +1591,7 @@ export function createSSRHandler(
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: isFallbackRender ? {} : params,
+            query: isFallbackRender ? {} : query,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/pages-i18n.ts
+++ b/packages/vinext/src/server/pages-i18n.ts
@@ -115,7 +115,10 @@ export function extractLocaleFromUrl(
 
   if (parts.length > 0 && i18nConfig.locales.includes(parts[0])) {
     const locale = parts[0];
-    const rest = "/" + parts.slice(1).join("/");
+    // Slice the locale prefix from the original pathname so significant path
+    // spelling such as a configured trailing slash survives normalization.
+    // This mirrors Next.js' normalizeLocalePath() behavior.
+    const rest = pathname.slice(locale.length + 1) || "/";
     return { locale, url: (rest || "/") + query, hadPrefix: true };
   }
 

--- a/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
+++ b/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
@@ -1,0 +1,20 @@
+export type PagesMiddlewareRewriteCacheState = {
+  cachePathname: string;
+  bypassCdnCache: boolean;
+};
+
+export function getPagesMiddlewareRewriteCacheState(
+  routeUrl: string,
+  hasMiddlewareRewrite: boolean,
+): PagesMiddlewareRewriteCacheState {
+  const url = new URL(routeUrl, "http://vinext.local");
+  if (!hasMiddlewareRewrite || !url.search) {
+    return { cachePathname: url.pathname || "/", bypassCdnCache: false };
+  }
+
+  url.searchParams.sort();
+  return {
+    cachePathname: `${url.pathname || "/"}?${url.searchParams.toString()}`,
+    bypassCdnCache: true,
+  };
+}

--- a/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
+++ b/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
@@ -1,7 +1,15 @@
+import type { isrGet, isrSet } from "./isr-cache.js";
+
 export type PagesMiddlewareRewriteCacheState = {
   cachePathname: string;
   bypassCdnCache: boolean;
+  /** Query-specific SSR state must not be read from or written to the shared origin ISR cache. */
+  bypassOriginCache: boolean;
 };
+
+/** Request-local cache dependencies for query-varying middleware rewrites. */
+export const bypassedPagesIsrGet: typeof isrGet = async () => null;
+export const bypassedPagesIsrSet: typeof isrSet = async () => {};
 
 export function getPagesMiddlewareRewriteCacheState(
   routeUrl: string,
@@ -9,12 +17,17 @@ export function getPagesMiddlewareRewriteCacheState(
 ): PagesMiddlewareRewriteCacheState {
   const url = new URL(routeUrl, "http://vinext.local");
   if (!hasMiddlewareRewrite || !url.search) {
-    return { cachePathname: url.pathname || "/", bypassCdnCache: false };
+    return {
+      cachePathname: url.pathname || "/",
+      bypassCdnCache: false,
+      bypassOriginCache: false,
+    };
   }
 
   url.searchParams.sort();
   return {
     cachePathname: `${url.pathname || "/"}?${url.searchParams.toString()}`,
     bypassCdnCache: true,
+    bypassOriginCache: true,
   };
 }

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -4,7 +4,7 @@ import type { Route } from "../routing/pages-router.js";
 import { normalizeStaticPathname } from "../routing/route-pattern.js";
 import type { CachedPagesValue, CacheControlMetadata } from "vinext/shims/cache-handler";
 import { applyCdnResponseHeaders } from "./cache-control.js";
-import { decideIsr } from "./isr-decision.js";
+import { decideIsr, ISR_NO_STORE_CACHE_CONTROL } from "./isr-decision.js";
 import { buildCacheStateHeaders } from "./cache-headers.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import {
@@ -199,7 +199,8 @@ export type ResolvePagesPageDataOptions = {
   params: Record<string, unknown>;
   query: Record<string, unknown>;
   nextDataQuery?: Record<string, unknown>;
-  bypassIsrHtmlCache?: boolean;
+  isrCachePathname?: string;
+  bypassCdnCache?: boolean;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -483,6 +484,7 @@ function buildPagesCacheResponse(
   expireSeconds?: number,
   cacheControl?: CacheControlMetadata,
   status?: number,
+  bypassCdnCache?: boolean,
 ): Response {
   // Legacy cache entries written before cacheControl metadata existed can still
   // hit this path without a persisted revalidate value; keep the historic
@@ -502,7 +504,11 @@ function buildPagesCacheResponse(
     "Content-Type": "text/html",
     ...buildCacheStateHeaders(cacheState),
   });
-  applyCdnResponseHeaders(headers, { cacheControl: cacheControlHeader });
+  if (bypassCdnCache) {
+    headers.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
+  } else {
+    applyCdnResponseHeaders(headers, { cacheControl: cacheControlHeader });
+  }
 
   if (fontLinkHeader) {
     headers.set("Link", fontLinkHeader);
@@ -680,10 +686,8 @@ export async function resolvePagesPageData(
   }
 
   if (isFallback) {
-    const pathname = options.routeUrl.split("?")[0];
-    const cached = options.bypassIsrHtmlCache
-      ? null
-      : await options.isrGet(options.isrCacheKey("pages", pathname));
+    const pathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
+    const cached = await options.isrGet(options.isrCacheKey("pages", pathname));
     if (cached?.value.value?.kind !== "PAGES") {
       const appShortCircuit = await loadForegroundAppInitialRenderProps();
       if (appShortCircuit) return appShortCircuit;
@@ -766,9 +770,9 @@ export async function resolvePagesPageData(
   let isrRevalidateSeconds: number | null = null;
 
   if (typeof options.pageModule.getStaticProps === "function") {
-    const pathname = options.routeUrl.split("?")[0];
+    const pathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", pathname);
-    const cached = options.bypassIsrHtmlCache ? null : await options.isrGet(cacheKey);
+    const cached = await options.isrGet(cacheKey);
     const cachedValue = cached?.value.value;
 
     // On-demand revalidation (`res.revalidate()`) must regenerate the entry
@@ -794,6 +798,7 @@ export async function resolvePagesPageData(
         options.expireSeconds,
         cached.value.cacheControl,
         cachedValue.status,
+        options.bypassCdnCache,
       );
       // Bot / crawler ETag consistency: attach an ETag to cache-HIT responses
       // for bot UAs so they are consistent with fresh-MISS bot responses (which
@@ -901,6 +906,7 @@ export async function resolvePagesPageData(
         options.expireSeconds,
         cached.value.cacheControl,
         cachedValue.status,
+        options.bypassCdnCache,
       );
       // Bot / crawler ETag consistency: same as the HIT branch — attach an
       // ETag to STALE responses for bot UAs and honour If-None-Match / 304.
@@ -977,7 +983,7 @@ export async function resolvePagesPageData(
       isrRevalidateSeconds = cached?.value.cacheControl?.revalidate ?? 31_536_000;
     }
 
-    if (shouldPersistFallbackData && !options.bypassIsrHtmlCache) {
+    if (shouldPersistFallbackData) {
       const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
       await options.isrSet(
         cacheKey,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -124,6 +124,8 @@ type RenderPagesIsrHtmlOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  query: Record<string, unknown>;
+  nextDataQuery?: Record<string, unknown>;
   renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
   routePattern: string;
   safeJsonStringify: (value: unknown) => string;
@@ -196,6 +198,8 @@ export type ResolvePagesPageDataOptions = {
   AppComponent?: unknown;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
+  nextDataQuery?: Record<string, unknown>;
+  bypassIsrHtmlCache?: boolean;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -587,6 +591,7 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.nextDataQuery ?? options.params,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     // Serialize the same readiness flags (gssp/gsp/autoExport/…) the initial
@@ -676,7 +681,9 @@ export async function resolvePagesPageData(
 
   if (isFallback) {
     const pathname = options.routeUrl.split("?")[0];
-    const cached = await options.isrGet(options.isrCacheKey("pages", pathname));
+    const cached = options.bypassIsrHtmlCache
+      ? null
+      : await options.isrGet(options.isrCacheKey("pages", pathname));
     if (cached?.value.value?.kind !== "PAGES") {
       const appShortCircuit = await loadForegroundAppInitialRenderProps();
       if (appShortCircuit) return appShortCircuit;
@@ -761,7 +768,7 @@ export async function resolvePagesPageData(
   if (typeof options.pageModule.getStaticProps === "function") {
     const pathname = options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", pathname);
-    const cached = await options.isrGet(cacheKey);
+    const cached = options.bypassIsrHtmlCache ? null : await options.isrGet(cacheKey);
     const cachedValue = cached?.value.value;
 
     // On-demand revalidation (`res.revalidate()`) must regenerate the entry
@@ -860,6 +867,8 @@ export async function resolvePagesPageData(
                 pageProps: freshPageProps,
                 props: freshRenderProps,
                 params: options.params,
+                query: options.query,
+                nextDataQuery: options.nextDataQuery,
                 renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
                 routePattern: options.routePattern,
                 safeJsonStringify: options.safeJsonStringify,
@@ -968,7 +977,7 @@ export async function resolvePagesPageData(
       isrRevalidateSeconds = cached?.value.cacheControl?.revalidate ?? 31_536_000;
     }
 
-    if (shouldPersistFallbackData) {
+    if (shouldPersistFallbackData && !options.bypassIsrHtmlCache) {
       const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
       await options.isrSet(
         cacheKey,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -38,6 +38,7 @@ import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { isDangerousScheme } from "vinext/shims/url-safety";
 import { encodeCacheTag } from "../utils/encode-cache-tag.js";
+import { bypassedPagesIsrGet, bypassedPagesIsrSet } from "./pages-middleware-rewrite-cache.js";
 
 export type PagesRedirectResult = {
   destination: string;
@@ -316,6 +317,8 @@ export type ResolvePagesPageDataOptions = {
   query: Record<string, unknown>;
   nextDataQuery?: Record<string, unknown>;
   bypassCdnCache?: boolean;
+  /** Skip shared origin ISR reads and writes for request-specific rewrite state. */
+  bypassOriginCache?: boolean;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -1060,6 +1063,8 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
 export async function resolvePagesPageData(
   options: ResolvePagesPageDataOptions,
 ): Promise<ResolvePagesPageDataResult> {
+  const requestIsrGet = options.bypassOriginCache ? bypassedPagesIsrGet : options.isrGet;
+  const requestIsrSet = options.bypassOriginCache ? bypassedPagesIsrSet : options.isrSet;
   // Next.js passes `params: null` (effectively) to gSSP/gSP context for
   // non-dynamic routes — see render.tsx's `...(pageIsDynamic ? { params } : undefined)`.
   // Internal bookkeeping (route param hydration, ISR HTML, getStaticPaths
@@ -1130,7 +1135,7 @@ export async function resolvePagesPageData(
     options.revalidateOnlyGenerated
   ) {
     const pathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
-    onDemandPreviousCacheEntry = await options.isrGet(options.isrCacheKey("pages", pathname));
+    onDemandPreviousCacheEntry = await requestIsrGet(options.isrCacheKey("pages", pathname));
     if (!onDemandPreviousCacheEntry) {
       return {
         kind: "response",
@@ -1177,7 +1182,7 @@ export async function resolvePagesPageData(
 
   if (isFallback) {
     const pathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
-    const cached = await options.isrGet(options.isrCacheKey("pages", pathname));
+    const cached = await requestIsrGet(options.isrCacheKey("pages", pathname));
     if (cached?.value.value?.kind !== "PAGES") {
       const appShortCircuit = await loadForegroundAppInitialRenderProps();
       if (appShortCircuit) return appShortCircuit;
@@ -1270,7 +1275,7 @@ export async function resolvePagesPageData(
     const cached =
       onDemandPreviousCacheEntry !== undefined
         ? onDemandPreviousCacheEntry
-        : await options.isrGet(cacheKey);
+        : await requestIsrGet(cacheKey);
     const cachedValue = cached?.value.value;
     const isLegacyCachedNotFound =
       cachedValue?.kind === "PAGES" &&
@@ -1311,7 +1316,7 @@ export async function resolvePagesPageData(
                 routeUrl: options.routeUrl,
                 sanitizeDestination: options.sanitizeDestination,
               });
-              await options.isrSet(
+              await requestIsrSet(
                 cacheKey,
                 {
                   kind: "REDIRECT",
@@ -1325,7 +1330,7 @@ export async function resolvePagesPageData(
             }
 
             if (freshResult.notFound) {
-              await options.isrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
+              await requestIsrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
               return;
             }
 
@@ -1353,7 +1358,7 @@ export async function resolvePagesPageData(
                 nextData: options.nextData,
                 vinext: options.vinext,
               });
-              await options.isrSet(
+              await requestIsrSet(
                 cacheKey,
                 buildPagesCacheValue(freshHtml, freshRenderProps, options.statusCode),
                 revalidateSeconds,
@@ -1366,7 +1371,7 @@ export async function resolvePagesPageData(
             // A cached redirect/not-found has no reusable HTML shell. Persist
             // the resolved props and let the next foreground request render
             // the canonical PAGES representation without re-running user code.
-            await options.isrSet(
+            await requestIsrSet(
               cacheKey,
               {
                 kind: "PAGES",
@@ -1598,7 +1603,7 @@ export async function resolvePagesPageData(
           routeUrl: options.routeUrl,
           sanitizeDestination: options.sanitizeDestination,
         });
-        await options.isrSet(
+        await requestIsrSet(
           cacheKey,
           {
             kind: "REDIRECT",
@@ -1620,7 +1625,7 @@ export async function resolvePagesPageData(
       const revalidateSeconds = resolvePagesRevalidateSeconds(result, options.routeUrl);
       const expireSeconds = resolvePagesExpireSeconds(result, options.expireSeconds);
       if (previewData === false) {
-        await options.isrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
+        await requestIsrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
       }
       const notFoundResult = buildPagesNotFoundResult(
         options,
@@ -1670,7 +1675,7 @@ export async function resolvePagesPageData(
 
     if (shouldPersistFallbackData && previewData === false) {
       const revalidateSeconds = isrRevalidateSeconds ?? false;
-      await options.isrSet(
+      await requestIsrSet(
         cacheKey,
         {
           kind: "PAGES",

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -1346,6 +1346,7 @@ export async function resolvePagesPageData(
                 pageProps: freshPageProps,
                 props: freshRenderProps,
                 params: options.params,
+                nextDataQuery: options.nextDataQuery,
                 renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
                 routePattern: options.routePattern,
                 safeJsonStringify: options.safeJsonStringify,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -10,7 +10,7 @@ import type {
   CacheControlMetadata,
 } from "vinext/shims/cache-handler";
 import { applyCdnResponseHeaders } from "./cache-control.js";
-import { buildMissIsrCacheControl, decideIsr } from "./isr-decision.js";
+import { buildMissIsrCacheControl, decideIsr, ISR_NO_STORE_CACHE_CONTROL } from "./isr-decision.js";
 import { buildCacheStateHeaders } from "./cache-headers.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import type { PagesPreviewData } from "./pages-preview.js";
@@ -230,6 +230,7 @@ type RenderPagesIsrHtmlOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  nextDataQuery?: Record<string, unknown>;
   renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
   routePattern: string;
   safeJsonStringify: (value: unknown) => string;
@@ -313,6 +314,8 @@ export type ResolvePagesPageDataOptions = {
   router?: PagesGetInitialPropsRouter;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
+  nextDataQuery?: Record<string, unknown>;
+  bypassCdnCache?: boolean;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -449,8 +452,15 @@ function applyCachedPagesRepresentationHeaders(
   response: Response,
   cacheState: "HIT" | "STALE",
   entry: CacheHandlerValue,
-  options: Pick<ResolvePagesPageDataOptions, "expireSeconds">,
+  options: Pick<ResolvePagesPageDataOptions, "expireSeconds" | "bypassCdnCache">,
 ): Response {
+  if (options.bypassCdnCache) {
+    response.headers.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
+    for (const [name, value] of Object.entries(buildCacheStateHeaders(cacheState))) {
+      response.headers.set(name, value);
+    }
+    return response;
+  }
   const { cacheControl } = decideIsr({
     cacheState,
     kind: "pages",
@@ -906,6 +916,7 @@ function buildPagesCacheResponse(
   cacheControl?: CacheControlMetadata,
   status?: number,
   cachedHeaders?: Record<string, string | string[]>,
+  bypassCdnCache?: boolean,
 ): Response {
   // Legacy cache entries written before cacheControl metadata existed can still
   // hit this path without a persisted revalidate value; keep the historic
@@ -925,7 +936,11 @@ function buildPagesCacheResponse(
     "Content-Type": "text/html; charset=utf-8",
     ...buildCacheStateHeaders(cacheState),
   });
-  applyCdnResponseHeaders(headers, { cacheControl: cacheControlHeader });
+  if (bypassCdnCache) {
+    headers.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
+  } else {
+    applyCdnResponseHeaders(headers, { cacheControl: cacheControlHeader });
+  }
 
   if (fontLinkHeader) {
     headers.set("Link", fontLinkHeader);
@@ -1029,6 +1044,7 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.nextDataQuery,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     // Serialize the same readiness flags (gssp/gsp/autoExport/…) the initial
@@ -1439,6 +1455,7 @@ export async function resolvePagesPageData(
         cached.value.cacheControl,
         cachedValue.status,
         cachedValue.headers,
+        options.bypassCdnCache,
       );
       // Bot / crawler ETag consistency: attach an ETag to cache-HIT responses
       // for bot UAs so they are consistent with fresh-MISS bot responses (which
@@ -1518,6 +1535,7 @@ export async function resolvePagesPageData(
         cached.value.cacheControl,
         cachedValue.status,
         cachedValue.headers,
+        options.bypassCdnCache,
       );
       // Bot / crawler ETag consistency: same as the HIT branch — attach an
       // ETag to STALE responses for bot UAs and honour If-None-Match / 304.

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -179,6 +179,7 @@ export type CreatePagesPageHandlerOptions = {
 // Internal render options (mirrors the options shape passed to `renderPage`).
 type RenderPageOptions = {
   isDataReq?: boolean;
+  hasMiddlewareRewrite?: boolean;
   statusCode?: number;
   asPath?: string;
   originalUrl?: string;
@@ -418,13 +419,16 @@ export function createPagesPageHandler(
         const routePattern = patternToNextFormat(route.pattern);
         const renderStatusCode =
           renderStatusCodeOverride ?? (routePattern === "/404" ? 404 : undefined);
+        const pageModule = route.module;
         const query = mergeRouteParamsIntoQuery(parseQuery(routeUrl), params);
+        const hasRewriteQuery = options?.hasMiddlewareRewrite === true;
+        const nextDataQuery =
+          typeof pageModule.getStaticProps === "function" && !hasRewriteQuery ? params : query;
 
         // Model Pages Router readiness for `next/navigation` compat hooks. The
         // serialized `__NEXT_DATA__` flags (gssp/gsp/gip/appGip/autoExport) plus
         // the configured-rewrites flag decide the initial `router.isReady` value,
         // mirroring Next.js's Pages adapter. See server/render.tsx readiness rule.
-        const pageModule = route.module;
         const pagesNextData = buildPagesReadinessNextData({
           pageModule,
           appComponent: AppComponent as { getInitialProps?: unknown } | null,
@@ -584,6 +588,8 @@ export function createPagesPageHandler(
           AppComponent,
           params,
           query,
+          nextDataQuery,
+          bypassIsrHtmlCache: hasRewriteQuery,
           asPath: renderAsPath ?? routeUrl,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
@@ -745,7 +751,8 @@ export function createPagesPageHandler(
           pageProps,
           props: renderProps,
           params,
-          query,
+          query: nextDataQuery,
+          bypassIsrHtmlCache: hasRewriteQuery,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -89,6 +89,22 @@ type VinextConfigSubset = {
   disableOptimizedLoading: boolean;
 };
 
+export function getPagesMiddlewareRewriteCacheState(
+  routeUrl: string,
+  hasMiddlewareRewrite: boolean,
+): { cachePathname: string; bypassCdnCache: boolean } {
+  const url = new URL(routeUrl, "http://vinext.local");
+  if (!hasMiddlewareRewrite || !url.search) {
+    return { cachePathname: url.pathname || "/", bypassCdnCache: false };
+  }
+
+  url.searchParams.sort();
+  return {
+    cachePathname: `${url.pathname || "/"}?${url.searchParams.toString()}`,
+    bypassCdnCache: true,
+  };
+}
+
 /**
  * Options accepted by `createPagesPageHandler`.
  *
@@ -422,6 +438,7 @@ export function createPagesPageHandler(
         const pageModule = route.module;
         const query = mergeRouteParamsIntoQuery(parseQuery(routeUrl), params);
         const hasRewriteQuery = options?.hasMiddlewareRewrite === true;
+        const rewriteCacheState = getPagesMiddlewareRewriteCacheState(routeUrl, hasRewriteQuery);
         const nextDataQuery =
           typeof pageModule.getStaticProps === "function" && !hasRewriteQuery ? params : query;
 
@@ -589,7 +606,8 @@ export function createPagesPageHandler(
           params,
           query,
           nextDataQuery,
-          bypassIsrHtmlCache: hasRewriteQuery,
+          isrCachePathname: rewriteCacheState.cachePathname,
+          bypassCdnCache: rewriteCacheState.bypassCdnCache,
           asPath: renderAsPath ?? routeUrl,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
@@ -752,7 +770,8 @@ export function createPagesPageHandler(
           props: renderProps,
           params,
           query: nextDataQuery,
-          bypassIsrHtmlCache: hasRewriteQuery,
+          isrCachePathname: rewriteCacheState.cachePathname,
+          bypassCdnCache: rewriteCacheState.bypassCdnCache,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -22,6 +22,7 @@ import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { renderPagesPageResponse } from "./pages-page-response.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
+import { getPagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
 import {
@@ -48,6 +49,8 @@ import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js"
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
+
+export { getPagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,22 +91,6 @@ type VinextConfigSubset = {
   clientTraceMetadata?: readonly string[];
   disableOptimizedLoading: boolean;
 };
-
-export function getPagesMiddlewareRewriteCacheState(
-  routeUrl: string,
-  hasMiddlewareRewrite: boolean,
-): { cachePathname: string; bypassCdnCache: boolean } {
-  const url = new URL(routeUrl, "http://vinext.local");
-  if (!hasMiddlewareRewrite || !url.search) {
-    return { cachePathname: url.pathname || "/", bypassCdnCache: false };
-  }
-
-  url.searchParams.sort();
-  return {
-    cachePathname: `${url.pathname || "/"}?${url.searchParams.toString()}`,
-    bypassCdnCache: true,
-  };
-}
 
 /**
  * Options accepted by `createPagesPageHandler`.

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -27,7 +27,11 @@ import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { renderPagesPageResponse } from "./pages-page-response.js";
-import { getPagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
+import {
+  bypassedPagesIsrGet,
+  bypassedPagesIsrSet,
+  getPagesMiddlewareRewriteCacheState,
+} from "./pages-middleware-rewrite-cache.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
@@ -121,8 +125,20 @@ function applyPagesErrorCachePolicy(
   revalidateSeconds: number | false | undefined,
   expireSeconds: number | undefined,
   cacheTagPathname: string,
+  bypassSharedCache = false,
 ): Response {
   const headers = new Headers(response.headers);
+  if (bypassSharedCache) {
+    headers.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
+    headers.delete("CDN-Cache-Control");
+    headers.delete("Cloudflare-CDN-Cache-Control");
+    headers.delete("Cache-Tag");
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
   const browserPolicy = headers.get("Cache-Control");
   const sharedPolicies = [
     headers.get("CDN-Cache-Control"),
@@ -315,6 +331,8 @@ type RenderPageOptions = {
   __notFoundExpireSeconds?: number;
   /** Source-page identity used for the outgoing notFound cache tag. */
   __notFoundCachePathname?: string;
+  /** Keep a request-private source render and its nested error page out of shared caches. */
+  __bypassRequestCache?: boolean;
   /** Internal recursion guard while a top-level on-demand request owns the batch. */
   __skipOnDemandCoalesce?: boolean;
   err?: unknown;
@@ -613,6 +631,12 @@ export function createPagesPageHandler(
           renderRouteUrl,
           hasMiddlewareRewrite,
         );
+        const bypassOriginCache =
+          rewriteCacheState.bypassOriginCache || options?.__bypassRequestCache === true;
+        const bypassCdnCache =
+          rewriteCacheState.bypassCdnCache || options?.__bypassRequestCache === true;
+        const requestIsrGet = bypassOriginCache ? bypassedPagesIsrGet : isrGet;
+        const requestIsrSet = bypassOriginCache ? bypassedPagesIsrSet : isrSet;
         const isrCachePathname =
           isStaticPropsRender &&
           (routePattern === "/404" || routePattern === "/500" || routePattern === "/_error")
@@ -809,8 +833,8 @@ export function createPagesPageHandler(
           fontLinkHeader,
           i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
           isrCacheKey: pageIsrCacheKey,
-          isrGet,
-          isrSet,
+          isrGet: requestIsrGet,
+          isrSet: requestIsrSet,
           expireSeconds: vinextConfig.expireTime,
           isBuildTimePrerendering:
             typeof process !== "undefined" && process.env && process.env.VINEXT_PRERENDER === "1",
@@ -834,7 +858,8 @@ export function createPagesPageHandler(
           params,
           query,
           nextDataQuery: query,
-          bypassCdnCache: rewriteCacheState.bypassCdnCache,
+          bypassCdnCache,
+          bypassOriginCache,
           asPath: routerAsPath,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
@@ -879,6 +904,7 @@ export function createPagesPageHandler(
               __notFoundRevalidateSeconds: pageDataResult.revalidateSeconds,
               __notFoundExpireSeconds: pageDataResult.expireSeconds,
               __notFoundCachePathname: isrCachePathname,
+              __bypassRequestCache: bypassOriginCache || bypassCdnCache,
             });
           } else {
             notFoundResponse = buildDefaultPagesNotFoundResponse();
@@ -902,6 +928,7 @@ export function createPagesPageHandler(
               errorPageRevalidateSeconds,
               errorPageExpireSeconds,
               errorResponseCachePathname,
+              bypassCdnCache,
             );
           }
           return finalizePagesPreviewResponse(response, preview);
@@ -958,7 +985,7 @@ export function createPagesPageHandler(
               init.headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
             }
           }
-          if (rewriteCacheState.bypassCdnCache) {
+          if (bypassCdnCache) {
             init.headers["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
           } else if (gsspRes) {
             // Default Cache-Control for gSSP-driven _next/data responses —
@@ -1057,14 +1084,15 @@ export function createPagesPageHandler(
           isrRevalidateSeconds,
           isOnDemandRevalidate,
           isStaticPropsRoute,
-          isrSet,
+          isrSet: requestIsrSet,
           i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
           isFallback: isFallbackRender,
           pageProps,
           props: renderProps,
           params,
           query,
-          bypassCdnCache: rewriteCacheState.bypassCdnCache,
+          bypassCdnCache,
+          bypassOriginCache,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },
@@ -1088,6 +1116,7 @@ export function createPagesPageHandler(
             errorPageRevalidateSeconds,
             errorPageExpireSeconds,
             errorResponseCachePathname,
+            bypassCdnCache,
           );
         }
         return finalizePagesPreviewResponse(pageResponse, preview);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -69,7 +69,11 @@ import {
   NEXTJS_DEPLOYMENT_ID_HEADER,
   VINEXT_CACHE_HEADER,
 } from "./headers.js";
-import { buildMissIsrCacheControl, ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
+import {
+  buildMissIsrCacheControl,
+  ISR_NEVER_CACHE_CONTROL,
+  ISR_NO_STORE_CACHE_CONTROL,
+} from "./isr-decision.js";
 import { encodeCacheTag } from "../utils/encode-cache-tag.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
 import {
@@ -582,9 +586,10 @@ export function createPagesPageHandler(
     const hasMiddlewareRewrite = options?.hasMiddlewareRewrite === true;
     const renderRouteUrl =
       isStaticPropsRender && !hasMiddlewareRewrite ? routeUrl.split("?")[0] : routeUrl;
-    const routerAsPathSource = isStaticPropsRender
-      ? renderRouteUrl
-      : (renderAsPath ?? renderRouteUrl);
+    const routerAsPathSource =
+      isStaticPropsRender && !hasMiddlewareRewrite
+        ? renderRouteUrl
+        : (renderAsPath ?? renderRouteUrl);
     const routerAsPath = i18nConfig
       ? extractLocaleFromUrl(routerAsPathSource, i18nConfig, locale).url
       : routerAsPathSource;
@@ -953,7 +958,9 @@ export function createPagesPageHandler(
               init.headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
             }
           }
-          if (gsspRes) {
+          if (rewriteCacheState.bypassCdnCache) {
+            init.headers["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
+          } else if (gsspRes) {
             // Default Cache-Control for gSSP-driven _next/data responses —
             // skip when gSSP already set one via res.setHeader. Fixes #1461.
             let hasUserCacheControl = false;

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -27,6 +27,7 @@ import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { renderPagesPageResponse } from "./pages-page-response.js";
+import { getPagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
@@ -297,6 +298,7 @@ export type CreatePagesPageHandlerOptions = {
 // Internal render options (mirrors the options shape passed to `renderPage`).
 type RenderPageOptions = {
   isDataReq?: boolean;
+  hasMiddlewareRewrite?: boolean;
   statusCode?: number;
   asPath?: string;
   originalUrl?: string;
@@ -577,7 +579,9 @@ export function createPagesPageHandler(
     // Pages getStaticProps renders are shared by pathname. Match Next.js by
     // removing request search state before exposing the render URL or router
     // context; otherwise a cold/stale request can persist its query in ISR.
-    const renderRouteUrl = isStaticPropsRender ? routeUrl.split("?")[0] : routeUrl;
+    const hasMiddlewareRewrite = options?.hasMiddlewareRewrite === true;
+    const renderRouteUrl =
+      isStaticPropsRender && !hasMiddlewareRewrite ? routeUrl.split("?")[0] : routeUrl;
     const routerAsPathSource = isStaticPropsRender
       ? renderRouteUrl
       : (renderAsPath ?? renderRouteUrl);
@@ -600,11 +604,15 @@ export function createPagesPageHandler(
         // custom 404 module (and its getStaticProps) runs. Keep this separate
         // from routeUrl so router, _document, and getInitialProps contexts
         // continue to observe the original request-facing URL.
+        const rewriteCacheState = getPagesMiddlewareRewriteCacheState(
+          renderRouteUrl,
+          hasMiddlewareRewrite,
+        );
         const isrCachePathname =
           isStaticPropsRender &&
           (routePattern === "/404" || routePattern === "/500" || routePattern === "/_error")
             ? routePattern
-            : renderRouteUrl.split("?")[0];
+            : rewriteCacheState.cachePathname;
         const isNotFoundErrorRender =
           routePattern === "/404" || (routePattern === "/_error" && renderStatusCode === 404);
         const isStatusErrorRender =
@@ -820,6 +828,8 @@ export function createPagesPageHandler(
           router,
           params,
           query,
+          nextDataQuery: query,
+          bypassCdnCache: rewriteCacheState.bypassCdnCache,
           asPath: routerAsPath,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
@@ -1047,6 +1057,7 @@ export function createPagesPageHandler(
           props: renderProps,
           params,
           query,
+          bypassCdnCache: rewriteCacheState.bypassCdnCache,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -187,7 +187,8 @@ type RenderPagesPageResponseOptions = {
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
   query?: Record<string, unknown>;
-  bypassIsrHtmlCache?: boolean;
+  isrCachePathname?: string;
+  bypassCdnCache?: boolean;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -599,13 +600,12 @@ export async function renderPagesPageResponse(
     // later matches the cached __NEXT_DATA__ block via a bare <script> marker.
     !options.scriptNonce &&
     options.isrRevalidateSeconds !== null &&
-    options.isrRevalidateSeconds > 0 &&
-    !options.bypassIsrHtmlCache
+    options.isrRevalidateSeconds > 0
   ) {
     const cacheBodyStreamPair = bodyStream.tee();
     responseBodyStream = cacheBodyStreamPair[0];
     const cacheBodyStream = cacheBodyStreamPair[1];
-    const isrPathname = options.routeUrl.split("?")[0];
+    const isrPathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
     const cacheKey = options.isrCacheKey("pages", isrPathname);
 
     schedulePagesIsrCacheWrite({
@@ -637,7 +637,7 @@ export async function renderPagesPageResponse(
   // this point, so the captured value matches main's original capture site.
   const userSetCacheControl = responseHeaders.has("Cache-Control");
 
-  if (options.scriptNonce || options.bypassIsrHtmlCache) {
+  if (options.scriptNonce || options.bypassCdnCache) {
     responseHeaders.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
   } else if (options.isrRevalidateSeconds) {
     // Fresh ISR (MISS) response: route through the CDN adapter so edge adapters

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -187,6 +187,7 @@ type RenderPagesPageResponseOptions = {
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
   query?: Record<string, unknown>;
+  bypassIsrHtmlCache?: boolean;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -254,6 +255,7 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "query"
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
@@ -265,7 +267,7 @@ export function buildPagesNextDataScript(
   const nextDataPayload: Record<string, unknown> = {
     props: options.props ?? { pageProps: options.pageProps },
     page: options.routePattern,
-    query: options.params,
+    query: options.query ?? options.params,
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -483,6 +485,7 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.query,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,
@@ -596,7 +599,8 @@ export async function renderPagesPageResponse(
     // later matches the cached __NEXT_DATA__ block via a bare <script> marker.
     !options.scriptNonce &&
     options.isrRevalidateSeconds !== null &&
-    options.isrRevalidateSeconds > 0
+    options.isrRevalidateSeconds > 0 &&
+    !options.bypassIsrHtmlCache
   ) {
     const cacheBodyStreamPair = bodyStream.tee();
     responseBodyStream = cacheBodyStreamPair[0];
@@ -633,7 +637,7 @@ export async function renderPagesPageResponse(
   // this point, so the captured value matches main's original capture site.
   const userSetCacheControl = responseHeaders.has("Cache-Control");
 
-  if (options.scriptNonce) {
+  if (options.scriptNonce || options.bypassIsrHtmlCache) {
     responseHeaders.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
   } else if (options.isrRevalidateSeconds) {
     // Fresh ISR (MISS) response: route through the CDN adapter so edge adapters

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -29,6 +29,7 @@ import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { NEXTJS_CACHE_HEADER } from "./headers.js";
+import { bypassedPagesIsrSet } from "./pages-middleware-rewrite-cache.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
@@ -198,6 +199,8 @@ type RenderPagesPageResponseOptions = {
   params: Record<string, unknown>;
   query?: Record<string, unknown>;
   bypassCdnCache?: boolean;
+  /** Skip shared origin ISR writes for request-specific rewrite state. */
+  bypassOriginCache?: boolean;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -618,6 +621,7 @@ export async function renderPagesPageResponse(
   );
 
   let responseBodyStream = bodyStream;
+  const requestIsrSet = options.bypassOriginCache ? bypassedPagesIsrSet : options.isrSet;
   if (
     // Keep nonce-bearing pages out of ISR writes: rewritePagesCachedHtml()
     // later matches the cached __NEXT_DATA__ block via a bare <script> marker.
@@ -640,7 +644,7 @@ export async function renderPagesPageResponse(
       pageData: options.props ?? { pageProps: options.pageProps },
       revalidateSeconds: options.isrRevalidateSeconds,
       routePattern: options.routePattern,
-      setCache: options.isrSet,
+      setCache: requestIsrSet,
       shellPrefix,
       shellSuffix,
       status: finalStatus,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -197,6 +197,7 @@ type RenderPagesPageResponseOptions = {
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
   query?: Record<string, unknown>;
+  bypassCdnCache?: boolean;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -266,6 +267,7 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "query"
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
@@ -280,7 +282,7 @@ export function buildPagesNextDataScript(
     // Next.js fallback:true shells intentionally omit the matched route
     // params. The live slug is published by the hydration query update after
     // the fallback data request resolves.
-    query: options.isFallback === true ? {} : options.params,
+    query: options.isFallback === true ? {} : (options.query ?? options.params),
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -498,6 +500,7 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.query,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,
@@ -668,7 +671,7 @@ export async function renderPagesPageResponse(
   // this point, so the captured value matches main's original capture site.
   const userSetCacheControl = responseHeaders.has("Cache-Control");
 
-  if (options.scriptNonce) {
+  if (options.scriptNonce || options.bypassCdnCache) {
     responseHeaders.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
   } else if (options.isrRevalidateSeconds !== null) {
     // Fresh ISR (MISS) response: route through the CDN adapter so edge adapters

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -36,18 +36,26 @@ import {
 } from "./request-pipeline.js";
 import type { HeaderRecord } from "./request-pipeline.js";
 import { mergeHeaders } from "./worker-utils.js";
+import { notFoundStaticAssetResponse } from "./http-error-responses.js";
 import { normalizeDefaultLocalePathname, stripI18nLocaleForApiRoute } from "./pages-i18n.js";
 import { mergeRewriteQuery } from "../utils/query.js";
 import { addBasePathToPathname, hasBasePath } from "../utils/base-path.js";
+import { isNextStaticPath } from "../utils/asset-prefix.js";
 
 // All "render options" that are passed through to the renderPage callback
 export type PagesRenderOptions = {
   isDataReq?: boolean;
+  hasMiddlewareRewrite?: boolean;
   renderErrorPageOnMiss?: boolean;
   originalUrl?: string;
 };
 
-export type FilesystemRoutePhase = "direct" | "beforeFiles" | "afterFiles" | "fallback";
+export type FilesystemRoutePhase =
+  | "direct"
+  | "middlewareRewrite"
+  | "beforeFiles"
+  | "afterFiles"
+  | "fallback";
 
 export async function fetchWorkerFilesystemRoute(
   request: Request,
@@ -98,6 +106,8 @@ export type PagesPipelineDeps = {
 
   // Pre-computed per-request values (adapter sets these)
   hadBasePath: boolean; // adapter computes: !basePath || hasBasePath(originalPathname, basePath)
+  assetPathPrefix?: string;
+  initialStaticAssetMiss?: boolean;
   isDataReq: boolean; // true if this was a /_next/data/ request (already normalized by adapter)
   isDataRequest: boolean; // trusted data classification for middleware protocol handling
   ctx?: unknown; // Cloudflare ExecutionContext or undefined (for Node)
@@ -304,6 +314,7 @@ export async function runPagesRequest(
   // Step 5: Middleware
   const originalResolvedUrl = pathname + search;
   let resolvedUrl = originalResolvedUrl;
+  let middlewareRewriteFired = false;
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
   const serveFilesystemRoute = async (
@@ -395,6 +406,7 @@ export async function runPagesRequest(
 
     if (result.rewriteUrl) {
       resolvedUrl = result.rewriteUrl;
+      middlewareRewriteFired = true;
     }
 
     // Reconciled superset: result.status takes priority over result.rewriteStatus
@@ -444,13 +456,31 @@ export async function runPagesRequest(
     };
   }
 
+  const staticAssetNotFoundResponse = (): PagesPipelineResult => ({
+    type: "response",
+    response: mergeHeaders(notFoundStaticAssetResponse(), middlewareHeaders, middlewareStatus),
+  });
+  const isStaticAssetPath = (value: string): boolean =>
+    isNextStaticPath(value, "", "") ||
+    (!!deps.assetPathPrefix && isNextStaticPath(value, "", deps.assetPathPrefix));
+
+  if (deps.initialStaticAssetMiss && !middlewareRewriteFired) {
+    return staticAssetNotFoundResponse();
+  }
+
   // Step 8b: Public-directory static files (post-middleware).
   // Served after middleware so middleware can intercept/redirect public files, and
   // before rewrites so a real public file wins over a fallback rewrite — matching the
   // pre-refactor prod-server ordering. Adapter callbacks own their path guards;
   // a true result means Node already wrote the response.
-  const directFilesystemResult = await serveFilesystemRoute(pathname, "direct");
+  const directFilesystemResult = await serveFilesystemRoute(
+    middlewareRewriteFired ? resolvedPathname : pathname,
+    middlewareRewriteFired ? "middlewareRewrite" : "direct",
+  );
   if (directFilesystemResult) return directFilesystemResult;
+  if (deps.initialStaticAssetMiss && isStaticAssetPath(resolvedPathname)) {
+    return staticAssetNotFoundResponse();
+  }
 
   // Step 9: beforeFiles rewrites
   // Next.js server-utils.ts applies every beforeFiles rule in sequence and
@@ -612,11 +642,17 @@ export async function runPagesRequest(
     // All adapters normalize real `/_next/data/` URLs before this point.
     const shouldDeferErrorPageOnMiss =
       !isDataReq && !isDataRequest && !!deps.matchPageRoute && !renderPageMatch;
-    const initialRenderOptions: PagesRenderOptions | undefined = shouldDeferErrorPageOnMiss
-      ? { renderErrorPageOnMiss: false }
-      : isDataReq
-        ? { isDataReq: true }
-        : undefined;
+    const buildRenderOptions = (extra?: PagesRenderOptions): PagesRenderOptions | undefined => {
+      if (!isDataReq && !middlewareRewriteFired && !extra) return undefined;
+      return {
+        ...(isDataReq ? { isDataReq: true } : {}),
+        ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+        ...extra,
+      };
+    };
+    const initialRenderOptions = buildRenderOptions(
+      shouldDeferErrorPageOnMiss ? { renderErrorPageOnMiss: false } : undefined,
+    );
 
     // Convert staged middleware headers to a Web Headers object for renderPage.
     // Adapters that need to inject per-request values (e.g. CSP nonces) into the
@@ -656,7 +692,7 @@ export async function runPagesRequest(
         if (fallbackFilesystemResult) return fallbackFilesystemResult;
         const fallbackApiResult = await handleResolvedApiRoute();
         if (fallbackApiResult) return fallbackApiResult;
-        response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+        response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
         matchedFallbackRewrite = true;
         if (response.status !== 404) break;
       }
@@ -664,7 +700,7 @@ export async function runPagesRequest(
 
     // Deferred 404 re-render
     if (response.status === 404 && shouldDeferErrorPageOnMiss && !matchedFallbackRewrite) {
-      response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+      response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
     }
 
     const merged = mergeHeaders(response, middlewareHeaders, middlewareStatus);
@@ -716,7 +752,13 @@ export async function runPagesRequest(
   return {
     type: "render",
     resolvedUrl,
-    renderOptions: isDataReq ? { isDataReq: true } : undefined,
+    renderOptions:
+      isDataReq || middlewareRewriteFired
+        ? {
+            ...(isDataReq ? { isDataReq: true } : {}),
+            ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+          }
+        : undefined,
     stagedHeaders: middlewareHeaders,
     requestHeaders: request.headers,
     middlewareStatus,

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -43,11 +43,17 @@ import { isOnDemandRevalidateRequest, PRERENDER_REVALIDATE_HEADER } from "./isr-
 // All "render options" that are passed through to the renderPage callback
 export type PagesRenderOptions = {
   isDataReq?: boolean;
+  hasMiddlewareRewrite?: boolean;
   renderErrorPageOnMiss?: boolean;
   originalUrl?: string;
 };
 
-export type FilesystemRoutePhase = "direct" | "beforeFiles" | "afterFiles" | "fallback";
+export type FilesystemRoutePhase =
+  | "direct"
+  | "middlewareRewrite"
+  | "beforeFiles"
+  | "afterFiles"
+  | "fallback";
 
 type PageRouteMatch = {
   route: { isDynamic: boolean; pattern?: string; dataKind?: "static" | "server" | "none" };
@@ -332,6 +338,7 @@ export async function runPagesRequest(
   const originalResolvedUrl = pathname + search;
   let resolvedUrl = originalResolvedUrl;
   let resolvedPathnameIsRequestPathname = true;
+  let middlewareRewriteFired = false;
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
   const serveFilesystemRoute = async (
@@ -427,6 +434,7 @@ export async function runPagesRequest(
     if (result.rewriteUrl) {
       resolvedUrl = result.rewriteUrl;
       resolvedPathnameIsRequestPathname = false;
+      middlewareRewriteFired = true;
     }
 
     // Reconciled superset: result.status takes priority over result.rewriteStatus
@@ -521,7 +529,10 @@ export async function runPagesRequest(
   // before rewrites so a real public file wins over a fallback rewrite — matching the
   // pre-refactor prod-server ordering. Adapter callbacks own their path guards;
   // a true result means Node already wrote the response.
-  const directFilesystemResult = await serveFilesystemRoute(pathname, "direct");
+  const directFilesystemResult = await serveFilesystemRoute(
+    middlewareRewriteFired ? resolvedPathname : pathname,
+    middlewareRewriteFired ? "middlewareRewrite" : "direct",
+  );
   if (directFilesystemResult) return directFilesystemResult;
 
   // Step 9: beforeFiles rewrites
@@ -698,11 +709,17 @@ export async function runPagesRequest(
     // All adapters normalize real `/_next/data/` URLs before this point.
     const shouldDeferErrorPageOnMiss =
       !isDataReq && !isDataRequest && !!deps.matchPageRoute && !renderPageMatch;
-    const initialRenderOptions: PagesRenderOptions | undefined = shouldDeferErrorPageOnMiss
-      ? { renderErrorPageOnMiss: false }
-      : isDataReq
-        ? { isDataReq: true }
-        : undefined;
+    const buildRenderOptions = (extra?: PagesRenderOptions): PagesRenderOptions | undefined => {
+      if (!isDataReq && !middlewareRewriteFired && !extra) return undefined;
+      return {
+        ...(isDataReq ? { isDataReq: true } : {}),
+        ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+        ...extra,
+      };
+    };
+    const initialRenderOptions = buildRenderOptions(
+      shouldDeferErrorPageOnMiss ? { renderErrorPageOnMiss: false } : undefined,
+    );
 
     // Convert staged middleware headers to a Web Headers object for renderPage.
     // Adapters that need to inject per-request values (e.g. CSP nonces) into the
@@ -747,7 +764,7 @@ export async function runPagesRequest(
         renderPageMatch = deps.matchPageRoute
           ? deps.matchPageRoute(resolvedPathname, request)
           : null;
-        response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+        response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
         matchedFallbackRewrite = true;
         if (response.status !== 404) break;
       }
@@ -755,7 +772,7 @@ export async function runPagesRequest(
 
     // Deferred 404 re-render
     if (response.status === 404 && shouldDeferErrorPageOnMiss && !matchedFallbackRewrite) {
-      response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+      response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
     }
 
     const matchedPathHeaders = { ...middlewareHeaders };
@@ -842,7 +859,13 @@ export async function runPagesRequest(
   return {
     type: "render",
     resolvedUrl,
-    renderOptions: isDataReq ? { isDataReq: true } : undefined,
+    renderOptions:
+      isDataReq || middlewareRewriteFired
+        ? {
+            ...(isDataReq ? { isDataReq: true } : {}),
+            ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+          }
+        : undefined,
     stagedHeaders: middlewareHeaders,
     requestHeaders: request.headers,
     middlewareStatus,

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1665,13 +1665,15 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // packages/next/src/server/lib/router-server.ts.
     const staticLookupPath = stripBasePath(pathname, basePath);
     const pagesAssetLookup = resolveAppRouterAssetPath(pathname, pagesAssetPathPrefix, assetPrefix);
+    let initialStaticAssetMiss = false;
     if (pagesAssetLookup) {
       if (await tryServeStatic(req, res, clientDir, pagesAssetLookup, compress, staticCache)) {
         return;
       }
-      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-      res.end("Not Found");
-      return;
+      initialStaticAssetMiss = true;
+      // Existing build assets bypass middleware, but a missing asset re-enters
+      // routing so middleware can rewrite the 404. Next.js exercises this for
+      // missing Pages chunks in middleware-general.
     }
 
     // ── Image optimization passthrough ──────────────────────────────
@@ -1787,6 +1789,8 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         configRewrites,
         configHeaders,
         hadBasePath,
+        assetPathPrefix: pagesAssetPathPrefix,
+        initialStaticAssetMiss,
         isDataReq,
         isDataRequest,
         ctx: undefined, // Node has no ExecutionContext

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -47,7 +47,7 @@ import {
   type PagesPipelineDeps,
   type PagesRenderOptions,
 } from "./pages-request-pipeline.js";
-import { mergeHeaders } from "./worker-utils.js";
+import { finalizeMissingStaticAssetResponse, mergeHeaders } from "./worker-utils.js";
 import {
   normalizeNextDataPagePathname,
   isNextDataPathname,
@@ -2012,9 +2012,12 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       if (result.type === "response") {
         const { response } = result;
         if (missingBuildAsset && response.status === 404) {
-          cancelResponseBody(response);
-          res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-          res.end("Not Found");
+          await sendWebResponse(
+            finalizeMissingStaticAssetResponse(response, true),
+            req,
+            res,
+            compress,
+          );
           return;
         }
         const shouldStream = isVinextStreamedHtmlResponse(response);

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -15,6 +15,23 @@ import { notFoundStaticAssetResponse } from "./http-error-responses.js";
  * Keep this in sync with prod-server.ts.
  */
 const NO_BODY_RESPONSE_STATUSES = new Set([204, 205, 304]);
+const REPLACED_BODY_HEADERS = new Set([
+  "accept-ranges",
+  "content-digest",
+  "content-disposition",
+  "content-encoding",
+  "content-language",
+  "content-length",
+  "content-location",
+  "content-md5",
+  "content-range",
+  "digest",
+  "etag",
+  "last-modified",
+  "repr-digest",
+  "trailer",
+  "transfer-encoding",
+]);
 
 type ResponseWithVinextStreamingMetadata = Response & {
   __vinextStreamedHtmlResponse?: boolean;
@@ -44,6 +61,7 @@ export function finalizeMissingStaticAssetResponse(
   cancelResponseBody(response);
   const notFound = notFoundStaticAssetResponse();
   const headers = new Headers(response.headers);
+  for (const name of REPLACED_BODY_HEADERS) headers.delete(name);
   headers.set("Content-Type", notFound.headers.get("Content-Type")!);
   return new Response(notFound.body, { status: 404, headers });
 }

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -42,7 +42,10 @@ export function finalizeMissingStaticAssetResponse(
 ): Response {
   if (!missingBuildAsset || response.status !== 404) return response;
   cancelResponseBody(response);
-  return notFoundStaticAssetResponse();
+  const notFound = notFoundStaticAssetResponse();
+  const headers = new Headers(response.headers);
+  headers.set("Content-Type", notFound.headers.get("Content-Type")!);
+  return new Response(notFound.body, { status: 404, headers });
 }
 
 function buildHeaderRecord(

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -170,9 +170,15 @@ export class NextRequest extends Request {
         }
       : undefined;
     this._nextUrl = new NextURL(url, undefined, urlConfig);
-    this._url = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE
-      ? url.toString()
-      : this._nextUrl.toString();
+    // File-shaped requests keep their original URL spelling even when
+    // trailingSlash is enabled. NextURL still exposes the configured slash
+    // policy, but middleware's request.url must not turn a missing static
+    // asset such as `manifest.json` into `manifest.json/`.
+    const preserveFileRequestUrl = /\.[^/]+$/.test(url.pathname);
+    this._url =
+      process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE || preserveFileRequestUrl
+        ? url.toString()
+        : this._nextUrl.toString();
     this._cookies = new RequestCookies(this.headers);
   }
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1328,17 +1328,14 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("short-circuits invalid `_next/static/*` paths with plain-text 404", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain(
-      'import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses"',
-    );
-    expect(content).toContain(
       'import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix"',
     );
     expect(content).toContain("assetPrefixPathname(vinextConfig?.assetPrefix");
     expect(content).toContain("isNextStaticPath(pathname, basePath, assetPathPrefix)");
-    expect(content).toContain("return notFoundStaticAssetResponse();");
+    expect(content).toContain("const initialStaticAssetMiss = isNextStaticPath(");
 
-    // The short-circuit must fire BEFORE runPagesRequest (which invokes renderPage)
-    // so the rich HTML 404 is never rendered for asset misses.
+    // Static misses must be classified before the shared pipeline, which then
+    // preserves the plain 404 unless middleware rewrites the request.
     const staticPos = content.indexOf("isNextStaticPath(pathname, basePath, assetPathPrefix)");
     const pipelinePos = content.indexOf("runPagesRequest(request, deps)");
     expect(staticPos).toBeGreaterThan(-1);
@@ -1347,7 +1344,7 @@ describe("generatePagesRouterWorkerEntry", () => {
 });
 
 describe("fetchWorkerFilesystemRoute", () => {
-  it.each(["beforeFiles", "afterFiles", "fallback"] as const)(
+  it.each(["middlewareRewrite", "beforeFiles", "afterFiles", "fallback"] as const)(
     "fetches rewritten assets during %s",
     async (phase) => {
       const fetchAsset = vi.fn(

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1646,12 +1646,16 @@ describe("readPagesRouterEntrySource", () => {
           canceled = true;
         },
       }),
-      { status: 404, headers: { "content-type": "text/html" } },
+      {
+        status: 404,
+        headers: { "content-type": "text/html", "x-from-middleware": "yes" },
+      },
     );
 
     const finalized = finalizeMissingStaticAssetResponse(routed404, true);
     expect(finalized.status).toBe(404);
     expect(finalized.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(finalized.headers.get("x-from-middleware")).toBe("yes");
     expect(await finalized.text()).toBe("Not Found");
     await vi.waitFor(() => expect(canceled).toBe(true));
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1648,13 +1648,50 @@ describe("readPagesRouterEntrySource", () => {
       }),
       {
         status: 404,
-        headers: { "content-type": "text/html", "x-from-middleware": "yes" },
+        headers: {
+          "accept-ranges": "bytes",
+          "content-digest": "sha-256=:stale:",
+          "content-disposition": 'attachment; filename="chunk.js"',
+          "content-type": "text/html",
+          "content-encoding": "gzip",
+          "content-language": "fr",
+          "content-length": "999",
+          "content-location": "/old-chunk.js",
+          "content-md5": "stale",
+          "content-range": "bytes 0-5/999",
+          etag: '"stale"',
+          digest: "sha-256=stale",
+          "last-modified": "Wed, 01 Jan 2025 00:00:00 GMT",
+          "repr-digest": "sha-256=:stale:",
+          trailer: "Digest",
+          "transfer-encoding": "chunked",
+          "x-from-middleware": "yes",
+        },
       },
     );
 
     const finalized = finalizeMissingStaticAssetResponse(routed404, true);
     expect(finalized.status).toBe(404);
     expect(finalized.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    for (const name of [
+      "accept-ranges",
+      "content-digest",
+      "content-disposition",
+      "content-encoding",
+      "content-language",
+      "content-length",
+      "content-location",
+      "content-md5",
+      "content-range",
+      "digest",
+      "etag",
+      "last-modified",
+      "repr-digest",
+      "trailer",
+      "transfer-encoding",
+    ]) {
+      expect(finalized.headers.get(name)).toBeNull();
+    }
     expect(finalized.headers.get("x-from-middleware")).toBe("yes");
     expect(await finalized.text()).toBe("Not Found");
     await vi.waitFor(() => expect(canceled).toBe(true));

--- a/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = "http://localhost:4175";
+
+test.describe("Pages middleware rewrite cache parity", () => {
+  test("query-invariant ISR rewrite preserves shared caching", async ({ request }) => {
+    const response = await request.get(`${BASE}/mw-rewrite-isr`);
+
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toContain("Hello from ISR");
+    expect(response.headers()["cache-control"]).toContain("s-maxage=1");
+  });
+
+  test("query-invariant static GSP rewrite does not force no-cache", async ({ request }) => {
+    const htmlResponse = await request.get(`${BASE}/mw-rewrite-static-gsp`);
+    expect(htmlResponse.status()).toBe(200);
+    expect(await htmlResponse.text()).toContain("Hello from static GSP");
+    expect(htmlResponse.headers()["cache-control"]).toBeUndefined();
+
+    const dataResponse = await request.get(
+      `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp.json`,
+    );
+    expect(dataResponse.status()).toBe(200);
+    expect(await dataResponse.json()).toMatchObject({
+      pageProps: { message: "Hello from static GSP" },
+    });
+    expect(dataResponse.headers()["cache-control"]).toBeUndefined();
+  });
+});

--- a/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
@@ -24,6 +24,28 @@ test.describe("Pages middleware rewrite cache parity", () => {
     expect(await dataResponse.json()).toMatchObject({
       pageProps: { message: "Hello from static GSP" },
     });
-    expect(dataResponse.headers()["cache-control"]).toBeUndefined();
+    expect(dataResponse.headers()["cache-control"]).toContain("s-maxage=");
+  });
+
+  test("query-varying static GSP rewrites stay private and preserve source router state", async ({
+    page,
+    request,
+  }) => {
+    const dataResponse = await request.get(
+      `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp-query.json?variant=one`,
+    );
+    expect(dataResponse.status()).toBe(200);
+    expect(dataResponse.headers()["cache-control"]).toBe("no-store, must-revalidate");
+    expect(await dataResponse.json()).toMatchObject({
+      pageProps: { message: "Hello from static GSP" },
+    });
+
+    await page.goto(`${BASE}/mw-rewrite-static-gsp-query?variant=one`);
+    await expect(page.getByTestId("as-path")).toHaveText(
+      "/mw-rewrite-static-gsp-query?variant=one",
+    );
+    await expect(page.getByTestId("query")).toHaveText(
+      JSON.stringify({ variant: "one", from: "middleware" }),
+    );
   });
 });

--- a/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
@@ -15,7 +15,9 @@ test.describe("Pages middleware rewrite cache parity", () => {
     const htmlResponse = await request.get(`${BASE}/mw-rewrite-static-gsp`);
     expect(htmlResponse.status()).toBe(200);
     expect(await htmlResponse.text()).toContain("Hello from static GSP");
-    expect(htmlResponse.headers()["cache-control"]).toBeUndefined();
+    expect(htmlResponse.headers()["cache-control"]).toBe(
+      "s-maxage=31536000, stale-while-revalidate",
+    );
 
     const dataResponse = await request.get(
       `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp.json`,

--- a/tests/e2e/pages-router/isr.spec.ts
+++ b/tests/e2e/pages-router/isr.spec.ts
@@ -24,6 +24,14 @@ test.describe("Pages Router ISR", () => {
     expect(["MISS", "HIT", "STALE"]).toContain(cacheHeader);
   });
 
+  test("middleware rewrite to an SSG page still runs getStaticProps", async ({ request }) => {
+    const res = await request.get(`${BASE}/mw-rewrite-isr`);
+
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toContain("Hello from ISR");
+    expect(res.headers()["cache-control"]).toBe("no-store, must-revalidate");
+  });
+
   test("second request within TTL is a cache HIT with same timestamp", async ({ request }) => {
     // First request: populate cache
     const res1 = await request.get(`${BASE}/isr-test`);

--- a/tests/e2e/pages-router/isr.spec.ts
+++ b/tests/e2e/pages-router/isr.spec.ts
@@ -32,6 +32,24 @@ test.describe("Pages Router ISR", () => {
     expect(res.headers()["cache-control"]).toBe("no-store, must-revalidate");
   });
 
+  test("middleware rewrite to a non-ISR GSP page disables HTML and data caching", async ({
+    request,
+  }) => {
+    const htmlResponse = await request.get(`${BASE}/mw-rewrite-static-gsp`);
+    expect(htmlResponse.status()).toBe(200);
+    expect(await htmlResponse.text()).toContain("Hello from static GSP");
+    expect(htmlResponse.headers()["cache-control"]).toBe("no-store, must-revalidate");
+
+    const dataResponse = await request.get(
+      `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp.json`,
+    );
+    expect(dataResponse.status()).toBe(200);
+    expect(await dataResponse.json()).toMatchObject({
+      pageProps: { message: "Hello from static GSP" },
+    });
+    expect(dataResponse.headers()["cache-control"]).toBe("no-store, must-revalidate");
+  });
+
   test("second request within TTL is a cache HIT with same timestamp", async ({ request }) => {
     // First request: populate cache
     const res1 = await request.get(`${BASE}/isr-test`);

--- a/tests/e2e/pages-router/isr.spec.ts
+++ b/tests/e2e/pages-router/isr.spec.ts
@@ -29,7 +29,7 @@ test.describe("Pages Router ISR", () => {
 
     expect(res.status()).toBe(200);
     expect(await res.text()).toContain("Hello from ISR");
-    expect(res.headers()["cache-control"]).toBe("no-store, must-revalidate");
+    expect(res.headers()["cache-control"]).toBe("no-cache, must-revalidate");
   });
 
   test("middleware rewrite to a non-ISR GSP page disables HTML and data caching", async ({
@@ -38,7 +38,7 @@ test.describe("Pages Router ISR", () => {
     const htmlResponse = await request.get(`${BASE}/mw-rewrite-static-gsp`);
     expect(htmlResponse.status()).toBe(200);
     expect(await htmlResponse.text()).toContain("Hello from static GSP");
-    expect(htmlResponse.headers()["cache-control"]).toBe("no-store, must-revalidate");
+    expect(htmlResponse.headers()["cache-control"]).toBe("no-cache, must-revalidate");
 
     const dataResponse = await request.get(
       `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp.json`,
@@ -47,7 +47,7 @@ test.describe("Pages Router ISR", () => {
     expect(await dataResponse.json()).toMatchObject({
       pageProps: { message: "Hello from static GSP" },
     });
-    expect(dataResponse.headers()["cache-control"]).toBe("no-store, must-revalidate");
+    expect(dataResponse.headers()["cache-control"]).toBe("no-cache, must-revalidate");
   });
 
   test("second request within TTL is a cache HIT with same timestamp", async ({ request }) => {

--- a/tests/e2e/pages-router/isr.spec.ts
+++ b/tests/e2e/pages-router/isr.spec.ts
@@ -29,16 +29,14 @@ test.describe("Pages Router ISR", () => {
 
     expect(res.status()).toBe(200);
     expect(await res.text()).toContain("Hello from ISR");
-    expect(res.headers()["cache-control"]).toBe("no-cache, must-revalidate");
+    expect(res.headers()["cache-control"]).toContain("s-maxage=1");
   });
 
-  test("middleware rewrite to a non-ISR GSP page disables HTML and data caching", async ({
-    request,
-  }) => {
+  test("query-invariant middleware rewrite keeps static GSP cache parity", async ({ request }) => {
     const htmlResponse = await request.get(`${BASE}/mw-rewrite-static-gsp`);
     expect(htmlResponse.status()).toBe(200);
     expect(await htmlResponse.text()).toContain("Hello from static GSP");
-    expect(htmlResponse.headers()["cache-control"]).toBe("no-cache, must-revalidate");
+    expect(htmlResponse.headers()["cache-control"]).toBeUndefined();
 
     const dataResponse = await request.get(
       `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp.json`,
@@ -47,7 +45,7 @@ test.describe("Pages Router ISR", () => {
     expect(await dataResponse.json()).toMatchObject({
       pageProps: { message: "Hello from static GSP" },
     });
-    expect(dataResponse.headers()["cache-control"]).toBe("no-cache, must-revalidate");
+    expect(dataResponse.headers()["cache-control"]).toBeUndefined();
   });
 
   test("second request within TTL is a cache HIT with same timestamp", async ({ request }) => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1044,6 +1044,11 @@ describe("extractLocaleFromUrl", () => {
     expect(result).toEqual({ locale: "de", url: "/", hadPrefix: true });
   });
 
+  it("preserves a trailing slash after extracting the locale prefix", () => {
+    const result = extractLocaleFromUrl("/fr/about/?foo=bar", i18nConfig);
+    expect(result).toEqual({ locale: "fr", url: "/about/?foo=bar", hadPrefix: true });
+  });
+
   it("returns default locale when no prefix", () => {
     const result = extractLocaleFromUrl("/about", i18nConfig);
     expect(result).toEqual({ locale: "en", url: "/about", hadPrefix: false });

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -30,6 +30,12 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/ssr", request.url));
   }
 
+  // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
+  // Missing Pages chunks still reach middleware, which may rewrite the 404.
+  if (url.pathname.includes("/_next/static/chunks/pages/_app-non-existent.js")) {
+    return NextResponse.rewrite(new URL("/about", request.url));
+  }
+
   // Rewrite /mw-rewrite-query to /ssr-query — preserves the original
   // request's query params on the rewrite target so getServerSideProps
   // sees them. Middleware preserves query by mutating `request.nextUrl`
@@ -269,6 +275,7 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/_next/static/chunks/pages/_app-non-existent.js",
     "/api/edge-search-params",
     "/edge-api-rewrite/:path*",
     "/((?!api|_next|favicon\\.ico|mw-object-gated).*)",

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -30,6 +30,10 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/ssr", request.url));
   }
 
+  if (url.pathname === "/mw-rewrite-isr") {
+    return NextResponse.rewrite(new URL("/isr-test", request.url));
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
   // Missing Pages chunks still reach middleware, which may rewrite the 404.
   if (url.pathname.includes("/_next/static/chunks/pages/_app-non-existent.js")) {

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -34,6 +34,10 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/isr-test", request.url));
   }
 
+  if (url.pathname === "/mw-rewrite-static-gsp") {
+    return NextResponse.rewrite(new URL("/static-gsp", request.url));
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
   // Missing Pages chunks still reach middleware, which may rewrite the 404.
   if (url.pathname.includes("/_next/static/chunks/pages/_app-non-existent.js")) {

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -37,6 +37,20 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/ssr", request.url));
   }
 
+  if (url.pathname === "/mw-rewrite-isr") {
+    return NextResponse.rewrite(new URL("/isr-test", request.url));
+  }
+
+  if (url.pathname === "/mw-rewrite-static-gsp") {
+    return NextResponse.rewrite(new URL("/static-gsp", request.url));
+  }
+
+  // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
+  // Missing Pages chunks still reach middleware, which may rewrite the 404.
+  if (url.pathname.includes("/_next/static/chunks/pages/_app-non-existent.js")) {
+    return NextResponse.rewrite(new URL("/about", request.url));
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware-node.js
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-general/app/middleware-node.js
   if (url.pathname === "/middleware-general-ssr") {
@@ -304,6 +318,7 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/_next/static/chunks/pages/_app-non-existent.js",
     "/api/edge-search-params",
     "/edge-api-rewrite/:path*",
     "/((?!api|_next|favicon\\.ico|mw-object-gated).*)",

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -45,6 +45,13 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/static-gsp", request.url));
   }
 
+  if (url.pathname === "/mw-rewrite-static-gsp-query") {
+    const target = request.nextUrl.clone();
+    target.pathname = "/static-gsp";
+    target.searchParams.set("from", "middleware");
+    return NextResponse.rewrite(target);
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
   // Missing Pages chunks still reach middleware, which may rewrite the 404.
   if (url.pathname.includes("/_next/static/chunks/pages/_app-non-existent.js")) {

--- a/tests/fixtures/pages-basic/pages/static-gsp.tsx
+++ b/tests/fixtures/pages-basic/pages/static-gsp.tsx
@@ -1,0 +1,15 @@
+type StaticGspProps = {
+  message: string;
+};
+
+export function getStaticProps() {
+  return {
+    props: {
+      message: "Hello from static GSP",
+    },
+  };
+}
+
+export default function StaticGsp({ message }: StaticGspProps) {
+  return <p data-testid="message">{message}</p>;
+}

--- a/tests/fixtures/pages-basic/pages/static-gsp.tsx
+++ b/tests/fixtures/pages-basic/pages/static-gsp.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from "next/router";
+
 type StaticGspProps = {
   message: string;
 };
@@ -11,5 +13,12 @@ export function getStaticProps() {
 }
 
 export default function StaticGsp({ message }: StaticGspProps) {
-  return <p data-testid="message">{message}</p>;
+  const router = useRouter();
+  return (
+    <>
+      <p data-testid="message">{message}</p>
+      <p data-testid="as-path">{router.asPath}</p>
+      <p data-testid="query">{JSON.stringify(router.query)}</p>
+    </>
+  );
 }

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -116,7 +116,7 @@ describe("pages page data", () => {
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
   });
 
-  it("bypasses pathname-only ISR cache entries for request-specific query values", async () => {
+  it("isolates middleware rewrite query variants in the ISR cache", async () => {
     const isrGet = vi.fn().mockResolvedValue({
       isStale: false,
       value: {
@@ -138,20 +138,94 @@ describe("pages page data", () => {
           },
         },
         query: { from: "middleware", slug: "post" },
-        bypassIsrHtmlCache: true,
+        isrCachePathname: "/posts/post?from=middleware",
+        bypassCdnCache: true,
         nextDataQuery: { from: "middleware", slug: "post" },
       }),
     );
 
-    expect(isrGet).not.toHaveBeenCalled();
-    expect(result).toMatchObject({ kind: "render", pageProps: { fresh: true } });
+    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post?from=middleware");
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    }
   });
 
-  it("does not persist fallback data for a middleware-rewritten SSG request", async () => {
+  it("reuses a query-invariant middleware rewrite ISR entry", async () => {
+    const getStaticProps = vi.fn(async () => ({ props: { fresh: true }, revalidate: 60 }));
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: false,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>cached rewrite</html>",
+          pageData: { pageProps: { cached: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        isrCachePathname: "/posts/post",
+        pageModule: { getStaticProps },
+      }),
+    );
+
+    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post");
+    expect(getStaticProps).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("x-vinext-cache")).toBe("HIT");
+      expect(result.response.headers.get("Cache-Control")).toContain("s-maxage=60");
+    }
+  });
+
+  it("revalidates a stale query-invariant middleware rewrite entry", async () => {
+    const triggerBackgroundRegeneration = vi.fn();
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: true,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>stale rewrite</html>",
+          pageData: { pageProps: { stale: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        isrCachePathname: "/posts/post",
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        triggerBackgroundRegeneration,
+      }),
+    );
+
+    expect(triggerBackgroundRegeneration).toHaveBeenCalledWith(
+      "pages:/posts/post",
+      expect.any(Function),
+      expect.objectContaining({ routePath: "/posts/[slug]" }),
+    );
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
+    }
+  });
+
+  it("persists fallback data under an isolated middleware rewrite query key", async () => {
     const isrSet = vi.fn(async () => {});
     await resolvePagesPageData(
       createOptions({
-        bypassIsrHtmlCache: true,
+        isrCachePathname: "/posts/post?from=middleware",
+        bypassCdnCache: true,
         isDataReq: true,
         isrSet,
         pageModule: {
@@ -167,7 +241,13 @@ describe("pages page data", () => {
       }),
     );
 
-    expect(isrSet).not.toHaveBeenCalled();
+    expect(isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post?from=middleware",
+      expect.objectContaining({ generatedFromDataRequest: true }),
+      expect.any(Number),
+      undefined,
+      300,
+    );
   });
 
   it("preserves custom app props in fallback shells", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -97,6 +97,8 @@ describe("pages page data", () => {
       },
       pageProps: { title: "fresh" },
       params: { slug: "post" },
+      query: { from: "middleware", slug: "post" },
+      nextDataQuery: { from: "middleware", slug: "post" },
       renderIsrPassToStringAsync: vi.fn(async () => "<div>fresh-body</div>"),
       routePattern: "/posts/[slug]",
       safeJsonStringify(value: unknown) {
@@ -108,9 +110,64 @@ describe("pages page data", () => {
     expect(html).toContain("<div>fresh-body</div>");
     expect(html).toContain('<aside data-gap="1"></aside>');
     expect(html).toContain('<script src="/tail.js"></script>');
+    expect(html).toContain('"query":{"from":"middleware","slug":"post"}');
     expect(html).toContain('"page":"/posts/[slug]"');
     expect(html).toContain('"slug":"post"');
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
+  });
+
+  it("bypasses pathname-only ISR cache entries for request-specific query values", async () => {
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: false,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>cached</html>",
+          pageData: { pageProps: { cached: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        query: { from: "middleware", slug: "post" },
+        bypassIsrHtmlCache: true,
+        nextDataQuery: { from: "middleware", slug: "post" },
+      }),
+    );
+
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ kind: "render", pageProps: { fresh: true } });
+  });
+
+  it("does not persist fallback data for a middleware-rewritten SSG request", async () => {
+    const isrSet = vi.fn(async () => {});
+    await resolvePagesPageData(
+      createOptions({
+        bypassIsrHtmlCache: true,
+        isDataReq: true,
+        isrSet,
+        pageModule: {
+          default: function Page() {},
+          getStaticPaths() {
+            return { fallback: true, paths: [] };
+          },
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        route: { isDynamic: true },
+      }),
+    );
+
+    expect(isrSet).not.toHaveBeenCalled();
   });
 
   it("preserves custom app props in fallback shells", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -160,7 +160,8 @@ describe("pages page data", () => {
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
   });
 
-  it("isolates middleware rewrite query variants in the ISR cache", async () => {
+  it("bypasses origin ISR reads for middleware rewrite query variants", async () => {
+    const getStaticProps = vi.fn(() => ({ props: { fresh: true }, revalidate: 60 }));
     const isrGet = vi.fn().mockResolvedValue({
       isStale: false,
       value: {
@@ -177,22 +178,19 @@ describe("pages page data", () => {
       createOptions({
         isrGet,
         pageModule: {
-          getStaticProps() {
-            return { props: { fresh: true }, revalidate: 60 };
-          },
+          getStaticProps,
         },
         query: { from: "middleware", slug: "post" },
         isrCachePathname: "/posts/post?from=middleware",
         bypassCdnCache: true,
+        bypassOriginCache: true,
         nextDataQuery: { from: "middleware", slug: "post" },
       }),
     );
 
-    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post?from=middleware");
-    expect(result).toMatchObject({ kind: "response" });
-    if (result.kind === "response") {
-      expect(result.response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
-    }
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(getStaticProps).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ kind: "render" });
   });
 
   it("reuses a query-invariant middleware rewrite ISR entry", async () => {
@@ -264,55 +262,49 @@ describe("pages page data", () => {
     }
   });
 
-  it("preserves middleware rewrite query state in stale ISR regeneration HTML", async () => {
+  it("does not read or regenerate legacy query-varying middleware rewrite entries", async () => {
     const isrSet = vi.fn(async () => {});
-    let regenerationPromise: Promise<void> | undefined;
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: true,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: '<div id="__next">stale</div><script>window.__NEXT_DATA__ = {}</script>',
+          pageData: { pageProps: { stale: true } },
+        },
+      },
+    });
+    const triggerBackgroundRegeneration = vi.fn();
     const result = await resolvePagesPageData(
       createOptions({
         isrCachePathname: "/posts/post?plant=rose",
         nextDataQuery: { plant: "rose", slug: "post" },
-        isrGet: vi.fn().mockResolvedValue({
-          isStale: true,
-          value: {
-            cacheControl: { revalidate: 60 },
-            value: {
-              kind: "PAGES",
-              html: '<div id="__next">stale</div><script>window.__NEXT_DATA__ = {}</script>',
-              pageData: { pageProps: { stale: true } },
-            },
-          },
-        }),
+        bypassOriginCache: true,
+        isrGet,
         isrSet,
         pageModule: {
           getStaticProps() {
             return { props: { fresh: true }, revalidate: 60 };
           },
         },
-        triggerBackgroundRegeneration: vi.fn((_key, callback) => {
-          regenerationPromise = callback();
-        }),
+        triggerBackgroundRegeneration,
       }),
     );
 
-    expect(result).toMatchObject({ kind: "response" });
-    await regenerationPromise;
-    expect(isrSet).toHaveBeenCalledWith(
-      "pages:/posts/post?plant=rose",
-      expect.objectContaining({
-        html: expect.stringContaining('"query":{"plant":"rose","slug":"post"}'),
-      }),
-      60,
-      undefined,
-      300,
-    );
+    expect(result).toMatchObject({ kind: "render" });
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(triggerBackgroundRegeneration).not.toHaveBeenCalled();
+    expect(isrSet).not.toHaveBeenCalled();
   });
 
-  it("persists fallback data under an isolated middleware rewrite query key", async () => {
+  it("does not persist fallback data for a query-varying middleware rewrite", async () => {
     const isrSet = vi.fn(async () => {});
     await resolvePagesPageData(
       createOptions({
         isrCachePathname: "/posts/post?from=middleware",
         bypassCdnCache: true,
+        bypassOriginCache: true,
         isDataReq: true,
         isrSet,
         pageModule: {
@@ -328,13 +320,31 @@ describe("pages page data", () => {
       }),
     );
 
-    expect(isrSet).toHaveBeenCalledWith(
-      "pages:/posts/post?from=middleware",
-      expect.objectContaining({ generatedFromDataRequest: true }),
-      expect.any(Number),
-      undefined,
-      300,
-    );
+    expect(isrSet).not.toHaveBeenCalled();
+  });
+
+  it("does not persist redirect or notFound results for query-varying rewrites", async () => {
+    for (const result of [
+      { redirect: { destination: "/elsewhere", permanent: false }, revalidate: 60 },
+      { notFound: true, revalidate: 60 },
+    ]) {
+      const isrSet = vi.fn(async () => {});
+      await resolvePagesPageData(
+        createOptions({
+          bypassCdnCache: true,
+          bypassOriginCache: true,
+          isrCachePathname: "/posts/post?from=middleware",
+          isrSet,
+          pageModule: {
+            getStaticProps() {
+              return result;
+            },
+          },
+        }),
+      );
+
+      expect(isrSet).not.toHaveBeenCalled();
+    }
   });
 
   it("preserves custom app props in fallback shells", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -264,6 +264,49 @@ describe("pages page data", () => {
     }
   });
 
+  it("preserves middleware rewrite query state in stale ISR regeneration HTML", async () => {
+    const isrSet = vi.fn(async () => {});
+    let regenerationPromise: Promise<void> | undefined;
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrCachePathname: "/posts/post?plant=rose",
+        nextDataQuery: { plant: "rose", slug: "post" },
+        isrGet: vi.fn().mockResolvedValue({
+          isStale: true,
+          value: {
+            cacheControl: { revalidate: 60 },
+            value: {
+              kind: "PAGES",
+              html: '<div id="__next">stale</div><script>window.__NEXT_DATA__ = {}</script>',
+              pageData: { pageProps: { stale: true } },
+            },
+          },
+        }),
+        isrSet,
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        triggerBackgroundRegeneration: vi.fn((_key, callback) => {
+          regenerationPromise = callback();
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({ kind: "response" });
+    await regenerationPromise;
+    expect(isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post?plant=rose",
+      expect.objectContaining({
+        html: expect.stringContaining('"query":{"plant":"rose","slug":"post"}'),
+      }),
+      60,
+      undefined,
+      300,
+    );
+  });
+
   it("persists fallback data under an isolated middleware rewrite query key", async () => {
     const isrSet = vi.fn(async () => {});
     await resolvePagesPageData(

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -142,6 +142,7 @@ describe("pages page data", () => {
       },
       pageProps: { title: "fresh" },
       params: { slug: "post" },
+      nextDataQuery: { from: "middleware", slug: "post" },
       renderIsrPassToStringAsync: vi.fn(async () => "<div>fresh-body</div>"),
       routePattern: "/posts/[slug]",
       safeJsonStringify(value: unknown) {
@@ -153,9 +154,144 @@ describe("pages page data", () => {
     expect(html).toContain("<div>fresh-body</div>");
     expect(html).toContain('<aside data-gap="1"></aside>');
     expect(html).toContain('<script src="/tail.js"></script>');
+    expect(html).toContain('"query":{"from":"middleware","slug":"post"}');
     expect(html).toContain('"page":"/posts/[slug]"');
     expect(html).toContain('"slug":"post"');
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
+  });
+
+  it("isolates middleware rewrite query variants in the ISR cache", async () => {
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: false,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>cached</html>",
+          pageData: { pageProps: { cached: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        query: { from: "middleware", slug: "post" },
+        isrCachePathname: "/posts/post?from=middleware",
+        bypassCdnCache: true,
+        nextDataQuery: { from: "middleware", slug: "post" },
+      }),
+    );
+
+    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post?from=middleware");
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    }
+  });
+
+  it("reuses a query-invariant middleware rewrite ISR entry", async () => {
+    const getStaticProps = vi.fn(async () => ({ props: { fresh: true }, revalidate: 60 }));
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: false,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>cached rewrite</html>",
+          pageData: { pageProps: { cached: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        isrCachePathname: "/posts/post",
+        pageModule: { getStaticProps },
+      }),
+    );
+
+    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post");
+    expect(getStaticProps).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("x-vinext-cache")).toBe("HIT");
+      expect(result.response.headers.get("Cache-Control")).toContain("s-maxage=60");
+    }
+  });
+
+  it("revalidates a stale query-invariant middleware rewrite entry", async () => {
+    const triggerBackgroundRegeneration = vi.fn();
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: true,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>stale rewrite</html>",
+          pageData: { pageProps: { stale: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        isrCachePathname: "/posts/post",
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        triggerBackgroundRegeneration,
+      }),
+    );
+
+    expect(triggerBackgroundRegeneration).toHaveBeenCalledWith(
+      "pages:/posts/post",
+      expect.any(Function),
+      expect.objectContaining({ routePath: "/posts/[slug]" }),
+    );
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
+    }
+  });
+
+  it("persists fallback data under an isolated middleware rewrite query key", async () => {
+    const isrSet = vi.fn(async () => {});
+    await resolvePagesPageData(
+      createOptions({
+        isrCachePathname: "/posts/post?from=middleware",
+        bypassCdnCache: true,
+        isDataReq: true,
+        isrSet,
+        pageModule: {
+          default: function Page() {},
+          getStaticPaths() {
+            return { fallback: true, paths: [] };
+          },
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        route: { isDynamic: true },
+      }),
+    );
+
+    expect(isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post?from=middleware",
+      expect.objectContaining({ generatedFromDataRequest: true }),
+      expect.any(Number),
+      undefined,
+      300,
+    );
   });
 
   it("preserves custom app props in fallback shells", async () => {

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -445,6 +445,29 @@ describe("createPagesPageHandler — _next/data", () => {
       pageProps: { previewData: { draft: true } },
     });
   });
+
+  it("keeps query-varying middleware rewrite SSG data misses private", async () => {
+    const routeModule = makePageModule({
+      getStaticProps: async () => ({ props: { message: "rewritten" }, revalidate: 60 }),
+    });
+    const handler = createPagesPageHandler(
+      makeOpts({ pageRoutes: [makeRoute("/static-gsp", routeModule)] }),
+    );
+    const dataUrl = "/_next/data/test-build-id/source.json";
+
+    const response = await handler(
+      makeRequest(dataUrl),
+      "/static-gsp?variant=middleware",
+      null,
+      null,
+      { isDataReq: true, hasMiddlewareRewrite: true, originalUrl: dataUrl },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(await response.json()).toMatchObject({ pageProps: { message: "rewritten" } });
+  });
 });
 
 describe("createPagesPageHandler — preview responses", () => {
@@ -901,6 +924,64 @@ describe("createPagesPageHandler — SSR context", () => {
       | undefined;
     expect(ctx?.asPath).toBe("/about?hello=world");
   });
+
+  it.each([
+    {
+      label: "plain source URL",
+      i18nConfig: null,
+      requestUrl: "/source/?browser=one",
+      rewrittenUrl: "/posts/first?from=middleware",
+      expectedAsPath: "/source/?browser=one",
+    },
+    {
+      label: "locale-prefixed trailing-slash source URL",
+      i18nConfig: { locales: ["en", "fr"], defaultLocale: "en" },
+      requestUrl: "/en/source/?browser=one",
+      rewrittenUrl: "/en/posts/first?from=middleware",
+      expectedAsPath: "/source/?browser=one",
+    },
+  ])(
+    "preserves the $label as asPath for a static middleware rewrite",
+    async ({ i18nConfig, requestUrl, rewrittenUrl, expectedAsPath }) => {
+      const setSSRContext = vi.fn();
+      const route = makeRoute(
+        "/posts/:id",
+        makePageModule({
+          getStaticProps: async () => ({ props: { message: "rewritten" } }),
+        }),
+      );
+      const handler = createPagesPageHandler(
+        makeOpts({
+          pageRoutes: [route],
+          i18nConfig,
+          setSSRContext,
+          vinextConfig: {
+            basePath: "",
+            assetPrefix: "",
+            trailingSlash: true,
+            disableOptimizedLoading: true,
+          },
+          matchRoute: (url) =>
+            url.split("?")[0] === "/posts/first" ? { route, params: { id: "first" } } : null,
+        }),
+      );
+
+      await handler(makeRequest(requestUrl), rewrittenUrl, null, null, {
+        asPath: requestUrl,
+        hasMiddlewareRewrite: true,
+        originalUrl: requestUrl,
+      });
+
+      const ctx = setSSRContext.mock.calls.find((call) => call[0] !== null)?.[0] as
+        | { pathname?: string; query?: Record<string, unknown>; asPath?: string }
+        | undefined;
+      expect(ctx).toMatchObject({
+        pathname: "/posts/[id]",
+        query: { from: "middleware", id: "first" },
+        asPath: expectedAsPath,
+      });
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -269,6 +269,58 @@ describe("createPagesPageHandler — route miss", () => {
       expect(genericResponse.headers.get("cache-control")).toBe("no-store");
       expect(genericResponse.headers.get("cdn-cache-control")).toBeNull();
       expect(genericResponse.headers.get("cache-tag")).toBeNull();
+      await sourceResponse.text();
+      await genericResponse.text();
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
+  it("keeps query-varying rewrite notFound error renders out of shared caches", async () => {
+    const originGet = vi.fn(async () => null);
+    const originSet = vi.fn(async () => {});
+    setCdnCacheAdapter({
+      ownsBackgroundRevalidation: false,
+      get: originGet,
+      set: originSet,
+      async revalidateTag() {},
+      buildResponseHeaders(input) {
+        return { "Cache-Control": input.cacheControl };
+      },
+    });
+    try {
+      const sourceRoute = makeRoute(
+        "/source",
+        makePageModule({ getStaticProps: async () => ({ notFound: true, revalidate: 7 }) }),
+      );
+      const notFoundRoute = makeRoute(
+        "/404",
+        makePageModule({ getStaticProps: async () => ({ props: {}, revalidate: 6000 }) }),
+      );
+      const handler = createPagesPageHandler(
+        makeOpts({ pageRoutes: [sourceRoute, notFoundRoute] }),
+      );
+
+      const response = await handler(
+        makeRequest("/middleware-source"),
+        "/source?from=middleware",
+        null,
+        null,
+        { hasMiddlewareRewrite: true },
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+      expect(response.headers.get("cdn-cache-control")).toBeNull();
+      expect(response.headers.get("cloudflare-cdn-cache-control")).toBeNull();
+      expect(response.headers.get("cache-tag")).toBeNull();
+      await response.text();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(originGet).not.toHaveBeenCalled();
+      expect(originSet).not.toHaveBeenCalled();
     } finally {
       setCdnCacheAdapter(new DefaultCdnCacheAdapter());
     }
@@ -447,6 +499,17 @@ describe("createPagesPageHandler — _next/data", () => {
   });
 
   it("keeps query-varying middleware rewrite SSG data misses private", async () => {
+    const originGet = vi.fn(async () => null);
+    const originSet = vi.fn(async () => {});
+    setCdnCacheAdapter({
+      ownsBackgroundRevalidation: false,
+      get: originGet,
+      set: originSet,
+      buildResponseHeaders() {
+        return {};
+      },
+      async revalidateTag() {},
+    });
     const routeModule = makePageModule({
       getStaticProps: async () => ({ props: { message: "rewritten" }, revalidate: 60 }),
     });
@@ -455,18 +518,24 @@ describe("createPagesPageHandler — _next/data", () => {
     );
     const dataUrl = "/_next/data/test-build-id/source.json";
 
-    const response = await handler(
-      makeRequest(dataUrl),
-      "/static-gsp?variant=middleware",
-      null,
-      null,
-      { isDataReq: true, hasMiddlewareRewrite: true, originalUrl: dataUrl },
-    );
+    try {
+      const response = await handler(
+        makeRequest(dataUrl),
+        "/static-gsp?variant=middleware",
+        null,
+        null,
+        { isDataReq: true, hasMiddlewareRewrite: true, originalUrl: dataUrl },
+      );
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
-    expect(response.headers.get("cdn-cache-control")).toBeNull();
-    expect(await response.json()).toMatchObject({ pageProps: { message: "rewritten" } });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+      expect(response.headers.get("cdn-cache-control")).toBeNull();
+      expect(await response.json()).toMatchObject({ pageProps: { message: "rewritten" } });
+      expect(originGet).not.toHaveBeenCalled();
+      expect(originSet).not.toHaveBeenCalled();
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
   });
 });
 

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -7,6 +7,11 @@ import {
   etagMatches,
 } from "../packages/vinext/src/server/pages-page-response.js";
 import { resolvePagesPageData } from "../packages/vinext/src/server/pages-page-data.js";
+import {
+  setCdnCacheAdapter,
+  DefaultCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -147,6 +152,72 @@ describe("isPagesStreamingBot", () => {
 });
 
 describe("pages page response", () => {
+  it("keeps CDN tags for a query-invariant middleware rewrite MISS", async () => {
+    const common = createCommonOptions();
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders(input) {
+        return {
+          "Cache-Control": "no-store",
+          "CDN-Cache-Control": input.cacheControl,
+          "Cache-Tag": input.tags?.join(",") ?? null,
+        };
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(adapter);
+
+    try {
+      const response = await renderPagesPageResponse({
+        ...common.options,
+        isrCachePathname: "/rewritten",
+        isrRevalidateSeconds: 60,
+        routePattern: "/target",
+        routeUrl: "/rewritten",
+      });
+
+      expect(response.headers.get("CDN-Cache-Control")).toContain("s-maxage=60");
+      expect(response.headers.get("Cache-Tag")).toBe("_N_T_/rewritten");
+      await response.text();
+      await settleMicrotasks();
+      expect(common.isrSet).toHaveBeenCalledWith(
+        "pages:/rewritten",
+        expect.any(Object),
+        60,
+        undefined,
+        undefined,
+      );
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
+  it("stores query-varying rewrite ISR output but keeps the CDN response private", async () => {
+    const common = createCommonOptions();
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      bypassCdnCache: true,
+      isrCachePathname: "/rewritten?variant=one",
+      isrRevalidateSeconds: 60,
+      routeUrl: "/rewritten?variant=one",
+    });
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    await response.text();
+    await settleMicrotasks();
+    expect(common.isrSet).toHaveBeenCalledWith(
+      "pages:/rewritten?variant=one",
+      expect.any(Object),
+      60,
+      undefined,
+      undefined,
+    );
+  });
+
   it("renders the document shell, merges gSSP headers, and marks streamed HTML responses", async () => {
     const common = createCommonOptions();
 

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -198,11 +198,12 @@ describe("pages page response", () => {
     }
   });
 
-  it("stores query-varying rewrite ISR output but keeps the CDN response private", async () => {
+  it("does not store query-varying rewrite ISR output and keeps the response private", async () => {
     const common = createCommonOptions();
     const response = await renderPagesPageResponse({
       ...common.options,
       bypassCdnCache: true,
+      bypassOriginCache: true,
       isrCachePathname: "/rewritten?variant=one",
       isrRevalidateSeconds: 60,
       routeUrl: "/rewritten?variant=one",
@@ -211,13 +212,7 @@ describe("pages page response", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
     await response.text();
     await settleMicrotasks();
-    expect(common.isrSet).toHaveBeenCalledWith(
-      "pages:/rewritten?variant=one",
-      expect.any(Object),
-      60,
-      undefined,
-      undefined,
-    );
+    expect(common.isrSet).not.toHaveBeenCalled();
   });
 
   it("renders the document shell, merges gSSP headers, and marks streamed HTML responses", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -7,6 +7,11 @@ import {
   etagMatches,
 } from "../packages/vinext/src/server/pages-page-response.js";
 import { resolvePagesPageData } from "../packages/vinext/src/server/pages-page-data.js";
+import {
+  setCdnCacheAdapter,
+  DefaultCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -149,6 +154,72 @@ describe("isPagesStreamingBot", () => {
 });
 
 describe("pages page response", () => {
+  it("keeps CDN tags for a query-invariant middleware rewrite MISS", async () => {
+    const common = createCommonOptions();
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders(input) {
+        return {
+          "Cache-Control": "no-store",
+          "CDN-Cache-Control": input.cacheControl,
+          "Cache-Tag": input.tags?.join(",") ?? null,
+        };
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(adapter);
+
+    try {
+      const response = await renderPagesPageResponse({
+        ...common.options,
+        isrCachePathname: "/rewritten",
+        isrRevalidateSeconds: 60,
+        routePattern: "/target",
+        routeUrl: "/rewritten",
+      });
+
+      expect(response.headers.get("CDN-Cache-Control")).toContain("s-maxage=60");
+      expect(response.headers.get("Cache-Tag")).toBe("_N_T_/rewritten");
+      await response.text();
+      await settleMicrotasks();
+      expect(common.isrSet).toHaveBeenCalledWith(
+        "pages:/rewritten",
+        expect.any(Object),
+        60,
+        undefined,
+        undefined,
+      );
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
+  it("stores query-varying rewrite ISR output but keeps the CDN response private", async () => {
+    const common = createCommonOptions();
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      bypassCdnCache: true,
+      isrCachePathname: "/rewritten?variant=one",
+      isrRevalidateSeconds: 60,
+      routeUrl: "/rewritten?variant=one",
+    });
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    await response.text();
+    await settleMicrotasks();
+    expect(common.isrSet).toHaveBeenCalledWith(
+      "pages:/rewritten?variant=one",
+      expect.any(Object),
+      60,
+      undefined,
+      undefined,
+    );
+  });
+
   it("renders the document shell, merges gSSP headers, and marks streamed HTML responses", async () => {
     const common = createCommonOptions();
 

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -6,8 +6,25 @@ import {
   type MiddlewareResult,
   type PagesRenderOptions,
 } from "../packages/vinext/src/server/pages-request-pipeline.js";
+import { getPagesMiddlewareRewriteCacheState } from "../packages/vinext/src/server/pages-page-handler.js";
 
 // Helpers
+
+describe("middleware rewrite cache state", () => {
+  it("uses the normalized pathname for query-invariant rewrites", () => {
+    expect(getPagesMiddlewareRewriteCacheState("/target", true)).toEqual({
+      cachePathname: "/target",
+      bypassCdnCache: false,
+    });
+  });
+
+  it("sorts query values into an isolated cache key and bypasses CDN storage", () => {
+    expect(getPagesMiddlewareRewriteCacheState("/target?z=2&a=1", true)).toEqual({
+      cachePathname: "/target?a=1&z=2",
+      bypassCdnCache: true,
+    });
+  });
+});
 
 function makeRequest(pathname: string, headers?: Record<string, string>): Request {
   return new Request(`http://localhost${pathname}`, { headers });

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -183,7 +183,7 @@ describe("middleware", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/bar",
-      undefined,
+      { hasMiddlewareRewrite: true },
       expect.any(Headers),
     );
   });
@@ -603,6 +603,72 @@ describe("serveFilesystemRoute", () => {
       { "set-cookie": ["a=1"] },
       "direct",
     );
+  });
+
+  it("keeps a plain static 404 with middleware response state when the asset miss is not rewritten", async () => {
+    const renderPage = makeRenderPage(200);
+    const result = await runPagesRequest(
+      makeRequest("/_next/static/chunks/pages/missing.js"),
+      baseDeps({
+        initialStaticAssetMiss: true,
+        runMiddleware: makeMiddleware({
+          status: 418,
+          responseHeaders: [["x-from-middleware", "yes"]],
+        }),
+        renderPage,
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.status).toBe(418);
+    expect(result.response.headers.get("x-from-middleware")).toBe("yes");
+    await expect(result.response.text()).resolves.toBe("Not Found");
+    expect(renderPage).not.toHaveBeenCalled();
+  });
+
+  it("re-probes a middleware rewrite target after an initial static asset miss", async () => {
+    const serveFilesystemRoute = vi.fn(async () => true);
+    const result = await runPagesRequest(
+      makeRequest("/_next/static/chunks/pages/missing.js"),
+      baseDeps({
+        initialStaticAssetMiss: true,
+        runMiddleware: makeMiddleware({ rewriteUrl: "/about" }),
+        serveFilesystemRoute,
+      }),
+    );
+
+    expect(result.type).toBe("handled");
+    expect(serveFilesystemRoute).toHaveBeenCalledWith("/about", {}, "middlewareRewrite");
+  });
+
+  it("keeps a plain static 404 when middleware rewrites the miss to another missing asset", async () => {
+    const renderPage = makeRenderPage(200);
+    const serveFilesystemRoute = vi.fn(async () => false);
+    const result = await runPagesRequest(
+      makeRequest("/_next/static/chunks/pages/missing.js"),
+      baseDeps({
+        initialStaticAssetMiss: true,
+        runMiddleware: makeMiddleware({
+          rewriteUrl: "/_next/static/chunks/pages/also-missing.js",
+          responseHeaders: [["x-from-middleware", "yes"]],
+        }),
+        serveFilesystemRoute,
+        renderPage,
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(serveFilesystemRoute).toHaveBeenCalledWith(
+      "/_next/static/chunks/pages/also-missing.js",
+      { "x-from-middleware": "yes" },
+      "middlewareRewrite",
+    );
+    expect(result.response.status).toBe(404);
+    expect(result.response.headers.get("x-from-middleware")).toBe("yes");
+    await expect(result.response.text()).resolves.toBe("Not Found");
+    expect(renderPage).not.toHaveBeenCalled();
   });
 
   it("runs after middleware — a middleware redirect wins over a public file", async () => {

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -587,7 +587,7 @@ describe("middleware", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/bar",
-      undefined,
+      { hasMiddlewareRewrite: true },
       expect.any(Headers),
     );
   });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1675,6 +1675,7 @@ describe("Pages Router integration", () => {
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
+    expect(nextData.query).toEqual({ id: "first", hello: "world" });
   });
 
   it("middleware rewrite with target-side query lets rewrite-target win on key conflicts", async () => {
@@ -4931,6 +4932,14 @@ describe("Production server middleware (Pages Router)", () => {
     const html = await res.text();
     // /rewritten should serve the content of /ssr page
     expect(html).toContain("Server-Side Rendered");
+  });
+
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("lets middleware rewrite a missing Pages chunk in production", async () => {
+    const res = await fetch(`${prodUrl}/_next/static/chunks/pages/_app-non-existent.js`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("About");
   });
 
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2301,6 +2301,7 @@ export default function Page({ marker }: { marker: string }) {
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
+    expect(nextData.query).toEqual({ id: "first", hello: "world" });
   });
 
   it("middleware rewrite with target-side query lets rewrite-target win on key conflicts", async () => {
@@ -6730,6 +6731,14 @@ describe("Production server middleware (Pages Router)", () => {
     const html = await res.text();
     // /rewritten should serve the content of /ssr page
     expect(html).toContain("Server-Side Rendered");
+  });
+
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("lets middleware rewrite a missing Pages chunk in production", async () => {
+    const res = await fetch(`${prodUrl}/_next/static/chunks/pages/_app-non-existent.js`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("About");
   });
 
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11059,6 +11059,16 @@ describe("NextURL basePath and locale properties", () => {
     }
   });
 
+  it("NextRequest.url preserves file-shaped requests with trailingSlash enabled", async () => {
+    const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+    const req = new NextRequest("http://localhost/_next/static/build/manifest.json?foo=1", {
+      nextConfig: { trailingSlash: true },
+    });
+
+    expect(req.nextUrl.href).toBe("http://localhost/_next/static/build/manifest.json/?foo=1");
+    expect(req.url).toBe("http://localhost/_next/static/build/manifest.json?foo=1");
+  });
+
   it("NextRequest passes config when input is a Request object", async () => {
     const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
     const raw = new Request("http://localhost/app/fr/dashboard");


### PR DESCRIPTION
## Summary

- preserve middleware rewrite query state in Pages data and HTML responses
- isolate query-varying ISR entries while retaining caching for query-invariant rewrites
- allow middleware rewrites for missing Pages chunks with consistent Node and Worker 404 semantics

## Next.js parity

Addresses middleware rewrite query, rewritten SSG, and missing static chunk failures from the middleware-general and middleware-trailing-slash suites.

## Validation

- targeted request/data/deploy tests — 388 passed
- targeted Pages/cache tests — 159 passed
- targeted format, lint, and type checks
- independent review loop — clean

Full suites and broad E2E validation are deferred to CI.