### PR TITLE
docs(app-router): document directoryToAppRoute's forward-slash contract

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1452,10 +1452,11 @@ function fileToAppRoute(
 }
 
 /**
- * `dir` and `appDir` must both be forward-slash. `dir` is split on
- * `path.posix.sep` and joined onto `appDir` with `path.posix.join`, and `appDir`
- * is threaded to the layout/slot/boundary discovery below, which build paths the
- * same way.
+ * `dir`, `appDir`, `pagePath`, and `routePath` must all be forward-slash. `dir`
+ * is split on `path.posix.sep` and joined onto `appDir` with `path.posix.join`.
+ * `appDir` is threaded to the layout/slot/boundary discovery below, which builds
+ * paths the same way. `pagePath` and `routePath` are stored on the route node as
+ * canonical ids that get compared and re-joined downstream.
  */
 function directoryToAppRoute(
   dir: string,
@@ -1464,7 +1465,7 @@ function directoryToAppRoute(
   pagePath: string | null,
   routePath: string | null,
 ): AppRouteGraphRoute | null {
-  const segments = dir === "." ? [] : dir.split(path.posix.sep);
+  const segments = dir === "." ? [] : dir.split("/");
 
   const params: string[] = [];
   let isDynamic = false;


### PR DESCRIPTION
## What

Expand the `directoryToAppRoute` doc comment to cover all four path inputs — `dir`, `appDir`, `pagePath`, and `routePath` must be forward-slash — and split `dir` on the `"/"` literal instead of `path.posix.sep`.

## Why

The doc previously only named `dir` and `appDir`. `pagePath` and `routePath` are also path inputs: they are stored verbatim on the route node as canonical ids and then compared and re-joined downstream — e.g. `path.dirname(route.pagePath)` becomes the `parentPageDir` that is matched against a forward-slash `slot.ownerDir` and reused as a `findFile` base. A native (backslash) `pagePath` / `routePath` would break those comparisons and re-introduce mixed separators, so the contract belongs on all four. `dir` is split with `path.posix.sep`, which is exactly `"/"`; using the literal states the forward-slash assumption directly.

## How

- Doc comment now lists `dir`, `appDir`, `pagePath`, and `routePath` as forward-slash, noting how each is consumed.
- `dir.split(path.posix.sep)` → `dir.split("/")` (equivalent value, clearer intent).

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- `path.posix.sep` === `"/"` on every platform, so the split is unchanged; the rest is comment only. No behavior change.
