### PR TITLE
fix(app-router): scroll past existing hoisted styles

### DIFF
--- a/packages/vinext/src/shims/app-router-scroll-state.ts
+++ b/packages/vinext/src/shims/app-router-scroll-state.ts
@@ -1,6 +1,7 @@
 export type AppRouterScrollIntent = Readonly<{
   commitId: number | null;
   hash: string | null;
+  headElements: ReadonlySet<Element> | null;
   id: number;
   // Set by the committed `AppRouterScrollTarget` when this navigation's first
   // route DOM node was a React-hoisted resource in `<head>` (e.g. a
@@ -45,6 +46,7 @@ export function beginAppRouterScrollIntent(hash: string | null): AppRouterScroll
   const intent = {
     commitId: null,
     hash,
+    headElements: typeof document === "undefined" ? null : new Set(document.head?.children ?? []),
     id: store.nextId,
     targetHoistedInHead: false,
   };

--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -150,14 +150,20 @@ export class AppRouterScrollTargetInner extends React.Component<{
       // oxlint-disable-next-line react/no-find-dom-node -- Next's default App Router scroll handler targets wrapperless route content after commit.
       node = findDOMNode(this);
 
-      if (node !== null && isInDocumentHead(node)) {
+      const headElement = node instanceof Element ? node : node?.parentElement;
+      if (
+        node !== null &&
+        headElement != null &&
+        isInDocumentHead(node) &&
+        !intent.headElements?.has(headElement)
+      ) {
         // React hoisted this navigation's first route DOM node into <head>
-        // (e.g. a precedence-ordered stylesheet rendered as the page's first
-        // child). Next's old App Router scroll handler walks the head siblings,
-        // finds nothing scrollable, and gives up without scrolling. Record that
-        // on this navigation's intent — without consuming it — so the
-        // post-commit fallback in next/navigation skips its document-top scroll
-        // for this navigation alone, never for unrelated navigations.
+        // (e.g. a newly introduced precedence-ordered stylesheet rendered as
+        // the page's first child). Next's old App Router scroll handler walks
+        // the head siblings, finds nothing scrollable, and gives up without
+        // scrolling. A stylesheet that was already present before navigation
+        // is not the target route's newly hoisted child, so let the document-top
+        // fallback handle that case.
         markAppRouterScrollIntentHeadHoisted(intent, this.props.commitId);
         return;
       }

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts
@@ -25,7 +25,9 @@ async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
 async function writeHoistedScrollFixture(fixtureRoot: string): Promise<void> {
   const appDir = path.join(fixtureRoot, "app");
   const hoistedDir = path.join(appDir, "hoisted");
+  const cssModuleDir = path.join(appDir, "css-module", "[num]");
   await fs.mkdir(hoistedDir, { recursive: true });
+  await fs.mkdir(cssModuleDir, { recursive: true });
   await linkFixtureNodeModules(fixtureRoot);
 
   await fs.writeFile(
@@ -66,6 +68,40 @@ export default function HomePage() {
       <div id="hoisted-page">Hoisted page</div>
       {Array.from({ length: 500 }, (_, index) => <div key={index}>{index}</div>)}
     </>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(cssModuleDir, "styles.module.css"),
+    `.square {
+  /* Intentionally empty: React still hoists the route stylesheet resource. */
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(cssModuleDir, "page.tsx"),
+    `import Link from "next/link";
+import styles from "./styles.module.css";
+
+export default async function CssModulePage({
+  params,
+}: {
+  params: Promise<{ num: string }>;
+}) {
+  const { num } = await params;
+  return (
+    <div>
+      {Array.from({ length: 100 }, (_, index) => (
+        <div key={index} style={{ height: 100, width: 100, margin: 10 }}>
+          <Link id="lower" href={\`/css-module/\${Number(num) - 1}\`} prefetch={false}>
+            lower
+          </Link>
+          <div>{num}</div>
+        </div>
+      ))}
+      <div className={styles.square} />
+    </div>
   );
 }
 `,
@@ -130,3 +166,28 @@ test("does not scroll to top when React hoists the route's first DOM node", asyn
     await fs.rm(app.fixtureRoot, { recursive: true, force: true });
   }
 });
+
+for (const clickMode of ["playwright", "javascript"] as const) {
+  test(`scrolls to top for CSS Module navigation clicked via ${clickMode}`, async ({ page }) => {
+    const app = await startHoistedScrollFixture();
+
+    try {
+      await page.goto(`${app.baseUrl}/css-module/1`);
+      await waitForAppRouterHydration(page);
+      await page.evaluate(() => window.scrollTo(0, 1000));
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(1000);
+
+      if (clickMode === "javascript") {
+        await page.evaluate(() => document.getElementById("lower")?.click());
+      } else {
+        await page.locator("#lower").first().click();
+      }
+
+      await expect(page).toHaveURL(`${app.baseUrl}/css-module/0`);
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+    } finally {
+      await app.server.close();
+      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+    }
+  });
+}

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13264,7 +13264,7 @@ describe("app router scroll intent state", () => {
     const { beginAppRouterScrollIntent, clearAppRouterScrollIntent } =
       await import("../packages/vinext/src/shims/app-router-scroll-state.js");
 
-    const originalDocument = globalThis.document;
+    const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
     const existingStylesheet = {} as Element;
     const existingMetadata = {} as Element;
     Object.defineProperty(globalThis, "document", {
@@ -13281,10 +13281,11 @@ describe("app router scroll intent state", () => {
       expect(intent.headElements?.has(existingMetadata)).toBe(true);
     } finally {
       clearAppRouterScrollIntent();
-      Object.defineProperty(globalThis, "document", {
-        configurable: true,
-        value: originalDocument,
-      });
+      if (originalDocumentDescriptor) {
+        Object.defineProperty(globalThis, "document", originalDocumentDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "document");
+      }
     }
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -13260,6 +13260,34 @@ describe("next/amp shim", () => {
 });
 
 describe("app router scroll intent state", () => {
+  it("captures the head elements that existed before navigation", async () => {
+    const { beginAppRouterScrollIntent, clearAppRouterScrollIntent } =
+      await import("../packages/vinext/src/shims/app-router-scroll-state.js");
+
+    const originalDocument = globalThis.document;
+    const existingStylesheet = {} as Element;
+    const existingMetadata = {} as Element;
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { head: { children: [existingStylesheet, existingMetadata] } },
+    });
+
+    try {
+      clearAppRouterScrollIntent();
+      const intent = beginAppRouterScrollIntent(null);
+
+      expect(intent.headElements).not.toBeNull();
+      expect(intent.headElements?.has(existingStylesheet)).toBe(true);
+      expect(intent.headElements?.has(existingMetadata)).toBe(true);
+    } finally {
+      clearAppRouterScrollIntent();
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  });
+
   it("clears a staged scroll intent when a same-document navigation supersedes it", async () => {
     const {
       beginAppRouterScrollIntent,
@@ -13505,6 +13533,7 @@ describe("app router scroll document-top fallback", () => {
     const intent = {
       commitId: 1,
       hash: null,
+      headElements: null,
       id: 1,
       targetHoistedInHead: true,
     };


### PR DESCRIPTION
## Summary
- snapshot existing `<head>` elements when App Router navigation begins
- only suppress the document-top fallback for resources newly hoisted by the target route
- preserve the existing no-scroll behavior for routes that introduce a new precedence-ordered head style

## Next.js parity
Fixes the failure from run 28143992598:

- `test/e2e/app-dir/autoscroll-with-css-modules/index.test.ts`

The route's CSS Module stylesheet is already present before navigation. With an untrusted JavaScript `element.click()`, vinext's scroll handler resolved that existing stylesheet as the first committed node and treated it as newly hoisted, suppressing the fallback scroll. Next.js scrolls to the document top in this case.

Reference:
- https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/autoscroll-with-css-modules/index.test.ts
- https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/client/components/layout-router.tsx

## Validation
- `vp test run tests/shims.test.ts -t 'app router scroll intent state|scroll fallback'` — 8 passed
- focused Chromium browser fixture — 3 passed
- targeted Next.js v16.2.6 deploy suite — 2 passed
- focused `vp check` — clean

Full suites are deferred to CI.
