### PR TITLE
test(pages-router): wrap the client-navigation page module URL as a Vite /@fs/ id on Windows

### DIFF
--- a/packages/vinext/src/utils/path.ts
+++ b/packages/vinext/src/utils/path.ts
@@ -1,4 +1,4 @@
-const isWindows = process.platform === "win32";
+export const isWindows = process.platform === "win32";
 
 /**
  * Convert Windows-style backslash path separators to forward slashes.

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15,7 +15,7 @@ import type {
   CacheHandlerValue,
   IncrementalCacheValue,
 } from "../packages/vinext/src/shims/cache.js";
-import { normalizePathSeparators } from "../packages/vinext/src/utils/path.ts";
+import { isWindows, normalizePathSeparators } from "../packages/vinext/src/utils/path.ts";
 
 const FIXTURE_DIR = PAGES_FIXTURE_DIR;
 
@@ -14459,6 +14459,18 @@ describe("Pages Router concurrent navigation", () => {
     return `<html><head></head><body>${nextDataScript}</body></html>`;
   }
 
+  // Resolve an absolute fixture path the router can dynamically import. POSIX
+  // absolute paths begin with `/` and pass the router's `isValidModulePath`
+  // guard unchanged, so they are returned as-is. On Windows the path is
+  // drive-qualified (`E:\...`) with no leading `/`, which the guard rejects and
+  // blocks before the import; wrap it as the Vite `/@fs/` URL Vite serves for
+  // on-disk files, which is importable and starts with `/`.
+  function fixtureModuleUrl(relativePath: string): string {
+    const absolutePath = path.resolve(import.meta.dirname, relativePath);
+    if (!isWindows) return absolutePath;
+    return "/@fs/" + normalizePathSeparators(absolutePath);
+  }
+
   function buildNavHtmlWithVinext(
     page: string,
     vinext: { pageModuleUrl?: string; appModuleUrl?: string; hasMiddleware?: boolean },
@@ -14790,7 +14802,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/docs/slug-1";
     win.location.href = "http://localhost/docs/slug-1";
     (globalThis as any).window = win;
@@ -14841,7 +14853,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/docs/slug-1";
     win.location.href = "http://localhost/docs/slug-1";
     (globalThis as any).window = win;
@@ -14892,7 +14904,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/docs/fr/slug-1";
     win.location.href = "http://localhost/docs/fr/slug-1";
     win.__VINEXT_LOCALE__ = "fr";
@@ -14956,7 +14968,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/docs/en/hello";
     win.location.href = "http://localhost/docs/en/hello";
     win.__VINEXT_LOCALE__ = "en";
@@ -15019,7 +15031,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/docs/fr/slug-1";
     win.location.href = "http://localhost/docs/fr/slug-1";
     win.__VINEXT_LOCALE__ = "fr";
@@ -15380,7 +15392,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/new";
     win.location.href = "http://localhost/new";
     Object.assign(win, {
@@ -15447,7 +15459,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/new";
     win.location.href = "http://localhost/new";
     Object.assign(win, {
@@ -15509,7 +15521,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.location.pathname = "/id/new";
     win.location.href = "http://localhost/id/new";
     Object.assign(win, {
@@ -15570,7 +15582,7 @@ describe("Pages Router concurrent navigation", () => {
     const originalCustomEvent = globalThis.CustomEvent;
     const listeners = new Map<string, (event: any) => void>();
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
 
     win.location.pathname = "/about";
     win.location.href = "http://localhost/about";
@@ -15647,7 +15659,7 @@ describe("Pages Router concurrent navigation", () => {
     const originalCustomEvent = globalThis.CustomEvent;
     const listeners = new Map<string, (event: any) => void>();
     const { win, render } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     win.scrollTo.mockImplementation((x: number, y: number) => {
       win.scrollX = x;
       win.scrollY = y;
@@ -16121,7 +16133,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win, {
       __VINEXT_LOCALE__: "id",
       __VINEXT_LOCALES__: ["en", "id", "fr"],
@@ -16179,7 +16191,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win, replaceState, render } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win.location, { origin: "http://localhost" });
     Object.assign(win, {
       __VINEXT_LOCALE__: "en",
@@ -16246,7 +16258,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win, render } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win.location, { origin: "http://localhost" });
     Object.assign(win.__NEXT_DATA__, {
       buildId: "build-1",
@@ -16376,7 +16388,7 @@ describe("Pages Router concurrent navigation", () => {
     const originalFetch = globalThis.fetch;
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const { win, replaceState, render } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win.location, {
       origin: "http://localhost",
       pathname: "/docs",
@@ -16449,7 +16461,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win, render } = createNavWindow();
-    const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win.location, { origin: "http://localhost" });
     Object.assign(win.__NEXT_DATA__, {
       buildId: "build-1",


### PR DESCRIPTION
## What

Add a `fixtureModuleUrl` helper in the Pages Router client-navigation test suite and route every `pageModuleUrl` through it. On POSIX it returns the absolute fixture path unchanged; on Windows it wraps the path as a Vite `/@fs/` URL. To gate that platform branch on the canonical flag, `isWindows` is now exported from `utils/path.ts`.

## Why

The tests built `pageModuleUrl` with `path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx")`. On POSIX that is `/…/fixtures/client-navigation-page.tsx`, which starts with `/` and slips through the router's `isValidModulePath` guard. On Windows it is `E:\…\fixtures\client-navigation-page.tsx`, which starts with a drive letter, so `isValidModulePath` rejects it, the router calls `scheduleHardNavigationAndThrow`, and `Router.push(...)` resolves to `false` — failing 12 locale / concurrent-navigation assertions.

The guard is correct and stays untouched: production never emits a drive path here. `createPagesDevModuleUrl` (dev) builds a root-relative path, replaces `\` with `/`, and prefixes the base; `resolveClientModuleUrl` (prod) returns a base-anchored asset URL. Both are always forward-slash, `/`-prefixed URLs. The fixture was the unrealistic part — it only worked on Windows by the accident that POSIX absolute paths begin with `/`.

The fix is scoped to Windows so the POSIX path stays byte-for-byte what it was: those tests were already green on Linux/macOS CI, so the helper returns the original `path.resolve(...)` there and only the Windows branch changes.

## How

- New `fixtureModuleUrl(relativePath)` helper next to `buildNavHtml`: resolves the absolute fixture path, returns it as-is on POSIX, and on Windows returns `"/@fs/" + normalizePathSeparators(absolutePath)`. `/@fs/` is the URL Vite serves for on-disk files, so it is importable and passes `isValidModulePath` (leading `/`, no `://`, no `..`). A Windows drive path has no leading slash, so no slash-stripping is needed.
- Exported `isWindows` from `packages/vinext/src/utils/path.ts` (previously a module-private const) so the test branches on the same platform flag `normalizePathSeparators` already uses, instead of duplicating `process.platform === "win32"`.
- Replaced all 15 `const pageModuleUrl = path.resolve(import.meta.dirname, "fixtures/client-navigation-page.tsx")` sites with `fixtureModuleUrl("fixtures/client-navigation-page.tsx")`.
- No router/source behavior change — `isValidModulePath` and the dynamic import stay as-is.

## Testing

- `vp test run --project unit tests/shims.test.ts` — the 12 Pages Router locale / concurrent-navigation failures are gone; the run is stable across repeats. The only remaining 2 failures (`next/error` and subpath-resolution fixtures) are a separate, independent fix unrelated to this change.
- `vp test run --project unit tests/shims.test.ts -t "fetches default-locale root through a locale-qualified URL without changing the browser URL"` — passes (representative of the cluster).
- `vp check packages/vinext/src/utils/path.ts tests/shims.test.ts` — format, lint, and typecheck clean.

Classified `test` because the runtime is untouched: the only source edit is making `isWindows` a named export (additive), the `isValidModulePath` guard is unchanged, and the helper just makes the fixture mirror the realistic, cross-platform URL form — while leaving the POSIX fixture identical to before.
