### PR TITLE
test(og-inline): use a forward-slash scoped package name in the linked-workspace fixture

### DIFF
--- a/tests/og-inline.test.ts
+++ b/tests/og-inline.test.ts
@@ -229,7 +229,11 @@ describe("vinext:og-inline-fetch-assets plugin", () => {
     expect(result?.code).toContain(packageFont.toString("base64"));
   });
 
-  it.each(["og-helper", path.join("@scope", "og-helper")])(
+  // A scoped package name is always forward-slash (`@scope/og-helper`), even on
+  // Windows — it is an npm specifier, not a filesystem path, so it must not go
+  // through `path.join` (which would yield `@scope\og-helper`). `path.join`
+  // below still turns it into the right nested directory on disk.
+  it.each(["og-helper", "@scope/og-helper"])(
     "inlines assets contained within a linked workspace package (%s)",
     async (packageName) => {
       const projectRoot = path.join(tmpDir, "linked-workspace", "app");


### PR DESCRIPTION
## What

In the og-inline "inlines assets contained within a linked workspace package" parameterized test, build the scoped package name as the literal `"@scope/og-helper"` instead of `path.join("@scope", "og-helper")`.

## Why

`path.join("@scope", "og-helper")` returns `@scope/og-helper` on POSIX but `@scope\og-helper` on Windows. The test feeds that value straight into the package.json `name` field and into the plugin's alias resolution as an npm specifier. A scoped package name is always forward-slash on every platform — it is a module specifier, not a filesystem path — so on Windows the backslash name never matches the plugin's package-boundary resolution: `resolveModuleBoundary` returns null, `transform` returns undefined, and `expect(result?.code).toContain(...)` throws "the given combination of arguments (undefined and string) is invalid". The non-scoped `og-helper` parameter passed because it has no separator to corrupt. The plugin is correct — production package names are always forward-slash — so this is a fixture-only bug.

## How

- Changed the `it.each` parameter from `path.join("@scope", "og-helper")` to `"@scope/og-helper"`, with a comment explaining a scoped name must not go through `path.join`.
- `packageDir` still uses `path.join(tmpDir, …, packageName)`, which correctly turns the forward-slash specifier into the nested `@scope/og-helper` directory on disk (path.join normalizes the separator per platform). On POSIX the value is byte-identical to before.

## Testing

- `vp test run --project unit tests/og-inline.test.ts` — 49 passed (was 1 failed: the `@scope` linked-workspace case).
- `vp check tests/og-inline.test.ts` — format, lint, and typecheck clean.

Classified `test` because only the fixture changes: the plugin's package-boundary resolution is untouched and already handles forward-slash scoped names, which is the only form production ever produces.
