### PR TITLE
fix(router): honor middleware app rewrites for page links

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2097,32 +2097,32 @@ async function navigateClient(
       // routeUrl === url (no mask), behaviour is unchanged.
       let dataTarget = resolvePagesDataNavigationTarget(routeUrl, __basePath);
       let middlewareDataResponse: Response | undefined;
-      if (!dataTarget) {
-        let middlewareEffect: MiddlewareDataEffect | null;
-        try {
-          middlewareEffect = await resolveMiddlewareDataEffect(browserUrl, controller.signal);
-        } catch (err: unknown) {
-          if (err instanceof DOMException && err.name === "AbortError") {
-            throw new NavigationCancelledError(browserUrl);
-          }
-          throw err;
+      let middlewareEffect: MiddlewareDataEffect | null;
+      try {
+        middlewareEffect = await resolveMiddlewareDataEffect(browserUrl, controller.signal);
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          throw new NavigationCancelledError(browserUrl);
         }
-        assertStillCurrent();
-        const redirectLocation = middlewareEffect?.redirectLocation ?? null;
-        if (redirectLocation) {
-          const redirectedUrl = resolveLocalRedirectUrl(redirectLocation);
-          if (!redirectedUrl) {
-            scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
-          }
-          window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-          routerRuntimeState.lastPathnameAndSearch =
-            window.location.pathname + window.location.search;
-          routerRuntimeState.lastHash = window.location.hash;
-          browserUrl = redirectedUrl;
-          htmlFetchUrl = redirectedUrl;
-        } else if (middlewareEffect?.rewriteTarget) {
+        throw err;
+      }
+      assertStillCurrent();
+      const redirectLocation = middlewareEffect?.redirectLocation ?? null;
+      if (redirectLocation) {
+        const redirectedUrl = resolveLocalRedirectUrl(redirectLocation);
+        if (!redirectedUrl) {
+          scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
+        }
+        window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
+        routerRuntimeState.lastPathnameAndSearch =
+          window.location.pathname + window.location.search;
+        routerRuntimeState.lastHash = window.location.hash;
+        browserUrl = redirectedUrl;
+        htmlFetchUrl = redirectedUrl;
+      } else if (middlewareEffect) {
+        middlewareDataResponse = middlewareEffect.response;
+        if (!dataTarget && middlewareEffect.rewriteTarget) {
           dataTarget = resolvePagesDataNavigationTarget(middlewareEffect.rewriteTarget, __basePath);
-          if (dataTarget) middlewareDataResponse = middlewareEffect.response;
         }
       }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2122,9 +2122,15 @@ async function navigateClient(
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
       } else if (middlewareEffect) {
+        // A masked navigation probes middleware using the browser-visible URL but must fetch page
+        // data using the route URL. Without a rewrite header those are different requests, so do
+        // not reuse the probe response even though that means one extra request for this rare path.
         if (middlewareEffect.rewriteTarget || routeUrl === url) {
           middlewareDataResponse = middlewareEffect.response;
         }
+        // App Router rewrite targets intentionally have no Pages data target. Keep the original
+        // source target so navigateClientData sees the rewrite header, fails target resolution,
+        // and schedules a hard navigation that boots the App Router at the visible URL.
         if (!dataTarget && middlewareEffect.rewriteTarget) {
           dataTarget = resolvePagesDataNavigationTarget(middlewareEffect.rewriteTarget, __basePath);
         }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2120,7 +2120,9 @@ async function navigateClient(
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
       } else if (middlewareEffect) {
-        middlewareDataResponse = middlewareEffect.response;
+        if (middlewareEffect.rewriteTarget || routeUrl === url) {
+          middlewareDataResponse = middlewareEffect.response;
+        }
         if (!dataTarget && middlewareEffect.rewriteTarget) {
           dataTarget = resolvePagesDataNavigationTarget(middlewareEffect.rewriteTarget, __basePath);
         }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2097,16 +2097,18 @@ async function navigateClient(
       // routeUrl === url (no mask), behaviour is unchanged.
       let dataTarget = resolvePagesDataNavigationTarget(routeUrl, __basePath);
       let middlewareDataResponse: Response | undefined;
-      let middlewareEffect: MiddlewareDataEffect | null;
-      try {
-        middlewareEffect = await resolveMiddlewareDataEffect(browserUrl, controller.signal);
-      } catch (err: unknown) {
-        if (err instanceof DOMException && err.name === "AbortError") {
-          throw new NavigationCancelledError(browserUrl);
+      let middlewareEffect: MiddlewareDataEffect | null = null;
+      if (hasVinextMiddleware(window.__NEXT_DATA__)) {
+        try {
+          middlewareEffect = await resolveMiddlewareDataEffect(browserUrl, controller.signal);
+        } catch (err: unknown) {
+          if (err instanceof DOMException && err.name === "AbortError") {
+            throw new NavigationCancelledError(browserUrl);
+          }
+          throw err;
         }
-        throw err;
+        assertStillCurrent();
       }
-      assertStillCurrent();
       const redirectLocation = middlewareEffect?.redirectLocation ?? null;
       if (redirectLocation) {
         const redirectedUrl = resolveLocalRedirectUrl(redirectLocation);

--- a/tests/e2e/app-router/pages-to-app-routing.spec.ts
+++ b/tests/e2e/app-router/pages-to-app-routing.spec.ts
@@ -64,4 +64,16 @@ test.describe("pages-to-app-routing: navigate from Pages Router to App Router vi
     await expect(page.locator("#app-page")).toHaveText("About");
     expect(page.url()).toContain("/rewrite-about");
   });
+
+  test("clicking an existing Pages path rewritten by middleware navigates to App Router", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/pages-to-app/middleware-rewrite`);
+    await waitForHydration(page);
+
+    await page.click("#to-middleware-rewritten-existing-page-link");
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#app-page")).toHaveText("About");
+    expect(page.url()).toContain("/exists-but-not-routed");
+  });
 });

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -17,6 +17,14 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // Test NextRequest.nextUrl - this would fail with TypeError if request is plain Request
   const { pathname } = request.nextUrl;
 
+  // Ported from Next.js: test/e2e/app-dir/app/middleware.js
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/middleware.js
+  // The source also exists in pages/, so the client must honor the middleware
+  // rewrite to the App Router destination instead of committing a Pages SPA navigation.
+  if (pathname === "/exists-but-not-routed") {
+    return NextResponse.rewrite(new URL("/about", request.url));
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware-node.js
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/app/middleware-node.js
   if (pathname === "/_next/static/middleware-rewrite.js") {
@@ -353,6 +361,7 @@ export const config = {
   runtime: "nodejs",
   matcher: [
     "/about",
+    "/exists-but-not-routed",
     "/middleware-redirect",
     "/middleware-rewrite",
     "/middleware-rewritten-use-pathname",

--- a/tests/fixtures/app-basic/pages/exists-but-not-routed.tsx
+++ b/tests/fixtures/app-basic/pages/exists-but-not-routed.tsx
@@ -1,0 +1,7 @@
+export async function getServerSideProps() {
+  return { props: {} };
+}
+
+export default function ExistsButNotRoutedPage() {
+  return <p id="pages-page">This Pages route should be rewritten by middleware.</p>;
+}

--- a/tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx
+++ b/tests/fixtures/app-basic/pages/pages-to-app/[slug].tsx
@@ -23,6 +23,9 @@ export default function PagesToAppPage({ params }: Props) {
       <Link id="to-rewritten-about-link" href="/rewrite-about">
         To Rewritten About
       </Link>
+      <Link id="to-middleware-rewritten-existing-page-link" href="/exists-but-not-routed">
+        To Middleware-Rewritten Existing Page
+      </Link>
     </>
   );
 }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16414,6 +16414,62 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("hard-navigates when middleware rewrites an existing Pages path to App Router", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const sourceLoader = vi.fn(async () => ({ default: () => null }));
+    Object.assign(win.location, { origin: "http://localhost" });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    Object.assign(win, {
+      __VINEXT_PAGE_PATTERNS__: ["/exists-but-not-routed"],
+      __VINEXT_PAGE_LOADERS__: {
+        "/exists-but-not-routed": sourceLoader,
+      },
+    });
+    const hrefAssignments = trackHrefAssignments(win);
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(
+      async () =>
+        new Response("{}", {
+          headers: {
+            "content-type": "application/json",
+            "x-nextjs-rewrite": "/about",
+          },
+        }),
+    );
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/exists-but-not-routed");
+
+      expect(result).toBe(false);
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(sourceLoader).not.toHaveBeenCalled();
+      expect(render).not.toHaveBeenCalled();
+      expect(hrefAssignments).toEqual([
+        "http://localhost/exists-but-not-routed",
+        "/exists-but-not-routed",
+      ]);
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("does not double-prefix basePath for middleware data redirects", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

- probe the Pages data endpoint for middleware effects even when a production page loader already matches the visible URL
- reuse that same response for normal Pages rewrites, avoiding a duplicate data request
- hard-handoff to the App Router when middleware rewrites an existing Pages path to an App destination

## Next.js parity

Fixes the failure from `test/e2e/app-dir/app/index.test.ts`:

> should support rewrites on client-side navigation from pages to app with existing pages path

Reference fixture: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/index.test.ts#L603-L626

## Validation

- `vp check` on all changed files
- `vp test run tests/shims.test.ts -t "middleware rewrites an existing Pages path to App Router|uses the rewritten page loader when the visible URL also matches a page|hydrates middleware rewrites to fallback pages"` — 3 passed
- `PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/pages-to-app-routing.spec.ts --workers=1` — 4 passed
- `vp run vinext#build`
- `vp run cloudflare#build`

The Next.js deploy wrapper could not isolate the single assertion; the full 108-test file run was stopped before deployment to respect the targeted/low-CPU constraint. CI should run the broader validation.
