### PR TITLE
fix(app-router): avoid probing client references

### DIFF
--- a/packages/vinext/src/server/app-page-probe.ts
+++ b/packages/vinext/src/server/app-page-probe.ts
@@ -17,6 +17,7 @@ const DEFAULT_SUBTREE_PROBE_MAX_NODES = 1000;
 const REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref");
 const REACT_LAZY_TYPE = Symbol.for("react.lazy");
 const REACT_MEMO_TYPE = Symbol.for("react.memo");
+const REACT_CLIENT_REFERENCE_TYPE = Symbol.for("react.client.reference");
 
 type ProbeReactServerSubtreeOptions = Readonly<{
   maxDepth?: number;
@@ -72,6 +73,10 @@ function isObjectLike(value: unknown): value is object {
 
 function isUnknownFunction(value: unknown): value is UnknownFunction {
   return typeof value === "function";
+}
+
+function isReactClientReference(value: unknown): boolean {
+  return isObjectLike(value) && Reflect.get(value, "$$typeof") === REACT_CLIENT_REFERENCE_TYPE;
 }
 
 function readReactMemoType(value: unknown): ReactMemoType | null {
@@ -144,6 +149,10 @@ export async function probeReactServerSubtree(
   ): Promise<boolean> => {
     if (wrapperDepth > maxDepth) {
       throw new AppPageSubtreeProbeLimitError("App page layout subtree probe exceeded max depth");
+    }
+
+    if (isReactClientReference(type)) {
+      return false;
     }
 
     if (isUnknownFunction(type)) {

--- a/tests/app-page-probe.test.ts
+++ b/tests/app-page-probe.test.ts
@@ -51,6 +51,23 @@ describe("app page probe helpers", () => {
     expect(calls).toEqual(["layout", "child"]);
   });
 
+  it("does not invoke client references returned below a layout result", async () => {
+    const ClientReference = Object.assign(
+      vi.fn(() => {
+        throw new Error("client reference must not execute on the server");
+      }),
+      { $$typeof: Symbol.for("react.client.reference") },
+    );
+
+    function Layout() {
+      return React.createElement("section", null, React.createElement(ClientReference));
+    }
+
+    await probeReactServerSubtree(React.createElement(Layout));
+
+    expect(ClientReference).not.toHaveBeenCalled();
+  });
+
   it("probes memo and forwardRef server components returned below a layout result", async () => {
     const calls: string[] = [];
 


### PR DESCRIPTION
## Summary
- treat React client references as opaque App Router probe boundaries
- prevent `router.refresh()` from invoking `next/link` client-reference proxies on the server
- add focused probe regression coverage

## Impact
The targeted Next.js `parallel-routes-revalidation` suite improves from 0 passed / 16 failed with a server crash to 7 passed / 9 assertion-level failures, while the server remains healthy. The remaining persisted-slot refresh semantics are intentionally excluded.

## Validation
- `vp test run tests/app-page-probe.test.ts` (29 passed, independent reviewer)
- scoped format/lint/type checks (independent reviewer)
- targeted Next.js v16.2.6 suite at concurrency 1 reaches assertions without server death