### PR TITLE
perf(app-router): skip speculative page probes for HTML renders

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -731,7 +731,7 @@ export default createAppRscHandler({
       ensureRouteLoaded: __ensureRouteLoaded,
       clientTraceMetadata: __clientTraceMetadata,
       reactMaxHeadersLength: __reactMaxHeadersLength,
-      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams, layoutParamAccess) {
+      buildPageElement(targetRoute, targetParams, targetOpts, targetSearchParams, layoutParamAccess, buildOptions) {
         return buildPageElements(targetRoute, targetParams, cleanPathname, {
           opts: targetOpts,
           searchParams: targetSearchParams,
@@ -739,6 +739,7 @@ export default createAppRscHandler({
           request,
           mountedSlotsHeader,
           renderMode,
+          observePageSearchParamsAccess: buildOptions?.observePageSearchParamsAccess === true,
         }, layoutParamAccess, displayPathname);
       },
       clientReuseManifest,

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -2,6 +2,7 @@ import type { CachedAppPageValue } from "vinext/shims/cache";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import { applyCdnResponseHeaders } from "./cache-control.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
+import { NEXTJS_CACHE_HEADER, VINEXT_CACHE_HEADER } from "./headers.js";
 import {
   createEmptyAppPageRenderObservationState,
   type AppPageRenderObservationState,
@@ -48,6 +49,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
+  omitPendingDynamicCacheState?: boolean;
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
@@ -75,9 +77,18 @@ type ScheduleAppPageRscCacheWriteOptions = {
   waitUntil?: (promise: Promise<void>) => void;
 };
 
-function applyPendingDynamicCdnHeaders(headers: Headers, tags?: readonly string[]): void {
+function applyPendingDynamicCdnHeaders(
+  headers: Headers,
+  tags?: readonly string[],
+  options: { omitCacheState?: boolean } = {},
+): void {
   const cacheable = headers.get("Cache-Control") ?? "";
   applyCdnResponseHeaders(headers, { cacheControl: cacheable, pendingDynamicCheck: true, tags });
+  if (options.omitCacheState === true) {
+    headers.delete(VINEXT_CACHE_HEADER);
+    headers.delete(NEXTJS_CACHE_HEADER);
+    return;
+  }
   setCacheStateHeaders(headers, "MISS");
 }
 
@@ -125,7 +136,9 @@ export function finalizeAppPageHtmlCacheResponse(
   );
   const clientHeaders = new Headers(response.headers);
   if (options.preserveClientResponseHeaders !== true) {
-    applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags());
+    applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags(), {
+      omitCacheState: options.omitPendingDynamicCacheState === true,
+    });
   }
 
   const cachePromise = (async () => {

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -230,6 +230,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
     opts: AppPageDispatchInterceptOptions | undefined,
     searchParams: URLSearchParams,
     layoutParamAccess?: AppLayoutParamAccessTracker,
+    options?: { observePageSearchParamsAccess?: boolean },
   ) => Promise<AppPageElement>;
   clientReuseManifest?: ClientReuseManifestParseResult;
   cleanPathname: string;
@@ -529,7 +530,13 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const isDynamicError = dynamicConfig === "error";
   const isForceDynamic = dynamicConfig === "force-dynamic";
   const isDraftMode = isDraftModeRequest(options.request, options.draftModeSecret);
+  const hasRequestSearchParams = !isForceStatic && hasSearchParams(options.searchParams);
   const layoutParamAccess = createAppLayoutParamAccessTracker();
+  const hasActiveLoadingBoundary = shouldSuppressLoadingBoundaries(
+    options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
+  )
+    ? false
+    : Boolean(route.loading?.default);
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
   setCurrentFetchCacheMode(options.fetchCache ?? null);
@@ -591,7 +598,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     const cachedPageResponse = await readAppPageCacheResponse({
       cleanPathname: options.cleanPathname,
       clearRequestContext: options.clearRequestContext,
-      hasRequestSearchParams: !isForceStatic && hasSearchParams(options.searchParams),
+      hasRequestSearchParams,
       isEdgeRuntime: options.isEdgeRuntime,
       isRscRequest: options.isRscRequest,
       isrDebug: options.isrDebug,
@@ -834,6 +841,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
           interceptResult.interceptOpts,
           options.searchParams,
           layoutParamAccess,
+          {
+            observePageSearchParamsAccess: !options.isRscRequest && hasRequestSearchParams,
+          },
         );
       },
       async probePageSpecialError() {
@@ -879,6 +889,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   if (pageBuildResult.response) {
     return pageBuildResult.response;
   }
+
   const navigationParams = resolveAppPageNavigationParams(
     route,
     options.params,
@@ -928,11 +939,8 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       return _peekRequestScopedCacheLife();
     },
     handlerStart: options.handlerStart,
-    hasLoadingBoundary: shouldSuppressLoadingBoundaries(
-      options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
-    )
-      ? false
-      : Boolean(route.loading?.default),
+    hasLoadingBoundary: hasActiveLoadingBoundary,
+    omitPendingDynamicCacheState: !options.isRscRequest && hasRequestSearchParams,
     formState: options.formState ?? null,
     isProgressiveActionRender: options.isProgressiveActionRender === true,
     isDynamicError,
@@ -975,6 +983,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     probePage() {
       return options.probePage();
     },
+    probePageBeforeRender: options.isRscRequest,
     classification: {
       getLayoutId(index) {
         const treePosition = route.layoutTreePositions?.[index] ?? 0;

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -71,6 +71,8 @@ export type AppPagePageRequest<TModule extends AppPageModule = AppPageModule> = 
   mountedSlotsHeader: string | null;
   /** Semantic RSC payload mode for this page render. */
   renderMode?: AppRscRenderMode;
+  /** Observe page `searchParams` access for cache-safety classification. */
+  observePageSearchParamsAccess?: boolean;
 };
 
 export type BuildPageElementsOptions<
@@ -165,6 +167,7 @@ export async function buildPageElements<
     isRscRequest,
     mountedSlotsHeader,
     renderMode = APP_RSC_RENDER_MODE_NAVIGATION,
+    observePageSearchParamsAccess = false,
   } = pageRequest;
 
   const pageModule: AppPageModule | null | undefined = route.page;
@@ -264,7 +267,8 @@ export async function buildPageElements<
   let pageSearchParamsThenable: unknown;
   if (searchParams) {
     const shouldObservePageSearchParamsAccess =
-      !shouldSuppressLoadingBoundaries(renderMode) && Boolean(route.loading?.default);
+      observePageSearchParamsAccess ||
+      (!shouldSuppressLoadingBoundaries(renderMode) && Boolean(route.loading?.default));
     pageSearchParamsThenable = shouldObservePageSearchParamsAccess
       ? makeObservedAppPageSearchParamsThenable(pageSearchParams)
       : makeThenableParams(pageSearchParams);

--- a/packages/vinext/src/server/app-page-probe.ts
+++ b/packages/vinext/src/server/app-page-probe.ts
@@ -395,6 +395,7 @@ type ProbeAppPageBeforeRenderResult = {
 
 type ProbeAppPageBeforeRenderOptions = {
   hasLoadingBoundary: boolean;
+  probePageBeforeRender?: boolean;
   skipProbes?: boolean;
   layoutCount: number;
   probeLayoutAt: (layoutIndex: number) => unknown;
@@ -457,7 +458,7 @@ export async function probeAppPageBeforeRender(
   // onError callback, and a short race window after shell-ready lets the
   // lifecycle swap the response to a 307/404 before bytes are flushed.
   // This mirrors Next.js's "until-first-byte-is-flushed" swap behavior.
-  if (options.hasLoadingBoundary) {
+  if (options.hasLoadingBoundary || options.probePageBeforeRender === false) {
     return { response: null, layoutFlags };
   }
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -142,6 +142,8 @@ type RenderAppPageLifecycleOptions = {
   isProgressiveActionRender?: boolean;
   isPrerender?: boolean;
   isProduction: boolean;
+  probePageBeforeRender?: boolean;
+  omitPendingDynamicCacheState?: boolean;
   isRscRequest: boolean;
   isrDebug?: AppPageDebugLogger;
   isrHtmlKey: (pathname: string) => string;
@@ -583,8 +585,10 @@ function wrapRscResponseForDevErrorReporting(
 export async function renderAppPageLifecycle(
   options: RenderAppPageLifecycleOptions,
 ): Promise<Response> {
+  const probePageBeforeRender = options.probePageBeforeRender ?? options.isRscRequest;
   const preRenderResult = await probeAppPageBeforeRender({
     hasLoadingBoundary: options.hasLoadingBoundary,
+    probePageBeforeRender,
     skipProbes: options.pprFallbackShellSignal !== undefined,
     layoutCount: options.layoutCount,
     probeLayoutAt(layoutIndex) {
@@ -913,19 +917,18 @@ export async function renderAppPageLifecycle(
     await htmlRender.metadataReady;
   }
 
-  // Routes with a route-level Suspense boundary (loading.tsx) skip the page
-  // probe — the page render happens once, inside the RSC stream. Mirror
-  // Next.js's `app-render.tsx:4293` catch shape: by the time the SSR shell
-  // promise has resolved, any redirect()/notFound() throw whose async work
-  // settles in microtasks during shell rendering has already fired through
-  // React's onError and been captured by the tracker. Convert that to a
-  // 307/404 before any bytes are flushed.
+  // Routes that skip the page probe render the page once, inside the RSC
+  // stream. Mirror Next.js's `app-render.tsx:4293` catch shape: by the time
+  // the SSR shell promise has resolved, any redirect()/notFound() throw whose
+  // async work settles in microtasks during shell rendering has already fired
+  // through React's onError and been captured by the tracker. Convert that to
+  // a 307/404 before any bytes are flushed.
   //
   // Late rejections — ones that settle after macrotask boundaries (real
   // I/O, setTimeout, etc.) — fall through to the streamed body, exactly
   // as Next.js does. The digest survives in the Flight payload for the
   // client router to consume.
-  if (options.hasLoadingBoundary) {
+  if (options.hasLoadingBoundary || !probePageBeforeRender) {
     const captured = rscErrorTracker.getCapturedSpecialError();
     if (captured) {
       const specialError = resolveAppPageSpecialError(captured);
@@ -945,8 +948,9 @@ export async function renderAppPageLifecycle(
       revalidateSeconds,
     }));
   }
+  let dynamicUsedDuringRender = options.consumeDynamicUsage();
+
   const draftCookie = options.getDraftModeCookieHeader();
-  const dynamicUsedDuringRender = options.consumeDynamicUsage();
   let dynamicUsedBeforeContextCleanup = dynamicUsedDuringRender;
 
   // Defer clearRequestContext() until the HTML stream is fully consumed by the
@@ -1064,6 +1068,7 @@ export async function renderAppPageLifecycle(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       interceptionContext: options.interceptionContext,
+      omitPendingDynamicCacheState: options.omitPendingDynamicCacheState,
       preserveClientResponseHeaders: !htmlResponsePolicy.shouldWriteToCache,
       expireSeconds,
       revalidateSeconds,

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -558,7 +558,7 @@ function createLayoutParamProbe(
 }
 
 describe("app page dispatch", () => {
-  it("does not reuse a speculative connection() page probe", async () => {
+  it("does not run a speculative connection() page probe for HTML renders", async () => {
     const probePage = vi.fn(async () => {
       await connection();
     });
@@ -572,7 +572,7 @@ describe("app page dispatch", () => {
     ]);
 
     expect(response.status).toBe(200);
-    expect(probePage).toHaveBeenCalledTimes(1);
+    expect(probePage).not.toHaveBeenCalled();
     await expect(response.text()).resolves.toBe("<html>page</html>");
   });
 
@@ -612,14 +612,23 @@ describe("app page dispatch", () => {
     const isrGet = vi.fn(async () =>
       buildISRCacheEntry(buildCachedAppPageValue("<html>cached empty query</html>")),
     );
+    const probePage = vi.fn(() => null);
     const { options } = createDispatchOptions({
       isProduction: true,
       isrGet,
-      probePage() {
-        markDynamicUsage();
-        markRenderRequestApiUsage("searchParams");
-        return null;
-      },
+      loadSsrHandler: async () => ({
+        async handleSsr() {
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              markDynamicUsage();
+              markRenderRequestApiUsage("searchParams");
+              controller.enqueue(new TextEncoder().encode("<html>page</html>"));
+              controller.close();
+            },
+          });
+        },
+      }),
+      probePage,
       revalidateSeconds: 60,
       searchParams: new URLSearchParams("search=hello"),
     });
@@ -627,9 +636,50 @@ describe("app page dispatch", () => {
     const response = await dispatchAppPage(options);
 
     expect(isrGet).toHaveBeenCalled();
+    expect(probePage).not.toHaveBeenCalled();
     expect(response.headers.get("x-vinext-cache")).toBeNull();
     expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
     await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
+  it("caches fresh query-bearing HTML when the page probe does not read searchParams", async () => {
+    const probePage = vi.fn(() => null);
+    const isrSet = vi.fn<DispatchOptions["isrSet"]>(async () => {});
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil(promise) {
+        waitUntilPromises.push(promise);
+      },
+    } satisfies ExecutionContextLike;
+    const { options } = createDispatchOptions({
+      isProduction: true,
+      isrSet,
+      probePage,
+      revalidateSeconds: 60,
+      searchParams: new URLSearchParams("utm_source=google"),
+    });
+
+    const response = await runWithExecutionContext(executionContext, () =>
+      dispatchAppPage(options),
+    );
+
+    expect(probePage).not.toHaveBeenCalled();
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    await Promise.all(waitUntilPromises.splice(0));
+    expect(isrSet).toHaveBeenCalledTimes(1);
+    const [cacheKey, cacheValue, revalidateSeconds, tags, expireSeconds] = isrSet.mock.calls[0]!;
+    expect(cacheKey).toBe("html:/posts/hello");
+    expect(cacheValue).toMatchObject({
+      kind: "APP_PAGE",
+      renderObservation: {
+        requestApis: expect.arrayContaining([{ kind: "searchParams", status: "notObserved" }]),
+      },
+    });
+    expect(revalidateSeconds).toBe(60);
+    expect(tags).toEqual(expect.arrayContaining(["_N_T_/posts/hello"]));
+    expect(expireSeconds).toBeUndefined();
   });
 
   it("serves cached production HTML when searchParams is only mentioned but not accessed", async () => {
@@ -1750,7 +1800,7 @@ describe("app page dispatch", () => {
 
     expect(isrGet.mock.calls.map(([key]) => key)).toEqual(["html:/en/blog/new-post"]);
     expect(isrGet).not.toHaveBeenCalledWith("html:/en/blog/[slug]");
-    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
     await expect(response.text()).resolves.toContain("fresh render");
     expect(buildPageElement).toHaveBeenCalled();
   });

--- a/tests/app-page-probe.test.ts
+++ b/tests/app-page-probe.test.ts
@@ -518,6 +518,37 @@ describe("app page probe helpers", () => {
     expect(renderPageSpecialError).not.toHaveBeenCalled();
     expect(result.response).toBeNull();
   });
+
+  it("skips the page probe when disabled for document rendering", async () => {
+    const probePage = vi.fn(() => {
+      throw new Error("page probe should not execute");
+    });
+    const renderPageSpecialError = vi.fn();
+
+    const result = await probeAppPageBeforeRender({
+      hasLoadingBoundary: false,
+      probePageBeforeRender: false,
+      layoutCount: 0,
+      probeLayoutAt() {
+        throw new Error("should not probe layouts");
+      },
+      probePage,
+      renderLayoutSpecialError() {
+        throw new Error("should not render a layout special error");
+      },
+      renderPageSpecialError,
+      resolveSpecialError() {
+        throw new Error("should not be reached when the page probe is skipped");
+      },
+      runWithSuppressedHookWarning(probe) {
+        return probe();
+      },
+    });
+
+    expect(probePage).not.toHaveBeenCalled();
+    expect(renderPageSpecialError).not.toHaveBeenCalled();
+    expect(result.response).toBeNull();
+  });
 });
 
 // Regression coverage for https://github.com/cloudflare/vinext/issues/1235.

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -410,6 +410,7 @@ describe("app page render lifecycle", () => {
 
     const response = await renderAppPageLifecycle({
       ...common.options,
+      isRscRequest: true,
       probePage() {
         throw { digest: "NEXT_NOT_FOUND" };
       },
@@ -419,6 +420,105 @@ describe("app page render lifecycle", () => {
     await expect(response.text()).resolves.toBe("page:404");
     expect(common.renderToReadableStream).not.toHaveBeenCalled();
     expect(common.renderPageSpecialError).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run the page probe before normal HTML rendering", async () => {
+    const common = createCommonOptions();
+    const probePage = vi.fn(() => {
+      throw new Error("page probe should not execute for HTML");
+    });
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isRscRequest: false,
+      probePage,
+    });
+
+    expect(probePage).not.toHaveBeenCalled();
+    expect(common.renderToReadableStream).toHaveBeenCalledTimes(1);
+    expect(common.renderPageSpecialError).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
+  it("streams lazy HTML while pending dynamic usage determines the cache write", async () => {
+    const common = createCommonOptions();
+    const streamGate = createDeferred();
+    let dynamicUsed = false;
+
+    const responsePromise = renderAppPageLifecycle({
+      ...common.options,
+      omitPendingDynamicCacheState: true,
+      consumeDynamicUsage() {
+        const value = dynamicUsed;
+        dynamicUsed = false;
+        return value;
+      },
+      isProduction: true,
+      loadSsrHandler: async () => ({
+        async handleSsr() {
+          return new ReadableStream<Uint8Array>({
+            async pull(controller) {
+              await streamGate.promise;
+              dynamicUsed = true;
+              controller.enqueue(new TextEncoder().encode("<html>dynamic</html>"));
+              controller.close();
+            },
+          });
+        },
+      }),
+      revalidateSeconds: 60,
+    });
+
+    const timeout = Symbol("timeout");
+    const response = await Promise.race([
+      responsePromise,
+      new Promise<typeof timeout>((resolve) => setTimeout(() => resolve(timeout), 50)),
+    ]);
+    expect(response).not.toBe(timeout);
+    expect(response).toBeInstanceOf(Response);
+    if (!(response instanceof Response)) {
+      throw new Error("Expected renderAppPageLifecycle to return a Response before stream pull");
+    }
+
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    streamGate.resolve();
+    await expect(response.text()).resolves.toBe("<html>dynamic</html>");
+    await Promise.all(common.waitUntilPromises.splice(0));
+    expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
+  it("recovers HTML page special errors from the real render when the page probe is skipped", async () => {
+    const common = createCommonOptions();
+    const notFoundError = Object.assign(new Error("NEXT_NOT_FOUND"), { digest: "NEXT_NOT_FOUND" });
+    let capturedOnError: ((error: unknown, ...args: unknown[]) => void) | null = null;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      hasLoadingBoundary: false,
+      isRscRequest: false,
+      loadSsrHandler: async () => ({
+        async handleSsr() {
+          capturedOnError?.(notFoundError, null, null);
+          return createStream(["<html>fallback</html>"]);
+        },
+      }),
+      probePage() {
+        throw new Error("page probe should not execute for HTML");
+      },
+      renderToReadableStream(_element, opts) {
+        capturedOnError = opts.onError;
+        return createStream(["flight-data"]);
+      },
+    });
+
+    expect(response.status).toBe(404);
+    expect(common.renderPageSpecialError).toHaveBeenCalledTimes(1);
+    expect(common.renderPageSpecialError).toHaveBeenCalledWith({
+      kind: "http-access-fallback",
+      statusCode: 404,
+    });
   });
 
   it("returns RSC responses and schedules an ISR cache write through waitUntil", async () => {


### PR DESCRIPTION
## Summary

This builds on the request-scoped fetch dedupe work from #1134. That change prevents identical render fetches from hitting the network twice, but HTML document requests can still pay duplicate userland work because `renderAppPageLifecycle()` invokes the App Router page probe before the real RSC render.

For data-heavy App Router pages, the probe can execute the page/server-component code path once, then the real RSC render executes it again. Hydrogen exposed this as extra Storefront GraphQL client work even when fetch dedupe is active.

This PR keeps layout probing/classification intact, but skips the speculative page probe for HTML document renders. Page-level `redirect()` / `notFound()` recovery now uses the existing RSC error tracker path after the real render starts, before HTML bytes flush. RSC requests keep the existing eager page-probe behavior.

For fresh query-bearing HTML renders, dispatch now asks the real page element to observe `searchParams` access and waits for the lazy HTML stream before finalizing the cache policy. That preserves cache safety when the page actually reads `searchParams`, without treating every `?utm_source=...` request as dynamic when the page never uses the query.

## What changed

- Added a `probePageBeforeRender` switch to `probeAppPageBeforeRender()` and disabled page probing for HTML document renders.
- Extended captured special-error recovery so skipped-probe HTML renders can still produce 307/404 responses before flush.
- Added an explicit page-element-builder flag for observing real page `searchParams` access during query-bearing HTML cache classification.
- Added a render-lifecycle option to buffer query-bearing HTML until lazy dynamic usage is known, then recreate the response stream.
- Updated dispatch/render/probe tests so duplicate execution, query-invariant caching, and actual `searchParams` usage are covered separately.

## Why

`#1134` fixed duplicate network fetches, but it does not remove duplicated page/userland execution. This PR targets that remaining layer: avoid running arbitrary page code once in the probe phase and again in the real render for a single HTML request.

Alex also pointed out that simply marking all query-bearing HTML dynamic would regress ISR for common tracking URLs. The revised approach avoids that: a fresh `/products?utm_source=google` render can populate ISR if the page does not read `searchParams`, while `/products?filter=alpha` remains dynamic when the page actually reads the query.

## Quick benchmark

Temporary local benchmark: 40 HTML render lifecycles, each with an 8ms synthetic `probePage()` cost.

- `origin/main`: `probeCalls=40`, `durationMs=423`
- this branch: `probeCalls=0`, `durationMs=19`

The benchmark models framework probe overhead directly; it does not depend on Hydrogen or Shopify.

## Validation

- `./node_modules/.bin/vp check`
  - format, lint, and type checks passed
- `./node_modules/.bin/vp test run tests/app-page-dispatch.test.ts tests/app-page-render.test.ts tests/app-page-probe.test.ts tests/app-page-element-builder.test.ts tests/entry-templates.test.ts`
  - 5 files passed, 176 tests passed
- `./node_modules/.bin/vp test run tests/app-router-production-server.test.ts -t "page ISR + searchParams"`
  - 2 tests passed, including the previous CI failure path