### PR TITLE
fix(config): make vite-tsconfig-paths an optional peer

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -98,7 +98,6 @@
     "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
     "vite-plugin-commonjs": "catalog:",
-    "vite-tsconfig-paths": "catalog:",
     "web-vitals": "catalog:"
   },
   "devDependencies": {
@@ -110,7 +109,8 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react-server-dom-webpack": "catalog:",
     "vite": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite-tsconfig-paths": "catalog:"
   },
   "peerDependencies": {
     "@mdx-js/rollup": "^3.0.0",
@@ -119,7 +119,8 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-server-dom-webpack": "^19.2.6",
-    "vite": "^7.0.0 || ^8.0.0"
+    "vite": "^7.0.0 || ^8.0.0",
+    "vite-tsconfig-paths": "^6.1.1"
   },
   "peerDependenciesMeta": {
     "@mdx-js/rollup": {
@@ -129,6 +130,9 @@
       "optional": true
     },
     "react-server-dom-webpack": {
+      "optional": true
+    },
+    "vite-tsconfig-paths": {
       "optional": true
     }
   },

--- a/packages/vinext/src/deploy.ts
+++ b/packages/vinext/src/deploy.ts
@@ -758,7 +758,7 @@ export function generateAppRouterViteConfig(info?: ProjectInfo): string {
     }),`);
 
   // Build resolve.alias for native module stubs (tsconfig paths are handled
-  // automatically by vite-tsconfig-paths inside the vinext plugin)
+  // by the vinext plugin's Vite 8 native support / Vite 7 fallback).
   let resolveBlock = "";
   const aliases: string[] = [];
 
@@ -795,7 +795,7 @@ export function generatePagesRouterViteConfig(info?: ProjectInfo): string {
   }
 
   // Build resolve.alias for native module stubs (tsconfig paths are handled
-  // automatically by vite-tsconfig-paths inside the vinext plugin)
+  // by the vinext plugin's Vite 8 native support / Vite 7 fallback).
   let resolveBlock = "";
   const aliases: string[] = [];
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -196,7 +196,6 @@ import { createWasmModuleImportPlugin } from "./plugins/wasm-module-import.js";
 import { getTypeofWindowReplacement, replaceTypeofWindow } from "./plugins/typeof-window.js";
 import { hasMdxFiles } from "./utils/mdx-scan.js";
 import { scanPublicFileRoutes } from "./utils/public-routes.js";
-import tsconfigPaths from "vite-tsconfig-paths";
 import type { Options as VitePluginReactOptions } from "@vitejs/plugin-react";
 import MagicString from "magic-string";
 import path from "node:path";
@@ -290,6 +289,7 @@ function hasServerOnlyMarkerImport(code: string): boolean {
 
 const __dirname = import.meta.dirname;
 type VitePluginReactModule = typeof import("@vitejs/plugin-react");
+type ViteTsconfigPathsModule = typeof import("vite-tsconfig-paths");
 
 function resolveOptionalDependency(projectRoot: string, specifier: string): string | null {
   try {
@@ -303,6 +303,19 @@ function resolveOptionalDependency(projectRoot: string, specifier: string): stri
   } catch {}
 
   return null;
+}
+
+async function loadVite7TsconfigPathsPlugin(projectRoot: string): Promise<Plugin> {
+  const resolvedPath = resolveOptionalDependency(projectRoot, "vite-tsconfig-paths");
+  if (!resolvedPath) {
+    throw new Error(
+      "[vinext] Vite 7 requires the optional peer dependency vite-tsconfig-paths " +
+        "for tsconfig path alias support. Install vite-tsconfig-paths or upgrade to Vite 8.",
+    );
+  }
+
+  const module = (await import(pathToFileURL(resolvedPath).href)) as ViteTsconfigPathsModule;
+  return module.default();
 }
 
 function resolveShimModulePath(shimsDir: string, moduleName: string): string {
@@ -1127,7 +1140,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Resolve tsconfig paths/baseUrl aliases so real-world Next.js repos
     // that use @/*, #/*, or baseUrl imports work out of the box.
     // Vite 8+ supports this natively via resolve.tsconfigPaths.
-    ...(viteMajorVersion >= 8 ? [] : [tsconfigPaths()]),
+    ...(viteMajorVersion >= 8 ? [] : [loadVite7TsconfigPathsPlugin(earlyBaseDir)]),
     // React Fast Refresh + JSX transform for client components.
     reactPluginPromise,
     // Transform CJS require()/module.exports to ESM before other plugins

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,9 +984,6 @@ importers:
       vite-plugin-commonjs:
         specifier: 'catalog:'
         version: 0.10.4
-      vite-tsconfig-paths:
-        specifier: 'catalog:'
-        version: 6.1.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
       web-vitals:
         specifier: 'catalog:'
         version: 4.2.4
@@ -1015,6 +1012,9 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
+      vite-tsconfig-paths:
+        specifier: 'catalog:'
+        version: 6.1.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
 
   tests/fixtures/app-basic:
     dependencies:

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -32,8 +32,23 @@ function isPlugin(plugin: PluginOption): plugin is Plugin {
   return !!plugin && !Array.isArray(plugin) && typeof plugin === "object" && "name" in plugin;
 }
 
-function findNamedPlugin(plugins: ReturnType<typeof vinext>, name: string) {
-  return plugins.find((plugin): plugin is Plugin => isPlugin(plugin) && plugin.name === name);
+async function collectPlugins(plugins: PluginOption[]): Promise<Plugin[]> {
+  const collected: Plugin[] = [];
+  for (const plugin of plugins) {
+    const resolved = await plugin;
+    if (!resolved) continue;
+    if (Array.isArray(resolved)) {
+      collected.push(...(await collectPlugins(resolved)));
+    } else if (isPlugin(resolved)) {
+      collected.push(resolved);
+    }
+  }
+  return collected;
+}
+
+async function findNamedPlugin(plugins: ReturnType<typeof vinext>, name: string) {
+  const collected = await collectPlugins(plugins);
+  return collected.find((plugin) => plugin.name === name);
 }
 
 afterEach(() => {
@@ -56,7 +71,7 @@ describe("Vite tsconfig paths support", () => {
 
     const plugins = vinext({ appDir: root });
 
-    expect(findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
+    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
   });
 
   it("uses resolve.tsconfigPaths on Vite 8 instead of vite-tsconfig-paths", async () => {
@@ -65,9 +80,9 @@ describe("Vite tsconfig paths support", () => {
 
     const plugins = vinext({ appDir: root });
 
-    expect(findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeUndefined();
+    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeUndefined();
 
-    const configPlugin = findNamedPlugin(plugins, "vinext:config") as {
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
       config?: (
         config: { root: string },
         env: { command: "serve"; mode: string },
@@ -103,7 +118,7 @@ describe("Vite tsconfig paths support", () => {
     );
 
     const plugins = vinext({ appDir: root });
-    const configPlugin = findNamedPlugin(plugins, "vinext:config") as {
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
       config?: (
         config: { root: string },
         env: { command: "serve"; mode: string },
@@ -154,7 +169,7 @@ describe("Vite tsconfig paths support", () => {
     );
 
     const plugins = vinext({ appDir: root });
-    const configPlugin = findNamedPlugin(plugins, "vinext:config") as {
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
       config?: (
         config: { root: string },
         env: { command: "serve"; mode: string },
@@ -179,7 +194,7 @@ describe("Vite tsconfig paths support", () => {
     process.chdir(root);
 
     const plugins = vinext({ appDir: root });
-    const configPlugin = findNamedPlugin(plugins, "vinext:config") as {
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
       config?: (
         config: { root: string; resolve?: Record<string, unknown> },
         env: { command: "serve"; mode: string },
@@ -205,9 +220,9 @@ describe("Vite tsconfig paths support", () => {
 
     const plugins = vinext({ appDir: root });
 
-    expect(findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeUndefined();
+    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeUndefined();
 
-    const configPlugin = findNamedPlugin(plugins, "vinext:config") as {
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
       config?: (
         config: { root: string },
         env: { command: "serve"; mode: string },
@@ -233,7 +248,7 @@ describe("Vite tsconfig paths support", () => {
 
     const plugins = vinext({ appDir: root });
 
-    expect(findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
+    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
     expect(warn).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledWith(
       "[vinext] Could not determine Vite major version from @voidzero-dev/vite-plus-core; assuming Vite 7",


### PR DESCRIPTION
## Summary
- move `vite-tsconfig-paths` out of vinext runtime dependencies and declare it as an optional peer
- lazy-load the plugin only for Vite 7, while Vite 8 continues to use native `resolve.tsconfigPaths`
- keep `vite-tsconfig-paths` as a dev dependency for repository tests and update the Vite 7/8 coverage

## Why
Vite 8 no longer needs `vite-tsconfig-paths`, and keeping it as a runtime dependency installs its unmaintained `tsconfck` transitive dependency for users who do not need the Vite 7 fallback.

## Impact
Vite 8 consumers no longer get `vite-tsconfig-paths` or `tsconfck` from vinext's runtime dependency tree. Vite 7 consumers still get the existing behavior when they install the optional peer; otherwise vinext reports an actionable error.

## Validation
- `pnpm install --lockfile-only --ignore-scripts`
- `vp test run tests/tsconfig-paths-vite8.test.ts`
- `vp check packages/vinext/src/index.ts packages/vinext/src/deploy.ts tests/tsconfig-paths-vite8.test.ts`
- `vp run vinext#build`