### PR TITLE
fix(app-router): exclude dev overlay from production client bundle

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2164,8 +2164,7 @@ function bootstrapHydration(
       // empty; if it throws again, devOnCaughtError/devOnUncaughtError
       // re-populates it. Without this, an old "DropZone is not defined"
       // error would linger after the developer fixed the bug.
-      const devErrorOverlay = await import("./dev-error-overlay.js");
-      devErrorOverlay.dismissOverlay();
+      devErrorOverlay?.dismissOverlay();
       // Interception context on HMR re-renders is intentionally deferred:
       // preserving intercepted modal state across HMR reloads is out of scope
       // for the previousNextUrl mechanism.

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -145,13 +145,6 @@ import {
 } from "../client/app-nav-failure-handler.js";
 import { createClientReuseManifestHeaderFromVisibleAppState } from "./app-browser-client-reuse-manifest.js";
 import {
-  devOnCaughtError,
-  dismissOverlay,
-  installDevErrorOverlay,
-  installViteHmrErrorHandler,
-  reportInitialDevServerErrors,
-} from "./dev-error-overlay.js";
-import {
   createRscRequestHeaders,
   createRscRequestUrl,
   getVinextRscCompatibilityId,
@@ -181,6 +174,7 @@ import {
 import { hasServerActions, loadServerActionClient } from "virtual:vinext-app-capabilities";
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
+type DevErrorOverlayModule = typeof import("./dev-error-overlay.js");
 
 type ServerActionResult = AppBrowserServerActionResult<AppWireElements>;
 
@@ -1398,10 +1392,12 @@ async function main(): Promise<void> {
   if (hasServerActions) registerServerActionCallback();
   installAppNavigationFailureListeners();
 
+  let devErrorOverlay: DevErrorOverlayModule | null = null;
   if (import.meta.env.DEV) {
-    installDevErrorOverlay();
-    installViteHmrErrorHandler(import.meta.hot);
-    reportInitialDevServerErrors();
+    devErrorOverlay = await import("./dev-error-overlay.js");
+    devErrorOverlay.installDevErrorOverlay();
+    devErrorOverlay.installViteHmrErrorHandler(import.meta.hot);
+    devErrorOverlay.reportInitialDevServerErrors();
   }
 
   const rscStream = await readInitialRscStream();
@@ -1413,10 +1409,13 @@ async function main(): Promise<void> {
   // The recovery path reloads the document, which resets the "starting" claim;
   // this module instance is intentionally not eligible to retry bootstrap.
   if (rscStream === null) return;
-  bootstrapHydration(rscStream);
+  bootstrapHydration(rscStream, devErrorOverlay);
 }
 
-function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
+function bootstrapHydration(
+  rscStream: ReadableStream<Uint8Array>,
+  devErrorOverlay: DevErrorOverlayModule | null,
+): void {
   const root = decodeAppElementsPromise(createFromReadableStream<AppWireElements>(rscStream));
   const initialNavigationSnapshot = createClientNavigationRenderSnapshot(
     window.location.href,
@@ -1426,18 +1425,19 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
 
   const onUncaughtError = createOnUncaughtError();
   const formState = consumeInitialFormState(getVinextBrowserGlobal());
-  const hydrateRootOptions = import.meta.env.DEV
-    ? createVinextHydrateRootOptions({
-        formState,
-        onCaughtError: createDevOnCaughtError(devOnCaughtError, onUncaughtError),
-        onUncaughtError,
-      })
-    : createVinextHydrateRootOptions({
-        formState,
-        onCaughtError: createProdOnCaughtError(onUncaughtError),
-        onRecoverableError: prodOnRecoverableError,
-        onUncaughtError,
-      });
+  const hydrateRootOptions =
+    import.meta.env.DEV && devErrorOverlay
+      ? createVinextHydrateRootOptions({
+          formState,
+          onCaughtError: createDevOnCaughtError(devErrorOverlay.devOnCaughtError, onUncaughtError),
+          onUncaughtError,
+        })
+      : createVinextHydrateRootOptions({
+          formState,
+          onCaughtError: createProdOnCaughtError(onUncaughtError),
+          onRecoverableError: prodOnRecoverableError,
+          onUncaughtError,
+        });
   const children = createElement(BrowserRoot, {
     initialElements: root,
     initialNavigationSnapshot,
@@ -2112,7 +2112,7 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
     }
   });
 
-  if (import.meta.hot) {
+  if (import.meta.env.DEV && import.meta.hot) {
     const applyRscHmrUpdate = async (updateId: number): Promise<void> => {
       if (updateId !== latestRscHmrUpdateId) return;
 
@@ -2164,7 +2164,8 @@ function bootstrapHydration(rscStream: ReadableStream<Uint8Array>): void {
       // empty; if it throws again, devOnCaughtError/devOnUncaughtError
       // re-populates it. Without this, an old "DropZone is not defined"
       // error would linger after the developer fixed the bug.
-      dismissOverlay();
+      const devErrorOverlay = await import("./dev-error-overlay.js");
+      devErrorOverlay.dismissOverlay();
       // Interception context on HMR re-renders is intentionally deferred:
       // preserving intercepted modal state across HMR reloads is out of scope
       // for the previousNextUrl mechanism.

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -58,6 +58,24 @@ describe("App Router Production build", () => {
     // directory.
     const clientAssets = fs.readdirSync(path.join(outDir, "client", "_next", "static", "chunks"));
     expect(clientAssets.some((f: string) => f.endsWith(".js"))).toBe(true);
+    const clientJs = readAllJs(path.join(outDir, "client"));
+
+    // Ported from Next.js:
+    // test/production/app-dir/browser-chunks/browser-chunks.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/production/app-dir/browser-chunks/browser-chunks.test.ts
+    //
+    // Dev overlay and HMR plumbing must not create a production client chunk
+    // edge. Keep this list focused on symbols/module ids that only belong to
+    // vinext's App Router dev overlay path.
+    for (const devOnlyNeedle of [
+      "dev-error-overlay",
+      "vinext-dev-error-overlay",
+      "installDevErrorOverlay",
+      "installViteHmrErrorHandler",
+      "rsc:update",
+    ]) {
+      expect(clientJs).not.toContain(devOnlyNeedle);
+    }
 
     // Ported from the client-reference chunk ownership covered by Next.js:
     // test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts


### PR DESCRIPTION
## Summary

- Move App Router dev error overlay imports behind dev-only dynamic imports
- Keep RSC HMR overlay cleanup inside the dev/HMR code path
- Add a production build regression test that rejects dev overlay/HMR-only strings in client chunks

## Verification

- pnpm test tests/app-router-production-build.test.ts
- PLAYWRIGHT_PROJECT=app-router pnpm exec playwright test --project=app-router tests/e2e/app-router/dev-error-overlay.spec.ts
- pnpm run check

Close #1724 