### PR TITLE
refactor(app-router): build typegen route paths on forward slashes

### DIFF
--- a/packages/vinext/src/typegen.ts
+++ b/packages/vinext/src/typegen.ts
@@ -6,6 +6,7 @@ import { patternToNextFormat } from "./routing/route-validation.js";
 import { decodeRouteSegment } from "./routing/utils.js";
 import { compareStrings } from "./utils/compare.js";
 import { findDir } from "./utils/project.js";
+import { normalizePathSeparators } from "./utils/path.js";
 
 type GenerateRouteTypesOptions = {
   root: string;
@@ -24,24 +25,24 @@ import "./.next/types/routes.d.ts";
 `;
 
 export async function generateRouteTypes(options: GenerateRouteTypesOptions): Promise<string> {
-  const root = path.resolve(options.root);
+  const root = normalizePathSeparators(path.resolve(options.root));
   const appDir = options.appDir
-    ? path.resolve(options.appDir)
-    : findDir(root, "app", path.join("src", "app"));
-  const outPath = path.join(root, ".next", "types", "routes.d.ts");
+    ? normalizePathSeparators(path.resolve(options.appDir))
+    : findDir(root, "app", path.posix.join("src", "app"));
+  const outPath = path.posix.join(root, ".next", "types", "routes.d.ts");
 
   const content = appDir
     ? renderRouteTypes(await collectRouteTypeModel(appDir, options.pageExtensions))
     : renderRouteTypes(emptyRouteTypeModel());
 
-  await fs.mkdir(path.dirname(outPath), { recursive: true });
+  await fs.mkdir(path.posix.dirname(outPath), { recursive: true });
   await fs.writeFile(outPath, content, "utf-8");
   await ensureNextEnvFile(root);
   return outPath;
 }
 
 async function ensureNextEnvFile(root: string): Promise<void> {
-  const envPath = path.join(root, "next-env.d.ts");
+  const envPath = path.posix.join(root, "next-env.d.ts");
   try {
     await fs.writeFile(envPath, NEXT_ENV_FILE_CONTENT, { encoding: "utf-8", flag: "wx" });
   } catch (error) {

--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -272,10 +272,14 @@ export function hasViteConfig(root: string): boolean {
  * Return the first candidate directory (resolved against `root`) that exists,
  * or null. Used to locate conventional `app`/`pages` directories that may live
  * at the root or under `src/`.
+ *
+ * `root` and `candidates` must be forward-slash, and the returned path is
+ * forward-slash too: the candidate is joined with `path.posix.join`, which only
+ * stays canonical when its inputs already are.
  */
 export function findDir(root: string, ...candidates: string[]): string | null {
   for (const candidate of candidates) {
-    const full = path.join(root, candidate);
+    const full = path.posix.join(root, candidate);
     try {
       if (fs.statSync(full).isDirectory()) return full;
     } catch {


### PR DESCRIPTION
## What

Make the typegen entry produce forward-slash paths and require its directory helper to do the same:

- `generateRouteTypes` normalizes `root` and an explicit `appDir` with `normalizePathSeparators`, and builds `outPath` / `envPath` / the `findDir` fallback with `path.posix`.
- `findDir` joins candidates with `path.posix.join` and documents that `root` and `candidates` must be forward-slash and that the returned path is forward-slash.

## Why

`generateRouteTypes` is one of the entry points into the App Router route model (it calls `collectRouteTypeModel(appDir, …)`), so `appDir` must be forward-slash before it flows into the graph builder — this is the "normalize the root once at the true entry" half of the migration. `path.resolve` returns native (backslash) paths on Windows, so `root` / `appDir` are normalized here; everything derived from them then uses `path.posix.*`, which stays canonical only when its inputs already are forward-slash. `findDir` is shared infrastructure, so its forward-slash precondition (and forward-slash return) is now part of its contract.

## How

- `typegen.ts`: `root` and the explicit-`appDir` branch wrap `path.resolve` in `normalizePathSeparators`; `findDir` fallback, `outPath`, `path.dirname(outPath)`, and `envPath` use `path.posix.*`.
- `project.ts`: `findDir` joins with `path.posix.join` and its doc states `root` / `candidates` / the return are forward-slash.

## Testing

- `vp check packages/vinext/src/typegen.ts packages/vinext/src/utils/project.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`normalizePathSeparators` returns its input; `path.posix` === `path`). On Windows the typegen `root` / `appDir` and the directory paths derived from them become forward-slash; the paths feed `fs` calls and the route model, which accept forward slashes, so behavior is preserved — hence `refactor`.
