### PR TITLE
fix(server): restore client trace metadata parity

### DIFF
--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -40,7 +40,10 @@ const carrierSetter: TextMapSetter = {
  *
  * The implementation mirrors Next.js's `NextTracerImpl.getTracePropagationData`:
  * we call `propagation.inject(activeContext, entries, setter)` and let the
- * setter push entries into our carrier array.
+ * setter push entries into our carrier array. When the registered API has a
+ * tracer provider but no active span, vinext creates and ends a short-lived
+ * span so request-time metadata has the same parent data Next.js exposes;
+ * optional OpenTelemetry failures always degrade to no metadata.
  */
 type OpenTelemetryApi = {
   context: { active(): unknown };

--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -83,31 +83,35 @@ const OPEN_TELEMETRY_API_SYMBOL = Symbol.for("opentelemetry.js.api.1");
 const OPEN_TELEMETRY_SPAN_SYMBOL = Symbol.for("OpenTelemetry Context Key SPAN");
 
 function getRegisteredOpenTelemetryTraceData(): ClientTraceDataEntry[] | null {
-  const registry = (globalThis as Record<symbol, unknown>)[OPEN_TELEMETRY_API_SYMBOL] as
-    | OpenTelemetryGlobal
-    | undefined;
-  if (!registry?.context || !registry.propagation) return null;
-
-  const activeContext = registry.context.active();
-  const hasActiveSpan = activeContext.getValue(OPEN_TELEMETRY_SPAN_SYMBOL) !== undefined;
-  const metadataSpan = hasActiveSpan
-    ? null
-    : registry.trace
-        ?.getTracer("vinext")
-        .startSpan("vinext.clientTraceMetadata", undefined, activeContext);
-  if (!hasActiveSpan && !metadataSpan) return [];
-  const context = metadataSpan
-    ? activeContext.setValue(OPEN_TELEMETRY_SPAN_SYMBOL, metadataSpan)
-    : activeContext;
-  const entries: ClientTraceDataEntry[] = [];
+  let metadataSpan: { end(): void } | null = null;
   try {
-    registry.context.with(context, () => {
-      registry.propagation!.inject(context, entries, carrierSetter);
+    const registry = (globalThis as Record<symbol, unknown>)[OPEN_TELEMETRY_API_SYMBOL] as
+      | OpenTelemetryGlobal
+      | undefined;
+    if (!registry?.context || !registry.propagation) return null;
+    const contextApi = registry.context;
+    const propagation = registry.propagation;
+
+    const activeContext = contextApi.active();
+    const hasActiveSpan = activeContext.getValue(OPEN_TELEMETRY_SPAN_SYMBOL) !== undefined;
+    metadataSpan = hasActiveSpan
+      ? null
+      : (registry.trace
+          ?.getTracer("vinext")
+          .startSpan("vinext.clientTraceMetadata", undefined, activeContext) ?? null);
+    const context = metadataSpan
+      ? activeContext.setValue(OPEN_TELEMETRY_SPAN_SYMBOL, metadataSpan)
+      : activeContext;
+    const entries: ClientTraceDataEntry[] = [];
+    contextApi.with(context, () => {
+      propagation.inject(context, entries, carrierSetter);
     });
+    return entries;
+  } catch {
+    return [];
   } finally {
     metadataSpan?.end();
   }
-  return entries;
 }
 
 function getOpenTelemetryTraceData(): ClientTraceDataEntry[] {

--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -66,16 +66,21 @@ type OpenTelemetryGlobal = {
       setter: TextMapSetter,
     ): void;
   };
+  trace?: {
+    getTracer(name: string): {
+      startSpan(
+        name: string,
+        options: undefined,
+        context: OpenTelemetryContext,
+      ): {
+        end(): void;
+      };
+    };
+  };
 };
 
 const OPEN_TELEMETRY_API_SYMBOL = Symbol.for("opentelemetry.js.api.1");
 const OPEN_TELEMETRY_SPAN_SYMBOL = Symbol.for("OpenTelemetry Context Key SPAN");
-
-function randomHex(bytes: number): string {
-  const values = new Uint8Array(bytes);
-  crypto.getRandomValues(values);
-  return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("");
-}
 
 function getRegisteredOpenTelemetryTraceData(): ClientTraceDataEntry[] | null {
   const registry = (globalThis as Record<symbol, unknown>)[OPEN_TELEMETRY_API_SYMBOL] as
@@ -85,21 +90,23 @@ function getRegisteredOpenTelemetryTraceData(): ClientTraceDataEntry[] | null {
 
   const activeContext = registry.context.active();
   const hasActiveSpan = activeContext.getValue(OPEN_TELEMETRY_SPAN_SYMBOL) !== undefined;
-  const context = hasActiveSpan
-    ? activeContext
-    : activeContext.setValue(OPEN_TELEMETRY_SPAN_SYMBOL, {
-        spanContext() {
-          return {
-            traceId: randomHex(16),
-            spanId: randomHex(8),
-            traceFlags: 1,
-          };
-        },
-      });
+  const metadataSpan = hasActiveSpan
+    ? null
+    : registry.trace
+        ?.getTracer("vinext")
+        .startSpan("vinext.clientTraceMetadata", undefined, activeContext);
+  if (!hasActiveSpan && !metadataSpan) return [];
+  const context = metadataSpan
+    ? activeContext.setValue(OPEN_TELEMETRY_SPAN_SYMBOL, metadataSpan)
+    : activeContext;
   const entries: ClientTraceDataEntry[] = [];
-  registry.context.with(context, () => {
-    registry.propagation!.inject(context, entries, carrierSetter);
-  });
+  try {
+    registry.context.with(context, () => {
+      registry.propagation!.inject(context, entries, carrierSetter);
+    });
+  } finally {
+    metadataSpan?.end();
+  }
   return entries;
 }
 

--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -49,7 +49,64 @@ type OpenTelemetryApi = {
   };
 };
 
+type OpenTelemetryContext = {
+  getValue(key: symbol): unknown;
+  setValue(key: symbol, value: unknown): OpenTelemetryContext;
+};
+
+type OpenTelemetryGlobal = {
+  context?: {
+    active(): OpenTelemetryContext;
+    with<T>(context: OpenTelemetryContext, fn: () => T): T;
+  };
+  propagation?: {
+    inject(
+      context: OpenTelemetryContext,
+      carrier: ClientTraceDataEntry[],
+      setter: TextMapSetter,
+    ): void;
+  };
+};
+
+const OPEN_TELEMETRY_API_SYMBOL = Symbol.for("opentelemetry.js.api.1");
+const OPEN_TELEMETRY_SPAN_SYMBOL = Symbol.for("OpenTelemetry Context Key SPAN");
+
+function randomHex(bytes: number): string {
+  const values = new Uint8Array(bytes);
+  crypto.getRandomValues(values);
+  return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("");
+}
+
+function getRegisteredOpenTelemetryTraceData(): ClientTraceDataEntry[] | null {
+  const registry = (globalThis as Record<symbol, unknown>)[OPEN_TELEMETRY_API_SYMBOL] as
+    | OpenTelemetryGlobal
+    | undefined;
+  if (!registry?.context || !registry.propagation) return null;
+
+  const activeContext = registry.context.active();
+  const hasActiveSpan = activeContext.getValue(OPEN_TELEMETRY_SPAN_SYMBOL) !== undefined;
+  const context = hasActiveSpan
+    ? activeContext
+    : activeContext.setValue(OPEN_TELEMETRY_SPAN_SYMBOL, {
+        spanContext() {
+          return {
+            traceId: randomHex(16),
+            spanId: randomHex(8),
+            traceFlags: 1,
+          };
+        },
+      });
+  const entries: ClientTraceDataEntry[] = [];
+  registry.context.with(context, () => {
+    registry.propagation!.inject(context, entries, carrierSetter);
+  });
+  return entries;
+}
+
 function getOpenTelemetryTraceData(): ClientTraceDataEntry[] {
+  const registeredEntries = getRegisteredOpenTelemetryTraceData();
+  if (registeredEntries) return registeredEntries;
+
   let api: OpenTelemetryApi | undefined;
   try {
     // Use require() at runtime so `@opentelemetry/api` is an optional peer.
@@ -117,6 +174,7 @@ export function renderClientTraceMetadataTags(
  */
 export function getClientTraceMetadataHTML(allowList: readonly string[] | undefined): string {
   if (!allowList || allowList.length === 0) return "";
+  if (typeof process !== "undefined" && process.env.VINEXT_PRERENDER === "1") return "";
   const entries = getOpenTelemetryTraceData();
   const filtered = filterClientTraceMetadata(entries, allowList);
   return renderClientTraceMetadataTags(filtered);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -48,6 +48,7 @@ import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js"
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
+import { hasPagesGetInitialProps } from "./pages-get-initial-props.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,6 +89,15 @@ type VinextConfigSubset = {
   clientTraceMetadata?: readonly string[];
   disableOptimizedLoading: boolean;
 };
+
+export function shouldEmitPagesClientTraceMetadata(
+  pageModule: PagesPageModule,
+  appComponent: unknown,
+): boolean {
+  if (typeof pageModule.getServerSideProps === "function") return true;
+  if (typeof pageModule.getStaticProps === "function") return false;
+  return hasPagesGetInitialProps(pageModule.default) || hasPagesGetInitialProps(appComponent);
+}
 
 /**
  * Options accepted by `createPagesPageHandler`.
@@ -734,7 +744,9 @@ export function createPagesPageHandler(
           getFontLinks,
           getFontStyles,
           getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
-          clientTraceMetadata: vinextConfig.clientTraceMetadata,
+          clientTraceMetadata: shouldEmitPagesClientTraceMetadata(pageModule, AppComponent)
+            ? vinextConfig.clientTraceMetadata
+            : undefined,
           gsspRes,
           isrCacheKey: pageIsrCacheKey,
           expireSeconds: vinextConfig.expireTime,

--- a/tests/client-trace-metadata.test.ts
+++ b/tests/client-trace-metadata.test.ts
@@ -244,7 +244,32 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
     expect(startSpan).not.toHaveBeenCalled();
   });
 
-  it("does not fabricate span-derived metadata without a registered tracer provider", () => {
+  it("preserves non-span propagation metadata without a registered tracer provider", () => {
+    const rootContext = {
+      getValue: () => undefined,
+      setValue: () => rootContext,
+    };
+    (globalThis as Record<symbol, unknown>)[apiSymbol] = {
+      version: "1.9.0",
+      context: { active: () => rootContext, with: (_context: unknown, fn: () => unknown) => fn() },
+      propagation: {
+        inject(
+          _context: unknown,
+          carrier: ClientTraceDataEntry[],
+          setter: { set(carrier: ClientTraceDataEntry[], key: string, value: string): void },
+        ) {
+          setter.set(carrier, "my-test-key-1", "my-test-value-1");
+        },
+      },
+    };
+
+    expect(getClientTraceMetadataHTML(["my-test-key-1", "my-parent-span-id"])).toBe(
+      '<meta name="my-test-key-1" content="my-test-value-1"/>',
+    );
+  });
+
+  it("fails open and ends a created span when registry propagation throws", () => {
+    const end = vi.fn();
     const rootContext = {
       getValue: () => undefined,
       setValue: () => rootContext,
@@ -254,12 +279,16 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
       context: { active: () => rootContext, with: (_context: unknown, fn: () => unknown) => fn() },
       propagation: {
         inject() {
-          throw new Error("propagation should not run without a span");
+          throw new Error("propagation failure");
         },
+      },
+      trace: {
+        getTracer: () => ({ startSpan: () => ({ end }) }),
       },
     };
 
     expect(getClientTraceMetadataHTML(["my-parent-span-id"])).toBe("");
+    expect(end).toHaveBeenCalledOnce();
   });
 
   it("does not emit trace metadata while prerendering", () => {

--- a/tests/client-trace-metadata.test.ts
+++ b/tests/client-trace-metadata.test.ts
@@ -5,7 +5,7 @@
  * Source: packages/next/src/server/lib/trace/utils.ts (getTracedMetadata)
  *         packages/next/src/server/app-render/make-get-server-inserted-html.tsx
  */
-import { afterEach, describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   filterClientTraceMetadata,
   getClientTraceMetadataHTML,

--- a/tests/client-trace-metadata.test.ts
+++ b/tests/client-trace-metadata.test.ts
@@ -79,12 +79,24 @@ describe("client trace metadata: renderClientTraceMetadataTags", () => {
 });
 
 describe("client trace metadata: getClientTraceMetadataHTML", () => {
-  // The default global has no `require`, so any optional OTel resolution
-  // returns no entries.
   type WithRequire = { require?: (id: string) => unknown };
+  const apiSymbol = Symbol.for("opentelemetry.js.api.1");
+  const spanSymbol = Symbol.for("OpenTelemetry Context Key SPAN");
+  const originalApiRegistry = (globalThis as Record<symbol, unknown>)[apiSymbol];
+  const originalPrerender = process.env.VINEXT_PRERENDER;
 
   afterEach(() => {
     delete (globalThis as WithRequire).require;
+    if (originalApiRegistry === undefined) {
+      delete (globalThis as Record<symbol, unknown>)[apiSymbol];
+    } else {
+      (globalThis as Record<symbol, unknown>)[apiSymbol] = originalApiRegistry;
+    }
+    if (originalPrerender === undefined) {
+      delete process.env.VINEXT_PRERENDER;
+    } else {
+      process.env.VINEXT_PRERENDER = originalPrerender;
+    }
   });
 
   it("returns empty string when the allow-list is unset", () => {
@@ -136,5 +148,74 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
     expect(html).toMatch(/<meta name="my-parent-span-id" content="[a-f0-9]{16}"\/>/);
     // Keys not on the allow-list MUST NOT appear in the head.
     expect(html).not.toContain("non-metadata-key-3");
+  });
+
+  it("reads the ESM OpenTelemetry global registry and creates a request span when needed", () => {
+    const rootContext = {
+      values: new Map<symbol, unknown>(),
+      getValue(key: symbol) {
+        return this.values.get(key);
+      },
+      setValue(key: symbol, value: unknown) {
+        const values = new Map(this.values);
+        values.set(key, value);
+        return { ...this, values };
+      },
+    };
+    let currentContext = rootContext;
+    (globalThis as Record<symbol, unknown>)[apiSymbol] = {
+      version: "1.9.0",
+      context: {
+        active: () => currentContext,
+        with<T>(context: typeof rootContext, fn: () => T): T {
+          const previous = currentContext;
+          currentContext = context;
+          try {
+            return fn();
+          } finally {
+            currentContext = previous;
+          }
+        },
+      },
+      propagation: {
+        inject(
+          context: typeof rootContext,
+          carrier: ClientTraceDataEntry[],
+          setter: { set(carrier: ClientTraceDataEntry[], key: string, value: string): void },
+        ) {
+          setter.set(carrier, "my-test-key-1", "my-test-value-1");
+          const span = context.getValue(spanSymbol) as { spanContext(): { spanId: string } };
+          setter.set(carrier, "my-parent-span-id", span.spanContext().spanId);
+        },
+      },
+    };
+
+    const first = getClientTraceMetadataHTML(["my-test-key-1", "my-parent-span-id"]);
+    const second = getClientTraceMetadataHTML(["my-test-key-1", "my-parent-span-id"]);
+
+    expect(first).toContain('<meta name="my-test-key-1" content="my-test-value-1"/>');
+    const firstSpanId = first.match(/my-parent-span-id" content="([a-f0-9]{16})"/)?.[1];
+    const secondSpanId = second.match(/my-parent-span-id" content="([a-f0-9]{16})"/)?.[1];
+    expect(firstSpanId).toMatch(/^[a-f0-9]{16}$/);
+    expect(secondSpanId).toMatch(/^[a-f0-9]{16}$/);
+    expect(secondSpanId).not.toBe(firstSpanId);
+  });
+
+  it("does not emit trace metadata while prerendering", () => {
+    process.env.VINEXT_PRERENDER = "1";
+    (globalThis as WithRequire).require = () => ({
+      context: { active: () => ({}) },
+      propagation: {
+        inject(
+          _context: unknown,
+          carrier: ClientTraceDataEntry[],
+          setter: { set(carrier: ClientTraceDataEntry[], key: string, value: string): void },
+        ) {
+          setter.set(carrier, "my-test-key-1", "my-test-value-1");
+        },
+      },
+    });
+
+    expect(getClientTraceMetadataHTML(["my-test-key-1"])).toBe("");
   });
 });

--- a/tests/client-trace-metadata.test.ts
+++ b/tests/client-trace-metadata.test.ts
@@ -163,6 +163,7 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
       },
     };
     let currentContext = rootContext;
+    const endedSpans: string[] = [];
     (globalThis as Record<symbol, unknown>)[apiSymbol] = {
       version: "1.9.0",
       context: {
@@ -188,6 +189,17 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
           setter.set(carrier, "my-parent-span-id", span.spanContext().spanId);
         },
       },
+      trace: {
+        getTracer: () => ({
+          startSpan: () => {
+            const spanId = crypto.randomUUID().replaceAll("-", "").slice(0, 16);
+            return {
+              spanContext: () => ({ spanId }),
+              end: () => endedSpans.push(spanId),
+            };
+          },
+        }),
+      },
     };
 
     const first = getClientTraceMetadataHTML(["my-test-key-1", "my-parent-span-id"]);
@@ -199,6 +211,55 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
     expect(firstSpanId).toMatch(/^[a-f0-9]{16}$/);
     expect(secondSpanId).toMatch(/^[a-f0-9]{16}$/);
     expect(secondSpanId).not.toBe(firstSpanId);
+    expect(endedSpans).toEqual([firstSpanId, secondSpanId]);
+  });
+
+  it("preserves an existing active span instead of starting another one", () => {
+    const activeSpan = { spanContext: () => ({ spanId: "0123456789abcdef" }) };
+    const activeContext = {
+      getValue: (key: symbol) => (key === spanSymbol ? activeSpan : undefined),
+      setValue: () => activeContext,
+    };
+    const startSpan = vi.fn();
+    (globalThis as Record<symbol, unknown>)[apiSymbol] = {
+      version: "1.9.0",
+      context: {
+        active: () => activeContext,
+        with: (_context: unknown, fn: () => unknown) => fn(),
+      },
+      propagation: {
+        inject(
+          context: typeof activeContext,
+          carrier: ClientTraceDataEntry[],
+          setter: { set(carrier: ClientTraceDataEntry[], key: string, value: string): void },
+        ) {
+          const span = context.getValue(spanSymbol) as typeof activeSpan;
+          setter.set(carrier, "my-parent-span-id", span.spanContext().spanId);
+        },
+      },
+      trace: { getTracer: () => ({ startSpan }) },
+    };
+
+    expect(getClientTraceMetadataHTML(["my-parent-span-id"])).toContain("0123456789abcdef");
+    expect(startSpan).not.toHaveBeenCalled();
+  });
+
+  it("does not fabricate span-derived metadata without a registered tracer provider", () => {
+    const rootContext = {
+      getValue: () => undefined,
+      setValue: () => rootContext,
+    };
+    (globalThis as Record<symbol, unknown>)[apiSymbol] = {
+      version: "1.9.0",
+      context: { active: () => rootContext, with: (_context: unknown, fn: () => unknown) => fn() },
+      propagation: {
+        inject() {
+          throw new Error("propagation should not run without a span");
+        },
+      },
+    };
+
+    expect(getClientTraceMetadataHTML(["my-parent-span-id"])).toBe("");
   });
 
   it("does not emit trace metadata while prerendering", () => {

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -6,7 +6,10 @@
  * i18n redirect, 405 method check, and internal-error guard.
  */
 import { describe, it, expect, vi } from "vite-plus/test";
-import { createPagesPageHandler } from "../packages/vinext/src/server/pages-page-handler.js";
+import {
+  createPagesPageHandler,
+  shouldEmitPagesClientTraceMetadata,
+} from "../packages/vinext/src/server/pages-page-handler.js";
 import type { CreatePagesPageHandlerOptions } from "../packages/vinext/src/server/pages-page-handler.js";
 
 // ---------------------------------------------------------------------------
@@ -95,6 +98,29 @@ function makeOpts(
     ...overrides,
   };
 }
+
+describe("shouldEmitPagesClientTraceMetadata", () => {
+  it("emits only for request-time production renders", () => {
+    expect(shouldEmitPagesClientTraceMetadata(makePageModule(), null)).toBe(false);
+    expect(
+      shouldEmitPagesClientTraceMetadata(
+        makePageModule({ getStaticProps: async () => ({ props: {} }) }),
+        null,
+      ),
+    ).toBe(false);
+    expect(
+      shouldEmitPagesClientTraceMetadata(
+        makePageModule({ getServerSideProps: async () => ({ props: {} }) }),
+        null,
+      ),
+    ).toBe(true);
+
+    const page = Object.assign(() => null, { getInitialProps: async () => ({}) });
+    const app = Object.assign(() => null, { getInitialProps: async () => ({}) });
+    expect(shouldEmitPagesClientTraceMetadata(makePageModule({ default: page }), null)).toBe(true);
+    expect(shouldEmitPagesClientTraceMetadata(makePageModule(), app)).toBe(true);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Route miss → 404 fallback


### PR DESCRIPTION
## Summary

- read registered OpenTelemetry propagation state in ESM production runtimes
- provide a request-local non-recording span context when vinext has no active framework span
- omit client trace metadata from prerendered App and static/SSG Pages output
- preserve metadata for dynamic App, GSSP, and legacy Pages request renders

Fixes the five baseline failures from `test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts` in deploy-suite run 28143992598.

## Next.js parity

Ported behavior from:
- `test/e2e/opentelemetry/client-trace-metadata/client-trace-metadata.test.ts`
- `packages/next/src/server/lib/trace/utils.ts`
- `packages/next/src/server/app-render/make-get-server-inserted-html.tsx`

## Validation

- `vp test run tests/client-trace-metadata.test.ts tests/pages-page-handler.test.ts` — 35/35
- focused `vp check` — clean
- exact Next.js v16.2.6 deploy suite, one worker, zero retries — 11/11
