### PR TITLE
refactor(app-router): consume directoryToAppRoute paths with path.posix

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1396,6 +1396,12 @@ function fileToAppRoute(
   );
 }
 
+/**
+ * `dir` and `appDir` must both be forward-slash. `dir` is split on
+ * `path.posix.sep` and joined onto `appDir` with `path.posix.join`, and `appDir`
+ * is threaded to the layout/slot/boundary discovery below, which build paths the
+ * same way.
+ */
 function directoryToAppRoute(
   dir: string,
   appDir: string,
@@ -1403,7 +1409,7 @@ function directoryToAppRoute(
   pagePath: string | null,
   routePath: string | null,
 ): AppRouteGraphRoute | null {
-  const segments = dir === "." ? [] : dir.split(path.sep);
+  const segments = dir === "." ? [] : dir.split(path.posix.sep);
 
   const params: string[] = [];
   let isDynamic = false;
@@ -1434,8 +1440,8 @@ function directoryToAppRoute(
   const errorPaths = errorEntries.map((entry) => entry.path);
   const errorTreePositions = errorEntries.map((entry) => entry.treePosition);
 
-  // Discover loading, error in the route's directory
-  const routeDir = dir === "." ? appDir : path.join(appDir, dir);
+  // Discover loading, error in the route's directory.
+  const routeDir = dir === "." ? appDir : path.posix.join(appDir, dir);
   const loadingPath = findFile(routeDir, "loading", matcher);
   const errorPath = findFile(routeDir, "error", matcher);
 


### PR DESCRIPTION
## What

In `directoryToAppRoute`, treat `dir` as a forward-slash relative path:

- split segments on `path.posix.sep` instead of `path.sep`
- build `routeDir` with `path.posix.join(appDir, dir)` instead of `path.join`

and document that both `dir` and `appDir` must be forward-slash.

## Why

Another link in the App Router route-graph forward-slash migration. `routeDir` feeds `findFile`, whose `path.posix.join` only stays canonical when the base is forward-slash, and the segment split must use the same separator the path is built with. Rather than normalize the join result, `dir` is required to already be forward-slash — its source (`path.dirname` of the scanned file) is normalized upstream, so the consumer here just uses `path.posix` throughout. `appDir` remains the propagated invariant, threaded to the layout/slot/boundary discovery that build the same way. Both preconditions are now documented on the function.

## How

- `dir.split(path.sep)` → `dir.split(path.posix.sep)`.
- `routeDir`'s `path.join(appDir, dir)` → `path.posix.join(appDir, dir)`.
- `directoryToAppRoute` doc comment now states `dir` and `appDir` must both be forward-slash.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix.sep` === `path.sep`, `path.posix.join` === `path.join`). On Windows this relies on `dir` / `appDir` being forward-slash, which is guaranteed by the upstream normalization of the scanned file path; behavior-preserving overall, hence `refactor`.
