### PR TITLE
feat(benchmarks): reduce repeated chart markers

### DIFF
--- a/apps/web/app/benchmarks/components/chart-points.ts
+++ b/apps/web/app/benchmarks/components/chart-points.ts
@@ -1,6 +1,12 @@
-export function visibleMarkerMask(values: readonly (number | null)[]): boolean[] {
-  return values.map(
+export function visibleMarkerMask(
+  values: readonly (number | null)[],
+  formatValue: (value: number) => string = String,
+): boolean[] {
+  const displayedValues = values.map((value) => (value === null ? null : formatValue(value)));
+
+  return displayedValues.map(
     (value, index) =>
-      value !== null && (values[index - 1] !== value || values[index + 1] !== value),
+      value !== null &&
+      (displayedValues[index - 1] !== value || displayedValues[index + 1] !== value),
   );
 }

--- a/apps/web/app/benchmarks/components/chart-points.ts
+++ b/apps/web/app/benchmarks/components/chart-points.ts
@@ -1,0 +1,6 @@
+export function visibleMarkerMask(values: readonly (number | null)[]): boolean[] {
+  return values.map(
+    (value, index) =>
+      value !== null && (values[index - 1] !== value || values[index + 1] !== value),
+  );
+}

--- a/apps/web/app/benchmarks/components/chart.tsx
+++ b/apps/web/app/benchmarks/components/chart.tsx
@@ -153,7 +153,7 @@ export function TrendChart({
 
           if (segments.length === 0) return null;
           const pathD = segments.join(" ");
-          const visibleMarkers = visibleMarkerMask(s.values);
+          const visibleMarkers = visibleMarkerMask(s.values, formatY);
 
           return (
             <g key={s.name}>

--- a/apps/web/app/benchmarks/components/chart.tsx
+++ b/apps/web/app/benchmarks/components/chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { visibleMarkerMask } from "./chart-points";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -42,6 +43,7 @@ export function TrendChart({
     x: number;
     y: number;
     content: string;
+    pointId: string;
   } | null>(null);
 
   // Collect all non-null values to determine y-axis bounds
@@ -128,7 +130,7 @@ export function TrendChart({
         })}
 
         {/* Series lines + dots */}
-        {series.map((s) => {
+        {series.map((s, seriesIndex) => {
           // Build path segments, breaking on null values
           const segments: string[] = [];
           let inSegment = false;
@@ -151,46 +153,57 @@ export function TrendChart({
 
           if (segments.length === 0) return null;
           const pathD = segments.join(" ");
+          const visibleMarkers = visibleMarkerMask(s.values);
 
           return (
             <g key={s.name}>
               {/* Line */}
               <path d={pathD} fill="none" stroke={s.color} strokeWidth="2" />
-              {/* Dots — only for non-null values */}
+              {/* Every point remains interactive; repeated plateau markers stay hidden. */}
               {s.values.map((v, i) => {
                 if (v === null) return null;
-                const circle = (
-                  <circle
-                    cx={scaleX(i)}
-                    cy={scaleY(v)}
-                    r="3.5"
-                    fill={s.color}
-                    stroke="white"
-                    strokeWidth="1.5"
-                    className="cursor-pointer"
-                    onMouseEnter={(e) => {
-                      const rect = svgRef.current?.getBoundingClientRect();
-                      if (!rect) return;
-                      setTooltip({
-                        x: e.clientX - rect.left,
-                        y: e.clientY - rect.top - 10,
-                        content: `${s.name}: ${formatY(v)} (${labels[i]})`,
-                      });
-                    }}
-                    onMouseLeave={() => setTooltip(null)}
-                  />
+                const pointId = `${seriesIndex}-${pointKeys[i]}`;
+                const point = (
+                  <g key={`${pointKeys[i]}-${s.name}`}>
+                    <circle
+                      cx={scaleX(i)}
+                      cy={scaleY(v)}
+                      r="3.5"
+                      fill={s.color}
+                      stroke="white"
+                      strokeWidth="1.5"
+                      opacity={visibleMarkers[i] || tooltip?.pointId === pointId ? 1 : 0}
+                      pointerEvents="none"
+                    />
+                    <circle
+                      cx={scaleX(i)}
+                      cy={scaleY(v)}
+                      r="8"
+                      fill="transparent"
+                      className="cursor-pointer"
+                      onMouseEnter={(e) => {
+                        const rect = svgRef.current?.getBoundingClientRect();
+                        if (!rect) return;
+                        setTooltip({
+                          x: e.clientX - rect.left,
+                          y: e.clientY - rect.top - 10,
+                          content: `${s.name}: ${formatY(v)} (${labels[i]})`,
+                          pointId,
+                        });
+                      }}
+                      onMouseLeave={() => setTooltip(null)}
+                    />
+                  </g>
                 );
                 const href = pointHrefs?.[i];
-                if (!href) {
-                  return <g key={`${pointKeys[i]}-${s.name}`}>{circle}</g>;
-                }
+                if (!href) return point;
                 return (
                   <a
                     key={`${pointKeys[i]}-${s.name}`}
                     href={href}
                     aria-label={`View commit ${labels[i]} benchmark results`}
                   >
-                    {circle}
+                    {point}
                   </a>
                 );
               })}

--- a/tests/benchmark-chart-points.test.ts
+++ b/tests/benchmark-chart-points.test.ts
@@ -10,6 +10,17 @@ describe("benchmark chart point markers", () => {
     expect(visibleMarkerMask([1, 2, 3, 4])).toEqual([true, true, true, true]);
   });
 
+  it("groups values that have the same displayed value", () => {
+    const formatValue = (value: number) => value.toFixed(1);
+
+    expect(visibleMarkerMask([117.21, 117.22, 117.24, 117.31], formatValue)).toEqual([
+      true,
+      false,
+      true,
+      true,
+    ]);
+  });
+
   it("treats missing values as plateau boundaries", () => {
     expect(visibleMarkerMask([null, 4, 4, null, 4, 4, 4])).toEqual([
       false,

--- a/tests/benchmark-chart-points.test.ts
+++ b/tests/benchmark-chart-points.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { visibleMarkerMask } from "../apps/web/app/benchmarks/components/chart-points";
+
+describe("benchmark chart point markers", () => {
+  it("shows only the boundaries of a repeated plateau", () => {
+    expect(visibleMarkerMask([5, 5, 5, 5])).toEqual([true, false, false, true]);
+  });
+
+  it("shows every non-repeated value", () => {
+    expect(visibleMarkerMask([1, 2, 3, 4])).toEqual([true, true, true, true]);
+  });
+
+  it("treats missing values as plateau boundaries", () => {
+    expect(visibleMarkerMask([null, 4, 4, null, 4, 4, 4])).toEqual([
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      true,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- show markers only at the first and last point of consecutive equal-value plateaus
- retain a transparent hit target for every benchmark run so links and tooltips remain available
- reveal hidden plateau markers on hover
- treat missing measurements as plateau boundaries

## Screenshot

![Benchmark chart with reduced plateau markers](https://github.com/user-attachments/assets/ac64d0ce-f590-402b-ab64-2c6e6d804f1e)

## Tests

- `vp test run tests/benchmark-chart-points.test.ts tests/performance-dashboard.test.ts`
- `vp check tests/benchmark-chart-points.test.ts apps/web/app/benchmarks/components/chart.tsx apps/web/app/benchmarks/components/chart-points.ts`
