### PR TITLE
fix(cache): bypass unstable cache in draft mode

### DIFF
--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1273,7 +1273,11 @@ export async function handleServerActionRscRequest<
         request: options.request,
         url: redirectTarget,
       });
-      setHeadersContext(headersContextFromRequest(redirectRenderRequest));
+      setHeadersContext(
+        headersContextFromRequest(redirectRenderRequest, {
+          draftModeSecret: options.draftModeSecret,
+        }),
+      );
       const redirectDynamicConfig = options.resolveRouteDynamicConfig?.(targetMatch.route);
       const redirectSearchParams = prepareActionPageRerenderContext({
         draftModeSecret: options.draftModeSecret,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -303,6 +303,7 @@ export type HandleServerActionRscRequestOptions<
 };
 
 function prepareActionPageRerenderContext(options: {
+  draftModeCookie: string | null | undefined;
   draftModeSecret: string;
   dynamicConfig: string | null | undefined;
   request: Request;
@@ -310,9 +311,13 @@ function prepareActionPageRerenderContext(options: {
   searchParams: URLSearchParams;
 }): URLSearchParams {
   if (options.dynamicConfig === "force-static" || options.dynamicConfig === "error") {
+    const rerenderRequest = createActionRerenderRequest({
+      draftModeCookie: options.draftModeCookie,
+      request: options.request,
+    });
     setHeadersContext(
       createStaticGenerationHeadersContext({
-        draftModeEnabled: isDraftModeRequest(options.request, options.draftModeSecret),
+        draftModeEnabled: isDraftModeRequest(rerenderRequest, options.draftModeSecret),
         draftModeSecret: options.draftModeSecret,
         dynamicConfig: options.dynamicConfig,
         routeKind: "page",
@@ -321,6 +326,24 @@ function prepareActionPageRerenderContext(options: {
     );
   }
   return options.dynamicConfig === "force-static" ? new URLSearchParams() : options.searchParams;
+}
+
+function createActionRerenderRequest(options: {
+  draftModeCookie: string | null | undefined;
+  request: Request;
+}): Request {
+  if (!options.draftModeCookie) return options.request;
+
+  const headers = new Headers(options.request.headers);
+  const cookieHeader = applySetCookieMutationsToRequestCookieHeader(headers.get("cookie"), [
+    options.draftModeCookie,
+  ]);
+  if (cookieHeader === null) {
+    headers.delete("cookie");
+  } else {
+    headers.set("cookie", cookieHeader);
+  }
+  return new Request(options.request.url, { headers });
 }
 
 /**
@@ -1280,6 +1303,7 @@ export async function handleServerActionRscRequest<
       );
       const redirectDynamicConfig = options.resolveRouteDynamicConfig?.(targetMatch.route);
       const redirectSearchParams = prepareActionPageRerenderContext({
+        draftModeCookie: actionDraftCookie,
         draftModeSecret: options.draftModeSecret,
         dynamicConfig: redirectDynamicConfig,
         request: redirectRenderRequest,
@@ -1430,6 +1454,7 @@ export async function handleServerActionRscRequest<
         actionRerenderTarget.route,
       );
       const actionRerenderSearchParams = prepareActionPageRerenderContext({
+        draftModeCookie: actionDraftCookie,
         draftModeSecret: options.draftModeSecret,
         dynamicConfig: actionRerenderDynamicConfig,
         request: options.request,

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -19,7 +19,11 @@
  * target used by the generated cache-adapter module.
  */
 
-import { getHeadersAccessPhase, markDynamicUsage as _markDynamic } from "./headers.js";
+import {
+  getHeadersAccessPhase,
+  isDraftModeEnabled,
+  markDynamicUsage as _markDynamic,
+} from "./headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import { fnv1a64 } from "../utils/hash.js";
 import { isInsideUnifiedScope, getRequestContext } from "./unified-request-context.js";
@@ -595,33 +599,39 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
       tagHash: tags.length > 0 ? fnv1a64(JSON.stringify(tags)) : null,
     });
 
-    // Try to get from cache. Stale entries are usable in normal App Router
-    // requests, but foreground-refresh inside revalidation scopes so the
-    // regenerated page/route stores fresh data.
-    const existing = await getDataCacheHandler().get(cacheKey, {
-      kind: "FETCH",
-      tags,
-    });
-    if (existing?.value && existing.value.kind === "FETCH") {
-      const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
-      if (cached.ok) {
-        if (existing.cacheState === "stale") {
-          if (shouldServeStaleUnstableCacheEntry()) {
-            scheduleUnstableCacheBackgroundRevalidation(cacheKey, () =>
-              refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
-            );
+    const isDraftMode = isDraftModeEnabled();
+    if (!isDraftMode) {
+      // Try to get from cache. Stale entries are usable in normal App Router
+      // requests, but foreground-refresh inside revalidation scopes so the
+      // regenerated page/route stores fresh data.
+      const existing = await getDataCacheHandler().get(cacheKey, {
+        kind: "FETCH",
+        tags,
+      });
+      if (existing?.value && existing.value.kind === "FETCH") {
+        const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
+        if (cached.ok) {
+          if (existing.cacheState === "stale") {
+            if (shouldServeStaleUnstableCacheEntry()) {
+              scheduleUnstableCacheBackgroundRevalidation(cacheKey, () =>
+                refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
+              );
+              return cached.value;
+            }
+          } else {
             return cached.value;
           }
-        } else {
-          return cached.value;
         }
+        // Corrupted entries fall through to a foreground refresh.
       }
-      // Corrupted entries fall through to a foreground refresh.
     }
 
     // Cache miss — call the function inside the unstable_cache ALS scope
     // so that headers()/cookies()/connection() can detect they're in a
     // cache scope and throw an appropriate error.
+    if (isDraftMode) {
+      return await _unstableCacheAls.run(true, () => fn(...args));
+    }
     return await refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds);
   };
 

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -1003,7 +1003,7 @@ export function isDraftModeRequest(request: Request, draftModeSecret: string): b
  */
 export function isDraftModeEnabled(): boolean {
   const context = _getState().headersContext;
-  if (!context || context.accessError) return false;
+  if (!context) return false;
   if (context.draftModeEnabled !== undefined) return context.draftModeEnabled;
   const secret = context.draftModeSecret;
   if (secret === undefined) return false;

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -996,6 +996,20 @@ export function isDraftModeRequest(request: Request, draftModeSecret: string): b
   );
 }
 
+/**
+ * Read the active request's draft-mode state without recording request API usage.
+ * Internal cache implementations use this to bypass persistent reads and writes,
+ * matching Next.js's request-level `workStore.isDraftMode` guard.
+ */
+export function isDraftModeEnabled(): boolean {
+  const context = _getState().headersContext;
+  if (!context || context.accessError) return false;
+  if (context.draftModeEnabled !== undefined) return context.draftModeEnabled;
+  const secret = context.draftModeSecret;
+  if (secret === undefined) return false;
+  return context.cookies.get(DRAFT_MODE_COOKIE) === validateDraftModeSecret(secret);
+}
+
 type DraftModeResult = {
   readonly isEnabled: boolean;
   enable(): void;

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -31,6 +31,7 @@ import {
   cookies,
   getHeadersContext,
   headersContextFromRequest,
+  isDraftModeEnabled,
   setHeadersAccessPhase,
   setHeadersContext,
 } from "../packages/vinext/src/shims/headers.js";
@@ -1653,10 +1654,12 @@ describe("app server action execution helpers", () => {
     // Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     const renderRequests: Request[] = [];
+    let redirectRenderDraftMode = false;
     const response = await handleServerActionRscRequest(
       createRscOptions({
         buildPageElement({ request }) {
           renderRequests.push(request);
+          redirectRenderDraftMode = isDraftModeEnabled();
           return "redirect-target:{}:none";
         },
         getAndClearPendingCookies() {
@@ -1679,7 +1682,7 @@ describe("app server action execution helpers", () => {
         },
         request: createFetchActionRequest({
           accept: "text/x-component",
-          cookie: "session=1; deleted=stale",
+          cookie: "session=1; deleted=stale; __prerender_bypass=draft-secret",
           "next-action": "action-id",
           rsc: "1",
         }),
@@ -1698,7 +1701,10 @@ describe("app server action execution helpers", () => {
     expect(renderRequest.headers.get("rsc")).toBeNull();
     expect(renderRequest.headers.get("content-type")).toBeNull();
     expect(renderRequest.headers.get("origin")).toBeNull();
-    expect(renderRequest.headers.get("cookie")).toBe("session=1; theme=dark");
+    expect(renderRequest.headers.get("cookie")).toBe(
+      "session=1; __prerender_bypass=draft-secret; theme=dark",
+    );
+    expect(redirectRenderDraftMode).toBe(true);
   });
 
   it("renders internal action redirects with the target route's root params", async () => {

--- a/tests/e2e/app-router/isr.spec.ts
+++ b/tests/e2e/app-router/isr.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type APIRequestContext } from "@playwright/test";
 
 const BASE = "http://localhost:4174";
 
@@ -384,4 +384,65 @@ test.describe("unstable_cache data cache (OpenNext compat)", () => {
 
     expect(value2).toBe(value1);
   });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-static/app-static.test.ts
+  test("unstable_cache bypasses cache in draft mode", async ({ request }) => {
+    const key = `bypass-${Date.now()}`;
+
+    try {
+      expect((await request.get(`${BASE}/nextjs-compat/api/draft-enable`)).status()).toBe(200);
+
+      const draft1 = await readDraftCachePage(request, key);
+      const draft2 = await readDraftCachePage(request, key);
+
+      expect(draft1.data).not.toBe(draft2.data);
+    } finally {
+      await request.get(`${BASE}/nextjs-compat/api/draft-disable`);
+    }
+  });
+
+  test("unstable_cache does not cache new results in draft mode", async ({ request }) => {
+    const key = `write-${Date.now()}`;
+
+    let draft;
+    try {
+      expect((await request.get(`${BASE}/nextjs-compat/api/draft-enable`)).status()).toBe(200);
+      draft = await readDraftCachePage(request, key);
+    } finally {
+      await request.get(`${BASE}/nextjs-compat/api/draft-disable`);
+    }
+
+    const normal = await readDraftCachePage(request, key);
+
+    expect(draft).toBeDefined();
+    expect(draft.data).not.toBe(normal.data);
+  });
+
+  test("unstable_cache exposes draft mode status", async ({ request }) => {
+    const key = `status-${Date.now()}`;
+
+    const normal = await readDraftCachePage(request, key);
+    expect(normal.draftMode).toBe("false");
+
+    try {
+      expect((await request.get(`${BASE}/nextjs-compat/api/draft-enable`)).status()).toBe(200);
+      const draft = await readDraftCachePage(request, key);
+      expect(draft.draftMode).toBe("true");
+    } finally {
+      await request.get(`${BASE}/nextjs-compat/api/draft-disable`);
+    }
+  });
 });
+
+async function readDraftCachePage(request: APIRequestContext, key: string) {
+  const response = await request.get(
+    `${BASE}/nextjs-compat/unstable-cache-draft?key=${encodeURIComponent(key)}`,
+  );
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+  return {
+    data: html.match(/id="cached-data">([^<]+)/)?.[1],
+    draftMode: html.match(/id="draft-mode-enabled">([^<]+)/)?.[1],
+  };
+}

--- a/tests/e2e/app-router/isr.spec.ts
+++ b/tests/e2e/app-router/isr.spec.ts
@@ -433,6 +433,48 @@ test.describe("unstable_cache data cache (OpenNext compat)", () => {
       await request.get(`${BASE}/nextjs-compat/api/draft-disable`);
     }
   });
+
+  // Extended from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-static/app-static.test.ts
+  test("dynamic error pages keep draft cache bypass separate from access errors", async ({
+    request,
+  }) => {
+    const normal = await readDynamicErrorDraftCachePage(request);
+
+    try {
+      expect((await request.get(`${BASE}/nextjs-compat/api/draft-enable`)).status()).toBe(200);
+      const draft1 = await readDynamicErrorDraftCachePage(request);
+      const draft2 = await readDynamicErrorDraftCachePage(request);
+
+      expect(draft1.draftMode).toBe("true");
+      expect(draft1.data).not.toBe(normal.data);
+      expect(draft2.data).not.toBe(draft1.data);
+    } finally {
+      await request.get(`${BASE}/nextjs-compat/api/draft-disable`);
+    }
+
+    expect((await readDynamicErrorDraftCachePage(request)).data).toBe(normal.data);
+  });
+
+  test("dynamic error route handlers keep draft cache bypass separate from access errors", async ({
+    request,
+  }) => {
+    const normal = await readDraftCacheRoute(request);
+
+    try {
+      expect((await request.get(`${BASE}/nextjs-compat/api/draft-enable`)).status()).toBe(200);
+      const draft1 = await readDraftCacheRoute(request);
+      const draft2 = await readDraftCacheRoute(request);
+
+      expect(draft1.draftMode).toBe(true);
+      expect(draft1.data).not.toBe(normal.data);
+      expect(draft2.data).not.toBe(draft1.data);
+    } finally {
+      await request.get(`${BASE}/nextjs-compat/api/draft-disable`);
+    }
+
+    expect((await readDraftCacheRoute(request)).data).toBe(normal.data);
+  });
 });
 
 async function readDraftCachePage(request: APIRequestContext, key: string) {
@@ -445,4 +487,22 @@ async function readDraftCachePage(request: APIRequestContext, key: string) {
     data: html.match(/id="cached-data">([^<]+)/)?.[1],
     draftMode: html.match(/id="draft-mode-enabled">([^<]+)/)?.[1],
   };
+}
+
+async function readDynamicErrorDraftCachePage(request: APIRequestContext) {
+  const response = await request.get(`${BASE}/nextjs-compat/unstable-cache-draft-dynamic-error`);
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+  return {
+    data: html.match(/id="cached-data">([^<]+)/)?.[1],
+    draftMode: html.match(/id="draft-mode-enabled">([^<]+)/)?.[1],
+  };
+}
+
+async function readDraftCacheRoute(request: APIRequestContext) {
+  const response = await request.get(
+    `${BASE}/nextjs-compat/api/unstable-cache-draft-dynamic-error`,
+  );
+  expect(response.status()).toBe(200);
+  return (await response.json()) as { data: string; draftMode: boolean };
 }

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -323,6 +323,27 @@ test.describe("Server Actions", () => {
     );
   });
 
+  // Matches Next.js v16.2.6 action rerender ordering in action-handler.ts:
+  // synchronize mutable cookies, update workStore.isDraftMode, then rerender.
+  // https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/app-render/action-handler.ts
+  test("same-route action rerenders apply draft mode before rebuilding cache context", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/nextjs-compat/action-draft-cache`);
+    await waitForAppRouterHydration(page);
+
+    const initialCachedData = await page.locator("#cached-data").textContent();
+    await expect(page.locator("#draft-mode-enabled")).toHaveText("false");
+
+    await page.click("#enable-draft");
+    await expect(page.locator("#draft-mode-enabled")).toHaveText("true");
+    await expect(page.locator("#cached-data")).not.toHaveText(initialCachedData ?? "");
+
+    await page.click("#disable-draft");
+    await expect(page.locator("#draft-mode-enabled")).toHaveText("false");
+    await expect(page.locator("#cached-data")).toHaveText(initialCachedData ?? "");
+  });
+
   test("action-redirect-test page SSR renders correctly", async ({ page }) => {
     await page.goto(`${BASE}/action-redirect-test`);
     await expect(page.locator("h1")).toHaveText("Action Redirect Test");

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-draft-cache/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-draft-cache/page.tsx
@@ -1,0 +1,45 @@
+import { revalidatePath, unstable_cache } from "next/cache";
+import { draftMode } from "next/headers";
+
+const routePath = "/nextjs-compat/action-draft-cache";
+const getCachedData = unstable_cache(
+  async () => Math.random().toString(36).slice(2),
+  ["nextjs-compat-action-draft-cache"],
+);
+
+export const dynamic = "error";
+
+export default async function ActionDraftCachePage() {
+  async function enableDraftMode() {
+    "use server";
+    (await draftMode()).enable();
+    revalidatePath(routePath);
+  }
+
+  async function disableDraftMode() {
+    "use server";
+    (await draftMode()).disable();
+    revalidatePath(routePath);
+  }
+
+  const draft = await draftMode();
+  const cachedData = await getCachedData();
+
+  return (
+    <main>
+      <h1>Action Draft Cache</h1>
+      <p id="draft-mode-enabled">{draft.isEnabled.toString()}</p>
+      <p id="cached-data">{cachedData}</p>
+      <form action={enableDraftMode}>
+        <button id="enable-draft" type="submit">
+          Enable Draft Mode
+        </button>
+      </form>
+      <form action={disableDraftMode}>
+        <button id="disable-draft" type="submit">
+          Disable Draft Mode
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/api/unstable-cache-draft-dynamic-error/route.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/api/unstable-cache-draft-dynamic-error/route.ts
@@ -1,0 +1,16 @@
+import { unstable_cache } from "next/cache";
+import { draftMode } from "next/headers";
+
+const getCachedData = unstable_cache(
+  async () => ({
+    data: Math.random().toString(36).slice(2),
+    draftMode: (await draftMode()).isEnabled,
+  }),
+  ["nextjs-compat-unstable-cache-draft-dynamic-error-route"],
+);
+
+export const dynamic = "error";
+
+export async function GET() {
+  return Response.json(await getCachedData());
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/unstable-cache-draft-dynamic-error/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/unstable-cache-draft-dynamic-error/page.tsx
@@ -1,0 +1,23 @@
+import { unstable_cache } from "next/cache";
+import { draftMode } from "next/headers";
+
+const getCachedData = unstable_cache(
+  async () => ({
+    data: Math.random().toString(36).slice(2),
+    draftMode: (await draftMode()).isEnabled,
+  }),
+  ["nextjs-compat-unstable-cache-draft-dynamic-error-page"],
+);
+
+export const dynamic = "error";
+
+export default async function Page() {
+  const cached = await getCachedData();
+
+  return (
+    <main>
+      <p id="cached-data">{cached.data}</p>
+      <p id="draft-mode-enabled">{cached.draftMode.toString()}</p>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/unstable-cache-draft/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/unstable-cache-draft/page.tsx
@@ -1,0 +1,27 @@
+import { unstable_cache } from "next/cache";
+import { draftMode } from "next/headers";
+
+const getCachedData = unstable_cache(
+  async (key: string) => {
+    const draft = await draftMode();
+    return {
+      data: `${key}-${Math.random().toString(36).slice(2)}`,
+      draftMode: draft.isEnabled,
+    };
+  },
+  ["nextjs-compat-unstable-cache-draft"],
+);
+
+export const dynamic = "force-dynamic";
+
+export default async function Page({ searchParams }: { searchParams: Promise<{ key?: string }> }) {
+  const { key = "default" } = await searchParams;
+  const cached = await getCachedData(key);
+
+  return (
+    <main>
+      <p id="cached-data">{cached.data}</p>
+      <p id="draft-mode-enabled">{cached.draftMode.toString()}</p>
+    </main>
+  );
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -21392,6 +21392,34 @@ describe("cache scope guards for dynamic APIs", () => {
     setCacheHandler(new MemoryCacheHandler());
   });
 
+  it("unstable_cache bypasses reads and writes while draft mode is enabled", async () => {
+    const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersContext } = await import("../packages/vinext/src/shims/headers.js");
+
+    setCacheHandler(new MemoryCacheHandler());
+    let calls = 0;
+    const cached = unstable_cache(async () => ++calls, ["test-draftmode-cache-bypass"]);
+
+    setHeadersContext({ headers: new Headers(), cookies: new Map(), draftModeSecret: "secret" });
+    await expect(cached()).resolves.toBe(1);
+    await expect(cached()).resolves.toBe(1);
+
+    setHeadersContext({
+      headers: new Headers({ cookie: "__prerender_bypass=secret" }),
+      cookies: new Map([["__prerender_bypass", "secret"]]),
+      draftModeSecret: "secret",
+    });
+    await expect(cached()).resolves.toBe(2);
+    await expect(cached()).resolves.toBe(3);
+
+    setHeadersContext({ headers: new Headers(), cookies: new Map(), draftModeSecret: "secret" });
+    await expect(cached()).resolves.toBe(1);
+
+    setHeadersContext(null);
+    setCacheHandler(new MemoryCacheHandler());
+  });
+
   it('draftMode().enable() throws inside "use cache" scope', async () => {
     const { cacheContextStorage } = await import("../packages/vinext/src/shims/cache-runtime.js");
     const { draftMode, setHeadersContext } =


### PR DESCRIPTION
## Summary

- bypass `unstable_cache` persistent reads while draft mode is enabled
- avoid writing newly computed draft-mode results to the data cache
- expose the active draft-mode state inside cached callbacks, including internal Server Action redirect renders
- add focused unit and app-router fixture coverage ported from Next.js v16.2.6

Supersedes stale/conflicted #2236 with a clean implementation from current `main`.

## Next.js parity

Verified against:

- `packages/next/src/server/web/spec-extension/unstable-cache.ts` at v16.2.6
- `test/e2e/app-dir/app-static/app-static.test.ts` at v16.2.6

The targeted upstream cases pass through vinext's deploy harness with concurrency 1:

- `should bypass cache in draft mode`
- `should not cache new result in draft mode`
- `should be able to read the draft mode status`

## Validation

- `vp test run tests/shims.test.ts -t 'unstable_cache bypasses reads and writes while draft mode is enabled' --maxWorkers=1`
- `vp test run tests/app-server-action-execution.test.ts -t 'renders internal action redirects with a clean GET request and action cookies' --maxWorkers=1`
- `PLAYWRIGHT_PROJECT=app-router playwright test tests/e2e/app-router/isr.spec.ts --workers=1 -g 'unstable_cache (bypasses cache|does not cache new results|exposes draft mode status)'`
- targeted `vp check` for the seven changed files
- targeted Next.js v16.2.6 `app-static.test.ts` deploy run, three cases only, concurrency 1

No cacheComponents, PPR, or resume coverage is included.
