### PR TITLE
fix(image): align Next.js image parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ These are intentional exclusions. For things that are missing today but on the r
 
 These are gaps we'd like to close — distinct from the [intentional exclusions](#whats-not-supported-and-wont-be) above.
 
-- **Image optimization doesn't happen at build time.** Remote images work via `@unpic/react` (auto-detects 28 CDN providers). Local images are routed through a `/_next/image` endpoint that can resize and transcode on Cloudflare Workers (via the Images binding) in production, but no build-time optimization or static resizing occurs.
+- **Image optimization doesn't happen at build time.** Local, public, and static images are routed through a `/_next/image` endpoint that can resize and transcode on Cloudflare Workers (via the Images binding) in production. Configured remote images are optimized by Node runtimes, but Worker deployments redirect them to the original unoptimized URL because Workers cannot bind DNS validation to the outbound fetch safely. As in Next.js, `remotePatterns` validates the initial source URL; redirects from an allowed source are not re-matched against those patterns.
 - **Google Fonts are loaded from the CDN, not self-hosted.** No `size-adjust` fallback font metrics. Local fonts work but `@font-face` CSS is injected at runtime, not extracted at build time.
 - **Route segment config** — `runtime` and `preferredRegion` are ignored (everything runs in the same environment).
 - **Node.js production server (`vinext start`)** works for testing but is less complete than Workers deployment. Cloudflare Workers is the primary target.

--- a/README.md
+++ b/README.md
@@ -417,29 +417,29 @@ These are deployed to Cloudflare Workers and updated on every push to `main`:
 
 Every `next/*` import is shimmed to a Vite-compatible implementation.
 
-| Module              |     | Notes                                                                                                                                  |
-| ------------------- | --- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `next/link`         | ✅  | All props including `prefetch` (IntersectionObserver), `onNavigate`, scroll restoration, `basePath`, `locale`                          |
-| `next/image`        | 🟡  | Remote images via [@unpic/react](https://unpic.pics) (28 CDNs). Local images via `<img>` + srcSet. No build-time optimization/resizing |
-| `next/head`         | ✅  | SSR collection + client-side DOM manipulation                                                                                          |
-| `next/router`       | ✅  | `useRouter`, `Router` singleton, events, client-side navigation, SSR context, i18n                                                     |
-| `next/navigation`   | ✅  | `usePathname`, `useSearchParams`, `useParams`, `useRouter`, `redirect`, `notFound`, `forbidden`, `unauthorized`                        |
-| `next/server`       | ✅  | `NextRequest`, `NextResponse`, `NextURL`, cookies, `userAgent`, `after`, `connection`, `URLPattern`                                    |
-| `next/headers`      | ✅  | Async `headers()`, `cookies()`, `draftMode()`                                                                                          |
-| `next/dynamic`      | ✅  | `ssr: true`, `ssr: false`, `loading` component                                                                                         |
-| `next/script`       | ✅  | All 4 strategies (`beforeInteractive`, `afterInteractive`, `lazyOnload`, `worker`)                                                     |
-| `next/font/google`  | 🟡  | Runtime CDN loading. No self-hosting, font subsetting, or fallback metrics                                                             |
-| `next/font/local`   | 🟡  | Runtime `@font-face` injection. Not extracted at build time                                                                            |
-| `next/og`           | ✅  | OG image generation via `@vercel/og` (Satori + resvg)                                                                                  |
-| `next/cache`        | ✅  | `revalidateTag`, `revalidatePath`, `unstable_cache`, pluggable `CacheHandler`, `"use cache"` with `cacheLife()` and `cacheTag()`       |
-| `next/form`         | ✅  | GET form interception + POST server action delegation                                                                                  |
-| `next/legacy/image` | ✅  | Translates legacy props to modern Image                                                                                                |
-| `next/error`        | ✅  | Default error page component                                                                                                           |
-| `next/config`       | ✅  | `getConfig` / `setConfig`                                                                                                              |
-| `next/document`     | ✅  | `Html`, `Head`, `Main`, `NextScript`                                                                                                   |
-| `next/constants`    | ✅  | All phase constants                                                                                                                    |
-| `next/amp`          | ⬜  | No-op (AMP is deprecated)                                                                                                              |
-| `next/web-vitals`   | ⬜  | No-op (use the `web-vitals` library directly)                                                                                          |
+| Module              |     | Notes                                                                                                                            |
+| ------------------- | --- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `next/link`         | ✅  | All props including `prefetch` (IntersectionObserver), `onNavigate`, scroll restoration, `basePath`, `locale`                    |
+| `next/image`        | ✅  | Responsive image attributes, custom loaders, pattern validation, and runtime image optimization                                  |
+| `next/head`         | ✅  | SSR collection + client-side DOM manipulation                                                                                    |
+| `next/router`       | ✅  | `useRouter`, `Router` singleton, events, client-side navigation, SSR context, i18n                                               |
+| `next/navigation`   | ✅  | `usePathname`, `useSearchParams`, `useParams`, `useRouter`, `redirect`, `notFound`, `forbidden`, `unauthorized`                  |
+| `next/server`       | ✅  | `NextRequest`, `NextResponse`, `NextURL`, cookies, `userAgent`, `after`, `connection`, `URLPattern`                              |
+| `next/headers`      | ✅  | Async `headers()`, `cookies()`, `draftMode()`                                                                                    |
+| `next/dynamic`      | ✅  | `ssr: true`, `ssr: false`, `loading` component                                                                                   |
+| `next/script`       | ✅  | All 4 strategies (`beforeInteractive`, `afterInteractive`, `lazyOnload`, `worker`)                                               |
+| `next/font/google`  | 🟡  | Runtime CDN loading. No self-hosting, font subsetting, or fallback metrics                                                       |
+| `next/font/local`   | 🟡  | Runtime `@font-face` injection. Not extracted at build time                                                                      |
+| `next/og`           | ✅  | OG image generation via `@vercel/og` (Satori + resvg)                                                                            |
+| `next/cache`        | ✅  | `revalidateTag`, `revalidatePath`, `unstable_cache`, pluggable `CacheHandler`, `"use cache"` with `cacheLife()` and `cacheTag()` |
+| `next/form`         | ✅  | GET form interception + POST server action delegation                                                                            |
+| `next/legacy/image` | ✅  | Translates legacy props to modern Image                                                                                          |
+| `next/error`        | ✅  | Default error page component                                                                                                     |
+| `next/config`       | ✅  | `getConfig` / `setConfig`                                                                                                        |
+| `next/document`     | ✅  | `Html`, `Head`, `Main`, `NextScript`                                                                                             |
+| `next/constants`    | ✅  | All phase constants                                                                                                              |
+| `next/amp`          | ⬜  | No-op (AMP is deprecated)                                                                                                        |
+| `next/web-vitals`   | ⬜  | No-op (use the `web-vitals` library directly)                                                                                    |
 
 ### Routing
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -96,7 +96,7 @@ const PLATFORM_FEATURES: readonly PlatformFeature[] = [
     icon: GaugeIcon,
     title: "Image optimization",
     description:
-      "Local images route through a runtime resize/transcode endpoint that integrates with the Cloudflare Images binding. Remote images use @unpic/react with auto-detection for 28 CDNs.",
+      "Local and remote images use Next.js-compatible responsive attributes, pattern validation, custom loaders, and runtime optimization.",
   },
 ];
 

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -92,7 +92,6 @@
     "dev": "vp pack --watch"
   },
   "dependencies": {
-    "@unpic/react": "catalog:",
     "@vercel/og": "catalog:",
     "image-size": "catalog:",
     "ipaddr.js": "catalog:",

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -72,7 +72,7 @@ function isAppRouterFile(file: string, type: AppRouterFileType): boolean {
 const IMPORT_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   next: { status: "supported", detail: "type-only exports (Metadata, NextPage, etc.)" },
   "next/link": { status: "supported" },
-  "next/image": { status: "supported", detail: "uses @unpic/react (no local optimization yet)" },
+  "next/image": { status: "supported", detail: "runtime image optimization and custom loaders" },
   "next/legacy/image": {
     status: "supported",
     detail: "pre-Next.js 13 Image API with layout prop; translated to modern Image",

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
+import { hasRemoteMatch, normalizeLocalPatterns } from "vinext/shims/image-config";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
 import { getHtmlLimitedBotRegex } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
@@ -74,6 +75,254 @@ export type HasCondition = {
   key: string;
   value?: string;
 };
+
+function validateImageNumberArray(
+  values: number[] | undefined,
+  name: "deviceSizes" | "imageSizes" | "qualities",
+  options: { minItems?: number; maxItems: number; min: number; max: number },
+): void {
+  if (values === undefined) return;
+  const path = `images.${name}`;
+  if (!Array.isArray(values)) {
+    throw new Error(`Expected array, received ${typeof values} at "${path}"`);
+  }
+  if (options.minItems !== undefined && values.length < options.minItems) {
+    throw new Error(`Array must contain at least ${options.minItems} element(s) at "${path}"`);
+  }
+  if (values.length > options.maxItems) {
+    throw new Error(`Array must contain at most ${options.maxItems} element(s) at "${path}"`);
+  }
+  for (const [index, value] of values.entries()) {
+    if (!Number.isInteger(value)) {
+      throw new Error(`Expected integer, received float at "${path}[${index}]"`);
+    }
+    if (value < options.min) {
+      throw new Error(
+        `Number must be greater than or equal to ${options.min} at "${path}[${index}]"`,
+      );
+    }
+    if (value > options.max) {
+      throw new Error(`Number must be less than or equal to ${options.max} at "${path}[${index}]"`);
+    }
+  }
+}
+
+function validateImageInteger(
+  value: number | undefined,
+  name: "maximumRedirects" | "maximumResponseBody" | "minimumCacheTTL",
+  min: number,
+  max?: number,
+): void {
+  if (value === undefined) return;
+  const path = `images.${name}`;
+  if (!Number.isInteger(value)) {
+    throw new Error(`Expected integer, received float at "${path}"`);
+  }
+  if (value < min) {
+    throw new Error(`Number must be greater than or equal to ${min} at "${path}"`);
+  }
+  if (max !== undefined && value > max) {
+    throw new Error(`Number must be less than or equal to ${max} at "${path}"`);
+  }
+}
+
+function validateImageBoolean(
+  value: boolean | undefined,
+  name: "dangerouslyAllowSVG" | "dangerouslyAllowLocalIP" | "disableStaticImages" | "unoptimized",
+): void {
+  if (value === undefined) return;
+  if (typeof value !== "boolean") {
+    throw new Error(`Expected boolean, received ${typeof value} at "images.${name}"`);
+  }
+}
+
+function validateOptionalString(
+  value: unknown,
+  path: string,
+  options: { maxLength?: number } = {},
+): void {
+  if (value === undefined) return;
+  if (typeof value !== "string") {
+    throw new Error(`Expected string, received ${typeof value} at "${path}"`);
+  }
+  if (options.maxLength !== undefined && value.length > options.maxLength) {
+    throw new Error(`String must contain at most ${options.maxLength} character(s) at "${path}"`);
+  }
+}
+
+function validateLocalPattern(pattern: unknown, index: number): void {
+  const path = `images.localPatterns[${index}]`;
+  if (!isUnknownRecord(pattern) || pattern instanceof URL) {
+    throw new Error(`Expected object at "${path}"`);
+  }
+  for (const key of Object.keys(pattern)) {
+    if (key !== "pathname" && key !== "search") {
+      throw new Error(`Unrecognized key '${key}' at "${path}"`);
+    }
+  }
+  validateOptionalString(pattern.pathname, `${path}.pathname`);
+  validateOptionalString(pattern.search, `${path}.search`);
+}
+
+function validateRemotePattern(pattern: unknown, index: number): void {
+  if (pattern instanceof URL) {
+    const protocol = pattern.protocol.replace(/:$/, "");
+    if (protocol !== "http" && protocol !== "https") {
+      throw new Error(
+        `Specified images.remotePatterns must have protocol "http" or "https" received "${protocol}".`,
+      );
+    }
+    return;
+  }
+  const path = `images.remotePatterns[${index}]`;
+  if (!isUnknownRecord(pattern)) {
+    throw new Error(`Expected object at "${path}"`);
+  }
+  for (const key of Object.keys(pattern)) {
+    if (!["protocol", "hostname", "port", "pathname", "search"].includes(key)) {
+      throw new Error(`Unrecognized key '${key}' at "${path}"`);
+    }
+  }
+  if (typeof pattern.hostname !== "string") {
+    throw new Error(`Expected string, received ${typeof pattern.hostname} at "${path}.hostname"`);
+  }
+  if (
+    pattern.protocol !== undefined &&
+    pattern.protocol !== "http" &&
+    pattern.protocol !== "https"
+  ) {
+    throw new Error(
+      `Invalid enum value. Expected 'http' | 'https', received '${JSON.stringify(pattern.protocol)}' at "${path}.protocol"`,
+    );
+  }
+  validateOptionalString(pattern.port, `${path}.port`, { maxLength: 5 });
+  validateOptionalString(pattern.pathname, `${path}.pathname`);
+  validateOptionalString(pattern.search, `${path}.search`);
+}
+
+function validateImageConfig(images: unknown): void {
+  if (images === undefined) return;
+  if (
+    !isUnknownRecord(images) ||
+    Array.isArray(images) ||
+    (Object.getPrototypeOf(images) !== Object.prototype && Object.getPrototypeOf(images) !== null)
+  ) {
+    throw new Error(
+      `Specified images should be an object received ${images === null ? "null" : typeof images}.\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config`,
+    );
+  }
+  const imageConfig = images as NonNullable<NextConfig["images"]>;
+  validateImageNumberArray(imageConfig.deviceSizes, "deviceSizes", {
+    maxItems: 25,
+    min: 1,
+    max: 10000,
+  });
+  validateImageNumberArray(imageConfig.imageSizes, "imageSizes", {
+    maxItems: 25,
+    min: 1,
+    max: 10000,
+  });
+  validateImageNumberArray(imageConfig.qualities, "qualities", {
+    minItems: 1,
+    maxItems: 20,
+    min: 1,
+    max: 100,
+  });
+  if (imageConfig.formats !== undefined) {
+    if (!Array.isArray(imageConfig.formats)) {
+      throw new Error(`Expected array, received ${typeof imageConfig.formats} at "images.formats"`);
+    }
+    if (imageConfig.formats.length > 4) {
+      throw new Error('Array must contain at most 4 element(s) at "images.formats"');
+    }
+    for (const [index, format] of imageConfig.formats.entries()) {
+      if (format !== "image/avif" && format !== "image/webp") {
+        throw new Error(
+          `Invalid enum value. Expected 'image/avif' | 'image/webp', received '${String(format)}' at "images.formats[${index}]"`,
+        );
+      }
+    }
+  }
+  if (imageConfig.localPatterns !== undefined) {
+    if (!Array.isArray(imageConfig.localPatterns)) {
+      throw new Error(
+        `Specified images.localPatterns should be an Array received ${typeof imageConfig.localPatterns}.\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config`,
+      );
+    }
+    if (imageConfig.localPatterns.length > 25) {
+      throw new Error('Array must contain at most 25 element(s) at "images.localPatterns"');
+    }
+    for (const [index, pattern] of imageConfig.localPatterns.entries()) {
+      validateLocalPattern(pattern, index);
+    }
+  }
+  if (imageConfig.remotePatterns !== undefined) {
+    if (!Array.isArray(imageConfig.remotePatterns)) {
+      throw new Error(
+        `Specified images.remotePatterns should be an Array received ${typeof imageConfig.remotePatterns}.\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config`,
+      );
+    }
+    if (imageConfig.remotePatterns.length > 50) {
+      throw new Error('Array must contain at most 50 element(s) at "images.remotePatterns"');
+    }
+    for (const [index, pattern] of imageConfig.remotePatterns.entries()) {
+      validateRemotePattern(pattern, index);
+    }
+  }
+  if (imageConfig.domains !== undefined) {
+    if (!Array.isArray(imageConfig.domains)) {
+      throw new Error(`Expected array, received ${typeof imageConfig.domains} at "images.domains"`);
+    }
+    if (imageConfig.domains.length > 50) {
+      throw new Error('Array must contain at most 50 element(s) at "images.domains"');
+    }
+    for (const [index, domain] of imageConfig.domains.entries()) {
+      validateOptionalString(domain, `images.domains[${index}]`);
+    }
+  }
+  if (
+    imageConfig.contentDispositionType !== undefined &&
+    imageConfig.contentDispositionType !== "inline" &&
+    imageConfig.contentDispositionType !== "attachment"
+  ) {
+    throw new Error(
+      `Invalid enum value. Expected 'inline' | 'attachment', received '${String(imageConfig.contentDispositionType)}' at "images.contentDispositionType"`,
+    );
+  }
+  validateOptionalString(imageConfig.contentSecurityPolicy, "images.contentSecurityPolicy");
+  if (
+    imageConfig.loader !== undefined &&
+    !["default", "imgix", "cloudinary", "akamai", "custom"].includes(imageConfig.loader)
+  ) {
+    throw new Error(
+      `Invalid enum value. Expected 'default' | 'imgix' | 'cloudinary' | 'akamai' | 'custom', received '${String(imageConfig.loader)}' at "images.loader"`,
+    );
+  }
+  validateOptionalString(imageConfig.loaderFile, "images.loaderFile");
+  validateOptionalString(imageConfig.path, "images.path");
+  validateImageBoolean(imageConfig.dangerouslyAllowSVG, "dangerouslyAllowSVG");
+  validateImageBoolean(imageConfig.dangerouslyAllowLocalIP, "dangerouslyAllowLocalIP");
+  validateImageBoolean(imageConfig.disableStaticImages, "disableStaticImages");
+  validateImageBoolean(imageConfig.unoptimized, "unoptimized");
+  validateImageInteger(imageConfig.maximumRedirects, "maximumRedirects", 0, 20);
+  validateImageInteger(
+    imageConfig.maximumResponseBody,
+    "maximumResponseBody",
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  validateImageInteger(imageConfig.minimumCacheTTL, "minimumCacheTTL", 0);
+  if (imageConfig.maximumDiskCacheSize !== undefined) {
+    throw new Error(
+      "images.maximumDiskCacheSize is not supported by vinext because image caching is runtime-adapter based rather than Next.js's Node disk cache",
+    );
+  }
+  if (imageConfig.customCacheHandler === true) {
+    throw new Error(
+      "images.customCacheHandler is not supported by vinext; configure vinext cache adapters instead",
+    );
+  }
+}
 
 export type NextRedirect = {
   source: string;
@@ -189,26 +438,53 @@ export type NextConfig = {
   headers?: () => Promise<NextHeader[]> | NextHeader[];
   /** Image optimization config */
   images?: {
-    remotePatterns?: Array<{
-      protocol?: string;
-      hostname: string;
-      port?: string;
+    localPatterns?: Array<{
       pathname?: string;
       search?: string;
     }>;
+    remotePatterns?: Array<
+      | URL
+      | {
+          protocol?: string;
+          hostname: string;
+          port?: string;
+          pathname?: string;
+          search?: string;
+        }
+    >;
     domains?: string[];
+    /** Global image loader implementation. */
+    loader?: "default" | "imgix" | "cloudinary" | "akamai" | "custom";
+    /** Project-relative custom loader module with a default export. */
+    loaderFile?: string;
+    /** URL prefix used by the configured image loader. Defaults to "/_next/image". */
+    path?: string;
+    /** Disable transforming imported image files into StaticImageData objects. */
+    disableStaticImages?: boolean;
     unoptimized?: boolean;
     /** Allowed device widths for image optimization. Defaults to Next.js defaults: [640, 750, 828, 1080, 1200, 1920, 2048, 3840] */
     deviceSizes?: number[];
-    /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [16, 32, 48, 64, 96, 128, 256, 384] */
+    /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [32, 48, 64, 96, 128, 256, 384] */
     imageSizes?: number[];
-    /** Allowed image qualities. When unset, any quality from 1-100 is permitted (matches Next.js). */
+    /** Allowed image qualities. Defaults to Next.js default: [75]. */
     qualities?: number[];
+    /** Preferred optimized image formats. Defaults to Next.js default: ["image/webp"]. */
+    formats?: Array<"image/avif" | "image/webp">;
+    /** Minimum cache lifetime in seconds for mutable optimized sources. Defaults to 14400 (4 hours). */
+    minimumCacheTTL?: number;
+    /** Next.js Node disk-cache limit. Unsupported by vinext's runtime-adapter image cache. */
+    maximumDiskCacheSize?: number;
+    /** Next.js custom image cache handler opt-in. Use vinext cache adapters instead. */
+    customCacheHandler?: boolean;
     /** Allow SVG images through the image optimization endpoint. SVG can contain scripts, so only enable if you trust all image sources. */
     dangerouslyAllowSVG?: boolean;
     /** Allow image optimization for hostnames that resolve to private IP addresses. This is a security risk (SSRF) — only enable for private networks when you understand the risk. */
     dangerouslyAllowLocalIP?: boolean;
-    /** Content-Disposition header for image responses. Defaults to "inline". */
+    /** Maximum number of redirects followed when fetching remote images. */
+    maximumRedirects?: number;
+    /** Maximum remote image response size in bytes. */
+    maximumResponseBody?: number;
+    /** Content-Disposition header for image responses. Defaults to "attachment". */
     contentDispositionType?: "inline" | "attachment";
     /** Content-Security-Policy header for image responses. Defaults to "script-src 'none'; frame-src 'none'; sandbox;" */
     contentSecurityPolicy?: string;
@@ -1324,6 +1600,74 @@ export async function resolveNextConfig(
     return resolved;
   }
 
+  validateImageConfig(config.images);
+
+  const normalizedAssetPrefix = normalizeAssetPrefix(config.assetPrefix);
+  if (
+    config.images ||
+    config.basePath ||
+    config.trailingSlash ||
+    normalizedAssetPrefix.startsWith("http://") ||
+    normalizedAssetPrefix.startsWith("https://")
+  ) {
+    config.images ??= {};
+  }
+
+  if (config.images) {
+    config.images.loader ??= "default";
+    config.images.path ??= "/_next/image";
+    if (
+      config.images.loader !== "default" &&
+      config.images.loader !== "custom" &&
+      config.images.path === "/_next/image"
+    ) {
+      throw new Error(
+        `Specified images.loader property (${config.images.loader}) also requires images.path property to be assigned to a URL prefix.\nSee more info here: https://nextjs.org/docs/api-reference/next/legacy/image#loader-configuration`,
+      );
+    }
+    if (
+      config.images.path === "/_next/image" &&
+      config.basePath &&
+      !config.images.path.startsWith(config.basePath)
+    ) {
+      config.images.path = `${config.basePath}${config.images.path}`;
+    }
+    if (
+      !config.images.path.endsWith("/") &&
+      (config.images.loader !== "default" || config.trailingSlash)
+    ) {
+      config.images.path += "/";
+    }
+    if (
+      normalizedAssetPrefix.startsWith("http://") ||
+      normalizedAssetPrefix.startsWith("https://")
+    ) {
+      const assetPrefixUrl = new URL(normalizedAssetPrefix);
+      config.images.remotePatterns ??= [];
+      if (
+        !hasRemoteMatch(config.images.domains ?? [], config.images.remotePatterns, assetPrefixUrl)
+      ) {
+        config.images.remotePatterns.push({
+          protocol: assetPrefixUrl.protocol.slice(0, -1),
+          hostname: assetPrefixUrl.hostname,
+          port: assetPrefixUrl.port,
+        });
+      }
+    }
+    if (config.images.loaderFile) {
+      if (config.images.loader !== "default" && config.images.loader !== "custom") {
+        throw new Error(
+          `Specified images.loader property (${config.images.loader}) cannot be used with images.loaderFile property. Please set images.loader to "custom".`,
+        );
+      }
+      const loaderFile = path.resolve(root, config.images.loaderFile);
+      if (!fs.existsSync(loaderFile)) {
+        throw new Error(`Specified images.loaderFile does not exist at "${loaderFile}".`);
+      }
+      config.images.loaderFile = loaderFile;
+    }
+  }
+
   // Resolve redirects
   let redirects: NextRedirect[] = [];
   if (config.redirects) {
@@ -1587,7 +1931,7 @@ export async function resolveNextConfig(
   const resolved: ResolvedNextConfig = {
     env: config.env ?? {},
     basePath: config.basePath ?? "",
-    assetPrefix: normalizeAssetPrefix(config.assetPrefix),
+    assetPrefix: normalizedAssetPrefix,
     trailingSlash: config.trailingSlash ?? false,
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,
@@ -1605,7 +1949,12 @@ export async function resolveNextConfig(
     redirects,
     rewrites,
     headers,
-    images: config.images,
+    images: config.images
+      ? {
+          ...config.images,
+          localPatterns: normalizeLocalPatterns(config.images.localPatterns),
+        }
+      : undefined,
     i18n,
     mdx,
     aliases,

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1602,6 +1602,24 @@ export async function resolveNextConfig(
 
   validateImageConfig(config.images);
 
+  config = {
+    ...config,
+    images: config.images
+      ? {
+          ...config.images,
+          localPatterns: config.images.localPatterns?.map((pattern) => ({ ...pattern })),
+          remotePatterns: config.images.remotePatterns?.map((pattern) =>
+            pattern instanceof URL ? new URL(pattern) : { ...pattern },
+          ),
+          domains: config.images.domains ? [...config.images.domains] : undefined,
+          deviceSizes: config.images.deviceSizes ? [...config.images.deviceSizes] : undefined,
+          imageSizes: config.images.imageSizes ? [...config.images.imageSizes] : undefined,
+          qualities: config.images.qualities ? [...config.images.qualities] : undefined,
+          formats: config.images.formats ? [...config.images.formats] : undefined,
+        }
+      : undefined,
+  };
+
   const normalizedAssetPrefix = normalizeAssetPrefix(config.assetPrefix);
   if (
     config.images ||

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -479,19 +479,37 @@ export function generateAppRouterWorkerEntry(): string {
  * For apps without image optimization, you can use vinext/server/app-router-entry
  * directly in wrangler.jsonc: "main": "vinext/server/app-router-entry"
  */
-import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isImageOptimizationPath } from "vinext/server/image-optimization";
+import { getWorkerRemoteImageRedirect, handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isImageOptimizationEnabled, isImageOptimizationPath } from "vinext/server/image-optimization";
 import type { ImageConfig } from "vinext/server/image-optimization";
 import handler from "vinext/server/app-router-entry";
 
 const imageConfig: ImageConfig = {
+  path: process.env.__VINEXT_IMAGE_PATH ?? "/_next/image",
+  loader: (process.env.__VINEXT_IMAGE_LOADER ?? "default") as ImageConfig["loader"],
   deviceSizes: JSON.parse(
     process.env.__VINEXT_IMAGE_DEVICE_SIZES ?? JSON.stringify(DEFAULT_DEVICE_SIZES),
   ),
   imageSizes: JSON.parse(
     process.env.__VINEXT_IMAGE_SIZES ?? JSON.stringify(DEFAULT_IMAGE_SIZES),
   ),
-  qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "null") ?? undefined,
+  qualities: JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "[75]"),
+  formats: JSON.parse(process.env.__VINEXT_IMAGE_FORMATS ?? '["image/webp"]'),
+  localPatterns: JSON.parse(
+    process.env.__VINEXT_IMAGE_LOCAL_PATTERNS ?? '[{"pathname":"**","search":""}]',
+  ),
+  remotePatterns: JSON.parse(process.env.__VINEXT_IMAGE_REMOTE_PATTERNS ?? "[]"),
+  unoptimized: process.env.__VINEXT_IMAGE_UNOPTIMIZED === "true",
+  domains: JSON.parse(process.env.__VINEXT_IMAGE_DOMAINS ?? "[]"),
+  maximumRedirects: Number(process.env.__VINEXT_IMAGE_MAXIMUM_REDIRECTS ?? "3"),
+  maximumResponseBody: Number(process.env.__VINEXT_IMAGE_MAXIMUM_RESPONSE_BODY ?? "50000000"),
+  minimumCacheTTL: Number(process.env.__VINEXT_IMAGE_MINIMUM_CACHE_TTL ?? "14400"),
   dangerouslyAllowSVG: process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG === "true",
+  dangerouslyAllowLocalIP: process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP === "true",
+  contentDispositionType:
+    process.env.__VINEXT_IMAGE_CONTENT_DISPOSITION_TYPE === "inline" ? "inline" : "attachment",
+  contentSecurityPolicy:
+    process.env.__VINEXT_IMAGE_CONTENT_SECURITY_POLICY ??
+    "script-src 'none'; frame-src 'none'; sandbox;",
 };
 
 interface Env {
@@ -523,11 +541,16 @@ export default {
     // Image optimization via Cloudflare Images binding.
     // The parseImageParams validation inside handleImageOptimization
     // normalizes backslashes and validates the origin hasn't changed.
-    if (isImageOptimizationPath(url.pathname)) {
+    if (isImageOptimizationPath(url.pathname, imageConfig.path)) {
+      if (!isImageOptimizationEnabled(imageConfig)) {
+        return new Response("This page could not be found", { status: 404 });
+      }
       const allowedWidths = [
         ...(imageConfig.deviceSizes ?? DEFAULT_DEVICE_SIZES),
         ...(imageConfig.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ];
+      const remoteRedirect = getWorkerRemoteImageRedirect(request, allowedWidths, imageConfig);
+      if (remoteRedirect) return remoteRedirect;
       return handleImageOptimization(request, {
         fetchAsset: (path) => env.ASSETS.fetch(new Request(new URL(path, request.url))),
         transformImage: async (body, { width, format, quality }) => {
@@ -554,7 +577,7 @@ export function generatePagesRouterWorkerEntry(): string {
  */
 import { fetchWorkerFilesystemRoute, runPagesRequest, wrapMiddlewareWithBasePath } from "vinext/server/pages-request-pipeline";
 import type { PagesPipelineDeps } from "vinext/server/pages-request-pipeline";
-import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isImageOptimizationPath } from "vinext/server/image-optimization";
+import { getWorkerRemoteImageRedirect, handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, imageOptimizationPathAfterBasePath, isImageOptimizationEnabled, isImageOptimizationPath } from "vinext/server/image-optimization";
 import type { ImageConfig } from "vinext/server/image-optimization";
 import { cloneRequestWithHeaders, cloneRequestWithUrl, filterInternalHeaders, isOpenRedirectShaped } from "vinext/server/request-pipeline";
 import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses";
@@ -591,7 +614,19 @@ const configRedirects = vinextConfig?.redirects ?? [];
 const configRewrites = vinextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] };
 const configHeaders = vinextConfig?.headers ?? [];
 const imageConfig: ImageConfig | undefined = vinextConfig?.images ? {
+  path: vinextConfig.images.path,
+  loader: vinextConfig.images.loader,
+  deviceSizes: vinextConfig.images.deviceSizes,
+  imageSizes: vinextConfig.images.imageSizes,
   qualities: vinextConfig.images.qualities,
+  formats: vinextConfig.images.formats,
+  localPatterns: vinextConfig.images.localPatterns,
+  remotePatterns: vinextConfig.images.remotePatterns,
+  unoptimized: vinextConfig.images.unoptimized,
+  domains: vinextConfig.images.domains,
+  maximumRedirects: vinextConfig.images.maximumRedirects,
+  maximumResponseBody: vinextConfig.images.maximumResponseBody,
+  minimumCacheTTL: vinextConfig.images.minimumCacheTTL,
   dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
   dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
   contentDispositionType: vinextConfig.images.contentDispositionType,
@@ -659,11 +694,16 @@ export default {
 
       // ── Image optimization via Cloudflare Images binding ──────────
       // Checked after basePath stripping so /<basePath>/_next/image works.
-      if (isImageOptimizationPath(pathname)) {
+      if (hadBasePath && isImageOptimizationPath(pathname, imageOptimizationPathAfterBasePath(imageConfig?.path, basePath))) {
+        if (!isImageOptimizationEnabled(imageConfig)) {
+          return new Response("This page could not be found", { status: 404 });
+        }
         const allowedWidths = [
           ...(vinextConfig?.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
           ...(vinextConfig?.images?.imageSizes ?? DEFAULT_IMAGE_SIZES),
         ];
+        const remoteRedirect = getWorkerRemoteImageRedirect(request, allowedWidths, imageConfig);
+        if (remoteRedirect) return remoteRedirect;
         return handleImageOptimization(request, {
           fetchAsset: (path) => env.ASSETS.fetch(new Request(new URL(path, request.url))),
           transformImage: async (body, { width, format, quality }) => {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -105,6 +105,10 @@ const appHookWarningSuppressionPath = resolveEntryPath(
 );
 const serverGlobalsPath = resolveEntryPath("../server/server-globals.js", import.meta.url);
 const appPagesBridgePath = resolveEntryPath("../server/app-pages-bridge.js", import.meta.url);
+const nodeRemoteImageFetchPath = resolveEntryPath(
+  "../server/node-remote-image-fetch.js",
+  import.meta.url,
+);
 
 /**
  * Resolved config options relevant to App Router request handling.
@@ -161,6 +165,8 @@ type AppRouterConfig = {
   /** Internationalization routing config for middleware matcher locale handling. */
   i18n?: NextI18nConfig | null;
   imageConfig?: ImageConfig;
+  /** Runtime that owns image I/O for the generated RSC entry. */
+  imageRuntime?: "node" | "worker";
   /**
    * Absolute path to `app/global-not-found.{tsx,ts,js,jsx}` when present.
    * When provided, route-miss 404s render this module standalone (it owns its
@@ -220,6 +226,7 @@ export function generateRscEntry(
   const inlineCss = config?.inlineCss === true;
   const cacheComponents = config?.cacheComponents === true;
   const hasServerActions = config?.hasServerActions !== false;
+  const imageRuntime = config?.imageRuntime ?? "node";
   const i18nConfig = config?.i18n ?? null;
   const hasPagesDir = config?.hasPagesDir ?? false;
   const publicFiles = config?.publicFiles ?? [];
@@ -598,6 +605,23 @@ export const __inlineCss = ${JSON.stringify(inlineCss)};
 export const __hasPagesDir = ${JSON.stringify(hasPagesDir)};
 export const getRenderedConcreteUrlPathsForRoute = __getRenderedConcreteUrlPathsForRoute;
 const __cacheComponents = ${JSON.stringify(cacheComponents)};
+const __imageRuntime = ${JSON.stringify(imageRuntime)};
+const __imageHandlers = ${
+    imageRuntime === "node"
+      ? `import.meta.env.DEV
+  ? {
+      async fetchRemote(url, addresses, signal) {
+        const { fetchRemoteImageFromValidatedAddresses } = await import(${JSON.stringify(nodeRemoteImageFetchPath)});
+        return fetchRemoteImageFromValidatedAddresses(url, addresses, signal);
+      },
+      async resolveHostnames(hostname) {
+        const { resolveRemoteImageHostnames } = await import(${JSON.stringify(nodeRemoteImageFetchPath)});
+        return resolveRemoteImageHostnames(hostname);
+      },
+    }
+  : undefined`
+      : "undefined"
+  };
 
 export async function seedMemoryCacheFromPrerender(serverDir) {
   const { seedMemoryCacheFromPrerender: __seedMemoryCacheFromPrerender } =
@@ -656,7 +680,9 @@ export default createAppRscHandler({
   configRedirects: __configRedirects,
   configRewrites: __configRewrites,
   imageConfig: __imageConfig,
-  isDev: process.env.NODE_ENV !== "production",
+  imageHandlers: __imageHandlers,
+  imageRuntime: __imageRuntime,
+  isDev: import.meta.env.DEV,
   draftModeSecret: __draftModeSecret,
   dispatchMatchedPage({
     clientReuseManifest,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -14,6 +14,7 @@ import { createValidFileMatcher } from "../routing/file-matcher.js";
 import { type ResolvedNextConfig } from "../config/next-config.js";
 import { isProxyFile } from "../server/middleware.js";
 import { findFileWithExts } from "./pages-entry-helpers.js";
+import { normalizeLocalPatterns, normalizeRemotePatterns } from "vinext/shims/image-config";
 
 const _requestContextShimPath = resolveEntryPath("../shims/request-context.js", import.meta.url);
 const _middlewareRuntimePath = resolveEntryPath("../server/middleware-runtime.js", import.meta.url);
@@ -122,9 +123,19 @@ export async function generateServerEntry(
     disableOptimizedLoading: nextConfig?.disableOptimizedLoading === true,
     clientTraceMetadata: nextConfig?.clientTraceMetadata,
     images: {
+      path: nextConfig?.images?.path,
+      loader: nextConfig?.images?.loader,
       deviceSizes: nextConfig?.images?.deviceSizes,
       imageSizes: nextConfig?.images?.imageSizes,
       qualities: nextConfig?.images?.qualities,
+      formats: nextConfig?.images?.formats,
+      localPatterns: normalizeLocalPatterns(nextConfig?.images?.localPatterns),
+      remotePatterns: normalizeRemotePatterns(nextConfig?.images?.remotePatterns ?? []),
+      unoptimized: nextConfig?.images?.unoptimized,
+      domains: nextConfig?.images?.domains,
+      maximumRedirects: nextConfig?.images?.maximumRedirects,
+      maximumResponseBody: nextConfig?.images?.maximumResponseBody,
+      minimumCacheTTL: nextConfig?.images?.minimumCacheTTL,
       dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
       dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
       contentDispositionType: nextConfig?.images?.contentDispositionType,

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -438,6 +438,8 @@ declare global {
        * `next.config.js` → `images.remotePatterns`.
        */
       __VINEXT_IMAGE_REMOTE_PATTERNS?: string;
+      __VINEXT_IMAGE_LOCAL_PATTERNS?: string;
+      __VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN?: string;
 
       /**
        * JSON-encoded array of allowed hostname strings from
@@ -468,6 +470,11 @@ declare global {
        * are allowed (`next.config.js` → `images.dangerouslyAllowLocalIP`).
        */
       __VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP?: string;
+      __VINEXT_IMAGE_UNOPTIMIZED?: string;
+      __VINEXT_IMAGE_MINIMUM_CACHE_TTL?: string;
+      __VINEXT_IMAGE_LOADER?: string;
+      __VINEXT_IMAGE_LOADER_FILE?: string;
+      __VINEXT_IMAGE_PATH?: string;
 
       /**
        * Next.js-compatible version string. vinext mirrors Next.js's

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -33,11 +33,20 @@ import { handleApiRoute } from "./server/api-handler.js";
 import {
   DEFAULT_DEVICE_SIZES,
   DEFAULT_IMAGE_SIZES,
+  handleImageOptimization,
+  imageOptimizationPathAfterBasePath,
+  isImageOptimizationEnabled,
   isImageOptimizationPath,
+  parseRemoteImageUrl,
   resolveDevImageRedirect,
 } from "./server/image-optimization.js";
+import { normalizeLocalPatterns, normalizeRemotePatterns } from "vinext/shims/image-config";
 
 import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
+import {
+  fetchRemoteImageFromValidatedAddresses,
+  resolveRemoteImageHostnames,
+} from "./server/node-remote-image-fetch.js";
 import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
 import { generateRscEntry } from "./entries/app-rsc-entry.js";
@@ -69,7 +78,6 @@ import {
   type NextConfigInput,
   type ResolvedNextConfig,
 } from "./config/next-config.js";
-
 import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
 import { isNextDataPathname, parseNextDataPathname } from "./server/pages-data-route.js";
 import {
@@ -549,6 +557,8 @@ const VIRTUAL_APP_SSR_ENTRY = "virtual:vinext-app-ssr-entry";
 const RESOLVED_APP_SSR_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_SSR_ENTRY;
 const VIRTUAL_APP_BROWSER_ENTRY = "virtual:vinext-app-browser-entry";
 const RESOLVED_APP_BROWSER_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_BROWSER_ENTRY;
+const VIRTUAL_IMAGE_LOADER = "virtual:vinext-image-loader";
+const RESOLVED_IMAGE_LOADER = VIRTUAL_PREFIX + VIRTUAL_IMAGE_LOADER;
 const VIRTUAL_ROOT_PARAMS = "virtual:vinext-root-params";
 const RESOLVED_ROOT_PARAMS = VIRTUAL_PREFIX + VIRTUAL_ROOT_PARAMS;
 /** Virtual module that registers config-driven cache adapters (see VinextOptions.cache). */
@@ -1444,12 +1454,22 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.__VINEXT_TRAILING_SLASH"] = JSON.stringify(
           nextConfig.trailingSlash ? "true" : "false",
         );
-        // Expose image remote patterns for validation in next/image shim
-        defines["process.env.__VINEXT_IMAGE_REMOTE_PATTERNS"] = JSON.stringify(
-          JSON.stringify(nextConfig.images?.remotePatterns ?? []),
-        );
-        defines["process.env.__VINEXT_IMAGE_DOMAINS"] = JSON.stringify(
-          JSON.stringify(nextConfig.images?.domains ?? []),
+        // Next.js only embeds image allowlists in development client bundles.
+        // Production clients defer validation to the optimizer endpoint, while
+        // server environments still receive the full config for SSR.
+        if (env?.command === "serve") {
+          defines["process.env.__VINEXT_IMAGE_REMOTE_PATTERNS"] = JSON.stringify(
+            JSON.stringify(normalizeRemotePatterns(nextConfig.images?.remotePatterns ?? [])),
+          );
+          defines["process.env.__VINEXT_IMAGE_LOCAL_PATTERNS"] = JSON.stringify(
+            JSON.stringify(normalizeLocalPatterns(nextConfig.images?.localPatterns)),
+          );
+          defines["process.env.__VINEXT_IMAGE_DOMAINS"] = JSON.stringify(
+            JSON.stringify(nextConfig.images?.domains ?? []),
+          );
+        }
+        defines["process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN"] = JSON.stringify(
+          String(nextConfig.images?.localPatterns === undefined),
         );
         // Expose allowed image widths (union of deviceSizes + imageSizes) for
         // server-side validation. Matches Next.js behavior: only configured
@@ -1458,16 +1478,19 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           const deviceSizes = nextConfig.images?.deviceSizes ?? [
             640, 750, 828, 1080, 1200, 1920, 2048, 3840,
           ];
-          const imageSizes = nextConfig.images?.imageSizes ?? [16, 32, 48, 64, 96, 128, 256, 384];
+          const imageSizes = nextConfig.images?.imageSizes ?? [32, 48, 64, 96, 128, 256, 384];
           defines["process.env.__VINEXT_IMAGE_DEVICE_SIZES"] = JSON.stringify(
             JSON.stringify(deviceSizes),
           );
           defines["process.env.__VINEXT_IMAGE_SIZES"] = JSON.stringify(JSON.stringify(imageSizes));
-          // Emit the configured qualities allowlist, or `null` when unset so the
-          // runtime permits any quality 1-100 (matches Next.js: an unset
-          // `images.qualities` is not restricted to a single value).
           defines["process.env.__VINEXT_IMAGE_QUALITIES"] = JSON.stringify(
-            JSON.stringify(nextConfig.images?.qualities ?? null),
+            JSON.stringify(nextConfig.images?.qualities ?? [75]),
+          );
+          defines["process.env.__VINEXT_IMAGE_FORMATS"] = JSON.stringify(
+            JSON.stringify(nextConfig.images?.formats ?? ["image/webp"]),
+          );
+          defines["process.env.__VINEXT_IMAGE_MINIMUM_CACHE_TTL"] = JSON.stringify(
+            String(nextConfig.images?.minimumCacheTTL ?? 14_400),
           );
         }
         // Expose dangerouslyAllowSVG flag for the image shim's auto-skip logic.
@@ -1479,6 +1502,31 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // When false (default), remote image URLs with literal private-IP hostnames are blocked.
         defines["process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP"] = JSON.stringify(
           String(nextConfig.images?.dangerouslyAllowLocalIP ?? false),
+        );
+        defines["process.env.__VINEXT_IMAGE_UNOPTIMIZED"] = JSON.stringify(
+          String(nextConfig.images?.unoptimized ?? false),
+        );
+        defines["process.env.__VINEXT_IMAGE_LOADER"] = JSON.stringify(
+          nextConfig.images?.loader ?? "default",
+        );
+        defines["process.env.__VINEXT_IMAGE_LOADER_FILE"] = JSON.stringify(
+          String(Boolean(nextConfig.images?.loaderFile)),
+        );
+        defines["process.env.__VINEXT_IMAGE_PATH"] = JSON.stringify(
+          nextConfig.images?.path ?? "/_next/image",
+        );
+        defines["process.env.__VINEXT_IMAGE_MAXIMUM_REDIRECTS"] = JSON.stringify(
+          String(nextConfig.images?.maximumRedirects ?? 3),
+        );
+        defines["process.env.__VINEXT_IMAGE_MAXIMUM_RESPONSE_BODY"] = JSON.stringify(
+          String(nextConfig.images?.maximumResponseBody ?? 50_000_000),
+        );
+        defines["process.env.__VINEXT_IMAGE_CONTENT_DISPOSITION_TYPE"] = JSON.stringify(
+          nextConfig.images?.contentDispositionType ?? "attachment",
+        );
+        defines["process.env.__VINEXT_IMAGE_CONTENT_SECURITY_POLICY"] = JSON.stringify(
+          nextConfig.images?.contentSecurityPolicy ??
+            "script-src 'none'; frame-src 'none'; sandbox;",
         );
         // Build ID — resolved from next.config generateBuildId() or random UUID.
         // Exposed so server entries and the next/server shim can inject it.
@@ -1685,6 +1733,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             "vinext/pages-router-runtime": path.posix.join(shimsDir, "pages-router-runtime"),
             "vinext/router-state": path.posix.join(shimsDir, "router-state"),
             "vinext/head-state": path.posix.join(shimsDir, "head-state"),
+            "vinext/shims/image-loader": VIRTUAL_IMAGE_LOADER,
             "vinext/i18n-state": path.posix.join(shimsDir, "i18n-state"),
             "vinext/i18n-context": path.posix.join(shimsDir, "i18n-context"),
             "vinext/cache": path.resolve(__dirname, "cache"),
@@ -2750,6 +2799,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (cleanId === VIRTUAL_RSC_ENTRY) return RESOLVED_RSC_ENTRY;
           if (cleanId === VIRTUAL_APP_SSR_ENTRY) return RESOLVED_APP_SSR_ENTRY;
           if (cleanId === VIRTUAL_APP_BROWSER_ENTRY) return RESOLVED_APP_BROWSER_ENTRY;
+          if (cleanId === VIRTUAL_IMAGE_LOADER) return RESOLVED_IMAGE_LOADER;
           if (cleanId === "next/root-params" || cleanId === "next/root-params.js") {
             return RESOLVED_ROOT_PARAMS;
           }
@@ -2870,10 +2920,25 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               hasServerActions,
               i18n: nextConfig?.i18n,
               imageConfig: {
+                path: nextConfig?.images?.path,
+                loader: nextConfig?.images?.loader,
                 deviceSizes: nextConfig?.images?.deviceSizes,
                 imageSizes: nextConfig?.images?.imageSizes,
                 qualities: nextConfig?.images?.qualities,
+                formats: nextConfig?.images?.formats,
+                localPatterns: normalizeLocalPatterns(nextConfig?.images?.localPatterns),
+                remotePatterns: normalizeRemotePatterns(nextConfig?.images?.remotePatterns ?? []),
+                unoptimized: nextConfig?.images?.unoptimized,
+                domains: nextConfig?.images?.domains,
+                maximumRedirects: nextConfig?.images?.maximumRedirects,
+                maximumResponseBody: nextConfig?.images?.maximumResponseBody,
+                minimumCacheTTL: nextConfig?.images?.minimumCacheTTL,
+                dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
+                dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
+                contentDispositionType: nextConfig?.images?.contentDispositionType,
+                contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
               },
+              imageRuntime: hasCloudflarePlugin ? "worker" : "node",
               hasPagesDir,
               publicFiles: scanPublicFileRoutes(root),
               globalNotFoundPath,
@@ -2924,6 +2989,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             pagesPrefetchRoutes,
             nextConfig.rewrites,
           );
+        }
+        if (id === RESOLVED_IMAGE_LOADER) {
+          const loaderModule =
+            nextConfig.images?.loaderFile ?? resolveShimModulePath(shimsDir, "image-loader");
+          return nextConfig.images?.loaderFile
+            ? `import * as __loaderModule from ${JSON.stringify(loaderModule)};
+const __loader = __loaderModule.default;
+if (typeof __loader !== "function") {
+  throw new Error("images.loaderFile detected but the file is missing default export.\\nRead more: https://nextjs.org/docs/messages/invalid-images-config");
+}
+export default __loader;`
+            : `export { default } from ${JSON.stringify(loaderModule)};`;
         }
         if (id.startsWith(RESOLVED_VIRTUAL_GOOGLE_FONTS + "?")) {
           return generateGoogleFontsVirtualModule(id, _fontGoogleShimPath);
@@ -3779,7 +3856,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
               // ── Image optimization passthrough (dev mode) ─────────────
               // In dev, redirect to the original asset URL so Vite serves it.
-              if (isImageOptimizationPath(url.split("?")[0]!)) {
+              if (
+                isImageOptimizationEnabled(nextConfig.images) &&
+                isImageOptimizationPath(
+                  url.split("?")[0]!,
+                  imageOptimizationPathAfterBasePath(
+                    nextConfig.images?.path,
+                    nextConfig.basePath ?? "",
+                  ),
+                )
+              ) {
                 const imageRequestUrl = new URL(url, `http://${req.headers.host || "localhost"}`);
                 const allowedWidths = [
                   ...(nextConfig.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
@@ -3789,7 +3875,24 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   imageRequestUrl,
                   allowedWidths,
                   nextConfig.images?.qualities,
+                  { isDev: true, localPatterns: nextConfig.images?.localPatterns },
                 );
+                const remoteSource = imageRequestUrl.searchParams.get("url");
+                if (!encodedLocation && parseRemoteImageUrl(remoteSource)) {
+                  const response = await handleImageOptimization(
+                    new Request(imageRequestUrl, { headers: req.headers as HeadersInit }),
+                    {
+                      fetchAsset: async () => new Response(null, { status: 404 }),
+                      fetchRemote: fetchRemoteImageFromValidatedAddresses,
+                      resolveHostnames: resolveRemoteImageHostnames,
+                    },
+                    allowedWidths,
+                    nextConfig.images,
+                    { isDev: true },
+                  );
+                  await writeWebResponseToNodeRes(res, response);
+                  return;
+                }
                 if (!encodedLocation) {
                   res.writeHead(400);
                   res.end("Invalid image optimization parameters");
@@ -4476,6 +4579,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
         const serverDefines: Record<string, string> = { ...nextConfig.compilerDefineServer };
 
+        serverDefines["process.env.__VINEXT_IMAGE_REMOTE_PATTERNS"] = JSON.stringify(
+          JSON.stringify(normalizeRemotePatterns(nextConfig.images?.remotePatterns ?? [])),
+        );
+        serverDefines["process.env.__VINEXT_IMAGE_LOCAL_PATTERNS"] = JSON.stringify(
+          JSON.stringify(normalizeLocalPatterns(nextConfig.images?.localPatterns)),
+        );
+        serverDefines["process.env.__VINEXT_IMAGE_DOMAINS"] = JSON.stringify(
+          JSON.stringify(nextConfig.images?.domains ?? []),
+        );
+
         // Mirror Next.js's compile-time `process.env.NEXT_RUNTIME` constant
         // (see packages/next/src/build/define-env.ts).  This is a build-time
         // define — it is inlined at compile time and has no runtime equivalent.
@@ -4606,6 +4719,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           code: new RegExp(`import\\s+\\w+\\s+from\\s+['"][^'"]+\\.(${IMAGE_EXTS})['"]`),
         },
         async handler(code, id) {
+          if (nextConfig.images?.disableStaticImages) return null;
           // The `code` filter above (a regex) only decides whether to invoke
           // this handler; it can fire on text inside comments, strings, or
           // template literals. Scanning must therefore be AST-based so we only
@@ -5015,9 +5129,20 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (!outDir) return;
 
           const imageConfig = {
+            path: nextConfig?.images?.path,
+            loader: nextConfig?.images?.loader,
             deviceSizes: nextConfig?.images?.deviceSizes,
             imageSizes: nextConfig?.images?.imageSizes,
             qualities: nextConfig?.images?.qualities,
+            formats: nextConfig?.images?.formats,
+            localPatterns: normalizeLocalPatterns(nextConfig?.images?.localPatterns),
+            remotePatterns: normalizeRemotePatterns(nextConfig?.images?.remotePatterns ?? []),
+            unoptimized: nextConfig?.images?.unoptimized,
+            domains: nextConfig?.images?.domains,
+            maximumRedirects: nextConfig?.images?.maximumRedirects,
+            maximumResponseBody: nextConfig?.images?.maximumResponseBody,
+            minimumCacheTTL: nextConfig?.images?.minimumCacheTTL,
+            dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
             dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
             contentDispositionType: nextConfig?.images?.contentDispositionType,
             contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4719,7 +4719,7 @@ export default __loader;`
           code: new RegExp(`import\\s+\\w+\\s+from\\s+['"][^'"]+\\.(${IMAGE_EXTS})['"]`),
         },
         async handler(code, id) {
-          if (nextConfig.images?.disableStaticImages) return null;
+          if (nextConfig?.images?.disableStaticImages) return null;
           // The `code` filter above (a regex) only decides whether to invoke
           // this handler; it can fire on text inside comments, strings, or
           // template literals. Scanning must therefore be AST-based so we only

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -61,9 +61,15 @@ import { buildPageCacheTags } from "./implicit-tags.js";
 import {
   DEFAULT_DEVICE_SIZES,
   DEFAULT_IMAGE_SIZES,
+  getWorkerRemoteImageRedirect,
+  handleImageOptimization,
+  imageOptimizationPathAfterBasePath,
+  isImageOptimizationEnabled,
   isImageOptimizationPath,
+  parseRemoteImageUrl,
   resolveDevImageRedirect,
   type ImageConfig,
+  type ImageHandlers,
 } from "./image-optimization.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
@@ -302,6 +308,8 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   ) => Promise<Response | null>;
   i18nConfig: NextI18nConfig | null;
   imageConfig?: ImageConfig;
+  imageHandlers?: Pick<ImageHandlers, "fetchRemote" | "resolveHostnames">;
+  imageRuntime?: "node" | "worker";
   isDev: boolean;
   loadPrerenderPagesRoutes?: () => Promise<unknown>;
   matchRoute: (pathname: string) => AppRscRouteMatch<TRoute> | null;
@@ -650,19 +658,48 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     }
   }
 
-  if (isImageOptimizationPath(cleanPathname)) {
+  if (
+    isImageOptimizationPath(
+      cleanPathname,
+      imageOptimizationPathAfterBasePath(options.imageConfig?.path, options.basePath),
+    )
+  ) {
+    if (!isImageOptimizationEnabled(options.imageConfig)) {
+      return new Response("This page could not be found", { status: 404 });
+    }
+    const allowedWidths = [
+      ...(options.imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
+      ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
+    ];
     const imageRedirect = resolveDevImageRedirect(
       url,
-      [
-        ...(options.imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
-        ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
-      ],
+      allowedWidths,
       options.imageConfig?.qualities,
-      { isDev: options.isDev },
+      { isDev: options.isDev, localPatterns: options.imageConfig?.localPatterns },
     );
-    if (!imageRedirect)
-      return new Response("Invalid image optimization parameters", { status: 400 });
-    return Response.redirect(new URL(imageRedirect, url.origin).href, 302);
+    if (imageRedirect) return Response.redirect(new URL(imageRedirect, url.origin).href, 302);
+
+    const imageSource = url.searchParams.get("url");
+    if (options.isDev && parseRemoteImageUrl(imageSource)) {
+      if (options.imageRuntime === "worker") {
+        return (
+          getWorkerRemoteImageRedirect(request, allowedWidths, options.imageConfig) ??
+          new Response("Invalid image optimization parameters", { status: 400 })
+        );
+      }
+      return handleImageOptimization(
+        request,
+        {
+          fetchAsset: async () => new Response(null, { status: 404 }),
+          ...options.imageHandlers,
+        },
+        allowedWidths,
+        options.imageConfig,
+        { isDev: true },
+      );
+    }
+
+    return new Response("Invalid image optimization parameters", { status: 400 });
   }
 
   if (options.handleMetadataRouteRequest) {

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -30,12 +30,6 @@ import { isIP } from "node:net";
 /** The pathname that triggers image optimization (matches Next.js). */
 export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
 
-/**
- * Vinext-prefixed alias for the image optimization endpoint. Accepted
- * alongside IMAGE_OPTIMIZATION_PATH so apps that wire image URLs to the
- * vinext-prefixed path continue to work; emit IMAGE_OPTIMIZATION_PATH
- * for any newly generated URLs.
- */
 /** Returns true when `pathname` matches the configured image optimization endpoint. */
 export function isImageOptimizationPath(
   pathname: string,

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -36,8 +36,6 @@ export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
  * vinext-prefixed path continue to work; emit IMAGE_OPTIMIZATION_PATH
  * for any newly generated URLs.
  */
-export const VINEXT_IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
-
 /** Returns true when `pathname` matches the configured image optimization endpoint. */
 export function isImageOptimizationPath(
   pathname: string,

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -7,8 +7,8 @@
  * server), serves the original file as a passthrough with appropriate
  * Cache-Control headers.
  *
- * Format negotiation: inspects the `Accept` header and serves AVIF, WebP,
- * or JPEG depending on client support.
+ * Format negotiation: inspects the `Accept` header and selects from the
+ * configured formats, which default to WebP like Next.js.
  *
  * Security: All image responses include Content-Security-Policy and
  * X-Content-Type-Options headers to prevent XSS via SVG or Content-Type
@@ -18,6 +18,14 @@
  */
 
 import { badRequestResponse } from "./http-error-responses.js";
+import {
+  hasLocalMatch,
+  hasRemoteMatch,
+  isPrivateIp,
+  type LocalPattern,
+  type RemotePatternInput,
+} from "vinext/shims/image-config";
+import { isIP } from "node:net";
 
 /** The pathname that triggers image optimization (matches Next.js). */
 export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
@@ -30,9 +38,27 @@ export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
  */
 export const VINEXT_IMAGE_OPTIMIZATION_PATH = "/_vinext/image";
 
-/** Returns true when `pathname` is either supported image optimization endpoint. */
-export function isImageOptimizationPath(pathname: string): boolean {
-  return pathname === IMAGE_OPTIMIZATION_PATH || pathname === VINEXT_IMAGE_OPTIMIZATION_PATH;
+/** Returns true when `pathname` matches the configured image optimization endpoint. */
+export function isImageOptimizationPath(
+  pathname: string,
+  configuredPath: string = IMAGE_OPTIMIZATION_PATH,
+): boolean {
+  if (pathname === configuredPath) return true;
+  if (configuredPath.length > 1 && configuredPath.endsWith("/")) {
+    return pathname === configuredPath.slice(0, -1);
+  }
+  return false;
+}
+
+/** Returns the configured optimizer path in the same basePath-stripped space as routing. */
+export function imageOptimizationPathAfterBasePath(
+  configuredPath: string = IMAGE_OPTIMIZATION_PATH,
+  basePath: string,
+): string {
+  if (!basePath) return configuredPath;
+  if (configuredPath === basePath) return "/";
+  if (configuredPath.startsWith(`${basePath}/`)) return configuredPath.slice(basePath.length);
+  return configuredPath;
 }
 
 /**
@@ -40,33 +66,50 @@ export function isImageOptimizationPath(pathname: string): boolean {
  * Controls SVG handling and security headers for the image endpoint.
  */
 export type ImageConfig = {
+  /** Configured optimizer URL path. */
+  path?: string;
+  /** Configured image loader. Only the default loader exposes the optimizer endpoint. */
+  loader?: "default" | "imgix" | "cloudinary" | "akamai" | "custom";
   /** Allowed device widths. Defaults to Next.js device sizes. */
   deviceSizes?: number[];
   /** Allowed fixed-image widths. Defaults to Next.js image sizes. */
   imageSizes?: number[];
-  /**
-   * Allowed output qualities. When unset, any quality from 1-100 is permitted
-   * (matches Next.js: an unset `images.qualities` is not restricted to a single
-   * value). When set, only the listed qualities are accepted.
-   */
+  /** Allowed output qualities. Defaults to [75]. */
   qualities?: number[];
+  /** Preferred optimized output formats. Defaults to ["image/webp"]. */
+  formats?: Array<"image/avif" | "image/webp">;
+  /** Disable optimization globally for next/image rendering. */
+  unoptimized?: boolean;
+  /** Allowed local image URL patterns. Defaults to local paths without query strings. */
+  localPatterns?: LocalPattern[];
+  /** Allowed remote image URL patterns. */
+  remotePatterns?: RemotePatternInput[];
+  /** Legacy allowed remote image hostnames. */
+  domains?: string[];
+  /** Maximum remote redirects. Defaults to 3. */
+  maximumRedirects?: number;
+  /** Maximum remote response size in bytes. Defaults to 50 MB. */
+  maximumResponseBody?: number;
+  /** Minimum cache lifetime in seconds for mutable optimized sources. Defaults to 4 hours. */
+  minimumCacheTTL?: number;
   /** Allow SVG through the image optimization endpoint. Default: false. */
   dangerouslyAllowSVG?: boolean;
   /**
    * Allow image optimization for hostnames that resolve to private IP addresses.
    * Default: false.
    *
-   * Note: This field is currently reserved for future server-side remote-image
-   * fetching. vinext's image optimization endpoint only serves local files, so
-   * there is no active server-side SSRF vector — the flag is consumed client-side
-   * via the image shim instead.
    */
   dangerouslyAllowLocalIP?: boolean;
-  /** Content-Disposition header value. Default: "inline". */
+  /** Content-Disposition header value. Default: "attachment". */
   contentDispositionType?: "inline" | "attachment";
   /** Content-Security-Policy header value. Default: "script-src 'none'; frame-src 'none'; sandbox;" */
   contentSecurityPolicy?: string;
 };
+
+/** Returns whether the built-in image optimization endpoint should be exposed. */
+export function isImageOptimizationEnabled(imageConfig?: ImageConfig): boolean {
+  return imageConfig?.unoptimized !== true && (imageConfig?.loader ?? "default") === "default";
+}
 
 /**
  * Next.js default device sizes and image sizes.
@@ -74,18 +117,39 @@ export type ImageConfig = {
  * config is provided. Matches Next.js defaults exactly.
  */
 export const DEFAULT_DEVICE_SIZES = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
-export const DEFAULT_IMAGE_SIZES = [16, 32, 48, 64, 96, 128, 256, 384];
+export const DEFAULT_IMAGE_SIZES = [32, 48, 64, 96, 128, 256, 384];
+export const DEFAULT_IMAGE_QUALITIES = [75];
+export const DEFAULT_IMAGE_FORMATS: Array<"image/avif" | "image/webp"> = ["image/webp"];
 const DEV_BLUR_MAX_WIDTH = 8;
 const DEV_BLUR_QUALITY = 70;
 
 export type ParseImageParamsOptions = {
   isDev?: boolean;
+  allowRemote?: boolean;
+  localPatterns?: LocalPattern[];
 };
+
+export function parseRemoteImageUrl(value: string | null): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username !== "" ||
+      url.password !== ""
+    ) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
 
 export function resolveDevImageRedirect(
   requestUrl: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
-  allowedQualities?: number[],
+  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
   options: ParseImageParamsOptions = { isDev: true },
 ): string | null {
   const params = parseImageParams(requestUrl, allowedWidths, allowedQualities, options);
@@ -113,16 +177,18 @@ export function resolveDevImageRedirect(
 export function parseImageParams(
   url: URL,
   allowedWidths: number[] = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES],
-  allowedQualities?: number[],
+  allowedQualities: number[] = DEFAULT_IMAGE_QUALITIES,
   options: ParseImageParamsOptions = {},
 ): { imageUrl: string; width: number; quality: number } | null {
   // Intentional hardening divergence from Next.js: reject duplicate and unknown
   // parameters so semantically identical transforms cannot occupy distinct
   // cache keys and amplify image transformation work.
-  const allowedParamNames = new Set(["url", "w", "q"]);
+  const allowedParamNames = new Set(["url", "w", "q", "dpl"]);
   for (const name of url.searchParams.keys()) {
     if (!allowedParamNames.has(name) || url.searchParams.getAll(name).length !== 1) return null;
   }
+  const deploymentId = url.searchParams.get("dpl");
+  if (deploymentId !== null && deploymentId.length === 0) return null;
 
   const imageUrl = url.searchParams.get("url");
   if (!imageUrl) return null;
@@ -141,13 +207,16 @@ export function parseImageParams(
   const isDevBlurQuality = options.isDev && quality === DEV_BLUR_QUALITY;
   if (width <= 0 || (!allowedWidths.includes(width) && !isDevBlurWidth)) return null;
   if (quality < 1 || quality > 100) return null;
-  // Only enforce the quality allowlist when `images.qualities` is configured.
-  // Matches Next.js: an unset `qualities` permits any quality from 1-100.
-  if (allowedQualities && !allowedQualities.includes(quality) && !isDevBlurQuality) {
+  if (!allowedQualities.includes(quality) && !isDevBlurQuality) {
     return null;
   }
 
-  // Prevent open redirect / SSRF — only allow path-relative URLs.
+  if (options.allowRemote) {
+    const remoteUrl = parseRemoteImageUrl(imageUrl);
+    if (remoteUrl) return { imageUrl: remoteUrl.href, width, quality };
+  }
+
+  // Prevent open redirect / SSRF — local sources must be path-relative URLs.
   // Normalize backslashes to forward slashes first: browsers and the URL
   // constructor treat /\evil.com as protocol-relative (//evil.com).
   const normalizedUrl = imageUrl.replaceAll("\\", "/");
@@ -157,6 +226,7 @@ export function parseImageParams(
   if (!normalizedUrl.startsWith("/") || normalizedUrl.startsWith("//")) {
     return null;
   }
+  if (!hasLocalMatch(options.localPatterns, normalizedUrl)) return null;
   // Double-check: after URL construction, the origin must not change.
   // This catches any remaining parser differentials.
   try {
@@ -169,6 +239,13 @@ export function parseImageParams(
     return null;
   }
 
+  try {
+    const pathname = decodeURIComponent(new URL(normalizedUrl, "https://localhost").pathname);
+    if (/\/(?:_next|_vinext)\/image(?:$|\/)/.test(pathname)) return null;
+  } catch {
+    return null;
+  }
+
   return { imageUrl: normalizedUrl, width, quality };
 }
 
@@ -176,18 +253,80 @@ export function parseImageParams(
  * Negotiate the best output format based on the Accept header.
  * Returns an IANA media type.
  */
-export function negotiateImageFormat(acceptHeader: string | null): string {
-  if (!acceptHeader) return "image/jpeg";
-  if (acceptHeader.includes("image/avif")) return "image/avif";
-  if (acceptHeader.includes("image/webp")) return "image/webp";
-  return "image/jpeg";
+export function negotiateImageFormat(
+  acceptHeader: string | null,
+  formats: readonly string[] = DEFAULT_IMAGE_FORMATS,
+): string {
+  if (!acceptHeader) return "";
+
+  const accepted = acceptHeader.split(",").flatMap((entry, position) => {
+    const [rawToken, ...parameters] = entry.trim().split(";");
+    const token = rawToken.trim().toLowerCase();
+    if (!token) return [];
+    let quality = 1;
+    for (const parameter of parameters) {
+      const match = parameter.trim().match(/^q\s*=\s*(0(?:\.\d+)?|1(?:\.0+)?)$/i);
+      if (match) quality = Number(match[1]);
+    }
+    return [{ token, quality, position }];
+  });
+
+  let selected = "";
+  let selectedQuality = -1;
+  for (const format of formats) {
+    const normalizedFormat = format.toLowerCase();
+    const exactMatches = accepted.filter(({ token }) => token === normalizedFormat);
+    const typeMatches = accepted.filter(({ token }) => token === "image/*");
+    const wildcardMatches = accepted.filter(({ token }) => token === "*/*");
+    const match = (
+      exactMatches.length > 0
+        ? exactMatches
+        : typeMatches.length > 0
+          ? typeMatches
+          : wildcardMatches
+    ).sort((left, right) => right.quality - left.quality || left.position - right.position)[0];
+    if (match && match.quality > 0 && match.quality > selectedQuality) {
+      selected = format;
+      selectedQuality = match.quality;
+    }
+  }
+  return selected;
 }
 
 /**
  * Standard Cache-Control header for optimized images.
  * Optimized images are immutable because the URL encodes the transform params.
  */
-export const IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+export const STATIC_IMAGE_CACHE_CONTROL = "public, max-age=315360000, immutable";
+export const DEFAULT_MINIMUM_CACHE_TTL = 14_400;
+
+export function getImageMaxAge(cacheControl: string | null): number {
+  if (!cacheControl) return 0;
+  let maxAge = 0;
+  const directives = cacheControl.split(",");
+  for (const directive of directives) {
+    const match = directive.trim().match(/^(s-maxage|max-age)\s*=\s*"?(\d+)"?$/i);
+    if (!match) continue;
+    const value = Number(match[2]);
+    if (match[1].toLowerCase() === "s-maxage") return value;
+    maxAge = value;
+  }
+  return maxAge;
+}
+
+export function getImageCacheControl(
+  imageUrl: string,
+  sourceCacheControl: string | null,
+  minimumCacheTTL = DEFAULT_MINIMUM_CACHE_TTL,
+  isDev = false,
+): string {
+  if (isDev) return "public, max-age=0, must-revalidate";
+  if (imageUrl.startsWith("/") && imageUrl.includes("/_next/static/media/")) {
+    return STATIC_IMAGE_CACHE_CONTROL;
+  }
+  const maxAge = Math.max(minimumCacheTTL, getImageMaxAge(sourceCacheControl));
+  return `public, max-age=${maxAge}, must-revalidate`;
+}
 
 /**
  * Content-Security-Policy for image optimization responses.
@@ -214,6 +353,19 @@ const SAFE_IMAGE_CONTENT_TYPES = new Set([
   "image/tiff",
 ]);
 
+const IMAGE_CONTENT_TYPE_EXTENSIONS = new Map([
+  ["image/jpeg", "jpeg"],
+  ["image/png", "png"],
+  ["image/gif", "gif"],
+  ["image/webp", "webp"],
+  ["image/avif", "avif"],
+  ["image/x-icon", "ico"],
+  ["image/vnd.microsoft.icon", "ico"],
+  ["image/bmp", "bmp"],
+  ["image/tiff", "tiff"],
+  ["image/svg+xml", "svg"],
+]);
+
 /**
  * Check if a Content-Type header value is a safe image type.
  * Returns false for SVG (unless dangerouslyAllowSVG is true), HTML, or any non-image type.
@@ -236,23 +388,83 @@ export function isSafeImageContentType(
  * regardless of whether the image was transformed or served as-is.
  * When an ImageConfig is provided, uses its values for CSP and Content-Disposition.
  */
-function setImageSecurityHeaders(headers: Headers, config?: ImageConfig): void {
+export function getImageContentDisposition(
+  imageUrl: string,
+  contentType: string | null,
+  type: string,
+) {
+  let pathname: string;
+  try {
+    pathname = new URL(imageUrl, "https://localhost").pathname;
+  } catch {
+    pathname = imageUrl.split("?", 1)[0];
+  }
+  const encodedBasename = pathname.split("/").pop() || "image";
+  let basename: string;
+  try {
+    basename = decodeURIComponent(encodedBasename);
+  } catch {
+    basename = encodedBasename;
+  }
+  const stem = basename.split(".", 1)[0] || "image";
+  const mediaType = contentType?.split(";", 1)[0].trim().toLowerCase();
+  const extension = (mediaType && IMAGE_CONTENT_TYPE_EXTENSIONS.get(mediaType)) || "bin";
+  return formatContentDisposition(`${stem}.${extension}`, type);
+}
+
+function formatContentDisposition(filename: string, type: string): string {
+  const fallback = filename.replace(/[^\x20-\x7e\xa0-\xff]/g, "?");
+  const quotedFallback = fallback.replace(/([\\"])/g, "\\$1");
+  const needsExtendedFilename = fallback !== filename || /%[0-9A-Fa-f]{2}/.test(filename);
+  const extendedFilename = encodeURIComponent(filename).replace(
+    /['()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
+  return `${type}; filename="${quotedFallback}"${needsExtendedFilename ? `; filename*=UTF-8''${extendedFilename}` : ""}`;
+}
+
+function setImageSecurityHeaders(
+  headers: Headers,
+  imageUrl: string,
+  contentType: string | null,
+  config?: ImageConfig,
+): void {
   headers.set(
     "Content-Security-Policy",
     config?.contentSecurityPolicy ?? IMAGE_CONTENT_SECURITY_POLICY,
   );
   headers.set("X-Content-Type-Options", "nosniff");
+  const dispositionType = config?.contentDispositionType === "inline" ? "inline" : "attachment";
   headers.set(
     "Content-Disposition",
-    config?.contentDispositionType === "attachment" ? "attachment" : "inline",
+    getImageContentDisposition(imageUrl, contentType, dispositionType),
   );
 }
 
-function createPassthroughImageResponse(source: Response, config?: ImageConfig): Response {
-  const headers = new Headers(source.headers);
-  headers.set("Cache-Control", IMAGE_CACHE_CONTROL);
+function createPassthroughImageResponse(
+  source: Response,
+  imageUrl: string,
+  config?: ImageConfig,
+  isDev = false,
+): Response {
+  const isRemote = parseRemoteImageUrl(imageUrl) !== null;
+  const headers = isRemote ? new Headers() : new Headers(source.headers);
+  if (isRemote) {
+    const contentType = source.headers.get("Content-Type");
+    if (contentType) headers.set("Content-Type", contentType);
+  }
+  headers.set(
+    "Cache-Control",
+    getImageCacheControl(
+      imageUrl,
+      source.headers.get("Cache-Control"),
+      config?.minimumCacheTTL,
+      isDev,
+    ),
+  );
   headers.set("Vary", "Accept");
-  setImageSecurityHeaders(headers, config);
+  setImageSecurityHeaders(headers, imageUrl, headers.get("Content-Type"), config);
   return new Response(source.body, { status: 200, headers });
 }
 
@@ -268,7 +480,257 @@ export type ImageHandlers = {
     body: ReadableStream,
     options: { width: number; format: string; quality: number },
   ) => Promise<Response>;
+  /** Optional fetch implementation bound to the already-validated addresses. */
+  fetchRemote?: (url: URL, addresses: readonly string[], signal: AbortSignal) => Promise<Response>;
+  /** Optional hostname resolver used by Node runtimes for private-IP checks. */
+  resolveHostnames?: (hostname: string) => Promise<string[]>;
 };
+
+/** Copy the complete image configuration used by runtime optimizer adapters. */
+export function createRuntimeImageConfig(config?: ImageConfig): ImageConfig | undefined {
+  if (!config) return undefined;
+  return {
+    path: config.path,
+    loader: config.loader,
+    deviceSizes: config.deviceSizes,
+    imageSizes: config.imageSizes,
+    qualities: config.qualities,
+    formats: config.formats,
+    unoptimized: config.unoptimized,
+    localPatterns: config.localPatterns,
+    remotePatterns: config.remotePatterns,
+    domains: config.domains,
+    maximumRedirects: config.maximumRedirects,
+    maximumResponseBody: config.maximumResponseBody,
+    minimumCacheTTL: config.minimumCacheTTL,
+    dangerouslyAllowSVG: config.dangerouslyAllowSVG,
+    dangerouslyAllowLocalIP: config.dangerouslyAllowLocalIP,
+    contentDispositionType: config.contentDispositionType,
+    contentSecurityPolicy: config.contentSecurityPolicy,
+  };
+}
+
+const DEFAULT_MAXIMUM_REDIRECTS = 3;
+const DEFAULT_MAXIMUM_RESPONSE_BODY = 50_000_000;
+const REMOTE_FETCH_TIMEOUT_MS = 7_000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function isLocalHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/, "");
+  return (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized.endsWith(".local") ||
+    normalized.endsWith(".internal")
+  );
+}
+
+/**
+ * Redirect configured remote image requests from Workers to their source URL.
+ *
+ * Workers cannot bind hostname validation to the subsequent outbound fetch, so
+ * proxying remote images would leave a DNS-rebinding SSRF gap. Node runtimes can
+ * continue to optimize remote images with their resolver-backed handler. Worker
+ * deployments safely fall back to the original, unoptimized remote image.
+ */
+export function getWorkerRemoteImageRedirect(
+  request: Request,
+  allowedWidths?: number[],
+  imageConfig: ImageConfig = {},
+): Response | null {
+  const requestUrl = new URL(request.url);
+  const rawImageUrl = requestUrl.searchParams.get("url");
+  if (!rawImageUrl) return null;
+
+  const rawSourceUrl = parseRemoteImageUrl(rawImageUrl);
+  if (!rawSourceUrl) return null;
+
+  const params = parseImageParams(requestUrl, allowedWidths, imageConfig.qualities, {
+    allowRemote: true,
+  });
+  if (!params) return badRequestResponse();
+
+  const sourceUrl = parseRemoteImageUrl(params.imageUrl);
+  if (!sourceUrl) return badRequestResponse();
+
+  if (
+    sourceUrl.username !== "" ||
+    sourceUrl.password !== "" ||
+    (!imageConfig.dangerouslyAllowLocalIP &&
+      (isLocalHostname(sourceUrl.hostname) || isPrivateIp(sourceUrl.hostname))) ||
+    !hasRemoteMatch(imageConfig.domains ?? [], imageConfig.remotePatterns ?? [], sourceUrl)
+  ) {
+    return badRequestResponse();
+  }
+
+  return new Response(null, {
+    status: 307,
+    headers: {
+      "Cache-Control": "private, no-store",
+      Location: sourceUrl.href,
+    },
+  });
+}
+
+async function validateRemoteTarget(
+  url: URL,
+  config: ImageConfig,
+  resolveHostnames?: (hostname: string) => Promise<string[]>,
+  requireRemoteMatch = false,
+): Promise<string[] | null> {
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username !== "" ||
+    url.password !== "" ||
+    (requireRemoteMatch && !hasRemoteMatch(config.domains ?? [], config.remotePatterns ?? [], url))
+  ) {
+    return null;
+  }
+
+  const hostname =
+    url.hostname.startsWith("[") && url.hostname.endsWith("]")
+      ? url.hostname.slice(1, -1)
+      : url.hostname;
+  if (!config.dangerouslyAllowLocalIP && isLocalHostname(hostname)) return null;
+  if (isIP(hostname)) {
+    if (!config.dangerouslyAllowLocalIP && isPrivateIp(hostname)) return null;
+    return [hostname];
+  }
+
+  if (!resolveHostnames) return null;
+
+  try {
+    const addresses = await resolveHostnames(hostname);
+    if (
+      addresses.length === 0 ||
+      (!config.dangerouslyAllowLocalIP && addresses.some(isPrivateIp))
+    ) {
+      return null;
+    }
+    return addresses;
+  } catch {
+    return null;
+  }
+}
+
+async function readBoundedResponse(response: Response, maximumBytes: number): Promise<Response> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && Number(contentLength) > maximumBytes) {
+    await response.body?.cancel();
+    return new Response("Remote image response is too large", { status: 413 });
+  }
+  if (!response.body) return new Response("Remote image response is empty", { status: 400 });
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalSize = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalSize += value.byteLength;
+      if (totalSize > maximumBytes) {
+        await reader.cancel();
+        return new Response("Remote image response is too large", { status: 413 });
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    try {
+      await reader.cancel(error);
+    } catch {}
+    return remoteFetchErrorResponse(error);
+  }
+
+  const body = new Uint8Array(totalSize);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new Response(body, { status: response.status, headers: response.headers });
+}
+
+function remoteFetchErrorResponse(error: unknown): Response {
+  const errorName =
+    typeof error === "object" && error !== null && "name" in error ? error.name : undefined;
+  const status = errorName === "AbortError" || errorName === "TimeoutError" ? 504 : 502;
+  return new Response(
+    status === 504 ? "Remote image request timed out" : "Remote image request failed",
+    { status },
+  );
+}
+
+async function fetchRemoteImage(
+  sourceUrl: string,
+  config: ImageConfig,
+  handlers: ImageHandlers,
+): Promise<Response> {
+  const fetchRemote = handlers.fetchRemote;
+  const maximumRedirects = config.maximumRedirects ?? DEFAULT_MAXIMUM_REDIRECTS;
+  const maximumResponseBody = config.maximumResponseBody ?? DEFAULT_MAXIMUM_RESPONSE_BODY;
+  let currentUrl = new URL(sourceUrl);
+
+  for (let redirectCount = 0; ; redirectCount++) {
+    const addresses = await validateRemoteTarget(
+      currentUrl,
+      config,
+      handlers.resolveHostnames,
+      redirectCount === 0,
+    );
+    if (!addresses || !fetchRemote) {
+      return new Response("Remote image URL is not allowed", { status: 400 });
+    }
+
+    let response: Response;
+    try {
+      response = await fetchRemote(
+        currentUrl,
+        addresses,
+        AbortSignal.timeout(REMOTE_FETCH_TIMEOUT_MS),
+      );
+    } catch (error) {
+      return remoteFetchErrorResponse(error);
+    }
+
+    const location = response.headers.get("location");
+    if (REDIRECT_STATUSES.has(response.status) && location) {
+      await response.body?.cancel();
+      if (redirectCount >= maximumRedirects) {
+        return new Response("Remote image redirected too many times", { status: 508 });
+      }
+      try {
+        currentUrl = new URL(location, currentUrl);
+      } catch {
+        return new Response("Remote image redirect is invalid", { status: 400 });
+      }
+      continue;
+    }
+
+    if (!response.ok) {
+      await response.body?.cancel();
+      return new Response("Remote image request failed", { status: response.status });
+    }
+
+    if (!isSafeImageContentType(response.headers.get("Content-Type"), config.dangerouslyAllowSVG)) {
+      await response.body?.cancel();
+      return new Response("The requested resource is not an allowed image type", { status: 400 });
+    }
+
+    return readBoundedResponse(response, maximumResponseBody);
+  }
+}
+
+function fetchImageSource(
+  imageUrl: string,
+  request: Request,
+  imageConfig: ImageConfig,
+  handlers: ImageHandlers,
+): Promise<Response> {
+  return parseRemoteImageUrl(imageUrl)
+    ? fetchRemoteImage(imageUrl, imageConfig, handlers)
+    : handlers.fetchAsset(imageUrl, request);
+}
 
 /**
  * Handle image optimization requests.
@@ -282,9 +744,18 @@ export async function handleImageOptimization(
   handlers: ImageHandlers,
   allowedWidths?: number[],
   imageConfig?: ImageConfig,
+  options: { isDev?: boolean } = {},
 ): Promise<Response> {
   const url = new URL(request.url);
-  const params = parseImageParams(url, allowedWidths, imageConfig?.qualities);
+  const params = parseImageParams(
+    url,
+    allowedWidths,
+    imageConfig?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+    {
+      allowRemote: true,
+      localPatterns: imageConfig?.localPatterns,
+    },
+  );
 
   if (!params) {
     return badRequestResponse();
@@ -293,19 +764,25 @@ export async function handleImageOptimization(
   const { imageUrl, width, quality } = params;
 
   // Fetch source image
-  const source = await handlers.fetchAsset(imageUrl, request);
+  const isRemote = parseRemoteImageUrl(imageUrl) !== null;
+  const source = await fetchImageSource(imageUrl, request, imageConfig ?? {}, handlers);
   if (!source.ok || !source.body) {
+    if (isRemote) return source;
     return new Response("Image not found", { status: 404 });
   }
-
-  // Negotiate output format from Accept header
-  const format = negotiateImageFormat(request.headers.get("Accept"));
 
   // Block unsafe Content-Types (e.g., SVG which can contain embedded scripts).
   // Check the source Content-Type before any processing. SVG is only allowed
   // when dangerouslyAllowSVG is explicitly enabled in next.config.js.
   const sourceContentType = source.headers.get("Content-Type");
+  const responseCacheControl = getImageCacheControl(
+    imageUrl,
+    source.headers.get("Cache-Control"),
+    imageConfig?.minimumCacheTTL,
+    options.isDev ?? false,
+  );
   if (!isSafeImageContentType(sourceContentType, imageConfig?.dangerouslyAllowSVG)) {
+    await source.body.cancel();
     return new Response("The requested resource is not an allowed image type", { status: 400 });
   }
 
@@ -314,8 +791,13 @@ export async function handleImageOptimization(
   // This matches Next.js behavior where SVG is a "bypass type".
   const sourceMediaType = sourceContentType?.split(";")[0].trim().toLowerCase();
   if (sourceMediaType === "image/svg+xml") {
-    return createPassthroughImageResponse(source, imageConfig);
+    return createPassthroughImageResponse(source, imageUrl, imageConfig, options.isDev ?? false);
   }
+
+  const format =
+    negotiateImageFormat(request.headers.get("Accept"), imageConfig?.formats) ||
+    sourceMediaType ||
+    "image/jpeg";
 
   // Transform if handler provided, otherwise serve original
   if (handlers.transformImage) {
@@ -326,15 +808,15 @@ export async function handleImageOptimization(
         quality,
       });
       const headers = new Headers(transformed.headers);
-      headers.set("Cache-Control", IMAGE_CACHE_CONTROL);
+      headers.set("Cache-Control", responseCacheControl);
       headers.set("Vary", "Accept");
-      setImageSecurityHeaders(headers, imageConfig);
 
       // Verify the transformed response also has a safe Content-Type.
       // A malicious or buggy transform handler could return HTML.
       if (!isSafeImageContentType(headers.get("Content-Type"), imageConfig?.dangerouslyAllowSVG)) {
         headers.set("Content-Type", format);
       }
+      setImageSecurityHeaders(headers, imageUrl, headers.get("Content-Type"), imageConfig);
 
       return new Response(transformed.body, { status: 200, headers });
     } catch (e) {
@@ -344,10 +826,10 @@ export async function handleImageOptimization(
 
   // Fallback: serve original image with cache headers
   try {
-    return createPassthroughImageResponse(source, imageConfig);
+    return createPassthroughImageResponse(source, imageUrl, imageConfig, options.isDev ?? false);
   } catch (e) {
     console.error("[vinext] Image fallback error, refetching source image:", e);
-    const refetchedSource = await handlers.fetchAsset(imageUrl, request);
+    const refetchedSource = await fetchImageSource(imageUrl, request, imageConfig ?? {}, handlers);
     if (!refetchedSource.ok || !refetchedSource.body) {
       return new Response("Image not found", { status: 404 });
     }
@@ -357,6 +839,11 @@ export async function handleImageOptimization(
       return new Response("The requested resource is not an allowed image type", { status: 400 });
     }
 
-    return createPassthroughImageResponse(refetchedSource, imageConfig);
+    return createPassthroughImageResponse(
+      refetchedSource,
+      imageUrl,
+      imageConfig,
+      options.isDev ?? false,
+    );
   }
 }

--- a/packages/vinext/src/server/node-remote-image-fetch.ts
+++ b/packages/vinext/src/server/node-remote-image-fetch.ts
@@ -1,0 +1,68 @@
+import type { LookupAddress, LookupOptions } from "node:dns";
+import { lookup as dnsLookup } from "node:dns/promises";
+import { request as requestHttp } from "node:http";
+import { request as requestHttps } from "node:https";
+import { Readable } from "node:stream";
+
+function addressFamily(address: string): 4 | 6 {
+  return address.includes(":") ? 6 : 4;
+}
+
+export async function resolveRemoteImageHostnames(hostname: string): Promise<string[]> {
+  return (await dnsLookup(hostname, { all: true })).map((entry) => entry.address);
+}
+
+export async function fetchRemoteImageFromValidatedAddresses(
+  url: URL,
+  addresses: readonly string[],
+  signal: AbortSignal,
+): Promise<Response> {
+  if (addresses.length === 0) throw new Error("No validated remote image addresses");
+
+  const request = url.protocol === "https:" ? requestHttps : requestHttp;
+  const response = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
+    const lookup = (
+      _hostname: string,
+      options: LookupOptions,
+      callback: (
+        error: NodeJS.ErrnoException | null,
+        address: string | LookupAddress[],
+        family?: number,
+      ) => void,
+    ) => {
+      const approved = addresses.map((address) => ({ address, family: addressFamily(address) }));
+      if ("all" in options && options.all) {
+        callback(null, approved);
+      } else {
+        const preferred = approved.find(({ family }) => family === options.family) ?? approved[0];
+        callback(null, preferred.address, preferred.family);
+      }
+    };
+
+    const outgoing = request(url, {
+      agent: false,
+      headers: { Accept: "image/avif,image/webp,image/*,*/*;q=0.8" },
+      lookup,
+      signal,
+    });
+    outgoing.once("response", resolve);
+    outgoing.once("error", reject);
+    outgoing.end();
+  });
+
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(response.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item);
+    } else {
+      headers.set(name, value);
+    }
+  }
+
+  return new Response(Readable.toWeb(response) as ReadableStream, {
+    status: response.statusCode ?? 500,
+    statusText: response.statusMessage,
+    headers,
+  });
+}

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -29,12 +29,24 @@ import {
   isImageOptimizationPath,
   IMAGE_CONTENT_SECURITY_POLICY,
   parseImageParams,
+  parseRemoteImageUrl,
   isSafeImageContentType,
   DEFAULT_DEVICE_SIZES,
   DEFAULT_IMAGE_SIZES,
+  createRuntimeImageConfig,
+  DEFAULT_IMAGE_QUALITIES,
+  getImageCacheControl,
+  getImageContentDisposition,
+  handleImageOptimization,
+  imageOptimizationPathAfterBasePath,
+  isImageOptimizationEnabled,
   type ImageConfig,
 } from "./image-optimization.js";
 import { normalizePath } from "./normalize-path.js";
+import {
+  fetchRemoteImageFromValidatedAddresses,
+  resolveRemoteImageHostnames,
+} from "./node-remote-image-fetch.js";
 import { filterInternalHeaders, isOpenRedirectShaped } from "./request-pipeline.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import {
@@ -83,6 +95,10 @@ import {
   parseAcceptedEncodings,
   selectContentEncoding,
 } from "./accept-encoding.js";
+
+export function getLocalImageLookupPath(imageUrl: string): string {
+  return imageUrl.split("?", 1)[0];
+}
 
 /**
  * mtime of the build each bare (query-less) server-entry URL was first
@@ -1340,21 +1356,55 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
 
     // Image optimization passthrough (Node.js prod server has no Images binding;
     // serves the original file with cache headers and security headers)
-    if (isImageOptimizationPath(pathname)) {
+    const appRequestHasBasePath = !appRouterBasePath || hasBasePath(pathname, appRouterBasePath);
+    const appRoutingPathname = stripBasePath(pathname, appRouterBasePath);
+    if (
+      appRequestHasBasePath &&
+      isImageOptimizationPath(
+        appRoutingPathname,
+        imageOptimizationPathAfterBasePath(imageConfig?.path, appRouterBasePath),
+      )
+    ) {
+      if (!isImageOptimizationEnabled(imageConfig)) {
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Not Found");
+        return;
+      }
       const parsedUrl = new URL(rawUrl, "http://localhost");
       const allowedWidths = [
         ...(imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
         ...(imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ];
-      const params = parseImageParams(parsedUrl, allowedWidths, imageConfig?.qualities);
+      const remoteSource = parsedUrl.searchParams.get("url");
+      if (parseRemoteImageUrl(remoteSource)) {
+        const response = await handleImageOptimization(
+          new Request(parsedUrl, { headers: req.headers as HeadersInit }),
+          {
+            fetchAsset: async () => new Response(null, { status: 404 }),
+            fetchRemote: fetchRemoteImageFromValidatedAddresses,
+            resolveHostnames: resolveRemoteImageHostnames,
+          },
+          allowedWidths,
+          imageConfig,
+        );
+        await sendWebResponse(response, req, res, false);
+        return;
+      }
+      const params = parseImageParams(
+        parsedUrl,
+        allowedWidths,
+        imageConfig?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+        { localPatterns: imageConfig?.localPatterns },
+      );
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");
         return;
       }
+      const imageLookupPath = getLocalImageLookupPath(params.imageUrl);
       // Block SVG and other unsafe content types by checking the file extension.
       // SVG is only allowed when dangerouslyAllowSVG is enabled in next.config.js.
-      const ext = path.extname(params.imageUrl).toLowerCase();
+      const ext = path.extname(imageLookupPath).toLowerCase();
       const ct = CONTENT_TYPES[ext] ?? "application/octet-stream";
       if (!isSafeImageContentType(ct, imageConfig?.dangerouslyAllowSVG)) {
         res.writeHead(400);
@@ -1363,18 +1413,22 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       }
       // Serve the original image with CSP and security headers
       const imageSecurityHeaders: Record<string, string> = {
+        "Cache-Control": getImageCacheControl(params.imageUrl, null, imageConfig?.minimumCacheTTL),
         "Content-Security-Policy":
           imageConfig?.contentSecurityPolicy ?? IMAGE_CONTENT_SECURITY_POLICY,
         "X-Content-Type-Options": "nosniff",
-        "Content-Disposition":
-          imageConfig?.contentDispositionType === "attachment" ? "attachment" : "inline",
+        "Content-Disposition": getImageContentDisposition(
+          imageLookupPath,
+          ct,
+          imageConfig?.contentDispositionType === "inline" ? "inline" : "attachment",
+        ),
       };
       if (
         await tryServeStatic(
           req,
           res,
           clientDir,
-          params.imageUrl,
+          imageLookupPath,
           false,
           staticCache,
           imageSecurityHeaders,
@@ -1552,15 +1606,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     ...(vinextConfig?.images?.imageSizes ?? DEFAULT_IMAGE_SIZES),
   ];
   // Extract image security config for SVG handling and security headers
-  const pagesImageConfig: ImageConfig | undefined = vinextConfig?.images
-    ? {
-        dangerouslyAllowSVG: vinextConfig.images.dangerouslyAllowSVG,
-        dangerouslyAllowLocalIP: vinextConfig.images.dangerouslyAllowLocalIP,
-        qualities: vinextConfig.images.qualities,
-        contentDispositionType: vinextConfig.images.contentDispositionType,
-        contentSecurityPolicy: vinextConfig.images.contentSecurityPolicy,
-      }
-    : undefined;
+  const pagesImageConfig = createRuntimeImageConfig(
+    vinextConfig?.images as ImageConfig | undefined,
+  );
 
   // Load client asset metadata used by the Pages renderer. Prerendered HTML is
   // rendered through this Node server too, so it needs the same globals that
@@ -1663,6 +1711,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // instead of falling through to the SSR/render handler (which would
     // render the full HTML 404 page). Matches Next.js's behaviour in
     // packages/next/src/server/lib/router-server.ts.
+    const hadBasePath = !basePath || hasBasePath(pathname, basePath);
     const staticLookupPath = stripBasePath(pathname, basePath);
     const pagesAssetLookup = resolveAppRouterAssetPath(pathname, pagesAssetPathPrefix, assetPrefix);
     if (pagesAssetLookup) {
@@ -1675,17 +1724,49 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     }
 
     // ── Image optimization passthrough ──────────────────────────────
-    if (isImageOptimizationPath(pathname) || isImageOptimizationPath(staticLookupPath)) {
+    if (
+      hadBasePath &&
+      isImageOptimizationPath(
+        staticLookupPath,
+        imageOptimizationPathAfterBasePath(pagesImageConfig?.path, basePath),
+      )
+    ) {
+      if (!isImageOptimizationEnabled(pagesImageConfig)) {
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Not Found");
+        return;
+      }
       const parsedUrl = new URL(rawUrl, "http://localhost");
-      const params = parseImageParams(parsedUrl, allowedImageWidths, pagesImageConfig?.qualities);
+      const remoteSource = parsedUrl.searchParams.get("url");
+      if (parseRemoteImageUrl(remoteSource)) {
+        const response = await handleImageOptimization(
+          new Request(parsedUrl, { headers: req.headers as HeadersInit }),
+          {
+            fetchAsset: async () => new Response(null, { status: 404 }),
+            fetchRemote: fetchRemoteImageFromValidatedAddresses,
+            resolveHostnames: resolveRemoteImageHostnames,
+          },
+          allowedImageWidths,
+          pagesImageConfig,
+        );
+        await sendWebResponse(response, req, res, false);
+        return;
+      }
+      const params = parseImageParams(
+        parsedUrl,
+        allowedImageWidths,
+        pagesImageConfig?.qualities ?? DEFAULT_IMAGE_QUALITIES,
+        { localPatterns: pagesImageConfig?.localPatterns },
+      );
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");
         return;
       }
+      const imageLookupPath = getLocalImageLookupPath(params.imageUrl);
       // Block SVG and other unsafe content types.
       // SVG is only allowed when dangerouslyAllowSVG is enabled.
-      const ext = path.extname(params.imageUrl).toLowerCase();
+      const ext = path.extname(imageLookupPath).toLowerCase();
       const ct = CONTENT_TYPES[ext] ?? "application/octet-stream";
       if (!isSafeImageContentType(ct, pagesImageConfig?.dangerouslyAllowSVG)) {
         res.writeHead(400);
@@ -1693,18 +1774,26 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         return;
       }
       const imageSecurityHeaders: Record<string, string> = {
+        "Cache-Control": getImageCacheControl(
+          params.imageUrl,
+          null,
+          pagesImageConfig?.minimumCacheTTL,
+        ),
         "Content-Security-Policy":
           pagesImageConfig?.contentSecurityPolicy ?? IMAGE_CONTENT_SECURITY_POLICY,
         "X-Content-Type-Options": "nosniff",
-        "Content-Disposition":
-          pagesImageConfig?.contentDispositionType === "attachment" ? "attachment" : "inline",
+        "Content-Disposition": getImageContentDisposition(
+          imageLookupPath,
+          ct,
+          pagesImageConfig?.contentDispositionType === "inline" ? "inline" : "attachment",
+        ),
       };
       if (
         await tryServeStatic(
           req,
           res,
           clientDir,
-          params.imageUrl,
+          imageLookupPath,
           false,
           staticCache,
           imageSecurityHeaders,
@@ -1723,7 +1812,6 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       // the basePath gating of rewrites/redirects/headers below — Next.js
       // only applies default rules to requests inside basePath, and only
       // applies `basePath: false` rules to requests outside it.
-      const hadBasePath = !basePath || hasBasePath(pathname, basePath);
       {
         const stripped = stripBasePath(pathname, basePath);
         if (stripped !== pathname) {

--- a/packages/vinext/src/shims/image-config.ts
+++ b/packages/vinext/src/shims/image-config.ts
@@ -8,9 +8,9 @@ import ipaddr from "ipaddr.js";
  * open-redirect attacks by blocking URLs that don't match any configured
  * pattern.
  *
- * Pattern matching follows Next.js semantics:
- * - `*` matches a single segment (subdomain in hostname, path segment in pathname)
- * - `**` matches any number of segments
+ * Pattern matching follows Next.js's picomatch semantics:
+ * - hostname `*` and `**` can match across dot-separated subdomains
+ * - pathname `*` matches one path segment and `**` matches across segments
  * - protocol, port, and search are matched exactly when specified
  */
 
@@ -22,6 +22,46 @@ export type RemotePattern = {
   search?: string;
 };
 
+export type RemotePatternInput = RemotePattern | URL | string;
+
+export type LocalPattern = {
+  pathname?: string;
+  search?: string;
+};
+
+export const DEFAULT_LOCAL_PATTERNS: LocalPattern[] = [{ pathname: "**", search: "" }];
+
+export function normalizeLocalPatterns(patterns?: LocalPattern[]): LocalPattern[] {
+  if (patterns === undefined) return DEFAULT_LOCAL_PATTERNS;
+  const normalized = patterns.map((pattern) => ({ ...pattern }));
+  if (
+    !normalized.some(
+      (pattern) => pattern.pathname === "/_next/static/media/**" && pattern.search === "",
+    )
+  ) {
+    normalized.push({ pathname: "/_next/static/media/**", search: "" });
+  }
+  return normalized;
+}
+
+export function normalizeRemotePattern(pattern: RemotePatternInput): RemotePattern {
+  if (typeof pattern === "string" || pattern instanceof URL) {
+    const url = typeof pattern === "string" ? new URL(pattern) : pattern;
+    return {
+      protocol: url.protocol.slice(0, -1),
+      hostname: url.hostname,
+      port: url.port,
+      pathname: url.pathname,
+      search: url.search,
+    };
+  }
+  return pattern;
+}
+
+export function normalizeRemotePatterns(patterns: RemotePatternInput[]): RemotePattern[] {
+  return patterns.map(normalizeRemotePattern);
+}
+
 // Cache compiled glob regexes — bounded by the number of distinct configured
 // remotePatterns. Key uses \0 as a separator; \0 cannot appear in a valid glob
 // or separator character, so there are no collisions. Compiled regexes are
@@ -31,9 +71,8 @@ const globRegexCache = new Map<string, RegExp>();
 /**
  * Convert a glob pattern (with `*` and `**`) to a RegExp.
  *
- * For hostnames, segments are separated by `.`:
- *   - `*` matches a single segment (no dots): [^.]+
- *   - `**` matches any number of segments: .+
+ * For hostnames, Next.js uses picomatch without treating `.` as a path
+ * separator, so both `*` and `**` can match nested subdomains.
  *
  * For pathnames, segments are separated by `/`:
  *   - `*` matches a single segment (no slashes): [^/]+
@@ -47,8 +86,8 @@ function globToRegex(pattern: string, separator: "." | "/"): RegExp {
   if (cached !== undefined) return cached;
   // Split by ** first, then handle * within each part
   let regexStr = "^";
-  const doubleStar = separator === "." ? ".+" : ".*";
-  const singleStar = separator === "." ? "[^.]+" : "[^/]+";
+  const doubleStar = ".*";
+  const singleStar = separator === "." ? ".*" : "[^/]+";
 
   const parts = pattern.split("**");
   for (let i = 0; i < parts.length; i++) {
@@ -75,7 +114,8 @@ function globToRegex(pattern: string, separator: "." | "/"): RegExp {
  * Check whether a URL matches a single remote pattern.
  * Follows the same semantics as Next.js's matchRemotePattern().
  */
-export function matchRemotePattern(pattern: RemotePattern, url: URL): boolean {
+export function matchRemotePattern(patternInput: RemotePatternInput, url: URL): boolean {
+  const pattern = normalizeRemotePattern(patternInput);
   // Protocol check (strip trailing colon for comparison)
   if (pattern.protocol !== undefined) {
     if (pattern.protocol.replace(/:$/, "") !== url.protocol.replace(/:$/, "")) {
@@ -116,12 +156,24 @@ export function matchRemotePattern(pattern: RemotePattern, url: URL): boolean {
  */
 export function hasRemoteMatch(
   domains: string[],
-  remotePatterns: RemotePattern[],
+  remotePatterns: RemotePatternInput[],
   url: URL,
 ): boolean {
   return (
     domains.some((domain) => url.hostname === domain) ||
     remotePatterns.some((p) => matchRemotePattern(p, url))
+  );
+}
+
+export function matchLocalPattern(pattern: LocalPattern, url: URL): boolean {
+  if (pattern.search !== undefined && pattern.search !== url.search) return false;
+  return globToRegex(pattern.pathname ?? "**", "/").test(url.pathname);
+}
+
+export function hasLocalMatch(localPatterns: LocalPattern[] | undefined, url: string): boolean {
+  const parsedUrl = new URL(url, "http://n");
+  return normalizeLocalPatterns(localPatterns).some((pattern) =>
+    matchLocalPattern(pattern, parsedUrl),
   );
 }
 

--- a/packages/vinext/src/shims/image-loader.ts
+++ b/packages/vinext/src/shims/image-loader.ts
@@ -1,0 +1,27 @@
+import { getDeploymentId } from "../utils/deployment-id.js";
+
+export type ImageLoaderProps = {
+  src: string;
+  width: number;
+  quality?: number;
+};
+
+const imagePath = process.env.__VINEXT_IMAGE_PATH ?? "/_next/image";
+
+const configuredImageLoader = Object.assign(
+  ({ src, width, quality }: ImageLoaderProps): string => {
+    if ((process.env.__VINEXT_IMAGE_LOADER ?? "default") === "custom") {
+      throw new Error(
+        `Image with src "${src}" is missing "loader" prop.\nRead more: https://nextjs.org/docs/messages/next-image-missing-loader`,
+      );
+    }
+    const deploymentId = src.startsWith("/") ? getDeploymentId() : undefined;
+    return `${imagePath}?url=${encodeURIComponent(src)}&w=${width}&q=${quality ?? 75}${deploymentId ? `&dpl=${deploymentId}` : ""}`;
+  },
+  process.env.__VINEXT_IMAGE_LOADER_FILE === "true" ||
+    (process.env.__VINEXT_IMAGE_LOADER ?? "default") === "custom"
+    ? {}
+    : { __next_img_default: true },
+);
+
+export default configuredImageLoader;

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -3,20 +3,26 @@
 /**
  * next/image shim
  *
- * Translates Next.js Image props to @unpic/react Image component.
- * @unpic/react auto-detects CDN from URL and uses native transforms.
- * For local images (relative paths), routes through `/_next/image`
- * for server-side optimization (resize, format negotiation, quality).
+ * Translates Next.js Image props to an img element whose generated attributes
+ * match Next.js. Optimized images route through `/_next/image` for resizing,
+ * format negotiation, and quality selection.
  *
  * Remote images are validated against `images.remotePatterns` and
- * `images.domains` from next.config.js. Unmatched URLs are blocked
- * in production and warn in development, matching Next.js behavior.
+ * `images.domains` from next.config.js during development. Production emits
+ * optimizer URLs and leaves authorization to the server endpoint, matching
+ * Next.js behavior.
  */
 import React, { forwardRef, useEffect, useLayoutEffect, useRef, useState } from "react";
 import * as ReactDOM from "react-dom";
-import { Image as UnpicImage } from "@unpic/react";
-import { hasRemoteMatch, isPrivateIp, type RemotePattern } from "./image-config.js";
+import { appendDeploymentIdQuery, getDeploymentId } from "../utils/deployment-id.js";
+import {
+  hasLocalMatch,
+  hasRemoteMatch,
+  type LocalPattern,
+  type RemotePattern,
+} from "./image-config.js";
 import { useMergedRef } from "./use-merged-ref.js";
+import configuredImageLoader from "vinext/shims/image-loader";
 
 export type StaticImageData = {
   src: string;
@@ -36,6 +42,15 @@ const __imageRemotePatterns: RemotePattern[] = (() => {
     return [];
   }
 })();
+const __imageLocalPatterns: LocalPattern[] = (() => {
+  try {
+    return JSON.parse(
+      process.env.__VINEXT_IMAGE_LOCAL_PATTERNS ?? '[{"pathname":"**","search":""}]',
+    );
+  } catch {
+    return [{ pathname: "**", search: "" }];
+  }
+})();
 const __imageDomains: string[] = (() => {
   try {
     return JSON.parse(process.env.__VINEXT_IMAGE_DOMAINS ?? "[]");
@@ -43,7 +58,8 @@ const __imageDomains: string[] = (() => {
     return [];
   }
 })();
-const __hasImageConfig = __imageRemotePatterns.length > 0 || __imageDomains.length > 0;
+const __rejectLocalQueryWithoutPattern =
+  process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN === "true";
 const __isDev = process.env.NODE_ENV !== "production";
 const __imageDeviceSizes: number[] = (() => {
   try {
@@ -54,6 +70,21 @@ const __imageDeviceSizes: number[] = (() => {
     return [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
   }
 })();
+const __imageSizes: number[] = (() => {
+  try {
+    return JSON.parse(process.env.__VINEXT_IMAGE_SIZES ?? "[32,48,64,96,128,256,384]");
+  } catch {
+    return [32, 48, 64, 96, 128, 256, 384];
+  }
+})();
+const __imageQualities: number[] = (() => {
+  try {
+    const qualities = JSON.parse(process.env.__VINEXT_IMAGE_QUALITIES ?? "[75]");
+    return Array.isArray(qualities) && qualities.length > 0 ? qualities : [75];
+  } catch {
+    return [75];
+  }
+})();
 /**
  * Whether dangerouslyAllowSVG is enabled in next.config.js.
  * When false (default), .svg sources auto-skip the optimization endpoint
@@ -62,58 +93,80 @@ const __imageDeviceSizes: number[] = (() => {
  * with security headers).
  */
 const __dangerouslyAllowSVG = process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_SVG === "true";
-/**
- * Whether dangerouslyAllowLocalIP is enabled in next.config.js.
- * When false (default), remote image URLs with literal private-IP hostnames
- * are blocked to mitigate SSRF risk.
- */
-const __dangerouslyAllowLocalIP = process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP === "true";
+const __imageUnoptimized = process.env.__VINEXT_IMAGE_UNOPTIMIZED === "true";
+const __imagePath = process.env.__VINEXT_IMAGE_PATH ?? "/_next/image";
+
+type ImageLoader = (params: { src: string; width: number; quality?: number }) => string;
+
+function isDefaultImageLoader(loader: ImageLoader): boolean {
+  return "__next_img_default" in loader;
+}
+
+function findClosestQuality(quality: number | undefined): number {
+  const requestedQuality = quality || 75;
+  return __imageQualities.reduce((closest, candidate) =>
+    Math.abs(candidate - requestedQuality) < Math.abs(closest - requestedQuality)
+      ? candidate
+      : closest,
+  );
+}
+
+function validateLocalUrl(src: string): void {
+  const localSrc = extractLocalDeploymentId(src).src;
+  if (!localSrc.startsWith("/") || localSrc.startsWith("//")) return;
+
+  if (localSrc.includes("?") && __rejectLocalQueryWithoutPattern) {
+    throw new Error(
+      `Image with src "${src}" is using a query string which is not configured in images.localPatterns.\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns`,
+    );
+  }
+
+  if (!__isDev || hasLocalMatch(__imageLocalPatterns, localSrc)) return;
+
+  throw new Error(
+    `Invalid src prop (${src}) on \`next/image\` does not match \`images.localPatterns\` configured in your \`next.config.js\`\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns`,
+  );
+}
 
 /**
  * Validate that a remote URL is allowed by the configured remote patterns.
  * Returns true if the URL is allowed, false otherwise.
  *
- * When no remotePatterns/domains are configured, all remote URLs are allowed
- * (backwards-compatible — user hasn't opted into restriction).
+ * Only URLs matching configured remotePatterns/domains are allowed. Next.js
+ * defaults both lists to empty, which denies all remote image optimization.
+ * Validation is only performed by the component in development. In production,
+ * Next.js still emits the optimizer URL and lets the image endpoint reject it.
  *
- * When patterns ARE configured, only matching URLs are allowed.
- * In development, non-matching URLs produce a console warning.
- * In production, non-matching URLs are blocked (src replaced with empty string).
- *
- * Private-IP hostnames are additionally rejected unless dangerouslyAllowLocalIP
- * is set, mirroring Next.js's fetchExternalImage guard.
+ * Private-address rejection belongs to the server-side optimizer, which can
+ * validate the resolved address instead of changing component render behavior.
  */
-function validateRemoteUrl(src: string): { allowed: boolean; reason?: string } {
+function validateRemoteUrl(src: string): void {
+  if (src.startsWith("//")) {
+    throw new Error(
+      `Failed to parse src "${src}" on \`next/image\`, protocol-relative URL (//) must be changed to an absolute URL (http:// or https://)`,
+    );
+  }
+
   let url: URL;
   try {
-    url = new URL(src, "http://n");
+    url = new URL(src);
   } catch {
-    return { allowed: false, reason: `Invalid URL: ${src}` };
+    throw new Error(
+      `Failed to parse src "${src}" on \`next/image\`, if using relative image it must start with a leading slash "/" or be an absolute URL (http:// or https://)`,
+    );
   }
 
-  if (!__dangerouslyAllowLocalIP && isPrivateIp(url.hostname)) {
-    // Best-effort guard for literal-IP hostnames only. Domain names resolving
-    // to private IPs cannot be caught without server-side DNS resolution.
-    // See: Next.js fetchExternalImage in packages/next/src/server/image-optimizer.ts
-    return {
-      allowed: false,
-      reason: `Image URL "${src}" resolved to private IP. If this is expected and you understand SSRF risk, use images.dangerouslyAllowLocalIP = true to continue.`,
-    };
-  }
+  if (hasRemoteMatch(__imageDomains, __imageRemotePatterns, url)) return;
 
-  if (!__hasImageConfig) {
-    // No image config — allow everything (backwards-compatible)
-    return { allowed: true };
-  }
+  throw new Error(
+    `Invalid src prop (${src}) on \`next/image\`, hostname "${url.hostname}" is not configured under images in your \`next.config.js\`\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-host`,
+  );
+}
 
-  if (hasRemoteMatch(__imageDomains, __imageRemotePatterns, url)) {
-    return { allowed: true };
-  }
-
-  return {
-    allowed: false,
-    reason: `Image URL "${src}" is not configured in images.remotePatterns or images.domains in next.config.js. See: https://nextjs.org/docs/messages/next-image-unconfigured-host`,
-  };
+function validateDefaultLoaderSource(src: string): void {
+  if (__isDev && src.startsWith("//")) validateRemoteUrl(src);
+  validateLocalUrl(src);
+  if (__isDev && !src.startsWith("/")) validateRemoteUrl(src);
 }
 
 /**
@@ -216,13 +269,6 @@ function sanitizeBlurDataURL(url: string): string | undefined {
   return url;
 }
 
-/**
- * Determine if a src is a remote URL (CDN-optimizable) or local.
- */
-function isRemoteUrl(src: string): boolean {
-  return src.startsWith("http://") || src.startsWith("https://") || src.startsWith("//");
-}
-
 function isSvgUrl(src: string): boolean {
   try {
     return new URL(src, "http://vinext.local").pathname.toLowerCase().endsWith(".svg");
@@ -270,6 +316,27 @@ function resolveImageSource(v: {
  * Configurable via `images.deviceSizes` in next.config.js.
  */
 const RESPONSIVE_WIDTHS = __imageDeviceSizes;
+const ALL_IMAGE_WIDTHS = [...__imageDeviceSizes, ...__imageSizes].sort((a, b) => a - b);
+
+function extractLocalDeploymentId(src: string): { src: string; deploymentId?: string } {
+  let deploymentId = getDeploymentId();
+  if (!src.startsWith("/") || src.startsWith("//")) return { src, deploymentId };
+
+  const queryIndex = src.indexOf("?");
+  if (queryIndex === -1) return { src, deploymentId };
+
+  const params = new URLSearchParams(src.slice(queryIndex + 1));
+  const sourceDeploymentId = params.get("dpl");
+  if (!sourceDeploymentId) return { src, deploymentId };
+
+  deploymentId = sourceDeploymentId;
+  params.delete("dpl");
+  const remainingQuery = params.toString();
+  return {
+    src: src.slice(0, queryIndex) + (remainingQuery ? `?${remainingQuery}` : ""),
+    deploymentId,
+  };
+}
 
 /**
  * Build a `/_next/image` optimization URL.
@@ -279,7 +346,12 @@ const RESPONSIVE_WIDTHS = __imageDeviceSizes;
  * server handles it as a passthrough (serves the original file).
  */
 export function imageOptimizationUrl(src: string, width: number, quality: number = 75): string {
-  return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
+  const localSource = extractLocalDeploymentId(src);
+  return `${__imagePath}?url=${encodeURIComponent(localSource.src)}&w=${width}&q=${quality}${
+    localSource.src.startsWith("/") && localSource.deploymentId
+      ? `&dpl=${localSource.deploymentId}`
+      : ""
+  }`;
 }
 
 function preloadImageResource(input: {
@@ -306,11 +378,69 @@ function preloadImageResource(input: {
  * server can resize and transcode the image. Only includes widths that are
  * <= 2x the original image width to avoid pointless upscaling.
  */
-function generateSrcSet(src: string, originalWidth: number, quality: number = 75): string {
-  const widths = RESPONSIVE_WIDTHS.filter((w) => w <= originalWidth * 2);
-  if (widths.length === 0)
-    return `${imageOptimizationUrl(src, originalWidth, quality)} ${originalWidth}w`;
-  return widths.map((w) => `${imageOptimizationUrl(src, w, quality)} ${w}w`).join(", ");
+function getImageWidths(
+  width: number | undefined,
+  sizes: string | undefined,
+): { widths: number[]; kind: "w" | "x" } {
+  if (sizes) {
+    const viewportWidthPattern = /(^|\s)(1?\d?\d)vw/g;
+    const viewportPercentages: number[] = [];
+    for (let match; (match = viewportWidthPattern.exec(sizes)); ) {
+      viewportPercentages.push(Number.parseInt(match[2], 10));
+    }
+    if (viewportPercentages.length > 0) {
+      const smallestRatio = Math.min(...viewportPercentages) * 0.01;
+      return {
+        widths: ALL_IMAGE_WIDTHS.filter(
+          (configuredWidth) => configuredWidth >= RESPONSIVE_WIDTHS[0] * smallestRatio,
+        ),
+        kind: "w",
+      };
+    }
+    return { widths: ALL_IMAGE_WIDTHS, kind: "w" };
+  }
+  if (width === undefined) return { widths: RESPONSIVE_WIDTHS, kind: "w" };
+  return {
+    widths: [
+      ...new Set(
+        [width, width * 2].map(
+          (targetWidth) =>
+            ALL_IMAGE_WIDTHS.find((configuredWidth) => configuredWidth >= targetWidth) ??
+            ALL_IMAGE_WIDTHS[ALL_IMAGE_WIDTHS.length - 1],
+        ),
+      ),
+    ],
+    kind: "x",
+  };
+}
+
+function generateResponsiveImageAttributes(
+  width: number | undefined,
+  sizes: string | undefined,
+  generateUrl: (width: number) => string,
+): { src: string; srcSet: string; sizes: string | undefined } {
+  const { widths, kind } = getImageWidths(width, sizes);
+  return {
+    sizes: !sizes && kind === "w" ? "100vw" : sizes,
+    srcSet: widths
+      .map(
+        (candidateWidth, index) =>
+          `${generateUrl(candidateWidth)} ${kind === "w" ? candidateWidth : index + 1}${kind}`,
+      )
+      .join(", "),
+    src: generateUrl(widths[widths.length - 1]),
+  };
+}
+
+function generateImageAttributes(
+  src: string,
+  width: number | undefined,
+  sizes: string | undefined,
+  quality: number,
+): { src: string; srcSet: string; sizes: string | undefined } {
+  return generateResponsiveImageAttributes(width, sizes, (candidateWidth) =>
+    imageOptimizationUrl(src, candidateWidth, quality),
+  );
 }
 
 const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
@@ -388,7 +518,19 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   } = resolveImageSource({ src: srcProp, width, height, blurDataURL });
   const shouldPreload = preload === true || priority === true;
   const priorityFetchPriority = priority ? "high" : undefined;
-  const imageLoading = priority ? "eager" : shouldPreload ? loading : (loading ?? "lazy");
+  const isSpecialSource = !src || src.startsWith("data:") || src.startsWith("blob:");
+  const effectiveLoader = loader ?? configuredImageLoader;
+  const isDefaultLoader = isDefaultImageLoader(effectiveLoader);
+  const isDefaultLoaderSvg = isDefaultLoader && isSvgUrl(src) && !__dangerouslyAllowSVG;
+  const effectiveUnoptimized =
+    _unoptimized === true || __imageUnoptimized || isSpecialSource || isDefaultLoaderSvg;
+  const imageLoading = isSpecialSource
+    ? undefined
+    : priority
+      ? "eager"
+      : shouldPreload
+        ? loading
+        : (loading ?? "lazy");
 
   const [completedBlurSrc, setCompletedBlurSrc] = useState<string | undefined>(undefined);
   const blurComplete = completedBlurSrc === src;
@@ -475,11 +617,13 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
         }
       : undefined;
 
-  if (_unoptimized === true) {
+  if (effectiveUnoptimized) {
     // Unoptimized images are fetched directly by the browser, so intentionally
     // skip remote URL validation: there is no server-side optimizer fetch and
     // therefore no SSRF surface. This matches Next.js behavior.
-    const renderedSrc = overrideSrc || src;
+    const renderedSrc =
+      overrideSrc ||
+      (src.startsWith("/") && !src.startsWith("//") ? appendDeploymentIdQuery(src) : src);
     const sanitizedBlur = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
     const blurStyle =
       !blurComplete && placeholder === "blur" && sanitizedBlur
@@ -515,156 +659,31 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
     );
   }
 
-  // If a custom loader is provided, use basic img with loader URL
-  if (loader) {
-    const resolvedSrc = loader({ src, width: imgWidth ?? 0, quality: quality ?? 75 });
-    preloadImageResource({
-      shouldPreload,
-      src: resolvedSrc,
-      sizes,
-      fetchPriority: priorityFetchPriority,
-    });
-    return (
-      <img
-        ref={mergedRef}
-        src={resolvedSrc}
-        alt={alt}
-        width={fill ? undefined : imgWidth}
-        height={fill ? undefined : imgHeight}
-        loading={imageLoading}
-        decoding="async"
-        sizes={sizes}
-        className={className}
-        onLoad={handleLoad}
-        onError={handleError}
-        style={fill ? getFillStyle(style) : style}
-        {...rest}
-      />
-    );
-  }
-
-  // For remote URLs, validate against remotePatterns. Non-fill images use
-  // @unpic/react for CDN URL transforms; fill uses a plain img so the DOM
-  // element keeps Next.js's absolute-positioned fill contract.
-  if (isRemoteUrl(src)) {
-    const validation = validateRemoteUrl(src);
-    if (!validation.allowed) {
-      if (__isDev) {
-        console.warn(`[next/image] ${validation.reason}`);
-        // In dev, render the image but with a warning — matches Next.js dev behavior
-      } else {
-        // In production, block the image entirely
-        console.error(`[next/image] ${validation.reason}`);
-        return null;
-      }
-    }
-
-    const sanitizedBlur = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
-    const showBlur = !blurComplete && placeholder === "blur" && sanitizedBlur;
-    const blurStyle = showBlur
-      ? {
-          backgroundImage: `url(${sanitizedBlur})`,
-          backgroundSize: "cover",
-          backgroundRepeat: "no-repeat",
-          backgroundPosition: "center",
-        }
-      : undefined;
-    const bg = showBlur ? `url(${sanitizedBlur})` : undefined;
-
-    if (fill) {
-      const imageSizes = sizes ?? "100vw";
-      preloadImageResource({
-        shouldPreload,
-        src,
-        sizes: imageSizes,
-        fetchPriority: priorityFetchPriority,
-      });
-      return (
-        <img
-          ref={mergedRef}
-          src={src}
-          alt={alt}
-          // `priority` is a Next.js concept — translate it to HTML attributes so
-          // it is never forwarded to the DOM as a non-boolean attribute, which
-          // would trigger React's "Received `true` for a non-boolean attribute"
-          // warning.
-          loading={imageLoading}
-          fetchPriority={priorityFetchPriority}
-          decoding="async"
-          sizes={imageSizes}
-          className={className}
-          data-nimg="fill"
-          onLoad={handleLoad}
-          onError={handleError}
-          style={getFillStyle(style, blurStyle)}
-          {...rest}
-        />
-      );
-    }
-    // constrained layout requires width+height or aspectRatio
-    if (imgWidth && imgHeight) {
-      // @unpic/react forwards additional image props through transformProps and
-      // merges `style` with generated layout styles at runtime, but its public
-      // React type omits `style`.
-      const unpicRuntimeStyleProps: { style?: React.CSSProperties } = { style };
-      preloadImageResource({
-        shouldPreload,
-        src,
-        sizes,
-        fetchPriority: priorityFetchPriority,
-      });
-      return (
-        <UnpicImage
-          src={src}
-          alt={alt}
-          width={imgWidth}
-          height={imgHeight}
-          layout="constrained"
-          // Same translation as above — never pass `priority` to the DOM.
-          loading={imageLoading}
-          fetchPriority={priorityFetchPriority}
-          sizes={sizes}
-          className={className}
-          {...unpicRuntimeStyleProps}
-          background={bg}
-          onLoad={handleLoad}
-          onError={handleError}
-          ref={mergedRef}
-        />
-      );
-    }
-    // Fall through to basic <img> if dimensions not provided
-    // (unpic requires them for constrained layout)
-  }
+  // For remote URLs, validate against remotePatterns before passing the source
+  // through the same default optimizer URL generation as local images.
+  if (isDefaultLoader) validateDefaultLoaderSource(src);
 
   // Route local images through the /_next/image optimization endpoint.
   // In production on Cloudflare Workers, this resizes and transcodes via
   // the Images binding. In dev, it serves the original file as a passthrough.
   // When `unoptimized` is true, bypass the endpoint entirely (Next.js compat).
-  // SVG sources auto-skip unless dangerouslyAllowSVG is enabled, matching
-  // Next.js behavior where .svg triggers unoptimized=true by default.
-  const imgQuality = quality ?? 75;
-  const isSvg = isSvgUrl(src);
-  const skipOptimization = isSvg && !__dangerouslyAllowSVG;
+  // Default-loader SVG sources have already taken the unoptimized path above.
+  // Custom loaders continue to process SVG sources normally.
+  const imgQuality = findClosestQuality(quality);
 
   // Build srcSet for responsive local images (common breakpoints).
   // Each entry points to /_next/image with the appropriate width.
-  const srcSet =
-    imgWidth && !fill && !skipOptimization
-      ? generateSrcSet(src, imgWidth, imgQuality)
-      : imgWidth && !fill
-        ? RESPONSIVE_WIDTHS.filter((w) => w <= imgWidth * 2)
-            .map((w) => `${src} ${w}w`)
-            .join(", ") || `${src} ${imgWidth}w`
-        : undefined;
+  const optimizedAttributes = !isDefaultLoader
+    ? generateResponsiveImageAttributes(imgWidth, sizes, (candidateWidth) =>
+        effectiveLoader({ src, width: candidateWidth, quality }),
+      )
+    : generateImageAttributes(src, fill ? undefined : imgWidth, sizes, imgQuality);
+  const srcSet = optimizedAttributes.srcSet;
 
   // The main `src` also goes through the optimization endpoint. Use the
   // declared width (or the first responsive width as fallback).
-  const optimizedSrc = skipOptimization
-    ? src
-    : imgWidth
-      ? imageOptimizationUrl(src, imgWidth, imgQuality)
-      : imageOptimizationUrl(src, RESPONSIVE_WIDTHS[0], imgQuality);
+  const optimizedSrc = optimizedAttributes?.src ?? src;
+  const renderedSrc = overrideSrc || optimizedSrc;
 
   // Blur placeholder: show a low-quality background while the image loads.
   // Sanitize blurDataURL to prevent CSS injection via crafted data URLs.
@@ -679,10 +698,10 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
         }
       : undefined;
 
-  const imageSizes = sizes ?? (fill ? "100vw" : undefined);
+  const imageSizes = optimizedAttributes?.sizes ?? sizes ?? (fill ? "100vw" : undefined);
   preloadImageResource({
     shouldPreload,
-    src: optimizedSrc,
+    src: renderedSrc,
     srcSet,
     sizes: imageSizes,
     fetchPriority: priorityFetchPriority,
@@ -693,7 +712,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   return (
     <img
       ref={mergedRef}
-      src={optimizedSrc}
+      src={renderedSrc}
       alt={alt}
       width={fill ? undefined : imgWidth}
       height={fill ? undefined : imgHeight}
@@ -749,11 +768,19 @@ export function getImageProps(props: ImageProps): {
     blurDataURL: imgBlurDataURL,
   } = resolveImageSource({ src: srcProp, width, height, blurDataURL: blurDataURLProp });
   const shouldPreload = _preload === true || priority === true;
+  const isSpecialSource = !src || src.startsWith("data:") || src.startsWith("blob:");
+  const effectiveLoader = loader ?? configuredImageLoader;
+  const isDefaultLoader = isDefaultImageLoader(effectiveLoader);
+  const isDefaultLoaderSvg = isDefaultLoader && isSvgUrl(src) && !__dangerouslyAllowSVG;
+  const effectiveUnoptimized =
+    _unoptimized === true || __imageUnoptimized || isSpecialSource || isDefaultLoaderSvg;
 
-  if (_unoptimized === true) {
+  if (effectiveUnoptimized) {
     // As in the component path, unoptimized images never reach the server-side
     // optimizer, so remote URL validation is intentionally unnecessary.
-    const renderedSrc = overrideSrc || src;
+    const renderedSrc =
+      overrideSrc ||
+      (src.startsWith("/") && !src.startsWith("//") ? appendDeploymentIdQuery(src) : src);
     const sanitizedBlurURL = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
     const blurStyle =
       placeholder === "blur" && sanitizedBlurURL
@@ -770,7 +797,13 @@ export function getImageProps(props: ImageProps): {
         alt,
         width: fill ? undefined : imgWidth,
         height: fill ? undefined : imgHeight,
-        loading: priority ? "eager" : shouldPreload ? loading : (loading ?? "lazy"),
+        loading: isSpecialSource
+          ? undefined
+          : priority
+            ? "eager"
+            : shouldPreload
+              ? loading
+              : (loading ?? "lazy"),
         fetchPriority: priority ? ("high" as const) : undefined,
         decoding: "async" as const,
         className,
@@ -781,45 +814,18 @@ export function getImageProps(props: ImageProps): {
     };
   }
 
-  // Validate remote URLs against configured patterns
-  let blockedInProd = false;
-  if (isRemoteUrl(src)) {
-    const validation = validateRemoteUrl(src);
-    if (!validation.allowed) {
-      if (__isDev) {
-        console.warn(`[next/image] ${validation.reason}`);
-      } else {
-        console.error(`[next/image] ${validation.reason}`);
-        blockedInProd = true;
-      }
-    }
-  }
+  if (isDefaultLoader) validateDefaultLoaderSource(src);
 
-  // Resolve src through custom loader if provided
-  const imgQuality = _quality ?? 75;
-  const resolvedSrc = blockedInProd
-    ? ""
-    : loader
-      ? loader({ src, width: imgWidth ?? 0, quality: imgQuality })
-      : src;
+  const imgQuality = findClosestQuality(_quality);
+  const customAttributes = !isDefaultLoader
+    ? generateResponsiveImageAttributes(imgWidth, sizes, (candidateWidth) =>
+        effectiveLoader({ src, width: candidateWidth, quality: _quality }),
+      )
+    : undefined;
 
-  // For local images (no loader, not remote), route through optimization endpoint.
-  // When `unoptimized` is true, bypass the endpoint entirely (Next.js compat).
-  // SVG sources auto-skip unless dangerouslyAllowSVG is enabled.
-  const isSvg = isSvgUrl(resolvedSrc);
-  const skipOpt =
-    (isSvg && !__dangerouslyAllowSVG) || blockedInProd || !!loader || isRemoteUrl(resolvedSrc);
-  const optimizedSrc = skipOpt
-    ? resolvedSrc
-    : imgWidth
-      ? imageOptimizationUrl(resolvedSrc, imgWidth, imgQuality)
-      : imageOptimizationUrl(resolvedSrc, RESPONSIVE_WIDTHS[0], imgQuality);
-
-  // Build srcSet for local images — each width points to /_next/image
-  const srcSet =
-    imgWidth && !fill && !isRemoteUrl(resolvedSrc) && !loader && !skipOpt
-      ? generateSrcSet(resolvedSrc, imgWidth, imgQuality)
-      : undefined;
+  const optimizedAttributes = !isDefaultLoader
+    ? customAttributes
+    : generateImageAttributes(src, fill ? undefined : imgWidth, sizes, imgQuality);
 
   // Blur placeholder styles — sanitize to prevent CSS injection
   const sanitizedBlurURL = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;
@@ -835,15 +841,15 @@ export function getImageProps(props: ImageProps): {
 
   return {
     props: {
-      src: optimizedSrc,
+      src: overrideSrc || optimizedAttributes?.src || src,
       alt,
       width: fill ? undefined : imgWidth,
       height: fill ? undefined : imgHeight,
       loading: priority ? "eager" : shouldPreload ? loading : (loading ?? "lazy"),
       fetchPriority: priority ? ("high" as const) : undefined,
       decoding: "async" as const,
-      srcSet,
-      sizes: sizes ?? (fill ? "100vw" : undefined),
+      srcSet: optimizedAttributes?.srcSet,
+      sizes: optimizedAttributes?.sizes ?? sizes ?? (fill ? "100vw" : undefined),
       className,
       "data-nimg": fill ? "fill" : "1",
       style: fill ? getFillStyle(style, blurStyle) : { ...blurStyle, ...style },

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -318,8 +318,9 @@ function resolveImageSource(v: {
  * These are the breakpoints used for srcSet generation.
  * Configurable via `images.deviceSizes` in next.config.js.
  */
-const RESPONSIVE_WIDTHS = __imageDeviceSizes;
-const ALL_IMAGE_WIDTHS = [...__imageDeviceSizes, ...__imageSizes].sort((a, b) => a - b);
+const RESPONSIVE_WIDTHS = [...__imageDeviceSizes].sort((a, b) => a - b);
+const FIXED_IMAGE_WIDTHS = [...__imageSizes].sort((a, b) => a - b);
+const ALL_IMAGE_WIDTHS = [...RESPONSIVE_WIDTHS, ...FIXED_IMAGE_WIDTHS].sort((a, b) => a - b);
 
 function extractLocalDeploymentId(src: string): { src: string; deploymentId?: string } {
   let deploymentId = getDeploymentId();

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -61,6 +61,7 @@ const __imageDomains: string[] = (() => {
 const __rejectLocalQueryWithoutPattern =
   process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN === "true";
 const __isDev = process.env.NODE_ENV !== "production";
+const __shouldValidatePatterns = process.env.NODE_ENV !== "test";
 const __imageDeviceSizes: number[] = (() => {
   try {
     return JSON.parse(
@@ -121,7 +122,8 @@ function validateLocalUrl(src: string): void {
     );
   }
 
-  if (!__isDev || hasLocalMatch(__imageLocalPatterns, localSrc)) return;
+  if (!__isDev || !__shouldValidatePatterns || hasLocalMatch(__imageLocalPatterns, localSrc))
+    return;
 
   throw new Error(
     `Invalid src prop (${src}) on \`next/image\` does not match \`images.localPatterns\` configured in your \`next.config.js\`\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns`,
@@ -156,7 +158,8 @@ function validateRemoteUrl(src: string): void {
     );
   }
 
-  if (hasRemoteMatch(__imageDomains, __imageRemotePatterns, url)) return;
+  if (!__shouldValidatePatterns || hasRemoteMatch(__imageDomains, __imageRemotePatterns, url))
+    return;
 
   throw new Error(
     `Invalid src prop (${src}) on \`next/image\`, hostname "${url.hostname}" is not configured under images in your \`next.config.js\`\nSee more info: https://nextjs.org/docs/messages/next-image-unconfigured-host`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,9 +963,6 @@ importers:
 
   packages/vinext:
     dependencies:
-      '@unpic/react':
-        specifier: 'catalog:'
-        version: 1.0.2(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@vercel/og':
         specifier: 'catalog:'
         version: 0.8.6

--- a/tests/app-router-next-config-codegen.test.ts
+++ b/tests/app-router-next-config-codegen.test.ts
@@ -121,13 +121,42 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         deviceSizes: [320, 640],
         imageSizes: [16],
         qualities: [60, 75],
+        formats: ["image/avif", "image/webp"],
+        dangerouslyAllowSVG: true,
+        contentDispositionType: "inline",
+        contentSecurityPolicy: "sandbox",
       },
     });
     expect(code).toContain("const __imageConfig");
     expect(code).toContain('"deviceSizes":[320,640]');
     expect(code).toContain('"qualities":[60,75]');
+    expect(code).toContain('"formats":["image/avif","image/webp"]');
+    expect(code).toContain('"dangerouslyAllowSVG":true');
+    expect(code).toContain('"contentDispositionType":"inline"');
+    expect(code).toContain('"contentSecurityPolicy":"sandbox"');
     expect(code).toContain("imageConfig: __imageConfig");
-    expect(code).toContain('isDev: process.env.NODE_ENV !== "production"');
+    expect(code).toContain("fetchRemoteImageFromValidatedAddresses");
+    expect(code).toContain("resolveRemoteImageHostnames");
+    expect(code).toContain("imageHandlers: __imageHandlers");
+    expect(code).toContain('const __imageRuntime = "node"');
+    expect(code).toContain("imageRuntime: __imageRuntime");
+    expect(code).toContain("isDev: import.meta.env.DEV");
+  });
+
+  it("omits Node image modules from Worker-targeted App Router entries", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalRoutes, null, [], null, "", false, {
+      imageConfig: {
+        deviceSizes: [320],
+        remotePatterns: [{ protocol: "https", hostname: "images.example.com" }],
+      },
+      imageRuntime: "worker",
+    });
+
+    expect(code).toContain('const __imageRuntime = "worker"');
+    expect(code).toContain("const __imageHandlers = undefined");
+    expect(code).not.toContain("node-remote-image-fetch");
+    expect(code).not.toContain("fetchRemoteImageFromValidatedAddresses");
+    expect(code).not.toContain("resolveRemoteImageHostnames");
   });
 
   it("routes hybrid Pages API misses through the Pages server entry", () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -100,6 +100,8 @@ function createHandler(overrides: Partial<TestHandlerOptions> = {}) {
         : async () => null,
     i18nConfig: overrides.i18nConfig ?? null,
     imageConfig: overrides.imageConfig,
+    imageHandlers: overrides.imageHandlers,
+    imageRuntime: overrides.imageRuntime,
     isDev: overrides.isDev ?? true,
     matchRoute:
       overrides.matchRoute ??
@@ -172,10 +174,125 @@ describe("createAppRscHandler", () => {
     expect(defaultOnly.status).toBe(400);
   });
 
+  it("matches configured image paths after stripping basePath", async () => {
+    const handler = createHandler({
+      imageConfig: { path: "/docs/_next/image", qualities: [75] },
+    });
+    const response = await handler(
+      new Request("https://example.test/docs/_next/image?url=%2Fimg.jpg&w=640&q=75"),
+      null,
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://example.test/img.jpg");
+
+    const outsideBasePath = await handler(
+      new Request("https://example.test/_next/image?url=%2Fimg.jpg&w=640&q=75"),
+      null,
+    );
+    expect(outsideBasePath.status).toBe(404);
+  });
+
+  it.each([
+    { imageConfig: { unoptimized: true }, label: "globally unoptimized images" },
+    { imageConfig: { loader: "custom" as const }, label: "a custom image loader" },
+  ])("returns 404 for manual optimizer requests with $label", async ({ imageConfig }) => {
+    const handler = createHandler({ imageConfig });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/image?url=%2Fimg.jpg&w=640&q=75"),
+      null,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("optimizes configured remote images in pure App Router dev", async () => {
+    const fetchRemote = vi.fn(
+      async () =>
+        new Response(Buffer.from([1, 2, 3]), { headers: { "Content-Type": "image/png" } }),
+    );
+    const handler = createHandler({
+      imageConfig: {
+        deviceSizes: [320],
+        remotePatterns: [
+          { protocol: "https", hostname: "images.example.com", pathname: "/allowed/**" },
+        ],
+      },
+      imageHandlers: {
+        fetchRemote,
+        resolveHostnames: async () => ["8.8.8.8"],
+      },
+    });
+
+    const response = await handler(
+      new Request(
+        "https://example.test/docs/_next/image?url=HTTPS%3A%2F%2Fimages.example.com%2Fallowed%2Fphoto.png&w=320&q=75",
+      ),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    expect(fetchRemote).toHaveBeenCalledOnce();
+  });
+
+  it("uses the Worker remote-image redirect path in Cloudflare App Router dev", async () => {
+    const handler = createHandler({
+      imageConfig: {
+        deviceSizes: [320],
+        remotePatterns: [
+          { protocol: "https", hostname: "images.example.com", pathname: "/allowed/**" },
+        ],
+      },
+      imageRuntime: "worker",
+    });
+
+    const response = await handler(
+      new Request(
+        "https://example.test/docs/_next/image?url=https%3A%2F%2Fimages.example.com%2Fallowed%2Fphoto.png&w=320&q=75",
+      ),
+      null,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://images.example.com/allowed/photo.png");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("uses App Router dev SVG and response security image config", async () => {
+    const handler = createHandler({
+      imageConfig: {
+        deviceSizes: [320],
+        remotePatterns: [{ protocol: "https", hostname: "images.example.com" }],
+        dangerouslyAllowSVG: true,
+        contentDispositionType: "inline",
+        contentSecurityPolicy: "sandbox allow-scripts",
+      },
+      imageHandlers: {
+        fetchRemote: async () =>
+          new Response('<svg xmlns="http://www.w3.org/2000/svg"></svg>', {
+            headers: { "Content-Type": "image/svg+xml" },
+          }),
+        resolveHostnames: async () => ["8.8.8.8"],
+      },
+    });
+
+    const response = await handler(
+      new Request(
+        "https://example.test/docs/_next/image?url=https%3A%2F%2Fimages.example.com%2Fphoto.svg&w=320&q=75",
+      ),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/svg+xml");
+    expect(response.headers.get("content-disposition")).toBe('inline; filename="photo.svg"');
+    expect(response.headers.get("content-security-policy")).toBe("sandbox allow-scripts");
+  });
+
   it("allows independent Next.js blur width and quality exceptions in pure App Router dev", async () => {
-    // The blur quality exception (q=70) is only observable when `qualities` is
-    // configured — with an unset allowlist any quality 1-100 is permitted, so
-    // pin it to [75] to exercise the dev-only exception itself.
+    // Pin the default explicitly to exercise the dev-only exception itself.
     const handler = createHandler({ imageConfig: { qualities: [75] } });
     for (const query of ["url=%2Fimg.jpg&w=8&q=75", "url=%2Fimg.jpg&w=640&q=70"]) {
       const response = await handler(
@@ -197,15 +314,13 @@ describe("createAppRscHandler", () => {
     }
   });
 
-  it("allows any quality 1-100 in production when images.qualities is unset", async () => {
-    // Matches Next.js: an unset `qualities` is not restricted to a single value,
-    // so q=70 (and any 1-100) is a normal quality even in production.
+  it("defaults production image qualities to [75]", async () => {
     const handler = createHandler({ isDev: false });
     const response = await handler(
       new Request("https://example.test/docs/_next/image?url=%2Fimg.jpg&w=640&q=70"),
       null,
     );
-    expect(response.status).toBe(302);
+    expect(response.status).toBe(400);
   });
 
   it("wraps dispatch responses with request-scoped finalization", async () => {

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -381,10 +381,17 @@ describe("optimizeDeps.exclude for vinext", () => {
 
   async function setupAppRouterConfigTest(prefix: string) {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
-    const mainPlugin = vinext().find(
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
       (plugin: any) => plugin.name === "vinext:config" && typeof plugin.config === "function",
     );
+    const serverDefinePlugin = plugins.find(
+      (plugin: any) =>
+        plugin.name === "vinext:compiler-define-server" &&
+        typeof plugin.configEnvironment === "function",
+    );
     expect(mainPlugin).toBeDefined();
+    expect(serverDefinePlugin).toBeDefined();
 
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
     await fsp.symlink(
@@ -410,9 +417,40 @@ describe("optimizeDeps.exclude for vinext", () => {
           { command },
         );
       },
+      serverDefines(name = "rsc") {
+        return (serverDefinePlugin as any).configEnvironment(name)?.define ?? {};
+      },
       cleanup: () => fsp.rm(root, { recursive: true, force: true }),
     };
   }
+
+  it("keeps production image allowlists out of client defines", async () => {
+    const fixture = await setupAppRouterConfigTest("vinext-image-pattern-defines-");
+    const patternDefines = [
+      "process.env.__VINEXT_IMAGE_REMOTE_PATTERNS",
+      "process.env.__VINEXT_IMAGE_LOCAL_PATTERNS",
+      "process.env.__VINEXT_IMAGE_DOMAINS",
+    ];
+
+    try {
+      const development = await fixture.config({}, "serve");
+      for (const define of patternDefines) {
+        expect(development.define).toHaveProperty(define);
+      }
+
+      const production = await fixture.config({}, "build");
+      for (const define of patternDefines) {
+        expect(production.define).not.toHaveProperty(define);
+        expect(fixture.serverDefines()).toHaveProperty(define);
+      }
+      expect(production.define).toHaveProperty(
+        "process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN",
+        '"true"',
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  }, 15000);
 
   it("excludes React from ssr optimizeDeps when ssr.external: true (App Router)", async () => {
     const fixture = await setupAppRouterConfigTest("vinext-optdeps-react-true-");

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -150,11 +150,19 @@ describe("compiler.define forwarding to Vite", () => {
       expect(rscResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+        "process.env.__VINEXT_IMAGE_REMOTE_PATTERNS": '"[]"',
+        "process.env.__VINEXT_IMAGE_LOCAL_PATTERNS":
+          '"[{\\"pathname\\":\\"**\\",\\"search\\":\\"\\"}]"',
+        "process.env.__VINEXT_IMAGE_DOMAINS": '"[]"',
         "process.env.NEXT_RUNTIME": '"nodejs"',
       });
       expect(ssrResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+        "process.env.__VINEXT_IMAGE_REMOTE_PATTERNS": '"[]"',
+        "process.env.__VINEXT_IMAGE_LOCAL_PATTERNS":
+          '"[{\\"pathname\\":\\"**\\",\\"search\\":\\"\\"}]"',
+        "process.env.__VINEXT_IMAGE_DOMAINS": '"[]"',
         "process.env.NEXT_RUNTIME": '"nodejs"',
       });
       // Client environment must never receive server-only defines.
@@ -296,9 +304,13 @@ describe("compiler.define forwarding to Vite", () => {
       // always returns a define object (never null) even without user defineServer.
       expect(rscResult).not.toBeNull();
       expect(rscResult?.define?.["process.env.NEXT_RUNTIME"]).toBe('"nodejs"');
-      // No other keys should be present when neither defineServer nor revalidate
-      // secret are configured.
-      expect(Object.keys(rscResult!.define!)).toEqual(["process.env.NEXT_RUNTIME"]);
+      expect(rscResult?.define).toEqual({
+        "process.env.__VINEXT_IMAGE_REMOTE_PATTERNS": '"[]"',
+        "process.env.__VINEXT_IMAGE_LOCAL_PATTERNS":
+          '"[{\\"pathname\\":\\"**\\",\\"search\\":\\"\\"}]"',
+        "process.env.__VINEXT_IMAGE_DOMAINS": '"[]"',
+        "process.env.NEXT_RUNTIME": '"nodejs"',
+      });
     } finally {
       if (prev === undefined) delete process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
       else process.env.__VINEXT_SHARED_REVALIDATE_SECRET = prev;

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import os from "node:os";
 import { pathToFileURL } from "node:url";
 import { execFileSync } from "node:child_process";
+import { transformWithOxc } from "vite";
 import {
   detectProject,
   deploy,
@@ -80,6 +81,49 @@ function readVinextPackageExports(): Record<string, unknown> {
     throw new Error("packages/vinext/package.json must define an exports object");
   }
   return parsed.exports;
+}
+
+async function loadGeneratedAppWorker(imageEnv: {
+  loader?: string;
+  unoptimized?: string;
+}): Promise<{ fetch(request: Request, env: unknown, ctx: unknown): Promise<Response> }> {
+  const previousLoader = process.env.__VINEXT_IMAGE_LOADER;
+  const previousUnoptimized = process.env.__VINEXT_IMAGE_UNOPTIMIZED;
+  if (imageEnv.loader === undefined) delete process.env.__VINEXT_IMAGE_LOADER;
+  else process.env.__VINEXT_IMAGE_LOADER = imageEnv.loader;
+  if (imageEnv.unoptimized === undefined) delete process.env.__VINEXT_IMAGE_UNOPTIMIZED;
+  else process.env.__VINEXT_IMAGE_UNOPTIMIZED = imageEnv.unoptimized;
+
+  try {
+    const source = generateAppRouterWorkerEntry()
+      .replace(
+        /import \{[^\n]+\} from "vinext\/server\/image-optimization";/,
+        `const DEFAULT_DEVICE_SIZES = [640];
+const DEFAULT_IMAGE_SIZES = [32];
+const isImageOptimizationPath = (pathname, configuredPath) => pathname === configuredPath;
+const isImageOptimizationEnabled = (config) => config.unoptimized !== true && config.loader === "default";
+const getWorkerRemoteImageRedirect = () => { throw new Error("optimizer should not run"); };
+const handleImageOptimization = () => { throw new Error("optimizer should not run"); };`,
+      )
+      .replace(/import type \{ ImageConfig \}[^\n]+\n/, "")
+      .replace(
+        'import handler from "vinext/server/app-router-entry";',
+        'const handler = { fetch() { return new Response("handler"); } };',
+      );
+    const transformed = await transformWithOxc(source, "generated-app-worker.ts", {
+      lang: "ts",
+    });
+    const moduleUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString("base64")}#${crypto.randomUUID()}`;
+    const loaded = (await import(moduleUrl)) as {
+      default: { fetch(request: Request, env: unknown, ctx: unknown): Promise<Response> };
+    };
+    return loaded.default;
+  } finally {
+    if (previousLoader === undefined) delete process.env.__VINEXT_IMAGE_LOADER;
+    else process.env.__VINEXT_IMAGE_LOADER = previousLoader;
+    if (previousUnoptimized === undefined) delete process.env.__VINEXT_IMAGE_UNOPTIMIZED;
+    else process.env.__VINEXT_IMAGE_UNOPTIMIZED = previousUnoptimized;
+  }
 }
 
 function extractVinextImportSubpaths(source: string): string[] {
@@ -675,12 +719,25 @@ describe("generateAppRouterWorkerEntry", () => {
 
   it("threads configured image widths and qualities into the App Router worker", () => {
     const content = generateAppRouterWorkerEntry();
+    expect(content).toContain("process.env.__VINEXT_IMAGE_PATH");
     expect(content).toContain("process.env.__VINEXT_IMAGE_DEVICE_SIZES");
     expect(content).toContain("process.env.__VINEXT_IMAGE_SIZES");
     expect(content).toContain("process.env.__VINEXT_IMAGE_QUALITIES");
+    expect(content).toContain("process.env.__VINEXT_IMAGE_FORMATS");
+    expect(content).toContain("process.env.__VINEXT_IMAGE_LOCAL_PATTERNS");
+    expect(content).toContain("process.env.__VINEXT_IMAGE_UNOPTIMIZED");
     expect(content).toContain("JSON.stringify(DEFAULT_DEVICE_SIZES)");
     expect(content).toContain("JSON.stringify(DEFAULT_IMAGE_SIZES)");
     expect(content).toContain("}, allowedWidths, imageConfig)");
+  });
+
+  it("threads custom image response security headers into the App Router worker", () => {
+    const content = generateAppRouterWorkerEntry();
+    expect(content).toContain("process.env.__VINEXT_IMAGE_CONTENT_DISPOSITION_TYPE");
+    expect(content).toContain("process.env.__VINEXT_IMAGE_CONTENT_SECURITY_POLICY");
+    expect(content).toContain("contentDispositionType:");
+    expect(content).toContain("contentSecurityPolicy:");
+    expect(content).toContain('=== "inline" ? "inline" : "attachment"');
   });
 
   it("declares Env interface with IMAGES binding", () => {
@@ -702,6 +759,44 @@ describe("generateAppRouterWorkerEntry", () => {
     expect(content).toContain("transformImage:");
     expect(content).toContain("env.ASSETS.fetch");
     expect(content).toContain("env.IMAGES");
+    expect(content).toContain("getWorkerRemoteImageRedirect");
+    expect(content).toContain("if (remoteRedirect) return remoteRedirect");
+    expect(content).not.toContain("resolveHostnamesWithDnsOverHttps");
+    expect(content).toContain("__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP");
+    expect(content).toContain("handleImageOptimization(request");
+  });
+
+  it("disables manual optimizer requests for unoptimized and non-default loaders", () => {
+    const content = generateAppRouterWorkerEntry();
+    const endpointCheck = content.indexOf("isImageOptimizationPath(url.pathname");
+    const enabledCheck = content.indexOf("isImageOptimizationEnabled(imageConfig)");
+    const optimizerCall = content.indexOf("handleImageOptimization(request");
+
+    expect(content).toContain('loader: (process.env.__VINEXT_IMAGE_LOADER ?? "default")');
+    expect(endpointCheck).toBeGreaterThanOrEqual(0);
+    expect(enabledCheck).toBeGreaterThan(endpointCheck);
+    expect(optimizerCall).toBeGreaterThan(enabledCheck);
+  });
+
+  it.each([
+    { imageEnv: { unoptimized: "true" }, label: "unoptimized images" },
+    { imageEnv: { loader: "custom" }, label: "a custom loader" },
+  ])("returns 404 for generated Worker optimizer requests with $label", async ({ imageEnv }) => {
+    const worker = await loadGeneratedAppWorker(imageEnv);
+    const response = await worker.fetch(
+      new Request("https://example.test/_next/image?url=%2Fimg.jpg&w=640&q=75"),
+      {},
+      {},
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("checks Worker remote redirects before invoking the image optimizer", () => {
+    const content = generateAppRouterWorkerEntry();
+    expect(content.indexOf("getWorkerRemoteImageRedirect(request")).toBeLessThan(
+      content.indexOf("handleImageOptimization(request"),
+    );
   });
 
   it("never wires a cache handler into the Worker entry", () => {
@@ -854,6 +949,36 @@ describe("scanPublicFileRoutes", () => {
 });
 
 describe("generatePagesRouterWorkerEntry", () => {
+  it("propagates remote image security config into the Worker adapter", () => {
+    const content = generatePagesRouterWorkerEntry();
+    for (const field of [
+      "path",
+      "localPatterns",
+      "remotePatterns",
+      "domains",
+      "maximumRedirects",
+      "maximumResponseBody",
+      "minimumCacheTTL",
+      "formats",
+      "unoptimized",
+      "loader",
+      "dangerouslyAllowLocalIP",
+    ]) {
+      expect(content).toContain(`${field}: vinextConfig.images.${field}`);
+    }
+  });
+
+  it("gates Pages Worker optimizer requests before image handling", () => {
+    const content = generatePagesRouterWorkerEntry();
+    const endpointCheck = content.indexOf("hadBasePath && isImageOptimizationPath");
+    const enabledCheck = content.indexOf("isImageOptimizationEnabled(imageConfig)");
+    const optimizerCall = content.indexOf("handleImageOptimization(request");
+
+    expect(endpointCheck).toBeGreaterThanOrEqual(0);
+    expect(enabledCheck).toBeGreaterThan(endpointCheck);
+    expect(optimizerCall).toBeGreaterThan(enabledCheck);
+  });
+
   it("keeps Cloudflare dev _next/data URLs intact for Worker normalization", () => {
     const indexSource = fs.readFileSync(
       path.join(import.meta.dirname, "../packages/vinext/src/index.ts"),
@@ -1036,6 +1161,16 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("transformImage:");
     expect(content).toContain("env.ASSETS.fetch");
     expect(content).toContain("env.IMAGES");
+    expect(content).toContain("getWorkerRemoteImageRedirect");
+    expect(content).toContain("if (remoteRedirect) return remoteRedirect");
+    expect(content).not.toContain("resolveHostnamesWithDnsOverHttps");
+  });
+
+  it("checks Worker remote redirects before invoking the image optimizer", () => {
+    const content = generatePagesRouterWorkerEntry();
+    expect(content.indexOf("getWorkerRemoteImageRedirect(request")).toBeLessThan(
+      content.indexOf("handleImageOptimization(request"),
+    );
   });
 
   it("re-enters the ASSETS binding after beforeFiles rewrites", () => {
@@ -1298,10 +1433,16 @@ describe("generatePagesRouterWorkerEntry", () => {
   it("checks image optimization after basePath stripping", () => {
     const content = generatePagesRouterWorkerEntry();
     const basePathPos = content.indexOf("const stripped = stripBasePath(pathname, basePath);");
-    const imagePos = content.indexOf("isImageOptimizationPath(pathname)");
+    const imagePos = content.indexOf(
+      "isImageOptimizationPath(pathname, imageOptimizationPathAfterBasePath(imageConfig?.path, basePath))",
+    );
     expect(basePathPos).toBeGreaterThan(-1);
     expect(imagePos).toBeGreaterThan(-1);
     expect(basePathPos).toBeLessThan(imagePos);
+    expect(content).toContain(
+      "hadBasePath && isImageOptimizationPath(pathname, imageOptimizationPathAfterBasePath(imageConfig?.path, basePath))",
+    );
+    expect(content).not.toContain("isImageOptimizationPath(pathname, imageConfig?.path) ||");
   });
 
   it("threads configured image widths and qualities into optimization validation", () => {
@@ -1309,6 +1450,9 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("vinextConfig?.images?.deviceSizes ?? DEFAULT_DEVICE_SIZES");
     expect(content).toContain("vinextConfig?.images?.imageSizes ?? DEFAULT_IMAGE_SIZES");
     expect(content).toContain("qualities: vinextConfig.images.qualities");
+    expect(content).toContain("formats: vinextConfig.images.formats");
+    expect(content).toContain("deviceSizes: vinextConfig.images.deviceSizes");
+    expect(content).toContain("imageSizes: vinextConfig.images.imageSizes");
     expect(content).toContain("}, allowedWidths, imageConfig)");
   });
 

--- a/tests/e2e/app-router/nextjs-compat/image.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/image.spec.ts
@@ -1,7 +1,32 @@
 import { test, expect } from "../../fixtures";
 import { waitForAppRouterHydration } from "../../helpers";
+import { createServer } from "node:http";
 
 test.describe("next/image", () => {
+  test("optimizes remote images through the generated dev handler", async ({ request }) => {
+    const imageBytes = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+    const origin = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "image/png" });
+      response.end(imageBytes);
+    });
+    await new Promise<void>((resolve) => origin.listen(4199, "127.0.0.1", resolve));
+
+    try {
+      const source = "http://127.0.0.1:4199/photo.png";
+      const response = await request.get(
+        `/_next/image?url=${encodeURIComponent(source)}&w=640&q=75`,
+      );
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()["content-type"]).toBe("image/png");
+      expect(await response.body()).toEqual(imageBytes);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        origin.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   test("removes blur placeholder after a transparent image loads", async ({
     page,
     consoleErrors,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -911,6 +911,19 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain("handleServerActionRequest({");
   });
 
+  it("generateRscEntry serializes local image patterns and unoptimized config", () => {
+    const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false, {
+      imageConfig: {
+        localPatterns: [{ pathname: "/assets/**", search: "?v=1" }],
+        unoptimized: true,
+      },
+    });
+
+    expect(code).toContain(
+      'const __imageConfig = {"localPatterns":[{"pathname":"/assets/**","search":"?v=1"}],"unoptimized":true};',
+    );
+  });
+
   it("generateRscEntry passes page-slot dynamic stale time config into App page dispatch", () => {
     // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
@@ -966,6 +979,47 @@ describe("App Router entry templates", () => {
 // ── Pages Router entry template runtime bootstrap ─────────────────────
 
 describe("Pages Router entry template", () => {
+  it("serializes the complete image optimizer config", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-image-entry-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      const code = await generateServerEntry(
+        pagesDir,
+        await resolveNextConfig({
+          images: {
+            path: "/docs/custom-image/",
+            qualities: [60],
+            formats: ["image/avif", "image/webp"],
+            localPatterns: [{ pathname: "/assets/**", search: "?v=1" }],
+            remotePatterns: [{ protocol: "https", hostname: "images.example.com" }],
+            unoptimized: true,
+            domains: ["legacy.example.com"],
+            maximumRedirects: 2,
+            maximumResponseBody: 1024,
+            minimumCacheTTL: 300,
+          },
+        }),
+        createValidFileMatcher(),
+        null,
+        null,
+      );
+
+      expect(code).toContain('"path":"/docs/custom-image/"');
+      expect(code).toContain(
+        '"qualities":[60],"formats":["image/avif","image/webp"],"localPatterns":[{"pathname":"/assets/**","search":"?v=1"},{"pathname":"/_next/static/media/**","search":""}],"remotePatterns":[{"protocol":"https","hostname":"images.example.com"}],"unoptimized":true,"domains":["legacy.example.com"],"maximumRedirects":2,"maximumResponseBody":1024,"minimumCacheTTL":300',
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("reports trusted _next/data classification from URL normalization", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-data-entry-"));
     const pagesDir = path.join(tmpDir, "pages");

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -29,6 +29,78 @@ import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
 
+describe("image config validation", () => {
+  const invalidCases: Array<[string, Record<string, unknown>, string]> = [
+    ["device size bounds", { deviceSizes: [0] }, "images.deviceSizes[0]"],
+    ["image size count", { imageSizes: Array.from({ length: 26 }, () => 32) }, "images.imageSizes"],
+    ["format enum", { formats: ["image/png"] }, "images.formats[0]"],
+    [
+      "local pattern count",
+      { localPatterns: Array.from({ length: 26 }, () => ({ pathname: "/**" })) },
+      "images.localPatterns",
+    ],
+    [
+      "remote pattern count",
+      { remotePatterns: Array.from({ length: 51 }, () => ({ hostname: "example.com" })) },
+      "images.remotePatterns",
+    ],
+    ["redirect bounds", { maximumRedirects: 21 }, "images.maximumRedirects"],
+    ["body bounds", { maximumResponseBody: 0 }, "images.maximumResponseBody"],
+    ["ttl integer", { minimumCacheTTL: 1.5 }, "images.minimumCacheTTL"],
+    [
+      "local pattern field",
+      { localPatterns: [{ pathname: 1 }] },
+      "images.localPatterns[0].pathname",
+    ],
+    [
+      "local pattern shape",
+      { localPatterns: [{ hostname: "example.com" }] },
+      "Unrecognized key 'hostname'",
+    ],
+    ["remote hostname", { remotePatterns: [{}] }, "images.remotePatterns[0].hostname"],
+    [
+      "remote protocol",
+      { remotePatterns: [{ hostname: "example.com", protocol: "ftp" }] },
+      "images.remotePatterns[0].protocol",
+    ],
+    [
+      "remote port",
+      { remotePatterns: [{ hostname: "example.com", port: "123456" }] },
+      "images.remotePatterns[0].port",
+    ],
+    [
+      "remote search",
+      { remotePatterns: [{ hostname: "example.com", search: 1 }] },
+      "images.remotePatterns[0].search",
+    ],
+    ["domain type", { domains: [1] }, "images.domains[0]"],
+    [
+      "domain count",
+      { domains: Array.from({ length: 51 }, () => "example.com") },
+      "images.domains",
+    ],
+    ["disposition enum", { contentDispositionType: "download" }, "images.contentDispositionType"],
+    ["SVG boolean", { dangerouslyAllowSVG: "true" }, "images.dangerouslyAllowSVG"],
+    ["local IP boolean", { dangerouslyAllowLocalIP: 1 }, "images.dangerouslyAllowLocalIP"],
+    ["unoptimized boolean", { unoptimized: null }, "images.unoptimized"],
+    [
+      "disk cache size",
+      { maximumDiskCacheSize: 0 },
+      "images.maximumDiskCacheSize is not supported by vinext",
+    ],
+    [
+      "custom cache handler",
+      { customCacheHandler: true },
+      "images.customCacheHandler is not supported by vinext",
+    ],
+  ];
+
+  it.each(invalidCases)("rejects invalid %s", async (_name, images, expectedPath) => {
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+    await expect(resolveNextConfig({ images: images as never })).rejects.toThrow(expectedPath);
+  });
+});
+
 class CapturingNodeResponse extends PassThrough {
   statusCode = 0;
   headers: Record<string, string | string[]> = {};

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -11,6 +11,10 @@
 import type { NextConfig } from "vinext";
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [{ protocol: "http", hostname: "127.0.0.1", port: "4199" }],
+    dangerouslyAllowLocalIP: true,
+  },
   // Used by E2E: nextjs-compat/gesture-transitions.spec.ts — enabled
   // fixture-wide solely for that spec (the only observable effect is the
   // optional `experimental_gesturePush` method being attached). Note this

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -543,6 +543,32 @@ describe("Image srcSet generation", () => {
     expect(html).toContain(`${optUrlHtml("/bg.png", 640)} 640w`);
     expect(html).toContain(`${optUrlHtml("/bg.png", 3840)} 3840w`);
   });
+
+  it("sorts configured widths for widthless and fill images", async () => {
+    process.env.__VINEXT_IMAGE_DEVICE_SIZES = JSON.stringify([1080, 640, 828]);
+    process.env.__VINEXT_IMAGE_SIZES = JSON.stringify([384, 32, 256]);
+    vi.resetModules();
+
+    try {
+      const { getImageProps: getConfiguredImageProps } =
+        await import("../packages/vinext/src/shims/image.js");
+      const widthless = getConfiguredImageProps({ alt: "widthless", src: "/widthless.png" });
+      const fill = getConfiguredImageProps({ alt: "fill", src: "/fill.png", fill: true });
+      const expected = [640, 828, 1080]
+        .map((width) => `${optUrl("/widthless.png", width)} ${width}w`)
+        .join(", ");
+      const expectedFill = [640, 828, 1080]
+        .map((width) => `${optUrl("/fill.png", width)} ${width}w`)
+        .join(", ");
+
+      expect(widthless.props.srcSet).toBe(expected);
+      expect(fill.props.srcSet).toBe(expectedFill);
+    } finally {
+      delete process.env.__VINEXT_IMAGE_DEVICE_SIZES;
+      delete process.env.__VINEXT_IMAGE_SIZES;
+      vi.resetModules();
+    }
+  });
 });
 
 // ─── getImageProps ──────────────────────────────────────────────────────

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -9,8 +9,13 @@
  * priority, custom loader, and static image data handling.
  */
 import { describe, it, expect, vi, afterEach } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import React from "react";
 import ReactDOMServer from "react-dom/server";
+import { createServer } from "vite-plus";
+import vinext from "../packages/vinext/src/index.js";
 import Image, { getImageProps, type StaticImageData } from "../packages/vinext/src/shims/image.js";
 
 /** Helper: expected optimization URL matching what the image shim produces. */
@@ -29,6 +34,41 @@ function optUrlHtml(src: string, w: number, q = 75): string {
 // against regression of https://github.com/cloudflare/vinext/issues/1513.
 
 describe("default loader emits /_next/image URLs (issue #1513)", () => {
+  it("uses the normalized configured optimizer path", async () => {
+    process.env.__VINEXT_IMAGE_PATH = "/docs/_next/image/";
+    vi.resetModules();
+
+    try {
+      const { imageOptimizationUrl } = await import("../packages/vinext/src/shims/image.js");
+      expect(imageOptimizationUrl("/photo.png", 828, 75)).toBe(
+        "/docs/_next/image/?url=%2Fphoto.png&w=828&q=75",
+      );
+    } finally {
+      delete process.env.__VINEXT_IMAGE_PATH;
+      vi.resetModules();
+    }
+  });
+
+  it("retains default-loader behavior with a configured optimizer path", async () => {
+    process.env.__VINEXT_IMAGE_PATH = "/docs/_next/image/";
+    process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN = "true";
+    vi.resetModules();
+
+    try {
+      const { getImageProps } = await import("../packages/vinext/src/shims/image.js");
+      expect(getImageProps({ alt: "svg", src: "/icon.svg", width: 32, height: 32 }).props.src).toBe(
+        "/icon.svg",
+      );
+      expect(() =>
+        getImageProps({ alt: "query", src: "/photo.png?v=1", width: 32, height: 32 }),
+      ).toThrow("is using a query string which is not configured in images.localPatterns");
+    } finally {
+      delete process.env.__VINEXT_IMAGE_PATH;
+      delete process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN;
+      vi.resetModules();
+    }
+  });
+
   it("imageOptimizationUrl uses /_next/image prefix", async () => {
     const { imageOptimizationUrl } = await import("../packages/vinext/src/shims/image.js");
     const url = imageOptimizationUrl("/photo.png", 828, 85);
@@ -52,9 +92,146 @@ describe("default loader emits /_next/image URLs (issue #1513)", () => {
   });
 });
 
+describe("global loader configuration", () => {
+  it("requires a loader prop when the configured loader is custom", async () => {
+    process.env.__VINEXT_IMAGE_LOADER = "custom";
+    vi.resetModules();
+
+    try {
+      const { getImageProps } = await import("../packages/vinext/src/shims/image.js");
+      expect(() =>
+        getImageProps({ alt: "custom", src: "/logo.png", width: 32, height: 32 }),
+      ).toThrow('is missing "loader" prop');
+    } finally {
+      delete process.env.__VINEXT_IMAGE_LOADER;
+      vi.resetModules();
+    }
+  });
+
+  it("uses current next/image semantics for configured built-in loader paths", async () => {
+    process.env.__VINEXT_IMAGE_LOADER = "imgix";
+    process.env.__VINEXT_IMAGE_PATH = "https://example.imgix.net/";
+    vi.resetModules();
+
+    try {
+      const loader = (await import("../packages/vinext/src/shims/image-loader.js")).default;
+      expect(loader({ src: "/logo.png", width: 640, quality: 80 })).toBe(
+        "https://example.imgix.net/?url=%2Flogo.png&w=640&q=80",
+      );
+    } finally {
+      delete process.env.__VINEXT_IMAGE_LOADER;
+      delete process.env.__VINEXT_IMAGE_PATH;
+      vi.resetModules();
+    }
+  });
+
+  it("uses images.loaderFile for Image and getImageProps", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-image-loader-"));
+    fs.mkdirSync(path.join(root, "app"), { recursive: true });
+    fs.symlinkSync(path.resolve("node_modules"), path.join(root, "node_modules"), "junction");
+    fs.writeFileSync(
+      path.join(root, "next.config.mjs"),
+      `export default { images: { loader: "custom", loaderFile: "./image-loader.js" } };`,
+    );
+    fs.writeFileSync(
+      path.join(root, "image-loader.js"),
+      `export default function loader({ src, width, quality }) { return \`${"${src}"}#w:${"${width}"},q:${"${quality || 50}"}\`; }`,
+    );
+    fs.writeFileSync(
+      path.join(root, "entry.tsx"),
+      `import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import Image, { getImageProps } from "next/image";
+export function render() {
+  return {
+    html: renderToStaticMarkup(<Image id="img" src="/logo.png" alt="logo" width={400} height={200} />),
+    props: getImageProps({ src: "/logo.png", alt: "logo", width: 400, height: 200 }).props,
+  };
+}`,
+    );
+
+    const server = await createServer({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [vinext({ appDir: root })],
+      server: { middlewareMode: true },
+    });
+
+    try {
+      const module = await server.ssrLoadModule("/entry.tsx");
+      const result = module.render();
+      expect(result.html).toContain("/logo.png#w:828,q:50");
+      expect(result.html).toContain("/logo.png#w:640,q:50 1x");
+      expect(result.props.src).toBe("/logo.png#w:828,q:50");
+      expect(result.props.srcSet).toContain("/logo.png#w:640,q:50 1x");
+    } finally {
+      await server.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 // ─── SSR rendering ──────────────────────────────────────────────────────
 
 describe("Image SSR rendering", () => {
+  it.each(["", "data:image/png;base64,abc", "blob:https://example.com/image"])(
+    "renders special source %s unoptimized without lazy loading",
+    (src) => {
+      const html = ReactDOMServer.renderToString(
+        React.createElement(Image, { alt: "special", src, width: 100, height: 100 }),
+      );
+      expect(html).not.toContain("/_next/image?");
+      expect(html).not.toContain('loading="lazy"');
+
+      const { props } = getImageProps({ alt: "special", src, width: 100, height: 100 });
+      expect(props.src).toBe(src);
+      expect(props.srcSet).toBeUndefined();
+      expect(props.loading).toBeUndefined();
+    },
+  );
+
+  it("appends deployment IDs to unoptimized local images without replacing existing IDs", async () => {
+    process.env.__VINEXT_DEPLOYMENT_ID = "deployment-2";
+    vi.resetModules();
+    const { default: ConfiguredImage } = await import("../packages/vinext/src/shims/image.js");
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(ConfiguredImage, {
+        alt: "direct",
+        src: "/photo.jpg?version=1",
+        width: 100,
+        height: 100,
+        unoptimized: true,
+      }),
+    );
+    expect(html).toContain('src="/photo.jpg?version=1&amp;dpl=deployment-2"');
+
+    const existing = ReactDOMServer.renderToString(
+      React.createElement(ConfiguredImage, {
+        alt: "existing",
+        src: "/photo.jpg?dpl=deployment-1",
+        width: 100,
+        height: 100,
+        unoptimized: true,
+      }),
+    );
+    expect(existing).toContain('src="/photo.jpg?dpl=deployment-1"');
+
+    const { getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    expect(
+      getConfiguredImageProps({
+        alt: "props",
+        src: "/photo.jpg",
+        width: 100,
+        height: 100,
+        unoptimized: true,
+      }).props.src,
+    ).toBe("/photo.jpg?dpl=deployment-2");
+    delete process.env.__VINEXT_DEPLOYMENT_ID;
+  });
+
   it("renders a basic <img> tag with correct attributes", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
@@ -66,7 +243,7 @@ describe("Image SSR rendering", () => {
     );
     expect(html).toContain('alt="a nice image"');
     // Local images are routed through the optimization endpoint
-    expect(html).toContain(`src="${optUrlHtml("/test.png", 100)}"`);
+    expect(html).toContain(`src="${optUrlHtml("/test.png", 256)}"`);
     expect(html).toContain('width="100"');
     expect(html).toContain('height="100"');
     expect(html).toContain('decoding="async"');
@@ -90,7 +267,8 @@ describe("Image SSR rendering", () => {
     expect(html).toContain('<link rel="preload"');
     expect(html).toContain('as="image"');
     expect(html).toContain('fetchPriority="high"');
-    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero.png", 640)} 640w`);
+    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero.png", 828)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/hero.png", 1920)} 2x`);
     expect(html).not.toContain(`href="${optUrlHtml("/hero.png", 800)}"`);
     expect(html).toContain('loading="eager"');
     expect(html).toContain('fetchPriority="high"');
@@ -109,7 +287,8 @@ describe("Image SSR rendering", () => {
     );
     expect(html).toContain('<link rel="preload"');
     expect(html).toContain('as="image"');
-    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero-preload.png", 640)} 640w`);
+    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero-preload.png", 828)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/hero-preload.png", 1920)} 2x`);
     expect(html).not.toContain('loading="lazy"');
     expect(html).not.toContain('fetchPriority="high"');
   });
@@ -166,6 +345,9 @@ describe("Image SSR rendering", () => {
       }),
     );
     expect(html).toContain('sizes="(max-width: 768px) 100vw, 50vw"');
+    expect(html).toContain(`${optUrlHtml("/img.png", 384)} 384w`);
+    expect(html).toContain(`${optUrlHtml("/img.png", 3840)} 3840w`);
+    expect(html).not.toContain(" 1x");
   });
 
   it("renders with blur placeholder styles", () => {
@@ -197,7 +379,10 @@ describe("Image SSR rendering", () => {
         loader,
       }),
     );
-    expect(html).toContain('src="https://cdn.example.com/photo.jpg?w=200&amp;q=75"');
+    expect(html).toContain('src="https://cdn.example.com/photo.jpg?w=640&amp;q=75"');
+    expect(html).toContain(
+      'srcSet="https://cdn.example.com/photo.jpg?w=256&amp;q=75 1x, https://cdn.example.com/photo.jpg?w=640&amp;q=75 2x"',
+    );
   });
 
   it("renders StaticImageData (import result)", () => {
@@ -214,25 +399,32 @@ describe("Image SSR rendering", () => {
         placeholder: "blur",
       }),
     );
-    expect(html).toContain(`src="${optUrlHtml("/_next/static/media/test.abc123.png", 800)}"`);
+    expect(html).toContain(`src="${optUrlHtml("/_next/static/media/test.abc123.png", 1920)}"`);
 
     expect(html).toContain('width="800"');
     expect(html).toContain('height="600"');
     expect(html).toContain("data:image/png;base64,xyz");
   });
 
-  it("bypasses optimization for deployment-tagged SVG static imports", () => {
-    const src = "/_next/static/media/icon.0123abcd.svg?dpl=deployment-1";
-    const html = ReactDOMServer.renderToString(
-      React.createElement(Image, {
-        alt: "static svg",
-        src: { src, width: 32, height: 32 },
-      }),
-    );
+  it("uses unoptimized attributes for default-loader SVG static imports", () => {
+    process.env.__VINEXT_DEPLOYMENT_ID = "deployment-1";
+    try {
+      const src = "/_next/static/media/icon.0123abcd.svg";
+      const html = ReactDOMServer.renderToString(
+        React.createElement(Image, {
+          alt: "static svg",
+          src: { src, width: 32, height: 32 },
+          sizes: "100vw",
+        }),
+      );
 
-    expect(html).toContain(`src="${src.replaceAll("&", "&amp;")}"`);
-    expect(html).toContain(`srcSet="${src.replaceAll("&", "&amp;")}`);
-    expect(html).not.toContain("/_next/image?");
+      expect(html).toContain('src="/_next/static/media/icon.0123abcd.svg?dpl=deployment-1"');
+      expect(html).not.toContain("srcSet=");
+      expect(html).not.toContain("sizes=");
+      expect(html).not.toContain("/_next/image?");
+    } finally {
+      delete process.env.__VINEXT_DEPLOYMENT_ID;
+    }
   });
 
   it("applies className and custom style", () => {
@@ -278,7 +470,7 @@ describe("Image SSR rendering", () => {
 // ─── srcSet generation ──────────────────────────────────────────────────
 
 describe("Image srcSet generation", () => {
-  it("generates srcSet for local images with width", () => {
+  it("generates fixed-size 1x and 2x srcSet entries", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
         alt: "test",
@@ -287,17 +479,11 @@ describe("Image srcSet generation", () => {
         height: 400,
       }),
     );
-    // RESPONSIVE_WIDTHS = [640, 750, 828, 1080, 1200, 1920, 2048, 3840]
-    // Filter: widths <= 500 * 2 = 1000 → [640, 750, 828]
-    expect(html).toContain("srcSet");
-    expect(html).toContain(`${optUrlHtml("/photo.png", 640)} 640w`);
-    expect(html).toContain(`${optUrlHtml("/photo.png", 750)} 750w`);
-    expect(html).toContain(`${optUrlHtml("/photo.png", 828)} 828w`);
-    // Should not include widths > 1000
-    expect(html).not.toContain("1080w");
+    expect(html).toContain(`${optUrlHtml("/photo.png", 640)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/photo.png", 1080)} 2x`);
   });
 
-  it("generates srcSet with all widths for large images", () => {
+  it("caps fixed-size srcSet entries at the largest configured width", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
         alt: "test",
@@ -306,12 +492,11 @@ describe("Image srcSet generation", () => {
         height: 1500,
       }),
     );
-    // widths <= 4000: all of them
-    expect(html).toContain(`${optUrlHtml("/large.png", 640)} 640w`);
-    expect(html).toContain(`${optUrlHtml("/large.png", 3840)} 3840w`);
+    expect(html).toContain(`${optUrlHtml("/large.png", 2048)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/large.png", 3840)} 2x`);
   });
 
-  it("generates fallback srcSet for very small images", () => {
+  it("uses Next.js default image sizes for small fixed images", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
         alt: "tiny",
@@ -320,12 +505,33 @@ describe("Image srcSet generation", () => {
         height: 16,
       }),
     );
-    // widths <= 32: none of RESPONSIVE_WIDTHS qualify
-    // Falls back to single: optimized icon.png at 16w
-    expect(html).toContain(`${optUrlHtml("/icon.png", 16)} 16w`);
+    expect(html).not.toContain(optUrlHtml("/icon.png", 16));
+    expect(html).toContain(`${optUrlHtml("/icon.png", 32)} 1x`);
   });
 
-  it("does not generate srcSet for fill mode", () => {
+  it("uses all configured widths for sizes without viewport percentages", () => {
+    const { props } = getImageProps({
+      alt: "responsive",
+      src: "/responsive.png",
+      width: 500,
+      height: 300,
+      sizes: "(max-width: 600px) 320px, 500px",
+    });
+
+    expect(props.srcSet).toContain(`${optUrl("/responsive.png", 32)} 32w`);
+    expect(props.srcSet).toContain(`${optUrl("/responsive.png", 3840)} 3840w`);
+    expect(props.srcSet).not.toContain(" 1x");
+  });
+
+  it("routes configured remote images through the optimizer", () => {
+    const src = "https://image-optimization-test.vercel.app/test.jpg";
+    const { props } = getImageProps({ alt: "remote", src, width: 200, height: 200, quality: 90 });
+
+    expect(props.src).toBe(optUrl(src, 640, 90));
+    expect(props.srcSet).toBe(`${optUrl(src, 256, 90)} 1x, ${optUrl(src, 640, 90)} 2x`);
+  });
+
+  it("generates a 100vw width srcSet for fill mode", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
         alt: "fill",
@@ -333,8 +539,9 @@ describe("Image srcSet generation", () => {
         fill: true,
       }),
     );
-    // Fill mode: no srcSet (srcSet is only for local non-fill images with width)
-    expect(html).not.toContain("srcSet");
+    expect(html).toContain('sizes="100vw"');
+    expect(html).toContain(`${optUrlHtml("/bg.png", 640)} 640w`);
+    expect(html).toContain(`${optUrlHtml("/bg.png", 3840)} 3840w`);
   });
 });
 
@@ -350,12 +557,55 @@ describe("getImageProps", () => {
     });
 
     expect(props.alt).toBe("a nice desc");
-    expect(props.src).toBe(optUrl("/test.png", 100));
+    expect(props.src).toBe(optUrl("/test.png", 256));
     expect(props.width).toBe(100);
     expect(props.height).toBe(200);
     expect(props.loading).toBe("lazy");
     expect(props.decoding).toBe("async");
     expect((props as any)["data-nimg"]).toBe("1");
+  });
+
+  it("uses direct image URLs when images.unoptimized is enabled", async () => {
+    process.env.__VINEXT_IMAGE_UNOPTIMIZED = "true";
+    vi.resetModules();
+    const { getImageProps: getUnoptimizedImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+
+    const { props } = getUnoptimizedImageProps({
+      alt: "direct",
+      src: "/direct.png",
+      width: 100,
+      height: 100,
+    });
+    expect(props.src).toBe("/direct.png");
+    expect(props.srcSet).toBeUndefined();
+
+    delete process.env.__VINEXT_IMAGE_UNOPTIMIZED;
+    vi.resetModules();
+  });
+
+  it("uses the nearest configured quality for default-loader URLs", async () => {
+    process.env.__VINEXT_IMAGE_QUALITIES = JSON.stringify([60, 90]);
+    vi.resetModules();
+    const { getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+
+    expect(
+      getConfiguredImageProps({ alt: "default quality", src: "/test.png", width: 100, height: 100 })
+        .props.src,
+    ).toContain("q=60");
+    expect(
+      getConfiguredImageProps({
+        alt: "nearest quality",
+        src: "/test.png",
+        width: 100,
+        height: 100,
+        quality: 80,
+      }).props.src,
+    ).toContain("q=90");
+
+    delete process.env.__VINEXT_IMAGE_QUALITIES;
+    vi.resetModules();
   });
 
   it("returns priority props", () => {
@@ -387,7 +637,7 @@ describe("getImageProps", () => {
     expect((props.style as any)?.height).toBe("100%");
   });
 
-  it("returns custom loader URL", () => {
+  it("returns responsive custom loader attributes", () => {
     const loader = ({ src, width }: { src: string; width: number }) =>
       `https://cdn.example.com${src}?w=${width}`;
 
@@ -399,7 +649,74 @@ describe("getImageProps", () => {
       loader,
     });
 
-    expect(props.src).toBe("https://cdn.example.com/photo.jpg?w=300");
+    expect(props.src).toBe("https://cdn.example.com/photo.jpg?w=640");
+    expect(props.srcSet).toBe(
+      "https://cdn.example.com/photo.jpg?w=384 1x, https://cdn.example.com/photo.jpg?w=640 2x",
+    );
+  });
+
+  it("uses overrideSrc with custom loader srcSet in component and getImageProps", () => {
+    const loader = ({ src, width }: { src: string; width: number }) =>
+      `https://cdn.example.com${src}?w=${width}`;
+    const overrideSrc = "https://images.example.com/original.jpg";
+
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "cdn",
+        src: "/photo.jpg",
+        width: 300,
+        height: 200,
+        loader,
+        overrideSrc,
+      }),
+    );
+    expect(html).toContain(`src="${overrideSrc}"`);
+    expect(html).toContain("https://cdn.example.com/photo.jpg?w=384 1x");
+    expect(html).toContain("https://cdn.example.com/photo.jpg?w=640 2x");
+
+    const { props } = getImageProps({
+      alt: "cdn",
+      src: "/photo.jpg",
+      width: 300,
+      height: 200,
+      loader,
+      overrideSrc,
+    });
+    expect(props.src).toBe(overrideSrc);
+    expect(props.srcSet).toBe(
+      "https://cdn.example.com/photo.jpg?w=384 1x, https://cdn.example.com/photo.jpg?w=640 2x",
+    );
+  });
+
+  it("passes raw quality to custom loaders regardless of configured qualities", async () => {
+    process.env.__VINEXT_IMAGE_QUALITIES = "[60]";
+    vi.resetModules();
+    const { getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const loader = vi.fn(({ quality }: { quality?: number }) => `/photo.jpg?q=${quality}`);
+
+    expect(
+      getConfiguredImageProps({
+        alt: "custom quality",
+        src: "/photo.jpg",
+        width: 300,
+        height: 200,
+        loader,
+        quality: 90,
+      }).props.src,
+    ).toBe("/photo.jpg?q=90");
+    expect(
+      getConfiguredImageProps({
+        alt: "default custom quality",
+        src: "/photo.jpg",
+        width: 300,
+        height: 200,
+        loader,
+      }).props.src,
+    ).toBe("/photo.jpg?q=undefined");
+    expect(loader).toHaveBeenCalledWith(expect.objectContaining({ quality: undefined }));
+
+    delete process.env.__VINEXT_IMAGE_QUALITIES;
   });
 
   it("returns blur placeholder styles", () => {
@@ -414,6 +731,52 @@ describe("getImageProps", () => {
 
     expect((props.style as any)?.backgroundImage).toBe("url(data:image/png;base64,test)");
     expect((props.style as any)?.backgroundSize).toBe("cover");
+  });
+
+  it("retains common image props with a custom loader", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "custom common props",
+        src: "/photo.jpg",
+        width: 300,
+        height: 200,
+        loader: ({ src, width }) => `${src}?w=${width}`,
+        priority: true,
+        placeholder: "blur",
+        blurDataURL: "data:image/png;base64,test",
+      }),
+    );
+    expect(html).toContain('fetchPriority="high"');
+    expect(html).toContain('data-nimg="1"');
+    expect(html).toContain("background-image:url(data:image/png;base64,test)");
+  });
+
+  it("uses custom loaders for SVG sources", () => {
+    const loader = ({ src, width }: { src: string; width: number }) =>
+      `https://cdn.example.com${src}?w=${width}`;
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "custom svg",
+        src: "/icon.svg",
+        width: 32,
+        height: 32,
+        loader,
+      }),
+    );
+    expect(html).toContain('src="https://cdn.example.com/icon.svg?w=64"');
+    expect(html).toContain("https://cdn.example.com/icon.svg?w=32 1x");
+
+    const { props } = getImageProps({
+      alt: "custom svg",
+      src: "/icon.svg",
+      width: 32,
+      height: 32,
+      loader,
+    });
+    expect(props.src).toBe("https://cdn.example.com/icon.svg?w=64");
+    expect(props.srcSet).toBe(
+      "https://cdn.example.com/icon.svg?w=32 1x, https://cdn.example.com/icon.svg?w=64 2x",
+    );
   });
 
   it("merges user style with default", () => {
@@ -453,20 +816,27 @@ describe("getImageProps", () => {
       src: staticImage,
     });
 
-    expect(props.src).toBe(optUrl("/static/photo.png", 1920));
+    expect(props.src).toBe(optUrl("/static/photo.png", 3840));
     expect(props.width).toBe(1920);
     expect(props.height).toBe(1080);
   });
 
-  it("getImageProps bypasses optimization for deployment-tagged SVG imports", () => {
-    const src = "/_next/static/media/icon.0123abcd.svg?dpl=deployment-1";
-    const { props } = getImageProps({
-      alt: "static svg",
-      src: { src, width: 32, height: 32 },
-    });
+  it("getImageProps uses unoptimized attributes for default-loader SVG imports", () => {
+    process.env.__VINEXT_DEPLOYMENT_ID = "deployment-1";
+    try {
+      const src = "/_next/static/media/icon.0123abcd.svg";
+      const { props } = getImageProps({
+        alt: "static svg",
+        src: { src, width: 32, height: 32 },
+        sizes: "100vw",
+      });
 
-    expect(props.src).toBe(src);
-    expect(props.srcSet).toBeUndefined();
+      expect(props.src).toBe(`${src}?dpl=deployment-1`);
+      expect(props.srcSet).toBeUndefined();
+      expect(props.sizes).toBeUndefined();
+    } finally {
+      delete process.env.__VINEXT_DEPLOYMENT_ID;
+    }
   });
 
   it("generates srcSet for local images", () => {
@@ -480,7 +850,28 @@ describe("getImageProps", () => {
     expect(props.srcSet).toBeDefined();
     expect(props.srcSet).toContain("/_next/image");
     expect(props.srcSet).toContain("photo.png");
-    expect(props.srcSet).toContain("w");
+    expect(props.srcSet).toContain("1x");
+    expect(props.srcSet).toContain("2x");
+  });
+
+  it("moves a static asset deployment id onto optimizer URLs", () => {
+    const { props } = getImageProps({
+      alt: "static",
+      src: {
+        src: "/_next/static/media/test.abc123.png?dpl=deployment-1",
+        width: 400,
+        height: 400,
+      },
+      quality: 85,
+    });
+
+    expect(props.src).toBe(
+      "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=828&q=85&dpl=deployment-1",
+    );
+    expect(props.srcSet).toBe(
+      "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=640&q=85&dpl=deployment-1 1x, " +
+        "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=828&q=85&dpl=deployment-1 2x",
+    );
   });
 
   it("handles loading=eager prop", () => {
@@ -790,6 +1181,33 @@ describe("unoptimized remote images", () => {
     expect(props.srcSet).toBeUndefined();
   });
 
+  it("uses overrideSrc as optimized src while preserving generated srcSet", () => {
+    const overrideSrc = "https://cdn.example.com/original.jpg";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "overridden optimized image",
+        src: "/photo.jpg",
+        overrideSrc,
+        width: 100,
+        height: 100,
+      }),
+    );
+
+    expect(html).toContain(`src="${overrideSrc}"`);
+    expect(html).toContain("srcSet=");
+    expect(html).toContain("/_next/image?url=%2Fphoto.jpg");
+
+    const { props } = getImageProps({
+      alt: "overridden optimized image",
+      src: "/photo.jpg",
+      overrideSrc,
+      width: 100,
+      height: 100,
+    });
+    expect(props.src).toBe(overrideSrc);
+    expect(props.srcSet).toContain("/_next/image?url=%2Fphoto.jpg");
+  });
+
   it("bypasses remote pattern validation in production", async () => {
     vi.stubEnv("NODE_ENV", "production");
     process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([
@@ -1034,7 +1452,7 @@ describe("onLoad / onError handler attachment (SSR)", () => {
     expect(html).toContain('data-nimg="1"');
   });
 
-  it("renders valid SSR output with both onLoad and onError (remote URL via UnpicImage)", () => {
+  it("renders valid SSR output with both onLoad and onError for a remote URL", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
         alt: "remote events",
@@ -1062,7 +1480,7 @@ describe("dangerouslyAllowLocalIP private-IP guard", () => {
     delete process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP;
   });
 
-  it("blocks private-IP remote URLs in production (Image returns null)", async () => {
+  it("defers private-IP rejection to the optimizer in production", async () => {
     vi.stubEnv("NODE_ENV", "production");
     process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
     process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
@@ -1080,26 +1498,8 @@ describe("dangerouslyAllowLocalIP private-IP guard", () => {
         height: 300,
       }),
     );
-    // Production: blocked → no img tag rendered
-    expect(html).not.toContain("<img");
-  });
-
-  it("blocks private-IP remote URLs in production (getImageProps returns empty src)", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
-    process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
-
-    vi.resetModules();
-    const { getImageProps: privateIpGetImageProps } =
-      await import("../packages/vinext/src/shims/image.js");
-
-    const { props } = privateIpGetImageProps({
-      alt: "private ip",
-      src: "http://192.168.1.1/photo.jpg",
-      width: 400,
-      height: 300,
-    });
-    expect(props.src).toBe("");
+    expect(html).toContain("<img");
+    expect(html).toContain("/_next/image?url=http%3A%2F%2F127.0.0.1%2Fphoto.jpg");
   });
 
   it("allows private-IP remote URLs when dangerouslyAllowLocalIP = true", async () => {
@@ -1146,30 +1546,257 @@ describe("dangerouslyAllowLocalIP private-IP guard", () => {
     expect(html).toContain('alt="public ip"');
   });
 
-  it("warns but does not block private-IP remote URLs in development", async () => {
+  it("defers configured private-IP rejection to the optimizer in development", async () => {
     vi.stubEnv("NODE_ENV", "development");
     process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([{ hostname: "**" }]);
     process.env.__VINEXT_IMAGE_DANGEROUSLY_ALLOW_LOCAL_IP = "false";
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
     // Module-level constants in image.tsx are evaluated at import time from
     // process.env, so we must re-evaluate the module after changing env.
     vi.resetModules();
-    const { default: PrivateIpImage } = await import("../packages/vinext/src/shims/image.js");
+    const { default: PrivateIpImage, getImageProps: getPrivateIpImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const props = {
+      alt: "private ip dev",
+      src: "http://172.16.0.1/photo.jpg",
+      width: 400,
+      height: 300,
+    };
 
+    const html = ReactDOMServer.renderToString(React.createElement(PrivateIpImage, props));
+    expect(html).toContain("/_next/image?url=http%3A%2F%2F172.16.0.1%2Fphoto.jpg");
+    expect(getPrivateIpImageProps(props).props.src).toContain(
+      "/_next/image?url=http%3A%2F%2F172.16.0.1%2Fphoto.jpg",
+    );
+  });
+});
+
+describe("remote URL protocol normalization", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete process.env.__VINEXT_IMAGE_REMOTE_PATTERNS;
+    delete process.env.__VINEXT_IMAGE_DOMAINS;
+    vi.restoreAllMocks();
+  });
+
+  it("validates mixed-case HTTPS component sources against remotePatterns", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([
+      { protocol: "https", hostname: "images.example.com", pathname: "/allowed/**" },
+    ]);
+
+    vi.resetModules();
+    const { default: ConfiguredImage } = await import("../packages/vinext/src/shims/image.js");
     const html = ReactDOMServer.renderToString(
-      React.createElement(PrivateIpImage, {
-        alt: "private ip dev",
-        src: "http://172.16.0.1/photo.jpg",
+      React.createElement(ConfiguredImage, {
+        alt: "configured remote image",
+        src: "HTTPS://images.example.com/allowed/photo.png",
         width: 400,
         height: 300,
       }),
     );
-    // Dev: warn but still render
-    expect(html).toContain("<img");
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("resolved to private IP"));
 
-    warnSpy.mockRestore();
+    expect(html).toContain("<img");
+    expect(html).toContain("/_next/image?");
+  });
+
+  it("defers mixed-case HTTP component validation in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([
+      { protocol: "https", hostname: "images.example.com", pathname: "/allowed/**" },
+    ]);
+    vi.resetModules();
+    const { default: ConfiguredImage } = await import("../packages/vinext/src/shims/image.js");
+    const html = ReactDOMServer.renderToString(
+      React.createElement(ConfiguredImage, {
+        alt: "unconfigured remote image",
+        src: "HTTP://unconfigured.example.com/photo.png",
+        width: 400,
+        height: 300,
+      }),
+    );
+
+    expect(html).toContain("<img");
+    expect(html).toContain("/_next/image?url=HTTP%3A%2F%2Funconfigured.example.com%2Fphoto.png");
+  });
+
+  it("validates mixed-case HTTPS getImageProps sources against remotePatterns", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([
+      { protocol: "https", hostname: "images.example.com", pathname: "/allowed/**" },
+    ]);
+
+    vi.resetModules();
+    const { getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const { props } = getConfiguredImageProps({
+      alt: "configured remote image",
+      src: "HTTPS://images.example.com/allowed/photo.png",
+      width: 400,
+      height: 300,
+    });
+
+    expect(props.src).toContain("/_next/image?");
+  });
+
+  it("defers mixed-case HTTP getImageProps validation in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.__VINEXT_IMAGE_REMOTE_PATTERNS = JSON.stringify([
+      { protocol: "https", hostname: "images.example.com", pathname: "/allowed/**" },
+    ]);
+    vi.resetModules();
+    const { getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const { props } = getConfiguredImageProps({
+      alt: "unconfigured remote image",
+      src: "HTTP://unconfigured.example.com/photo.png",
+      width: 400,
+      height: 300,
+    });
+
+    expect(props.src).toContain(
+      "/_next/image?url=HTTP%3A%2F%2Funconfigured.example.com%2Fphoto.png",
+    );
+  });
+});
+
+describe("unconfigured remote image hosts", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete process.env.__VINEXT_IMAGE_REMOTE_PATTERNS;
+    delete process.env.__VINEXT_IMAGE_DOMAINS;
+    vi.resetModules();
+  });
+
+  it("emits optimizer URLs for unconfigured remote images in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    delete process.env.__VINEXT_IMAGE_REMOTE_PATTERNS;
+    delete process.env.__VINEXT_IMAGE_DOMAINS;
+    vi.resetModules();
+    const { default: UnconfiguredImage, getImageProps: getUnconfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const src = "https://images.example.com/photo.png";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(UnconfiguredImage, {
+        alt: "unconfigured remote image",
+        src,
+        width: 400,
+        height: 300,
+      }),
+    );
+
+    expect(html).toContain("<img");
+    expect(html).toContain("/_next/image?url=https%3A%2F%2Fimages.example.com%2Fphoto.png");
+    expect(
+      getUnconfiguredImageProps({
+        alt: "unconfigured remote image",
+        src,
+        width: 400,
+        height: 300,
+      }).props.src,
+    ).toContain("/_next/image?url=https%3A%2F%2Fimages.example.com%2Fphoto.png");
+  });
+
+  it.each([
+    ["https://images.example.com/photo.png", 'hostname "images.example.com" is not configured'],
+    [
+      "//images.example.com/photo.png",
+      "protocol-relative URL (//) must be changed to an absolute URL",
+    ],
+    ["images.example.com/photo.png", "if using relative image it must start with a leading slash"],
+  ])("throws for invalid remote src %s in development", async (src, message) => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.resetModules();
+    const { default: InvalidImage, getImageProps: getInvalidImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const props = { alt: "invalid remote image", src, width: 400, height: 300 };
+
+    expect(() => ReactDOMServer.renderToString(React.createElement(InvalidImage, props))).toThrow(
+      message,
+    );
+    expect(() => getInvalidImageProps(props)).toThrow(message);
+  });
+});
+
+describe("local image patterns", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete process.env.__VINEXT_IMAGE_LOCAL_PATTERNS;
+    delete process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN;
+    delete process.env.__VINEXT_IMAGE_QUALITIES;
+    vi.resetModules();
+  });
+
+  it.each(["development", "production"])(
+    "throws for default query-bearing local URLs in %s",
+    async (nodeEnv) => {
+      vi.stubEnv("NODE_ENV", nodeEnv);
+      process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN = "true";
+      vi.resetModules();
+      const { default: ConfiguredImage, getImageProps: getConfiguredImageProps } =
+        await import("../packages/vinext/src/shims/image.js");
+      const props = {
+        alt: "query image",
+        src: "/photo.jpg?v=1",
+        width: 300,
+        height: 200,
+      };
+
+      expect(() =>
+        ReactDOMServer.renderToString(React.createElement(ConfiguredImage, props)),
+      ).toThrow(
+        'Image with src "/photo.jpg?v=1" is using a query string which is not configured in images.localPatterns.',
+      );
+      expect(() => getConfiguredImageProps(props)).toThrow(
+        'Image with src "/photo.jpg?v=1" is using a query string which is not configured in images.localPatterns.',
+      );
+    },
+  );
+
+  it("throws for configured localPatterns mismatches in development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    process.env.__VINEXT_IMAGE_LOCAL_PATTERNS = JSON.stringify([
+      { pathname: "/assets/**", search: "" },
+    ]);
+    vi.resetModules();
+    const { default: ConfiguredImage, getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const props = { alt: "unmatched image", src: "/photo.jpg", width: 300, height: 200 };
+
+    expect(() =>
+      ReactDOMServer.renderToString(React.createElement(ConfiguredImage, props)),
+    ).toThrow("does not match `images.localPatterns`");
+    expect(() => getConfiguredImageProps(props)).toThrow("does not match `images.localPatterns`");
+  });
+
+  it("defers configured localPatterns mismatches to the optimizer in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.__VINEXT_IMAGE_LOCAL_PATTERNS = JSON.stringify([
+      { pathname: "/assets/**", search: "" },
+    ]);
+    vi.resetModules();
+    const { default: ConfiguredImage, getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const props = { alt: "unmatched image", src: "/photo.jpg", width: 300, height: 200 };
+
+    expect(ReactDOMServer.renderToString(React.createElement(ConfiguredImage, props))).toContain(
+      "/_next/image?url=%2Fphoto.jpg",
+    );
+    expect(getConfiguredImageProps(props).props.src).toContain("/_next/image?url=%2Fphoto.jpg");
+  });
+
+  it("allows configured query-bearing local URLs in production without embedding patterns", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    delete process.env.__VINEXT_IMAGE_LOCAL_PATTERNS;
+    process.env.__VINEXT_IMAGE_REJECT_LOCAL_QUERY_WITHOUT_PATTERN = "false";
+    vi.resetModules();
+    const { default: ConfiguredImage, getImageProps: getConfiguredImageProps } =
+      await import("../packages/vinext/src/shims/image.js");
+    const props = { alt: "query image", src: "/photo.jpg?v=1", width: 300, height: 200 };
+
+    expect(ReactDOMServer.renderToString(React.createElement(ConfiguredImage, props))).toContain(
+      "%2Fphoto.jpg%3Fv%3D1",
+    );
+    expect(getConfiguredImageProps(props).props.src).toContain("%2Fphoto.jpg%3Fv%3D1");
   });
 });

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -527,8 +527,8 @@ describe("Image srcSet generation", () => {
     const src = "https://image-optimization-test.vercel.app/test.jpg";
     const { props } = getImageProps({ alt: "remote", src, width: 200, height: 200, quality: 90 });
 
-    expect(props.src).toBe(optUrl(src, 640, 90));
-    expect(props.srcSet).toBe(`${optUrl(src, 256, 90)} 1x, ${optUrl(src, 640, 90)} 2x`);
+    expect(props.src).toBe(optUrl(src, 640, 75));
+    expect(props.srcSet).toBe(`${optUrl(src, 256, 75)} 1x, ${optUrl(src, 640, 75)} 2x`);
   });
 
   it("generates a 100vw width srcSet for fill mode", () => {
@@ -866,11 +866,11 @@ describe("getImageProps", () => {
     });
 
     expect(props.src).toBe(
-      "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=828&q=85&dpl=deployment-1",
+      "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=828&q=75&dpl=deployment-1",
     );
     expect(props.srcSet).toBe(
-      "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=640&q=85&dpl=deployment-1 1x, " +
-        "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=828&q=85&dpl=deployment-1 2x",
+      "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=640&q=75&dpl=deployment-1 1x, " +
+        "/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.abc123.png&w=828&q=75&dpl=deployment-1 2x",
     );
   });
 

--- a/tests/image-config.test.ts
+++ b/tests/image-config.test.ts
@@ -7,11 +7,63 @@
  */
 import { describe, it, expect } from "vite-plus/test";
 import {
+  hasLocalMatch,
   matchRemotePattern,
   hasRemoteMatch,
   isPrivateIp,
+  normalizeRemotePatterns,
+  normalizeLocalPatterns,
   type RemotePattern,
 } from "../packages/vinext/src/shims/image-config.js";
+
+describe("localPatterns", () => {
+  it("defaults to allowing local paths without query strings", () => {
+    expect(hasLocalMatch(undefined, "/images/hero.png")).toBe(true);
+    expect(hasLocalMatch(undefined, "/images/hero.png?v=1")).toBe(false);
+  });
+
+  it("matches configured pathname and query patterns", () => {
+    const patterns = normalizeLocalPatterns([{ pathname: "/images/**", search: "?v=1" }]);
+    expect(hasLocalMatch(patterns, "/images/hero.png?v=1")).toBe(true);
+    expect(hasLocalMatch(patterns, "/images/hero.png?v=2")).toBe(false);
+    expect(hasLocalMatch(patterns, "/other/hero.png?v=1")).toBe(false);
+  });
+
+  it("automatically allows static image imports", () => {
+    const patterns = normalizeLocalPatterns([{ pathname: "/images/**", search: "" }]);
+    expect(hasLocalMatch(patterns, "/_next/static/media/hero.1234.png")).toBe(true);
+  });
+});
+
+describe("URL remotePatterns", () => {
+  it("normalizes and matches URL-form patterns", () => {
+    const patterns = normalizeRemotePatterns([new URL("https://assets.example.com/images/**?v=1")]);
+    expect(patterns).toEqual([
+      {
+        protocol: "https",
+        hostname: "assets.example.com",
+        port: "",
+        pathname: "/images/**",
+        search: "?v=1",
+      },
+    ]);
+    expect(
+      hasRemoteMatch([], patterns, new URL("https://assets.example.com/images/hero.png?v=1")),
+    ).toBe(true);
+    expect(
+      hasRemoteMatch([], patterns, new URL("https://assets.example.com/images/hero.png?v=2")),
+    ).toBe(false);
+  });
+
+  it("accepts URL-form patterns directly at runtime", () => {
+    expect(
+      matchRemotePattern(
+        new URL("https://assets.example.com/images/**"),
+        new URL("https://assets.example.com/images/hero.png"),
+      ),
+    ).toBe(true);
+  });
+});
 
 // ─── matchRemotePattern: hostname matching ──────────────────────────────
 
@@ -26,17 +78,11 @@ describe("matchRemotePattern hostname", () => {
     expect(matchRemotePattern(pattern, new URL("https://other.com/img.png"))).toBe(false);
   });
 
-  it("matches single-segment wildcard (*)", () => {
+  it("matches wildcard (*) across nested subdomains like Next.js picomatch", () => {
     const pattern: RemotePattern = { hostname: "*.example.com" };
     expect(matchRemotePattern(pattern, new URL("https://cdn.example.com/img.png"))).toBe(true);
     expect(matchRemotePattern(pattern, new URL("https://images.example.com/img.png"))).toBe(true);
-  });
-
-  it("single wildcard does not match deep subdomains", () => {
-    const pattern: RemotePattern = { hostname: "*.example.com" };
-    expect(matchRemotePattern(pattern, new URL("https://deep.cdn.example.com/img.png"))).toBe(
-      false,
-    );
+    expect(matchRemotePattern(pattern, new URL("https://deep.cdn.example.com/img.png"))).toBe(true);
   });
 
   it("matches double-star wildcard (**) for deep subdomains", () => {

--- a/tests/image-imports.test.ts
+++ b/tests/image-imports.test.ts
@@ -1,14 +1,25 @@
-import { describe, it, expect } from "vite-plus/test";
+import { afterEach, describe, it, expect } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import vm from "node:vm";
 import vinext from "../packages/vinext/src/index.js";
 import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
-import type { Plugin } from "vite-plus";
+import { createServer, type Plugin, type ViteDevServer } from "vite-plus";
 
 // ── Helpers ───────────────────────────────────────────────────
 const IMAGES_DIR = path.resolve(import.meta.dirname, "./fixtures/images");
 const PNG_PATH = path.join(IMAGES_DIR, "test-4x3.png");
 const JPG_PATH = path.join(IMAGES_DIR, "test-8x6.jpg");
+let fixtureServer: ViteDevServer | undefined;
+let fixtureRoot: string | undefined;
+
+afterEach(async () => {
+  await fixtureServer?.close();
+  fixtureServer = undefined;
+  if (fixtureRoot) fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  fixtureRoot = undefined;
+});
 
 /** Unwrap a Vite plugin hook that may use the object-with-filter format */
 function unwrapHook(hook: any): Function {
@@ -111,10 +122,65 @@ describe("vinext:image-imports — load", () => {
     const result = await load.call(context, `\0vinext-image-meta:${PNG_PATH}`);
     expect(result).toContain('"width":4');
   });
+
+  it("emits optimized static imports from an absolute assetPrefix", async () => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-image-asset-prefix-"));
+    fs.mkdirSync(path.join(fixtureRoot, "app"));
+    fs.writeFileSync(
+      path.join(fixtureRoot, "app", "page.tsx"),
+      "export default function Page() { return null; }\n",
+    );
+
+    const plugins = vinext({
+      nextConfig: { assetPrefix: "https://cdn.example.com/assets" },
+    }) as Plugin[];
+    const configPlugin = plugins.find((plugin) => plugin.name === "vinext:config");
+    const imagePlugin = plugins.find((plugin) => plugin.name === "vinext:image-imports");
+    expect(configPlugin).toBeDefined();
+    expect(imagePlugin).toBeDefined();
+
+    await unwrapHook(configPlugin!.config).call(
+      configPlugin,
+      { root: fixtureRoot, plugins: [] },
+      { command: "build", mode: "production" },
+    );
+
+    const result = await unwrapHook(imagePlugin!.load).call(
+      Object.assign(Object.create(imagePlugin!), {
+        addWatchFile() {},
+        environment: { config: { command: "build" } },
+      }),
+      `\0vinext-image-url:${PNG_PATH}`,
+    );
+    expect(result).toContain("https://cdn.example.com/assets/_next/static/media/");
+  });
 });
 
 // ── transform ─────────────────────────────────────────────────
 describe("vinext:image-imports — transform", () => {
+  it("leaves image imports as ordinary Vite URLs when disableStaticImages is true", async () => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-disable-static-images-"));
+    fs.writeFileSync(
+      path.join(fixtureRoot, "next.config.mjs"),
+      "export default { images: { disableStaticImages: true } };\n",
+    );
+    fs.copyFileSync(PNG_PATH, path.join(fixtureRoot, "image.png"));
+    fs.writeFileSync(
+      path.join(fixtureRoot, "entry.ts"),
+      'import image from "./image.png"; export default image;\n',
+    );
+    fixtureServer = await createServer({
+      root: fixtureRoot,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [vinext()],
+      server: { middlewareMode: true },
+    });
+
+    const module = await fixtureServer.ssrLoadModule("/entry.ts");
+    expect(module.default).toBeTypeOf("string");
+    expect(module.default).toContain("/image.png");
+  });
   // Fake file ID in the images directory so path.resolve works
   const fakeId = path.join(IMAGES_DIR, "page.tsx");
 

--- a/tests/image-optimization-parity.test.ts
+++ b/tests/image-optimization-parity.test.ts
@@ -873,19 +873,21 @@ async function createImageFixture(router: "app" | "pages"): Promise<string> {
   await fs.writeFile(path.join(rootDir, "public", "hello world.png"), PNG_1X1);
   const configPath = path.join(rootDir, router === "app" ? "next.config.ts" : "next.config.mjs");
   const configSource = await fs.readFile(configPath, "utf8");
-  const declaration =
-    router === "app" ? "const nextConfig: NextConfig = {" : "const nextConfig = {";
-  await fs.writeFile(
-    configPath,
-    configSource.replace(
-      declaration,
-      `${declaration}
+  const updatedConfigSource =
+    router === "app"
+      ? configSource.replace(
+          'remotePatterns: [{ protocol: "http", hostname: "127.0.0.1", port: "4199" }],',
+          'remotePatterns: [{ protocol: "http", hostname: "localhost", pathname: "/**" }],',
+        )
+      : configSource.replace(
+          "const nextConfig = {",
+          `const nextConfig = {
   images: {
     remotePatterns: [{ protocol: "http", hostname: "localhost", pathname: "/**" }],
     dangerouslyAllowLocalIP: true,
   },`,
-    ),
-  );
+        );
+  await fs.writeFile(configPath, updatedConfigSource);
 
   if (router === "app") {
     await fs.rm(path.join(rootDir, "app", "alias-test"), { recursive: true, force: true });
@@ -1017,17 +1019,6 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
       expect(imageUrl.searchParams.get("q")).toBe("75");
 
       const res = await fetch(imageUrl);
-      expect(res.status).toBe(200);
-    });
-
-    // Both /_next/image and /_vinext/image are accepted so apps wired to
-    // either prefix get images served through the same optimizer pipeline.
-    it("routes /_vinext/image requests through the optimizer", async () => {
-      const vinextUrl = new URL("/_vinext/image", baseUrl);
-      vinextUrl.searchParams.set("url", "/hello world.png");
-      vinextUrl.searchParams.set("w", "64");
-      vinextUrl.searchParams.set("q", "75");
-      const res = await fetch(vinextUrl);
       expect(res.status).toBe(200);
     });
 

--- a/tests/image-optimization-parity.test.ts
+++ b/tests/image-optimization-parity.test.ts
@@ -513,7 +513,7 @@ describe("remote next/image endpoint security", () => {
       remoteHandlers(async (input) => {
         const url = requestInputUrl(input);
         redirectedUrls.push(url);
-        return url.includes("images.example.com")
+        return new URL(url).hostname === "images.example.com"
           ? Response.redirect("https://cdn.example.net/test.png", 302)
           : new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } });
       }),

--- a/tests/image-optimization-parity.test.ts
+++ b/tests/image-optimization-parity.test.ts
@@ -1,14 +1,859 @@
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { createServer } from "node:http";
 import path from "node:path";
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { ViteDevServer } from "vite-plus";
 import { APP_FIXTURE_DIR, PAGES_FIXTURE_DIR, startFixtureServer } from "./helpers.js";
+import {
+  createRuntimeImageConfig,
+  getWorkerRemoteImageRedirect,
+  getImageCacheControl,
+  getImageContentDisposition,
+  handleImageOptimization,
+  imageOptimizationPathAfterBasePath,
+  negotiateImageFormat,
+  parseImageParams,
+  parseRemoteImageUrl,
+  isImageOptimizationPath,
+  type ImageConfig,
+} from "../packages/vinext/src/server/image-optimization.js";
+import { fetchRemoteImageFromValidatedAddresses } from "../packages/vinext/src/server/node-remote-image-fetch.js";
+import {
+  getLocalImageLookupPath,
+  startProdServer,
+} from "../packages/vinext/src/server/prod-server.js";
 
 const PNG_1X1 = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4//8/AwAI/AL+X8n26QAAAABJRU5ErkJggg==",
   "base64",
 );
+
+const REMOTE_CONFIG: ImageConfig = {
+  remotePatterns: [{ protocol: "https", hostname: "images.example.com", pathname: "/allowed/**" }],
+  maximumRedirects: 1,
+  maximumResponseBody: PNG_1X1.byteLength,
+};
+
+it("recognizes configured image paths with optional trailing slashes", () => {
+  expect(isImageOptimizationPath("/docs/_next/image", "/docs/_next/image/")).toBe(true);
+  expect(isImageOptimizationPath("/docs/_next/image/", "/docs/_next/image/")).toBe(true);
+  expect(isImageOptimizationPath("/_next/image", "/docs/_next/image/")).toBe(false);
+  expect(isImageOptimizationPath("/_vinext/image", "/docs/_next/image/")).toBe(false);
+  expect(isImageOptimizationPath("/other/image", "/docs/_next/image/")).toBe(false);
+});
+
+it("recognizes the basePath-prefixed default optimizer route", () => {
+  expect(isImageOptimizationPath("/docs/_next/image", "/docs/_next/image")).toBe(true);
+  expect(isImageOptimizationPath("/unrelated/_next/image", "/docs/_next/image")).toBe(false);
+});
+
+it("normalizes configured image paths into the stripped basePath routing space", () => {
+  expect(imageOptimizationPathAfterBasePath("/docs/_next/image/", "/docs")).toBe("/_next/image/");
+  expect(imageOptimizationPathAfterBasePath("/_next/image", "/docs")).toBe("/_next/image");
+});
+
+it("preserves the configured image path in runtime config", () => {
+  expect(createRuntimeImageConfig({ path: "/docs/_next/image/" })?.path).toBe("/docs/_next/image/");
+});
+
+it("preserves loader identity in runtime image config", () => {
+  expect(createRuntimeImageConfig({ loader: "custom", unoptimized: true })).toMatchObject({
+    loader: "custom",
+    unoptimized: true,
+  });
+});
+
+it.each([
+  { imageConfig: { unoptimized: true }, label: "unoptimized images" },
+  { imageConfig: { loader: "custom" as const }, label: "a custom loader" },
+])("returns 404 for Node production optimizer requests with $label", async ({ imageConfig }) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-image-disabled-prod-"));
+  const serverDir = path.join(root, "server");
+  await fs.mkdir(serverDir, { recursive: true });
+  await fs.mkdir(path.join(root, "client"), { recursive: true });
+  await fs.writeFile(
+    path.join(serverDir, "index.js"),
+    `export const __assetPrefix = "";
+export const __basePath = "";
+export const __inlineCss = false;
+export const __hasPagesDir = false;
+export async function seedMemoryCacheFromPrerender() { return 0; }
+export default async function handler() { return new Response("fallback", { status: 418 }); }`,
+  );
+  await fs.writeFile(path.join(serverDir, "image-config.json"), JSON.stringify(imageConfig));
+  const started = await startProdServer({ port: 0, host: "127.0.0.1", outDir: root });
+  const server = "server" in started ? started.server : started;
+
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/_next/image?url=%2Fimg.jpg&w=640&q=75`,
+    );
+    expect(response.status).toBe(404);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+async function startImagePathProdServer(router: "app" | "pages") {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `vinext-${router}-image-path-prod-`));
+  const serverDir = path.join(root, "server");
+  const clientDir = path.join(root, "client");
+  await fs.mkdir(serverDir, { recursive: true });
+  await fs.mkdir(clientDir, { recursive: true });
+  await fs.writeFile(path.join(clientDir, "img.png"), PNG_1X1);
+
+  const imageConfig = {
+    path: "/docs/custom-image/",
+    loader: "default",
+    deviceSizes: [640],
+    imageSizes: [],
+    qualities: [75],
+  };
+  if (router === "app") {
+    await fs.writeFile(
+      path.join(serverDir, "index.js"),
+      `export const __assetPrefix = "";
+export const __basePath = "/docs";
+export const __inlineCss = false;
+export const __hasPagesDir = false;
+export async function seedMemoryCacheFromPrerender() { return 0; }
+export default async function handler() { return new Response("fallback", { status: 418 }); }`,
+    );
+    await fs.writeFile(path.join(serverDir, "image-config.json"), JSON.stringify(imageConfig));
+  } else {
+    await fs.writeFile(
+      path.join(serverDir, "entry.js"),
+      `export const vinextConfig = ${JSON.stringify({ basePath: "/docs", images: imageConfig })};
+export async function renderPage() { return new Response("fallback", { status: 418 }); }
+export async function handleApiRoute() { return new Response("fallback", { status: 418 }); }
+export async function runMiddleware() { return null; }`,
+    );
+  }
+
+  const started = await startProdServer({ port: 0, host: "127.0.0.1", outDir: root });
+  const server = "server" in started ? started.server : started;
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+  return { root, server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+it.each(["app", "pages"] as const)(
+  "%s Node production matches custom trailing-slash image paths inside basePath only",
+  async (router) => {
+    const fixture = await startImagePathProdServer(router);
+    try {
+      const optimized = await fetch(
+        `${fixture.baseUrl}/docs/custom-image/?url=%2Fimg.png&w=640&q=75`,
+      );
+      expect(optimized.status).toBe(200);
+      expect(Buffer.from(await optimized.arrayBuffer())).toEqual(PNG_1X1);
+
+      const unprefixed = await fetch(`${fixture.baseUrl}/custom-image/?url=%2Fimg.png&w=640&q=75`, {
+        redirect: "manual",
+      });
+      expect(unprefixed.status).not.toBe(200);
+    } finally {
+      await new Promise<void>((resolve) => fixture.server.close(() => resolve()));
+      await fs.rm(fixture.root, { recursive: true, force: true });
+    }
+  },
+);
+
+it("strips query parameters only for local production filesystem lookup", () => {
+  expect(getLocalImageLookupPath("/images/hero.png?v=1")).toBe("/images/hero.png");
+});
+
+function remoteOptimizerRequest(source: string): Request {
+  const url = new URL("http://vinext.test/_next/image");
+  url.searchParams.set("url", source);
+  url.searchParams.set("w", "64");
+  url.searchParams.set("q", "75");
+  return new Request(url);
+}
+
+function remoteHandlers(
+  fetchRemote: (url: URL, addresses: readonly string[], signal: AbortSignal) => Promise<Response>,
+  resolveHostnames: (hostname: string) => Promise<string[]> = async () => ["8.8.8.8"],
+) {
+  return {
+    fetchAsset: async () => new Response(null, { status: 404 }),
+    fetchRemote,
+    resolveHostnames,
+  };
+}
+
+function requestInputUrl(input: URL): string {
+  return input.href;
+}
+
+describe("remote image URL parsing", () => {
+  it.each([
+    ["HTTP://images.example.com/test.png", "http://images.example.com/test.png"],
+    ["HTTPS://images.example.com/test.png", "https://images.example.com/test.png"],
+  ])("normalizes mixed-case HTTP(S) URLs: %s", (source, expected) => {
+    expect(parseRemoteImageUrl(source)?.href).toBe(expected);
+  });
+});
+
+describe("local image URL patterns", () => {
+  it("rejects query-bearing local URLs by default", () => {
+    const request = new URL(
+      "http://vinext.test/_next/image?url=%2Fimages%2Fhero.png%3Fv%3D1&w=64&q=75",
+    );
+    expect(parseImageParams(request, [64], [75])).toBeNull();
+  });
+
+  it("allows explicitly matched local URLs with queries", () => {
+    const request = new URL(
+      "http://vinext.test/_next/image?url=%2Fimages%2Fhero.png%3Fv%3D1&w=64&q=75",
+    );
+    expect(
+      parseImageParams(request, [64], [75], {
+        localPatterns: [{ pathname: "/images/**", search: "?v=1" }],
+      }),
+    ).toEqual({ imageUrl: "/images/hero.png?v=1", width: 64, quality: 75 });
+  });
+});
+
+describe("remote next/image endpoint security", () => {
+  it("fetches an allowed remote image through the real optimizer handler", async () => {
+    const requestedUrls: string[] = [];
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(async (input) => {
+        requestedUrls.push(requestInputUrl(input));
+        return new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } });
+      }),
+      [64],
+      REMOTE_CONFIG,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(PNG_1X1);
+    expect(requestedUrls).toEqual(["https://images.example.com/allowed/test.png"]);
+  });
+
+  it("binds every Node fetch and redirect to validated DNS addresses", async () => {
+    const requestedHosts: string[] = [];
+    const server = createServer((request, response) => {
+      requestedHosts.push(request.headers.host ?? "");
+      if (request.url === "/allowed/start.png") {
+        const address = server.address();
+        if (!address || typeof address === "string") throw new Error("Image server closed");
+        response.writeHead(302, {
+          Location: `http://cdn.example.net:${address.port}/final.png`,
+        });
+        response.end();
+        return;
+      }
+      response.writeHead(200, { "Content-Type": "image/png" });
+      response.end(PNG_1X1);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Image test server failed");
+
+    const resolvedHosts: string[] = [];
+    try {
+      const response = await handleImageOptimization(
+        remoteOptimizerRequest(`HTTP://images.example.com:${address.port}/allowed/start.png`),
+        remoteHandlers(fetchRemoteImageFromValidatedAddresses, async (hostname) => {
+          resolvedHosts.push(hostname);
+          return ["127.0.0.1"];
+        }),
+        [64],
+        {
+          ...REMOTE_CONFIG,
+          remotePatterns: [
+            { protocol: "http", hostname: "images.example.com", pathname: "/allowed/**" },
+          ],
+          dangerouslyAllowLocalIP: true,
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(resolvedHosts).toEqual(["images.example.com", "cdn.example.net"]);
+      expect(requestedHosts).toEqual([
+        `images.example.com:${address.port}`,
+        `cdn.example.net:${address.port}`,
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("does not reuse a pooled socket after a hostname resolves to a different address", async () => {
+    const firstServer = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "image/png" });
+      response.end("first");
+    });
+    await new Promise<void>((resolve) => firstServer.listen(0, "127.0.0.1", resolve));
+    const firstAddress = firstServer.address();
+    if (!firstAddress || typeof firstAddress === "string") throw new Error("Image server failed");
+
+    const secondServer = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "image/png" });
+      response.end("second");
+    });
+    await new Promise<void>((resolve, reject) => {
+      secondServer.once("error", reject);
+      secondServer.listen(firstAddress.port, "::1", () => {
+        secondServer.off("error", reject);
+        resolve();
+      });
+    });
+
+    try {
+      const url = new URL(`http://images.example.com:${firstAddress.port}/image.png`);
+      const first = await fetchRemoteImageFromValidatedAddresses(
+        url,
+        ["127.0.0.1"],
+        AbortSignal.timeout(1_000),
+      );
+      expect(await first.text()).toBe("first");
+
+      const second = await fetchRemoteImageFromValidatedAddresses(
+        url,
+        ["::1"],
+        AbortSignal.timeout(1_000),
+      );
+      expect(await second.text()).toBe("second");
+    } finally {
+      await Promise.all(
+        [firstServer, secondServer].map(
+          (server) =>
+            new Promise<void>((resolve, reject) =>
+              server.close((error) => (error ? reject(error) : resolve())),
+            ),
+        ),
+      );
+    }
+  });
+
+  it("returns a controlled timeout when a remote body stalls after headers", async () => {
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(
+        async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(PNG_1X1.subarray(0, 1));
+              },
+              async pull(controller) {
+                await new Promise((resolve) => setTimeout(resolve, 1));
+                controller.error(new DOMException("body timed out", "TimeoutError"));
+              },
+            }),
+            { headers: { "Content-Type": "image/png" } },
+          ),
+      ),
+      [64],
+      REMOTE_CONFIG,
+    );
+
+    expect(response.status).toBe(504);
+    expect(await response.text()).toBe("Remote image request timed out");
+  });
+
+  it.each(["AbortError", "TimeoutError"])(
+    "returns 504 when remote headers never arrive with %s",
+    async (errorName) => {
+      const response = await handleImageOptimization(
+        remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+        remoteHandlers(async () => {
+          throw new DOMException("headers timed out", errorName);
+        }),
+        [64],
+        REMOTE_CONFIG,
+      );
+
+      expect(response.status).toBe(504);
+      expect(await response.text()).toBe("Remote image request timed out");
+    },
+  );
+
+  it("accepts public IPv6 literals without DNS and rejects private IPv6 literals", async () => {
+    const resolvedHosts: string[] = [];
+    const fetchedAddresses: (readonly string[])[] = [];
+    const handlers = remoteHandlers(
+      async (_url, addresses) => {
+        fetchedAddresses.push(addresses);
+        return new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } });
+      },
+      async (hostname) => {
+        resolvedHosts.push(hostname);
+        return ["8.8.8.8"];
+      },
+    );
+
+    const publicResponse = await handleImageOptimization(
+      remoteOptimizerRequest("https://[2606:4700:4700::1111]/image.png"),
+      handlers,
+      [64],
+      { ...REMOTE_CONFIG, domains: ["[2606:4700:4700::1111]"], remotePatterns: [] },
+    );
+    const privateResponse = await handleImageOptimization(
+      remoteOptimizerRequest("https://[fc00::1]/image.png"),
+      handlers,
+      [64],
+      { ...REMOTE_CONFIG, domains: ["[fc00::1]"], remotePatterns: [] },
+    );
+    const linkLocalResponse = await handleImageOptimization(
+      remoteOptimizerRequest("https://[fe80::1]/image.png"),
+      handlers,
+      [64],
+      { ...REMOTE_CONFIG, domains: ["[fe80::1]"], remotePatterns: [] },
+    );
+
+    expect(publicResponse.status).toBe(200);
+    expect(privateResponse.status).toBe(400);
+    expect(linkLocalResponse.status).toBe(400);
+    expect(resolvedHosts).toEqual([]);
+    expect(fetchedAddresses).toEqual([["2606:4700:4700::1111"]]);
+  });
+
+  it("does not forward remote response headers outside the image allowlist", async () => {
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(
+        async () =>
+          new Response(PNG_1X1, {
+            headers: {
+              "Content-Type": "image/png",
+              "Cache-Control": "public, max-age=60",
+              "Set-Cookie": "session=attacker; Path=/; HttpOnly",
+              "Content-Encoding": "gzip",
+              "Content-Length": String(PNG_1X1.byteLength),
+              "X-Upstream-Secret": "do-not-forward",
+            },
+          }),
+      ),
+      [64],
+      REMOTE_CONFIG,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=14400, must-revalidate");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-upstream-secret")).toBeNull();
+  });
+
+  it("rejects unconfigured hosts and credentials before fetching", async () => {
+    let fetchCount = 0;
+    const fetchRemote = async () => {
+      fetchCount++;
+      return new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } });
+    };
+
+    for (const source of [
+      "https://other.example.com/allowed/test.png",
+      "https://user:pass@images.example.com/allowed/test.png",
+    ]) {
+      const response = await handleImageOptimization(
+        remoteOptimizerRequest(source),
+        remoteHandlers(fetchRemote),
+        [64],
+        REMOTE_CONFIG,
+      );
+      expect(response.status).toBe(400);
+    }
+    expect(fetchCount).toBe(0);
+  });
+
+  it("rejects literal, resolved, and redirect-to-private targets", async () => {
+    const privateConfig: ImageConfig = {
+      ...REMOTE_CONFIG,
+      remotePatterns: [
+        ...REMOTE_CONFIG.remotePatterns!,
+        { protocol: "https", hostname: "127.0.0.1", pathname: "/**" },
+      ],
+    };
+
+    const literal = await handleImageOptimization(
+      remoteOptimizerRequest("https://127.0.0.1/test.png"),
+      remoteHandlers(async () => new Response(PNG_1X1)),
+      [64],
+      privateConfig,
+    );
+    expect(literal.status).toBe(400);
+
+    const resolved = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(
+        async () => new Response(PNG_1X1),
+        async () => ["10.0.0.8"],
+      ),
+      [64],
+      REMOTE_CONFIG,
+    );
+    expect(resolved.status).toBe(400);
+
+    const redirected = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(async () => Response.redirect("https://127.0.0.1/private.png", 302)),
+      [64],
+      privateConfig,
+    );
+    expect(redirected.status).toBe(400);
+
+    const redirectedUrls: string[] = [];
+    const redirectedToUnconfiguredHost = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(async (input) => {
+        const url = requestInputUrl(input);
+        redirectedUrls.push(url);
+        return url.includes("images.example.com")
+          ? Response.redirect("https://cdn.example.net/test.png", 302)
+          : new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } });
+      }),
+      [64],
+      REMOTE_CONFIG,
+    );
+    expect(redirectedToUnconfiguredHost.status).toBe(200);
+    expect(redirectedUrls).toEqual([
+      "https://images.example.com/allowed/test.png",
+      "https://cdn.example.net/test.png",
+    ]);
+  });
+
+  it("fails closed without DNS validation and rejects literal private IPs", async () => {
+    let fetchCount = 0;
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      {
+        fetchAsset: async () => new Response(null, { status: 404 }),
+        fetchRemote: async () => {
+          fetchCount++;
+          return new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } });
+        },
+      },
+      [64],
+      REMOTE_CONFIG,
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchCount).toBe(0);
+
+    const privateResponse = await handleImageOptimization(
+      remoteOptimizerRequest("https://127.0.0.1/test.png"),
+      {
+        fetchAsset: async () => new Response(null, { status: 404 }),
+        fetchRemote: async () => {
+          fetchCount++;
+          return new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } });
+        },
+      },
+      [64],
+      {
+        ...REMOTE_CONFIG,
+        remotePatterns: [{ protocol: "https", hostname: "127.0.0.1", pathname: "/**" }],
+      },
+    );
+
+    expect(privateResponse.status).toBe(400);
+    expect(fetchCount).toBe(0);
+  });
+
+  it("redirects configured Worker remote images without proxying them", () => {
+    const response = getWorkerRemoteImageRedirect(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      [64],
+      REMOTE_CONFIG,
+    );
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe("https://images.example.com/allowed/test.png");
+    expect(response?.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("honors dangerouslyAllowLocalIP for configured Worker remote images", () => {
+    const config: ImageConfig = {
+      ...REMOTE_CONFIG,
+      dangerouslyAllowLocalIP: true,
+      remotePatterns: [{ protocol: "https", hostname: "127.0.0.1", pathname: "/**" }],
+    };
+    const response = getWorkerRemoteImageRedirect(
+      remoteOptimizerRequest("https://127.0.0.1/test.png"),
+      [64],
+      config,
+    );
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe("https://127.0.0.1/test.png");
+  });
+
+  it.each([false, true])(
+    "redirects mixed-case Worker remote URLs when dangerouslyAllowLocalIP is %s",
+    (dangerouslyAllowLocalIP) => {
+      const response = getWorkerRemoteImageRedirect(
+        remoteOptimizerRequest("HTTPS://images.example.com/allowed/test.png"),
+        [64],
+        { ...REMOTE_CONFIG, dangerouslyAllowLocalIP },
+      );
+
+      expect(response?.status).toBe(307);
+      expect(response?.headers.get("location")).toBe("https://images.example.com/allowed/test.png");
+    },
+  );
+
+  it("rejects unsafe Worker remote redirects and ignores local image requests", () => {
+    const unconfigured = getWorkerRemoteImageRedirect(
+      remoteOptimizerRequest("https://other.example.com/test.png"),
+      [64],
+      REMOTE_CONFIG,
+    );
+    const privateTarget = getWorkerRemoteImageRedirect(
+      remoteOptimizerRequest("https://127.0.0.1/test.png"),
+      [64],
+      {
+        ...REMOTE_CONFIG,
+        remotePatterns: [{ protocol: "https", hostname: "127.0.0.1", pathname: "/**" }],
+      },
+    );
+    const localRequest = remoteOptimizerRequest("/public/test.png");
+
+    expect(unconfigured?.status).toBe(400);
+    expect(privateTarget?.status).toBe(400);
+    expect(getWorkerRemoteImageRedirect(localRequest, [64], REMOTE_CONFIG)).toBeNull();
+  });
+
+  it("rejects remote fetching without validated DNS addresses", async () => {
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      {
+        fetchAsset: async () => new Response(null, { status: 404 }),
+        fetchRemote: async () =>
+          new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } }),
+      },
+      [64],
+      { ...REMOTE_CONFIG, dangerouslyAllowLocalIP: true },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("caps redirects and response bodies", async () => {
+    const redirectLoop = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(async (input) => Response.redirect(requestInputUrl(input), 302)),
+      [64],
+      REMOTE_CONFIG,
+    );
+    expect(redirectLoop.status).toBe(508);
+
+    const oversized = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(
+        async () =>
+          new Response(Buffer.concat([PNG_1X1, Buffer.from([0])]), {
+            headers: { "Content-Type": "image/png" },
+          }),
+      ),
+      [64],
+      REMOTE_CONFIG,
+    );
+    expect(oversized.status).toBe(413);
+  });
+
+  it("rejects unsafe remote content types", async () => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode("<html>not an image</html>"));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(async () => new Response(body, { headers: { "Content-Type": "text/html" } })),
+      [64],
+      REMOTE_CONFIG,
+    );
+
+    expect(response.status).toBe(400);
+    expect(cancelled).toBe(true);
+  });
+});
+
+describe("runtime image config projection", () => {
+  it("preserves remote and security settings used by Pages Node production", () => {
+    const config: ImageConfig = {
+      deviceSizes: [320],
+      imageSizes: [16],
+      qualities: [60],
+      formats: ["image/avif", "image/webp"],
+      remotePatterns: [{ protocol: "https", hostname: "images.example.com" }],
+      domains: ["legacy.example.com"],
+      maximumRedirects: 2,
+      maximumResponseBody: 1024,
+      minimumCacheTTL: 300,
+      dangerouslyAllowSVG: true,
+      dangerouslyAllowLocalIP: true,
+      contentDispositionType: "attachment",
+      contentSecurityPolicy: "sandbox",
+    };
+
+    expect(createRuntimeImageConfig(config)).toEqual(config);
+  });
+
+  it("uses the Next.js quality and format defaults", () => {
+    const request = new URL("http://vinext.test/_next/image?url=%2Fimage.png&w=640&q=75");
+    expect(parseImageParams(request)).not.toBeNull();
+    request.searchParams.set("q", "80");
+    expect(parseImageParams(request)).toBeNull();
+
+    expect(negotiateImageFormat("image/avif,image/webp")).toBe("image/webp");
+    expect(negotiateImageFormat("image/avif,image/webp", ["image/avif", "image/webp"])).toBe(
+      "image/avif",
+    );
+  });
+
+  it("honors Accept qualities while preserving configured server preference", () => {
+    const formats = ["image/avif", "image/webp"] as const;
+    expect(negotiateImageFormat("image/avif;q=0.5,image/webp;q=0.9", formats)).toBe("image/webp");
+    expect(negotiateImageFormat("image/webp,image/avif", formats)).toBe("image/avif");
+    expect(negotiateImageFormat("image/avif;q=0,image/webp;q=0", formats)).toBe("");
+    expect(negotiateImageFormat("image/avif;q=0,*/*;q=1", formats)).toBe("image/webp");
+  });
+
+  it("uses configured formats for runtime transformations", async () => {
+    const transformedFormats: string[] = [];
+    const handlers = {
+      fetchAsset: async () => new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } }),
+      transformImage: async (
+        body: ReadableStream,
+        options: { width: number; format: string; quality: number },
+      ) => {
+        await body.cancel();
+        transformedFormats.push(options.format);
+        return new Response(PNG_1X1, { headers: { "Content-Type": options.format } });
+      },
+    };
+    const request = new Request("http://vinext.test/_next/image?url=%2Fimage.png&w=640&q=75", {
+      headers: { Accept: "image/avif,image/webp" },
+    });
+
+    await handleImageOptimization(request, handlers);
+    await handleImageOptimization(request, handlers, undefined, {
+      formats: ["image/avif", "image/webp"],
+    });
+
+    expect(transformedFormats).toEqual(["image/webp", "image/avif"]);
+  });
+
+  it("shares standards-compliant local image Content-Disposition generation", () => {
+    expect(getImageContentDisposition("/café.jpg", "image/png", "attachment")).toBe(
+      'attachment; filename="café.png"',
+    );
+  });
+});
+
+describe("next/image cache control parity", () => {
+  it("keeps hashed static imports immutable", () => {
+    for (const imageUrl of [
+      "/_next/static/media/hero.abc123.png",
+      "/docs/_next/static/media/hero.abc123.png",
+    ]) {
+      expect(getImageCacheControl(imageUrl, "max-age=60", 300)).toBe(
+        "public, max-age=315360000, immutable",
+      );
+    }
+  });
+
+  it("uses minimumCacheTTL for mutable public images", () => {
+    expect(getImageCacheControl("/hero.png", "public, max-age=60", 300)).toBe(
+      "public, max-age=300, must-revalidate",
+    );
+  });
+
+  it("honors a longer upstream TTL for remote images", async () => {
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(
+        async () =>
+          new Response(PNG_1X1, {
+            headers: {
+              "Content-Type": "image/png",
+              "Cache-Control": "public, max-age=60, s-maxage=900",
+            },
+          }),
+      ),
+      [64],
+      { ...REMOTE_CONFIG, minimumCacheTTL: 300 },
+    );
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=900, must-revalidate");
+  });
+
+  it("disables mutable image caching in development", async () => {
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/test.png"),
+      remoteHandlers(
+        async () =>
+          new Response(PNG_1X1, {
+            headers: {
+              "Content-Type": "image/png",
+              "Cache-Control": "public, max-age=900",
+            },
+          }),
+      ),
+      [64],
+      REMOTE_CONFIG,
+      { isDev: true },
+    );
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+  });
+});
+
+describe("next/image response security header parity", () => {
+  it("includes a standards-encoded, content-type-derived filename in Content-Disposition", async () => {
+    const createResponse = (contentDispositionType?: "inline" | "attachment") =>
+      handleImageOptimization(
+        remoteOptimizerRequest("https://images.example.com/allowed/héllo world.jpg?version=1"),
+        remoteHandlers(
+          async () => new Response(PNG_1X1, { headers: { "Content-Type": "image/png" } }),
+        ),
+        [64],
+        { ...REMOTE_CONFIG, contentDispositionType },
+      );
+
+    expect((await createResponse()).headers.get("content-disposition")).toBe(
+      'attachment; filename="héllo world.png"',
+    );
+    expect((await createResponse("inline")).headers.get("content-disposition")).toBe(
+      'inline; filename="héllo world.png"',
+    );
+  });
+
+  it("uses an extended filename for characters outside ISO-8859-1", async () => {
+    const response = await handleImageOptimization(
+      remoteOptimizerRequest("https://images.example.com/allowed/日本語.jpg"),
+      remoteHandlers(
+        async () => new Response(PNG_1X1, { headers: { "Content-Type": "image/jpeg" } }),
+      ),
+      [64],
+      REMOTE_CONFIG,
+    );
+
+    expect(response.headers.get("content-disposition")).toBe(
+      "attachment; filename=\"???.jpeg\"; filename*=UTF-8''%E6%97%A5%E6%9C%AC%E8%AA%9E.jpeg",
+    );
+  });
+});
 
 async function createImageFixture(router: "app" | "pages"): Promise<string> {
   const baseFixtureDir = router === "app" ? APP_FIXTURE_DIR : PAGES_FIXTURE_DIR;
@@ -26,6 +871,21 @@ async function createImageFixture(router: "app" | "pages"): Promise<string> {
   await fs.mkdir(path.join(rootDir, "public"), { recursive: true });
   await fs.writeFile(path.join(rootDir, "public", "äöüščří.png"), PNG_1X1);
   await fs.writeFile(path.join(rootDir, "public", "hello world.png"), PNG_1X1);
+  const configPath = path.join(rootDir, router === "app" ? "next.config.ts" : "next.config.mjs");
+  const configSource = await fs.readFile(configPath, "utf8");
+  const declaration =
+    router === "app" ? "const nextConfig: NextConfig = {" : "const nextConfig = {";
+  await fs.writeFile(
+    configPath,
+    configSource.replace(
+      declaration,
+      `${declaration}
+  images: {
+    remotePatterns: [{ protocol: "http", hostname: "localhost", pathname: "/**" }],
+    dangerouslyAllowLocalIP: true,
+  },`,
+    ),
+  );
 
   if (router === "app") {
     await fs.rm(path.join(rootDir, "app", "alias-test"), { recursive: true, force: true });
@@ -100,14 +960,29 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
     let server: ViteDevServer;
     let baseUrl: string;
     let fixtureDir: string;
+    let remoteImageServer: ReturnType<typeof createServer>;
+    let remoteImagePort: number;
 
     beforeAll(async () => {
+      remoteImageServer = createServer((_request, response) => {
+        response.writeHead(200, { "Content-Type": "image/png" });
+        response.end(PNG_1X1);
+      });
+      await new Promise<void>((resolve) => remoteImageServer.listen(0, "127.0.0.1", resolve));
+      const remoteAddress = remoteImageServer.address();
+      if (!remoteAddress || typeof remoteAddress === "string") {
+        throw new Error("Remote image fixture failed to start");
+      }
+      remoteImagePort = remoteAddress.port;
       fixtureDir = await createImageFixture(router);
       ({ server, baseUrl } = await startFixtureServer(fixtureDir, { appRouter: router === "app" }));
     }, 30000);
 
     afterAll(async () => {
       await server?.close();
+      await new Promise<void>((resolve, reject) =>
+        remoteImageServer?.close((error) => (error ? reject(error) : resolve())),
+      );
       await fs.rm(fixtureDir, { recursive: true, force: true });
     });
 
@@ -121,7 +996,7 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
 
       expect(imageUrl.pathname).toBe("/_next/image");
       expect(imageUrl.searchParams.get("url")).toBe("/äöüščří.png");
-      expect(imageUrl.searchParams.get("w")).toBe("64");
+      expect(imageUrl.searchParams.get("w")).toBe("128");
       expect(imageUrl.searchParams.get("q")).toBe("75");
 
       const res = await fetch(imageUrl);
@@ -138,7 +1013,7 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
 
       expect(imageUrl.pathname).toBe("/_next/image");
       expect(imageUrl.searchParams.get("url")).toBe("/hello world.png");
-      expect(imageUrl.searchParams.get("w")).toBe("64");
+      expect(imageUrl.searchParams.get("w")).toBe("128");
       expect(imageUrl.searchParams.get("q")).toBe("75");
 
       const res = await fetch(imageUrl);
@@ -154,6 +1029,17 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
       vinextUrl.searchParams.set("q", "75");
       const res = await fetch(vinextUrl);
       expect(res.status).toBe(200);
+    });
+
+    it("optimizes mixed-case remote HTTP URLs", async () => {
+      const imageUrl = new URL("/_next/image", baseUrl);
+      imageUrl.searchParams.set("url", `HTTP://localhost:${remoteImagePort}/remote.png`);
+      imageUrl.searchParams.set("w", "64");
+      imageUrl.searchParams.set("q", "75");
+
+      const res = await fetch(imageUrl);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/png");
     });
   });
 }

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1334,6 +1334,45 @@ describe("parseBodySizeLimit", () => {
   });
 });
 
+describe("resolveNextConfig image localPatterns", () => {
+  it("normalizes the default optimizer path when images is omitted", async () => {
+    const withBasePath = await resolveNextConfig({ basePath: "/docs" });
+    expect(withBasePath.images?.path).toBe("/docs/_next/image");
+
+    const withTrailingSlash = await resolveNextConfig({ trailingSlash: true });
+    expect(withTrailingSlash.images?.path).toBe("/_next/image/");
+  });
+
+  it("allows an absolute assetPrefix origin without broadening remote access", async () => {
+    const resolved = await resolveNextConfig({
+      assetPrefix: "https://cdn.example.com/assets",
+      images: {
+        remotePatterns: [{ protocol: "https", hostname: "images.example.com", pathname: "/ok/**" }],
+      },
+    });
+
+    expect(resolved.images?.remotePatterns).toEqual([
+      { protocol: "https", hostname: "images.example.com", pathname: "/ok/**" },
+      { protocol: "https", hostname: "cdn.example.com", port: "" },
+    ]);
+  });
+
+  it("defaults to rejecting local query strings and allows static imports", async () => {
+    const resolved = await resolveNextConfig({ images: {} });
+    expect(resolved.images?.localPatterns).toEqual([{ pathname: "**", search: "" }]);
+  });
+
+  it("preserves configured patterns and adds the static import pattern", async () => {
+    const resolved = await resolveNextConfig({
+      images: { localPatterns: [{ pathname: "/assets/**", search: "?v=1" }] },
+    });
+    expect(resolved.images?.localPatterns).toEqual([
+      { pathname: "/assets/**", search: "?v=1" },
+      { pathname: "/_next/static/media/**", search: "" },
+    ]);
+  });
+});
+
 describe("resolveNextConfig serverExternalPackages", () => {
   it("defaults to empty array when no config is provided", async () => {
     const resolved = await resolveNextConfig(null);
@@ -2469,6 +2508,114 @@ describe("resolveNextConfig cacheHandler", () => {
   it("defaults cacheMaxMemorySize to undefined when not configured", async () => {
     const resolved = await resolveNextConfig({});
     expect(resolved.cacheMaxMemorySize).toBeUndefined();
+  });
+});
+
+describe("resolveNextConfig images", () => {
+  // Ported from Next.js: test/integration/image-optimizer/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/integration/image-optimizer/test/index.test.ts
+  it.each([null, [], "invalid"])("rejects a non-object images value: %j", async (images) => {
+    await expect(resolveNextConfig({ images } as any)).rejects.toThrow(
+      "Specified images should be an object",
+    );
+  });
+
+  it("rejects URL remote patterns with non-http protocols", async () => {
+    await expect(
+      resolveNextConfig({ images: { remotePatterns: [new URL("file://example.com/**")] } }),
+    ).rejects.toThrow(
+      'Specified images.remotePatterns must have protocol "http" or "https" received "file".',
+    );
+  });
+
+  it("validates contentSecurityPolicy as a string", async () => {
+    await expect(
+      resolveNextConfig({ images: { contentSecurityPolicy: 42 as unknown as string } }),
+    ).rejects.toThrow('Expected string, received number at "images.contentSecurityPolicy"');
+  });
+
+  it("prefixes the default image path with basePath and trailingSlash", async () => {
+    const resolved = await resolveNextConfig({
+      basePath: "/docs",
+      trailingSlash: true,
+      images: {},
+    });
+    expect(resolved.images?.path).toBe("/docs/_next/image/");
+  });
+
+  it("preserves explicitly configured image paths", async () => {
+    const resolved = await resolveNextConfig({
+      basePath: "/docs",
+      trailingSlash: true,
+      images: { path: "/media/image" },
+    });
+    expect(resolved.images?.path).toBe("/media/image/");
+  });
+
+  it("resolves loaderFile and normalizes built-in loader paths", async () => {
+    const tmpDir = makeTempDir();
+    const loaderFile = path.join(tmpDir, "image-loader.ts");
+    fs.writeFileSync(loaderFile, "export default ({ src }) => src");
+
+    try {
+      const custom = await resolveNextConfig(
+        { images: { loader: "custom", loaderFile: "./image-loader.ts" } },
+        tmpDir,
+      );
+      expect(custom.images).toMatchObject({
+        loader: "custom",
+        loaderFile,
+        path: "/_next/image/",
+      });
+
+      const imgix = await resolveNextConfig(
+        { images: { loader: "imgix", path: "https://example.imgix.net" } },
+        tmpDir,
+      );
+      expect(imgix.images).toMatchObject({
+        loader: "imgix",
+        path: "https://example.imgix.net/",
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects invalid global loader combinations", async () => {
+    await expect(resolveNextConfig({ images: { loader: "imgix" } })).rejects.toThrow(
+      "also requires images.path",
+    );
+    await expect(
+      resolveNextConfig({ images: { loader: "imgix", path: "/cdn", loaderFile: "loader.js" } }),
+    ).rejects.toThrow("cannot be used with images.loaderFile property");
+  });
+
+  it("rejects an empty qualities array", async () => {
+    await expect(resolveNextConfig({ images: { qualities: [] } })).rejects.toThrow(
+      'Array must contain at least 1 element(s) at "images.qualities"',
+    );
+  });
+
+  it("rejects more than 20 qualities", async () => {
+    await expect(
+      resolveNextConfig({
+        images: { qualities: Array.from({ length: 21 }, (_, index) => index + 1) },
+      }),
+    ).rejects.toThrow('Array must contain at most 20 element(s) at "images.qualities"');
+  });
+
+  it.each([
+    { qualities: [75.5], message: 'Expected integer, received float at "images.qualities[0]"' },
+    {
+      qualities: [0],
+      message: 'Number must be greater than or equal to 1 at "images.qualities[0]"',
+    },
+    {
+      qualities: [101],
+      message: 'Number must be less than or equal to 100 at "images.qualities[0]"',
+    },
+  ])("rejects invalid image qualities: $qualities", async ({ qualities, message }) => {
+    await expect(resolveNextConfig({ images: { qualities } })).rejects.toThrow(message);
   });
 });
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1335,6 +1335,52 @@ describe("parseBodySizeLimit", () => {
 });
 
 describe("resolveNextConfig image localPatterns", () => {
+  it("does not mutate shared image config across resolutions", async () => {
+    const firstRoot = makeTempDir();
+    const secondRoot = makeTempDir();
+    const sharedImages = {
+      loader: "custom" as const,
+      loaderFile: "./image-loader.js",
+      remotePatterns: [{ protocol: "https", hostname: "images.example.com" }],
+    };
+    fs.writeFileSync(path.join(firstRoot, "image-loader.js"), "export default () => '';");
+    fs.writeFileSync(path.join(secondRoot, "image-loader.js"), "export default () => '';");
+
+    try {
+      const first = await resolveNextConfig(
+        {
+          basePath: "/docs",
+          trailingSlash: true,
+          assetPrefix: "https://cdn.example.com/assets",
+          images: sharedImages,
+        },
+        firstRoot,
+      );
+      const second = await resolveNextConfig({ images: sharedImages }, secondRoot);
+
+      expect(first.images?.path).toBe("/docs/_next/image/");
+      expect(first.images?.loaderFile).toBe(path.join(firstRoot, "image-loader.js"));
+      expect(first.images?.remotePatterns).toContainEqual({
+        protocol: "https",
+        hostname: "cdn.example.com",
+        port: "",
+      });
+      expect(second.images?.path).toBe("/_next/image/");
+      expect(second.images?.loaderFile).toBe(path.join(secondRoot, "image-loader.js"));
+      expect(second.images?.remotePatterns).toEqual([
+        { protocol: "https", hostname: "images.example.com" },
+      ]);
+      expect(sharedImages).toEqual({
+        loader: "custom",
+        loaderFile: "./image-loader.js",
+        remotePatterns: [{ protocol: "https", hostname: "images.example.com" }],
+      });
+    } finally {
+      fs.rmSync(firstRoot, { recursive: true, force: true });
+      fs.rmSync(secondRoot, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes the default optimizer path when images is omitted", async () => {
     const withBasePath = await resolveNextConfig({ basePath: "/docs" });
     expect(withBasePath.images?.path).toBe("/docs/_next/image");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2392,6 +2392,80 @@ describe("Pages Router dev server origin check", () => {
   });
 });
 
+describe("Pages Router dev image optimizer configuration", () => {
+  it("matches basePath and trailing-slash image endpoints after Vite strips the basePath", async () => {
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-image-basepath-"));
+    let server: ViteDevServer | undefined;
+
+    try {
+      await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+      await fsp.symlink(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(tmpDir, "node_modules"),
+        "junction",
+      );
+      await fsp.writeFile(
+        path.join(tmpDir, "pages", "index.tsx"),
+        `export default function Home() { return <div>image optimizer basePath</div>; }`,
+      );
+      await fsp.writeFile(path.join(tmpDir, "public-image.png"), "image");
+      await fsp.writeFile(
+        path.join(tmpDir, "next.config.mjs"),
+        `export default { basePath: "/docs", trailingSlash: true };\n`,
+      );
+
+      const fixture = await startFixtureServer(tmpDir);
+      server = fixture.server;
+
+      const response = await fetch(
+        `${fixture.baseUrl}/docs/_next/image/?url=%2Fpublic-image.png&w=640&q=75`,
+        { redirect: "manual" },
+      );
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/public-image.png");
+    } finally {
+      await server?.close();
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it("returns 404 when the built-in optimizer is disabled", async () => {
+    for (const images of [{ unoptimized: true }, { loader: "custom" as const }]) {
+      const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-image-disabled-"));
+      let server: ViteDevServer | undefined;
+
+      try {
+        await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+        await fsp.symlink(
+          path.resolve(import.meta.dirname, "../node_modules"),
+          path.join(tmpDir, "node_modules"),
+          "junction",
+        );
+        await fsp.writeFile(
+          path.join(tmpDir, "pages", "index.tsx"),
+          `export default function Home() { return <div>image optimizer disabled</div>; }`,
+        );
+        await fsp.writeFile(
+          path.join(tmpDir, "next.config.mjs"),
+          `export default ${JSON.stringify({ images })};\n`,
+        );
+
+        const fixture = await startFixtureServer(tmpDir);
+        server = fixture.server;
+
+        const response = await fetch(`${fixture.baseUrl}/_next/image?url=%2Fimage.png&w=640&q=75`, {
+          redirect: "manual",
+        });
+
+        expect(response.status).toBe(404);
+      } finally {
+        await server?.close();
+        await fsp.rm(tmpDir, { recursive: true, force: true });
+      }
+    }
+  }, 30000);
+});
+
 // Ported from Next.js: test/development/basic/allowed-dev-origins.test.ts
 // https://github.com/vercel/next.js/blob/canary/test/development/basic/allowed-dev-origins.test.ts
 describe("Pages Router allowedDevOrigins config", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18136,7 +18136,7 @@ describe("next/image enhancements", () => {
     // Local images now route through the optimization endpoint
     expect(result.props.src).toContain("/_next/image");
     expect(result.props.src).toContain("url=%2Fphoto.jpg");
-    expect(result.props.src).toContain("w=800");
+    expect(result.props.src).toContain("w=1920");
     expect(result.props.alt).toBe("Test");
     expect(result.props.width).toBe(800);
     expect(result.props.height).toBe(600);
@@ -18163,7 +18163,7 @@ describe("next/image enhancements", () => {
     });
     expect(result.props.src).toContain("/_next/image");
     expect(result.props.src).toContain("url=%2Fimported.jpg");
-    expect(result.props.src).toContain("w=1200");
+    expect(result.props.src).toContain("w=3840");
     expect(result.props.width).toBe(1200);
     expect(result.props.height).toBe(800);
   });
@@ -18183,15 +18183,17 @@ describe("next/image enhancements", () => {
     expect(result.props.srcSet).toContain("w");
   });
 
-  it("getImageProps does not generate srcSet for fill images", async () => {
+  it("getImageProps generates responsive srcSet and sizes for fill images", async () => {
     const { getImageProps } = await import("../packages/vinext/src/shims/image.js");
     const result = getImageProps({
       src: "/bg.jpg",
       alt: "Background",
       fill: true,
     });
-    expect(result.props.srcSet).toBeUndefined();
-    expect(result.props.sizes).toBe("100vw"); // fill implies 100vw
+    expect(result.props.srcSet).toBe(
+      "/_next/image?url=%2Fbg.jpg&w=640&q=75 640w, /_next/image?url=%2Fbg.jpg&w=750&q=75 750w, /_next/image?url=%2Fbg.jpg&w=828&q=75 828w, /_next/image?url=%2Fbg.jpg&w=1080&q=75 1080w, /_next/image?url=%2Fbg.jpg&w=1200&q=75 1200w, /_next/image?url=%2Fbg.jpg&w=1920&q=75 1920w, /_next/image?url=%2Fbg.jpg&w=2048&q=75 2048w, /_next/image?url=%2Fbg.jpg&w=3840&q=75 3840w",
+    );
+    expect(result.props.sizes).toBe("100vw");
   });
 
   it("getImageProps includes fetchPriority for priority images", async () => {
@@ -18250,7 +18252,7 @@ describe("next/image enhancements", () => {
       loader: ({ src, width, quality }) => `https://cdn.example.com${src}?w=${width}&q=${quality}`,
     });
     // Custom loader bypasses the /_next/image endpoint
-    expect(result.props.src).toBe("https://cdn.example.com/photo.jpg?w=800&q=75");
+    expect(result.props.src).toBe("https://cdn.example.com/photo.jpg?w=1920&q=undefined");
     expect(result.props.src).not.toContain("/_next/image");
   });
 
@@ -18405,7 +18407,7 @@ describe("next/image component rendering", () => {
           `https://cdn.example.com${src}?w=${width}&q=${quality}`,
       }),
     );
-    expect(html).toContain('src="https://cdn.example.com/photo.jpg?w=800&amp;q=75"');
+    expect(html).toContain('src="https://cdn.example.com/photo.jpg?w=1920&amp;q=undefined"');
   });
 
   it("renders with custom sizes attribute", async () => {
@@ -19149,12 +19151,6 @@ describe("image optimization request parsing", () => {
     expect(IMAGE_OPTIMIZATION_PATH).toBe("/_next/image");
   });
 
-  it("VINEXT_IMAGE_OPTIMIZATION_PATH is /_vinext/image", async () => {
-    const { VINEXT_IMAGE_OPTIMIZATION_PATH } =
-      await import("../packages/vinext/src/server/image-optimization.js");
-    expect(VINEXT_IMAGE_OPTIMIZATION_PATH).toBe("/_vinext/image");
-  });
-
   it("isImageOptimizationPath accepts only the configured endpoint", async () => {
     const { isImageOptimizationPath } =
       await import("../packages/vinext/src/server/image-optimization.js");
@@ -19281,7 +19277,7 @@ describe("handleImageOptimization", () => {
     const response = await handleImageOptimization(request, handlers);
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("original-image-data");
-    expect(response.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=14400, must-revalidate");
     expect(response.headers.get("Vary")).toBe("Accept");
   });
 
@@ -19387,7 +19383,7 @@ describe("handleImageOptimization", () => {
     expect(fetchCount).toBe(2);
     expect(response.headers.get("Content-Type")).toBe("image/jpeg");
     expect(response.headers.get("ETag")).toBe('"refetched-etag"');
-    expect(response.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=14400, must-revalidate");
     expect(response.headers.get("Vary")).toBe("Accept");
   });
 
@@ -19664,7 +19660,7 @@ describe("handleImageOptimization", () => {
       "script-src 'none'; frame-src 'none'; sandbox;",
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
-    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="img.svg"');
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="logo.svg"');
   });
 
   it("applies custom contentDispositionType", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18595,8 +18595,8 @@ describe("image remote pattern matching", () => {
     const pattern = { hostname: "*.example.com" };
     expect(matchRemotePattern(pattern, new URL("https://cdn.example.com/img.jpg"))).toBe(true);
     expect(matchRemotePattern(pattern, new URL("https://images.example.com/img.jpg"))).toBe(true);
-    // Single * should NOT match nested subdomains
-    expect(matchRemotePattern(pattern, new URL("https://a.b.example.com/img.jpg"))).toBe(false);
+    // Next.js picomatch treats dots as ordinary hostname characters.
+    expect(matchRemotePattern(pattern, new URL("https://a.b.example.com/img.jpg"))).toBe(true);
     // Should not match bare domain
     expect(matchRemotePattern(pattern, new URL("https://example.com/img.jpg"))).toBe(false);
   });
@@ -18824,6 +18824,35 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
+  it("parseImageParams accepts the Next.js deployment id parameter", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      parseImageParams(
+        new URL(
+          "http://localhost/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.png&w=640&q=75&dpl=deployment-1",
+        ),
+      ),
+    ).toEqual({
+      imageUrl: "/_next/static/media/test.png",
+      width: 640,
+      quality: 75,
+    });
+  });
+
+  it("parseImageParams rejects empty and duplicate deployment ids", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75&dpl=")),
+    ).toBeNull();
+    expect(
+      parseImageParams(
+        new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75&dpl=one&dpl=two"),
+      ),
+    ).toBeNull();
+  });
+
   it("parseImageParams rejects source URLs longer than 3072 characters", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
@@ -18833,6 +18862,22 @@ describe("image optimization request parsing", () => {
     url.searchParams.set("w", "640");
     url.searchParams.set("q", "75");
     expect(parseImageParams(url)).toBeNull();
+  });
+
+  it("parseImageParams rejects recursive optimizer source URLs", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    for (const imageUrl of [
+      "/_next/image?url=%2Fimg.jpg&w=640&q=75",
+      "/docs/_next/image/source.png",
+      "/_vinext/image?url=%2Fimg.jpg&w=640&q=75",
+    ]) {
+      const url = new URL("http://localhost/_next/image");
+      url.searchParams.set("url", imageUrl);
+      url.searchParams.set("w", "640");
+      url.searchParams.set("q", "75");
+      expect(parseImageParams(url)).toBeNull();
+    }
   });
 
   it("parseImageParams blocks data: URIs (exotic scheme bypass)", async () => {
@@ -18876,19 +18921,15 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
-  it("parseImageParams permits any quality 1-100 when qualities is unset", async () => {
-    // Matches Next.js: an unset `images.qualities` is not restricted to a single
-    // value. Regression test for non-75 qualities (e.g. `<Image quality={90}>`)
-    // returning 400 from the image optimization endpoint.
+  it("parseImageParams defaults qualities to [75]", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    for (const q of [1, 50, 75, 90, 100]) {
-      const params = parseImageParams(
-        new URL(`http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=${q}`),
-      );
-      expect(params).not.toBeNull();
-      expect(params!.quality).toBe(q);
-    }
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75")),
+    ).not.toBeNull();
+    expect(
+      parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=90")),
+    ).toBeNull();
   });
 
   it("parseImageParams enforces the allowlist only when qualities is configured", async () => {
@@ -19012,9 +19053,7 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
-  it("parseImageParams allows any quality 1-100 when qualities is unset", async () => {
-    // Matches Next.js: an unset `images.qualities` does not restrict the quality
-    // to a single value — any integer from 1-100 is accepted.
+  it("parseImageParams rejects non-default quality when qualities is unset", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
     expect(
@@ -19022,7 +19061,7 @@ describe("image optimization request parsing", () => {
     ).not.toBeNull();
     expect(
       parseImageParams(new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=80")),
-    ).not.toBeNull();
+    ).toBeNull();
   });
 
   it("parseImageParams accepts configured qualities", async () => {
@@ -19085,10 +19124,10 @@ describe("image optimization request parsing", () => {
     expect(params!.width).toBe(64);
   });
 
-  it("negotiateImageFormat prefers AVIF over WebP", async () => {
+  it("negotiateImageFormat defaults to WebP only", async () => {
     const { negotiateImageFormat } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    expect(negotiateImageFormat("image/avif,image/webp,image/jpeg")).toBe("image/avif");
+    expect(negotiateImageFormat("image/avif,image/webp,image/jpeg")).toBe("image/webp");
   });
 
   it("negotiateImageFormat selects WebP when no AVIF", async () => {
@@ -19097,11 +19136,11 @@ describe("image optimization request parsing", () => {
     expect(negotiateImageFormat("image/webp,image/jpeg")).toBe("image/webp");
   });
 
-  it("negotiateImageFormat falls back to JPEG", async () => {
+  it("negotiateImageFormat returns no negotiated format for unsupported Accept", async () => {
     const { negotiateImageFormat } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    expect(negotiateImageFormat("image/png,image/jpeg")).toBe("image/jpeg");
-    expect(negotiateImageFormat(null)).toBe("image/jpeg");
+    expect(negotiateImageFormat("image/png,image/jpeg")).toBe("");
+    expect(negotiateImageFormat(null)).toBe("");
   });
 
   it("IMAGE_OPTIMIZATION_PATH is /_next/image", async () => {
@@ -19116,11 +19155,11 @@ describe("image optimization request parsing", () => {
     expect(VINEXT_IMAGE_OPTIMIZATION_PATH).toBe("/_vinext/image");
   });
 
-  it("isImageOptimizationPath accepts both supported endpoints", async () => {
+  it("isImageOptimizationPath accepts only the configured endpoint", async () => {
     const { isImageOptimizationPath } =
       await import("../packages/vinext/src/server/image-optimization.js");
     expect(isImageOptimizationPath("/_next/image")).toBe(true);
-    expect(isImageOptimizationPath("/_vinext/image")).toBe(true);
+    expect(isImageOptimizationPath("/_vinext/image")).toBe(false);
     expect(isImageOptimizationPath("/_next/image/")).toBe(false);
     expect(isImageOptimizationPath("/_next/image.png")).toBe(false);
     expect(isImageOptimizationPath("/_next/data")).toBe(false);
@@ -19131,7 +19170,7 @@ describe("image optimization request parsing", () => {
     const { DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES } =
       await import("../packages/vinext/src/server/image-optimization.js");
     expect(DEFAULT_DEVICE_SIZES).toEqual([640, 750, 828, 1080, 1200, 1920, 2048, 3840]);
-    expect(DEFAULT_IMAGE_SIZES).toEqual([16, 32, 48, 64, 96, 128, 256, 384]);
+    expect(DEFAULT_IMAGE_SIZES).toEqual([32, 48, 64, 96, 128, 256, 384]);
   });
 });
 
@@ -19492,7 +19531,7 @@ describe("handleImageOptimization", () => {
       "script-src 'none'; frame-src 'none'; sandbox;",
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
-    expect(response.headers.get("Content-Disposition")).toBe("inline");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="img.jpeg"');
   });
 
   it("sets Content-Security-Policy header on transformed responses", async () => {
@@ -19520,7 +19559,7 @@ describe("handleImageOptimization", () => {
       "script-src 'none'; frame-src 'none'; sandbox;",
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
-    expect(response.headers.get("Content-Disposition")).toBe("inline");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="img.webp"');
   });
 
   it("overrides unsafe Content-Type from transform handler", async () => {
@@ -19625,7 +19664,7 @@ describe("handleImageOptimization", () => {
       "script-src 'none'; frame-src 'none'; sandbox;",
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
-    expect(response.headers.get("Content-Disposition")).toBe("inline");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="img.svg"');
   });
 
   it("applies custom contentDispositionType", async () => {
@@ -19643,10 +19682,10 @@ describe("handleImageOptimization", () => {
       contentDispositionType: "attachment",
     });
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Disposition")).toBe("attachment");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="img.jpeg"');
   });
 
-  it("defaults Content-Disposition to inline when contentDispositionType is invalid", async () => {
+  it("defaults Content-Disposition to attachment when contentDispositionType is invalid", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
     const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
@@ -19661,7 +19700,7 @@ describe("handleImageOptimization", () => {
       contentDispositionType: "bogus" as "inline",
     });
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Disposition")).toBe("inline");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="img.jpeg"');
   });
 
   it("applies custom contentSecurityPolicy", async () => {
@@ -19683,7 +19722,7 @@ describe("handleImageOptimization", () => {
     expect(response.headers.get("Content-Security-Policy")).toBe(customCSP);
   });
 
-  it("default behavior unchanged when no imageConfig provided", async () => {
+  it("uses Next.js security defaults when no imageConfig is provided", async () => {
     const { handleImageOptimization } =
       await import("../packages/vinext/src/server/image-optimization.js");
     const request = new Request("http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75");
@@ -19699,7 +19738,7 @@ describe("handleImageOptimization", () => {
     expect(response.headers.get("Content-Security-Policy")).toBe(
       "script-src 'none'; frame-src 'none'; sandbox;",
     );
-    expect(response.headers.get("Content-Disposition")).toBe("inline");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="img.jpeg"');
   });
 });
 

--- a/tests/static-image-emission.test.ts
+++ b/tests/static-image-emission.test.ts
@@ -347,13 +347,13 @@ async function assertStaticImageProductionParity(
     const src = getAttribute(html, id, "src");
     const srcset = getAttribute(html, id, "srcset");
     const managedUrl = `${effectiveAssetPrefix}/_next/static/media/${expectedImage}`;
-    const managedSourceUrl = options.deploymentId
-      ? `${managedUrl}?dpl=${options.deploymentId}`
-      : managedUrl;
-    expect(new URL(src, "http://vinext.test").searchParams.get("url")).toBe(managedSourceUrl);
-    expect(src).toContain("q=85");
+    const optimizedSrc = new URL(src, "http://vinext.test");
+    expect(optimizedSrc.searchParams.get("url")).toBe(managedUrl);
+    expect(optimizedSrc.searchParams.get("q")).toBe("75");
+    expect(optimizedSrc.searchParams.get("dpl")).toBe(options.deploymentId ?? null);
     expect(src).not.toContain("data%3Aimage");
-    expect(srcset).toContain(`url=${encodeURIComponent(managedSourceUrl)}`);
+    expect(srcset).toContain(`url=${encodeURIComponent(managedUrl)}`);
+    if (options.deploymentId) expect(srcset).toContain(`dpl=${options.deploymentId}`);
     expect(srcset).not.toContain("data%3Aimage");
   }
 


### PR DESCRIPTION
## Summary

Aligns vinext's modern `next/image` behavior with Next.js across App Router and Pages Router, in development, Node production, and Cloudflare Workers.

This is intentionally one focused image-parity change. The iterative local history was squashed into a single conventional commit while preserving the independently reviewed tree exactly.

## Scope

- matches responsive `src`/`srcSet` generation, `sizes`, qualities, `overrideSrc`, unoptimized/SVG/data/blob behavior, deployment IDs, static imports, and custom/global loaders
- validates and propagates modern `images` configuration, including local/remote patterns, formats, qualities, paths, base paths, trailing slashes, security options, cache controls, and optimizer enablement
- aligns optimizer routing, cache headers, content negotiation, `Content-Disposition`, response limits, redirects, and local/public/static image handling across App and Pages runtimes
- adds DNS-pinned Node remote fetching with redirect revalidation, private-address controls, timeout/body limits, Host/SNI preservation, and recursive-optimizer rejection
- keeps Node-only image networking out of Worker bundles and preserves configured path/basePath behavior in every runtime

## Next.js reference

Compared against pinned Next.js commit [`ee6e79b1792a4d401ddf2480f40a83549fe8e722`](https://github.com/vercel/next.js/tree/ee6e79b1792a4d401ddf2480f40a83549fe8e722), including:

- [`test/e2e/app-dir/next-image/next-image.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/next-image/next-image.test.ts)
- [`test/unit/image-optimizer/match-remote-pattern-with-url.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/unit/image-optimizer/match-remote-pattern-with-url.test.ts)
- [`test/unit/image-optimizer/find-closest-quality.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/unit/image-optimizer/find-closest-quality.test.ts)
- [`test/unit/image-optimizer/fetch-external-image.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/unit/image-optimizer/fetch-external-image.test.ts)
- [`test/integration/image-optimizer`](https://github.com/vercel/next.js/tree/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/integration/image-optimizer)

## Security and Worker limitation

Node remote optimization resolves and validates addresses before connecting, pins the selected address for the request, preserves the original Host/SNI, validates redirects, rejects unsafe/private targets unless explicitly allowed, and applies response/time limits.

Cloudflare Workers deliberately do **not** proxy configured remote images. Workers cannot safely bind the DNS validation result to the subsequent outbound `fetch()`, so Worker deployments return a validated redirect to the original remote URL instead. Local, public, and static images continue to use the Worker image optimization path. As in the pinned Next.js behavior, `remotePatterns` validates the initial source URL; redirect destinations are not re-matched.

## Validation

Development used only targeted vinext-owned tests and fixtures, generally with one worker. Coverage includes image component/config/optimizer tests, App and Pages handlers, generated Worker execution, static image imports, production HTTP behavior, and a focused App Router browser fixture with a local remote-image origin.

The final exact tree received an independent no-edit review with no actionable findings.

No raw Next.js E2E suite was run locally, and no broad local suite was run. Full coverage is deferred to CI.
