### PR TITLE
docs(app-router): document findFile's forward-slash contract

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2696,6 +2696,9 @@ const findFileProbeCache = new WeakMap<ValidFileMatcher, Map<string, string | nu
  * registered per-scan cache; otherwise falls back to a direct probe (identical
  * result). The `null` "not found" outcome is cached too, so repeated misses on
  * shared ancestors cost a single set of `existsSync` calls per scan.
+ *
+ * `dir` must be forward-slash. The returned path comes from `findFileWithExts`,
+ * so it is forward-slash too.
  */
 function findFile(dir: string, name: string, matcher: ValidFileMatcher): string | null {
   const cache = findFileProbeCache.get(matcher);


### PR DESCRIPTION
## What

Add a note to the `findFile` doc comment: `dir` must be forward-slash, and since the result comes from `findFileWithExts`, the returned path is forward-slash too.

## Why

`findFile` is the caching wrapper every route-graph lookup goes through (layouts, pages, default/loading/error, slot pages). It delegates to `findFileWithExts`, which builds the path with `path.posix.join` and therefore inherits the same separator contract — a native (backslash) `dir` would yield a mixed separator like `app\dashboard/layout.tsx` on Windows. Carrying the contract onto `findFile` makes the invariant visible at the layer its callers actually use, so `discoverLayouts`, `discoverParallelSlots`, the intercept discovery, etc. know they must pass a forward-slash `dir` and can rely on a forward-slash result.

## How

- Added the forward-slash precondition / return note to the `findFile` JSDoc, mirroring the wording on `findFileWithExts`.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- Comment only — no behavior change.
