### PR TITLE
fix(actions): match root params execution phases

### DIFF
--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -85,6 +85,14 @@ export function normalizeServerActionThrownValue(data: unknown, responseStatus: 
   return createServerActionHttpFallbackError(responseStatus) ?? data;
 }
 
+export function shouldSyncServerActionHttpFallbackHead<TRoot>(
+  result: AppBrowserServerActionResult<TRoot> | TRoot,
+): boolean {
+  if (!isServerActionResult<TRoot>(result) || result.root !== undefined) return false;
+
+  return result.returnValue?.ok !== false;
+}
+
 export async function readInvalidServerActionResponseError(
   response: Pick<Response, "headers" | "status" | "text">,
   hasRedirectLocation: boolean,

--- a/packages/vinext/src/server/app-browser-server-action-client.ts
+++ b/packages/vinext/src/server/app-browser-server-action-client.ts
@@ -11,6 +11,7 @@ import {
   parseServerActionRevalidationHeader,
   readInvalidServerActionResponseError,
   shouldClearClientNavigationCachesForServerActionResult,
+  shouldSyncServerActionHttpFallbackHead,
   type AppBrowserServerActionResult,
   type ServerActionRevalidationKind,
 } from "./app-browser-action-result.js";
@@ -218,8 +219,9 @@ export async function invokeClientServerAction(
     return undefined;
   }
 
-  const hasSameUrlRerenderPayload = isServerActionResult(result) && result.root !== undefined;
-  deps.syncServerActionHttpFallbackHead(hasSameUrlRerenderPayload ? null : fetchResponse.status);
+  deps.syncServerActionHttpFallbackHead(
+    shouldSyncServerActionHttpFallbackHead(result) ? fetchResponse.status : null,
+  );
 
   if (isServerActionResult(result)) {
     if (result.root !== undefined) {

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -7,6 +7,7 @@ import {
 import type { ExecutionContextLike } from "vinext/shims/request-context";
 import type { CachedRouteValue } from "vinext/shims/cache-handler";
 import type { NextRequest } from "vinext/shims/server";
+import { runWithRootParamsUsage } from "vinext/shims/root-params";
 import {
   createStaticGenerationHeadersContext,
   getAppRouteStaticGenerationErrorMessage,
@@ -150,9 +151,16 @@ export async function runAppRouteHandler(
       return getAppRouteStaticGenerationErrorMessage(options.routePattern, expression);
     },
   });
-  const response = await options.handlerFn(trackedRequest.request, {
-    params: options.params,
-  });
+  const response = await runWithRootParamsUsage(
+    {
+      kind: "route-handler",
+      routePattern: options.routePattern ?? new URL(options.request.url).pathname,
+    },
+    () =>
+      options.handlerFn(trackedRequest.request, {
+        params: options.params,
+      }),
+  );
 
   return {
     dynamicUsedInHandler: options.consumeDynamicUsage(),

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -759,11 +759,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     actionError && typeof actionError === "object" && "digest" in actionError
       ? String(actionError.digest)
       : null;
-  if (
-    actionFailed &&
-    middlewareContext.status === null &&
-    (!actionErrorDigest || parseNextHttpErrorDigest(actionErrorDigest) === null)
-  ) {
+  const actionHttpFallbackStatus = actionErrorDigest
+    ? (parseNextHttpErrorDigest(actionErrorDigest)?.status ?? null)
+    : null;
+  const normalizedProgressiveActionError =
+    actionHttpFallbackStatus === null || actionHttpFallbackStatus === 404
+      ? actionError
+      : { digest: "NEXT_NOT_FOUND" };
+  if (actionFailed && middlewareContext.status === null && actionHttpFallbackStatus === null) {
     middlewareContext.status = 500;
   }
 
@@ -1008,7 +1011,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     cleanPathname,
     displayPathname: canonicalPathname,
     formState,
-    actionError,
+    actionError: normalizedProgressiveActionError,
     actionFailed,
     handlerStart,
     interceptionContext: interceptionContextHeader,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -58,6 +58,7 @@ import { notFoundResponse } from "./http-error-responses.js";
 import { getRenderedConcreteUrlPathsForRoute } from "./pregenerated-concrete-paths.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { buildPageCacheTags } from "./implicit-tags.js";
+import { parseNextHttpErrorDigest } from "./next-error-digest.js";
 import {
   DEFAULT_DEVICE_SIZES,
   DEFAULT_IMAGE_SIZES,
@@ -754,6 +755,17 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       : null;
   const actionFailed = failedProgressiveActionResult !== null;
   const actionError = failedProgressiveActionResult?.actionError;
+  const actionErrorDigest =
+    actionError && typeof actionError === "object" && "digest" in actionError
+      ? String(actionError.digest)
+      : null;
+  if (
+    actionFailed &&
+    middlewareContext.status === null &&
+    (!actionErrorDigest || parseNextHttpErrorDigest(actionErrorDigest) === null)
+  ) {
+    middlewareContext.status = 500;
+  }
 
   const serverActionResponse =
     isPostRequest && actionId && options.handleServerActionRequest

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -15,7 +15,12 @@ import {
   setCurrentForceDynamicFetchDefault,
 } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
-import { createRootParamsUsageController, runWithRootParamsUsage } from "vinext/shims/root-params";
+import {
+  createRootParamsUsageController,
+  pickRootParams,
+  runWithRootParamsScope,
+  runWithRootParamsUsage,
+} from "vinext/shims/root-params";
 import { isExternalUrl } from "../config/config-matchers.js";
 import { splitPathSegments } from "../routing/utils.js";
 import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
@@ -96,6 +101,7 @@ type AppServerActionRedirect = {
 type AppServerActionRoute = {
   page?: unknown;
   pattern: string;
+  rootParamNames?: readonly string[];
   routeHandler?: unknown;
   routeSegments?: readonly string[];
   params?: readonly string[] | null;
@@ -1255,7 +1261,6 @@ export async function handleServerActionRscRequest<
           headers: withoutRscBodyHeaders(redirectHeaders),
         });
       }
-      rootParamsUsage.transitionToRender();
       const currentMatch = options.matchRoute(options.cleanPathname);
       // Hydrate the current route before resolving its runtime below.
       if (currentMatch) await options.ensureRouteLoaded?.(currentMatch.route);
@@ -1291,27 +1296,33 @@ export async function handleServerActionRscRequest<
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(targetMatch.route) ?? null);
       setCurrentForceDynamicFetchDefault(redirectDynamicConfig === "force-dynamic");
       setCurrentFetchSoftTags(buildServerActionPageTags(targetMatch.route, targetPathname));
-      const element = options.buildPageElement({
-        cleanPathname: targetPathname,
-        interceptOpts: undefined,
-        isRscRequest: true,
-        mountedSlotsHeader: null,
-        params: targetMatch.params,
-        request: redirectRenderRequest,
-        route: targetMatch.route,
-        searchParams: redirectSearchParams,
-        renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
-        observeMetadataSearchParamsAccess: redirectDynamicConfig !== "force-static",
-        observePageSearchParamsAccess: redirectDynamicConfig !== "force-static",
-      });
-      const onRenderError = options.createRscOnErrorHandler(
-        redirectRenderRequest,
-        targetPathname,
-        targetMatch.route.pattern,
-      );
-      const rscStream = await options.renderToReadableStream(
-        { root: element, returnValue },
-        { temporaryReferences, onError: onRenderError },
+      const rscStream = await runWithRootParamsScope(
+        pickRootParams(targetMatch.params, targetMatch.route.rootParamNames),
+        () =>
+          runWithRootParamsUsage({ kind: "route" }, async () => {
+            const element = options.buildPageElement({
+              cleanPathname: targetPathname,
+              interceptOpts: undefined,
+              isRscRequest: true,
+              mountedSlotsHeader: null,
+              params: targetMatch.params,
+              request: redirectRenderRequest,
+              route: targetMatch.route,
+              searchParams: redirectSearchParams,
+              renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+              observeMetadataSearchParamsAccess: redirectDynamicConfig !== "force-static",
+              observePageSearchParamsAccess: redirectDynamicConfig !== "force-static",
+            });
+            const onRenderError = options.createRscOnErrorHandler(
+              redirectRenderRequest,
+              targetPathname,
+              targetMatch.route.pattern,
+            );
+            return options.renderToReadableStream(
+              { root: element, returnValue },
+              { temporaryReferences, onError: onRenderError },
+            );
+          }),
       );
       const redirectResponseStatus = shouldUseForwardedActionRedirectStatus({
         actionWasForwarded,
@@ -1339,11 +1350,12 @@ export async function handleServerActionRscRequest<
 
     // HTTP access fallbacks always rerender so the page's fallback boundary and
     // metadata are included. Generic errors only rerender after revalidation.
-    // Forwarded actions never render because this worker does not own the page.
+    // Forwarded generic actions never render because this worker does not own
+    // the page, but HTTP fallbacks always rerender in Next.js.
     const isHttpFallback = actionStatus === 401 || actionStatus === 403 || actionStatus === 404;
     const shouldSkipPageRendering =
-      actionWasForwarded ||
-      (!isHttpFallback && actionRevalidationKind === ACTION_DID_NOT_REVALIDATE);
+      !isHttpFallback &&
+      (actionWasForwarded || actionRevalidationKind === ACTION_DID_NOT_REVALIDATE);
     if (shouldSkipPageRendering) {
       const onRenderError = options.createRscOnErrorHandler(
         options.request,
@@ -1432,19 +1444,26 @@ export async function handleServerActionRscRequest<
       setCurrentFetchSoftTags(
         buildServerActionPageTags(actionRerenderTarget.route, options.cleanPathname),
       );
-      element = options.buildPageElement({
-        cleanPathname: options.cleanPathname,
-        interceptOpts: actionRerenderTarget.interceptOpts,
-        isRscRequest: options.isRscRequest,
-        mountedSlotsHeader: options.mountedSlotsHeader,
-        params: actionRerenderTarget.params,
-        request: options.request,
-        route: actionRerenderTarget.route,
-        searchParams: actionRerenderSearchParams,
-        renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
-        observeMetadataSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
-        observePageSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
-      });
+      const buildActionRerenderElement = () =>
+        options.buildPageElement({
+          cleanPathname: options.cleanPathname,
+          interceptOpts: actionRerenderTarget.interceptOpts,
+          isRscRequest: options.isRscRequest,
+          mountedSlotsHeader: options.mountedSlotsHeader,
+          params: actionRerenderTarget.params,
+          request: options.request,
+          route: actionRerenderTarget.route,
+          searchParams: actionRerenderSearchParams,
+          renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+          observeMetadataSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
+          observePageSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
+        });
+      element =
+        actionWasForwarded && isHttpFallback
+          ? await runWithRootParamsUsage({ kind: "route" }, async () =>
+              buildActionRerenderElement(),
+            )
+          : buildActionRerenderElement();
       errorPattern = actionRerenderTarget.route.pattern;
     } else {
       const actionRouteId = options.createPayloadRouteId(options.cleanPathname, null);
@@ -1456,10 +1475,14 @@ export async function handleServerActionRscRequest<
       options.cleanPathname,
       errorPattern,
     );
-    const rscStream = await options.renderToReadableStream(
-      { root: element, returnValue },
-      { temporaryReferences, onError: onRenderError },
-    );
+    const renderActionRerender = () =>
+      options.renderToReadableStream(
+        { root: element, returnValue },
+        { temporaryReferences, onError: onRenderError },
+      );
+    const rscStream = await (actionWasForwarded && isHttpFallback
+      ? runWithRootParamsUsage({ kind: "route" }, renderActionRerender)
+      : renderActionRerender());
 
     const actionHeaders = new Headers({
       "Content-Type": VINEXT_RSC_CONTENT_TYPE,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -15,7 +15,7 @@ import {
   setCurrentForceDynamicFetchDefault,
 } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
-import { runWithRootParamsUsage } from "vinext/shims/root-params";
+import { createRootParamsUsageController, runWithRootParamsUsage } from "vinext/shims/root-params";
 import { isExternalUrl } from "../config/config-matchers.js";
 import { splitPathSegments } from "../routing/utils.js";
 import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
@@ -853,9 +853,14 @@ export async function handleProgressiveServerActionRequest(
     let actionError: unknown = undefined;
     let actionFailed = false;
     let actionResult: unknown;
+    const rootParamsUsage = createRootParamsUsageController();
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
     try {
-      actionResult = await runWithRootParamsUsage({ kind: "server-action" }, action);
+      actionResult = await runWithRootParamsUsage(
+        { kind: "server-action" },
+        action,
+        rootParamsUsage,
+      );
     } catch (error) {
       actionRedirect = getActionRedirect(error);
       if (!actionRedirect) {
@@ -881,6 +886,7 @@ export async function handleProgressiveServerActionRequest(
     }
 
     if (!actionRedirect) {
+      rootParamsUsage.transitionToRender();
       // Capture cookies/headers set during action execution so the caller can
       // apply them to the rendered page response. Mirrors Next.js'
       // `res.setHeader('set-cookie', ...)` path in app-render.tsx, which
@@ -1157,12 +1163,15 @@ export async function handleServerActionRscRequest<
     let actionRedirect: AppServerActionRedirect | null = null;
     let actionStatus = 200;
     const actionWasForwarded = Boolean(options.request.headers.get(ACTION_FORWARDED_HEADER));
+    const rootParamsUsage = createRootParamsUsageController();
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
     try {
       try {
         validateServerActionArgs(args);
-        const data = await runWithRootParamsUsage({ kind: "server-action" }, () =>
-          action.apply(null, args),
+        const data = await runWithRootParamsUsage(
+          { kind: "server-action" },
+          () => action.apply(null, args),
+          rootParamsUsage,
         );
         returnValue = { ok: true, data };
       } catch (error) {
@@ -1240,6 +1249,7 @@ export async function handleServerActionRscRequest<
           headers: withoutRscBodyHeaders(redirectHeaders),
         });
       }
+      rootParamsUsage.transitionToRender();
       const currentMatch = options.matchRoute(options.cleanPathname);
       // Hydrate the current route before resolving its runtime below.
       if (currentMatch) await options.ensureRouteLoaded?.(currentMatch.route);
@@ -1363,6 +1373,8 @@ export async function handleServerActionRscRequest<
         options.clearRequestContext,
       );
     }
+
+    rootParamsUsage.transitionToRender();
 
     const match = options.matchRoute(options.cleanPathname);
     let element: TElement;

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1331,15 +1331,13 @@ export async function handleServerActionRscRequest<
       actionPendingCookies.length > 0 || Boolean(actionDraftCookie),
     );
 
-    // When an action returned a non-200 HTTP fallback status (e.g. 404 from
-    // notFound()), skip the early page render so the error boundary displays
-    // the fallback payload embedded in returnValue. Forwarded actions always
-    // skip rerendering regardless of status (the forwarded worker doesn't own
-    // the page's layout tree). Otherwise only skip when the action status is
-    // 200 and no revalidation side-effects occurred.
+    // Response status and page rerendering are independent. Next.js skips the
+    // page tree whenever the action did not revalidate (including failed and
+    // HTTP fallback actions), while still returning the action's non-200
+    // status. Forwarded actions also skip because this worker does not own the
+    // page's layout tree.
     const shouldSkipPageRendering =
-      actionWasForwarded ||
-      (actionStatus === 200 && actionRevalidationKind === ACTION_DID_NOT_REVALIDATE);
+      actionWasForwarded || actionRevalidationKind === ACTION_DID_NOT_REVALIDATE;
     if (shouldSkipPageRendering) {
       const onRenderError = options.createRscOnErrorHandler(
         options.request,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -852,6 +852,7 @@ export async function handleProgressiveServerActionRequest(
     let actionRedirect: AppServerActionRedirect | null = null;
     let actionError: unknown = undefined;
     let actionFailed = false;
+    let actionThrew = false;
     let actionResult: unknown;
     const rootParamsUsage = createRootParamsUsageController();
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
@@ -862,6 +863,7 @@ export async function handleProgressiveServerActionRequest(
         rootParamsUsage,
       );
     } catch (error) {
+      actionThrew = true;
       actionRedirect = getActionRedirect(error);
       if (!actionRedirect) {
         actionError = error;
@@ -883,10 +885,11 @@ export async function handleProgressiveServerActionRequest(
       }
     } finally {
       options.setHeadersAccessPhase(previousHeadersPhase);
+      if (actionThrew) rootParamsUsage.transitionToRender();
     }
 
     if (!actionRedirect) {
-      rootParamsUsage.transitionToRender();
+      if (!actionThrew) rootParamsUsage.transitionToRender();
       // Capture cookies/headers set during action execution so the caller can
       // apply them to the rendered page response. Mirrors Next.js'
       // `res.setHeader('set-cookie', ...)` path in app-render.tsx, which
@@ -1162,6 +1165,7 @@ export async function handleServerActionRscRequest<
     let returnValue: AppServerActionReturnValue;
     let actionRedirect: AppServerActionRedirect | null = null;
     let actionStatus = 200;
+    let actionThrew = false;
     const actionWasForwarded = Boolean(options.request.headers.get(ACTION_FORWARDED_HEADER));
     const rootParamsUsage = createRootParamsUsageController();
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
@@ -1175,6 +1179,7 @@ export async function handleServerActionRscRequest<
         );
         returnValue = { ok: true, data };
       } catch (error) {
+        actionThrew = true;
         actionRedirect = getActionRedirect(error);
         if (actionRedirect) {
           returnValue = { ok: true, data: undefined };
@@ -1192,6 +1197,7 @@ export async function handleServerActionRscRequest<
       }
     } finally {
       options.setHeadersAccessPhase(previousHeadersPhase);
+      if (actionThrew && !actionWasForwarded) rootParamsUsage.transitionToRender();
     }
 
     if (actionRedirect) {
@@ -1331,13 +1337,13 @@ export async function handleServerActionRscRequest<
       actionPendingCookies.length > 0 || Boolean(actionDraftCookie),
     );
 
-    // Response status and page rerendering are independent. Next.js skips the
-    // page tree whenever the action did not revalidate (including failed and
-    // HTTP fallback actions), while still returning the action's non-200
-    // status. Forwarded actions also skip because this worker does not own the
-    // page's layout tree.
+    // HTTP access fallbacks always rerender so the page's fallback boundary and
+    // metadata are included. Generic errors only rerender after revalidation.
+    // Forwarded actions never render because this worker does not own the page.
+    const isHttpFallback = actionStatus === 401 || actionStatus === 403 || actionStatus === 404;
     const shouldSkipPageRendering =
-      actionWasForwarded || actionRevalidationKind === ACTION_DID_NOT_REVALIDATE;
+      actionWasForwarded ||
+      (!isHttpFallback && actionRevalidationKind === ACTION_DID_NOT_REVALIDATE);
     if (shouldSkipPageRendering) {
       const onRenderError = options.createRscOnErrorHandler(
         options.request,
@@ -1372,7 +1378,7 @@ export async function handleServerActionRscRequest<
       );
     }
 
-    rootParamsUsage.transitionToRender();
+    if (!actionThrew) rootParamsUsage.transitionToRender();
 
     const match = options.matchRoute(options.cleanPathname);
     let element: TElement;

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -15,6 +15,7 @@ import {
   setCurrentForceDynamicFetchDefault,
 } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
+import { runWithRootParamsUsage } from "vinext/shims/root-params";
 import { isExternalUrl } from "../config/config-matchers.js";
 import { splitPathSegments } from "../routing/utils.js";
 import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
@@ -854,7 +855,7 @@ export async function handleProgressiveServerActionRequest(
     let actionResult: unknown;
     const previousHeadersPhase = options.setHeadersAccessPhase("action");
     try {
-      actionResult = await action();
+      actionResult = await runWithRootParamsUsage({ kind: "server-action" }, action);
     } catch (error) {
       actionRedirect = getActionRedirect(error);
       if (!actionRedirect) {
@@ -1160,7 +1161,9 @@ export async function handleServerActionRscRequest<
     try {
       try {
         validateServerActionArgs(args);
-        const data = await action.apply(null, args);
+        const data = await runWithRootParamsUsage({ kind: "server-action" }, () =>
+          action.apply(null, args),
+        );
         returnValue = { ok: true, data };
       } catch (error) {
         actionRedirect = getActionRedirect(error);
@@ -1172,6 +1175,7 @@ export async function handleServerActionRscRequest<
             actionStatus = httpFallbackStatus;
             returnValue = { ok: false, data: error };
           } else {
+            actionStatus = 500;
             console.error("[vinext] Server action error:", error);
             returnValue = { ok: false, data: options.sanitizeErrorForClient(error) };
           }

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -17,7 +17,7 @@ export type RootParamsUsage =
   | { kind: "route-handler"; routePattern: string };
 
 type RootParamsUsageState = RootParamsUsage & {
-  phase: "active" | "render" | "inactive";
+  phase: "active" | "render";
 };
 
 export type RootParamsUsageController = {

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -20,6 +20,10 @@ type RootParamsUsageState = RootParamsUsage & {
   phase: "active" | "render" | "inactive";
 };
 
+export type RootParamsUsageController = {
+  transitionToRender(): void;
+};
+
 function createRootParamsUsageError(message: string): Error {
   return new Error(message);
 }
@@ -70,31 +74,32 @@ export function getRootParam(name: string): Promise<string | string[] | undefine
   return Promise.resolve(getState().rootParams?.[name]);
 }
 
-export function runWithRootParamsUsage<T>(usage: RootParamsUsage, fn: () => Promise<T>): Promise<T>;
+export function runWithRootParamsUsage<T>(
+  usage: RootParamsUsage,
+  fn: () => Promise<T>,
+  controller?: RootParamsUsageController,
+): Promise<T>;
 export function runWithRootParamsUsage<T>(
   usage: RootParamsUsage,
   fn: () => T | Promise<T>,
+  controller?: RootParamsUsageController,
 ): T | Promise<T>;
 export function runWithRootParamsUsage<T>(
   usage: RootParamsUsage,
   fn: () => T | Promise<T>,
+  controller?: RootParamsUsageController,
 ): T | Promise<T> {
   const state: RootParamsUsageState = { ...usage, phase: "active" };
-  return _usageAls.run(state, () => {
-    try {
-      const result = fn();
-      if (result && typeof (result as PromiseLike<T>).then === "function") {
-        return Promise.resolve(result).finally(() => {
-          state.phase = usage.kind === "server-action" ? "render" : "inactive";
-        });
-      }
-      state.phase = usage.kind === "server-action" ? "render" : "inactive";
-      return result;
-    } catch (error) {
-      state.phase = usage.kind === "server-action" ? "render" : "inactive";
-      throw error;
-    }
-  });
+  if (controller) {
+    controller.transitionToRender = () => {
+      if (usage.kind === "server-action") state.phase = "render";
+    };
+  }
+  return _usageAls.run(state, fn);
+}
+
+export function createRootParamsUsageController(): RootParamsUsageController {
+  return { transitionToRender() {} };
 }
 
 export function runWithRootParamsScope<T>(params: RootParams, fn: () => Promise<T>): Promise<T>;

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -11,9 +11,23 @@ export type RootParamsState = {
   rootParams: RootParams | null;
 };
 
+export type RootParamsUsage =
+  | { kind: "route" }
+  | { kind: "server-action" }
+  | { kind: "route-handler"; routePattern: string };
+
+type RootParamsUsageState = RootParamsUsage & {
+  phase: "active" | "render" | "inactive";
+};
+
+function createRootParamsUsageError(message: string): Error {
+  return new Error(message);
+}
+
 const _FALLBACK_KEY = Symbol.for("vinext.rootParams.fallback");
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 const _als = getOrCreateAls<RootParamsState>("vinext.rootParams.als");
+const _usageAls = getOrCreateAls<RootParamsUsageState>("vinext.rootParams.usage.als");
 
 const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   rootParams: null,
@@ -42,7 +56,45 @@ export function setRootParams(params: RootParams | null): void {
 }
 
 export function getRootParam(name: string): Promise<string | string[] | undefined> {
+  const usage = _usageAls.getStore();
+  if (usage?.kind === "server-action" && usage.phase === "active") {
+    throw createRootParamsUsageError(
+      `\`import('next/root-params').${name}()\` was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route.`,
+    );
+  }
+  if (usage?.kind === "route-handler" && usage.phase === "active") {
+    throw createRootParamsUsageError(
+      `Route ${usage.routePattern} used \`import('next/root-params').${name}()\` inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.`,
+    );
+  }
   return Promise.resolve(getState().rootParams?.[name]);
+}
+
+export function runWithRootParamsUsage<T>(usage: RootParamsUsage, fn: () => Promise<T>): Promise<T>;
+export function runWithRootParamsUsage<T>(
+  usage: RootParamsUsage,
+  fn: () => T | Promise<T>,
+): T | Promise<T>;
+export function runWithRootParamsUsage<T>(
+  usage: RootParamsUsage,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  const state: RootParamsUsageState = { ...usage, phase: "active" };
+  return _usageAls.run(state, () => {
+    try {
+      const result = fn();
+      if (result && typeof (result as PromiseLike<T>).then === "function") {
+        return Promise.resolve(result).finally(() => {
+          state.phase = usage.kind === "server-action" ? "render" : "inactive";
+        });
+      }
+      state.phase = usage.kind === "server-action" ? "render" : "inactive";
+      return result;
+    } catch (error) {
+      state.phase = usage.kind === "server-action" ? "render" : "inactive";
+      throw error;
+    }
+  });
 }
 
 export function runWithRootParamsScope<T>(params: RootParams, fn: () => Promise<T>): Promise<T>;

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -21,6 +21,7 @@ import {
   parseServerActionRevalidationHeader,
   readInvalidServerActionResponseError,
   shouldClearClientNavigationCachesForServerActionResult,
+  shouldSyncServerActionHttpFallbackHead,
   shouldScheduleRefreshForDiscardedServerAction,
 } from "../packages/vinext/src/server/app-browser-action-result.js";
 import {
@@ -900,6 +901,23 @@ describe("app browser entry navigation scheduling", () => {
     } else {
       throw new Error("Expected fallback to have a digest property");
     }
+  });
+
+  it("lets thrown action HTTP fallbacks own their boundary robots metadata", () => {
+    expect(
+      shouldSyncServerActionHttpFallbackHead({
+        returnValue: { ok: false, data: new Error("sanitized") },
+      }),
+    ).toBe(false);
+    expect(shouldSyncServerActionHttpFallbackHead({ returnValue: { ok: true, data: null } })).toBe(
+      true,
+    );
+    expect(
+      shouldSyncServerActionHttpFallbackHead({
+        root: { __route: "/current" },
+        returnValue: { ok: false, data: new Error("sanitized") },
+      }),
+    ).toBe(false);
   });
 
   it("preserves ordinary server action errors for 500 responses", () => {

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -91,7 +91,7 @@ describe("app route handler execution helpers", () => {
     );
   });
 
-  it("deactivates route-handler root params restrictions after execution", async () => {
+  it("keeps route-handler root params restrictions for deferred work", async () => {
     const dynamicUsage = createDynamicUsageState();
     let deferredRead!: Promise<string | string[] | undefined>;
     let releaseDeferred!: () => void;
@@ -114,7 +114,7 @@ describe("app route handler execution helpers", () => {
     );
 
     releaseDeferred();
-    await expect(deferredRead).resolves.toBe("en");
+    await expect(deferredRead).rejects.toThrow("inside a Route Handler");
   });
 
   it("runs force-static route handlers with empty request APIs without marking dynamic usage", async () => {

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -12,6 +12,7 @@ import {
   executeAppRouteHandler,
   runAppRouteHandler,
 } from "../packages/vinext/src/server/app-route-handler-execution.js";
+import { getRootParam, runWithRootParamsScope } from "../packages/vinext/src/shims/root-params.js";
 
 // The fetch-cache shim captures `originalFetch` from globalThis at import
 // time, so stub fetch BEFORE importing it (same pattern as
@@ -66,6 +67,54 @@ describe("app route handler execution helpers", () => {
     expect(receivedParams).toEqual({ slug: "demo" });
     expect(dynamicUsedInHandler).toBe(true);
     await expect(response.json()).resolves.toEqual({ header: "pong" });
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  it("rejects next/root-params inside route handlers", async () => {
+    const dynamicUsage = createDynamicUsageState();
+
+    await expect(
+      runAppRouteHandler({
+        consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+        async handlerFn() {
+          await getRootParam("lang");
+          return new Response("unreachable");
+        },
+        markDynamicUsage: dynamicUsage.markDynamicUsage,
+        params: { lang: "en", locale: "us" },
+        request: new Request("https://example.com/en/us/route-handler"),
+        routePattern: "/[lang]/[locale]/route-handler",
+      }),
+    ).rejects.toThrow(
+      "Route /[lang]/[locale]/route-handler used `import('next/root-params').lang()` inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.",
+    );
+  });
+
+  it("deactivates route-handler root params restrictions after execution", async () => {
+    const dynamicUsage = createDynamicUsageState();
+    let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
+
+    await runWithRootParamsScope({ lang: "en" }, () =>
+      runAppRouteHandler({
+        consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+        async handlerFn() {
+          deferredRead = deferred.then(() => getRootParam("lang"));
+          return new Response("ok");
+        },
+        markDynamicUsage: dynamicUsage.markDynamicUsage,
+        params: { lang: "en" },
+        request: new Request("https://example.com/en/route-handler"),
+        routePattern: "/[lang]/route-handler",
+      }),
+    );
+
+    releaseDeferred();
+    await expect(deferredRead).resolves.toBe("en");
   });
 
   it("runs force-static route handlers with empty request APIs without marking dynamic usage", async () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -277,6 +277,79 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  it("returns HTTP 500 for progressive action execution failures", async () => {
+    const dispatchMatchedPage = vi.fn(async ({ middlewareContext }) =>
+      Promise.resolve(new Response("error page", { status: middlewareContext.status ?? 200 })),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      async handleProgressiveActionRequest() {
+        return {
+          kind: "form-state",
+          formState: null,
+          actionError: new Error("boom"),
+          actionFailed: true,
+          pendingCookies: [],
+          draftCookie: null,
+          revalidationKind: 0,
+        };
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "content-type": "multipart/form-data; boundary=vinext" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(500);
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionFailed: true,
+        middlewareContext: expect.objectContaining({ status: 500 }),
+      }),
+    );
+  });
+
+  it("preserves progressive action HTTP fallback status handling", async () => {
+    const dispatchMatchedPage = vi.fn(async ({ middlewareContext }) =>
+      Promise.resolve(new Response("not found", { status: middlewareContext.status ?? 404 })),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      async handleProgressiveActionRequest() {
+        return {
+          kind: "form-state",
+          formState: null,
+          actionError: { digest: "NEXT_NOT_FOUND" },
+          actionFailed: true,
+          pendingCookies: [],
+          draftCookie: null,
+          revalidationKind: 0,
+        };
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "content-type": "multipart/form-data; boundary=vinext" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(404);
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        middlewareContext: expect.objectContaining({ status: null }),
+      }),
+    );
+  });
+
   // Regression for issue #1483 — `cookies().set(...)` / `cookies().delete(...)`
   // and `draftMode().enable()` invoked inside a no-JS server action must flow
   // through to the page rerender response. Before the fix, those Set-Cookie

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -350,6 +350,46 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  it("normalizes progressive forbidden fallbacks to Next.js not-found rendering", async () => {
+    const dispatchMatchedPage = vi.fn(async ({ actionError, middlewareContext }) =>
+      Promise.resolve(
+        new Response(JSON.stringify(actionError), { status: middlewareContext.status ?? 404 }),
+      ),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      async handleProgressiveActionRequest() {
+        return {
+          kind: "form-state",
+          formState: null,
+          actionError: { digest: "NEXT_HTTP_ERROR_FALLBACK;403" },
+          actionFailed: true,
+          pendingCookies: [],
+          draftCookie: null,
+          revalidationKind: 0,
+        };
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "content-type": "multipart/form-data; boundary=vinext" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ digest: "NEXT_NOT_FOUND" });
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionError: { digest: "NEXT_NOT_FOUND" },
+        middlewareContext: expect.objectContaining({ status: null }),
+      }),
+    );
+  });
+
   // Regression for issue #1483 — `cookies().set(...)` / `cookies().delete(...)`
   // and `draftMode().enable()` invoked inside a no-JS server action must flow
   // through to the page rerender response. Before the fix, those Set-Cookie

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1213,6 +1213,39 @@ describe("app server action execution helpers", () => {
     errorSpy.mockRestore();
   });
 
+  it("rerenders the page for failed fetch actions that revalidate", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const buildPageElement = vi.fn(() => "rerendered-page");
+    let renderedModel: TestActionModel | null = null;
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement,
+        getAndClearPendingCookies() {
+          return ["action=1; Path=/"];
+        },
+        loadServerAction() {
+          return Promise.resolve(() => {
+            throw new Error("action failed");
+          });
+        },
+        renderToReadableStream(model) {
+          renderedModel = model;
+          return new Response("action-error-flight").body;
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(500);
+    expect(buildPageElement).toHaveBeenCalledOnce();
+    expect(renderedModel).toEqual({
+      root: "rerendered-page",
+      returnValue: expect.objectContaining({ ok: false }),
+    });
+    expect(response?.headers.get("x-action-revalidated")).toBe("1");
+    errorSpy.mockRestore();
+  });
+
   // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/simple.test.ts
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-root-params-getters/simple.test.ts
   it("allows root params during the rerender after a successful fetch action", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -41,6 +41,7 @@ type TestRoute = {
   page?: unknown;
   params: readonly string[];
   pattern: string;
+  rootParamNames?: readonly string[];
   routeHandler?: unknown;
   routeSegments?: readonly string[];
   runtime?: "edge" | "experimental-edge" | "nodejs" | null;
@@ -1700,6 +1701,50 @@ describe("app server action execution helpers", () => {
     expect(renderRequest.headers.get("cookie")).toBe("session=1; theme=dark");
   });
 
+  it("renders internal action redirects with the target route's root params", async () => {
+    let renderedRootParam: string | string[] | undefined;
+
+    await runWithRootParamsScope({ lang: "source" }, () =>
+      handleServerActionRscRequest(
+        createRscOptions({
+          async renderToReadableStream(model) {
+            renderedRootParam = await getRootParam("lang");
+            return new Response(JSON.stringify(model)).body;
+          },
+          loadServerAction() {
+            return Promise.resolve(() => redirect("/fr/target"));
+          },
+          matchRoute(pathname) {
+            if (pathname === "/fr/target") {
+              return {
+                params: { lang: "fr" },
+                route: {
+                  id: "redirect-target",
+                  page: {},
+                  params: ["lang"],
+                  pattern: "/[lang]/target",
+                  rootParamNames: ["lang"],
+                },
+              };
+            }
+            return {
+              params: { lang: "source" },
+              route: {
+                id: "dashboard",
+                page: {},
+                params: ["lang"],
+                pattern: "/[lang]/dashboard",
+                rootParamNames: ["lang"],
+              },
+            };
+          },
+        }),
+      ),
+    );
+
+    expect(renderedRootParam).toBe("fr");
+  });
+
   it("keeps redirected action render context alive until the Flight body is consumed", async () => {
     // Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-node-middleware.test.ts
@@ -2241,6 +2286,45 @@ describe("app server action execution helpers", () => {
       returnValue: { ok: true, data: "action-result" },
     });
     expect(renderToReadableStream).toHaveBeenCalledTimes(1);
+    releaseDeferred();
+    await expect(deferredRead).rejects.toThrow("was used inside a Server Action");
+  });
+
+  it("rerenders forwarded action HTTP fallbacks", async () => {
+    let renderedModel: TestActionModel | null = null;
+    let renderedRootParam: string | string[] | undefined;
+    let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
+    const fallbackError = { digest: "NEXT_HTTP_ERROR_FALLBACK;404" };
+
+    const response = await runWithRootParamsScope({ lang: "en" }, () =>
+      handleServerActionRscRequest(
+        createRscOptions({
+          loadServerAction() {
+            return Promise.resolve(() => {
+              deferredRead = deferred.then(() => getRootParam("lang"));
+              throw fallbackError;
+            });
+          },
+          request: createFetchActionRequest({ "x-action-forwarded": "1" }),
+          async renderToReadableStream(model) {
+            renderedModel = model;
+            renderedRootParam = await getRootParam("lang");
+            return new Response("fallback-flight").body;
+          },
+        }),
+      ),
+    );
+
+    expect(response?.status).toBe(404);
+    expect(renderedRootParam).toBe("en");
+    expect(renderedModel).toEqual({
+      root: "dashboard:{}:none",
+      returnValue: { ok: false, data: fallbackError },
+    });
     releaseDeferred();
     await expect(deferredRead).rejects.toThrow("was used inside a Server Action");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1186,19 +1186,30 @@ describe("app server action execution helpers", () => {
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-root-params-getters/simple.test.ts
   it("rejects next/root-params inside fetch server actions", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const buildPageElement = vi.fn(() => "should-not-render");
+    let renderedModel: TestActionModel | null = null;
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
+        buildPageElement,
         decodeReply() {
           return Promise.resolve([]);
         },
         loadServerAction() {
           return Promise.resolve(() => getRootParam("lang"));
         },
+        renderToReadableStream(model) {
+          renderedModel = model;
+          return new Response("action-error-flight").body;
+        },
       }),
     );
 
     expect(response?.status).toBe(500);
+    expect(buildPageElement).not.toHaveBeenCalled();
+    expect(renderedModel).toEqual({
+      returnValue: expect.objectContaining({ ok: false }),
+    });
     errorSpy.mockRestore();
   });
 
@@ -1797,7 +1808,6 @@ describe("app server action execution helpers", () => {
       expect(await response?.text()).toBe("too-many-args-flight");
       expect(action).not.toHaveBeenCalled();
       expect(renderedModel).toEqual({
-        root: "dashboard:{}:none",
         returnValue: {
           ok: false,
           data: "Server Action arguments list is too long (1001). Maximum allowed is 1000.",
@@ -2389,10 +2399,7 @@ describe("app server action execution helpers", () => {
 
       expect(response?.status).toBe(statusCode);
       expect(await response?.text()).toBe("fallback-flight");
-      expect(renderedModel).toEqual({
-        root: "dashboard:{}:none",
-        returnValue: { ok: false, data: fallbackError },
-      });
+      expect(renderedModel).toEqual({ returnValue: { ok: false, data: fallbackError } });
     }
   });
 

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -323,6 +323,37 @@ describe("app server action execution helpers", () => {
     errorSpy.mockRestore();
   });
 
+  it("allows deferred root params reads after failed progressive actions", async () => {
+    const formData = new FormData();
+    formData.set("$ACTION_ID_test", "");
+    let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await runWithRootParamsScope({ lang: "en" }, () =>
+      handleProgressiveServerActionRequest(
+        createOptions({
+          async decodeAction() {
+            return () => {
+              deferredRead = deferred.then(() => getRootParam("lang"));
+              throw new Error("action failed");
+            };
+          },
+          readFormDataWithLimit() {
+            return Promise.resolve(formData);
+          },
+        }),
+      ),
+    );
+
+    releaseDeferred();
+    await expect(deferredRead).resolves.toBe("en");
+    errorSpy.mockRestore();
+  });
+
   it("reads streamed action text bodies and enforces the byte limit", async () => {
     const validRequest = new Request("https://example.com/action", {
       method: "POST",
@@ -1244,6 +1275,56 @@ describe("app server action execution helpers", () => {
     });
     expect(response?.headers.get("x-action-revalidated")).toBe("1");
     errorSpy.mockRestore();
+  });
+
+  it("allows deferred root params reads after failed fetch actions", async () => {
+    let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await runWithRootParamsScope({ lang: "en" }, () =>
+      handleServerActionRscRequest(
+        createRscOptions({
+          loadServerAction() {
+            return Promise.resolve(() => {
+              deferredRead = deferred.then(() => getRootParam("lang"));
+              throw new Error("action failed");
+            });
+          },
+        }),
+      ),
+    );
+
+    releaseDeferred();
+    await expect(deferredRead).resolves.toBe("en");
+    errorSpy.mockRestore();
+  });
+
+  it("allows deferred root params reads after external action redirects", async () => {
+    let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
+
+    await runWithRootParamsScope({ lang: "en" }, () =>
+      handleServerActionRscRequest(
+        createRscOptions({
+          loadServerAction() {
+            return Promise.resolve(() => {
+              deferredRead = deferred.then(() => getRootParam("lang"));
+              redirect("https://other.example/target");
+            });
+          },
+        }),
+      ),
+    );
+
+    releaseDeferred();
+    await expect(deferredRead).resolves.toBe("en");
   });
 
   // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/simple.test.ts
@@ -2432,7 +2513,10 @@ describe("app server action execution helpers", () => {
 
       expect(response?.status).toBe(statusCode);
       expect(await response?.text()).toBe("fallback-flight");
-      expect(renderedModel).toEqual({ returnValue: { ok: false, data: fallbackError } });
+      expect(renderedModel).toEqual({
+        root: "dashboard:{}:none",
+        returnValue: { ok: false, data: fallbackError },
+      });
     }
   });
 

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -8,6 +8,7 @@ import {
   readActionFormDataWithLimit,
   type HandleProgressiveServerActionRequestOptions,
 } from "../packages/vinext/src/server/app-server-action-execution.js";
+import { getRootParam, runWithRootParamsScope } from "../packages/vinext/src/shims/root-params.js";
 import {
   createServerActionNotFoundResponse,
   throwOnServerActionNotFound,
@@ -295,6 +296,33 @@ function createRscOptions(
 }
 
 describe("app server action execution helpers", () => {
+  // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  it("rejects next/root-params inside progressive server actions", async () => {
+    const formData = new FormData();
+    formData.set("$ACTION_ID_test", "");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await handleProgressiveServerActionRequest(
+      createOptions({
+        async decodeAction() {
+          return () => getRootParam("lang");
+        },
+        readFormDataWithLimit() {
+          return Promise.resolve(formData);
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({ kind: "form-state", actionFailed: true });
+    expect(result && "actionError" in result ? result.actionError : null).toMatchObject({
+      name: "Error",
+      message:
+        "`import('next/root-params').lang()` was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route.",
+    });
+    errorSpy.mockRestore();
+  });
+
   it("reads streamed action text bodies and enforces the byte limit", async () => {
     const validRequest = new Request("https://example.com/action", {
       method: "POST",
@@ -1154,6 +1182,84 @@ describe("app server action execution helpers", () => {
     expect(navigationContexts).toEqual([{ params: {}, pathname: "/dashboard" }]);
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  it("rejects next/root-params inside fetch server actions", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        decodeReply() {
+          return Promise.resolve([]);
+        },
+        loadServerAction() {
+          return Promise.resolve(() => getRootParam("lang"));
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(500);
+    errorSpy.mockRestore();
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-root-params-getters/simple.test.ts
+  it("allows root params during the rerender after a successful fetch action", async () => {
+    let pageParam!: Promise<string | string[] | undefined>;
+    let metadataParam!: Promise<string | string[] | undefined>;
+    const buildPageElement = vi.fn(() => {
+      pageParam = getRootParam("lang");
+      metadataParam = getRootParam("lang");
+      return "rerendered-page";
+    });
+    const renderToReadableStream = vi.fn(
+      (model: TestActionModel) => new Response(JSON.stringify(model)).body,
+    );
+
+    const response = await runWithRootParamsScope({ lang: "en" }, () =>
+      handleServerActionRscRequest(
+        createRscOptions({
+          buildPageElement,
+          loadServerAction() {
+            return Promise.resolve(async () => {
+              await revalidatePath("/dashboard");
+              return "updated";
+            });
+          },
+          renderToReadableStream,
+        }),
+      ),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(buildPageElement).toHaveBeenCalledOnce();
+    await expect(pageParam).resolves.toBe("en");
+    await expect(metadataParam).resolves.toBe("en");
+    expect(JSON.parse(await response!.text())).toEqual({
+      root: "rerendered-page",
+      returnValue: { ok: true, data: "updated" },
+    });
+  });
+
+  it("allows deferred post-action render work to read root params", async () => {
+    let deferredRead!: Promise<string | string[] | undefined>;
+
+    await runWithRootParamsScope({ lang: "en" }, () =>
+      handleServerActionRscRequest(
+        createRscOptions({
+          loadServerAction() {
+            return Promise.resolve(() => {
+              deferredRead = Promise.resolve().then(() => getRootParam("lang"));
+              return "updated";
+            });
+          },
+        }),
+      ),
+    );
+
+    await expect(deferredRead).resolves.toBe("en");
+  });
+
   it("skips page rerendering for fetch actions that do not revalidate", async () => {
     const buildPageElement = vi.fn(() => "dashboard:{}:none");
     const setNavigationContext = vi.fn();
@@ -1667,10 +1773,11 @@ describe("app server action execution helpers", () => {
         }),
       );
 
-      expect(response?.status).toBe(200);
+      expect(response?.status).toBe(500);
       expect(await response?.text()).toBe("too-many-args-flight");
       expect(action).not.toHaveBeenCalled();
       expect(renderedModel).toEqual({
+        root: "dashboard:{}:none",
         returnValue: {
           ok: false,
           data: "Server Action arguments list is too long (1001). Maximum allowed is 1000.",

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1243,13 +1243,18 @@ describe("app server action execution helpers", () => {
 
   it("allows deferred post-action render work to read root params", async () => {
     let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
 
     await runWithRootParamsScope({ lang: "en" }, () =>
       handleServerActionRscRequest(
         createRscOptions({
           loadServerAction() {
-            return Promise.resolve(() => {
-              deferredRead = Promise.resolve().then(() => getRootParam("lang"));
+            return Promise.resolve(async () => {
+              deferredRead = deferred.then(() => getRootParam("lang"));
+              await revalidatePath("/dashboard");
               return "updated";
             });
           },
@@ -1257,10 +1262,16 @@ describe("app server action execution helpers", () => {
       ),
     );
 
+    releaseDeferred();
     await expect(deferredRead).resolves.toBe("en");
   });
 
   it("skips page rerendering for fetch actions that do not revalidate", async () => {
+    let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
     const buildPageElement = vi.fn(() => "dashboard:{}:none");
     const setNavigationContext = vi.fn();
     const renderToReadableStream = vi.fn(
@@ -1271,6 +1282,12 @@ describe("app server action execution helpers", () => {
       const response = await handleServerActionRscRequest(
         createRscOptions({
           buildPageElement,
+          loadServerAction() {
+            return Promise.resolve(() => {
+              deferredRead = deferred.then(() => getRootParam("lang"));
+              return "action-result";
+            });
+          },
           middlewareHeaders: new Headers([[VINEXT_RSC_COMPATIBILITY_ID_HEADER, "spoofed-compat"]]),
           renderToReadableStream,
           setNavigationContext,
@@ -1287,6 +1304,9 @@ describe("app server action execution helpers", () => {
       const model = JSON.parse(await response!.text()) as Partial<TestActionModel>;
       expect(model.returnValue).toEqual({ ok: true, data: "action-result" });
       expect(model).not.toHaveProperty("root");
+
+      releaseDeferred();
+      await expect(deferredRead).rejects.toThrow("was used inside a Server Action");
     });
   });
 
@@ -2070,12 +2090,23 @@ describe("app server action execution helpers", () => {
   // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action.test.ts
   it("processes forwarded action POSTs but suppresses same-page rerenders", async () => {
+    let deferredRead!: Promise<string | string[] | undefined>;
+    let releaseDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve;
+    });
     const renderToReadableStream = vi.fn(
       (model: TestActionModel) => new Response(JSON.stringify(model)).body,
     );
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => {
+            deferredRead = deferred.then(() => getRootParam("lang"));
+            return "action-result";
+          });
+        },
         request: createFetchActionRequest({ "x-action-forwarded": "1" }),
         renderToReadableStream,
       }),
@@ -2086,6 +2117,8 @@ describe("app server action execution helpers", () => {
       returnValue: { ok: true, data: "action-result" },
     });
     expect(renderToReadableStream).toHaveBeenCalledTimes(1);
+    releaseDeferred();
+    await expect(deferredRead).rejects.toThrow("was used inside a Server Action");
   });
 
   it("preserves forwarded action cookie and revalidation side effects without a rerender", async () => {

--- a/tests/root-params.test.ts
+++ b/tests/root-params.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vite-plus/test";
-import { getRootParam, runWithRootParamsScope } from "../packages/vinext/src/shims/root-params.js";
+import {
+  getRootParam,
+  runWithRootParamsScope,
+  runWithRootParamsUsage,
+} from "../packages/vinext/src/shims/root-params.js";
 import {
   runWithRequestContext,
   createRequestContext,
@@ -43,6 +47,78 @@ describe("next/root-params shim", () => {
       outer: "en",
       inner: "es",
       outerAfter: "en",
+    });
+  });
+
+  it("rejects access inside server actions", () => {
+    try {
+      void runWithRootParamsUsage({ kind: "server-action" }, () => getRootParam("lang"));
+      throw new Error("Expected root params access to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        name: "Error",
+        message:
+          "`import('next/root-params').lang()` was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route.",
+      });
+    }
+  });
+
+  it("rejects access inside route handlers", () => {
+    expect(() =>
+      runWithRootParamsUsage(
+        { kind: "route-handler", routePattern: "/[lang]/[locale]/route-handler" },
+        () => getRootParam("lang"),
+      ),
+    ).toThrow(
+      "Route /[lang]/[locale]/route-handler used `import('next/root-params').lang()` inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.",
+    );
+  });
+
+  it("restores route access after restricted execution", async () => {
+    await runWithRootParamsScope({ lang: "en" }, async () => {
+      expect(() =>
+        runWithRootParamsUsage({ kind: "server-action" }, () => getRootParam("lang")),
+      ).toThrow();
+      await expect(getRootParam("lang")).resolves.toBe("en");
+    });
+  });
+
+  it("allows deferred work after a server action settles", async () => {
+    await runWithRootParamsScope({ lang: "en" }, async () => {
+      let resolveDeferred!: () => void;
+      const deferred = new Promise<void>((resolve) => {
+        resolveDeferred = resolve;
+      });
+      let postActionRead!: Promise<string | string[] | undefined>;
+      await runWithRootParamsUsage({ kind: "server-action" }, async () => {
+        postActionRead = deferred.then(() => getRootParam("lang"));
+      });
+
+      resolveDeferred();
+      await expect(postActionRead).resolves.toBe("en");
+    });
+  });
+
+  it("isolates concurrent action cleanup", async () => {
+    await runWithRootParamsScope({ lang: "en" }, async () => {
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const first = runWithRootParamsUsage({ kind: "server-action" }, async () => {
+        await firstGate;
+        return getRootParam("lang");
+      });
+
+      await expect(
+        Promise.resolve().then(() =>
+          runWithRootParamsUsage({ kind: "server-action" }, () => getRootParam("lang")),
+        ),
+      ).rejects.toThrow("was used inside a Server Action");
+      releaseFirst();
+      await expect(first).rejects.toThrow("was used inside a Server Action");
+      await expect(getRootParam("lang")).resolves.toBe("en");
     });
   });
 

--- a/tests/root-params.test.ts
+++ b/tests/root-params.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vite-plus/test";
 import {
+  createRootParamsUsageController,
   getRootParam,
   runWithRootParamsScope,
   runWithRootParamsUsage,
@@ -84,7 +85,29 @@ describe("next/root-params shim", () => {
     });
   });
 
-  it("allows deferred work after a server action settles", async () => {
+  it("allows deferred work after a server action transitions to rendering", async () => {
+    await runWithRootParamsScope({ lang: "en" }, async () => {
+      const controller = createRootParamsUsageController();
+      let resolveDeferred!: () => void;
+      const deferred = new Promise<void>((resolve) => {
+        resolveDeferred = resolve;
+      });
+      let postActionRead!: Promise<string | string[] | undefined>;
+      await runWithRootParamsUsage(
+        { kind: "server-action" },
+        async () => {
+          postActionRead = deferred.then(() => getRootParam("lang"));
+        },
+        controller,
+      );
+
+      controller.transitionToRender();
+      resolveDeferred();
+      await expect(postActionRead).resolves.toBe("en");
+    });
+  });
+
+  it("keeps deferred work restricted when a server action does not rerender", async () => {
     await runWithRootParamsScope({ lang: "en" }, async () => {
       let resolveDeferred!: () => void;
       const deferred = new Promise<void>((resolve) => {
@@ -96,7 +119,7 @@ describe("next/root-params shim", () => {
       });
 
       resolveDeferred();
-      await expect(postActionRead).resolves.toBe("en");
+      await expect(postActionRead).rejects.toThrow("was used inside a Server Action");
     });
   });
 


### PR DESCRIPTION
## Summary
- reject `next/root-params` access from Server Actions and Route Handlers with Next.js-compatible errors
- transition Server Actions to render phase only when a rerender actually occurs
- preserve restrictions for forwarded/no-rerender actions and detached Route Handler work
- return HTTP 500 for failed fetch/progressive actions while preserving control-flow statuses

## Validation
- 97 targeted tests across root params, Server Actions, and Route Handlers
- focused `vp check`
- `vp run vinext#build`

Next.js reference: `v16.2.6` (`ee6e79b1792a4d401ddf2480f40a83549fe8e722`).