### PR TITLE
test(shims): expect forward-slash shim ids in the next/error and subpath resolution fixtures

### DIFF
--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -21574,10 +21574,12 @@ describe("shim alias map .js variants", () => {
     const hook = configPlugin.resolveId as {
       handler: (this: { environment?: { name?: string } }, id: string) => string | undefined;
     };
-    const clientShim = path.resolve(import.meta.dirname, "../packages/vinext/src/shims/error.tsx");
-    const reactServerShim = path.resolve(
-      import.meta.dirname,
-      "../packages/vinext/src/shims/error.react-server.ts",
+    // resolveId returns Vite-style ids: forward slashes on every platform.
+    const clientShim = normalizePathSeparators(
+      path.resolve(import.meta.dirname, "../packages/vinext/src/shims/error.tsx"),
+    );
+    const reactServerShim = normalizePathSeparators(
+      path.resolve(import.meta.dirname, "../packages/vinext/src/shims/error.react-server.ts"),
     );
 
     expect(hook.handler.call({ environment: { name: "rsc" } }, "next/error")).toBe(reactServerShim);
@@ -21696,15 +21698,16 @@ describe("vinext shim package-subpath resolution", () => {
 
   it("strips JavaScript extensions and Vite queries from package subpaths", () => {
     const hook = getResolveIdHook();
-    const expectedShim = path.resolve(
-      import.meta.dirname,
-      "../packages/vinext/src/shims/navigation.ts",
+    // resolveId returns Vite-style ids: forward slashes on every platform.
+    const expectedShim = normalizePathSeparators(
+      path.resolve(import.meta.dirname, "../packages/vinext/src/shims/navigation.ts"),
     );
-    const expectedReactServerShim = path.resolve(
-      import.meta.dirname,
-      "../packages/vinext/src/shims/navigation.react-server.ts",
+    const expectedReactServerShim = normalizePathSeparators(
+      path.resolve(import.meta.dirname, "../packages/vinext/src/shims/navigation.react-server.ts"),
     );
-    const expectedOgShim = path.resolve(import.meta.dirname, "../packages/vinext/src/shims/og.tsx");
+    const expectedOgShim = normalizePathSeparators(
+      path.resolve(import.meta.dirname, "../packages/vinext/src/shims/og.tsx"),
+    );
 
     expect(hook.filter.id.test("vinext/shims/navigation.js?v=123")).toBe(true);
     expect(hook.filter.id.test("\0vinext/shims/navigation.js?v=123")).toBe(true);


### PR DESCRIPTION
## What

Wrap the expected shim paths in the "resolves next/error to the react-server shim" and "strips JavaScript extensions and Vite queries from package subpaths" tests with `normalizePathSeparators`, so they compare against the forward-slash ids that `vinext:config`'s `resolveId` returns on Windows.

## Why

`vinext:config`'s `resolveId` hook returns Vite-style module ids — forward slashes on every platform — because it resolves shims through `_shimsDir`, which is normalized at module load (and the font plugins' `id.startsWith(_shimsDir)` guards plus the module-graph `canonicalize` require that forward-slash form). The two fixtures built their expected values with raw `path.resolve(import.meta.dirname, …)`, which yields backslashes on Windows, so the assertions failed there with `Received: "E:/…/error.react-server.ts"` vs `Expected: "E:\…\error.react-server.ts"`. The source is correct; the fixtures were the only two resolveId tests in this file that did not normalize — the sibling app-rsc-handler and `@vercel/og` tests already wrap their expected values in `normalizePathSeparators` for exactly this reason. This is a fixture-only mismatch, not a production bug.

## How

- next/error test: `clientShim` and `reactServerShim` now wrap their `path.resolve(...)` in `normalizePathSeparators(...)`.
- subpath resolution test: `expectedShim`, `expectedReactServerShim`, and `expectedOgShim` now wrap their `path.resolve(...)` in `normalizePathSeparators(...)`.
- Added the same `// resolveId returns Vite-style ids: forward slashes on every platform.` comment the sibling tests carry, so the intent is documented once per block.
- `normalizePathSeparators` was already imported in this file and is a no-op on POSIX, so the expected values are byte-identical there.

## Testing

- `vp test run --project unit tests/shims.test.ts -t "resolves next/error to the react-server shim only in the RSC environment"` — passes.
- `vp test run --project unit tests/shims.test.ts -t "strips JavaScript extensions and Vite queries from package subpaths"` — passes.
- `vp test run --project unit tests/shims.test.ts` — failures drop from 14 to 12; the remaining 12 are the separate navigation/locale cluster, unaffected by this change.
- `vp check tests/shims.test.ts` — format, lint, and typecheck clean.

Classified `test` because only fixtures change: the source already returns the forward-slash id, and the production code path is untouched.
