### PR TITLE
fix(css): support namespace CSS Module imports

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3296,6 +3296,7 @@ export const loadServerActionClient = ${
         },
       },
     },
+    createCssModuleImportCompatibilityPlugin({ compiledMdx: true }),
     // Shim React canary/experimental APIs (ViewTransition, addTransitionType)
     // that exist in Next.js's bundled React canary but not in stable React 19.
     // Provides graceful no-op fallbacks so projects using these APIs degrade

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -129,6 +129,7 @@ import { renderVinextBuiltUrl } from "./utils/built-asset-url.js";
 import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
 import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
+import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import {
@@ -1286,6 +1287,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // load. Matches Turbopack's behaviour for the Next.js
     // `css-modules-data-urls` fixture. See plugins/css-data-url.ts.
     dataUrlCssPlugin(),
+    createCssModuleImportCompatibilityPlugin(),
     {
       name: "vinext:config",
       enforce: "pre",

--- a/packages/vinext/src/plugins/css-module-imports.ts
+++ b/packages/vinext/src/plugins/css-module-imports.ts
@@ -2,7 +2,7 @@ import type { Plugin } from "vite";
 import { parseAst } from "vite";
 import MagicString from "magic-string";
 
-const CSS_MODULE_RE = /\.module\.(?:css|scss|sass)(?:[?#].*)?$/i;
+const CSS_MODULE_RE = /\.module\.(?:css|scss|sass)$/i;
 const SCRIPT_RE = /\.(?:[cm]?[jt]sx?)(?:[?#].*)?$/i;
 
 type AstImportSpecifier = {

--- a/packages/vinext/src/plugins/css-module-imports.ts
+++ b/packages/vinext/src/plugins/css-module-imports.ts
@@ -25,7 +25,7 @@ type AstImportDeclaration = {
 type ScriptLanguage = "js" | "jsx" | "ts" | "tsx";
 
 function scriptLanguage(id: string): ScriptLanguage {
-  const cleanId = id.split("?", 1)[0];
+  const cleanId = id.split("?", 1)[0].toLowerCase();
   if (cleanId.endsWith(".tsx")) return "tsx";
   if (cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")) return "ts";
   return "jsx";
@@ -79,7 +79,7 @@ export function createCssModuleImportCompatibilityPlugin(
     name: options.compiledMdx
       ? "vinext:css-module-import-compatibility-mdx"
       : "vinext:css-module-import-compatibility",
-    enforce: "pre",
+    enforce: options.compiledMdx ? "post" : "pre",
     transform: {
       filter: { id: idFilter, code: CSS_MODULE_HINT_RE },
       handler(code, id) {

--- a/packages/vinext/src/plugins/css-module-imports.ts
+++ b/packages/vinext/src/plugins/css-module-imports.ts
@@ -23,8 +23,7 @@ function scriptLanguage(id: string): ScriptLanguage {
   const cleanId = id.split("?", 1)[0];
   if (cleanId.endsWith(".tsx")) return "tsx";
   if (cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")) return "ts";
-  if (cleanId.endsWith(".jsx")) return "jsx";
-  return "js";
+  return "jsx";
 }
 
 export function rewriteCssModuleNamespaceImports(

--- a/packages/vinext/src/plugins/css-module-imports.ts
+++ b/packages/vinext/src/plugins/css-module-imports.ts
@@ -1,0 +1,80 @@
+import type { Plugin } from "vite";
+import { parseAst } from "vite";
+import MagicString from "magic-string";
+
+const CSS_MODULE_RE = /\.module\.(?:css|scss|sass)(?:[?#].*)?$/i;
+const SCRIPT_RE = /\.(?:[cm]?[jt]sx?)(?:[?#].*)?$/i;
+
+type AstImportSpecifier = {
+  type?: string;
+  start?: number;
+  end?: number;
+};
+
+type AstImportDeclaration = {
+  type?: string;
+  source?: { value?: unknown };
+  specifiers?: AstImportSpecifier[];
+};
+
+type ScriptLanguage = "js" | "jsx" | "ts" | "tsx";
+
+function scriptLanguage(id: string): ScriptLanguage {
+  const cleanId = id.split("?", 1)[0];
+  if (cleanId.endsWith(".tsx")) return "tsx";
+  if (cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")) return "ts";
+  if (cleanId.endsWith(".jsx")) return "jsx";
+  return "js";
+}
+
+export function rewriteCssModuleNamespaceImports(
+  code: string,
+  lang: ScriptLanguage = "js",
+): {
+  code: string;
+  map: ReturnType<MagicString["generateMap"]>;
+} | null {
+  let ast: ReturnType<typeof parseAst>;
+  try {
+    ast = parseAst(code, { lang });
+  } catch {
+    return null;
+  }
+
+  let output: MagicString | null = null;
+  for (const statement of ast.body as AstImportDeclaration[]) {
+    if (statement.type !== "ImportDeclaration") continue;
+    if (typeof statement.source?.value !== "string") continue;
+    if (!CSS_MODULE_RE.test(statement.source.value)) continue;
+    if (statement.specifiers?.length !== 1) continue;
+
+    const specifier = statement.specifiers[0];
+    if (specifier.type !== "ImportNamespaceSpecifier") continue;
+    if (typeof specifier.start !== "number" || typeof specifier.end !== "number") continue;
+
+    const namespaceBinding = code
+      .slice(specifier.start, specifier.end)
+      .match(/^\*\s+as\s+(.+)$/s)?.[1];
+    if (!namespaceBinding) continue;
+
+    output ??= new MagicString(code);
+    output.overwrite(specifier.start, specifier.end, namespaceBinding);
+  }
+
+  if (!output) return null;
+  return {
+    code: output.toString(),
+    map: output.generateMap({ hires: true }),
+  };
+}
+
+export function createCssModuleImportCompatibilityPlugin(): Plugin {
+  return {
+    name: "vinext:css-module-import-compatibility",
+    enforce: "pre",
+    transform(code, id) {
+      if (!SCRIPT_RE.test(id) || !code.includes(".module.")) return null;
+      return rewriteCssModuleNamespaceImports(code, scriptLanguage(id));
+    },
+  };
+}

--- a/packages/vinext/src/plugins/css-module-imports.ts
+++ b/packages/vinext/src/plugins/css-module-imports.ts
@@ -3,18 +3,23 @@ import { parseAst } from "vite";
 import MagicString from "magic-string";
 
 const CSS_MODULE_RE = /\.module\.(?:css|scss|sass)$/i;
+const CSS_MODULE_HINT_RE = /\.module\.(?:css|scss|sass)/i;
 const SCRIPT_RE = /\.(?:[cm]?[jt]sx?)(?:[?#].*)?$/i;
+const MDX_RE = /\.mdx$/i;
 
 type AstImportSpecifier = {
   type?: string;
   start?: number;
   end?: number;
+  local?: { name?: unknown };
 };
 
 type AstImportDeclaration = {
   type?: string;
+  importKind?: string;
   source?: { value?: unknown };
   specifiers?: AstImportSpecifier[];
+  attributes?: unknown[];
 };
 
 type ScriptLanguage = "js" | "jsx" | "ts" | "tsx";
@@ -43,21 +48,20 @@ export function rewriteCssModuleNamespaceImports(
   let output: MagicString | null = null;
   for (const statement of ast.body as AstImportDeclaration[]) {
     if (statement.type !== "ImportDeclaration") continue;
+    if (statement.importKind === "type") continue;
     if (typeof statement.source?.value !== "string") continue;
     if (!CSS_MODULE_RE.test(statement.source.value)) continue;
+    if (statement.attributes && statement.attributes.length > 0) continue;
     if (statement.specifiers?.length !== 1) continue;
 
     const specifier = statement.specifiers[0];
     if (specifier.type !== "ImportNamespaceSpecifier") continue;
     if (typeof specifier.start !== "number" || typeof specifier.end !== "number") continue;
 
-    const namespaceBinding = code
-      .slice(specifier.start, specifier.end)
-      .match(/^\*\s+as\s+(.+)$/s)?.[1];
-    if (!namespaceBinding) continue;
+    if (typeof specifier.local?.name !== "string") continue;
 
     output ??= new MagicString(code);
-    output.overwrite(specifier.start, specifier.end, namespaceBinding);
+    output.overwrite(specifier.start, specifier.end, specifier.local.name);
   }
 
   if (!output) return null;
@@ -67,13 +71,23 @@ export function rewriteCssModuleNamespaceImports(
   };
 }
 
-export function createCssModuleImportCompatibilityPlugin(): Plugin {
+export function createCssModuleImportCompatibilityPlugin(
+  options: { compiledMdx?: boolean } = {},
+): Plugin {
+  const idFilter = options.compiledMdx ? MDX_RE : SCRIPT_RE;
   return {
-    name: "vinext:css-module-import-compatibility",
+    name: options.compiledMdx
+      ? "vinext:css-module-import-compatibility-mdx"
+      : "vinext:css-module-import-compatibility",
     enforce: "pre",
-    transform(code, id) {
-      if (!SCRIPT_RE.test(id) || !code.includes(".module.")) return null;
-      return rewriteCssModuleNamespaceImports(code, scriptLanguage(id));
+    transform: {
+      filter: { id: idFilter, code: CSS_MODULE_HINT_RE },
+      handler(code, id) {
+        return rewriteCssModuleNamespaceImports(
+          code,
+          options.compiledMdx ? "jsx" : scriptLanguage(id),
+        );
+      },
     },
   };
 }

--- a/tests/css-module-imports.test.ts
+++ b/tests/css-module-imports.test.ts
@@ -6,14 +6,14 @@ describe("CSS Module import compatibility", () => {
     const source = [
       'import * as css from "./styles.module.css";',
       'import * as scss from "example/index.module.scss";',
-      'import * as sass from "./styles.module.sass?inline";',
+      'import * as sass from "./styles.module.sass";',
     ].join("\n");
 
     expect(rewriteCssModuleNamespaceImports(source)?.code).toBe(
       [
         'import css from "./styles.module.css";',
         'import scss from "example/index.module.scss";',
-        'import sass from "./styles.module.sass?inline";',
+        'import sass from "./styles.module.sass";',
       ].join("\n"),
     );
   });
@@ -34,6 +34,8 @@ describe("CSS Module import compatibility", () => {
       'import styles from "./styles.module.scss";',
       'import { red } from "./styles.module.scss";',
       'const lazy = import("./styles.module.scss");',
+      'import * as inlineCss from "./styles.module.css?inline";',
+      'import * as rawScss from "./styles.module.scss?raw";',
       'import * as globalStyles from "./styles.scss";',
       'import * as packageModule from "example";',
     ].join("\n");

--- a/tests/css-module-imports.test.ts
+++ b/tests/css-module-imports.test.ts
@@ -29,6 +29,17 @@ describe("CSS Module import compatibility", () => {
     );
   });
 
+  it("parses imports from .js modules containing JSX", () => {
+    const source = [
+      'import * as classes from "example/index.module.scss";',
+      'export default function Page() { return <div className={classes["red-text"]} />; }',
+    ].join("\n");
+
+    expect(rewriteCssModuleNamespaceImports(source, "jsx")?.code).toContain(
+      'import classes from "example/index.module.scss";',
+    );
+  });
+
   it("leaves existing default, named, dynamic, and non-module imports unchanged", () => {
     const source = [
       'import styles from "./styles.module.scss";',

--- a/tests/css-module-imports.test.ts
+++ b/tests/css-module-imports.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
-import { rewriteCssModuleNamespaceImports } from "../packages/vinext/src/plugins/css-module-imports.js";
+import {
+  createCssModuleImportCompatibilityPlugin,
+  rewriteCssModuleNamespaceImports,
+} from "../packages/vinext/src/plugins/css-module-imports.js";
 
 describe("CSS Module import compatibility", () => {
   it("rewrites namespace CSS Module imports to the default locals object", () => {
@@ -40,6 +43,44 @@ describe("CSS Module import compatibility", () => {
     );
   });
 
+  it("uses the AST binding for commented namespace imports", () => {
+    const source = 'import * /* webpack */ as styles from "./styles.module.scss";';
+
+    expect(rewriteCssModuleNamespaceImports(source)?.code).toBe(
+      'import styles from "./styles.module.scss";',
+    );
+  });
+
+  it("rewrites namespace imports after MDX compilation", async () => {
+    const { default: mdx } = await import("@mdx-js/rollup");
+    const mdxPlugin = mdx() as {
+      config: (config: unknown, env: unknown) => void;
+      transform: (code: string, id: string) => Promise<string | { code: string } | undefined>;
+    };
+    mdxPlugin.config({}, { command: "build", mode: "production" });
+    const compiled = await mdxPlugin.transform.call(
+      {} as never,
+      'import * as styles from "./styles.module.scss";\n\n# Hello',
+      "/project/page.mdx",
+    );
+    expect(compiled).toBeTruthy();
+
+    const compatibilityPlugin = createCssModuleImportCompatibilityPlugin({ compiledMdx: true });
+    const compatibilityTransform =
+      typeof compatibilityPlugin.transform === "function"
+        ? compatibilityPlugin.transform
+        : compatibilityPlugin.transform?.handler;
+    const result = await compatibilityTransform?.call(
+      {} as never,
+      typeof compiled === "string" ? compiled : compiled!.code,
+      "/project/page.mdx",
+    );
+
+    expect(result && typeof result !== "string" ? result.code : result).toContain(
+      'import styles from "./styles.module.scss";',
+    );
+  });
+
   it("leaves existing default, named, dynamic, and non-module imports unchanged", () => {
     const source = [
       'import styles from "./styles.module.scss";',
@@ -47,6 +88,8 @@ describe("CSS Module import compatibility", () => {
       'const lazy = import("./styles.module.scss");',
       'import * as inlineCss from "./styles.module.css?inline";',
       'import * as rawScss from "./styles.module.scss?raw";',
+      'import type * as styleTypes from "./styles.module.scss";',
+      'import * as attributed from "./styles.module.css" with { type: "css" };',
       'import * as globalStyles from "./styles.scss";',
       'import * as packageModule from "example";',
     ].join("\n");

--- a/tests/css-module-imports.test.ts
+++ b/tests/css-module-imports.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+import { rewriteCssModuleNamespaceImports } from "../packages/vinext/src/plugins/css-module-imports.js";
+
+describe("CSS Module import compatibility", () => {
+  it("rewrites namespace CSS Module imports to the default locals object", () => {
+    const source = [
+      'import * as css from "./styles.module.css";',
+      'import * as scss from "example/index.module.scss";',
+      'import * as sass from "./styles.module.sass?inline";',
+    ].join("\n");
+
+    expect(rewriteCssModuleNamespaceImports(source)?.code).toBe(
+      [
+        'import css from "./styles.module.css";',
+        'import scss from "example/index.module.scss";',
+        'import sass from "./styles.module.sass?inline";',
+      ].join("\n"),
+    );
+  });
+
+  it("parses imports from TSX modules", () => {
+    const source = [
+      'import * as classes from "example/index.module.scss";',
+      'export default function Page(): React.ReactNode { return <div className={classes["red-text"]} />; }',
+    ].join("\n");
+
+    expect(rewriteCssModuleNamespaceImports(source, "tsx")?.code).toContain(
+      'import classes from "example/index.module.scss";',
+    );
+  });
+
+  it("leaves existing default, named, dynamic, and non-module imports unchanged", () => {
+    const source = [
+      'import styles from "./styles.module.scss";',
+      'import { red } from "./styles.module.scss";',
+      'const lazy = import("./styles.module.scss");',
+      'import * as globalStyles from "./styles.scss";',
+      'import * as packageModule from "example";',
+    ].join("\n");
+
+    expect(rewriteCssModuleNamespaceImports(source)).toBeNull();
+  });
+});

--- a/tests/css-module-imports.test.ts
+++ b/tests/css-module-imports.test.ts
@@ -32,6 +32,20 @@ describe("CSS Module import compatibility", () => {
     );
   });
 
+  it("selects the TypeScript parser for uppercase extensions", () => {
+    const plugin = createCssModuleImportCompatibilityPlugin();
+    const transform =
+      typeof plugin.transform === "function" ? plugin.transform : plugin.transform?.handler;
+    const source = [
+      'import * as classes from "example/index.module.scss";',
+      'export default function Page(): React.ReactNode { return <div className={classes["red-text"]} />; }',
+    ].join("\n");
+
+    expect(transform?.call({} as never, source, "/project/Page.TSX")).toMatchObject({
+      code: expect.stringContaining('import classes from "example/index.module.scss";'),
+    });
+  });
+
   it("parses imports from .js modules containing JSX", () => {
     const source = [
       'import * as classes from "example/index.module.scss";',
@@ -66,6 +80,7 @@ describe("CSS Module import compatibility", () => {
     expect(compiled).toBeTruthy();
 
     const compatibilityPlugin = createCssModuleImportCompatibilityPlugin({ compiledMdx: true });
+    expect(compatibilityPlugin.enforce).toBe("post");
     const compatibilityTransform =
       typeof compatibilityPlugin.transform === "function"
         ? compatibilityPlugin.transform

--- a/tests/scss-composes.test.ts
+++ b/tests/scss-composes.test.ts
@@ -153,7 +153,7 @@ describe("SCSS CSS-module composes (production build)", () => {
     const tmpDir = await makeFixture({
       "app/layout.tsx":
         "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n",
-      "pages/index.tsx": [
+      "pages/index.js": [
         'import * as classes from "example/index.module.scss";',
         "export default function Home() {",
         '  return <div className={classes["red-text"]}>node module</div>;',

--- a/tests/scss-composes.test.ts
+++ b/tests/scss-composes.test.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, it, expect } from "vite-plus/test";
-import { build } from "vite-plus";
+import { build, createBuilder } from "vite-plus";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -111,6 +111,33 @@ async function buildAndCollect(tmpDir: string): Promise<{ css: string; js: strin
   }
 }
 
+async function buildHybridAndCollect(tmpDir: string): Promise<{ css: string; js: string }> {
+  const builder = await createBuilder({
+    root: tmpDir,
+    configFile: false,
+    plugins: [vinext({ appDir: tmpDir })],
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+  const clientDir = path.join(tmpDir, "dist", "client");
+  const files = await fs.readdir(clientDir, { withFileTypes: true, recursive: true });
+  const cssFiles = files.filter((entry) => entry.isFile() && entry.name.endsWith(".css"));
+  const jsFiles = files.filter((entry) => entry.isFile() && entry.name.endsWith(".js"));
+  const readOutput = async (entries: typeof files) =>
+    (
+      await Promise.all(
+        entries.map((entry) => {
+          const parent =
+            (entry as { parentPath?: string; path?: string }).parentPath ??
+            (entry as { path?: string }).path ??
+            clientDir;
+          return fs.readFile(path.join(parent, entry.name), "utf8");
+        }),
+      )
+    ).join("\n");
+  return { css: await readOutput(cssFiles), js: await readOutput(jsFiles) };
+}
+
 const PAGE = [
   'import styles from "../styles/index.module.scss";',
   "export default function Home() {",
@@ -120,6 +147,32 @@ const PAGE = [
 ].join("\n");
 
 describe("SCSS CSS-module composes (production build)", () => {
+  // Ported from Next.js: test/e2e/app-dir/scss/nm-module/nm-module.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/scss/nm-module/nm-module.test.ts
+  it("emits a directly imported .module.scss from node_modules in hybrid builds (nm-module)", async () => {
+    const tmpDir = await makeFixture({
+      "app/layout.tsx":
+        "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n",
+      "pages/index.tsx": [
+        'import * as classes from "example/index.module.scss";',
+        "export default function Home() {",
+        '  return <div className={classes["red-text"]}>node module</div>;',
+        "}",
+        "",
+      ].join("\n"),
+      "node_modules/example/package.json": JSON.stringify({ name: "example", version: "1.0.0" }),
+      "node_modules/example/index.module.scss": "$var: red;\n.red-text {\n  color: $var;\n}\n",
+    });
+    try {
+      const { css, js } = await buildHybridAndCollect(tmpDir);
+      expect(css).not.toContain("$var");
+      expect(css).toContain("color:red");
+      expect(js).toMatch(/_red-text_[\w-]+/);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 60_000);
+
   it("composes from an external .module.scss containing SCSS syntax (composes-external)", async () => {
     const tmpDir = await makeFixture({
       "pages/index.tsx": PAGE,


### PR DESCRIPTION
## Summary
- rewrite static namespace imports of CSS Modules to Vite's default locals export
- preserve Next.js's CommonJS CSS Module compatibility semantics for package styles
- cover the hybrid App + Pages production graph used by the failing fixture

## Next.js parity
Fixes both failures from `test/e2e/app-dir/scss/nm-module/nm-module.test.ts` in deploy-suite run 28143992598.

Next.js intentionally configures CSS Modules with `esModule: false` for backwards compatibility, so `import * as classes from "example/index.module.scss"` exposes the locals object directly. Vite exposes that object as the default export; without this compatibility rewrite the namespace access is undefined and the stylesheet is tree-shaken.

References:
- https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/scss/nm-module/nm-module.test.ts
- https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/webpack/config/blocks/css/loaders/modules.ts

## Validation
- `vp test run tests/css-module-imports.test.ts tests/scss-composes.test.ts` — 9/9
- focused `vp check` on touched files
- exact Next.js v16.2.6 deploy suite, concurrency 1 — 2/2

Excludes cacheComponents, PPR, resume, and fallback-shell work.
