### PR TITLE
fix(pages): match custom document head ordering

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1329,6 +1329,18 @@ export async function resolveNextConfig(
     return resolved;
   }
 
+  if (
+    config.crossOrigin !== undefined &&
+    config.crossOrigin !== "anonymous" &&
+    config.crossOrigin !== "use-credentials"
+  ) {
+    console.warn(
+      "Invalid next.config options detected:\n" +
+        '    Invalid option at "crossOrigin": expected "anonymous" or "use-credentials"\n' +
+        "See more info here: https://nextjs.org/docs/messages/invalid-next-config",
+    );
+  }
+
   // Resolve redirects
   let redirects: NextRedirect[] = [];
   if (config.redirects) {

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -163,6 +163,8 @@ export type NextConfig = {
    * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix
    */
   assetPrefix?: string;
+  /** Cross-origin mode applied to framework scripts and preload links. */
+  crossOrigin?: "anonymous" | "use-credentials";
   /** Whether to add trailing slashes */
   trailingSlash?: boolean;
   /** Internationalization routing config */
@@ -461,6 +463,8 @@ export type ResolvedNextConfig = {
    * `test/e2e/optimized-loading` test fixture.
    */
   disableOptimizedLoading: boolean;
+  /** Cross-origin mode applied to framework scripts and preload links. */
+  crossOrigin: "anonymous" | "use-credentials" | undefined;
   /**
    * Mirrors Next.js `experimental.scrollRestoration`. When true, the Pages
    * Router client takes ownership of browser history scroll restoration by
@@ -1311,6 +1315,7 @@ export async function resolveNextConfig(
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      crossOrigin: undefined,
       scrollRestoration: false,
       compilerDefine: {},
       compilerDefineServer: {},
@@ -1639,6 +1644,10 @@ export async function resolveNextConfig(
     // Next.js stores this under `experimental.disableOptimizedLoading`.
     // Default `false` matches Next.js: page scripts get `defer` in <head>.
     disableOptimizedLoading: experimental?.disableOptimizedLoading === true,
+    crossOrigin:
+      config.crossOrigin === "anonymous" || config.crossOrigin === "use-credentials"
+        ? config.crossOrigin
+        : undefined,
     scrollRestoration: experimental?.scrollRestoration === true,
     compilerDefine: serializeCompilerDefine(config.compiler?.define),
     compilerDefineServer: serializeCompilerDefine(config.compiler?.defineServer),

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -120,6 +120,7 @@ export async function generateServerEntry(
     // (the default), page scripts are emitted with `defer` in <head>. See
     // `.nextjs-ref/packages/next/src/pages/_document.tsx` getScripts().
     disableOptimizedLoading: nextConfig?.disableOptimizedLoading === true,
+    crossOrigin: nextConfig?.crossOrigin,
     clientTraceMetadata: nextConfig?.clientTraceMetadata,
     images: {
       deviceSizes: nextConfig?.images?.deviceSizes,
@@ -358,6 +359,7 @@ const _renderPage = __createPagesPageHandler({
     htmlLimitedBots: vinextConfig.htmlLimitedBots,
     clientTraceMetadata: vinextConfig.clientTraceMetadata,
     disableOptimizedLoading: vinextConfig.disableOptimizedLoading,
+    crossOrigin: vinextConfig.crossOrigin,
   },
   buildId,
   hasMiddleware: __hasMiddleware,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4270,6 +4270,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                         (nextConfig?.rewrites.fallback.length ?? 0) > 0,
                       nextConfig?.clientTraceMetadata,
                       nextConfig?.htmlLimitedBots,
+                      nextConfig?.crossOrigin,
                     ),
                   };
                 }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -43,6 +43,10 @@ import {
   prependToHtmlHead,
   safeJsonStringify,
 } from "./html.js";
+import {
+  applyDocumentAssetProps,
+  extractDocumentAssetProps,
+} from "./pages-document-asset-props.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { getScriptNonceFromNodeHeaderSources } from "./csp.js";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
@@ -216,6 +220,7 @@ async function streamPageToResponse(
     setDocumentInitialHead?: (head: React.ReactNode[]) => void;
     /** Buffer the body before writing headers so error-page fallback remains safe. */
     bufferBodyBeforeHeaders?: boolean;
+    crossOrigin?: string;
   },
 ): Promise<void> {
   const {
@@ -232,6 +237,7 @@ async function streamPageToResponse(
     documentContext,
     setDocumentInitialHead,
     bufferBodyBeforeHeaders = false,
+    crossOrigin,
   } = options;
 
   // Custom `_document.getInitialProps()` may opt in to wrapping the page tree
@@ -284,13 +290,13 @@ async function streamPageToResponse(
 
   // Now that the shell has rendered (and any _document.getInitialProps
   // has injected its tags), collect head HTML.
-  let headHTML = getHeadHTML();
-  if (documentRenderPage.status === "rendered" && documentRenderPage.stylesHTML) {
-    headHTML += `\n  ${documentRenderPage.stylesHTML}`;
-  }
+  const headHTML = getHeadHTML();
+  const documentStylesHTML =
+    documentRenderPage.status === "rendered" ? documentRenderPage.stylesHTML : "";
 
   // Build the document shell with a placeholder for the body
   let shellTemplate: string;
+  let documentAssetProps = {};
 
   if (DocumentComponent) {
     // When the renderPage path already invoked getInitialProps, reuse its
@@ -303,19 +309,30 @@ async function streamPageToResponse(
     const docElement = docProps
       ? React.createElement(DocumentComponent, docProps)
       : React.createElement(DocumentComponent);
-    let docHtml = await renderToStringAsync(docElement);
+    const renderedDocument = extractDocumentAssetProps(await renderToStringAsync(docElement));
+    documentAssetProps = renderedDocument.props;
+    let docHtml = renderedDocument.html;
+    const generatedFontHeadHTML = applyDocumentAssetProps(
+      fontHeadHTML,
+      { headNonce: renderedDocument.props.headNonce },
+      renderedDocument.props.headCrossOrigin ?? crossOrigin,
+    );
+    const generatedScripts = applyDocumentAssetProps(scripts, renderedDocument.props, crossOrigin);
     // Replace __NEXT_MAIN__ with our stream marker
     docHtml = docHtml.replace("__NEXT_MAIN__", STREAM_BODY_MARKER);
     if (headHTML) {
       docHtml = prependToHtmlHead(docHtml, `\n  ${headHTML}\n`);
     }
-    if (fontHeadHTML) {
-      docHtml = docHtml.replace("</head>", `  ${fontHeadHTML}</head>`);
+    if (generatedFontHeadHTML || documentStylesHTML) {
+      docHtml = docHtml.replace(
+        "</head>",
+        `  ${generatedFontHeadHTML}${documentStylesHTML}\n</head>`,
+      );
     }
     // Inject scripts: replace placeholder or append before </body>
-    docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", scripts);
+    docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", generatedScripts);
     if (!docHtml.includes("__NEXT_DATA__")) {
-      docHtml = docHtml.replace("</body>", `  ${scripts}\n</body>`);
+      docHtml = docHtml.replace("</body>", `  ${generatedScripts}\n</body>`);
     }
     shellTemplate = docHtml;
   } else {
@@ -325,7 +342,7 @@ async function streamPageToResponse(
     shellTemplate = `<!DOCTYPE html>
 <html>
 <head>
-  ${fontHeadHTML}${headHTML}
+  ${fontHeadHTML}${headHTML}${documentStylesHTML}
 </head>
 <body>
   <div id="__next">${STREAM_BODY_MARKER}</div>
@@ -447,6 +464,7 @@ export function createSSRHandler(
    */
   clientTraceMetadata?: readonly string[],
   htmlLimitedBots?: string,
+  crossOrigin?: string,
 ) {
   const matcher = fileMatcher ?? createValidFileMatcher();
 
@@ -1798,6 +1816,7 @@ hydrate();
               ? headShim.setDocumentInitialHead
               : undefined,
           bufferBodyBeforeHeaders: true,
+          crossOrigin,
         });
         _renderEnd = now();
 

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -312,10 +312,16 @@ async function streamPageToResponse(
     let docHtml = renderedDocument.html;
     const generatedFontHeadHTML = applyDocumentAssetProps(
       fontHeadHTML,
-      { headNonce: renderedDocument.props.headNonce },
+      renderedDocument.props,
       renderedDocument.props.headCrossOrigin ?? crossOrigin,
+      "head",
     );
-    const generatedScripts = applyDocumentAssetProps(scripts, renderedDocument.props, crossOrigin);
+    const generatedScripts = applyDocumentAssetProps(
+      scripts,
+      renderedDocument.props,
+      crossOrigin,
+      "script",
+    );
     // Replace __NEXT_MAIN__ with our stream marker
     docHtml = docHtml.replace("__NEXT_MAIN__", STREAM_BODY_MARKER);
     if (headHTML) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -296,7 +296,6 @@ async function streamPageToResponse(
 
   // Build the document shell with a placeholder for the body
   let shellTemplate: string;
-  let documentAssetProps = {};
 
   if (DocumentComponent) {
     // When the renderPage path already invoked getInitialProps, reuse its
@@ -310,7 +309,6 @@ async function streamPageToResponse(
       ? React.createElement(DocumentComponent, docProps)
       : React.createElement(DocumentComponent);
     const renderedDocument = extractDocumentAssetProps(await renderToStringAsync(docElement));
-    documentAssetProps = renderedDocument.props;
     let docHtml = renderedDocument.html;
     const generatedFontHeadHTML = applyDocumentAssetProps(
       fontHeadHTML,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -36,7 +36,13 @@ import "vinext/shims/router-state";
 import { runWithHeadState } from "vinext/shims/head-state";
 import { runWithServerInsertedHTMLState } from "vinext/shims/navigation-state";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
-import { createInlineScriptTag, createNonceAttribute, safeJsonStringify } from "./html.js";
+import {
+  createInlineScriptTag,
+  createNonceAttribute,
+  movePagesDefaultHeadTagsFirst,
+  prependToHtmlHead,
+  safeJsonStringify,
+} from "./html.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { getScriptNonceFromNodeHeaderSources } from "./csp.js";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
@@ -300,9 +306,11 @@ async function streamPageToResponse(
     let docHtml = await renderToStringAsync(docElement);
     // Replace __NEXT_MAIN__ with our stream marker
     docHtml = docHtml.replace("__NEXT_MAIN__", STREAM_BODY_MARKER);
-    // Inject head tags
-    if (headHTML || fontHeadHTML) {
-      docHtml = docHtml.replace("</head>", `  ${fontHeadHTML}${headHTML}\n</head>`);
+    if (headHTML) {
+      docHtml = prependToHtmlHead(docHtml, `\n  ${headHTML}\n`);
+    }
+    if (fontHeadHTML) {
+      docHtml = docHtml.replace("</head>", `  ${fontHeadHTML}</head>`);
     }
     // Inject scripts: replace placeholder or append before </body>
     docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", scripts);
@@ -328,7 +336,10 @@ async function streamPageToResponse(
 
   // Apply Vite's HTML transforms (injects HMR client, etc.) on the full
   // shell template, then split at the body marker.
-  const transformedShell = await server.transformIndexHtml(url, shellTemplate);
+  let transformedShell = await server.transformIndexHtml(url, shellTemplate);
+  if (DocumentComponent && headHTML) {
+    transformedShell = movePagesDefaultHeadTagsFirst(transformedShell);
+  }
   const markerIdx = transformedShell.indexOf(STREAM_BODY_MARKER);
   const prefix = transformedShell.slice(0, markerIdx);
   const suffix = transformedShell.slice(markerIdx + STREAM_BODY_MARKER.length);

--- a/packages/vinext/src/server/html.ts
+++ b/packages/vinext/src/server/html.ts
@@ -56,3 +56,40 @@ export function createNonceAttribute(nonce?: string): string {
 export function createInlineScriptTag(content: string, nonce?: string): string {
   return `<script${createNonceAttribute(nonce)}>${content}</script>`;
 }
+
+export function prependToHtmlHead(html: string, content: string): string {
+  if (!content) return html;
+
+  const headOpenEnd = html.search(/<head(?:\s[^>]*)?>/i);
+  if (headOpenEnd === -1) return html;
+
+  const insertionIndex = html.indexOf(">", headOpenEnd) + 1;
+  return html.slice(0, insertionIndex) + content + html.slice(insertionIndex);
+}
+
+export function movePagesDefaultHeadTagsFirst(html: string): string {
+  const headOpenStart = html.search(/<head(?:\s[^>]*)?>/i);
+  if (headOpenStart === -1) return html;
+
+  const headOpenEnd = html.indexOf(">", headOpenStart) + 1;
+  const headCloseStart = html.search(/<\/head\s*>/i);
+  if (headCloseStart === -1 || headCloseStart < headOpenEnd) return html;
+
+  const defaultTags: string[] = [];
+  const headContent = html.slice(headOpenEnd, headCloseStart);
+  const withoutDefaults = headContent.replace(
+    /<meta\b(?=[^>]*\bdata-next-head(?:=(?:""|'')|\s|>))(?=[^>]*(?:\bcharset=["'][^"']+["']|\bname=["']viewport["']))[^>]*\/?>/gi,
+    (tag) => {
+      if (/\bcharset=["'][^"']+["']/i.test(tag)) {
+        defaultTags.unshift(tag);
+      } else {
+        defaultTags.push(tag);
+      }
+      return "";
+    },
+  );
+
+  return (
+    html.slice(0, headOpenEnd) + defaultTags.join("") + withoutDefaults + html.slice(headCloseStart)
+  );
+}

--- a/packages/vinext/src/server/pages-asset-tags.ts
+++ b/packages/vinext/src/server/pages-asset-tags.ts
@@ -109,6 +109,7 @@ type CollectAssetTagsOptions = {
   basePath?: string;
   assetPrefix?: string;
   deploymentId?: string;
+  crossOrigin?: string;
 };
 
 /**
@@ -137,6 +138,9 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   // upstream tests (e.g. test/e2e/optimized-loading) assert the literal `defer`
   // attribute, and adding it preserves parity without changing browser behaviour.
   const deferAttr = options.disableOptimizedLoading ? "" : " defer";
+  const crossOriginAttr = options.crossOrigin
+    ? ` crossorigin="${options.crossOrigin}"`
+    : " crossorigin";
 
   // SSR-manifest / client-entry values are base-anchored (so the lazy-chunk
   // membership test below matches the base-anchored __VINEXT_LAZY_CHUNKS__), but
@@ -165,14 +169,24 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   if (typeof globalThis !== "undefined" && globalThis.__VINEXT_CLIENT_ENTRY__) {
     const entry = globalThis.__VINEXT_CLIENT_ENTRY__;
     seen.add(entry);
-    tags.push('<link rel="modulepreload"' + nonceAttr + ' href="' + href(entry) + '" />');
+    tags.push(
+      '<link rel="modulepreload"' +
+        nonceAttr +
+        ' href="' +
+        href(entry) +
+        '"' +
+        crossOriginAttr +
+        " />",
+    );
     tags.push(
       '<script type="module"' +
         deferAttr +
         nonceAttr +
         ' src="' +
         href(entry) +
-        '" crossorigin></script>',
+        '"' +
+        crossOriginAttr +
+        "></script>",
     );
   }
 
@@ -237,14 +251,24 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
         // Membership test uses the base-anchored `tf` (same key-space as
         // __VINEXT_LAZY_CHUNKS__), NOT the re-anchored href.
         if (lazySet && lazySet.has(tf)) continue;
-        tags.push('<link rel="modulepreload"' + nonceAttr + ' href="' + href(tf) + '" />');
+        tags.push(
+          '<link rel="modulepreload"' +
+            nonceAttr +
+            ' href="' +
+            href(tf) +
+            '"' +
+            crossOriginAttr +
+            " />",
+        );
         tags.push(
           '<script type="module"' +
             deferAttr +
             nonceAttr +
             ' src="' +
             href(tf) +
-            '" crossorigin></script>',
+            '"' +
+            crossOriginAttr +
+            "></script>",
         );
       }
     }

--- a/packages/vinext/src/server/pages-asset-tags.ts
+++ b/packages/vinext/src/server/pages-asset-tags.ts
@@ -138,9 +138,10 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   // upstream tests (e.g. test/e2e/optimized-loading) assert the literal `defer`
   // attribute, and adding it preserves parity without changing browser behaviour.
   const deferAttr = options.disableOptimizedLoading ? "" : " defer";
-  const crossOriginAttr = options.crossOrigin
+  const scriptCrossOriginAttr = options.crossOrigin
     ? ` crossorigin="${options.crossOrigin}"`
     : " crossorigin";
+  const preloadCrossOriginAttr = options.crossOrigin ? ` crossorigin="${options.crossOrigin}"` : "";
 
   // SSR-manifest / client-entry values are base-anchored (so the lazy-chunk
   // membership test below matches the base-anchored __VINEXT_LAZY_CHUNKS__), but
@@ -175,7 +176,7 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
         ' href="' +
         href(entry) +
         '"' +
-        crossOriginAttr +
+        preloadCrossOriginAttr +
         " />",
     );
     tags.push(
@@ -185,7 +186,7 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
         ' src="' +
         href(entry) +
         '"' +
-        crossOriginAttr +
+        scriptCrossOriginAttr +
         "></script>",
     );
   }
@@ -257,7 +258,7 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
             ' href="' +
             href(tf) +
             '"' +
-            crossOriginAttr +
+            preloadCrossOriginAttr +
             " />",
         );
         tags.push(
@@ -267,7 +268,7 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
             ' src="' +
             href(tf) +
             '"' +
-            crossOriginAttr +
+            scriptCrossOriginAttr +
             "></script>",
         );
       }

--- a/packages/vinext/src/server/pages-document-asset-props.ts
+++ b/packages/vinext/src/server/pages-document-asset-props.ts
@@ -85,10 +85,3 @@ export function applyDocumentAssetProps(
       ),
     );
 }
-
-export const documentAssetMarkerAttributes = {
-  headNonce: HEAD_NONCE_ATTR,
-  headCrossOrigin: HEAD_CROSS_ORIGIN_ATTR,
-  scriptNonce: SCRIPT_NONCE_ATTR,
-  scriptCrossOrigin: SCRIPT_CROSS_ORIGIN_ATTR,
-} as const;

--- a/packages/vinext/src/server/pages-document-asset-props.ts
+++ b/packages/vinext/src/server/pages-document-asset-props.ts
@@ -7,6 +7,8 @@ export type DocumentAssetProps = {
   scriptCrossOrigin?: string;
 };
 
+type DocumentAssetOwner = "head" | "script";
+
 const HEAD_NONCE_ATTR = "data-vinext-head-nonce";
 const HEAD_CROSS_ORIGIN_ATTR = "data-vinext-head-cross-origin";
 const SCRIPT_NONCE_ATTR = "data-vinext-script-nonce";
@@ -60,28 +62,19 @@ export function applyDocumentAssetProps(
   html: string,
   props: DocumentAssetProps,
   configuredCrossOrigin?: string,
+  owner: DocumentAssetOwner = "script",
 ): string {
-  const scriptNonce = props.scriptNonce;
-  const preloadNonce = props.headNonce;
-  const scriptCrossOrigin = props.scriptCrossOrigin ?? configuredCrossOrigin;
-  const preloadCrossOrigin =
-    props.headCrossOrigin ?? props.scriptCrossOrigin ?? configuredCrossOrigin;
+  const nonce = owner === "head" ? props.headNonce : props.scriptNonce;
+  const crossOrigin =
+    owner === "head"
+      ? (props.headCrossOrigin ?? configuredCrossOrigin)
+      : (props.scriptCrossOrigin ?? configuredCrossOrigin);
 
   return html
     .replace(/<script\b[^>]*>/gi, (tag) =>
-      addAttribute(
-        addAttribute(tag, "nonce", scriptNonce, true),
-        "crossorigin",
-        scriptCrossOrigin,
-        true,
-      ),
+      addAttribute(addAttribute(tag, "nonce", nonce, true), "crossorigin", crossOrigin, true),
     )
-    .replace(/<link\b[^>]*\brel="(?:preload|modulepreload)"[^>]*>/gi, (tag) =>
-      addAttribute(
-        addAttribute(tag, "nonce", preloadNonce, true),
-        "crossorigin",
-        preloadCrossOrigin,
-        true,
-      ),
+    .replace(/<link\b[^>]*\brel="(?:preload|modulepreload|stylesheet)"[^>]*>/gi, (tag) =>
+      addAttribute(addAttribute(tag, "nonce", nonce, true), "crossorigin", crossOrigin, true),
     );
 }

--- a/packages/vinext/src/server/pages-document-asset-props.ts
+++ b/packages/vinext/src/server/pages-document-asset-props.ts
@@ -1,0 +1,94 @@
+import { escapeHtmlAttr } from "./html.js";
+
+export type DocumentAssetProps = {
+  headNonce?: string;
+  headCrossOrigin?: string;
+  scriptNonce?: string;
+  scriptCrossOrigin?: string;
+};
+
+const HEAD_NONCE_ATTR = "data-vinext-head-nonce";
+const HEAD_CROSS_ORIGIN_ATTR = "data-vinext-head-cross-origin";
+const SCRIPT_NONCE_ATTR = "data-vinext-script-nonce";
+const SCRIPT_CROSS_ORIGIN_ATTR = "data-vinext-script-cross-origin";
+
+function readAttribute(html: string, name: string): string | undefined {
+  const match = html.match(new RegExp(`\\s${name}="([^"]*)"`));
+  return match?.[1];
+}
+
+export function extractDocumentAssetProps(html: string): {
+  html: string;
+  props: DocumentAssetProps;
+} {
+  const props = {
+    headNonce: readAttribute(html, HEAD_NONCE_ATTR),
+    headCrossOrigin: readAttribute(html, HEAD_CROSS_ORIGIN_ATTR),
+    scriptNonce: readAttribute(html, SCRIPT_NONCE_ATTR),
+    scriptCrossOrigin: readAttribute(html, SCRIPT_CROSS_ORIGIN_ATTR),
+  };
+  const cleanedHtml = html.replace(
+    new RegExp(
+      `\\s(?:${HEAD_NONCE_ATTR}|${HEAD_CROSS_ORIGIN_ATTR}|${SCRIPT_NONCE_ATTR}|${SCRIPT_CROSS_ORIGIN_ATTR})="[^"]*"`,
+      "g",
+    ),
+    "",
+  );
+  return { html: cleanedHtml, props };
+}
+
+function addAttribute(
+  tag: string,
+  name: string,
+  value: string | undefined,
+  replaceExisting = false,
+): string {
+  if (value === undefined) return tag;
+  const attributePattern = new RegExp(`\\s${name}(?:="[^"]*")?`, "i");
+  if (attributePattern.test(tag)) {
+    return replaceExisting
+      ? tag.replace(attributePattern, ` ${name}="${escapeHtmlAttr(value)}"`)
+      : tag;
+  }
+  return tag.replace(/\s*\/?>$/, (ending) => {
+    const closing = ending.includes("/") ? " />" : ">";
+    return ` ${name}="${escapeHtmlAttr(value)}"${closing}`;
+  });
+}
+
+export function applyDocumentAssetProps(
+  html: string,
+  props: DocumentAssetProps,
+  configuredCrossOrigin?: string,
+): string {
+  const scriptNonce = props.scriptNonce;
+  const preloadNonce = props.headNonce;
+  const scriptCrossOrigin = props.scriptCrossOrigin ?? configuredCrossOrigin;
+  const preloadCrossOrigin =
+    props.headCrossOrigin ?? props.scriptCrossOrigin ?? configuredCrossOrigin;
+
+  return html
+    .replace(/<script\b[^>]*>/gi, (tag) =>
+      addAttribute(
+        addAttribute(tag, "nonce", scriptNonce, true),
+        "crossorigin",
+        scriptCrossOrigin,
+        true,
+      ),
+    )
+    .replace(/<link\b[^>]*\brel="(?:preload|modulepreload)"[^>]*>/gi, (tag) =>
+      addAttribute(
+        addAttribute(tag, "nonce", preloadNonce, true),
+        "crossorigin",
+        preloadCrossOrigin,
+        true,
+      ),
+    );
+}
+
+export const documentAssetMarkerAttributes = {
+  headNonce: HEAD_NONCE_ATTR,
+  headCrossOrigin: HEAD_CROSS_ORIGIN_ATTR,
+  scriptNonce: SCRIPT_NONCE_ATTR,
+  scriptCrossOrigin: SCRIPT_CROSS_ORIGIN_ATTR,
+} as const;

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -724,6 +724,7 @@ export function createPagesPageHandler(
             const el = createPageElement(PageComponent, AppComponent, currentProps);
             return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
           },
+          disableOptimizedLoading: vinextConfig.disableOptimizedLoading,
           enhancePageElement(renderPageOpts) {
             const el = enhancePageElement(PageComponent, AppComponent, renderProps, renderPageOpts);
             return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -87,6 +87,7 @@ type VinextConfigSubset = {
   htmlLimitedBots?: string;
   clientTraceMetadata?: readonly string[];
   disableOptimizedLoading: boolean;
+  crossOrigin?: string;
 };
 
 /**
@@ -710,6 +711,7 @@ export function createPagesPageHandler(
           basePath: vinextConfig.basePath,
           assetPrefix: vinextConfig.assetPrefix,
           deploymentId: process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
+          crossOrigin: vinextConfig.crossOrigin,
         });
 
         return await renderPagesPageResponse({
@@ -757,6 +759,7 @@ export function createPagesPageHandler(
           routeUrl,
           safeJsonStringify,
           scriptNonce,
+          crossOrigin: vinextConfig.crossOrigin,
           statusCode: renderStatusCode,
           nextData: serializedPagesNextData,
           userAgent: request.headers.get("user-agent") ?? undefined,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -332,18 +332,21 @@ async function buildPagesShellHtml(
     let html = renderedDocument.html;
     const generatedFontHeadHTML = applyDocumentAssetProps(
       fontHeadHTML,
-      { headNonce: renderedDocument.props.headNonce },
+      renderedDocument.props,
       renderedDocument.props.headCrossOrigin ?? options.crossOrigin,
+      "head",
     );
     const generatedAssetTags = applyDocumentAssetProps(
       options.assetTags,
       renderedDocument.props,
       options.crossOrigin,
+      "head",
     );
     const generatedNextDataScript = applyDocumentAssetProps(
       nextDataScript,
       renderedDocument.props,
       options.crossOrigin,
+      "script",
     );
     html = html.replace("__NEXT_MAIN__", bodyMarker);
     if (options.ssrHeadHTML) {

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -11,7 +11,7 @@ import {
 } from "./isr-decision.js";
 import { encodeCacheTag } from "../utils/encode-cache-tag.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
-import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
+import { createNonceAttribute, escapeHtmlAttr, prependToHtmlHead } from "./html.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { reportRequestError } from "./instrumentation.js";
 import {
@@ -321,11 +321,11 @@ async function buildPagesShellHtml(
       : React.createElement(options.DocumentComponent);
     let html = await options.renderDocumentToString(docElement);
     html = html.replace("__NEXT_MAIN__", bodyMarker);
-    if (options.ssrHeadHTML || options.assetTags || fontHeadHTML) {
-      html = html.replace(
-        "</head>",
-        `  ${fontHeadHTML}${options.ssrHeadHTML}\n  ${options.assetTags}\n</head>`,
-      );
+    if (options.ssrHeadHTML) {
+      html = prependToHtmlHead(html, `\n  ${options.ssrHeadHTML}\n`);
+    }
+    if (options.assetTags || fontHeadHTML) {
+      html = html.replace("</head>", `  ${fontHeadHTML}${options.assetTags}\n</head>`);
     }
     html = html.replace("<!-- __NEXT_SCRIPTS__ -->", nextDataScript);
     if (!html.includes("__NEXT_DATA__")) {

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -199,6 +199,7 @@ type RenderPagesPageResponseOptions = {
   safeJsonStringify: (value: unknown) => string;
   scriptNonce?: string;
   crossOrigin?: string;
+  disableOptimizedLoading: boolean;
   statusCode?: number;
   vinext?: VinextNextData["__vinext"];
   nextData?: PagesNextDataExtras;
@@ -225,6 +226,22 @@ type RenderPagesPageResponseOptions = {
    */
   requestCacheControl?: string;
 };
+
+function splitPagesAssetTags(assetTags: string): {
+  headAssetTags: string;
+  runtimeScriptTags: string;
+} {
+  const runtimeScriptTags: string[] = [];
+  const headAssetTags = assetTags.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, (tag) => {
+    runtimeScriptTags.push(tag);
+    return "";
+  });
+
+  return {
+    headAssetTags: headAssetTags.replace(/\n{2,}/g, "\n").trim(),
+    runtimeScriptTags: runtimeScriptTags.join("\n"),
+  };
+}
 
 function buildPagesFontHeadHtml(
   fontLinks: string[],
@@ -317,9 +334,14 @@ async function buildPagesShellHtml(
      */
     resolvedDocProps?: Record<string, unknown> | null;
     crossOrigin?: string;
+    disableOptimizedLoading: boolean;
     documentStylesHTML?: string;
   },
 ): Promise<string> {
+  const { headAssetTags, runtimeScriptTags } = options.disableOptimizedLoading
+    ? splitPagesAssetTags(options.assetTags)
+    : { headAssetTags: options.assetTags, runtimeScriptTags: "" };
+
   if (options.DocumentComponent) {
     const docProps =
       options.resolvedDocProps ?? (await loadUserDocumentInitialProps(options.DocumentComponent));
@@ -336,14 +358,20 @@ async function buildPagesShellHtml(
       renderedDocument.props.headCrossOrigin ?? options.crossOrigin,
       "head",
     );
-    const generatedAssetTags = applyDocumentAssetProps(
-      options.assetTags,
+    const generatedHeadAssetTags = applyDocumentAssetProps(
+      headAssetTags,
       renderedDocument.props,
       options.crossOrigin,
       "head",
     );
+    const generatedRuntimeScriptTags = applyDocumentAssetProps(
+      runtimeScriptTags,
+      renderedDocument.props,
+      options.crossOrigin,
+      "script",
+    );
     const generatedNextDataScript = applyDocumentAssetProps(
-      nextDataScript,
+      [nextDataScript, generatedRuntimeScriptTags].filter(Boolean).join("\n"),
       renderedDocument.props,
       options.crossOrigin,
       "script",
@@ -352,10 +380,10 @@ async function buildPagesShellHtml(
     if (options.ssrHeadHTML) {
       html = prependToHtmlHead(html, `\n  ${options.ssrHeadHTML}\n`);
     }
-    if (generatedAssetTags || generatedFontHeadHTML || options.documentStylesHTML) {
+    if (generatedHeadAssetTags || generatedFontHeadHTML || options.documentStylesHTML) {
       html = html.replace(
         "</head>",
-        `  ${generatedFontHeadHTML}${generatedAssetTags}\n  ${options.documentStylesHTML ?? ""}\n</head>`,
+        `  ${generatedFontHeadHTML}${generatedHeadAssetTags}\n  ${options.documentStylesHTML ?? ""}\n</head>`,
       );
     }
     html = html.replace("<!-- __NEXT_SCRIPTS__ -->", generatedNextDataScript);
@@ -371,10 +399,11 @@ async function buildPagesShellHtml(
   return applyDocumentAssetProps(
     "<!DOCTYPE html>\n<html>\n<head>\n" +
       `  ${fontHeadHTML}${options.ssrHeadHTML}\n` +
-      `  ${options.assetTags}\n` +
+      `  ${headAssetTags}\n` +
       "</head>\n<body>\n" +
       `  <div id="__next">${bodyMarker}</div>\n` +
       `  ${nextDataScript}\n` +
+      `  ${runtimeScriptTags}\n` +
       "</body>\n</html>",
     {},
     options.crossOrigin,
@@ -610,6 +639,7 @@ export async function renderPagesPageResponse(
     // `skipped` means it was never invoked → fall through to the fast path.
     resolvedDocProps: documentRenderPage.status === "skipped" ? null : documentRenderPage.docProps,
     crossOrigin: options.crossOrigin,
+    disableOptimizedLoading: options.disableOptimizedLoading,
     documentStylesHTML,
   });
 

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -231,14 +231,19 @@ function splitPagesAssetTags(assetTags: string): {
   headAssetTags: string;
   runtimeScriptTags: string;
 } {
+  const headAssetTags: string[] = [];
   const runtimeScriptTags: string[] = [];
-  const headAssetTags = assetTags.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, (tag) => {
-    runtimeScriptTags.push(tag);
-    return "";
-  });
+
+  for (const tag of assetTags.split("\n")) {
+    if (tag.trimStart().startsWith("<script")) {
+      runtimeScriptTags.push(tag);
+    } else if (tag.trim()) {
+      headAssetTags.push(tag);
+    }
+  }
 
   return {
-    headAssetTags: headAssetTags.replace(/\n{2,}/g, "\n").trim(),
+    headAssetTags: headAssetTags.join("\n"),
     runtimeScriptTags: runtimeScriptTags.join("\n"),
   };
 }

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -23,6 +23,10 @@ import { fnv1a52 } from "../utils/hash.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
+import {
+  applyDocumentAssetProps,
+  extractDocumentAssetProps,
+} from "./pages-document-asset-props.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
@@ -194,6 +198,7 @@ type RenderPagesPageResponseOptions = {
   routeUrl: string;
   safeJsonStringify: (value: unknown) => string;
   scriptNonce?: string;
+  crossOrigin?: string;
   statusCode?: number;
   vinext?: VinextNextData["__vinext"];
   nextData?: PagesNextDataExtras;
@@ -311,6 +316,8 @@ async function buildPagesShellHtml(
      * second time). `null` means use the normal fast path.
      */
     resolvedDocProps?: Record<string, unknown> | null;
+    crossOrigin?: string;
+    documentStylesHTML?: string;
   },
 ): Promise<string> {
   if (options.DocumentComponent) {
@@ -319,17 +326,38 @@ async function buildPagesShellHtml(
     const docElement = docProps
       ? React.createElement(options.DocumentComponent, docProps)
       : React.createElement(options.DocumentComponent);
-    let html = await options.renderDocumentToString(docElement);
+    const renderedDocument = extractDocumentAssetProps(
+      await options.renderDocumentToString(docElement),
+    );
+    let html = renderedDocument.html;
+    const generatedFontHeadHTML = applyDocumentAssetProps(
+      fontHeadHTML,
+      { headNonce: renderedDocument.props.headNonce },
+      renderedDocument.props.headCrossOrigin ?? options.crossOrigin,
+    );
+    const generatedAssetTags = applyDocumentAssetProps(
+      options.assetTags,
+      renderedDocument.props,
+      options.crossOrigin,
+    );
+    const generatedNextDataScript = applyDocumentAssetProps(
+      nextDataScript,
+      renderedDocument.props,
+      options.crossOrigin,
+    );
     html = html.replace("__NEXT_MAIN__", bodyMarker);
     if (options.ssrHeadHTML) {
       html = prependToHtmlHead(html, `\n  ${options.ssrHeadHTML}\n`);
     }
-    if (options.assetTags || fontHeadHTML) {
-      html = html.replace("</head>", `  ${fontHeadHTML}${options.assetTags}\n</head>`);
+    if (generatedAssetTags || generatedFontHeadHTML || options.documentStylesHTML) {
+      html = html.replace(
+        "</head>",
+        `  ${generatedFontHeadHTML}${generatedAssetTags}\n  ${options.documentStylesHTML ?? ""}\n</head>`,
+      );
     }
-    html = html.replace("<!-- __NEXT_SCRIPTS__ -->", nextDataScript);
+    html = html.replace("<!-- __NEXT_SCRIPTS__ -->", generatedNextDataScript);
     if (!html.includes("__NEXT_DATA__")) {
-      html = html.replace("</body>", `  ${nextDataScript}\n</body>`);
+      html = html.replace("</body>", `  ${generatedNextDataScript}\n</body>`);
     }
     return html;
   }
@@ -337,14 +365,16 @@ async function buildPagesShellHtml(
   // charset + viewport are emitted via getSSRHeadHTML() (next/head's
   // defaultHead seeds them with data-next-head=""), matching Next.js's
   // canonical ordering. Don't duplicate them here.
-  return (
+  return applyDocumentAssetProps(
     "<!DOCTYPE html>\n<html>\n<head>\n" +
-    `  ${fontHeadHTML}${options.ssrHeadHTML}\n` +
-    `  ${options.assetTags}\n` +
-    "</head>\n<body>\n" +
-    `  <div id="__next">${bodyMarker}</div>\n` +
-    `  ${nextDataScript}\n` +
-    "</body>\n</html>"
+      `  ${fontHeadHTML}${options.ssrHeadHTML}\n` +
+      `  ${options.assetTags}\n` +
+      "</head>\n<body>\n" +
+      `  <div id="__next">${bodyMarker}</div>\n` +
+      `  ${nextDataScript}\n` +
+      "</body>\n</html>",
+    {},
+    options.crossOrigin,
   );
 }
 
@@ -565,12 +595,8 @@ export async function renderPagesPageResponse(
   const traceMetaHTML = getClientTraceMetadataHTML(options.clientTraceMetadata);
   let ssrHeadHTML = headFromShim;
   if (traceMetaHTML) ssrHeadHTML += `\n  ${traceMetaHTML}`;
-  // `styles` returned by `_document.getInitialProps()` (e.g. collected
-  // styled-components / emotion <style> tags) is already rendered to a string
-  // by the shared helper, ready to merge into the SSR head.
-  if (documentRenderPage.status === "rendered" && documentRenderPage.stylesHTML) {
-    ssrHeadHTML += `\n  ${documentRenderPage.stylesHTML}`;
-  }
+  const documentStylesHTML =
+    documentRenderPage.status === "rendered" ? documentRenderPage.stylesHTML : "";
   const shellHtml = await buildPagesShellHtml(bodyMarker, fontHeadHTML, nextDataScript, {
     assetTags: options.assetTags,
     DocumentComponent: options.DocumentComponent,
@@ -580,6 +606,8 @@ export async function renderPagesPageResponse(
     // resolved props instead of calling it a second time.
     // `skipped` means it was never invoked → fall through to the fast path.
     resolvedDocProps: documentRenderPage.status === "skipped" ? null : documentRenderPage.docProps,
+    crossOrigin: options.crossOrigin,
+    documentStylesHTML,
   });
 
   options.clearSsrContext();

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -7,6 +7,13 @@
  */
 import React from "react";
 
+const documentAssetMarkerAttributes = {
+  headNonce: "data-vinext-head-nonce",
+  headCrossOrigin: "data-vinext-head-cross-origin",
+  scriptNonce: "data-vinext-script-nonce",
+  scriptCrossOrigin: "data-vinext-script-cross-origin",
+} as const;
+
 export function Html({
   children,
   lang,
@@ -31,15 +38,22 @@ export function Html({
  */
 export function Head({
   children,
-  nonce: _nonce,
-  crossOrigin: _crossOrigin,
   ...props
 }: React.HTMLAttributes<HTMLHeadElement> & {
   children?: React.ReactNode;
   nonce?: string;
   crossOrigin?: "anonymous" | "use-credentials" | "";
 }) {
-  return <head {...props}>{children}</head>;
+  const { nonce, crossOrigin, ...headProps } = props;
+  return (
+    <head
+      {...headProps}
+      {...(nonce ? { [documentAssetMarkerAttributes.headNonce]: nonce } : {})}
+      {...(crossOrigin ? { [documentAssetMarkerAttributes.headCrossOrigin]: crossOrigin } : {})}
+    >
+      {children}
+    </head>
+  );
 }
 
 /**
@@ -54,8 +68,14 @@ export function Main() {
  * actual hydration scripts (__NEXT_DATA__ + entry module).
  * Uses dangerouslySetInnerHTML so the HTML comment survives renderToString.
  */
-export function NextScript() {
-  return <span dangerouslySetInnerHTML={{ __html: "<!-- __NEXT_SCRIPTS__ -->" }} />;
+export function NextScript({ nonce, crossOrigin }: { nonce?: string; crossOrigin?: string }) {
+  return (
+    <span
+      {...(nonce ? { [documentAssetMarkerAttributes.scriptNonce]: nonce } : {})}
+      {...(crossOrigin ? { [documentAssetMarkerAttributes.scriptCrossOrigin]: crossOrigin } : {})}
+      dangerouslySetInnerHTML={{ __html: "<!-- __NEXT_SCRIPTS__ -->" }}
+    />
+  );
 }
 
 /**

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -29,8 +29,17 @@ export function Html({
  * ordering (`<meta charset>` first, then `<meta viewport>`, then user tags,
  * all with `data-next-head=""`). See `test/e2e/next-head/index.test.ts`.
  */
-export function Head({ children }: { children?: React.ReactNode }) {
-  return <head>{children}</head>;
+export function Head({
+  children,
+  nonce: _nonce,
+  crossOrigin: _crossOrigin,
+  ...props
+}: React.HTMLAttributes<HTMLHeadElement> & {
+  children?: React.ReactNode;
+  nonce?: string;
+  crossOrigin?: "anonymous" | "use-credentials" | "";
+}) {
+  return <head {...props}>{children}</head>;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,6 +1449,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/og-font-package: {}
+
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,8 +1449,6 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
-  tests/fixtures/og-font-package: {}
-
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -29,6 +29,14 @@ describe("NextScript", () => {
     // Dev-server replaces this HTML comment with __NEXT_DATA__ + module script tags
     expect(html).toContain("<!-- __NEXT_SCRIPTS__ -->");
   });
+
+  it("preserves nonce and crossOrigin for document asset propagation", () => {
+    const html = render(
+      React.createElement(NextScript, { nonce: "test-nonce", crossOrigin: "anonymous" }),
+    );
+    expect(html).toContain('data-vinext-script-nonce="test-nonce"');
+    expect(html).toContain('data-vinext-script-cross-origin="anonymous"');
+  });
 });
 
 describe("Head", () => {
@@ -53,6 +61,14 @@ describe("Head", () => {
     // pipeline as user-supplied tags.
     expect(html).not.toContain("charSet=");
     expect(html).not.toContain('name="viewport"');
+  });
+
+  it("preserves nonce and crossOrigin for document preload propagation", () => {
+    const html = render(
+      React.createElement(Head, { nonce: "test-nonce", crossOrigin: "anonymous" }),
+    );
+    expect(html).toContain('data-vinext-head-nonce="test-nonce"');
+    expect(html).toContain('data-vinext-head-cross-origin="anonymous"');
   });
 });
 

--- a/tests/e2e/pages-router-prod/production.spec.ts
+++ b/tests/e2e/pages-router-prod/production.spec.ts
@@ -135,6 +135,26 @@ test.describe("Pages Router Production Build", () => {
     expect(html).toContain("utf-8");
     expect(html).toContain("viewport");
   });
+
+  test("places charset first in head with a custom document", async ({ page }) => {
+    await page.goto(`${BASE}/`);
+
+    expect(
+      await page.evaluate(() =>
+        Array.from(document.head.children)
+          .slice(0, 2)
+          .map((element) => element.outerHTML)
+          .join(""),
+      ),
+    ).toBe(
+      '<meta charset="utf-8" data-next-head=""><meta name="viewport" content="width=device-width" data-next-head="">',
+    );
+    await expect(page.locator('head meta[name="description"]')).toHaveAttribute(
+      "content",
+      "A vinext test app",
+    );
+    await expect(page.locator("head")).toHaveAttribute("data-document-head", "true");
+  });
 });
 
 function decodeHtmlText(text: string): string {

--- a/tests/e2e/pages-router/head-and-dynamic.spec.ts
+++ b/tests/e2e/pages-router/head-and-dynamic.spec.ts
@@ -28,6 +28,28 @@ test.describe("next/head client-side updates", () => {
     const charset = await page.locator('meta[charSet="utf-8"]').count();
     expect(charset).toBeGreaterThan(0);
   });
+
+  test("places charset first in head with a custom document", async ({ page }) => {
+    await page.goto(`${BASE}/`);
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          Array.from(document.head.children)
+            .slice(0, 2)
+            .map((element) => element.outerHTML)
+            .join(""),
+        ),
+      )
+      .toBe(
+        '<meta charset="utf-8" data-next-head=""><meta name="viewport" content="width=device-width" data-next-head="">',
+      );
+    await expect(page.locator('head meta[name="description"]')).toHaveAttribute(
+      "content",
+      "A vinext test app",
+    );
+    await expect(page.locator("head")).toHaveAttribute("data-document-head", "true");
+  });
 });
 
 test.describe("next/dynamic", () => {

--- a/tests/fixtures/pages-basic/pages/_document.tsx
+++ b/tests/fixtures/pages-basic/pages/_document.tsx
@@ -3,7 +3,7 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head>
+      <Head data-document-head="true">
         <meta name="description" content="A vinext test app" />
       </Head>
       <body className="custom-body">

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1441,6 +1441,20 @@ describe("resolveNextConfig disableOptimizedLoading", () => {
   });
 });
 
+describe("resolveNextConfig crossOrigin", () => {
+  it("reads supported crossOrigin values", async () => {
+    const anonymous = await resolveNextConfig({ crossOrigin: "anonymous" });
+    const credentials = await resolveNextConfig({ crossOrigin: "use-credentials" });
+    expect(anonymous.crossOrigin).toBe("anonymous");
+    expect(credentials.crossOrigin).toBe("use-credentials");
+  });
+
+  it("ignores unsupported crossOrigin values", async () => {
+    const resolved = await resolveNextConfig({ crossOrigin: "invalid" as "anonymous" });
+    expect(resolved.crossOrigin).toBeUndefined();
+  });
+});
+
 describe("resolveNextConfig scrollRestoration", () => {
   it("defaults scrollRestoration to false", async () => {
     const resolved = await resolveNextConfig({});
@@ -1875,6 +1889,7 @@ describe("detectNextIntlConfig", () => {
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      crossOrigin: undefined,
       scrollRestoration: false,
       compilerDefine: {},
       compilerDefineServer: {},

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1449,9 +1449,19 @@ describe("resolveNextConfig crossOrigin", () => {
     expect(credentials.crossOrigin).toBe("use-credentials");
   });
 
-  it("ignores unsupported crossOrigin values", async () => {
+  it("warns about unsupported crossOrigin values", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const resolved = await resolveNextConfig({ crossOrigin: "invalid" as "anonymous" });
+
     expect(resolved.crossOrigin).toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid next.config options detected"),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"crossOrigin"'));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("https://nextjs.org/docs/messages/invalid-next-config"),
+    );
   });
 });
 

--- a/tests/pages-asset-tags.test.ts
+++ b/tests/pages-asset-tags.test.ts
@@ -173,6 +173,20 @@ describe("collectAssetTags", () => {
     expect(result).toContain('src="/page.js"');
   });
 
+  it("applies configured crossOrigin to scripts and modulepreloads", () => {
+    const manifest = makeManifest({ "page.tsx": ["page.js"] });
+    const result = collectAssetTags({
+      manifest,
+      moduleIds: ["page.tsx"],
+      disableOptimizedLoading: true,
+      crossOrigin: "anonymous",
+    });
+    expect(result).toContain(
+      '<link rel="modulepreload" href="/page.js" crossorigin="anonymous" />',
+    );
+    expect(result).toContain('src="/page.js" crossorigin="anonymous"></script>');
+  });
+
   it("adds defer attribute when disableOptimizedLoading is false", () => {
     const manifest = makeManifest({ "page.tsx": ["page.js"] });
     const result = collectAssetTags({

--- a/tests/pages-document-assets.test.ts
+++ b/tests/pages-document-assets.test.ts
@@ -7,22 +7,33 @@ import path from "node:path";
 import vinext from "../packages/vinext/src/index.js";
 import { startProdServer } from "../packages/vinext/src/server/prod-server.js";
 
-function assertDocumentAssetProps(html: string, requirePreloads: boolean): void {
+function assertDocumentAssetProps(html: string, requireHeadAssets: boolean): void {
   expect(html).not.toContain("data-vinext-head-nonce");
   expect(html).not.toContain("data-vinext-script-nonce");
 
-  const scripts = (html.match(/<script\b[^>]*>/g) ?? []).filter((tag) =>
-    tag.includes('nonce="test-nonce"'),
+  const documentScripts = (html.match(/<script\b[^>]*>/g) ?? []).filter((tag) =>
+    tag.includes('nonce="script-nonce"'),
   );
-  const preloads = (html.match(/<link\b[^>]*rel="(?:preload|modulepreload)"[^>]*>/g) ?? []).filter(
-    (tag) => !tag.includes('id="user-preload"'),
-  );
-  expect(scripts.length).toBeGreaterThan(0);
-  if (requirePreloads) expect(preloads.length).toBeGreaterThan(0);
-
-  for (const tag of [...scripts, ...preloads]) {
-    expect(tag).toContain('nonce="test-nonce"');
+  expect(documentScripts.length).toBeGreaterThan(0);
+  for (const tag of documentScripts) {
     expect(tag).toContain('crossorigin="anonymous"');
+  }
+
+  const generatedHeadAssets = (html.match(/<(?:script|link)\b[^>]*>/g) ?? []).filter(
+    (tag) =>
+      !tag.includes('id="user-') &&
+      !tag.includes("/@vite/") &&
+      (tag.includes('rel="stylesheet"') ||
+        tag.includes('rel="preload"') ||
+        tag.includes('rel="modulepreload"') ||
+        (tag.includes("<script") && tag.includes("src="))),
+  );
+  if (requireHeadAssets) {
+    expect(generatedHeadAssets.length).toBeGreaterThan(0);
+    for (const tag of generatedHeadAssets) {
+      expect(tag).toContain('nonce="head-nonce"');
+      expect(tag).toContain('crossorigin="use-credentials"');
+    }
   }
 
   expect(html).toMatch(
@@ -59,17 +70,26 @@ describe("Pages _document script and preload props", () => {
     );
     await fsp.writeFile(
       path.join(root, "pages", "index.tsx"),
-      "export default function Page() { return <main>ok</main>; }\n",
+      'import "../style.css";\nexport default function Page() { return <main className="cascade">ok</main>; }\n',
     );
+    await fsp.writeFile(path.join(root, "style.css"), ".cascade { color: green }\n");
     await fsp.writeFile(
       path.join(root, "pages", "_document.tsx"),
       `import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
-  return <Html><Head nonce="test-nonce">
+  return <Html><Head nonce="head-nonce" crossOrigin="use-credentials">
+    <style id="custom-document-style">{".cascade { color: red }"}</style>
     <script id="user-script" src="/user.js" nonce="user-nonce" crossOrigin="use-credentials" />
     <link id="user-preload" rel="preload" href="/user.js" as="script" nonce="user-preload-nonce" crossOrigin="use-credentials" />
-  </Head><body><Main /><NextScript nonce="test-nonce" /></body></Html>;
+  </Head><body><Main /><NextScript nonce="script-nonce" /></body></Html>;
 }
+Document.getInitialProps = async (ctx) => {
+  const initialProps = await ctx.defaultGetInitialProps(ctx);
+  return {
+    ...initialProps,
+    styles: <style id="collected-document-style">{".cascade { color: blue }"}</style>,
+  };
+};
 `,
     );
 
@@ -123,8 +143,11 @@ export default function Document() {
     expect(response.status).toBe(200);
     const html = await response.text();
     assertDocumentAssetProps(html, false);
+    expect(html.indexOf('id="custom-document-style"')).toBeLessThan(
+      html.indexOf('id="collected-document-style"'),
+    );
     const viteScripts = (html.match(/<script\b[^>]*>/g) ?? []).filter(
-      (tag) => !tag.includes('id="user-script"') && !tag.includes('nonce="test-nonce"'),
+      (tag) => !tag.includes('id="user-script"') && !tag.includes('nonce="script-nonce"'),
     );
     expect(viteScripts.length).toBeGreaterThan(0);
     for (const tag of viteScripts) {
@@ -136,6 +159,10 @@ export default function Document() {
   it("propagates props in production", async () => {
     const response = await fetch(prodUrl);
     expect(response.status).toBe(200);
-    assertDocumentAssetProps(await response.text(), true);
+    const html = await response.text();
+    assertDocumentAssetProps(html, true);
+    expect(html.indexOf('id="custom-document-style"')).toBeLessThan(
+      html.indexOf('id="collected-document-style"'),
+    );
   });
 });

--- a/tests/pages-document-assets.test.ts
+++ b/tests/pages-document-assets.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { build, createServer, type ViteDevServer } from "vite-plus";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vinext from "../packages/vinext/src/index.js";
+import { startProdServer } from "../packages/vinext/src/server/prod-server.js";
+
+function assertDocumentAssetProps(html: string, requirePreloads: boolean): void {
+  expect(html).not.toContain("data-vinext-head-nonce");
+  expect(html).not.toContain("data-vinext-script-nonce");
+
+  const scripts = html.match(/<script\b[^>]*>/g) ?? [];
+  const preloads = html.match(/<link\b[^>]*rel="(?:preload|modulepreload)"[^>]*>/g) ?? [];
+  expect(scripts.length).toBeGreaterThan(0);
+  if (requirePreloads) expect(preloads.length).toBeGreaterThan(0);
+
+  for (const tag of [...scripts, ...preloads]) {
+    expect(tag).toContain('nonce="test-nonce"');
+    expect(tag).toContain('crossorigin="anonymous"');
+  }
+}
+
+// Ported from Next.js: test/e2e/app-document/rendering.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-document/rendering.test.ts
+describe("Pages _document script and preload props", () => {
+  let root: string;
+  let outDir: string;
+  let devServer: ViteDevServer;
+  let devUrl: string;
+  let prodServer: import("node:http").Server;
+  let prodUrl: string;
+
+  beforeAll(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-document-assets-"));
+    outDir = path.join(root, "dist");
+    await fsp.symlink(
+      path.resolve(import.meta.dirname, "../node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    await fsp.mkdir(path.join(root, "pages"));
+    await fsp.writeFile(path.join(root, "package.json"), JSON.stringify({ type: "module" }));
+    await fsp.writeFile(
+      path.join(root, "next.config.mjs"),
+      'export default { crossOrigin: "anonymous" };\n',
+    );
+    await fsp.writeFile(
+      path.join(root, "pages", "index.tsx"),
+      "export default function Page() { return <main>ok</main>; }\n",
+    );
+    await fsp.writeFile(
+      path.join(root, "pages", "_document.tsx"),
+      `import { Html, Head, Main, NextScript } from "next/document";
+export default function Document() {
+  return <Html><Head nonce="test-nonce" /><body><Main /><NextScript nonce="test-nonce" /></body></Html>;
+}
+`,
+    );
+
+    devServer = await createServer({
+      root,
+      configFile: false,
+      plugins: [vinext({ disableAppRouter: true })],
+      server: { host: "127.0.0.1", port: 0 },
+      logLevel: "silent",
+    });
+    await devServer.listen();
+    const devAddress = devServer.httpServer!.address() as { port: number };
+    devUrl = `http://127.0.0.1:${devAddress.port}`;
+
+    for (const buildOptions of [
+      {
+        outDir: path.join(outDir, "server"),
+        ssr: "virtual:vinext-server-entry",
+        rollupOptions: { output: { entryFileNames: "entry.js" } },
+      },
+      {
+        outDir: path.join(outDir, "client"),
+        manifest: true,
+        ssrManifest: true,
+        rollupOptions: { input: "virtual:vinext-client-entry" },
+      },
+    ]) {
+      await build({
+        root,
+        configFile: false,
+        plugins: [vinext({ disableAppRouter: true })],
+        logLevel: "silent",
+        build: buildOptions,
+      });
+    }
+
+    const started = await startProdServer({ port: 0, host: "127.0.0.1", outDir });
+    prodServer = "server" in started ? started.server : started;
+    const prodAddress = prodServer.address() as { port: number };
+    prodUrl = `http://127.0.0.1:${prodAddress.port}`;
+  }, 120000);
+
+  afterAll(async () => {
+    await devServer?.close();
+    if (prodServer) await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("propagates props in development", async () => {
+    const response = await fetch(devUrl);
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    assertDocumentAssetProps(html, false);
+  });
+
+  it("propagates props in production", async () => {
+    const response = await fetch(prodUrl);
+    expect(response.status).toBe(200);
+    assertDocumentAssetProps(await response.text(), true);
+  });
+});

--- a/tests/pages-document-assets.test.ts
+++ b/tests/pages-document-assets.test.ts
@@ -11,8 +11,12 @@ function assertDocumentAssetProps(html: string, requirePreloads: boolean): void 
   expect(html).not.toContain("data-vinext-head-nonce");
   expect(html).not.toContain("data-vinext-script-nonce");
 
-  const scripts = html.match(/<script\b[^>]*>/g) ?? [];
-  const preloads = html.match(/<link\b[^>]*rel="(?:preload|modulepreload)"[^>]*>/g) ?? [];
+  const scripts = (html.match(/<script\b[^>]*>/g) ?? []).filter((tag) =>
+    tag.includes('nonce="test-nonce"'),
+  );
+  const preloads = (html.match(/<link\b[^>]*rel="(?:preload|modulepreload)"[^>]*>/g) ?? []).filter(
+    (tag) => !tag.includes('id="user-preload"'),
+  );
   expect(scripts.length).toBeGreaterThan(0);
   if (requirePreloads) expect(preloads.length).toBeGreaterThan(0);
 
@@ -20,6 +24,13 @@ function assertDocumentAssetProps(html: string, requirePreloads: boolean): void 
     expect(tag).toContain('nonce="test-nonce"');
     expect(tag).toContain('crossorigin="anonymous"');
   }
+
+  expect(html).toMatch(
+    /<script[^>]*id="user-script"[^>]*nonce="user-nonce"[^>]*crossorigin="use-credentials"/,
+  );
+  expect(html).toMatch(
+    /<link[^>]*id="user-preload"[^>]*nonce="user-preload-nonce"[^>]*crossorigin="use-credentials"/,
+  );
 }
 
 // Ported from Next.js: test/e2e/app-document/rendering.test.ts
@@ -54,7 +65,10 @@ describe("Pages _document script and preload props", () => {
       path.join(root, "pages", "_document.tsx"),
       `import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
-  return <Html><Head nonce="test-nonce" /><body><Main /><NextScript nonce="test-nonce" /></body></Html>;
+  return <Html><Head nonce="test-nonce">
+    <script id="user-script" src="/user.js" nonce="user-nonce" crossOrigin="use-credentials" />
+    <link id="user-preload" rel="preload" href="/user.js" as="script" nonce="user-preload-nonce" crossOrigin="use-credentials" />
+  </Head><body><Main /><NextScript nonce="test-nonce" /></body></Html>;
 }
 `,
     );
@@ -109,6 +123,14 @@ export default function Document() {
     expect(response.status).toBe(200);
     const html = await response.text();
     assertDocumentAssetProps(html, false);
+    const viteScripts = (html.match(/<script\b[^>]*>/g) ?? []).filter(
+      (tag) => !tag.includes('id="user-script"') && !tag.includes('nonce="test-nonce"'),
+    );
+    expect(viteScripts.length).toBeGreaterThan(0);
+    for (const tag of viteScripts) {
+      expect(tag).not.toContain("nonce=");
+      expect(tag).not.toContain("crossorigin=");
+    }
   });
 
   it("propagates props in production", async () => {

--- a/tests/pages-document-assets.test.ts
+++ b/tests/pages-document-assets.test.ts
@@ -19,20 +19,32 @@ function assertDocumentAssetProps(html: string, requireHeadAssets: boolean): voi
     expect(tag).toContain('crossorigin="anonymous"');
   }
 
-  const generatedHeadAssets = (html.match(/<(?:script|link)\b[^>]*>/gi) ?? []).filter(
+  const headHtml = html.slice(html.indexOf("<head"), html.indexOf("</head>"));
+  const bodyHtml = html.slice(html.indexOf("<body"));
+  const generatedHeadAssets = (headHtml.match(/<link\b[^>]*>/gi) ?? []).filter(
     (tag) =>
       !tag.includes('id="user-') &&
       !tag.includes("/@vite/") &&
       (tag.includes('rel="stylesheet"') ||
         tag.includes('rel="preload"') ||
-        tag.includes('rel="modulepreload"') ||
-        (tag.includes("<script") && tag.includes("src="))),
+        tag.includes('rel="modulepreload"')),
   );
   if (requireHeadAssets) {
     expect(generatedHeadAssets.length).toBeGreaterThan(0);
     for (const tag of generatedHeadAssets) {
       expect(tag).toContain('nonce="head-nonce"');
       expect(tag).toContain('crossorigin="use-credentials"');
+    }
+
+    const generatedRuntimeScripts = (bodyHtml.match(/<script\b[^>]*src=[^>]*>/gi) ?? []).filter(
+      (tag) => !tag.includes('id="user-script"'),
+    );
+    expect(generatedRuntimeScripts.length).toBeGreaterThan(0);
+    for (const tag of generatedRuntimeScripts) {
+      expect(tag).toContain('nonce="script-nonce"');
+      expect(tag).toContain('crossorigin="anonymous"');
+      expect(tag).not.toContain('nonce="head-nonce"');
+      expect(tag).not.toContain('crossorigin="use-credentials"');
     }
   }
 
@@ -66,7 +78,7 @@ describe("Pages _document script and preload props", () => {
     await fsp.writeFile(path.join(root, "package.json"), JSON.stringify({ type: "module" }));
     await fsp.writeFile(
       path.join(root, "next.config.mjs"),
-      'export default { crossOrigin: "anonymous" };\n',
+      'export default { crossOrigin: "anonymous", experimental: { disableOptimizedLoading: true } };\n',
     );
     await fsp.writeFile(
       path.join(root, "pages", "index.tsx"),

--- a/tests/pages-document-assets.test.ts
+++ b/tests/pages-document-assets.test.ts
@@ -11,7 +11,7 @@ function assertDocumentAssetProps(html: string, requireHeadAssets: boolean): voi
   expect(html).not.toContain("data-vinext-head-nonce");
   expect(html).not.toContain("data-vinext-script-nonce");
 
-  const documentScripts = (html.match(/<script\b[^>]*>/g) ?? []).filter((tag) =>
+  const documentScripts = (html.match(/<script\b[^>]*>/gi) ?? []).filter((tag) =>
     tag.includes('nonce="script-nonce"'),
   );
   expect(documentScripts.length).toBeGreaterThan(0);
@@ -19,7 +19,7 @@ function assertDocumentAssetProps(html: string, requireHeadAssets: boolean): voi
     expect(tag).toContain('crossorigin="anonymous"');
   }
 
-  const generatedHeadAssets = (html.match(/<(?:script|link)\b[^>]*>/g) ?? []).filter(
+  const generatedHeadAssets = (html.match(/<(?:script|link)\b[^>]*>/gi) ?? []).filter(
     (tag) =>
       !tag.includes('id="user-') &&
       !tag.includes("/@vite/") &&
@@ -146,7 +146,7 @@ Document.getInitialProps = async (ctx) => {
     expect(html.indexOf('id="custom-document-style"')).toBeLessThan(
       html.indexOf('id="collected-document-style"'),
     );
-    const viteScripts = (html.match(/<script\b[^>]*>/g) ?? []).filter(
+    const viteScripts = (html.match(/<script\b[^>]*>/gi) ?? []).filter(
       (tag) => !tag.includes('id="user-script"') && !tag.includes('nonce="script-nonce"'),
     );
     expect(viteScripts.length).toBeGreaterThan(0);

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -7,6 +7,10 @@ import {
   etagMatches,
 } from "../packages/vinext/src/server/pages-page-response.js";
 import { resolvePagesPageData } from "../packages/vinext/src/server/pages-page-data.js";
+import {
+  movePagesDefaultHeadTagsFirst,
+  prependToHtmlHead,
+} from "../packages/vinext/src/server/html.js";
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -55,7 +59,7 @@ function createCommonOptions() {
   const isrSet = vi.fn(async () => {});
   const renderDocumentToString = vi.fn(
     async () =>
-      '<!DOCTYPE html><html><head></head><body><div id="__next">__NEXT_MAIN__</div><!-- __NEXT_SCRIPTS__ --></body></html>',
+      '<!DOCTYPE html><html><head><meta name="document-head" content="1" /></head><body><div id="__next">__NEXT_MAIN__</div><!-- __NEXT_SCRIPTS__ --></body></html>',
   );
   const renderIsrPassToStringAsync = vi.fn(async () => "<div>cached-body</div>");
   const renderToReadableStream = vi.fn(async () => createStream(["<div>live-body</div>"]));
@@ -106,6 +110,49 @@ function createCommonOptions() {
     },
   };
 }
+
+describe("prependToHtmlHead", () => {
+  it("inserts managed tags before custom document children", () => {
+    expect(
+      prependToHtmlHead(
+        '<html><head data-theme="dark"><meta name="document" /></head></html>',
+        '<meta charset="utf-8" />',
+      ),
+    ).toBe(
+      '<html><head data-theme="dark"><meta charset="utf-8" /><meta name="document" /></head></html>',
+    );
+  });
+
+  it("moves transformed default head tags before injected development scripts", () => {
+    expect(
+      movePagesDefaultHeadTagsFirst(
+        '<html><head><script src="/@vite/client"></script><meta name="document" /><meta name="viewport" content="width=device-width" data-next-head="" /><meta charset="utf-8" data-next-head="" /></head></html>',
+      ),
+    ).toBe(
+      '<html><head><meta charset="utf-8" data-next-head="" /><meta name="viewport" content="width=device-width" data-next-head="" /><script src="/@vite/client"></script><meta name="document" /></head></html>',
+    );
+  });
+
+  it("leaves matching body markup outside the head untouched", () => {
+    expect(
+      movePagesDefaultHeadTagsFirst(
+        '<html><head><script src="/@vite/client"></script><meta charset="utf-8" data-next-head="" /></head><body><meta name="viewport" content="body" data-next-head="" /></body></html>',
+      ),
+    ).toBe(
+      '<html><head><meta charset="utf-8" data-next-head="" /><script src="/@vite/client"></script></head><body><meta name="viewport" content="body" data-next-head="" /></body></html>',
+    );
+  });
+
+  it("moves a user-overridden charset before transformed development scripts", () => {
+    expect(
+      movePagesDefaultHeadTagsFirst(
+        '<html><head><script src="/@vite/client"></script><meta charset="utf-16" data-next-head="" /><meta name="viewport" content="width=device-width" data-next-head="" /></head></html>',
+      ),
+    ).toBe(
+      '<html><head><meta charset="utf-16" data-next-head="" /><meta name="viewport" content="width=device-width" data-next-head="" /><script src="/@vite/client"></script></head></html>',
+    );
+  });
+});
 
 describe("isPagesStreamingBot", () => {
   it("detects Googlebot as a streaming bot", () => {
@@ -177,6 +224,12 @@ describe("pages page response", () => {
     const html = await response.text();
     expect(html).toContain("<div>live-body</div>");
     expect(html).toContain('<meta name="test-head" content="1" />');
+    expect(html.indexOf('<meta name="test-head"')).toBeLessThan(
+      html.indexOf('<meta name="document-head"'),
+    );
+    expect(html.indexOf('<meta name="document-head"')).toBeLessThan(
+      html.indexOf('<link rel="stylesheet" href="/font.css"'),
+    );
     expect(html).toContain('<link rel="stylesheet" href="/font.css" />');
     expect(html).toContain('<script id="__NEXT_DATA__" type="application/json">');
     const nextDataMatch = html.match(

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -403,7 +403,7 @@ describe("pages page response", () => {
     const html = await response.text();
     expect(html).not.toContain("data-vinext-head-nonce");
     expect(html).not.toContain("data-vinext-script-nonce");
-    for (const tag of html.match(/<script\b[^>]*>/g) ?? []) {
+    for (const tag of html.match(/<script\b[^>]*>/gi) ?? []) {
       expect(tag).toContain('nonce="test-nonce"');
       expect(tag).toContain('crossorigin="anonymous"');
     }

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -384,6 +384,35 @@ describe("pages page response", () => {
     );
   });
 
+  // Ported from Next.js: test/e2e/app-document/rendering.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-document/rendering.test.ts
+  it("applies _document nonce and configured crossOrigin to generated scripts and preloads", async () => {
+    const common = createCommonOptions();
+    common.renderDocumentToString.mockResolvedValue(
+      '<!DOCTYPE html><html><head data-vinext-head-nonce="test-nonce"></head><body><div id="__next">__NEXT_MAIN__</div><span data-vinext-script-nonce="test-nonce"><!-- __NEXT_SCRIPTS__ --></span></body></html>',
+    );
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      assetTags:
+        '<link rel="modulepreload" href="/entry.js" />\n' +
+        '<script type="module" src="/entry.js"></script>',
+      crossOrigin: "anonymous",
+    });
+
+    const html = await response.text();
+    expect(html).not.toContain("data-vinext-head-nonce");
+    expect(html).not.toContain("data-vinext-script-nonce");
+    for (const tag of html.match(/<script\b[^>]*>/g) ?? []) {
+      expect(tag).toContain('nonce="test-nonce"');
+      expect(tag).toContain('crossorigin="anonymous"');
+    }
+    for (const tag of html.match(/<link\b[^>]*rel="(?:preload|modulepreload)"[^>]*>/g) ?? []) {
+      expect(tag).toContain('nonce="test-nonce"');
+      expect(tag).toContain('crossorigin="anonymous"');
+    }
+  });
+
   it("renders page before collecting SSR head HTML to prevent style race conditions", async () => {
     // Ported from Next.js: vercel/next.js@9853944
     // styled-jsx (and <Head>) styles must be collected AFTER rendering completes,

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -79,6 +79,7 @@ function createCommonOptions() {
       DocumentComponent: function TestDocument() {
         return null;
       },
+      disableOptimizedLoading: false,
       flushPreloads: vi.fn(async () => {}),
       fontLinkHeader: "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
       fontPreloads: [{ href: "/font.woff2", type: "font/woff2" }],
@@ -411,6 +412,37 @@ describe("pages page response", () => {
       expect(tag).toContain('nonce="test-nonce"');
       expect(tag).toContain('crossorigin="anonymous"');
     }
+  });
+
+  it("uses NextScript props for runtime scripts when optimized loading is disabled", async () => {
+    const common = createCommonOptions();
+    common.renderDocumentToString.mockResolvedValue(
+      '<!DOCTYPE html><html><head data-vinext-head-nonce="head-nonce" data-vinext-head-cross-origin="use-credentials"></head><body><div id="__next">__NEXT_MAIN__</div><span data-vinext-script-nonce="script-nonce" data-vinext-script-cross-origin="anonymous"><!-- __NEXT_SCRIPTS__ --></span></body></html>',
+    );
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      assetTags:
+        '<link rel="stylesheet" href="/style.css" />\n' +
+        '<link rel="modulepreload" href="/entry.js" />\n' +
+        '<script type="module" src="/entry.js"></script>',
+      disableOptimizedLoading: true,
+    });
+
+    const html = await response.text();
+    const head = html.slice(html.indexOf("<head"), html.indexOf("</head>"));
+    const body = html.slice(html.indexOf("<body"));
+
+    expect(head).toMatch(
+      /<link[^>]*rel="stylesheet"[^>]*href="\/style\.css"[^>]*nonce="head-nonce"[^>]*crossorigin="use-credentials"/,
+    );
+    expect(head).toMatch(
+      /<link[^>]*rel="modulepreload"[^>]*href="\/entry\.js"[^>]*nonce="head-nonce"[^>]*crossorigin="use-credentials"/,
+    );
+    expect(head).not.toContain('<script type="module" src="/entry.js"');
+    expect(body).toContain(
+      '<script type="module" src="/entry.js" nonce="script-nonce" crossorigin="anonymous">',
+    );
   });
 
   it("renders page before collecting SSR head HTML to prevent style race conditions", async () => {

--- a/tests/static-export.test.ts
+++ b/tests/static-export.test.ts
@@ -193,7 +193,7 @@ describe("Static export — Pages Router (served via HTTP)", () => {
     const res = await fetch(`${baseUrl}/`);
     const html = await res.text();
     expect(html).toContain("<html");
-    expect(html).toContain("<head>");
+    expect(html).toContain("<head");
     expect(html).toContain("</head>");
     expect(html).toContain("<body");
     expect(html).toContain("</body>");


### PR DESCRIPTION
## Summary

- keep charset and viewport first when rendering custom Documents
- propagate custom Head nonce and crossOrigin to generated head assets
- preserve Next.js ordering for managed tags, custom Document children, generated assets, and collected styles

## Next.js parity

Addresses the `next/head` charset ordering failure and related custom `_document` asset/CSS ordering gaps.

## Validation

- targeted unit/integration tests — 306 passed
- focused dev and production Pages fixtures — passed with one worker
- targeted format, lint, and type checks
- independent review loop — clean

Full suites are deferred to CI.