### PR TITLE
fix(ssr): ignore runtime renderer import in Vite

### DIFF
--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -125,7 +125,7 @@ async function loadStaticPrerender(): Promise<StaticPrerender> {
       const reactDomPackageJson = require.resolve("react-dom/package.json");
       const reactDomDir = path.dirname(reactDomPackageJson);
       const devRendererPath = path.join(reactDomDir, "cjs/react-dom-server.edge.development.js");
-      const devRenderer: unknown = await import(devRendererPath);
+      const devRenderer: unknown = await import(/* @vite-ignore */ devRendererPath);
       if (isStaticPrerenderModule(devRenderer)) {
         return devRenderer.prerender;
       }


### PR DESCRIPTION
## Summary

- mark the runtime-resolved React development renderer import with `@vite-ignore`
- prevent Vite import analysis from warning about a path that intentionally cannot be statically analyzed

## Why

`loadStaticPrerender()` resolves React's internal development renderer from the installed `react-dom` package at runtime. Vite sees the computed import when consuming vinext's built SSR runtime and reports that it cannot analyze the dynamic import.

## Validation

- `vp check packages/vinext/src/server/app-ssr-entry.ts`
- `vp run vinext#build`
- confirmed `packages/vinext/dist/server/app-ssr-entry.js` preserves the `/* @vite-ignore */` directive immediately inside `import()`
