### PR TITLE
docs(app-router): document the forward-slash appDir contract on appRouter/appRouteGraph

### DIFF
--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -49,6 +49,9 @@ export function invalidateAppRouteCache(): void {
  * TODO(#726): Layer 4 should consume this read model directly once the
  * navigation planner owns route graph facts.
  *
+ * `appDir` must be forward-slash — callers normalize it at their entry, and it
+ * flows into `buildAppRouteGraph`, which builds every path with `path.posix.*`.
+ *
  * @internal
  */
 export async function appRouteGraph(
@@ -71,6 +74,8 @@ export async function appRouteGraph(
 
 /**
  * Scan the app/ directory and return a list of routes.
+ *
+ * `appDir` must be forward-slash — it is forwarded to `appRouteGraph`.
  */
 export async function appRouter(
   appDir: string,


### PR DESCRIPTION
## What

Add a precondition note to the `appRouteGraph` and `appRouter` doc comments: `appDir` must be a forward-slash path.

## Why

These are the public entries into the App Router route model, and the slash invariant of the route-graph forward-slash migration converges here. `appDir` flows into `buildAppRouteGraph`, which builds every path with `path.posix.*` — those only stay canonical when their base is already forward-slash. Each caller normalizes `appDir` at its own entry; spelling the contract out on the shared entry points keeps future callers from passing a native (backslash) path on Windows.

## How

- `appRouteGraph` doc: `appDir` must be forward-slash — callers normalize it at their entry, and it flows into `buildAppRouteGraph` (which builds with `path.posix.*`).
- `appRouter` doc: `appDir` must be forward-slash — it is forwarded to `appRouteGraph`.

## Testing

- `vp check packages/vinext/src/routing/app-router.ts` — format, lint, and typecheck clean.
- Comments only — no behavior change.
