### PR TITLE
refactor(app-router): yield forward-slash ids from scanWithExtensions

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -939,8 +939,8 @@ export async function buildAppRouteGraph(
     scanMatcher.extensions,
     excludeDir,
   )) {
-    const dir = path.dirname(file);
-    const routeDir = dir === "." ? appDir : path.join(appDir, dir);
+    const dir = path.posix.dirname(file);
+    const routeDir = dir === "." ? appDir : path.posix.join(appDir, dir);
     if (!hasParallelSlotDirectory(routeDir)) continue;
     if (discoverParallelSlots(routeDir, appDir, scanMatcher).length === 0) continue;
 

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { glob } from "node:fs/promises";
 import path from "node:path";
 import { escapeRegExp } from "../utils/regex.js";
+import { normalizePathSeparators } from "../utils/path.js";
 
 const DEFAULT_PAGE_EXTENSIONS = ["tsx", "ts", "jsx", "js"] as const;
 
@@ -163,6 +164,11 @@ export function normalizeViteResolveExtensions(extensions: readonly string[]): s
 
 /**
  * Use function-form exclude for Node < 22.14 compatibility.
+ *
+ * Yields forward-slash relative paths: node's glob emits native (backslash)
+ * separators on Windows, so each match is normalized — this is the entry point
+ * that lets downstream consumers treat the scanned paths as canonical
+ * forward-slash ids.
  */
 export async function* scanWithExtensions(
   stem: string,
@@ -175,6 +181,6 @@ export async function* scanWithExtensions(
     cwd,
     ...(exclude ? { exclude } : {}),
   })) {
-    yield file;
+    yield normalizePathSeparators(file);
   }
 }


### PR DESCRIPTION
## What

Normalize the route scan output at its source and consume it with `path.posix`:

- `scanWithExtensions` yields `normalizePathSeparators(file)` instead of the raw glob result.
- The ghost-parent loop in `buildAppRouteGraph` derives `dir` / `routeDir` with `path.posix.dirname` / `path.posix.join`.

## Why

This is the entry of the App Router route-graph forward-slash migration. node's `glob` emits native (backslash) relative paths on Windows, so `scanWithExtensions` is the one boundary where the scanned ids enter the graph builder — normalizing there lets every downstream consumer treat them as canonical forward-slash ids and use `path.posix.*` (which only stays canonical when its inputs already are forward-slash) instead of re-normalizing each output. The ghost-parent loop is the first consumer wired up to that guarantee: now that the scanned `file` is forward-slash, `path.posix.dirname(file)` and `path.posix.join(appDir, dir)` produce a forward-slash `routeDir`.

## How

- `file-matcher.ts`: import `normalizePathSeparators`, `yield normalizePathSeparators(file)`, and document that `scanWithExtensions` yields forward-slash paths.
- `app-route-graph.ts`: the ghost-parent loop uses `path.posix.dirname` / `path.posix.join`.

## Testing

- `vp check packages/vinext/src/routing/file-matcher.ts packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`normalizePathSeparators` returns its input; `path.posix` === `path`). On Windows the scanned ids become forward-slash and the ghost-parent `routeDir` follows; consumers use fs ops and path comparisons that accept forward slashes, so behavior is preserved — hence `refactor`.
