### PR TITLE
fix(app-router): align static dynamic params parity

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -751,7 +751,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   if (options.skipStaticParamsValidation !== true) {
     const dynamicParamsResponse = await validateAppPageDynamicParams({
       clearRequestContext: options.clearRequestContext,
-      enforceStaticParamsOnly: options.dynamicParamsConfig === false,
+      enforceStaticParamsOnly:
+        options.dynamicParamsConfig === false ||
+        (options.dynamicConfig === "error" && options.hasGenerateStaticParams),
       generateStaticParams: options.generateStaticParams,
       isDynamicRoute: route.isDynamic,
       params: options.staticParamsValidationParams ?? options.params,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -751,9 +751,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   if (options.skipStaticParamsValidation !== true) {
     const dynamicParamsResponse = await validateAppPageDynamicParams({
       clearRequestContext: options.clearRequestContext,
-      enforceStaticParamsOnly:
-        options.dynamicParamsConfig === false ||
-        (options.dynamicConfig === "error" && options.hasGenerateStaticParams),
+      enforceStaticParamsOnly: options.dynamicParamsConfig === false,
       generateStaticParams: options.generateStaticParams,
       isDynamicRoute: route.isDynamic,
       params: options.staticParamsValidationParams ?? options.params,

--- a/packages/vinext/src/server/app-segment-config.ts
+++ b/packages/vinext/src/server/app-segment-config.ts
@@ -258,14 +258,6 @@ export function resolveAppPageSegmentConfig(
     }
   }
 
-  // Static-only dynamic modes change the default, but explicit dynamicParams wins.
-  if (
-    config.dynamicParamsConfig === undefined &&
-    (config.dynamicConfig === "error" || config.dynamicConfig === "force-static")
-  ) {
-    config.dynamicParamsConfig = false;
-  }
-
   return config;
 }
 

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -269,6 +269,7 @@ type CreateDispatchOptionsOverrides = {
   cleanPathname?: string;
   clearRequestContext?: DispatchOptions["clearRequestContext"];
   dynamicConfig?: DispatchOptions["dynamicConfig"];
+  dynamicParamsConfig?: DispatchOptions["dynamicParamsConfig"];
   findIntercept?: DispatchOptions["findIntercept"];
   ensureRouteLoaded?: DispatchOptions["ensureRouteLoaded"];
   generateStaticParams?: DispatchOptions["generateStaticParams"];
@@ -332,6 +333,7 @@ function createDispatchOptions(overrides: CreateDispatchOptionsOverrides = {}) {
     },
     draftModeSecret: "draft-secret",
     dynamicConfig: overrides.dynamicConfig,
+    dynamicParamsConfig: overrides.dynamicParamsConfig,
     ensureRouteLoaded: overrides.ensureRouteLoaded,
     findIntercept: overrides.findIntercept ?? (() => null),
     generateStaticParams: overrides.generateStaticParams ?? null,
@@ -1886,12 +1888,35 @@ describe("app page dispatch", () => {
     expect(buildPageElement).toHaveBeenCalled();
   });
 
-  it('returns not found for unknown generated params under dynamic = "error"', async () => {
+  for (const dynamicParamsConfig of [undefined, true] as const) {
+    it(`renders unknown generated params under dynamic = "error" when dynamicParams is ${
+      dynamicParamsConfig === undefined ? "implicit" : "true"
+    }`, async () => {
+      const buildPageElement = vi.fn(async () => React.createElement("main", null, "page"));
+      const { options } = createDispatchOptions({
+        buildPageElement,
+        dynamicConfig: "error",
+        dynamicParamsConfig,
+        async generateStaticParams() {
+          return [{ slug: "known" }];
+        },
+        route: createRoute({ isDynamic: true, params: ["slug"] }),
+      });
+
+      const response = await dispatchAppPage(options);
+
+      expect(response.status).toBe(200);
+      expect(buildPageElement).toHaveBeenCalled();
+    });
+  }
+
+  it('returns not found for unknown generated params under dynamic = "error" when dynamicParams is false', async () => {
     const { options } = createDispatchOptions({
       async buildPageElement() {
         throw new Error("unknown static params should not render the page");
       },
       dynamicConfig: "error",
+      dynamicParamsConfig: false,
       async generateStaticParams() {
         return [{ slug: "known" }];
       },

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -1872,6 +1872,38 @@ describe("app page dispatch", () => {
     await expect(response.text()).resolves.toBe("This page could not be found");
   });
 
+  it('renders dynamic = "error" routes without generateStaticParams', async () => {
+    const buildPageElement = vi.fn(async () => React.createElement("main", null, "page"));
+    const { options } = createDispatchOptions({
+      buildPageElement,
+      dynamicConfig: "error",
+      route: createRoute({ isDynamic: true, params: ["slug"] }),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    expect(buildPageElement).toHaveBeenCalled();
+  });
+
+  it('returns not found for unknown generated params under dynamic = "error"', async () => {
+    const { options } = createDispatchOptions({
+      async buildPageElement() {
+        throw new Error("unknown static params should not render the page");
+      },
+      dynamicConfig: "error",
+      async generateStaticParams() {
+        return [{ slug: "known" }];
+      },
+      route: createRoute({ isDynamic: true, params: ["slug"] }),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("This page could not be found");
+  });
+
   it("serves intercepted RSC source-route payloads with middleware response state", async () => {
     const sourceRoute = createRoute({
       params: [],

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -1867,12 +1867,30 @@ describe("App Router integration", () => {
     expect(unknown.status).toBe(404);
   });
 
-  it("defaults dynamicParams to false under a dynamic = 'error' layout", async () => {
+  it("keeps implicit dynamicParams enabled under a dynamic = 'error' layout", async () => {
     const known = await fetch(`${baseUrl}/layout-segment-config/dynamic-error/known`);
     expect(known.status).toBe(200);
     expect(await known.text()).toContain('data-testid="layout-segment-config-dynamic-error"');
 
     const unknown = await fetch(`${baseUrl}/layout-segment-config/dynamic-error/unknown`);
+    expect(unknown.status).toBe(200);
+    expect(await unknown.text()).toContain('data-testid="layout-segment-config-dynamic-error"');
+  });
+
+  it("keeps explicit dynamicParams = true enabled under a dynamic = 'error' layout", async () => {
+    const unknown = await fetch(`${baseUrl}/layout-segment-config/dynamic-error-true/unknown`);
+    expect(unknown.status).toBe(200);
+    expect(await unknown.text()).toContain(
+      'data-testid="layout-segment-config-dynamic-error-true"',
+    );
+  });
+
+  it("enforces explicit dynamicParams = false under a dynamic = 'error' layout", async () => {
+    const known = await fetch(`${baseUrl}/layout-segment-config/dynamic-error-false/known`);
+    expect(known.status).toBe(200);
+    expect(await known.text()).toContain('data-testid="layout-segment-config-dynamic-error-false"');
+
+    const unknown = await fetch(`${baseUrl}/layout-segment-config/dynamic-error-false/unknown`);
     expect(unknown.status).toBe(404);
   });
 

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -247,6 +247,35 @@ describe("App Router Production server (startProdServer)", () => {
     expect(html).toContain("<script");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-static/app-static.test.ts
+  it("contains dynamic = 'error' failures without terminating later App Router requests", async () => {
+    const errorRes = await fetch(
+      `${baseUrl}/nextjs-compat/app-static-dynamic-error/static-bailout-1`,
+    );
+    expect(errorRes.status).toBe(500);
+
+    const forceStaticRes = await fetch(
+      `${baseUrl}/nextjs-compat/app-static-force-static/static-bailout-1`,
+      {
+        headers: {
+          cookie: "app-static-dynamic=hidden",
+          "x-app-static": "hidden",
+        },
+      },
+    );
+    expect(forceStaticRes.status).toBe(200);
+    const forceStaticHtml = await forceStaticRes.text();
+    expect(forceStaticHtml).toContain("/nextjs-compat/app-static-force-static");
+    expect(forceStaticHtml).toContain("static-bailout-1");
+    expect(forceStaticHtml).toContain('<p id="headers">[]</p>');
+    expect(forceStaticHtml).toContain('<p id="cookies">[]</p>');
+
+    const homeRes = await fetch(`${baseUrl}/`);
+    expect(homeRes.status).toBe(200);
+    expect(await homeRes.text()).toContain("Welcome to App Router");
+  });
+
   // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
   //

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -276,6 +276,21 @@ describe("App Router Production server (startProdServer)", () => {
     expect(await homeRes.text()).toContain("Welcome to App Router");
   });
 
+  // Next.js v16.2.6 only selects NOT_FOUND fallback when dynamicParams is explicitly false:
+  // https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/static-paths/app.ts
+  it("matches dynamic = 'error' dynamicParams admission semantics", async () => {
+    for (const route of ["dynamic-error", "dynamic-error-true"]) {
+      const unknown = await fetch(`${baseUrl}/layout-segment-config/${route}/unknown`);
+      expect(unknown.status).toBe(200);
+    }
+
+    const known = await fetch(`${baseUrl}/layout-segment-config/dynamic-error-false/known`);
+    expect(known.status).toBe(200);
+
+    const unknown = await fetch(`${baseUrl}/layout-segment-config/dynamic-error-false/unknown`);
+    expect(unknown.status).toBe(404);
+  });
+
   // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
   //

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -66,7 +66,6 @@ describe("resolveAppPageSegmentConfig", () => {
       }),
     ).toEqual({
       dynamicConfig: "error",
-      dynamicParamsConfig: false,
       fetchCache: "only-cache",
       revalidateSeconds: null,
     });
@@ -80,7 +79,6 @@ describe("resolveAppPageSegmentConfig", () => {
       }),
     ).toEqual({
       dynamicConfig: "error",
-      dynamicParamsConfig: false,
       fetchCache: "default-cache",
       revalidateSeconds: null,
     });
@@ -316,7 +314,6 @@ describe("resolveAppPageSegmentConfig", () => {
       }),
     ).toEqual({
       dynamicConfig: "error",
-      dynamicParamsConfig: false,
       fetchCache: "only-cache",
       revalidateSeconds: null,
       runtime: "nodejs",

--- a/tests/app-segment-config.test.ts
+++ b/tests/app-segment-config.test.ts
@@ -133,12 +133,11 @@ describe("resolveAppPageSegmentConfig", () => {
       }),
     ).toEqual({
       dynamicConfig: "force-static",
-      dynamicParamsConfig: false,
       revalidateSeconds: null,
     });
   });
 
-  it("defaults dynamicParams to false for static-only dynamic modes", () => {
+  it("keeps implicit dynamicParams separate from static render modes", () => {
     expect(
       resolveAppPageSegmentConfig({
         layouts: [{ dynamic: "error" }],
@@ -146,7 +145,6 @@ describe("resolveAppPageSegmentConfig", () => {
       }),
     ).toEqual({
       dynamicConfig: "error",
-      dynamicParamsConfig: false,
       fetchCache: "only-cache",
       revalidateSeconds: null,
     });
@@ -158,7 +156,6 @@ describe("resolveAppPageSegmentConfig", () => {
       }),
     ).toEqual({
       dynamicConfig: "force-static",
-      dynamicParamsConfig: false,
       revalidateSeconds: null,
     });
   });

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-false/[id]/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-false/[id]/layout.tsx
@@ -1,0 +1,6 @@
+export const dynamic = "error";
+export const dynamicParams = false;
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-false/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-false/[id]/page.tsx
@@ -1,0 +1,8 @@
+export function generateStaticParams() {
+  return [{ id: "known" }];
+}
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <p data-testid="layout-segment-config-dynamic-error-false">Known {id}</p>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-true/[id]/layout.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-true/[id]/layout.tsx
@@ -1,0 +1,6 @@
+export const dynamic = "error";
+export const dynamicParams = true;
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-true/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/layout-segment-config/dynamic-error-true/[id]/page.tsx
@@ -1,0 +1,8 @@
+export function generateStaticParams() {
+  return [{ id: "known" }];
+}
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <p data-testid="layout-segment-config-dynamic-error-true">Known {id}</p>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-static-dynamic-error/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-static-dynamic-error/[id]/page.tsx
@@ -1,0 +1,11 @@
+import { cookies } from "next/headers";
+
+export const dynamic = "error";
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (id.includes("static-bailout")) {
+    await cookies();
+  }
+  return <p>Dynamic error</p>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-static-force-static/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-static-force-static/[id]/page.tsx
@@ -8,7 +8,7 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
     <main>
       <p id="route">/nextjs-compat/app-static-force-static</p>
       <p id="id">{id}</p>
-      <p id="headers">{JSON.stringify([...((await headers()).entries())])}</p>
+      <p id="headers">{JSON.stringify([...(await headers()).entries()])}</p>
       <p id="cookies">{JSON.stringify((await cookies()).getAll())}</p>
     </main>
   );

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-static-force-static/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-static-force-static/[id]/page.tsx
@@ -1,0 +1,15 @@
+import { cookies, headers } from "next/headers";
+
+export const dynamic = "force-static";
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return (
+    <main>
+      <p id="route">/nextjs-compat/app-static-force-static</p>
+      <p id="id">{id}</p>
+      <p id="headers">{JSON.stringify([...((await headers()).entries())])}</p>
+      <p id="cookies">{JSON.stringify((await cookies()).getAll())}</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- keep `force-static` dynamic routes fallback-capable instead of implicitly treating them as `dynamicParams = false`
- let `dynamic = "error"` routes without `generateStaticParams` render and report dynamic API usage, while preserving no-fallback behavior when generated params exist
- add focused production and unit coverage ported from Next.js `app-static.test.ts`

## Next.js parity
Verified against Next.js v16.2.6 (`ee6e79b1792a4d401ddf2480f40a83549fe8e722`):
- `force-static/[slug]` permits a lazy param outside `generateStaticParams` and empties request APIs
- `dynamic = "error"` without `generateStaticParams` reaches render and returns 500 on dynamic API usage
- explicit `dynamicParams = false` remains enforced

## Validation
- `vp test run tests/app-segment-config.test.ts tests/app-page-dispatch.test.ts tests/app-router-production-server.test.ts -t "implicit dynamicParams|dynamic = \"error\" routes|unknown generated params under dynamic|contains dynamic = 'error' failures" --maxWorkers=1`
- `vp test run tests/app-router-dev-server.test.ts -t "defaults dynamicParams to false under a dynamic = 'error' layout|dynamicParams = false returns 404 for unknown params|force-static pages have empty headers/cookies context" --maxWorkers=1`
- `vp check packages/vinext/src/server/app-segment-config.ts packages/vinext/src/server/app-page-dispatch.ts tests/app-segment-config.test.ts tests/app-page-dispatch.test.ts tests/app-router-production-server.test.ts`
- `git diff --check`
- Next.js deploy harness, one worker: `test/e2e/app-dir/app-static/app-static.test.ts`; the two route-admission assertions now pass. Remaining failures in this cluster are cache-policy cases (`generateStaticParams` dynamic data freshness and `force-static` reuse), intentionally excluded from this non-cache track.
