### PR TITLE
docs(routing): document findFileWithExts' forward-slash contract

### DIFF
--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -92,6 +92,9 @@ export function findFileWithExtensions(basePath: string, matcher: ValidFileMatch
 /**
  * Find a file by basename and configured page extension in a directory.
  * Returns the first matching absolute path, or null if not found.
+ *
+ * `dir` must be forward-slash. The returned path is built with `path.posix.join`,
+ * so it is forward-slash too.
  */
 export function findFileWithExts(
   dir: string,


### PR DESCRIPTION
## What

Add a note to the `findFileWithExts` doc comment: `dir` must be forward-slash, and because the candidate is built with `path.posix.join`, the returned path is forward-slash too.

## Why

`findFileWithExts` is the leaf that produces every route file path (layouts, pages, default/loading/error, slot pages). It joins `dir` with `path.posix.join`, which only yields a canonical forward-slash id when the base already is — a native (backslash) `dir` produces a mixed separator like `app\dashboard/layout.tsx` on Windows. Spelling the contract out makes the invariant explicit so every caller (`findFile` → `discoverLayouts`, `discoverParallelSlots`, the intercept discovery, etc.) knows it must pass a forward-slash `dir` and can rely on a forward-slash result.

## How

- Added the forward-slash precondition / return note to the `findFileWithExts` JSDoc.

## Testing

- `vp check packages/vinext/src/routing/file-matcher.ts` — format, lint, and typecheck clean.
- Comment only — no behavior change.
