### PR TITLE
refactor(check): match findDir's forward-slash contract in checkConventions

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -932,11 +932,9 @@ export function checkConventions(root: string): CheckItem[] {
   const items: CheckItem[] = [];
 
   // Check for pages/ and app/ at root level, then fall back to src/
-  const pagesDir = findDir(root, "pages", path.join("src", "pages"));
-  const appDirPath = findDir(root, "app", path.join("src", "app"));
+  const pagesDir = findDir(root, "pages", "src/pages");
+  const appDirPath = findDir(root, "app", "src/app");
 
-  const hasPages = pagesDir !== null;
-  const hasApp = appDirPath !== null;
   const hasProxy =
     fs.existsSync(path.join(root, "proxy.ts")) || fs.existsSync(path.join(root, "proxy.js"));
   const hasMiddleware =
@@ -944,7 +942,7 @@ export function checkConventions(root: string): CheckItem[] {
     fs.existsSync(path.join(root, "middleware.js"));
 
   if (pagesDir !== null) {
-    const isSrc = pagesDir.includes(path.join("src", "pages"));
+    const isSrc = pagesDir.includes("src/pages");
     items.push({
       name: isSrc ? "Pages Router (src/pages/)" : "Pages Router (pages/)",
       status: "supported",
@@ -975,7 +973,7 @@ export function checkConventions(root: string): CheckItem[] {
   }
 
   if (appDirPath !== null) {
-    const isSrc = appDirPath.includes(path.join("src", "app"));
+    const isSrc = appDirPath.includes("src/app");
     items.push({
       name: isSrc ? "App Router (src/app/)" : "App Router (app/)",
       status: "supported",
@@ -1009,7 +1007,7 @@ export function checkConventions(root: string): CheckItem[] {
     items.push({ name: "middleware.ts (deprecated in Next.js 16)", status: "supported" });
   }
 
-  if (!hasPages && !hasApp) {
+  if (pagesDir === null && appDirPath === null) {
     items.push({
       name: "No pages/ or app/ directory found",
       status: "unsupported",


### PR DESCRIPTION
## What

In `checkConventions`, pass forward-slash candidate literals to `findDir` and test its forward-slash return with forward-slash substrings:

- `findDir(root, "pages", path.join("src", "pages"))` → `findDir(root, "pages", "src/pages")` (and the `app` variant).
- `pagesDir.includes(path.join("src", "pages"))` → `pagesDir.includes("src/pages")` (and the `app` variant).
- Inlined the `hasPages` / `hasApp` booleans into the `pagesDir !== null` / `appDirPath !== null` checks.

## Why

`findDir` now requires forward-slash `candidates` and returns a forward-slash path. `path.join("src", "pages")` is `src\pages` on Windows, which would both violate that candidate contract and never appear as a substring of `findDir`'s forward-slash result — so the `isSrc` detection would mislabel an `src/pages` (or `src/app`) project as a root-level one on Windows. Using forward-slash literals keeps the candidate and the substring test consistent with `findDir`.

## How

- Replaced the two `path.join("src", …)` candidate args and the two `.includes(path.join("src", …))` checks with forward-slash string literals.
- Dropped the now-single-use `hasPages` / `hasApp` locals in favor of the existing null checks.

## Testing

- `vp check packages/vinext/src/check.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.join("src", "pages")` === `"src/pages"`). On Windows the `src/`-vs-root detection now matches `findDir`'s forward-slash output instead of silently failing; behavior-preserving against the new `findDir` contract, hence `refactor`.
