### PR TITLE
refactor(config): normalize the resolveId id once and drop the Windows backslash branches

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2744,7 +2744,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // browser entry imports our virtual module using the already-resolved
           // ID (with \0 prefix). We need to re-resolve it so the client
           // environment's import-analysis can find it.
-          const cleanId = id.startsWith(VIRTUAL_PREFIX) ? id.slice(1) : id;
+          //
+          // Normalize separators up front so the importer-relative virtual-entry
+          // checks below only need the forward-slash form: on Windows a virtual
+          // specifier resolved against an importer (e.g. Rolldown's fallback
+          // joins the importer dir with a native `\`) arrives as
+          // `E:\proj\virtual:vinext-rsc-entry`. normalizePathSeparators is a
+          // no-op on POSIX.
+          const cleanId = normalizePathSeparators(id.startsWith(VIRTUAL_PREFIX) ? id.slice(1) : id);
 
           if (cleanId === "vinext/server/app-rsc-handler") {
             if (
@@ -2772,16 +2779,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // Pages Router virtual modules
           if (cleanId === VIRTUAL_SERVER_ENTRY) return RESOLVED_SERVER_ENTRY;
           if (cleanId === VIRTUAL_CLIENT_ENTRY) return RESOLVED_CLIENT_ENTRY;
-          if (
-            cleanId.endsWith("/" + VIRTUAL_SERVER_ENTRY) ||
-            cleanId.endsWith("\\" + VIRTUAL_SERVER_ENTRY)
-          ) {
+          if (cleanId.endsWith("/" + VIRTUAL_SERVER_ENTRY)) {
             return RESOLVED_SERVER_ENTRY;
           }
-          if (
-            cleanId.endsWith("/" + VIRTUAL_CLIENT_ENTRY) ||
-            cleanId.endsWith("\\" + VIRTUAL_CLIENT_ENTRY)
-          ) {
+          if (cleanId.endsWith("/" + VIRTUAL_CLIENT_ENTRY)) {
             return RESOLVED_CLIENT_ENTRY;
           }
           // App Router virtual modules
@@ -2794,36 +2795,23 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
           if (
             cleanId === VIRTUAL_CACHE_ADAPTERS ||
-            cleanId.endsWith("/" + VIRTUAL_CACHE_ADAPTERS) ||
-            cleanId.endsWith("\\" + VIRTUAL_CACHE_ADAPTERS)
+            cleanId.endsWith("/" + VIRTUAL_CACHE_ADAPTERS)
           ) {
             return RESOLVED_CACHE_ADAPTERS;
           }
           if (cleanId.startsWith(VIRTUAL_GOOGLE_FONTS + "?")) {
             return RESOLVED_VIRTUAL_GOOGLE_FONTS + cleanId.slice(VIRTUAL_GOOGLE_FONTS.length);
           }
-          if (
-            cleanId.endsWith("/" + VIRTUAL_RSC_ENTRY) ||
-            cleanId.endsWith("\\" + VIRTUAL_RSC_ENTRY)
-          ) {
+          if (cleanId.endsWith("/" + VIRTUAL_RSC_ENTRY)) {
             return RESOLVED_RSC_ENTRY;
           }
-          if (
-            cleanId.endsWith("/" + VIRTUAL_APP_SSR_ENTRY) ||
-            cleanId.endsWith("\\" + VIRTUAL_APP_SSR_ENTRY)
-          ) {
+          if (cleanId.endsWith("/" + VIRTUAL_APP_SSR_ENTRY)) {
             return RESOLVED_APP_SSR_ENTRY;
           }
-          if (
-            cleanId.endsWith("/" + VIRTUAL_APP_BROWSER_ENTRY) ||
-            cleanId.endsWith("\\" + VIRTUAL_APP_BROWSER_ENTRY)
-          ) {
+          if (cleanId.endsWith("/" + VIRTUAL_APP_BROWSER_ENTRY)) {
             return RESOLVED_APP_BROWSER_ENTRY;
           }
-          if (
-            cleanId.includes("/" + VIRTUAL_GOOGLE_FONTS + "?") ||
-            cleanId.includes("\\" + VIRTUAL_GOOGLE_FONTS + "?")
-          ) {
+          if (cleanId.includes("/" + VIRTUAL_GOOGLE_FONTS + "?")) {
             const queryIndex = cleanId.indexOf(VIRTUAL_GOOGLE_FONTS + "?");
             return (
               RESOLVED_VIRTUAL_GOOGLE_FONTS +


### PR DESCRIPTION
## What

Normalize the incoming `id` to forward slashes at the top of the `vinext:config` `resolveId` handler (right after stripping the `\0` prefix), and remove the seven `|| cleanId.endsWith("\\" + …)` / `includes("\\" + …)` disjuncts that existed only to catch the Windows separator. Each virtual-entry check now matches the forward-slash form alone.

## Why

A virtual specifier (`virtual:vinext-rsc-entry`, the Pages/App entry facades, the cache-adapters and Google-fonts virtuals) can reach `resolveId` already anchored to an importer directory — e.g. Rolldown's fallback resolution joins the importer dir with the specifier. On Windows that join uses a native backslash, so the id arrives as `E:\proj\virtual:vinext-rsc-entry`. The handler coped by testing both `endsWith("/" + X)` and `endsWith("\\" + X)` at every site, duplicating the separator concern across seven branches. Normalizing once at the boundary is the same pattern the rest of the codebase already uses (`_shimsDir`, the module-graph `canonicalize`), and it keeps every downstream comparison single-separator. `normalizePathSeparators` is a no-op on POSIX, so behavior there is identical, and on Windows a backslash id is normalized to the exact forward-slash form the `/` branch already matched.

## How

- `cleanId` is now `normalizePathSeparators(id.startsWith(VIRTUAL_PREFIX) ? id.slice(1) : id)`, with a comment explaining the importer-relative Windows case.
- Dropped the backslash disjunct from the `VIRTUAL_SERVER_ENTRY`, `VIRTUAL_CLIENT_ENTRY`, `VIRTUAL_CACHE_ADAPTERS`, `VIRTUAL_RSC_ENTRY`, `VIRTUAL_APP_SSR_ENTRY`, `VIRTUAL_APP_BROWSER_ENTRY`, and `VIRTUAL_GOOGLE_FONTS` checks.
- Return values are untouched — they are constants (`RESOLVED_*`) or come from `resolveShimModulePath(_shimsDir, …)`, which is already forward-slash. The Google-fonts branch still slices the `?…` query off the normalized id, which carries no separators.
- Out of scope: `isVirtualEntryFacade` keeps its dual-separator check — it runs in `renderChunk` against Rolldown's `chunk.facadeModuleId`, a different boundary, normalized separately if needed.

## Testing

- `vp test run --project unit tests/app-router-next-config-codegen.test.ts` — 27 passed (this drives the real Vite plugin container's `resolveId("virtual:vinext-rsc-entry")`).
- `vp test run --project unit tests/middleware-server-only.test.ts` — 4 passed (full app build resolving `virtual:vinext-app-ssr-entry` end-to-end).
- `vp test run --project unit tests/build-optimization.test.ts` — all passed.
- `vp test run --project unit tests/shims.test.ts` — failure count unchanged at 14 (the pre-existing navigation/locale and resolveId-fixture issues, none related to this change).
- `vp check packages/vinext/src/index.ts` — format, lint, and typecheck clean.

Classified `refactor` because it is behavior-preserving: on Windows a backslash id normalizes to the same forward-slash form the `/` branch already accepted, and on POSIX `normalizePathSeparators` returns its input unchanged. It only removes the duplicated separator handling.
