### PR TITLE
fix(app-router): match interception route precedence

### DIFF
--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -4,7 +4,7 @@ import {
   matchRoutePatternPrefix,
   type RoutePatternParams,
 } from "../routing/route-pattern.js";
-import { sortRoutes, splitPathnameForRouteMatch } from "../routing/utils.js";
+import { splitPathnameForRouteMatch } from "../routing/utils.js";
 
 /**
  * Sentinel slot key used for sibling-style interception entries.
@@ -201,6 +201,33 @@ function matchInterceptSource(sourceParts: string[], entry: AppRscInterceptLooku
   return matchRoutePatternPrefix(sourceParts, patternParts);
 }
 
+function interceptSegmentPrecedence(segment: string): number {
+  if (!segment.startsWith(":")) return 0;
+  if (segment.endsWith("*")) return 3;
+  if (segment.endsWith("+")) return 2;
+  return 1;
+}
+
+function compareInterceptTargetPatterns(
+  a: AppRscInterceptLookupEntry,
+  b: AppRscInterceptLookupEntry,
+): number {
+  const sharedLength = Math.min(a.targetPatternParts.length, b.targetPatternParts.length);
+  for (let index = 0; index < sharedLength; index++) {
+    const aSegment = a.targetPatternParts[index];
+    const bSegment = b.targetPatternParts[index];
+    const precedence = interceptSegmentPrecedence(aSegment) - interceptSegmentPrecedence(bSegment);
+    if (precedence !== 0) return precedence;
+
+    if (aSegment !== bSegment && !aSegment.startsWith(":") && !bSegment.startsWith(":")) {
+      return aSegment.localeCompare(bSegment);
+    }
+  }
+
+  const lengthDifference = a.targetPatternParts.length - b.targetPatternParts.length;
+  return lengthDifference !== 0 ? lengthDifference : a.targetPattern.localeCompare(b.targetPattern);
+}
+
 function createInterceptLookup<Route extends AppRscRouteForMatching>(
   routes: Route[],
 ): AppRscInterceptLookupEntry[] {
@@ -284,9 +311,7 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
       }
     }
   }
-  return sortRoutes(interceptLookup.map((entry) => ({ pattern: entry.targetPattern, entry }))).map(
-    ({ entry }) => entry,
-  );
+  return interceptLookup.sort(compareInterceptTargetPatterns);
 }
 
 export function matchAppRscRoutePattern(

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -219,7 +219,7 @@ function compareInterceptTargetPatterns(
     const precedence = interceptSegmentPrecedence(aSegment) - interceptSegmentPrecedence(bSegment);
     if (precedence !== 0) return precedence;
 
-    if (aSegment !== bSegment && !aSegment.startsWith(":") && !bSegment.startsWith(":")) {
+    if (aSegment !== bSegment) {
       return aSegment.localeCompare(bSegment);
     }
   }
@@ -311,6 +311,8 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
       }
     }
   }
+  // Array.prototype.sort is stable, so entries with identical target patterns
+  // retain declaration order across slots and sources.
   return interceptLookup.sort(compareInterceptTargetPatterns);
 }
 

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -4,7 +4,7 @@ import {
   matchRoutePatternPrefix,
   type RoutePatternParams,
 } from "../routing/route-pattern.js";
-import { splitPathnameForRouteMatch } from "../routing/utils.js";
+import { sortRoutes, splitPathnameForRouteMatch } from "../routing/utils.js";
 
 /**
  * Sentinel slot key used for sibling-style interception entries.
@@ -284,7 +284,9 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
       }
     }
   }
-  return interceptLookup;
+  return sortRoutes(interceptLookup.map((entry) => ({ pattern: entry.targetPattern, entry }))).map(
+    ({ entry }) => entry,
+  );
 }
 
 export function matchAppRscRoutePattern(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,6 +1449,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/og-font-package: {}
+
   tests/fixtures/pages-basepath-trailing-slash:
     dependencies:
       react:

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -220,6 +220,70 @@ describe("App RSC route matching", () => {
     });
   });
 
+  it("orders equally specific dynamic interception segments lexicographically", () => {
+    // Mirrors Next.js compareRouteSegments, including dynamic parameter names:
+    // packages/next/src/shared/lib/router/utils/sortable-routes.ts
+    const matcher = createAppRscRouteMatcher([
+      route("/", [], {
+        modal: {
+          intercepts: [
+            {
+              targetPattern: "/:name/foo",
+              interceptLayouts: [],
+              page: "name-page",
+              params: ["name"],
+            },
+            {
+              targetPattern: "/:id/foo",
+              interceptLayouts: [],
+              page: "id-page",
+              params: ["id"],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/value/foo", "/")).toMatchObject({
+      targetPattern: "/:id/foo",
+      page: "id-page",
+      matchedParams: { id: "value" },
+    });
+  });
+
+  it("preserves declaration order for identical interception targets", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/", [], {
+        first: {
+          intercepts: [
+            {
+              targetPattern: "/photos/:id",
+              interceptLayouts: [],
+              page: "first-page",
+              params: ["id"],
+            },
+          ],
+        },
+        second: {
+          intercepts: [
+            {
+              targetPattern: "/photos/:id",
+              interceptLayouts: [],
+              page: "second-page",
+              params: ["id"],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/photos/42", "/")).toMatchObject({
+      slotKey: "first",
+      page: "first-page",
+      matchedParams: { id: "42" },
+    });
+  });
+
   it("shares lazy intercept load state across fresh match objects", () => {
     const matcher = createAppRscRouteMatcher([
       route("/feed", ["feed"], {

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -158,6 +158,68 @@ describe("App RSC route matching", () => {
     });
   });
 
+  it("orders overlapping interception targets segment by segment", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/", [], {
+        modal: {
+          intercepts: [
+            {
+              targetPattern: "/:name/static",
+              interceptLayouts: [],
+              page: "dynamic-prefix",
+              params: ["name"],
+            },
+            {
+              targetPattern: "/foo/:id",
+              interceptLayouts: [],
+              page: "static-prefix",
+              params: ["id"],
+            },
+            {
+              targetPattern: "/files/:slug*",
+              interceptLayouts: [],
+              page: "optional-catch-all",
+              params: ["slug"],
+            },
+            {
+              targetPattern: "/files/:slug+",
+              interceptLayouts: [],
+              page: "catch-all",
+              params: ["slug"],
+            },
+            {
+              targetPattern: "/files/:id",
+              interceptLayouts: [],
+              page: "dynamic",
+              params: ["id"],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/foo/static", "/")).toMatchObject({
+      targetPattern: "/foo/:id",
+      page: "static-prefix",
+      matchedParams: { id: "static" },
+    });
+    expect(matcher.findIntercept("/files/one", "/")).toMatchObject({
+      targetPattern: "/files/:id",
+      page: "dynamic",
+      matchedParams: { id: "one" },
+    });
+    expect(matcher.findIntercept("/files/one/two", "/")).toMatchObject({
+      targetPattern: "/files/:slug+",
+      page: "catch-all",
+      matchedParams: { slug: ["one", "two"] },
+    });
+    expect(matcher.findIntercept("/files", "/")).toMatchObject({
+      targetPattern: "/files/:slug*",
+      page: "optional-catch-all",
+      matchedParams: {},
+    });
+  });
+
   it("shares lazy intercept load state across fresh match objects", () => {
     const matcher = createAppRscRouteMatcher([
       route("/feed", ["feed"], {

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -123,6 +123,41 @@ describe("App RSC route matching", () => {
     });
   });
 
+  it("prefers static interception targets over dynamic targets", () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+    // https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+    const matcher = createAppRscRouteMatcher([
+      route("/", [], {
+        modal: {
+          intercepts: [
+            {
+              sourceMatchPattern: "/",
+              targetPattern: "/:username/:id",
+              interceptLayouts: [],
+              page: "dynamic-page",
+              params: ["username", "id"],
+            },
+            {
+              sourceMatchPattern: "/",
+              targetPattern: "/explicit-layout/deeper",
+              interceptLayouts: ["explicit-layout"],
+              page: "static-page",
+              params: [],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/explicit-layout/deeper", "/")).toMatchObject({
+      targetPattern: "/explicit-layout/deeper",
+      interceptLayouts: ["explicit-layout"],
+      page: "static-page",
+      matchedParams: {},
+    });
+  });
+
   it("shares lazy intercept load state across fresh match objects", () => {
     const matcher = createAppRscRouteMatcher([
       route("/feed", ["feed"], {

--- a/tests/e2e/app-router/interception-dynamic-single-segment.spec.ts
+++ b/tests/e2e/app-router/interception-dynamic-single-segment.spec.ts
@@ -98,4 +98,19 @@ test.describe("interception-dynamic-single-segment", () => {
     await expect(page.locator("#modal")).toContainText("Modal: New User Form");
     await expect(page.locator("#children")).toContainText("Admin Dashboard - Users");
   });
+
+  test("prefers a nested static interception over a broad dynamic interception", async ({
+    page,
+  }) => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+    // https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+    await page.goto(`${BASE}/interception-dyn-single`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("#nested-static-link");
+
+    await expect(page.locator("#modal")).toContainText("Modal: Nested static interception");
+    await expect(page.locator("#modal")).not.toContainText("Modal: Dynamic fallback");
+  });
 });

--- a/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)[a]/[b]/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)[a]/[b]/page.tsx
@@ -1,0 +1,3 @@
+export default function DynamicModal() {
+  return <div>Modal: Dynamic fallback</div>;
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)explicit-layout/deeper/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/@modal/(.)explicit-layout/deeper/page.tsx
@@ -1,0 +1,3 @@
+export default function NestedStaticModal() {
+  return <div>Modal: Nested static interception</div>;
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/[a]/[b]/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/[a]/[b]/page.tsx
@@ -1,0 +1,3 @@
+export default function DynamicPage() {
+  return <div>Dynamic page</div>;
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/explicit-layout/deeper/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/explicit-layout/deeper/page.tsx
@@ -1,0 +1,3 @@
+export default function NestedStaticPage() {
+  return <div>Nested static page</div>;
+}

--- a/tests/fixtures/app-basic/app/interception-dyn-single/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-dyn-single/page.tsx
@@ -6,6 +6,9 @@ export default function Page() {
       <Link href="/interception-dyn-single/groups/123" id="groups-link">
         Group 123
       </Link>
+      <Link href="/interception-dyn-single/explicit-layout/deeper" id="nested-static-link">
+        Nested static interception
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- match interception targets segment by segment instead of applying whole-route sorting to normalized matcher patterns
- preserve Next.js specificity at each segment: static, dynamic, catch-all, then optional catch-all
- cover overlapping static/dynamic prefixes and dynamic/catch-all target selection in the App RSC matcher

## Next.js parity

Pinned against Next.js commit [`ee6e79b1792a4d401ddf2480f40a83549fe8e722`](https://github.com/vercel/next.js/tree/ee6e79b1792a4d401ddf2480f40a83549fe8e722).

- Interception E2E: [`test/e2e/app-dir/interception-dynamic-single-segment/interception-dynamic-single-segment.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/test/e2e/app-dir/interception-dynamic-single-segment/interception-dynamic-single-segment.test.ts)
- Route specificity source: [`packages/next/src/shared/lib/router/utils/sortable-routes.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/shared/lib/router/utils/sortable-routes.ts)
- Route specificity tests: [`packages/next/src/shared/lib/router/utils/sortable-routes.test.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/shared/lib/router/utils/sortable-routes.test.ts)

## Targeted validation

- `vp test run tests/app-rsc-route-matching.test.ts --maxWorkers=1` — 22/22 passed
- An earlier exact fixture browser assertion passed before the comparator refinement; the later Playwright rerun was stopped when the fixture configuration started multiple servers to avoid unnecessary local CPU use
- Unit coverage was expanded after that refinement to directly exercise segment-by-segment static, dynamic, catch-all, and optional catch-all precedence

No broad or raw Next.js E2E suite was run locally; CI is left to perform broader validation.
