### PR TITLE
fix(perf): widen dev cold-start noise threshold

### DIFF
--- a/benchmarks/perf/format-pr-comment.mjs
+++ b/benchmarks/perf/format-pr-comment.mjs
@@ -7,6 +7,8 @@ const resultsPath = resolve(process.argv[2] ?? "performance-artifact/perf-result
 const responsePath = resolve(process.argv[3] ?? "performance-upload.json");
 const outputPath = resolve(process.argv[4] ?? "performance-comment.md");
 const results = JSON.parse(await readFile(resultsPath, "utf8"));
+const DEFAULT_CHANGE_THRESHOLD = 1.5;
+const DEV_COLD_START_CHANGE_THRESHOLD = 3;
 
 if (results.run.kind !== "pull_request") {
   await writeFile(outputPath, "");
@@ -71,10 +73,16 @@ function measurementChange(measurement) {
   );
 }
 
+function changeThreshold(measurement) {
+  return measurement.benchmarkId?.endsWith("-dev-cold-start-root")
+    ? DEV_COLD_START_CHANGE_THRESHOLD
+    : DEFAULT_CHANGE_THRESHOLD;
+}
+
 function changeCell(measurement, hasComparisonBaseline) {
   const change = measurementChange(measurement);
   if (change === null) return hasComparisonBaseline ? "Current only" : "New";
-  const neutral = Math.abs(change) < 1.5;
+  const neutral = Math.abs(change) < changeThreshold(measurement);
   const improved = measurement.lowerIsBetter ? change < 0 : change > 0;
   const indicator = neutral ? "⚫" : improved ? "🟢" : "🔴";
   return `${indicator} ${change > 0 ? "+" : ""}${change.toFixed(1)}%`;
@@ -90,7 +98,7 @@ const regressions = measurements.filter((measurement) => {
   const change = measurementChange(measurement);
   return (
     change !== null &&
-    Math.abs(change) >= 1.5 &&
+    Math.abs(change) >= changeThreshold(measurement) &&
     (measurement.lowerIsBetter ? change > 0 : change < 0)
   );
 }).length;
@@ -98,7 +106,7 @@ const improvements = measurements.filter((measurement) => {
   const change = measurementChange(measurement);
   return (
     change !== null &&
-    Math.abs(change) >= 1.5 &&
+    Math.abs(change) >= changeThreshold(measurement) &&
     (measurement.lowerIsBetter ? change < 0 : change > 0)
   );
 }).length;
@@ -143,7 +151,7 @@ const body = [
     : `Measured \`${comparison.head.shortSha}\`. No benchmark run is available for base \`${results.run.baseSha.slice(0, 7)}\`.`,
   "",
   comparison.baseline
-    ? `**${improvements} improved · ${regressions} regressed · ${neutral} within ±1.5%**`
+    ? `**${improvements} improved · ${regressions} regressed · ${neutral} within noise threshold**`
     : `**${measurements.length} measurements recorded · baseline unavailable**`,
   "",
   "| Scenario | Framework | Baseline | Current | Change |",
@@ -152,7 +160,7 @@ const body = [
   "",
   `[View detailed results and traces](${dashboardUrl})`,
   "",
-  `<sub>🟢 improvement · 🔴 regression · ⚫ change below 1.5%${
+  `<sub>🟢 improvement · 🔴 regression · ⚫ below threshold (3% dev cold start; 1.5% otherwise)${
     hasPairedBaseline
       ? hasUnpairedMeasurement
         ? hasHistoricalBaseline && hasCurrentOnlyMeasurement

--- a/scripts/performance-trace.test.ts
+++ b/scripts/performance-trace.test.ts
@@ -381,7 +381,7 @@ describe("performance traces", () => {
     ]);
     const comment = await readFile(commentPath, "utf8");
     expect(comment).toContain("<!-- vinext-performance-benchmarks -->");
-    expect(comment).toContain("1 improved · 0 regressed · 1 within ±1.5%");
+    expect(comment).toContain("1 improved · 0 regressed · 1 within noise threshold");
     expect(comment).toContain("🟢 -10.0%");
     expect(comment).toContain("⚫ +0.6%");
     expect(comment).toContain("@\u200beveryone");

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -592,8 +592,58 @@ describe("paired performance benchmarks", () => {
     expect(comment).toContain(
       "using alternating same-runner rounds. Next.js was unchanged and skipped.",
     );
-    expect(comment).toContain("1 improved · 0 regressed · 0 within ±1.5%");
+    expect(comment).toContain("1 improved · 0 regressed · 0 within noise threshold");
     expect(comment).not.toContain("Next.js |");
+  });
+
+  it("uses a wider noise threshold for dev cold start", () => {
+    const directory = mkdtempSync(join(tmpdir(), "vinext-perf-cold-start-comment-"));
+    const resultsPath = join(directory, "results.json");
+    const responsePath = join(directory, "response.json");
+    const outputPath = join(directory, "comment.md");
+    writeFileSync(
+      resultsPath,
+      JSON.stringify({
+        run: {
+          kind: "pull_request",
+          pullRequest: 42,
+          baseSha: "b".repeat(40),
+          measuredAt: "2026-01-01T00:00:00.000Z",
+        },
+        benchmarks: [],
+      }),
+    );
+    writeFileSync(
+      responsePath,
+      JSON.stringify({
+        comparison: {
+          head: { shortSha: "aaaaaaa" },
+          baseline: { shortSha: "bbbbbbb" },
+          measurements: [
+            {
+              ...commentMeasurement("vinext-dev-cold-start-root", 1000, 977),
+              label: "Dev server cold start",
+            },
+            {
+              ...commentMeasurement("vinext-production-build", 100, 98),
+              label: "Production build time",
+            },
+          ],
+        },
+      }),
+    );
+
+    execFileSync(
+      process.execPath,
+      ["benchmarks/perf/format-pr-comment.mjs", resultsPath, responsePath, outputPath],
+      { cwd: join(import.meta.dirname, "..") },
+    );
+
+    const comment = readFileSync(outputPath, "utf8");
+    expect(comment).toContain("1 improved · 0 regressed · 1 within noise threshold");
+    expect(comment).toContain("| Dev server cold start | vinext | 1.00 s | 977 ms | ⚫ -2.3% |");
+    expect(comment).toContain("| Production build time | vinext | 100 ms | 98 ms | 🟢 -2.0% |");
+    expect(comment).toContain("3% dev cold start; 1.5% otherwise");
   });
 
   it("labels mixed paired and historical PR comment baselines", () => {


### PR DESCRIPTION
## Summary

- use a 3% significance threshold for dev server cold-start measurements
- keep the existing 1.5% threshold for build time and bundle-size measurements
- update the benchmark comment wording and add focused regression coverage

## Threshold analysis

Reviewed the 50 most recently updated merged PRs; 45 had performance benchmark comments. I selected 18 controls whose changes were limited to tests, docs, workflows, release metadata, CLI/check/typegen/deploy code, or the benchmark dashboard and should not affect the measured dev-server startup path.

For the absolute vinext cold-start delta in those controls:

| Statistic | Result |
|---|---:|
| Median | 1.2% |
| 90th percentile | 2.0% |
| 95th percentile | 2.05% |
| Maximum | 2.3% |
| False signals at 1.5% | 7 / 18 |
| False signals at 3% | 0 / 18 |

Representative false improvements:

- [PR #2267](https://github.com/cloudflare/vinext/pull/2267#issuecomment-4772641679): test-only change, reported -2.3%
- [PR #2282](https://github.com/cloudflare/vinext/pull/2282#issuecomment-4774112849): CLI/path handling change, reported -2.0%
- [PR #2263](https://github.com/cloudflare/vinext/pull/2263#issuecomment-4772141011): GitHub Action dependency update, reported -1.6%
- [PR #2207](https://github.com/cloudflare/vinext/pull/2207#issuecomment-4757360729): E2E test-only change, reported -1.8%

A 3% cutoff clears the observed 2.3% control maximum with margin while retaining the tighter threshold for deterministic metrics.

## Test plan

- `vp check benchmarks/perf/format-pr-comment.mjs tests/performance-benchmarks.test.ts`
- `vp test run tests/performance-benchmarks.test.ts`