### PR TITLE
fix(pages-router): split scanned file paths on forward slashes

### DIFF
--- a/packages/vinext/src/routing/pages-router.ts
+++ b/packages/vinext/src/routing/pages-router.ts
@@ -101,8 +101,9 @@ function fileToRoute(file: string, pagesDir: string, matcher: ValidFileMatcher):
   const withoutExt = matcher.stripExtension(file);
   if (withoutExt === file) return null;
 
-  // Convert to URL segments
-  const segments = withoutExt.split(path.sep);
+  // Convert to URL segments. `file` comes from `scanWithExtensions`, which
+  // yields forward-slash paths on every platform, so split on "/".
+  const segments = withoutExt.split("/");
 
   // Handle index files: pages/index.tsx -> /
   const lastSegment = segments[segments.length - 1];
@@ -230,8 +231,9 @@ async function scanApiRoutes(pagesDir: string, matcher: ValidFileMatcher): Promi
   const routes: Route[] = [];
 
   for (const file of files) {
-    // Reuse fileToRoute but pretend the file is under a virtual "api/" prefix
-    const route = fileToRoute(path.join("api", file), pagesDir, matcher);
+    // Reuse fileToRoute but pretend the file is under a virtual "api/" prefix.
+    // Use path.posix.join to keep the forward-slash form `fileToRoute` expects.
+    const route = fileToRoute(path.posix.join("api", file), pagesDir, matcher);
     if (route) {
       routes.push(route);
     }


### PR DESCRIPTION
## What

In the Pages Router scanner, consume the scanned file paths as forward-slash:

- `fileToRoute`: split the route path into segments on `"/"` instead of `path.sep`.
- `scanApiRoutes`: build the virtual `api/` prefix with `path.posix.join` instead of `path.join`.

## Why

`scanWithExtensions` yields forward-slash relative paths on every platform — it normalizes node's `glob` output, which is backslash on Windows. `fileToRoute` then split that path on `path.sep`, which is `\` on Windows, so `"posts/[id]".split("\\")` returned a single un-split segment: the URL pattern was computed from the whole path and routes like `/posts/:id` were never discovered. Pages Router route discovery was silently broken on Windows. `scanApiRoutes` had the mirror problem — `path.join("api", file)` reintroduced backslashes that `fileToRoute` then could not split. Both now use the forward-slash form that `scanWithExtensions` guarantees.

## How

- `withoutExt.split(path.sep)` → `withoutExt.split("/")`.
- `fileToRoute(path.join("api", file), …)` → `fileToRoute(path.posix.join("api", file), …)`.

## Testing

- `vp test run --project unit tests/routing.test.ts` — Pages Router discovery / matching cases pass again (failures drop from 28 to 15; the remaining are separate App Router / fixture root causes).
- `vp test run --project unit tests/route-sorting.test.ts` — 6 → 5 (the Pages Router sibling-dynamic case passes).
- `vp check packages/vinext/src/routing/pages-router.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.sep` === `"/"`, `path.posix.join` === `path.join`). Classified `fix` because it restores Pages Router route discovery on Windows, which the scanner's forward-slash output had broken.
