### PR TITLE
fix(app-router): restore intercepted history slots

### DIFF
--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -618,6 +618,7 @@ export function createAppBrowserNavigationController(
       previousNextUrl: options.restoredState.previousNextUrl,
       rootLayoutTreePath: options.restoredState.rootLayoutTreePath,
       routeId: options.restoredState.routeId,
+      restoredHistorySnapshot: true,
       skippedLayoutIds: [],
     };
   }

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -127,6 +127,7 @@ export type PendingNavigationCommit = {
   previousNextUrl: string | null;
   rootLayoutTreePath: string | null;
   routeId: string;
+  restoredHistorySnapshot?: boolean;
   skippedLayoutIds: readonly string[];
 };
 
@@ -465,6 +466,7 @@ function planPendingRootBoundaryFlightResponse(options: {
       kind: "flightResponseArrived",
       result: {
         ...(cacheEntryReuseProof ? { cacheEntryReuseProof } : {}),
+        ...(options.pending.restoredHistorySnapshot ? { restoredHistorySnapshot: true } : {}),
         // Approval call sites must pass the executor's targetHref so the
         // planner trace and future hard-nav executor agree with the browser
         // URL. The fallback remains for lower-level tests and direct disposition

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -1284,6 +1284,7 @@ function createCacheEntryProposalFields(
 function validateInterceptedPreservation(options: {
   currentSnapshot: RouteSnapshot;
   currentTopology: RouteTopologySnapshot;
+  lane: OperationLane;
   routeManifest: RouteManifest | null;
   targetSnapshot: RouteSnapshot;
   targetTopology: RouteTopologySnapshot;
@@ -1305,8 +1306,9 @@ function validateInterceptedPreservation(options: {
 
   const sourceIdentity = getVisibleInterceptionSourceIdentity(options.currentSnapshot);
   if (
-    proof.sourceMatchedUrl !== sourceIdentity.matchedUrl ||
-    proof.sourceRouteId !== sourceIdentity.routeId
+    options.lane !== "traverse" &&
+    (proof.sourceMatchedUrl !== sourceIdentity.matchedUrl ||
+      proof.sourceRouteId !== sourceIdentity.routeId)
   ) {
     return {
       kind: "rejected",
@@ -1464,6 +1466,7 @@ function planFlightResponseArrived(options: {
     const validation = validateInterceptedPreservation({
       currentSnapshot: options.state.visibleSnapshot,
       currentTopology: currentTopology.topology,
+      lane: options.event.token.lane,
       routeManifest: options.routeManifest,
       targetSnapshot,
       targetTopology: targetTopology.topology,

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -156,6 +156,7 @@ export type NavigationDecision =
 export type FlightResult = {
   cacheEntryReuseProof?: CacheEntryReuseProof;
   href: string;
+  restoredHistorySnapshot?: boolean;
   targetSnapshot: RouteSnapshot;
 };
 
@@ -1284,7 +1285,7 @@ function createCacheEntryProposalFields(
 function validateInterceptedPreservation(options: {
   currentSnapshot: RouteSnapshot;
   currentTopology: RouteTopologySnapshot;
-  lane: OperationLane;
+  restoredHistorySnapshot: boolean;
   routeManifest: RouteManifest | null;
   targetSnapshot: RouteSnapshot;
   targetTopology: RouteTopologySnapshot;
@@ -1306,7 +1307,7 @@ function validateInterceptedPreservation(options: {
 
   const sourceIdentity = getVisibleInterceptionSourceIdentity(options.currentSnapshot);
   if (
-    options.lane !== "traverse" &&
+    !options.restoredHistorySnapshot &&
     (proof.sourceMatchedUrl !== sourceIdentity.matchedUrl ||
       proof.sourceRouteId !== sourceIdentity.routeId)
   ) {
@@ -1466,7 +1467,7 @@ function planFlightResponseArrived(options: {
     const validation = validateInterceptedPreservation({
       currentSnapshot: options.state.visibleSnapshot,
       currentTopology: currentTopology.topology,
-      lane: options.event.token.lane,
+      restoredHistorySnapshot: options.event.result.restoredHistorySnapshot === true,
       routeManifest: options.routeManifest,
       targetSnapshot,
       targetTopology: targetTopology.topology,

--- a/tests/e2e/app-router/parallel-catchall-specificity.spec.ts
+++ b/tests/e2e/app-router/parallel-catchall-specificity.spec.ts
@@ -1,0 +1,25 @@
+// Ported from Next.js:
+// test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts
+
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+const BASE = "http://localhost:4174/parallel-catchall-specificity";
+
+test("restores an intercepted slot before matching its catch-all sibling", async ({ page }) => {
+  await page.goto(BASE);
+  await waitForAppRouterHydration(page);
+
+  await page.locator('a[href$="/comments/product"]').click();
+  await expect(page.getByRole("heading", { name: "Modal" })).toBeVisible();
+
+  await page.locator('a[href$="/u/foobar/l"]').click();
+  await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
+
+  await page.goBack();
+  await expect(page.getByRole("heading", { name: "Modal" })).toBeVisible();
+
+  await page.locator('a[href$="/trending"]').click();
+  await expect(page.getByRole("heading", { name: "Trending" })).toBeVisible();
+});

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/(.)comments/[productId]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/(.)comments/[productId]/page.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <section>
+      <h1>Modal</h1>
+      <Link href="/parallel-catchall-specificity/u/foobar/l">Profile Link</Link>
+      <Link href="/parallel-catchall-specificity/trending">Trending Link</Link>
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/[...catchAll]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function CatchAll() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/@modal/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/comments/[productId]/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/comments/[productId]/page.tsx
@@ -1,0 +1,3 @@
+export default async function Page({ params }: { params: Promise<{ productId: string }> }) {
+  return <h1>{(await params).productId}</h1>;
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/default.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/layout.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <main>
+      {children}
+      {modal}
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/page.tsx
@@ -1,0 +1,5 @@
+import Link from "next/link";
+
+export default function Page() {
+  return <Link href="/parallel-catchall-specificity/comments/product">Open comments</Link>;
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/trending/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/trending/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Trending</h1>;
+}

--- a/tests/fixtures/app-basic/app/parallel-catchall-specificity/u/[username]/l/page.tsx
+++ b/tests/fixtures/app-basic/app/parallel-catchall-specificity/u/[username]/l/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Profile</h1>;
+}

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -428,6 +428,7 @@ function planFlightResponseFromSnapshots(options: {
   cacheEntryReuseProof?: CacheEntryReuseProof;
   currentSnapshot: RouteSnapshot;
   lane?: OperationToken["lane"];
+  restoredHistorySnapshot?: boolean;
   routeManifest?: RouteManifest | null;
   targetSnapshot: RouteSnapshot;
   tokenGraphVersion?: string | null;
@@ -449,6 +450,7 @@ function planFlightResponseFromSnapshots(options: {
           ? { cacheEntryReuseProof: options.cacheEntryReuseProof }
           : {}),
         href: options.targetSnapshot.displayUrl,
+        ...(options.restoredHistorySnapshot ? { restoredHistorySnapshot: true } : {}),
         targetSnapshot: options.targetSnapshot,
       },
       token,
@@ -1814,6 +1816,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     const decision = planFlightResponseFromSnapshots({
       currentSnapshot,
       lane: "traverse",
+      restoredHistorySnapshot: true,
       targetSnapshot,
     });
 
@@ -1854,6 +1857,7 @@ describe("navigationPlanner root-boundary decisions", () => {
     const decision = planFlightResponseFromSnapshots({
       currentSnapshot,
       lane: "traverse",
+      restoredHistorySnapshot: true,
       targetSnapshot,
     });
 
@@ -1863,6 +1867,42 @@ describe("navigationPlanner root-boundary decisions", () => {
     }
     expect(decision.proposal.reason).toBe("interceptedCurrentRootBoundary");
     expect(decision.proposal.preservePreviousSlotIds).toEqual([]);
+  });
+
+  it("rejects a fresh traverse response from an unrelated interception source", () => {
+    const currentSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot("/", ["layout:/", "layout:/feed"]),
+      displayUrl: "https://example.com/profile",
+      matchedUrl: "/profile",
+      routeId: "route:/profile",
+    };
+    const targetSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot(
+        "/",
+        ["layout:/", "layout:/feed"],
+        [],
+        [createSlotBinding("slot:modal:/feed", "layout:/feed", "active")],
+      ),
+      displayUrl: "https://example.com/photos/42",
+      interception: createInterceptionSnapshot(),
+      interceptionContext: "/feed",
+      matchedUrl: "/photos/42",
+      routeId: "route:/photos/42\u0000/feed",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      lane: "traverse",
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("hardNavigate");
+    if (decision.kind !== "hardNavigate") {
+      throw new Error("Expected hardNavigate decision");
+    }
+    expect(decision.trace.entries[0]?.code).toBe(
+      NavigationTraceReasonCodes.interceptedRejectedUnknownSource,
+    );
   });
 
   it("does not preserve layouts across root-boundary uncertainty", () => {

--- a/tests/navigation-planner.test.ts
+++ b/tests/navigation-planner.test.ts
@@ -1825,6 +1825,46 @@ describe("navigationPlanner root-boundary decisions", () => {
     expect(decision.proposal.preservePreviousSlotIds).toEqual(["slot:activity:/feed"]);
   });
 
+  it("allows traverse to restore an intercepted world from a catch-all sibling", () => {
+    const currentSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot(
+        "/",
+        ["layout:/", "layout:/feed"],
+        [],
+        [createSlotBinding("slot:modal:/feed", "layout:/feed", "active")],
+      ),
+      displayUrl: "https://example.com/profile",
+      matchedUrl: "/profile",
+      routeId: "route:/profile",
+    };
+    const targetSnapshot: RouteSnapshot = {
+      ...createRouteSnapshot(
+        "/",
+        ["layout:/", "layout:/feed"],
+        [],
+        [createSlotBinding("slot:modal:/feed", "layout:/feed", "active")],
+      ),
+      displayUrl: "https://example.com/photos/42",
+      interception: createInterceptionSnapshot(),
+      interceptionContext: "/feed",
+      matchedUrl: "/photos/42",
+      routeId: "route:/photos/42\u0000/feed",
+    };
+
+    const decision = planFlightResponseFromSnapshots({
+      currentSnapshot,
+      lane: "traverse",
+      targetSnapshot,
+    });
+
+    expect(decision.kind).toBe("proposeCommit");
+    if (decision.kind !== "proposeCommit") {
+      throw new Error("Expected proposeCommit decision");
+    }
+    expect(decision.proposal.reason).toBe("interceptedCurrentRootBoundary");
+    expect(decision.proposal.preservePreviousSlotIds).toEqual([]);
+  });
+
   it("does not preserve layouts across root-boundary uncertainty", () => {
     const currentSnapshot = createRouteSnapshot("/", ["layout:/"]);
     const targetSnapshot = createRouteSnapshot(null, ["layout:/"]);


### PR DESCRIPTION
## Summary

- restore previously intercepted parallel-slot worlds during browser history traversal even when the current route is the slot's catch-all sibling
- keep forward navigation interception source validation unchanged
- add a local App Router regression for modal → catch-all page → back → new catch-all navigation

## Next.js parity

Fixes the remaining failure from run 28143992598 in:

- `test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts`

Next.js restores the exact router tree stored in browser history. Vinext incorrectly required the restored interception source to match the currently visible catch-all route, rejected the snapshot, and fell back to a document navigation that lost the modal.

Reference: https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts

## Validation

- `vp test run tests/navigation-planner.test.ts tests/app-browser-history-controller.test.ts --maxWorkers=1` — 58 passed
- local App Router browser regression, one worker — 1 passed
- exact Next.js v16.2.6 targeted deploy suite, concurrency 1 — 1 passed
- targeted `vp check` — passed before disposable dependency links were removed

Excludes cacheComponents, PPR, resume, fallback-shell, and external endpoint failures.
