### PR TITLE
refactor(cli): pass a forward-slash root to runPrerender

### DIFF
--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -152,6 +152,13 @@ export function assertNoFatalPrerenderRoutes(routes: readonly PrerenderRouteResu
   );
 }
 
+/**
+ * Statically generate routes and return the prerender result.
+ *
+ * `options.root` must be forward-slash — it is passed to `findDir` and flows
+ * into the route model. The caller (the `vinext build` entry in cli.ts)
+ * normalizes it.
+ */
 export async function runPrerender(options: RunPrerenderOptions): Promise<PrerenderResult | null> {
   const { root } = options;
 

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -639,7 +639,7 @@ async function buildApp() {
     process.stdout.write("\x1b[0m");
     console.log(`  ${label}`);
     prerenderResult = await runPrerender({
-      root: process.cwd(),
+      root: normalizePathSeparators(process.cwd()),
       concurrency: parsed.prerenderConcurrency,
     });
   }


### PR DESCRIPTION
## What

Normalize the `root` passed to `runPrerender` at the build entry, and document the contract:

- `cli.ts` `buildApp()`: `runPrerender({ root: process.cwd(), … })` → `root: normalizePathSeparators(process.cwd())`.
- `runPrerender` doc: `options.root` must be forward-slash.

## Why

`runPrerender` resolves the app/pages directories with `findDir` and feeds the result into the route model, both of which expect a forward-slash `root`. `process.cwd()` is native (backslash) on Windows, so the build entry normalizes it before the call — consistent with the other `vinext build` consumers (`printBuildReport`, `hasAppDir`, `detectProject`) that already receive a forward-slash `root`. The precondition is documented on the function for consistency with those entry points.

## How

- `buildApp()` wraps the `root` passed to `runPrerender` in `normalizePathSeparators`.
- `runPrerender` doc states `options.root` must be forward-slash (passed to `findDir` and the route model; normalized by the caller).

## Testing

- `vp check packages/vinext/src/cli.ts packages/vinext/src/build/run-prerender.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`normalizePathSeparators` returns its input). On Windows `runPrerender` now receives a forward-slash `root`, so its `findDir` lookups and the route model resolve as on POSIX; behavior-preserving, hence `refactor`.
