### PR TITLE
fix(app-router): bind layout-only children defaults

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -961,6 +961,13 @@ export async function buildAppRouteGraph(
 
     const route = directoryToAppRoute(dir, appDir, scanMatcher, null, null);
     if (!route) continue;
+    const hasOwnedSlotPage = route.parallelSlots.some(
+      (slot) => path.dirname(slot.ownerDir) === routeDir && slot.pagePath !== null,
+    );
+    if (!route.pagePath && !hasOwnedSlotPage) {
+      ghostParentRoutes.push(route);
+      continue;
+    }
     if (routePatterns.has(route.pattern)) {
       ghostParentRoutes.push(route);
       continue;
@@ -1510,6 +1517,7 @@ function directoryToAppRoute(
 
   // Discover loading, error in the route's directory.
   const routeDir = dir === "." ? appDir : path.posix.join(appDir, dir);
+  const effectivePagePath = pagePath ?? (routePath ? null : findFile(routeDir, "default", matcher));
   const loadingPath = findFile(routeDir, "loading", matcher);
   const errorPath = findFile(routeDir, "error", matcher);
 
@@ -1533,7 +1541,7 @@ function directoryToAppRoute(
   return {
     ids: createAppRouteSemanticIds({
       pattern: pattern === "/" ? "/" : pattern,
-      pagePath,
+      pagePath: effectivePagePath,
       routePath,
       routeSegments: segments,
       layoutTreePositions,
@@ -1541,7 +1549,7 @@ function directoryToAppRoute(
       slots: parallelSlots,
     }),
     pattern: pattern === "/" ? "/" : pattern,
-    pagePath,
+    pagePath: effectivePagePath,
     routePath,
     layouts,
     templates,

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -967,7 +967,7 @@ export async function buildAppRouteGraph(
         candidate.patternParts.at(-1)?.endsWith("*") &&
         patternsStructurallyEquivalent(candidate.patternParts.slice(0, -1), route.patternParts),
     );
-    if (!route.pagePath && optionalCatchAllOwnsPattern) {
+    if (optionalCatchAllOwnsPattern) {
       ghostParentRoutes.push(route);
       continue;
     }

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -961,10 +961,13 @@ export async function buildAppRouteGraph(
 
     const route = directoryToAppRoute(dir, appDir, scanMatcher, null, null);
     if (!route) continue;
-    const hasOwnedSlotPage = route.parallelSlots.some(
-      (slot) => path.dirname(slot.ownerDir) === routeDir && slot.pagePath !== null,
+    const optionalCatchAllOwnsPattern = routes.some(
+      (candidate) =>
+        candidate.patternParts.length === route.patternParts.length + 1 &&
+        candidate.patternParts.at(-1)?.endsWith("*") &&
+        patternsStructurallyEquivalent(candidate.patternParts.slice(0, -1), route.patternParts),
     );
-    if (!route.pagePath && !hasOwnedSlotPage) {
+    if (!route.pagePath && optionalCatchAllOwnsPattern) {
       ghostParentRoutes.push(route);
       continue;
     }

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -636,6 +636,27 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  it("keeps a standalone layout-only slot owner as a route", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "parallel-nested/home/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "parallel-nested/home/@parallel/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "parallel-nested/home/@parallel/nested/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const parent = findRoute(graph.routes, "/parallel-nested/home");
+      const nested = findRoute(graph.routes, "/parallel-nested/home/nested");
+
+      expect(parent.pagePath).toBeNull();
+      expect(parent.parallelSlots.find((slot) => slot.name === "parallel")?.defaultPath).toBe(
+        path.join(appDir, "parallel-nested/home/@parallel/default.tsx"),
+      );
+      expect(nested.parallelSlots.find((slot) => slot.name === "parallel")?.pagePath).toBe(
+        path.join(appDir, "parallel-nested/home/@parallel/nested/page.tsx"),
+      );
+    });
+  });
+
   // Ported from Next.js: test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
   it("keeps a sibling slot active when children are inside a route group", async () => {

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -621,6 +621,7 @@ describe("App Router route graph builder", () => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
       await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
       await writeAppFile(appDir, "[locale]/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "[locale]/default.tsx", EMPTY_PAGE);
       await writeAppFile(appDir, "[locale]/@slot/default.tsx", EMPTY_PAGE);
       await writeAppFile(appDir, "[locale]/@slot/other/page.tsx", EMPTY_PAGE);
       await writeAppFile(appDir, "[locale]/[[...catchAll]]/page.tsx", EMPTY_PAGE);

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -583,6 +583,59 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  // Ported from Next.js:
+  // test/e2e/app-dir/parallel-routes-catchall-default/parallel-routes-catchall-default.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-catchall-default/parallel-routes-catchall-default.test.ts
+  it("matches nested parallel slot pages before an ancestor optional catch-all", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/[[...catchAll]]/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/nested/[foo]/[bar]/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "[locale]/nested/[foo]/[bar]/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/nested/[foo]/[bar]/@slot/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/nested/[foo]/[bar]/@slot/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/nested/[foo]/[bar]/@slot/[baz]/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/nested/[foo]/[bar]/@slot/[baz]/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const nested = findRoute(graph.routes, "/:locale/nested/:foo/:bar");
+      const nestedBaz = findRoute(graph.routes, "/:locale/nested/:foo/:bar/:baz");
+
+      expect(nested.pagePath).toBe(path.join(appDir, "[locale]/nested/[foo]/[bar]/default.tsx"));
+      expect(nested.parallelSlots.find((slot) => slot.name === "slot")?.pagePath).toBe(
+        path.join(appDir, "[locale]/nested/[foo]/[bar]/@slot/page.tsx"),
+      );
+      expect(nestedBaz.pagePath).toBe(path.join(appDir, "[locale]/nested/[foo]/[bar]/default.tsx"));
+      expect(nestedBaz.parallelSlots.find((slot) => slot.name === "slot")?.pagePath).toBe(
+        path.join(appDir, "[locale]/nested/[foo]/[bar]/@slot/[baz]/page.tsx"),
+      );
+    });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/parallel-routes-catchall-slotted-non-catchalls.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/parallel-routes-catchall-slotted-non-catchalls.test.ts
+  it("lets an optional catch-all supply children for a layout-only slot owner", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "[locale]/@slot/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/@slot/other/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "[locale]/[[...catchAll]]/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const localeCatchAll = findRoute(graph.routes, "/:locale/:catchAll*");
+
+      expect(graph.routes.some((route) => route.pattern === "/:locale")).toBe(false);
+      expect(localeCatchAll.parallelSlots.find((slot) => slot.name === "slot")).toMatchObject({
+        pagePath: null,
+        defaultPath: path.join(appDir, "[locale]/@slot/default.tsx"),
+      });
+    });
+  });
+
   // Ported from Next.js: test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-group-depth/parallel-routes-group-depth.test.ts
   it("keeps a sibling slot active when children are inside a route group", async () => {

--- a/tests/e2e/app-router/parallel-slot-default.spec.ts
+++ b/tests/e2e/app-router/parallel-slot-default.spec.ts
@@ -1,0 +1,16 @@
+// Ported from Next.js:
+// test/e2e/app-dir/parallel-routes-catchall-default/parallel-routes-catchall-default.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-catchall-default/parallel-routes-catchall-default.test.ts
+
+import { expect, test } from "@playwright/test";
+
+const BASE = "http://localhost:4174";
+
+test("renders the implicit children default beside a nested parallel slot", async ({ page }) => {
+  await page.goto(`${BASE}/parallel-slot-default/nested/foo/bar/baz`);
+
+  await expect(page.getByTestId("parallel-slot-default-children")).toHaveText(
+    "nested children default",
+  );
+  await expect(page.getByTestId("parallel-slot-default-slot")).toHaveText("slot dynamic page: baz");
+});

--- a/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/@slot/[baz]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/@slot/[baz]/page.tsx
@@ -1,0 +1,4 @@
+export default async function Page({ params }: { params: Promise<{ baz: string }> }) {
+  const { baz } = await params;
+  return <p>slot dynamic page: {baz}</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/@slot/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/@slot/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <p>slot default</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/@slot/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>slot root page</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <p>nested children default</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-slot-default/nested/[foo]/[bar]/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode;
+  slot: React.ReactNode;
+}) {
+  return (
+    <main>
+      <div data-testid="parallel-slot-default-children">{children}</div>
+      <div data-testid="parallel-slot-default-slot">{slot}</div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- bind `default.tsx` as the implicit children page for layout-only App Router routes
- keep default-less parallel-slot owners as graph metadata instead of competing URL routes
- add graph and browser fixture regressions for nested slot defaults and optional catch-all ownership

## Next.js parity
Targets failures from run 28143992598:
- `parallel-routes-catchall-default`: 1 test now passing
- `parallel-routes-catchall-dynamic-segment`: 1 test now passing
- `parallel-routes-catchall-slotted-non-catchalls`: 1 test now passing

The related specificity, layout soft-navigation, and no-children-slot failures still fail and are separate follow-up tracks.

## Validation
- `vp check packages/vinext/src/routing/app-route-graph.ts tests/app-route-graph.test.ts tests/e2e/app-router/parallel-slot-default.spec.ts`
- `vp test run tests/app-route-graph.test.ts` — 59 passed
- `PLAYWRIGHT_PROJECT=app-router vp exec playwright test tests/e2e/app-router/parallel-slot-default.spec.ts --workers=1` — 1 passed
- exact Next.js v16.2.6 targeted deploy suites — 3 passed / 0 failed
