### PR TITLE
fix(app-router): include page segment in flight state

### DIFF
--- a/packages/vinext/src/server/app-page-segment-state.ts
+++ b/packages/vinext/src/server/app-page-segment-state.ts
@@ -1,6 +1,8 @@
 import type { AppPageParams } from "./app-page-boundary.js";
 import { isCatchAllSegment, isOptionalCatchAllSegment } from "../routing/utils.js";
 
+export const APP_PAGE_SEGMENT_KEY = "__PAGE__";
+
 function isDynamicSegment(segment: string): boolean {
   return segment.startsWith("[") && segment.endsWith("]") && !segment.includes(".");
 }
@@ -111,6 +113,7 @@ export function resolveAppPageChildSegments(
     resolvedSegments.push(segment);
   }
 
+  resolvedSegments.push(APP_PAGE_SEGMENT_KEY);
   return resolvedSegments;
 }
 

--- a/packages/vinext/src/server/app-page-segment-state.ts
+++ b/packages/vinext/src/server/app-page-segment-state.ts
@@ -1,7 +1,7 @@
 import type { AppPageParams } from "./app-page-boundary.js";
 import { isCatchAllSegment, isOptionalCatchAllSegment } from "../routing/utils.js";
 
-export const APP_PAGE_SEGMENT_KEY = "__PAGE__";
+const APP_PAGE_SEGMENT_KEY = "__PAGE__";
 
 function isDynamicSegment(segment: string): boolean {
   return segment.startsWith("[") && segment.endsWith("]") && !segment.includes(".");

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -133,7 +133,9 @@ function useChildSegments(parallelRoutesKey: string = "children"): string[] {
   // Try/catch for unit tests that call this hook outside a React render tree.
   try {
     const segmentMap = React.useContext(ctx);
-    return segmentMap[parallelRoutesKey] ?? [];
+    return (segmentMap[parallelRoutesKey] ?? []).filter(
+      (segment) => !segment.startsWith("__PAGE__"),
+    );
   } catch {
     return [];
   }

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -460,7 +460,7 @@ describe("app page route wiring helpers", () => {
         parts: ["a", "b"],
         slug: "post",
       }),
-    ).toEqual(["blog", "post", "a/b"]);
+    ).toEqual(["blog", "post", "a/b", "__PAGE__"]);
   });
 
   it("builds layout entries from tree paths instead of visible URL segments", () => {

--- a/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts
@@ -242,7 +242,7 @@ test.describe("App Router experimental.inlineCss production parity", () => {
         },
       })
     ).text();
-    expect(rscPayload).toContain("__route");
+    expect(rscPayload).toContain("__PAGE__");
     expect(rscPayload).not.toContain("font-size");
 
     const htmlPayload = await (await page.request.get(`${inlineCssApp.baseUrl}/a?_rsc`)).text();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1359,6 +1359,34 @@ describe("next/navigation shim", () => {
     expect(html).toContain("[]");
   });
 
+  it("hides internal page segment markers from selected layout hooks", async () => {
+    const React = await import("react");
+    const ReactDOMServer = await import("react-dom/server");
+    const { createElement } = React;
+    const { LayoutSegmentProvider } =
+      await import("../packages/vinext/src/shims/layout-segment-context.js");
+    const { useSelectedLayoutSegment, useSelectedLayoutSegments } =
+      await import("../packages/vinext/src/shims/navigation.js");
+
+    function TestComponent() {
+      const segments = useSelectedLayoutSegments();
+      const segment = useSelectedLayoutSegment();
+      return createElement("span", null, JSON.stringify({ segment, segments }));
+    }
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      createElement(LayoutSegmentProvider, {
+        segmentMap: { children: ["blog", "__PAGE__"] },
+        // oxlint-disable-next-line react/no-children-prop
+        children: createElement(TestComponent),
+      }),
+    );
+
+    expect(html).toContain(
+      "{&quot;segment&quot;:&quot;blog&quot;,&quot;segments&quot;:[&quot;blog&quot;]}",
+    );
+  });
+
   // -------------------------------------------------------------------------
   // unstable_rethrow + unstable_isUnrecognizedActionError
   //


### PR DESCRIPTION
## Summary
- terminate App Router child segment state with Next.js' `__PAGE__` marker
- hide the internal page marker from `useSelectedLayoutSegment(s)`
- restore the exact Next.js inline-CSS Flight payload assertion

## Validation
- `vp test run tests/app-page-segment-state.test.ts tests/app-page-route-wiring.test.ts --maxWorkers=1`
- `vp test run tests/shims.test.ts -t "useSelectedLayoutSegment" --maxWorkers=1`
- `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific npx playwright test tests/e2e/app-router/nextjs-compat/inline-css.browser.spec.ts --workers=1 --retries=0`
- Next.js v16.2.6 `test/e2e/app-dir/app-inline-css/index.test.ts`: 6/6 passed with `NEXT_TEST_CONCURRENCY=1`

`vp check` formatting passed, but the local Vite+/tsgolint process crashed with an internal `Resource temporarily unavailable` panic; CI will run the exact-head check.