### PR TITLE
refactor(app-router): build fileToAppRoute paths with path.posix

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1419,6 +1419,11 @@ function findCatchAllPage(dir: string, matcher: ValidFileMatcher): string | null
 
 /**
  * Convert a file path relative to app/ into an AppRoute.
+ *
+ * `file` and `appDir` must be forward-slash. `file` comes from
+ * `scanWithExtensions` (already forward-slash) and is joined onto `appDir` with
+ * `path.posix.join` to form the page/route path, so a native input would
+ * produce a mixed separator on Windows.
  */
 function fileToAppRoute(
   file: string,
@@ -1427,7 +1432,7 @@ function fileToAppRoute(
   matcher: ValidFileMatcher,
 ): AppRouteGraphRoute | null {
   // Remove the filename (page.tsx or route.ts)
-  let dir = path.dirname(file);
+  let dir = path.posix.dirname(file);
 
   // `@children` is transparent in routing: `app/foo/@children/page.tsx`
   // provides the children prop for `/foo` and registers a real page route
@@ -1437,8 +1442,8 @@ function fileToAppRoute(
   // layouts/boundaries are sourced from the parent. Mirrors Next.js'
   // `normalizeAppPath` which drops any `@` segment (including `@children`)
   // from the URL. See packages/next/src/shared/lib/router/utils/app-paths.ts.
-  if (type === "page" && dir !== "." && path.basename(dir) === "@children") {
-    const parent = path.dirname(dir);
+  if (type === "page" && dir !== "." && path.posix.basename(dir) === "@children") {
+    const parent = path.posix.dirname(dir);
     dir = parent === "" || parent === "." ? "." : parent;
   }
 
@@ -1446,8 +1451,8 @@ function fileToAppRoute(
     dir,
     appDir,
     matcher,
-    type === "page" ? path.join(appDir, file) : null,
-    type === "route" ? path.join(appDir, file) : null,
+    type === "page" ? path.posix.join(appDir, file) : null,
+    type === "route" ? path.posix.join(appDir, file) : null,
   );
 }
 


### PR DESCRIPTION
## What

Consume `file` / `appDir` with `path.posix.*` throughout `fileToAppRoute`, and document that both must be forward-slash:

- `path.dirname(file)` → `path.posix.dirname(file)`
- the `@children` handling: `path.basename(dir)` / `path.dirname(dir)` → `path.posix.*`
- the page/route path: `path.join(appDir, file)` → `path.posix.join(appDir, file)`

## Why

`file` comes from `scanWithExtensions` (already forward-slash) and `appDir` is forward-slash by the route-graph contract, so the page/route path stored on the node should stay a canonical forward-slash id. `path.join` is `path.win32.join` on Windows and would rebuild it with backslashes even from forward-slash inputs, so `path.posix.join` is required to keep `pagePath` / `routePath` forward-slash. `path.dirname` / `path.basename` are separator-preserving, so `path.posix.*` is equivalent for forward-slash input — it just states the POSIX space explicitly and keeps the function consistent.

## How

- Swapped the `path.dirname` / `path.basename` / `path.join` calls in `fileToAppRoute` for `path.posix.*`.
- Added a doc note: `file` and `appDir` must be forward-slash (`file` from `scanWithExtensions`, joined with `path.posix.join`).

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix` === `path`). On Windows, given the forward-slash `file` / `appDir`, `pagePath` / `routePath` are now forward-slash canonical ids instead of backslash; the `dirname` / `basename` results are unchanged. Behavior-preserving against the forward-slash contract, hence `refactor`.
