### PR TITLE
refactor(app-router): descend findSlotRootPage with path.posix.join to preserve forward-slash ids

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2011,6 +2011,9 @@ function patternsStructurallyEquivalent(a: readonly string[], b: readonly string
  *
  * Returns the absolute page path, or null if no root-level page is found.
  *
+ * `slotDir` must be forward-slash: the `path.posix.join` descent stays a
+ * canonical id only when the base already is.
+ *
  * Only descends into route-group directories (those whose name starts with `(`
  * and ends with `)`). Dynamic segments, regular named dirs, and `@slot` dirs
  * are not transparent and are therefore not searched.
@@ -2030,7 +2033,7 @@ function findSlotRootPage(slotDir: string, matcher: ValidFileMatcher): string | 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     if (!entry.name.startsWith("(") || !entry.name.endsWith(")")) continue;
-    const found = findSlotRootPage(path.join(slotDir, entry.name), matcher);
+    const found = findSlotRootPage(path.posix.join(slotDir, entry.name), matcher);
     if (found) return found;
   }
   return null;


### PR DESCRIPTION
## What

Change `findSlotRootPage`'s recursive route-group descent from `path.join(slotDir, entry.name)` to `path.posix.join(...)`, and document that `slotDir` must be a forward-slash path.

## Why

This is one link in the App Router route-graph forward-slash migration. Route file paths should be canonical forward-slash ids (matching the module ids the rest of the pipeline stores). `path.join` is `path.win32.join` on Windows, so it re-introduces backslashes even when the base is forward-slash; `path.posix.join` keeps the descent on forward slashes — but only when `slotDir` already is forward-slash, which is why the precondition is now spelled out in the doc comment. The fix is being applied bottom-up: each `path.join` that builds a path becomes `path.posix.join`, and the slash guarantee is pushed up to the true entry rather than normalized at every output.

## How

- `findSlotRootPage` recurses with `path.posix.join(slotDir, entry.name)`.
- Added a one-line precondition to the JSDoc: `slotDir` must be forward-slash, since `path.posix.join` only stays canonical when the base already is.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix.join` === `path.join`). On Windows this only becomes observable once the caller (`discoverParallelSlots`) passes a forward-slash `slotDir`, which lands in the next link of the chain; this change is the descent half of that link and is classified `refactor` because it is behavior-preserving on its own.
