### PR TITLE
perf(app): omit unused PPR runtime

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -44,6 +44,7 @@ export default {
         "src/server/app-middleware.ts",
         "src/server/app-page-dispatch.ts",
         "src/server/app-page-head.ts",
+        "src/server/app-page-ppr-runtime.ts",
         "src/server/app-prerender-static-params.ts",
         "src/server/app-route-module-loader.ts",
         // Client-side instrumentation bundle: loaded as a side-effect module

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -64,6 +64,10 @@ const appPageRouteWiringPath = resolveEntryPath(
 );
 const appPageProbePath = resolveEntryPath("../server/app-page-probe.js", import.meta.url);
 const appPageDispatchPath = resolveEntryPath("../server/app-page-dispatch.js", import.meta.url);
+const appPagePprRuntimePath = resolveEntryPath(
+  "../server/app-page-ppr-runtime.js",
+  import.meta.url,
+);
 const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
 const appSegmentConfigPath = resolveEntryPath("../server/app-segment-config.js", import.meta.url);
 const appRscRouteMatchingPath = resolveEntryPath(
@@ -338,6 +342,14 @@ import { buildAppPageProbes as __buildAppPageProbes } from ${JSON.stringify(appP
 import {
   dispatchAppPage as __dispatchAppPage,
 } from ${JSON.stringify(appPageDispatchPath)};
+${
+  cacheComponents
+    ? `import {
+  appPagePprRuntime as __appPagePprRuntime,
+  createAppPprFallbackShells as __createAppPprFallbackShells,
+} from ${JSON.stringify(appPagePprRuntimePath)};`
+    : ""
+}
 import {
   resolveAppPageGenerateStaticParamsSources as __resolveAppPageGenerateStaticParamsSources,
 } from ${JSON.stringify(appPageRequestPath)};
@@ -597,7 +609,6 @@ export const __assetPrefix = ${JSON.stringify(assetPrefix)};
 export const __inlineCss = ${JSON.stringify(inlineCss)};
 export const __hasPagesDir = ${JSON.stringify(hasPagesDir)};
 export const getRenderedConcreteUrlPathsForRoute = __getRenderedConcreteUrlPathsForRoute;
-const __cacheComponents = ${JSON.stringify(cacheComponents)};
 
 export async function seedMemoryCacheFromPrerender(serverDir) {
   const { seedMemoryCacheFromPrerender: __seedMemoryCacheFromPrerender } =
@@ -652,7 +663,13 @@ export default createAppRscHandler({
   },
   registerCacheAdapters: __registerConfiguredCacheAdapters,
   configHeaders: __configHeaders,
-  cacheComponents: __cacheComponents,
+  ${
+    cacheComponents
+      ? `createPprFallbackShells(route, params) {
+    return __createAppPprFallbackShells(route, params);
+  },`
+      : ""
+  }
   configRedirects: __configRedirects,
   configRewrites: __configRewrites,
   imageConfig: __imageConfig,
@@ -766,6 +783,7 @@ export default createAppRscHandler({
       params,
       pprFallbackCacheShells,
       pprFallbackShell,
+      pprRuntime: ${cacheComponents ? "__appPagePprRuntime" : "undefined"},
       renderedConcreteUrlPaths,
       skipStaticParamsValidation,
       staticParamsValidationParams,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -8,6 +8,7 @@ import {
 } from "vinext/shims/cache-request-state";
 import type { CachedAppPageValue } from "vinext/shims/cache-handler";
 import type { RootParams } from "vinext/shims/root-params";
+import type { PprFallbackShellState } from "vinext/shims/ppr-fallback-shell";
 import {
   consumeDynamicUsage,
   consumeInvalidDynamicUsageError,
@@ -21,12 +22,6 @@ import {
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
 import {
-  beginPprFallbackShellFinalRender,
-  createPprFallbackShellState,
-  getPprFallbackShellState,
-  runWithPprFallbackShellState,
-} from "vinext/shims/ppr-fallback-shell";
-import {
   ensureFetchPatch,
   type FetchCacheMode,
   getCollectedFetchTags,
@@ -38,6 +33,7 @@ import {
 } from "vinext/shims/fetch-cache";
 import { AppElementsWire, type AppOutgoingElements } from "./app-elements.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
+import type { WarmPprFallbackShellCachesOptions } from "./app-ppr-fallback-shell-render.js";
 import {
   resolveAppPageParentHttpAccessBoundary,
   resolveAppPageParentHttpAccessBoundaryModule,
@@ -92,8 +88,8 @@ import {
 
 type AppPageParams = Record<string, string | string[]>;
 type AppPageElement = ReactNode | Readonly<Record<string, ReactNode>>;
-type AppPageRenderableElement = ReactNode | AppOutgoingElements;
-type AppPageBoundaryOnError = (
+export type AppPageRenderableElement = ReactNode | AppOutgoingElements;
+export type AppPageBoundaryOnError = (
   error: unknown,
   requestInfo: unknown,
   errorContext: unknown,
@@ -166,7 +162,7 @@ type EffectiveLayoutClassifications = Readonly<{
   buildTimeReasons: ReadonlyMap<number, ClassificationReason> | null | undefined;
 }>;
 
-type AppPageDispatchRoute = {
+export type AppPageDispatchRoute = {
   __buildTimeClassifications?: LayoutClassificationOptions["buildTimeClassifications"];
   __buildTimeReasons?: LayoutClassificationOptions["buildTimeReasons"];
   error?: AppPageModule | null;
@@ -197,7 +193,23 @@ function resolveAppPageRouteBoundaryModule(
   return null;
 }
 
-type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
+export type AppPagePprRuntime<TRoute extends AppPageDispatchRoute> = {
+  beginFinalRender(state: AppPagePprState): void;
+  getState(): AppPagePprState | null;
+  run<T>(shell: NonNullable<DispatchAppPageOptions<TRoute>["pprFallbackShell"]>, fn: () => T): T;
+  tryServe(
+    options: DispatchAppPageOptions<TRoute>,
+    currentRevalidateSeconds: number | null,
+    isDraftMode: boolean,
+    isForceStatic: boolean,
+    isForceDynamic: boolean,
+  ): Promise<Response | null>;
+  warm(options: WarmPprFallbackShellCachesOptions): Promise<void>;
+};
+
+export type AppPagePprState = PprFallbackShellState;
+
+export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   /** Configured basePath (e.g. "/blog"). Used to prefix redirect Locations. */
   basePath?: string;
   /**
@@ -276,6 +288,7 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
     fallbackParamNames: readonly string[];
     routePattern: string;
   };
+  pprRuntime?: AppPagePprRuntime<TRoute>;
   /**
    * Set of concrete URL paths that were pre-rendered at build time for this
    * route. When the exact cache entry for a known pregenerated path is absent
@@ -410,7 +423,7 @@ function getEffectiveLayoutClassifications(
   return createEffectiveLayoutClassifications(route, debugClassification !== undefined);
 }
 
-function shouldReadAppPageCache(options: {
+export function shouldReadAppPageCache(options: {
   isProgressiveActionRender: boolean;
   isDraftMode: boolean;
   isForceDynamic: boolean;
@@ -429,7 +442,7 @@ function shouldReadAppPageCache(options: {
   );
 }
 
-function hasSearchParams(searchParams: URLSearchParams | null | undefined): boolean {
+export function hasSearchParams(searchParams: URLSearchParams | null | undefined): boolean {
   return searchParams !== null && searchParams !== undefined && searchParams.size > 0;
 }
 
@@ -479,18 +492,6 @@ async function runAppPageRevalidationContext<
   });
 }
 
-type PprFallbackShellEligibility =
-  | { kind: "probe-fallback-shells"; fallbackShells: readonly AppPagePprFallbackCacheShell[] }
-  | {
-      kind:
-        | "skip-known-pregenerated-route"
-        | "skip-no-fallback-shells"
-        | "skip-rsc-request"
-        | "skip-non-get"
-        | "skip-search-params"
-        | "skip-cache-disabled";
-    };
-
 function toInterceptOptions(
   interceptionContext: string | null,
   intercept: AppPageDispatchIntercept,
@@ -507,138 +508,15 @@ function toInterceptOptions(
   };
 }
 
-/**
- * Request-phase fallback-shell gate. Callers must run the exact cache read and
- * static-param validation before this classification step.
- */
-function classifyPprFallbackShellEligibility<TRoute extends AppPageDispatchRoute>(
-  options: DispatchAppPageOptions<TRoute>,
-  currentRevalidateSeconds: number | null,
-  isDraftMode: boolean,
-  isForceStatic: boolean,
-  isForceDynamic: boolean,
-): PprFallbackShellEligibility {
-  // Serving a reusable fallback shell is only safe for an unknown dynamic
-  // child path. If this concrete URL was pregenerated, a missing exact cache
-  // entry is a cache availability problem, not a routing signal. Fall through
-  // to fresh render instead.
-  const isKnownPregeneratedRoute =
-    options.renderedConcreteUrlPaths?.has(options.cleanPathname) === true;
-  if (isKnownPregeneratedRoute) {
-    return { kind: "skip-known-pregenerated-route" };
-  }
-
-  const fallbackShells = options.pprFallbackCacheShells;
-  if (!fallbackShells || fallbackShells.length === 0) {
-    return { kind: "skip-no-fallback-shells" };
-  }
-  if (options.isRscRequest) {
-    return { kind: "skip-rsc-request" };
-  }
-  if (options.request.method !== "GET") {
-    return { kind: "skip-non-get" };
-  }
-  if (!isForceStatic && hasSearchParams(options.searchParams)) {
-    return { kind: "skip-search-params" };
-  }
-  if (
-    !shouldReadAppPageCache({
-      isDraftMode,
-      isForceDynamic,
-      isProgressiveActionRender: options.isProgressiveActionRender === true,
-      isProduction: options.isProduction,
-      isRscRequest: false,
-      revalidateSeconds: currentRevalidateSeconds,
-      scriptNonce: options.scriptNonce,
-    })
-  ) {
-    return { kind: "skip-cache-disabled" };
-  }
-
-  return { kind: "probe-fallback-shells", fallbackShells };
-}
-
-async function probePprFallbackShellCache<TRoute extends AppPageDispatchRoute>(
-  options: DispatchAppPageOptions<TRoute>,
-  route: TRoute,
-  fallbackShells: readonly AppPagePprFallbackCacheShell[],
-  currentRevalidateSeconds: number | null,
-): Promise<Response | null> {
-  const { readAppPageFallbackShellCacheResponse } = await import("./app-page-cache.js");
-  const { rewriteAppPprFallbackShellHtmlNavigation } = await import("./app-ppr-fallback-shell.js");
-  for (const fallbackShell of fallbackShells) {
-    const fallbackShellResponse = await readAppPageFallbackShellCacheResponse({
-      clearRequestContext: options.clearRequestContext,
-      expireSeconds: options.expireSeconds,
-      fallbackPathname: fallbackShell.pathname,
-      isEdgeRuntime: options.isEdgeRuntime,
-      isrDebug: options.isrDebug,
-      isrGet: options.isrGet,
-      isrHtmlKey: options.isrHtmlKey,
-      middlewareHeaders: options.middlewareContext.headers,
-      middlewareStatus: options.middlewareContext.status,
-      revalidateSeconds: currentRevalidateSeconds ?? 0,
-      rewriteHtml(html) {
-        return rewriteAppPprFallbackShellHtmlNavigation({
-          html,
-          params: options.params,
-          pathname: options.cleanPathname,
-          searchParams: options.searchParams,
-        });
-      },
-    });
-    if (fallbackShellResponse) {
-      return fallbackShellResponse;
-    }
-  }
-
-  return null;
-}
-
-async function tryServePprFallbackShell<TRoute extends AppPageDispatchRoute>(
-  options: DispatchAppPageOptions<TRoute>,
-  route: TRoute,
-  currentRevalidateSeconds: number | null,
-  isDraftMode: boolean,
-  isForceStatic: boolean,
-  isForceDynamic: boolean,
-): Promise<Response | null> {
-  const decision = classifyPprFallbackShellEligibility(
-    options,
-    currentRevalidateSeconds,
-    isDraftMode,
-    isForceStatic,
-    isForceDynamic,
-  );
-
-  switch (decision.kind) {
-    case "skip-known-pregenerated-route":
-    case "skip-no-fallback-shells":
-    case "skip-rsc-request":
-    case "skip-non-get":
-    case "skip-search-params":
-    case "skip-cache-disabled":
-      return null;
-    case "probe-fallback-shells":
-      return await probePprFallbackShellCache(
-        options,
-        route,
-        decision.fallbackShells,
-        currentRevalidateSeconds,
-      );
-  }
-}
-
 export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
 ): Promise<Response> {
   const dispatch = () => runWithFetchDedupe(() => dispatchAppPageInner(options));
-  if (!options.pprFallbackShell) {
+  if (!options.pprFallbackShell || !options.pprRuntime) {
     return await dispatch();
   }
 
-  const fallbackShellState = createPprFallbackShellState(options.pprFallbackShell);
-  return await runWithPprFallbackShellState(fallbackShellState, dispatch);
+  return await options.pprRuntime.run(options.pprFallbackShell, dispatch);
 }
 
 async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
@@ -851,14 +729,15 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     }
   }
 
-  const fallbackShellResponse = await tryServePprFallbackShell(
-    options,
-    route,
-    currentRevalidateSeconds,
-    isDraftMode,
-    isForceStatic,
-    isForceDynamic,
-  );
+  const fallbackShellResponse = options.pprRuntime
+    ? await options.pprRuntime.tryServe(
+        options,
+        currentRevalidateSeconds,
+        isDraftMode,
+        isForceStatic,
+        isForceDynamic,
+      )
+    : null;
   if (fallbackShellResponse) {
     return fallbackShellResponse;
   }
@@ -981,14 +860,13 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       resolveSpecialError: resolveAppPageSpecialError,
     });
 
-  const fallbackShellState = getPprFallbackShellState();
+  const fallbackShellState = options.pprRuntime?.getState() ?? null;
   if (fallbackShellState && process.env.VINEXT_PRERENDER === "1" && !options.isRscRequest) {
     const warmupBuildResult = await buildCurrentPageElement();
     if (warmupBuildResult.response) {
       return warmupBuildResult.response;
     }
-    const { warmPprFallbackShellCaches } = await import("./app-ppr-fallback-shell-render.js");
-    await warmPprFallbackShellCaches({
+    await options.pprRuntime!.warm({
       element: warmupBuildResult.element,
       onError: options.createRscOnErrorHandler(options.cleanPathname, route.pattern),
       renderToReadableStream: options.renderToReadableStream,
@@ -1017,7 +895,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     route,
     options.debugClassification,
   );
-  const activeFallbackShellState = getPprFallbackShellState();
+  const activeFallbackShellState = options.pprRuntime?.getState() ?? null;
   const pprFallbackShellSignal = activeFallbackShellState?.abortController.signal;
   const pprFallbackShellReactSignal = activeFallbackShellState?.reactAbortController.signal;
 
@@ -1080,7 +958,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     pprFallbackShellReactSignal,
     abortPprFallbackShell: activeFallbackShellState
       ? () => {
-          beginPprFallbackShellFinalRender(activeFallbackShellState);
+          options.pprRuntime!.beginFinalRender(activeFallbackShellState);
         }
       : undefined,
     layoutParamAccess,

--- a/packages/vinext/src/server/app-page-ppr-runtime.ts
+++ b/packages/vinext/src/server/app-page-ppr-runtime.ts
@@ -1,0 +1,126 @@
+import {
+  beginPprFallbackShellFinalRender,
+  createPprFallbackShellState,
+  getPprFallbackShellState,
+  runWithPprFallbackShellState,
+} from "vinext/shims/ppr-fallback-shell";
+import {
+  hasSearchParams,
+  shouldReadAppPageCache,
+  type AppPageDispatchRoute,
+  type AppPagePprRuntime,
+  type DispatchAppPageOptions,
+} from "./app-page-dispatch.js";
+
+type PprFallbackShellEligibility =
+  | {
+      kind: "probe-fallback-shells";
+      fallbackShells: NonNullable<
+        DispatchAppPageOptions<AppPageDispatchRoute>["pprFallbackCacheShells"]
+      >;
+    }
+  | {
+      kind:
+        | "skip-known-pregenerated-route"
+        | "skip-no-fallback-shells"
+        | "skip-rsc-request"
+        | "skip-non-get"
+        | "skip-search-params"
+        | "skip-cache-disabled";
+    };
+
+function classifyPprFallbackShellEligibility<TRoute extends AppPageDispatchRoute>(
+  options: DispatchAppPageOptions<TRoute>,
+  currentRevalidateSeconds: number | null,
+  isDraftMode: boolean,
+  isForceStatic: boolean,
+  isForceDynamic: boolean,
+): PprFallbackShellEligibility {
+  if (options.renderedConcreteUrlPaths?.has(options.cleanPathname) === true) {
+    return { kind: "skip-known-pregenerated-route" };
+  }
+
+  const fallbackShells = options.pprFallbackCacheShells;
+  if (!fallbackShells || fallbackShells.length === 0) {
+    return { kind: "skip-no-fallback-shells" };
+  }
+  if (options.isRscRequest) return { kind: "skip-rsc-request" };
+  if (options.request.method !== "GET") return { kind: "skip-non-get" };
+  if (!isForceStatic && hasSearchParams(options.searchParams)) {
+    return { kind: "skip-search-params" };
+  }
+  if (
+    !shouldReadAppPageCache({
+      isDraftMode,
+      isForceDynamic,
+      isProgressiveActionRender: options.isProgressiveActionRender === true,
+      isProduction: options.isProduction,
+      isRscRequest: false,
+      revalidateSeconds: currentRevalidateSeconds,
+      scriptNonce: options.scriptNonce,
+    })
+  ) {
+    return { kind: "skip-cache-disabled" };
+  }
+
+  return { kind: "probe-fallback-shells", fallbackShells };
+}
+
+async function probePprFallbackShellCache<TRoute extends AppPageDispatchRoute>(
+  options: DispatchAppPageOptions<TRoute>,
+  fallbackShells: NonNullable<DispatchAppPageOptions<TRoute>["pprFallbackCacheShells"]>,
+  currentRevalidateSeconds: number | null,
+): Promise<Response | null> {
+  const { readAppPageFallbackShellCacheResponse } = await import("./app-page-cache.js");
+  const { rewriteAppPprFallbackShellHtmlNavigation } = await import("./app-ppr-fallback-shell.js");
+  for (const fallbackShell of fallbackShells) {
+    const fallbackShellResponse = await readAppPageFallbackShellCacheResponse({
+      clearRequestContext: options.clearRequestContext,
+      expireSeconds: options.expireSeconds,
+      fallbackPathname: fallbackShell.pathname,
+      isEdgeRuntime: options.isEdgeRuntime,
+      isrDebug: options.isrDebug,
+      isrGet: options.isrGet,
+      isrHtmlKey: options.isrHtmlKey,
+      middlewareHeaders: options.middlewareContext.headers,
+      middlewareStatus: options.middlewareContext.status,
+      revalidateSeconds: currentRevalidateSeconds ?? 0,
+      rewriteHtml(html) {
+        return rewriteAppPprFallbackShellHtmlNavigation({
+          html,
+          params: options.params,
+          pathname: options.cleanPathname,
+          searchParams: options.searchParams,
+        });
+      },
+    });
+    if (fallbackShellResponse) return fallbackShellResponse;
+  }
+  return null;
+}
+
+export const appPagePprRuntime: AppPagePprRuntime<AppPageDispatchRoute> = {
+  beginFinalRender: beginPprFallbackShellFinalRender,
+  getState: getPprFallbackShellState,
+  run(shell, fn) {
+    return runWithPprFallbackShellState(createPprFallbackShellState(shell), fn);
+  },
+  async tryServe(options, currentRevalidateSeconds, isDraftMode, isForceStatic, isForceDynamic) {
+    const decision = classifyPprFallbackShellEligibility(
+      options,
+      currentRevalidateSeconds,
+      isDraftMode,
+      isForceStatic,
+      isForceDynamic,
+    );
+    return decision.kind === "probe-fallback-shells"
+      ? probePprFallbackShellCache(options, decision.fallbackShells, currentRevalidateSeconds)
+      : null;
+  },
+  async warm(options) {
+    const { warmPprFallbackShellCaches } = await import("./app-ppr-fallback-shell-render.js");
+    await warmPprFallbackShellCaches(options);
+  },
+};
+
+export { createAppPprFallbackShells } from "./app-ppr-fallback-shell.js";

--- a/packages/vinext/src/server/app-ppr-fallback-shell-render.ts
+++ b/packages/vinext/src/server/app-ppr-fallback-shell-render.ts
@@ -15,7 +15,7 @@ type AppPageBoundaryOnError = (
 
 type AppPageRenderableElement = ReactNode | Record<string, ReactNode>;
 
-export async function warmPprFallbackShellCaches(options: {
+export type WarmPprFallbackShellCachesOptions = {
   element: AppPageRenderableElement;
   onError: AppPageBoundaryOnError;
   renderToReadableStream: (
@@ -23,7 +23,11 @@ export async function warmPprFallbackShellCaches(options: {
     options: { onError: AppPageBoundaryOnError; signal?: AbortSignal },
   ) => ReadableStream<Uint8Array>;
   state: PprFallbackShellState;
-}): Promise<void> {
+};
+
+export async function warmPprFallbackShellCaches(
+  options: WarmPprFallbackShellCachesOptions,
+): Promise<void> {
   let warmupError: unknown = null;
   const warmupStream = options.renderToReadableStream(options.element, {
     signal: options.state.abortController.signal,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -265,7 +265,6 @@ type NavigationContextValue = {
 type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   basePath: string;
   buildId: string | null;
-  cacheComponents?: boolean;
   clearRequestContext: () => void;
   configHeaders: NextHeader[];
   configRedirects: NextRedirect[];
@@ -297,6 +296,10 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
     options: HandleProgressiveActionRequestOptions,
   ) => Promise<Response | ProgressiveActionFormStateResult | null>;
   handleMetadataRouteRequest?: (cleanPathname: string) => Promise<Response | null>;
+  createPprFallbackShells?: (
+    route: Pick<AppRscHandlerRoute, "params" | "pattern" | "rootParamNames">,
+    params: AppPageParams,
+  ) => AppPagePprFallbackCacheShell[];
   handleServerActionRequest?: (
     options: HandleServerActionRequestOptions,
   ) => Promise<Response | null>;
@@ -932,14 +935,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   const resolvedSearchParams = getResolvedSearchParams();
   let runtimeFallbackShells: AppPagePprFallbackCacheShell[] = [];
   if (
-    options.cacheComponents === true &&
+    options.createPprFallbackShells &&
     request.method === "GET" &&
     !isRscRequest &&
     !isPrerenderFallbackShell &&
     route.params
   ) {
-    const { createAppPprFallbackShells } = await import("./app-ppr-fallback-shell.js");
-    runtimeFallbackShells = createAppPprFallbackShells(
+    runtimeFallbackShells = options.createPprFallbackShells(
       {
         params: route.params,
         pattern: route.pattern,

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -36,6 +36,7 @@ import type { AppPageMiddlewareContext } from "../packages/vinext/src/server/app
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
 import { markAppPprDynamicFallbackShellHtml } from "../packages/vinext/src/server/app-ppr-fallback-shell.js";
+import { appPagePprRuntime } from "../packages/vinext/src/server/app-page-ppr-runtime.js";
 import {
   runWithExecutionContext,
   type ExecutionContextLike,
@@ -285,6 +286,7 @@ type CreateDispatchOptionsOverrides = {
   mountedSlotsHeader?: string | null;
   params?: Record<string, string | string[]>;
   pprFallbackCacheShells?: DispatchOptions["pprFallbackCacheShells"];
+  pprRuntime?: DispatchOptions["pprRuntime"];
   probeLayoutAt?: DispatchOptions["probeLayoutAt"];
   probePage?: DispatchOptions["probePage"];
   renderedConcreteUrlPaths?: DispatchOptions["renderedConcreteUrlPaths"];
@@ -374,6 +376,7 @@ function createDispatchOptions(overrides: CreateDispatchOptionsOverrides = {}) {
     mountedSlotsHeader: overrides.mountedSlotsHeader,
     params,
     pprFallbackCacheShells: overrides.pprFallbackCacheShells,
+    pprRuntime: overrides.pprRuntime,
     probeLayoutAt: overrides.probeLayoutAt ?? createLayoutParamProbe(route, params, []),
     probePage: overrides.probePage ?? (() => null),
     renderedConcreteUrlPaths: overrides.renderedConcreteUrlPaths,
@@ -437,6 +440,7 @@ function createPprBlogDispatchOptions(overrides: CreateDispatchOptionsOverrides 
     isProduction: true,
     params: { locale: "en", slug: "new-post" },
     pprFallbackCacheShells: pprBlogFallbackShells,
+    pprRuntime: appPagePprRuntime,
     revalidateSeconds: 60,
     route: createPprBlogRoute(),
     ...overrides,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -838,6 +838,35 @@ describe("App Router entry templates", () => {
     expect(withMiddleware).toContain("return __applyAppMiddleware({");
   });
 
+  it("generateRscEntry only includes the PPR runtime when Cache Components is enabled", () => {
+    const withoutCacheComponents = generateRscEntry(
+      "/tmp/test/app",
+      minimalAppRoutes,
+      null,
+      [],
+      null,
+      "",
+      false,
+    );
+    const withCacheComponents = generateRscEntry(
+      "/tmp/test/app",
+      minimalAppRoutes,
+      null,
+      [],
+      null,
+      "",
+      false,
+      { cacheComponents: true },
+    );
+
+    expect(withoutCacheComponents).not.toContain("app-page-ppr-runtime.js");
+    expect(withoutCacheComponents).not.toContain("createPprFallbackShells(route, params)");
+    expect(withoutCacheComponents).toContain("pprRuntime: undefined");
+    expect(withCacheComponents).toContain("app-page-ppr-runtime.js");
+    expect(withCacheComponents).toContain("createPprFallbackShells(route, params)");
+    expect(withCacheComponents).toContain("pprRuntime: __appPagePprRuntime");
+  });
+
   it("generateRscEntry only includes metadata route response handling when routes exist", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-entry-metadata-runtime-"));
     const filePath = path.join(tmpDir, "sitemap.ts");


### PR DESCRIPTION
This change moves PPR fallback-shell handling behind an optional runtime that is included only when Cache Components are enabled.

Normal apps without Cache Components omit about 2.35 KB gzip from the RSC bundle without changing request behavior.

It follows the same conditional-runtime pattern as [#2194](https://github.com/cloudflare/vinext/pull/2194), [#2196](https://github.com/cloudflare/vinext/pull/2196), and [#2206](https://github.com/cloudflare/vinext/pull/2206).