### PR TITLE
fix(image): match App Router deploy parity

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -189,13 +189,16 @@ export type NextConfig = {
   headers?: () => Promise<NextHeader[]> | NextHeader[];
   /** Image optimization config */
   images?: {
-    remotePatterns?: Array<{
-      protocol?: string;
-      hostname: string;
-      port?: string;
-      pathname?: string;
-      search?: string;
-    }>;
+    remotePatterns?: Array<
+      | URL
+      | {
+          protocol?: string;
+          hostname: string;
+          port?: string;
+          pathname?: string;
+          search?: string;
+        }
+    >;
     domains?: string[];
     unoptimized?: boolean;
     /** Allowed device widths for image optimization. Defaults to Next.js defaults: [640, 750, 828, 1080, 1200, 1920, 2048, 3840] */
@@ -1642,6 +1645,23 @@ export async function resolveNextConfig(
     };
   }
 
+  const images = config.images
+    ? {
+        ...config.images,
+        remotePatterns: config.images.remotePatterns?.map((pattern) =>
+          pattern instanceof URL
+            ? {
+                protocol: pattern.protocol.slice(0, -1),
+                hostname: pattern.hostname,
+                port: pattern.port,
+                pathname: pattern.pathname,
+                search: pattern.search,
+              }
+            : { ...pattern },
+        ),
+      }
+    : undefined;
+
   const resolved: ResolvedNextConfig = {
     env: config.env ?? {},
     basePath: config.basePath ?? "",
@@ -1663,7 +1683,7 @@ export async function resolveNextConfig(
     redirects,
     rewrites,
     headers,
-    images: config.images,
+    images,
     i18n,
     mdx,
     aliases,

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -119,7 +119,7 @@ export function parseImageParams(
   // Intentional hardening divergence from Next.js: reject duplicate and unknown
   // parameters so semantically identical transforms cannot occupy distinct
   // cache keys and amplify image transformation work.
-  const allowedParamNames = new Set(["url", "w", "q"]);
+  const allowedParamNames = new Set(["url", "w", "q", "dpl"]);
   for (const name of url.searchParams.keys()) {
     if (!allowedParamNames.has(name) || url.searchParams.getAll(name).length !== 1) return null;
   }

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -337,8 +337,7 @@ function preloadImageResource(input: {
  * Generate a srcSet string for responsive images.
  *
  * Each width points to the `/_next/image` optimization endpoint so the
- * server can resize and transcode the image. Only includes widths that are
- * <= 2x the original image width to avoid pointless upscaling.
+ * server can resize and transcode the image.
  */
 function getImageWidths(width: number): number[] {
   return [
@@ -359,10 +358,17 @@ function generateImageAttributes(
   sizes?: string,
 ): { src: string; srcSet: string } {
   if (sizes) {
-    const widths = RESPONSIVE_WIDTHS.filter((candidateWidth) => candidateWidth <= width * 2);
-    const candidates = widths.length > 0 ? widths : [width];
+    const viewportWidthPattern = /(^|\s)(1?\d?\d)vw/g;
+    const viewportPercentages = Array.from(sizes.matchAll(viewportWidthPattern), (match) =>
+      Number.parseInt(match[2], 10),
+    );
+    const minimumWidth =
+      viewportPercentages.length > 0
+        ? RESPONSIVE_WIDTHS[0] * (Math.min(...viewportPercentages) * 0.01)
+        : 0;
+    const candidates = ALL_IMAGE_WIDTHS.filter((candidateWidth) => candidateWidth >= minimumWidth);
     return {
-      src: imageOptimizationUrl(src, width, quality),
+      src: imageOptimizationUrl(src, candidates[candidates.length - 1], quality),
       srcSet: candidates
         .map(
           (candidateWidth) =>

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -15,6 +15,7 @@
 import React, { forwardRef, useEffect, useLayoutEffect, useRef, useState } from "react";
 import * as ReactDOM from "react-dom";
 import { Image as UnpicImage } from "@unpic/react";
+import { getDeploymentId } from "../utils/deployment-id.js";
 import { hasRemoteMatch, isPrivateIp, type RemotePattern } from "./image-config.js";
 import { useMergedRef } from "./use-merged-ref.js";
 
@@ -52,6 +53,13 @@ const __imageDeviceSizes: number[] = (() => {
     );
   } catch {
     return [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
+  }
+})();
+const __imageSizes: number[] = (() => {
+  try {
+    return JSON.parse(process.env.__VINEXT_IMAGE_SIZES ?? "[16,32,48,64,96,128,256,384]");
+  } catch {
+    return [16, 32, 48, 64, 96, 128, 256, 384];
   }
 })();
 /**
@@ -269,7 +277,30 @@ function resolveImageSource(v: {
  * These are the breakpoints used for srcSet generation.
  * Configurable via `images.deviceSizes` in next.config.js.
  */
-const RESPONSIVE_WIDTHS = __imageDeviceSizes;
+const RESPONSIVE_WIDTHS = [...__imageDeviceSizes].sort((left, right) => left - right);
+const ALL_IMAGE_WIDTHS = [...RESPONSIVE_WIDTHS, ...__imageSizes].sort(
+  (left, right) => left - right,
+);
+
+function extractLocalDeploymentId(src: string): { src: string; deploymentId?: string } {
+  let deploymentId = getDeploymentId();
+  if (!src.startsWith("/") || src.startsWith("//")) return { src, deploymentId };
+
+  const queryIndex = src.indexOf("?");
+  if (queryIndex === -1) return { src, deploymentId };
+
+  const params = new URLSearchParams(src.slice(queryIndex + 1));
+  const sourceDeploymentId = params.get("dpl");
+  if (!sourceDeploymentId) return { src, deploymentId };
+
+  deploymentId = sourceDeploymentId;
+  params.delete("dpl");
+  const remainingQuery = params.toString();
+  return {
+    src: src.slice(0, queryIndex) + (remainingQuery ? `?${remainingQuery}` : ""),
+    deploymentId,
+  };
+}
 
 /**
  * Build a `/_next/image` optimization URL.
@@ -279,7 +310,10 @@ const RESPONSIVE_WIDTHS = __imageDeviceSizes;
  * server handles it as a passthrough (serves the original file).
  */
 export function imageOptimizationUrl(src: string, width: number, quality: number = 75): string {
-  return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${quality}`;
+  const source = extractLocalDeploymentId(src);
+  const deploymentQuery =
+    source.src.startsWith("/") && source.deploymentId ? `&dpl=${source.deploymentId}` : "";
+  return `/_next/image?url=${encodeURIComponent(source.src)}&w=${width}&q=${quality}${deploymentQuery}`;
 }
 
 function preloadImageResource(input: {
@@ -306,11 +340,48 @@ function preloadImageResource(input: {
  * server can resize and transcode the image. Only includes widths that are
  * <= 2x the original image width to avoid pointless upscaling.
  */
-function generateSrcSet(src: string, originalWidth: number, quality: number = 75): string {
-  const widths = RESPONSIVE_WIDTHS.filter((w) => w <= originalWidth * 2);
-  if (widths.length === 0)
-    return `${imageOptimizationUrl(src, originalWidth, quality)} ${originalWidth}w`;
-  return widths.map((w) => `${imageOptimizationUrl(src, w, quality)} ${w}w`).join(", ");
+function getImageWidths(width: number): number[] {
+  return [
+    ...new Set(
+      [width, width * 2].map(
+        (targetWidth) =>
+          ALL_IMAGE_WIDTHS.find((configuredWidth) => configuredWidth >= targetWidth) ??
+          ALL_IMAGE_WIDTHS[ALL_IMAGE_WIDTHS.length - 1],
+      ),
+    ),
+  ];
+}
+
+function generateImageAttributes(
+  src: string,
+  width: number,
+  quality: number = 75,
+  sizes?: string,
+): { src: string; srcSet: string } {
+  if (sizes) {
+    const widths = RESPONSIVE_WIDTHS.filter((candidateWidth) => candidateWidth <= width * 2);
+    const candidates = widths.length > 0 ? widths : [width];
+    return {
+      src: imageOptimizationUrl(src, width, quality),
+      srcSet: candidates
+        .map(
+          (candidateWidth) =>
+            `${imageOptimizationUrl(src, candidateWidth, quality)} ${candidateWidth}w`,
+        )
+        .join(", "),
+    };
+  }
+
+  const widths = getImageWidths(width);
+  return {
+    src: imageOptimizationUrl(src, widths[widths.length - 1], quality),
+    srcSet: widths
+      .map(
+        (candidateWidth, index) =>
+          `${imageOptimizationUrl(src, candidateWidth, quality)} ${index + 1}x`,
+      )
+      .join(", "),
+  };
 }
 
 const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
@@ -649,21 +720,24 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
 
   // Build srcSet for responsive local images (common breakpoints).
   // Each entry points to /_next/image with the appropriate width.
-  const srcSet =
+  const optimizedAttributes =
     imgWidth && !fill && !skipOptimization
-      ? generateSrcSet(src, imgWidth, imgQuality)
-      : imgWidth && !fill
-        ? RESPONSIVE_WIDTHS.filter((w) => w <= imgWidth * 2)
-            .map((w) => `${src} ${w}w`)
-            .join(", ") || `${src} ${imgWidth}w`
-        : undefined;
+      ? generateImageAttributes(src, imgWidth, imgQuality, sizes)
+      : undefined;
+  const srcSet = optimizedAttributes
+    ? optimizedAttributes.srcSet
+    : imgWidth && !fill
+      ? RESPONSIVE_WIDTHS.filter((w) => w <= imgWidth * 2)
+          .map((w) => `${src} ${w}w`)
+          .join(", ") || `${src} ${imgWidth}w`
+      : undefined;
 
   // The main `src` also goes through the optimization endpoint. Use the
   // declared width (or the first responsive width as fallback).
   const optimizedSrc = skipOptimization
     ? src
-    : imgWidth
-      ? imageOptimizationUrl(src, imgWidth, imgQuality)
+    : optimizedAttributes
+      ? optimizedAttributes.src
       : imageOptimizationUrl(src, RESPONSIVE_WIDTHS[0], imgQuality);
 
   // Blur placeholder: show a low-quality background while the image loads.
@@ -809,17 +883,18 @@ export function getImageProps(props: ImageProps): {
   const isSvg = isSvgUrl(resolvedSrc);
   const skipOpt =
     (isSvg && !__dangerouslyAllowSVG) || blockedInProd || !!loader || isRemoteUrl(resolvedSrc);
+  const optimizedAttributes =
+    imgWidth && !fill && !skipOpt
+      ? generateImageAttributes(resolvedSrc, imgWidth, imgQuality, sizes)
+      : null;
   const optimizedSrc = skipOpt
     ? resolvedSrc
-    : imgWidth
-      ? imageOptimizationUrl(resolvedSrc, imgWidth, imgQuality)
+    : optimizedAttributes
+      ? optimizedAttributes.src
       : imageOptimizationUrl(resolvedSrc, RESPONSIVE_WIDTHS[0], imgQuality);
 
   // Build srcSet for local images — each width points to /_next/image
-  const srcSet =
-    imgWidth && !fill && !isRemoteUrl(resolvedSrc) && !loader && !skipOpt
-      ? generateSrcSet(resolvedSrc, imgWidth, imgQuality)
-      : undefined;
+  const srcSet = optimizedAttributes?.srcSet;
 
   // Blur placeholder styles — sanitize to prevent CSS injection
   const sanitizedBlurURL = imgBlurDataURL ? sanitizeBlurDataURL(imgBlurDataURL) : undefined;

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -17,6 +17,10 @@ import Image, { getImageProps, type StaticImageData } from "../packages/vinext/s
 function optUrl(src: string, w: number, q = 75): string {
   return `/_next/image?url=${encodeURIComponent(src)}&w=${w}&q=${q}`;
 }
+
+function deployedOptUrl(src: string, w: number, q: number, deploymentId: string): string {
+  return `${optUrl(src, w, q)}&dpl=${deploymentId}`;
+}
 /** Same as optUrl but with HTML entity encoding (for SSR output assertions). */
 function optUrlHtml(src: string, w: number, q = 75): string {
   return optUrl(src, w, q).replace(/&/g, "&amp;");
@@ -36,6 +40,13 @@ describe("default loader emits /_next/image URLs (issue #1513)", () => {
     expect(url).toContain("url=%2Fphoto.png");
     expect(url).toContain("w=828");
     expect(url).toContain("q=85");
+  });
+
+  it("keeps the deployment ID outside the optimized source URL", async () => {
+    const { imageOptimizationUrl } = await import("../packages/vinext/src/shims/image.js");
+    expect(imageOptimizationUrl("/_next/static/media/test.hash.png?dpl=deploy-1", 828, 85)).toBe(
+      deployedOptUrl("/_next/static/media/test.hash.png", 828, 85, "deploy-1"),
+    );
   });
 
   it("Image SSR src starts with /_next/image, not /_vinext/image", () => {
@@ -66,7 +77,7 @@ describe("Image SSR rendering", () => {
     );
     expect(html).toContain('alt="a nice image"');
     // Local images are routed through the optimization endpoint
-    expect(html).toContain(`src="${optUrlHtml("/test.png", 100)}"`);
+    expect(html).toContain(`src="${optUrlHtml("/test.png", 256)}"`);
     expect(html).toContain('width="100"');
     expect(html).toContain('height="100"');
     expect(html).toContain('decoding="async"');
@@ -90,7 +101,8 @@ describe("Image SSR rendering", () => {
     expect(html).toContain('<link rel="preload"');
     expect(html).toContain('as="image"');
     expect(html).toContain('fetchPriority="high"');
-    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero.png", 640)} 640w`);
+    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero.png", 828)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/hero.png", 1920)} 2x`);
     expect(html).not.toContain(`href="${optUrlHtml("/hero.png", 800)}"`);
     expect(html).toContain('loading="eager"');
     expect(html).toContain('fetchPriority="high"');
@@ -109,7 +121,8 @@ describe("Image SSR rendering", () => {
     );
     expect(html).toContain('<link rel="preload"');
     expect(html).toContain('as="image"');
-    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero-preload.png", 640)} 640w`);
+    expect(html).toContain(`imageSrcSet="${optUrlHtml("/hero-preload.png", 828)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/hero-preload.png", 1920)} 2x`);
     expect(html).not.toContain('loading="lazy"');
     expect(html).not.toContain('fetchPriority="high"');
   });
@@ -166,6 +179,8 @@ describe("Image SSR rendering", () => {
       }),
     );
     expect(html).toContain('sizes="(max-width: 768px) 100vw, 50vw"');
+    expect(html).toContain(`${optUrlHtml("/img.png", 640)} 640w`);
+    expect(html).not.toContain(`${optUrlHtml("/img.png", 640)} 1x`);
   });
 
   it("renders with blur placeholder styles", () => {
@@ -214,7 +229,7 @@ describe("Image SSR rendering", () => {
         placeholder: "blur",
       }),
     );
-    expect(html).toContain(`src="${optUrlHtml("/_next/static/media/test.abc123.png", 800)}"`);
+    expect(html).toContain(`src="${optUrlHtml("/_next/static/media/test.abc123.png", 1920)}"`);
 
     expect(html).toContain('width="800"');
     expect(html).toContain('height="600"');
@@ -278,7 +293,27 @@ describe("Image SSR rendering", () => {
 // ─── srcSet generation ──────────────────────────────────────────────────
 
 describe("Image srcSet generation", () => {
-  it("generates srcSet for local images with width", () => {
+  // Ported from Next.js: test/e2e/app-dir/next-image/next-image.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-image/next-image.test.ts
+  it("uses fixed-image x descriptors for a 400px static import", () => {
+    const src = "/_next/static/media/test.hash.png?dpl=deploy-1";
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Image, {
+        alt: "static import",
+        src: { src, width: 400, height: 400 },
+        quality: 85,
+      }),
+    );
+
+    expect(html).toContain(
+      `src="${deployedOptUrl("/_next/static/media/test.hash.png", 828, 85, "deploy-1").replaceAll("&", "&amp;")}"`,
+    );
+    expect(html).toContain(
+      `${deployedOptUrl("/_next/static/media/test.hash.png", 640, 85, "deploy-1").replaceAll("&", "&amp;")} 1x, ${deployedOptUrl("/_next/static/media/test.hash.png", 828, 85, "deploy-1").replaceAll("&", "&amp;")} 2x`,
+    );
+  });
+
+  it("generates fixed-size 1x and 2x srcSet entries", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
         alt: "test",
@@ -287,12 +322,9 @@ describe("Image srcSet generation", () => {
         height: 400,
       }),
     );
-    // RESPONSIVE_WIDTHS = [640, 750, 828, 1080, 1200, 1920, 2048, 3840]
-    // Filter: widths <= 500 * 2 = 1000 → [640, 750, 828]
     expect(html).toContain("srcSet");
-    expect(html).toContain(`${optUrlHtml("/photo.png", 640)} 640w`);
-    expect(html).toContain(`${optUrlHtml("/photo.png", 750)} 750w`);
-    expect(html).toContain(`${optUrlHtml("/photo.png", 828)} 828w`);
+    expect(html).toContain(`${optUrlHtml("/photo.png", 640)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/photo.png", 1080)} 2x`);
     // Should not include widths > 1000
     expect(html).not.toContain("1080w");
   });
@@ -306,12 +338,11 @@ describe("Image srcSet generation", () => {
         height: 1500,
       }),
     );
-    // widths <= 4000: all of them
-    expect(html).toContain(`${optUrlHtml("/large.png", 640)} 640w`);
-    expect(html).toContain(`${optUrlHtml("/large.png", 3840)} 3840w`);
+    expect(html).toContain(`${optUrlHtml("/large.png", 2048)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/large.png", 3840)} 2x`);
   });
 
-  it("generates fallback srcSet for very small images", () => {
+  it("uses Next.js default image sizes for small fixed images", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Image, {
         alt: "tiny",
@@ -320,9 +351,8 @@ describe("Image srcSet generation", () => {
         height: 16,
       }),
     );
-    // widths <= 32: none of RESPONSIVE_WIDTHS qualify
-    // Falls back to single: optimized icon.png at 16w
-    expect(html).toContain(`${optUrlHtml("/icon.png", 16)} 16w`);
+    expect(html).toContain(`${optUrlHtml("/icon.png", 16)} 1x`);
+    expect(html).toContain(`${optUrlHtml("/icon.png", 32)} 2x`);
   });
 
   it("does not generate srcSet for fill mode", () => {
@@ -350,7 +380,7 @@ describe("getImageProps", () => {
     });
 
     expect(props.alt).toBe("a nice desc");
-    expect(props.src).toBe(optUrl("/test.png", 100));
+    expect(props.src).toBe(optUrl("/test.png", 256));
     expect(props.width).toBe(100);
     expect(props.height).toBe(200);
     expect(props.loading).toBe("lazy");
@@ -453,7 +483,7 @@ describe("getImageProps", () => {
       src: staticImage,
     });
 
-    expect(props.src).toBe(optUrl("/static/photo.png", 1920));
+    expect(props.src).toBe(optUrl("/static/photo.png", 3840));
     expect(props.width).toBe(1920);
     expect(props.height).toBe(1080);
   });

--- a/tests/image-optimization-parity.test.ts
+++ b/tests/image-optimization-parity.test.ts
@@ -158,5 +158,21 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
   });
 }
 
+describe("image deployment query parity", () => {
+  it("accepts Next.js deployment IDs without including them in the source path", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    const requestUrl = new URL(
+      "http://vinext.test/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.hash.png&w=828&q=85&dpl=deploy-1",
+    );
+
+    expect(parseImageParams(requestUrl)).toEqual({
+      imageUrl: "/_next/static/media/test.hash.png",
+      width: 828,
+      quality: 85,
+    });
+  });
+});
+
 runLocalImageUrlParitySuite("app");
 runLocalImageUrlParitySuite("pages");

--- a/tests/image-optimization-parity.test.ts
+++ b/tests/image-optimization-parity.test.ts
@@ -121,7 +121,7 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
 
       expect(imageUrl.pathname).toBe("/_next/image");
       expect(imageUrl.searchParams.get("url")).toBe("/äöüščří.png");
-      expect(imageUrl.searchParams.get("w")).toBe("64");
+      expect(imageUrl.searchParams.get("w")).toBe("128");
       expect(imageUrl.searchParams.get("q")).toBe("75");
 
       const res = await fetch(imageUrl);
@@ -138,7 +138,7 @@ function runLocalImageUrlParitySuite(router: "app" | "pages"): void {
 
       expect(imageUrl.pathname).toBe("/_next/image");
       expect(imageUrl.searchParams.get("url")).toBe("/hello world.png");
-      expect(imageUrl.searchParams.get("w")).toBe("64");
+      expect(imageUrl.searchParams.get("w")).toBe("128");
       expect(imageUrl.searchParams.get("q")).toBe("75");
 
       const res = await fetch(imageUrl);

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -901,6 +901,32 @@ describe("loadNextConfig with tsconfig path aliases", () => {
   });
 });
 
+describe("resolveNextConfig image patterns", () => {
+  it("normalizes URL remote patterns for runtime serialization", async () => {
+    const config = await resolveNextConfig(
+      {
+        images: {
+          remotePatterns: [new URL("https://image-optimization-test.vercel.app/**")],
+        },
+      },
+      "/tmp/project",
+    );
+
+    expect(config.images?.remotePatterns).toEqual([
+      {
+        protocol: "https",
+        hostname: "image-optimization-test.vercel.app",
+        port: "",
+        pathname: "/**",
+        search: "",
+      },
+    ]);
+    expect(JSON.parse(JSON.stringify(config.images?.remotePatterns))).toEqual(
+      config.images?.remotePatterns,
+    );
+  });
+});
+
 describe("resolveNextConfig alias extraction", () => {
   it("prefers turbopack resolveExtensions and falls back to webpack extensions", async () => {
     const fallback = await resolveNextConfig({

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18226,6 +18226,22 @@ describe("next/image enhancements", () => {
     expect(result.props.srcSet).toContain("w");
   });
 
+  it("getImageProps uses Next.js width candidates for responsive sizes", async () => {
+    const { getImageProps } = await import("../packages/vinext/src/shims/image.js");
+    const result = getImageProps({
+      src: "/photo.jpg",
+      alt: "Responsive",
+      width: 500,
+      height: 300,
+      sizes: "(max-width: 768px) 100vw, 50vw",
+    });
+
+    expect(result.props.src).toContain("w=3840");
+    expect(result.props.srcSet).toContain("w=384");
+    expect(result.props.srcSet).toContain("w=3840");
+    expect(result.props.srcSet).not.toContain("w=256");
+  });
+
   it("getImageProps does not generate srcSet for fill images", async () => {
     const { getImageProps } = await import("../packages/vinext/src/shims/image.js");
     const result = getImageProps({

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18179,7 +18179,7 @@ describe("next/image enhancements", () => {
     // Local images now route through the optimization endpoint
     expect(result.props.src).toContain("/_next/image");
     expect(result.props.src).toContain("url=%2Fphoto.jpg");
-    expect(result.props.src).toContain("w=800");
+    expect(result.props.src).toContain("w=1920");
     expect(result.props.alt).toBe("Test");
     expect(result.props.width).toBe(800);
     expect(result.props.height).toBe(600);
@@ -18206,7 +18206,7 @@ describe("next/image enhancements", () => {
     });
     expect(result.props.src).toContain("/_next/image");
     expect(result.props.src).toContain("url=%2Fimported.jpg");
-    expect(result.props.src).toContain("w=1200");
+    expect(result.props.src).toContain("w=3840");
     expect(result.props.width).toBe(1200);
     expect(result.props.height).toBe(800);
   });

--- a/tests/static-image-emission.test.ts
+++ b/tests/static-image-emission.test.ts
@@ -347,13 +347,14 @@ async function assertStaticImageProductionParity(
     const src = getAttribute(html, id, "src");
     const srcset = getAttribute(html, id, "srcset");
     const managedUrl = `${effectiveAssetPrefix}/_next/static/media/${expectedImage}`;
-    const managedSourceUrl = options.deploymentId
-      ? `${managedUrl}?dpl=${options.deploymentId}`
-      : managedUrl;
-    expect(new URL(src, "http://vinext.test").searchParams.get("url")).toBe(managedSourceUrl);
+    expect(new URL(src, "http://vinext.test").searchParams.get("url")).toBe(managedUrl);
+    expect(new URL(src, "http://vinext.test").searchParams.get("dpl")).toBe(
+      options.deploymentId ?? null,
+    );
     expect(src).toContain("q=85");
     expect(src).not.toContain("data%3Aimage");
-    expect(srcset).toContain(`url=${encodeURIComponent(managedSourceUrl)}`);
+    expect(srcset).toContain(`url=${encodeURIComponent(managedUrl)}`);
+    if (options.deploymentId) expect(srcset).toContain(`dpl=${options.deploymentId}`);
     expect(srcset).not.toContain("data%3Aimage");
   }
 


### PR DESCRIPTION
## Summary
- preserve deployment IDs as optimizer query parameters for static images
- generate valid fixed-size `1x`/`2x` srcsets from configured Next.js widths
- normalize URL-form `remotePatterns` before config serialization

## Next.js parity
Fixes all 10 failures in `test/e2e/app-dir/next-image/next-image.test.ts` from run 28143992598.

## Validation
- exact targeted Next.js deploy suite: 10/10 passed, concurrency 1
- 65 image component tests
- focused config, optimizer, and static emission tests
- scoped checks and package build
- independent review: no actionable findings

Full suites are deferred to CI.
