### PR TITLE
refactor(cli): pass a forward-slash root to printBuildReport

### DIFF
--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -753,7 +753,8 @@ export function formatBuildReport(rows: RouteRow[], routerLabel = "app"): string
  * Scans the project at `root`, classifies all routes, and prints the
  * Next.js-style build report to stdout.
  *
- * Called at the end of `vinext build` in cli.ts.
+ * `root` must be forward-slash — it is passed to `findDir`. The caller (the
+ * `vinext build` entry in cli.ts) normalizes it.
  */
 export async function printBuildReport(options: {
   root: string;

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -650,7 +650,7 @@ async function buildApp() {
   process.stdout.write("\x1b[0m");
   const { printBuildReport } = await import("./build/report.js");
   await printBuildReport({
-    root: process.cwd(),
+    root: normalizePathSeparators(process.cwd()),
     pageExtensions: resolvedNextConfig.pageExtensions,
     prerenderResult: prerenderResult ?? undefined,
   });


### PR DESCRIPTION
## What

Normalize the `root` passed to `printBuildReport` at the build entry, and document the contract:

- `cli.ts` `buildApp()`: `printBuildReport({ root: process.cwd(), … })` → `root: normalizePathSeparators(process.cwd())`.
- `printBuildReport` doc: `root` must be forward-slash.

## Why

`printBuildReport` resolves the app/pages directories with `findDir`, which requires a forward-slash `root` and forward-slash candidates. `process.cwd()` is native (backslash) on Windows, so the build entry normalizes it before the call — matching how the other `vinext build` consumers (`hasAppDir`, `detectProject`, the route model) already receive a forward-slash `root`. The contract is documented on the function for consistency with the other `root`-taking entry points.

## How

- `buildApp()` wraps the `root` passed to `printBuildReport` in `normalizePathSeparators`.
- `printBuildReport` doc states `root` must be forward-slash (passed to `findDir`; normalized by the caller).

## Testing

- `vp check packages/vinext/src/cli.ts packages/vinext/src/build/report.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`normalizePathSeparators` returns its input). On Windows `printBuildReport` now receives a forward-slash `root`, so its `findDir` lookups resolve `app` / `pages` (and the `src/` variants) as on POSIX; behavior-preserving, hence `refactor`.
