### PR TITLE
perf(app): omit unused file metadata runtime

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -64,6 +64,7 @@ const appPageRouteWiringPath = resolveEntryPath(
 );
 const appPageProbePath = resolveEntryPath("../server/app-page-probe.js", import.meta.url);
 const appPageDispatchPath = resolveEntryPath("../server/app-page-dispatch.js", import.meta.url);
+const fileBasedMetadataPath = resolveEntryPath("../server/file-based-metadata.js", import.meta.url);
 const appPageRequestPath = resolveEntryPath("../server/app-page-request.js", import.meta.url);
 const appSegmentConfigPath = resolveEntryPath("../server/app-segment-config.js", import.meta.url);
 const appRscRouteMatchingPath = resolveEntryPath(
@@ -315,6 +316,15 @@ ${
     ? `const __loadMetadataRouteResponse = () => import(${JSON.stringify(metadataRouteResponsePath)});`
     : ""
 }
+${
+  (metadataRoutes?.length ?? 0) > 0
+    ? `const __loadFileBasedMetadata = () => import(${JSON.stringify(fileBasedMetadataPath)});
+async function __applyFileBasedMetadata(...args) {
+  const { applyFileBasedMetadata } = await __loadFileBasedMetadata();
+  return applyFileBasedMetadata(...args);
+}`
+    : ""
+}
 import {
   sanitizeErrorForClient as __sanitizeErrorForClient,
 } from ${JSON.stringify(appRscErrorsPath)};
@@ -513,6 +523,7 @@ const createRscOnErrorHandler = (request, pathname, routePath) =>
   createAppRscOnErrorHandler(_reportRequestError, request, pathname, routePath);
 
 const __fallbackRenderer = __createAppFallbackRenderer({
+  ${(metadataRoutes?.length ?? 0) > 0 ? "applyFileBasedMetadata: __applyFileBasedMetadata," : ""}
   basePath: __basePath,
   trailingSlash: __trailingSlash,
   rootBoundaries: {
@@ -562,6 +573,7 @@ async function buildPageElements(route, params, routePath, pageRequest, layoutPa
   // Hydrate lazy page/route-handler modules before any synchronous read.
   await __ensureRouteLoaded(route);
   return __buildPageElements({
+    ${(metadataRoutes?.length ?? 0) > 0 ? "applyFileBasedMetadata: __applyFileBasedMetadata," : ""}
     route,
     params,
     routePath,

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -13,6 +13,7 @@ import type { AppPageMiddlewareContext } from "./app-page-response.js";
 import type { AppPageSsrHandler } from "./app-page-stream.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
 import type { AppElements } from "./app-elements.js";
+import type { ApplyAppPageFileBasedMetadata } from "./app-page-head.js";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AppPageComponent = import("react").ComponentType<any>;
@@ -40,6 +41,7 @@ type AppFallbackRendererFontProviders = {
 };
 
 type AppFallbackRendererOptions<TModule extends AppPageModule = AppPageModule> = {
+  applyFileBasedMetadata?: ApplyAppPageFileBasedMetadata;
   clearRequestContext: () => void;
   createRscOnErrorHandler: (
     request: Request,
@@ -141,6 +143,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
   options: AppFallbackRendererOptions<TModule>,
 ): AppFallbackRenderer<TModule> {
   const {
+    applyFileBasedMetadata,
     basePath = "",
     clearRequestContext,
     createRscOnErrorHandler: buildRscOnErrorHandler,
@@ -220,6 +223,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
         const globalNotFoundComponent = globalNotFoundModule?.default ?? null;
         if (globalNotFoundComponent) {
           return renderAppPageHttpAccessFallback({
+            applyFileBasedMetadata,
             boundaryComponent: globalNotFoundComponent,
             boundaryModule: globalNotFoundModule ?? null,
             buildFontLinkHeader: fontProviders.buildFontLinkHeader,
@@ -256,6 +260,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       }
 
       return renderAppPageHttpAccessFallback({
+        applyFileBasedMetadata,
         basePath,
         trailingSlash,
         boundaryComponent: opts?.boundaryComponent ?? null,
@@ -324,6 +329,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       callContext,
     ) {
       return renderAppPageErrorBoundary({
+        applyFileBasedMetadata,
         basePath,
         trailingSlash,
         buildFontLinkHeader: fontProviders.buildFontLinkHeader,

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -9,7 +9,7 @@ import { isNavigationSignalError } from "../utils/navigation-signal.js";
 import { resolveAppPageSpecialError, type AppPageFontPreload } from "./app-page-execution.js";
 import type { AppPageMiddlewareContext } from "./app-page-response.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
-import { resolveAppPageHead } from "./app-page-head.js";
+import { resolveAppPageHead, type ApplyAppPageFileBasedMetadata } from "./app-page-head.js";
 import {
   renderAppPageBoundaryResponse,
   resolveAppPageErrorBoundary,
@@ -72,6 +72,7 @@ export type AppPageBoundaryRoute<TModule extends AppPageModule = AppPageModule> 
 };
 
 type AppPageBoundaryRenderCommonOptions<TModule extends AppPageModule = AppPageModule> = {
+  applyFileBasedMetadata?: ApplyAppPageFileBasedMetadata;
   buildFontLinkHeader: (preloads: readonly AppPageFontPreload[] | null | undefined) => string;
   clearRequestContext: () => void;
   createRscOnErrorHandler: (pathname: string, routePath: string) => AppPageBoundaryOnError;
@@ -351,6 +352,7 @@ export async function renderAppPageHttpAccessFallback<TModule extends AppPageMod
   const pathname = new URL(options.requestUrl).pathname;
   const routeSegments = resolveHttpAccessFallbackHeadRouteSegments(options.route, layoutModules);
   const { metadata, viewport } = await resolveAppPageHead({
+    applyFileBasedMetadata: options.applyFileBasedMetadata,
     basePath: options.basePath ?? "",
     layoutModules,
     layoutTreePositions: resolveHttpAccessFallbackHeadLayoutTreePositions(
@@ -435,6 +437,7 @@ export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(
   if (!errorBoundary.isGlobalError) {
     try {
       const { metadata, viewport } = await resolveAppPageHead({
+        applyFileBasedMetadata: options.applyFileBasedMetadata,
         basePath: options.basePath ?? "",
         fallbackOnFileMetadataError: true,
         layoutModules,

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -1,6 +1,10 @@
 import { createElement } from "react";
 import { makeThenableParams } from "vinext/shims/thenable-params";
-import { resolveActiveParallelRouteHeadInputs, resolveAppPageHead } from "./app-page-head.js";
+import {
+  resolveActiveParallelRouteHeadInputs,
+  resolveAppPageHead,
+  type ApplyAppPageFileBasedMetadata,
+} from "./app-page-head.js";
 import { SIBLING_PAGE_INTERCEPT_SLOT_KEY } from "./app-rsc-route-matching.js";
 import {
   buildAppPageElements,
@@ -73,6 +77,7 @@ export type BuildPageElementsOptions<
   TModule extends AppPageModule = AppPageModule,
   TErrorModule extends AppPageErrorModule = AppPageErrorModule,
 > = {
+  applyFileBasedMetadata?: ApplyAppPageFileBasedMetadata;
   route: AppPageBuildRoute<TModule, TErrorModule>;
   params: AppPageParams;
   routePath: string;
@@ -234,6 +239,7 @@ export async function buildPageElements<
     pageSearchParams,
     viewport: resolvedViewport,
   } = await resolveAppPageHead({
+    applyFileBasedMetadata: options.applyFileBasedMetadata,
     basePath: options.basePath ?? "",
     layoutModules: route.layouts,
     layoutTreePositions: route.layoutTreePositions,

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -40,6 +40,9 @@ export type AppPageSearchParams = Record<string, string | string[]>;
 
 type AppPageHeadModule = Record<string, unknown>;
 
+export type ApplyAppPageFileBasedMetadata =
+  typeof import("./file-based-metadata.js").applyFileBasedMetadata;
+
 type AppPageHeadSource = {
   metadata: Metadata | null;
   routeSegments: readonly string[];
@@ -76,6 +79,7 @@ type ResolveActiveParallelRouteHeadInputsOptions<
 };
 
 type ResolveAppPageHeadOptions<TModule extends AppPageHeadModule = AppPageHeadModule> = {
+  applyFileBasedMetadata?: ApplyAppPageFileBasedMetadata;
   /**
    * Configured next.config `basePath`. Threaded into `applyFileBasedMetadata`
    * so file-based metadata route URLs (icon, opengraph-image, manifest, ...)
@@ -439,10 +443,9 @@ async function resolveAppPageHeadInner<TModule extends AppPageHeadModule>(
   metadataSources.push(...parallelMetadataSources);
   let metadata = resolvedMetadataBase;
 
-  if (options.metadataRoutes.length > 0) {
+  if (options.applyFileBasedMetadata && options.metadataRoutes.length > 0) {
     try {
-      const { applyFileBasedMetadata } = await import("./file-based-metadata.js");
-      metadata = await applyFileBasedMetadata(
+      metadata = await options.applyFileBasedMetadata(
         resolvedMetadataBase,
         options.routePath,
         options.params,

--- a/tests/app-page-boundary-render.test.ts
+++ b/tests/app-page-boundary-render.test.ts
@@ -8,6 +8,7 @@ import {
 import type { AppElements } from "../packages/vinext/src/server/app-elements.js";
 import type { MetadataFileRoute } from "../packages/vinext/src/server/metadata-routes.js";
 import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { applyFileBasedMetadata } from "../packages/vinext/src/server/file-based-metadata.js";
 
 function createStreamFromMarkup(markup: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -47,6 +48,7 @@ function createCommonOptions() {
   }));
 
   return {
+    applyFileBasedMetadata,
     buildFontLinkHeader(preloads: readonly { href: string; type: string }[] | null | undefined) {
       if (!preloads || preloads.length === 0) {
         return "";

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -873,8 +873,11 @@ describe("App Router entry templates", () => {
       );
 
       expect(withoutMetadataRoutes).not.toContain("metadata-route-response.js");
+      expect(withoutMetadataRoutes).not.toContain("file-based-metadata.js");
       expect(withoutMetadataRoutes).not.toContain("handleMetadataRouteRequest(cleanPathname)");
       expect(withMetadataRoutes).toContain("metadata-route-response.js");
+      expect(withMetadataRoutes).toContain("file-based-metadata.js");
+      expect(withMetadataRoutes).toContain("applyFileBasedMetadata: __applyFileBasedMetadata");
       expect(withMetadataRoutes).toContain("handleMetadataRouteRequest(cleanPathname)");
       expect(withMetadataRoutes).toContain("await __loadMetadataRouteResponse()");
     } finally {


### PR DESCRIPTION
File-based metadata resolution is now injected into the App Router runtime only when the route scan finds metadata files. Apps without file-based metadata omit that runtime while module `metadata` and `generateMetadata` behavior remains unchanged. Focused boundary, entry-template, and metadata-route tests pass alongside targeted checks, knip, and the vinext package build.