### PR TITLE
fix(pages-router): allow server-only in API routes

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1219,6 +1219,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       getMiddlewarePath: () => middlewarePath,
       getCanonicalMiddlewarePath: () =>
         middlewarePath ? (tryRealpathSync(middlewarePath) ?? middlewarePath) : null,
+      isNeutralServerModule: (id) => {
+        const canonicalId = canonicalizePageTransformPath(id);
+        return isWithinPagesDirectory(canonicalId) && isApiPage(canonicalId);
+      },
       serverOnlyShimPath: resolveShimModulePath(shimsDir, "server-only"),
     }),
     // Resolve `data:text/css[+module],...` imports into virtual CSS files so

--- a/packages/vinext/src/plugins/middleware-server-only.ts
+++ b/packages/vinext/src/plugins/middleware-server-only.ts
@@ -2,8 +2,8 @@ import type { Plugin } from "vite";
 import { normalizePathSeparators } from "../utils/path.js";
 
 /**
- * Allow `import 'server-only'` from middleware (and any module reachable
- * from middleware) in the SSR environment.
+ * Allow `import 'server-only'` from neutral server targets (and any module
+ * reachable from them) in the SSR environment.
  *
  * Background: middleware runs server-side, so importing `server-only` is
  * semantically correct. However, vinext bundles middleware into the SSR
@@ -13,9 +13,9 @@ import { normalizePathSeparators } from "../utils/path.js";
  *
  *   'server-only' cannot be imported in client build ('ssr' environment)
  *
- * Next.js solves this with webpack `issuerLayer` rules: middleware (and
- * `instrumentation`) sit in the `neutralTarget` layer where `server-only`
- * is aliased to a no-op while `client-only` still errors. See
+ * Next.js solves this with webpack `issuerLayer` rules: middleware,
+ * instrumentation, and Pages API routes sit in server-only or neutral layers
+ * where `server-only` is aliased to a no-op while `client-only` still errors. See
  *   packages/next/src/build/webpack-config.ts ("Alias server-only and
  *   client-only to proper exports based on bundling layers")
  *
@@ -23,7 +23,8 @@ import { normalizePathSeparators } from "../utils/path.js";
  * the behavior with import-chain taint tracking:
  *
  *   1. Seed a `tainted` set with the middleware entry path (and its
- *      canonical realpath).
+ *      canonical realpath), and recognize other neutral server entry modules
+ *      such as Pages API routes through `isNeutralServerModule`.
  *   2. For every resolveId call from a tainted importer, resolve the import
  *      via `this.resolve(..., { skipSelf: true })` and add the resolved id
  *      to the tainted set. This propagates the taint along the import graph
@@ -47,6 +48,7 @@ import { normalizePathSeparators } from "../utils/path.js";
 export function createMiddlewareServerOnlyPlugin(options: {
   getMiddlewarePath: () => string | null;
   getCanonicalMiddlewarePath: () => string | null;
+  isNeutralServerModule?: (id: string) => boolean;
   serverOnlyShimPath: string;
 }): Plugin {
   // Tracks module IDs reachable from the middleware entry. The set is
@@ -113,7 +115,9 @@ export function createMiddlewareServerOnlyPlugin(options: {
         // and plugin-rsc's validator allows it there.
         if (this.environment?.name === "rsc") return;
         if (!importer) return;
-        if (!isTainted(importer)) return;
+        if (!isTainted(importer) && !options.isNeutralServerModule?.(canonicalizeId(importer))) {
+          return;
+        }
 
         // server-only from a tainted importer → swap in the no-op shim
         // path before plugin-rsc's pre-resolveId can claim it as the

--- a/tests/middleware-server-only.test.ts
+++ b/tests/middleware-server-only.test.ts
@@ -66,6 +66,28 @@ async function buildFixture(): Promise<{ tmpDir: string }> {
     path.join(tmpDir, "pages", "pages-ssr.tsx"),
     `export default function PagesSsr() { return <div>pages-ssr</div>; }\n`,
   );
+  await writeFile(
+    path.join(tmpDir, "lib", "api-server-only.ts"),
+    `import "server-only";
+import * as React from "react";
+
+export function getReactExports() {
+  return Object.keys(Object(React));
+}
+`,
+  );
+  await writeFile(
+    path.join(tmpDir, "pages", "api", "server-only-edge.ts"),
+    `import "server-only";
+import { getReactExports } from "../../lib/api-server-only";
+
+export default async function handler() {
+  return Response.json({ React: getReactExports() });
+}
+
+export const runtime = "edge";
+`,
+  );
 
   // A helper that the middleware imports. Mirrors the Next.js fixture's
   // `lib/mixed-lib`-style transitive case: `server-only` must remain a


### PR DESCRIPTION
## Summary

- treat Pages API routes as neutral server import-chain roots
- allow direct and transitive `server-only` imports without weakening validation for ordinary Pages client modules
- cover both direct and transitive Pages API cases in the local fixture suite

## Next.js parity

The pinned Next.js `v16.2.6` reference (`ee6e79b1792a4d401ddf2480f40a83549fe8e722`) permits `server-only` in Pages API routes and modules imported by them.

This fixes the 13 module-layer failures in deploy-suite run `27858251903`, which all came from the same build abort while processing `pages/api/server-only-edge.js`.

## Validation

- `vp test run tests/middleware-server-only.test.ts` — 4/4 passed with one worker
- independent exact-head review — clean

No broad local suite or raw Next.js E2E was run.
