### PR TITLE
test(deploy): stabilize Wrangler fallback resolution test

### DIFF
--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -298,7 +298,7 @@ describe("resolveWranglerBin", () => {
   });
 
   it("returns a clear fallback path when Wrangler is missing", () => {
-    expect(resolveWranglerBin(tmpDir)).toBe(
+    expect(resolveWranglerBin(tmpDir, () => null)).toBe(
       path.join(tmpDir, "node_modules", "wrangler", "bin", "wrangler.js"),
     );
   });


### PR DESCRIPTION
## Summary

Stabilize the `resolveWranglerBin` fallback-path test by injecting a resolver that explicitly returns `null` for the missing-Wrangler case.

When tests run through the local pnpm-generated CLI shim, `NODE_PATH` can include `node_modules/.pnpm/node_modules`. In workspaces where `wrangler` is privately hoisted there, Node's `createRequire(...).resolve("wrangler/package.json")` can find the workspace copy even though the temporary test project does not have Wrangler installed.

The test is meant to verify the fallback behavior when Wrangler is missing, not Node/pnpm module resolution behavior, so this makes that condition explicit.

## Verification

- `pnpm test`