### PR TITLE
docs(app-router): document discoverInterceptingRoutes' forward-slash contract

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2210,6 +2210,10 @@ function isInterceptionMarkerDir(name: string): boolean {
  * Intercepting routes use conventions like (.)photo, (..)feed, (...), etc.
  * They intercept navigation to another route and render within the slot instead.
  *
+ * `slotDir`, `routeDir`, and `appDir` must be forward-slash. They are passed
+ * down to `path.posix.join` and `path.posix.relative` when building the
+ * intercept page paths and target patterns.
+ *
  * @param slotDir - The parallel slot directory (e.g. app/feed/@modal)
  * @param routeDir - The directory of the route that owns this slot (e.g. app/feed)
  * @param appDir - The root app directory


### PR DESCRIPTION
## What

Add a note to the `discoverInterceptingRoutes` doc comment: `slotDir`, `routeDir`, and `appDir` must be forward-slash.

## Why

`discoverInterceptingRoutes` threads all three directories down to `scanForInterceptingPages` / `collectInterceptingPages`, which build the intercept page paths with `path.posix.join` and the target / source-match patterns with `path.posix.relative`. Those only stay canonical when their inputs are forward-slash, so a native (backslash) directory would yield mixed-separator intercept paths on Windows. Documenting the precondition keeps the contract consistent with the other route-graph discovery functions.

## How

- Added the forward-slash precondition sentence to the `discoverInterceptingRoutes` JSDoc, above the existing `@param` list.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- Comment only — no behavior change.
