### PR TITLE
fix(app): preinitialize bootstrap dependencies

### DIFF
--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -268,6 +268,14 @@ declare global {
   var __VINEXT_DYNAMIC_PRELOADS__: Record<string, string[]> | undefined;
 
   /**
+   * Static imports of the App Router browser entry. During SSR these are
+   * preinitialized as modules so React hoists them into `<head>`, leaving the
+   * browser entry as the only bootstrap script in `<body>`.
+   */
+  // oxlint-disable-next-line no-var
+  var __VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__: string[] | undefined;
+
+  /**
    * The client entry JS filename (e.g. `"_next/static/entry-abc123.js"`) for Pages
    * Router builds.
    * Injected into the Worker entry at build time for Pages Router only.

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -5497,6 +5497,7 @@ export const loadServerActionClient = ${
               // pure App Router gets its client entry via the RSC plugin.
               const script = buildRuntimeGlobalsScript({
                 clientEntryFile,
+                appBootstrapPreinitModules: runtimeMetadata.appBootstrapPreinitModules,
                 ssrManifest: ssrManifestData,
                 lazyChunks: lazyChunksData,
                 dynamicPreloads: dynamicPreloadsData,
@@ -5529,6 +5530,7 @@ export const loadServerActionClient = ${
             // Prepend globals to worker entry
             const script = buildRuntimeGlobalsScript({
               clientEntryFile,
+              appBootstrapPreinitModules: runtimeMetadata.appBootstrapPreinitModules,
               ssrManifest: ssrManifestData,
               lazyChunks: lazyChunksData,
               dynamicPreloads: dynamicPreloadsData,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -3,6 +3,7 @@
 import "./server-globals.js";
 import type { ReactNode } from "react";
 import type { ReactFormState } from "react-dom/client";
+import { preinitModule } from "react-dom";
 import { Fragment, createElement as createReactElement, use } from "react";
 import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 import type { RenderToReadableStreamOptions } from "react-dom/server";
@@ -415,6 +416,12 @@ export async function handleSsr(
         let flightRoot: PromiseLike<AppWireElements> | null = null;
 
         function VinextFlightRoot(): ReactNode {
+          for (const moduleUrl of globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__ ?? []) {
+            preinitModule(moduleUrl, {
+              as: "script",
+              nonce: options?.scriptNonce,
+            });
+          }
           if (!flightRoot) {
             flightRoot = createFromReadableStream<AppWireElements>(ssrStream);
           }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -398,6 +398,7 @@ function installClientBuildManifestGlobals(
   assetPrefix: string,
 ): void {
   const metadata = computeClientRuntimeMetadata({ clientDir, assetBase, assetPrefix });
+  globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__ = metadata.appBootstrapPreinitModules;
   globalThis.__VINEXT_LAZY_CHUNKS__ = metadata.lazyChunks;
   globalThis.__VINEXT_DYNAMIC_PRELOADS__ = metadata.dynamicPreloads;
 }
@@ -1163,6 +1164,7 @@ function installPagesClientAssetGlobals(options: {
   });
 
   globalThis.__VINEXT_CLIENT_ENTRY__ = metadata.clientEntryFile;
+  globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__ = metadata.appBootstrapPreinitModules;
   globalThis.__VINEXT_LAZY_CHUNKS__ = metadata.lazyChunks;
   globalThis.__VINEXT_DYNAMIC_PRELOADS__ = metadata.dynamicPreloads;
 

--- a/packages/vinext/src/utils/client-runtime-metadata.ts
+++ b/packages/vinext/src/utils/client-runtime-metadata.ts
@@ -15,7 +15,7 @@ import {
   dynamicImportPreloadsWithBase,
 } from "./lazy-chunks.js";
 import { manifestFileWithBase, manifestFileWithAssetPrefix } from "./manifest-paths.js";
-import { resolveAssetsDir } from "./asset-prefix.js";
+import { isAbsoluteAssetPrefix, resolveAssetsDir } from "./asset-prefix.js";
 
 type ClientRuntimeMetadata = {
   clientEntryFile?: string;
@@ -108,7 +108,10 @@ export function computeClientRuntimeMetadata(opts: {
   metadata.appBootstrapPreinitModules = collectAppBootstrapPreinitModules(
     buildManifest,
     clientEntryManifest?.appBrowserEntry,
-    (file) => manifestFileWithAssetPrefix(file, opts.assetBase, opts.assetPrefix),
+    (file) => {
+      const url = manifestFileWithAssetPrefix(file, opts.assetBase, opts.assetPrefix);
+      return isAbsoluteAssetPrefix(opts.assetPrefix) ? url : "/" + url;
+    },
   );
 
   // `lazyChunks` and `dynamicPreloads` live in DIFFERENT key-spaces and must be

--- a/packages/vinext/src/utils/client-runtime-metadata.ts
+++ b/packages/vinext/src/utils/client-runtime-metadata.ts
@@ -19,9 +19,47 @@ import { resolveAssetsDir } from "./asset-prefix.js";
 
 type ClientRuntimeMetadata = {
   clientEntryFile?: string;
+  appBootstrapPreinitModules?: string[];
   lazyChunks?: string[];
   dynamicPreloads?: Record<string, string[]>;
 };
+
+function collectAppBootstrapPreinitModules(
+  buildManifest: NonNullable<ReturnType<typeof readClientBuildManifest>>,
+  appBrowserEntry: string | undefined,
+  applyBase: (file: string) => string,
+): string[] | undefined {
+  if (!appBrowserEntry) return undefined;
+
+  const entryKey = Object.keys(buildManifest).find(
+    (key) => buildManifest[key].file === appBrowserEntry,
+  );
+  if (!entryKey) return undefined;
+
+  const modules: string[] = [];
+  const seenFiles = new Set<string>();
+  const visitedChunks = new Set<string>();
+
+  function visit(key: string): void {
+    if (visitedChunks.has(key)) return;
+    visitedChunks.add(key);
+
+    const chunk = buildManifest[key];
+    if (!chunk) return;
+
+    for (const importedKey of chunk.imports ?? []) {
+      const importedChunk = buildManifest[importedKey];
+      if (importedChunk?.file.endsWith(".js") && !seenFiles.has(importedChunk.file)) {
+        seenFiles.add(importedChunk.file);
+        modules.push(applyBase(importedChunk.file));
+      }
+      visit(importedKey);
+    }
+  }
+
+  visit(entryKey);
+  return modules.length > 0 ? modules : undefined;
+}
 
 /**
  * Read the client build manifest and compute runtime metadata used by
@@ -45,11 +83,11 @@ export function computeClientRuntimeMetadata(opts: {
 }): ClientRuntimeMetadata {
   const buildManifestPath = path.join(opts.clientDir, ".vite", "manifest.json");
   const buildManifest = readClientBuildManifest(buildManifestPath);
+  const clientEntryManifest = readClientEntryManifest(opts.clientDir);
 
   const metadata: ClientRuntimeMetadata = {};
 
   if (opts.includeClientEntry) {
-    const clientEntryManifest = readClientEntryManifest(opts.clientDir);
     const entryOptions = {
       buildManifest,
       clientDir: opts.clientDir,
@@ -66,6 +104,12 @@ export function computeClientRuntimeMetadata(opts: {
   }
 
   if (!buildManifest) return metadata;
+
+  metadata.appBootstrapPreinitModules = collectAppBootstrapPreinitModules(
+    buildManifest,
+    clientEntryManifest?.appBrowserEntry,
+    (file) => manifestFileWithAssetPrefix(file, opts.assetBase, opts.assetPrefix),
+  );
 
   // `lazyChunks` and `dynamicPreloads` live in DIFFERENT key-spaces and must be
   // normalised differently:
@@ -107,6 +151,7 @@ export function computeClientRuntimeMetadata(opts: {
  */
 export function buildRuntimeGlobalsScript(input: {
   clientEntryFile?: string | null;
+  appBootstrapPreinitModules?: string[] | null;
   ssrManifest?: Record<string, string[]> | null;
   lazyChunks?: string[] | null;
   dynamicPreloads?: Record<string, string[]> | null;
@@ -119,6 +164,11 @@ export function buildRuntimeGlobalsScript(input: {
   const globals: string[] = [];
   if (input.clientEntryFile) {
     globals.push(`globalThis.__VINEXT_CLIENT_ENTRY__ = ${JSON.stringify(input.clientEntryFile)};`);
+  }
+  if (input.appBootstrapPreinitModules && input.appBootstrapPreinitModules.length > 0) {
+    globals.push(
+      `globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__ = ${JSON.stringify(input.appBootstrapPreinitModules)};`,
+    );
   }
   if (input.ssrManifest && Object.keys(input.ssrManifest).length > 0) {
     globals.push(`globalThis.__VINEXT_SSR_MANIFEST__ = ${JSON.stringify(input.ssrManifest)};`);

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -247,6 +247,22 @@ describe("App Router Production server (startProdServer)", () => {
     expect(html).toContain("<script");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/index.test.ts
+  it("emits only the bootstrap script in the body and preinitializes the rest", async () => {
+    expect(globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__).toBeTruthy();
+    const res = await fetch(`${baseUrl}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const asyncScripts = html.match(/<script\b[^>]*\basync(?:=(?:""|''|async))?[^>]*>/g) ?? [];
+    const bodyHtml = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/)?.[1] ?? "";
+    const bodyAsyncScripts =
+      bodyHtml.match(/<script\b[^>]*\basync(?:=(?:""|''|async))?[^>]*>/g) ?? [];
+
+    expect(asyncScripts.length).toBeGreaterThan(1);
+    expect(bodyAsyncScripts).toHaveLength(1);
+  });
+
   // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
   //
@@ -315,6 +331,9 @@ describe("App Router Production server (startProdServer)", () => {
     expect(firstHtml).toContain(
       '<script nonce="first">Object.assign(((self[Symbol.for("vinext.navigationRuntime")]',
     );
+    for (const tag of firstHtml.match(/<script\b[^>]*\basync[^>]*><\/script>/g) ?? []) {
+      expect(tag).toContain('nonce="first"');
+    }
 
     const secondRes = await fetch(`${baseUrl}/revalidate-test?csp-nonce=second`);
     expect(secondRes.status).toBe(200);
@@ -473,6 +492,7 @@ describe("App Router Production server (startProdServer)", () => {
     let assetPrefixServer: import("node:http").Server | undefined;
     const prodGlobalKeys = [
       "__VINEXT_CLIENT_ENTRY__",
+      "__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__",
       "__VINEXT_DYNAMIC_PRELOADS__",
       "__VINEXT_LAZY_CHUNKS__",
       "__VINEXT_SSR_MANIFEST__",
@@ -577,6 +597,7 @@ describe("App Router Production server (startProdServer)", () => {
     let assetPrefixServer: import("node:http").Server | undefined;
     const prodGlobalKeys = [
       "__VINEXT_CLIENT_ENTRY__",
+      "__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__",
       "__VINEXT_DYNAMIC_PRELOADS__",
       "__VINEXT_LAZY_CHUNKS__",
       "__VINEXT_SSR_MANIFEST__",
@@ -1065,6 +1086,7 @@ describe("App Router Production server (startProdServer)", () => {
       let ccServer: import("node:http").Server | undefined;
       const prodGlobalKeys = [
         "__VINEXT_CLIENT_ENTRY__",
+        "__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__",
         "__VINEXT_DYNAMIC_PRELOADS__",
         "__VINEXT_LAZY_CHUNKS__",
         "__VINEXT_SSR_MANIFEST__",
@@ -1588,6 +1610,7 @@ describe("App Router production server entry module identity", () => {
     const EVAL_COUNT_KEY = "__vinext_test_entry_evaluations__";
     const prodGlobalKeys = [
       "__VINEXT_CLIENT_ENTRY__",
+      "__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__",
       "__VINEXT_DYNAMIC_PRELOADS__",
       "__VINEXT_LAZY_CHUNKS__",
       "__VINEXT_SSR_MANIFEST__",

--- a/tests/client-build-manifest.test.ts
+++ b/tests/client-build-manifest.test.ts
@@ -336,6 +336,44 @@ describe("computeClientRuntimeMetadata", () => {
     });
   });
 
+  it("computes App Router bootstrap module preinitialization from the browser entry imports", async () => {
+    await fsp.writeFile(
+      path.join(clientDir, ".vite", "manifest.json"),
+      JSON.stringify({
+        "virtual:vinext-app-browser-entry": {
+          file: "_next/static/app-entry.js",
+          isEntry: true,
+          imports: ["shared.js", "runtime.js"],
+        },
+        "shared.js": {
+          file: "_next/static/shared.js",
+          imports: ["runtime.js", "styles.css"],
+        },
+        "runtime.js": {
+          file: "_next/static/runtime.js",
+        },
+        "styles.css": {
+          file: "_next/static/styles.css",
+        },
+      }),
+    );
+    await fsp.writeFile(
+      path.join(clientDir, "vinext-client-entry-manifest.json"),
+      JSON.stringify({ appBrowserEntry: "_next/static/app-entry.js" }),
+    );
+
+    expect(
+      computeClientRuntimeMetadata({
+        clientDir,
+        assetBase: "/docs/",
+        assetPrefix: "https://cdn.example.com/assets",
+      }).appBootstrapPreinitModules,
+    ).toEqual([
+      "https://cdn.example.com/assets/_next/static/shared.js",
+      "https://cdn.example.com/assets/_next/static/runtime.js",
+    ]);
+  });
+
   it("applies base path to all paths", async () => {
     await fsp.writeFile(
       path.join(clientDir, ".vite", "manifest.json"),

--- a/tests/client-build-manifest.test.ts
+++ b/tests/client-build-manifest.test.ts
@@ -372,6 +372,28 @@ describe("computeClientRuntimeMetadata", () => {
       "https://cdn.example.com/assets/_next/static/shared.js",
       "https://cdn.example.com/assets/_next/static/runtime.js",
     ]);
+
+    expect(
+      computeClientRuntimeMetadata({
+        clientDir,
+        assetBase: "/",
+        assetPrefix: "",
+      }).appBootstrapPreinitModules,
+    ).toEqual(["/_next/static/shared.js", "/_next/static/runtime.js"]);
+    expect(
+      computeClientRuntimeMetadata({
+        clientDir,
+        assetBase: "/docs/",
+        assetPrefix: "",
+      }).appBootstrapPreinitModules,
+    ).toEqual(["/docs/_next/static/shared.js", "/docs/_next/static/runtime.js"]);
+    expect(
+      computeClientRuntimeMetadata({
+        clientDir,
+        assetBase: "/docs/",
+        assetPrefix: "/cdn",
+      }).appBootstrapPreinitModules,
+    ).toEqual(["/cdn/_next/static/shared.js", "/cdn/_next/static/runtime.js"]);
   });
 
   it("applies base path to all paths", async () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -2742,7 +2742,7 @@ describe("Cloudflare closeBundle lazy chunk injection", () => {
 
     const code = fs.readFileSync(path.join(tmpDir, "dist", "server", "index.js"), "utf-8");
     expect(code).toContain(
-      'globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__ = ["assets/framework.js"];',
+      'globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__ = ["/assets/framework.js"];',
     );
   });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -2554,6 +2554,7 @@ describe("Cloudflare closeBundle lazy chunk injection", () => {
     if (!fs.existsSync(workerEntry)) return;
     const script = buildRuntimeGlobalsScript({
       clientEntryFile: runtimeMetadata.clientEntryFile,
+      appBootstrapPreinitModules: runtimeMetadata.appBootstrapPreinitModules,
       ssrManifest: ssrManifestData,
       lazyChunks: runtimeMetadata.lazyChunks,
       dynamicPreloads: runtimeMetadata.dynamicPreloads,
@@ -2612,6 +2613,7 @@ describe("Cloudflare closeBundle lazy chunk injection", () => {
 
     const script = buildRuntimeGlobalsScript({
       clientEntryFile: runtimeMetadata.clientEntryFile,
+      appBootstrapPreinitModules: runtimeMetadata.appBootstrapPreinitModules,
       ssrManifest: ssrManifestData,
       lazyChunks: runtimeMetadata.lazyChunks,
       dynamicPreloads: runtimeMetadata.dynamicPreloads,
@@ -2641,6 +2643,15 @@ describe("Cloudflare closeBundle lazy chunk injection", () => {
       path.join(root, "dist", "client", ".vite", "manifest.json"),
       JSON.stringify(manifest),
     );
+    const appBrowserEntry = Object.values(manifest).find(
+      (entry: any) => entry.isEntry && entry.file.includes("app-entry"),
+    )?.file;
+    if (appBrowserEntry) {
+      fs.writeFileSync(
+        path.join(root, "dist", "client", "vinext-client-entry-manifest.json"),
+        JSON.stringify({ appBrowserEntry }),
+      );
+    }
 
     // dist/client/.vite/ssr-manifest.json (optional)
     if (ssrManifest) {
@@ -2722,6 +2733,17 @@ describe("Cloudflare closeBundle lazy chunk injection", () => {
     // Eager chunks should NOT be in the lazy list
     expect(lazyChunks).not.toContain("assets/app-entry.js");
     expect(lazyChunks).not.toContain("assets/framework.js");
+  });
+
+  it("App Router: injects static browser-entry imports for SSR preinitialization", () => {
+    setupAppRouterBuildOutput(tmpDir, manifestWithLazyChunks);
+
+    simulateCloseBundleAppRouter(tmpDir);
+
+    const code = fs.readFileSync(path.join(tmpDir, "dist", "server", "index.js"), "utf-8");
+    expect(code).toContain(
+      'globalThis.__VINEXT_APP_BOOTSTRAP_PREINIT_MODULES__ = ["assets/framework.js"];',
+    );
   });
 
   it("App Router: injects __VINEXT_DYNAMIC_PRELOADS__ into dist/server/index.js", () => {

--- a/tests/e2e/app-front-redirect-issue/front-redirect-issue.spec.ts
+++ b/tests/e2e/app-front-redirect-issue/front-redirect-issue.spec.ts
@@ -20,7 +20,7 @@ test.describe("app dir - front redirect issue", () => {
     expect(page.url()).toBe(`${BASE}/vercel-user`);
     await expect(page.locator("#visible-url")).toHaveText("/vercel-user");
 
-    const bootstrapScripts = page.locator('script[type="module"][src]');
+    const bootstrapScripts = page.locator('body script#_R_[type="module"][src]');
     await expect(bootstrapScripts).toHaveCount(1);
     const bootstrapSrc = await bootstrapScripts.first().getAttribute("src");
     expect(bootstrapSrc).toBeTruthy();


### PR DESCRIPTION
## Summary
- derive the App browser entry static import closure from the Vite client manifest
- preinitialize those ESM chunks during SSR so React hoists async module scripts into `<head>`
- keep the browser entry as the only async bootstrap script in `<body>`, matching Next.js
- thread the metadata through Node and Cloudflare Worker production runtimes

## Validation
- `vp test run tests/app-router-production-server.test.ts -t "emits only the bootstrap script|does not reuse cached HTML across requests with different CSP nonces"`
- `vp test run tests/client-build-manifest.test.ts -t "bootstrap module preinitialization"`
- `vp test run tests/deploy.test.ts -t "static browser-entry imports"`
- targeted `vp check` for all changed files

Next.js reference: `test/e2e/app-dir/app/index.test.ts` bootstrap scripts assertion.