### PR TITLE
refactor(app-router): descend scanForInterceptingPages with path.posix.join

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2375,6 +2375,10 @@ export function findOwnerRouteForDir(
 /**
  * Recursively scan a directory tree for page.tsx files that are inside
  * intercepting route directories.
+ *
+ * `currentDir`, `routeDir`, and `appDir` must be forward-slash. `currentDir`
+ * descends with `path.posix.join` and all three reach the `path.posix.join` /
+ * `path.posix.relative` calls that build the intercept page paths and patterns.
  */
 function scanForInterceptingPages(
   currentDir: string,
@@ -2394,12 +2398,12 @@ function scanForInterceptingPages(
 
     // Check if this directory name starts with an interception convention
     const interceptMatch = matchInterceptConvention(entry.name);
+    const interceptDir = path.posix.join(currentDir, entry.name);
 
     if (interceptMatch) {
       // This directory is the start of an intercepting route
       // e.g. "(.)photos" means intercept same-level "photos" route
       const restOfName = entry.name.slice(interceptMatch.prefix.length);
-      const interceptDir = path.join(currentDir, entry.name);
 
       // Find page files within this intercepting directory tree.
       // `currentDir` is the *parent* of the marker dir — used by
@@ -2418,13 +2422,7 @@ function scanForInterceptingPages(
       );
     } else {
       // Regular subdirectory — keep scanning for intercepting dirs
-      scanForInterceptingPages(
-        path.join(currentDir, entry.name),
-        routeDir,
-        appDir,
-        results,
-        matcher,
-      );
+      scanForInterceptingPages(interceptDir, routeDir, appDir, results, matcher);
     }
   }
 }


### PR DESCRIPTION
## What

In `scanForInterceptingPages`, hoist the child directory join and make it `path.posix.join`, and document that `currentDir` / `routeDir` / `appDir` must be forward-slash:

- `const interceptDir = path.posix.join(currentDir, entry.name)` is computed once and reused by both the intercept-marker branch and the recursive scan.
- The two previous `path.join(currentDir, entry.name)` calls are removed.

## Why

`currentDir` is forward-slash by the route-graph contract, and the scan descends it recursively, so the join must keep it forward-slash. `path.join` is `path.win32.join` on Windows and would rebuild the child path with backslashes, which the intercept page lookups (`findFile` / `path.posix.join`) would then turn into mixed separators. `path.posix.join` keeps the descent canonical. Both branches were joining `currentDir` + `entry.name` independently, so computing it once removes the duplication.

## How

- Hoisted `interceptDir` out of the marker branch, switched it to `path.posix.join`, and reused it in the recursive `scanForInterceptingPages` call.
- Added a doc note: `currentDir` / `routeDir` / `appDir` must be forward-slash.

## Testing

- `vp check packages/vinext/src/routing/app-route-graph.ts` — format, lint, and typecheck clean.
- No-op on POSIX (`path.posix.join` === `path.join`). On Windows the recursive descent stays forward-slash given a forward-slash `currentDir`; the join value is otherwise unchanged. Behavior-preserving, hence `refactor`.
