### PR TITLE
fix(cache): keep updateTag misuse catchable

### DIFF
--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -162,7 +162,7 @@ export function refresh(): void {
  *
  * @see https://nextjs.org/docs/app/api-reference/functions/updateTag
  */
-export async function updateTag(tag: string): Promise<void> {
+export function updateTag(tag: string): Promise<void> {
   if (getHeadersAccessPhase() !== "action") {
     throw new Error(
       "updateTag can only be called from within a Server Action. " +
@@ -172,7 +172,7 @@ export async function updateTag(tag: string): Promise<void> {
   }
   markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Expire the tag immediately (same as revalidateTag without SWR)
-  await _invalidateEncodedTag(encodeCacheTag(tag));
+  return _invalidateEncodedTag(encodeCacheTag(tag));
 }
 
 /**

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -789,6 +789,19 @@ describe("App Router Production server (startProdServer)", () => {
     expect(json).toHaveProperty("message");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-static/app-static.test.ts
+  it("lets route handlers synchronously catch updateTag errors without crashing", async () => {
+    const res = await fetch(`${baseUrl}/nextjs-compat/api/update-tag-error`);
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining("updateTag can only be called from within a Server Action"),
+    });
+
+    const healthRes = await fetch(`${baseUrl}/api/hello`);
+    expect(healthRes.status).toBe(200);
+  });
+
   it("runs an exact API middleware matcher for a trailing-slash route handler request", async () => {
     const res = await fetch(`${baseUrl}/api/header-override-delete/`);
 

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/update-tag-error/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/update-tag-error/route.ts
@@ -1,0 +1,16 @@
+import { updateTag } from "next/cache";
+import { NextResponse } from "next/server";
+
+export function GET() {
+  try {
+    updateTag("test-tag");
+    return NextResponse.json({ error: "Should not reach here" });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4830,7 +4830,7 @@ describe("next/cache shim", () => {
     // Simulate a route handler phase
     const previousPhase = setHeadersAccessPhase("route-handler");
     try {
-      await expect(updateTag("some-tag")).rejects.toThrow(
+      expect(() => updateTag("some-tag")).toThrow(
         /updateTag can only be called from within a Server Action/,
       );
     } finally {
@@ -4844,7 +4844,7 @@ describe("next/cache shim", () => {
 
     const previousPhase = setHeadersAccessPhase("render");
     try {
-      await expect(updateTag("some-tag")).rejects.toThrow(
+      expect(() => updateTag("some-tag")).toThrow(
         /updateTag can only be called from within a Server Action/,
       );
     } finally {


### PR DESCRIPTION
## Summary
- throw `updateTag()` invalid-context errors synchronously
- keep valid Server Action invalidation asynchronous and awaitable
- prevent caught Route Handler misuse from terminating the deployed server

## Next.js parity
Fixes the server crash behind the connection-refused failures in `test/e2e/app-dir/app-static/app-static.test.ts` from run 28143992598.

## Validation
- focused cache shim tests
- production Route Handler health regression
- targeted Next.js Route Handler and later Server Action assertions passed, concurrency 1
- scoped checks and package build
- independent review: no actionable findings

Full suites are deferred to CI.
