### PR TITLE
fix(headers): strip internal dev request ID headers

### DIFF
--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -161,6 +161,8 @@ export const NEXT_ROUTER_STATE_TREE_HEADER = "Next-Router-State-Tree";
 export const NEXT_ROUTER_PREFETCH_HEADER = "Next-Router-Prefetch";
 export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER = "Next-Router-Segment-Prefetch";
 export const NEXT_URL_HEADER = "Next-Url";
+export const NEXT_REQUEST_ID_HEADER = "x-nextjs-request-id";
+export const NEXT_HTML_REQUEST_ID_HEADER = "x-nextjs-html-request-id";
 
 /** Lowercase flight header variants used in middleware forwarding. */
 export const FLIGHT_HEADERS: readonly string[] = [

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -8,7 +8,12 @@
  * We support both the sync (legacy) and async patterns.
  */
 
-import { MIDDLEWARE_SET_COOKIE_HEADER } from "../server/headers.js";
+import {
+  FLIGHT_HEADERS,
+  MIDDLEWARE_SET_COOKIE_HEADER,
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
+} from "../server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../server/middleware-request-headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import {
@@ -737,7 +742,13 @@ function _getReadonlyCookies(ctx: HeadersContext): RequestCookies {
 
 function _getReadonlyHeaders(ctx: HeadersContext): Headers {
   if (!ctx.readonlyHeaders) {
-    ctx.readonlyHeaders = _sealHeaders(ctx.headers);
+    const cleaned = new Headers(ctx.headers);
+    for (const header of FLIGHT_HEADERS) {
+      cleaned.delete(header);
+    }
+    cleaned.delete(NEXT_REQUEST_ID_HEADER);
+    cleaned.delete(NEXT_HTML_REQUEST_ID_HEADER);
+    ctx.readonlyHeaders = _sealHeaders(cleaned);
   }
 
   return ctx.readonlyHeaders;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3370,6 +3370,34 @@ describe("next/headers shim", () => {
     setHeadersContext(null);
   });
 
+  it("headers() strips internal flight and dev request-id headers from userland reads", async () => {
+    // Ported from Next.js:
+    // packages/next/src/server/async-storage/request-store.ts
+    // https://github.com/vercel/next.js/blob/bba8fe18eb21d49dac68cdddef64e8906dc9f804/packages/next/src/server/async-storage/request-store.ts
+    const { setHeadersContext, headers } = await import("../packages/vinext/src/shims/headers.js");
+    const reqHeaders = new Headers({
+      rsc: "1",
+      "Next-Router-State-Tree": "tree",
+      "x-nextjs-request-id": "dev-request",
+      "x-nextjs-html-request-id": "dev-html-request",
+      "x-custom": "test-value",
+    });
+    setHeadersContext({
+      headers: reqHeaders,
+      cookies: new Map(),
+    });
+
+    const h = await headers();
+    expect(h.get("x-custom")).toBe("test-value");
+    expect(h.get("rsc")).toBeNull();
+    expect(h.get("Next-Router-State-Tree")).toBeNull();
+    expect(h.get("x-nextjs-request-id")).toBeNull();
+    expect(h.get("x-nextjs-html-request-id")).toBeNull();
+    expect(reqHeaders.get("x-nextjs-request-id")).toBe("dev-request");
+    expect(reqHeaders.get("x-nextjs-html-request-id")).toBe("dev-html-request");
+    setHeadersContext(null);
+  });
+
   it("headers() supports the legacy sync access pattern", async () => {
     // Next.js docs: headers() temporarily supports sync property access in v15.
     const { setHeadersContext, headers } = await import("../packages/vinext/src/shims/headers.js");


### PR DESCRIPTION
Close #1934 

## Summary

- Strip `x-nextjs-request-id` and `x-nextjs-html-request-id` from the read-only `headers()` view exposed to userland.
- Keep the raw request headers intact so internal code can still read those values if needed.
- Add a regression test matching the upstream Next.js behavior from vercel/next.js#94703.

## Verification

- `pnpm test tests/shims.test.ts -t "headers\\(\\) strips internal flight and dev request-id headers"`
- `pnpm test tests/shims.test.ts -t "next/headers shim"`
- `pnpm exec vp fmt --check packages/vinext/src/server/headers.ts packages/vinext/src/shims/headers.ts tests/shims.test.ts`