### PR TITLE
fix(app-router): preserve global error details

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -801,14 +801,14 @@ export default createAppRscHandler({
           makeThenableParams,
         }));
       },
-      renderErrorBoundaryPage(renderErr) {
+      renderErrorBoundaryPage(renderErr, errorOrigin) {
         const __activeIntercept = findIntercept(cleanPathname, interceptionContext);
         return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, scriptNonce, middlewareContext, {
           isEdgeRuntime: __isEdgeRuntime(__segmentConfig.runtime),
           sourcePageSegments: __activeIntercept?.slotKey === __SIBLING_PAGE_INTERCEPT_SLOT_KEY
             ? __activeIntercept.sourcePageSegments
             : null,
-        });
+        }, errorOrigin);
       },
       renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
         const __activeIntercept = findIntercept(cleanPathname, interceptionContext);

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -108,6 +108,7 @@ type AppFallbackRenderer<TModule extends AppPageModule = AppPageModule> = {
     scriptNonce: string | undefined,
     middlewareContext: AppPageMiddlewareContext,
     callContext?: AppFallbackRendererCallContext,
+    errorOrigin?: "rsc" | "ssr",
   ) => Promise<Response | null>;
   renderHttpAccessFallback: (
     route: AppPageBoundaryRoute<TModule> | null,
@@ -322,6 +323,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
       scriptNonce,
       middlewareContext,
       callContext,
+      errorOrigin = "rsc",
     ) {
       return renderAppPageErrorBoundary({
         basePath,
@@ -332,6 +334,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
           return buildRscOnErrorHandler(request, pathname, routePath);
         },
         error,
+        errorOrigin,
         getFontLinks: fontProviders.getFontLinks,
         getFontPreloads: fontProviders.getFontPreloads,
         getFontStyles: fontProviders.getFontStyles,

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -1,7 +1,12 @@
 import { Fragment, createElement, type ComponentType, type ReactNode } from "react";
 import { buildClientHookErrorMessage } from "vinext/shims/client-hook-error";
 import DefaultGlobalError from "vinext/shims/default-global-error";
-import { ErrorBoundary, GlobalErrorBoundary } from "vinext/shims/error-boundary";
+import {
+  ErrorBoundary,
+  GlobalErrorBoundary,
+  SerializedErrorBoundary,
+  type SerializedBoundaryError,
+} from "vinext/shims/error-boundary";
 import { LayoutSegmentProvider } from "vinext/shims/layout-segment-context";
 import { MetadataHead, ViewportHead } from "vinext/shims/metadata";
 import type { NavigationContext } from "vinext/shims/navigation";
@@ -127,6 +132,7 @@ type RenderAppPageHttpAccessFallbackOptions<TModule extends AppPageModule = AppP
 
 type RenderAppPageErrorBoundaryOptions<TModule extends AppPageModule = AppPageModule> = {
   error: unknown;
+  errorOrigin?: "rsc" | "ssr";
   matchedParams?: AppPageParams | null;
   route?: AppPageBoundaryRoute<TModule> | null;
   sanitizeErrorForClient: (error: Error) => Error;
@@ -426,7 +432,8 @@ export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(
   const rawError =
     options.error instanceof Error ? options.error : new Error(String(options.error));
   rewriteClientHookError(rawError);
-  const errorObject = options.sanitizeErrorForClient(rawError);
+  const errorObject =
+    options.errorOrigin === "ssr" ? rawError : options.sanitizeErrorForClient(rawError);
   const matchedParams = options.matchedParams ?? options.route?.params ?? {};
   const layoutModules = options.route?.layouts ?? options.rootLayouts;
   const pathname = new URL(options.requestUrl).pathname;
@@ -474,7 +481,18 @@ export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(
   // this extra wrapping. Mirrors Next.js's outer
   // `RootErrorBoundary errorComponent={DefaultGlobalError}`.
   const buildElement = (BoundaryComponent: AppPageComponent): ReactNode => {
-    const boundaryElement = createElement(BoundaryComponent, { error: errorObject });
+    const serializedError = {
+      digest: "digest" in errorObject ? String(errorObject.digest) : undefined,
+      message: errorObject.message,
+      name: errorObject.name,
+      stack: process.env.NODE_ENV !== "production" ? errorObject.stack : undefined,
+    } satisfies SerializedBoundaryError;
+    const boundaryElement = errorBoundary.isGlobalError
+      ? createElement(SerializedErrorBoundary, {
+          error: serializedError,
+          fallback: BoundaryComponent,
+        })
+      : createElement(BoundaryComponent, { error: errorObject });
     return wrapRenderedBoundaryElement({
       element: createElement(
         Fragment,

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -487,12 +487,13 @@ export async function renderAppPageErrorBoundary<TModule extends AppPageModule>(
       name: errorObject.name,
       stack: process.env.NODE_ENV !== "production" ? errorObject.stack : undefined,
     } satisfies SerializedBoundaryError;
-    const boundaryElement = errorBoundary.isGlobalError
-      ? createElement(SerializedErrorBoundary, {
-          error: serializedError,
-          fallback: BoundaryComponent,
-        })
-      : createElement(BoundaryComponent, { error: errorObject });
+    const boundaryElement =
+      errorBoundary.isGlobalError && BoundaryComponent !== DEFAULT_GLOBAL_ERROR_COMPONENT
+        ? createElement(SerializedErrorBoundary, {
+            error: serializedError,
+            fallback: BoundaryComponent,
+          })
+        : createElement(BoundaryComponent, { error: errorObject });
     return wrapRenderedBoundaryElement({
       element: createElement(
         Fragment,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -290,7 +290,10 @@ type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   probeLayoutAt: (layoutIndex: number, layoutParamAccess?: AppLayoutParamAccessTracker) => unknown;
   probePage: () => unknown;
   expireSeconds?: number;
-  renderErrorBoundaryPage: (error: unknown) => Promise<Response | null>;
+  renderErrorBoundaryPage: (
+    error: unknown,
+    errorOrigin?: "rsc" | "ssr",
+  ) => Promise<Response | null>;
   renderHttpAccessFallbackPage: (
     statusCode: number,
     opts: {
@@ -1128,8 +1131,8 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     revalidateSeconds: currentRevalidateSeconds,
     mountedSlotsHeader: options.mountedSlotsHeader,
     renderMode: options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
-    renderErrorBoundaryResponse(renderError) {
-      return options.renderErrorBoundaryPage(renderError);
+    renderErrorBoundaryResponse(renderError, errorOrigin) {
+      return options.renderErrorBoundaryPage(renderError, errorOrigin);
     },
     renderLayoutSpecialError(specialError, layoutIndex) {
       return renderLayoutSpecialError(options, specialError, layoutIndex);

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -168,7 +168,10 @@ type RenderAppPageLifecycleOptions = {
   expireSeconds?: number;
   formState?: ReactFormState | null;
   revalidateSeconds: number | null;
-  renderErrorBoundaryResponse: (error: unknown) => Promise<Response | null>;
+  renderErrorBoundaryResponse: (
+    error: unknown,
+    errorOrigin: "rsc" | "ssr",
+  ) => Promise<Response | null>;
   renderLayoutSpecialError: (
     specialError: AppPageSpecialError,
     layoutIndex: number,
@@ -866,7 +869,11 @@ export async function renderAppPageLifecycle(
       }
     },
     renderErrorBoundaryResponse(error) {
-      return options.renderErrorBoundaryResponse(rscErrorTracker.getCapturedError() ?? error);
+      const capturedRscError = rscErrorTracker.getCapturedError();
+      return options.renderErrorBoundaryResponse(
+        capturedRscError ?? error,
+        capturedRscError === null ? "ssr" : "rsc",
+      );
     },
     async renderHtmlStream() {
       const ssrHandler = await options.loadSsrHandler();

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -153,8 +153,18 @@ export function createRscOnErrorHandler(
       return String(error.digest);
     }
 
-    if (nodeEnv === "production" && error) {
-      return errorDigest(getThrownValueMessage(error) + getThrownValueStack(error));
+    if (error) {
+      const digest = errorDigest(getThrownValueMessage(error) + getThrownValueStack(error));
+      if (error instanceof Error) {
+        try {
+          Object.assign(error, { digest });
+        } catch {
+          // Digest attachment is best-effort. User code can throw frozen or
+          // otherwise non-extensible Error instances, and the onError handler
+          // must not replace the original failure with a mutation TypeError.
+        }
+      }
+      return digest;
     }
 
     return undefined;

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -14,6 +14,28 @@ export type ErrorBoundaryProps = {
   resetKey?: string | null;
 };
 
+export type SerializedBoundaryError = {
+  digest?: string;
+  message: string;
+  name?: string;
+  stack?: string;
+};
+
+export function SerializedErrorBoundary({
+  fallback: Fallback,
+  error,
+}: {
+  fallback: React.ComponentType<{ error: Error & { digest?: string }; reset: () => void }>;
+  error: SerializedBoundaryError;
+}) {
+  const reconstructedError = Object.assign(new Error(error.message), {
+    digest: error.digest,
+    name: error.name ?? "Error",
+    stack: error.stack,
+  });
+  return <Fallback error={reconstructedError} reset={() => globalThis.location?.reload()} />;
+}
+
 type CapturedError = {
   thrownValue: unknown;
 };

--- a/tests/app-page-boundary-render.test.ts
+++ b/tests/app-page-boundary-render.test.ts
@@ -136,6 +136,10 @@ function GlobalErrorBoundary({ error }: { error: Error }) {
   return React.createElement("p", { "data-boundary": "global-error" }, `global:${error.message}`);
 }
 
+function GlobalErrorBoundaryWithStack({ error }: { error: Error }) {
+  return React.createElement("p", { "data-boundary": "global-error" }, error.stack);
+}
+
 type TestModule = {
   default: React.ComponentType<any>;
   metadata?: { description?: string; title?: string };
@@ -167,6 +171,10 @@ const routeErrorModule = {
 
 const globalErrorModule = {
   default: GlobalErrorBoundary,
+} satisfies TestModule;
+
+const globalErrorModuleWithStack = {
+  default: GlobalErrorBoundaryWithStack,
 } satisfies TestModule;
 
 function ThrowingGlobalErrorBoundary(): React.ReactNode {
@@ -518,6 +526,57 @@ describe("app page boundary render helpers", () => {
     expect(html).toContain('data-layout="root"');
     expect(html).toContain('data-boundary="route-error"');
     expect(html).toContain("route:safe:secret");
+  });
+
+  it("does not serialize production SSR stacks into the global error payload", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const common = createCommonOptions();
+    const error = new Error("client page error");
+    error.stack = "/private/deployment/server.js:42";
+
+    try {
+      const response = await renderAppPageErrorBoundary<TestModule>({
+        ...common,
+        error,
+        errorOrigin: "ssr",
+        globalErrorModule,
+        sanitizeErrorForClient(value: Error) {
+          return value;
+        },
+      });
+
+      const html = await response?.text();
+      expect(html).toContain("client page error");
+      expect(html).not.toContain("/private/deployment/server.js:42");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("preserves development RSC stacks in the global error payload", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const common = createCommonOptions();
+    const error = Object.assign(new Error("server page error"), {
+      digest: "12345",
+      stack: "/app/rsc/page.tsx:2",
+    });
+
+    try {
+      const response = await renderAppPageErrorBoundary<TestModule>({
+        ...common,
+        error,
+        errorOrigin: "rsc",
+        globalErrorModule: globalErrorModuleWithStack,
+        sanitizeErrorForClient(value: Error) {
+          return value;
+        },
+      });
+
+      const html = await response?.text();
+      expect(html).toContain("/app/rsc/page.tsx:2");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("preserves middleware headers on error boundary responses", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -606,8 +606,27 @@ describe("app page render lifecycle", () => {
       },
     });
 
-    expect(common.renderErrorBoundaryResponse).toHaveBeenCalledWith(rscError);
+    expect(common.renderErrorBoundaryResponse).toHaveBeenCalledWith(rscError, "rsc");
     await expect(response.text()).resolves.toBe("boundary:rsc-original");
+  });
+
+  it("marks uncaptured SSR errors as SSR-origin boundary failures", async () => {
+    const common = createCommonOptions();
+    const ssrError = new Error("ssr-decoder");
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      async loadSsrHandler() {
+        return {
+          async handleSsr() {
+            throw ssrError;
+          },
+        };
+      },
+    });
+
+    expect(common.renderErrorBoundaryResponse).toHaveBeenCalledWith(ssrError, "ssr");
+    await expect(response.text()).resolves.toBe("boundary:ssr-decoder");
   });
 
   it("writes paired HTML and RSC cache entries for cacheable HTML responses", async () => {

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -149,6 +149,37 @@ describe("app RSC error primitives", () => {
         routeType: "render",
       },
     );
+    expect(error).toMatchObject({ digest: errorDigest("render failedstack") });
+  });
+
+  it("stamps generic development RSC errors with the returned digest", () => {
+    const onError = createRscOnErrorHandler({
+      errorContext: null,
+      nodeEnv: "development",
+      reportRequestError() {},
+      requestInfo: null,
+    });
+    const error = new Error("render failed");
+    error.stack = "stack";
+
+    expect(onError(error)).toBe(errorDigest("render failedstack"));
+    expect(error).toMatchObject({ digest: errorDigest("render failedstack") });
+  });
+
+  it("returns a digest without masking frozen RSC errors", () => {
+    const onError = createRscOnErrorHandler({
+      errorContext: null,
+      nodeEnv: "development",
+      reportRequestError() {},
+      requestInfo: null,
+    });
+    const error = new Error("render failed");
+    error.stack = "stack";
+    Object.freeze(error);
+
+    expect(() => onError(error)).not.toThrow();
+    expect(onError(error)).toBe(errorDigest("render failedstack"));
+    expect(error).not.toHaveProperty("digest");
   });
 
   it("reports non-Error thrown values with the previous String(error) message", () => {

--- a/tests/e2e/app-router/error-handling.spec.ts
+++ b/tests/e2e/app-router/error-handling.spec.ts
@@ -3,6 +3,22 @@ import { test, expect } from "@playwright/test";
 const BASE = "http://localhost:4174";
 
 test.describe("Error Boundaries", () => {
+  test("global-error preserves server and SSR client error semantics after hydration", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/global-error-rsc`);
+    await expect(page.locator('[data-testid="global-error-message"]')).toContainText(
+      "server page error",
+    );
+    await expect(page.locator('[data-testid="global-error-digest"]')).not.toBeEmpty();
+
+    await page.goto(`${BASE}/nextjs-compat/global-error-ssr`);
+    await expect(page.locator('[data-testid="global-error-message"]')).toHaveText(
+      "client page error",
+    );
+    await expect(page.locator('[data-testid="global-error-digest"]')).toHaveCount(0);
+  });
+
   test("error.tsx catches client component error on button click", async ({ page }) => {
     await page.goto(`${BASE}/error-test`);
 

--- a/tests/fixtures/app-basic/app/global-error.tsx
+++ b/tests/fixtures/app-basic/app/global-error.tsx
@@ -6,7 +6,13 @@ import { usePathname } from "next/navigation";
  * Global error boundary — catches errors in the root layout.
  * Must include its own <html> and <body> tags since it replaces the root layout.
  */
-export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
   // Exercises the built-in fallback: when global-error.tsx itself throws during
   // render, vinext (like Next.js) should render the default global-error UI
   // instead of crashing the request. Keyed on the pathname (not the error
@@ -22,6 +28,7 @@ export default function GlobalError({ error, reset }: { error: Error; reset: () 
         <div data-testid="global-error">
           <h1>Something went wrong!</h1>
           <p data-testid="global-error-message">{error.message}</p>
+          {error.digest ? <p data-testid="global-error-digest">{error.digest}</p> : null}
           <button onClick={reset}>Try again</button>
         </div>
       </body>

--- a/tests/nextjs-compat/global-error.test.ts
+++ b/tests/nextjs-compat/global-error.test.ts
@@ -72,7 +72,7 @@ describe("Next.js compat: global-error", () => {
     const { res, html } = await fetchHtml(baseUrl, "/nextjs-compat/route-group-error/child");
     expect(res.status).toBe(200);
     expect(html).toContain("Route group error boundary");
-    expect(html).not.toContain("global-error");
+    expect(html).not.toContain('data-testid="global-error"');
   });
 
   // ── Server component error (RSC throw -> global-error) ─────
@@ -310,14 +310,16 @@ describe("Next.js compat: global-error (production preview)", () => {
     expect(html).toContain("global-error");
     expect(html).toContain("The specific message is omitted in production builds");
     expect(html).not.toContain("server page error");
+    expect(html).toMatch(/data-testid="global-error-digest"[^>]*>\w+</);
   });
 
   it("client component SSR throw without local error.tsx renders global-error with 500", async () => {
     const { res, html } = await fetchHtml(baseUrl, "/nextjs-compat/global-error-ssr");
     expect(res.status).toBe(500);
     expect(html).toContain("global-error");
-    expect(html).toContain("The specific message is omitted in production builds");
-    expect(html).not.toContain("client page error");
+    expect(html).toContain("client page error");
+    expect(html).not.toContain("The specific message is omitted in production builds");
+    expect(html).not.toContain('data-testid="global-error-digest"');
   });
 
   it("server component throw with local error.tsx renders that boundary with 200", async () => {


### PR DESCRIPTION
## Summary
- distinguish RSC render errors from SSR client-component errors at the app page boundary
- preserve the correct message, digest, and development stack for custom global error boundaries
- reconstruct the serialized error during client hydration

## Next.js parity
Targets the two failures in `test/e2e/app-dir/global-error/basic/index.test.ts` from Next.js v16.2.6.

## Validation
- 106 targeted unit/integration tests passed
- targeted App Router Playwright test passed with one worker
- `vp run vinext#build` passed
- scoped format/lint/types passed
- independent review found no actionable issues
