### PR TITLE
fix(config): match trailing-slash route sources

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -951,11 +951,11 @@ export function matchRedirect(
 ): { destination: string; permanent: boolean } | null {
   if (redirects.length === 0) return null;
 
-  // Strip trailing slash so the locale-static fast path (Map.get on the
+  // Strip trailing slash for the locale-static fast path (Map.get on the
   // pathname) matches keys derived from slash-free source patterns. The
-  // linear fallback also passes through `matchConfigPattern` which strips
-  // again, but normalizing once here keeps both paths consistent.
-  pathname = stripTrailingSlashForConfigMatch(pathname);
+  // linear fallback receives the original pathname so matchConfigPattern can
+  // apply the same optional-slash behavior to slash-ending source patterns.
+  const normalizedPathname = stripTrailingSlashForConfigMatch(pathname);
 
   const index = _getRedirectIndex(redirects);
 
@@ -981,7 +981,7 @@ export function matchRedirect(
     // (the locale segment was optional). Mandatory-locale entries — emitted
     // by `applyLocaleToRoutes` as `/:nextInternalLocale(en|fr)/foo` — must
     // not match here because they require the locale segment to be present.
-    const noLocaleBucket = index.localeStatic.get(pathname);
+    const noLocaleBucket = index.localeStatic.get(normalizedPathname);
     if (noLocaleBucket) {
       for (const entry of noLocaleBucket) {
         if (!entry.optional) continue; // mandatory-locale rule — skip
@@ -1007,10 +1007,10 @@ export function matchRedirect(
     // Case 2: locale prefix present — first path segment is the locale.
     // Find the second slash: pathname = "/locale/rest/of/path"
     //                                         ^--- slashTwo
-    const slashTwo = pathname.indexOf("/", 1);
+    const slashTwo = normalizedPathname.indexOf("/", 1);
     if (slashTwo !== -1) {
-      const suffix = pathname.slice(slashTwo); // e.g. "/security"
-      const localePart = pathname.slice(1, slashTwo); // e.g. "en"
+      const suffix = normalizedPathname.slice(slashTwo); // e.g. "/security"
+      const localePart = normalizedPathname.slice(1, slashTwo); // e.g. "en"
       const localeBucket = index.localeStatic.get(suffix);
       if (localeBucket) {
         for (const entry of localeBucket) {
@@ -1458,9 +1458,7 @@ export function matchHeaders(
   ctx: RequestContext,
   basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
 ): Array<{ key: string; value: string }> {
-  // Header source regexes are compiled without a trailing-slash tolerance,
-  // so the incoming pathname must be normalized the same way config rewrites
-  // and redirects are. See `stripTrailingSlashForConfigMatch`.
+  const pathnameHadTrailingSlash = pathname.length > 1 && pathname.endsWith("/");
   pathname = stripTrailingSlashForConfigMatch(pathname);
 
   const result: Array<{ key: string; value: string }> = [];
@@ -1468,8 +1466,11 @@ export function matchHeaders(
     if (!shouldEvaluateRule(rule.basePath, basePathState)) continue;
     // Cache the compiled source regex — escapeHeaderSource() + safeRegExp() are
     // pure functions of rule.source and the result never changes between requests.
-    const sourceRegex = getCachedRegex(_compiledHeaderSourceCache, rule.source, () =>
-      safeRegExp("^" + escapeHeaderSource(rule.source) + "$"),
+    const source = pathnameHadTrailingSlash
+      ? stripTrailingSlashForConfigMatch(rule.source)
+      : rule.source;
+    const sourceRegex = getCachedRegex(_compiledHeaderSourceCache, source, () =>
+      safeRegExp("^" + escapeHeaderSource(source) + "$"),
     );
     if (sourceRegex && sourceRegex.test(pathname)) {
       if (rule.has || rule.missing) {

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -770,19 +770,17 @@ function extractConstraint(str: string, re: RegExp): string | null {
  *
  * The root path `"/"` is preserved as-is.
  */
-function stripTrailingSlashForConfigMatch(pathname: string): string {
-  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+function stripTrailingSlashForConfigMatch(value: string): string {
+  return value.length > 1 && value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 export function matchConfigPattern(
   pathname: string,
   pattern: string,
 ): Record<string, string> | null {
-  // See `stripTrailingSlashForConfigMatch` — the source pattern itself is left
-  // unchanged because catch-all patterns (`:param*` / `:param+`) and the root
-  // `/` already consume any trailing slash; stripping the pattern would change
-  // those semantics.
+  const pathnameHadTrailingSlash = pathname.length > 1 && pathname.endsWith("/");
   pathname = stripTrailingSlashForConfigMatch(pathname);
+  if (pathnameHadTrailingSlash) pattern = stripTrailingSlashForConfigMatch(pattern);
 
   // If the pattern contains regex groups like (\d+) or (.*), use regex matching.
   // Also enter this branch when a catch-all parameter (:param* or :param+) is

--- a/tests/app-trailing-slash-isr.test.ts
+++ b/tests/app-trailing-slash-isr.test.ts
@@ -1,0 +1,52 @@
+// Ported from Next.js: test/e2e/app-dir/trailingslash/trailingslash.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/trailingslash/trailingslash.test.ts
+
+import fs from "node:fs";
+import path from "node:path";
+import { createBuilder, preview } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import vinext from "../packages/vinext/src/index.js";
+
+const FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/app-trailing-slash-isr");
+
+describe("App Router trailing-slash ISR with generated static params", () => {
+  let previewServer: Awaited<ReturnType<typeof preview>>;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const builder = await createBuilder({
+      root: FIXTURE_DIR,
+      plugins: [vinext({ appDir: FIXTURE_DIR })],
+      logLevel: "silent",
+    });
+    await builder.buildApp();
+
+    previewServer = await preview({
+      root: FIXTURE_DIR,
+      plugins: [vinext({ appDir: FIXTURE_DIR })],
+      preview: { port: 0 },
+      logLevel: "silent",
+    });
+    const address = previewServer.httpServer.address();
+    baseUrl = address && typeof address === "object" ? `http://localhost:${address.port}` : "";
+  }, 120_000);
+
+  afterAll(() => {
+    previewServer?.httpServer.close();
+    fs.rmSync(path.join(FIXTURE_DIR, "dist"), { recursive: true, force: true });
+  });
+
+  it("serves the rewritten generated path from its canonical source URL", async () => {
+    const destinationResponse = await fetch(`${baseUrl}/en/legacy/`);
+    const destinationHtml = await destinationResponse.text();
+    const response = await fetch(`${baseUrl}/en`);
+    const html = await response.text();
+
+    expect(destinationResponse.status).toBe(200);
+    expect(destinationHtml).toContain('id="generated-at"');
+    expect(response.status).toBe(200);
+    expect(response.url).toBe(`${baseUrl}/en/`);
+    expect(html).toContain('id="generated-at"');
+    expect(html).toContain("generated-<!-- -->en");
+  });
+});

--- a/tests/fixtures/app-trailing-slash-isr/app/[lang]/layout.tsx
+++ b/tests/fixtures/app-trailing-slash-isr/app/[lang]/layout.tsx
@@ -1,0 +1,7 @@
+export function generateStaticParams() {
+  return [{ lang: "en" }, { lang: "es" }];
+}
+
+export default function LangLayout({ children }: { children: React.ReactNode }) {
+  return <main>{children}</main>;
+}

--- a/tests/fixtures/app-trailing-slash-isr/app/[lang]/legacy/page.tsx
+++ b/tests/fixtures/app-trailing-slash-isr/app/[lang]/legacy/page.tsx
@@ -1,0 +1,6 @@
+export const revalidate = 900;
+
+export default async function Page({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params;
+  return <span id="generated-at">generated-{lang}</span>;
+}

--- a/tests/fixtures/app-trailing-slash-isr/app/layout.tsx
+++ b/tests/fixtures/app-trailing-slash-isr/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/app-trailing-slash-isr/next.config.js
+++ b/tests/fixtures/app-trailing-slash-isr/next.config.js
@@ -1,0 +1,11 @@
+export default {
+  trailingSlash: true,
+  async rewrites() {
+    return [
+      {
+        source: "/:lang(en|es)/",
+        destination: "/:lang/legacy/",
+      },
+    ];
+  },
+};

--- a/tests/fixtures/app-trailing-slash-isr/package.json
+++ b/tests/fixtures/app-trailing-slash-isr/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10319,6 +10319,10 @@ describe("matchConfigPattern", () => {
     });
     // Regex-group pattern with a trailing slash.
     expect(matchConfigPattern("/123/", "/:id(\\d+)")).toEqual({ id: "123" });
+    // Next.js appends an optional trailing-slash matcher even when the source
+    // itself ends in `/`, so both canonical forms match the same rule.
+    expect(matchConfigPattern("/en/", "/:lang(en|es)/")).toEqual({ lang: "en" });
+    expect(matchConfigPattern("/en", "/:lang(en|es)/")).toBeNull();
   });
 
   it("preserves the root path and catch-all semantics under trailing slash", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10602,6 +10602,20 @@ describe("matchRedirect locale-static index", () => {
     expect(result!.permanent).toBe(false);
   });
 
+  it("matches a slash-ending source against a canonical slashed pathname", async () => {
+    const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      {
+        source: "/:lang(en|es)/",
+        destination: "/:lang/legacy/",
+        permanent: false,
+      },
+    ];
+
+    expect(matchRedirect("/en/", redirects, emptyCtx)?.destination).toBe("/en/legacy/");
+    expect(matchRedirect("/en", redirects, emptyCtx)).toBeNull();
+  });
+
   it("matches a locale-prefixed pathname (locale omitted)", async () => {
     const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
     const redirects = makeLocaleRules(["/security", "/advisory-board"]);
@@ -11160,6 +11174,10 @@ describe("matchHeaders", () => {
         source: "/api/:path*",
         headers: [{ key: "x-api-header", value: "1" }],
       },
+      {
+        source: "/docs/",
+        headers: [{ key: "x-docs-header", value: "1" }],
+      },
     ];
 
     const aboutMatched = matchHeaders("/about/", rules, makeCtx());
@@ -11167,6 +11185,9 @@ describe("matchHeaders", () => {
 
     const apiMatched = matchHeaders("/api/users/", rules, makeCtx());
     expect(apiMatched).toEqual([{ key: "x-api-header", value: "1" }]);
+    const docsMatched = matchHeaders("/docs/", rules, makeCtx());
+    expect(docsMatched).toEqual([{ key: "x-docs-header", value: "1" }]);
+    expect(matchHeaders("/docs", rules, makeCtx())).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- match config rewrites, redirects, and headers when sources end in `/`
- preserve Next.js optional trailing-slash matching after canonical request normalization
- restore generated-static-param ISR routes reached through trailing-slash rewrites

## Next.js parity
Targets two failures in the trailing-slash ISR/generateStaticParams deploy-suite cluster. The prerendered destination was correct; the canonical rewritten source failed before ISR assertions because its config source no longer matched.

## Validation
- targeted production fixture: rewritten source renders the generated static route
- 16 focused matcher assertions
- scoped format, lint, and type checks
- `vp run vinext#build`
- independent review: no actionable findings

Full suites are deferred to CI.
