### PR TITLE
fix(cache): bypass unstable cache in draft mode

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -997,6 +997,7 @@ export default createAppRscHandler({
         __clearRequestContext();
       },
       contentType,
+      draftModeSecret: __draftModeSecret,
       createNotFoundElement(actionRouteId) {
         return {
           ...__AppElementsWire.createMetadataEntries({

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -246,6 +246,7 @@ export type HandleServerActionRscRequestOptions<
     body: string | FormData,
     options: DecodeServerActionReplyOptions<TTemporaryReferences>,
   ) => Promise<unknown[]> | unknown[];
+  draftModeSecret?: string;
   /**
    * Hydrate a route's lazy page/route-handler modules before reading
    * `route.page` / `route.routeHandler` on action redirect targets and
@@ -1221,7 +1222,11 @@ export async function handleServerActionRscRequest<
         request: options.request,
         url: redirectTarget,
       });
-      setHeadersContext(headersContextFromRequest(redirectRenderRequest));
+      setHeadersContext(
+        headersContextFromRequest(redirectRenderRequest, {
+          draftModeSecret: options.draftModeSecret,
+        }),
+      );
       const redirectNavigationParams = resolveAppPageNavigationParams(
         targetMatch.route,
         targetMatch.params,

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -19,7 +19,11 @@
  * target used by the generated cache-adapter module.
  */
 
-import { getHeadersAccessPhase, markDynamicUsage as _markDynamic } from "./headers.js";
+import {
+  getHeadersAccessPhase,
+  isDraftModeEnabled,
+  markDynamicUsage as _markDynamic,
+} from "./headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import { fnv1a64 } from "../utils/hash.js";
 import { isInsideUnifiedScope, getRequestContext } from "./unified-request-context.js";
@@ -595,33 +599,39 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
       tagHash: tags.length > 0 ? fnv1a64(JSON.stringify(tags)) : null,
     });
 
-    // Try to get from cache. Stale entries are usable in normal App Router
-    // requests, but foreground-refresh inside revalidation scopes so the
-    // regenerated page/route stores fresh data.
-    const existing = await getDataCacheHandler().get(cacheKey, {
-      kind: "FETCH",
-      tags,
-    });
-    if (existing?.value && existing.value.kind === "FETCH") {
-      const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
-      if (cached.ok) {
-        if (existing.cacheState === "stale") {
-          if (shouldServeStaleUnstableCacheEntry()) {
-            scheduleUnstableCacheBackgroundRevalidation(cacheKey, () =>
-              refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
-            );
+    const isDraftMode = isDraftModeEnabled();
+    if (!isDraftMode) {
+      // Try to get from cache. Stale entries are usable in normal App Router
+      // requests, but foreground-refresh inside revalidation scopes so the
+      // regenerated page/route stores fresh data.
+      const existing = await getDataCacheHandler().get(cacheKey, {
+        kind: "FETCH",
+        tags,
+      });
+      if (existing?.value && existing.value.kind === "FETCH") {
+        const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
+        if (cached.ok) {
+          if (existing.cacheState === "stale") {
+            if (shouldServeStaleUnstableCacheEntry()) {
+              scheduleUnstableCacheBackgroundRevalidation(cacheKey, () =>
+                refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
+              );
+              return cached.value;
+            }
+          } else {
             return cached.value;
           }
-        } else {
-          return cached.value;
         }
+        // Corrupted entries fall through to a foreground refresh.
       }
-      // Corrupted entries fall through to a foreground refresh.
     }
 
     // Cache miss — call the function inside the unstable_cache ALS scope
     // so that headers()/cookies()/connection() can detect they're in a
     // cache scope and throw an appropriate error.
+    if (isDraftMode) {
+      return await _unstableCacheAls.run(true, () => fn(...args));
+    }
     return await refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds);
   };
 

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -977,6 +977,19 @@ export function isDraftModeRequest(request: Request, draftModeSecret: string): b
   );
 }
 
+/**
+ * Read the active request's draft-mode state without recording request API usage.
+ * Internal cache implementations use this to bypass persistent reads and writes,
+ * matching Next.js's request-level `workStore.isDraftMode` guard.
+ */
+export function isDraftModeEnabled(): boolean {
+  const context = _getState().headersContext;
+  if (!context || context.accessError) return false;
+  const secret = context.draftModeSecret;
+  if (secret === undefined) return false;
+  return context.cookies.get(DRAFT_MODE_COOKIE) === validateDraftModeSecret(secret);
+}
+
 type DraftModeResult = {
   readonly isEnabled: boolean;
   enable(): void;

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../packages/vinext/src/shims/cache.js";
 import {
   cookies,
+  isDraftModeEnabled,
   setHeadersAccessPhase,
   setHeadersContext,
 } from "../packages/vinext/src/shims/headers.js";
@@ -1235,12 +1236,15 @@ describe("app server action execution helpers", () => {
     // Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     const renderRequests: Request[] = [];
+    let redirectRenderDraftMode = false;
     const response = await handleServerActionRscRequest(
       createRscOptions({
         buildPageElement({ request }) {
           renderRequests.push(request);
+          redirectRenderDraftMode = isDraftModeEnabled();
           return "redirect-target:{}:none";
         },
+        draftModeSecret: "draft-secret",
         getAndClearPendingCookies() {
           return ["theme=dark; Path=/", "deleted=; Path=/; Max-Age=0"];
         },
@@ -1261,7 +1265,7 @@ describe("app server action execution helpers", () => {
         },
         request: createFetchActionRequest({
           accept: "text/x-component",
-          cookie: "session=1; deleted=stale",
+          cookie: "session=1; deleted=stale; __prerender_bypass=draft-secret",
           "next-action": "action-id",
           rsc: "1",
         }),
@@ -1280,7 +1284,10 @@ describe("app server action execution helpers", () => {
     expect(renderRequest.headers.get("rsc")).toBeNull();
     expect(renderRequest.headers.get("content-type")).toBeNull();
     expect(renderRequest.headers.get("origin")).toBeNull();
-    expect(renderRequest.headers.get("cookie")).toBe("session=1; theme=dark");
+    expect(renderRequest.headers.get("cookie")).toBe(
+      "session=1; __prerender_bypass=draft-secret; theme=dark",
+    );
+    expect(redirectRenderDraftMode).toBe(true);
   });
 
   it("keeps redirected action render context alive until the Flight body is consumed", async () => {

--- a/tests/e2e/app-router/isr.spec.ts
+++ b/tests/e2e/app-router/isr.spec.ts
@@ -374,4 +374,36 @@ test.describe("unstable_cache data cache (OpenNext compat)", () => {
 
     expect(value2).toBe(value1);
   });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-static/app-static.test.ts
+  test("unstable_cache bypasses persistent data in draft mode", async ({ request }) => {
+    const readPage = async () => {
+      const response = await request.get(`${BASE}/nextjs-compat/unstable-cache-draft`);
+      expect(response.status()).toBe(200);
+      const html = await response.text();
+      return {
+        data: html.match(/id="cached-data">([^<]+)/)?.[1],
+        draftMode: html.match(/id="draft-mode-enabled">([^<]+)/)?.[1],
+      };
+    };
+
+    const normal1 = await readPage();
+    const normal2 = await readPage();
+    expect(normal1.data).toBeDefined();
+    expect(normal2.data).toBe(normal1.data);
+    expect(normal2.draftMode).toBe("false");
+
+    expect((await request.get(`${BASE}/nextjs-compat/api/draft-enable`)).status()).toBe(200);
+    const draft1 = await readPage();
+    const draft2 = await readPage();
+    expect(draft1.data).not.toBe(normal1.data);
+    expect(draft2.data).not.toBe(draft1.data);
+    expect(draft2.draftMode).toBe("true");
+
+    expect((await request.get(`${BASE}/nextjs-compat/api/draft-disable`)).status()).toBe(200);
+    const normal3 = await readPage();
+    expect(normal3.data).toBe(normal1.data);
+    expect(normal3.draftMode).toBe("false");
+  });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/unstable-cache-draft/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/unstable-cache-draft/page.tsx
@@ -1,0 +1,21 @@
+import { unstable_cache } from "next/cache";
+import { draftMode } from "next/headers";
+
+const getCachedData = unstable_cache(
+  async () => Math.random().toString(36).slice(2),
+  ["nextjs-compat-unstable-cache-draft"],
+);
+
+export const dynamic = "force-dynamic";
+
+export default async function Page() {
+  const data = await getCachedData();
+  const draft = await draftMode();
+
+  return (
+    <main>
+      <p id="cached-data">{data}</p>
+      <p id="draft-mode-enabled">{draft.isEnabled.toString()}</p>
+    </main>
+  );
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -21349,6 +21349,34 @@ describe("cache scope guards for dynamic APIs", () => {
     setCacheHandler(new MemoryCacheHandler());
   });
 
+  it("unstable_cache bypasses reads and writes while draft mode is enabled", async () => {
+    const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersContext } = await import("../packages/vinext/src/shims/headers.js");
+
+    setCacheHandler(new MemoryCacheHandler());
+    let calls = 0;
+    const cached = unstable_cache(async () => ++calls, ["test-draftmode-cache-bypass"]);
+
+    setHeadersContext({ headers: new Headers(), cookies: new Map(), draftModeSecret: "secret" });
+    await expect(cached()).resolves.toBe(1);
+    await expect(cached()).resolves.toBe(1);
+
+    setHeadersContext({
+      headers: new Headers({ cookie: "__prerender_bypass=secret" }),
+      cookies: new Map([["__prerender_bypass", "secret"]]),
+      draftModeSecret: "secret",
+    });
+    await expect(cached()).resolves.toBe(2);
+    await expect(cached()).resolves.toBe(3);
+
+    setHeadersContext({ headers: new Headers(), cookies: new Map(), draftModeSecret: "secret" });
+    await expect(cached()).resolves.toBe(1);
+
+    setHeadersContext(null);
+    setCacheHandler(new MemoryCacheHandler());
+  });
+
   it('draftMode().enable() throws inside "use cache" scope', async () => {
     const { cacheContextStorage } = await import("../packages/vinext/src/shims/cache-runtime.js");
     const { draftMode, setHeadersContext } =


### PR DESCRIPTION
## Summary

- bypass persistent `unstable_cache` reads and writes while draft mode is enabled
- preserve the draft-mode secret across in-process Server Action redirects
- add focused unit and App Router fixture coverage for both behaviors

## Next.js parity

This matches the behavior of the pinned Next.js v16.2.6 reference at commit `ee6e79b1792a4d401ddf2480f40a83549fe8e722`, where draft mode bypasses persistent `unstable_cache` operations.

The fix addresses 3 genuine failures from the app-static suite in run 27858251903. It intentionally excludes the separate Suspense fallback HTML parity gap and the 9 `ECONNREFUSED` cascades that followed the deployed server exiting.

## Validation

All validation was targeted and used one worker:

- draft-mode cache unit tests: 3/3 passed
- Server Action redirect test: 1/1 passed
- App Router Playwright fixture: 1/1 passed
- scoped format, lint, types, and `git diff --check` passed

No raw Next.js E2E or broad local suite was run.
