### PR TITLE
fix(app): preserve metadata icons across navigation

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -286,17 +286,21 @@ const discardedServerActionRefreshScheduler = createDiscardedServerActionRefresh
 });
 const NavigationCommitSignal = browserNavigationController.NavigationCommitSignal;
 const ACTION_HTTP_FALLBACK_ROBOTS_META_ATTR = "data-vinext-action-http-fallback";
+const RELOCATED_METADATA_ICON_ATTR = "data-vinext-relocated-metadata-icon";
 
-function syncMetadataIcons(): void {
+function syncMetadataIcons(preserveExistingWhenNoBodyIcons: boolean): void {
   const bodyIcons = document.body.querySelectorAll<HTMLLinkElement>(
     'link[rel="icon"], link[rel="apple-touch-icon"]',
   );
-  if (bodyIcons.length === 0) return;
+  if (preserveExistingWhenNoBodyIcons && bodyIcons.length === 0) return;
 
   document.head
-    .querySelectorAll('link[rel="icon"], link[rel="apple-touch-icon"]')
+    .querySelectorAll(`link[${RELOCATED_METADATA_ICON_ATTR}]`)
     .forEach((icon) => icon.remove());
-  bodyIcons.forEach((icon) => document.head.appendChild(icon));
+  bodyIcons.forEach((icon) => {
+    icon.setAttribute(RELOCATED_METADATA_ICON_ATTR, "");
+    document.head.appendChild(icon);
+  });
 }
 
 function syncServerActionHttpFallbackHead(status: number | null): void {
@@ -585,7 +589,7 @@ function createNavigationCommitEffect(options: {
     // URL has been updated; the recovery hard-nav target is no longer needed.
     clearAppNavigationFailureTarget(href);
     commitClientNavigationState(navId);
-    queueMicrotask(syncMetadataIcons);
+    queueMicrotask(() => syncMetadataIcons(false));
   };
 }
 
@@ -1118,9 +1122,9 @@ function BrowserRoot({
   useLayoutEffect(() => {
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
     removeStylesheetLinksCoveredByInlineCss();
-    syncMetadataIcons();
+    syncMetadataIcons(treeState.renderId === 0);
     getNavigationRuntime()?.functions.pingVisibleLinks?.();
-  }, [treeState.elements]);
+  }, [treeState.elements, treeState.renderId]);
 
   useLayoutEffect(() => {
     if (treeState.renderId !== 0) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -287,6 +287,18 @@ const discardedServerActionRefreshScheduler = createDiscardedServerActionRefresh
 const NavigationCommitSignal = browserNavigationController.NavigationCommitSignal;
 const ACTION_HTTP_FALLBACK_ROBOTS_META_ATTR = "data-vinext-action-http-fallback";
 
+function syncMetadataIcons(): void {
+  const bodyIcons = document.body.querySelectorAll<HTMLLinkElement>(
+    'link[rel="icon"], link[rel="apple-touch-icon"]',
+  );
+  if (bodyIcons.length === 0) return;
+
+  document.head
+    .querySelectorAll('link[rel="icon"], link[rel="apple-touch-icon"]')
+    .forEach((icon) => icon.remove());
+  bodyIcons.forEach((icon) => document.head.appendChild(icon));
+}
+
 function syncServerActionHttpFallbackHead(status: number | null): void {
   document.head
     .querySelectorAll(`meta[${ACTION_HTTP_FALLBACK_ROBOTS_META_ATTR}="robots"]`)
@@ -573,6 +585,7 @@ function createNavigationCommitEffect(options: {
     // URL has been updated; the recovery hard-nav target is no longer needed.
     clearAppNavigationFailureTarget(href);
     commitClientNavigationState(navId);
+    queueMicrotask(syncMetadataIcons);
   };
 }
 
@@ -1105,6 +1118,7 @@ function BrowserRoot({
   useLayoutEffect(() => {
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
     removeStylesheetLinksCoveredByInlineCss();
+    syncMetadataIcons();
     getNavigationRuntime()?.functions.pingVisibleLinks?.();
   }, [treeState.elements]);
 

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -12,6 +12,10 @@ import {
 } from "./app-rsc-embedded-chunks.js";
 import { NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION } from "../client/navigation-runtime.js";
 
+const METADATA_ICON_LINK_RE =
+  /<link\b(?=[^>]*\brel=(?:"(?:icon|apple-touch-icon)"|'(?:icon|apple-touch-icon)'|(?:icon|apple-touch-icon)(?:\s|>)))[^>]*>/i;
+const REINSERT_ICON_SCRIPT = `document.querySelectorAll('body link[rel="icon"], body link[rel="apple-touch-icon"]').forEach(el => document.head.appendChild(el))`;
+
 type RscEmbedTransform = {
   flush(): string;
   finalize(): Promise<string>;
@@ -426,6 +430,7 @@ export function createTickBufferedTransform(
   const encoder = new TextEncoder();
   const insertsPerFlush = typeof injectHTML === "function";
   let injected = false;
+  let iconScriptInjected = false;
   let preHeadInjected = false;
   let suffixStripped = false;
   let buffered: string[] = [];
@@ -468,6 +473,24 @@ export function createTickBufferedTransform(
     if (insertion) {
       controller.enqueue(encoder.encode(insertion));
     }
+  };
+
+  const insertMetadataIconScript = (html: string): string => {
+    if (iconScriptInjected) return html;
+    const headEnd = html.indexOf("</head>");
+    const searchStart = headEnd === -1 ? 0 : headEnd + "</head>".length;
+    const bodyHtml = html.slice(searchStart);
+    const iconMatch = METADATA_ICON_LINK_RE.exec(bodyHtml);
+    if (!iconMatch) return html;
+    iconScriptInjected = true;
+    const iconEnd = searchStart + iconMatch.index + iconMatch[0].length;
+    const metadataContainerEnd = html.indexOf("</div>", iconEnd);
+    const insertAt = metadataContainerEnd === -1 ? iconEnd : metadataContainerEnd + "</div>".length;
+    return (
+      html.slice(0, insertAt) +
+      createInlineScriptTag(REINSERT_ICON_SCRIPT, inlineCssScriptNonce) +
+      html.slice(insertAt)
+    );
   };
 
   /**
@@ -532,7 +555,7 @@ export function createTickBufferedTransform(
       inlineCssPrependCss = "";
     }
 
-    let working = inlineCssResult.html;
+    let working = insertMetadataIconScript(inlineCssResult.html);
     if (!preHeadInjected) {
       const result = spliceAfterHeadOpen(working);
       if (result.spliced) {

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -14,7 +14,7 @@ import { NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION } from "../client/navigation-runt
 
 const METADATA_ICON_LINK_RE =
   /<link\b(?=[^>]*\brel=(?:"(?:icon|apple-touch-icon)"|'(?:icon|apple-touch-icon)'|(?:icon|apple-touch-icon)(?:\s|>)))[^>]*>/i;
-const REINSERT_ICON_SCRIPT = `document.querySelectorAll('body link[rel="icon"], body link[rel="apple-touch-icon"]').forEach(el => document.head.appendChild(el))`;
+const REINSERT_ICON_SCRIPT = `document.querySelectorAll('body link[rel="icon"], body link[rel="apple-touch-icon"]').forEach(el => { el.setAttribute('data-vinext-relocated-metadata-icon', ''); document.head.appendChild(el) })`;
 
 type RscEmbedTransform = {
   flush(): string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,6 +1449,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/og-font-package: {}
+
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,8 +1449,6 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
-  tests/fixtures/og-font-package: {}
-
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -217,6 +217,26 @@ async function runTransform(
   return out;
 }
 
+it("adds a nonce-aware relocation script after streamed body metadata icons", async () => {
+  const out = await runTransform(
+    [
+      '<html><head></head><body><div hidden><link rel="icon" href="/heart.png"></div></body></html>',
+    ],
+    { inlineCssScriptNonce: "icon-nonce" },
+  );
+
+  expect(out).toContain('<script nonce="icon-nonce">document.querySelectorAll');
+  expect(out).toContain('body link[rel="icon"]');
+});
+
+it("does not add a relocation script when metadata icons render in head", async () => {
+  const out = await runTransform([
+    '<html><head><link rel="icon" href="/heart.png"></head><body></body></html>',
+  ]);
+
+  expect(out).not.toContain("document.querySelectorAll");
+});
+
 async function runDelayedTransform(
   chunks: string[],
   options: {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -227,6 +227,7 @@ it("adds a nonce-aware relocation script after streamed body metadata icons", as
 
   expect(out).toContain('<script nonce="icon-nonce">document.querySelectorAll');
   expect(out).toContain('body link[rel="icon"]');
+  expect(out).toContain("data-vinext-relocated-metadata-icon");
 });
 
 it("does not add a relocation script when metadata icons render in head", async () => {

--- a/tests/e2e/app-router/metadata.spec.ts
+++ b/tests/e2e/app-router/metadata.spec.ts
@@ -106,8 +106,9 @@ test.describe("Streaming metadata icons", () => {
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-icons/metadata-icons.test.ts
     const html = await (await page.request.get(`${BASE}/metadata-icons-stream`)).text();
     expect(html).toContain(
-      `document.querySelectorAll('body link[rel="icon"], body link[rel="apple-touch-icon"]').forEach(el => document.head.appendChild(el))`,
+      `document.querySelectorAll('body link[rel="icon"], body link[rel="apple-touch-icon"]')`,
     );
+    expect(html).toContain("data-vinext-relocated-metadata-icon");
     expect(html).not.toContain("«nxt-icon»");
 
     await page.goto(`${BASE}/metadata-icons-stream`);
@@ -120,5 +121,29 @@ test.describe("Streaming metadata icons", () => {
     await expect(page.locator('body link[rel="icon"]')).toHaveCount(0);
     await expect(page.locator('head link[rel="icon"][href^="/star.png"]')).toHaveCount(1);
     await expect(page.locator('head link[rel="icon"][href^="/heart.png"]')).toHaveCount(0);
+  });
+
+  test("preserves manual icons and clears managed icons across empty routes and history", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/metadata-icons-stream`);
+    await expect(page.locator('head link[rel="icon"][href^="/heart.png"]')).toHaveCount(1);
+    const layoutIcon = page.locator('head link[data-testid="manual-layout-icon"]');
+    await expect(layoutIcon).toHaveCount(1);
+
+    await page.locator("#metadata-icons-none-link").click();
+    await expect(page).toHaveURL(/\/metadata-icons-stream\/no-icon$/);
+    await expect(page.locator('head link[rel="icon"][href^="/heart.png"]')).toHaveCount(0);
+    await expect(layoutIcon).toHaveCount(1);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/metadata-icons-stream$/);
+    await expect(page.locator('head link[rel="icon"][href^="/heart.png"]')).toHaveCount(1);
+    await expect(layoutIcon).toHaveCount(1);
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/metadata-icons-stream\/no-icon$/);
+    await expect(page.locator('head link[rel="icon"][href^="/heart.png"]')).toHaveCount(0);
+    await expect(layoutIcon).toHaveCount(1);
   });
 });

--- a/tests/e2e/app-router/metadata.spec.ts
+++ b/tests/e2e/app-router/metadata.spec.ts
@@ -99,3 +99,26 @@ test.describe("Metadata Routes", () => {
     expect(json).toHaveProperty("name");
   });
 });
+
+test.describe("Streaming metadata icons", () => {
+  test("moves streamed icons into head and replaces them on navigation", async ({ page }) => {
+    // Ported from Next.js: test/e2e/app-dir/metadata-icons/metadata-icons.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-icons/metadata-icons.test.ts
+    const html = await (await page.request.get(`${BASE}/metadata-icons-stream`)).text();
+    expect(html).toContain(
+      `document.querySelectorAll('body link[rel="icon"], body link[rel="apple-touch-icon"]').forEach(el => document.head.appendChild(el))`,
+    );
+    expect(html).not.toContain("«nxt-icon»");
+
+    await page.goto(`${BASE}/metadata-icons-stream`);
+
+    await expect(page.locator('body link[rel="icon"]')).toHaveCount(0);
+    await expect(page.locator('head link[rel="icon"][href^="/heart.png"]')).toHaveCount(1);
+
+    await page.locator("#metadata-icons-sub-link").click();
+    await expect(page).toHaveURL(/\/metadata-icons-stream\/sub$/);
+    await expect(page.locator('body link[rel="icon"]')).toHaveCount(0);
+    await expect(page.locator('head link[rel="icon"][href^="/star.png"]')).toHaveCount(1);
+    await expect(page.locator('head link[rel="icon"][href^="/heart.png"]')).toHaveCount(0);
+  });
+});

--- a/tests/fixtures/app-basic/app/metadata-icons-stream/layout.tsx
+++ b/tests/fixtures/app-basic/app/metadata-icons-stream/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <link rel="icon" href="/manual-layout-icon.png" data-testid="manual-layout-icon" />
+      {children}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/metadata-icons-stream/no-icon/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-icons-stream/no-icon/page.tsx
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <Link id="metadata-icons-root-link" href="/metadata-icons-stream">
+      Root icon
+    </Link>
+  );
+}

--- a/tests/fixtures/app-basic/app/metadata-icons-stream/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-icons-stream/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+import { connection } from "next/server";
+
+export async function generateMetadata() {
+  await connection();
+  return { icons: { icon: "/heart.png?v=root" } };
+}
+
+export default function Page() {
+  return (
+    <Link id="metadata-icons-sub-link" href="/metadata-icons-stream/sub">
+      Sub icon
+    </Link>
+  );
+}

--- a/tests/fixtures/app-basic/app/metadata-icons-stream/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-icons-stream/page.tsx
@@ -8,8 +8,13 @@ export async function generateMetadata() {
 
 export default function Page() {
   return (
-    <Link id="metadata-icons-sub-link" href="/metadata-icons-stream/sub">
-      Sub icon
-    </Link>
+    <>
+      <Link id="metadata-icons-sub-link" href="/metadata-icons-stream/sub">
+        Sub icon
+      </Link>
+      <Link id="metadata-icons-none-link" href="/metadata-icons-stream/no-icon">
+        No icon
+      </Link>
+    </>
   );
 }

--- a/tests/fixtures/app-basic/app/metadata-icons-stream/sub/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-icons-stream/sub/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+import { connection } from "next/server";
+
+export async function generateMetadata() {
+  await connection();
+  return { icons: { icon: "/star.png?v=sub" } };
+}
+
+export default function Page() {
+  return (
+    <Link id="metadata-icons-root-link" href="/metadata-icons-stream">
+      Root icon
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- relocate streamed App Router metadata icons from the response body into `<head>`
- track only vinext-managed relocated icons so layout, manual, and third-party icons remain untouched
- replace or clear managed icons across client navigation, including back and forward history traversal
- propagate the CSP nonce to the inline relocation script

## Next.js parity

This restores parity with the pinned Next.js metadata icons coverage:

- [`test/e2e/app-dir/metadata-icons/metadata-icons.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/metadata-icons/metadata-icons.test.ts)

Pinned Next.js commit: `ee6e79b1792a4d401ddf2480f40a83549fe8e722`.

## Validation

Targeted local validation completed before publication:

- `tests/app-ssr-stream.test.ts`: focused metadata-icon assertion passed
- `tests/e2e/app-router/metadata.spec.ts`: 2 focused Playwright tests passed with one worker
- targeted formatting, lint, and type checks passed

No broad local suite or raw Next.js E2E was run.
