### PR TITLE
fix(pages): match ESM externals behavior

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -396,6 +396,8 @@ export type ResolvedNextConfig = {
   reactMaxHeadersLength: number;
   /** Serialized htmlLimitedBots regexp source from next.config. */
   htmlLimitedBots: string | undefined;
+  /** Packages that must stay bundled and pass through Vite transforms. */
+  transpilePackages: string[];
   /**
    * Packages that should be treated as server-external (not bundled by Vite).
    * Sourced from `serverExternalPackages` or the legacy
@@ -1300,6 +1302,7 @@ export async function resolveNextConfig(
       expireTime: DEFAULT_EXPIRE_TIME,
       reactMaxHeadersLength: DEFAULT_REACT_MAX_HEADERS_LENGTH,
       htmlLimitedBots: undefined,
+      transpilePackages: [],
       serverExternalPackages: [],
       cacheHandler: undefined,
       cacheMaxMemorySize: undefined,
@@ -1467,6 +1470,17 @@ export async function resolveNextConfig(
     experimental?.serverComponentsExternalPackages,
   );
   const serverExternalPackages = topLevelServerExternalPackages ?? legacyServerComponentsExternal;
+  const transpilePackages = readStringArray(config.transpilePackages);
+  const externalPackageConflicts = transpilePackages.filter((packageName) =>
+    serverExternalPackages.includes(packageName),
+  );
+  if (externalPackageConflicts.length > 0) {
+    throw new Error(
+      `The packages specified in the 'transpilePackages' conflict with the 'serverExternalPackages': ${externalPackageConflicts.join(
+        ", ",
+      )}`,
+    );
+  }
 
   // Warn about unsupported experimental.swcEnvOptions. vinext uses Vite for
   // transforms, not SWC, so automatic polyfill injection is not applicable.
@@ -1621,6 +1635,7 @@ export async function resolveNextConfig(
         ? config.reactMaxHeadersLength
         : DEFAULT_REACT_MAX_HEADERS_LENGTH,
     htmlLimitedBots,
+    transpilePackages,
     serverExternalPackages,
     cacheHandler,
     cacheMaxMemorySize,

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -256,6 +256,8 @@ export type NextConfig = {
   enablePrerenderSourceMaps?: boolean;
   /** Transpile packages (Vite handles this natively) */
   transpilePackages?: string[];
+  /** Bundle Pages Router dependencies instead of externalizing them. */
+  bundlePagesRouterDependencies?: boolean;
   /**
    * Packages that should be treated as server-external (not bundled by Vite).
    * Corresponds to Next.js `serverExternalPackages` (or the legacy
@@ -396,6 +398,10 @@ export type ResolvedNextConfig = {
   reactMaxHeadersLength: number;
   /** Serialized htmlLimitedBots regexp source from next.config. */
   htmlLimitedBots: string | undefined;
+  /** Whether Pages Router dependencies may use native ESM externalization. */
+  esmExternals: boolean | "loose";
+  /** Bundle all Pages Router dependencies unless explicitly server-external. */
+  bundlePagesRouterDependencies: boolean;
   /** Packages that must stay bundled and pass through Vite transforms. */
   transpilePackages: string[];
   /**
@@ -1302,6 +1308,8 @@ export async function resolveNextConfig(
       expireTime: DEFAULT_EXPIRE_TIME,
       reactMaxHeadersLength: DEFAULT_REACT_MAX_HEADERS_LENGTH,
       htmlLimitedBots: undefined,
+      esmExternals: true,
+      bundlePagesRouterDependencies: false,
       transpilePackages: [],
       serverExternalPackages: [],
       cacheHandler: undefined,
@@ -1470,6 +1478,10 @@ export async function resolveNextConfig(
     experimental?.serverComponentsExternalPackages,
   );
   const serverExternalPackages = topLevelServerExternalPackages ?? legacyServerComponentsExternal;
+  const rawEsmExternals = experimental?.esmExternals;
+  const esmExternals =
+    rawEsmExternals === false || rawEsmExternals === "loose" ? rawEsmExternals : true;
+  const bundlePagesRouterDependencies = config.bundlePagesRouterDependencies === true;
   const transpilePackages = readStringArray(config.transpilePackages);
   const externalPackageConflicts = transpilePackages.filter((packageName) =>
     serverExternalPackages.includes(packageName),
@@ -1635,6 +1647,8 @@ export async function resolveNextConfig(
         ? config.reactMaxHeadersLength
         : DEFAULT_REACT_MAX_HEADERS_LENGTH,
     htmlLimitedBots,
+    esmExternals,
+    bundlePagesRouterDependencies,
     transpilePackages,
     serverExternalPackages,
     cacheHandler,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1223,7 +1223,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       serverOnlyShimPath: resolveShimModulePath(shimsDir, "server-only"),
     }),
     createPagesNodeExternalsPlugin({
+      getRoot: () => root,
       getPagesDir: () => (hasPagesDir ? pagesDir : null),
+      getEsmExternals: () => nextConfig?.esmExternals ?? true,
+      getBundlePagesRouterDependencies: () => nextConfig?.bundlePagesRouterDependencies ?? false,
       getTranspilePackages: () => nextConfig?.transpilePackages ?? [],
       isEnabled: () => !hasCloudflarePlugin && !hasNitroPlugin,
     }),

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -128,6 +128,7 @@ import {
   INSTRUMENTATION_CLIENT_EMPTY_MODULE,
 } from "./client/instrumentation-client-inject.js";
 import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
+import { createPagesNodeExternalsPlugin } from "./plugins/pages-node-externals.js";
 import { validateMiddlewareModuleExports } from "./plugins/middleware-export-validation.js";
 import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
 import { createDynamicPreloadMetadataPlugin } from "./plugins/dynamic-preload-metadata.js";
@@ -1220,6 +1221,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       getCanonicalMiddlewarePath: () =>
         middlewarePath ? (tryRealpathSync(middlewarePath) ?? middlewarePath) : null,
       serverOnlyShimPath: resolveShimModulePath(shimsDir, "server-only"),
+    }),
+    createPagesNodeExternalsPlugin({
+      getPagesDir: () => (hasPagesDir ? pagesDir : null),
+      getTranspilePackages: () => nextConfig?.transpilePackages ?? [],
+      isEnabled: () => !hasCloudflarePlugin && !hasNitroPlugin,
     }),
     // Resolve `data:text/css[+module],...` imports into virtual CSS files so
     // Vite's CSS pipeline (LightningCSS, CSS modules) processes them instead

--- a/packages/vinext/src/plugins/pages-node-externals.ts
+++ b/packages/vinext/src/plugins/pages-node-externals.ts
@@ -5,7 +5,10 @@ import type { Plugin } from "vite";
 import { stripViteModuleQuery } from "../utils/path.js";
 
 type PagesNodeExternalsOptions = {
+  getRoot: () => string;
   getPagesDir: () => string | null;
+  getEsmExternals: () => boolean | "loose";
+  getBundlePagesRouterDependencies: () => boolean;
   getTranspilePackages: () => readonly string[];
   isEnabled: () => boolean;
 };
@@ -23,6 +26,7 @@ const FRAMEWORK_PACKAGES = new Set([
 
 const MODULE_SPECIFIER_RE =
   /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s*)?["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
+const STATIC_REQUIRE_RE = /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 
 function isBarePackageRequest(id: string): boolean {
   return (
@@ -104,6 +108,7 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
   let isBuild = false;
   const pagesOwnedModules = new Set<string>();
   const nativeEsmCache = new Map<string, boolean>();
+  const requireRequestsByImporter = new Map<string, Set<string>>();
 
   return {
     name: "vinext:pages-node-externals",
@@ -111,6 +116,26 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
 
     configResolved(config) {
       isBuild = config.command === "build";
+    },
+
+    transform: {
+      order: "pre",
+      handler(code, id) {
+        if (!isBuild || !options.isEnabled() || this.environment?.name === "client") return null;
+        if (!code.includes("require")) return null;
+
+        const requests = new Set<string>();
+        STATIC_REQUIRE_RE.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = STATIC_REQUIRE_RE.exec(code)) !== null) {
+          const request = match[1];
+          if (request && isBarePackageRequest(request)) requests.add(request);
+        }
+        if (requests.size > 0) {
+          requireRequestsByImporter.set(realpathIfExists(stripViteModuleQuery(id)), requests);
+        }
+        return null;
+      },
     },
 
     async resolveId(id, importer) {
@@ -139,6 +164,9 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
       }
 
       if (!importerIsPagesOwned) return null;
+      if (options.getEsmExternals() === false || options.getBundlePagesRouterDependencies()) {
+        return null;
+      }
       const packageName = getPackageName(id);
       if (!packageName) return null;
       if (
@@ -150,6 +178,24 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
         options.getTranspilePackages().includes(packageName)
       ) {
         return null;
+      }
+
+      const canonicalImporter = cleanImporter ? realpathIfExists(cleanImporter) : null;
+      const isRequireRequest = Boolean(
+        canonicalImporter && requireRequestsByImporter.get(canonicalImporter)?.has(id),
+      );
+      if (isRequireRequest) {
+        const requireFromImporter = createRequire(
+          canonicalImporter ?? path.join(pagesDir, "index.js"),
+        );
+        const requireResolved = realpathIfExists(requireFromImporter.resolve(id));
+        if (canNodeImport(requireResolved) && options.getEsmExternals() !== "loose") {
+          throw new Error(
+            `ESM packages (${id}) need to be imported. Use 'import' to reference the package instead. https://nextjs.org/docs/messages/import-esm-externals`,
+          );
+        }
+        pagesOwnedModules.add(requireResolved);
+        return canNodeImport(requireResolved) ? { id, external: true } : requireResolved;
       }
 
       const resolved = await this.resolve(id, importer, { skipSelf: true });
@@ -169,7 +215,17 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
           canNodeImport(cleanResolved) && !hasNodeUnsupportedRelativeImport(cleanResolved);
         nativeEsmCache.set(cleanResolved, shouldExternalize);
       }
-      if (shouldExternalize) return { id, external: true };
+      if (shouldExternalize) {
+        const rootImporter = path.join(options.getRoot(), "__vinext_external_resolve__.js");
+        const rootResolved = await this.resolve(id, rootImporter, { skipSelf: true });
+        const cleanRootResolved = rootResolved?.external
+          ? null
+          : rootResolved
+            ? realpathIfExists(stripViteModuleQuery(rootResolved.id))
+            : null;
+        if (cleanRootResolved !== cleanResolved) return null;
+        return { id, external: true };
+      }
 
       try {
         const requireFromImporter = createRequire(cleanImporter ?? path.join(pagesDir, "index.js"));

--- a/packages/vinext/src/plugins/pages-node-externals.ts
+++ b/packages/vinext/src/plugins/pages-node-externals.ts
@@ -1,0 +1,187 @@
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import type { Plugin } from "vite";
+import { stripViteModuleQuery } from "../utils/path.js";
+
+type PagesNodeExternalsOptions = {
+  getPagesDir: () => string | null;
+  getTranspilePackages: () => readonly string[];
+  isEnabled: () => boolean;
+};
+
+const FRAMEWORK_PACKAGES = new Set([
+  "@vitejs/plugin-react",
+  "@vitejs/plugin-rsc",
+  "react",
+  "react-dom",
+  "react-server-dom-webpack",
+  "scheduler",
+  "vite",
+  "vinext",
+]);
+
+const MODULE_SPECIFIER_RE =
+  /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s*)?["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+function isBarePackageRequest(id: string): boolean {
+  return (
+    id !== "" &&
+    id[0] !== "." &&
+    id[0] !== "/" &&
+    id[0] !== "\0" &&
+    !id.includes(":") &&
+    !path.isAbsolute(id)
+  );
+}
+
+function getPackageName(id: string): string | null {
+  const [first, second] = id.split("/");
+  if (!first) return null;
+  return first.startsWith("@") ? (second ? `${first}/${second}` : null) : first;
+}
+
+function isInsideDirectory(directory: string, file: string): boolean {
+  const relative = path.relative(realpathIfExists(directory), realpathIfExists(file));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function realpathIfExists(file: string): string {
+  try {
+    return fs.realpathSync.native(file);
+  } catch {
+    return file;
+  }
+}
+
+function findPackageJson(file: string): string | null {
+  let directory = path.dirname(file);
+  while (true) {
+    const candidate = path.join(directory, "package.json");
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(directory);
+    if (parent === directory || path.basename(directory) === "node_modules") return null;
+    directory = parent;
+  }
+}
+
+function canNodeImport(file: string): boolean {
+  const extension = path.extname(file);
+  if (extension === ".mjs") return true;
+  if (extension !== ".js") return false;
+
+  const packageJson = findPackageJson(file);
+  if (!packageJson) return false;
+  try {
+    return (
+      (JSON.parse(fs.readFileSync(packageJson, "utf8")) as { type?: unknown }).type === "module"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasNodeUnsupportedRelativeImport(file: string): boolean {
+  let source: string;
+  try {
+    source = fs.readFileSync(file, "utf8");
+  } catch {
+    return true;
+  }
+
+  MODULE_SPECIFIER_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = MODULE_SPECIFIER_RE.exec(source)) !== null) {
+    const specifier = match[1] ?? match[2] ?? match[3];
+    if (!specifier?.startsWith(".")) continue;
+    const extension = path.extname(specifier.split(/[?#]/, 1)[0] ?? specifier);
+    if (!extension) return true;
+  }
+  return false;
+}
+
+export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOptions): Plugin {
+  let isBuild = false;
+  const pagesOwnedModules = new Set<string>();
+  const nativeEsmCache = new Map<string, boolean>();
+
+  return {
+    name: "vinext:pages-node-externals",
+    enforce: "pre",
+
+    configResolved(config) {
+      isBuild = config.command === "build";
+    },
+
+    async resolveId(id, importer) {
+      if (!isBuild || !options.isEnabled() || this.environment?.name === "client") return null;
+
+      const pagesDir = options.getPagesDir();
+      if (!pagesDir) return null;
+      const cleanImporter = importer ? stripViteModuleQuery(importer) : null;
+      const importerIsPagesOwned = Boolean(
+        cleanImporter &&
+        path.isAbsolute(cleanImporter) &&
+        (isInsideDirectory(pagesDir, cleanImporter) || pagesOwnedModules.has(cleanImporter)),
+      );
+
+      if (!isBarePackageRequest(id)) {
+        const resolved = await this.resolve(id, importer, { skipSelf: true });
+        if (!resolved || resolved.external) return null;
+        const cleanResolved = realpathIfExists(stripViteModuleQuery(resolved.id));
+        if (
+          path.isAbsolute(cleanResolved) &&
+          (isInsideDirectory(pagesDir, cleanResolved) || importerIsPagesOwned)
+        ) {
+          pagesOwnedModules.add(cleanResolved);
+        }
+        return null;
+      }
+
+      if (!importerIsPagesOwned) return null;
+      const packageName = getPackageName(id);
+      if (!packageName) return null;
+      if (
+        FRAMEWORK_PACKAGES.has(packageName) ||
+        id === "next" ||
+        id.startsWith("next/") ||
+        id.startsWith("vinext/") ||
+        id.startsWith("@vinext/") ||
+        options.getTranspilePackages().includes(packageName)
+      ) {
+        return null;
+      }
+
+      const resolved = await this.resolve(id, importer, { skipSelf: true });
+      if (!resolved || resolved.external) return null;
+      const cleanResolved = realpathIfExists(stripViteModuleQuery(resolved.id));
+      if (
+        !path.isAbsolute(cleanResolved) ||
+        !cleanResolved.includes(`${path.sep}node_modules${path.sep}`)
+      ) {
+        return null;
+      }
+      pagesOwnedModules.add(cleanResolved);
+
+      let shouldExternalize = nativeEsmCache.get(cleanResolved);
+      if (shouldExternalize === undefined) {
+        shouldExternalize =
+          canNodeImport(cleanResolved) && !hasNodeUnsupportedRelativeImport(cleanResolved);
+        nativeEsmCache.set(cleanResolved, shouldExternalize);
+      }
+      if (shouldExternalize) return { id, external: true };
+
+      try {
+        const requireFromImporter = createRequire(cleanImporter ?? path.join(pagesDir, "index.js"));
+        const requireResolved = realpathIfExists(requireFromImporter.resolve(id));
+        if (requireResolved !== cleanResolved) {
+          pagesOwnedModules.add(requireResolved);
+          return requireResolved;
+        }
+      } catch {
+        // Keep Vite's import-condition resolution when no require fallback exists.
+      }
+      return null;
+    },
+  };
+}

--- a/tests/esm-externals.test.ts
+++ b/tests/esm-externals.test.ts
@@ -45,7 +45,14 @@ async function writePackage(
 
 async function createFixture(
   router: "pages" | "app",
-  options: { transpilePackages?: string[] } = {},
+  options: {
+    transpilePackages?: string[];
+    esmExternals?: boolean;
+    bundlePagesRouterDependencies?: boolean;
+    requireEsm?: boolean;
+    requireConditional?: boolean;
+    nestedVersion?: boolean;
+  } = {},
 ): Promise<string> {
   const root = await fsp.mkdtemp(path.join(os.tmpdir(), `vinext-esm-externals-${router}-`));
   fixtureRoots.push(root);
@@ -118,22 +125,56 @@ async function createFixture(
   );
 
   if (router === "pages") {
-    await writePackage(
-      root,
-      "transitive-esm-package",
-      {
-        type: "module",
-        exports: { ".": "./index.js" },
-      },
-      {
-        "index.js": `export default "Transitive"; if (Math.random() < 0) import("fail");`,
-      },
-    );
-    await writeFile(
-      root,
-      "node_modules/invalid-esm-package/alternative.js",
-      `module.exports = require("transitive-esm-package").default === "Transitive" ? "Alternative" : "Wrong";`,
-    );
+    if (options.requireEsm) {
+      await writePackage(
+        root,
+        "required-esm-package",
+        { type: "module", exports: { ".": "./index.js" } },
+        { "index.js": `export default "Required ESM";` },
+      );
+    }
+    if (options.requireConditional) {
+      await writePackage(
+        root,
+        "required-conditional-package",
+        {
+          exports: {
+            ".": { import: "./import.mjs", require: "./require.cjs" },
+          },
+        },
+        {
+          "import.mjs": `export default "Import Version";`,
+          "require.cjs": `module.exports = "Require Version";`,
+        },
+      );
+    }
+    if (options.nestedVersion) {
+      await writePackage(
+        root,
+        "nested-version-package",
+        { type: "module", exports: { ".": "./index.js" } },
+        { "index.js": `export default "Root Version";` },
+      );
+      await writeFile(
+        root,
+        "pages/nested/node_modules/nested-version-package/package.json",
+        JSON.stringify({
+          name: "nested-version-package",
+          type: "module",
+          exports: { ".": "./index.js" },
+        }),
+      );
+      await writeFile(
+        root,
+        "pages/nested/node_modules/nested-version-package/index.js",
+        `export default "Nested Version";`,
+      );
+      await writeFile(
+        root,
+        "pages/nested/value.ts",
+        `import value from "nested-version-package"; export default value;`,
+      );
+    }
   }
 
   const imports =
@@ -146,20 +187,32 @@ import World2 from "esm-package2/entry";
 import World3 from "invalid-esm-package/entry";`;
 
   if (router === "pages") {
-    if (options.transpilePackages) {
+    if (
+      options.transpilePackages ||
+      options.esmExternals !== undefined ||
+      options.bundlePagesRouterDependencies
+    ) {
       await writeFile(
         root,
         "next.config.mjs",
-        `export default { transpilePackages: ${JSON.stringify(options.transpilePackages)} };\n`,
+        `export default ${JSON.stringify({
+          transpilePackages: options.transpilePackages,
+          bundlePagesRouterDependencies: options.bundlePagesRouterDependencies,
+          experimental:
+            options.esmExternals === undefined ? undefined : { esmExternals: options.esmExternals },
+        })};\n`,
       );
     }
     await writeFile(
       root,
       "pages/index.tsx",
       `${imports}
+${options.requireEsm ? `const requiredEsm = require("required-esm-package");` : ""}
+${options.requireConditional ? `const requiredConditional = require("required-conditional-package");` : ""}
+${options.nestedVersion ? `import nestedVersion from "./nested/value";` : ""}
 export function getServerSideProps() { return { props: { server: [World1, World2, World3].join("+") } }; }
 export default function Page({ server }: { server: string }) {
-  return <p>{server}</p>;
+  return <p>{server}${options.requireEsm ? `+${"${requiredEsm.default}"}` : ""}${options.requireConditional ? `+${"${requiredConditional}"}` : ""}${options.nestedVersion ? `+${"${nestedVersion}"}` : ""}</p>;
 }
 `,
     );
@@ -273,4 +326,57 @@ describe("ESM external package parity", () => {
     const root = await createFixture("pages", { transpilePackages: ["esm-package1"] });
     await expect(buildFixture(root, "pages")).rejects.toThrow(/failed to resolve import "fail"/i);
   }, 120_000);
+
+  it("bundles a nested package version that differs from root resolution", async () => {
+    const root = await createFixture("pages", { nestedVersion: true });
+    const outDir = await buildFixture(root, "pages");
+    const server = unwrapStartedProdServer(
+      await startProdServer({ host: "127.0.0.1", port: 0, outDir }),
+    );
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("Missing server address");
+      expect(await (await fetch(`http://127.0.0.1:${address.port}/`)).text()).toContain(
+        "Nested Version",
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }, 120_000);
+
+  it("rejects strict require of an ESM-only package", async () => {
+    const root = await createFixture("pages", { requireEsm: true });
+    await expect(buildFixture(root, "pages")).rejects.toThrow(
+      "ESM packages (required-esm-package) need to be imported",
+    );
+  }, 120_000);
+
+  it("uses the require export for a conditional package", async () => {
+    const root = await createFixture("pages", { requireConditional: true });
+    const outDir = await buildFixture(root, "pages");
+    const server = unwrapStartedProdServer(
+      await startProdServer({ host: "127.0.0.1", port: 0, outDir }),
+    );
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("Missing server address");
+      const html = await (await fetch(`http://127.0.0.1:${address.port}/`)).text();
+      expect(html).toContain("Require Version");
+      expect(html).not.toContain("Import Version");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }, 120_000);
+
+  it.each([
+    ["experimental.esmExternals false", { esmExternals: false }],
+    ["bundlePagesRouterDependencies true", { bundlePagesRouterDependencies: true }],
+  ])(
+    "bundles native ESM when %s",
+    async (_name, options) => {
+      const root = await createFixture("pages", options);
+      await expect(buildFixture(root, "pages")).rejects.toThrow(/failed to resolve import "fail"/i);
+    },
+    120_000,
+  );
 });

--- a/tests/esm-externals.test.ts
+++ b/tests/esm-externals.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Ported from Next.js: test/e2e/esm-externals/esm-externals.test.ts
+ * https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/esm-externals/esm-externals.test.ts
+ */
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { build, createBuilder } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+import { startProdServer } from "../packages/vinext/src/server/prod-server.js";
+
+const WORKSPACE_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+const fixtureRoots: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(fixtureRoots.map((root) => fsp.rm(root, { recursive: true, force: true })));
+});
+
+async function writeFile(root: string, name: string, contents: string): Promise<void> {
+  const file = path.join(root, name);
+  await fsp.mkdir(path.dirname(file), { recursive: true });
+  await fsp.writeFile(file, contents, "utf8");
+}
+
+async function linkDependency(root: string, name: string): Promise<void> {
+  const destination = path.join(root, "node_modules", name);
+  await fsp.mkdir(path.dirname(destination), { recursive: true });
+  await fsp.symlink(path.join(WORKSPACE_NODE_MODULES, name), destination, "junction");
+}
+
+async function writePackage(
+  root: string,
+  name: string,
+  manifest: object,
+  files: Record<string, string>,
+): Promise<void> {
+  await writeFile(root, `node_modules/${name}/package.json`, JSON.stringify({ name, ...manifest }));
+  await Promise.all(
+    Object.entries(files).map(([file, contents]) =>
+      writeFile(root, `node_modules/${name}/${file}`, contents),
+    ),
+  );
+}
+
+async function createFixture(
+  router: "pages" | "app",
+  options: { transpilePackages?: string[] } = {},
+): Promise<string> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), `vinext-esm-externals-${router}-`));
+  fixtureRoots.push(root);
+  await writeFile(root, "package.json", JSON.stringify({ type: "module" }));
+  await linkDependency(root, "react");
+  await linkDependency(root, "react-dom");
+  await linkDependency(root, "styled-jsx");
+
+  for (const prefix of router === "app" ? ["app-"] : [""]) {
+    await writePackage(
+      root,
+      `${prefix}esm-package1`,
+      {
+        exports: {
+          "./entry": {
+            browser: "./browser.mjs",
+            import: "./correct.mjs",
+            require: "./wrong.js",
+          },
+        },
+      },
+      {
+        "browser.mjs": `export default "World"; if (typeof window === "undefined") throw new Error("browser export used on server");`,
+        "correct.mjs": `export default "World"; if (Math.random() < 0) import("fail");`,
+        "wrong.js": `module.exports = "Wrong";`,
+      },
+    );
+    await writePackage(
+      root,
+      `${prefix}esm-package2`,
+      {
+        type: "module",
+        exports: {
+          "./entry": {
+            browser: "./browser.mjs",
+            import: "./correct.js",
+            require: "./wrong.cjs",
+          },
+        },
+      },
+      {
+        "browser.mjs": `export default "World"; if (typeof window === "undefined") throw new Error("browser export used on server");`,
+        "correct.js": `await 1; export default "World"; if (Math.random() < 0) import("fail");`,
+        "wrong.cjs": `module.exports = "Wrong";`,
+      },
+    );
+  }
+
+  const cjsName = router === "app" ? "app-cjs-esm-package" : "invalid-esm-package";
+  await writePackage(
+    root,
+    cjsName,
+    {
+      exports: {
+        "./entry": {
+          browser: "./browser.js",
+          import: "./correct.js",
+          require: "./alternative.js",
+        },
+      },
+    },
+    {
+      "browser.js": `export default "World"; if (typeof window === "undefined") throw new Error("browser export used on server");`,
+      "correct.js":
+        router === "app"
+          ? `module.exports = "World"; if (Math.random() < 0) require("fail");`
+          : `export default "World";`,
+      "alternative.js": `module.exports = "Alternative";`,
+    },
+  );
+
+  if (router === "pages") {
+    await writePackage(
+      root,
+      "transitive-esm-package",
+      {
+        type: "module",
+        exports: { ".": "./index.js" },
+      },
+      {
+        "index.js": `export default "Transitive"; if (Math.random() < 0) import("fail");`,
+      },
+    );
+    await writeFile(
+      root,
+      "node_modules/invalid-esm-package/alternative.js",
+      `module.exports = require("transitive-esm-package").default === "Transitive" ? "Alternative" : "Wrong";`,
+    );
+  }
+
+  const imports =
+    router === "app"
+      ? `import World1 from "app-esm-package1/entry";
+import World2 from "app-esm-package2/entry";
+import World3 from "app-cjs-esm-package/entry";`
+      : `import World1 from "esm-package1/entry";
+import World2 from "esm-package2/entry";
+import World3 from "invalid-esm-package/entry";`;
+
+  if (router === "pages") {
+    if (options.transpilePackages) {
+      await writeFile(
+        root,
+        "next.config.mjs",
+        `export default { transpilePackages: ${JSON.stringify(options.transpilePackages)} };\n`,
+      );
+    }
+    await writeFile(
+      root,
+      "pages/index.tsx",
+      `${imports}
+export function getServerSideProps() { return { props: { server: [World1, World2, World3].join("+") } }; }
+export default function Page({ server }: { server: string }) {
+  return <p>{server}</p>;
+}
+`,
+    );
+  } else {
+    await writeFile(
+      root,
+      "next.config.mjs",
+      `export default { serverExternalPackages: ["app-esm-package1", "app-esm-package2", "app-cjs-esm-package"] };\n`,
+    );
+    await writeFile(
+      root,
+      "app/layout.tsx",
+      `export default function Layout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }\n`,
+    );
+    await writeFile(
+      root,
+      "app/page.tsx",
+      `${imports}
+export default function Page() { return <p>{[World1, World2, World3].join("+")}</p>; }
+`,
+    );
+  }
+  return root;
+}
+
+async function buildFixture(root: string, router: "pages" | "app"): Promise<string> {
+  const outDir = path.join(root, "dist");
+  if (router === "pages") {
+    await build({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [vinext({ disableAppRouter: true })],
+      build: {
+        outDir: path.join(outDir, "server"),
+        ssr: "virtual:vinext-server-entry",
+        rolldownOptions: { output: { entryFileNames: "entry.js" } },
+      },
+    });
+    await build({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [vinext({ disableAppRouter: true })],
+      build: {
+        outDir: path.join(outDir, "client"),
+        manifest: true,
+        ssrManifest: true,
+        rolldownOptions: { input: "virtual:vinext-client-entry" },
+      },
+    });
+  } else {
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [
+        vinext({
+          appDir: root,
+          rscOutDir: path.join(outDir, "server"),
+          ssrOutDir: path.join(outDir, "server", "ssr"),
+          clientOutDir: path.join(outDir, "client"),
+        }),
+      ],
+    });
+    await builder.buildApp();
+  }
+  return outDir;
+}
+
+function unwrapStartedProdServer(
+  result: import("node:http").Server | { server: import("node:http").Server },
+): import("node:http").Server {
+  return "server" in result ? result.server : result;
+}
+
+async function renderFixture(router: "pages" | "app"): Promise<{ html: string; root: string }> {
+  const root = await createFixture(router);
+  const outDir = await buildFixture(root, router);
+  const server = unwrapStartedProdServer(
+    await startProdServer({ host: "127.0.0.1", port: 0, outDir }),
+  );
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Missing server address");
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+    expect(response.status).toBe(200);
+    return { html: await response.text(), root };
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+describe("ESM external package parity", () => {
+  it("resolves Pages packages using import semantics while bundling invalid ESM", async () => {
+    const { html } = await renderFixture("pages");
+    expect(html).toContain("World+World+Alternative");
+    expect(html).not.toContain("Wrong");
+  }, 120_000);
+
+  it("loads App serverExternalPackages through Node ESM semantics", async () => {
+    const { html } = await renderFixture("app");
+    expect(html).toContain("World+World+World");
+    expect(html).not.toContain("Wrong");
+    expect(html).not.toContain("Alternative");
+  }, 120_000);
+
+  it("keeps transpilePackages bundled instead of externalizing native ESM", async () => {
+    const root = await createFixture("pages", { transpilePackages: ["esm-package1"] });
+    await expect(buildFixture(root, "pages")).rejects.toThrow(/failed to resolve import "fail"/i);
+  }, 120_000);
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1372,6 +1372,30 @@ describe("resolveNextConfig serverExternalPackages", () => {
   });
 });
 
+describe("resolveNextConfig transpilePackages", () => {
+  it("defaults to an empty array", async () => {
+    expect((await resolveNextConfig(null)).transpilePackages).toEqual([]);
+  });
+
+  it("preserves string package names", async () => {
+    expect(
+      (await resolveNextConfig({ transpilePackages: ["esm-package", 42] as string[] }))
+        .transpilePackages,
+    ).toEqual(["esm-package"]);
+  });
+
+  it("rejects packages that are also server-external", async () => {
+    await expect(
+      resolveNextConfig({
+        transpilePackages: ["esm-package"],
+        serverExternalPackages: ["esm-package"],
+      }),
+    ).rejects.toThrow(
+      "The packages specified in the 'transpilePackages' conflict with the 'serverExternalPackages': esm-package",
+    );
+  });
+});
+
 describe("resolveNextConfig serverActionsBodySizeLimit", () => {
   it("defaults to 1MB when no config is provided", async () => {
     const resolved = await resolveNextConfig(null);
@@ -1862,6 +1886,7 @@ describe("detectNextIntlConfig", () => {
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
       serverActionsBodySizeLimitLabel: "1 MB",
       htmlLimitedBots: undefined,
+      transpilePackages: [],
       serverExternalPackages: [],
       cacheHandler: undefined,
       cacheMaxMemorySize: undefined,

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1396,6 +1396,23 @@ describe("resolveNextConfig transpilePackages", () => {
   });
 });
 
+describe("resolveNextConfig Pages dependency bundling", () => {
+  it("defaults to ESM externalization without dependency bundling", async () => {
+    const resolved = await resolveNextConfig(null);
+    expect(resolved.esmExternals).toBe(true);
+    expect(resolved.bundlePagesRouterDependencies).toBe(false);
+  });
+
+  it("preserves explicit Pages dependency bundling flags", async () => {
+    const resolved = await resolveNextConfig({
+      bundlePagesRouterDependencies: true,
+      experimental: { esmExternals: false },
+    });
+    expect(resolved.esmExternals).toBe(false);
+    expect(resolved.bundlePagesRouterDependencies).toBe(true);
+  });
+});
+
 describe("resolveNextConfig serverActionsBodySizeLimit", () => {
   it("defaults to 1MB when no config is provided", async () => {
     const resolved = await resolveNextConfig(null);
@@ -1886,6 +1903,8 @@ describe("detectNextIntlConfig", () => {
       serverActionsBodySizeLimit: 1 * 1024 * 1024,
       serverActionsBodySizeLimitLabel: "1 MB",
       htmlLimitedBots: undefined,
+      esmExternals: true,
+      bundlePagesRouterDependencies: false,
       transpilePackages: [],
       serverExternalPackages: [],
       cacheHandler: undefined,


### PR DESCRIPTION
## Summary
- externalize native-loadable ESM dependencies in Pages production builds
- preserve nested package ownership and import/require condition semantics
- honor Next.js Pages bundling controls and transpile precedence

## Validation
- `vp test run tests/esm-externals.test.ts tests/next-config.test.ts` — 214 passed
- scoped `vp check` and `git diff --check`
- independent cumulative review: clean

## Next.js parity
Targets the failures in `test/e2e/esm-externals/esm-externals.test.ts` from deploy-suite run 27858251903. Investigation and reproduction used vinext-owned fixtures; no raw Next.js E2E was run locally.
