### PR TITLE
perf(link): omit Pages runtime in app-only builds

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1407,6 +1407,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
         // Expose basePath to client-side code
         defines["process.env.__NEXT_ROUTER_BASEPATH"] = JSON.stringify(nextConfig.basePath);
+        // Let shared client shims compile out Pages-only behavior in pure App
+        // Router builds while retaining it for Pages and hybrid applications.
+        defines["process.env.__VINEXT_HAS_PAGES_ROUTER"] = JSON.stringify(String(hasPagesDir));
         // Expose experimental.staleTimes.static to client-side code so the
         // App Router prefetch cache can honor the configured freshness window.
         // Value is in seconds; matches Next.js' `define-env.ts` plumbing.

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -226,6 +226,15 @@ function resolvePagesLinkNavigationHref(href: string, locale: string | false | u
   );
 }
 
+function applyPagesNavigationFallback(href: string, replace: boolean): void {
+  if (replace) {
+    window.history.replaceState({}, "", href);
+  } else {
+    window.history.pushState({}, "", href);
+  }
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
 /**
  * Collapse repeated forward-slashes (and convert backslashes to forward-slashes)
  * in the path portion of a URL, preserving any query string.
@@ -1055,7 +1064,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         ? pagesNavigateHref
         : undefined;
     const pagesHrefForLink = pagesAsForLink === undefined ? pagesNavigateHref : routeHrefRaw;
-    // Resolve relative hrefs (#hash, ?query) for onNavigate and the hard-navigation fallback.
+    // Resolve relative hrefs (#hash, ?query) for onNavigate and the navigation fallback.
     // Pages query-only links must use the rewrite-aware target resolved above,
     // so callbacks and router-error fallback agree with the actual navigation.
     const absoluteFullHref = toBrowserNavigationHref(
@@ -1151,14 +1160,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
           locale,
           interpolateDynamicRoute: resolvedHref.startsWith("?"),
         },
-        fallback: () => {
-          if (replace) {
-            window.history.replaceState({}, "", absoluteFullHref);
-          } else {
-            window.history.pushState({}, "", absoluteFullHref);
-          }
-          window.dispatchEvent(new PopStateEvent("popstate"));
-        },
+        fallback: () => applyPagesNavigationFallback(absoluteFullHref, replace),
       });
     } else if (replace) {
       window.location.replace(absoluteFullHref);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -92,6 +92,8 @@ type NavigateEvent = {
   defaultPrevented: boolean;
 };
 
+const HAS_PAGES_ROUTER = process.env.__VINEXT_HAS_PAGES_ROUTER !== "false";
+
 type LinkProps = {
   href: string | { pathname?: string; query?: UrlQuery };
   /** URL displayed in the browser (when href is a route pattern like /user/[id]) */
@@ -198,6 +200,7 @@ function resolveHref(href: LinkProps["href"]): string {
 }
 
 function resolvePagesQueryOnlyHref(href: string): string {
+  if (!HAS_PAGES_ROUTER) return href;
   if (!href.startsWith("?") || typeof window === "undefined") return href;
 
   const pagesRouter = window.next?.appDir === true ? undefined : window.next?.router;
@@ -529,7 +532,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
           },
         );
-      } else if (window.__NEXT_DATA__) {
+      } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {
         // Pages Router prefetch. When a code-split loader is registered for
         // the target route (prod builds expose them on window via the
         // generated client entry), prefetch the data JSON + warm the page
@@ -838,7 +841,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // computes `resolvedAs` for the dynamic-route branch (packages/next/src/
   // shared/lib/router/router.ts around L987).
   const rawResolvedHref = as ?? resolveHref(href);
-  const concreteRouteHref = resolveConcreteRouteHref(href, as);
+  const concreteRouteHref = HAS_PAGES_ROUTER ? resolveConcreteRouteHref(href, as) : null;
   const routeHrefRaw = concreteRouteHref ?? (typeof href === "string" ? href : resolveHref(href));
 
   // Mirror Next.js: emit a console.error when the href contains repeated
@@ -1034,9 +1037,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     e.preventDefault();
 
     const hasAppNavigationRuntime = Boolean(getNavigationRuntime()?.functions.navigate);
-    const pagesNavigateHref = resolvedHref.startsWith("?")
-      ? resolvePagesLinkNavigationHref(resolvedHref, locale)
-      : navigateHref;
+    const pagesNavigateHref =
+      HAS_PAGES_ROUTER && resolvedHref.startsWith("?")
+        ? resolvePagesLinkNavigationHref(resolvedHref, locale)
+        : navigateHref;
     // When the Link author passed both `href` (route pattern) AND `as` (mask),
     // forward the original route-pattern href to Pages Router as the `url`
     // argument. The router uses `url` to fetch the page module / data, while
@@ -1044,7 +1048,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // semantics. When no mask is present, leave `pagesAsForLink` undefined so
     // existing single-arg navigation (the dominant code path) is unaffected.
     const pagesAsForLink =
-      typeof as === "string" && typeof routeHrefRaw === "string" && as !== routeHrefRaw
+      HAS_PAGES_ROUTER &&
+      typeof as === "string" &&
+      typeof routeHrefRaw === "string" &&
+      as !== routeHrefRaw
         ? pagesNavigateHref
         : undefined;
     const pagesHrefForLink = pagesAsForLink === undefined ? pagesNavigateHref : routeHrefRaw;
@@ -1095,6 +1102,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // (`setPending`, `setLinkForCurrentNavigation`) would be a no-op at best
     // and a stale `useLinkStatus` indicator at worst.
     if (
+      HAS_PAGES_ROUTER &&
       hasAppNavigationRuntime &&
       ["pages", "document"].includes(resolveHybridClientRouteOwner(navigateHref, __basePath) ?? "")
     ) {
@@ -1124,7 +1132,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         );
       });
       return;
-    } else {
+    } else if (HAS_PAGES_ROUTER) {
       // Next.js only consumes onRouterTransitionStart in the App Router.
       // Pages Router still executes instrumentation-client side effects
       // during startup, but it does not invoke the named export on navigation.
@@ -1152,6 +1160,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
           window.dispatchEvent(new PopStateEvent("popstate"));
         },
       });
+    } else if (replace) {
+      window.location.replace(absoluteFullHref);
+    } else {
+      window.location.assign(absoluteFullHref);
     }
   };
 

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -200,6 +200,7 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(result.optimizeDeps?.exclude).toContain("@lingui/macro");
       // No duplicates
       expect(new Set(result.optimizeDeps.exclude).size).toBe(result.optimizeDeps.exclude.length);
+      expect(result.define?.["process.env.__VINEXT_HAS_PAGES_ROUTER"]).toBe('"true"');
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
@@ -318,6 +319,7 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(result.environments.rsc.optimizeDeps?.exclude).toContain("vinext");
       expect(result.environments.ssr.optimizeDeps?.exclude).toContain("vinext");
       expect(result.environments.client.optimizeDeps?.exclude).toContain("vinext");
+      expect(result.define?.["process.env.__VINEXT_HAS_PAGES_ROUTER"]).toBe('"false"');
       for (const shimExclude of rscClientShimExcludes) {
         expect(result.optimizeDeps?.exclude).toContain(shimExclude);
         expect(result.environments.rsc.optimizeDeps?.exclude).toContain(shimExclude);

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -383,6 +383,85 @@ afterEach(() => {
 });
 
 describe("Link App Router navigation scheduling", () => {
+  it.each([
+    { locationMethod: "assign" as const, replace: false },
+    { locationMethod: "replace" as const, replace: true },
+  ])(
+    "uses document navigation in App-only builds when replace=$replace",
+    async ({ replace, locationMethod }) => {
+      const previousHasPagesRouter = process.env.__VINEXT_HAS_PAGES_ROUTER;
+      process.env.__VINEXT_HAS_PAGES_ROUTER = "false";
+      vi.resetModules();
+
+      try {
+        let capturedAnchorProps: CapturedAnchorProps | undefined;
+        mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE({
+          captureAnchor(type, props) {
+            if (type === "a" && props !== null && typeof props === "object") {
+              capturedAnchorProps = props;
+            }
+          },
+        });
+
+        const pushState = vi.fn();
+        const replaceState = vi.fn();
+        const dispatchEvent = vi.fn();
+        const locationAssign = vi.fn();
+        const locationReplace = vi.fn();
+        vi.stubGlobal("window", {
+          addEventListener: vi.fn(),
+          dispatchEvent,
+          history: { pushState, replaceState },
+          location: {
+            assign: locationAssign,
+            href: "https://example.com/current",
+            origin: "https://example.com",
+            replace: locationReplace,
+          },
+          scrollTo: vi.fn(),
+        });
+
+        const { default: IsolatedLink } = await import("../packages/vinext/src/shims/link.js");
+        const React = await vi.importActual<typeof import("react")>("react");
+        ReactDOMServer.renderToString(
+          React.createElement(
+            IsolatedLink,
+            { href: "/target", prefetch: false, replace },
+            "target",
+          ),
+        );
+
+        const onClick = capturedAnchorProps?.onClick;
+        if (onClick === undefined) {
+          throw new Error("Expected rendered Link anchor to expose an onClick handler");
+        }
+        const clickEvent = {
+          button: 0,
+          currentTarget: { hasAttribute: () => false, target: "" },
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+        };
+        await onClick(clickEvent);
+
+        expect(clickEvent.defaultPrevented).toBe(true);
+        expect(
+          { assign: locationAssign, replace: locationReplace }[locationMethod],
+        ).toHaveBeenCalledWith("/target");
+        expect(pushState).not.toHaveBeenCalled();
+        expect(replaceState).not.toHaveBeenCalled();
+        expect(dispatchEvent).not.toHaveBeenCalled();
+      } finally {
+        if (previousHasPagesRouter === undefined) {
+          delete process.env.__VINEXT_HAS_PAGES_ROUTER;
+        } else {
+          process.env.__VINEXT_HAS_PAGES_ROUTER = previousHasPagesRouter;
+        }
+      }
+    },
+  );
+
   it("clicking an RSC Link starts app-router navigation inside a React transition", async () => {
     vi.resetModules();
 


### PR DESCRIPTION
Pure App Router builds now compile Pages-only navigation, prefetching, interpolation, and hybrid route ownership logic out of `next/link`. Pages Router and hybrid applications retain the existing behavior. If the App navigation runtime is unavailable, App-only links use document navigation so the destination still renders without relying on a missing client runtime.