### PR TITLE
refactor(check): compute scanImports relative paths with path.posix.relative

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -568,6 +568,10 @@ export function hasFreeCjsGlobal(content: string): boolean {
 
 /**
  * Scan source files for `import ... from 'next/...'` statements.
+ *
+ * `root` must be forward-slash: it is passed to `findSourceFiles` (which
+ * requires it) and used as the base of `path.posix.relative`, which only yields
+ * a canonical relative path when both operands are forward-slash.
  */
 export function scanImports(root: string): CheckItem[] {
   const files = findSourceFiles(root);
@@ -596,7 +600,7 @@ export function scanImports(root: string): CheckItem[] {
         // Normalize: next/font/google -> next/font/google
         const normalized = mod === "next" ? "next" : mod;
         if (!importUsage.has(normalized)) importUsage.set(normalized, []);
-        const relFile = normalizePathSeparators(path.relative(root, file));
+        const relFile = path.posix.relative(root, file);
         const usedInFiles = importUsage.get(normalized) ?? [];
         if (!usedInFiles.includes(relFile)) {
           usedInFiles.push(relFile);


### PR DESCRIPTION
## What

In `scanImports`, derive the reported file path with `path.posix.relative(root, file)` instead of `normalizePathSeparators(path.relative(root, file))`, and document that `root` must be forward-slash.

## Why

`path.relative` is `path.win32.relative` on Windows, so it always returns a backslash path regardless of its inputs — which is why it was wrapped in `normalizePathSeparators`. Now that both operands are forward-slash (`root` is normalized by the caller and `file` comes from `findSourceFiles`, which returns forward-slash paths), `path.posix.relative` produces the canonical forward-slash relative path directly, no post-normalization needed. This matches the migration's rule: use `path.posix.*` once the inputs are guaranteed forward-slash, and only fall back to `normalizePathSeparators` where an input cannot be guaranteed.

## How

- `relFile` uses `path.posix.relative(root, file)`.
- Added a `scanImports` doc note: `root` must be forward-slash (it feeds `findSourceFiles` and is the base of `path.posix.relative`).
- `normalizePathSeparators` stays imported — still used by another scanner whose `path.relative` operands are not both guaranteed forward-slash.

## Testing

- `vp check packages/vinext/src/check.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix.relative` === `path.relative`). On Windows the reported relative paths are forward-slash, identical to the previous `normalizePathSeparators(path.relative(...))` result given forward-slash `root`/`file`; behavior-preserving, hence `refactor`.
