### PR TITLE
refactor(app-router): compute discoverParallelSlots owner segments and key with path.posix.relative

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2117,6 +2117,11 @@ function findSlotRootPage(slotDir: string, matcher: ValidFileMatcher): string | 
 /**
  * Discover parallel route slots (@team, @analytics, etc.) in a directory.
  * Returns a ParallelSlot for each @-prefixed subdirectory that has a page or default component.
+ *
+ * `dir` and `appDir` must be forward-slash. The slot directory is built from
+ * `dir` with `path.posix.join`, and the owner segments and slot key come from
+ * `path.posix.relative(appDir, …)`, which only yields a forward-slash relative
+ * path when both operands already are.
  */
 function discoverParallelSlots(
   dir: string,
@@ -2150,16 +2155,16 @@ function discoverParallelSlots(
     // Only include slots that have at least a page, default, or intercepting route
     if (!pagePath && !defaultPath && interceptingRoutes.length === 0) continue;
 
-    const ownerSegments = path
+    const ownerSegments = path.posix
       .relative(appDir, dir)
-      .split(path.sep)
+      .split("/")
       .filter((segment) => segment.length > 0);
     const ownerTreePath = createAppRouteGraphTreePath(ownerSegments, ownerSegments.length);
 
     const configLayoutPaths = findSlotConfigLayoutPaths(slotDir, pagePath, matcher);
     slots.push({
       id: createAppRouteGraphSlotId(slotName, ownerTreePath),
-      key: `${slotName}@${path.relative(appDir, slotDir).replace(/\\/g, "/")}`,
+      key: `${slotName}@${path.posix.relative(appDir, slotDir)}`,
       name: slotName,
       ownerDir: slotDir,
       ownerTreePath,


### PR DESCRIPTION
## What

In `discoverParallelSlots`, derive the owner segments and slot key with `path.posix.relative` instead of native `path.relative` + normalization, and document that `dir` / `appDir` must be forward-slash:

- `ownerSegments`: `path.relative(appDir, dir).split(path.sep)` → `path.posix.relative(appDir, dir).split("/")`.
- `key`: `path.relative(appDir, slotDir).replace(/\\/g, "/")` → `path.posix.relative(appDir, slotDir)`.

## Why

`appDir`, `dir`, and `slotDir` are forward-slash by the route-graph contract. `path.relative` is `path.win32.relative` on Windows, which always returns a backslash path regardless of its inputs — which is why the owner segments were split on `path.sep` and the key was wrapped in `.replace(/\\/g, "/")`. With forward-slash operands, `path.posix.relative` produces the forward-slash relative path directly, so the segment split can use `"/"` and the key no longer needs the normalization pass. Same result, without the native-then-normalize dance.

## How

- `ownerSegments` uses `path.posix.relative(appDir, dir)` and splits on `"/"`.
- `key` uses `path.posix.relative(appDir, slotDir)` and drops the `.replace`.
- Doc note: `dir` / `appDir` must be forward-slash, slot dir built with `path.posix.join`, owner segments / key from `path.posix.relative`.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix.relative` === `path.relative`, `path.sep` === `"/"`). On Windows, given the forward-slash `appDir` / `dir` / `slotDir`, the owner segments and key are identical to the previous normalized result. Behavior-preserving, hence `refactor`.
