### PR TITLE
refactor(check): join findSourceFiles paths with path.posix.join

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -308,6 +308,11 @@ const LIBRARY_SUPPORT: Record<string, { status: Status; detail?: string }> = {
 
 /**
  * Recursively find all source files in a directory.
+ *
+ * `dir` must be forward-slash, and the returned paths are forward-slash too:
+ * each entry is joined with `path.posix.join`, which only stays canonical when
+ * the base already is. This keeps downstream substring checks (e.g.
+ * `f.includes("/api/")`) and reported paths consistent across platforms.
  */
 function findSourceFiles(
   dir: string,
@@ -318,10 +323,7 @@ function findSourceFiles(
 
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
-    // Forward slashes so downstream substring checks (e.g. `f.includes("/api/")`)
-    // and reported paths are consistent across platforms — path.join yields
-    // backslashes on Windows, which would break those checks.
-    const fullPath = normalizePathSeparators(path.join(dir, entry.name));
+    const fullPath = path.posix.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (
         entry.name === "node_modules" ||


### PR DESCRIPTION
## What

In `findSourceFiles`, build each entry path with `path.posix.join(dir, entry.name)` instead of `normalizePathSeparators(path.join(dir, entry.name))`, and document that `dir` must be forward-slash and the returned paths are forward-slash.

## Why

Same forward-slash invariant the rest of this work follows: rather than normalize the `path.join` result on every entry, require `dir` to already be forward-slash and join with `path.posix.join`, which stays canonical when its base is. The recursion feeds back forward-slash `fullPath`s, and the top-level `dir` is forward-slash from the caller, so the per-entry normalization is no longer needed. Downstream substring checks (e.g. `f.includes("/api/")`) and reported paths stay forward-slash on every platform, exactly as the old inline comment intended — now expressed as a precondition on the function instead.

## How

- `fullPath` uses `path.posix.join(dir, entry.name)`; the per-entry `normalizePathSeparators(path.join(...))` and its inline comment are removed.
- Added a `findSourceFiles` doc note: `dir` must be forward-slash and the returned paths are forward-slash.
- `normalizePathSeparators` stays imported — still used for the `path.relative(root, file)` results elsewhere in the file (those have a native source).

## Testing

- `vp check packages/vinext/src/check.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix.join` === `path.join`). On Windows the result is identical to the previous `normalizePathSeparators(path.join(...))` as long as `dir` is forward-slash, which the caller now guarantees; behavior-preserving, hence `refactor`.
