### PR TITLE
fix(router): refresh shallow rewrite query state

### DIFF
--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
@@ -33,6 +33,12 @@ import type {
 
 export type HybridClientOwner = "app" | "document" | "pages";
 
+export type PagesClientRouteResolution = {
+  href: string;
+  params: Record<string, string | string[]>;
+  pattern: string;
+};
+
 declare global {
   // oxlint-disable-next-line typescript-eslint/consistent-type-definitions
   interface Window {
@@ -133,16 +139,20 @@ function matchPagesRoute(
   href: string,
   basePath: string,
   routes: readonly VinextPagesLinkPrefetchRoute[],
-): VinextPagesLinkPrefetchRoute | null {
+): { params: Record<string, string | string[]>; route: VinextPagesLinkPrefetchRoute } | null {
   const pathname = resolveSameOriginPathname(href, basePath);
   if (pathname === null) return null;
-  return (
-    matchRouteWithTrie(pathname, routes as VinextPagesLinkPrefetchRoute[], pagesRouteTrieCache)
-      ?.route ?? null
+  return matchRouteWithTrie(
+    pathname,
+    routes as VinextPagesLinkPrefetchRoute[],
+    pagesRouteTrieCache,
   );
 }
 
-export function resolvePagesClientRoutePattern(href: string, basePath: string): string | null {
+export function resolvePagesClientRoute(
+  href: string,
+  basePath: string,
+): PagesClientRouteResolution | null {
   if (typeof window === "undefined") return null;
 
   const pagesRoutes = window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__;
@@ -157,7 +167,7 @@ export function resolvePagesClientRoutePattern(href: string, basePath: string): 
 
   let pagesMatch = matchPagesRoute(href, basePath, pagesRoutes);
 
-  if (rewrites && (pagesMatch === null || pagesMatch.isDynamic)) {
+  if (rewrites && (pagesMatch === null || pagesMatch.route.isDynamic)) {
     for (const rewrite of rewrites.afterFiles) {
       const afterFilesRewrite = resolveClientRewrite(href, basePath, [rewrite]);
       if (afterFilesRewrite?.kind === "document") return null;
@@ -179,7 +189,13 @@ export function resolvePagesClientRoutePattern(href: string, basePath: string): 
     }
   }
 
-  return pagesMatch ? patternFromParts(pagesMatch.patternParts) : null;
+  return pagesMatch
+    ? {
+        href,
+        params: pagesMatch.params,
+        pattern: patternFromParts(pagesMatch.route.patternParts),
+      }
+    : null;
 }
 
 /**
@@ -211,7 +227,9 @@ export function resolveHybridClientRouteOwner(
   }
 
   let appMatch = appRoutes ? matchAppRoute(href, basePath, appRoutes) : null;
-  let pagesMatch = pagesRoutes ? matchPagesRoute(href, basePath, pagesRoutes) : null;
+  let pagesMatch = pagesRoutes
+    ? (matchPagesRoute(href, basePath, pagesRoutes)?.route ?? null)
+    : null;
 
   if (
     rewrites &&
@@ -224,7 +242,9 @@ export function resolveHybridClientRouteOwner(
       if (afterFilesRewrite?.kind !== "rewrite") continue;
       href = afterFilesRewrite.href;
       appMatch = appRoutes ? matchAppRoute(href, basePath, appRoutes) : null;
-      pagesMatch = pagesRoutes ? matchPagesRoute(href, basePath, pagesRoutes) : null;
+      pagesMatch = pagesRoutes
+        ? (matchPagesRoute(href, basePath, pagesRoutes)?.route ?? null)
+        : null;
       if (appMatch || pagesMatch) break;
     }
   }
@@ -236,7 +256,9 @@ export function resolveHybridClientRouteOwner(
       if (fallbackRewrite?.kind !== "rewrite") continue;
       href = fallbackRewrite.href;
       appMatch = appRoutes ? matchAppRoute(href, basePath, appRoutes) : null;
-      pagesMatch = pagesRoutes ? matchPagesRoute(href, basePath, pagesRoutes) : null;
+      pagesMatch = pagesRoutes
+        ? (matchPagesRoute(href, basePath, pagesRoutes)?.route ?? null)
+        : null;
       if (appMatch || pagesMatch) break;
     }
   }

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
@@ -142,6 +142,46 @@ function matchPagesRoute(
   );
 }
 
+export function resolvePagesClientRoutePattern(href: string, basePath: string): string | null {
+  if (typeof window === "undefined") return null;
+
+  const pagesRoutes = window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__;
+  if (!pagesRoutes) return null;
+  const rewrites = window.__VINEXT_CLIENT_REWRITES__;
+
+  if (rewrites) {
+    const beforeFilesRewrite = resolveClientRewrite(href, basePath, rewrites.beforeFiles, true);
+    if (beforeFilesRewrite?.kind === "document") return null;
+    if (beforeFilesRewrite?.kind === "rewrite") href = beforeFilesRewrite.href;
+  }
+
+  let pagesMatch = matchPagesRoute(href, basePath, pagesRoutes);
+
+  if (rewrites && (pagesMatch === null || pagesMatch.isDynamic)) {
+    for (const rewrite of rewrites.afterFiles) {
+      const afterFilesRewrite = resolveClientRewrite(href, basePath, [rewrite]);
+      if (afterFilesRewrite?.kind === "document") return null;
+      if (afterFilesRewrite?.kind !== "rewrite") continue;
+      href = afterFilesRewrite.href;
+      pagesMatch = matchPagesRoute(href, basePath, pagesRoutes);
+      if (pagesMatch) break;
+    }
+  }
+
+  if (rewrites && pagesMatch === null) {
+    for (const rewrite of rewrites.fallback) {
+      const fallbackRewrite = resolveClientRewrite(href, basePath, [rewrite]);
+      if (fallbackRewrite?.kind === "document") return null;
+      if (fallbackRewrite?.kind !== "rewrite") continue;
+      href = fallbackRewrite.href;
+      pagesMatch = matchPagesRoute(href, basePath, pagesRoutes);
+      if (pagesMatch) break;
+    }
+  }
+
+  return pagesMatch ? patternFromParts(pagesMatch.patternParts) : null;
+}
+
 /**
  * Decide which router should own a soft-navigated URL. Returns:
  *   - "app"    → the App Router runtime handles the navigation (RSC fetch).

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
@@ -25,7 +25,11 @@ import {
 import type { NextRewrite } from "../../config/next-config.js";
 import { stripBasePath } from "../../utils/base-path.js";
 import { getLocalePathPrefix } from "../../utils/domain-locale.js";
-import { mergeRewriteQuery } from "../../utils/query.js";
+import {
+  mergeRewriteQuery,
+  mergeRouteParamsIntoQuery,
+  parseQueryString,
+} from "../../utils/query.js";
 import type {
   VinextLinkPrefetchRoute,
   VinextPagesLinkPrefetchRoute,
@@ -37,6 +41,7 @@ export type PagesClientRouteResolution = {
   href: string;
   params: Record<string, string | string[]>;
   pattern: string;
+  query: Record<string, string | string[]>;
 };
 
 declare global {
@@ -194,6 +199,7 @@ export function resolvePagesClientRoute(
         href,
         params: pagesMatch.params,
         pattern: patternFromParts(pagesMatch.route.patternParts),
+        query: mergeRouteParamsIntoQuery(parseQueryString(href), pagesMatch.params),
       }
     : null;
 }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2574,9 +2574,7 @@ async function performNavigation(
   const htmlFetchUrl =
     errorRouteHtmlFetchUrl ?? getPagesHtmlFetchUrl(fullRouteUrl, navigationLocale);
   const requestedShallow = options?.shallow === true;
-  const shallow =
-    requestedShallow &&
-    (hasVinextMiddleware(window.__NEXT_DATA__) || isSamePagesRoute(interpolatedRoute));
+  const shallow = requestedShallow && isSamePagesRoute(interpolatedRoute);
   const hashOnly = options?._h !== 1 && interpolatedRoute === resolved && isHashOnlyChange(full);
   const doScroll = options?.scroll ?? (hashOnly || !shallow);
   const hash = extractHash(resolved);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -37,7 +37,10 @@ import {
   getPagesRouterComponentsMap,
   markAppRouteDetectedOnPrefetch,
 } from "./internal/app-route-detection.js";
-import { resolveHybridClientRouteOwner } from "./internal/hybrid-client-route-owner.js";
+import {
+  resolveHybridClientRouteOwner,
+  resolvePagesClientRoutePattern,
+} from "./internal/hybrid-client-route-owner.js";
 import { dedupedPagesDataFetch } from "./internal/pages-data-fetch-dedup.js";
 import { installWindowNext, type PagesRouterPublicInstance } from "../client/window-next.js";
 import { isUnknownRecord } from "../utils/record.js";
@@ -414,7 +417,6 @@ type PagesRouterRuntimeState = {
   activeNavigation: {
     id: number;
     eventUrl: string;
-    shallow: boolean;
     cancellationEventEmitted: boolean;
   } | null;
   cancelPendingRenderCommit: (() => void) | null;
@@ -635,20 +637,21 @@ function getLocalPathname(url: string): string | null {
 }
 
 function isSamePagesRoute(destinationUrl: string): boolean {
-  const destinationPathname = getLocalPathname(destinationUrl);
   const currentRoute = window.__NEXT_DATA__?.page;
-  if (!destinationPathname || !currentRoute) return false;
-
-  const locales = window.__VINEXT_LOCALES__;
-  const stripLocale = (pathname: string): string => {
-    const locale = getLocalePathPrefix(pathname, locales);
-    if (!locale) return pathname;
-    return pathname.slice(locale.length + 1) || "/";
-  };
-  const normalizedDestinationPathname = stripLocale(destinationPathname);
-  const currentPathname = stripLocale(stripBasePath(window.location.pathname, __basePath));
-  if (normalizedDestinationPathname === currentPathname) return true;
-  return extractRouteParamsFromPath(currentRoute, normalizedDestinationPathname) !== null;
+  if (!currentRoute) return false;
+  if (!window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__) {
+    const destinationPathname = getLocalPathname(destinationUrl);
+    if (!destinationPathname) return false;
+    const locale = getLocalePathPrefix(destinationPathname, window.__VINEXT_LOCALES__);
+    const pathname = locale
+      ? destinationPathname.slice(locale.length + 1) || "/"
+      : destinationPathname;
+    return extractRouteParamsFromPath(currentRoute, pathname) !== null;
+  }
+  const destinationRoute = resolvePagesClientRoutePattern(destinationUrl, __basePath);
+  const currentPatternParts = routePatternParts(currentRoute);
+  const currentRoutePattern = `/${currentPatternParts.join("/")}`;
+  return destinationRoute === currentRoutePattern;
 }
 
 function resolvePagesErrorHtmlFetchUrl(
@@ -1460,15 +1463,13 @@ function cancelPreviousRenderCommit(): void {
   routerRuntimeState.cancelPendingRenderCommit = null;
 }
 
-function supersedePendingNavigation(): number {
+function supersedePendingNavigation(routeProps: { shallow: boolean } = { shallow: false }): number {
   const activeNavigation = routerRuntimeState.activeNavigation;
   if (activeNavigation && !activeNavigation.cancellationEventEmitted) {
     activeNavigation.cancellationEventEmitted = true;
     const error = new NavigationCancelledError(activeNavigation.eventUrl);
     error.cancellationEventEmitted = true;
-    routerEvents.emit("routeChangeError", error, activeNavigation.eventUrl, {
-      shallow: activeNavigation.shallow,
-    });
+    routerEvents.emit("routeChangeError", error, activeNavigation.eventUrl, routeProps);
   }
   const previousAbortController = routerRuntimeState.activeAbortController;
   if (previousAbortController) queueMicrotask(() => previousAbortController.abort());
@@ -2112,7 +2113,6 @@ async function navigateClient(
   const activeNavigation = {
     id: navId,
     eventUrl: options.eventUrl ?? url,
-    shallow: false,
     cancellationEventEmitted: false,
   };
   routerRuntimeState.activeNavigation = activeNavigation;
@@ -2646,7 +2646,7 @@ async function performNavigation(
     // Mirrors Next.js: packages/next/src/shared/lib/router/router.ts:1034-1046.
     if (mode === "push") saveScrollPosition();
     const eventUrl = resolveHashUrl(full);
-    supersedePendingNavigation();
+    supersedePendingNavigation({ shallow });
     routerEvents.emit("hashChangeStart", eventUrl, { shallow });
     updateHistory(mode, resolved.startsWith("#") ? resolved : full, navState);
     if (doScroll) scrollToHashTarget(extractHash(resolved));
@@ -2686,7 +2686,7 @@ async function performNavigation(
 
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
-  if (shallow) supersedePendingNavigation();
+  if (shallow) supersedePendingNavigation({ shallow });
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
@@ -2704,7 +2704,7 @@ async function performNavigation(
       // for the dominant case.
       fullRouteUrl,
     );
-    if (result === "cancelled") return true;
+    if (result === "cancelled") return false;
     if (result === "failed") return false;
   } else {
     // Shallow navigations skip the render-commit path, so apply the scroll
@@ -3044,7 +3044,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   }
   routerRuntimeState.lastPathnameAndSearch = browserUrl;
 
-  const navigationId = supersedePendingNavigation();
+  const navigationId = supersedePendingNavigation({ shallow });
 
   if (isHashOnly) {
     // Hash-only back/forward — no page fetch needed.

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -426,7 +426,7 @@ type PagesRouterRuntimeState = {
   isFirstPopStateEvent: boolean;
   routerDidNavigate: boolean;
   currentShallow: boolean;
-  currentShallowRouteParams: Record<string, string | string[]> | null;
+  currentShallowQuery: Record<string, string | string[]> | null;
   deprecatedEventBridgeInstalled: boolean;
   pagesRouterReady: boolean;
   publicRouter?: Record<string, unknown>;
@@ -462,7 +462,7 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
     isFirstPopStateEvent: true,
     routerDidNavigate: false,
     currentShallow: false,
-    currentShallowRouteParams: null,
+    currentShallowQuery: null,
     deprecatedEventBridgeInstalled: false,
     pagesRouterReady: typeof window === "undefined" || !shouldDeferInitialPagesRouterReady(),
   };
@@ -661,7 +661,14 @@ function resolveSamePagesRoute(destinationUrl: string): PagesClientRouteResoluti
       pathname === currentPathname
         ? (extractRouteParamsFromPath(currentRoute, pathname) ?? {})
         : extractRouteParamsFromPath(currentRoute, pathname);
-    return params === null ? null : { href: destinationUrl, params, pattern: currentRoute };
+    return params === null
+      ? null
+      : {
+          href: destinationUrl,
+          params,
+          pattern: currentRoute,
+          query: mergeRouteParamsIntoQuery(parseQueryString(destinationUrl), params),
+        };
   }
   const destinationRoute = resolvePagesClientRoute(destinationUrl, __basePath);
   const currentPatternParts = routePatternParts(currentRoute);
@@ -860,7 +867,7 @@ function stampInitialHistoryState(): void {
   const existingKey = getRouterStateKey(existingState);
   if (existingKey !== undefined) initialState.key = existingKey;
   routerRuntimeState.currentShallow = false;
-  routerRuntimeState.currentShallowRouteParams = null;
+  routerRuntimeState.currentShallowQuery = null;
   routerRuntimeState.currentHistoryKey = initialState.key;
   window.history.replaceState(initialState, "");
 }
@@ -1306,12 +1313,12 @@ function getPathnameAndQuery(): {
     addQueryParam(searchQuery, key, value);
   }
   const isShallowNavigation = routerRuntimeState.currentShallow;
-  const query = isShallowNavigation ? { ...searchQuery } : { ...searchQuery, ...routeQuery };
+  const query = isShallowNavigation
+    ? { ...searchQuery, ...routerRuntimeState.currentShallowQuery }
+    : { ...searchQuery, ...routeQuery };
   if (isShallowNavigation) {
     for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
-      const routeParam =
-        routerRuntimeState.currentShallowRouteParams?.[routeParamName] ??
-        routeQuery[routeParamName];
+      const routeParam = query[routeParamName] ?? routeQuery[routeParamName];
       if (routeParam !== undefined) query[routeParamName] = routeParam;
     }
   }
@@ -2375,7 +2382,7 @@ function updateHistory(
     url: string;
     as: string;
     options: { locale?: string; shallow?: boolean };
-    routeParams?: Record<string, string | string[]>;
+    query?: Record<string, string | string[]>;
   },
 ): void {
   const previousKey = getRouterStateKey(window.history.state);
@@ -2392,7 +2399,7 @@ function updateHistory(
   };
   if (navState.options.shallow === true && window.__NEXT_DATA__?.page) {
     state.__vinext_route = window.__NEXT_DATA__.page;
-    state.__vinext_params = navState.routeParams;
+    state.__vinext_query = navState.query;
   }
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
@@ -2412,7 +2419,7 @@ type VinextHistoryState = {
   options: { locale?: string; shallow?: boolean };
   __N: true;
   key: string;
-  __vinext_params?: Record<string, string | string[]>;
+  __vinext_query?: Record<string, string | string[]>;
   __vinext_route?: string;
 };
 
@@ -2669,7 +2676,7 @@ async function performNavigation(
     url: resolvedRouteNoHash,
     as: resolvedNoHash,
     options: navStateOptions,
-    routeParams: shallowRoute?.params,
+    query: shallowRoute?.query,
   };
 
   // Hash-only change — no page fetch needed.
@@ -2731,7 +2738,7 @@ async function performNavigation(
   const pendingNavigation = shallow
     ? (supersedePendingNavigation({ shallow }), undefined)
     : beginPendingNavigation(resolved, { shallow });
-  routerRuntimeState.currentShallowRouteParams = shallowRoute?.params ?? null;
+  routerRuntimeState.currentShallowQuery = shallowRoute?.query ?? null;
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
@@ -2949,7 +2956,7 @@ function isNextRouterState(state: unknown): state is {
   options: TransitionOptions;
   __N: true;
   key?: string;
-  __vinext_params?: Record<string, string | string[]>;
+  __vinext_query?: Record<string, string | string[]>;
   __vinext_route?: string;
 } {
   return (
@@ -3080,8 +3087,8 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     state.__vinext_route === window.__NEXT_DATA__?.page &&
     routerRuntimeState.currentShallow;
   routerRuntimeState.currentShallow = shallow;
-  routerRuntimeState.currentShallowRouteParams =
-    shallow && isNextRouterState(state) ? (state.__vinext_params ?? null) : null;
+  routerRuntimeState.currentShallowQuery =
+    shallow && isNextRouterState(state) ? (state.__vinext_query ?? null) : null;
 
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1435,6 +1435,14 @@ function cancelPreviousRenderCommit(): void {
   routerRuntimeState.cancelPendingRenderCommit = null;
 }
 
+function supersedePendingNavigation(): number {
+  const previousAbortController = routerRuntimeState.activeAbortController;
+  if (previousAbortController) queueMicrotask(() => previousAbortController.abort());
+  cancelPreviousRenderCommit();
+  routerRuntimeState.activeAbortController = null;
+  return ++routerRuntimeState.navigationId;
+}
+
 function scheduleHardNavigationAndThrow(url: string, message: string): never {
   if (typeof window === "undefined") {
     throw new HardNavigationScheduledError(message);
@@ -2062,17 +2070,9 @@ async function navigateClient(
 ): Promise<void> {
   if (typeof window === "undefined") return;
 
-  // Supersede the prior navigation immediately via navigationId below, but
-  // defer its AbortSignal by one microtask. A synchronous identical push can
-  // then join the shared _next/data fetch before the prior waiter releases;
-  // different destinations still abort the abandoned request in this turn.
-  const previousAbortController = routerRuntimeState.activeAbortController;
-  if (previousAbortController) queueMicrotask(() => previousAbortController.abort());
-  cancelPreviousRenderCommit();
   const controller = new AbortController();
+  const navId = supersedePendingNavigation();
   routerRuntimeState.activeAbortController = controller;
-
-  const navId = ++routerRuntimeState.navigationId;
 
   /** Check if this navigation is still the active one. If not, throw. */
   function assertStillCurrent(): void {
@@ -2304,6 +2304,9 @@ function updateHistory(
     __N: true,
     key,
   };
+  if (navState.options.shallow === true && window.__NEXT_DATA__?.page) {
+    state.__vinext_route = window.__NEXT_DATA__.page;
+  }
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
   routerRuntimeState.currentShallow = navState.options.shallow === true;
@@ -2322,6 +2325,7 @@ type VinextHistoryState = {
   options: { locale?: string; shallow?: boolean };
   __N: true;
   key: string;
+  __vinext_route?: string;
 };
 
 function createHistoryKey(): string {
@@ -2591,6 +2595,7 @@ async function performNavigation(
     const eventUrl = resolveHashUrl(full);
     routerEvents.emit("hashChangeStart", eventUrl, { shallow });
     updateHistory(mode, resolved.startsWith("#") ? resolved : full, navState);
+    supersedePendingNavigation();
     if (doScroll) scrollToHashTarget(extractHash(resolved));
     onStateUpdate?.();
     routerEvents.emit("hashChangeComplete", eventUrl, { shallow });
@@ -2648,6 +2653,7 @@ async function performNavigation(
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {
+    supersedePendingNavigation();
     // Shallow navigations skip the render-commit path, so apply the scroll
     // reset synchronously here — before routeChangeComplete. This matches the
     // non-shallow path, where the x/y reset runs inside the render-commit
@@ -2844,6 +2850,7 @@ function isNextRouterState(state: unknown): state is {
   options: TransitionOptions;
   __N: true;
   key?: string;
+  __vinext_route?: string;
 } {
   return (
     typeof state === "object" &&
@@ -2970,6 +2977,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   const shallow =
     isNextRouterState(state) &&
     state.options?.shallow === true &&
+    state.__vinext_route === window.__NEXT_DATA__?.page &&
     routerRuntimeState.currentShallow;
   routerRuntimeState.currentShallow = shallow;
 
@@ -2984,6 +2992,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   routerRuntimeState.lastPathnameAndSearch = browserUrl;
 
   if (isHashOnly) {
+    supersedePendingNavigation();
     // Hash-only back/forward — no page fetch needed.
     //
     // `forcedScroll` is intentionally discarded here: only the hash anchor is
@@ -3018,14 +3027,14 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // compatibility.
   routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow });
   if (shallow) {
+    const navigationId = supersedePendingNavigation();
     if (forcedScroll === undefined) {
       routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: true });
       dispatchNavigateEvent();
       return;
     }
     void (async () => {
-      const isCurrent = () =>
-        targetKey === undefined || routerRuntimeState.currentHistoryKey === targetKey;
+      const isCurrent = () => navigationId === routerRuntimeState.navigationId;
       await restorePagesRouterScrollPosition(forcedScroll, isCurrent);
       if (!isCurrent()) return;
       routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: true });

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -39,7 +39,8 @@ import {
 } from "./internal/app-route-detection.js";
 import {
   resolveHybridClientRouteOwner,
-  resolvePagesClientRoutePattern,
+  resolvePagesClientRoute,
+  type PagesClientRouteResolution,
 } from "./internal/hybrid-client-route-owner.js";
 import { dedupedPagesDataFetch } from "./internal/pages-data-fetch-dedup.js";
 import { installWindowNext, type PagesRouterPublicInstance } from "../client/window-next.js";
@@ -425,6 +426,7 @@ type PagesRouterRuntimeState = {
   isFirstPopStateEvent: boolean;
   routerDidNavigate: boolean;
   currentShallow: boolean;
+  currentShallowRouteParams: Record<string, string | string[]> | null;
   deprecatedEventBridgeInstalled: boolean;
   pagesRouterReady: boolean;
   publicRouter?: Record<string, unknown>;
@@ -460,6 +462,7 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
     isFirstPopStateEvent: true,
     routerDidNavigate: false,
     currentShallow: false,
+    currentShallowRouteParams: null,
     deprecatedEventBridgeInstalled: false,
     pagesRouterReady: typeof window === "undefined" || !shouldDeferInitialPagesRouterReady(),
   };
@@ -642,25 +645,28 @@ function getLocalPathname(url: string): string | null {
   }
 }
 
-function isSamePagesRoute(destinationUrl: string): boolean {
+function resolveSamePagesRoute(destinationUrl: string): PagesClientRouteResolution | null {
   const currentRoute = window.__NEXT_DATA__?.page;
-  if (!currentRoute) return false;
+  if (!currentRoute) return null;
   if (!window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__) {
     const destinationPathname = getLocalPathname(destinationUrl);
-    if (!destinationPathname) return false;
+    if (!destinationPathname) return null;
     const stripLocale = (pathname: string): string => {
       const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
       return locale ? pathname.slice(locale.length + 1) || "/" : pathname;
     };
     const pathname = stripLocale(destinationPathname);
     const currentPathname = stripLocale(stripBasePath(window.location.pathname, __basePath));
-    if (pathname === currentPathname) return true;
-    return extractRouteParamsFromPath(currentRoute, pathname) !== null;
+    const params =
+      pathname === currentPathname
+        ? (extractRouteParamsFromPath(currentRoute, pathname) ?? {})
+        : extractRouteParamsFromPath(currentRoute, pathname);
+    return params === null ? null : { href: destinationUrl, params, pattern: currentRoute };
   }
-  const destinationRoute = resolvePagesClientRoutePattern(destinationUrl, __basePath);
+  const destinationRoute = resolvePagesClientRoute(destinationUrl, __basePath);
   const currentPatternParts = routePatternParts(currentRoute);
   const currentRoutePattern = `/${currentPatternParts.join("/")}`;
-  return destinationRoute === currentRoutePattern;
+  return destinationRoute?.pattern === currentRoutePattern ? destinationRoute : null;
 }
 
 function resolvePagesErrorHtmlFetchUrl(
@@ -854,6 +860,7 @@ function stampInitialHistoryState(): void {
   const existingKey = getRouterStateKey(existingState);
   if (existingKey !== undefined) initialState.key = existingKey;
   routerRuntimeState.currentShallow = false;
+  routerRuntimeState.currentShallowRouteParams = null;
   routerRuntimeState.currentHistoryKey = initialState.key;
   window.history.replaceState(initialState, "");
 }
@@ -1302,7 +1309,9 @@ function getPathnameAndQuery(): {
   const query = isShallowNavigation ? { ...searchQuery } : { ...searchQuery, ...routeQuery };
   if (isShallowNavigation) {
     for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
-      const routeParam = routeQuery[routeParamName];
+      const routeParam =
+        routerRuntimeState.currentShallowRouteParams?.[routeParamName] ??
+        routeQuery[routeParamName];
       if (routeParam !== undefined) query[routeParamName] = routeParam;
     }
   }
@@ -2362,7 +2371,12 @@ function dispatchNavigateEvent(): void {
 function updateHistory(
   mode: "push" | "replace",
   fullUrl: string,
-  navState: { url: string; as: string; options: { locale?: string; shallow?: boolean } },
+  navState: {
+    url: string;
+    as: string;
+    options: { locale?: string; shallow?: boolean };
+    routeParams?: Record<string, string | string[]>;
+  },
 ): void {
   const previousKey = getRouterStateKey(window.history.state);
   const key =
@@ -2378,6 +2392,7 @@ function updateHistory(
   };
   if (navState.options.shallow === true && window.__NEXT_DATA__?.page) {
     state.__vinext_route = window.__NEXT_DATA__.page;
+    state.__vinext_params = navState.routeParams;
   }
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
@@ -2397,6 +2412,7 @@ type VinextHistoryState = {
   options: { locale?: string; shallow?: boolean };
   __N: true;
   key: string;
+  __vinext_params?: Record<string, string | string[]>;
   __vinext_route?: string;
 };
 
@@ -2507,6 +2523,7 @@ async function performNavigation(
   if (isExternalUrl(resolved)) {
     const localPath = toSameOriginAppPath(resolved, __basePath);
     if (localPath == null) {
+      supersedePendingNavigation({ shallow: false });
       if (mode === "push") window.location.assign(resolved);
       else window.location.replace(resolved);
       return true;
@@ -2596,7 +2613,8 @@ async function performNavigation(
     errorRouteHtmlFetchUrl ?? getPagesHtmlFetchUrl(fullRouteUrl, navigationLocale);
   const requestedShallow = options?.shallow === true;
   const routeIdentityUrl = withBasePath(interpolatedRoute, __basePath);
-  const shallow = requestedShallow && isSamePagesRoute(routeIdentityUrl);
+  const shallowRoute = requestedShallow ? resolveSamePagesRoute(routeIdentityUrl) : null;
+  const shallow = shallowRoute !== null;
   const hashOnly = options?._h !== 1 && interpolatedRoute === resolved && isHashOnlyChange(full);
   const doScroll = options?.scroll ?? (hashOnly || !shallow);
   const hash = extractHash(resolved);
@@ -2651,6 +2669,7 @@ async function performNavigation(
     url: resolvedRouteNoHash,
     as: resolvedNoHash,
     options: navStateOptions,
+    routeParams: shallowRoute?.params,
   };
 
   // Hash-only change — no page fetch needed.
@@ -2701,6 +2720,7 @@ async function performNavigation(
     (appPathEntry !== undefined && "__appRouter" in appPathEntry && appPathEntry.__appRouter) ||
     ["app", "document"].includes(resolveHybridClientRouteOwner(resolved, __basePath) ?? "");
   if (appRouteDetected) {
+    supersedePendingNavigation({ shallow: false });
     if (mode === "push") window.location.assign(full);
     else window.location.replace(full);
     return new Promise<boolean>(() => {});
@@ -2711,6 +2731,7 @@ async function performNavigation(
   const pendingNavigation = shallow
     ? (supersedePendingNavigation({ shallow }), undefined)
     : beginPendingNavigation(resolved, { shallow });
+  routerRuntimeState.currentShallowRouteParams = shallowRoute?.params ?? null;
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
@@ -2928,6 +2949,7 @@ function isNextRouterState(state: unknown): state is {
   options: TransitionOptions;
   __N: true;
   key?: string;
+  __vinext_params?: Record<string, string | string[]>;
   __vinext_route?: string;
 } {
   return (
@@ -3058,6 +3080,8 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     state.__vinext_route === window.__NEXT_DATA__?.page &&
     routerRuntimeState.currentShallow;
   routerRuntimeState.currentShallow = shallow;
+  routerRuntimeState.currentShallowRouteParams =
+    shallow && isNextRouterState(state) ? (state.__vinext_params ?? null) : null;
 
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1263,10 +1263,13 @@ function getPathnameAndQuery(): {
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
-  const query = { ...searchQuery };
-  for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
-    const routeParam = routeQuery[routeParamName];
-    if (routeParam !== undefined) query[routeParamName] = routeParam;
+  const isShallowNavigation = window.history?.state?.options?.shallow === true;
+  const query = isShallowNavigation ? { ...searchQuery } : { ...searchQuery, ...routeQuery };
+  if (isShallowNavigation) {
+    for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
+      const routeParam = routeQuery[routeParamName];
+      if (routeParam !== undefined) query[routeParamName] = routeParam;
+    }
   }
   // asPath uses the resolved browser path, not the route pattern
   const asPath =

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -3018,8 +3018,19 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // compatibility.
   routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow });
   if (shallow) {
-    routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: true });
-    dispatchNavigateEvent();
+    if (forcedScroll === undefined) {
+      routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: true });
+      dispatchNavigateEvent();
+      return;
+    }
+    void (async () => {
+      const isCurrent = () =>
+        targetKey === undefined || routerRuntimeState.currentHistoryKey === targetKey;
+      await restorePagesRouterScrollPosition(forcedScroll, isCurrent);
+      if (!isCurrent()) return;
+      routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: true });
+      dispatchNavigateEvent();
+    })();
     return;
   }
   void (async () => {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1320,7 +1320,11 @@ function getPathnameAndQuery(): {
     : { ...searchQuery, ...routeQuery };
   if (isShallowNavigation) {
     for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
-      const routeParam = query[routeParamName] ?? routeQuery[routeParamName];
+      const routeParam = Object.hasOwn(query, routeParamName)
+        ? query[routeParamName]
+        : Object.hasOwn(routeQuery, routeParamName)
+          ? routeQuery[routeParamName]
+          : undefined;
       if (routeParam !== undefined) setQueryValue(query, routeParamName, routeParam);
     }
   }
@@ -3083,7 +3087,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     state.options?.shallow === true &&
     routerRuntimeState.currentShallow &&
     withBasePath(state.as, __basePath) === browserUrl
-      ? resolveSamePagesRoute(browserUrl)
+      ? resolveSamePagesRoute(withBasePath(state.url, __basePath))
       : null;
   const shallow = restoredShallowRoute !== null;
   routerRuntimeState.currentShallow = shallow;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1263,7 +1263,7 @@ function getPathnameAndQuery(): {
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
-  const query = { ...routeQuery, ...searchQuery };
+  const query = { ...searchQuery };
   for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
     const routeParam = routeQuery[routeParamName];
     if (routeParam !== undefined) query[routeParamName] = routeParam;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -430,6 +430,12 @@ type PagesRouterRuntimeState = {
   publicRouter?: Record<string, unknown>;
 };
 
+type PendingNavigation = {
+  activeNavigation: NonNullable<PagesRouterRuntimeState["activeNavigation"]>;
+  controller: AbortController;
+  navigationId: number;
+};
+
 type PagesRouterRuntimeComponents = {
   CommitBoundary: ComponentType<{
     children?: ReactNode;
@@ -642,10 +648,13 @@ function isSamePagesRoute(destinationUrl: string): boolean {
   if (!window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__) {
     const destinationPathname = getLocalPathname(destinationUrl);
     if (!destinationPathname) return false;
-    const locale = getLocalePathPrefix(destinationPathname, window.__VINEXT_LOCALES__);
-    const pathname = locale
-      ? destinationPathname.slice(locale.length + 1) || "/"
-      : destinationPathname;
+    const stripLocale = (pathname: string): string => {
+      const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
+      return locale ? pathname.slice(locale.length + 1) || "/" : pathname;
+    };
+    const pathname = stripLocale(destinationPathname);
+    const currentPathname = stripLocale(stripBasePath(window.location.pathname, __basePath));
+    if (pathname === currentPathname) return true;
     return extractRouteParamsFromPath(currentRoute, pathname) !== null;
   }
   const destinationRoute = resolvePagesClientRoutePattern(destinationUrl, __basePath);
@@ -1479,6 +1488,22 @@ function supersedePendingNavigation(routeProps: { shallow: boolean } = { shallow
   return ++routerRuntimeState.navigationId;
 }
 
+function beginPendingNavigation(
+  eventUrl: string,
+  routeProps: { shallow: boolean },
+): PendingNavigation {
+  const navigationId = supersedePendingNavigation(routeProps);
+  const controller = new AbortController();
+  const activeNavigation = {
+    id: navigationId,
+    eventUrl,
+    cancellationEventEmitted: false,
+  };
+  routerRuntimeState.activeAbortController = controller;
+  routerRuntimeState.activeNavigation = activeNavigation;
+  return { activeNavigation, controller, navigationId };
+}
+
 function scheduleHardNavigationAndThrow(url: string, message: string): never {
   if (typeof window === "undefined") {
     throw new HardNavigationScheduledError(message);
@@ -2104,18 +2129,13 @@ async function navigateClient(
    * (display) into the data fetch step.
    */
   routeUrl: string = url,
+  pendingNavigation?: PendingNavigation,
 ): Promise<void> {
   if (typeof window === "undefined") return;
 
-  const controller = new AbortController();
-  const navId = supersedePendingNavigation();
-  routerRuntimeState.activeAbortController = controller;
-  const activeNavigation = {
-    id: navId,
-    eventUrl: options.eventUrl ?? url,
-    cancellationEventEmitted: false,
-  };
-  routerRuntimeState.activeNavigation = activeNavigation;
+  const navigation =
+    pendingNavigation ?? beginPendingNavigation(options.eventUrl ?? url, { shallow: false });
+  const { activeNavigation, controller, navigationId: navId } = navigation;
 
   /** Check if this navigation is still the active one. If not, throw. */
   function assertStillCurrent(): void {
@@ -2229,9 +2249,10 @@ async function runNavigateClient(
    * Defaults to `fullUrl`, making this a no-op for callers without a mask.
    */
   routeUrl: string = fullUrl,
+  pendingNavigation?: PendingNavigation,
 ): Promise<"completed" | "cancelled" | "failed"> {
   try {
-    await navigateClient(fullUrl, fetchUrl, options, routeUrl);
+    await navigateClient(fullUrl, fetchUrl, options, routeUrl, pendingNavigation);
     return "completed";
   } catch (err: unknown) {
     if (!(err instanceof NavigationCancelledError && err.cancellationEventEmitted)) {
@@ -2574,7 +2595,8 @@ async function performNavigation(
   const htmlFetchUrl =
     errorRouteHtmlFetchUrl ?? getPagesHtmlFetchUrl(fullRouteUrl, navigationLocale);
   const requestedShallow = options?.shallow === true;
-  const shallow = requestedShallow && isSamePagesRoute(interpolatedRoute);
+  const routeIdentityUrl = withBasePath(interpolatedRoute, __basePath);
+  const shallow = requestedShallow && isSamePagesRoute(routeIdentityUrl);
   const hashOnly = options?._h !== 1 && interpolatedRoute === resolved && isHashOnlyChange(full);
   const doScroll = options?.scroll ?? (hashOnly || !shallow);
   const hash = extractHash(resolved);
@@ -2686,7 +2708,9 @@ async function performNavigation(
 
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
-  if (shallow) supersedePendingNavigation({ shallow });
+  const pendingNavigation = shallow
+    ? (supersedePendingNavigation({ shallow }), undefined)
+    : beginPendingNavigation(resolved, { shallow });
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
@@ -2703,6 +2727,7 @@ async function performNavigation(
       // fullRouteUrl === full when there is no mask, so this is a no-op
       // for the dominant case.
       fullRouteUrl,
+      pendingNavigation,
     );
     if (result === "cancelled") return false;
     if (result === "failed") return false;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -649,15 +649,32 @@ function getLocalPathname(url: string): string | null {
 function resolveSamePagesRoute(destinationUrl: string): PagesClientRouteResolution | null {
   const currentRoute = window.__NEXT_DATA__?.page;
   if (!currentRoute) return null;
-  if (!window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__) {
-    const destinationPathname = getLocalPathname(destinationUrl);
-    if (!destinationPathname) return null;
-    const stripLocale = (pathname: string): string => {
-      const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
-      return locale ? pathname.slice(locale.length + 1) || "/" : pathname;
+  const destinationPathname = getLocalPathname(destinationUrl);
+  if (!destinationPathname) return null;
+  const stripLocale = (pathname: string): string => {
+    const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
+    return locale ? pathname.slice(locale.length + 1) || "/" : pathname;
+  };
+  const pathname = stripLocale(destinationPathname);
+  const currentPathname = stripLocale(stripBasePath(window.location.pathname, __basePath));
+  const resolveVisiblePathFallback = (): PagesClientRouteResolution | null => {
+    if (pathname !== currentPathname) return null;
+    const params: Record<string, string | string[]> = {};
+    const nextDataQuery = window.__NEXT_DATA__?.query;
+    for (const paramName of extractRouteParamNames(currentRoute)) {
+      const value = nextDataQuery?.[paramName];
+      if (typeof value === "string" || Array.isArray(value)) {
+        setQueryValue(params, paramName, Array.isArray(value) ? [...value] : value);
+      }
+    }
+    return {
+      href: destinationUrl,
+      params,
+      pattern: currentRoute,
+      query: mergeRouteParamsIntoQuery(parseQueryString(destinationUrl), params),
     };
-    const pathname = stripLocale(destinationPathname);
-    const currentPathname = stripLocale(stripBasePath(window.location.pathname, __basePath));
+  };
+  if (!window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__) {
     const params =
       pathname === currentPathname
         ? (extractRouteParamsFromPath(currentRoute, pathname) ?? {})
@@ -674,7 +691,10 @@ function resolveSamePagesRoute(destinationUrl: string): PagesClientRouteResoluti
   const destinationRoute = resolvePagesClientRoute(destinationUrl, __basePath);
   const currentPatternParts = routePatternParts(currentRoute);
   const currentRoutePattern = `/${currentPatternParts.join("/")}`;
-  return destinationRoute?.pattern === currentRoutePattern ? destinationRoute : null;
+  if (destinationRoute?.pattern === currentRoutePattern) return destinationRoute;
+  return destinationRoute === null && hasVinextMiddleware(window.__NEXT_DATA__)
+    ? resolveVisiblePathFallback()
+    : null;
 }
 
 function resolvePagesErrorHtmlFetchUrl(
@@ -3086,6 +3106,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     isNextRouterState(state) &&
     state.options?.shallow === true &&
     routerRuntimeState.currentShallow &&
+    state.__vinext_route === window.__NEXT_DATA__?.page &&
     withBasePath(state.as, __basePath) === browserUrl
       ? resolveSamePagesRoute(withBasePath(state.url, __basePath))
       : null;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1263,7 +1263,11 @@ function getPathnameAndQuery(): {
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
-  const query = { ...searchQuery, ...routeQuery };
+  const query = { ...routeQuery, ...searchQuery };
+  for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
+    const routeParam = routeQuery[routeParamName];
+    if (routeParam !== undefined) query[routeParamName] = routeParam;
+  }
   // asPath uses the resolved browser path, not the route pattern
   const asPath =
     getCurrentHistoryAsPath() ?? resolvedPath + window.location.search + window.location.hash;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2965,11 +2965,13 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   }
 
   // Next.js only carries shallow mode across popstate when both the target
-  // entry and the current router transition are shallow. Vinext currently
-  // resolves every non-hash popstate through a fresh server navigation, so
-  // the resulting router state is always deep and must publish all server
-  // query metadata, even when the restored entry was originally shallow.
-  routerRuntimeState.currentShallow = false;
+  // entry and the current router transition are shallow. A persisted shallow
+  // target must not promote a deep traversal back to shallow mode.
+  const shallow =
+    isNextRouterState(state) &&
+    state.options?.shallow === true &&
+    routerRuntimeState.currentShallow;
+  routerRuntimeState.currentShallow = shallow;
 
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,
@@ -3008,13 +3010,18 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   const effectiveLocale = typeof stateLocale === "string" ? stateLocale : window.__VINEXT_LOCALE__;
 
   const fullAppUrl = appUrl + window.location.hash;
-  routerEvents.emit("routeChangeStart", fullAppUrl, { shallow: false });
+  routerEvents.emit("routeChangeStart", fullAppUrl, { shallow });
   // Note: The browser has already updated window.location by the time popstate
   // fires, so this is not truly "before" the URL change. In Next.js the popstate
   // handler calls replaceState to store history metadata — beforeHistoryChange
   // precedes that call, not the URL change itself. We emit it here for API
   // compatibility.
-  routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow: false });
+  routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow });
+  if (shallow) {
+    routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: true });
+    dispatchNavigateEvent();
+    return;
+  }
   void (async () => {
     // When manual scroll restoration is enabled we drive the position from the
     // sessionStorage snapshot keyed by history key. When it is disabled we

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -411,6 +411,12 @@ type PagesRouterRuntimeState = {
   historyKeyCounter: number;
   navigationId: number;
   activeAbortController: AbortController | null;
+  activeNavigation: {
+    id: number;
+    eventUrl: string;
+    shallow: boolean;
+    cancellationEventEmitted: boolean;
+  } | null;
   cancelPendingRenderCommit: (() => void) | null;
   beforePopStateCb?: BeforePopStateCallback;
   lastPathnameAndSearch: string;
@@ -439,6 +445,7 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
     historyKeyCounter: 0,
     navigationId: 0,
     activeAbortController: null,
+    activeNavigation: null,
     cancelPendingRenderCommit: null,
     lastPathnameAndSearch:
       typeof window !== "undefined" ? window.location.pathname + window.location.search : "",
@@ -627,6 +634,16 @@ function getLocalPathname(url: string): string | null {
   }
 }
 
+function isSamePagesRoute(destinationUrl: string): boolean {
+  const destinationPathname = getLocalPathname(destinationUrl);
+  const currentRoute = window.__NEXT_DATA__?.page;
+  if (!destinationPathname || !currentRoute) return false;
+
+  const currentPathname = stripBasePath(window.location.pathname, __basePath);
+  if (destinationPathname === currentPathname) return true;
+  return extractRouteParamsFromPath(currentRoute, destinationPathname) !== null;
+}
+
 function resolvePagesErrorHtmlFetchUrl(
   url: string | UrlObject,
   locale: string | undefined,
@@ -804,8 +821,8 @@ function buildInitialRouterState(): VinextHistoryState {
 }
 
 /**
- * Stamp the initial document entry with router-shaped state (only if no
- * state is present). Called once at runtime install so the entry has a
+ * Stamp the initial document entry with router-shaped state. Called once at
+ * runtime install so the entry has a
  * locale stamped before any push could overwrite the active locale global.
  */
 function stampInitialHistoryState(): void {
@@ -1412,6 +1429,7 @@ function notifyNextNavigationPagesContext(): void {
  */
 class NavigationCancelledError extends Error {
   cancelled = true;
+  cancellationEventEmitted = false;
   constructor(route: string) {
     super(`Abort fetching component for route: "${route}"`);
     this.name = "NavigationCancelledError";
@@ -1436,10 +1454,20 @@ function cancelPreviousRenderCommit(): void {
 }
 
 function supersedePendingNavigation(): number {
+  const activeNavigation = routerRuntimeState.activeNavigation;
+  if (activeNavigation && !activeNavigation.cancellationEventEmitted) {
+    activeNavigation.cancellationEventEmitted = true;
+    const error = new NavigationCancelledError(activeNavigation.eventUrl);
+    error.cancellationEventEmitted = true;
+    routerEvents.emit("routeChangeError", error, activeNavigation.eventUrl, {
+      shallow: activeNavigation.shallow,
+    });
+  }
   const previousAbortController = routerRuntimeState.activeAbortController;
   if (previousAbortController) queueMicrotask(() => previousAbortController.abort());
   cancelPreviousRenderCommit();
   routerRuntimeState.activeAbortController = null;
+  routerRuntimeState.activeNavigation = null;
   return ++routerRuntimeState.navigationId;
 }
 
@@ -1461,6 +1489,7 @@ type NavigateClientOptions = {
    */
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
+  eventUrl?: string;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -2073,6 +2102,13 @@ async function navigateClient(
   const controller = new AbortController();
   const navId = supersedePendingNavigation();
   routerRuntimeState.activeAbortController = controller;
+  const activeNavigation = {
+    id: navId,
+    eventUrl: options.eventUrl ?? url,
+    shallow: false,
+    cancellationEventEmitted: false,
+  };
+  routerRuntimeState.activeNavigation = activeNavigation;
 
   /** Check if this navigation is still the active one. If not, throw. */
   function assertStillCurrent(): void {
@@ -2148,10 +2184,16 @@ async function navigateClient(
         );
       }
     }
+  } catch (error: unknown) {
+    if (error instanceof NavigationCancelledError) {
+      error.cancellationEventEmitted = activeNavigation.cancellationEventEmitted;
+    }
+    throw error;
   } finally {
     // Clean up the abort controller if this navigation is still the active one
     if (navId === routerRuntimeState.navigationId) {
       routerRuntimeState.activeAbortController = null;
+      routerRuntimeState.activeNavigation = null;
     }
   }
 }
@@ -2185,7 +2227,9 @@ async function runNavigateClient(
     await navigateClient(fullUrl, fetchUrl, options, routeUrl);
     return "completed";
   } catch (err: unknown) {
-    routerEvents.emit("routeChangeError", err, resolvedUrl, { shallow: false });
+    if (!(err instanceof NavigationCancelledError && err.cancellationEventEmitted)) {
+      routerEvents.emit("routeChangeError", err, resolvedUrl, { shallow: false });
+    }
     if (err instanceof NavigationCancelledError) {
       return "cancelled";
     }
@@ -2522,8 +2566,8 @@ async function performNavigation(
   const errorRouteHtmlFetchUrl = resolvePagesErrorHtmlFetchUrl(url, navigationLocale);
   const htmlFetchUrl =
     errorRouteHtmlFetchUrl ?? getPagesHtmlFetchUrl(fullRouteUrl, navigationLocale);
-  const shallow = options?.shallow ?? false;
-  const doScroll = options?.scroll !== false;
+  const shallow = options?.shallow === true && isSamePagesRoute(interpolatedRoute);
+  const doScroll = options?.scroll ?? !shallow;
   const hash = extractHash(resolved);
   // Only pass {x, y} restoration through renderPagesRouterElement's commit
   // callback. Hash scrolling is deferred until after routeChangeComplete so
@@ -2531,8 +2575,8 @@ async function performNavigation(
   // scroll after completion.
   const scrollTarget = doScroll ? { x: 0, y: 0 } : null;
   const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
-    ? { allowNotFoundResponse: true, mode, scroll: scrollTarget }
-    : { mode, scroll: scrollTarget };
+    ? { allowNotFoundResponse: true, mode, scroll: scrollTarget, eventUrl: resolved }
+    : { mode, scroll: scrollTarget, eventUrl: resolved };
 
   // Next.js push→replace coercion (narrowed): when the display URL (asPath)
   // doesn't change AND the route URL DOES change AND the locale doesn't
@@ -2593,9 +2637,9 @@ async function performNavigation(
     // Mirrors Next.js: packages/next/src/shared/lib/router/router.ts:1034-1046.
     if (mode === "push") saveScrollPosition();
     const eventUrl = resolveHashUrl(full);
+    supersedePendingNavigation();
     routerEvents.emit("hashChangeStart", eventUrl, { shallow });
     updateHistory(mode, resolved.startsWith("#") ? resolved : full, navState);
-    supersedePendingNavigation();
     if (doScroll) scrollToHashTarget(extractHash(resolved));
     onStateUpdate?.();
     routerEvents.emit("hashChangeComplete", eventUrl, { shallow });
@@ -2633,6 +2677,7 @@ async function performNavigation(
 
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
+  if (shallow) supersedePendingNavigation();
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
@@ -2653,7 +2698,6 @@ async function performNavigation(
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {
-    supersedePendingNavigation();
     // Shallow navigations skip the render-commit path, so apply the scroll
     // reset synchronously here — before routeChangeComplete. This matches the
     // non-shallow path, where the x/y reset runs inside the render-commit
@@ -2991,8 +3035,9 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   }
   routerRuntimeState.lastPathnameAndSearch = browserUrl;
 
+  const navigationId = supersedePendingNavigation();
+
   if (isHashOnly) {
-    supersedePendingNavigation();
     // Hash-only back/forward — no page fetch needed.
     //
     // `forcedScroll` is intentionally discarded here: only the hash anchor is
@@ -3005,9 +3050,9 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     // L1381-1403 and L1780). The snapshot stays in sessionStorage, so a later
     // non-hash popstate to this entry still restores the saved position.
     const hashUrl = appUrl + window.location.hash;
-    routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
+    routerEvents.emit("hashChangeStart", hashUrl, { shallow });
     scrollToHashTarget(window.location.hash);
-    routerEvents.emit("hashChangeComplete", hashUrl, { shallow: false });
+    routerEvents.emit("hashChangeComplete", hashUrl, { shallow });
     dispatchNavigateEvent();
     return;
   }
@@ -3027,7 +3072,6 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // compatibility.
   routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow });
   if (shallow) {
-    const navigationId = supersedePendingNavigation();
     if (forcedScroll === undefined) {
       routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: true });
       dispatchNavigateEvent();

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -67,6 +67,7 @@ import {
   appendSearchParamsToUrl,
   mergeRouteParamsIntoQuery,
   parseQueryString,
+  setQueryValue,
   type UrlQuery,
   urlQueryToSearchParams,
 } from "../utils/query.js";
@@ -1236,12 +1237,13 @@ function getRouteParamsFromQuery(
   const params: Record<string, string | string[]> = {};
   let hasParam = false;
   for (const name of names) {
+    if (!Object.hasOwn(query, name)) continue;
     const value = query[name];
     if (typeof value === "string") {
-      params[name] = value;
+      setQueryValue(params, name, value);
       hasParam = true;
     } else if (Array.isArray(value)) {
-      params[name] = [...value];
+      setQueryValue(params, name, [...value]);
       hasParam = true;
     }
   }
@@ -1258,9 +1260,9 @@ function getRouteQueryFromNextData(
   if (extractRouteParamsFromPath(nextData.page, resolvedPath) === null) {
     for (const [key, value] of Object.entries(nextData.query)) {
       if (typeof value === "string") {
-        routeQuery[key] = value;
+        setQueryValue(routeQuery, key, value);
       } else if (Array.isArray(value)) {
-        routeQuery[key] = [...value];
+        setQueryValue(routeQuery, key, [...value]);
       }
     }
     return routeQuery;
@@ -1275,9 +1277,9 @@ function getRouteQueryFromNextData(
   for (const key of routeParamNames) {
     const value = nextData.query[key];
     if (typeof value === "string") {
-      routeQuery[key] = value;
+      setQueryValue(routeQuery, key, value);
     } else if (Array.isArray(value)) {
-      routeQuery[key] = [...value];
+      setQueryValue(routeQuery, key, [...value]);
     }
   }
   return routeQuery;
@@ -1293,7 +1295,7 @@ function getPathnameAndQuery(): {
     if (_ssrCtx) {
       const query: Record<string, string | string[]> = {};
       for (const [key, value] of Object.entries(_ssrCtx.query)) {
-        query[key] = Array.isArray(value) ? [...value] : value;
+        setQueryValue(query, key, Array.isArray(value) ? [...value] : value);
       }
       return { pathname: _ssrCtx.pathname, query, asPath: _ssrCtx.asPath };
     }
@@ -1319,7 +1321,7 @@ function getPathnameAndQuery(): {
   if (isShallowNavigation) {
     for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
       const routeParam = query[routeParamName] ?? routeQuery[routeParamName];
-      if (routeParam !== undefined) query[routeParamName] = routeParam;
+      if (routeParam !== undefined) setQueryValue(query, routeParamName, routeParam);
     }
   }
   // asPath uses the resolved browser path, not the route pattern
@@ -2382,7 +2384,6 @@ function updateHistory(
     url: string;
     as: string;
     options: { locale?: string; shallow?: boolean };
-    query?: Record<string, string | string[]>;
   },
 ): void {
   const previousKey = getRouterStateKey(window.history.state);
@@ -2399,7 +2400,6 @@ function updateHistory(
   };
   if (navState.options.shallow === true && window.__NEXT_DATA__?.page) {
     state.__vinext_route = window.__NEXT_DATA__.page;
-    state.__vinext_query = navState.query;
   }
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
@@ -2419,7 +2419,6 @@ type VinextHistoryState = {
   options: { locale?: string; shallow?: boolean };
   __N: true;
   key: string;
-  __vinext_query?: Record<string, string | string[]>;
   __vinext_route?: string;
 };
 
@@ -2676,7 +2675,6 @@ async function performNavigation(
     url: resolvedRouteNoHash,
     as: resolvedNoHash,
     options: navStateOptions,
-    query: shallowRoute?.query,
   };
 
   // Hash-only change — no page fetch needed.
@@ -2956,7 +2954,6 @@ function isNextRouterState(state: unknown): state is {
   options: TransitionOptions;
   __N: true;
   key?: string;
-  __vinext_query?: Record<string, string | string[]>;
   __vinext_route?: string;
 } {
   return (
@@ -3081,14 +3078,16 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // Next.js only carries shallow mode across popstate when both the target
   // entry and the current router transition are shallow. A persisted shallow
   // target must not promote a deep traversal back to shallow mode.
-  const shallow =
+  const restoredShallowRoute =
     isNextRouterState(state) &&
     state.options?.shallow === true &&
-    state.__vinext_route === window.__NEXT_DATA__?.page &&
-    routerRuntimeState.currentShallow;
+    routerRuntimeState.currentShallow &&
+    withBasePath(state.as, __basePath) === browserUrl
+      ? resolveSamePagesRoute(browserUrl)
+      : null;
+  const shallow = restoredShallowRoute !== null;
   routerRuntimeState.currentShallow = shallow;
-  routerRuntimeState.currentShallowQuery =
-    shallow && isNextRouterState(state) ? (state.__vinext_query ?? null) : null;
+  routerRuntimeState.currentShallowQuery = restoredShallowRoute?.query ?? null;
 
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -416,6 +416,7 @@ type PagesRouterRuntimeState = {
   lastPathnameAndSearch: string;
   isFirstPopStateEvent: boolean;
   routerDidNavigate: boolean;
+  currentShallow: boolean;
   deprecatedEventBridgeInstalled: boolean;
   pagesRouterReady: boolean;
   publicRouter?: Record<string, unknown>;
@@ -443,6 +444,7 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
       typeof window !== "undefined" ? window.location.pathname + window.location.search : "",
     isFirstPopStateEvent: true,
     routerDidNavigate: false,
+    currentShallow: false,
     deprecatedEventBridgeInstalled: false,
     pagesRouterReady: typeof window === "undefined" || !shouldDeferInitialPagesRouterReady(),
   };
@@ -812,13 +814,10 @@ function stampInitialHistoryState(): void {
   if (!window.history) return;
 
   const existingState = window.history.state;
-  if (existingState !== null && existingState !== undefined) {
-    routerRuntimeState.currentHistoryKey =
-      getRouterStateKey(existingState) ?? routerRuntimeState.currentHistoryKey;
-    return;
-  }
-
   const initialState = buildInitialRouterState();
+  const existingKey = getRouterStateKey(existingState);
+  if (existingKey !== undefined) initialState.key = existingKey;
+  routerRuntimeState.currentShallow = false;
   routerRuntimeState.currentHistoryKey = initialState.key;
   window.history.replaceState(initialState, "");
 }
@@ -1263,7 +1262,7 @@ function getPathnameAndQuery(): {
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
-  const isShallowNavigation = window.history?.state?.options?.shallow === true;
+  const isShallowNavigation = routerRuntimeState.currentShallow;
   const query = isShallowNavigation ? { ...searchQuery } : { ...searchQuery, ...routeQuery };
   if (isShallowNavigation) {
     for (const routeParamName of extractRouteParamNames(nextData?.page ?? "")) {
@@ -2307,6 +2306,7 @@ function updateHistory(
   };
   if (mode === "push") window.history.pushState(state, "", fullUrl);
   else window.history.replaceState(state, "", fullUrl);
+  routerRuntimeState.currentShallow = navState.options.shallow === true;
   routerRuntimeState.currentHistoryKey = key;
   routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
   routerRuntimeState.routerDidNavigate = true;
@@ -2963,6 +2963,13 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     });
     if (!shouldContinue) return;
   }
+
+  // Next.js only carries shallow mode across popstate when both the target
+  // entry and the current router transition are shallow. Vinext currently
+  // resolves every non-hash popstate through a fresh server navigation, so
+  // the resulting router state is always deep and must publish all server
+  // query metadata, even when the restored entry was originally shallow.
+  routerRuntimeState.currentShallow = false;
 
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -639,9 +639,16 @@ function isSamePagesRoute(destinationUrl: string): boolean {
   const currentRoute = window.__NEXT_DATA__?.page;
   if (!destinationPathname || !currentRoute) return false;
 
-  const currentPathname = stripBasePath(window.location.pathname, __basePath);
-  if (destinationPathname === currentPathname) return true;
-  return extractRouteParamsFromPath(currentRoute, destinationPathname) !== null;
+  const locales = window.__VINEXT_LOCALES__;
+  const stripLocale = (pathname: string): string => {
+    const locale = getLocalePathPrefix(pathname, locales);
+    if (!locale) return pathname;
+    return pathname.slice(locale.length + 1) || "/";
+  };
+  const normalizedDestinationPathname = stripLocale(destinationPathname);
+  const currentPathname = stripLocale(stripBasePath(window.location.pathname, __basePath));
+  if (normalizedDestinationPathname === currentPathname) return true;
+  return extractRouteParamsFromPath(currentRoute, normalizedDestinationPathname) !== null;
 }
 
 function resolvePagesErrorHtmlFetchUrl(
@@ -2566,8 +2573,12 @@ async function performNavigation(
   const errorRouteHtmlFetchUrl = resolvePagesErrorHtmlFetchUrl(url, navigationLocale);
   const htmlFetchUrl =
     errorRouteHtmlFetchUrl ?? getPagesHtmlFetchUrl(fullRouteUrl, navigationLocale);
-  const shallow = options?.shallow === true && isSamePagesRoute(interpolatedRoute);
-  const doScroll = options?.scroll ?? !shallow;
+  const requestedShallow = options?.shallow === true;
+  const shallow =
+    requestedShallow &&
+    (hasVinextMiddleware(window.__NEXT_DATA__) || isSamePagesRoute(interpolatedRoute));
+  const hashOnly = options?._h !== 1 && interpolatedRoute === resolved && isHashOnlyChange(full);
+  const doScroll = options?.scroll ?? (hashOnly || !shallow);
   const hash = extractHash(resolved);
   // Only pass {x, y} restoration through renderPagesRouterElement's commit
   // callback. Hash scrolling is deferred until after routeChangeComplete so
@@ -2627,7 +2638,7 @@ async function performNavigation(
   // disagree), the underlying page module changes even if the address bar
   // didn't — so the hash-only shortcut MUST NOT skip the fetch. Mirrors
   // Next.js where `onlyAHashChange` runs only after the route is unchanged.
-  if (options?._h !== 1 && interpolatedRoute === resolved && isHashOnlyChange(full)) {
+  if (hashOnly) {
     // Snapshot the outgoing entry's scroll before updateHistory mints a new
     // key, so a later back-popstate restores the position the user had
     // reached here rather than {x: 0, y: 0}. Upstream snapshots inside

--- a/packages/vinext/src/utils/query.ts
+++ b/packages/vinext/src/utils/query.ts
@@ -6,7 +6,7 @@ type UrlQueryValue = string | number | boolean | null | undefined;
 
 export type UrlQuery = Record<string, UrlQueryValue | readonly UrlQueryValue[]>;
 
-function setOwnQueryValue(
+export function setQueryValue(
   obj: Record<string, string | string[]>,
   key: string,
   value: string | string[],
@@ -26,13 +26,13 @@ export function addQueryParam(
 ): void {
   if (Object.hasOwn(obj, key)) {
     const current = obj[key];
-    setOwnQueryValue(
+    setQueryValue(
       obj,
       key,
       Array.isArray(current) ? current.concat(value) : [current as string, value],
     );
   } else {
-    setOwnQueryValue(obj, key, value);
+    setQueryValue(obj, key, value);
   }
 }
 
@@ -48,7 +48,7 @@ export function mergeRouteParamsIntoQuery(
 ): Record<string, string | string[]> {
   const merged: Record<string, string | string[]> = { ...query };
   for (const [key, value] of Object.entries(params)) {
-    setOwnQueryValue(merged, key, Array.isArray(value) ? [...value] : value);
+    setQueryValue(merged, key, Array.isArray(value) ? [...value] : value);
   }
   return merged;
 }

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -3,7 +3,7 @@ import { waitForHydration } from "../helpers";
 
 const BASE = "http://localhost:4175";
 
-// Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+// Extends the shallow-routing scenario from Next.js with middleware-injected query state:
 // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
 test("middleware alias supports deep then shallow navigation", async ({ page }) => {
   await page.goto(`${BASE}/sha`);
@@ -13,7 +13,9 @@ test("middleware alias supports deep then shallow navigation", async ({ page }) 
   const initialCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
   await page.evaluate(() => (window as any).next.router.push("/sha?hello=goodbye"));
   await expect(page).toHaveURL(`${BASE}/sha?hello=goodbye`);
-  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"goodbye"}');
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText(
+    '{"hello":"goodbye","from":"middleware"}',
+  );
   await expect
     .poll(() => page.evaluate(() => (window as any).__NEXT_DATA__.query))
     .toEqual({ hello: "goodbye", from: "middleware" });

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { waitForHydration } from "../helpers";
+
+const BASE = "http://localhost:4175";
+
+// Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+test("middleware alias supports deep then shallow navigation", async ({ page }) => {
+  await page.goto(`${BASE}/sha`);
+  await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
+  await waitForHydration(page);
+
+  const initialCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+  await page.evaluate(() => (window as any).next.router.push("/sha?hello=goodbye"));
+  await expect(page).toHaveURL(`${BASE}/sha?hello=goodbye`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"goodbye"}');
+  const deepCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+  expect(deepCallId).not.toBe(initialCallId);
+
+  await page.evaluate(() =>
+    (window as any).next.router.push("/sha?hello=world", undefined, { shallow: true }),
+  );
+  await expect(page).toHaveURL(`${BASE}/sha?hello=world`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"world"}');
+  expect(await page.locator('[data-testid="gssp-call-id"]').textContent()).toBe(deepCallId);
+});

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -46,3 +46,59 @@ test("middleware alias supports deep then shallow navigation", async ({ page }) 
   const reloadCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
   expect(reloadCallId).not.toBe(deepCallId);
 });
+
+test("Back and Forward stay shallow only between consecutive shallow entries", async ({ page }) => {
+  await page.goto(`${BASE}/sha?hello=initial`);
+  await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
+  await waitForHydration(page);
+
+  const requests: string[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/sha" || url.pathname.startsWith("/_next/data/")) {
+      requests.push(url.pathname + url.search);
+    }
+  });
+
+  await page.evaluate(() =>
+    (window as any).next.router.push("/sha?hello=one", undefined, { shallow: true }),
+  );
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"one"}');
+
+  await page.evaluate(() =>
+    (window as any).next.router.push("/sha?hello=two", undefined, { shallow: true }),
+  );
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"two"}');
+  const shallowCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+  requests.length = 0;
+
+  await page.goBack();
+  await expect(page).toHaveURL(`${BASE}/sha?hello=one`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"one"}');
+  expect(await page.locator('[data-testid="gssp-call-id"]').textContent()).toBe(shallowCallId);
+  expect(requests).toEqual([]);
+
+  await page.goForward();
+  await expect(page).toHaveURL(`${BASE}/sha?hello=two`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"two"}');
+  expect(await page.locator('[data-testid="gssp-call-id"]').textContent()).toBe(shallowCallId);
+  expect(requests).toEqual([]);
+
+  await page.goBack();
+  await page.goBack();
+  await expect(page).toHaveURL(`${BASE}/sha?hello=initial`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText(
+    '{"hello":"initial","from":"middleware"}',
+  );
+  const deepCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+  expect(deepCallId).not.toBe(shallowCallId);
+
+  requests.length = 0;
+  await page.goForward();
+  await expect(page).toHaveURL(`${BASE}/sha?hello=one`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText(
+    '{"hello":"one","from":"middleware"}',
+  );
+  expect(await page.locator('[data-testid="gssp-call-id"]').textContent()).not.toBe(deepCallId);
+  expect(requests.length).toBeGreaterThan(0);
+});

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -28,4 +28,21 @@ test("middleware alias supports deep then shallow navigation", async ({ page }) 
   await expect(page).toHaveURL(`${BASE}/sha?hello=world`);
   await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"world"}');
   expect(await page.locator('[data-testid="gssp-call-id"]').textContent()).toBe(deepCallId);
+
+  await page.goBack();
+  await expect(page).toHaveURL(`${BASE}/sha?hello=goodbye`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText(
+    '{"hello":"goodbye","from":"middleware"}',
+  );
+  await page.goForward();
+  await expect(page).toHaveURL(`${BASE}/sha?hello=world`);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText(
+    '{"hello":"world","from":"middleware"}',
+  );
+
+  await page.reload();
+  await waitForHydration(page);
+  await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"world"}');
+  const reloadCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+  expect(reloadCallId).not.toBe(deepCallId);
 });

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -3,9 +3,9 @@ import { waitForHydration } from "../helpers";
 
 const BASE = "http://localhost:4175";
 
-// Extends the shallow-routing scenario from Next.js with middleware-injected query state:
+// Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
 // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
-test("middleware alias supports deep then shallow navigation", async ({ page }) => {
+test("same-page middleware rewrite stays shallow", async ({ page }) => {
   await page.goto(`${BASE}/sha`);
   await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
   await waitForHydration(page);
@@ -47,7 +47,7 @@ test("middleware alias supports deep then shallow navigation", async ({ page }) 
   expect(reloadCallId).not.toBe(deepCallId);
 });
 
-test("requested cross-path navigation stays shallow when middleware can rewrite it", async ({
+test("cross-page navigation is not shallow just because middleware is present", async ({
   page,
 }) => {
   await page.goto(`${BASE}/sha`);
@@ -63,9 +63,12 @@ test("requested cross-path navigation stays shallow when middleware can rewrite 
   );
 
   await expect(page).toHaveURL(`${BASE}/about`);
-  await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
-  expect(await page.locator('[data-testid="gssp-call-id"]').textContent()).toBe(callId);
-  expect(requests.filter((pathname) => pathname === "/about")).toEqual([]);
+  await expect(page.locator("h1")).toHaveText("About");
+  expect(await page.locator('[data-testid="gssp-call-id"]').count()).toBe(0);
+  expect(
+    requests.some((pathname) => pathname === "/about" || pathname.includes("/_next/data/")),
+  ).toBe(true);
+  expect(callId).not.toBeNull();
 });
 
 test("Back and Forward stay shallow only between consecutive shallow entries", async ({ page }) => {

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -14,6 +14,9 @@ test("middleware alias supports deep then shallow navigation", async ({ page }) 
   await page.evaluate(() => (window as any).next.router.push("/sha?hello=goodbye"));
   await expect(page).toHaveURL(`${BASE}/sha?hello=goodbye`);
   await expect(page.locator('[data-testid="router-query"]')).toHaveText('{"hello":"goodbye"}');
+  await expect
+    .poll(() => page.evaluate(() => (window as any).__NEXT_DATA__.query))
+    .toEqual({ hello: "goodbye", from: "middleware" });
   const deepCallId = await page.locator('[data-testid="gssp-call-id"]').textContent();
   expect(deepCallId).not.toBe(initialCallId);
 

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -47,6 +47,27 @@ test("middleware alias supports deep then shallow navigation", async ({ page }) 
   expect(reloadCallId).not.toBe(deepCallId);
 });
 
+test("requested cross-path navigation stays shallow when middleware can rewrite it", async ({
+  page,
+}) => {
+  await page.goto(`${BASE}/sha`);
+  await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
+  await waitForHydration(page);
+
+  const callId = await page.locator('[data-testid="gssp-call-id"]').textContent();
+  const requests: string[] = [];
+  page.on("request", (request) => requests.push(new URL(request.url()).pathname));
+
+  await page.evaluate(() =>
+    (window as any).next.router.push("/about", undefined, { shallow: true }),
+  );
+
+  await expect(page).toHaveURL(`${BASE}/about`);
+  await expect(page.locator("h1")).toHaveText("Shallow Routing Test");
+  expect(await page.locator('[data-testid="gssp-call-id"]').textContent()).toBe(callId);
+  expect(requests.filter((pathname) => pathname === "/about")).toEqual([]);
+});
+
 test("Back and Forward stay shallow only between consecutive shallow entries", async ({ page }) => {
   await page.goto(`${BASE}/sha?hello=initial`);
   await expect(page.locator("h1")).toHaveText("Shallow Routing Test");

--- a/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-shallow-routing.spec.ts
@@ -71,6 +71,44 @@ test("cross-page navigation is not shallow just because middleware is present", 
   expect(callId).not.toBeNull();
 });
 
+test("static routes beat dynamic routes for shallow identity", async ({ page }) => {
+  await page.goto(`${BASE}/posts/42`);
+  await waitForHydration(page);
+
+  await page.evaluate(() =>
+    (window as any).next.router.push("/posts/missing", undefined, { shallow: true }),
+  );
+
+  await expect(page).toHaveURL(`${BASE}/posts/missing`);
+  await expect(page.locator("body")).toContainText("404");
+});
+
+test("rewrite aliases stay shallow only when they resolve to the same page", async ({ page }) => {
+  await page.goto(`${BASE}/about`);
+  await waitForHydration(page);
+  const aboutRequests: string[] = [];
+  page.on("request", (request) => aboutRequests.push(new URL(request.url()).pathname));
+
+  await page.evaluate(() =>
+    (window as any).next.router.push("/shallow-about-alias", undefined, { shallow: true }),
+  );
+  await expect(page).toHaveURL(`${BASE}/shallow-about-alias`);
+  await expect(page.locator("h1")).toHaveText("About");
+  expect(aboutRequests.filter((pathname) => pathname.includes("/_next/data/")).length).toBe(0);
+
+  await page.goto(`${BASE}/posts/42`);
+  await waitForHydration(page);
+  const dynamicRequests: string[] = [];
+  page.on("request", (request) => dynamicRequests.push(new URL(request.url()).pathname));
+
+  await page.evaluate(() =>
+    (window as any).next.router.push("/shallow-post-alias/43", undefined, { shallow: true }),
+  );
+  await expect(page).toHaveURL(`${BASE}/shallow-post-alias/43`);
+  await expect(page.locator('[data-testid="query"]')).toHaveText("Query ID: 43");
+  expect(dynamicRequests.filter((pathname) => pathname.includes("/_next/data/")).length).toBe(0);
+});
+
 test("Back and Forward stay shallow only between consecutive shallow entries", async ({ page }) => {
   await page.goto(`${BASE}/sha?hello=initial`);
   await expect(page.locator("h1")).toHaveText("Shallow Routing Test");

--- a/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
+++ b/tests/e2e/pages-scroll-restoration/reload-scroll-backforward-restoration.spec.ts
@@ -44,6 +44,41 @@ async function pushWithPagesRouter(page: Page, href: string): Promise<void> {
   }, href);
 }
 
+async function shallowPushWithoutScroll(page: Page, href: string): Promise<void> {
+  await page.evaluate(async (target) => {
+    if (!window.next?.router) {
+      throw new Error("window.next.router is not installed");
+    }
+    await Promise.resolve(
+      (window as any).next.router.push(target, undefined, { shallow: true, scroll: false }),
+    );
+  }, href);
+}
+
+async function traverseHistoryAndCaptureCompletion(
+  page: Page,
+  direction: "back" | "forward",
+): Promise<{ url: string; x: number; y: number }> {
+  return page.evaluate((historyDirection) => {
+    const router = window.next?.router;
+    if (!router || !("events" in router)) {
+      throw new Error("window.next.router events are not installed");
+    }
+    return new Promise<{ url: string; x: number; y: number }>((resolve) => {
+      const handler = (...args: unknown[]) => {
+        router.events.off("routeChangeComplete", handler);
+        const [url] = args;
+        if (typeof url !== "string") {
+          throw new Error("routeChangeComplete did not include a URL");
+        }
+        resolve({ url, x: Math.floor(window.scrollX), y: Math.floor(window.scrollY) });
+      };
+      router.events.on("routeChangeComplete", handler);
+      window.history[historyDirection]();
+    });
+  }, direction);
+}
+
 async function isPagesRouterReady(page: Page): Promise<boolean> {
   return page.evaluate(() => {
     const router = window.next?.router;
@@ -155,6 +190,33 @@ test.describe("reload-scroll-back-restoration", () => {
     const scrollAtEvent = await scrollAtEventPromise;
     expect(scrollAtEvent).not.toBeNull();
     expect(scrollAtEvent!.y).toBe(initialScroll.y);
+  });
+
+  test("should restore consecutive shallow history entries before routeChangeComplete", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/0`);
+    await waitForHydration(page);
+
+    await shallowPushWithoutScroll(page, "/0?step=1");
+    await page.evaluate(() => window.scrollTo(0, 1200));
+    const firstEntryScroll = await getScrollPosition(page);
+
+    await shallowPushWithoutScroll(page, "/0?step=2");
+    await page.evaluate(() => window.scrollTo(0, 2400));
+    const secondEntryScroll = await getScrollPosition(page);
+
+    expect(firstEntryScroll).not.toEqual(secondEntryScroll);
+
+    const backCompletion = await traverseHistoryAndCaptureCompletion(page, "back");
+    expect(backCompletion).toEqual({ url: "/0?step=1", ...firstEntryScroll });
+    await expect(page).toHaveURL(`${BASE}/0?step=1`);
+    await expectScrollPosition(page, firstEntryScroll);
+
+    const forwardCompletion = await traverseHistoryAndCaptureCompletion(page, "forward");
+    expect(forwardCompletion).toEqual({ url: "/0?step=2", ...secondEntryScroll });
+    await expect(page).toHaveURL(`${BASE}/0?step=2`);
+    await expectScrollPosition(page, secondEntryScroll);
   });
 
   test("should reject navigation, emit routeChangeError and fallback to hard navigation on render error", async ({

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -30,6 +30,10 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/ssr", request.url));
   }
 
+  if (url.pathname === "/sha") {
+    return NextResponse.rewrite(new URL(`/shallow-test${url.search}`, request.url));
+  }
+
   // Rewrite /mw-rewrite-query to /ssr-query — preserves the original
   // request's query params on the rewrite target so getServerSideProps
   // sees them. Middleware preserves query by mutating `request.nextUrl`

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -31,7 +31,9 @@ export function middleware(request: NextRequest) {
   }
 
   if (url.pathname === "/sha") {
-    return NextResponse.rewrite(new URL(`/shallow-test${url.search}`, request.url));
+    const target = new URL(`/shallow-test${url.search}`, request.url);
+    target.searchParams.set("from", "middleware");
+    return NextResponse.rewrite(target);
   }
 
   // Rewrite /mw-rewrite-query to /ssr-query — preserves the original

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -58,6 +58,14 @@ const nextConfig = {
           source: "/rewrite-navigation-same/3",
           destination: "/rewrite-navigation-same/003",
         },
+        {
+          source: "/shallow-about-alias",
+          destination: "/about",
+        },
+        {
+          source: "/shallow-post-alias/:id",
+          destination: "/posts/:id",
+        },
         // Used by Vitest: pages-router.test.ts — beforeFiles rewrite gated on
         // a cookie injected by middleware. Middleware injects mw-before-user=1
         // when ?mw-auth is present. The beforeFiles rewrite should see this

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -23,7 +23,10 @@ import type {
   VinextPagesLinkPrefetchRoute,
 } from "../packages/vinext/src/client/vinext-next-data.js";
 import type { NextRewrite } from "../packages/vinext/src/config/next-config.js";
-import { resolveHybridClientRouteOwner } from "../packages/vinext/src/shims/internal/hybrid-client-route-owner.js";
+import {
+  resolveHybridClientRouteOwner,
+  resolvePagesClientRoute,
+} from "../packages/vinext/src/shims/internal/hybrid-client-route-owner.js";
 
 const APP_BASE = "http://localhost/";
 
@@ -318,5 +321,30 @@ describe("resolveHybridClientRouteOwner", () => {
     // matching the server's normalisation.
     expect(resolveHybridClientRouteOwner("/base/pages-dir/foobar", "/base")).toBe("pages");
     expect(resolveHybridClientRouteOwner("/base/a", "/base")).toBe("app");
+  });
+});
+
+describe("resolvePagesClientRoute", () => {
+  it("returns the rewritten href and destination params", () => {
+    installWindow({
+      app: [],
+      pages: [pagesRoute(["catalog", ":category", ":slug", ":locale"])],
+      rewrites: {
+        afterFiles: [],
+        beforeFiles: [
+          {
+            source: "/store/:slug/:section",
+            destination: "/catalog/:section/:slug/en",
+          },
+        ],
+        fallback: [],
+      },
+    });
+
+    expect(resolvePagesClientRoute("/store/guide/books?preview=1", "")).toEqual({
+      href: "/catalog/books/guide/en?preview=1",
+      params: { category: "books", locale: "en", slug: "guide" },
+      pattern: "/catalog/:category/:slug/:locale",
+    });
   });
 });

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -325,26 +325,31 @@ describe("resolveHybridClientRouteOwner", () => {
 });
 
 describe("resolvePagesClientRoute", () => {
-  it("returns the rewritten href and destination params", () => {
+  it("returns the rewritten href, query, and destination params", () => {
     installWindow({
       app: [],
-      pages: [pagesRoute(["catalog", ":category", ":slug", ":locale"])],
+      pages: [pagesRoute(["catalog", ":slug"])],
       rewrites: {
         afterFiles: [],
         beforeFiles: [
           {
-            source: "/store/:slug/:section",
-            destination: "/catalog/:section/:slug/en",
+            source: "/store/:slug",
+            destination: "/catalog/:slug?view=grid&slug=destination",
           },
         ],
         fallback: [],
       },
     });
 
-    expect(resolvePagesClientRoute("/store/guide/books?preview=1", "")).toEqual({
-      href: "/catalog/books/guide/en?preview=1",
-      params: { category: "books", locale: "en", slug: "guide" },
-      pattern: "/catalog/:category/:slug/:locale",
+    expect(resolvePagesClientRoute("/store/guide?preview=1&view=list&slug=visible", "")).toEqual({
+      href: "/catalog/guide?preview=1&view=grid&slug=destination",
+      params: { slug: "guide" },
+      pattern: "/catalog/:slug",
+      query: {
+        preview: "1",
+        slug: "guide",
+        view: "grid",
+      },
     });
   });
 });

--- a/tests/pages-router-i18n-sticky-locale.test.ts
+++ b/tests/pages-router-i18n-sticky-locale.test.ts
@@ -576,7 +576,7 @@ describe("Pages Router initial-entry history state", () => {
     }
   });
 
-  it("install does not overwrite pre-existing history state", async () => {
+  it("install replaces foreign history state with valid router state", async () => {
     const previousWindow = (globalThis as any).window;
     const { win, replaceState } = createNavWindow();
     win.history.state = { foreign: true };
@@ -584,7 +584,13 @@ describe("Pages Router initial-entry history state", () => {
 
     try {
       await installRuntime(win);
-      expect(replaceState).not.toHaveBeenCalled();
+      expect(replaceState).toHaveBeenCalledOnce();
+      expect(replaceState.mock.calls[0]?.[0]).toMatchObject({
+        __N: true,
+        url: "/",
+        as: "/",
+        options: { locale: "fr" },
+      });
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2512,8 +2512,8 @@ describe("Virtual server entry generation", () => {
       // matching, while pageLoaders must use Next.js bracket format.
       const codeWithoutRouteManifests = code
         .replace(
-        /__VINEXT_PAGES_LINK_PREFETCH_ROUTES__\s*=\s*(\[[\s\S]*?\]);/,
-        "__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = /* stripped for test */;",
+          /__VINEXT_PAGES_LINK_PREFETCH_ROUTES__\s*=\s*(\[[\s\S]*?\]);/,
+          "__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = /* stripped for test */;",
         )
         .replace(
           /__VINEXT_CLIENT_REWRITES__\s*=\s*([^;]+);/,

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2507,20 +2507,23 @@ describe("Virtual server entry generation", () => {
       expect(code).toContain('"/posts/[id]"');
       // Catch-all routes: pages/docs/[...slug].tsx
       expect(code).toContain('"/docs/[...slug]"');
-      // Should NOT contain Express-style :param patterns for any route
-      expect(code).not.toMatch(/["']\/(posts|blog|articles|docs|products)\/:[\w]+["']/);
-      // Strip the `__VINEXT_PAGES_LINK_PREFETCH_ROUTES__` manifest before the
-      // next two assertions. The manifest is exempt because it carries the
-      // internal pattern shape (with `:slug+` / `:slug*`) so the client-side
-      // hybrid owner resolver can rebuild a pattern from `patternParts` to
-      // feed `routePrecedence`. The pageLoaders map (above) still uses
-      // Next.js bracket format for hydration keys.
-      const codeWithoutPrefetchManifest = code.replace(
+      // Strip route manifests before checking page-loader keys. They retain
+      // internal `:param` patterns for client-side ownership and rewrite
+      // matching, while pageLoaders must use Next.js bracket format.
+      const codeWithoutRouteManifests = code
+        .replace(
         /__VINEXT_PAGES_LINK_PREFETCH_ROUTES__\s*=\s*(\[[\s\S]*?\]);/,
         "__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = /* stripped for test */;",
+        )
+        .replace(
+          /__VINEXT_CLIENT_REWRITES__\s*=\s*([^;]+);/,
+          "__VINEXT_CLIENT_REWRITES__ = /* stripped for test */;",
+        );
+      expect(codeWithoutRouteManifests).not.toMatch(
+        /["']\/(posts|blog|articles|docs|products)\/:[\w]+["']/,
       );
-      expect(codeWithoutPrefetchManifest).not.toContain(":slug+");
-      expect(codeWithoutPrefetchManifest).not.toContain(":slug*");
+      expect(codeWithoutRouteManifests).not.toContain(":slug+");
+      expect(codeWithoutRouteManifests).not.toContain(":slug*");
     } finally {
       await testServer.close();
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13939,7 +13939,7 @@ describe("next/compat/router shim", () => {
       },
       __NEXT_DATA__: {
         page: "/shallow-test",
-        query: { hello: "goodbye" },
+        query: { hello: "goodbye", from: "middleware" },
         isFallback: false,
       },
       __VINEXT_LOCALE__: undefined,

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13922,8 +13922,6 @@ describe("next/compat/router shim", () => {
   });
 
   it("prefers the current search query over stale rewrite query state", async () => {
-    // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
-    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const { useRouter: useCompatRouter } =
@@ -13937,6 +13935,7 @@ describe("next/compat/router shim", () => {
         search: "?hello=world",
         hash: "",
       },
+      history: { state: { options: { shallow: true } } },
       __NEXT_DATA__: {
         page: "/shallow-test",
         query: { hello: "goodbye", from: "middleware" },
@@ -13958,6 +13957,53 @@ describe("next/compat/router shim", () => {
 
       expect(captured).not.toBeNull();
       expect((captured as any).query).toEqual({ hello: "world" });
+      expect((captured as any).pathname).toBe("/shallow-test");
+      expect((captured as any).asPath).toBe("/sha?hello=world");
+    } finally {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
+  it("preserves rewrite query state after deep navigation", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter: useCompatRouter } =
+      await import("../packages/vinext/src/shims/compat-router.js");
+    const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
+
+    const previousWindow = (globalThis as any).window;
+    (globalThis as any).window = {
+      location: {
+        pathname: "/sha",
+        search: "?hello=world",
+        hash: "",
+      },
+      history: { state: { options: { shallow: false } } },
+      __NEXT_DATA__: {
+        page: "/shallow-test",
+        query: { hello: "goodbye", from: "middleware" },
+        isFallback: false,
+      },
+      __VINEXT_LOCALE__: undefined,
+      __VINEXT_LOCALES__: undefined,
+      __VINEXT_DEFAULT_LOCALE__: undefined,
+    };
+
+    try {
+      let captured: unknown = "NOT_SET";
+      function Probe() {
+        captured = useCompatRouter();
+        return React.createElement("div", null, "probe");
+      }
+
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)));
+
+      expect(captured).not.toBeNull();
+      expect((captured as any).query).toEqual({ hello: "goodbye", from: "middleware" });
       expect((captured as any).pathname).toBe("/shallow-test");
       expect((captured as any).asPath).toBe("/sha?hello=world");
     } finally {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14560,6 +14560,48 @@ describe("Pages Router concurrent navigation", () => {
     return { win, pushState, replaceState, render };
   }
 
+  it("matches localized dynamic paths before validating shallow route identity", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/en/posts/42",
+      href: "http://localhost/en/posts/42",
+    });
+    Object.assign(win, {
+      __VINEXT_LOCALE__: "en",
+      __VINEXT_LOCALES__: ["en", "fr"],
+      __VINEXT_DEFAULT_LOCALE__: "en",
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/posts/[id]",
+        query: { id: "42" },
+      },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("localized same-route shallow navigation must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(Router.push("/en/posts/43", undefined, { shallow: true })).resolves.toBe(true);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(win.history.pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ shallow: true }) }),
+        "",
+        "/en/posts/43",
+      );
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   /**
    * Build a minimal HTML response that navigateClient can parse.
    * Includes __NEXT_DATA__ with a pageModuleUrl pointing to the given path.
@@ -14846,6 +14888,9 @@ describe("Pages Router concurrent navigation", () => {
     const previousTrailingSlash = process.env.__VINEXT_TRAILING_SLASH;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
+    (
+      win.__NEXT_DATA__.__vinext as { pageModuleUrl: string; hasMiddleware?: boolean }
+    ).hasMiddleware = true;
     (globalThis as any).window = win;
     process.env.__VINEXT_TRAILING_SLASH = "true";
     vi.resetModules();
@@ -16908,6 +16953,41 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it.each(["push", "replace"] as const)(
+    "defaults hash-only shallow %s navigation to scroll=true",
+    async (mode) => {
+      const previousWindow = (globalThis as any).window;
+      const previousDocument = (globalThis as any).document;
+      const originalFetch = globalThis.fetch;
+      const { win } = createNavWindow();
+      (globalThis as any).window = win;
+
+      const target = { scrollIntoView: vi.fn() };
+      (globalThis as any).document = {
+        getElementById: vi.fn((id: string) => (id === "target" ? target : null)),
+        getElementsByName: vi.fn(() => []),
+      };
+      globalThis.fetch = vi.fn(async () => {
+        throw new Error("hash-only navigations must not fetch page HTML");
+      });
+      vi.resetModules();
+
+      try {
+        const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+        await expect(Router[mode]("#target", undefined, { shallow: true })).resolves.toBe(true);
+        expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: "auto" });
+      } finally {
+        vi.resetModules();
+        if (previousWindow === undefined) delete (globalThis as any).window;
+        else (globalThis as any).window = previousWindow;
+        if (previousDocument === undefined) delete (globalThis as any).document;
+        else (globalThis as any).document = previousDocument;
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
+
   it("does not scroll hash-only pushes when scroll is false", async () => {
     const previousWindow = (globalThis as any).window;
     const previousDocument = (globalThis as any).document;
@@ -17138,6 +17218,37 @@ describe("Pages Router concurrent navigation", () => {
       );
       deepResponse.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
       await navigation;
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("preserves requested cross-route shallow navigation when middleware makes route identity unknowable", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    (
+      win.__NEXT_DATA__.__vinext as { pageModuleUrl: string; hasMiddleware?: boolean }
+    ).hasMiddleware = true;
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("middleware-backed shallow navigation must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(Router.push("/page-a", undefined, { shallow: true })).resolves.toBe(true);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect((win.history as any).pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ shallow: true }) }),
+        "",
+        "/page-a",
+      );
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) delete (globalThis as any).window;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13921,6 +13921,54 @@ describe("next/compat/router shim", () => {
     }
   });
 
+  it("prefers the current search query over stale rewrite query state", async () => {
+    // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter: useCompatRouter } =
+      await import("../packages/vinext/src/shims/compat-router.js");
+    const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
+
+    const previousWindow = (globalThis as any).window;
+    (globalThis as any).window = {
+      location: {
+        pathname: "/sha",
+        search: "?hello=world",
+        hash: "",
+      },
+      __NEXT_DATA__: {
+        page: "/shallow-test",
+        query: { hello: "goodbye" },
+        isFallback: false,
+      },
+      __VINEXT_LOCALE__: undefined,
+      __VINEXT_LOCALES__: undefined,
+      __VINEXT_DEFAULT_LOCALE__: undefined,
+    };
+
+    try {
+      let captured: unknown = "NOT_SET";
+      function Probe() {
+        captured = useCompatRouter();
+        return React.createElement("div", null, "probe");
+      }
+
+      renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)));
+
+      expect(captured).not.toBeNull();
+      expect((captured as any).query).toEqual({ hello: "world" });
+      expect((captured as any).pathname).toBe("/shallow-test");
+      expect((captured as any).asPath).toBe("/sha?hello=world");
+    } finally {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("treats prototype property names as ordinary query keys in client router state", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -637,7 +637,6 @@ describe("next/navigation shim", () => {
         search: "?from=committed",
         hash: "",
         href: "http://localhost/current?from=committed",
-        origin: "http://localhost",
       },
       history: {
         state: null,
@@ -14499,6 +14498,7 @@ describe("Pages Router concurrent navigation", () => {
         hash: "",
         href: "http://localhost/",
         hostname: "localhost",
+        origin: "http://localhost",
         assign: vi.fn(),
         replace: vi.fn(),
         reload: vi.fn(),
@@ -14567,8 +14567,12 @@ describe("Pages Router concurrent navigation", () => {
     Object.assign(win.location, {
       pathname: "/en/posts/42",
       href: "http://localhost/en/posts/42",
+      origin: "http://localhost",
     });
     Object.assign(win, {
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, isDynamic: true, patternParts: ["posts", ":id"] },
+      ],
       __VINEXT_LOCALE__: "en",
       __VINEXT_LOCALES__: ["en", "fr"],
       __VINEXT_DEFAULT_LOCALE__: "en",
@@ -14594,6 +14598,129 @@ describe("Pages Router concurrent navigation", () => {
         "",
         "/en/posts/43",
       );
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it.each([
+    {
+      name: "prefers a static page over a dynamic page",
+      currentPage: "/posts/[id]",
+      currentPathname: "/posts/42",
+      destination: "/posts/missing",
+      routes: [
+        { canPrefetchLoadingShell: false, isDynamic: false, patternParts: ["posts", "missing"] },
+        { canPrefetchLoadingShell: false, isDynamic: true, patternParts: ["posts", ":id"] },
+      ],
+    },
+    {
+      name: "prefers a dynamic page over a catch-all page",
+      currentPage: "/docs/[...slug]",
+      currentPathname: "/docs/guides/intro",
+      destination: "/docs/api",
+      routes: [
+        { canPrefetchLoadingShell: false, isDynamic: true, patternParts: ["docs", ":section"] },
+        { canPrefetchLoadingShell: false, isDynamic: true, patternParts: ["docs", ":slug+"] },
+      ],
+    },
+  ])("$name before validating shallow route identity", async (scenario) => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: scenario.currentPathname,
+      href: `http://localhost${scenario.currentPathname}`,
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: scenario.routes,
+      __NEXT_DATA__: { ...win.__NEXT_DATA__, page: scenario.currentPage },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(buildNavHtml(scenario.destination, `/@fs/pages${scenario.destination}.js`)),
+    );
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await Router.push(scenario.destination, undefined, { shallow: true });
+
+      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(win.history.pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ shallow: false }) }),
+        "",
+        scenario.destination,
+      );
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it.each([
+    {
+      name: "static",
+      page: "/about",
+      pathname: "/about",
+      alias: "/about-alias",
+      destination: "/about",
+      route: { canPrefetchLoadingShell: false, isDynamic: false, patternParts: ["about"] },
+    },
+    {
+      name: "dynamic",
+      page: "/posts/[id]",
+      pathname: "/posts/42",
+      alias: "/post-alias/43",
+      destination: "/posts/43",
+      route: {
+        canPrefetchLoadingShell: false,
+        isDynamic: true,
+        patternParts: ["posts", ":id"],
+      },
+    },
+  ])("keeps configured rewrite aliases to the same $name page shallow", async (scenario) => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: scenario.pathname,
+      href: `http://localhost${scenario.pathname}`,
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [scenario.route],
+      __VINEXT_CLIENT_REWRITES__: {
+        beforeFiles: [
+          {
+            source: scenario.alias.replace(/\/\d+$/, "/:id"),
+            destination: scenario.destination.replace(/\/\d+$/, "/:id"),
+          },
+        ],
+        afterFiles: [],
+        fallback: [],
+      },
+      __NEXT_DATA__: { ...win.__NEXT_DATA__, page: scenario.page },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("same-page rewrite alias must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(Router.push(scenario.alias, undefined, { shallow: true })).resolves.toBe(true);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) delete (globalThis as any).window;
@@ -15423,9 +15550,9 @@ describe("Pages Router concurrent navigation", () => {
       return fetchB.promise;
     };
 
-    const errors: Array<{ err: unknown; url: string }> = [];
+    const errors: Array<{ err: unknown; url: string; routeProps: unknown }> = [];
     const onRouteChangeError = (...args: unknown[]) => {
-      errors.push({ err: args[0], url: String(args[1]) });
+      errors.push({ err: args[0], url: String(args[1]), routeProps: args[2] });
     };
 
     try {
@@ -15443,7 +15570,7 @@ describe("Pages Router concurrent navigation", () => {
       fetchB.resolve(new Response(buildNavHtml("/page-b", "/@fs/pages/page-b.js")));
       fetchA.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
 
-      await Promise.allSettled([navA, navB]);
+      const [resultA] = await Promise.all([navA, navB]);
 
       // The superseded navigation (page-a) should emit routeChangeError
       // with a cancelled error, matching Next.js behavior
@@ -15451,6 +15578,8 @@ describe("Pages Router concurrent navigation", () => {
       expect(cancelledError).toBeDefined();
       const errObj = cancelledError?.err;
       expect(errObj).toHaveProperty("cancelled", true);
+      expect(cancelledError?.routeProps).toEqual({ shallow: false });
+      expect(resultA).toBe(false);
     } finally {
       const routerModule = await import("../packages/vinext/src/shims/router.js");
       const Router = routerModule.default;
@@ -17166,10 +17295,10 @@ describe("Pages Router concurrent navigation", () => {
     globalThis.fetch = vi.fn(() => deepResponse.promise);
 
     const completedUrls: string[] = [];
-    const errors: Array<{ err: unknown; url: string }> = [];
+    const errors: Array<{ err: unknown; url: string; routeProps: unknown }> = [];
     const onRouteChangeComplete = (...args: unknown[]) => completedUrls.push(String(args[0]));
     const onRouteChangeError = (...args: unknown[]) => {
-      errors.push({ err: args[0], url: String(args[1]) });
+      errors.push({ err: args[0], url: String(args[1]), routeProps: args[2] });
     };
 
     try {
@@ -17183,13 +17312,14 @@ describe("Pages Router concurrent navigation", () => {
 
       await expect(Router.replace("/?shallow=1", undefined, { shallow: true })).resolves.toBe(true);
       deepResponse.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
-      await deepNavigation;
+      await expect(deepNavigation).resolves.toBe(false);
 
       expect(render).not.toHaveBeenCalled();
       expect(completedUrls).toEqual(["/?shallow=1"]);
       expect(errors).toContainEqual({
         err: expect.objectContaining({ cancelled: true }),
         url: "/page-a",
+        routeProps: { shallow: true },
       });
     } finally {
       const { default: Router } = await import("../packages/vinext/src/shims/router.js");
@@ -18123,7 +18253,7 @@ describe("Pages Router _next/data client navigation", () => {
         }),
       );
 
-      await expect(Promise.all([firstPush, secondPush])).resolves.toEqual([true, true]);
+      await expect(Promise.all([firstPush, secondPush])).resolves.toEqual([false, true]);
       expect(routeChangeErrors).toHaveLength(1);
       expect(routeChangeErrors[0]).toMatchObject({ cancelled: true });
       expect(routeChangeComplete).toHaveBeenCalledTimes(1);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17028,6 +17028,180 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("shallow replace supersedes pending deep navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    (globalThis as any).window = win;
+
+    const deepResponse = createDeferred<Response>();
+    globalThis.fetch = vi.fn(() => deepResponse.promise);
+
+    const completedUrls: string[] = [];
+    const errors: Array<{ err: unknown; url: string }> = [];
+    const onRouteChangeComplete = (...args: unknown[]) => completedUrls.push(String(args[0]));
+    const onRouteChangeError = (...args: unknown[]) => {
+      errors.push({ err: args[0], url: String(args[1]) });
+    };
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeComplete", onRouteChangeComplete);
+      Router.events.on("routeChangeError", onRouteChangeError);
+
+      const deepNavigation = Router.push("/page-a");
+      await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+
+      await expect(Router.replace("/page-b?shallow=1", undefined, { shallow: true })).resolves.toBe(
+        true,
+      );
+      deepResponse.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
+      await deepNavigation;
+
+      expect(render).not.toHaveBeenCalled();
+      expect(completedUrls).toEqual(["/page-b?shallow=1"]);
+      expect(errors).toContainEqual({
+        err: expect.objectContaining({ cancelled: true }),
+        url: "/page-a",
+      });
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeComplete", onRouteChangeComplete);
+      Router.events.off("routeChangeError", onRouteChangeError);
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it.each(["shallow", "deep"] as const)(
+    "same-key %s replace supersedes pending shallow popstate scroll restoration",
+    async (replacementKind) => {
+      const previousWindow = (globalThis as any).window;
+      const previousDocument = (globalThis as any).document;
+      const originalFetch = globalThis.fetch;
+      const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+      const originalScrollRestorationEnv = process.env.__NEXT_SCROLL_RESTORATION;
+      const listeners = new Map<string, (event: any) => void>();
+      const animationFrames: FrameRequestCallback[] = [];
+      const { win } = createNavWindow();
+      const targetKey = "key-target";
+
+      win.scrollTo = vi.fn((x: number, y: number) => {
+        if (x === 0 && y === 0) {
+          win.scrollX = x;
+          win.scrollY = y;
+        }
+      });
+
+      win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+        listeners.set(type, handler);
+      });
+      (win.history as any).scrollRestoration = "auto";
+      (win.history as any).state = {
+        __N: true,
+        url: "/current",
+        as: "/current",
+        options: { shallow: true },
+        key: "key-current",
+      };
+      const sessionStore = new Map<string, string>([
+        [`__next_scroll_${targetKey}`, JSON.stringify({ x: 40, y: 600 })],
+      ]);
+      (win as any).sessionStorage = {
+        getItem: (key: string) => sessionStore.get(key) ?? null,
+        setItem: (key: string, value: string) => void sessionStore.set(key, value),
+        removeItem: (key: string) => void sessionStore.delete(key),
+      };
+      (globalThis as any).window = win;
+      (globalThis as any).document = {
+        documentElement: {
+          dataset: {},
+          style: { scrollBehavior: "" },
+          getClientRects: vi.fn(),
+        },
+      };
+      globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      });
+      process.env.__NEXT_SCROLL_RESTORATION = "true";
+      globalThis.fetch = vi.fn(
+        async () => new Response(buildNavHtml("/replacement", "/@fs/pages/replacement.js")),
+      );
+
+      const completedUrls: string[] = [];
+      const onRouteChangeComplete = (...args: unknown[]) => completedUrls.push(String(args[0]));
+
+      try {
+        vi.resetModules();
+        const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+        const { installPagesRouterRuntime } =
+          await import("../packages/vinext/src/shims/pages-router-runtime.js");
+        installPagesRouterRuntime();
+        Router.events.on("routeChangeComplete", onRouteChangeComplete);
+
+        await Router.replace("/current", undefined, { shallow: true });
+        completedUrls.length = 0;
+
+        const popstateHandler = listeners.get("popstate");
+        expect(popstateHandler).toBeDefined();
+        (win.history as any).state = {
+          __N: true,
+          url: "/target",
+          as: "/target",
+          options: { shallow: true },
+          key: targetKey,
+          __vinext_route: "/",
+        };
+        win.location.pathname = "/target";
+        win.location.href = "http://localhost/target";
+        popstateHandler!({ state: (win.history as any).state });
+
+        await vi.waitFor(() => expect(animationFrames).toHaveLength(1));
+        expect(win.scrollTo).toHaveBeenCalledWith(40, 600);
+
+        const replacement = Router.replace("/replacement", undefined, {
+          shallow: replacementKind === "shallow",
+        });
+        await replacement;
+        expect((win.history as any).replaceState).toHaveBeenLastCalledWith(
+          expect.objectContaining({ key: targetKey }),
+          "",
+          "/replacement",
+        );
+
+        animationFrames.shift()!(0);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(completedUrls).not.toContain("/target");
+        if (replacementKind === "shallow") {
+          expect(completedUrls).toContain("/replacement");
+        } else {
+          expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        }
+      } finally {
+        const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+        Router.events.off("routeChangeComplete", onRouteChangeComplete);
+        vi.resetModules();
+        if (previousWindow === undefined) delete (globalThis as any).window;
+        else (globalThis as any).window = previousWindow;
+        if (previousDocument === undefined) delete (globalThis as any).document;
+        else (globalThis as any).document = previousDocument;
+        globalThis.fetch = originalFetch;
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+        if (originalScrollRestorationEnv === undefined) {
+          delete process.env.__NEXT_SCROLL_RESTORATION;
+        } else {
+          process.env.__NEXT_SCROLL_RESTORATION = originalScrollRestorationEnv;
+        }
+      }
+    },
+  );
+
   it("abort signal fires when navigation is superseded — AbortError becomes NavigationCancelledError", async () => {
     // Verify that the AbortController signal passed to fetch actually fires when a
     // newer navigation starts, and that the resulting AbortError is converted into

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14729,7 +14729,7 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
-  it("uses rewritten destination params for shallow query refreshes", async () => {
+  it("uses rewritten destination query and renamed params for shallow query refreshes", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
@@ -14750,7 +14750,7 @@ describe("Pages Router concurrent navigation", () => {
         beforeFiles: [
           {
             source: "/store/:slug/:section",
-            destination: "/catalog/:section/:slug/en",
+            destination: "/catalog/:section/:slug/en?view=grid&slug=destination",
           },
         ],
         afterFiles: [],
@@ -14772,7 +14772,9 @@ describe("Pages Router concurrent navigation", () => {
       const { default: Router } = await import("../packages/vinext/src/shims/router.js");
 
       await expect(
-        Router.push("/store/guide/books?preview=1", undefined, { shallow: true }),
+        Router.push("/store/guide/books?preview=1&view=list&slug=visible", undefined, {
+          shallow: true,
+        }),
       ).resolves.toBe(true);
 
       expect(globalThis.fetch).not.toHaveBeenCalled();
@@ -14781,13 +14783,20 @@ describe("Pages Router concurrent navigation", () => {
         locale: "en",
         preview: "1",
         slug: "guide",
+        view: "grid",
       });
       expect(win.history.pushState).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          __vinext_params: { category: "books", locale: "en", slug: "guide" },
+          __vinext_query: {
+            category: "books",
+            locale: "en",
+            preview: "1",
+            slug: "guide",
+            view: "grid",
+          },
         }),
         "",
-        "/store/guide/books?preview=1",
+        "/store/guide/books?preview=1&view=list&slug=visible",
       );
     } finally {
       vi.resetModules();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2491,7 +2491,7 @@ describe("window.next debug global", () => {
       // Shallow push avoids the HTML fetch + render path so this unit test
       // does not need a navigateClient stub. The boolean-return contract
       // applies equally to shallow and non-shallow navigations.
-      const result = await win.next.router.push("/foo", undefined, { shallow: true });
+      const result = await win.next.router.push("/?foo=1", undefined, { shallow: true });
       expect(result).toBe(true);
     } finally {
       (globalThis as any).window = previousWindow;
@@ -2520,7 +2520,7 @@ describe("window.next debug global", () => {
       vi.resetModules();
       await import("../packages/vinext/src/shims/router.js");
 
-      const result = await win.next.router.replace("/foo", undefined, { shallow: true });
+      const result = await win.next.router.replace("/?foo=1", undefined, { shallow: true });
       expect(result).toBe(true);
     } finally {
       (globalThis as any).window = previousWindow;
@@ -2528,12 +2528,7 @@ describe("window.next debug global", () => {
     }
   });
 
-  // Shallow navigations skip the render-commit path, so the scroll reset is
-  // applied synchronously in performNavigation — before routeChangeComplete.
-  // This matches the non-shallow path, where the x/y reset runs inside the
-  // render-commit callback (also ahead of routeChangeComplete). Pins the
-  // ordering so listeners observe the final scroll position.
-  it("shallow push applies the scroll reset before routeChangeComplete", async () => {
+  it("valid shallow push defaults scroll to false", async () => {
     const previousWindow = (globalThis as any).window;
     const order: string[] = [];
     const win: any = {
@@ -2547,9 +2542,9 @@ describe("window.next debug global", () => {
       history: { state: null, pushState() {}, replaceState() {} },
       addEventListener() {},
       dispatchEvent() {},
-      scrollTo(x: number, y: number) {
+      scrollTo: vi.fn((x: number, y: number) => {
         order.push(`scrollTo:${x},${y}`);
-      },
+      }),
     };
     (globalThis as any).window = win;
 
@@ -2560,9 +2555,10 @@ describe("window.next debug global", () => {
       win.next.router.events.on("routeChangeComplete", () => {
         order.push("routeChangeComplete");
       });
-      const result = await win.next.router.push("/foo", undefined, { shallow: true });
+      const result = await win.next.router.push("/?step=one", undefined, { shallow: true });
       expect(result).toBe(true);
-      expect(order).toEqual(["scrollTo:0,0", "routeChangeComplete"]);
+      expect(order).toEqual(["routeChangeComplete"]);
+      expect(win.scrollTo).not.toHaveBeenCalled();
     } finally {
       (globalThis as any).window = previousWindow;
       vi.resetModules();
@@ -16116,6 +16112,54 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("hash-only popstate events carry the effective shallow value", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      getElementById: vi.fn(() => null),
+      getElementsByName: vi.fn(() => []),
+    };
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      await Router.push("/#one", undefined, { shallow: true });
+      const payloads: Array<{ shallow: boolean }> = [];
+      Router.events.on("hashChangeStart", (_url, options) =>
+        payloads.push(options as { shallow: boolean }),
+      );
+      Router.events.on("hashChangeComplete", (_url, options) =>
+        payloads.push(options as { shallow: boolean }),
+      );
+
+      win.location.hash = "#two";
+      win.location.href = "http://localhost/#two";
+      listeners.get("popstate")!({
+        state: {
+          __N: true,
+          url: "/",
+          as: "/",
+          options: { shallow: true },
+          key: "key-two",
+          __vinext_route: "/",
+        },
+      });
+      expect(payloads).toEqual([{ shallow: true }, { shallow: true }]);
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+    }
+  });
+
   // A hash-only push must snapshot the outgoing entry's scroll under its key
   // before updateHistory mints the new entry's key — otherwise a later
   // back-popstate to the departed entry restores {x: 0, y: 0} instead of the
@@ -17053,14 +17097,12 @@ describe("Pages Router concurrent navigation", () => {
       const deepNavigation = Router.push("/page-a");
       await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
 
-      await expect(Router.replace("/page-b?shallow=1", undefined, { shallow: true })).resolves.toBe(
-        true,
-      );
+      await expect(Router.replace("/?shallow=1", undefined, { shallow: true })).resolves.toBe(true);
       deepResponse.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
       await deepNavigation;
 
       expect(render).not.toHaveBeenCalled();
-      expect(completedUrls).toEqual(["/page-b?shallow=1"]);
+      expect(completedUrls).toEqual(["/?shallow=1"]);
       expect(errors).toContainEqual({
         err: expect.objectContaining({ cancelled: true }),
         url: "/page-a",
@@ -17075,6 +17117,121 @@ describe("Pages Router concurrent navigation", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("cross-route shallow navigation falls back to a deep navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    (globalThis as any).window = win;
+    const deepResponse = createDeferred<Response>();
+    globalThis.fetch = vi.fn(() => deepResponse.promise);
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const navigation = Router.push("/page-a", undefined, { shallow: true });
+      await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+      expect((win.history as any).pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ shallow: false }) }),
+        "",
+        "/page-a",
+      );
+      deepResponse.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
+      await navigation;
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it.each(["shallow", "hash", "popstate"] as const)(
+    "emits deferred deep cancellation before replacement %s events",
+    async (replacementKind) => {
+      const previousWindow = (globalThis as any).window;
+      const previousDocument = (globalThis as any).document;
+      const originalFetch = globalThis.fetch;
+      const listeners = new Map<string, (event: any) => void>();
+      const { win } = createNavWindow();
+      (win as any).__VINEXT_PAGE_LOADERS__ = { "/": async () => ({ default: () => null }) };
+      win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+        listeners.set(type, handler);
+      });
+      (globalThis as any).window = win;
+      (globalThis as any).document = {
+        getElementById: vi.fn(() => null),
+        getElementsByName: vi.fn(() => []),
+      };
+      const deepResponse = createDeferred<Response>();
+      globalThis.fetch = vi
+        .fn()
+        .mockImplementationOnce(() => deepResponse.promise)
+        .mockImplementation(
+          async () => new Response(buildNavHtml("/", "/@fs/pages/index.js", { step: "pop" })),
+        );
+      const order: string[] = [];
+
+      try {
+        vi.resetModules();
+        const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+        const { installPagesRouterRuntime } =
+          await import("../packages/vinext/src/shims/pages-router-runtime.js");
+        installPagesRouterRuntime();
+        Router.events.on("routeChangeError", (_error, url) => order.push(`error:${String(url)}`));
+        Router.events.on("routeChangeStart", (url) => order.push(`routeStart:${String(url)}`));
+        Router.events.on("routeChangeComplete", (url) =>
+          order.push(`routeComplete:${String(url)}`),
+        );
+        Router.events.on("hashChangeStart", (url) => order.push(`hashStart:${String(url)}`));
+        Router.events.on("hashChangeComplete", (url) => order.push(`hashComplete:${String(url)}`));
+
+        const deepNavigation = Router.push("/page-a");
+        await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+        order.length = 0;
+
+        if (replacementKind === "shallow") {
+          await Router.replace("/?step=shallow", undefined, { shallow: true });
+        } else if (replacementKind === "hash") {
+          await Router.replace("/page-a#hash");
+        } else {
+          win.location.pathname = "/";
+          win.location.search = "?step=pop";
+          win.location.href = "http://localhost/?step=pop";
+          listeners.get("popstate")!({
+            state: {
+              __N: true,
+              url: "/",
+              as: "/?step=pop",
+              options: { shallow: true },
+              key: "key-pop",
+              __vinext_route: "/",
+            },
+          });
+          await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+        }
+
+        expect(order[0]).toBe("error:/page-a");
+        expect(order.slice(1)).toEqual(
+          replacementKind === "hash"
+            ? ["hashStart:/page-a#hash", "hashComplete:/page-a#hash"]
+            : replacementKind === "shallow"
+              ? ["routeStart:/?step=shallow", "routeComplete:/?step=shallow"]
+              : ["routeStart:/?step=pop", "routeComplete:/?step=pop"],
+        );
+        deepResponse.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
+        await deepNavigation;
+        expect(order.filter((event) => event === "error:/page-a")).toHaveLength(1);
+      } finally {
+        vi.resetModules();
+        if (previousWindow === undefined) delete (globalThis as any).window;
+        else (globalThis as any).window = previousWindow;
+        if (previousDocument === undefined) delete (globalThis as any).document;
+        else (globalThis as any).document = previousDocument;
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
 
   it.each(["shallow", "deep"] as const)(
     "same-key %s replace supersedes pending shallow popstate scroll restoration",

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14888,6 +14888,10 @@ describe("Pages Router concurrent navigation", () => {
     const previousTrailingSlash = process.env.__VINEXT_TRAILING_SLASH;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
+    const currentPathname = new URL(target, "http://localhost").pathname.replace(/\/$/, "") || "/";
+    win.location.pathname = currentPathname;
+    win.location.href = `http://localhost${currentPathname}`;
+    win.__NEXT_DATA__.page = currentPathname;
     (
       win.__NEXT_DATA__.__vinext as { pageModuleUrl: string; hasMiddleware?: boolean }
     ).hasMiddleware = true;
@@ -17226,26 +17230,25 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
-  it("preserves requested cross-route shallow navigation when middleware makes route identity unknowable", async () => {
+  it("does not preserve cross-route shallow navigation when middleware is present", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
+    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
     (
       win.__NEXT_DATA__.__vinext as { pageModuleUrl: string; hasMiddleware?: boolean }
     ).hasMiddleware = true;
     (globalThis as any).window = win;
-    globalThis.fetch = vi.fn(async () => {
-      throw new Error("middleware-backed shallow navigation must not fetch page HTML");
-    });
+    globalThis.fetch = vi.fn(async () => new Response(buildNavHtml("/page-a", pageModuleUrl)));
 
     try {
       vi.resetModules();
       const { default: Router } = await import("../packages/vinext/src/shims/router.js");
 
       await expect(Router.push("/page-a", undefined, { shallow: true })).resolves.toBe(true);
-      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(globalThis.fetch).toHaveBeenCalledOnce();
       expect((win.history as any).pushState).toHaveBeenLastCalledWith(
-        expect.objectContaining({ options: expect.objectContaining({ shallow: true }) }),
+        expect.objectContaining({ options: expect.objectContaining({ shallow: false }) }),
         "",
         "/page-a",
       );
@@ -17370,11 +17373,15 @@ describe("Pages Router concurrent navigation", () => {
       (win.history as any).scrollRestoration = "auto";
       (win.history as any).state = {
         __N: true,
-        url: "/current",
-        as: "/current",
+        url: "/",
+        as: "/?step=current",
         options: { shallow: true },
         key: "key-current",
+        __vinext_route: "/",
       };
+      win.location.pathname = "/";
+      win.location.search = "?step=current";
+      win.location.href = "http://localhost/?step=current";
       const sessionStore = new Map<string, string>([
         [`__next_scroll_${targetKey}`, JSON.stringify({ x: 40, y: 600 })],
       ]);
@@ -17411,43 +17418,44 @@ describe("Pages Router concurrent navigation", () => {
         installPagesRouterRuntime();
         Router.events.on("routeChangeComplete", onRouteChangeComplete);
 
-        await Router.replace("/current", undefined, { shallow: true });
+        await Router.replace("/?step=current", undefined, { shallow: true });
         completedUrls.length = 0;
 
         const popstateHandler = listeners.get("popstate");
         expect(popstateHandler).toBeDefined();
         (win.history as any).state = {
           __N: true,
-          url: "/target",
-          as: "/target",
+          url: "/?step=target",
+          as: "/?step=target",
           options: { shallow: true },
           key: targetKey,
           __vinext_route: "/",
         };
-        win.location.pathname = "/target";
-        win.location.href = "http://localhost/target";
+        win.location.pathname = "/";
+        win.location.search = "?step=target";
+        win.location.href = "http://localhost/?step=target";
         popstateHandler!({ state: (win.history as any).state });
 
         await vi.waitFor(() => expect(animationFrames).toHaveLength(1));
         expect(win.scrollTo).toHaveBeenCalledWith(40, 600);
 
-        const replacement = Router.replace("/replacement", undefined, {
+        const replacement = Router.replace("/?step=replacement", undefined, {
           shallow: replacementKind === "shallow",
         });
         await replacement;
         expect((win.history as any).replaceState).toHaveBeenLastCalledWith(
           expect.objectContaining({ key: targetKey }),
           "",
-          "/replacement",
+          "/?step=replacement",
         );
 
         animationFrames.shift()!(0);
         await Promise.resolve();
         await Promise.resolve();
 
-        expect(completedUrls).not.toContain("/target");
+        expect(completedUrls).not.toContain("/?step=target");
         if (replacementKind === "shallow") {
-          expect(completedUrls).toContain("/replacement");
+          expect(completedUrls).toContain("/?step=replacement");
         } else {
           expect(globalThis.fetch).toHaveBeenCalledTimes(1);
         }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14729,6 +14729,53 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("keeps a basePath-qualified rewrite alias to the same page shallow", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    Object.assign(win.location, {
+      pathname: "/docs/about",
+      href: "http://localhost/docs/about",
+    });
+    Object.assign(win, {
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, isDynamic: false, patternParts: ["about"] },
+      ],
+      __VINEXT_CLIENT_REWRITES__: {
+        beforeFiles: [{ source: "/about-alias", destination: "/about" }],
+        afterFiles: [],
+        fallback: [],
+      },
+      __NEXT_DATA__: { ...win.__NEXT_DATA__, page: "/about" },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("same-page basePath rewrite alias must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(Router.push("/about-alias", undefined, { shallow: true })).resolves.toBe(true);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(win.history.pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ shallow: true }) }),
+        "",
+        "/docs/about-alias",
+      );
+    } finally {
+      vi.resetModules();
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   /**
    * Build a minimal HTML response that navigateClient can parse.
    * Includes __NEXT_DATA__ with a pageModuleUrl pointing to the given path.
@@ -17281,6 +17328,68 @@ describe("Pages Router concurrent navigation", () => {
       } else {
         (globalThis as any).window = previousWindow;
       }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("emits deep navigation cancellation before the winning start and history events", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    Object.assign(win, {
+      __VINEXT_PAGE_LOADERS__: {
+        "/page-a": async () => ({ default: () => null }),
+        "/page-b": async () => ({ default: () => null }),
+      },
+    });
+    (globalThis as any).window = win;
+
+    const fetchA = createDeferred<Response>();
+    const fetchB = createDeferred<Response>();
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementationOnce(() => fetchA.promise)
+      .mockImplementationOnce(() => fetchB.promise);
+
+    const events: string[] = [];
+    const onRouteChangeError = (...args: unknown[]) => events.push(`error:${String(args[1])}`);
+    const onRouteChangeStart = (...args: unknown[]) => events.push(`start:${String(args[0])}`);
+    const onBeforeHistoryChange = (...args: unknown[]) => events.push(`history:${String(args[0])}`);
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeError", onRouteChangeError);
+      Router.events.on("routeChangeStart", onRouteChangeStart);
+      Router.events.on("beforeHistoryChange", onBeforeHistoryChange);
+
+      const navigationA = Router.push("/page-a");
+      await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+      const navigationB = Router.push("/page-b");
+
+      expect(events).toEqual([
+        "start:/page-a",
+        "history:/page-a",
+        "error:/page-a",
+        "start:/page-b",
+        "history:/page-b",
+      ]);
+
+      fetchB.resolve(new Response(buildNavHtml("/page-b", "/@fs/pages/page-b.js")));
+      fetchA.resolve(new Response(buildNavHtml("/page-a", "/@fs/pages/page-a.js")));
+      const results = await Promise.allSettled([navigationA, navigationB]);
+      expect(results).toEqual([
+        { status: "fulfilled", value: false },
+        { status: "fulfilled", value: true },
+      ]);
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeError", onRouteChangeError);
+      Router.events.off("routeChangeStart", onRouteChangeStart);
+      Router.events.off("beforeHistoryChange", onBeforeHistoryChange);
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
       globalThis.fetch = originalFetch;
     }
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14560,6 +14560,47 @@ describe("Pages Router concurrent navigation", () => {
     return { win, pushState, replaceState, render };
   }
 
+  it("prefers special-name dynamic route params over same-key search params", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/actual-constructor/actual-to-string/actual-prototype",
+      search: "?constructor=spoofed&toString=spoofed&__proto__=spoofed",
+      href: "http://localhost/actual-constructor/actual-to-string/actual-prototype?constructor=spoofed&toString=spoofed&__proto__=spoofed",
+    });
+    Object.assign(win, {
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/[constructor]/[toString]/[__proto__]",
+        query: {},
+        isFallback: false,
+      },
+    });
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const runtimeStateKey = Symbol.for("vinext.pagesRouter.runtimeState");
+      const runtimeState = (globalThis as any).window[runtimeStateKey];
+      runtimeState.currentShallow = true;
+      runtimeState.currentShallowQuery = JSON.parse(
+        '{"constructor":"actual-constructor","toString":"actual-to-string","__proto__":"actual-prototype"}',
+      );
+      const query = Router.query as Record<string, string | string[]>;
+      expect(Object.hasOwn(query, "constructor")).toBe(true);
+      expect(query.constructor).toBe("actual-constructor");
+      expect(Object.hasOwn(query, "toString")).toBe(true);
+      expect(query["toString"]).toBe("actual-to-string");
+      expect(Object.hasOwn(query, "__proto__")).toBe(true);
+      expect(query["__proto__"]).toBe("actual-prototype");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
   it("matches localized dynamic paths before validating shallow route identity", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -14928,6 +14969,96 @@ describe("Pages Router concurrent navigation", () => {
         slug: "reference",
         step: "two",
         view: "grid",
+      });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("re-resolves masked shallow Back and Forward from href while preserving as", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/catalog/old/entry/fr",
+      href: "http://localhost/catalog/old/entry/fr",
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      addEventListener: vi.fn((type: string, handler: (event: any) => void) => {
+        listeners.set(type, handler);
+      }),
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        {
+          canPrefetchLoadingShell: false,
+          isDynamic: true,
+          patternParts: ["catalog", ":category", ":slug", ":locale"],
+        },
+      ],
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/catalog/[category]/[slug]/[locale]",
+        query: { category: "old", locale: "fr", slug: "entry" },
+      },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("masked shallow Back/Forward must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      await Router.push(
+        "/catalog/books/guide/en?view=grid&step=one",
+        "/store/guide/books?step=one",
+        { shallow: true },
+      );
+      const firstState = win.history.pushState.mock.calls.at(-1)?.[0];
+      await Router.push(
+        "/catalog/music/reference/en?view=list&step=two",
+        "/store/reference/music?step=two",
+        { shallow: true },
+      );
+      const secondState = win.history.pushState.mock.calls.at(-1)?.[0];
+
+      Object.assign(win.location, {
+        pathname: "/store/guide/books",
+        search: "?step=one",
+        href: "http://localhost/store/guide/books?step=one",
+      });
+      listeners.get("popstate")!({ state: firstState });
+      expect(Router.asPath).toBe("/store/guide/books?step=one");
+      expect(Router.query).toEqual({
+        category: "books",
+        locale: "en",
+        slug: "guide",
+        step: "one",
+        view: "grid",
+      });
+
+      Object.assign(win.location, {
+        pathname: "/store/reference/music",
+        search: "?step=two",
+        href: "http://localhost/store/reference/music?step=two",
+      });
+      listeners.get("popstate")!({ state: secondState });
+      expect(Router.asPath).toBe("/store/reference/music?step=two");
+      expect(Router.query).toEqual({
+        category: "music",
+        locale: "en",
+        slug: "reference",
+        step: "two",
+        view: "list",
       });
       expect(globalThis.fetch).not.toHaveBeenCalled();
     } finally {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14647,6 +14647,54 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("keeps same-visible middleware rewrites shallow without retaining middleware-only query", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/sha",
+      search: "?hello=goodbye",
+      href: "http://localhost/sha?hello=goodbye",
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, isDynamic: false, patternParts: ["shallow-test"] },
+      ],
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/shallow-test",
+        query: { hello: "goodbye", from: "middleware" },
+        __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+      },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("same-visible middleware rewrite must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(Router.push("/sha?hello=world", undefined, { shallow: true })).resolves.toBe(
+        true,
+      );
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(Router.query).toEqual({ hello: "world" });
+      expect(win.history.pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ shallow: true }) }),
+        "",
+        "/sha?hello=world",
+      );
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it.each([
     {
       name: "prefers a static page over a dynamic page",
@@ -15061,6 +15109,68 @@ describe("Pages Router concurrent navigation", () => {
         view: "list",
       });
       expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not restore shallow state across different stored page routes", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/page-two",
+      href: "http://localhost/page-two",
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      addEventListener: vi.fn((type: string, handler: (event: any) => void) => {
+        listeners.set(type, handler);
+      }),
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, isDynamic: false, patternParts: ["page-one"] },
+        { canPrefetchLoadingShell: false, isDynamic: false, patternParts: ["page-two"] },
+      ],
+      __NEXT_DATA__: { ...win.__NEXT_DATA__, page: "/page-two", query: {} },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(
+      async () => new Response(buildNavHtml("/page-one", "/@fs/pages/page-one.js")),
+    );
+
+    try {
+      vi.resetModules();
+      await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      const runtimeState = (globalThis as any).window[
+        Symbol.for("vinext.pagesRouter.runtimeState")
+      ];
+      runtimeState.currentShallow = true;
+
+      Object.assign(win.location, {
+        pathname: "/page-one",
+        search: "?params=testParams",
+        href: "http://localhost/page-one?params=testParams",
+      });
+      listeners.get("popstate")!({
+        state: {
+          __N: true,
+          url: "/page-one?params=testParams",
+          as: "/page-one?params=testParams",
+          options: { shallow: true },
+          key: "page-one",
+          __vinext_route: "/page-one",
+        },
+      });
+
+      await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+      expect(runtimeState.currentShallow).toBe(false);
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) delete (globalThis as any).window;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13852,6 +13852,9 @@ describe("next/compat/router shim", () => {
       __VINEXT_DEFAULT_LOCALE__: undefined,
     };
 
+    const runtimeStateKey = Symbol.for("vinext.pagesRouter.runtimeState");
+    (globalThis as any).window[runtimeStateKey] = { currentShallow: true };
+
     try {
       let captured: unknown = "NOT_SET";
       function Probe() {
@@ -13922,12 +13925,6 @@ describe("next/compat/router shim", () => {
   });
 
   it("prefers the current search query over stale rewrite query state", async () => {
-    const React = await import("react");
-    const { renderToStaticMarkup } = await import("react-dom/server");
-    const { useRouter: useCompatRouter } =
-      await import("../packages/vinext/src/shims/compat-router.js");
-    const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
-
     const previousWindow = (globalThis as any).window;
     (globalThis as any).window = {
       location: {
@@ -13935,7 +13932,19 @@ describe("next/compat/router shim", () => {
         search: "?hello=world",
         hash: "",
       },
-      history: { state: { options: { shallow: true } } },
+      history: {
+        state: {
+          __N: true,
+          url: "/shallow-test?hello=world",
+          as: "/sha?hello=world",
+          options: { shallow: true },
+          key: "shallow",
+        },
+        replaceState: vi.fn(function (this: { state: unknown }, state: unknown) {
+          this.state = state;
+        }),
+      },
+      addEventListener: vi.fn(),
       __NEXT_DATA__: {
         page: "/shallow-test",
         query: { hello: "goodbye", from: "middleware" },
@@ -13947,6 +13956,15 @@ describe("next/compat/router shim", () => {
     };
 
     try {
+      vi.resetModules();
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const { useRouter: useCompatRouter } =
+        await import("../packages/vinext/src/shims/compat-router.js");
+      const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
+      const runtimeStateKey = Symbol.for("vinext.pagesRouter.runtimeState");
+      (globalThis as any).window[runtimeStateKey].currentShallow = true;
+
       let captured: unknown = "NOT_SET";
       function Probe() {
         captured = useCompatRouter();
@@ -13960,6 +13978,7 @@ describe("next/compat/router shim", () => {
       expect((captured as any).pathname).toBe("/shallow-test");
       expect((captured as any).asPath).toBe("/sha?hello=world");
     } finally {
+      vi.resetModules();
       if (previousWindow === undefined) {
         delete (globalThis as any).window;
       } else {
@@ -13968,13 +13987,7 @@ describe("next/compat/router shim", () => {
     }
   });
 
-  it("preserves rewrite query state after deep navigation", async () => {
-    const React = await import("react");
-    const { renderToStaticMarkup } = await import("react-dom/server");
-    const { useRouter: useCompatRouter } =
-      await import("../packages/vinext/src/shims/compat-router.js");
-    const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
-
+  it("does not treat persisted shallow history state as a current shallow navigation", async () => {
     const previousWindow = (globalThis as any).window;
     (globalThis as any).window = {
       location: {
@@ -13982,7 +13995,19 @@ describe("next/compat/router shim", () => {
         search: "?hello=world",
         hash: "",
       },
-      history: { state: { options: { shallow: false } } },
+      history: {
+        state: {
+          __N: true,
+          url: "/shallow-test?hello=world",
+          as: "/sha?hello=world",
+          options: { shallow: true },
+          key: "reloaded-shallow",
+        },
+        replaceState: vi.fn(function (this: { state: unknown }, state: unknown) {
+          this.state = state;
+        }),
+      },
+      addEventListener: vi.fn(),
       __NEXT_DATA__: {
         page: "/shallow-test",
         query: { hello: "goodbye", from: "middleware" },
@@ -13994,6 +14019,13 @@ describe("next/compat/router shim", () => {
     };
 
     try {
+      vi.resetModules();
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const { useRouter: useCompatRouter } =
+        await import("../packages/vinext/src/shims/compat-router.js");
+      const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
+
       let captured: unknown = "NOT_SET";
       function Probe() {
         captured = useCompatRouter();
@@ -14007,6 +14039,7 @@ describe("next/compat/router shim", () => {
       expect((captured as any).pathname).toBe("/shallow-test");
       expect((captured as any).asPath).toBe("/sha?hello=world");
     } finally {
+      vi.resetModules();
       if (previousWindow === undefined) {
         delete (globalThis as any).window;
       } else {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14729,6 +14729,74 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("uses rewritten destination params for shallow query refreshes", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/catalog/old/entry/fr",
+      href: "http://localhost/catalog/old/entry/fr",
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        {
+          canPrefetchLoadingShell: false,
+          isDynamic: true,
+          patternParts: ["catalog", ":category", ":slug", ":locale"],
+        },
+      ],
+      __VINEXT_CLIENT_REWRITES__: {
+        beforeFiles: [
+          {
+            source: "/store/:slug/:section",
+            destination: "/catalog/:section/:slug/en",
+          },
+        ],
+        afterFiles: [],
+        fallback: [],
+      },
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/catalog/[category]/[slug]/[locale]",
+        query: { category: "old", locale: "fr", slug: "entry" },
+      },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("same-page rewrite alias must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(
+        Router.push("/store/guide/books?preview=1", undefined, { shallow: true }),
+      ).resolves.toBe(true);
+
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(Router.query).toEqual({
+        category: "books",
+        locale: "en",
+        preview: "1",
+        slug: "guide",
+      });
+      expect(win.history.pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __vinext_params: { category: "books", locale: "en", slug: "guide" },
+        }),
+        "",
+        "/store/guide/books?preview=1",
+      );
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("keeps a basePath-qualified rewrite alias to the same page shallow", async () => {
     const previousWindow = (globalThis as any).window;
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
@@ -18380,6 +18448,65 @@ describe("Pages Router _next/data client navigation", () => {
       vi.resetModules();
     }
   });
+
+  it.each(["push", "replace"] as const)(
+    "cancels a deferred Pages navigation before hard App handoff via %s",
+    async (mode) => {
+      const previousWindow = (globalThis as any).window;
+      const originalFetch = globalThis.fetch;
+      const slowLoader = vi.fn(async () => makePageModule("slow"));
+      const { win, render } = createDataNavWindow({
+        loaders: { "/": vi.fn(async () => makePageModule("home")), "/slow": slowLoader },
+      });
+      Object.assign(win, {
+        __VINEXT_LINK_PREFETCH_ROUTES__: [
+          { canPrefetchLoadingShell: false, isDynamic: false, patternParts: ["app-page"] },
+        ],
+        __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+          { canPrefetchLoadingShell: false, isDynamic: true, patternParts: [":slug"] },
+        ],
+      });
+      (globalThis as any).window = win;
+      vi.resetModules();
+
+      let resolveFetch: (response: Response) => void = () => {};
+      const deferredFetch = new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+      globalThis.fetch = vi.fn(() => deferredFetch) as any;
+
+      try {
+        const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+        const errors: Array<{ cancelled?: boolean }> = [];
+        Router.events.on("routeChangeError", (error) => errors.push(error as any));
+
+        const pagesNavigation = Router.push("/slow");
+        const hardNavigation = Router[mode]("/app-page");
+
+        expect(errors).toEqual([expect.objectContaining({ cancelled: true })]);
+        expect(win.location[mode === "push" ? "assign" : "replace"]).toHaveBeenCalledWith(
+          "/app-page",
+        );
+
+        resolveFetch(
+          new Response(JSON.stringify({ pageProps: { stale: true } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+
+        await expect(pagesNavigation).resolves.toBe(false);
+        expect(render).not.toHaveBeenCalled();
+        expect(slowLoader).not.toHaveBeenCalled();
+        void hardNavigation;
+      } finally {
+        if (previousWindow === undefined) delete (globalThis as any).window;
+        else (globalThis as any).window = previousWindow;
+        globalThis.fetch = originalFetch;
+        vi.resetModules();
+      }
+    },
+  );
 
   it("threads full Pages props through _app during data navigation", async () => {
     const previousWindow = (globalThis as any).window;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14787,17 +14787,12 @@ describe("Pages Router concurrent navigation", () => {
       });
       expect(win.history.pushState).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          __vinext_query: {
-            category: "books",
-            locale: "en",
-            preview: "1",
-            slug: "guide",
-            view: "grid",
-          },
+          __vinext_route: "/catalog/[category]/[slug]/[locale]",
         }),
         "",
         "/store/guide/books?preview=1&view=list&slug=visible",
       );
+      expect(win.history.pushState.mock.calls.at(-1)?.[0]).not.toHaveProperty("__vinext_query");
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) delete (globalThis as any).window;
@@ -14847,6 +14842,221 @@ describe("Pages Router concurrent navigation", () => {
       vi.resetModules();
       if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
       else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("re-resolves shallow Back and Forward query from each rewrite alias URL", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/catalog/old/entry/fr",
+      href: "http://localhost/catalog/old/entry/fr",
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      addEventListener: vi.fn((type: string, handler: (event: any) => void) => {
+        listeners.set(type, handler);
+      }),
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        {
+          canPrefetchLoadingShell: false,
+          isDynamic: true,
+          patternParts: ["catalog", ":category", ":slug", ":locale"],
+        },
+      ],
+      __VINEXT_CLIENT_REWRITES__: {
+        beforeFiles: [
+          {
+            source: "/store/:slug/:section",
+            destination: "/catalog/:section/:slug/en?view=grid",
+          },
+        ],
+        afterFiles: [],
+        fallback: [],
+      },
+      __NEXT_DATA__: {
+        ...win.__NEXT_DATA__,
+        page: "/catalog/[category]/[slug]/[locale]",
+        query: { category: "old", locale: "fr", slug: "entry" },
+      },
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("shallow Back/Forward must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      await Router.push("/store/guide/books?step=one", undefined, { shallow: true });
+      const firstState = win.history.pushState.mock.calls.at(-1)?.[0];
+      await Router.push("/store/reference/music?step=two", undefined, { shallow: true });
+      const secondState = win.history.pushState.mock.calls.at(-1)?.[0];
+
+      Object.assign(win.location, {
+        pathname: "/store/guide/books",
+        search: "?step=one",
+        href: "http://localhost/store/guide/books?step=one",
+      });
+      listeners.get("popstate")!({ state: firstState });
+      expect(Router.query).toEqual({
+        category: "books",
+        locale: "en",
+        slug: "guide",
+        step: "one",
+        view: "grid",
+      });
+
+      Object.assign(win.location, {
+        pathname: "/store/reference/music",
+        search: "?step=two",
+        href: "http://localhost/store/reference/music?step=two",
+      });
+      listeners.get("popstate")!({ state: secondState });
+      expect(Router.query).toEqual({
+        category: "music",
+        locale: "en",
+        slug: "reference",
+        step: "two",
+        view: "grid",
+      });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("demotes stale conditional rewrite history entries from shallow popstate", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    Object.assign(win, {
+      addEventListener: vi.fn((type: string, handler: (event: any) => void) => {
+        listeners.set(type, handler);
+      }),
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, isDynamic: true, patternParts: ["catalog", ":slug"] },
+      ],
+      __VINEXT_CLIENT_REWRITES__: {
+        beforeFiles: [
+          {
+            source: "/store/:slug",
+            destination: "/catalog/:slug?access=member",
+            has: [{ type: "cookie", key: "member", value: "yes" }],
+          },
+        ],
+        afterFiles: [],
+        fallback: [],
+      },
+      __NEXT_DATA__: { ...win.__NEXT_DATA__, page: "/catalog/[slug]", query: { slug: "old" } },
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = { cookie: "member=yes" };
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          buildNavHtml("/store/[slug]", "/@fs/pages/store/[slug].js", { slug: "guide" }),
+        ),
+    );
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      await Router.push("/store/guide", undefined, { shallow: true });
+      const state = win.history.pushState.mock.calls.at(-1)?.[0];
+      await Router.push("/store/reference", undefined, { shallow: true });
+
+      (globalThis as any).document.cookie = "";
+      Object.assign(win.location, {
+        pathname: "/store/guide",
+        search: "",
+        href: "http://localhost/store/guide",
+      });
+      listeners.get("popstate")!({ state });
+
+      await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("ignores forged shallow history query and preserves special query keys safely", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win } = createNavWindow();
+    Object.assign(win, {
+      addEventListener: vi.fn((type: string, handler: (event: any) => void) => {
+        listeners.set(type, handler);
+      }),
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, isDynamic: false, patternParts: [] },
+      ],
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("validated same-route shallow popstate must not fetch page HTML");
+    });
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      await Router.push("/?safe=one", undefined, { shallow: true });
+
+      Object.assign(win.location, {
+        pathname: "/",
+        search: "?safe=two&__proto__=prototype-value&constructor=constructor-value",
+        href: "http://localhost/?safe=two&__proto__=prototype-value&constructor=constructor-value",
+      });
+      listeners.get("popstate")!({
+        state: {
+          __N: true,
+          url: "/?safe=two",
+          as: "/?safe=two&__proto__=prototype-value&constructor=constructor-value",
+          options: { shallow: true },
+          key: "forged-query",
+          __vinext_route: "/",
+          __vinext_query: JSON.parse(
+            '{"safe":"forged","__proto__":"forged-prototype","constructor":"forged-constructor"}',
+          ),
+        },
+      });
+
+      const query = Router.query as Record<string, string | string[]>;
+      expect(query.safe).toBe("two");
+      expect(Object.getPrototypeOf(query)).toBe(Object.prototype);
+      expect(Object.hasOwn(query, "__proto__")).toBe(true);
+      expect(query["__proto__"]).toBe("prototype-value");
+      expect(Object.hasOwn(query, "constructor")).toBe(true);
+      expect(query.constructor).toBe("constructor-value");
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
       if (previousWindow === undefined) delete (globalThis as any).window;
       else (globalThis as any).window = previousWindow;
       globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- distinguish shallow navigations from deep navigations using the persisted history state
- rebuild shallow-navigation query state from the visible URL while preserving matched dynamic route params
- preserve middleware-injected rewrite query state after deep navigation

## Validation
- 4 focused router unit tests, including explicit shallow and deep rewrite branches
- 1 focused production Playwright test
- 12 existing dev shallow-routing tests
- scoped `vp check`, `git diff --check`, independent review: clean

## Next.js parity
Fixes the remaining shallow-linking assertion from `middleware-general/test/index.test.ts` in deploy-suite run 27858251903. The production regression test extends that upstream scenario with middleware-injected query state to cover both deep and shallow navigation. No raw Next.js E2E was run locally.
