### PR TITLE
fix(app-router): hash RSC navigation queries

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -61,6 +61,7 @@ export type NavigationRuntimeFunctions = {
    */
   notifyLinkNavigationStart?: () => void;
   pingVisibleLinks?: () => void;
+  getRscStateFingerprint?: () => string;
 };
 
 export type NavigationRuntimeBootstrap = {
@@ -114,7 +115,8 @@ function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntim
     isOptionalRuntimeFunction(Reflect.get(value, "navigateExternal")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigate")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "notifyLinkNavigationStart")) &&
-    isOptionalRuntimeFunction(Reflect.get(value, "pingVisibleLinks"))
+    isOptionalRuntimeFunction(Reflect.get(value, "pingVisibleLinks")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "getRscStateFingerprint"))
   );
 }
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -163,9 +163,9 @@ import {
 } from "./app-optimistic-routing.js";
 import {
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
-  NEXT_ROUTER_STATE_TREE_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_RSC_REDIRECT_HEADER,
+  VINEXT_RSC_STATE_HEADER,
 } from "./headers.js";
 import { removeStylesheetLinksCoveredByInlineCss } from "./app-inline-css-client.js";
 import {
@@ -1605,7 +1605,7 @@ function bootstrapHydration(
             navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
         });
         requestHeaders.set(
-          NEXT_ROUTER_STATE_TREE_HEADER,
+          VINEXT_RSC_STATE_HEADER,
           createAppRscStateFingerprint(routerStateAtNavStart),
         );
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -152,6 +152,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "./app-rsc-render-mode.js";
+import { createAppRscStateFingerprint } from "./app-rsc-state-fingerprint.js";
 import { blockDangerousStreamedRscRedirect } from "./app-browser-rsc-redirect.js";
 import {
   createOptimisticRouteTemplate,
@@ -162,6 +163,7 @@ import {
 } from "./app-optimistic-routing.js";
 import {
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
+  NEXT_ROUTER_STATE_TREE_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_RSC_REDIRECT_HEADER,
 } from "./headers.js";
@@ -1602,6 +1604,10 @@ function bootstrapHydration(
           renderMode:
             navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
         });
+        requestHeaders.set(
+          NEXT_ROUTER_STATE_TREE_HEADER,
+          createAppRscStateFingerprint(routerStateAtNavStart),
+        );
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
         const visitedResponseCandidate = shouldBypassNavigationCache
           ? {
@@ -2036,6 +2042,7 @@ function bootstrapHydration(
     clearNavigationCaches: clearClientNavigationCaches,
     commitHashNavigation: (href, historyUpdateMode, scroll) =>
       historyController.commitHashOnlyNavigation(href, historyUpdateMode, scroll),
+    getRscStateFingerprint: () => createAppRscStateFingerprint(getBrowserRouterState()),
     navigate: navigateRsc,
   });
 

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -14,6 +14,7 @@ import {
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
+  VINEXT_RSC_STATE_HEADER,
 } from "./headers.js";
 import { applyDeploymentIdHeader } from "../utils/deployment-id.js";
 
@@ -37,6 +38,7 @@ export const VINEXT_RSC_VARY_HEADER = [
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_URL_HEADER,
+  VINEXT_RSC_STATE_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
@@ -159,6 +161,7 @@ function normalizeRenderModeHeaderValue(value: string | null): string | null {
 
 type CreateCacheBustingInputOptions = {
   includeRenderModeHeader?: boolean;
+  includeStateHeader?: boolean;
 };
 
 function createCacheBustingInput(
@@ -172,6 +175,7 @@ function createCacheBustingInput(
     headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
     headers.get(NEXT_ROUTER_STATE_TREE_HEADER),
     headers.get(NEXT_URL_HEADER),
+    ...(options.includeStateHeader === false ? [] : [headers.get(VINEXT_RSC_STATE_HEADER)]),
     headers.get(VINEXT_INTERCEPTION_CONTEXT_HEADER),
     headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
     ...(options.includeRenderModeHeader === false
@@ -197,7 +201,10 @@ function computeLegacyRscCacheBustingSearchParam(headers: Headers): string {
 }
 
 async function computePreviousRscCacheBustingSearchParam(headers: Headers): Promise<string | null> {
-  const input = createCacheBustingInput(headers, { includeRenderModeHeader: false });
+  const input = createCacheBustingInput(headers, {
+    includeRenderModeHeader: false,
+    includeStateHeader: false,
+  });
   if (input === null) {
     return null;
   }
@@ -206,7 +213,10 @@ async function computePreviousRscCacheBustingSearchParam(headers: Headers): Prom
 }
 
 function computePreviousLegacyRscCacheBustingSearchParam(headers: Headers): string | null {
-  const input = createCacheBustingInput(headers, { includeRenderModeHeader: false });
+  const input = createCacheBustingInput(headers, {
+    includeRenderModeHeader: false,
+    includeStateHeader: false,
+  });
   return input === null ? null : fnv1a64(input);
 }
 

--- a/packages/vinext/src/server/app-rsc-state-fingerprint.ts
+++ b/packages/vinext/src/server/app-rsc-state-fingerprint.ts
@@ -1,0 +1,19 @@
+import type { AppRouterState } from "./app-browser-state.js";
+
+export type AppRscStateFingerprintInput = Pick<
+  AppRouterState,
+  "layoutIds" | "navigationSnapshot" | "rootLayoutTreePath" | "routeId" | "slotBindings"
+>;
+
+export function createAppRscStateFingerprint(state: AppRscStateFingerprintInput): string {
+  return encodeURIComponent(
+    JSON.stringify({
+      layoutIds: state.layoutIds,
+      pathname: state.navigationSnapshot.pathname,
+      rootLayoutTreePath: state.rootLayoutTreePath,
+      routeId: state.routeId,
+      search: state.navigationSnapshot.searchParams.toString(),
+      slotBindings: state.slotBindings,
+    }),
+  );
+}

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -61,6 +61,9 @@ export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context
 /** RSC render mode (e.g. "navigation", "prefetch"). */
 export const VINEXT_RSC_RENDER_MODE_HEADER = "X-Vinext-Rsc-Render-Mode";
 
+/** Stable visible-router-state fingerprint used to vary client RSC requests. */
+export const VINEXT_RSC_STATE_HEADER = "X-Vinext-Rsc-State";
+
 /** Disabled-by-default client hint describing already-held App Router payload entries. */
 export const VINEXT_CLIENT_REUSE_MANIFEST_HEADER = "X-Vinext-Client-Reuse-Manifest";
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -43,7 +43,7 @@ import {
   stripRscSuffix,
 } from "../server/app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../server/app-rsc-render-mode.js";
-import { NEXT_ROUTER_STATE_TREE_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
+import { VINEXT_MOUNTED_SLOTS_HEADER, VINEXT_RSC_STATE_HEADER } from "../server/headers.js";
 import { isDangerousScheme, reportBlockedDangerousNavigation } from "./url-safety.js";
 import {
   canLinkIntentPrefetch,
@@ -466,7 +466,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         }
         const rscStateFingerprint = getNavigationRuntime()?.functions.getRscStateFingerprint?.();
         if (rscStateFingerprint) {
-          headers.set(NEXT_ROUTER_STATE_TREE_HEADER, rscStateFingerprint);
+          headers.set(VINEXT_RSC_STATE_HEADER, rscStateFingerprint);
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
@@ -508,7 +508,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
                   shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
                 }
                 if (rscStateFingerprint) {
-                  shellHeaders.set(NEXT_ROUTER_STATE_TREE_HEADER, rscStateFingerprint);
+                  shellHeaders.set(VINEXT_RSC_STATE_HEADER, rscStateFingerprint);
                 }
                 const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
                 const shellResponse = await fetch(shellRscUrl, {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -43,7 +43,7 @@ import {
   stripRscSuffix,
 } from "../server/app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../server/app-rsc-render-mode.js";
-import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
+import { NEXT_ROUTER_STATE_TREE_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
 import { isDangerousScheme, reportBlockedDangerousNavigation } from "./url-safety.js";
 import {
   canLinkIntentPrefetch,
@@ -464,6 +464,10 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
+        const rscStateFingerprint = getNavigationRuntime()?.functions.getRscStateFingerprint?.();
+        if (rscStateFingerprint) {
+          headers.set(NEXT_ROUTER_STATE_TREE_HEADER, rscStateFingerprint);
+        }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
         const rscUrl = await createRscRequestUrl(fullHref, headers);
@@ -502,6 +506,9 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
                 });
                 if (mountedSlotsHeader) {
                   shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+                }
+                if (rscStateFingerprint) {
+                  shellHeaders.set(NEXT_ROUTER_STATE_TREE_HEADER, rscStateFingerprint);
                 }
                 const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
                 const shellResponse = await fetch(shellRscUrl, {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -37,6 +37,7 @@ import {
 } from "../server/app-rsc-cache-busting.js";
 import { hasPendingAppRouterPageRedirect } from "../server/app-browser-mpa-navigation.js";
 import {
+  NEXT_ROUTER_STATE_TREE_HEADER,
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
@@ -1893,6 +1894,10 @@ const _appRouter: AppRouterInstance = {
       const headers = createRscRequestHeaders({ interceptionContext });
       if (mountedSlotsHeader) {
         headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+      }
+      const rscStateFingerprint = getNavigationRuntime()?.functions.getRscStateFingerprint?.();
+      if (rscStateFingerprint) {
+        headers.set(NEXT_ROUTER_STATE_TREE_HEADER, rscStateFingerprint);
       }
       const rscUrl = await createRscRequestUrl(fullHref, headers);
       const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -37,10 +37,10 @@ import {
 } from "../server/app-rsc-cache-busting.js";
 import { hasPendingAppRouterPageRedirect } from "../server/app-browser-mpa-navigation.js";
 import {
-  NEXT_ROUTER_STATE_TREE_HEADER,
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
+  VINEXT_RSC_STATE_HEADER,
 } from "../server/headers.js";
 import {
   isAbsoluteOrProtocolRelativeUrl,
@@ -1897,7 +1897,7 @@ const _appRouter: AppRouterInstance = {
       }
       const rscStateFingerprint = getNavigationRuntime()?.functions.getRscStateFingerprint?.();
       if (rscStateFingerprint) {
-        headers.set(NEXT_ROUTER_STATE_TREE_HEADER, rscStateFingerprint);
+        headers.set(VINEXT_RSC_STATE_HEADER, rscStateFingerprint);
       }
       const rscUrl = await createRscRequestUrl(fullHref, headers);
       const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -110,6 +110,17 @@ describe("App Router RSC cache-busting", () => {
     expect(feedHash).not.toBe(galleryHash);
   });
 
+  it("varies RSC URLs by the vinext visible-router-state fingerprint", async () => {
+    const firstHeaders = createRscRequestHeaders();
+    firstHeaders.set("X-Vinext-Rsc-State", "first");
+    const secondHeaders = createRscRequestHeaders();
+    secondHeaders.set("X-Vinext-Rsc-State", "second");
+
+    await expect(createRscRequestUrl("/photos/42", firstHeaders)).resolves.not.toBe(
+      await createRscRequestUrl("/photos/42", secondHeaders),
+    );
+  });
+
   it("varies preserve-current-UI refresh payloads from normal navigations", async () => {
     const navigationHash = await computeRscCacheBustingSearchParam(createRscRequestHeaders());
     const refreshHash = await computeRscCacheBustingSearchParam(
@@ -310,7 +321,7 @@ describe("App Router RSC cache-busting", () => {
 
   it("exports the full Vary value for RSC-bearing App Router responses", () => {
     expect(VINEXT_RSC_VARY_HEADER).toBe(
-      "RSC, Accept, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Next-Url, X-Vinext-Interception-Context, X-Vinext-Mounted-Slots, X-Vinext-Rsc-Render-Mode",
+      "RSC, Accept, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Next-Url, X-Vinext-Rsc-State, X-Vinext-Interception-Context, X-Vinext-Mounted-Slots, X-Vinext-Rsc-Render-Mode",
     );
   });
 

--- a/tests/app-rsc-state-fingerprint.test.ts
+++ b/tests/app-rsc-state-fingerprint.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAppRscStateFingerprint,
+  type AppRscStateFingerprintInput,
+} from "../packages/vinext/src/server/app-rsc-state-fingerprint.js";
+import { ReadonlyURLSearchParams } from "../packages/vinext/src/shims/readonly-url-search-params.js";
+
+function createState(pathname: string, search = ""): AppRscStateFingerprintInput {
+  return {
+    layoutIds: ["layout:/", "layout:/docs"],
+    navigationSnapshot: {
+      params: {},
+      pathname,
+      searchParams: new ReadonlyURLSearchParams(new URLSearchParams(search)),
+    },
+    rootLayoutTreePath: "layout:/",
+    routeId: "page:/docs/[slug]",
+    slotBindings: [],
+  };
+}
+
+describe("createAppRscStateFingerprint", () => {
+  it("is stable for the same visible router state", () => {
+    expect(createAppRscStateFingerprint(createState("/docs/a", "tab=one"))).toBe(
+      createAppRscStateFingerprint(createState("/docs/a", "tab=one")),
+    );
+  });
+
+  it("varies with the visible pathname and search params", () => {
+    const original = createAppRscStateFingerprint(createState("/docs/a", "tab=one"));
+    expect(createAppRscStateFingerprint(createState("/docs/b", "tab=one"))).not.toBe(original);
+    expect(createAppRscStateFingerprint(createState("/docs/a", "tab=two"))).not.toBe(original);
+  });
+});

--- a/tests/e2e/app-router/nextjs-compat/rsc-query-routing.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/rsc-query-routing.spec.ts
@@ -1,0 +1,37 @@
+// Ported from Next.js: test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+
+test("preserves the hashed RSC query across a config redirect", async ({ page }) => {
+  await page.goto(`${BASE}/nextjs-compat/rsc-query-redirect`);
+  await waitForAppRouterHydration(page);
+
+  const requests: string[] = [];
+  page.on("request", (request) => {
+    if (request.url().includes("?_rsc=")) requests.push(request.url());
+  });
+
+  await page.getByRole("link", { name: "Redirect Link" }).click();
+  await expect(page.getByRole("heading", { name: "Redirect Dest" })).toBeVisible();
+
+  expect(requests[0]).toContain("/nextjs-compat/rsc-query-redirect/source?_rsc=");
+  expect(requests[1]).toContain("/nextjs-compat/rsc-query-redirect/dest?_rsc=");
+});
+
+test("includes the hashed RSC query on a rewritten navigation", async ({ page }) => {
+  await page.goto(`${BASE}/nextjs-compat/rsc-query-rewrite`);
+  await waitForAppRouterHydration(page);
+
+  const requests: string[] = [];
+  page.on("request", (request) => {
+    if (request.url().includes("?_rsc=")) requests.push(request.url());
+  });
+
+  await page.getByRole("link", { name: "Rewrite Link" }).click();
+  await expect(page.getByRole("heading", { name: "Rewrite Dest" })).toBeVisible();
+
+  expect(requests[0]).toContain("/nextjs-compat/rsc-query-rewrite/source?_rsc=");
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-redirect/dest/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-redirect/dest/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Redirect Dest</h1>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-redirect/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-redirect/page.tsx
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <Link prefetch={false} href="/nextjs-compat/rsc-query-redirect/source">
+      Redirect Link
+    </Link>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-rewrite/dest/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-rewrite/dest/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Rewrite Dest</h1>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-rewrite/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-rewrite/page.tsx
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <Link prefetch={false} href="/nextjs-compat/rsc-query-rewrite/source">
+      Rewrite Link
+    </Link>
+  );
+}

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -84,6 +84,11 @@ const nextConfig: NextConfig = {
         destination: "/about",
         permanent: false,
       },
+      {
+        source: "/nextjs-compat/rsc-query-redirect/source",
+        destination: "/nextjs-compat/rsc-query-redirect/dest",
+        permanent: true,
+      },
     ];
   },
 
@@ -121,6 +126,10 @@ const nextConfig: NextConfig = {
         {
           source: "/rewrite-search-param/:term",
           destination: "/search?q=from-rewrite",
+        },
+        {
+          source: "/nextjs-compat/rsc-query-rewrite/source",
+          destination: "/nextjs-compat/rsc-query-rewrite/dest",
         },
       ],
       afterFiles: [


### PR DESCRIPTION
## Summary

- attach a stable visible-router-state fingerprint to App Router RSC navigation requests
- use the same fingerprint for Link and router prefetches so `_rsc` URLs are non-empty, state-aware variants
- preserve the hashed `_rsc` query through config redirects and rewrites
- add focused unit and browser regressions ported from Next.js v16.2.6

## Impact

Fixes both failures from `test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts` in run 28143992598.

## Validation

- `vp check` on all touched files
- `vp test run tests/app-rsc-state-fingerprint.test.ts tests/app-rsc-cache-busting.test.ts --maxWorkers=1` — 35 passed
- `PLAYWRIGHT_PROJECT=app-router vp exec playwright test tests/e2e/app-router/nextjs-compat/rsc-query-routing.spec.ts --workers=1` — 2 passed
- targeted Next.js v16.2.6 deploy suite, one worker — 2 passed
