### PR TITLE
fix(middleware): run on missing build assets

### DIFF
--- a/examples/app-router-cloudflare/middleware.ts
+++ b/examples/app-router-cloudflare/middleware.ts
@@ -4,11 +4,17 @@ import { NextRequest, NextResponse } from "next/server";
  * Middleware for app-router-cloudflare example.
  */
 export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === "/_next/static/middleware-rewrite.js") {
+    return new Response("rewritten missing asset", {
+      headers: { "content-type": "text/plain" },
+    });
+  }
+
   const response = NextResponse.next();
   response.headers.set("x-mw-ran", "true");
   return response;
 }
 
 export const config = {
-  matcher: ["/api/:path*", "/"],
+  matcher: ["/api/:path*", "/", "/_next/static/middleware-rewrite.js"],
 };

--- a/examples/pages-router-cloudflare/middleware.ts
+++ b/examples/pages-router-cloudflare/middleware.ts
@@ -7,6 +7,12 @@ import { NextRequest, NextResponse } from "next/server";
  * that middleware actually ran (and didn't crash with the outsideEmitter bug).
  */
 export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === "/_next/static/middleware-rewrite.js") {
+    return new Response("rewritten missing asset", {
+      headers: { "content-type": "text/plain" },
+    });
+  }
+
   if (request.nextUrl.pathname === "/headers-before-middleware-rewrite") {
     return NextResponse.rewrite(new URL("/ssr", request.url));
   }
@@ -31,5 +37,6 @@ export const config = {
     "/headers-before-middleware-rewrite",
     "/redirect-before-middleware-rewrite",
     "/redirect-before-middleware-response",
+    "/_next/static/middleware-rewrite.js",
   ],
 };

--- a/examples/pages-router-cloudflare/worker/index.ts
+++ b/examples/pages-router-cloudflare/worker/index.ts
@@ -20,13 +20,19 @@ import {
   proxyExternalRequest,
   sanitizeDestination,
 } from "vinext/config/config-matchers";
-import { mergeHeaders } from "vinext/server/worker-utils";
+import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses";
+import {
+  finalizeMissingStaticAssetResponse,
+  mergeHeaders,
+} from "vinext/server/worker-utils";
+import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { renderPage, handleApiRoute, runMiddleware, vinextConfig, matchPageRoute } from "virtual:vinext-server-entry";
 
 // Extract config values (embedded at build time in the server entry)
 const basePath: string = vinextConfig?.basePath ?? "";
+const assetPathPrefix: string = assetPrefixPathname(vinextConfig?.assetPrefix ?? "");
 const trailingSlash: boolean = vinextConfig?.trailingSlash ?? false;
 const configRedirects = vinextConfig?.redirects ?? [];
 const configRewrites = vinextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] };
@@ -38,6 +44,7 @@ export default {
       const url = new URL(request.url);
       let pathname = url.pathname;
       let urlWithQuery = pathname + url.search;
+      const missingBuildAsset = isNextStaticPath(pathname, basePath, assetPathPrefix);
 
       // Block protocol-relative URL open redirects (//evil.com/ or /\evil.com/).
       // Normalize backslashes: browsers treat /\ as // in URL context.
@@ -109,7 +116,7 @@ export default {
             });
           }
           if (result.response) {
-            return result.response;
+            return finalizeMissingStaticAssetResponse(result.response, missingBuildAsset);
           }
         }
 
@@ -238,10 +245,15 @@ export default {
       }
 
       if (!response) {
-        return new Response("404 - Not found", { status: 404 });
+        return missingBuildAsset
+          ? notFoundStaticAssetResponse()
+          : new Response("404 - Not found", { status: 404 });
       }
 
-      return mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus);
+      return finalizeMissingStaticAssetResponse(
+        mergeHeaders(response, middlewareHeaders, middlewareRewriteStatus),
+        missingBuildAsset,
+      );
     } catch (error) {
       console.error("[vinext] Worker error:", error);
       return new Response("Internal Server Error", { status: 500 });

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -558,6 +558,7 @@ import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isI
 import type { ImageConfig } from "vinext/server/image-optimization";
 import { cloneRequestWithHeaders, cloneRequestWithUrl, filterInternalHeaders, isOpenRedirectShaped } from "vinext/server/request-pipeline";
 import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses";
+import { finalizeMissingStaticAssetResponse } from "vinext/server/worker-utils";
 import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix";
 import { hasBasePath, stripBasePath } from "vinext/utils/base-path";
 
@@ -616,15 +617,11 @@ export default {
         return new Response("This page could not be found", { status: 404 });
       }
 
-      // Invalid \`_next/static/*\` paths short-circuit with a plain-text 404
-      // instead of falling through to renderPage (which would render the full
-      // HTML 404 page with bootstrap scripts + CSS). Valid assets are served
-      // by Cloudflare's ASSETS binding BEFORE the worker runs; only misses
-      // reach this code. Matches Next.js (#1337):
-      //   packages/next/src/server/lib/router-server.ts
-      if (isNextStaticPath(pathname, basePath, assetPathPrefix)) {
-        return notFoundStaticAssetResponse();
-      }
+      // Valid assets are served by Cloudflare's ASSETS binding before the
+      // worker runs. Missing asset-shaped requests still need to reach
+      // middleware so it can rewrite or respond; a final 404 is converted
+      // back to Next.js's canonical plain-text static-file response below.
+      const missingBuildAsset = isNextStaticPath(pathname, basePath, assetPathPrefix);
 
       // Strip internal headers from inbound requests so they cannot be
       // forged to influence routing or impersonate internal state.
@@ -716,10 +713,12 @@ export default {
 
       const result = await runPagesRequest(request, deps);
       if (result.type === "response") {
-        return result.response;
+        return finalizeMissingStaticAssetResponse(result.response, missingBuildAsset);
       }
       // Should not reach here for prod/worker (all callbacks supplied).
-      return new Response("This page could not be found", { status: 404 });
+      return missingBuildAsset
+        ? notFoundStaticAssetResponse()
+        : new Response("This page could not be found", { status: 404 });
 
     } catch (error) {
       console.error("[vinext] Worker error:", error);

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -26,7 +26,7 @@ import rscHandler, {
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
-import { resolveStaticAssetSignal } from "./worker-utils.js";
+import { finalizeMissingStaticAssetResponse, resolveStaticAssetSignal } from "./worker-utils.js";
 import {
   cloneRequestWithHeaders,
   filterInternalHeaders,
@@ -96,14 +96,15 @@ async function handleRequest(
     return badRequestResponse();
   }
 
-  // Invalid `_next/static/*` paths short-circuit with a plain-text 404
-  // instead of falling through to the RSC handler (which would render the
-  // full HTML 404 page). Valid assets are served by Cloudflare's ASSETS
-  // binding BEFORE the worker is invoked; only misses reach this code.
-  // Matches Next.js: packages/next/src/server/lib/router-server.ts.
-  if (isNextStaticPath(url.pathname, __workerBasePath, __workerAssetPathPrefix)) {
-    return notFoundStaticAssetResponse();
-  }
+  // Valid assets are served by Cloudflare's ASSETS binding before the worker
+  // is invoked. Missing asset-shaped requests still need to reach middleware
+  // so it can rewrite or respond; a final 404 is converted back to Next.js's
+  // canonical plain-text static-file response below.
+  const missingBuildAsset = isNextStaticPath(
+    url.pathname,
+    __workerBasePath,
+    __workerAssetPathPrefix,
+  );
 
   // Strip internal headers from inbound requests before any handler or
   // middleware sees them. Must happen before the RSC handler runs.
@@ -133,19 +134,20 @@ async function handleRequest(
   const result = await (ctx ? runWithExecutionContext(ctx, handleFn) : handleFn());
 
   if (result instanceof Response) {
+    let response = result;
     if (env?.ASSETS) {
       const assetFetcher = env.ASSETS;
-      const assetResponse = await resolveStaticAssetSignal(result, {
+      const assetResponse = await resolveStaticAssetSignal(response, {
         fetchAsset: (path) =>
           Promise.resolve(assetFetcher.fetch(new Request(new URL(path, request.url)))),
       });
-      if (assetResponse) return assetResponse;
+      if (assetResponse) response = assetResponse;
     }
-    return result;
+    return finalizeMissingStaticAssetResponse(response, missingBuildAsset);
   }
 
   if (result === null || result === undefined) {
-    return notFoundResponse();
+    return missingBuildAsset ? notFoundStaticAssetResponse() : notFoundResponse();
   }
 
   return new Response(String(result), { status: 200 });

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1318,10 +1318,11 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     // Cloudflare's ASSETS binding serves these directly in Workers; this
     // branch is the Node fallback.
     //
-    // Asset-shaped requests that don't find a file return a plain-text 404
-    // instead of falling through to the RSC handler (which would render
-    // the full HTML 404 page). Matches Next.js's behaviour in
-    // packages/next/src/server/lib/router-server.ts.
+    // Existing build assets bypass middleware. Missing asset-shaped requests
+    // must still reach middleware so it can rewrite or respond; if routing
+    // ultimately returns 404, convert it back to the canonical plain-text
+    // static-file response below.
+    let missingBuildAsset = false;
     {
       const assetLookupPath = resolveAppRouterAssetPath(
         pathname,
@@ -1332,9 +1333,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
         if (await tryServeStatic(req, res, clientDir, assetLookupPath, compress, staticCache)) {
           return;
         }
-        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-        res.end("Not Found");
-        return;
+        missingBuildAsset = true;
       }
     }
 
@@ -1432,6 +1431,13 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
           res,
           compress,
         );
+        return;
+      }
+
+      if (missingBuildAsset && response.status === 404) {
+        cancelResponseBody(response);
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Not Found");
         return;
       }
 
@@ -1659,19 +1665,17 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // `staticLookupPath` is still computed because non-asset paths below
     // (image-optimization, SSR routing) match against the basePath-stripped form.
     //
-    // Asset-shaped requests that don't find a file return a plain-text 404
-    // instead of falling through to the SSR/render handler (which would
-    // render the full HTML 404 page). Matches Next.js's behaviour in
-    // packages/next/src/server/lib/router-server.ts.
+    // Existing build assets bypass middleware. Missing asset-shaped requests
+    // must still reach middleware so it can rewrite or respond; if routing
+    // ultimately returns 404, convert it back to the canonical plain-text
+    // static-file response below.
     const staticLookupPath = stripBasePath(pathname, basePath);
     const pagesAssetLookup = resolveAppRouterAssetPath(pathname, pagesAssetPathPrefix, assetPrefix);
+    const missingBuildAsset = pagesAssetLookup !== null;
     if (pagesAssetLookup) {
       if (await tryServeStatic(req, res, clientDir, pagesAssetLookup, compress, staticCache)) {
         return;
       }
-      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-      res.end("Not Found");
-      return;
     }
 
     // ── Image optimization passthrough ──────────────────────────────
@@ -1856,6 +1860,12 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
 
       if (result.type === "response") {
         const { response } = result;
+        if (missingBuildAsset && response.status === 404) {
+          cancelResponseBody(response);
+          res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+          res.end("Not Found");
+          return;
+        }
         const shouldStream = isVinextStreamedHtmlResponse(response);
         // Passthrough responses (middleware short-circuits, external proxies, redirects)
         // carry no defaultContentType — send them verbatim without injecting a

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -5,6 +5,7 @@
  * Router worker entry through "vinext/server/worker-utils".
  */
 import { VINEXT_STATIC_FILE_HEADER } from "./headers.js";
+import { notFoundStaticAssetResponse } from "./http-error-responses.js";
 
 /**
  * Merge middleware/config headers into a response.
@@ -33,6 +34,15 @@ function cancelResponseBody(response: Response): void {
   void body.cancel().catch(() => {
     /* ignore cancellation failures on discarded bodies */
   });
+}
+
+export function finalizeMissingStaticAssetResponse(
+  response: Response,
+  missingBuildAsset: boolean,
+): Response {
+  if (!missingBuildAsset || response.status !== 404) return response;
+  cancelResponseBody(response);
+  return notFoundStaticAssetResponse();
 }
 
 function buildHeaderRecord(

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -715,6 +715,21 @@ export default function HomePage() {
 }
 `,
     );
+    fs.writeFileSync(
+      path.join(tmpDir, "middleware.ts"),
+      `import { NextResponse } from "next/server";
+
+export default function middleware(request: Request) {
+  const url = new URL(request.url);
+  if (url.pathname.endsWith("/_next/static/middleware-rewrite.js")) {
+    return new Response("rewritten missing asset", {
+      headers: { "content-type": "text/plain" },
+    });
+  }
+  return NextResponse.next({ headers: { "x-middleware-ran": "1" } });
+}
+`,
+    );
 
     const outDir = path.join(tmpDir, "dist");
 
@@ -780,10 +795,24 @@ export default function HomePage() {
       for (const url of assetUrls) {
         const assetRes = await fetch(`${baseUrl}${url}`);
         expect(assetRes.status, `expected 200 for ${url}`).toBe(200);
+        expect(assetRes.headers.get("x-middleware-ran")).toBeNull();
         if (url.endsWith(".js")) {
           expect(assetRes.headers.get("content-type")).toContain("javascript");
         }
       }
+
+      // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+      const rewrittenMissingAsset = await fetch(
+        `${baseUrl}/docs/_next/static/middleware-rewrite.js`,
+      );
+      expect(rewrittenMissingAsset.status).toBe(200);
+      expect(await rewrittenMissingAsset.text()).toBe("rewritten missing asset");
+
+      const unhandledMissingAsset = await fetch(`${baseUrl}/docs/_next/static/missing.js`);
+      expect(unhandledMissingAsset.status).toBe(404);
+      expect(unhandledMissingAsset.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+      expect(await unhandledMissingAsset.text()).toBe("Not Found");
     } finally {
       server.close();
     }

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -669,8 +669,14 @@ describe("assetPrefix end-to-end build", () => {
       const bundleRes = await fetch(`${baseUrl}${bootstrapMatch![1]}`);
       expect(bundleRes.status).toBe(200);
 
-      // Invalid `_next/static/*` paths return plain-text 404 (Next.js
-      // parity — see packages/next/src/server/lib/router-server.ts).
+      // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+      const rewrittenMissingAsset = await fetch(`${baseUrl}/_next/static/middleware-rewrite.js`);
+      expect(rewrittenMissingAsset.status).toBe(200);
+      expect(await rewrittenMissingAsset.text()).toBe("rewritten missing asset");
+
+      // Unhandled `_next/static/*` paths still return the canonical plain-text
+      // 404 after middleware and routing have had a chance to handle them.
       const invalidRes = await fetch(`${baseUrl}/_next/static/does-not-exist.js`);
       expect(invalidRes.status).toBe(404);
       expect(invalidRes.headers.get("content-type")).toBe("text/plain; charset=utf-8");

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -48,6 +48,7 @@ import {
 } from "../packages/vinext/src/utils/client-runtime-metadata.js";
 import { fetchWorkerFilesystemRoute } from "../packages/vinext/src/server/pages-request-pipeline.js";
 import {
+  finalizeMissingStaticAssetResponse,
   mergeHeaders,
   resolveStaticAssetSignal,
 } from "../packages/vinext/src/server/worker-utils.js";
@@ -1217,7 +1218,36 @@ describe("generatePagesRouterWorkerEntry", () => {
     // now called inside runPagesRequest. The worker delegates to the pipeline.
     expect(content).toContain("runPagesRequest(request, deps)");
     expect(content).toContain('result.type === "response"');
-    expect(content).toContain("return result.response");
+    expect(content).toContain(
+      "return finalizeMissingStaticAssetResponse(result.response, missingBuildAsset)",
+    );
+  });
+
+  it("finalizes only missing build-asset 404 responses", async () => {
+    let canceled = false;
+    const routed404 = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("rendered 404"));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 404, headers: { "content-type": "text/html" } },
+    );
+
+    const finalized = finalizeMissingStaticAssetResponse(routed404, true);
+    expect(finalized.status).toBe(404);
+    expect(finalized.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await finalized.text()).toBe("Not Found");
+    await vi.waitFor(() => expect(canceled).toBe(true));
+
+    const middlewareResponse = new Response("rewritten missing asset", { status: 200 });
+    expect(finalizeMissingStaticAssetResponse(middlewareResponse, true)).toBe(middlewareResponse);
+
+    const regular404 = new Response("rendered 404", { status: 404 });
+    expect(finalizeMissingStaticAssetResponse(regular404, false)).toBe(regular404);
   });
 
   it("resolveStaticAssetSignal fetches and merges static asset responses with middleware status", async () => {
@@ -1321,11 +1351,9 @@ describe("generatePagesRouterWorkerEntry", () => {
     expect(content).toContain("runPagesRequest(request, deps)");
   });
 
-  // Regression for #1337: invalid `_next/static/*` paths must short-circuit
-  // with a plain-text 404 instead of falling through to renderPage (which
-  // would render the full HTML 404 page with bootstrap scripts + CSS).
-  // Matches Next.js: packages/next/src/server/lib/router-server.ts.
-  it("short-circuits invalid `_next/static/*` paths with plain-text 404", () => {
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("runs middleware before finalizing missing `_next/static/*` responses", () => {
     const content = generatePagesRouterWorkerEntry();
     expect(content).toContain(
       'import { notFoundStaticAssetResponse } from "vinext/server/http-error-responses"',
@@ -1334,15 +1362,23 @@ describe("generatePagesRouterWorkerEntry", () => {
       'import { assetPrefixPathname, isNextStaticPath } from "vinext/utils/asset-prefix"',
     );
     expect(content).toContain("assetPrefixPathname(vinextConfig?.assetPrefix");
-    expect(content).toContain("isNextStaticPath(pathname, basePath, assetPathPrefix)");
-    expect(content).toContain("return notFoundStaticAssetResponse();");
+    expect(content).toContain(
+      "const missingBuildAsset = isNextStaticPath(pathname, basePath, assetPathPrefix)",
+    );
+    expect(content).toContain(
+      "finalizeMissingStaticAssetResponse(result.response, missingBuildAsset)",
+    );
 
-    // The short-circuit must fire BEFORE runPagesRequest (which invokes renderPage)
-    // so the rich HTML 404 is never rendered for asset misses.
+    // Detection happens before routing, but the response is finalized only
+    // after runPagesRequest has given middleware a chance to handle the miss.
     const staticPos = content.indexOf("isNextStaticPath(pathname, basePath, assetPathPrefix)");
     const pipelinePos = content.indexOf("runPagesRequest(request, deps)");
+    const finalizePos = content.indexOf(
+      "finalizeMissingStaticAssetResponse(result.response, missingBuildAsset)",
+    );
     expect(staticPos).toBeGreaterThan(-1);
     expect(pipelinePos).toBeGreaterThan(staticPos);
+    expect(finalizePos).toBeGreaterThan(pipelinePos);
   });
 });
 

--- a/tests/e2e/cloudflare-pages-router/middleware.spec.ts
+++ b/tests/e2e/cloudflare-pages-router/middleware.spec.ts
@@ -41,4 +41,17 @@ test.describe("middleware.ts on Pages Router Cloudflare Workers (prod build)", (
     expect(html).toContain("Server-Side Rendered on Workers");
     expect(html).toContain("Cloudflare-Workers");
   });
+
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  test("middleware can handle a missing build asset", async ({ request }) => {
+    const rewritten = await request.get(`${BASE}/_next/static/middleware-rewrite.js`);
+    expect(rewritten.status()).toBe(200);
+    expect(await rewritten.text()).toBe("rewritten missing asset");
+
+    const unhandled = await request.get(`${BASE}/_next/static/missing.js`);
+    expect(unhandled.status()).toBe(404);
+    expect(unhandled.headers()["content-type"]).toBe("text/plain; charset=utf-8");
+    expect(await unhandled.text()).toBe("Not Found");
+  });
 });

--- a/tests/e2e/cloudflare-workers/ssr.spec.ts
+++ b/tests/e2e/cloudflare-workers/ssr.spec.ts
@@ -51,6 +51,19 @@ test.describe("Cloudflare Workers SSR", () => {
     expect(response?.status()).toBe(404);
   });
 
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  test("middleware can handle a missing build asset", async ({ request }) => {
+    const rewritten = await request.get(`${BASE}/_next/static/middleware-rewrite.js`);
+    expect(rewritten.status()).toBe(200);
+    expect(await rewritten.text()).toBe("rewritten missing asset");
+
+    const unhandled = await request.get(`${BASE}/_next/static/missing.js`);
+    expect(unhandled.status()).toBe(404);
+    expect(unhandled.headers()["content-type"]).toBe("text/plain; charset=utf-8");
+    expect(await unhandled.text()).toBe("Not Found");
+  });
+
   test("root layout wraps pages with html/head/body", async ({ page }) => {
     await page.goto(`${BASE}/`);
 

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -17,6 +17,14 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // Test NextRequest.nextUrl - this would fail with TypeError if request is plain Request
   const { pathname } = request.nextUrl;
 
+  // Ported from Next.js: test/e2e/middleware-general/app/middleware-node.js
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/app/middleware-node.js
+  if (pathname === "/_next/static/middleware-rewrite.js") {
+    return new Response("rewritten missing asset", {
+      headers: { "content-type": "text/plain" },
+    });
+  }
+
   // Record this invocation so tests can detect double-execution.
   // In a hybrid app+pages fixture the Vite connect handler runs middleware
   // via ssrLoadModule (SSR env) and then the RSC entry runs it again inline
@@ -376,6 +384,7 @@ export const config = {
     "/",
     "/mw-gated-before",
     "/mw-gated-fallback",
+    "/_next/static/middleware-rewrite.js",
     {
       source: "/mw-object-gated",
       has: [{ type: "header", key: "x-mw-allow", value: "1" }],


### PR DESCRIPTION
## Summary

- let missing `/_next/static/*` requests reach middleware instead of returning from the static-file fast path
- preserve the fast path for existing build assets so middleware still does not run for successful chunk requests
- restore the canonical plain-text `404 Not Found` response when middleware/routing does not handle the missing asset
- keep App Router and Pages Router production server behavior aligned

## Failure cluster

The latest Next.js deploy-suite artifact for `test/e2e/middleware-general/test/node-runtime.test.ts` showed the non-cache assertion:

- `should be able to rewrite on _next/static/chunks/pages/ 404`: expected `200`, received `404`

The related original-request-shape assertion also observed no middleware header for a missing `/_next/static/*` URL. Data-request assertions from the same suite are owned separately by #2239; the Suspense/app-static cluster is also actively owned elsewhere.

## Root cause

The Node production servers served existing build assets before middleware, which is correct, but also returned a static-layer 404 immediately for missing asset-shaped paths. Next.js allows middleware to rewrite or respond to a missing `/_next/static/*` request before falling back to its plain-text asset 404.

## Next.js parity

Regression coverage is ported from:

- `test/e2e/middleware-general/test/index.test.ts`
- https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts

The local fixture verifies all three parts of the contract:

1. existing emitted assets return `200` without middleware headers
2. middleware can handle a missing `/_next/static/*` request
3. an unhandled missing asset remains `404 text/plain; charset=utf-8` with body `Not Found`

## Validation

Targeted one-worker tests only:

- `vp test run tests/asset-prefix.test.ts -t "Pages Router with basePath alone serves assets" --maxWorkers=1`
- `vp test run tests/asset-prefix.test.ts -t "unset: emits URLs under /_next/static/" --maxWorkers=1`
- `vp check packages/vinext/src/server/prod-server.ts tests/asset-prefix.test.ts`
