### PR TITLE
fix(app-router): prefetch user Suspense shells

### DIFF
--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -21,6 +21,10 @@ import {
 } from "./app-page-execution.js";
 import { probeAppPageBeforeRender } from "./app-page-probe.js";
 import {
+  createPrefetchSuspenseShellState,
+  runWithPrefetchSuspenseShellState,
+} from "vinext/shims/prefetch-suspense-shell";
+import {
   buildAppPageHtmlResponse,
   buildAppPageRscResponse,
   resolveAppPageHtmlResponsePolicy,
@@ -37,7 +41,10 @@ import {
   renderAppPageHtmlStreamWithRecovery,
   type AppPageSsrHandler,
 } from "./app-page-stream.js";
-import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
+  type AppRscRenderMode,
+} from "./app-rsc-render-mode.js";
 import {
   createArtifactCompatibilityEnvelope,
   createArtifactCompatibilityGraphVersion,
@@ -689,6 +696,20 @@ export async function renderAppPageLifecycle(
   // an outer runWithRequestContext / runWithFetchDedupe scope keeping the ALS
   // store alive across that consumption.
   let rscStream = await runWithFetchDedupe(async () => {
+    if (
+      options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL &&
+      options.prerenderToReadableStream
+    ) {
+      const shellState = createPrefetchSuspenseShellState(options.cleanPathname);
+      const pendingResult = runWithPrefetchSuspenseShellState(shellState, () =>
+        options.prerenderToReadableStream!(outgoingElement, {
+          onError: rscErrorTracker.onRenderError,
+          signal: shellState.reactAbortController.signal,
+        }),
+      );
+      return (await pendingResult).prelude;
+    }
+
     if (options.pprFallbackShellSignal && options.prerenderToReadableStream) {
       const reactSignal = options.pprFallbackShellReactSignal ?? options.pprFallbackShellSignal;
       const pendingResult = options.prerenderToReadableStream(outgoingElement, {
@@ -796,6 +817,9 @@ export async function renderAppPageLifecycle(
       middlewareContext: options.middlewareContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
       params: options.navigationParams,
+      partialShell:
+        options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL &&
+        dynamicUsedDuringBuild,
       policy: rscResponsePolicy,
       timing: buildResponseTiming({
         compileEnd,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -842,6 +842,12 @@ export async function renderAppPageLifecycle(
         responseKind: "rsc",
       }),
     });
+    if (prefetchSuspenseShellWasAborted) {
+      rscResponse.headers.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+      rscResponse.headers.delete("CDN-Cache-Control");
+      rscResponse.headers.delete("Cloudflare-CDN-Cache-Control");
+      rscResponse.headers.delete("Cache-Tag");
+    }
 
     // In dev mode, wrap the RSC response body to forward invalid dynamic usage
     // errors after the stream is consumed. This mirrors Next.js behavior where

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -794,7 +794,9 @@ export async function renderAppPageLifecycle(
     // When skip transport is enabled, omit cacheState because the response is a
     // per-client payload, not a shared-cache MISS/HIT artifact. The absence also
     // keeps finalizeAppPageRscCacheResponse from overwriting no-store.
-    const rscResponsePolicy = shouldBypassRscCacheForSkipTransport
+    const shouldBypassRscCache =
+      shouldBypassRscCacheForSkipTransport || prefetchSuspenseShellWasAborted;
+    const rscResponsePolicy = shouldBypassRscCache
       ? { cacheControl: NO_STORE_CACHE_CONTROL }
       : resolveAppPageRscResponsePolicy({
           dynamicUsedDuringBuild,
@@ -808,6 +810,8 @@ export async function renderAppPageLifecycle(
         });
     if (shouldBypassRscCacheForSkipTransport) {
       options.isrDebug?.("RSC cache write skipped (skip transport payload)", options.cleanPathname);
+    } else if (prefetchSuspenseShellWasAborted) {
+      options.isrDebug?.("RSC cache write skipped (partial Suspense shell)", options.cleanPathname);
     }
     const shouldEmitDynamicStaleTime =
       options.dynamicStaleTimeSeconds !== undefined &&
@@ -858,7 +862,9 @@ export async function renderAppPageLifecycle(
 
     return finalizeAppPageRscCacheResponse(devRscResponse, {
       capturedRscDataPromise:
-        options.isProduction && shouldCaptureRscForCacheMetadata ? capturedRscDataRef.value : null,
+        options.isProduction && shouldCaptureRscForCacheMetadata && !prefetchSuspenseShellWasAborted
+          ? capturedRscDataRef.value
+          : null,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,
       consumeRenderObservationState: options.consumeRenderObservationState,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -23,6 +23,8 @@ import { probeAppPageBeforeRender } from "./app-page-probe.js";
 import {
   createPrefetchSuspenseShellState,
   runWithPrefetchSuspenseShellState,
+  schedulePrefetchSuspenseShellAbort,
+  wasPrefetchSuspenseShellAborted,
 } from "vinext/shims/prefetch-suspense-shell";
 import {
   buildAppPageHtmlResponse,
@@ -695,6 +697,7 @@ export async function renderAppPageLifecycle(
   // standalone call would establish here is only effective if the caller has
   // an outer runWithRequestContext / runWithFetchDedupe scope keeping the ALS
   // store alive across that consumption.
+  let prefetchSuspenseShellWasAborted = false;
   let rscStream = await runWithFetchDedupe(async () => {
     if (
       options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL &&
@@ -707,7 +710,14 @@ export async function renderAppPageLifecycle(
           signal: shellState.reactAbortController.signal,
         }),
       );
-      return (await pendingResult).prelude;
+      const cancelAbort = schedulePrefetchSuspenseShellAbort(shellState);
+      try {
+        const result = await pendingResult;
+        prefetchSuspenseShellWasAborted = wasPrefetchSuspenseShellAborted(shellState);
+        return result.prelude;
+      } finally {
+        cancelAbort();
+      }
     }
 
     if (options.pprFallbackShellSignal && options.prerenderToReadableStream) {
@@ -819,7 +829,7 @@ export async function renderAppPageLifecycle(
       params: options.navigationParams,
       partialShell:
         options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL &&
-        dynamicUsedDuringBuild,
+        prefetchSuspenseShellWasAborted,
       policy: rscResponsePolicy,
       timing: buildResponseTiming({
         compileEnd,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -271,9 +271,6 @@ export function buildAppPageRscResponse(
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
   }
-  if (options.partialShell) {
-    headers.set(VINEXT_RSC_PARTIAL_SHELL_HEADER, "1");
-  }
   applyDynamicStaleTimeHeader(headers, options.dynamicStaleTimeSeconds);
   if (options.policy.cacheControl) {
     headers.set("Cache-Control", options.policy.cacheControl);
@@ -282,6 +279,9 @@ export function buildAppPageRscResponse(
     setCacheStateHeaders(headers, options.policy.cacheState);
   }
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
+  if (options.partialShell) {
+    headers.set(VINEXT_RSC_PARTIAL_SHELL_HEADER, "1");
+  }
   applyRscCompatibilityIdHeader(headers);
 
   applyTimingHeader(headers, options.timing);

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -281,6 +281,8 @@ export function buildAppPageRscResponse(
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
   if (options.partialShell) {
     headers.set(VINEXT_RSC_PARTIAL_SHELL_HEADER, "1");
+  } else {
+    headers.delete(VINEXT_RSC_PARTIAL_SHELL_HEADER);
   }
   applyRscCompatibilityIdHeader(headers);
 

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -7,6 +7,7 @@ import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
+  VINEXT_RSC_PARTIAL_SHELL_HEADER,
   VINEXT_TIMING_HEADER,
 } from "./headers.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
@@ -64,6 +65,7 @@ type BuildAppPageRscResponseOptions = {
   middlewareContext: AppPageMiddlewareContext;
   mountedSlotsHeader?: string | null;
   params?: Record<string, unknown>;
+  partialShell?: boolean;
   policy: AppPageResponsePolicy;
   timing?: AppPageResponseTiming;
 };
@@ -268,6 +270,9 @@ export function buildAppPageRscResponse(
   }
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
+  }
+  if (options.partialShell) {
+    headers.set(VINEXT_RSC_PARTIAL_SHELL_HEADER, "1");
   }
   applyDynamicStaleTimeHeader(headers, options.dynamicStaleTimeSeconds);
   if (options.policy.cacheControl) {

--- a/packages/vinext/src/server/app-rsc-render-mode.ts
+++ b/packages/vinext/src/server/app-rsc-render-mode.ts
@@ -1,12 +1,15 @@
 export type AppRscRenderMode =
   | "navigation"
   | "prefetch-loading-shell"
+  | "prefetch-suspense-shell"
   | "refresh-preserve-ui"
   | "action-rerender-preserve-ui";
 
 export const APP_RSC_RENDER_MODE_NAVIGATION = "navigation" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL =
   "prefetch-loading-shell" satisfies AppRscRenderMode;
+export const APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL =
+  "prefetch-suspense-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI =
   "refresh-preserve-ui" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI =
@@ -27,6 +30,9 @@ export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | n
   if (mode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL) {
     return "prefetch-loading-shell";
   }
+  if (mode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL) {
+    return "prefetch-suspense-shell";
+  }
 
   return shouldUsePreserveUiCacheVariant(mode) ? "preserve-ui" : null;
 }
@@ -35,6 +41,8 @@ export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
   switch (value) {
     case APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL:
       return APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
+    case APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL:
+      return APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL;
     case APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI:
       return APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI;
     case APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI:

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -30,7 +30,10 @@ type FinalizeAppRscResponseOptions = {
 };
 
 function lockPartialShellCacheHeaders(response: Response, isPartialShell: boolean): void {
-  if (!isPartialShell) return;
+  if (!isPartialShell) {
+    response.headers.delete(VINEXT_RSC_PARTIAL_SHELL_HEADER);
+    return;
+  }
 
   response.headers.set(VINEXT_RSC_PARTIAL_SHELL_HEADER, "1");
   applyCdnResponseHeaders(response.headers, { cacheControl: NO_STORE_CACHE_CONTROL });

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -1,7 +1,7 @@
 import type { NextHeader, NextI18nConfig } from "../config/next-config.js";
 import type { RequestContext } from "../config/config-matchers.js";
-import { VINEXT_STATIC_FILE_HEADER } from "./headers.js";
-import { applyCdnResponseHeaders } from "./cache-control.js";
+import { VINEXT_RSC_PARTIAL_SHELL_HEADER, VINEXT_STATIC_FILE_HEADER } from "./headers.js";
+import { applyCdnResponseHeaders, NO_STORE_CACHE_CONTROL } from "./cache-control.js";
 import { applyConfigHeadersToResponse } from "./request-pipeline.js";
 import { VINEXT_RSC_VARY_HEADER } from "./app-rsc-cache-busting.js";
 import { mergeVaryHeader } from "./middleware-response-headers.js";
@@ -28,6 +28,15 @@ type FinalizeAppRscResponseOptions = {
    */
   requestContext: RequestContext;
 };
+
+function lockPartialShellCacheHeaders(response: Response): void {
+  if (response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER) !== "1") return;
+
+  response.headers.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+  response.headers.delete("CDN-Cache-Control");
+  response.headers.delete("Cloudflare-CDN-Cache-Control");
+  response.headers.delete("Cache-Tag");
+}
 
 /**
  * Apply App Router response finalization that must happen outside individual
@@ -74,6 +83,7 @@ export function finalizeAppRscResponse(
   }
 
   if (!options.configHeaders.length) {
+    lockPartialShellCacheHeaders(response);
     return response;
   }
 
@@ -110,6 +120,7 @@ export function finalizeAppRscResponse(
     requestContext: options.requestContext,
     basePathState: { basePath: options.basePath, hadBasePath },
   });
+  lockPartialShellCacheHeaders(response);
 
   return response;
 }

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -29,10 +29,11 @@ type FinalizeAppRscResponseOptions = {
   requestContext: RequestContext;
 };
 
-function lockPartialShellCacheHeaders(response: Response): void {
-  if (response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER) !== "1") return;
+function lockPartialShellCacheHeaders(response: Response, isPartialShell: boolean): void {
+  if (!isPartialShell) return;
 
-  response.headers.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+  response.headers.set(VINEXT_RSC_PARTIAL_SHELL_HEADER, "1");
+  applyCdnResponseHeaders(response.headers, { cacheControl: NO_STORE_CACHE_CONTROL });
   response.headers.delete("CDN-Cache-Control");
   response.headers.delete("Cloudflare-CDN-Cache-Control");
   response.headers.delete("Cache-Tag");
@@ -60,6 +61,7 @@ export function finalizeAppRscResponse(
   if (response.status >= 300 && response.status < 400) {
     return response;
   }
+  const isPartialShell = response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER) === "1";
 
   if (!response.headers.has(VINEXT_STATIC_FILE_HEADER)) {
     const varyHeader = response.headers.get("Vary");
@@ -83,7 +85,7 @@ export function finalizeAppRscResponse(
   }
 
   if (!options.configHeaders.length) {
-    lockPartialShellCacheHeaders(response);
+    lockPartialShellCacheHeaders(response, isPartialShell);
     return response;
   }
 
@@ -120,7 +122,7 @@ export function finalizeAppRscResponse(
     requestContext: options.requestContext,
     basePathState: { basePath: options.basePath, hadBasePath },
   });
-  lockPartialShellCacheHeaders(response);
+  lockPartialShellCacheHeaders(response, isPartialShell);
 
   return response;
 }

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -61,6 +61,9 @@ export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context
 /** RSC render mode (e.g. "navigation", "prefetch"). */
 export const VINEXT_RSC_RENDER_MODE_HEADER = "X-Vinext-Rsc-Render-Mode";
 
+/** Marks an RSC prefetch response that contains a partial Suspense shell. */
+export const VINEXT_RSC_PARTIAL_SHELL_HEADER = "X-Vinext-Rsc-Partial-Shell";
+
 /** Disabled-by-default client hint describing already-held App Router payload entries. */
 export const VINEXT_CLIENT_REUSE_MANIFEST_HEADER = "X-Vinext-Client-Reuse-Manifest";
 

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -28,6 +28,7 @@ import {
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
 import { createPprFallbackShellSuspensePromise } from "./ppr-fallback-shell.js";
+import { suspendPrefetchSuspenseShell } from "./prefetch-suspense-shell.js";
 import type { RenderRequestApiKind } from "../server/cache-proof.js";
 
 // ---------------------------------------------------------------------------
@@ -875,6 +876,10 @@ export function headers(): Promise<Headers> & Headers {
   }
 
   markDynamicUsage();
+  const prefetchShellPromise = suspendPrefetchSuspenseShell("`headers()`");
+  if (prefetchShellPromise) {
+    return _decorateSuspendingRequestApiPromise(prefetchShellPromise);
+  }
   const fallbackShellPromise = createPprFallbackShellSuspensePromise<Headers>("`headers()`");
   if (fallbackShellPromise) {
     return _decorateSuspendingRequestApiPromise(fallbackShellPromise);
@@ -910,6 +915,10 @@ export function cookies(): Promise<RequestCookies> & RequestCookies {
   }
 
   markDynamicUsage();
+  const prefetchShellPromise = suspendPrefetchSuspenseShell("`cookies()`");
+  if (prefetchShellPromise) {
+    return _decorateSuspendingRequestApiPromise(prefetchShellPromise);
+  }
   const fallbackShellPromise = createPprFallbackShellSuspensePromise<RequestCookies>("`cookies()`");
   if (fallbackShellPromise) {
     return _decorateSuspendingRequestApiPromise(fallbackShellPromise);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -42,7 +42,10 @@ import {
   stripRscCacheBustingSearchParam,
   stripRscSuffix,
 } from "../server/app-rsc-cache-busting.js";
-import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+  APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
+} from "../server/app-rsc-render-mode.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
 import { isDangerousScheme, reportBlockedDangerousNavigation } from "./url-safety.js";
 import {
@@ -332,6 +335,7 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
 
 function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
   cacheForNavigation: boolean;
+  prefetchSuspenseShell: boolean;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
@@ -343,6 +347,7 @@ function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
     // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
     // keyed by the concrete RSC URL, so this cannot reuse data across params.
     cacheForNavigation: !hasLoadingShell,
+    prefetchSuspenseShell: route.isDynamic && !hasLoadingShell,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -366,25 +371,46 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
   prefetchShellFirst: boolean;
+  prefetchSuspenseShell: boolean;
   shouldPrefetch: boolean;
 } {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchShellFirst: false,
+      prefetchSuspenseShell: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchShellFirst: false,
+      prefetchSuspenseShell: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchShellFirst: false,
+      prefetchSuspenseShell: false,
+      shouldPrefetch: false,
+    };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchShellFirst: false,
+      prefetchSuspenseShell: false,
+      shouldPrefetch: false,
+    };
   }
 
   return resolveMatchedAutoAppRoutePrefetch(match.route);
@@ -425,7 +451,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
   }
 
   const schedule =
-    priority === "high"
+    priority === "high" || hasAppNavigationRuntime()
       ? (fn: () => void) => {
           fn();
         }
@@ -448,7 +474,12 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         const autoPrefetch =
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchHref)
-            : { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true };
+            : {
+                cacheForNavigation: true,
+                prefetchShellFirst: true,
+                prefetchSuspenseShell: false,
+                shouldPrefetch: true,
+              };
         if (!autoPrefetch.shouldPrefetch) return;
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
@@ -459,7 +490,9 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           interceptionContext,
           renderMode: isOptimisticRouteShellPrefetch
             ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
-            : undefined,
+            : autoPrefetch.prefetchSuspenseShell
+              ? APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL
+              : undefined,
         });
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -508,7 +508,11 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           }
 
           const existing = getPrefetchCache().get(cacheKey);
-          if (existing?.cacheForNavigation === false && existing.optimisticRouteShell !== true) {
+          if (
+            existing?.cacheForNavigation === false &&
+            existing.optimisticRouteShell !== true &&
+            existing.partialSuspenseShell !== true
+          ) {
             existing.cacheForNavigation = true;
           }
         }
@@ -628,7 +632,7 @@ function promotePrefetchEntriesForNavigation(href: string): void {
   }
 
   for (const [cacheKey, entry] of getPrefetchCache()) {
-    if (entry.optimisticRouteShell === true) continue;
+    if (entry.optimisticRouteShell === true || entry.partialSuspenseShell === true) continue;
 
     const [rscUrl] = cacheKey.split("\0", 1);
     let cached: URL;

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -450,8 +450,11 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
     return;
   }
 
+  const appAutoPrefetch =
+    hasAppNavigationRuntime() && mode === "auto" ? resolveAutoAppRoutePrefetch(prefetchHref) : null;
+
   const schedule =
-    priority === "high" || hasAppNavigationRuntime()
+    priority === "high" || appAutoPrefetch?.prefetchSuspenseShell === true
       ? (fn: () => void) => {
           fn();
         }
@@ -473,7 +476,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         }
         const autoPrefetch =
           mode === "auto"
-            ? resolveAutoAppRoutePrefetch(prefetchHref)
+            ? (appAutoPrefetch ?? resolveAutoAppRoutePrefetch(prefetchHref))
             : {
                 cacheForNavigation: true,
                 prefetchShellFirst: true,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -508,7 +508,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           }
 
           const existing = getPrefetchCache().get(cacheKey);
-          if (existing?.cacheForNavigation === false) {
+          if (existing?.cacheForNavigation === false && existing.optimisticRouteShell !== true) {
             existing.cacheForNavigation = true;
           }
         }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -40,6 +40,7 @@ import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
+  VINEXT_RSC_PARTIAL_SHELL_HEADER,
 } from "../server/headers.js";
 import {
   isAbsoluteOrProtocolRelativeUrl,
@@ -739,6 +740,10 @@ export function prefetchRscResponse(
   entry.pending = fetchPromise
     .then(async (response) => {
       if (response.ok) {
+        if (response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER) === "1") {
+          entry.cacheForNavigation = false;
+          entry.optimisticRouteShell = true;
+        }
         entry.snapshot = await snapshotRscResponse(response);
         entry.expiresAt = resolveCachedRscResponseExpiresAt(
           entry.timestamp,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -414,6 +414,7 @@ function findPrefetchCacheEntryForNavigation(
   if (
     exactEntry &&
     exactEntry.cacheForNavigation !== false &&
+    exactEntry.optimisticRouteShell !== true &&
     isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
   ) {
     return { cacheKey: exactCacheKey, entry: exactEntry };
@@ -424,7 +425,7 @@ function findPrefetchCacheEntryForNavigation(
 
   for (const [cacheKey, entry] of cache) {
     if (cacheKey === exactCacheKey) continue;
-    if (entry.cacheForNavigation === false) continue;
+    if (entry.cacheForNavigation === false || entry.optimisticRouteShell === true) continue;
 
     const source = parsePrefetchCacheKey(cacheKey);
     if (source.interceptionContext !== interceptionContext) continue;
@@ -788,6 +789,7 @@ export function consumePrefetchResponse(
   if (
     exactEntry &&
     exactEntry.cacheForNavigation !== false &&
+    exactEntry.optimisticRouteShell !== true &&
     !isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
   ) {
     deletePrefetchCacheEntry(cache, getPrefetchedUrls(), exactCacheKey, exactEntry, false);
@@ -804,7 +806,7 @@ export function consumePrefetchResponse(
   // Skip in-flight snapshots and error-path residue where pending cleared
   // without a successful transition to a cache-seeded entry.
   if (entry.pending || entry.outcome !== "cache-seeded") return null;
-  if (entry.cacheForNavigation === false) return null;
+  if (entry.cacheForNavigation === false || entry.optimisticRouteShell === true) return null;
 
   deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, false);
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -246,6 +246,7 @@ export type PrefetchCacheEntry = {
   mountedSlotsHeader?: string | null;
   onInvalidateCallbacks?: Set<() => void>;
   optimisticRouteShell?: boolean;
+  partialSuspenseShell?: boolean;
   outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
   pending?: Promise<void>;
@@ -415,6 +416,7 @@ function findPrefetchCacheEntryForNavigation(
     exactEntry &&
     exactEntry.cacheForNavigation !== false &&
     exactEntry.optimisticRouteShell !== true &&
+    exactEntry.partialSuspenseShell !== true &&
     isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
   ) {
     return { cacheKey: exactCacheKey, entry: exactEntry };
@@ -425,7 +427,13 @@ function findPrefetchCacheEntryForNavigation(
 
   for (const [cacheKey, entry] of cache) {
     if (cacheKey === exactCacheKey) continue;
-    if (entry.cacheForNavigation === false || entry.optimisticRouteShell === true) continue;
+    if (
+      entry.cacheForNavigation === false ||
+      entry.optimisticRouteShell === true ||
+      entry.partialSuspenseShell === true
+    ) {
+      continue;
+    }
 
     const source = parsePrefetchCacheKey(cacheKey);
     if (source.interceptionContext !== interceptionContext) continue;
@@ -743,7 +751,7 @@ export function prefetchRscResponse(
       if (response.ok) {
         if (response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER) === "1") {
           entry.cacheForNavigation = false;
-          entry.optimisticRouteShell = true;
+          entry.partialSuspenseShell = true;
         }
         entry.snapshot = await snapshotRscResponse(response);
         entry.expiresAt = resolveCachedRscResponseExpiresAt(
@@ -790,6 +798,7 @@ export function consumePrefetchResponse(
     exactEntry &&
     exactEntry.cacheForNavigation !== false &&
     exactEntry.optimisticRouteShell !== true &&
+    exactEntry.partialSuspenseShell !== true &&
     !isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
   ) {
     deletePrefetchCacheEntry(cache, getPrefetchedUrls(), exactCacheKey, exactEntry, false);
@@ -806,7 +815,13 @@ export function consumePrefetchResponse(
   // Skip in-flight snapshots and error-path residue where pending cleared
   // without a successful transition to a cache-seeded entry.
   if (entry.pending || entry.outcome !== "cache-seeded") return null;
-  if (entry.cacheForNavigation === false || entry.optimisticRouteShell === true) return null;
+  if (
+    entry.cacheForNavigation === false ||
+    entry.optimisticRouteShell === true ||
+    entry.partialSuspenseShell === true
+  ) {
+    return null;
+  }
 
   deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, false);
 

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -247,6 +247,7 @@ declare module "next/navigation" {
     mountedSlotsHeader?: string | null;
     onInvalidateCallbacks?: Set<() => void>;
     optimisticRouteShell?: boolean;
+    partialSuspenseShell?: boolean;
     outcome: "pending" | "cache-seeded";
     snapshot?: CachedRscResponse;
     pending?: Promise<void>;

--- a/packages/vinext/src/shims/prefetch-suspense-shell.ts
+++ b/packages/vinext/src/shims/prefetch-suspense-shell.ts
@@ -1,0 +1,46 @@
+import { getOrCreateAls } from "./internal/als-registry.js";
+import { makeHangingPromise } from "./internal/make-hanging-promise.js";
+
+type PrefetchSuspenseShellState = {
+  dynamicAbortController: AbortController;
+  reactAbortController: AbortController;
+  abortScheduled: boolean;
+  route: string;
+};
+
+const prefetchSuspenseShellAls = getOrCreateAls<PrefetchSuspenseShellState>(
+  "vinext.prefetchSuspenseShell.als",
+);
+
+export function createPrefetchSuspenseShellState(route: string): PrefetchSuspenseShellState {
+  return {
+    dynamicAbortController: new AbortController(),
+    reactAbortController: new AbortController(),
+    abortScheduled: false,
+    route,
+  };
+}
+
+export function runWithPrefetchSuspenseShellState<T>(
+  state: PrefetchSuspenseShellState,
+  fn: () => T,
+): T {
+  return prefetchSuspenseShellAls.run(state, fn);
+}
+
+export function suspendPrefetchSuspenseShell(expression: string): Promise<never> | null {
+  const state = prefetchSuspenseShellAls.getStore();
+  if (!state) return null;
+
+  if (!state.abortScheduled) {
+    state.abortScheduled = true;
+    setTimeout(() => {
+      setTimeout(() => {
+        state.reactAbortController.abort();
+        state.dynamicAbortController.abort();
+      }, 0);
+    }, 0);
+  }
+
+  return makeHangingPromise(state.dynamicAbortController.signal, state.route, expression);
+}

--- a/packages/vinext/src/shims/prefetch-suspense-shell.ts
+++ b/packages/vinext/src/shims/prefetch-suspense-shell.ts
@@ -4,7 +4,7 @@ import { makeHangingPromise } from "./internal/make-hanging-promise.js";
 type PrefetchSuspenseShellState = {
   dynamicAbortController: AbortController;
   reactAbortController: AbortController;
-  abortScheduled: boolean;
+  aborted: boolean;
   route: string;
 };
 
@@ -16,7 +16,7 @@ export function createPrefetchSuspenseShellState(route: string): PrefetchSuspens
   return {
     dynamicAbortController: new AbortController(),
     reactAbortController: new AbortController(),
-    abortScheduled: false,
+    aborted: false,
     route,
   };
 }
@@ -28,19 +28,29 @@ export function runWithPrefetchSuspenseShellState<T>(
   return prefetchSuspenseShellAls.run(state, fn);
 }
 
+export function schedulePrefetchSuspenseShellAbort(state: PrefetchSuspenseShellState): () => void {
+  let innerTimer: ReturnType<typeof setTimeout> | undefined;
+  const outerTimer = setTimeout(() => {
+    innerTimer = setTimeout(() => {
+      state.aborted = true;
+      state.reactAbortController.abort();
+      state.dynamicAbortController.abort();
+    }, 0);
+  }, 0);
+
+  return () => {
+    clearTimeout(outerTimer);
+    if (innerTimer !== undefined) clearTimeout(innerTimer);
+  };
+}
+
+export function wasPrefetchSuspenseShellAborted(state: PrefetchSuspenseShellState): boolean {
+  return state.aborted;
+}
+
 export function suspendPrefetchSuspenseShell(expression: string): Promise<never> | null {
   const state = prefetchSuspenseShellAls.getStore();
   if (!state) return null;
-
-  if (!state.abortScheduled) {
-    state.abortScheduled = true;
-    setTimeout(() => {
-      setTimeout(() => {
-        state.reactAbortController.abort();
-        state.dynamicAbortController.abort();
-      }, 0);
-    }, 0);
-  }
 
   return makeHangingPromise(state.dynamicAbortController.signal, state.route, expression);
 }

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -1060,12 +1060,10 @@ export async function connection(): Promise<void> {
   markRenderRequestApiUsage("connection");
   throwIfInsideCacheScope("connection()");
   markDynamicUsage();
-  if (getHeadersContext()?.headers.get("x-vinext-rsc-render-mode") === "prefetch-suspense-shell") {
-    const { suspendPrefetchSuspenseShell } = await import("./prefetch-suspense-shell.js");
-    const pendingShell = suspendPrefetchSuspenseShell("connection()");
-    if (pendingShell) {
-      await pendingShell;
-    }
+  const { suspendPrefetchSuspenseShell } = await import("./prefetch-suspense-shell.js");
+  const pendingShell = suspendPrefetchSuspenseShell("connection()");
+  if (pendingShell) {
+    await pendingShell;
   }
   const pendingProbe = suspendConnectionProbe();
   if (pendingProbe) {

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -1060,6 +1060,13 @@ export async function connection(): Promise<void> {
   markRenderRequestApiUsage("connection");
   throwIfInsideCacheScope("connection()");
   markDynamicUsage();
+  if (getHeadersContext()?.headers.get("x-vinext-rsc-render-mode") === "prefetch-suspense-shell") {
+    const { suspendPrefetchSuspenseShell } = await import("./prefetch-suspense-shell.js");
+    const pendingShell = suspendPrefetchSuspenseShell("connection()");
+    if (pendingShell) {
+      await pendingShell;
+    }
+  }
   const pendingProbe = suspendConnectionProbe();
   if (pendingProbe) {
     await pendingProbe;

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -452,6 +452,16 @@ describe("app page response helpers", () => {
     expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBe("60");
   });
 
+  it("marks partial Suspense shell RSC responses", () => {
+    const response = buildAppPageRscResponse(createBody("shell"), {
+      middlewareContext: { headers: null, status: null },
+      partialShell: true,
+      policy: {},
+    });
+
+    expect(response.headers.get("x-vinext-rsc-partial-shell")).toBe("1");
+  });
+
   it("keeps the framework compatibility ID when middleware sets the internal header", () => {
     const middlewareHeaders = new Headers({
       [VINEXT_RSC_COMPATIBILITY_ID_HEADER]: "middleware-compat",

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -10,7 +10,10 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
-import { VINEXT_DYNAMIC_STALE_TIME_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  VINEXT_DYNAMIC_STALE_TIME_HEADER,
+  VINEXT_RSC_PARTIAL_SHELL_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import { withEnvVar } from "./env-test-helpers.js";
 
 function createBody(text: string): ReadableStream {
@@ -404,6 +407,20 @@ describe("app page response helpers", () => {
     expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
     expect(response.headers.get("x-vinext-timing")).toBe("10,5,-1");
     await expect(response.text()).resolves.toBe("flight");
+  });
+
+  it("does not allow middleware to mark a full RSC response as a partial shell", () => {
+    const response = buildAppPageRscResponse(createBody("flight"), {
+      middlewareContext: {
+        headers: new Headers({ [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1" }),
+        status: null,
+      },
+      partialShell: false,
+      policy: { cacheControl: "s-maxage=60" },
+    });
+
+    expect(response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER)).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("s-maxage=60");
   });
 
   it("emits the `x-edge-runtime: 1` marker on RSC responses when the route opts into the edge runtime (issue #1531)", () => {

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -107,6 +107,27 @@ describe("finalizeAppRscResponse — config header application", () => {
     expect(response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER)).toBe("1");
   });
 
+  it("removes config-injected partial shell markers from full responses", () => {
+    const response = new Response("body", {
+      headers: { "Cache-Control": "s-maxage=30" },
+    });
+
+    finalizeAppRscResponse(response, new Request("http://example.com/about"), {
+      basePath: "",
+      configHeaders: [
+        {
+          source: "/about",
+          headers: [{ key: VINEXT_RSC_PARTIAL_SHELL_HEADER, value: "1" }],
+        },
+      ],
+      i18nConfig: null,
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER)).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("s-maxage=30");
+  });
+
   it("uses the active CDN adapter to clear custom cache headers", () => {
     const adapter: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vite-plus/test";
 import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
 import { VINEXT_RSC_PARTIAL_SHELL_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  DefaultCdnCacheAdapter,
+  setCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
 import type { RequestContext } from "../packages/vinext/src/config/config-matchers.js";
 
 function makeRequestContext(headers: Headers = new Headers()): RequestContext {
@@ -87,6 +92,7 @@ describe("finalizeAppRscResponse — config header application", () => {
             { key: "CDN-Cache-Control", value: "s-maxage=30" },
             { key: "Cloudflare-CDN-Cache-Control", value: "s-maxage=30" },
             { key: "Cache-Tag", value: "partial-shell" },
+            { key: VINEXT_RSC_PARTIAL_SHELL_HEADER, value: "0" },
           ],
         },
       ],
@@ -98,6 +104,45 @@ describe("finalizeAppRscResponse — config header application", () => {
     expect(response.headers.get("cdn-cache-control")).toBeNull();
     expect(response.headers.get("cloudflare-cdn-cache-control")).toBeNull();
     expect(response.headers.get("cache-tag")).toBeNull();
+    expect(response.headers.get(VINEXT_RSC_PARTIAL_SHELL_HEADER)).toBe("1");
+  });
+
+  it("uses the active CDN adapter to clear custom cache headers", () => {
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders(input) {
+        return {
+          "Cache-Control": input.cacheControl,
+          "Surrogate-Control": null,
+        };
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(adapter);
+    try {
+      const response = new Response("shell", {
+        headers: {
+          [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1",
+          "Surrogate-Control": "max-age=30",
+        },
+      });
+
+      finalizeAppRscResponse(response, new Request("http://example.com/about"), {
+        basePath: "",
+        configHeaders: [],
+        i18nConfig: null,
+        requestContext: makeRequestContext(),
+      });
+
+      expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+      expect(response.headers.get("surrogate-control")).toBeNull();
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
   });
 });
 

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
+import { VINEXT_RSC_PARTIAL_SHELL_HEADER } from "../packages/vinext/src/server/headers.js";
 import type { RequestContext } from "../packages/vinext/src/config/config-matchers.js";
 
 function makeRequestContext(headers: Headers = new Headers()): RequestContext {
@@ -66,6 +67,37 @@ describe("finalizeAppRscResponse — config header application", () => {
     });
 
     expect(response.headers.get("x-added")).toBeNull();
+  });
+
+  it("keeps partial Suspense shells uncacheable after config headers", () => {
+    const response = new Response("shell", {
+      headers: {
+        [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1",
+      },
+    });
+    const request = new Request("http://example.com/about");
+
+    finalizeAppRscResponse(response, request, {
+      basePath: "",
+      configHeaders: [
+        {
+          source: "/about",
+          headers: [
+            { key: "Cache-Control", value: "s-maxage=30" },
+            { key: "CDN-Cache-Control", value: "s-maxage=30" },
+            { key: "Cloudflare-CDN-Cache-Control", value: "s-maxage=30" },
+            { key: "Cache-Tag", value: "partial-shell" },
+          ],
+        },
+      ],
+      i18nConfig: null,
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBeNull();
+    expect(response.headers.get("cache-tag")).toBeNull();
   });
 });
 

--- a/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
@@ -86,6 +86,8 @@ export default function Page() {
     path.join(dynamicDir, "page.tsx"),
     `import { Suspense } from "react";
 
+export const revalidate = 30;
+
 async function DynamicContent({ param }: { param: string }) {
   await new Promise((resolve) => setTimeout(resolve, 5_000));
   return <div id={\`dynamic-page-content-\${param}\`}>{\`Dynamic page \${param}\`}</div>;
@@ -182,7 +184,10 @@ test("prefetches a fallback from a user Suspense boundary", async ({ page }) => 
       );
     });
     await page.click("#reveal-link");
-    expect((await prefetchResponse).ok()).toBe(true);
+    const response = await prefetchResponse;
+    expect(response.ok()).toBe(true);
+    expect(response.headers()["cache-control"]).toBe("no-store, must-revalidate");
+    expect(response.headers()["x-vinext-cache"]).toBeUndefined();
     await expect
       .poll(() =>
         page.evaluate(() =>

--- a/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
@@ -1,0 +1,208 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+type ProductionApp = {
+  baseUrl: string;
+  fixtureRoot: string;
+  server: Server;
+};
+
+async function closeServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await closed;
+}
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+  await fs.mkdir(targetNodeModules, { recursive: true });
+
+  for (const sourceNodeModules of [
+    path.resolve(process.cwd(), "node_modules"),
+    path.resolve(process.cwd(), "packages/vinext/node_modules"),
+    path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules"),
+  ]) {
+    for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+      if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
+      const target = path.join(targetNodeModules, entry.name);
+      try {
+        await fs.symlink(
+          path.join(sourceNodeModules, entry.name),
+          target,
+          entry.isDirectory() ? "junction" : "file",
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+    }
+  }
+}
+
+async function writeFixture(fixtureRoot: string): Promise<void> {
+  const appDir = path.join(fixtureRoot, "app");
+  const sourceDir = path.join(appDir, "mismatching-prefetch");
+  const dynamicDir = path.join(sourceDir, "dynamic-page", "[param]");
+  await fs.mkdir(dynamicDir, { recursive: true });
+  await linkFixtureNodeModules(fixtureRoot);
+
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "layout.tsx"),
+    `import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(sourceDir, "page.tsx"),
+    `"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+const href = "/mismatching-prefetch/dynamic-page/a?mismatch-rewrite=./b";
+
+export default function Page() {
+  const [visible, setVisible] = useState(false);
+  return <main>
+    <button id="reveal-link" onClick={() => setVisible(true)}>Reveal link</button>
+    {visible ? <Link id="mismatch-link" href={href}>Navigate</Link> : null}
+  </main>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(dynamicDir, "page.tsx"),
+    `import { Suspense } from "react";
+import { connection } from "next/server";
+
+export function generateStaticParams() {
+  return [{ param: "a" }, { param: "b" }];
+}
+
+async function DynamicContent({ param }: { param: string }) {
+  await connection();
+  return <div id={\`dynamic-page-content-\${param}\`}>{\`Dynamic page \${param}\`}</div>;
+}
+
+export default async function Page({ params }: { params: Promise<{ param: string }> }) {
+  const { param } = await params;
+  return <Suspense fallback={<div id={\`dynamic-page-loading-\${param}\`}>{\`Loading \${param}...\`}</div>}>
+    <DynamicContent param={param} />
+  </Suspense>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(fixtureRoot, "middleware.ts"),
+    `import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  if (request.headers.get("x-vinext-rsc-render-mode")?.startsWith("prefetch-")) {
+    return NextResponse.next();
+  }
+  const destination = request.nextUrl.searchParams.get("mismatch-rewrite");
+  return destination ? NextResponse.rewrite(new URL(destination, request.url)) : NextResponse.next();
+}
+
+export const config = { matcher: "/mismatching-prefetch/:path*" };
+`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/dist/index.js");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({ plugins: [vinext({ appDir: import.meta.dirname })] });
+`,
+  );
+}
+
+async function buildAndServeFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-mismatch-prefetch-"));
+  await writeFixture(fixtureRoot);
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const { startProdServer } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/server/prod-server.js")).href
+  );
+  const started = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir: path.join(fixtureRoot, "dist"),
+    noCompression: true,
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${started.port}`,
+    fixtureRoot,
+    server: started.server,
+  };
+}
+
+test.setTimeout(90_000);
+
+// Ported from Next.js:
+// test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+test("prefetches a fallback from a user Suspense boundary", async ({ page }) => {
+  const app = await buildAndServeFixture();
+
+  try {
+    await page.goto(`${app.baseUrl}/mismatching-prefetch`);
+    await waitForAppRouterHydration(page);
+
+    const prefetchResponse = page.waitForResponse(async (response) => {
+      const request = response.request();
+      return (
+        request.headers()["x-vinext-rsc-render-mode"]?.startsWith("prefetch-") === true &&
+        response.url().includes("/mismatching-prefetch/dynamic-page/a?") &&
+        response.headers()["x-vinext-rsc-partial-shell"] === "1" &&
+        (await response.text()).includes("Loading a...")
+      );
+    });
+    await page.click("#reveal-link");
+    expect((await prefetchResponse).ok()).toBe(true);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          Array.from(
+            (
+              window as Window & {
+                __VINEXT_RSC_PREFETCH_CACHE__?: Map<string, { cacheForNavigation?: boolean }>;
+              }
+            ).__VINEXT_RSC_PREFETCH_CACHE__?.values() ?? [],
+          ).some((entry) => entry.cacheForNavigation === false),
+        ),
+      )
+      .toBe(true);
+  } finally {
+    await closeServer(app.server);
+    await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
@@ -85,14 +85,9 @@ export default function Page() {
   await fs.writeFile(
     path.join(dynamicDir, "page.tsx"),
     `import { Suspense } from "react";
-import { connection } from "next/server";
-
-export function generateStaticParams() {
-  return [{ param: "a" }, { param: "b" }];
-}
 
 async function DynamicContent({ param }: { param: string }) {
-  await connection();
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
   return <div id={\`dynamic-page-content-\${param}\`}>{\`Dynamic page \${param}\`}</div>;
 }
 

--- a/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
@@ -107,7 +107,12 @@ export default async function Page({ params }: { params: Promise<{ param: string
 
 export function middleware(request: NextRequest) {
   if (request.headers.get("x-vinext-rsc-render-mode")?.startsWith("prefetch-")) {
-    return NextResponse.next();
+    const response = NextResponse.next();
+    response.headers.set("Cache-Control", "s-maxage=30");
+    response.headers.set("CDN-Cache-Control", "s-maxage=30");
+    response.headers.set("Cloudflare-CDN-Cache-Control", "s-maxage=30");
+    response.headers.set("Cache-Tag", "partial-shell");
+    return response;
   }
   const destination = request.nextUrl.searchParams.get("mismatch-rewrite");
   return destination ? NextResponse.rewrite(new URL(destination, request.url)) : NextResponse.next();
@@ -187,6 +192,9 @@ test("prefetches a fallback from a user Suspense boundary", async ({ page }) => 
     const response = await prefetchResponse;
     expect(response.ok()).toBe(true);
     expect(response.headers()["cache-control"]).toBe("no-store, must-revalidate");
+    expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cache-tag"]).toBeUndefined();
     expect(response.headers()["x-vinext-cache"]).toBeUndefined();
     await expect
       .poll(() =>

--- a/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
@@ -112,6 +112,7 @@ export function middleware(request: NextRequest) {
     response.headers.set("CDN-Cache-Control", "s-maxage=30");
     response.headers.set("Cloudflare-CDN-Cache-Control", "s-maxage=30");
     response.headers.set("Cache-Tag", "partial-shell");
+    response.headers.set("X-Vinext-Rsc-Partial-Shell", "0");
     return response;
   }
   const destination = request.nextUrl.searchParams.get("mismatch-rewrite");

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -12,7 +12,10 @@ import {
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
 } from "../packages/vinext/src/server/app-rsc-render-mode.js";
-import { VINEXT_RSC_RENDER_MODE_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  VINEXT_RSC_PARTIAL_SHELL_HEADER,
+  VINEXT_RSC_RENDER_MODE_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
 
 type CapturedEffect = () => void | (() => void);
@@ -1473,6 +1476,41 @@ describe("Link prefetch scheduling", () => {
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry?.cacheForNavigation).toBe(true);
       expect(entry?.optimisticRouteShell).toBe(false);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not promote a server-declared partial shell on repeat prefetch", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/clothing/1",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry).toBeDefined();
+      entry!.cacheForNavigation = false;
+      entry!.optimisticRouteShell = true;
+      result.fetch.mockResolvedValue(
+        new Response("shell", {
+          headers: { [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1" },
+        }),
+      );
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 2);
+      await flushPrefetchTasks();
+
+      expect(Array.from(getPrefetchCache().values())[0]).toMatchObject({
+        cacheForNavigation: false,
+        optimisticRouteShell: true,
+      });
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -8,7 +8,10 @@ import {
   type LinkPrefetchDecision,
   type LinkPrefetchRouterMode,
 } from "../packages/vinext/src/shims/link-prefetch.js";
-import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+  APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { VINEXT_RSC_RENDER_MODE_HEADER } from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
 
@@ -1418,6 +1421,26 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("starts App Router viewport prefetches without waiting for browser idle", async () => {
+    const observer = stubIntersectionObserver();
+    const idleCallback = vi.fn();
+    vi.stubGlobal("requestIdleCallback", idleCallback);
+    const result = await renderIsolatedLink({
+      href: "/products/1",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(idleCallback).not.toHaveBeenCalled();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("full-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
     const observer = stubIntersectionObserver();
 
@@ -1444,7 +1467,7 @@ describe("Link prefetch scheduling", () => {
       );
       const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
-        null,
+        APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
       );
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
@@ -1749,7 +1772,7 @@ describe("Link prefetch scheduling", () => {
       );
       const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
-        null,
+        APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
       );
     } finally {
       result.restoreNodeEnv();

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1496,7 +1496,7 @@ describe("Link prefetch scheduling", () => {
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry).toBeDefined();
       entry!.cacheForNavigation = false;
-      entry!.optimisticRouteShell = true;
+      entry!.partialSuspenseShell = true;
       result.fetch.mockResolvedValue(
         new Response("shell", {
           headers: { [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1" },
@@ -1509,7 +1509,8 @@ describe("Link prefetch scheduling", () => {
 
       expect(Array.from(getPrefetchCache().values())[0]).toMatchObject({
         cacheForNavigation: false,
-        optimisticRouteShell: true,
+        optimisticRouteShell: false,
+        partialSuspenseShell: true,
       });
     } finally {
       result.restoreNodeEnv();

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1444,6 +1444,25 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("keeps ordinary App Router viewport prefetches on the idle queue", async () => {
+    const observer = stubIntersectionObserver();
+    const idleCallback = vi.fn();
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback: idleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+
+      expect(idleCallback).toHaveBeenCalledTimes(1);
+      expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("full-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
     const observer = stubIntersectionObserver();
 

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -325,21 +325,25 @@ describe("Link App Router prefetch mode", () => {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
         prefetchShellFirst: true,
+        prefetchSuspenseShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
         prefetchShellFirst: false,
+        prefetchSuspenseShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
         prefetchShellFirst: true,
+        prefetchSuspenseShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
         prefetchShellFirst: false,
+        prefetchSuspenseShell: true,
         shouldPrefetch: true,
       });
       // Ported from Next.js:
@@ -348,11 +352,13 @@ describe("Link App Router prefetch mode", () => {
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
         prefetchShellFirst: false,
+        prefetchSuspenseShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
         prefetchShellFirst: false,
+        prefetchSuspenseShell: false,
         shouldPrefetch: false,
       });
     } finally {

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -342,7 +342,8 @@ describe("prefetch cache eviction", () => {
 
     expect(getPrefetchCache().get(rscUrl)).toMatchObject({
       cacheForNavigation: false,
-      optimisticRouteShell: true,
+      optimisticRouteShell: false,
+      partialSuspenseShell: true,
     });
     expect(consumePrefetchResponse(rscUrl)).toBeNull();
   });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -347,6 +347,30 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(rscUrl)).toBeNull();
   });
 
+  it("rejects partial shells even if their navigation flag is promoted", async () => {
+    const rscUrl = "/promoted-suspense-shell.rsc";
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("shell", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1",
+          },
+        }),
+      ),
+    );
+
+    await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
+
+    const entry = getPrefetchCache().get(rscUrl);
+    expect(entry).toBeDefined();
+    entry!.cacheForNavigation = true;
+
+    expect(hasPrefetchCacheEntryForNavigation(rscUrl)).toBe(false);
+    expect(consumePrefetchResponse(rscUrl)).toBeNull();
+  });
+
   it("derives the interception context from the current pathname", () => {
     (globalThis as any).window.location.pathname = "/feed";
 

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -15,6 +15,7 @@ import { VINEXT_RSC_COMPATIBILITY_ID_HEADER } from "../packages/vinext/src/serve
 import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_RSC_PARTIAL_SHELL_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 
 type Navigation = typeof import("../packages/vinext/src/shims/navigation.js");
@@ -321,6 +322,29 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(rscUrl, null, null)).toBeNull();
     expect(cache.has(rscUrl)).toBe(true);
     expect(prefetched.has(rscUrl)).toBe(true);
+  });
+
+  it("downgrades server-declared partial shells from navigation reuse", async () => {
+    const rscUrl = "/suspense-shell.rsc";
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("shell", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1",
+          },
+        }),
+      ),
+    );
+
+    await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
+
+    expect(getPrefetchCache().get(rscUrl)).toMatchObject({
+      cacheForNavigation: false,
+      optimisticRouteShell: true,
+    });
+    expect(consumePrefetchResponse(rscUrl)).toBeNull();
   });
 
   it("derives the interception context from the current pathname", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3415,6 +3415,39 @@ describe("next/headers shim", () => {
     setHeadersContext(null);
   });
 
+  it("headers() and cookies() suspend during Suspense shell prefetch", async () => {
+    const { createPrefetchSuspenseShellState, runWithPrefetchSuspenseShellState } =
+      await import("../packages/vinext/src/shims/prefetch-suspense-shell.js");
+    const { setHeadersContext, headers, cookies } =
+      await import("../packages/vinext/src/shims/headers.js");
+    setHeadersContext({
+      headers: new Headers({ "x-custom": "test-value" }),
+      cookies: new Map([["session", "abc123"]]),
+    });
+
+    try {
+      const requestApis: Array<() => Promise<object> & object> = [() => headers(), () => cookies()];
+      for (const readRequestApi of requestApis) {
+        const state = createPrefetchSuspenseShellState("/suspense-prefetch");
+        const pending = runWithPrefetchSuspenseShellState(state, readRequestApi);
+        let settled = false;
+        void pending
+          .catch(() => {})
+          .finally(() => {
+            settled = true;
+          });
+
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        state.dynamicAbortController.abort();
+        await expect(pending).rejects.toThrow("render was aborted");
+      }
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
   it("headers() and cookies() reuse request API promise identity within a request context", async () => {
     // Next.js caches request API promises by the underlying request object:
     // packages/next/src/server/request/headers.ts

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4650,6 +4650,33 @@ describe("next/server shim", () => {
     expect(ranAfterConnection).toBe(false);
   });
 
+  it("connection() suspends from shell state even when request headers omit the render mode", async () => {
+    const { createPrefetchSuspenseShellState, runWithPrefetchSuspenseShellState } =
+      await import("../packages/vinext/src/shims/prefetch-suspense-shell.js");
+    const { setHeadersContext } = await import("../packages/vinext/src/shims/headers.js");
+    const { connection } = await import("../packages/vinext/src/shims/server.js");
+    setHeadersContext({ headers: new Headers(), cookies: new Map() });
+    const state = createPrefetchSuspenseShellState("/suspense-prefetch");
+
+    try {
+      const pending = runWithPrefetchSuspenseShellState(state, connection);
+      let settled = false;
+      void pending
+        .catch(() => {})
+        .finally(() => {
+          settled = true;
+        });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      state.dynamicAbortController.abort();
+      await expect(pending).rejects.toThrow("render was aborted");
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
   it("URLPattern is exported and available in Node 20+", async () => {
     const { URLPattern } = await import("../packages/vinext/src/shims/server.js");
     // Node 22+ has URLPattern globally; if available, test it works


### PR DESCRIPTION
## Summary

- start App Router viewport prefetches immediately instead of waiting for browser idle
- add a request-local prefetch mode that captures user-authored `<Suspense>` fallbacks when `connection()` suspends
- mark partial shell responses so they cannot be consumed as complete navigation payloads
- preserve full prefetch reuse for dynamic routes whose render completes without a dynamic boundary

## Next.js parity

Targets the first-stage failure in Next.js v16.2.6:

- `test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts`

Before this change the exact suite timed out waiting for any request after revealing the link. After this change the request starts immediately and the focused non-cache fixture receives `Loading a...` from the user Suspense boundary.

The upstream fixture itself enables `cacheComponents: true`; its remaining response-body mismatch is cacheComponents-specific and intentionally excluded from this PR. Route-identity recovery after the shell is independently covered by #2358.

Overlap was checked against:

- #2318 — Next.js prefetch protocol headers/cache ownership
- #2331 — `loading.tsx` ancestor loading boundaries
- #2332 — loading-shell cache reuse across search params

This PR does not duplicate those behaviors.

## Validation

- 261 focused unit assertions across Link scheduling, prefetch cache, RSC request/response, and render mode tests
- focused `vp check` on all changed files
- `vp run vinext#build`
- isolated production browser fixture, one worker: 1/1 passed
- exact upstream suite, one worker: advanced from `Timed out waiting for a request to be initiated` to response-body inspection; remaining mismatch is under `cacheComponents: true`

Excludes PPR, resume, fallback-shell persistence, and cacheComponents behavior.
