### PR TITLE
fix(app-router): scope static params across parallel routes

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -759,10 +759,14 @@ export default createAppRscHandler({
       layouts: route.layouts,
       layoutTreePositions: route.layoutTreePositions,
       page: route.page,
-      parallelPages: Object.values(route.slots ?? {}).map((slot) => ({
+      parallelBranches: Object.values(route.slots ?? {}).map((slot) => ({
+        layout: slot.layout,
+        configLayouts: slot.configLayouts,
+        configLayoutTreePositions: slot.configLayoutTreePositions,
         page: slot.page ?? slot.default,
         paramNames: slot.slotParamNames,
         patternParts: slot.slotPatternParts,
+        routeSegments: slot.routeSegments,
       })),
       routePatternParts: route.patternParts,
       routeSegments: route.routeSegments,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -747,12 +747,14 @@ export default createAppRscHandler({
       layouts: route.layouts,
       layoutTreePositions: route.layoutTreePositions,
       page: route.page,
+      parallelBranches: Object.values(route.slots ?? {}).map((slot) => ({
+        layout: slot.layout,
+        configLayouts: slot.configLayouts,
+        configLayoutTreePositions: slot.configLayoutTreePositions,
+        page: slot.page ?? slot.default,
+        routeSegments: slot.routeSegments,
+      })),
       parallelPages: Object.values(route.slots ?? {}).map((slot) => slot.page ?? slot.default),
-      parallelSegments: Object.values(route.slots ?? {}).flatMap((slot) => [
-        slot.layout,
-        ...(slot.configLayouts ?? []),
-        slot.page ?? slot.default,
-      ]),
       routeSegments: route.routeSegments,
     });
     const __generateStaticParams = __resolveAppPageGenerateStaticParamsSources({

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -745,6 +745,7 @@ export default createAppRscHandler({
     const PageComponent = route.page?.default;
     const __segmentConfig = __resolveAppPageSegmentConfig({
       layouts: route.layouts,
+      layoutTreePositions: route.layoutTreePositions,
       page: route.page,
       parallelPages: Object.values(route.slots ?? {}).map((slot) => slot.page ?? slot.default),
       parallelSegments: Object.values(route.slots ?? {}).flatMap((slot) => [
@@ -752,11 +753,18 @@ export default createAppRscHandler({
         ...(slot.configLayouts ?? []),
         slot.page ?? slot.default,
       ]),
+      routeSegments: route.routeSegments,
     });
     const __generateStaticParams = __resolveAppPageGenerateStaticParamsSources({
       layouts: route.layouts,
       layoutTreePositions: route.layoutTreePositions,
       page: route.page,
+      parallelPages: Object.values(route.slots ?? {}).map((slot) => ({
+        page: slot.page ?? slot.default,
+        paramNames: slot.slotParamNames,
+        patternParts: slot.slotPatternParts,
+      })),
+      routePatternParts: route.patternParts,
       routeSegments: route.routeSegments,
     });
     const _asyncRouteParams = makeThenableParams(params);

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -22,10 +22,14 @@ type GenerateStaticParamsSource = {
   parentParamNames: readonly string[];
 };
 
-type ParallelGenerateStaticParamsModule = {
+type ParallelGenerateStaticParamsBranch = {
+  configLayouts?: readonly (GenerateStaticParamsModule | null | undefined)[] | null;
+  configLayoutTreePositions?: readonly number[] | null;
+  layout?: GenerateStaticParamsModule | null;
   page?: GenerateStaticParamsModule | null;
   paramNames?: readonly string[] | null;
   patternParts?: readonly string[] | null;
+  routeSegments?: readonly string[] | null;
 };
 
 export type ValidateAppPageDynamicParamsOptions = {
@@ -44,7 +48,7 @@ type ResolveAppPageGenerateStaticParamsSourcesOptions = {
   layouts?: readonly (GenerateStaticParamsModule | null | undefined)[];
   layoutTreePositions?: readonly number[];
   page?: GenerateStaticParamsModule | null;
-  parallelPages?: readonly (ParallelGenerateStaticParamsModule | null | undefined)[];
+  parallelBranches?: readonly (ParallelGenerateStaticParamsBranch | null | undefined)[];
   routePatternParts?: readonly string[];
   routeSegments: readonly string[];
 };
@@ -252,6 +256,23 @@ function getLayoutGenerateStaticParamsBoundary(layoutTreePosition: number | unde
   return (layoutTreePosition ?? 0) - 1;
 }
 
+function getParallelParentParamNames(
+  routeParamNames: readonly string[],
+  branch: ParallelGenerateStaticParamsBranch,
+  boundaryPosition: number,
+): string[] {
+  const slotParamNames = branch.paramNames ?? routeParamNames;
+  const branchParamNames = collectParentParamNames(branch.routeSegments ?? [], boundaryPosition);
+  const branchParamNameSet = new Set(
+    (branch.routeSegments ?? []).flatMap((segment) => {
+      const name = getAppPageSegmentParamName(segment);
+      return name ? [name] : [];
+    }),
+  );
+  const ownerParamNames = slotParamNames.filter((name) => !branchParamNameSet.has(name));
+  return [...new Set([...ownerParamNames, ...branchParamNames])];
+}
+
 export function resolveAppPageGenerateStaticParamsSources(
   options: ResolveAppPageGenerateStaticParamsSourcesOptions,
 ): GenerateStaticParamsSource[] {
@@ -283,17 +304,9 @@ export function resolveAppPageGenerateStaticParamsSources(
     const name = getAppPageSegmentParamName(segment);
     return name ? [name] : [];
   });
-  for (const parallelPage of options.parallelPages ?? []) {
-    if (!parallelPage) continue;
-    const page = parallelPage.page;
-    if (typeof page?.generateStaticParams !== "function") continue;
-
-    const slotParamNames = parallelPage.paramNames ?? routeParamNames;
-    const lastSlotPatternPart = parallelPage.patternParts?.at(-1);
-    const parentParamNames =
-      lastSlotPatternPart === undefined || lastSlotPatternPart.startsWith(":")
-        ? slotParamNames.slice(0, -1)
-        : slotParamNames;
+  for (const parallelBranch of options.parallelBranches ?? []) {
+    if (!parallelBranch) continue;
+    const slotParamNames = parallelBranch.paramNames ?? routeParamNames;
     const paramAliases = Object.fromEntries(
       routeParamNames.flatMap((routeParamName, index) => {
         const slotParamName = slotParamNames[index];
@@ -302,14 +315,35 @@ export function resolveAppPageGenerateStaticParamsSources(
           : [];
       }),
     );
+    const addParallelSource = (
+      module: GenerateStaticParamsModule | null | undefined,
+      boundaryPosition: number,
+    ) => {
+      if (typeof module?.generateStaticParams !== "function") return;
+      sources.push({
+        generateStaticParams: module.generateStaticParams,
+        ...(Object.keys(paramAliases).length > 0 ? { paramAliases } : {}),
+        ...(parallelBranch.patternParts ? { paramPatternParts: parallelBranch.patternParts } : {}),
+        ...(options.routePatternParts ? { routePatternParts: options.routePatternParts } : {}),
+        parentParamNames: getParallelParentParamNames(
+          routeParamNames,
+          parallelBranch,
+          boundaryPosition,
+        ),
+      });
+    };
 
-    sources.push({
-      generateStaticParams: page.generateStaticParams,
-      ...(Object.keys(paramAliases).length > 0 ? { paramAliases } : {}),
-      ...(parallelPage.patternParts ? { paramPatternParts: parallelPage.patternParts } : {}),
-      ...(options.routePatternParts ? { routePatternParts: options.routePatternParts } : {}),
-      parentParamNames,
+    addParallelSource(parallelBranch.layout, -1);
+    parallelBranch.configLayouts?.forEach((layout, index) => {
+      addParallelSource(
+        layout,
+        getLayoutGenerateStaticParamsBoundary(parallelBranch.configLayoutTreePositions?.[index]),
+      );
     });
+    addParallelSource(
+      parallelBranch.page,
+      Math.max(0, (parallelBranch.routeSegments?.length ?? 0) - 1),
+    );
   }
 
   return sources;

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -1,6 +1,7 @@
 import type { AppPageSpecialError } from "./app-page-execution.js";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { getAppPageSegmentParamName } from "./app-page-params.js";
+import { matchRoutePattern } from "../routing/route-pattern.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
 import { loadAppInterceptLayouts } from "./app-route-module-loader.js";
@@ -15,7 +16,16 @@ type GenerateStaticParamsModule = {
 
 type GenerateStaticParamsSource = {
   generateStaticParams: GenerateStaticParams;
+  paramAliases?: Readonly<Record<string, string>>;
+  paramPatternParts?: readonly string[];
+  routePatternParts?: readonly string[];
   parentParamNames: readonly string[];
+};
+
+type ParallelGenerateStaticParamsModule = {
+  page?: GenerateStaticParamsModule | null;
+  paramNames?: readonly string[] | null;
+  patternParts?: readonly string[] | null;
 };
 
 export type ValidateAppPageDynamicParamsOptions = {
@@ -34,6 +44,8 @@ type ResolveAppPageGenerateStaticParamsSourcesOptions = {
   layouts?: readonly (GenerateStaticParamsModule | null | undefined)[];
   layoutTreePositions?: readonly number[];
   page?: GenerateStaticParamsModule | null;
+  parallelPages?: readonly (ParallelGenerateStaticParamsModule | null | undefined)[];
+  routePatternParts?: readonly string[];
   routeSegments: readonly string[];
 };
 
@@ -176,6 +188,46 @@ function pickRouteParams(
   return params;
 }
 
+function remapRouteParams(
+  matchedParams: AppPageParams,
+  source: Pick<
+    GenerateStaticParamsSource,
+    "paramAliases" | "paramPatternParts" | "routePatternParts"
+  >,
+): AppPageParams {
+  if (source.paramPatternParts && source.routePatternParts) {
+    const urlParts: string[] = [];
+    for (const part of source.routePatternParts) {
+      if (!part.startsWith(":")) {
+        urlParts.push(part);
+        continue;
+      }
+
+      const paramName = part.slice(1).replace(/[+*]$/, "");
+      const value = matchedParams[paramName];
+      if (Array.isArray(value)) {
+        urlParts.push(...value.map(encodeURIComponent));
+      } else if (value !== undefined) {
+        urlParts.push(encodeURIComponent(value));
+      }
+    }
+
+    const slotParams = matchRoutePattern(urlParts, source.paramPatternParts);
+    if (slotParams) return slotParams;
+  }
+
+  if (!source.paramAliases) return matchedParams;
+
+  const params: AppPageParams = { ...matchedParams };
+  for (const [routeParamName, sourceParamName] of Object.entries(source.paramAliases)) {
+    const value = matchedParams[routeParamName];
+    if (value === undefined) continue;
+    delete params[routeParamName];
+    params[sourceParamName] = value;
+  }
+  return params;
+}
+
 function collectParentParamNames(
   routeSegments: readonly string[],
   boundaryPosition: number,
@@ -224,6 +276,39 @@ export function resolveAppPageGenerateStaticParamsSources(
         options.routeSegments,
         Math.max(0, options.routeSegments.length - 1),
       ),
+    });
+  }
+
+  const routeParamNames = options.routeSegments.flatMap((segment) => {
+    const name = getAppPageSegmentParamName(segment);
+    return name ? [name] : [];
+  });
+  for (const parallelPage of options.parallelPages ?? []) {
+    if (!parallelPage) continue;
+    const page = parallelPage.page;
+    if (typeof page?.generateStaticParams !== "function") continue;
+
+    const slotParamNames = parallelPage.paramNames ?? routeParamNames;
+    const lastSlotPatternPart = parallelPage.patternParts?.at(-1);
+    const parentParamNames =
+      lastSlotPatternPart === undefined || lastSlotPatternPart.startsWith(":")
+        ? slotParamNames.slice(0, -1)
+        : slotParamNames;
+    const paramAliases = Object.fromEntries(
+      routeParamNames.flatMap((routeParamName, index) => {
+        const slotParamName = slotParamNames[index];
+        return slotParamName && slotParamName !== routeParamName
+          ? [[routeParamName, slotParamName]]
+          : [];
+      }),
+    );
+
+    sources.push({
+      generateStaticParams: page.generateStaticParams,
+      ...(Object.keys(paramAliases).length > 0 ? { paramAliases } : {}),
+      ...(parallelPage.patternParts ? { paramPatternParts: parallelPage.patternParts } : {}),
+      ...(options.routePatternParts ? { routePatternParts: options.routePatternParts } : {}),
+      parentParamNames,
     });
   }
 
@@ -298,12 +383,13 @@ export async function validateAppPageDynamicParams(
   }
 
   for (const source of generateStaticParamsSources) {
+    const sourceParams = remapRouteParams(options.params, source);
     const staticParams = await runWithFetchDedupe(() =>
       source.generateStaticParams({
-        params: pickRouteParams(options.params, source.parentParamNames),
+        params: pickRouteParams(sourceParams, source.parentParamNames),
       }),
     );
-    if (Array.isArray(staticParams) && !areStaticParamsAllowed(options.params, staticParams)) {
+    if (Array.isArray(staticParams) && !areStaticParamsAllowed(sourceParams, staticParams)) {
       options.clearRequestContext();
       return notFoundResponse();
     }

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -7,6 +7,7 @@ type AppRouteSegmentConfigModule = {
   dynamic?: unknown;
   dynamicParams?: unknown;
   fetchCache?: unknown;
+  generateStaticParams?: unknown;
   revalidate?: unknown;
   runtime?: unknown;
   unstable_dynamicStaleTime?: unknown;
@@ -23,9 +24,11 @@ type EffectiveAppPageSegmentConfig = {
 
 type ResolveAppPageSegmentConfigOptions = {
   layouts?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
+  layoutTreePositions?: readonly number[];
   page?: AppRouteSegmentConfigModule | null;
   parallelPages?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
   parallelSegments?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
+  routeSegments?: readonly string[];
 };
 
 const DYNAMIC_VALUES = new Set<unknown>(["auto", "error", "force-dynamic", "force-static"]);
@@ -83,6 +86,62 @@ function resolveDynamicStaleTimeSeconds(
   return current === undefined ? value : Math.min(current, value);
 }
 
+function isDynamicSegment(segment: string): boolean {
+  return segment.startsWith("[") && segment.endsWith("]");
+}
+
+function resolveDynamicParamsConfig(
+  options: ResolveAppPageSegmentConfigOptions,
+): boolean | undefined {
+  const segments = [...(options.layouts ?? []), options.page];
+  let dynamicParamsConfig: boolean | undefined;
+
+  for (const segment of segments) {
+    if (segment?.dynamicParams === false) {
+      dynamicParamsConfig = false;
+    } else if (segment?.dynamicParams === true && dynamicParamsConfig !== false) {
+      dynamicParamsConfig = true;
+    }
+  }
+
+  if (dynamicParamsConfig !== false || !options.routeSegments) {
+    return dynamicParamsConfig;
+  }
+
+  let lastDynamicPosition = -1;
+  for (let index = options.routeSegments.length - 1; index >= 0; index--) {
+    if (isDynamicSegment(options.routeSegments[index])) {
+      lastDynamicPosition = index;
+      break;
+    }
+  }
+  if (lastDynamicPosition < 0) return dynamicParamsConfig;
+
+  const layouts = options.layouts ?? [];
+  const layoutPositions = options.layoutTreePositions ?? [];
+  let lastDynamicSegmentIsStaticOnly = false;
+  let lastDynamicSegmentHasStaticParams = false;
+
+  layouts.forEach((layout, index) => {
+    const ownerPosition = (layoutPositions[index] ?? 0) - 1;
+    if (ownerPosition !== lastDynamicPosition) return;
+    if (layout?.dynamicParams === false) lastDynamicSegmentIsStaticOnly = true;
+    if (typeof layout?.generateStaticParams === "function") {
+      lastDynamicSegmentHasStaticParams = true;
+    }
+  });
+
+  if (options.page?.dynamicParams === false) lastDynamicSegmentIsStaticOnly = true;
+  if (typeof options.page?.generateStaticParams === "function") {
+    lastDynamicSegmentHasStaticParams = true;
+  }
+  if (options.parallelPages?.some((page) => typeof page?.generateStaticParams === "function")) {
+    lastDynamicSegmentHasStaticParams = true;
+  }
+
+  return lastDynamicSegmentIsStaticOnly || lastDynamicSegmentHasStaticParams ? false : undefined;
+}
+
 function isCacheFetchCacheMode(value: FetchCacheMode): boolean {
   return value === "default-cache" || value === "force-cache" || value === "only-cache";
 }
@@ -111,6 +170,7 @@ export function resolveAppPageSegmentConfig(
   const config: EffectiveAppPageSegmentConfig = {
     revalidateSeconds: null,
   };
+  config.dynamicParamsConfig = resolveDynamicParamsConfig(options);
   let hasForceCache = false;
   let hasForceNoStore = false;
   let hasOnlyCache = false;
@@ -130,12 +190,6 @@ export function resolveAppPageSegmentConfig(
 
     if (isRouteSegmentRuntime(segment.runtime)) {
       config.runtime = segment.runtime;
-    }
-
-    if (segment.dynamicParams === false) {
-      config.dynamicParamsConfig = false;
-    } else if (segment.dynamicParams === true && config.dynamicParamsConfig !== false) {
-      config.dynamicParamsConfig = true;
     }
 
     if (isRouteSegmentFetchCache(segment.fetchCache)) {

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -22,10 +22,19 @@ type EffectiveAppPageSegmentConfig = {
   runtime?: "edge" | "experimental-edge" | "nodejs";
 };
 
+type ParallelAppPageSegmentConfigBranch = {
+  configLayouts?: readonly (AppRouteSegmentConfigModule | null | undefined)[] | null;
+  configLayoutTreePositions?: readonly number[] | null;
+  layout?: AppRouteSegmentConfigModule | null;
+  page?: AppRouteSegmentConfigModule | null;
+  routeSegments?: readonly string[] | null;
+};
+
 type ResolveAppPageSegmentConfigOptions = {
   layouts?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
   layoutTreePositions?: readonly number[];
   page?: AppRouteSegmentConfigModule | null;
+  parallelBranches?: readonly (ParallelAppPageSegmentConfigBranch | null | undefined)[];
   parallelPages?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
   parallelSegments?: readonly (AppRouteSegmentConfigModule | null | undefined)[];
   routeSegments?: readonly string[];
@@ -90,10 +99,20 @@ function isDynamicSegment(segment: string): boolean {
   return segment.startsWith("[") && segment.endsWith("]");
 }
 
+function getParallelSegments(
+  options: ResolveAppPageSegmentConfigOptions,
+): readonly (AppRouteSegmentConfigModule | null | undefined)[] {
+  if (!options.parallelBranches) return options.parallelSegments ?? [];
+  return options.parallelBranches.flatMap((branch) =>
+    branch ? [branch.layout, ...(branch.configLayouts ?? []), branch.page] : [],
+  );
+}
+
 function resolveDynamicParamsConfig(
   options: ResolveAppPageSegmentConfigOptions,
 ): boolean | undefined {
-  const segments = [...(options.layouts ?? []), options.page];
+  const parallelSegments = getParallelSegments(options);
+  const segments = [...(options.layouts ?? []), options.page, ...parallelSegments];
   let dynamicParamsConfig: boolean | undefined;
 
   for (const segment of segments) {
@@ -135,10 +154,38 @@ function resolveDynamicParamsConfig(
   if (typeof options.page?.generateStaticParams === "function") {
     lastDynamicSegmentHasStaticParams = true;
   }
-  if (
-    options.parallelSegments?.some((segment) => typeof segment?.generateStaticParams === "function")
-  ) {
-    lastDynamicSegmentHasStaticParams = true;
+
+  for (const branch of options.parallelBranches ?? []) {
+    if (!branch) continue;
+    const branchStartPosition = options.routeSegments.length - (branch.routeSegments?.length ?? 0);
+    const checkSegment = (
+      segment: AppRouteSegmentConfigModule | null | undefined,
+      ownerPosition: number,
+    ) => {
+      if (ownerPosition !== lastDynamicPosition) return;
+      if (segment?.dynamicParams === false) lastDynamicSegmentIsStaticOnly = true;
+      if (typeof segment?.generateStaticParams === "function") {
+        lastDynamicSegmentHasStaticParams = true;
+      }
+    };
+
+    checkSegment(branch.layout, branchStartPosition - 1);
+    branch.configLayouts?.forEach((layout, index) => {
+      checkSegment(
+        layout,
+        branchStartPosition + (branch.configLayoutTreePositions?.[index] ?? 0) - 1,
+      );
+    });
+    checkSegment(branch.page, branchStartPosition + (branch.routeSegments?.length ?? 0) - 1);
+  }
+
+  if (!options.parallelBranches) {
+    for (const segment of parallelSegments) {
+      if (segment?.dynamicParams === false) lastDynamicSegmentIsStaticOnly = true;
+      if (typeof segment?.generateStaticParams === "function") {
+        lastDynamicSegmentHasStaticParams = true;
+      }
+    }
   }
 
   return lastDynamicSegmentIsStaticOnly || lastDynamicSegmentHasStaticParams ? false : undefined;
@@ -164,6 +211,7 @@ export function resolveAppPageSegmentConfig(
   options: ResolveAppPageSegmentConfigOptions,
 ): EffectiveAppPageSegmentConfig {
   const segments = [...(options.layouts ?? []), options.page];
+  const parallelSegments = getParallelSegments(options);
   // Reduction strategies differ by field:
   // - dynamic: child segments override parents.
   // - dynamicParams: false is sticky across the route tree.
@@ -236,7 +284,7 @@ export function resolveAppPageSegmentConfig(
     );
   }
 
-  for (const segment of options.parallelSegments ?? []) {
+  for (const segment of parallelSegments) {
     if (!segment) continue;
 
     // Next.js traverses every parallel branch. Vinext's flattened route graph
@@ -249,12 +297,6 @@ export function resolveAppPageSegmentConfig(
       config.dynamicConfig = "force-dynamic";
     } else if (config.dynamicConfig === undefined && isRouteSegmentDynamic(segment.dynamic)) {
       config.dynamicConfig = segment.dynamic;
-    }
-
-    if (segment.dynamicParams === false) {
-      config.dynamicParamsConfig = false;
-    } else if (segment.dynamicParams === true && config.dynamicParamsConfig === undefined) {
-      config.dynamicParamsConfig = true;
     }
 
     if (config.runtime === undefined && isRouteSegmentRuntime(segment.runtime)) {

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -135,7 +135,9 @@ function resolveDynamicParamsConfig(
   if (typeof options.page?.generateStaticParams === "function") {
     lastDynamicSegmentHasStaticParams = true;
   }
-  if (options.parallelPages?.some((page) => typeof page?.generateStaticParams === "function")) {
+  if (
+    options.parallelSegments?.some((segment) => typeof segment?.generateStaticParams === "function")
+  ) {
     lastDynamicSegmentHasStaticParams = true;
   }
 

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -114,11 +114,12 @@ describe("app page request helpers", () => {
       clearRequestContext() {},
       enforceStaticParamsOnly: true,
       generateStaticParams: resolveAppPageGenerateStaticParamsSources({
-        parallelPages: [
+        parallelBranches: [
           {
             page: { generateStaticParams: () => [{ slug: "static-123" }] },
             paramNames: ["locale", "slug"],
             patternParts: [":locale", "gsp", "stories", ":slug"],
+            routeSegments: ["stories", "[slug]"],
           },
         ],
         routePatternParts: [":locale", "gsp", "stories", ":slug"],
@@ -137,11 +138,12 @@ describe("app page request helpers", () => {
       clearRequestContext() {},
       enforceStaticParamsOnly: true,
       generateStaticParams: resolveAppPageGenerateStaticParamsSources({
-        parallelPages: [
+        parallelBranches: [
           {
             page: { generateStaticParams },
             paramNames: ["name"],
             patternParts: [":name"],
+            routeSegments: ["[name]"],
           },
         ],
         routePatternParts: [":id"],
@@ -153,6 +155,38 @@ describe("app page request helpers", () => {
 
     expect(response).toBeNull();
     expect(generateStaticParams).toHaveBeenCalledWith({ params: {} });
+  });
+
+  it("collects generateStaticParams from active parallel layouts", async () => {
+    const rootLayoutGenerateStaticParams = vi.fn(() => [{ locale: "en" }]);
+    const nestedLayoutGenerateStaticParams = vi.fn(() => [{ slug: "static-123" }]);
+    const generateStaticParams = resolveAppPageGenerateStaticParamsSources({
+      parallelBranches: [
+        {
+          layout: { generateStaticParams: rootLayoutGenerateStaticParams },
+          configLayouts: [null, { generateStaticParams: nestedLayoutGenerateStaticParams }],
+          configLayoutTreePositions: [1, 2],
+          paramNames: ["locale", "slug"],
+          patternParts: [":locale", "gsp", "stories", ":slug"],
+          routeSegments: ["stories", "[slug]"],
+        },
+      ],
+      routePatternParts: [":locale", "gsp", "stories", ":slug"],
+      routeSegments: ["[locale]", "gsp", "stories", "[slug]"],
+    });
+    const validate = (slug: string) =>
+      validateAppPageDynamicParams({
+        clearRequestContext() {},
+        enforceStaticParamsOnly: true,
+        generateStaticParams,
+        isDynamicRoute: true,
+        params: { locale: "en", slug },
+      });
+
+    await expect(validate("static-123")).resolves.toBeNull();
+    await expect(validate("dynamic-123")).resolves.toMatchObject({ status: 404 });
+    expect(rootLayoutGenerateStaticParams).toHaveBeenCalledWith({ params: { locale: "en" } });
+    expect(nestedLayoutGenerateStaticParams).toHaveBeenCalledWith({ params: { locale: "en" } });
   });
 
   // Ported from Next.js: packages/next/src/build/static-paths/app.test.ts

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -109,6 +109,52 @@ describe("app page request helpers", () => {
     expect(itemGenerateStaticParams).toHaveBeenCalledWith({ params: { category: "docs" } });
   });
 
+  it("enforces generateStaticParams from a parallel page", async () => {
+    const response = await validateAppPageDynamicParams({
+      clearRequestContext() {},
+      enforceStaticParamsOnly: true,
+      generateStaticParams: resolveAppPageGenerateStaticParamsSources({
+        parallelPages: [
+          {
+            page: { generateStaticParams: () => [{ slug: "static-123" }] },
+            paramNames: ["locale", "slug"],
+            patternParts: [":locale", "gsp", "stories", ":slug"],
+          },
+        ],
+        routePatternParts: [":locale", "gsp", "stories", ":slug"],
+        routeSegments: ["[locale]", "gsp", "stories", "[slug]"],
+      }),
+      isDynamicRoute: true,
+      params: { locale: "en", slug: "dynamic-123" },
+    });
+
+    expect(response?.status).toBe(404);
+  });
+
+  it("remaps parallel page params before validating generateStaticParams", async () => {
+    const generateStaticParams = vi.fn(() => [{ name: "post" }]);
+    const response = await validateAppPageDynamicParams({
+      clearRequestContext() {},
+      enforceStaticParamsOnly: true,
+      generateStaticParams: resolveAppPageGenerateStaticParamsSources({
+        parallelPages: [
+          {
+            page: { generateStaticParams },
+            paramNames: ["name"],
+            patternParts: [":name"],
+          },
+        ],
+        routePatternParts: [":id"],
+        routeSegments: ["[id]"],
+      }),
+      isDynamicRoute: true,
+      params: { id: "post" },
+    });
+
+    expect(response).toBeNull();
+    expect(generateStaticParams).toHaveBeenCalledWith({ params: {} });
+  });
+
   // Ported from Next.js: packages/next/src/build/static-paths/app.test.ts
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/app.test.ts
   it("throws when generateStaticParams throws", async () => {

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -315,8 +315,61 @@ describe("resolveAppPageSegmentConfig", () => {
       resolveAppPageSegmentConfig({
         layouts: [{ dynamicParams: false, generateStaticParams: () => [{ locale: "en" }] }],
         layoutTreePositions: [1],
-        parallelSegments: [{ generateStaticParams: () => [{ slug: "static-123" }] }],
+        parallelBranches: [
+          {
+            configLayouts: [{ generateStaticParams: () => [{ slug: "static-123" }] }],
+            configLayoutTreePositions: [2],
+            routeSegments: ["stories", "[slug]"],
+          },
+        ],
         routeSegments: ["[locale]", "gsp", "stories", "[slug]"],
+      }).dynamicParamsConfig,
+    ).toBe(false);
+  });
+
+  it("ignores parallel generateStaticParams owned by a parent dynamic segment", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamicParams: false, generateStaticParams: () => [{ locale: "en" }] }],
+        layoutTreePositions: [1],
+        parallelBranches: [
+          {
+            configLayouts: [{ generateStaticParams: () => [{ locale: "en" }] }],
+            configLayoutTreePositions: [1],
+            routeSegments: ["[locale]", "no-gsp", "stories", "[slug]"],
+          },
+        ],
+        routeSegments: ["[locale]", "no-gsp", "stories", "[slug]"],
+      }).dynamicParamsConfig,
+    ).toBeUndefined();
+  });
+
+  it("ignores parallel dynamicParams=false owned by a parent dynamic segment", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        parallelBranches: [
+          {
+            configLayouts: [{ dynamicParams: false }],
+            configLayoutTreePositions: [1],
+            routeSegments: ["[locale]", "no-gsp", "stories", "[slug]"],
+          },
+        ],
+        routeSegments: ["[locale]", "no-gsp", "stories", "[slug]"],
+      }).dynamicParamsConfig,
+    ).toBeUndefined();
+  });
+
+  it("enforces parallel dynamicParams=false owned by the leaf dynamic segment", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        parallelBranches: [
+          {
+            configLayouts: [{ dynamicParams: false }],
+            configLayoutTreePositions: [2],
+            routeSegments: ["stories", "[slug]"],
+          },
+        ],
+        routeSegments: ["[locale]", "no-gsp", "stories", "[slug]"],
       }).dynamicParamsConfig,
     ).toBe(false);
   });

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -209,6 +209,28 @@ describe("resolveAppPageSegmentConfig", () => {
     });
   });
 
+  it("allows an ungenerated dynamic child below an ancestor dynamicParams=false segment", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamicParams: false, generateStaticParams() {} }, {}],
+        layoutTreePositions: [1, 2],
+        page: {},
+        routeSegments: ["[locale]", "no-gsp", "stories", "[slug]"],
+      }).dynamicParamsConfig,
+    ).toBeUndefined();
+  });
+
+  it("enforces ancestor dynamicParams=false when the dynamic child generates params", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamicParams: false, generateStaticParams() {} }, {}],
+        layoutTreePositions: [1, 2],
+        page: { generateStaticParams() {} },
+        routeSegments: ["[locale]", "gsp", "stories", "[slug]"],
+      }).dynamicParamsConfig,
+    ).toBe(false);
+  });
+
   it("resolves revalidate = false as Infinity (cache indefinitely)", () => {
     expect(
       resolveAppPageSegmentConfig({

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -310,6 +310,17 @@ describe("resolveAppPageSegmentConfig", () => {
     });
   });
 
+  it("keeps dynamicParams=false active when a parallel layout generates the leaf param", () => {
+    expect(
+      resolveAppPageSegmentConfig({
+        layouts: [{ dynamicParams: false, generateStaticParams: () => [{ locale: "en" }] }],
+        layoutTreePositions: [1],
+        parallelSegments: [{ generateStaticParams: () => [{ slug: "static-123" }] }],
+        routeSegments: ["[locale]", "gsp", "stories", "[slug]"],
+      }).dynamicParamsConfig,
+    ).toBe(false);
+  });
+
   it("uses slot-only route config values", () => {
     // Next.js collectAppPageSegments() includes parallel route layouts/pages
     // before reduceAppConfig() selects the route-level config.

--- a/tests/e2e/app-router/parallel-routes-root-param.spec.ts
+++ b/tests/e2e/app-router/parallel-routes-root-param.spec.ts
@@ -28,11 +28,12 @@ test.describe("parallel routes under a static root param", () => {
     );
   });
 
-  test("enforces generated child params when the child has generateStaticParams", async ({
-    page,
-  }) => {
+  test("enforces generated child params from a parallel layout", async ({ page }) => {
     expect((await page.goto("/parallel-root-param/en/gsp/stories/static-123"))?.status()).toBe(200);
     await expect(page.getByTestId("parallel-root-story")).toHaveText("Story: en/static-123");
+    await expect(page.getByTestId("parallel-root-breadcrumb")).toHaveText(
+      "Breadcrumb: en/static-123",
+    );
 
     expect((await page.goto("/parallel-root-param/en/gsp/stories/dynamic-123"))?.status()).toBe(
       404,

--- a/tests/e2e/app-router/parallel-routes-root-param.spec.ts
+++ b/tests/e2e/app-router/parallel-routes-root-param.spec.ts
@@ -5,15 +5,23 @@ import { expect, test } from "@playwright/test";
 // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts
 
 test.describe("parallel routes under a static root param", () => {
-  test("keeps child params dynamic when the child has no generateStaticParams", async ({
-    page,
-  }) => {
-    const response = await page.goto("/parallel-root-param/es/no-gsp/stories/dynamic-123");
+  for (const locale of ["en", "fr"]) {
+    test(`keeps child params dynamic for generated locale ${locale}`, async ({ page }) => {
+      const response = await page.goto(`/parallel-root-param/${locale}/no-gsp/stories/dynamic-123`);
 
-    expect(response?.status()).toBe(200);
-    await expect(page.getByTestId("parallel-root-story")).toHaveText("Story: es/dynamic-123");
-    await expect(page.getByTestId("parallel-root-breadcrumb")).toHaveText(
-      "Breadcrumb: es/dynamic-123",
+      expect(response?.status()).toBe(200);
+      await expect(page.getByTestId("parallel-root-story")).toHaveText(
+        `Story: ${locale}/dynamic-123`,
+      );
+      await expect(page.getByTestId("parallel-root-breadcrumb")).toHaveText(
+        `Breadcrumb: ${locale}/dynamic-123`,
+      );
+    });
+  }
+
+  test("rejects an unknown root param with a valid generated leaf", async ({ request }) => {
+    expect((await request.get("/parallel-root-param/es/gsp/stories/static-123")).status()).toBe(
+      404,
     );
   });
 

--- a/tests/e2e/app-router/parallel-routes-root-param.spec.ts
+++ b/tests/e2e/app-router/parallel-routes-root-param.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+// Ported from Next.js:
+// test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts
+
+test.describe("parallel routes under a static root param", () => {
+  test("keeps child params dynamic when the child has no generateStaticParams", async ({
+    page,
+  }) => {
+    const response = await page.goto("/parallel-root-param/es/no-gsp/stories/dynamic-123");
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByTestId("parallel-root-story")).toHaveText("Story: es/dynamic-123");
+    await expect(page.getByTestId("parallel-root-breadcrumb")).toHaveText(
+      "Breadcrumb: es/dynamic-123",
+    );
+  });
+
+  test("keeps child params dynamic during soft navigation", async ({ page }) => {
+    await page.goto("/parallel-root-param/en");
+    await page.getByRole("link", { name: "Dynamic child" }).click();
+
+    await expect(page).toHaveURL(/\/parallel-root-param\/es\/no-gsp\/stories\/dynamic-123$/);
+    await expect(page.getByTestId("parallel-root-story")).toHaveText("Story: es/dynamic-123");
+    await expect(page.getByTestId("parallel-root-breadcrumb")).toHaveText(
+      "Breadcrumb: es/dynamic-123",
+    );
+  });
+
+  test("enforces generated child params when the child has generateStaticParams", async ({
+    page,
+  }) => {
+    expect((await page.goto("/parallel-root-param/en/gsp/stories/static-123"))?.status()).toBe(200);
+    await expect(page.getByTestId("parallel-root-story")).toHaveText("Story: en/static-123");
+
+    expect((await page.goto("/parallel-root-param/en/gsp/stories/dynamic-123"))?.status()).toBe(
+      404,
+    );
+  });
+
+  test("renders the 404 boundary for an unknown generated child during soft navigation", async ({
+    page,
+  }) => {
+    await page.goto("/parallel-root-param/en");
+    await page.getByRole("link", { name: "Unknown static child" }).click();
+
+    await expect(page).toHaveURL(/\/parallel-root-param\/en\/gsp\/stories\/dynamic-123$/);
+    await expect(page.getByText("This page could not be found", { exact: true })).toBeVisible();
+  });
+
+  test("enforces generated params on the root page", async ({ request }) => {
+    expect((await request.get("/parallel-root-param/en")).status()).toBe(200);
+    expect((await request.get("/parallel-root-param/es")).status()).toBe(404);
+  });
+});

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -955,6 +955,10 @@ describe("App Router entry templates", () => {
     );
     expect(code).toContain("paramNames: slot.slotParamNames");
     expect(code).toContain("patternParts: slot.slotPatternParts");
+    expect(code).toContain("layout: slot.layout");
+    expect(code).toContain("configLayouts: slot.configLayouts");
+    expect(code).toContain("configLayoutTreePositions: slot.configLayoutTreePositions");
+    expect(code).toContain("routeSegments: slot.routeSegments");
     expect(code).toContain("routePatternParts: route.patternParts");
     expect(code).toContain("slot.page ?? slot.default");
     expect(code).toContain("...(slot.configLayouts ?? [])");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -953,6 +953,7 @@ describe("App Router entry templates", () => {
     expect(code).toContain(
       "parallelPages: Object.values(route.slots ?? {}).map((slot) => slot.page ?? slot.default)",
     );
+    expect(code).toContain("parallelBranches: Object.values(route.slots ?? {}).map((slot) => ({");
     expect(code).toContain("paramNames: slot.slotParamNames");
     expect(code).toContain("patternParts: slot.slotPatternParts");
     expect(code).toContain("layout: slot.layout");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -953,6 +953,9 @@ describe("App Router entry templates", () => {
     expect(code).toContain(
       "parallelPages: Object.values(route.slots ?? {}).map((slot) => slot.page ?? slot.default)",
     );
+    expect(code).toContain("paramNames: slot.slotParamNames");
+    expect(code).toContain("patternParts: slot.slotPatternParts");
+    expect(code).toContain("routePatternParts: route.patternParts");
     expect(code).toContain("slot.page ?? slot.default");
     expect(code).toContain("...(slot.configLayouts ?? [])");
     expect(code).toContain("interceptLayoutSegments:");

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/@breadcrumbs/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/@breadcrumbs/default.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../no-gsp/@breadcrumbs/default";

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/@breadcrumbs/stories/[slug]/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/@breadcrumbs/stories/[slug]/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function generateStaticParams() {
+  return [{ slug: "static-123" }];
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/@breadcrumbs/stories/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/@breadcrumbs/stories/[slug]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../../no-gsp/@breadcrumbs/stories/[slug]/page";

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from "../no-gsp/layout";

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/stories/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/stories/[slug]/page.tsx
@@ -1,5 +1,1 @@
 export { default } from "../../../no-gsp/stories/[slug]/page";
-
-export function generateStaticParams() {
-  return [{ slug: "static-123" }];
-}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/stories/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/gsp/stories/[slug]/page.tsx
@@ -1,0 +1,5 @@
+export { default } from "../../../no-gsp/stories/[slug]/page";
+
+export function generateStaticParams() {
+  return [{ slug: "static-123" }];
+}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return [{ locale: "en" }, { locale: "fr" }];
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/@breadcrumbs/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/@breadcrumbs/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <p>Default breadcrumbs</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/@breadcrumbs/stories/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/@breadcrumbs/stories/[slug]/page.tsx
@@ -4,5 +4,9 @@ export default async function Breadcrumbs({
   params: Promise<{ locale: string; slug: string }>;
 }) {
   const { locale, slug } = await params;
-  return <p data-testid="parallel-root-breadcrumb">Breadcrumb: {locale}/{slug}</p>;
+  return (
+    <p data-testid="parallel-root-breadcrumb">
+      Breadcrumb: {locale}/{slug}
+    </p>
+  );
 }

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/@breadcrumbs/stories/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/@breadcrumbs/stories/[slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Breadcrumbs({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>;
+}) {
+  const { locale, slug } = await params;
+  return <p data-testid="parallel-root-breadcrumb">Breadcrumb: {locale}/{slug}</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export default function Layout({
+  breadcrumbs,
+  children,
+}: {
+  breadcrumbs: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <>
+      <div data-testid="parallel-root-breadcrumbs">{breadcrumbs}</div>
+      {children}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/stories/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/stories/[slug]/page.tsx
@@ -4,5 +4,9 @@ export default async function Page({
   params: Promise<{ locale: string; slug: string }>;
 }) {
   const { locale, slug } = await params;
-  return <p data-testid="parallel-root-story">Story: {locale}/{slug}</p>;
+  return (
+    <p data-testid="parallel-root-story">
+      Story: {locale}/{slug}
+    </p>
+  );
 }

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/stories/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/no-gsp/stories/[slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>;
+}) {
+  const { locale, slug } = await params;
+  return <p data-testid="parallel-root-story">Story: {locale}/{slug}</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-root-param/[locale]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-root-param/[locale]/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default async function Page({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return (
+    <>
+      <p data-testid="parallel-root-locale">Locale: {locale}</p>
+      <Link href="/parallel-root-param/es/no-gsp/stories/dynamic-123">Dynamic child</Link>
+      <Link href="/parallel-root-param/en/gsp/stories/dynamic-123">Unknown static child</Link>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- scope `dynamicParams = false` validation to the relevant generated dynamic segment
- collect `generateStaticParams` from active parallel pages and layouts with slot parameter remapping
- add upstream-shaped hard/soft navigation coverage for dynamic children under root params

## Next.js parity impact
Addresses all five failures in `parallel-routes-root-param-dynamic-child.test.ts` in vinext-owned production fixtures: dynamic no-GSP routes return 200, generated GSP routes return 200, and unknown generated/root params return 404.

## Validation
- 94 targeted unit/integration tests passed
- 5 targeted production Playwright tests passed under Node 24 with one worker
- focused format/lint/type checks passed
- two independent reviews; final review had no findings