### PR TITLE
perf(client): omit unused server action client

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -38,6 +38,7 @@ export default {
         // Build-time entries referenced by path constant (Vite reads them
         // from disk via `fs`), so knip wouldn't otherwise trace them.
         "src/server/app-browser-entry.ts",
+        "src/server/app-browser-server-action-client.ts",
         "src/server/app-ssr-entry.ts",
         // Runtime helpers imported by generated virtual entries. The imports
         // are emitted as strings, so knip cannot trace them statically.

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2,6 +2,7 @@ import type {
   CSSModulesOptions,
   Plugin,
   PluginOption,
+  ResolvedConfig,
   SassPreprocessorOptions,
   UserConfig,
   ViteDevServer,
@@ -549,6 +550,8 @@ const VIRTUAL_APP_SSR_ENTRY = "virtual:vinext-app-ssr-entry";
 const RESOLVED_APP_SSR_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_SSR_ENTRY;
 const VIRTUAL_APP_BROWSER_ENTRY = "virtual:vinext-app-browser-entry";
 const RESOLVED_APP_BROWSER_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_BROWSER_ENTRY;
+const VIRTUAL_APP_CAPABILITIES = "virtual:vinext-app-capabilities";
+const RESOLVED_APP_CAPABILITIES = VIRTUAL_PREFIX + VIRTUAL_APP_CAPABILITIES;
 const VIRTUAL_ROOT_PARAMS = "virtual:vinext-root-params";
 const RESOLVED_ROOT_PARAMS = VIRTUAL_PREFIX + VIRTUAL_ROOT_PARAMS;
 /** Virtual module that registers config-driven cache adapters (see VinextOptions.cache). */
@@ -580,6 +583,10 @@ function createStaticImageAsset(imagePath: string): { fileName: string; source: 
  */
 const _shimsDir = normalizePathSeparators(path.resolve(__dirname, "shims")) + "/";
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
+const _appBrowserServerActionClientPath = resolveShimModulePath(
+  normalizePathSeparators(path.resolve(__dirname, "server")),
+  "app-browser-server-action-client",
+);
 const _appRscHandlerPath = resolveShimModulePath(
   normalizePathSeparators(path.resolve(__dirname, "server")),
   "app-rsc-handler",
@@ -1030,6 +1037,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           cause,
         });
       });
+  }
+
+  async function resolveHasServerActions(
+    config: Pick<ResolvedConfig, "command" | "plugins">,
+  ): Promise<boolean> {
+    if (config.command !== "build" || !rscPluginModulePromise) return true;
+
+    const { getPluginApi } = await rscPluginModulePromise;
+    const pluginApi = getPluginApi(config);
+    if (!pluginApi || pluginApi.manager.isScanBuild) return true;
+    return Object.keys(pluginApi.manager.serverReferenceMetaMap).length > 0;
   }
 
   const reactOptions = options.react && options.react !== true ? options.react : undefined;
@@ -2750,6 +2768,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (cleanId === VIRTUAL_RSC_ENTRY) return RESOLVED_RSC_ENTRY;
           if (cleanId === VIRTUAL_APP_SSR_ENTRY) return RESOLVED_APP_SSR_ENTRY;
           if (cleanId === VIRTUAL_APP_BROWSER_ENTRY) return RESOLVED_APP_BROWSER_ENTRY;
+          if (cleanId === VIRTUAL_APP_CAPABILITIES) return RESOLVED_APP_CAPABILITIES;
           if (cleanId === "next/root-params" || cleanId === "next/root-params.js") {
             return RESOLVED_ROOT_PARAMS;
           }
@@ -2819,14 +2838,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         if (id === RESOLVED_RSC_ENTRY && hasAppDir) {
           const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
           const metaRoutes = scanMetadataFiles(appDir);
-          let hasServerActions = true;
-          if (this.environment?.config.command === "build" && rscPluginModulePromise) {
-            const { getPluginApi } = await rscPluginModulePromise;
-            const pluginApi = getPluginApi(this.environment.config);
-            if (pluginApi && !pluginApi.manager.isScanBuild) {
-              hasServerActions = Object.keys(pluginApi.manager.serverReferenceMetaMap).length > 0;
-            }
-          }
+          const hasServerActions = await resolveHasServerActions(this.environment.config);
           // Check for global-error.tsx at app root
           const globalErrorPath = findFileWithExts(appDir, "global-error", fileMatcher);
           // Check for global-not-found.tsx at app root (Next.js 16+ feature)
@@ -2924,6 +2936,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             pagesPrefetchRoutes,
             nextConfig.rewrites,
           );
+        }
+        if (id === RESOLVED_APP_CAPABILITIES && hasAppDir) {
+          const hasServerActions = await resolveHasServerActions(this.environment.config);
+          return `
+export const hasServerActions = ${JSON.stringify(hasServerActions)};
+export const loadServerActionClient = ${
+            hasServerActions
+              ? `() => import(${JSON.stringify(_appBrowserServerActionClientPath)})`
+              : "null"
+          };
+`;
         }
         if (id.startsWith(RESOLVED_VIRTUAL_GOOGLE_FONTS + "?")) {
           return generateGoogleFontsVirtualModule(id, _fontGoogleShimPath);

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -13,8 +13,6 @@ import {
 import {
   createFromFetch,
   createFromReadableStream,
-  createTemporaryReferenceSet,
-  encodeReply,
   setServerCallback,
 } from "@vitejs/plugin-rsc/browser";
 import { flushSync } from "react-dom";
@@ -88,16 +86,9 @@ import {
 import {
   createDiscardedServerActionRefreshScheduler,
   createServerActionInitiationSnapshot,
-  createServerActionResultFacts,
-  isServerActionResult,
-  normalizeServerActionThrownValue,
-  parseServerActionRevalidationHeader,
-  readInvalidServerActionResponseError,
-  shouldClearClientNavigationCachesForServerActionResult,
   type ServerActionRevalidationKind,
   type AppBrowserServerActionResult,
 } from "./app-browser-action-result.js";
-import { applyServerActionResultDecision } from "./app-browser-server-action-navigation.js";
 import {
   consumeInitialFormState,
   createVinextHydrateRootOptions,
@@ -118,7 +109,6 @@ import {
   isCacheRestorableAppPayloadMetadata,
   readHistoryStatePreviousNextUrl,
   resolveInterceptionContextFromPreviousNextUrl,
-  resolveServerActionRequestState,
   type AppNavigationPayloadOrigin,
   type AppRouterState,
   type HistoryTraversalIntent,
@@ -161,12 +151,9 @@ import {
   installViteHmrErrorHandler,
   reportInitialDevServerErrors,
 } from "./dev-error-overlay.js";
-import { DANGEROUS_URL_BLOCK_MESSAGE, isDangerousScheme } from "vinext/shims/url-safety";
-import { throwOnServerActionNotFound } from "./server-action-not-found.js";
 import {
   createRscRequestHeaders,
   createRscRequestUrl,
-  createServerActionRequestUrl,
   getVinextRscCompatibilityId,
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
@@ -181,9 +168,6 @@ import {
   type OptimisticRouteTemplate,
 } from "./app-optimistic-routing.js";
 import {
-  ACTION_REDIRECT_HEADER,
-  ACTION_REDIRECT_STATUS_HEADER,
-  ACTION_REDIRECT_TYPE_HEADER,
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_RSC_REDIRECT_HEADER,
@@ -194,6 +178,7 @@ import {
   type NavigationReuseFacts,
   type VisitedResponseCacheCandidateFacts,
 } from "./navigation-planner.js";
+import { hasServerActions, loadServerActionClient } from "virtual:vinext-app-capabilities";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 
@@ -271,19 +256,25 @@ const browserNavigationController = createAppBrowserNavigationController({
   syncHistoryStatePreviousNextUrl: (previousNextUrl, bfcacheIds) =>
     historyController.syncCurrentHistoryStatePreviousNextUrl(previousNextUrl, bfcacheIds),
 });
-const discardedServerActionRefreshScheduler = createDiscardedServerActionRefreshScheduler({
-  runRefresh() {
-    clearClientNavigationCaches();
-    void getNavigationRuntime()?.functions.navigate?.(
-      window.location.href,
-      0,
-      "refresh",
-      undefined,
-      undefined,
-      true,
-    );
-  },
-});
+const discardedServerActionRefreshScheduler = hasServerActions
+  ? createDiscardedServerActionRefreshScheduler({
+      runRefresh() {
+        clearClientNavigationCaches();
+        void getNavigationRuntime()?.functions.navigate?.(
+          window.location.href,
+          0,
+          "refresh",
+          undefined,
+          undefined,
+          true,
+        );
+      },
+    })
+  : {
+      markNavigationSettled() {},
+      markNavigationStart() {},
+      schedule() {},
+    };
 const NavigationCommitSignal = browserNavigationController.NavigationCommitSignal;
 const ACTION_HTTP_FALLBACK_ROBOTS_META_ATTR = "data-vinext-action-http-fallback";
 
@@ -614,68 +605,6 @@ async function renderNavigationPayload(
     navId,
     visibleCommitMode,
   });
-}
-
-function resolveActionRedirectTarget(
-  response: Response,
-): { href: string; type: string; status: number } | null {
-  const actionRedirect = response.headers.get(ACTION_REDIRECT_HEADER);
-  if (!actionRedirect) return null;
-
-  if (isDangerousScheme(actionRedirect)) {
-    console.error(DANGEROUS_URL_BLOCK_MESSAGE);
-    return null;
-  }
-
-  try {
-    let redirectUrl: URL;
-    if (actionRedirect.startsWith("/") || /^[a-z]+:/i.test(actionRedirect)) {
-      redirectUrl = new URL(actionRedirect, window.location.href);
-    } else {
-      const baseParsed = new URL(window.location.href);
-      let baseDir = baseParsed.pathname;
-      if (!baseDir.endsWith("/")) {
-        baseDir = baseDir + "/";
-      }
-      redirectUrl = new URL(actionRedirect, `${baseParsed.origin}${baseDir}${baseParsed.search}`);
-    }
-
-    if (redirectUrl.origin !== window.location.origin) {
-      browserNavigationController.performHardNavigation(actionRedirect);
-      return null;
-    }
-    const statusHeader = response.headers.get(ACTION_REDIRECT_STATUS_HEADER);
-    const status = statusHeader ? parseInt(statusHeader, 10) : 307;
-    return {
-      href: redirectUrl.href,
-      type: response.headers.get(ACTION_REDIRECT_TYPE_HEADER) ?? "push",
-      status,
-    };
-  } catch {
-    browserNavigationController.performHardNavigation(actionRedirect);
-    return null;
-  }
-}
-
-class ServerActionRedirectError extends Error {
-  readonly digest: string;
-  readonly handled = true;
-
-  constructor(target: { href: string; type: string; status: number }) {
-    super("NEXT_REDIRECT");
-    const redirectUrl = new URL(target.href, window.location.href);
-    const redirectHref = redirectUrl.pathname + redirectUrl.search + redirectUrl.hash;
-    const redirectType = target.type === "push" ? "push" : "replace";
-    this.digest = `NEXT_REDIRECT;${redirectType};${encodeURIComponent(redirectHref)};${target.status};`;
-  }
-}
-
-function createServerActionRedirectError(target: {
-  href: string;
-  type: string;
-  status: number;
-}): Error {
-  return new ServerActionRedirectError(target);
 }
 
 async function commitSameUrlNavigatePayload(
@@ -1415,197 +1344,50 @@ function applyRuntimeRscBootstrap(rsc: NavigationRuntimeRscBootstrap): void {
 }
 
 function registerServerActionCallback(): void {
-  const serverActionCallback: Parameters<typeof setServerCallback>[0] = async (id, args) => {
-    syncServerActionHttpFallbackHead(null);
-    const temporaryReferences = createTemporaryReferenceSet();
-    // Carry the interception context + mounted slots from the current router
-    // state so the server-action re-render rebuilds the intercepted tree
-    // instead of replacing it with the direct page. Parity with Next.js,
-    // which sends `Next-URL` on action POSTs when the current tree contains
-    // an interception route.
-    const actionInitiation = createActionInitiationSnapshot();
-    // Keep history aligned with the captured snapshot. Action POST headers
-    // read from actionInitiation, not from history, after this point.
-    historyController.syncCurrentHistoryStatePreviousNextUrl(
-      actionInitiation.routerState.previousNextUrl,
-      actionInitiation.routerState.bfcacheIds,
-    );
-    const body = await encodeReply(args, { temporaryReferences });
-    const { headers } = resolveServerActionRequestState({
-      actionId: id,
-      basePath: __basePath,
-      elements: actionInitiation.routerState.elements,
-      previousNextUrl: actionInitiation.routerState.previousNextUrl,
-    });
-
-    const fetchResponse = await fetch(createServerActionRequestUrl(actionInitiation.path), {
-      method: "POST",
-      headers,
-      body,
-    });
-
-    // Surface an `UnrecognizedActionError` so client `catch` blocks can detect
-    // client/server deployment skew via `unstable_isUnrecognizedActionError`.
-    throwOnServerActionNotFound(fetchResponse, id);
-
-    const hasActionRedirect = fetchResponse.headers.has(ACTION_REDIRECT_HEADER);
-    const actionRedirectTarget = resolveActionRedirectTarget(fetchResponse);
-    if (hasActionRedirect && !actionRedirectTarget) {
-      return undefined;
-    }
-
-    const actionResultFacts = createServerActionResultFacts({
-      actionRedirectHref: actionRedirectTarget?.href ?? null,
-      actionRedirectType: actionRedirectTarget?.type ?? null,
-      clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
-      compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
-      contentTypeHeader: fetchResponse.headers.get("content-type"),
-      currentHref: actionInitiation.href,
-      origin: window.location.origin,
-      responseUrl: fetchResponse.url,
-    });
-    const fetchResponseIsRsc = actionResultFacts.isRscContentType;
-    const actionResultDecision = navigationPlanner.classifyServerActionResult(actionResultFacts);
-    if (
-      applyServerActionResultDecision(
-        actionResultDecision,
-        clearClientNavigationCaches,
-        (url, historyMode) => browserNavigationController.performHardNavigation(url, historyMode),
-      )
-    ) {
-      return undefined;
-    }
-
-    const revalidation = parseServerActionRevalidationHeader(fetchResponse.headers);
-    if (revalidation !== "none") {
-      // The revalidation header is the server's cache-invalidation signal. Clear
-      // restorable BFCache ids and snapshots before body decoding so no pending
-      // traversal can synchronously restore visible state from the old
-      // client-state epoch.
-      clearClientNavigationCaches();
-    }
-    const invalidResponseError = await readInvalidServerActionResponseError(
-      fetchResponse.clone(),
-      actionRedirectTarget !== null,
-    );
-    if (invalidResponseError) {
-      throw invalidResponseError;
-    }
-    if (actionRedirectTarget && !fetchResponseIsRsc) {
-      browserNavigationController.performHardNavigation(actionRedirectTarget.href);
-      return undefined;
-    }
-    const flightResponse =
-      fetchResponse.status === 303
-        ? new Response(fetchResponse.body, {
-            headers: fetchResponse.headers,
-            status: 200,
-            statusText: "OK",
-          })
-        : fetchResponse;
-    const result = await createFromFetch<ServerActionResult | AppWireElements>(
-      Promise.resolve(flightResponse),
-      { temporaryReferences },
-    );
-    if (
-      revalidation === "none" &&
-      shouldClearClientNavigationCachesForServerActionResult(result, revalidation)
-    ) {
-      clearClientNavigationCaches();
-    }
-
-    if (actionRedirectTarget) {
-      if (isServerActionResult(result) && result.root !== undefined) {
-        const decoded = AppElementsWire.decode(result.root);
-        const hashIdx = actionRedirectTarget.href.indexOf("#");
-        const hash = hashIdx !== -1 ? actionRedirectTarget.href.slice(hashIdx) : "";
-        const actionScrollIntent = beginAppRouterScrollIntent(hash || null);
-        if (actionRedirectTarget.type === "push") {
-          saveScrollPosition();
-        }
-        void renderNavigationPayload(
-          Promise.resolve(decoded),
-          createClientNavigationRenderSnapshot(
-            actionRedirectTarget.href,
-            actionInitiation.routerState.navigationSnapshot.params,
-          ),
-          actionRedirectTarget.href,
-          actionInitiation.navigationId,
-          actionRedirectTarget.type === "push" ? "push" : "replace",
-          {},
-          null,
-          null,
-          FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
-          actionRedirectTarget.type === "push" ? "navigate" : "replace",
-          "server-action",
-          null,
-          actionScrollIntent,
-        ).catch(() => {
-          browserNavigationController.performHardNavigation(actionRedirectTarget.href);
-        });
-        // Action redirects must throw a redirect error to abort the action call and
-        // propagate the redirect to the caller. Unlike Next.js which can suspend
-        // form actions on the client, vinext commits the SPA redirect navigation
-        // asynchronously in the background; returning a pending promise would suspend
-        // the React tree and block the background navigation's state update from committing.
-        throw createServerActionRedirectError(actionRedirectTarget);
-      }
-
-      browserNavigationController.performHardNavigation(actionRedirectTarget.href);
-      return undefined;
-    }
-
-    const hasSameUrlRerenderPayload = isServerActionResult(result) && result.root !== undefined;
-    syncServerActionHttpFallbackHead(hasSameUrlRerenderPayload ? null : fetchResponse.status);
-
-    // Server actions stay on the same URL and use commitSameUrlNavigatePayload()
-    // for merge-based dispatch. This path does not call
-    // activateNavigationSnapshot() because there is no URL change to commit, so
-    // hooks continue reading the live external-store values directly. If server
-    // actions ever trigger URL changes via RSC payload (instead of hard
-    // redirects), this would need renderNavigationPayload().
-    if (isServerActionResult(result)) {
-      if (result.root !== undefined) {
-        const returnValue =
-          result.returnValue && !result.returnValue.ok
-            ? {
-                ok: false,
-                data: normalizeServerActionThrownValue(
-                  result.returnValue.data,
-                  fetchResponse.status,
-                ),
-              }
-            : result.returnValue;
-        return commitSameUrlNavigatePayload(
-          Promise.resolve(AppElementsWire.decode(result.root)),
-          actionInitiation,
-          returnValue,
-          revalidation,
-        );
-      }
-
-      if (result.returnValue) {
-        if (!result.returnValue.ok) {
-          throw normalizeServerActionThrownValue(result.returnValue.data, fetchResponse.status);
-        }
-        return result.returnValue.data;
-      }
-
-      return undefined;
-    }
-
-    return commitSameUrlNavigatePayload(
-      Promise.resolve(AppElementsWire.decode(result)),
-      actionInitiation,
-      undefined,
-      revalidation,
-    );
-  };
-
   setServerCallback((id, args) => {
     const releaseCacheInvalidationGuard = historyController.beginCacheInvalidationGuard();
-    return Promise.resolve()
-      .then(() => serverActionCallback(id, args))
+    return loadServerActionClient!()
+      .then(({ invokeClientServerAction }) =>
+        invokeClientServerAction(id, args, {
+          basePath: __basePath,
+          clearClientNavigationCaches,
+          clientRscCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
+          commitSameUrlNavigatePayload,
+          createActionInitiationSnapshot,
+          navigationPlanner,
+          performHardNavigation: (url, historyMode) =>
+            browserNavigationController.performHardNavigation(url, historyMode),
+          renderRedirectPayload(elements, target, actionInitiation) {
+            const hashIdx = target.href.indexOf("#");
+            const hash = hashIdx !== -1 ? target.href.slice(hashIdx) : "";
+            const actionScrollIntent = beginAppRouterScrollIntent(hash || null);
+            if (target.type === "push") saveScrollPosition();
+            void renderNavigationPayload(
+              Promise.resolve(elements),
+              createClientNavigationRenderSnapshot(
+                target.href,
+                actionInitiation.routerState.navigationSnapshot.params,
+              ),
+              target.href,
+              actionInitiation.navigationId,
+              target.type === "push" ? "push" : "replace",
+              {},
+              null,
+              null,
+              FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+              target.type === "push" ? "navigate" : "replace",
+              "server-action",
+              null,
+              actionScrollIntent,
+            ).catch(() => {
+              browserNavigationController.performHardNavigation(target.href);
+            });
+          },
+          syncCurrentHistoryState: (previousNextUrl, bfcacheIds) =>
+            historyController.syncCurrentHistoryStatePreviousNextUrl(previousNextUrl, bfcacheIds),
+          syncServerActionHttpFallbackHead,
+        }),
+      )
       .finally(releaseCacheInvalidationGuard);
   });
 }
@@ -1613,7 +1395,7 @@ function registerServerActionCallback(): void {
 async function main(): Promise<void> {
   if (!claimInitialAppRouterBootstrap()) return;
 
-  registerServerActionCallback();
+  if (hasServerActions) registerServerActionCallback();
   installAppNavigationFailureListeners();
 
   if (import.meta.env.DEV) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1346,14 +1346,14 @@ function applyRuntimeRscBootstrap(rsc: NavigationRuntimeRscBootstrap): void {
 function registerServerActionCallback(): void {
   setServerCallback((id, args) => {
     const releaseCacheInvalidationGuard = historyController.beginCacheInvalidationGuard();
+    const actionInitiation = createActionInitiationSnapshot();
     return loadServerActionClient!()
       .then(({ invokeClientServerAction }) =>
-        invokeClientServerAction(id, args, {
+        invokeClientServerAction(id, args, actionInitiation, {
           basePath: __basePath,
           clearClientNavigationCaches,
           clientRscCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
           commitSameUrlNavigatePayload,
-          createActionInitiationSnapshot,
           navigationPlanner,
           performHardNavigation: (url, historyMode) =>
             browserNavigationController.performHardNavigation(url, historyMode),

--- a/packages/vinext/src/server/app-browser-server-action-client.ts
+++ b/packages/vinext/src/server/app-browser-server-action-client.ts
@@ -53,7 +53,6 @@ export type ClientServerActionDeps = {
     returnValue: ServerActionResult["returnValue"] | undefined,
     revalidation: ServerActionRevalidationKind,
   ): Promise<unknown>;
-  createActionInitiationSnapshot(): ClientServerActionInitiation;
   navigationPlanner: typeof import("./navigation-planner.js").navigationPlanner;
   performHardNavigation(url: string, historyMode?: "assign" | "replace"): void;
   renderRedirectPayload(
@@ -123,11 +122,11 @@ class ServerActionRedirectError extends Error {
 export async function invokeClientServerAction(
   id: string,
   args: unknown[],
+  actionInitiation: ClientServerActionInitiation,
   deps: ClientServerActionDeps,
 ): Promise<unknown> {
   deps.syncServerActionHttpFallbackHead(null);
   const temporaryReferences = createTemporaryReferenceSet();
-  const actionInitiation = deps.createActionInitiationSnapshot();
   deps.syncCurrentHistoryState(
     actionInitiation.routerState.previousNextUrl,
     actionInitiation.routerState.bfcacheIds,

--- a/packages/vinext/src/server/app-browser-server-action-client.ts
+++ b/packages/vinext/src/server/app-browser-server-action-client.ts
@@ -1,0 +1,256 @@
+import {
+  createFromFetch,
+  createTemporaryReferenceSet,
+  encodeReply,
+} from "@vitejs/plugin-rsc/browser";
+import { DANGEROUS_URL_BLOCK_MESSAGE, isDangerousScheme } from "vinext/shims/url-safety";
+import {
+  createServerActionResultFacts,
+  isServerActionResult,
+  normalizeServerActionThrownValue,
+  parseServerActionRevalidationHeader,
+  readInvalidServerActionResponseError,
+  shouldClearClientNavigationCachesForServerActionResult,
+  type AppBrowserServerActionResult,
+  type ServerActionRevalidationKind,
+} from "./app-browser-action-result.js";
+import { applyServerActionResultDecision } from "./app-browser-server-action-navigation.js";
+import { resolveServerActionRequestState, type AppRouterState } from "./app-browser-state.js";
+import { AppElementsWire, type AppElements, type AppWireElements } from "./app-elements.js";
+import {
+  createServerActionRequestUrl,
+  VINEXT_RSC_COMPATIBILITY_ID_HEADER,
+} from "./app-rsc-cache-busting.js";
+import { throwOnServerActionNotFound } from "./server-action-not-found.js";
+import {
+  ACTION_REDIRECT_HEADER,
+  ACTION_REDIRECT_STATUS_HEADER,
+  ACTION_REDIRECT_TYPE_HEADER,
+} from "./headers.js";
+
+type ServerActionResult = AppBrowserServerActionResult<AppWireElements>;
+
+export type ClientServerActionInitiation = {
+  href: string;
+  navigationId: number;
+  path: string;
+  routerState: AppRouterState;
+};
+
+type ActionRedirectTarget = {
+  href: string;
+  type: string;
+  status: number;
+};
+
+export type ClientServerActionDeps = {
+  basePath: string;
+  clearClientNavigationCaches(): void;
+  clientRscCompatibilityId: string | null;
+  commitSameUrlNavigatePayload(
+    elements: Promise<AppElements>,
+    actionInitiation: ClientServerActionInitiation,
+    returnValue: ServerActionResult["returnValue"] | undefined,
+    revalidation: ServerActionRevalidationKind,
+  ): Promise<unknown>;
+  createActionInitiationSnapshot(): ClientServerActionInitiation;
+  navigationPlanner: typeof import("./navigation-planner.js").navigationPlanner;
+  performHardNavigation(url: string, historyMode?: "assign" | "replace"): void;
+  renderRedirectPayload(
+    elements: AppElements,
+    target: ActionRedirectTarget,
+    actionInitiation: ClientServerActionInitiation,
+  ): void;
+  syncCurrentHistoryState(
+    previousNextUrl: string | null,
+    bfcacheIds: Readonly<Record<string, string>>,
+  ): void;
+  syncServerActionHttpFallbackHead(status: number | null): void;
+};
+
+function resolveActionRedirectTarget(
+  response: Response,
+  performHardNavigation: ClientServerActionDeps["performHardNavigation"],
+): ActionRedirectTarget | null {
+  const actionRedirect = response.headers.get(ACTION_REDIRECT_HEADER);
+  if (!actionRedirect) return null;
+
+  if (isDangerousScheme(actionRedirect)) {
+    console.error(DANGEROUS_URL_BLOCK_MESSAGE);
+    return null;
+  }
+
+  try {
+    let redirectUrl: URL;
+    if (actionRedirect.startsWith("/") || /^[a-z]+:/i.test(actionRedirect)) {
+      redirectUrl = new URL(actionRedirect, window.location.href);
+    } else {
+      const baseParsed = new URL(window.location.href);
+      let baseDir = baseParsed.pathname;
+      if (!baseDir.endsWith("/")) baseDir += "/";
+      redirectUrl = new URL(actionRedirect, `${baseParsed.origin}${baseDir}${baseParsed.search}`);
+    }
+
+    if (redirectUrl.origin !== window.location.origin) {
+      performHardNavigation(actionRedirect);
+      return null;
+    }
+    const statusHeader = response.headers.get(ACTION_REDIRECT_STATUS_HEADER);
+    return {
+      href: redirectUrl.href,
+      type: response.headers.get(ACTION_REDIRECT_TYPE_HEADER) ?? "push",
+      status: statusHeader ? parseInt(statusHeader, 10) : 307,
+    };
+  } catch {
+    performHardNavigation(actionRedirect);
+    return null;
+  }
+}
+
+class ServerActionRedirectError extends Error {
+  readonly digest: string;
+  readonly handled = true;
+
+  constructor(target: ActionRedirectTarget) {
+    super("NEXT_REDIRECT");
+    const redirectUrl = new URL(target.href, window.location.href);
+    const redirectHref = redirectUrl.pathname + redirectUrl.search + redirectUrl.hash;
+    const redirectType = target.type === "push" ? "push" : "replace";
+    this.digest = `NEXT_REDIRECT;${redirectType};${encodeURIComponent(redirectHref)};${target.status};`;
+  }
+}
+
+export async function invokeClientServerAction(
+  id: string,
+  args: unknown[],
+  deps: ClientServerActionDeps,
+): Promise<unknown> {
+  deps.syncServerActionHttpFallbackHead(null);
+  const temporaryReferences = createTemporaryReferenceSet();
+  const actionInitiation = deps.createActionInitiationSnapshot();
+  deps.syncCurrentHistoryState(
+    actionInitiation.routerState.previousNextUrl,
+    actionInitiation.routerState.bfcacheIds,
+  );
+  const body = await encodeReply(args, { temporaryReferences });
+  const headers = resolveServerActionRequestState({
+    actionId: id,
+    basePath: deps.basePath,
+    elements: actionInitiation.routerState.elements,
+    previousNextUrl: actionInitiation.routerState.previousNextUrl,
+  }).headers;
+  const fetchResponse = await fetch(createServerActionRequestUrl(actionInitiation.path), {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  throwOnServerActionNotFound(fetchResponse, id);
+
+  const hasActionRedirect = fetchResponse.headers.has(ACTION_REDIRECT_HEADER);
+  const actionRedirectTarget = resolveActionRedirectTarget(fetchResponse, (url, historyMode) =>
+    deps.performHardNavigation(url, historyMode),
+  );
+  if (hasActionRedirect && !actionRedirectTarget) return undefined;
+
+  const actionResultFacts = createServerActionResultFacts({
+    actionRedirectHref: actionRedirectTarget?.href ?? null,
+    actionRedirectType: actionRedirectTarget?.type ?? null,
+    clientCompatibilityId: deps.clientRscCompatibilityId,
+    compatibilityIdHeader: fetchResponse.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
+    contentTypeHeader: fetchResponse.headers.get("content-type"),
+    currentHref: actionInitiation.href,
+    origin: window.location.origin,
+    responseUrl: fetchResponse.url,
+  });
+  const fetchResponseIsRsc = actionResultFacts.isRscContentType;
+  const actionResultDecision = deps.navigationPlanner.classifyServerActionResult(actionResultFacts);
+  if (
+    applyServerActionResultDecision(
+      actionResultDecision,
+      () => deps.clearClientNavigationCaches(),
+      (url, historyMode) => deps.performHardNavigation(url, historyMode),
+    )
+  ) {
+    return undefined;
+  }
+
+  const revalidation = parseServerActionRevalidationHeader(fetchResponse.headers);
+  if (revalidation !== "none") deps.clearClientNavigationCaches();
+  const invalidResponseError = await readInvalidServerActionResponseError(
+    fetchResponse.clone(),
+    actionRedirectTarget !== null,
+  );
+  if (invalidResponseError) throw invalidResponseError;
+  if (actionRedirectTarget && !fetchResponseIsRsc) {
+    deps.performHardNavigation(actionRedirectTarget.href);
+    return undefined;
+  }
+
+  const flightResponse =
+    fetchResponse.status === 303
+      ? new Response(fetchResponse.body, {
+          headers: fetchResponse.headers,
+          status: 200,
+          statusText: "OK",
+        })
+      : fetchResponse;
+  const result = await createFromFetch<ServerActionResult | AppWireElements>(
+    Promise.resolve(flightResponse),
+    { temporaryReferences },
+  );
+  if (
+    revalidation === "none" &&
+    shouldClearClientNavigationCachesForServerActionResult(result, revalidation)
+  ) {
+    deps.clearClientNavigationCaches();
+  }
+
+  if (actionRedirectTarget) {
+    if (isServerActionResult(result) && result.root !== undefined) {
+      deps.renderRedirectPayload(
+        AppElementsWire.decode(result.root),
+        actionRedirectTarget,
+        actionInitiation,
+      );
+      throw new ServerActionRedirectError(actionRedirectTarget);
+    }
+    deps.performHardNavigation(actionRedirectTarget.href);
+    return undefined;
+  }
+
+  const hasSameUrlRerenderPayload = isServerActionResult(result) && result.root !== undefined;
+  deps.syncServerActionHttpFallbackHead(hasSameUrlRerenderPayload ? null : fetchResponse.status);
+
+  if (isServerActionResult(result)) {
+    if (result.root !== undefined) {
+      const returnValue =
+        result.returnValue && !result.returnValue.ok
+          ? {
+              ok: false,
+              data: normalizeServerActionThrownValue(result.returnValue.data, fetchResponse.status),
+            }
+          : result.returnValue;
+      return deps.commitSameUrlNavigatePayload(
+        Promise.resolve(AppElementsWire.decode(result.root)),
+        actionInitiation,
+        returnValue,
+        revalidation,
+      );
+    }
+    if (result.returnValue) {
+      if (!result.returnValue.ok) {
+        throw normalizeServerActionThrownValue(result.returnValue.data, fetchResponse.status);
+      }
+      return result.returnValue.data;
+    }
+    return undefined;
+  }
+
+  return deps.commitSameUrlNavigatePayload(
+    Promise.resolve(AppElementsWire.decode(result)),
+    actionInitiation,
+    undefined,
+    revalidation,
+  );
+}

--- a/packages/vinext/src/virtual-vinext-app-capabilities.d.ts
+++ b/packages/vinext/src/virtual-vinext-app-capabilities.d.ts
@@ -1,0 +1,6 @@
+declare module "virtual:vinext-app-capabilities" {
+  type ServerActionClient = typeof import("./server/app-browser-server-action-client.js");
+
+  export const hasServerActions: boolean;
+  export const loadServerActionClient: (() => Promise<ServerActionClient>) | null;
+}

--- a/tests/app-browser-server-action-client.test.ts
+++ b/tests/app-browser-server-action-client.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shims/navigation.js";
+import { createServerActionInitiationSnapshot } from "../packages/vinext/src/server/app-browser-action-result.js";
+import { invokeClientServerAction } from "../packages/vinext/src/server/app-browser-server-action-client.js";
+import type { AppRouterState } from "../packages/vinext/src/server/app-browser-state.js";
+import {
+  AppElementsWire,
+  normalizeAppElements,
+} from "../packages/vinext/src/server/app-elements.js";
+import { ACTION_REDIRECT_HEADER } from "../packages/vinext/src/server/headers.js";
+import { navigationPlanner } from "../packages/vinext/src/server/navigation-planner.js";
+
+vi.mock("@vitejs/plugin-rsc/browser", () => ({
+  createFromFetch: vi.fn(),
+  createTemporaryReferenceSet: vi.fn(() => new Map()),
+  encodeReply: vi.fn(async () => "encoded-action-args"),
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("app browser server action client", () => {
+  it("uses action state captured before the lazy client loads", async () => {
+    const elements = normalizeAppElements(
+      AppElementsWire.createMetadataEntries({
+        interception: null,
+        interceptionContext: null,
+        layoutIds: [AppElementsWire.encodeLayoutId("/")],
+        rootLayoutTreePath: "/",
+        routeId: "route:/original",
+        slotBindings: [],
+      }),
+    );
+    const routerState: AppRouterState = {
+      activeOperation: null,
+      bfcacheIds: {},
+      elements,
+      interception: null,
+      interceptionContext: null,
+      layoutFlags: {},
+      layoutIds: [AppElementsWire.encodeLayoutId("/")],
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/original", {}),
+      previousNextUrl: null,
+      renderId: 0,
+      rootLayoutTreePath: "/",
+      routeId: "route:/original",
+      slotBindings: [],
+      visibleCommitVersion: 0,
+    };
+    const actionInitiation = createServerActionInitiationSnapshot({
+      href: "https://example.com/original?tab=1",
+      navigationId: 42,
+      routerState,
+    });
+    vi.stubGlobal("window", {
+      location: {
+        href: "https://example.com/newer",
+        origin: "https://example.com",
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 303,
+        headers: {
+          [ACTION_REDIRECT_HEADER]: "/target",
+          "content-type": "text/plain",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await invokeClientServerAction("action-id", [], actionInitiation, {
+      basePath: "",
+      clearClientNavigationCaches: vi.fn(),
+      clientRscCompatibilityId: null,
+      commitSameUrlNavigatePayload: vi.fn(),
+      navigationPlanner,
+      performHardNavigation: vi.fn(),
+      renderRedirectPayload: vi.fn(),
+      syncCurrentHistoryState: vi.fn(),
+      syncServerActionHttpFallbackHead: vi.fn(),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/original?tab=1",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -77,8 +77,13 @@ describe("App Router Production build", () => {
       const source = entry?.src?.replaceAll("\\", "/") ?? key.replaceAll("\\", "/");
       return entry?.name === "link" || /\/shims\/link\.(?:js|tsx)$/.test(source);
     });
+    const serverActionClientKey = Object.keys(clientManifest).find((key) => {
+      const source = clientManifest[key]?.src?.replaceAll("\\", "/") ?? key.replaceAll("\\", "/");
+      return source.includes("/server/app-browser-server-action-client.");
+    });
     expect(browserEntryKey).toBeDefined();
     expect(linkEntryKey).toBeDefined();
+    expect(serverActionClientKey).toBeDefined();
 
     const eagerKeys = new Set<string>();
     const visitEagerImports = (key: string): void => {
@@ -107,6 +112,48 @@ describe("App Router Production build", () => {
     const buildIdPath = path.join(outDir, "server", "BUILD_ID");
     expect(fs.existsSync(buildIdPath)).toBe(true);
     expect(fs.readFileSync(buildIdPath, "utf-8").trim().length).toBeGreaterThan(0);
+  }, 30000);
+
+  it("omits the browser server-action client when the app has no server actions", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-action-free-client-"));
+
+    try {
+      fs.symlinkSync(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(tmpDir, "node_modules"),
+        "junction",
+      );
+      fs.mkdirSync(path.join(tmpDir, "app"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "layout.tsx"),
+        `export default function Root({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "page.tsx"),
+        `export default function Page() {
+  return <p>action-free</p>;
+}
+`,
+      );
+
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const clientDir = path.join(tmpDir, "dist", "client");
+      const manifest = fs.readFileSync(path.join(clientDir, ".vite", "manifest.json"), "utf-8");
+      expect(manifest).not.toContain("app-browser-server-action-client");
+      expect(readAllJs(clientDir)).not.toContain("UnrecognizedActionError");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   }, 30000);
 
   it("adopts __VINEXT_SHARED_BUILD_ID so the runtime and BUILD_ID file agree", async () => {


### PR DESCRIPTION
This PR moves browser-side server action handling into a lazy chunk and removes it entirely from production apps without server actions. Action-free client bundles shrink by about 3.7 KB gzip, while apps using actions load the runtime only when needed but gain roughly 0.8 KB total chunk overhead. It is the client-side counterpart to #2206, which removed the unused server-side action runtime.

Same pattern as  #2194 and #2196.