### PR TITLE
fix(config): encode destination query params

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1153,9 +1153,10 @@ function substituteDestinationParams(destination: string, params: Record<string,
 
   return destination.replace(
     paramRe,
-    (_token, key: string, _modifier: string | undefined, offset: number) => {
+    (_token, key: string, modifier: string | undefined, offset: number) => {
       if (!isDestinationQueryOffset(destination, offset)) return params[key];
-      return encodeURIComponent(params[key]);
+      const encoded = encodeURIComponent(params[key]);
+      return modifier === "*" || modifier === "+" ? encoded.replace(/%2F/gi, "/") : encoded;
     },
   );
 }

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1127,9 +1127,12 @@ export function matchesRewriteSource(
  * Substitute all matched route params into a redirect/rewrite destination.
  *
  * Handles repeated params (e.g. `/api/:id/:id`) and catch-all suffix forms
- * (`:path*`, `:path+`) in a single pass. Params interpolated anywhere in the
- * query component are URI-encoded so decoded separators cannot create new
- * query keys or values. Unknown params are left intact.
+ * (`:path*`, `:path+`) in a single pass. Vinext matches config routes against
+ * an already-decoded pathname, unlike Next.js's config-route matcher which
+ * retains encoded source captures through destination interpolation. Re-encode
+ * params used in the query component so `%26` and `%3D` retain the same wire
+ * representation instead of becoming new query syntax. Unknown params are left
+ * intact.
  */
 function substituteDestinationParams(destination: string, params: Record<string, string>): string {
   const keys = Object.keys(params);
@@ -1164,11 +1167,11 @@ function substituteDestinationParams(destination: string, params: Record<string,
 /**
  * Check whether a destination param starts inside the query component.
  *
- * Encoding both query keys and values is deliberate defense-in-depth: although
- * Next.js config validation normally limits placeholder placement, vinext's
- * runtime matcher must not let a decoded `&` or `=` create query syntax in any
- * accepted destination form. The pathname, hostname, and fragment retain their
- * existing substitution behavior.
+ * Encoding both query keys and values is deliberate because vinext accepts the
+ * decoded `cleanPathname` at this layer. Next.js preserves percent-encoded route
+ * captures until after destination query interpolation; without compensating
+ * here, vinext turns encoded `&` and `=` path data into query delimiters. The
+ * pathname, hostname, and fragment retain their existing substitution behavior.
  */
 function isDestinationQueryOffset(destination: string, offset: number): boolean {
   const queryStart = destination.indexOf("?");

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1127,7 +1127,9 @@ export function matchesRewriteSource(
  * Substitute all matched route params into a redirect/rewrite destination.
  *
  * Handles repeated params (e.g. `/api/:id/:id`) and catch-all suffix forms
- * (`:path*`, `:path+`) in a single pass. Unknown params are left intact.
+ * (`:path*`, `:path+`) in a single pass. Params interpolated anywhere in the
+ * query component are URI-encoded so decoded separators cannot create new
+ * query keys or values. Unknown params are left intact.
  */
 function substituteDestinationParams(destination: string, params: Record<string, string>): string {
   const keys = Object.keys(params);
@@ -1149,7 +1151,30 @@ function substituteDestinationParams(destination: string, params: Record<string,
     _compiledDestinationParamCache.set(cacheKey, paramRe);
   }
 
-  return destination.replace(paramRe, (_token, key: string) => params[key]);
+  return destination.replace(
+    paramRe,
+    (_token, key: string, _modifier: string | undefined, offset: number) => {
+      if (!isDestinationQueryOffset(destination, offset)) return params[key];
+      return encodeURIComponent(params[key]);
+    },
+  );
+}
+
+/**
+ * Check whether a destination param starts inside the query component.
+ *
+ * Encoding both query keys and values is deliberate defense-in-depth: although
+ * Next.js config validation normally limits placeholder placement, vinext's
+ * runtime matcher must not let a decoded `&` or `=` create query syntax in any
+ * accepted destination form. The pathname, hostname, and fragment retain their
+ * existing substitution behavior.
+ */
+function isDestinationQueryOffset(destination: string, offset: number): boolean {
+  const queryStart = destination.indexOf("?");
+  if (queryStart === -1 || offset <= queryStart) return false;
+
+  const hashStart = destination.indexOf("#");
+  return hashStart === -1 || (hashStart > queryStart && offset < hashStart);
 }
 
 /**

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11788,7 +11788,7 @@ describe("matchRewrite with external URLs", () => {
       ...emptyCtx,
       headers: new Headers({ "x-authorized": "yes" }),
     });
-    expect(result).toBe("/home?authorized=yes&path=docs%2Fintro");
+    expect(result).toBe("/home?authorized=yes&path=docs/intro");
   });
 
   it("encodes path params substituted into rewrite query values", async () => {
@@ -11954,14 +11954,14 @@ describe("matchRedirect destination param substitution", () => {
     const redirects = [
       {
         source: "/go/:next*",
-        destination: "/login?next=/:next&safe=1",
+        destination: "/login?next=/:next*&safe=1",
         permanent: false,
       },
     ];
     const result = matchRedirect("/go/foo&next=https://evil.example", redirects, emptyCtx);
 
     expect(result).toEqual({
-      destination: "/login?next=/foo%26next%3Dhttps%3A%2F%2Fevil.example&safe=1",
+      destination: "/login?next=/foo%26next%3Dhttps%3A//evil.example&safe=1",
       permanent: false,
     });
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11788,7 +11788,50 @@ describe("matchRewrite with external URLs", () => {
       ...emptyCtx,
       headers: new Headers({ "x-authorized": "yes" }),
     });
-    expect(result).toBe("/home?authorized=yes&path=docs/intro");
+    expect(result).toBe("/home?authorized=yes&path=docs%2Fintro");
+  });
+
+  it("encodes path params substituted into rewrite query values", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    // Matches the final Next.js URL behavior while also encoding query-key
+    // placeholders as defense-in-depth when vinext accepts unusual syntax.
+    // https://github.com/vercel/next.js/blob/v16.2.9/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+    const result = matchRewrite(
+      "/search/foo&admin=true",
+      [{ source: "/search/:term", destination: "/api/search?q=:term&fixed=1" }],
+      emptyCtx,
+    );
+
+    expect(result).toBe("/api/search?q=foo%26admin%3Dtrue&fixed=1&term=foo%26admin%3Dtrue");
+  });
+
+  it("encodes params substituted into rewrite query keys", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const result = matchRewrite(
+      "/search/foo&admin=true",
+      [{ source: "/search/:term", destination: "/api/search?:term=value&fixed=1" }],
+      emptyCtx,
+    );
+
+    expect(result).toBe("/api/search?foo%26admin%3Dtrue=value&fixed=1&term=foo%26admin%3Dtrue");
+  });
+
+  it("encodes repeated params throughout the rewrite query component", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const result = matchRewrite(
+      "/search/a/b&admin=true",
+      [
+        {
+          source: "/search/:term*",
+          destination: "https://example.com/api?:term=:term&again=:term#raw=:term",
+        },
+      ],
+      emptyCtx,
+    );
+
+    expect(result).toBe(
+      "https://example.com/api?a%2Fb%26admin%3Dtrue=a%2Fb%26admin%3Dtrue&again=a%2Fb%26admin%3Dtrue#raw=a/b&admin=true",
+    );
   });
 
   it("appends source params not referenced by the rewrite destination", async () => {
@@ -11833,6 +11876,17 @@ describe("matchRewrite with external URLs", () => {
     );
 
     expect(result).toBe("/status#500");
+  });
+
+  it("does not query-encode params in fragment text after a question mark", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const result = matchRewrite(
+      "/docs/foo&bar=true",
+      [{ source: "/docs/:code", destination: "/status#next?value=:code" }],
+      emptyCtx,
+    );
+
+    expect(result).toBe("/status#next?value=foo&bar=true");
   });
 });
 
@@ -11890,6 +11944,26 @@ describe("matchRedirect destination param substitution", () => {
       headers: new Headers({ "x-authorized": "yes" }),
     });
     expect(result).toEqual({ destination: "/home?authorized=yes", permanent: false });
+  });
+
+  it("encodes path params substituted into redirect query values", async () => {
+    const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
+    // Matches the final Next.js URL behavior while protecting every accepted
+    // query-component placeholder from creating new query syntax.
+    // https://github.com/vercel/next.js/blob/v16.2.9/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+    const redirects = [
+      {
+        source: "/go/:next*",
+        destination: "/login?next=/:next&safe=1",
+        permanent: false,
+      },
+    ];
+    const result = matchRedirect("/go/foo&next=https://evil.example", redirects, emptyCtx);
+
+    expect(result).toEqual({
+      destination: "/login?next=/foo%26next%3Dhttps%3A%2F%2Fevil.example&safe=1",
+      permanent: false,
+    });
   });
 });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11793,8 +11793,9 @@ describe("matchRewrite with external URLs", () => {
 
   it("encodes path params substituted into rewrite query values", async () => {
     const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
-    // Matches the final Next.js URL behavior while also encoding query-key
-    // placeholders as defense-in-depth when vinext accepts unusual syntax.
+    // Next.js retains the encoded source capture through destination
+    // interpolation. Vinext receives a decoded pathname here, so it must
+    // re-encode the query substitution to produce the same wire URL.
     // https://github.com/vercel/next.js/blob/v16.2.9/packages/next/src/shared/lib/router/utils/prepare-destination.ts
     const result = matchRewrite(
       "/search/foo&admin=true",
@@ -11948,8 +11949,9 @@ describe("matchRedirect destination param substitution", () => {
 
   it("encodes path params substituted into redirect query values", async () => {
     const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
-    // Matches the final Next.js URL behavior while protecting every accepted
-    // query-component placeholder from creating new query syntax.
+    // Next.js retains the encoded source capture through destination
+    // interpolation. Vinext receives a decoded pathname here, so it must
+    // re-encode the query substitution to produce the same Location value.
     // https://github.com/vercel/next.js/blob/v16.2.9/packages/next/src/shared/lib/router/utils/prepare-destination.ts
     const redirects = [
       {


### PR DESCRIPTION
## Summary

- preserve encoded route separators when decoded vinext path captures are interpolated into rewrite and redirect queries
- retain catch-all `/` separators and existing pathname/fragment interpolation behavior
- cover query values, unusual query-key placeholders, repeated placeholders, external destinations, and fragment boundaries

## Why this is needed

Vinext evaluates config routes against an already-decoded `cleanPathname`. Next.js retains encoded source captures through destination interpolation, so an input such as `foo%26admin=true` remains encoded in the emitted query URL. Without compensating at substitution time, vinext turns that path data into new query delimiters.

## Verification

- real Next.js 16.2.7 webpack dev server for the rewrite and redirect wire behavior
- `vp check packages/vinext/src/config/config-matchers.ts tests/shims.test.ts`
- `vp test run tests/shims.test.ts` (1,148 tests)
