### PR TITLE
docs(app-router): document buildAppRouteGraph's forward-slash appDir contract

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -864,6 +864,13 @@ function createRouteManifestGraphVersion(segmentGraph: StaticSegmentGraph): Grap
   return `graph:${createHash("sha256").update(JSON.stringify(stableShape)).digest("hex")}`;
 }
 
+/**
+ * Build the App Router route graph by scanning `appDir`.
+ *
+ * `appDir` must be forward-slash. Every path in the graph is derived from it
+ * with `path.posix.*` and `findFile`, so a native appDir would produce mixed
+ * separators on Windows. Production callers normalize it at their entry.
+ */
 export async function buildAppRouteGraph(
   appDir: string,
   matcher: ValidFileMatcher,


### PR DESCRIPTION
## What

Add a doc comment to `buildAppRouteGraph` stating that `appDir` must be forward-slash.

## Why

`buildAppRouteGraph` is the entry to the App Router route-graph builder — tests call it directly and production reaches it through `appRouter` / `appRouteGraph`. Every path in the graph (pages, layouts, templates, slot pages, intercepts) is derived from `appDir` with `path.posix.*` and `findFile`, all of which only stay canonical when their base is forward-slash. A native (backslash) `appDir` would produce mixed separators like `app\dashboard/layout.tsx` on Windows. Production callers already normalize the root at their entry, so the contract is documented here rather than re-normalized inside the builder.

## How

- Added the JSDoc precondition: `appDir` must be forward-slash, derived paths use `path.posix.*` / `findFile`, and callers normalize at their entry.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- Comment only — no behavior change.
