### PR TITLE
refactor(cli): normalize the check/init root to forward slashes at the CLI entry

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -1111,6 +1111,10 @@ export function checkConventions(root: string): CheckItem[] {
 
 /**
  * Run the full compatibility check.
+ *
+ * `root` must be forward-slash — callers normalize it at the CLI entry, and it
+ * is forwarded to `scanImports` / `checkConventions` / `findDir`, which build
+ * paths with `path.posix.*`.
  */
 export function runCheck(root: string): CheckResult {
   const imports = scanImports(root);

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -48,6 +48,7 @@ import {
   tryAcquireLockfile,
 } from "./server/dev-lockfile.js";
 import { generateRouteTypes } from "./typegen.js";
+import { normalizePathSeparators } from "./utils/path.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -770,11 +771,10 @@ async function check() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("check");
 
-  const root = process.cwd();
   console.log(`\n  vinext check\n`);
   console.log("  Scanning project...\n");
 
-  const result = runCheck(root);
+  const result = runCheck(normalizePathSeparators(process.cwd()));
   console.log(formatReport(result));
 }
 

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -29,6 +29,7 @@ import {
   hasViteConfig,
   hasAppDir,
 } from "./utils/project.js";
+import { normalizePathSeparators } from "./utils/path.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -267,7 +268,7 @@ export function updateGitignore(root: string): boolean {
 // ─── Main Entry ──────────────────────────────────────────────────────────────
 
 export async function init(options: InitOptions): Promise<InitResult> {
-  const root = path.resolve(options.root);
+  const root = normalizePathSeparators(path.resolve(options.root));
   const port = options.port ?? 3001;
   const exec =
     options._exec ??


### PR DESCRIPTION
## What

Normalize `root` at the two CLI entries that originate it, and document the contract on `runCheck`:

- `cli.ts` `check()`: `root = normalizePathSeparators(process.cwd())`.
- `init.ts` `init()`: `root = normalizePathSeparators(path.resolve(options.root))`.
- `runCheck` doc: `root` must be forward-slash.

## Why

These are the true entry points where `root` is created — `process.cwd()` and `path.resolve` both return native (backslash) paths on Windows. Normalizing once here lets everything downstream (`runCheck` → `scanImports` / `checkConventions` / `findDir`, and `init`'s project helpers) treat `root` as a canonical forward-slash id and build with `path.posix.*` instead of re-normalizing each derived path. This is the "normalize the root once at the true entry" anchor for the check/init forward-slash chain.

## How

- `check()` wraps `process.cwd()` in `normalizePathSeparators`.
- `init()` wraps `path.resolve(options.root)` in `normalizePathSeparators`.
- `runCheck` doc states `root` must be forward-slash and is forwarded to the `path.posix.*`-based scanners.

## Testing

- `vp check packages/vinext/src/cli.ts packages/vinext/src/init.ts packages/vinext/src/check.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`normalizePathSeparators` returns its input). On Windows the check/init `root` is now forward-slash, so the paths derived from it are too; the values feed `fs` calls and forward-slash substring checks, so behavior is preserved — hence `refactor`.
