### PR TITLE
refactor(app-router): build parallel-slot dirs with path.posix.join

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1771,6 +1771,10 @@ function discoverBoundaryFilePerLayout(
  * Walk from appDir through each segment to the route's directory. At each level
  * that has @slot dirs, collect them. Slots at the route's own directory level
  * use page.tsx; slots at ancestor levels use default.tsx only.
+ *
+ * `appDir` and `routeDir` must be forward-slash — `currentDir` descends from
+ * `appDir` via `path.posix.join`, and the `dir === routeDir` active-level test
+ * below only matches when both share the canonical separator.
  */
 function discoverInheritedParallelSlots(
   segments: string[],
@@ -1792,7 +1796,7 @@ function discoverInheritedParallelSlots(
   dirsToCheck.push({ dir: appDir, layoutIdx, segmentIndex: 0 });
 
   for (let i = 0; i < segments.length; i++) {
-    currentDir = path.join(currentDir, segments[i]);
+    currentDir = path.posix.join(currentDir, segments[i]);
     if (findFile(currentDir, "layout", matcher)) {
       layoutIdx++;
     }
@@ -2060,7 +2064,7 @@ function discoverParallelSlots(
     if (entry.name === "@children") continue;
 
     const slotName = entry.name.slice(1); // "@team" -> "team"
-    const slotDir = path.join(dir, entry.name);
+    const slotDir = path.posix.join(dir, entry.name);
 
     // A slot page may live inside a route-group subdirectory of the slot
     // (e.g. @slot/(group)/page.tsx). Route groups are transparent in the URL,


### PR DESCRIPTION
## What

In the parallel-slot discovery, build the slot directory and the inherited-slot walk directory with `path.posix.join` instead of `path.join`:

- `discoverParallelSlots`: `slotDir = path.posix.join(dir, entry.name)`
- `discoverInheritedParallelSlots`: `currentDir = path.posix.join(currentDir, segments[i])`

## Why

Another link in the App Router route-graph forward-slash migration. `path.join` is `path.win32.join` on Windows, so it re-introduces backslashes even when the base is forward-slash; `path.posix.join` keeps the directory on forward slashes as long as the base already is. The `slotDir` produced here is exactly the value `findSlotRootPage` consumes — the previous step documented that it must be forward-slash, and this step makes its construction preserve that form. The slash guarantee continues to be pushed up toward the entry (`dir` / `currentDir` / `appDir`) rather than normalized at each output.

## How

- Swapped the two `path.join` calls that build `slotDir` and `currentDir` for `path.posix.join`.
- Documented on `discoverInheritedParallelSlots` that both `appDir` and `routeDir` must be forward-slash: `currentDir` descends from `appDir` via `path.posix.join`, and the `dir === routeDir` active-level test only matches when both share the canonical separator.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix.join` === `path.join`). On Windows these dirs become canonical forward-slash only once their inputs (`dir` / `currentDir`, ultimately `appDir`) are guaranteed forward-slash, which lands in later links; this change is behavior-preserving on its own, hence `refactor`.