### PR TITLE
fix(app-router): discover nested leaf slot routes

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -957,9 +957,9 @@ export async function buildAppRouteGraph(
     const dir = path.posix.dirname(file);
     const routeDir = dir === "." ? appDir : path.posix.join(appDir, dir);
     if (!hasParallelSlotDirectory(routeDir)) continue;
-    if (discoverParallelSlots(routeDir, appDir, scanMatcher).length === 0) continue;
+    if (discoverParallelSlots(routeDir, appDir, scanMatcher, true).length === 0) continue;
 
-    const route = directoryToAppRoute(dir, appDir, scanMatcher, null, null);
+    const route = directoryToAppRoute(dir, appDir, scanMatcher, null, null, true);
     if (!route) continue;
     if (routePatterns.has(route.pattern)) {
       ghostParentRoutes.push(route);
@@ -1476,6 +1476,7 @@ function directoryToAppRoute(
   matcher: ValidFileMatcher,
   pagePath: string | null,
   routePath: string | null,
+  includeNestedOnlySlots = false,
 ): AppRouteGraphRoute | null {
   const segments = dir === "." ? [] : dir.split("/");
 
@@ -1528,7 +1529,13 @@ function directoryToAppRoute(
   // Discover parallel slots (@team, @analytics, etc.).
   // Slots at the route's own directory use page.tsx; slots at ancestor directories
   // (inherited from parent layouts) use default.tsx as fallback.
-  const parallelSlots = discoverInheritedParallelSlots(segments, appDir, routeDir, matcher);
+  const parallelSlots = discoverInheritedParallelSlots(
+    segments,
+    appDir,
+    routeDir,
+    matcher,
+    includeNestedOnlySlots,
+  );
 
   return {
     ids: createAppRouteSemanticIds({
@@ -1855,6 +1862,7 @@ function discoverInheritedParallelSlots(
   appDir: string,
   routeDir: string,
   matcher: ValidFileMatcher,
+  includeNestedOnlySlots = false,
 ): AppRouteGraphParallelSlot[] {
   const slotMap = new Map<string, AppRouteGraphParallelSlot>();
 
@@ -1886,9 +1894,14 @@ function discoverInheritedParallelSlots(
     if (lvlLayoutIdx < 0 && routeHasLayout) continue;
 
     const slotLayoutIdx = Math.max(lvlLayoutIdx, 0);
-    const slotsAtLevel = discoverParallelSlots(dir, appDir, matcher);
     const segmentsBelow = segments.slice(segmentIndex);
     const isActiveUrlLevel = dir === routeDir || segmentsBelow.every(isInvisibleSegment);
+    const slotsAtLevel = discoverParallelSlots(
+      dir,
+      appDir,
+      matcher,
+      includeNestedOnlySlots && isActiveUrlLevel,
+    );
 
     for (const slot of slotsAtLevel) {
       if (isActiveUrlLevel) {
@@ -2141,6 +2154,7 @@ function discoverParallelSlots(
   dir: string,
   appDir: string,
   matcher: ValidFileMatcher,
+  includeNestedOnlySlots = false,
 ): AppRouteGraphParallelSlot[] {
   if (!fs.existsSync(dir)) return [];
 
@@ -2165,7 +2179,7 @@ function discoverParallelSlots(
     const pagePath = findSlotRootPage(slotDir, matcher);
     const defaultPath = findFile(slotDir, "default", matcher);
     const interceptingRoutes = discoverInterceptingRoutes(slotDir, dir, appDir, matcher);
-    const hasNestedPages = findSlotSubPages(slotDir, matcher).length > 0;
+    const hasNestedPages = includeNestedOnlySlots && findSlotSubPages(slotDir, matcher).length > 0;
 
     // A slot with only nested pages still owns URL sub-routes. Keeping it in
     // the graph lets discoverSlotSubRoutes materialize shapes such as

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -2129,7 +2129,8 @@ function findSlotRootPage(slotDir: string, matcher: ValidFileMatcher): string | 
 
 /**
  * Discover parallel route slots (@team, @analytics, etc.) in a directory.
- * Returns a ParallelSlot for each @-prefixed subdirectory that has a page or default component.
+ * Returns a ParallelSlot for each @-prefixed subdirectory that has a page,
+ * default component, intercepting route, or nested page-backed sub-route.
  *
  * `dir` and `appDir` must be forward-slash. The slot directory is built from
  * `dir` with `path.posix.join`, and the owner segments and slot key come from
@@ -2164,9 +2165,12 @@ function discoverParallelSlots(
     const pagePath = findSlotRootPage(slotDir, matcher);
     const defaultPath = findFile(slotDir, "default", matcher);
     const interceptingRoutes = discoverInterceptingRoutes(slotDir, dir, appDir, matcher);
+    const hasNestedPages = findSlotSubPages(slotDir, matcher).length > 0;
 
-    // Only include slots that have at least a page, default, or intercepting route
-    if (!pagePath && !defaultPath && interceptingRoutes.length === 0) continue;
+    // A slot with only nested pages still owns URL sub-routes. Keeping it in
+    // the graph lets discoverSlotSubRoutes materialize shapes such as
+    // `@slot/other/page.tsx` when the owner has no children page of its own.
+    if (!pagePath && !defaultPath && interceptingRoutes.length === 0 && !hasNestedPages) continue;
 
     const ownerSegments = path.posix
       .relative(appDir, dir)

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -465,6 +465,26 @@ describe("App Router route graph builder", () => {
   // Ported from Next.js: test/e2e/app-dir/parallel-routes-catchall/
   // ("should match correctly when defining an explicit slot but no page").
   describe("explicit slot but no page (issue #1535)", () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
+    // https://github.com/vercel/next.js/tree/v16.2.6/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
+    it("uses the parent children default for a leaf parallel-slot sub-route", async () => {
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "no-children/layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "no-children/default.tsx", EMPTY_PAGE);
+        await writeAppFile(appDir, "no-children/@slot/other/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const route = findRoute(graph.routes, "/no-children/other");
+
+        expect(route.pagePath).toBe(path.join(appDir, "no-children/default.tsx"));
+        expect(route.parallelSlots.find((slot) => slot.name === "slot")?.pagePath).toBe(
+          path.join(appDir, "no-children/@slot/other/page.tsx"),
+        );
+      });
+    });
+
     it("falls children through to the sibling catch-all for a slot-only sub-route", async () => {
       // /baz: @slot/baz/page.tsx exists, but there is no baz/page.tsx and no
       // root default.tsx. Next.js serves /baz's children from the sibling

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -82,6 +82,18 @@ test.describe("Parallel Routes", () => {
     const response = await page.goto(`${BASE}/dashboard/team`);
     expect(response?.status()).toBe(404);
   });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts
+  test("slot-only leaf route renders the children default", async ({ page }) => {
+    await page.goto(`${BASE}/parallel-leaf-default/other`);
+
+    await expect(page.getByTestId("parallel-leaf-slot")).toHaveText("Parallel leaf other slot");
+    await expect(page.getByTestId("parallel-leaf-children")).toHaveText(
+      "Parallel leaf children default",
+    );
+  });
 });
 
 test.describe("Intercepting Routes", () => {

--- a/tests/fixtures/app-basic/app/parallel-leaf-default/@slot/other/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-leaf-default/@slot/other/page.tsx
@@ -1,0 +1,3 @@
+export default function ParallelLeafOtherSlot() {
+  return <p>Parallel leaf other slot</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-leaf-default/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-leaf-default/default.tsx
@@ -1,0 +1,3 @@
+export default function ParallelLeafChildrenDefault() {
+  return <p>Parallel leaf children default</p>;
+}

--- a/tests/fixtures/app-basic/app/parallel-leaf-default/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-leaf-default/layout.tsx
@@ -1,0 +1,14 @@
+export default function ParallelLeafDefaultLayout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode;
+  slot: React.ReactNode;
+}) {
+  return (
+    <>
+      <div data-testid="parallel-leaf-slot">{slot}</div>
+      <div data-testid="parallel-leaf-children">{children}</div>
+    </>
+  );
+}

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -678,7 +678,10 @@ describe("appRouter - route discovery", () => {
     });
   });
 
-  it("does not discover nested @slot sub-routes when the slot root has no page or default", async () => {
+  // Ported from Next.js:
+  // test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
+  // https://github.com/vercel/next.js/tree/v16.2.6/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
+  it("discovers nested @slot sub-routes when the children default can fill the leaf", async () => {
     await withTempDir("vinext-app-slot-nested-only-rootless-", async (tmpDir) => {
       const appDir = path.join(tmpDir, "app");
       await mkdir(path.join(appDir, "inbox", "@modal", "profile"), { recursive: true });
@@ -691,8 +694,16 @@ describe("appRouter - route discovery", () => {
       const patterns = routes.map((route) => route.pattern);
 
       expect(patterns).toContain("/inbox");
-      expect(patterns).not.toContain("/inbox/profile");
-      expect(matchAppRoute("/inbox/profile", routes)).toBeNull();
+      expect(patterns).toContain("/inbox/profile");
+      expect(matchAppRoute("/inbox/profile", routes)).toMatchObject({
+        pagePath: path.join(appDir, "inbox", "default.tsx"),
+        parallelSlots: [
+          expect.objectContaining({
+            name: "modal",
+            pagePath: path.join(appDir, "inbox", "@modal", "profile", "page.tsx"),
+          }),
+        ],
+      });
     });
   });
 

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -678,10 +678,7 @@ describe("appRouter - route discovery", () => {
     });
   });
 
-  // Ported from Next.js:
-  // test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
-  // https://github.com/vercel/next.js/tree/v16.2.6/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
-  it("discovers nested @slot sub-routes when the children default can fill the leaf", async () => {
+  it("does not discover nested @slot sub-routes when the slot root has no page or default", async () => {
     await withTempDir("vinext-app-slot-nested-only-rootless-", async (tmpDir) => {
       const appDir = path.join(tmpDir, "app");
       await mkdir(path.join(appDir, "inbox", "@modal", "profile"), { recursive: true });
@@ -694,8 +691,30 @@ describe("appRouter - route discovery", () => {
       const patterns = routes.map((route) => route.pattern);
 
       expect(patterns).toContain("/inbox");
-      expect(patterns).toContain("/inbox/profile");
-      expect(matchAppRoute("/inbox/profile", routes)).toMatchObject({
+      expect(patterns).not.toContain("/inbox/profile");
+      expect(matchAppRoute("/inbox/profile", routes)).toBeNull();
+    });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
+  // https://github.com/vercel/next.js/tree/v16.2.6/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children
+  it("discovers a nested-only slot route for a layout-only parent", async () => {
+    await withTempDir("vinext-app-slot-nested-layout-only-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "inbox", "@modal", "profile"), { recursive: true });
+      await writeFile(
+        path.join(appDir, "inbox", "layout.tsx"),
+        "export default function Layout({ children, modal }) { return children ?? modal }",
+      );
+      await writeFile(path.join(appDir, "inbox", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "inbox", "@modal", "profile", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const match = matchAppRoute("/inbox/profile", routes);
+
+      expect(match).toMatchObject({
         route: {
           pagePath: path.join(appDir, "inbox", "default.tsx"),
           parallelSlots: [

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -696,13 +696,16 @@ describe("appRouter - route discovery", () => {
       expect(patterns).toContain("/inbox");
       expect(patterns).toContain("/inbox/profile");
       expect(matchAppRoute("/inbox/profile", routes)).toMatchObject({
-        pagePath: path.join(appDir, "inbox", "default.tsx"),
-        parallelSlots: [
-          expect.objectContaining({
-            name: "modal",
-            pagePath: path.join(appDir, "inbox", "@modal", "profile", "page.tsx"),
-          }),
-        ],
+        route: {
+          pagePath: path.join(appDir, "inbox", "default.tsx"),
+          parallelSlots: [
+            expect.objectContaining({
+              name: "modal",
+              pagePath: path.join(appDir, "inbox", "@modal", "profile", "page.tsx"),
+            }),
+          ],
+        },
+        params: {},
       });
     });
   });


### PR DESCRIPTION
## Summary
- retain parallel slots that only contain nested page routes
- materialize slot-only leaf routes with the parent `children` default
- add focused route-graph and browser regressions

## Next.js parity

Fixes the remaining failure from:

`test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts`

The original requested `parallel-routes-use-selected-layout-segment` failures are already covered by #2246. PR #2347 covers the separate `parallel-routes-layouts` suite.

Reference: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts

## Validation
- `vp test run tests/app-route-graph.test.ts` — 58 passed
- focused App Router browser regression, one worker — 1 passed
- exact Next.js v16.2.6 deploy suite, concurrency 1 — 5 passed
- focused `vp check` — passed
- `vp run vinext#build` — passed
