### PR TITLE
fix(app-router): preserve interception across middleware rewrites

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -744,6 +744,11 @@ type NavigationRequestState = {
   previousNextUrl: string | null;
 };
 
+function getCurrentMatchedRoutePathname(): string | null {
+  const routeKey = AppElementsWire.parseElementKey(getBrowserRouterState().routeId);
+  return routeKey?.kind === "route" ? routeKey.path : null;
+}
+
 function getRequestState(
   navigationKind: NavigationKind,
   targetPathname: string,
@@ -805,6 +810,7 @@ function getRequestState(
       const middlewareRewriteInterceptionContext =
         resolveMiddlewareRewriteNavigationInterceptionContext({
           basePath: __basePath,
+          currentMatchedPathname: getCurrentMatchedRoutePathname(),
           currentPathname: window.location.pathname,
           routeManifest: getBrowserRouteManifest(),
           targetPathname,

--- a/packages/vinext/src/server/app-browser-interception-context.ts
+++ b/packages/vinext/src/server/app-browser-interception-context.ts
@@ -9,6 +9,7 @@ import { stripBasePath } from "../utils/base-path.js";
 
 type ResolveManifestNavigationInterceptionContextOptions = {
   basePath: string;
+  currentMatchedPathname?: string | null;
   currentPathname: string;
   routeManifest: RouteManifest | null;
   targetPathname: string;
@@ -50,18 +51,33 @@ export function resolveMiddlewareRewriteNavigationInterceptionContext(
   if (options.routeManifest === null) return null;
 
   const currentPathname = stripBasePath(options.currentPathname, options.basePath);
+  const currentMatchedPathname = options.currentMatchedPathname
+    ? stripBasePath(options.currentMatchedPathname, options.basePath)
+    : null;
   const targetPathname = stripBasePath(options.targetPathname, options.basePath);
   const sourceParts = splitPathnameForRouteMatch(currentPathname);
+  const matchedSourceParts = currentMatchedPathname
+    ? splitPathnameForRouteMatch(currentMatchedPathname)
+    : null;
   const targetParts = splitPathnameForRouteMatch(targetPathname);
 
   for (const interception of options.routeManifest.segmentGraph.interceptions.values()) {
-    if (!matchRoutePatternPrefix(sourceParts, interception.sourcePatternParts)) continue;
     if (
       !matchRoutePatternWithOptionalDynamicSegments(targetParts, interception.targetPatternParts)
     ) {
       continue;
     }
-    return currentPathname;
+    if (matchRoutePatternPrefix(sourceParts, interception.sourcePatternParts)) {
+      return currentPathname;
+    }
+
+    if (
+      currentMatchedPathname !== null &&
+      matchedSourceParts !== null &&
+      matchRoutePatternPrefix(matchedSourceParts, interception.sourcePatternParts)
+    ) {
+      return currentMatchedPathname;
+    }
   }
 
   return null;

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -366,7 +366,9 @@ function createMountedParallelSlotSnapshots(
 
 function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshot {
   const displayUrl = createSnapshotPathAndSearch(state.navigationSnapshot);
-  const matchedUrl = normalizeNavigationSnapshotMatchedUrl(state.navigationSnapshot.pathname);
+  const matchedUrl =
+    state.interception?.targetMatchedUrl ??
+    normalizeNavigationSnapshotMatchedUrl(state.navigationSnapshot.pathname);
   return {
     displayUrl,
     interception: state.interception,
@@ -389,9 +391,9 @@ function createVisibleRouteSnapshot(state: AppRouterState): RouteSnapshot {
 
 function createPendingRouteSnapshot(pending: PendingNavigationCommit): RouteSnapshot {
   const displayUrl = createSnapshotPathAndSearch(pending.action.navigationSnapshot);
-  const matchedUrl = normalizeNavigationSnapshotMatchedUrl(
-    pending.action.navigationSnapshot.pathname,
-  );
+  const matchedUrl =
+    pending.action.interception?.targetMatchedUrl ??
+    normalizeNavigationSnapshotMatchedUrl(pending.action.navigationSnapshot.pathname);
   return {
     displayUrl,
     interception: pending.action.interception,

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -226,6 +226,7 @@ export async function buildPageElements<
   const hasPageModule = !!pageModule;
   const renderIdentity = createAppPageRenderIdentity({
     displayPathname,
+    targetMatchedPathname: routePath,
     interceptionContext: opts?.interceptionContext ?? null,
     interceptSourceMatchedUrl: opts?.interceptSourceMatchedUrl ?? null,
     // Sibling intercepts are full-page replacements with no slot proof.

--- a/packages/vinext/src/server/app-page-render-identity.ts
+++ b/packages/vinext/src/server/app-page-render-identity.ts
@@ -4,6 +4,7 @@ import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js
 
 type AppPageRenderIdentityInput = {
   displayPathname: string;
+  targetMatchedPathname?: string;
   interceptionContext?: string | null;
   interceptSourceMatchedUrl?: string | null;
   interceptSlotId?: string | null;
@@ -35,7 +36,9 @@ export function createAppPageRenderIdentity(
   input: AppPageRenderIdentityInput,
 ): AppPageRenderIdentity {
   const interceptionContext = input.interceptionContext ?? null;
-  const targetMatchedPathname = normalizeAppPageRenderMatchedPathname(input.displayPathname);
+  const targetMatchedPathname = normalizeAppPageRenderMatchedPathname(
+    input.targetMatchedPathname ?? input.displayPathname,
+  );
   const sourceMatchedPathname = normalizeAppPageInterceptionProofPathname(
     input.interceptSourceMatchedUrl ?? null,
   );

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -777,6 +777,12 @@ function stripInterceptionContextFromRouteId(routeId: string): string {
   return separatorIndex === -1 ? routeId : routeId.slice(0, separatorIndex);
 }
 
+function matchedUrlFromConcreteRouteId(routeId: string): string | null {
+  const normalizedRouteId = stripInterceptionContextFromRouteId(routeId);
+  if (!normalizedRouteId.startsWith("route:/")) return null;
+  return normalizedRouteId.slice("route:".length);
+}
+
 function getMatchedUrlPathname(matchedUrl: string): string {
   try {
     return new URL(matchedUrl, "https://vinext.local").pathname;
@@ -822,6 +828,16 @@ function findRouteManifestRouteByIdOrMatchedUrl(options: {
   const route = options.routeManifest.segmentGraph.routes.get(routeId);
   if (route && routeManifestRouteMatchesUrl(route, options.matchedUrl)) {
     return route;
+  }
+
+  const concreteRouteMatchedUrl =
+    route === undefined ? matchedUrlFromConcreteRouteId(options.routeId) : null;
+  if (concreteRouteMatchedUrl !== null) {
+    const concreteRoute = findRouteManifestRouteByMatchedUrl(
+      options.routeManifest,
+      concreteRouteMatchedUrl,
+    );
+    if (concreteRoute !== null) return concreteRoute;
   }
 
   return findRouteManifestRouteByMatchedUrl(options.routeManifest, options.matchedUrl);
@@ -1153,8 +1169,9 @@ function getVisibleInterceptionSourceIdentity(
       routeId: snapshot.interception.sourceRouteId,
     };
   }
+  const concreteMatchedUrl = matchedUrlFromConcreteRouteId(snapshot.routeId);
   return {
-    matchedUrl: snapshot.matchedUrl,
+    matchedUrl: concreteMatchedUrl ?? snapshot.matchedUrl,
     routeId: snapshot.routeId,
   };
 }

--- a/tests/app-browser-interception-context.test.ts
+++ b/tests/app-browser-interception-context.test.ts
@@ -108,6 +108,18 @@ describe("resolveMiddlewareRewriteNavigationInterceptionContext", () => {
     ).toBe("/interception-mw/en");
   });
 
+  it("uses the middleware-matched source pathname from the current route state", () => {
+    expect(
+      resolveMiddlewareRewriteNavigationInterceptionContext({
+        basePath: "",
+        currentMatchedPathname: "/interception-mw/en",
+        currentPathname: "/interception-mw",
+        routeManifest: createRouteManifest([localePhotoInterception]),
+        targetPathname: "/interception-mw/foo/p/1",
+      }),
+    ).toBe("/interception-mw/en");
+  });
+
   it("does not infer fallback context when the target cannot be an intercepted route", () => {
     expect(
       resolveMiddlewareRewriteNavigationInterceptionContext({

--- a/tests/app-page-render-identity.test.ts
+++ b/tests/app-page-render-identity.test.ts
@@ -37,6 +37,20 @@ describe("createAppPageRenderIdentity", () => {
     });
   });
 
+  it("uses the middleware-matched target for interception proof without changing display pathname", () => {
+    const identity = createAppPageRenderIdentity({
+      displayPathname: "/interception-mw/foo/p/1",
+      targetMatchedPathname: "/interception-mw/en/foo/p/1",
+      interceptionContext: "/interception-mw/en",
+      interceptSourceMatchedUrl: "/interception-mw/en",
+      interceptSlotId: "slot:modal:/interception-mw/[locale]",
+    });
+
+    expect(identity.displayPathname).toBe("/interception-mw/foo/p/1");
+    expect(identity.interception?.targetMatchedUrl).toBe("/interception-mw/en/foo/p/1");
+    expect(identity.interception?.targetRouteId).toBe("route:/interception-mw/en/foo/p/1");
+  });
+
   it("normalizes encoded source and target pathnames before encoding route IDs", () => {
     const identity = createAppPageRenderIdentity({
       displayPathname: "/photos/caf%C3%A9",

--- a/tests/e2e/app-router/interception-dynamic-segment-middleware.spec.ts
+++ b/tests/e2e/app-router/interception-dynamic-segment-middleware.spec.ts
@@ -5,13 +5,11 @@ import { test, expect } from "@playwright/test";
 import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
-// Middleware rewrites /interception-mw/foo/p/1 → /interception-mw/en/foo/p/1
-// so the app sees /en as the [locale] segment and [username]=foo, [id]=1.
-const LOCALE_HOME = `${BASE}/interception-mw/en`;
+const HOME = `${BASE}/interception-mw`;
 
 test.describe("interception-dynamic-segment-middleware", () => {
   test("intercepts dynamic route when middleware rewrites add locale prefix", async ({ page }) => {
-    await page.goto(LOCALE_HOME);
+    await page.goto(HOME);
     await waitForAppRouterHydration(page);
 
     // Click the link that points to /interception-mw/foo/p/1 (no locale).
@@ -22,7 +20,7 @@ test.describe("interception-dynamic-segment-middleware", () => {
   });
 
   test("refresh after interception shows non-intercepted page", async ({ page }) => {
-    await page.goto(LOCALE_HOME);
+    await page.goto(HOME);
     await waitForAppRouterHydration(page);
 
     await page.click("#link-foo-p-1");
@@ -38,14 +36,14 @@ test.describe("interception-dynamic-segment-middleware", () => {
   test("back/forward navigation preserves intercepted state with middleware active", async ({
     page,
   }) => {
-    await page.goto(LOCALE_HOME);
+    await page.goto(HOME);
     await waitForAppRouterHydration(page);
 
     await page.click("#link-foo-p-1");
     await expect(page.locator("#modal")).toContainText("intercepted");
 
     await page.goBack();
-    await expect(page).toHaveURL(LOCALE_HOME);
+    await expect(page).toHaveURL(HOME);
 
     await page.goForward();
     await expect(page.locator("#modal")).toContainText("intercepted");
@@ -53,7 +51,7 @@ test.describe("interception-dynamic-segment-middleware", () => {
 
   test("repeated interceptions with middleware work consistently", async ({ page }) => {
     for (let i = 0; i < 2; i++) {
-      await page.goto(LOCALE_HOME);
+      await page.goto(HOME);
       await waitForAppRouterHydration(page);
 
       await page.click("#link-foo-p-1");

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -265,7 +265,7 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // Scoped exclusively to /interception-mw/* to avoid interfering with other tests.
   // Mirrors Next.js: test/e2e/app-dir/interception-dynamic-segment-middleware/middleware.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/interception-dynamic-segment-middleware/middleware.ts
-  if (pathname.startsWith("/interception-mw/")) {
+  if (pathname === "/interception-mw" || pathname.startsWith("/interception-mw/")) {
     const withoutPrefix = pathname.slice("/interception-mw".length); // → /foo/p/1
     const locale = "en";
     const hasLocale = withoutPrefix.startsWith(`/${locale}/`) || withoutPrefix === `/${locale}`;

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -1181,6 +1181,64 @@ describe("navigationPlanner root-boundary decisions", () => {
     expect(decision.proposal.preserveElementIds).toEqual(["layout:/", "layout:/dashboard"]);
   });
 
+  it("uses concrete route ids when middleware rewrites hide dynamic source params", () => {
+    const slotId = "slot:modal:/interception-mw/:locale";
+    const routeManifest = createTestRouteManifest([
+      {
+        layoutIds: ["layout:/", "layout:/interception-mw/:locale"],
+        pattern: "/interception-mw/:locale",
+        rootBoundaryId: "root-boundary:/",
+        slotBindings: [createSlotBinding(slotId, "layout:/interception-mw/:locale", "active")],
+        interceptions: [
+          {
+            sourcePattern: "/interception-mw/:locale",
+            targetPattern: "/interception-mw/:locale/:username/p/:id",
+            slotId,
+            ownerLayoutId: "layout:/interception-mw/:locale",
+          },
+        ],
+      },
+      {
+        layoutIds: ["layout:/", "layout:/interception-mw/:locale"],
+        pattern: "/interception-mw/:locale/:username/p/:id",
+        rootBoundaryId: "root-boundary:/",
+      },
+    ]);
+    const currentSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot(
+        "root-boundary:/",
+        ["layout:/", "layout:/interception-mw/:locale"],
+        [{ ownerLayoutId: "layout:/interception-mw/:locale", slotId }],
+        [createSlotBinding(slotId, "layout:/interception-mw/:locale", "active")],
+      ),
+      displayUrl: "https://example.com/interception-mw",
+      matchedUrl: "/interception-mw",
+      routeId: "route:/interception-mw/en",
+    };
+    const targetSnapshot: RouteSnapshot = {
+      ...currentSnapshot,
+      displayUrl: "https://example.com/interception-mw/foo/p/1",
+      interception: {
+        sourceMatchedUrl: "/interception-mw/en",
+        sourceRouteId: "route:/interception-mw/en",
+        slotId,
+        targetMatchedUrl: "/interception-mw/en/foo/p/1",
+        targetRouteId: "route:/interception-mw/en/foo/p/1",
+      },
+      interceptionContext: "/interception-mw/en",
+      matchedUrl: "/interception-mw/en/foo/p/1",
+      routeId: "route:/interception-mw/en",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      routeManifest,
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+  });
+
   it("does not let stale manifest route IDs override the matched URL", () => {
     const routeManifest = createTestRouteManifest([
       {


### PR DESCRIPTION
## Summary

- preserve the internally matched source route when middleware hides dynamic segments from the browser URL
- distinguish browser-visible and middleware-matched target paths in interception proof metadata
- let navigation planning validate concrete dynamic route IDs without weakening stale-route safety
- strengthen the local Next.js parity fixture to start from the browser-visible rewritten URL

## Validation

- `vp test run tests/app-browser-interception-context.test.ts tests/app-page-render-identity.test.ts tests/navigation-planner.test.ts tests/app-rsc-route-matching.test.ts tests/app-browser-history-controller.test.ts` — 95 passed
- `CI=1 PLAYWRIGHT_PROJECT=app-router playwright test tests/e2e/app-router/interception-dynamic-segment-middleware.spec.ts --workers=1 --retries=0` — 4 passed
- targeted `vp check` on all changed files
- `vp run vinext#build`

The exact Next.js deploy-suite attempt stopped before deployment because the disposable worktree reuses a dependency symlink and `vp env` attempted to replace it non-interactively. No suite assertion was reached; CI should run the clean install/build path.
