### PR TITLE
feat(web): add Vite configuration examples

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -19,3 +19,18 @@ body {
     -apple-system,
     sans-serif;
 }
+
+.vinext-code-block pre {
+  margin: 0;
+  overflow-x: auto;
+  padding: 1.25rem;
+  background: transparent !important;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.7;
+}
+
+.vinext-code-block code {
+  display: block;
+  min-width: max-content;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -17,6 +17,10 @@ import {
   PlugsIcon,
   SparkleIcon,
 } from "@phosphor-icons/react/dist/ssr";
+import typescript from "shiki/langs/typescript.mjs";
+import githubDarkDefault from "shiki/themes/github-dark-default.mjs";
+import { createHighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 // ISR: 5-minute revalidate. The home page is fully static so the cached
 // output is effectively reused indefinitely between deploys; the revalidate
@@ -115,7 +119,80 @@ const EXAMPLES = [
   },
 ] as const;
 
+const VITE_CONFIG_EXAMPLES = [
+  {
+    title: "Start with vinext",
+    description: "The smallest config for running a Next.js app through Vite.",
+    code: `import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext()],
+});`,
+  },
+  {
+    title: "Deploy to Cloudflare Workers",
+    description:
+      "Add the Cloudflare Vite plugin and back vinext's data cache with a Workers KV binding.",
+    code: `import { cloudflare } from "@cloudflare/vite-plugin";
+import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [
+    vinext({
+      cache: {
+        data: kvDataAdapter(),
+      },
+    }),
+    cloudflare({
+      viteEnvironment: {
+        name: "rsc",
+        childEnvironments: ["ssr"],
+      },
+    }),
+  ],
+});`,
+  },
+  {
+    title: "Or deploy with Nitro",
+    description: "Use Nitro when you want adapters for Node, Vercel, Netlify, AWS, and more.",
+    code: `import { nitro } from "nitro/vite";
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext(), nitro()],
+});`,
+  },
+] as const;
+
 const CARD = "flex w-full flex-col gap-3 rounded-lg bg-kumo-base p-6 ring ring-kumo-hairline";
+
+let highlighterPromise: ReturnType<typeof createHighlighterCore> | undefined;
+
+function getHighlighter() {
+  return (highlighterPromise ??= createHighlighterCore({
+    langs: [typescript],
+    themes: [githubDarkDefault],
+    engine: createJavaScriptRegexEngine(),
+  }));
+}
+
+async function CodeExample({ code }: { code: string }) {
+  const highlightedCode = (await getHighlighter()).codeToHtml(code, {
+    lang: "typescript",
+    theme: "github-dark-default",
+  });
+
+  return (
+    <div
+      className="vinext-code-block overflow-hidden rounded-b-lg"
+      dangerouslySetInnerHTML={{ __html: highlightedCode }}
+    />
+  );
+}
 
 export default function Home() {
   return (
@@ -309,6 +386,54 @@ export default function Home() {
               Migration guide
             </LinkButton>
           </div>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-5xl px-6 pb-24">
+        <div className="mb-10 max-w-2xl">
+          <Badge variant="outline" className="mb-4">
+            vite.config.ts
+          </Badge>
+          <Text variant="heading2" as="h2">
+            Configure vinext in Vite
+          </Text>
+          <p className="mt-3 text-kumo-subtle">
+            Start with the vinext plugin, then add the adapter for your deployment target. Your
+            routes, components, and Next.js configuration stay exactly where they are.
+          </p>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl bg-kumo-base ring-1 ring-kumo-hairline">
+          {VITE_CONFIG_EXAMPLES.map(({ title, description, code }, index) => (
+            <article
+              key={title}
+              className="grid min-w-0 border-b border-kumo-hairline last:border-b-0 md:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)]"
+            >
+              <div className="flex gap-4 p-6 md:p-8">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-kumo-elevated font-mono text-xs font-medium text-kumo-subtle ring-1 ring-kumo-hairline">
+                  {String(index + 1).padStart(2, "0")}
+                </div>
+                <div className="min-w-0 pt-0.5">
+                  <Text variant="heading3" as="h3">
+                    {title}
+                  </Text>
+                  <p className="mt-2 text-sm leading-relaxed text-kumo-subtle">{description}</p>
+                </div>
+              </div>
+
+              <div className="min-w-0 border-t border-kumo-hairline bg-[#0d1117] md:border-l md:border-t-0">
+                <div className="flex items-center gap-3 border-b border-white/10 px-5 py-3">
+                  <div className="flex gap-1.5" aria-hidden="true">
+                    <span className="size-2.5 rounded-full bg-[#ff5f57]" />
+                    <span className="size-2.5 rounded-full bg-[#febc2e]" />
+                    <span className="size-2.5 rounded-full bg-[#28c840]" />
+                  </div>
+                  <span className="font-mono text-xs text-[#8b949e]">vite.config.ts</span>
+                </div>
+                <CodeExample code={code} />
+              </div>
+            </article>
+          ))}
         </div>
       </section>
     </>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "shiki": "catalog:",
     "vinext": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ catalogs:
     server-only:
       specifier: ^0.0.1
       version: 0.0.1
+    shiki:
+      specifier: 4.0.2
+      version: 4.0.2
     swr:
       specifier: ^2.0.0
       version: 2.4.0
@@ -338,6 +341,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.7(react@19.2.7)
+      shiki:
+        specifier: 'catalog:'
+        version: 4.0.2
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ catalog:
   react-server-dom-webpack: ^19.2.7
   sass: 1.100.0
   server-only: ^0.0.1
+  shiki: 4.0.2
   swr: ^2.0.0
   tailwind-merge: ^3.3.0
   tailwindcss: 4.1.4


### PR DESCRIPTION
## Summary

- add a Vite configuration section to the bottom of the web homepage
- show minimal vinext, Cloudflare Workers with KV data cache, and Nitro configurations
- render focused TypeScript highlighting with Shiki's core API and JavaScript regex engine
- present the examples in a responsive, stepped configuration panel

## Implementation notes

The homepage imports only the TypeScript grammar and GitHub dark theme. It uses Shiki's JavaScript regex engine rather than Oniguruma WASM so highlighting works in the Cloudflare Workers runtime.

## Validation

- `vp check apps/web/app/page.tsx apps/web/app/globals.css apps/web/package.json pnpm-workspace.yaml pnpm-lock.yaml`
- served the app with `vinext dev --port 3011`
- verified `/` returns HTTP 200 with all three highlighted examples
- confirmed there are no Shiki WebAssembly or missing-module runtime errors
