### PR TITLE
fix(config): match deprecation warning parity

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -241,6 +241,42 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     status: "partial",
     detail: "config recognized; vinext does not implement navigation result caching",
   },
+  "experimental.middlewarePrefetch": {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
+  "experimental.proxyPrefetch": {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
+  "experimental.middlewareClientMaxBodySize": {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
+  "experimental.proxyClientMaxBodySize": {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
+  "experimental.externalMiddlewareRewritesResolve": {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
+  "experimental.externalProxyRewritesResolve": {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
+  "experimental.instrumentationHook": {
+    status: "unsupported",
+    detail: "not recognized; instrumentation files are enabled automatically",
+  },
+  skipMiddlewareUrlNormalize: {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
+  skipProxyUrlNormalize: {
+    status: "unsupported",
+    detail: "not recognized; use of this option is ignored",
+  },
   "i18n.domains": {
     status: "partial",
     detail: "supported for Pages Router; App Router unchanged",
@@ -870,6 +906,8 @@ export function analyzeConfig(root: string): CheckItem[] {
     "webpack",
     "reactStrictMode",
     "poweredByHeader",
+    "skipMiddlewareUrlNormalize",
+    "skipProxyUrlNormalize",
   ];
 
   for (const opt of configOptions) {

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -826,6 +826,14 @@ function hasConfigProperty(config: NextConfig, propertyPath: string): boolean {
   return true;
 }
 
+const emittedConfigWarnings = new Set<string>();
+
+function warnConfigOnce(message: string): void {
+  if (emittedConfigWarnings.has(message)) return;
+  emittedConfigWarnings.add(message);
+  console.warn(message);
+}
+
 function warnDeprecatedConfigOptions(config: NextConfig, root: string): void {
   const configFileName = path.basename(findNextConfigPath(root) ?? "next.config.js");
   const warnings = [
@@ -852,7 +860,7 @@ function warnDeprecatedConfigOptions(config: NextConfig, root: string): void {
   ] as const;
 
   for (const [propertyPath, warning] of warnings) {
-    if (hasConfigProperty(config, propertyPath)) console.warn(warning);
+    if (hasConfigProperty(config, propertyPath)) warnConfigOnce(warning);
   }
 }
 

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -817,6 +817,45 @@ export function findNextConfigPath(root: string): string | null {
   return null;
 }
 
+function hasConfigProperty(config: NextConfig, propertyPath: string): boolean {
+  let current: unknown = config;
+  for (const property of propertyPath.split(".")) {
+    if (!isUnknownRecord(current) || current[property] === undefined) return false;
+    current = current[property];
+  }
+  return true;
+}
+
+function warnDeprecatedConfigOptions(config: NextConfig, root: string): void {
+  const configFileName = path.basename(findNextConfigPath(root) ?? "next.config.js");
+  const warnings = [
+    [
+      "experimental.middlewarePrefetch",
+      `\`experimental.middlewarePrefetch\` is deprecated. Please use \`experimental.proxyPrefetch\` instead in ${configFileName}.`,
+    ],
+    [
+      "experimental.middlewareClientMaxBodySize",
+      `\`experimental.middlewareClientMaxBodySize\` is deprecated. Please use \`experimental.proxyClientMaxBodySize\` instead in ${configFileName}.`,
+    ],
+    [
+      "experimental.externalMiddlewareRewritesResolve",
+      `\`experimental.externalMiddlewareRewritesResolve\` is deprecated. Please use \`experimental.externalProxyRewritesResolve\` instead in ${configFileName}.`,
+    ],
+    [
+      "skipMiddlewareUrlNormalize",
+      `\`skipMiddlewareUrlNormalize\` is deprecated. Please use \`skipProxyUrlNormalize\` instead in ${configFileName}.`,
+    ],
+    [
+      "experimental.instrumentationHook",
+      `\`experimental.instrumentationHook\` is no longer needed, because \`instrumentation.js\` is available by default. You can remove it from ${configFileName}.`,
+    ],
+  ] as const;
+
+  for (const [propertyPath, warning] of warnings) {
+    if (hasConfigProperty(config, propertyPath)) console.warn(warning);
+  }
+}
+
 export async function resolveNextConfigInput(
   config: NextConfigInput,
   phase: string = PHASE_DEVELOPMENT_SERVER,
@@ -1323,6 +1362,8 @@ export async function resolveNextConfig(
     detectNextIntlConfig(root, resolved);
     return resolved;
   }
+
+  warnDeprecatedConfigOptions(config, root);
 
   // Resolve redirects
   let redirects: NextRedirect[] = [];

--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -618,7 +618,14 @@ ensure_python_command_for_native_builds
 # (ERR_PNPM_IGNORED_BUILDS). The install still completes — packages are
 # written to node_modules — but the exit code is 1. Tolerate this by
 # verifying that the vinext local package was linked into node_modules.
-run_pnpm install --strict-peer-dependencies=false --no-frozen-lockfile >> "${BUILD_LOG}" 2>&1 || true
+INSTALL_LOG="$(mktemp)"
+run_pnpm install --strict-peer-dependencies=false --no-frozen-lockfile > "${INSTALL_LOG}" 2>&1 || true
+# Dependency-manager deprecation summaries describe the deploy harness's own
+# transitive dependencies, not the application under test. Keep the rest of
+# the install output available for diagnostics without polluting cliOutput
+# assertions that specifically inspect application deprecation warnings.
+"${VINEXT_DIR}/scripts/filter-e2e-install-log.sh" < "${INSTALL_LOG}" >> "${BUILD_LOG}"
+rm -f "${INSTALL_LOG}"
 if [ ! -d "node_modules/vinext" ]; then
   echo "pnpm install failed: node_modules/vinext not found" >&2
   exit 1

--- a/scripts/filter-e2e-install-log.sh
+++ b/scripts/filter-e2e-install-log.sh
@@ -1,7 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sed \
-  -e '/deprecated subdependencies found:/d' \
-  -e '/\[DEP0169\] DeprecationWarning:/d' \
-  -e '/Use `node --trace-deprecation/d'
+awk '
+  /^> .* (preinstall|install|postinstall)( |$)/ {
+    in_lifecycle_script = 1
+  }
+
+  in_lifecycle_script && /^$/ {
+    in_lifecycle_script = 0
+    print
+    next
+  }
+
+  !in_lifecycle_script && /deprecated subdependencies found:/ {
+    next
+  }
+
+  !in_lifecycle_script && /\[DEP0169\] DeprecationWarning: .*url\.parse\(\)/ {
+    skipped_node_warning = 1
+    next
+  }
+
+  !in_lifecycle_script && skipped_node_warning && /^\(Use `node --trace-deprecation .*` to show where the warning was created\)$/ {
+    skipped_node_warning = 0
+    next
+  }
+
+  {
+    skipped_node_warning = 0
+    print
+  }
+'

--- a/scripts/filter-e2e-install-log.sh
+++ b/scripts/filter-e2e-install-log.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sed \
+  -e '/deprecated subdependencies found:/d' \
+  -e '/\[DEP0169\] DeprecationWarning:/d' \
+  -e '/Use `node --trace-deprecation/d'

--- a/scripts/filter-e2e-install-log.sh
+++ b/scripts/filter-e2e-install-log.sh
@@ -6,7 +6,7 @@ awk '
     in_lifecycle_script = 1
   }
 
-  in_lifecycle_script && /^$/ {
+  in_lifecycle_script && /^Done in .* using pnpm v[0-9]/ {
     in_lifecycle_script = 0
     print
     next

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -527,6 +527,42 @@ describe("analyzeConfig", () => {
     expect(item?.detail).toContain("not applicable");
   });
 
+  it("detects unrecognized middleware and proxy config options as unsupported", () => {
+    writeFile(
+      "next.config.mjs",
+      `export default {
+        skipMiddlewareUrlNormalize: true,
+        skipProxyUrlNormalize: true,
+        experimental: {
+          middlewarePrefetch: "strict",
+          proxyPrefetch: "strict",
+          middlewareClientMaxBodySize: "5mb",
+          proxyClientMaxBodySize: "5mb",
+          externalMiddlewareRewritesResolve: true,
+          externalProxyRewritesResolve: true,
+          instrumentationHook: true,
+        },
+      };`,
+    );
+
+    const items = analyzeConfig(tmpDir);
+    const unsupportedNames = items
+      .filter((item) => item.status === "unsupported")
+      .map((item) => item.name);
+
+    expect(unsupportedNames).toEqual([
+      "skipMiddlewareUrlNormalize",
+      "skipProxyUrlNormalize",
+      "experimental.middlewarePrefetch",
+      "experimental.proxyPrefetch",
+      "experimental.middlewareClientMaxBodySize",
+      "experimental.proxyClientMaxBodySize",
+      "experimental.externalMiddlewareRewritesResolve",
+      "experimental.externalProxyRewritesResolve",
+      "experimental.instrumentationHook",
+    ]);
+  });
+
   it("detects allowedDevOrigins as supported", () => {
     writeFile(
       "next.config.mjs",

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vite-plus/test";
+
+describe("Next.js deploy harness logging", () => {
+  it("removes install-time deprecation noise from application cliOutput", () => {
+    const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
+
+    expect(script).toContain('"${VINEXT_DIR}/scripts/filter-e2e-install-log.sh"');
+    expect(script).toContain('>> "${BUILD_LOG}"');
+
+    const output = execFileSync("bash", ["scripts/filter-e2e-install-log.sh"], {
+      input:
+        "(node:8211) [DEP0169] DeprecationWarning: `url.parse()` is deprecated\n" +
+        "(Use `node --trace-deprecation ...` to show where the warning was created)\n" +
+        "WARN 1 deprecated subdependencies found: tsconfck@3.1.6\n" +
+        "Progress: resolved 370, reused 298, downloaded 0, added 292, done\n" +
+        "Application warning: keep this diagnostic\n",
+      encoding: "utf8",
+    });
+
+    expect(output).toBe(
+      "Progress: resolved 370, reused 298, downloaded 0, added 292, done\n" +
+        "Application warning: keep this diagnostic\n",
+    );
+  });
+});

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -25,4 +25,30 @@ describe("Next.js deploy harness logging", () => {
         "Application warning: keep this diagnostic\n",
     );
   });
+
+  it("preserves matching diagnostics from application lifecycle scripts", () => {
+    const output = execFileSync("bash", ["scripts/filter-e2e-install-log.sh"], {
+      input:
+        "WARN 1 deprecated subdependencies found: tsconfck@3.1.6\n" +
+        "> application@1.0.0 postinstall /tmp/application\n" +
+        "> node postinstall.js\n" +
+        "(node:9211) [DEP0169] DeprecationWarning: `url.parse()` is deprecated\n" +
+        "(Use `node --trace-deprecation ...` to show where the warning was created)\n" +
+        "1 deprecated subdependencies found: application-owned diagnostic\n" +
+        "Application install error: keep this diagnostic\n" +
+        "\n" +
+        "WARN 2 deprecated subdependencies found: harness@1.0.0\n",
+      encoding: "utf8",
+    });
+
+    expect(output).toBe(
+      "> application@1.0.0 postinstall /tmp/application\n" +
+        "> node postinstall.js\n" +
+        "(node:9211) [DEP0169] DeprecationWarning: `url.parse()` is deprecated\n" +
+        "(Use `node --trace-deprecation ...` to show where the warning was created)\n" +
+        "1 deprecated subdependencies found: application-owned diagnostic\n" +
+        "Application install error: keep this diagnostic\n" +
+        "\n",
+    );
+  });
 });

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -37,6 +37,9 @@ describe("Next.js deploy harness logging", () => {
         "1 deprecated subdependencies found: application-owned diagnostic\n" +
         "Application install error: keep this diagnostic\n" +
         "\n" +
+        "(node:9212) [DEP0169] DeprecationWarning: `url.parse()` is deprecated\n" +
+        "2 deprecated subdependencies found: later application diagnostic\n" +
+        "Done in 1.2s using pnpm v11.1.1\n" +
         "WARN 2 deprecated subdependencies found: harness@1.0.0\n",
       encoding: "utf8",
     });
@@ -48,7 +51,10 @@ describe("Next.js deploy harness logging", () => {
         "(Use `node --trace-deprecation ...` to show where the warning was created)\n" +
         "1 deprecated subdependencies found: application-owned diagnostic\n" +
         "Application install error: keep this diagnostic\n" +
-        "\n",
+        "\n" +
+        "(node:9212) [DEP0169] DeprecationWarning: `url.parse()` is deprecated\n" +
+        "2 deprecated subdependencies found: later application diagnostic\n" +
+        "Done in 1.2s using pnpm v11.1.1\n",
     );
   });
 });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -83,15 +83,34 @@ describe("deprecated config warnings", () => {
     ]);
   });
 
-  it("warns when deprecated options are explicitly false", async () => {
+  it("warns once across repeated config resolution", async () => {
+    const root = makeTempDir();
+    fs.writeFileSync(path.join(root, "next.config.mjs"), "export default {}\n");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    await resolveNextConfig({
-      skipMiddlewareUrlNormalize: false,
-      experimental: { instrumentationHook: false },
-    });
+    try {
+      await resolveNextConfig(
+        {
+          skipMiddlewareUrlNormalize: false,
+          experimental: { instrumentationHook: false },
+        },
+        root,
+      );
+      await resolveNextConfig(
+        {
+          skipMiddlewareUrlNormalize: false,
+          experimental: { instrumentationHook: false },
+        },
+        root,
+      );
 
-    expect(warn).toHaveBeenCalledTimes(2);
+      expect(warn.mock.calls.map(([message]) => message)).toEqual([
+        "`skipMiddlewareUrlNormalize` is deprecated. Please use `skipProxyUrlNormalize` instead in next.config.mjs.",
+        "`experimental.instrumentationHook` is no longer needed, because `instrumentation.js` is available by default. You can remove it from next.config.mjs.",
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -48,6 +48,53 @@ describe("invalid config files", () => {
   });
 });
 
+describe("deprecated config warnings", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not warn when no config file exists", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig(null);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("matches Next.js warnings for explicitly configured deprecated options", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      skipMiddlewareUrlNormalize: true,
+      experimental: {
+        middlewarePrefetch: "strict",
+        instrumentationHook: true,
+        middlewareClientMaxBodySize: "5mb",
+        externalMiddlewareRewritesResolve: true,
+      },
+    });
+
+    expect(warn.mock.calls.map(([message]) => message)).toEqual([
+      "`experimental.middlewarePrefetch` is deprecated. Please use `experimental.proxyPrefetch` instead in next.config.js.",
+      "`experimental.middlewareClientMaxBodySize` is deprecated. Please use `experimental.proxyClientMaxBodySize` instead in next.config.js.",
+      "`experimental.externalMiddlewareRewritesResolve` is deprecated. Please use `experimental.externalProxyRewritesResolve` instead in next.config.js.",
+      "`skipMiddlewareUrlNormalize` is deprecated. Please use `skipProxyUrlNormalize` instead in next.config.js.",
+      "`experimental.instrumentationHook` is no longer needed, because `instrumentation.js` is available by default. You can remove it from next.config.js.",
+    ]);
+  });
+
+  it("warns when deprecated options are explicitly false", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await resolveNextConfig({
+      skipMiddlewareUrlNormalize: false,
+      experimental: { instrumentationHook: false },
+    });
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("loadNextConfig with CJS next.config.js under type:module", () => {
   // Real-world shape from the Next.js deploy suite: `vinext init` flips
   // package.json to `"type": "module"`, but the test fixture's


### PR DESCRIPTION
## Summary
- match Next.js v16.2.6 warnings for explicitly configured deprecated options
- emit each warning once per process, matching Next.js `Log.warnOnce`
- filter only package-manager install noise from deploy-suite output while preserving application lifecycle diagnostics

## Next.js parity
Addresses the two failures in `test/e2e/deprecation-warnings/deprecation-warnings.test.ts` from the latest deploy-suite report.

## Validation
- focused config and deploy-script tests
- lifecycle log-filter shell probes
- scoped `vp check`
- `vp run vinext#build`
- independent review: no actionable findings

Full suites are deferred to CI.
