### PR TITLE
feat(web): compare benchmarks with recent median

### DIFF
--- a/apps/web/app/benchmarks/components/dashboard.tsx
+++ b/apps/web/app/benchmarks/components/dashboard.tsx
@@ -5,8 +5,11 @@ import { Table } from "@cloudflare/kumo/components/table";
 import {
   PerformanceResultsTable,
   PerformanceTrends,
+  type PerformanceMeasurement,
   type PerformanceRun,
 } from "./performance-results";
+
+const RECENT_BASELINE_RUNS = 10;
 
 export function Dashboard({ runs }: { runs: PerformanceRun[] }) {
   if (runs.length === 0) {
@@ -18,6 +21,14 @@ export function Dashboard({ runs }: { runs: PerformanceRun[] }) {
   }
 
   const latest = runs[0];
+  const baselineRuns = runs.slice(1, RECENT_BASELINE_RUNS + 1);
+  const bundleMeasurements = latest.measurements.filter(
+    (measurement) => measurement.unit === "bytes",
+  );
+  const otherMeasurements = latest.measurements.filter(
+    (measurement) => measurement.unit !== "bytes",
+  );
+  const baselineMeasurements = recentMedianMeasurements(bundleMeasurements, baselineRuns);
 
   return (
     <div className="space-y-8">
@@ -31,7 +42,28 @@ export function Dashboard({ runs }: { runs: PerformanceRun[] }) {
             {new Date(latest.measuredAt).toLocaleDateString()}
           </span>
         </div>
-        <PerformanceResultsTable measurements={latest.measurements} />
+        <div className="space-y-5">
+          {otherMeasurements.length > 0 && (
+            <PerformanceResultsTable measurements={otherMeasurements} />
+          )}
+          {bundleMeasurements.length > 0 && (
+            <div>
+              <div className="mb-2 flex items-baseline gap-2">
+                <h3 className="font-medium">Bundle sizes</h3>
+                {baselineRuns.length > 0 && (
+                  <span className="text-xs text-gray-500">
+                    vs prior {baselineRuns.length}-run median
+                  </span>
+                )}
+              </div>
+              <PerformanceResultsTable
+                measurements={bundleMeasurements}
+                baselineMeasurements={baselineRuns.length > 0 ? baselineMeasurements : undefined}
+                baselineLabel={`Prior ${baselineRuns.length}-run median`}
+              />
+            </div>
+          )}
+        </div>
       </section>
 
       <section>
@@ -45,6 +77,34 @@ export function Dashboard({ runs }: { runs: PerformanceRun[] }) {
       </section>
     </div>
   );
+}
+
+export function recentMedianMeasurements(
+  currentMeasurements: PerformanceMeasurement[],
+  baselineRuns: PerformanceRun[],
+): PerformanceMeasurement[] {
+  return currentMeasurements.flatMap((current) => {
+    const historical = baselineRuns.flatMap((run) => {
+      const measurement = run.measurements.find(
+        (candidate) => candidate.benchmarkId === current.benchmarkId,
+      );
+      return measurement ? [measurement] : [];
+    });
+    if (historical.length === 0) return [];
+
+    return [
+      {
+        ...current,
+        median: median(historical.map((measurement) => measurement.median)),
+      },
+    ];
+  });
+}
+
+function median(values: number[]) {
+  const sorted = values.toSorted((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
 }
 
 function PerformanceRunHistory({ runs }: { runs: PerformanceRun[] }) {

--- a/apps/web/app/benchmarks/components/performance-results.tsx
+++ b/apps/web/app/benchmarks/components/performance-results.tsx
@@ -39,10 +39,12 @@ const PERFORMANCE_COLORS = ["#f6821f", "#2563eb", "#16a34a", "#9333ea", "#dc2626
 export function PerformanceResultsTable({
   measurements,
   baselineMeasurements,
+  baselineLabel = "Baseline",
   renderFrameworkLabel,
 }: {
   measurements: PerformanceMeasurement[];
   baselineMeasurements?: PerformanceMeasurement[];
+  baselineLabel?: string;
   renderFrameworkLabel?: (measurement: PerformanceMeasurement) => ReactNode;
 }) {
   const comparisonMode = baselineMeasurements !== undefined;
@@ -75,7 +77,7 @@ export function PerformanceResultsTable({
           <Table.Row>
             <Table.Head>Scenario</Table.Head>
             <Table.Head>Framework</Table.Head>
-            {comparisonMode && <Table.Head>Baseline</Table.Head>}
+            {comparisonMode && <Table.Head>{baselineLabel}</Table.Head>}
             <Table.Head>{comparisonMode ? "Current" : "Median"}</Table.Head>
             {comparisonMode && <Table.Head>Change</Table.Head>}
             <Table.Head>Range</Table.Head>

--- a/tests/performance-dashboard-components.test.ts
+++ b/tests/performance-dashboard-components.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { recentMedianMeasurements } from "../apps/web/app/benchmarks/components/dashboard";
+import type {
+  PerformanceMeasurement,
+  PerformanceRun,
+} from "../apps/web/app/benchmarks/components/performance-results";
+
+function measurement(benchmarkId: string, median: number, unit = "bytes"): PerformanceMeasurement {
+  return {
+    benchmarkId,
+    scenarioId: benchmarkId,
+    suite: "Build",
+    label: benchmarkId,
+    description: benchmarkId,
+    implementationId: "vinext",
+    implementationLabel: "vinext",
+    unit,
+    lowerIsBetter: true,
+    median,
+    mean: median,
+    standardDeviation: 0,
+    rounds: 1,
+    min: median,
+    max: median,
+  };
+}
+
+function run(id: string, measurements: PerformanceMeasurement[]): PerformanceRun {
+  return {
+    id,
+    commitSha: id.repeat(40),
+    shortSha: id.repeat(7),
+    measuredAt: "2026-06-21T00:00:00.000Z",
+    measurements,
+  };
+}
+
+describe("performance dashboard rolling baseline", () => {
+  it("uses the median of each benchmark's available historical measurements", () => {
+    const current = [measurement("rsc", 130), measurement("server", 220)];
+    const baseline = recentMedianMeasurements(current, [
+      run("a", [measurement("rsc", 100)]),
+      run("b", [measurement("rsc", 120), measurement("server", 200)]),
+      run("c", [measurement("rsc", 110), measurement("server", 180)]),
+    ]);
+
+    expect(baseline.map(({ benchmarkId, median }) => [benchmarkId, median])).toEqual([
+      ["rsc", 110],
+      ["server", 190],
+    ]);
+  });
+
+  it("omits benchmarks with no historical measurement", () => {
+    const baseline = recentMedianMeasurements(
+      [measurement("new-metric", 100)],
+      [run("a", [measurement("other-metric", 90)])],
+    );
+
+    expect(baseline).toEqual([]);
+  });
+
+  it("can calculate the bundle baseline independently from timing benchmarks", () => {
+    const current = [measurement("server", 220), measurement("build", 500, "ms")];
+    const bundles = current.filter((candidate) => candidate.unit === "bytes");
+    const baseline = recentMedianMeasurements(bundles, [
+      run("a", [measurement("server", 200), measurement("build", 450, "ms")]),
+    ]);
+
+    expect(baseline.map(({ benchmarkId, median }) => [benchmarkId, median])).toEqual([
+      ["server", 200],
+    ]);
+  });
+});


### PR DESCRIPTION
This PR compares bundle-size benchmarks against the median of up to 10 prior main runs, making size regressions easier to spot without expecting every commit to reduce output. Timing and build-duration benchmarks retain their existing latest-result presentation, while new bundle metrics remain current-only until historical data exists. Focused tests cover rolling median calculation, missing historical measurements, and exclusion of non-byte benchmarks.