### PR TITLE
fix(app-router): skip prefetches for bots

### DIFF
--- a/packages/vinext/src/shims/form.tsx
+++ b/packages/vinext/src/shims/form.tsx
@@ -42,6 +42,7 @@ import { toSameOriginPath, withBasePath } from "./url-utils.js";
 import { createRscRequestHeaders, createRscRequestUrl } from "../server/app-rsc-cache-busting.js";
 import { AppElementsWire } from "../server/app-elements.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
+import { isBotUserAgent } from "../utils/html-limited-bots.js";
 
 // Mirrors `__NEXT_ROUTER_BASEPATH` exposure in `next/link` / `next/router`.
 // `addBasePath` is only applied to the form-level `action` prop. A submitter's
@@ -324,6 +325,8 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
         for (const entry of entries) {
           if (entry.isIntersecting || entry.intersectionRatio > 0) {
             void (async () => {
+              if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
+
               // Mirror the Link/router prefetch computation so the cache key the
               // navigation later looks up matches what we prefetch here. Without
               // this, intercepted routes or pages with mounted parallel slots

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -407,7 +407,6 @@ export function resolveAutoAppRoutePrefetch(href: string): {
  */
 function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "high" = "low"): void {
   if (typeof window === "undefined") return;
-  if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
 
   const prefetchHref = getLinkPrefetchHref({
     href,
@@ -436,6 +435,8 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
   schedule(() => {
     void (async () => {
       if (hasAppNavigationRuntime()) {
+        if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
+
         // Hybrid ownership: skip the App RSC prefetch when Pages owns the
         // URL. The App's `__VINEXT_LINK_PREFETCH_ROUTES__` may include an
         // App catch-all that also matches the same path, so a naive

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -68,6 +68,7 @@ import {
 } from "../client/pages-router-link-navigation.js";
 import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
 import { stripBasePath } from "../utils/base-path.js";
+import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import {
   prefetchPagesData,
   resolvePagesDataNavigationTarget,
@@ -406,6 +407,7 @@ export function resolveAutoAppRoutePrefetch(href: string): {
  */
 function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "high" = "low"): void {
   if (typeof window === "undefined") return;
+  if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
 
   const prefetchHref = getLinkPrefetchHref({
     href,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -49,6 +49,7 @@ import {
 } from "./url-utils.js";
 import { navigationPlanner } from "../server/navigation-planner.js";
 import { stripBasePath } from "../utils/base-path.js";
+import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
 import { markPprFallbackShellDynamicBoundary } from "./ppr-fallback-shell.js";
@@ -1848,6 +1849,7 @@ const _appRouter: AppRouterInstance = {
   prefetch(href: string, options?: PrefetchOptions): void {
     assertSafeNavigationUrl(href);
     if (isServer) return;
+    if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
     // Validate the URL is parseable. Mirrors Next.js's createPrefetchURL:
     // `packages/next/src/client/components/app-router-utils.ts` — when the URL
     // cannot be converted, Next.js throws so the call site (and its surrounding

--- a/tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts
@@ -128,7 +128,7 @@ test.describe("Next.js compat: bot prefetching in production", () => {
   // Ported from Next.js:
   // test/e2e/app-dir/app-prefetch/prefetching.test.ts
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-prefetch/prefetching.test.ts
-  test("does not prefetch links for a bot user agent", async ({ page }) => {
+  test("does not prefetch links but still navigates for a bot user agent", async ({ page }) => {
     const app = await buildAndServePrefetchBotFixture();
 
     try {
@@ -153,6 +153,10 @@ test.describe("Next.js compat: bot prefetching in production", () => {
       await page.waitForTimeout(1_000);
 
       expect(targetRequests).toEqual([]);
+
+      await page.locator("#target-link").click();
+      await expect(page.locator("#target-page")).toHaveText("Target page");
+      expect(targetRequests).toHaveLength(1);
     } finally {
       await page.close();
       await closeServer(app.server);

--- a/tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const GOOGLEBOT_USER_AGENT =
+  "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 " +
+  "(compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+
+type ProductionApp = {
+  baseUrl: string;
+  fixtureRoot: string;
+  server: Server;
+};
+
+async function closeServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await closed;
+}
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+
+  await fs.mkdir(targetNodeModules, { recursive: true });
+  for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+async function writePrefetchBotFixture(fixtureRoot: string): Promise<void> {
+  const appDir = path.join(fixtureRoot, "app");
+  const targetDir = path.join(appDir, "target");
+  await fs.mkdir(targetDir, { recursive: true });
+  await linkFixtureNodeModules(fixtureRoot);
+
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "layout.tsx"),
+    `import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "page.tsx"),
+    `import Link from "next/link";
+
+export default function Page() {
+  return <Link href="/target" id="target-link">Target</Link>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(targetDir, "page.tsx"),
+    `export default function TargetPage() {
+  return <p id="target-page">Target page</p>;
+}
+`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});
+`,
+  );
+}
+
+async function buildAndServePrefetchBotFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-prefetch-bot-"));
+  await writePrefetchBotFixture(fixtureRoot);
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const { startProdServer } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/server/prod-server.js")).href
+  );
+  const started = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir: path.join(fixtureRoot, "dist"),
+    noCompression: true,
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${started.port}`,
+    fixtureRoot,
+    server: started.server,
+  };
+}
+
+test.setTimeout(90_000);
+
+test.describe("Next.js compat: bot prefetching in production", () => {
+  // Ported from Next.js:
+  // test/e2e/app-dir/app-prefetch/prefetching.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+  test("does not prefetch links for a bot user agent", async ({ page }) => {
+    const app = await buildAndServePrefetchBotFixture();
+
+    try {
+      await page.addInitScript((userAgent) => {
+        Object.defineProperty(window.navigator, "userAgent", {
+          configurable: true,
+          value: userAgent,
+        });
+      }, GOOGLEBOT_USER_AGENT);
+
+      const targetRequests: string[] = [];
+      page.on("request", (request) => {
+        const url = new URL(request.url());
+        if (url.pathname === "/target" && request.headers().rsc === "1") {
+          targetRequests.push(request.url());
+        }
+      });
+
+      await page.goto(app.baseUrl);
+      await waitForAppRouterHydration(page);
+      await page.locator("#target-link").hover();
+      await page.waitForTimeout(1_000);
+
+      expect(targetRequests).toEqual([]);
+    } finally {
+      await page.close();
+      await closeServer(app.server);
+      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts
@@ -42,7 +42,9 @@ async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
 async function writePrefetchBotFixture(fixtureRoot: string): Promise<void> {
   const appDir = path.join(fixtureRoot, "app");
   const targetDir = path.join(appDir, "target");
+  const formTargetDir = path.join(appDir, "form-target");
   await fs.mkdir(targetDir, { recursive: true });
+  await fs.mkdir(formTargetDir, { recursive: true });
   await linkFixtureNodeModules(fixtureRoot);
 
   await fs.writeFile(
@@ -60,10 +62,17 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   );
   await fs.writeFile(
     path.join(appDir, "page.tsx"),
-    `import Link from "next/link";
+    `import Form from "next/form";
+import Link from "next/link";
 
 export default function Page() {
-  return <Link href="/target" id="target-link">Target</Link>;
+  return <>
+    <Link href="/target" id="target-link">Target</Link>
+    <Form action="/form-target" id="target-form">
+      <input name="q" defaultValue="vinext" />
+      <button type="submit">Submit form</button>
+    </Form>
+  </>;
 }
 `,
   );
@@ -71,6 +80,14 @@ export default function Page() {
     path.join(targetDir, "page.tsx"),
     `export default function TargetPage() {
   return <p id="target-page">Target page</p>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(formTargetDir, "page.tsx"),
+    `export default async function FormTargetPage({ searchParams }: { searchParams: Promise<{ q?: string }> }) {
+  const { q } = await searchParams;
+  return <p id="form-target-page">Form target: {q}</p>;
 }
 `,
   );
@@ -128,7 +145,9 @@ test.describe("Next.js compat: bot prefetching in production", () => {
   // Ported from Next.js:
   // test/e2e/app-dir/app-prefetch/prefetching.test.ts
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-prefetch/prefetching.test.ts
-  test("does not prefetch links but still navigates for a bot user agent", async ({ page }) => {
+  test("does not prefetch links or forms but still navigates for a bot user agent", async ({
+    page,
+  }) => {
     const app = await buildAndServePrefetchBotFixture();
 
     try {
@@ -140,10 +159,14 @@ test.describe("Next.js compat: bot prefetching in production", () => {
       }, GOOGLEBOT_USER_AGENT);
 
       const targetRequests: string[] = [];
+      const formTargetRequests: string[] = [];
       page.on("request", (request) => {
         const url = new URL(request.url());
         if (url.pathname === "/target" && request.headers().rsc === "1") {
           targetRequests.push(request.url());
+        }
+        if (url.pathname === "/form-target" && request.headers().rsc === "1") {
+          formTargetRequests.push(request.url());
         }
       });
 
@@ -153,10 +176,21 @@ test.describe("Next.js compat: bot prefetching in production", () => {
       await page.waitForTimeout(1_000);
 
       expect(targetRequests).toEqual([]);
+      expect(formTargetRequests).toEqual([]);
 
       await page.locator("#target-link").click();
       await expect(page.locator("#target-page")).toHaveText("Target page");
       expect(targetRequests).toHaveLength(1);
+
+      await page.goBack();
+      await expect(page.locator("#target-form")).toBeVisible();
+      await page.waitForTimeout(1_000);
+      expect(formTargetRequests).toEqual([]);
+
+      await page.getByRole("button", { name: "Submit form" }).click();
+      await expect(page.locator("#form-target-page")).toHaveText("Form target: vinext");
+      await expect(page).toHaveURL(`${app.baseUrl}/form-target?q=vinext`);
+      expect(formTargetRequests).toHaveLength(1);
     } finally {
       await page.close();
       await closeServer(app.server);

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -81,7 +81,10 @@ function createFormDataClass({ supportsSubmitter }: { supportsSubmitter: boolean
   };
 }
 
-function renderClientForm(props: Record<string, unknown>) {
+function renderClientForm(
+  props: Record<string, unknown>,
+  { effects = [] }: { effects?: Array<() => void | (() => void)> } = {},
+) {
   // `forwardRef()` exposes the wrapped render function on `.render`, which lets us
   // exercise the submit handler directly without adding a DOM renderer just for this shim.
   //
@@ -103,7 +106,9 @@ function renderClientForm(props: Record<string, unknown>) {
     useCallback(fn: unknown) {
       return fn;
     },
-    useEffect() {},
+    useEffect(effect: () => void | (() => void)) {
+      effects.push(effect);
+    },
     // Minimal pass-through for anything else that might be called
     readContext: () => null,
     useContext: () => null,
@@ -128,6 +133,7 @@ function renderClientForm(props: Record<string, unknown>) {
     expect(rendered.type).toBe("form");
     return rendered.props as {
       onSubmit: (event: any) => Promise<void>;
+      ref: (node: HTMLFormElement | null) => void;
     };
   } finally {
     ReactSharedInternals.H = previousDispatcher;
@@ -209,6 +215,7 @@ function installClientGlobals({ supportsSubmitter }: { supportsSubmitter: boolea
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 // ─── SSR rendering ──────────────────────────────────────────────────────
@@ -780,6 +787,57 @@ describe("Form file input warning", () => {
 // ─── prefetch prop ──────────────────────────────────────────────────────
 
 describe("Form prefetch prop", () => {
+  it("does not viewport-prefetch App Router forms for a bot user agent", async () => {
+    // App Router Form prefetches through vinext's shared RSC prefetch path,
+    // which mirrors the bot suppression applied to Link/router.prefetch.
+    vi.stubEnv("NODE_ENV", "production");
+    const effects: Array<() => void | (() => void)> = [];
+    const fetch = vi.fn();
+    const observe = vi.fn();
+    let intersectionCallback: IntersectionObserverCallback | undefined;
+
+    class FakeIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+      }
+
+      observe = observe;
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+      takeRecords = vi.fn(() => []);
+    }
+
+    const { window } = createWindowStub();
+    vi.stubGlobal("window", {
+      ...window,
+      navigator: {
+        userAgent: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+      },
+    });
+    vi.stubGlobal("fetch", fetch);
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+
+    const { ref } = renderClientForm({ action: "/search" }, { effects });
+    const form = {} as HTMLFormElement;
+    ref(form);
+    for (const effect of effects) effect();
+
+    expect(observe).toHaveBeenCalledWith(form);
+    intersectionCallback?.(
+      [
+        {
+          intersectionRatio: 1,
+          isIntersecting: true,
+          target: form,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      {} as IntersectionObserver,
+    );
+    await Promise.resolve();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("accepts prefetch={false} without errors", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     expect(() => {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1336,6 +1336,89 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("preserves Pages Router viewport, explicit, and intent prefetches for a bot user agent", async () => {
+    const botWindowOverrides = {
+      __NEXT_DATA__: {
+        __vinext: {
+          pageModuleUrl: "/_next/static/chunks/pages/current.js",
+        },
+      },
+      navigator: {
+        userAgent: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+      },
+    };
+
+    const defaultViewportObserver = stubIntersectionObserver();
+    const defaultViewportResult = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/pages-bot-default-viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: botWindowOverrides,
+    });
+
+    try {
+      defaultViewportObserver.dispatchIntersectingEntry(defaultViewportResult.anchor);
+      await flushPrefetchTasks();
+
+      expect(defaultViewportResult.pagePrefetchLinks).toEqual([
+        {
+          as: "document",
+          href: "/pages-bot-default-viewport-prefetch-target",
+          rel: "prefetch",
+        },
+      ]);
+    } finally {
+      defaultViewportResult.restoreNodeEnv();
+    }
+
+    const explicitViewportObserver = stubIntersectionObserver();
+    const viewportResult = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/pages-bot-explicit-viewport-prefetch-target",
+      nodeEnv: "production",
+      props: { prefetch: true },
+      windowOverrides: botWindowOverrides,
+    });
+
+    try {
+      explicitViewportObserver.dispatchIntersectingEntry(viewportResult.anchor);
+      await flushPrefetchTasks();
+
+      expect(viewportResult.pagePrefetchLinks).toEqual([
+        {
+          as: "document",
+          href: "/pages-bot-explicit-viewport-prefetch-target",
+          rel: "prefetch",
+        },
+      ]);
+    } finally {
+      viewportResult.restoreNodeEnv();
+    }
+
+    const intentResult = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/pages-bot-intent-prefetch-target",
+      nodeEnv: "production",
+      props: { prefetch: false },
+      windowOverrides: botWindowOverrides,
+    });
+
+    try {
+      intentResult.capturedAnchorProps.onMouseEnter?.({ currentTarget: intentResult.anchor });
+      await flushPrefetchTasks();
+
+      expect(intentResult.pagePrefetchLinks).toEqual([
+        {
+          as: "document",
+          href: "/pages-bot-intent-prefetch-target",
+          rel: "prefetch",
+        },
+      ]);
+    } finally {
+      intentResult.restoreNodeEnv();
+    }
+  });
+
   it("re-prefetches visible links after the prefetch cache is invalidated", async () => {
     const observer = stubIntersectionObserver();
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1310,6 +1310,32 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("does not prefetch visible or hovered links for a bot user agent", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/app-prefetch/prefetching.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: {
+        navigator: {
+          userAgent: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+        },
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("re-prefetches visible links after the prefetch cache is invalidated", async () => {
     const observer = stubIntersectionObserver();
 

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -45,6 +45,7 @@ beforeEach(async () => {
       hash: "",
       href: "http://localhost/",
     },
+    navigator: { userAgent: "Mozilla/5.0" },
     addEventListener: () => {},
     history: { pushState: () => {}, replaceState: () => {}, state: null },
     dispatchEvent: () => {},
@@ -119,6 +120,19 @@ async function waitForPrefetchSetup(isReady: () => boolean = () => true): Promis
 }
 
 describe("prefetch cache eviction", () => {
+  it("router.prefetch does not fetch for a bot user agent", async () => {
+    const fetch = vi.fn();
+    (globalThis as any).fetch = fetch;
+    (globalThis as any).window.navigator.userAgent =
+      "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+
+    appRouterInstance.prefetch("/dashboard");
+    await waitForPrefetchSetup();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(getPrefetchedUrls().size).toBe(0);
+  });
+
   it("router.prefetch ignores external absolute URLs", async () => {
     const fetch = vi.fn();
     (globalThis as any).fetch = fetch;


### PR DESCRIPTION
## Summary

- skip App Router Link viewport/intent prefetches for bot user agents
- skip programmatic `router.prefetch()` for bots through the same existing Next.js-compatible matcher
- add focused unit coverage plus a production browser regression

## Parity target

Report `28143992598` showed `test/e2e/app-dir/app-prefetch/prefetching.test.ts` failing `should not prefetch for a bot user agent` because vinext issued an RSC request for `/static-page`.

Next.js v16.2.6 gates all prefetch URL creation with `isBot(window.navigator.userAgent)` in `packages/next/src/client/components/app-router-utils.ts`.

This track intentionally avoids:

- PR #2318's prefetch protocol, partial loading-shell, and priority changes
- PR #2251 / #2104's client cache and navigation commit work
- cacheComponents / segment-cache behavior

## Validation

- `vp check packages/vinext/src/shims/link.tsx packages/vinext/src/shims/navigation.ts tests/link-navigation.test.ts tests/prefetch-cache.test.ts tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts`
- `vp test run tests/link-navigation.test.ts tests/prefetch-cache.test.ts --maxWorkers=1`
- `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific npx playwright test tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts --workers=1 --retries=0`
- `NEXTJS_PREPARE=0 NEXT_TEST_CONCURRENCY=1 vp env exec --node 24 ./scripts/run-nextjs-deploy-suite.sh /Users/jamesanderson/Developer/vinext/.nextjs-ref --retries 0 -c 1 --debug test/e2e/app-dir/app-prefetch/prefetching.test.ts`
  - selected assertion `should not prefetch for a bot user agent` passes
  - the suite still reports the known unrelated legacy loading/protocol/priority failures tracked outside this PR
