### PR TITLE
fix(pages): preserve prerender rewrite query parity

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -43,6 +43,8 @@ export type VinextNextData = {
     hasMiddleware?: boolean;
     /** True when build-time rewrites can affect the initial Pages Router ready state. */
     hasRewrites?: boolean;
+    /** Server-resolved query retained through the initial router readiness transition. */
+    initialResolvedQuery?: Record<string, string | string[]>;
   };
 } & NEXT_DATA;
 

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -59,8 +59,6 @@ export async function generateClientEntry(
     ...pageRoutes.map(toPagesLinkPrefetchRoute),
     ...apiRoutes.map((route) => ({ ...toPagesLinkPrefetchRoute(route), documentOnly: true })),
   ];
-  const instrumentationClientPath = options.instrumentationClientPath ?? null;
-
   // Build a map of route pattern -> dynamic import.
   // Keys must use Next.js bracket format (e.g. "/user/[id]") to match
   // __NEXT_DATA__.page which is set via patternToNextFormat() during SSR.
@@ -75,26 +73,7 @@ export async function generateClientEntry(
 
   const appFileBase = appFilePath ? normalizePathSeparators(appFilePath) : undefined;
 
-  // Refs #1474: Side-effect-import the user's `instrumentation-client.{ts,js}`
-  // (when present at project root or in `src/`) BEFORE any other module so its
-  // top-level statements run before `hydrateRoot()` is called. Mirrors
-  // Next.js's `page-bootstrap.ts`, which side-effect-imports
-  // `require-instrumentation-client` ahead of `initialize`/`hydrate`
-  // (.nextjs-ref/packages/next/src/client/page-bootstrap.ts L1).
-  //
-  // The `vinext/instrumentation-client` import below pulls in the hook
-  // surface (`onRouterTransitionStart`) for navigation events. It also
-  // re-imports the user file via the `private-next-instrumentation-client`
-  // alias, but tree-shakers can be conservative about the side effects of
-  // an indirectly-loaded module. Importing the user's file directly here
-  // makes the contract explicit: bare side-effect imports are always
-  // preserved by Vite/Rolldown's import-analysis pipeline.
-  const userInstrumentationImport = instrumentationClientPath
-    ? `import ${JSON.stringify(normalizePathSeparators(instrumentationClientPath))};\n`
-    : "";
-
-  return `${userInstrumentationImport}
-import "vinext/instrumentation-client";
+  return `
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
 
@@ -155,6 +134,11 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
+
+// Load instrumentation only after serialized locale state is available. The
+// user's instrumentation module may import next/router, whose module setup
+// stamps the initial history entry with the active locale.
+await import("vinext/instrumentation-client");
 
 const {
   default: Router,

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -76,6 +76,11 @@ export async function generateClientEntry(
   return `
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
+import Router, {
+  wrapWithRouterContext,
+  _initializePagesRouterReadyFromNextData,
+  _syncInitialPagesRouterStateFromNextData,
+} from "next/router";
 
 const pageLoaders = {
 ${loaderEntries.join(",\n")}
@@ -133,18 +138,8 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALE__ = window.__NEXT_DATA__.locale;
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
+  _syncInitialPagesRouterStateFromNextData();
 }
-
-// Load instrumentation only after serialized locale state is available. The
-// user's instrumentation module may import next/router, whose module setup
-// stamps the initial history entry with the active locale.
-await import("vinext/instrumentation-client");
-
-const {
-  default: Router,
-  wrapWithRouterContext,
-  _initializePagesRouterReadyFromNextData,
-} = await import("next/router");
 
 async function hydrate() {
   const nextData = window.__NEXT_DATA__;
@@ -152,6 +147,9 @@ async function hydrate() {
     console.error("[vinext] No __NEXT_DATA__ found");
     return;
   }
+
+  // Load instrumentation only after serialized locale state is available.
+  await import("vinext/instrumentation-client");
 
   _initializePagesRouterReadyFromNextData(nextData);
 

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -97,10 +97,6 @@ export async function generateClientEntry(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
-import Router, {
-  wrapWithRouterContext,
-  _initializePagesRouterReadyFromNextData,
-} from "next/router";
 
 const pageLoaders = {
 ${loaderEntries.join(",\n")}
@@ -159,6 +155,12 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
+
+const {
+  default: Router,
+  wrapWithRouterContext,
+  _initializePagesRouterReadyFromNextData,
+} = await import("next/router");
 
 async function hydrate() {
   const nextData = window.__NEXT_DATA__;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4287,6 +4287,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   req.__vinextMiddlewareStatus,
                   pipelineResult.isDataReq,
                   originalRequestUrl,
+                  pipelineResult.renderOptions?.rewriteQueryKeys,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1236,6 +1236,7 @@ export function createSSRHandler(
                           pageModuleUrl: regenPageUrl,
                           appModuleUrl: regenAppUrl,
                           hasMiddleware,
+                          initialResolvedQuery: query,
                         },
                       };
 
@@ -1584,6 +1585,7 @@ export function createSSRHandler(
             pageModuleUrl,
             appModuleUrl,
             hasMiddleware,
+            initialResolvedQuery: query,
           },
         };
 

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1602,7 +1602,6 @@ export function createSSRHandler(
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
-import Router, { wrapWithRouterContext, _initializePagesRouterReadyFromNextData } from "next/router";
 
 const nextDataElement = document.getElementById("__NEXT_DATA__");
 if (nextDataElement?.textContent) {
@@ -1611,6 +1610,11 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
+const {
+  default: Router,
+  wrapWithRouterContext,
+  _initializePagesRouterReadyFromNextData,
+} = await import("next/router");
 const nextData = window.__NEXT_DATA__;
 _initializePagesRouterReadyFromNextData(nextData);
 const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1599,7 +1599,6 @@ export function createSSRHandler(
         // Stores the React root and page loader for client-side navigation.
         const hydrationScript = `
 <script type="module"${nonceAttr}>
-import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
 
@@ -1610,6 +1609,7 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }
+await import("vinext/instrumentation-client");
 const {
   default: Router,
   wrapWithRouterContext,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -648,6 +648,7 @@ export function createSSRHandler(
           routerShim.setSSRContext({
             pathname: patternToNextFormat(route.pattern),
             query,
+            initialQuery: params,
             asPath: requestAsPath,
             navigationIsReady,
             nextData: pagesNextData,
@@ -789,6 +790,7 @@ export function createSSRHandler(
               routerShim.setSSRContext({
                 pathname: patternToNextFormat(route.pattern),
                 query,
+                initialQuery: params,
                 asPath: requestAsPath,
                 navigationIsReady: false,
                 locale: locale ?? currentDefaultLocale,
@@ -1170,6 +1172,7 @@ export function createSSRHandler(
                         routerShim.setSSRContext({
                           pathname: patternToNextFormat(route.pattern),
                           query,
+                          initialQuery: params,
                           asPath: requestAsPath,
                           navigationIsReady,
                           locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -39,7 +39,11 @@ import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import { createInlineScriptTag, createNonceAttribute, safeJsonStringify } from "./html.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { getScriptNonceFromNodeHeaderSources } from "./csp.js";
-import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
+import {
+  buildInitialPagesRouterQuery,
+  mergeRouteParamsIntoQuery,
+  parseQueryString as parseQuery,
+} from "../utils/query.js";
 import path from "node:path";
 import React from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
@@ -474,6 +478,7 @@ export function createSSRHandler(
      */
     isDataReq: boolean = false,
     originalUrl: string = url,
+    rewriteQueryKeys: string[] = [],
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -577,6 +582,7 @@ export function createSSRHandler(
       ? params
       : null;
     const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
+    const initialQuery = buildInitialPagesRouterQuery(query, params, rewriteQueryKeys);
 
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
@@ -648,7 +654,7 @@ export function createSSRHandler(
           routerShim.setSSRContext({
             pathname: patternToNextFormat(route.pattern),
             query,
-            initialQuery: params,
+            initialQuery,
             asPath: requestAsPath,
             navigationIsReady,
             nextData: pagesNextData,
@@ -790,7 +796,7 @@ export function createSSRHandler(
               routerShim.setSSRContext({
                 pathname: patternToNextFormat(route.pattern),
                 query,
-                initialQuery: params,
+                initialQuery,
                 asPath: requestAsPath,
                 navigationIsReady: false,
                 locale: locale ?? currentDefaultLocale,
@@ -1172,7 +1178,7 @@ export function createSSRHandler(
                         routerShim.setSSRContext({
                           pathname: patternToNextFormat(route.pattern),
                           query,
-                          initialQuery: params,
+                          initialQuery,
                           asPath: requestAsPath,
                           navigationIsReady,
                           locale: locale ?? currentDefaultLocale,
@@ -1237,7 +1243,7 @@ export function createSSRHandler(
                         {
                           props: freshRenderProps,
                           page: patternToNextFormat(route.pattern),
-                          query: params,
+                          query: initialQuery,
                           buildId: process.env.__VINEXT_BUILD_ID,
                           isFallback: false,
                           locale: locale ?? currentDefaultLocale,
@@ -1660,7 +1666,7 @@ hydrate();
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: params,
+            query: initialQuery,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1601,6 +1601,11 @@ export function createSSRHandler(
 <script type="module"${nonceAttr}>
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
+import Router, {
+  wrapWithRouterContext,
+  _initializePagesRouterReadyFromNextData,
+  _syncInitialPagesRouterStateFromNextData,
+} from "next/router";
 
 const nextDataElement = document.getElementById("__NEXT_DATA__");
 if (nextDataElement?.textContent) {
@@ -1608,14 +1613,10 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALE__ = window.__NEXT_DATA__.locale;
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
+  _syncInitialPagesRouterStateFromNextData();
 }
-await import("vinext/instrumentation-client");
-const {
-  default: Router,
-  wrapWithRouterContext,
-  _initializePagesRouterReadyFromNextData,
-} = await import("next/router");
 const nextData = window.__NEXT_DATA__;
+await import("vinext/instrumentation-client");
 _initializePagesRouterReadyFromNextData(nextData);
 const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};
 const rawPageProps = props.pageProps;

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1451,6 +1451,7 @@ export function createSSRHandler(
           }
           const dataHeaders: Record<string, string | string[] | number> = {
             "Content-Type": "application/json",
+            "x-vinext-resolved-query": JSON.stringify(query),
           };
           if (gsspExtraHeaders) {
             for (const [k, v] of Object.entries(gsspExtraHeaders)) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1451,13 +1451,18 @@ export function createSSRHandler(
           }
           const dataHeaders: Record<string, string | string[] | number> = {
             "Content-Type": "application/json",
-            "x-vinext-resolved-query": JSON.stringify(query),
           };
           if (gsspExtraHeaders) {
             for (const [k, v] of Object.entries(gsspExtraHeaders)) {
               dataHeaders[k] = v;
             }
           }
+          for (const headerName of Object.keys(dataHeaders)) {
+            if (headerName.toLowerCase() === "x-vinext-resolved-query") {
+              delete dataHeaders[headerName];
+            }
+          }
+          dataHeaders["x-vinext-resolved-query"] = JSON.stringify(query);
           // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
           // every _next/data response so the client router can detect a new
           // deployment and trigger a hard navigation (deployment-skew

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -124,6 +124,7 @@ type RenderPagesIsrHtmlOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  initialQuery?: Record<string, unknown>;
   renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
   routePattern: string;
   safeJsonStringify: (value: unknown) => string;
@@ -196,6 +197,7 @@ export type ResolvePagesPageDataOptions = {
   AppComponent?: unknown;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
+  initialQuery?: Record<string, unknown>;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -587,6 +589,7 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    initialQuery: options.initialQuery,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     // Serialize the same readiness flags (gssp/gsp/autoExport/…) the initial
@@ -860,6 +863,7 @@ export async function resolvePagesPageData(
                 pageProps: freshPageProps,
                 props: freshRenderProps,
                 params: options.params,
+                initialQuery: options.initialQuery,
                 renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
                 routePattern: options.routePattern,
                 safeJsonStringify: options.safeJsonStringify,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -13,7 +13,11 @@
  */
 
 import type { ComponentType, ReactNode } from "react";
-import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
+import {
+  buildInitialPagesRouterQuery,
+  mergeRouteParamsIntoQuery,
+  parseQueryString as parseQuery,
+} from "../utils/query.js";
 import { patternToNextFormat } from "../routing/route-validation.js";
 import { resolvePagesI18nRequest } from "./pages-i18n.js";
 import { createPagesReqRes } from "./pages-node-compat.js";
@@ -182,6 +186,7 @@ type RenderPageOptions = {
   statusCode?: number;
   asPath?: string;
   originalUrl?: string;
+  rewriteQueryKeys?: string[];
   renderErrorPageOnMiss?: boolean;
   __isInternalErrorRender?: boolean;
   __forcedRoute?: PageRoute;
@@ -419,6 +424,7 @@ export function createPagesPageHandler(
         const renderStatusCode =
           renderStatusCodeOverride ?? (routePattern === "/404" ? 404 : undefined);
         const query = mergeRouteParamsIntoQuery(parseQuery(routeUrl), params);
+        const initialQuery = buildInitialPagesRouterQuery(query, params, options?.rewriteQueryKeys);
 
         // Model Pages Router readiness for `next/navigation` compat hooks. The
         // serialized `__NEXT_DATA__` flags (gssp/gsp/gip/appGip/autoExport) plus
@@ -444,7 +450,7 @@ export function createPagesPageHandler(
             setSSRContext({
               pathname: routePattern,
               query,
-              initialQuery: params,
+              initialQuery,
               asPath: renderAsPath ?? routeUrl,
               navigationIsReady,
               locale,
@@ -644,7 +650,7 @@ export function createPagesPageHandler(
           setSSRContext({
             pathname: routePattern,
             query,
-            initialQuery: params,
+            initialQuery,
             asPath: renderAsPath ?? routeUrl,
             navigationIsReady: false,
             locale,
@@ -747,6 +753,7 @@ export function createPagesPageHandler(
           pageProps,
           props: renderProps,
           params,
+          initialQuery,
           query,
           renderDocumentToString(element) {
             return renderToStringAsync(element);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -668,7 +668,6 @@ export function createPagesPageHandler(
         // props like __N_SSP, __N_SSG) as JSON instead of the full HTML page.
         if (isDataReq) {
           const init: ResponseInit & { headers: Record<string, string> } = { headers: {} };
-          init.headers["x-vinext-resolved-query"] = safeJsonStringify(query);
           if (gsspRes && typeof gsspRes.getHeaders === "function") {
             const gsspHeaders = gsspRes.getHeaders();
             for (const k of Object.keys(gsspHeaders)) {
@@ -677,6 +676,12 @@ export function createPagesPageHandler(
               init.headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
             }
           }
+          for (const headerName of Object.keys(init.headers)) {
+            if (headerName.toLowerCase() === "x-vinext-resolved-query") {
+              delete init.headers[headerName];
+            }
+          }
+          init.headers["x-vinext-resolved-query"] = safeJsonStringify(query);
           if (gsspRes) {
             // Default Cache-Control for gSSP-driven _next/data responses —
             // skip when gSSP already set one via res.setHeader. Fixes #1461.

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -668,6 +668,7 @@ export function createPagesPageHandler(
         // props like __N_SSP, __N_SSG) as JSON instead of the full HTML page.
         if (isDataReq) {
           const init: ResponseInit & { headers: Record<string, string> } = { headers: {} };
+          init.headers["x-vinext-resolved-query"] = safeJsonStringify(query);
           if (gsspRes && typeof gsspRes.getHeaders === "function") {
             const gsspHeaders = gsspRes.getHeaders();
             for (const k of Object.keys(gsspHeaders)) {

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -516,6 +516,7 @@ export function createPagesPageHandler(
             pageModuleUrl,
             appModuleUrl,
             hasMiddleware,
+            initialResolvedQuery: query,
           },
         };
         const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareHeaders);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -444,6 +444,7 @@ export function createPagesPageHandler(
             setSSRContext({
               pathname: routePattern,
               query,
+              initialQuery: params,
               asPath: renderAsPath ?? routeUrl,
               navigationIsReady,
               locale,
@@ -643,6 +644,7 @@ export function createPagesPageHandler(
           setSSRContext({
             pathname: routePattern,
             query,
+            initialQuery: params,
             asPath: renderAsPath ?? routeUrl,
             navigationIsReady: false,
             locale,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -186,6 +186,7 @@ type RenderPagesPageResponseOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  initialQuery?: Record<string, unknown>;
   query?: Record<string, unknown>;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
@@ -254,6 +255,7 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "initialQuery"
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
@@ -265,7 +267,7 @@ export function buildPagesNextDataScript(
   const nextDataPayload: Record<string, unknown> = {
     props: options.props ?? { pageProps: options.pageProps },
     page: options.routePattern,
-    query: options.params,
+    query: options.initialQuery ?? options.params,
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -483,6 +485,7 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    initialQuery: options.initialQuery,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -45,6 +45,7 @@ export type PagesRenderOptions = {
   isDataReq?: boolean;
   renderErrorPageOnMiss?: boolean;
   originalUrl?: string;
+  rewriteQueryKeys?: string[];
 };
 
 export type FilesystemRoutePhase = "direct" | "beforeFiles" | "afterFiles" | "fallback";
@@ -304,6 +305,21 @@ export async function runPagesRequest(
   // Step 5: Middleware
   const originalResolvedUrl = pathname + search;
   let resolvedUrl = originalResolvedUrl;
+  const rewriteQueryKeys = new Set<string>();
+  const recordRewriteQueryKeys = (rewriteUrl: string, inheritedUrl?: string): void => {
+    const rewriteParams = new URL(rewriteUrl, url).searchParams;
+    const inheritedParams = inheritedUrl ? new URL(inheritedUrl, url).searchParams : null;
+    for (const key of rewriteParams.keys()) {
+      if (
+        inheritedParams &&
+        inheritedParams.has(key) &&
+        JSON.stringify(inheritedParams.getAll(key)) === JSON.stringify(rewriteParams.getAll(key))
+      ) {
+        continue;
+      }
+      rewriteQueryKeys.add(key);
+    }
+  };
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
   const serveFilesystemRoute = async (
@@ -394,6 +410,7 @@ export async function runPagesRequest(
     }
 
     if (result.rewriteUrl) {
+      recordRewriteQueryKeys(result.rewriteUrl, originalResolvedUrl);
       resolvedUrl = result.rewriteUrl;
     }
 
@@ -468,6 +485,7 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, rewritten) };
       }
+      recordRewriteQueryKeys(rewritten);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       configRewriteFired = true;
@@ -547,6 +565,7 @@ export async function runPagesRequest(
           // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
           return { type: "response", response: await proxyExternal(request, rewritten) };
         }
+        recordRewriteQueryKeys(rewritten);
         resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameChanged = true;
@@ -595,6 +614,7 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
+        recordRewriteQueryKeys(fallbackRewrite);
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         const fallbackFilesystemResult = await serveFilesystemRoute(resolvedPathname, "fallback");
@@ -612,11 +632,22 @@ export async function runPagesRequest(
     // All adapters normalize real `/_next/data/` URLs before this point.
     const shouldDeferErrorPageOnMiss =
       !isDataReq && !isDataRequest && !!deps.matchPageRoute && !renderPageMatch;
-    const initialRenderOptions: PagesRenderOptions | undefined = shouldDeferErrorPageOnMiss
-      ? { renderErrorPageOnMiss: false }
-      : isDataReq
-        ? { isDataReq: true }
-        : undefined;
+    const buildRenderOptions = (
+      extra?: Omit<PagesRenderOptions, "rewriteQueryKeys">,
+    ): PagesRenderOptions | undefined => {
+      if (!extra && rewriteQueryKeys.size === 0) return undefined;
+      return {
+        ...extra,
+        ...(rewriteQueryKeys.size > 0 ? { rewriteQueryKeys: [...rewriteQueryKeys] } : {}),
+      };
+    };
+    const initialRenderOptions = buildRenderOptions(
+      shouldDeferErrorPageOnMiss
+        ? { renderErrorPageOnMiss: false }
+        : isDataReq
+          ? { isDataReq: true }
+          : undefined,
+    );
 
     // Convert staged middleware headers to a Web Headers object for renderPage.
     // Adapters that need to inject per-request values (e.g. CSP nonces) into the
@@ -650,13 +681,14 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
+        recordRewriteQueryKeys(fallbackRewrite);
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         const fallbackFilesystemResult = await serveFilesystemRoute(resolvedPathname, "fallback");
         if (fallbackFilesystemResult) return fallbackFilesystemResult;
         const fallbackApiResult = await handleResolvedApiRoute();
         if (fallbackApiResult) return fallbackApiResult;
-        response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+        response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
         matchedFallbackRewrite = true;
         if (response.status !== 404) break;
       }
@@ -664,7 +696,7 @@ export async function runPagesRequest(
 
     // Deferred 404 re-render
     if (response.status === 404 && shouldDeferErrorPageOnMiss && !matchedFallbackRewrite) {
-      response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+      response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
     }
 
     const merged = mergeHeaders(response, middlewareHeaders, middlewareStatus);
@@ -702,6 +734,7 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, fallbackRewrite) };
       }
+      recordRewriteQueryKeys(fallbackRewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       const fallbackFilesystemResult = await serveFilesystemRoute(resolvedPathname, "fallback");
@@ -716,7 +749,13 @@ export async function runPagesRequest(
   return {
     type: "render",
     resolvedUrl,
-    renderOptions: isDataReq ? { isDataReq: true } : undefined,
+    renderOptions:
+      isDataReq || rewriteQueryKeys.size > 0
+        ? {
+            ...(isDataReq ? { isDataReq: true } : {}),
+            ...(rewriteQueryKeys.size > 0 ? { rewriteQueryKeys: [...rewriteQueryKeys] } : {}),
+          }
+        : undefined,
     stagedHeaders: middlewareHeaders,
     requestHeaders: request.headers,
     middlewareStatus,

--- a/packages/vinext/src/shims/router-state.ts
+++ b/packages/vinext/src/shims/router-state.ts
@@ -24,6 +24,7 @@ import {
 export type SSRContext = {
   pathname: string;
   query: Record<string, string | string[]>;
+  initialQuery?: Record<string, string | string[]>;
   asPath: string;
   navigationIsReady?: boolean;
   locale?: string;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1263,11 +1263,18 @@ function getPathnameAndQuery(): {
   // not the resolved path ("/posts/42"). __NEXT_DATA__.page holds the route
   // pattern and is updated by navigateClient() on every client-side navigation.
   const pathname = window.__NEXT_DATA__?.page ?? resolvedPath;
-  const nextData = window.__NEXT_DATA__;
+  const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
   const isReady = isPagesRouterReady();
   const routeQuery: Record<string, string | string[]> = {};
   if (isReady) {
-    Object.assign(routeQuery, getRouteQueryFromNextData(nextData, resolvedPath));
+    const initialResolvedQuery = nextData?.__vinext?.initialResolvedQuery;
+    if (!routerRuntimeState.routerDidNavigate && initialResolvedQuery) {
+      for (const [key, value] of Object.entries(initialResolvedQuery)) {
+        routeQuery[key] = Array.isArray(value) ? [...value] : value;
+      }
+    } else {
+      Object.assign(routeQuery, getRouteQueryFromNextData(nextData, resolvedPath));
+    }
   } else {
     for (const [key, value] of Object.entries(nextData?.query ?? {})) {
       if (typeof value === "string") {
@@ -1281,7 +1288,10 @@ function getPathnameAndQuery(): {
   // route params. URL search values are published after hydration so the
   // browser snapshot stays aligned with the prerendered server HTML.
   const searchQuery: Record<string, string | string[]> = {};
-  if (isReady) {
+  if (
+    isReady &&
+    (routerRuntimeState.routerDidNavigate || !nextData?.__vinext?.initialResolvedQuery)
+  ) {
     const params = new URLSearchParams(window.location.search);
     for (const [key, value] of params) {
       addQueryParam(searchQuery, key, value);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -816,15 +816,12 @@ function stampInitialHistoryState(): void {
   if (!window.history) return;
 
   const existingState = window.history.state;
-  if (existingState !== null && existingState !== undefined) {
-    routerRuntimeState.currentHistoryKey =
-      getRouterStateKey(existingState) ?? routerRuntimeState.currentHistoryKey;
-    return;
-  }
-
   const initialState = buildInitialRouterState();
   routerRuntimeState.currentHistoryKey = initialState.key;
-  window.history.replaceState(initialState, "");
+  window.history.replaceState(
+    isUnknownRecord(existingState) ? { ...existingState, ...initialState } : initialState,
+    "",
+  );
 }
 
 setStampInitialHistoryState(stampInitialHistoryState);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -786,7 +786,7 @@ export function isHashOnlyChange(href: string): boolean {
 
 /**
  * Build router-shaped state for the initial document entry. Captures the
- * active locale (from `window.__VINEXT_LOCALE__`) so a back-navigation
+ * active locale (from the serialized document state) so a back-navigation
  * popstate to this entry can recover its locale instead of falling back to
  * the live window global — the locale may have changed by the time the user
  * navigates back.
@@ -794,7 +794,8 @@ export function isHashOnlyChange(href: string): boolean {
 function buildInitialRouterState(): VinextHistoryState {
   const appPath = stripBasePath(window.location.pathname, __basePath) + window.location.search;
   const options: { locale?: string; shallow?: boolean } = {};
-  if (window.__VINEXT_LOCALE__ !== undefined) options.locale = window.__VINEXT_LOCALE__;
+  const initialLocale = window.__VINEXT_LOCALE__ ?? window.__NEXT_DATA__?.locale;
+  if (initialLocale !== undefined) options.locale = initialLocale;
   return {
     url: appPath,
     as: appPath,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -901,6 +901,7 @@ function readScrollPositionFromSessionStorage(key: string): ScrollPosition | nul
 type SSRContext = {
   pathname: string;
   query: Record<string, string | string[]>;
+  initialQuery?: Record<string, string | string[]>;
   asPath: string;
   navigationIsReady?: boolean;
   nextData?: VinextNextData;
@@ -1242,9 +1243,16 @@ function getPathnameAndQuery(): {
   if (typeof window === "undefined") {
     const _ssrCtx = _getSSRContext();
     if (_ssrCtx) {
-      const query: Record<string, string | string[]> = {};
-      for (const [key, value] of Object.entries(_ssrCtx.query)) {
-        query[key] = Array.isArray(value) ? [...value] : value;
+      const isReady = _ssrCtx.navigationIsReady ?? true;
+      let query: Record<string, string | string[]> = {};
+      if (isReady) {
+        for (const [key, value] of Object.entries(_ssrCtx.query)) {
+          query[key] = Array.isArray(value) ? [...value] : value;
+        }
+      } else {
+        for (const [key, value] of Object.entries(_ssrCtx.initialQuery ?? {})) {
+          query[key] = Array.isArray(value) ? [...value] : value;
+        }
       }
       return { pathname: _ssrCtx.pathname, query, asPath: _ssrCtx.asPath };
     }
@@ -1256,12 +1264,28 @@ function getPathnameAndQuery(): {
   // pattern and is updated by navigateClient() on every client-side navigation.
   const pathname = window.__NEXT_DATA__?.page ?? resolvedPath;
   const nextData = window.__NEXT_DATA__;
-  const routeQuery = getRouteQueryFromNextData(nextData, resolvedPath);
-  // URL search params always reflect the current URL
+  const isReady = isPagesRouterReady();
+  const routeQuery: Record<string, string | string[]> = {};
+  if (isReady) {
+    Object.assign(routeQuery, getRouteQueryFromNextData(nextData, resolvedPath));
+  } else {
+    for (const [key, value] of Object.entries(nextData?.query ?? {})) {
+      if (typeof value === "string") {
+        routeQuery[key] = value;
+      } else if (Array.isArray(value)) {
+        routeQuery[key] = [...value];
+      }
+    }
+  }
+  // Before the initial Pages Router ready transition, Next.js exposes only
+  // route params. URL search values are published after hydration so the
+  // browser snapshot stays aligned with the prerendered server HTML.
   const searchQuery: Record<string, string | string[]> = {};
-  const params = new URLSearchParams(window.location.search);
-  for (const [key, value] of params) {
-    addQueryParam(searchQuery, key, value);
+  if (isReady) {
+    const params = new URLSearchParams(window.location.search);
+    for (const [key, value] of params) {
+      addQueryParam(searchQuery, key, value);
+    }
   }
   const query = { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -814,10 +814,16 @@ function buildInitialRouterState(): VinextHistoryState {
 function stampInitialHistoryState(): void {
   installManualScrollRestoration();
 
+  syncInitialHistoryStateFromNextData();
+}
+
+function syncInitialHistoryStateFromNextData(): void {
   if (!window.history) return;
 
   const existingState = window.history.state;
   const initialState = buildInitialRouterState();
+  const existingKey = getRouterStateKey(existingState);
+  if (existingKey !== undefined) initialState.key = existingKey;
   routerRuntimeState.currentHistoryKey = initialState.key;
   window.history.replaceState(
     isUnknownRecord(existingState) ? { ...existingState, ...initialState } : initialState,
@@ -3587,5 +3593,6 @@ const _PAGES_NAVIGATION_ACCESSOR_KEY = Symbol.for(
 // without relying on React effect timing in a Node test environment.
 export { markPagesRouterReady as _markPagesRouterReady };
 export { initializePagesRouterReadyFromNextData as _initializePagesRouterReadyFromNextData };
+export { syncInitialHistoryStateFromNextData as _syncInitialPagesRouterStateFromNextData };
 
 export default Router;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -418,10 +418,6 @@ type PagesRouterRuntimeState = {
   // Any router-owned history update, including a hash-only change. This keeps
   // Safari replay filtering and back/forward handling aligned with Next.js.
   routerDidNavigate: boolean;
-  // A navigation that changes the rendered page/query owner. Hash-only
-  // changes leave this false so the server-resolved initial query remains
-  // authoritative for the current document.
-  pageDidNavigate: boolean;
   deprecatedEventBridgeInstalled: boolean;
   pagesRouterReady: boolean;
   publicRouter?: Record<string, unknown>;
@@ -449,7 +445,6 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
       typeof window !== "undefined" ? window.location.pathname + window.location.search : "",
     isFirstPopStateEvent: true,
     routerDidNavigate: false,
-    pageDidNavigate: false,
     deprecatedEventBridgeInstalled: false,
     pagesRouterReady: typeof window === "undefined" || !shouldDeferInitialPagesRouterReady(),
   };
@@ -805,6 +800,7 @@ function buildInitialRouterState(): VinextHistoryState {
     options,
     __N: true,
     key: createHistoryKey(),
+    __vinext_queryOwner: "server",
   };
 }
 
@@ -1272,10 +1268,11 @@ function getPathnameAndQuery(): {
   const pathname = window.__NEXT_DATA__?.page ?? resolvedPath;
   const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
   const isReady = isPagesRouterReady();
+  const usesServerResolvedQuery = getCurrentQueryOwner() === "server";
   const routeQuery: Record<string, string | string[]> = {};
   if (isReady) {
     const initialResolvedQuery = nextData?.__vinext?.initialResolvedQuery;
-    if (!routerRuntimeState.pageDidNavigate && initialResolvedQuery) {
+    if (usesServerResolvedQuery && initialResolvedQuery) {
       for (const [key, value] of Object.entries(initialResolvedQuery)) {
         routeQuery[key] = Array.isArray(value) ? [...value] : value;
       }
@@ -1295,10 +1292,7 @@ function getPathnameAndQuery(): {
   // route params. URL search values are published after hydration so the
   // browser snapshot stays aligned with the prerendered server HTML.
   const searchQuery: Record<string, string | string[]> = {};
-  if (
-    isReady &&
-    (routerRuntimeState.pageDidNavigate || !nextData?.__vinext?.initialResolvedQuery)
-  ) {
+  if (isReady && (!usesServerResolvedQuery || !nextData?.__vinext?.initialResolvedQuery)) {
     const params = new URLSearchParams(window.location.search);
     for (const [key, value] of params) {
       addQueryParam(searchQuery, key, value);
@@ -1330,6 +1324,12 @@ function getCurrentHistoryAsPath(): string | null {
   } catch {
     return null;
   }
+}
+
+function getCurrentQueryOwner(): VinextHistoryState["__vinext_queryOwner"] {
+  const state = window.history?.state;
+  if (!isNextRouterState(state)) return "browser";
+  return state.__vinext_queryOwner ?? "server";
 }
 
 export function getPagesNavigationIsReadyFromSerializedState(
@@ -2339,13 +2339,13 @@ function updateHistory(
     options: navState.options,
     __N: true,
     key,
+    __vinext_queryOwner: marksPageNavigation ? "browser" : getCurrentQueryOwner(),
   };
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
   routerRuntimeState.currentHistoryKey = key;
   routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
   routerRuntimeState.routerDidNavigate = true;
-  if (marksPageNavigation) routerRuntimeState.pageDidNavigate = true;
 }
 
 /**
@@ -2358,6 +2358,7 @@ type VinextHistoryState = {
   options: { locale?: string; shallow?: boolean };
   __N: true;
   key: string;
+  __vinext_queryOwner?: "server" | "browser";
 };
 
 function createHistoryKey(): string {
@@ -2880,6 +2881,7 @@ function isNextRouterState(state: unknown): state is {
   options: TransitionOptions;
   __N: true;
   key?: string;
+  __vinext_queryOwner?: "server" | "browser";
 } {
   return (
     typeof state === "object" &&
@@ -3029,8 +3031,6 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     dispatchNavigateEvent();
     return;
   }
-
-  routerRuntimeState.pageDidNavigate = true;
 
   // If the restored history entry carries an explicit locale, honour it
   // when computing the fetch URL so default-locale roots still go through

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -816,12 +816,15 @@ function stampInitialHistoryState(): void {
   if (!window.history) return;
 
   const existingState = window.history.state;
+  if (existingState !== null && existingState !== undefined) {
+    routerRuntimeState.currentHistoryKey =
+      getRouterStateKey(existingState) ?? routerRuntimeState.currentHistoryKey;
+    return;
+  }
+
   const initialState = buildInitialRouterState();
   routerRuntimeState.currentHistoryKey = initialState.key;
-  window.history.replaceState(
-    isUnknownRecord(existingState) ? { ...existingState, ...initialState } : initialState,
-    "",
-  );
+  window.history.replaceState(initialState, "");
 }
 
 setStampInitialHistoryState(stampInitialHistoryState);
@@ -1913,20 +1916,35 @@ async function navigateClientData(
   // merged in one object, with route params winning on key collision (so
   // `/posts/123?id=456` still exposes `id: "123"`). Without this, code reading
   // `window.__NEXT_DATA__.query` directly would see only the dynamic params.
-  const mergedQuery = mergeRouteParamsIntoQuery(parseQueryString(target.search), target.params);
+  let routeParams = target.params;
+  if (target.pattern === initialTarget.pattern) {
+    try {
+      const visibleUrl = new URL(url, window.location.href);
+      const visiblePagePath = stripBasePath(visibleUrl.pathname, __basePath);
+      const visibleLocale = getLocalePathPrefix(visiblePagePath, window.__VINEXT_LOCALES__);
+      const visibleRoutePath = visibleLocale
+        ? visiblePagePath.slice(visibleLocale.length + 1) || "/"
+        : visiblePagePath;
+      routeParams = extractRouteParamsFromPath(target.pattern, visibleRoutePath) ?? routeParams;
+    } catch {
+      routeParams = initialTarget.params;
+    }
+  }
+  const mergedQuery = mergeRouteParamsIntoQuery(parseQueryString(target.search), routeParams);
   const resolvedQueryHeader = res.headers.get(VINEXT_RESOLVED_QUERY_HEADER);
   let resolvedQuery = mergedQuery;
   if (resolvedQueryHeader) {
     try {
       const parsed = JSON.parse(resolvedQueryHeader);
       if (isUnknownRecord(parsed)) {
-        resolvedQuery = {};
+        const parsedResolvedQuery: Record<string, string | string[]> = {};
         for (const [key, value] of Object.entries(parsed)) {
-          if (typeof value === "string") setOwnQueryValue(resolvedQuery, key, value);
+          if (typeof value === "string") setOwnQueryValue(parsedResolvedQuery, key, value);
           else if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
-            setOwnQueryValue(resolvedQuery, key, [...value]);
+            setOwnQueryValue(parsedResolvedQuery, key, [...value]);
           }
         }
+        resolvedQuery = mergeRouteParamsIntoQuery(parsedResolvedQuery, routeParams);
       }
     } catch {
       // Ignore malformed optional metadata and retain browser-derived query ownership.
@@ -2048,6 +2066,24 @@ async function navigateClientHtml(
   }
 
   const nextData = parseVinextNextDataJson(nextDataJson);
+  try {
+    const visibleUrl = new URL(browserUrl, window.location.href);
+    const visiblePagePath = stripBasePath(visibleUrl.pathname, __basePath);
+    const visibleLocale = getLocalePathPrefix(visiblePagePath, window.__VINEXT_LOCALES__);
+    const visibleRoutePath = visibleLocale
+      ? visiblePagePath.slice(visibleLocale.length + 1) || "/"
+      : visiblePagePath;
+    const visibleRouteParams = extractRouteParamsFromPath(nextData.page, visibleRoutePath);
+    const initialResolvedQuery = nextData.__vinext?.initialResolvedQuery;
+    if (visibleRouteParams && initialResolvedQuery) {
+      nextData.__vinext = {
+        ...nextData.__vinext,
+        initialResolvedQuery: mergeRouteParamsIntoQuery(initialResolvedQuery, visibleRouteParams),
+      };
+    }
+  } catch {
+    // Keep the server-resolved query when the visible URL cannot be parsed.
+  }
   const props = nextData.props && typeof nextData.props === "object" ? nextData.props : {};
   const rawPageProps = props.pageProps;
   const pageProps: Record<string, unknown> = isUnknownRecord(rawPageProps) ? rawPageProps : {};

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -63,6 +63,7 @@ import {
   appendSearchParamsToUrl,
   mergeRouteParamsIntoQuery,
   parseQueryString,
+  setOwnQueryValue,
   type UrlQuery,
   urlQueryToSearchParams,
 } from "../utils/query.js";
@@ -1247,7 +1248,11 @@ function navigationRequiresServerQueryOwnership(nextData: VinextNextData): boole
     addQueryParam(browserQuery, key, value);
   }
   const routeParams = extractRouteParamsFromPath(nextData.page, resolvedPath);
-  if (routeParams) Object.assign(browserQuery, routeParams);
+  if (routeParams) {
+    for (const [key, value] of Object.entries(routeParams)) {
+      setOwnQueryValue(browserQuery, key, Array.isArray(value) ? [...value] : value);
+    }
+  }
 
   return !queryValuesEqual(browserQuery, serverQuery);
 }
@@ -1293,11 +1298,11 @@ function getPathnameAndQuery(): {
       let query: Record<string, string | string[]> = {};
       if (isReady) {
         for (const [key, value] of Object.entries(_ssrCtx.query)) {
-          query[key] = Array.isArray(value) ? [...value] : value;
+          setOwnQueryValue(query, key, Array.isArray(value) ? [...value] : value);
         }
       } else {
         for (const [key, value] of Object.entries(_ssrCtx.initialQuery ?? {})) {
-          query[key] = Array.isArray(value) ? [...value] : value;
+          setOwnQueryValue(query, key, Array.isArray(value) ? [...value] : value);
         }
       }
       return { pathname: _ssrCtx.pathname, query, asPath: _ssrCtx.asPath };
@@ -1317,17 +1322,21 @@ function getPathnameAndQuery(): {
     const initialResolvedQuery = nextData?.__vinext?.initialResolvedQuery;
     if (usesServerResolvedQuery && initialResolvedQuery) {
       for (const [key, value] of Object.entries(initialResolvedQuery)) {
-        routeQuery[key] = Array.isArray(value) ? [...value] : value;
+        setOwnQueryValue(routeQuery, key, Array.isArray(value) ? [...value] : value);
       }
     } else {
-      Object.assign(routeQuery, getRouteQueryFromNextData(nextData, resolvedPath));
+      for (const [key, value] of Object.entries(
+        getRouteQueryFromNextData(nextData, resolvedPath),
+      )) {
+        setOwnQueryValue(routeQuery, key, Array.isArray(value) ? [...value] : value);
+      }
     }
   } else {
     for (const [key, value] of Object.entries(nextData?.query ?? {})) {
       if (typeof value === "string") {
-        routeQuery[key] = value;
+        setOwnQueryValue(routeQuery, key, value);
       } else if (Array.isArray(value)) {
-        routeQuery[key] = [...value];
+        setOwnQueryValue(routeQuery, key, [...value]);
       }
     }
   }
@@ -1341,7 +1350,12 @@ function getPathnameAndQuery(): {
       addQueryParam(searchQuery, key, value);
     }
   }
-  const query = { ...searchQuery, ...routeQuery };
+  const query: Record<string, string | string[]> = {};
+  for (const source of [searchQuery, routeQuery]) {
+    for (const [key, value] of Object.entries(source)) {
+      setOwnQueryValue(query, key, Array.isArray(value) ? [...value] : value);
+    }
+  }
   // asPath uses the resolved browser path, not the route pattern
   const asPath =
     getCurrentHistoryAsPath() ?? resolvedPath + window.location.search + window.location.hash;
@@ -1908,9 +1922,9 @@ async function navigateClientData(
       if (isUnknownRecord(parsed)) {
         resolvedQuery = {};
         for (const [key, value] of Object.entries(parsed)) {
-          if (typeof value === "string") resolvedQuery[key] = value;
+          if (typeof value === "string") setOwnQueryValue(resolvedQuery, key, value);
           else if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
-            resolvedQuery[key] = [...value];
+            setOwnQueryValue(resolvedQuery, key, [...value]);
           }
         }
       }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -415,7 +415,13 @@ type PagesRouterRuntimeState = {
   beforePopStateCb?: BeforePopStateCallback;
   lastPathnameAndSearch: string;
   isFirstPopStateEvent: boolean;
+  // Any router-owned history update, including a hash-only change. This keeps
+  // Safari replay filtering and back/forward handling aligned with Next.js.
   routerDidNavigate: boolean;
+  // A navigation that changes the rendered page/query owner. Hash-only
+  // changes leave this false so the server-resolved initial query remains
+  // authoritative for the current document.
+  pageDidNavigate: boolean;
   deprecatedEventBridgeInstalled: boolean;
   pagesRouterReady: boolean;
   publicRouter?: Record<string, unknown>;
@@ -443,6 +449,7 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
       typeof window !== "undefined" ? window.location.pathname + window.location.search : "",
     isFirstPopStateEvent: true,
     routerDidNavigate: false,
+    pageDidNavigate: false,
     deprecatedEventBridgeInstalled: false,
     pagesRouterReady: typeof window === "undefined" || !shouldDeferInitialPagesRouterReady(),
   };
@@ -1268,7 +1275,7 @@ function getPathnameAndQuery(): {
   const routeQuery: Record<string, string | string[]> = {};
   if (isReady) {
     const initialResolvedQuery = nextData?.__vinext?.initialResolvedQuery;
-    if (!routerRuntimeState.routerDidNavigate && initialResolvedQuery) {
+    if (!routerRuntimeState.pageDidNavigate && initialResolvedQuery) {
       for (const [key, value] of Object.entries(initialResolvedQuery)) {
         routeQuery[key] = Array.isArray(value) ? [...value] : value;
       }
@@ -1290,7 +1297,7 @@ function getPathnameAndQuery(): {
   const searchQuery: Record<string, string | string[]> = {};
   if (
     isReady &&
-    (routerRuntimeState.routerDidNavigate || !nextData?.__vinext?.initialResolvedQuery)
+    (routerRuntimeState.pageDidNavigate || !nextData?.__vinext?.initialResolvedQuery)
   ) {
     const params = new URLSearchParams(window.location.search);
     for (const [key, value] of params) {
@@ -2319,6 +2326,7 @@ function updateHistory(
   mode: "push" | "replace",
   fullUrl: string,
   navState: { url: string; as: string; options: { locale?: string; shallow?: boolean } },
+  marksPageNavigation = true,
 ): void {
   const previousKey = getRouterStateKey(window.history.state);
   const key =
@@ -2337,6 +2345,7 @@ function updateHistory(
   routerRuntimeState.currentHistoryKey = key;
   routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
   routerRuntimeState.routerDidNavigate = true;
+  if (marksPageNavigation) routerRuntimeState.pageDidNavigate = true;
 }
 
 /**
@@ -2617,7 +2626,7 @@ async function performNavigation(
     if (mode === "push") saveScrollPosition();
     const eventUrl = resolveHashUrl(full);
     routerEvents.emit("hashChangeStart", eventUrl, { shallow });
-    updateHistory(mode, resolved.startsWith("#") ? resolved : full, navState);
+    updateHistory(mode, resolved.startsWith("#") ? resolved : full, navState, false);
     if (doScroll) scrollToHashTarget(extractHash(resolved));
     onStateUpdate?.();
     routerEvents.emit("hashChangeComplete", eventUrl, { shallow });
@@ -3020,6 +3029,8 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     dispatchNavigateEvent();
     return;
   }
+
+  routerRuntimeState.pageDidNavigate = true;
 
   // If the restored history entry carries an explicit locale, honour it
   // when computing the fetch URL so default-locale roots still go through

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -805,9 +805,9 @@ function buildInitialRouterState(): VinextHistoryState {
 }
 
 /**
- * Stamp the initial document entry with router-shaped state (only if no
- * state is present). Called once at runtime install so the entry has a
- * locale stamped before any push could overwrite the active locale global.
+ * Stamp the initial document entry with router-shaped state. Preserve fields
+ * owned by userland or third-party history integrations while ensuring the
+ * router metadata needed for back/forward and query ownership is present.
  */
 function stampInitialHistoryState(): void {
   installManualScrollRestoration();
@@ -815,15 +815,12 @@ function stampInitialHistoryState(): void {
   if (!window.history) return;
 
   const existingState = window.history.state;
-  if (existingState !== null && existingState !== undefined) {
-    routerRuntimeState.currentHistoryKey =
-      getRouterStateKey(existingState) ?? routerRuntimeState.currentHistoryKey;
-    return;
-  }
-
   const initialState = buildInitialRouterState();
   routerRuntimeState.currentHistoryKey = initialState.key;
-  window.history.replaceState(initialState, "");
+  window.history.replaceState(
+    isUnknownRecord(existingState) ? { ...existingState, ...initialState } : initialState,
+    "",
+  );
 }
 
 setStampInitialHistoryState(stampInitialHistoryState);
@@ -1238,6 +1235,52 @@ function getRouteQueryFromNextData(
   return routeQuery;
 }
 
+function navigationRequiresServerQueryOwnership(nextData: VinextNextData): boolean {
+  const serverQuery = nextData.__vinext?.initialResolvedQuery;
+  if (!serverQuery || !nextData.page) return false;
+
+  const resolvedPath = stripBasePath(window.location.pathname, __basePath);
+  if (extractRouteParamsFromPath(nextData.page, resolvedPath) === null) return false;
+
+  const browserQuery: Record<string, string | string[]> = {};
+  for (const [key, value] of new URLSearchParams(window.location.search)) {
+    addQueryParam(browserQuery, key, value);
+  }
+  const routeParams = extractRouteParamsFromPath(nextData.page, resolvedPath);
+  if (routeParams) Object.assign(browserQuery, routeParams);
+
+  return !queryValuesEqual(browserQuery, serverQuery);
+}
+
+function queryValuesEqual(
+  left: Record<string, string | string[]>,
+  right: Record<string, string | string[]>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+
+  for (const key of leftKeys) {
+    const leftValue = left[key];
+    const rightValue = right[key];
+    if (Array.isArray(leftValue) || Array.isArray(rightValue)) {
+      if (!Array.isArray(leftValue) || !Array.isArray(rightValue)) return false;
+      if (leftValue.length !== rightValue.length) return false;
+      if (leftValue.some((value, index) => value !== rightValue[index])) return false;
+    } else if (leftValue !== rightValue) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function updateCurrentQueryOwnership(nextData: VinextNextData): void {
+  if (!navigationRequiresServerQueryOwnership(nextData)) return;
+  const state = window.history.state;
+  if (!isNextRouterState(state) || state.__vinext_queryOwner === "server") return;
+  window.history.replaceState({ ...state, __vinext_queryOwner: "server" }, "");
+}
+
 function getPathnameAndQuery(): {
   pathname: string;
   query: Record<string, string | string[]>;
@@ -1498,6 +1541,8 @@ type PagesDataResponse = {
   // that outer envelope through App during hydration/navigation.
   [key: string]: unknown;
 };
+
+const VINEXT_RESOLVED_QUERY_HEADER = "x-vinext-resolved-query";
 
 function isPageComponent(value: unknown): value is ComponentType<Record<string, unknown>> {
   if (typeof value === "function") return true;
@@ -1855,6 +1900,24 @@ async function navigateClientData(
   // `/posts/123?id=456` still exposes `id: "123"`). Without this, code reading
   // `window.__NEXT_DATA__.query` directly would see only the dynamic params.
   const mergedQuery = mergeRouteParamsIntoQuery(parseQueryString(target.search), target.params);
+  const resolvedQueryHeader = res.headers.get(VINEXT_RESOLVED_QUERY_HEADER);
+  let resolvedQuery = mergedQuery;
+  if (resolvedQueryHeader) {
+    try {
+      const parsed = JSON.parse(resolvedQueryHeader);
+      if (isUnknownRecord(parsed)) {
+        resolvedQuery = {};
+        for (const [key, value] of Object.entries(parsed)) {
+          if (typeof value === "string") resolvedQuery[key] = value;
+          else if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+            resolvedQuery[key] = [...value];
+          }
+        }
+      }
+    } catch {
+      // Ignore malformed optional metadata and retain browser-derived query ownership.
+    }
+  }
 
   const prev = window.__NEXT_DATA__ as NonNullable<Window["__NEXT_DATA__"]> | undefined;
   // Locale-prefixed URLs change the active locale; the JSON envelope itself
@@ -1876,6 +1939,10 @@ async function navigateClientData(
     query: mergedQuery,
     buildId: target.buildId,
     isFallback: false,
+    __vinext: {
+      ...(prev as VinextNextData | undefined)?.__vinext,
+      initialResolvedQuery: resolvedQuery,
+    },
     ...(nextLocale !== undefined ? { locale: nextLocale } : {}),
   } as unknown as NonNullable<Window["__NEXT_DATA__"]> & VinextNextData;
 
@@ -1884,6 +1951,7 @@ async function navigateClientData(
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
   window.__NEXT_DATA__ = nextData;
+  updateCurrentQueryOwnership(nextData);
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();
@@ -2062,6 +2130,7 @@ async function navigateClientHtml(
     routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
   }
   window.__NEXT_DATA__ = nextData;
+  updateCurrentQueryOwnership(nextData);
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();

--- a/packages/vinext/src/utils/query.ts
+++ b/packages/vinext/src/utils/query.ts
@@ -53,6 +53,21 @@ export function mergeRouteParamsIntoQuery(
   return merged;
 }
 
+export function buildInitialPagesRouterQuery(
+  resolvedQuery: Record<string, string | string[]>,
+  params: Record<string, string | string[]>,
+  rewriteQueryKeys: readonly string[] = [],
+): Record<string, string | string[]> {
+  const initialQuery: Record<string, string | string[]> = {};
+  for (const key of rewriteQueryKeys) {
+    const value = resolvedQuery[key];
+    if (typeof value === "string" || Array.isArray(value)) {
+      setOwnQueryValue(initialQuery, key, Array.isArray(value) ? [...value] : value);
+    }
+  }
+  return mergeRouteParamsIntoQuery(initialQuery, params);
+}
+
 /**
  * Parse a URL's query string into a Record, with multi-value keys promoted to arrays.
  *

--- a/packages/vinext/src/utils/query.ts
+++ b/packages/vinext/src/utils/query.ts
@@ -6,7 +6,7 @@ type UrlQueryValue = string | number | boolean | null | undefined;
 
 export type UrlQuery = Record<string, UrlQueryValue | readonly UrlQueryValue[]>;
 
-function setOwnQueryValue(
+export function setOwnQueryValue(
   obj: Record<string, string | string[]>,
   key: string,
   value: string | string[],
@@ -46,7 +46,10 @@ export function mergeRouteParamsIntoQuery(
   query: Record<string, string | string[]>,
   params: Record<string, string | string[]>,
 ): Record<string, string | string[]> {
-  const merged: Record<string, string | string[]> = { ...query };
+  const merged: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(query)) {
+    setOwnQueryValue(merged, key, Array.isArray(value) ? [...value] : value);
+  }
   for (const [key, value] of Object.entries(params)) {
     setOwnQueryValue(merged, key, Array.isArray(value) ? [...value] : value);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,6 +1449,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/og-font-package: {}
+
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,8 +1449,6 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
-  tests/fixtures/og-font-package: {}
-
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
@@ -57,4 +57,34 @@ test.describe("Pages prerender rewrite query", () => {
       { visible: "browser", same: "destination", from: "config" },
     );
   });
+
+  test("preserves destination query for a same-path config rewrite", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "http://localhost:4175/prerender-query-same?visible=browser&same=visible",
+      {},
+      { same: "destination", from: "config" },
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+
+  test("preserves destination query for a dynamic same-path config rewrite", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "http://localhost:4175/prerender-query-same-dynamic/a%2Fb?visible=browser&same=visible",
+      { slug: "a/b" },
+      { same: "destination", from: "config", slug: "a/b" },
+      { visible: "browser", same: "destination", from: "config", slug: "a/b" },
+    );
+  });
+
+  test("does not resurrect visible query removed by middleware", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "http://localhost:4175/prerender-middleware-clear?allowed=kept&removed=visible",
+      {},
+      {},
+      { allowed: "kept" },
+    );
+  });
 });

--- a/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type Page } from "@playwright/test";
+
+async function expectHydratedQuery(
+  page: Page,
+  url: string,
+  expectedParams: unknown,
+  expectedInitialQuery: unknown,
+  expectedQuery: unknown,
+) {
+  const hydrationErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error" && /hydration|did not match/i.test(message.text())) {
+      hydrationErrors.push(message.text());
+    }
+  });
+
+  await page.goto(url);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#params").innerText()))
+    .toEqual(expectedParams);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+  expect(await page.evaluate(() => (window as any).__NEXT_DATA__.query)).toEqual(
+    expectedInitialQuery,
+  );
+  expect(hydrationErrors).toEqual([]);
+}
+
+test.describe("Pages prerender rewrite query", () => {
+  test("preserves destination query for static GSP hydration", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "http://localhost:4175/prerender-rewrite?visible=browser&same=visible",
+      {},
+      { same: "destination", from: "config" },
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+
+  test("preserves destination query with encoded dynamic params", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "http://localhost:4175/prerender-rewrite-dynamic/a%2Fb?visible=browser&same=visible",
+      { slug: "a/b" },
+      { same: "destination", from: "config", slug: "a/b" },
+      { visible: "browser", same: "destination", from: "config", slug: "a/b" },
+    );
+  });
+
+  test("preserves destination query with absent optional params", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "http://localhost:4175/prerender-rewrite-optional?visible=browser&same=visible",
+      {},
+      { same: "destination", from: "config" },
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+});

--- a/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
@@ -218,4 +218,17 @@ test.describe("Pages prerender rewrite query", () => {
       { allowed: "kept" },
     );
   });
+
+  test("trusts server query metadata over a spoofed GSSP header", async ({ page }) => {
+    await page.goto("http://localhost:4175/about");
+    await page.evaluate(async () => {
+      await (window as any).next.router.push(
+        "/prerender-query-gssp?__proto__=first&__proto__=second&tag=a&tag=b",
+      );
+    });
+
+    await expect
+      .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+      .toEqual(JSON.parse('{"__proto__":["first","second"],"tag":["a","b"]}'));
+  });
 });

--- a/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
@@ -73,6 +73,26 @@ async function expectBackForwardRestoresQuery(page: Page, url: string, expectedQ
     .toEqual(expectedQuery);
 }
 
+async function expectClientNavigationPreservesServerQuery(
+  page: Page,
+  url: string,
+  expectedQuery: unknown,
+  mode: "push" | "replace",
+) {
+  await page.goto("http://localhost:4175/about");
+  await page.evaluate(
+    async ({ navigationMode, target }) => {
+      await (window as any).next.router[navigationMode](target);
+    },
+    { navigationMode: mode, target: url },
+  );
+
+  await expect(page).toHaveURL(new RegExp(`${new URL(url).pathname}.*$`));
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+}
+
 test.describe("Pages prerender rewrite query", () => {
   test("preserves destination query for static GSP hydration", async ({ page }) => {
     await expectHydratedQuery(
@@ -135,6 +155,33 @@ test.describe("Pages prerender rewrite query", () => {
   });
 
   for (const mode of ["push", "replace"] as const) {
+    test(`preserves static same-path rewrite query after client ${mode}`, async ({ page }) => {
+      await expectClientNavigationPreservesServerQuery(
+        page,
+        "http://localhost:4175/prerender-query-same?visible=client&same=visible",
+        { visible: "client", same: "destination", from: "config" },
+        mode,
+      );
+    });
+
+    test(`preserves dynamic same-path rewrite query after client ${mode}`, async ({ page }) => {
+      await expectClientNavigationPreservesServerQuery(
+        page,
+        "http://localhost:4175/prerender-query-same-dynamic/a%2Fb?visible=client&same=visible",
+        { visible: "client", same: "destination", from: "config", slug: "a/b" },
+        mode,
+      );
+    });
+
+    test(`keeps middleware-cleared query removed after client ${mode}`, async ({ page }) => {
+      await expectClientNavigationPreservesServerQuery(
+        page,
+        "http://localhost:4175/prerender-middleware-clear?allowed=kept&removed=visible",
+        { allowed: "kept" },
+        mode,
+      );
+    });
+
     test(`preserves same-path rewrite query after hash-only ${mode}`, async ({ page }) => {
       await expectHashNavigationPreservesQuery(
         page,

--- a/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
@@ -27,6 +27,27 @@ async function expectHydratedQuery(
   expect(hydrationErrors).toEqual([]);
 }
 
+async function expectHashNavigationPreservesQuery(
+  page: Page,
+  url: string,
+  expectedQuery: unknown,
+  mode: "push" | "replace",
+) {
+  await page.goto(url);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+
+  await page.evaluate(async (navigationMode) => {
+    await (window as any).next.router[navigationMode]("#after-hydration");
+  }, mode);
+
+  await expect(page).toHaveURL(/#after-hydration$/);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+}
+
 test.describe("Pages prerender rewrite query", () => {
   test("preserves destination query for static GSP hydration", async ({ page }) => {
     await expectHydratedQuery(
@@ -87,4 +108,26 @@ test.describe("Pages prerender rewrite query", () => {
       { allowed: "kept" },
     );
   });
+
+  for (const mode of ["push", "replace"] as const) {
+    test(`preserves same-path rewrite query after hash-only ${mode}`, async ({ page }) => {
+      await expectHashNavigationPreservesQuery(
+        page,
+        "http://localhost:4175/prerender-query-same?visible=browser&same=visible",
+        { visible: "browser", same: "destination", from: "config" },
+        mode,
+      );
+    });
+
+    test(`does not resurrect middleware-removed query after hash-only ${mode}`, async ({
+      page,
+    }) => {
+      await expectHashNavigationPreservesQuery(
+        page,
+        "http://localhost:4175/prerender-middleware-clear?allowed=kept&removed=visible",
+        { allowed: "kept" },
+        mode,
+      );
+    });
+  }
 });

--- a/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts
@@ -48,6 +48,31 @@ async function expectHashNavigationPreservesQuery(
     .toEqual(expectedQuery);
 }
 
+async function expectBackForwardRestoresQuery(page: Page, url: string, expectedQuery: unknown) {
+  await page.goto(url);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+
+  await page.evaluate(async () => {
+    await (window as any).next.router.push("/about");
+  });
+  await expect(page).toHaveURL(/\/about$/);
+
+  await page.goBack();
+  await expect(page).toHaveURL(new RegExp(`${new URL(url).pathname}.*$`));
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+
+  await page.goForward();
+  await expect(page).toHaveURL(/\/about$/);
+  await page.goBack();
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+}
+
 test.describe("Pages prerender rewrite query", () => {
   test("preserves destination query for static GSP hydration", async ({ page }) => {
     await expectHydratedQuery(
@@ -130,4 +155,20 @@ test.describe("Pages prerender rewrite query", () => {
       );
     });
   }
+
+  test("restores same-path rewrite query across back and forward", async ({ page }) => {
+    await expectBackForwardRestoresQuery(
+      page,
+      "http://localhost:4175/prerender-query-same?visible=browser&same=visible",
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+
+  test("keeps middleware-removed query cleared across back and forward", async ({ page }) => {
+    await expectBackForwardRestoresQuery(
+      page,
+      "http://localhost:4175/prerender-middleware-clear?allowed=kept&removed=visible",
+      { allowed: "kept" },
+    );
+  });
 });

--- a/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
@@ -230,4 +230,17 @@ test.describe("Pages prerender rewrite query", () => {
       .poll(async () => JSON.parse(await page.locator("#query").innerText()))
       .toEqual({ visible: "client", same: "destination", from: "config" });
   });
+
+  test("trusts server query metadata over a spoofed GSSP header", async ({ page }) => {
+    await page.goto("/about");
+    await page.evaluate(async () => {
+      await (window as any).next.router.push(
+        "/prerender-query-gssp?__proto__=first&__proto__=second&tag=a&tag=b",
+      );
+    });
+
+    await expect
+      .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+      .toEqual(JSON.parse('{"__proto__":["first","second"],"tag":["a","b"]}'));
+  });
 });

--- a/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
@@ -27,6 +27,27 @@ async function expectHydratedQuery(
   expect(hydrationErrors).toEqual([]);
 }
 
+async function expectHashNavigationPreservesQuery(
+  page: Page,
+  url: string,
+  expectedQuery: unknown,
+  mode: "push" | "replace",
+) {
+  await page.goto(url);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+
+  await page.evaluate(async (navigationMode) => {
+    await (window as any).next.router[navigationMode]("#after-hydration");
+  }, mode);
+
+  await expect(page).toHaveURL(/#after-hydration$/);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+}
+
 test.describe("Pages prerender rewrite query", () => {
   test("preserves destination query for static GSP hydration", async ({ page }) => {
     await expectHydratedQuery(
@@ -86,5 +107,39 @@ test.describe("Pages prerender rewrite query", () => {
       {},
       { allowed: "kept" },
     );
+  });
+
+  for (const mode of ["push", "replace"] as const) {
+    test(`preserves same-path rewrite query after hash-only ${mode}`, async ({ page }) => {
+      await expectHashNavigationPreservesQuery(
+        page,
+        "/prerender-query-same?visible=browser&same=visible",
+        { visible: "browser", same: "destination", from: "config" },
+        mode,
+      );
+    });
+
+    test(`does not resurrect middleware-removed query after hash-only ${mode}`, async ({
+      page,
+    }) => {
+      await expectHashNavigationPreservesQuery(
+        page,
+        "/prerender-middleware-clear?allowed=kept&removed=visible",
+        { allowed: "kept" },
+        mode,
+      );
+    });
+  }
+
+  test("switches to browser query authority after a real page navigation", async ({ page }) => {
+    await page.goto("/prerender-query-same?visible=initial&same=visible");
+    await page.evaluate(async () => {
+      await (window as any).next.router.push("/prerender-rewrite?visible=client&same=visible");
+    });
+
+    await expect(page).toHaveURL(/\/prerender-rewrite\?visible=client&same=visible$/);
+    await expect
+      .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+      .toEqual({ visible: "client", same: "destination", from: "config" });
   });
 });

--- a/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type Page } from "@playwright/test";
+
+async function expectHydratedQuery(
+  page: Page,
+  url: string,
+  expectedParams: unknown,
+  expectedInitialQuery: unknown,
+  expectedQuery: unknown,
+) {
+  const hydrationErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error" && /hydration|did not match/i.test(message.text())) {
+      hydrationErrors.push(message.text());
+    }
+  });
+
+  await page.goto(url);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#params").innerText()))
+    .toEqual(expectedParams);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+  expect(await page.evaluate(() => (window as any).__NEXT_DATA__.query)).toEqual(
+    expectedInitialQuery,
+  );
+  expect(hydrationErrors).toEqual([]);
+}
+
+test.describe("Pages prerender rewrite query", () => {
+  test("preserves destination query for static GSP hydration", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "/prerender-rewrite?visible=browser&same=visible",
+      {},
+      { same: "destination", from: "config" },
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+
+  test("preserves destination query with encoded dynamic params", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "/prerender-rewrite-dynamic/a%2Fb?visible=browser&same=visible",
+      { slug: "a/b" },
+      { same: "destination", from: "config", slug: "a/b" },
+      { visible: "browser", same: "destination", from: "config", slug: "a/b" },
+    );
+  });
+
+  test("preserves destination query with absent optional params", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "/prerender-rewrite-optional?visible=browser&same=visible",
+      {},
+      { same: "destination", from: "config" },
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+});

--- a/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
@@ -48,6 +48,31 @@ async function expectHashNavigationPreservesQuery(
     .toEqual(expectedQuery);
 }
 
+async function expectBackForwardRestoresQuery(page: Page, url: string, expectedQuery: unknown) {
+  await page.goto(url);
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+
+  await page.evaluate(async () => {
+    await (window as any).next.router.push("/about");
+  });
+  await expect(page).toHaveURL(/\/about$/);
+
+  await page.goBack();
+  await expect(page).toHaveURL(new RegExp(`${new URL(url, "http://localhost").pathname}.*$`));
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+
+  await page.goForward();
+  await expect(page).toHaveURL(/\/about$/);
+  await page.goBack();
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+}
+
 test.describe("Pages prerender rewrite query", () => {
   test("preserves destination query for static GSP hydration", async ({ page }) => {
     await expectHydratedQuery(
@@ -130,6 +155,22 @@ test.describe("Pages prerender rewrite query", () => {
       );
     });
   }
+
+  test("restores same-path rewrite query across back and forward", async ({ page }) => {
+    await expectBackForwardRestoresQuery(
+      page,
+      "/prerender-query-same?visible=browser&same=visible",
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+
+  test("keeps middleware-removed query cleared across back and forward", async ({ page }) => {
+    await expectBackForwardRestoresQuery(
+      page,
+      "/prerender-middleware-clear?allowed=kept&removed=visible",
+      { allowed: "kept" },
+    );
+  });
 
   test("switches to browser query authority after a real page navigation", async ({ page }) => {
     await page.goto("/prerender-query-same?visible=initial&same=visible");

--- a/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
@@ -73,6 +73,26 @@ async function expectBackForwardRestoresQuery(page: Page, url: string, expectedQ
     .toEqual(expectedQuery);
 }
 
+async function expectClientNavigationPreservesServerQuery(
+  page: Page,
+  url: string,
+  expectedQuery: unknown,
+  mode: "push" | "replace",
+) {
+  await page.goto("/about");
+  await page.evaluate(
+    async ({ navigationMode, target }) => {
+      await (window as any).next.router[navigationMode](target);
+    },
+    { navigationMode: mode, target: url },
+  );
+
+  await expect(page).toHaveURL(new RegExp(`${new URL(url, "http://localhost").pathname}.*$`));
+  await expect
+    .poll(async () => JSON.parse(await page.locator("#query").innerText()))
+    .toEqual(expectedQuery);
+}
+
 test.describe("Pages prerender rewrite query", () => {
   test("preserves destination query for static GSP hydration", async ({ page }) => {
     await expectHydratedQuery(
@@ -135,6 +155,33 @@ test.describe("Pages prerender rewrite query", () => {
   });
 
   for (const mode of ["push", "replace"] as const) {
+    test(`preserves static same-path rewrite query after client ${mode}`, async ({ page }) => {
+      await expectClientNavigationPreservesServerQuery(
+        page,
+        "/prerender-query-same?visible=client&same=visible",
+        { visible: "client", same: "destination", from: "config" },
+        mode,
+      );
+    });
+
+    test(`preserves dynamic same-path rewrite query after client ${mode}`, async ({ page }) => {
+      await expectClientNavigationPreservesServerQuery(
+        page,
+        "/prerender-query-same-dynamic/a%2Fb?visible=client&same=visible",
+        { visible: "client", same: "destination", from: "config", slug: "a/b" },
+        mode,
+      );
+    });
+
+    test(`keeps middleware-cleared query removed after client ${mode}`, async ({ page }) => {
+      await expectClientNavigationPreservesServerQuery(
+        page,
+        "/prerender-middleware-clear?allowed=kept&removed=visible",
+        { allowed: "kept" },
+        mode,
+      );
+    });
+
     test(`preserves same-path rewrite query after hash-only ${mode}`, async ({ page }) => {
       await expectHashNavigationPreservesQuery(
         page,

--- a/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
+++ b/tests/e2e/pages-router/prerender-rewrite-query.spec.ts
@@ -57,4 +57,34 @@ test.describe("Pages prerender rewrite query", () => {
       { visible: "browser", same: "destination", from: "config" },
     );
   });
+
+  test("preserves destination query for a same-path config rewrite", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "/prerender-query-same?visible=browser&same=visible",
+      {},
+      { same: "destination", from: "config" },
+      { visible: "browser", same: "destination", from: "config" },
+    );
+  });
+
+  test("preserves destination query for a dynamic same-path config rewrite", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "/prerender-query-same-dynamic/a%2Fb?visible=browser&same=visible",
+      { slug: "a/b" },
+      { same: "destination", from: "config", slug: "a/b" },
+      { visible: "browser", same: "destination", from: "config", slug: "a/b" },
+    );
+  });
+
+  test("does not resurrect visible query removed by middleware", async ({ page }) => {
+    await expectHydratedQuery(
+      page,
+      "/prerender-middleware-clear?allowed=kept&removed=visible",
+      {},
+      {},
+      { allowed: "kept" },
+    );
+  });
 });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1042,7 +1042,7 @@ describe("Pages Router entry template", () => {
   //
   // Ported from Next.js: test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/instrumentation-client-hook/instrumentation-client-hook.test.ts
-  it("imports the user's instrumentation-client.ts before calling hydrateRoot()", async () => {
+  it("loads instrumentation after locale bootstrap and before calling hydrateRoot()", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-"));
     const pagesDir = path.join(tmpDir, "pages");
     const instrumentationClientPath = path.join(tmpDir, "instrumentation-client.ts");
@@ -1065,15 +1065,21 @@ describe("Pages Router entry template", () => {
         { instrumentationClientPath },
       );
 
-      // The user's `instrumentation-client.ts` must be imported as a
-      // side-effect import (no `from`, no `as`) so its top-level statements
-      // execute when the client entry module is evaluated.
-      const userImportIndex = code.indexOf(`import ${JSON.stringify(instrumentationClientPath)}`);
+      const localeBootstrapIndex = code.indexOf(
+        "window.__VINEXT_LOCALE__ = window.__NEXT_DATA__.locale",
+      );
+      const instrumentationImportIndex = code.indexOf(
+        'await import("vinext/instrumentation-client")',
+      );
+      const routerImportIndex = code.indexOf('await import("next/router")');
       const hydrateRootIndex = code.indexOf("hydrateRoot(");
 
-      expect(userImportIndex).toBeGreaterThanOrEqual(0);
+      expect(localeBootstrapIndex).toBeGreaterThanOrEqual(0);
+      expect(instrumentationImportIndex).toBeGreaterThan(localeBootstrapIndex);
+      expect(routerImportIndex).toBeGreaterThan(instrumentationImportIndex);
       expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
-      expect(userImportIndex).toBeLessThan(hydrateRootIndex);
+      expect(instrumentationImportIndex).toBeLessThan(hydrateRootIndex);
+      expect(code).not.toContain(`import ${JSON.stringify(instrumentationClientPath)}`);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -1099,7 +1105,7 @@ describe("Pages Router entry template", () => {
 
       // Sanity check: the entry still wires up hydration and the hooks alias.
       expect(code).toContain("hydrateRoot(");
-      expect(code).toContain("vinext/instrumentation-client");
+      expect(code).toContain('await import("vinext/instrumentation-client")');
       // No spurious bare imports referring to a non-existent project file.
       expect(code).not.toMatch(/import "[^"]*instrumentation-client\.ts"/);
     } finally {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1142,12 +1142,13 @@ describe("Pages Router entry template", () => {
       expect(code).toContain(
         'const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};',
       );
-      expect(code).toContain("default: Router,");
+      expect(code).toContain("import Router, {");
       expect(code).toContain("wrapWithRouterContext,");
       expect(code).toContain("_initializePagesRouterReadyFromNextData,");
-      expect(code).toContain('} = await import("next/router");');
+      expect(code).toContain("_syncInitialPagesRouterStateFromNextData,");
+      expect(code).toContain('} from "next/router";');
       expect(code.indexOf("JSON.parse(nextDataElement.textContent)")).toBeLessThan(
-        code.indexOf('await import("next/router")'),
+        code.indexOf("_syncInitialPagesRouterStateFromNextData();"),
       );
       expect(code).toContain("_initializePagesRouterReadyFromNextData(nextData);");
       expect(code).toContain("router: Router,");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1071,12 +1071,13 @@ describe("Pages Router entry template", () => {
       const instrumentationImportIndex = code.indexOf(
         'await import("vinext/instrumentation-client")',
       );
-      const routerImportIndex = code.indexOf('await import("next/router")');
+      const routerImportIndex = code.indexOf('from "next/router"');
       const hydrateRootIndex = code.indexOf("hydrateRoot(");
 
       expect(localeBootstrapIndex).toBeGreaterThanOrEqual(0);
       expect(instrumentationImportIndex).toBeGreaterThan(localeBootstrapIndex);
-      expect(routerImportIndex).toBeGreaterThan(instrumentationImportIndex);
+      expect(routerImportIndex).toBeGreaterThanOrEqual(0);
+      expect(routerImportIndex).toBeLessThan(localeBootstrapIndex);
       expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
       expect(instrumentationImportIndex).toBeLessThan(hydrateRootIndex);
       expect(code).not.toContain(`import ${JSON.stringify(instrumentationClientPath)}`);

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1135,10 +1135,13 @@ describe("Pages Router entry template", () => {
       expect(code).toContain(
         'const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};',
       );
-      expect(code).toContain("import Router, {");
+      expect(code).toContain("default: Router,");
       expect(code).toContain("wrapWithRouterContext,");
       expect(code).toContain("_initializePagesRouterReadyFromNextData,");
-      expect(code).toContain('} from "next/router";');
+      expect(code).toContain('} = await import("next/router");');
+      expect(code.indexOf("JSON.parse(nextDataElement.textContent)")).toBeLessThan(
+        code.indexOf('await import("next/router")'),
+      );
       expect(code).toContain("_initializePagesRouterReadyFromNextData(nextData);");
       expect(code).toContain("router: Router,");
       expect(code).toContain("pageProps: rawPageProps,");

--- a/tests/fixtures/instrumentation-client-imports-router.ts
+++ b/tests/fixtures/instrumentation-client-imports-router.ts
@@ -1,0 +1,9 @@
+import Router from "../../packages/vinext/src/shims/router.js";
+
+const instrumentationWindow = window as Window & {
+  __INSTRUMENTATION_INITIAL_ROUTER_STATE__?: unknown;
+};
+
+instrumentationWindow.__INSTRUMENTATION_INITIAL_ROUTER_STATE__ = window.history.state;
+
+export default Router;

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -92,6 +92,11 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(url);
   }
 
+  if (url.pathname === "/prerender-middleware-clear") {
+    url.searchParams.delete("removed");
+    return NextResponse.rewrite(url);
+  }
+
   if (url.pathname === "/rewrite-with-cookie") {
     const res = NextResponse.rewrite(new URL("/ssr", request.url));
     res.cookies.set("rewrite-cookie", "visible", { path: "/" });

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -74,6 +74,14 @@ const nextConfig = {
           source: "/prerender-rewrite-optional/:parts*",
           destination: "/prerender-query-optional/:parts*?from=config&same=destination",
         },
+        {
+          source: "/prerender-query-same",
+          destination: "/prerender-query-same?from=config&same=destination",
+        },
+        {
+          source: "/prerender-query-same-dynamic/:slug",
+          destination: "/prerender-query-same-dynamic/:slug?from=config&same=destination",
+        },
         // Used by Vitest: pages-router.test.ts — beforeFiles rewrite gated on
         // a cookie injected by middleware. Middleware injects mw-before-user=1
         // when ?mw-auth is present. The beforeFiles rewrite should see this

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -58,6 +58,22 @@ const nextConfig = {
           source: "/rewrite-navigation-same/3",
           destination: "/rewrite-navigation-same/003",
         },
+        {
+          source: "/prerender-rewrite",
+          destination: "/prerender-query?from=config&same=destination",
+        },
+        {
+          source: "/prerender-rewrite-dynamic/:slug",
+          destination: "/prerender-query-dynamic/:slug?from=config&same=destination",
+        },
+        {
+          source: "/prerender-rewrite-optional",
+          destination: "/prerender-query-optional?from=config&same=destination",
+        },
+        {
+          source: "/prerender-rewrite-optional/:parts*",
+          destination: "/prerender-query-optional/:parts*?from=config&same=destination",
+        },
         // Used by Vitest: pages-router.test.ts — beforeFiles rewrite gated on
         // a cookie injected by middleware. Middleware injects mw-before-user=1
         // when ?mw-auth is present. The beforeFiles rewrite should see this

--- a/tests/fixtures/pages-basic/pages/prerender-middleware-clear.tsx
+++ b/tests/fixtures/pages-basic/pages/prerender-middleware-clear.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from "next/router";
+
+export function getStaticProps() {
+  return { props: { params: {} } };
+}
+
+export default function PrerenderMiddlewareClear({ params }: { params: Record<string, string> }) {
+  return (
+    <>
+      <pre id="params">{JSON.stringify(params)}</pre>
+      <pre id="query">{JSON.stringify(useRouter().query)}</pre>
+    </>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/prerender-query-dynamic/[slug].tsx
+++ b/tests/fixtures/pages-basic/pages/prerender-query-dynamic/[slug].tsx
@@ -1,0 +1,18 @@
+import { useRouter } from "next/router";
+
+export function getStaticPaths() {
+  return { paths: [{ params: { slug: "a/b" } }], fallback: "blocking" };
+}
+
+export function getStaticProps({ params }: { params?: { slug?: string } }) {
+  return { props: { params: params ?? {} } };
+}
+
+export default function PrerenderQueryDynamic({ params }: { params: Record<string, string> }) {
+  return (
+    <>
+      <pre id="params">{JSON.stringify(params)}</pre>
+      <pre id="query">{JSON.stringify(useRouter().query)}</pre>
+    </>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/prerender-query-gssp.tsx
+++ b/tests/fixtures/pages-basic/pages/prerender-query-gssp.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from "next/router";
+
+export async function getServerSideProps({
+  res,
+}: {
+  res: { setHeader(name: string, value: string): void };
+}) {
+  res.setHeader("X-Vinext-Resolved-Query", JSON.stringify({ spoofed: "user" }));
+  return { props: {} };
+}
+
+export default function PrerenderQueryGssp() {
+  return <pre id="query">{JSON.stringify(useRouter().query)}</pre>;
+}

--- a/tests/fixtures/pages-basic/pages/prerender-query-optional/[[...parts]]/index.tsx
+++ b/tests/fixtures/pages-basic/pages/prerender-query-optional/[[...parts]]/index.tsx
@@ -1,0 +1,18 @@
+import { useRouter } from "next/router";
+
+export function getStaticPaths() {
+  return { paths: [{ params: { parts: [] } }], fallback: "blocking" };
+}
+
+export function getStaticProps({ params }: { params?: { parts?: string[] } }) {
+  return { props: { params: params ?? {} } };
+}
+
+export default function PrerenderQueryOptional({ params }: { params: Record<string, string[]> }) {
+  return (
+    <>
+      <pre id="params">{JSON.stringify(params)}</pre>
+      <pre id="query">{JSON.stringify(useRouter().query)}</pre>
+    </>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/prerender-query-same-dynamic/[slug].tsx
+++ b/tests/fixtures/pages-basic/pages/prerender-query-same-dynamic/[slug].tsx
@@ -1,0 +1,18 @@
+import { useRouter } from "next/router";
+
+export function getStaticPaths() {
+  return { paths: [{ params: { slug: "a/b" } }], fallback: "blocking" };
+}
+
+export function getStaticProps({ params }: { params?: { slug?: string } }) {
+  return { props: { params: params ?? {} } };
+}
+
+export default function PrerenderQuerySameDynamic({ params }: { params: Record<string, string> }) {
+  return (
+    <>
+      <pre id="params">{JSON.stringify(params)}</pre>
+      <pre id="query">{JSON.stringify(useRouter().query)}</pre>
+    </>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/prerender-query-same.tsx
+++ b/tests/fixtures/pages-basic/pages/prerender-query-same.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from "next/router";
+
+export function getStaticProps() {
+  return { props: { params: {} } };
+}
+
+export default function PrerenderQuerySame({ params }: { params: Record<string, string> }) {
+  return (
+    <>
+      <pre id="params">{JSON.stringify(params)}</pre>
+      <pre id="query">{JSON.stringify(useRouter().query)}</pre>
+    </>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/prerender-query.tsx
+++ b/tests/fixtures/pages-basic/pages/prerender-query.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from "next/router";
+
+type Props = {
+  params: Record<string, string>;
+};
+
+export function getStaticProps({ params }: { params?: Record<string, string> }) {
+  return {
+    props: {
+      params: params ?? {},
+    },
+  };
+}
+
+export default function PrerenderQuery({ params }: Props) {
+  return (
+    <>
+      <pre id="params">{JSON.stringify(params)}</pre>
+      <pre id="query">{JSON.stringify(useRouter().query)}</pre>
+    </>
+  );
+}

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -439,7 +439,7 @@ describe("beforeFiles rewrites", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/to?keep=1&stage=1",
-      undefined,
+      { rewriteQueryKeys: ["stage"] },
       expect.any(Headers),
     );
   });
@@ -467,7 +467,7 @@ describe("beforeFiles rewrites", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/destination?first=1&second=2",
-      undefined,
+      { rewriteQueryKeys: ["first", "second"] },
       expect.any(Headers),
     );
     expect(result.response.headers.get("x-nextjs-rewrite")).toBe("/destination?first=1&second=2");
@@ -1162,7 +1162,7 @@ describe("deferred error page re-render on 404", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/fallback-target?from=fallback",
-      undefined,
+      { rewriteQueryKeys: ["from"] },
       expect.any(Headers),
     );
     expect(result.response.headers.get("x-nextjs-rewrite")).toBe("/fallback-target?from=fallback");

--- a/tests/pages-router-i18n-sticky-locale.test.ts
+++ b/tests/pages-router-i18n-sticky-locale.test.ts
@@ -576,7 +576,7 @@ describe("Pages Router initial-entry history state", () => {
     }
   });
 
-  it("install does not overwrite pre-existing history state", async () => {
+  it("install preserves pre-existing history fields while stamping router state", async () => {
     const previousWindow = (globalThis as any).window;
     const { win, replaceState } = createNavWindow();
     win.history.state = { foreign: true };
@@ -584,7 +584,14 @@ describe("Pages Router initial-entry history state", () => {
 
     try {
       await installRuntime(win);
-      expect(replaceState).not.toHaveBeenCalled();
+      expect(replaceState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          foreign: true,
+          __N: true,
+          options: { locale: "fr" },
+        }),
+        "",
+      );
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -500,6 +500,16 @@ describe("Pages Router integration", () => {
     expect(html).toContain("This is the about page.");
   });
 
+  it("preserves configured rewrite query during GSP prerender SSR in dev", async () => {
+    const res = await fetch(`${baseUrl}/prerender-rewrite?visible=browser&same=visible`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<pre id="params">{}</pre>');
+    expect(html).toContain(
+      '<pre id="query">{&quot;from&quot;:&quot;config&quot;,&quot;same&quot;:&quot;destination&quot;}</pre>',
+    );
+  });
+
   // Refs #1463: Pages Router should reject non-GET/HEAD methods to static
   // (no `getServerSideProps`) pages with a 405 + `Allow: GET, HEAD`.
   // Ported from Next.js: test/e2e/prerender.test.ts

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -4905,6 +4905,16 @@ describe("Production server middleware (Pages Router)", () => {
     expect(deferInHead.length).toBeGreaterThan(0);
   });
 
+  // Ported from Next.js: test/e2e/prerender.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/prerender.test.ts
+  it("does not expose URL search params during non-dynamic GSP prerender SSR", async () => {
+    const res = await fetch(`${prodUrl}/prerender-query?hello=world`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('<pre id="params">{}</pre>');
+    expect(html).toContain('<pre id="query">{}</pre>');
+  });
+
   it("does not serve cached production Pages ISR HTML to CSP nonce requests", async () => {
     const first = await fetch(`${prodUrl}/isr-test`);
     expect(first.status).toBe(200);

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   appendSearchParamsToUrl,
+  mergeRouteParamsIntoQuery,
   mergeRewriteQuery,
   parseQueryString,
 } from "../packages/vinext/src/utils/query.js";
@@ -131,6 +132,14 @@ describe("parseQueryString", () => {
     expect(parseQueryString("/search?tag=a&tag=b")).toEqual({ tag: ["a", "b"] });
   });
 
+  it("preserves duplicate __proto__ keys without changing the object prototype", () => {
+    const query = parseQueryString("/search?__proto__=first&__proto__=second");
+
+    expect(Object.getPrototypeOf(query)).toBe(Object.prototype);
+    expect(Object.hasOwn(query, "__proto__")).toBe(true);
+    expect(query.__proto__).toEqual(["first", "second"]);
+  });
+
   // Regression for #1471: Pages Router `<Link>` strips query string from href.
   // When a page is requested as `/linker?href=/about?hello=world`, the value of
   // the `href` query param is `/about?hello=world` (RFC 3986 only treats the
@@ -151,5 +160,17 @@ describe("parseQueryString", () => {
 
   it("stops at the URL hash fragment", () => {
     expect(parseQueryString("/about?foo=bar#section")).toEqual({ foo: "bar" });
+  });
+});
+
+describe("mergeRouteParamsIntoQuery", () => {
+  it("preserves own __proto__ query values and duplicate arrays", () => {
+    const query = parseQueryString("/search?__proto__=first&__proto__=second&tag=a&tag=b");
+    const merged = mergeRouteParamsIntoQuery(query, {});
+
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+    expect(Object.hasOwn(merged, "__proto__")).toBe(true);
+    expect(merged.__proto__).toEqual(["first", "second"]);
+    expect(merged.tag).toEqual(["a", "b"]);
   });
 });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14430,6 +14430,43 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("stamps initial router state without dropping third-party history fields", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win, replaceState } = createNavWindow();
+    win.history.state = {
+      analyticsEntry: "landing",
+      nested: { retained: true },
+    } as any;
+    replaceState.mockImplementation((state: unknown) => {
+      win.history.state = state as any;
+    });
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+
+      expect(win.history.state).toEqual(
+        expect.objectContaining({
+          analyticsEntry: "landing",
+          nested: { retained: true },
+          __N: true,
+          __vinext_queryOwner: "server",
+          url: "/",
+          as: "/",
+        }),
+      );
+      expect(replaceState).toHaveBeenCalledWith(expect.any(Object), "");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   /**
    * Helper: create a mock window suitable for non-shallow Router.push().
    * Returns an object with the window mock plus helpers for controlling

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14433,10 +14433,14 @@ describe("Pages Router concurrent navigation", () => {
   it("stamps initial router state without dropping third-party history fields", async () => {
     const previousWindow = (globalThis as any).window;
     const { win, replaceState } = createNavWindow();
+    const listeners = new Map<string, (event: any) => void>();
     win.history.state = {
       analyticsEntry: "landing",
       nested: { retained: true },
     } as any;
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
     replaceState.mockImplementation((state: unknown) => {
       win.history.state = state as any;
     });
@@ -14454,9 +14458,24 @@ describe("Pages Router concurrent navigation", () => {
           __vinext_queryOwner: "server",
           url: "/",
           as: "/",
+          options: {},
+          key: expect.any(String),
         }),
       );
-      expect(replaceState).toHaveBeenCalledWith(expect.any(Object), "");
+      expect(replaceState).toHaveBeenCalledWith(win.history.state, "");
+
+      const beforePopState = vi.fn(() => false);
+      (win as any).next.router.beforePopState(beforePopState);
+      win.__VINEXT_LOCALE__ = "en";
+      listeners.get("popstate")!({ state: win.history.state });
+
+      expect(beforePopState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "/",
+          as: "/",
+          options: {},
+        }),
+      );
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13789,6 +13789,77 @@ describe("next/compat/router shim", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/prerender.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/prerender.test.ts
+  it("suppresses search params from useRouter().query before prerender hydration", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter, wrapWithRouterContext, setSSRContext } =
+      await import("../packages/vinext/src/shims/router.js");
+
+    let capturedQuery: unknown;
+    function Probe() {
+      capturedQuery = useRouter().query;
+      return React.createElement("div");
+    }
+
+    setSSRContext({
+      pathname: "/something",
+      query: { hello: "world" },
+      initialQuery: {},
+      asPath: "/something?hello=world",
+      navigationIsReady: false,
+    });
+    try {
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)));
+      expect(capturedQuery).toEqual({});
+    } finally {
+      setSSRContext(null);
+    }
+
+    setSSRContext({
+      pathname: "/blog/[post]",
+      query: { post: "post-1", hello: "world" },
+      initialQuery: { post: "post-1" },
+      asPath: "/blog/post-1?hello=world",
+      navigationIsReady: false,
+    });
+    try {
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)));
+      expect(capturedQuery).toEqual({ post: "post-1" });
+    } finally {
+      setSSRContext(null);
+    }
+
+    setSSRContext({
+      pathname: "/docs/[[...slug]]",
+      query: { slug: "query" },
+      initialQuery: {},
+      asPath: "/docs?slug=query",
+      navigationIsReady: false,
+    });
+    try {
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)));
+      expect(capturedQuery).toEqual({});
+    } finally {
+      setSSRContext(null);
+    }
+
+    setSSRContext({
+      pathname: "/blog/[post]",
+      query: { post: "hello world", q: "1" },
+      initialQuery: { post: "hello world" },
+      asPath: "/blog/hello%20world?q=1",
+      navigationIsReady: false,
+    });
+    try {
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)));
+      expect(capturedQuery).toEqual({ post: "hello world" });
+    } finally {
+      setSSRContext(null);
+    }
+  });
+
   it("does not defer Pages Router readiness for dynamic getStaticProps routes without search", async () => {
     const { getPagesNavigationIsReadyFromSerializedState } =
       await import("../packages/vinext/src/shims/router.js");
@@ -22436,6 +22507,91 @@ describe("default-locale path normalisation (issue #1336, item 4)", () => {
 // runtime object rather than in module-local variables.
 // ---------------------------------------------------------------------------
 describe("Pages Router runtime state sharing", () => {
+  it("keeps search params hidden until the initial Pages Router ready transition", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: {
+        pathname: "/something",
+        search: "?hello=world",
+        hash: "",
+        href: "http://localhost/something?hello=world",
+        hostname: "localhost",
+      },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+      __NEXT_DATA__: {
+        page: "/something",
+        query: {},
+        gsp: true,
+        isFallback: false,
+        props: { pageProps: {} },
+      },
+      __VINEXT_PAGE_LOADERS__: {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      expect(Router.isReady).toBe(false);
+      expect(Router.query).toEqual({});
+
+      expect(routerModule._markPagesRouterReady()).toBe(true);
+      expect(Router.query).toEqual({ hello: "world" });
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
+  it("filters rewritten search values from the pre-ready Pages Router query", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: {
+        pathname: "/source",
+        search: "?hello=world",
+        hash: "",
+        href: "http://localhost/source?hello=world",
+        hostname: "localhost",
+      },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+      dispatchEvent() {},
+      scrollTo() {},
+      __NEXT_DATA__: {
+        page: "/destination/[slug]",
+        query: { slug: "article" },
+        gsp: true,
+        isFallback: false,
+        props: { pageProps: {} },
+        __vinext: { hasRewrites: true },
+      },
+      __VINEXT_PAGE_LOADERS__: {},
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      expect(routerModule.default.query).toEqual({ slug: "article" });
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("shares RouterContext across duplicated next/router module instances", async () => {
     vi.resetModules();
     const contextA = await import("../packages/vinext/src/shims/internal/router-context.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14438,6 +14438,12 @@ describe("Pages Router concurrent navigation", () => {
       analyticsEntry: "landing",
       nested: { retained: true },
     } as any;
+    win.__NEXT_DATA__ = {
+      ...win.__NEXT_DATA__,
+      locale: "fr",
+      locales: ["en", "fr"],
+      defaultLocale: "en",
+    } as any;
     win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
       listeners.set(type, handler);
     });
@@ -14458,7 +14464,7 @@ describe("Pages Router concurrent navigation", () => {
           __vinext_queryOwner: "server",
           url: "/",
           as: "/",
-          options: {},
+          options: { locale: "fr" },
           key: expect.any(String),
         }),
       );
@@ -14473,7 +14479,7 @@ describe("Pages Router concurrent navigation", () => {
         expect.objectContaining({
           url: "/",
           as: "/",
-          options: {},
+          options: { locale: "fr" },
         }),
       );
     } finally {
@@ -14483,6 +14489,115 @@ describe("Pages Router concurrent navigation", () => {
       } else {
         (globalThis as any).window = previousWindow;
       }
+    }
+  });
+
+  it("restores the serialized initial locale after cross-locale navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalCustomEvent = globalThis.CustomEvent;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win, pushState, replaceState } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    win.location.pathname = "/fr/about";
+    win.location.href = "http://localhost/fr/about";
+    win.__NEXT_DATA__ = {
+      ...win.__NEXT_DATA__,
+      page: "/about",
+      locale: "fr",
+      locales: ["en", "fr"],
+      defaultLocale: "en",
+    } as any;
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    replaceState.mockImplementation((state: unknown, _title: string, url?: string) => {
+      win.history.state = state as any;
+      if (url) {
+        const parsed = new URL(url, "http://localhost");
+        win.location.pathname = parsed.pathname;
+        win.location.search = parsed.search;
+        win.location.href = parsed.href;
+      }
+    });
+    pushState.mockImplementation((state: unknown, _title: string, url: string) => {
+      win.history.state = state as any;
+      const parsed = new URL(url, "http://localhost");
+      win.location.pathname = parsed.pathname;
+      win.location.search = parsed.search;
+      win.location.href = parsed.href;
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).CustomEvent = class CustomEventMock {
+      constructor(public type: string) {}
+    } as any;
+
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          buildNavHtml(
+            "/about",
+            pageModuleUrl,
+            {},
+            {
+              locale: "en",
+              locales: ["en", "fr"],
+              defaultLocale: "en",
+            },
+          ),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          buildNavHtml(
+            "/about",
+            pageModuleUrl,
+            {},
+            {
+              locale: "fr",
+              locales: ["en", "fr"],
+              defaultLocale: "en",
+            },
+          ),
+        ),
+      );
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const initialState = win.history.state;
+
+      expect(initialState).toEqual(
+        expect.objectContaining({
+          url: "/fr/about",
+          as: "/fr/about",
+          options: { locale: "fr" },
+        }),
+      );
+
+      win.__VINEXT_LOCALE__ = "fr";
+      win.__VINEXT_LOCALES__ = ["en", "fr"];
+      win.__VINEXT_DEFAULT_LOCALE__ = "en";
+      await routerModule.default.push("/about", undefined, { locale: "en" });
+
+      expect(win.__VINEXT_LOCALE__).toBe("en");
+      expect(win.location.pathname).toBe("/about");
+
+      win.location.pathname = "/fr/about";
+      win.location.href = "http://localhost/fr/about";
+      listeners.get("popstate")!({ state: initialState });
+      await vi.waitFor(() => expect(win.__VINEXT_LOCALE__).toBe("fr"));
+
+      expect(fetch).toHaveBeenNthCalledWith(2, "/fr/about", expect.any(Object));
+      expect(win.location.pathname).toBe("/fr/about");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      (globalThis as any).CustomEvent = originalCustomEvent;
     }
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14566,9 +14566,13 @@ describe("Pages Router concurrent navigation", () => {
 
     try {
       vi.resetModules();
-      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      win.__VINEXT_LOCALE__ = "fr";
+      win.__VINEXT_LOCALES__ = ["en", "fr"];
+      win.__VINEXT_DEFAULT_LOCALE__ = "en";
+      const routerModule = await import("./fixtures/instrumentation-client-imports-router.js");
       const initialState = win.history.state;
 
+      expect((win as any).__INSTRUMENTATION_INITIAL_ROUTER_STATE__).toBe(initialState);
       expect(initialState).toEqual(
         expect.objectContaining({
           url: "/fr/about",
@@ -14577,9 +14581,6 @@ describe("Pages Router concurrent navigation", () => {
         }),
       );
 
-      win.__VINEXT_LOCALE__ = "fr";
-      win.__VINEXT_LOCALES__ = ["en", "fr"];
-      win.__VINEXT_DEFAULT_LOCALE__ = "en";
       await routerModule.default.push("/about", undefined, { locale: "en" });
 
       expect(win.__VINEXT_LOCALE__).toBe("en");


### PR DESCRIPTION
## Summary

- match Next.js Pages Router readiness by hiding prerendered URL search params until hydration completes when rewrites may affect the initial route
- preserve server-resolved rewrite query ownership across hydration, client push/replace, hash navigation, and browser history traversal
- safely transport resolved query metadata through GSP/GSSP responses without allowing user headers or prototype keys to corrupt it
- cover static, dynamic, optional catch-all, middleware-cleared, same-path rewrite, GSP, and GSSP cases in vinext-owned fixtures

## Next.js parity references

- [`packages/next/src/shared/lib/router/router.ts`](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/shared/lib/router/router.ts) — initial `isReady` calculation and hydration query update behavior
- [`test/e2e/prerender.test.ts`](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/prerender.test.ts) — prerendered rewrite query/params behavior
- [`test/e2e/middleware-rewrites/test/index.test.ts`](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts) — rewritten Pages Router readiness and query behavior

## Targeted local validation

- `vp test run tests/query.test.ts` — 25 passed
- targeted `tests/pages-router.test.ts` prerender/rewrite assertions
- targeted `tests/shims.test.ts` Pages Router readiness, query ownership, navigation, hash, and history assertions
- targeted `tests/e2e/pages-router/prerender-rewrite-query.spec.ts` assertions with one Playwright worker
- targeted `tests/e2e/pages-router-prod/prerender-rewrite-query.spec.ts` assertions with one Playwright worker
- focused format, lint, and type checks

No full local suite or raw Next.js E2E was run.
