### PR TITLE
fix(app-router): canonicalize initial history URLs

### DIFF
--- a/packages/vinext/src/server/app-browser-history-controller.ts
+++ b/packages/vinext/src/server/app-browser-history-controller.ts
@@ -62,6 +62,11 @@ type CommitNavigationHistoryOptions = {
   stageClientParams: () => void;
 };
 
+export function createCanonicalBrowserHistoryHref(href: string): string {
+  const url = new URL(href);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 function stripVinextScrollState(state: unknown): unknown {
   if (!state || typeof state !== "object") {
     return state;
@@ -346,7 +351,7 @@ export class AppBrowserHistoryController {
         previousNextUrl: null,
         traversalIndex: this.#currentHistoryTraversalIndex,
       }),
-      this.#readCurrentHref(),
+      createCanonicalBrowserHistoryHref(this.#readCurrentHref()),
     );
   }
 

--- a/tests/app-browser-history-controller.test.ts
+++ b/tests/app-browser-history-controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   AppBrowserHistoryController,
+  createCanonicalBrowserHistoryHref,
   type RestorableSnapshotCandidate,
 } from "../packages/vinext/src/server/app-browser-history-controller.js";
 import {
@@ -230,6 +231,23 @@ describe("AppBrowserHistoryController hash-only navigation", () => {
 });
 
 describe("AppBrowserHistoryController history metadata sync", () => {
+  it("canonicalizes a bare trailing query marker during bootstrap", () => {
+    const { controller, store } = createController({
+      initialHref: "https://example.com/reload-error?#section",
+    });
+
+    controller.writeBootstrapHistoryMetadata();
+
+    expect(store.replaced).toHaveLength(1);
+    expect(store.replaced[0]?.href).toBe("/reload-error#section");
+  });
+
+  it("preserves non-empty query strings when canonicalizing history hrefs", () => {
+    expect(createCanonicalBrowserHistoryHref("https://example.com/page?value=1#section")).toBe(
+      "/page?value=1#section",
+    );
+  });
+
   it("preserves the BFCache epoch check when deciding whether to re-sync", () => {
     // A fresh document with no stored epoch starts at document epoch 0.
     const { controller, store } = createController();

--- a/tests/e2e/app-router/nextjs-compat/ssr-error-shell-recovery.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/ssr-error-shell-recovery.browser.spec.ts
@@ -234,6 +234,41 @@ export default function Client(): React.ReactNode {
 `,
   );
 
+  // Ported from Next.js:
+  // test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+  // The built-in Reload button is an empty GET form. Browsers request the
+  // current path with a trailing `?`; the App Router must canonicalize that
+  // back to the query-less URL after the document reloads.
+  const reloadDir = path.join(appDir, "reload-error");
+  await fs.mkdir(reloadDir, { recursive: true });
+  await fs.writeFile(
+    path.join(reloadDir, "page.tsx"),
+    `import React from "react";
+import Client from "./Client";
+
+export default function ReloadErrorPage() {
+  return (
+    <>
+      <h1>Reload Error Page</h1>
+      <Client />
+    </>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(reloadDir, "Client.tsx"),
+    `"use client";
+import React, { useState } from "react";
+
+export default function Client() {
+  const [shouldThrow, setShouldThrow] = useState(false);
+  if (shouldThrow) throw new Error("reload error");
+  return <button id="trigger-reload-error" onClick={() => setShouldThrow(true)}>Trigger</button>;
+}
+`,
+  );
+
   const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
   await fs.writeFile(
     path.join(fixtureRoot, "vite.config.ts"),
@@ -328,6 +363,14 @@ test.describe("SSR shell-error recovery (no custom global-error.tsx)", () => {
       await expect(page.getByRole("button", { name: "Reload" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
 
+      await page.goto(`${app.baseUrl}/reload-error`, { waitUntil: "load" });
+      await page.locator("#trigger-reload-error").click();
+      await expect(page.getByRole("heading", { name: "This page couldn’t load" })).toBeVisible();
+      const urlBeforeReload = page.url();
+      await page.getByRole("button", { name: "Reload" }).click();
+      await expect(page.getByRole("heading", { name: "Reload Error Page" })).toBeVisible();
+      expect(page.url()).toBe(urlBeforeReload);
+
       // The boundary routes throw on purpose, and React logs caught boundary
       // errors to the console. Drop those expected entries but stay strict
       // about anything else; the fixture re-asserts emptiness at teardown.
@@ -335,6 +378,7 @@ test.describe("SSR shell-error recovery (no custom global-error.tsx)", () => {
         (message) =>
           !message.includes("boundary throw") &&
           !message.includes("always no boundary throw") &&
+          !message.includes("reload error") &&
           !message.includes("genuine server digest error") &&
           !message.includes("Expected error to opt out of server rendering") &&
           // The recovery and global-error documents intentionally preserve


### PR DESCRIPTION
## Summary
- canonicalize initial App Router history URLs so a trailing bare `?` is removed
- match Next.js reload behavior for default error pages
- add production browser coverage for the reload-button path

## Next.js parity
Targets the retained failure in `test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts`.

## Validation
- targeted Chrome and WebKit production tests passed
- 15 focused unit tests passed
- `vp run vinext#build` passed
- scoped format/lint/types passed
- independent review found no actionable issues
