### PR TITLE
refactor(typegen): pass the findDir candidate as a forward-slash literal

### DIFF
--- a/packages/vinext/src/typegen.ts
+++ b/packages/vinext/src/typegen.ts
@@ -28,7 +28,7 @@ export async function generateRouteTypes(options: GenerateRouteTypesOptions): Pr
   const root = normalizePathSeparators(path.resolve(options.root));
   const appDir = options.appDir
     ? normalizePathSeparators(path.resolve(options.appDir))
-    : findDir(root, "app", path.posix.join("src", "app"));
+    : findDir(root, "app", "src/app");
   const outPath = path.posix.join(root, ".next", "types", "routes.d.ts");
 
   const content = appDir


### PR DESCRIPTION
## What

In `generateRouteTypes`, pass the `src/app` fallback to `findDir` as the literal `"src/app"` instead of `path.posix.join("src", "app")`.

## Why

`findDir`'s `candidates` are forward-slash by contract, and `path.posix.join("src", "app")` is just `"src/app"` — the literal is simpler, has no runtime indirection, and matches how the other caller (`checkConventions`) passes its `"src/pages"` / `"src/app"` candidates. Pure simplification with no behavior change.

## How

- `findDir(root, "app", path.posix.join("src", "app"))` → `findDir(root, "app", "src/app")`.

## Testing

- `vp check packages/vinext/src/typegen.ts` — format, lint, and typecheck clean.
- `path.posix.join("src", "app")` === `"src/app"` on every platform, so the value passed to `findDir` is identical; behavior-preserving, hence `refactor`.