### PR TITLE
fix(app-router): support instant route prefetch shells

### DIFF
--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -133,6 +133,47 @@ export function hasNamedExport(code: string, name: string): boolean {
   return hasNamedExportInProgram(program, name);
 }
 
+/**
+ * Returns whether a named export is statically known to be truthy.
+ *
+ * Object/array/function-like initializers are treated as truthy without
+ * evaluating user code. External re-exports are also treated as truthy because
+ * their runtime value cannot be determined safely.
+ */
+export function hasTruthyNamedExport(code: string, name: string): boolean {
+  const program = parseRouteModule(code);
+  if (!program) return false;
+
+  const localName = findExportedLocalNameInProgram(program, name);
+  if (localName === null) return false;
+
+  const initializer =
+    findExportedConstInitializerInProgram(program, name) ??
+    findLocalConstInitializerInProgram(program, localName);
+  if (initializer === null) return true;
+
+  const expression = unwrapStaticExpression(initializer);
+  if (expression.type !== "Literal") return true;
+  return Boolean(expression.value);
+}
+
+function findExportedLocalNameInProgram(program: Program, name: string): string | null {
+  for (const node of program.body) {
+    if (node.type !== "ExportNamedDeclaration") continue;
+    if (node.exportKind === "type") continue;
+    if (declarationHasBindingName(node.declaration, name)) return name;
+
+    for (const specifier of node.specifiers) {
+      if (specifier.exportKind === "type") continue;
+      if (moduleExportNameValue(specifier.exported) === name) {
+        return moduleExportNameValue(specifier.local);
+      }
+    }
+  }
+
+  return null;
+}
+
 function hasNamedExportInProgram(program: Program, name: string): boolean {
   for (const node of program.body) {
     if (node.type !== "ExportNamedDeclaration") continue;
@@ -178,6 +219,17 @@ function findExportedConstInitializerInProgram(program: Program, name: string): 
       if (bindingName(declarator.id) === name) {
         return declarator.init;
       }
+    }
+  }
+
+  return null;
+}
+
+function findLocalConstInitializerInProgram(program: Program, name: string): Expression | null {
+  for (const node of program.body) {
+    if (node.type !== "VariableDeclaration" || node.kind !== "const") continue;
+    for (const declarator of node.declarations) {
+      if (bindingName(declarator.id) === name) return declarator.init;
     }
   }
 

--- a/packages/vinext/src/build/report.ts
+++ b/packages/vinext/src/build/report.ts
@@ -157,6 +157,38 @@ export function hasTruthyNamedExport(code: string, name: string): boolean {
   return Boolean(expression.value);
 }
 
+export function hasNamedExportObjectStringProperty(
+  code: string,
+  name: string,
+  property: string,
+  expectedValue: string,
+): boolean {
+  const program = parseRouteModule(code);
+  if (!program) return false;
+
+  const localName = findExportedLocalNameInProgram(program, name);
+  if (localName === null) return false;
+  const initializer =
+    findExportedConstInitializerInProgram(program, name) ??
+    findLocalConstInitializerInProgram(program, localName);
+  if (initializer === null) return false;
+
+  const expression = unwrapStaticExpression(initializer);
+  if (expression.type !== "ObjectExpression") return false;
+  for (const candidate of expression.properties) {
+    if (
+      candidate.type !== "Property" ||
+      candidate.computed ||
+      propertyName(candidate.key) !== property
+    ) {
+      continue;
+    }
+    const value = unwrapStaticExpression(candidate.value);
+    return value.type === "Literal" && value.value === expectedValue;
+  }
+  return false;
+}
+
 function findExportedLocalNameInProgram(program: Program, name: string): string | null {
   for (const node of program.body) {
     if (node.type !== "ExportNamedDeclaration") continue;

--- a/packages/vinext/src/client/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/client/app-route-prefetch-policy.ts
@@ -1,0 +1,63 @@
+import type { VinextLinkPrefetchRoute } from "./vinext-next-data.js";
+import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
+import { stripBasePath } from "../utils/base-path.js";
+
+export type AppRoutePrefetchPolicy = {
+  cacheForNavigation: boolean;
+  prefetchInstantShell: boolean;
+  prefetchShellFirst: boolean;
+  prefetchSuspenseShell: boolean;
+  shouldPrefetch: boolean;
+};
+
+const routeTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
+const unavailablePolicy: AppRoutePrefetchPolicy = {
+  cacheForNavigation: false,
+  prefetchInstantShell: false,
+  prefetchShellFirst: false,
+  prefetchSuspenseShell: false,
+  shouldPrefetch: false,
+};
+
+export function resolveAppRoutePrefetchPolicy(options: {
+  basePath: string;
+  currentHref: string;
+  href: string;
+  routes: VinextLinkPrefetchRoute[] | undefined;
+}): AppRoutePrefetchPolicy {
+  if (!options.routes) return unavailablePolicy;
+
+  let url: URL;
+  let currentUrl: URL;
+  try {
+    currentUrl = new URL(options.currentHref);
+    url = new URL(options.href, currentUrl);
+  } catch {
+    return unavailablePolicy;
+  }
+  if (url.origin !== currentUrl.origin) return unavailablePolicy;
+
+  const routeHref = `${stripBasePath(url.pathname, options.basePath)}${url.search}`;
+  const match = matchRouteWithTrie(routeHref, options.routes, routeTrieCache);
+  if (!match) return unavailablePolicy;
+
+  const route = match.route;
+  const hasLoadingShell = route.canPrefetchLoadingShell;
+  if (route.hasInstant) {
+    return {
+      cacheForNavigation: true,
+      prefetchInstantShell: true,
+      prefetchSuspenseShell: true,
+      prefetchShellFirst: false,
+      shouldPrefetch: true,
+    };
+  }
+
+  return {
+    cacheForNavigation: !hasLoadingShell,
+    prefetchInstantShell: false,
+    prefetchSuspenseShell: route.isDynamic && !hasLoadingShell,
+    prefetchShellFirst: !route.isDynamic,
+    shouldPrefetch: true,
+  };
+}

--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -11,6 +11,7 @@ import { isUnknownRecord } from "../utils/record.js";
 export type VinextLinkPrefetchRoute = {
   canPrefetchLoadingShell: boolean;
   documentOnly?: boolean;
+  hasInstant?: boolean;
   isDynamic: boolean;
   patternParts: string[];
 };

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -69,6 +69,7 @@ export function toDocumentOnlyAppRoute(route: AppRoute): VinextLinkPrefetchRoute
 export function toLinkPrefetchRoute(route: AppRoute): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: route.loadingPath !== null,
+    ...(route.hasInstant ? { hasInstant: true } : {}),
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
   };

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3544,6 +3544,7 @@ export const loadServerActionClient = ${
               for (const layoutPath of route.layouts) files.add(layoutPath);
               for (const slot of route.parallelSlots) {
                 if (slot.pagePath) files.add(slot.pagePath);
+                if (slot.layoutPath) files.add(slot.layoutPath);
                 for (const layoutPath of slot.configLayoutPaths ?? []) files.add(layoutPath);
               }
             }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3573,6 +3573,7 @@ export const loadServerActionClient = ${
             routeChanged = true;
           }
           if (hasAppDir && shouldInvalidateAppRouteFile(appDir, filePath, fileMatcher)) {
+            instantConfigByFile.set(filePath, routeModuleHasInstant(filePath));
             invalidateAppRoutingModules();
             regenerateAppRouteTypes();
             routeChanged = true;
@@ -3590,6 +3591,7 @@ export const loadServerActionClient = ${
             routeChanged = true;
           }
           if (hasAppDir && shouldInvalidateAppRouteFile(appDir, filePath, fileMatcher)) {
+            instantConfigByFile.delete(filePath);
             invalidateAppRoutingModules();
             regenerateAppRouteTypes();
             routeChanged = true;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3424,9 +3424,12 @@ export const loadServerActionClient = ${
         }
 
         function invalidateHybridClientEntries() {
-          if (!hasAppDir || !hasPagesDir) return;
+          if (!hasAppDir) return;
           for (const env of Object.values(server.environments)) {
-            for (const id of [RESOLVED_CLIENT_ENTRY, RESOLVED_APP_BROWSER_ENTRY]) {
+            const ids = hasPagesDir
+              ? [RESOLVED_CLIENT_ENTRY, RESOLVED_APP_BROWSER_ENTRY]
+              : [RESOLVED_APP_BROWSER_ENTRY];
+            for (const id of ids) {
               const mod = env.moduleGraph.getModuleById(id);
               if (mod) env.moduleGraph.invalidateModule(mod);
             }
@@ -3576,6 +3579,11 @@ export const loadServerActionClient = ${
             invalidateHybridClientEntries();
             revalidateHybridRoutes();
           }
+        });
+        server.watcher.on("change", (filePath: string) => {
+          if (!hasAppDir || !shouldInvalidateAppRouteFile(appDir, filePath, fileMatcher)) return;
+          invalidateAppRoutingModules();
+          invalidateHybridClientEntries();
         });
 
         // ── Dev request origin check ─────────────────────────────────────

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -22,6 +22,7 @@ import {
   invalidateAppRouteCache,
   matchAppRoute,
 } from "./routing/app-router.js";
+import { routeModuleHasInstant } from "./routing/app-route-graph.js";
 import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import {
   buildViteResolveExtensions,
@@ -3534,6 +3535,24 @@ export const loadServerActionClient = ${
         regenerateAppRouteTypes();
         revalidateHybridRoutes();
 
+        const instantConfigByFile = new Map<string, boolean>();
+        if (hasAppDir) {
+          void appRouteGraph(appDir, nextConfig?.pageExtensions, fileMatcher).then((graph) => {
+            const files = new Set<string>();
+            for (const route of graph.routes) {
+              if (route.pagePath) files.add(route.pagePath);
+              for (const layoutPath of route.layouts) files.add(layoutPath);
+              for (const slot of route.parallelSlots) {
+                if (slot.pagePath) files.add(slot.pagePath);
+                for (const layoutPath of slot.configLayoutPaths ?? []) files.add(layoutPath);
+              }
+            }
+            for (const filePath of files) {
+              instantConfigByFile.set(filePath, routeModuleHasInstant(filePath));
+            }
+          });
+        }
+
         // Node throws on unhandled 'error' events on sockets. When a browser
         // drops the connection mid-response (common in dev: HMR triggers a
         // reload while an RSC stream is still flushing), the next res.write
@@ -3582,7 +3601,11 @@ export const loadServerActionClient = ${
         });
         server.watcher.on("change", (filePath: string) => {
           if (!hasAppDir || !shouldInvalidateAppRouteFile(appDir, filePath, fileMatcher)) return;
-          invalidateAppRoutingModules();
+          const nextHasInstant = routeModuleHasInstant(filePath);
+          const previousHasInstant = instantConfigByFile.get(filePath) ?? false;
+          instantConfigByFile.set(filePath, nextHasInstant);
+          if (nextHasInstant === previousHasInstant) return;
+          invalidateAppRouteCache();
           invalidateHybridClientEntries();
         });
 

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -196,7 +196,7 @@ export type AppRoute = {
   hasInstant?: boolean;
 };
 
-function routeModuleHasInstant(filePath: string | null): boolean {
+export function routeModuleHasInstant(filePath: string | null): boolean {
   if (filePath === null) return false;
   try {
     return hasNamedExportObjectStringProperty(

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -12,6 +12,7 @@ import { findFileWithExts, scanWithExtensions, type ValidFileMatcher } from "./f
 import { validateRoutePatterns } from "./route-validation.js";
 import { compareStrings } from "../utils/compare.js";
 import { normalizePathSeparators } from "../utils/path.js";
+import { hasTruthyNamedExport } from "../build/report.js";
 
 type InterceptingRoute = {
   /** The interception convention: "." | ".." | "../.." | "..." */
@@ -191,7 +192,34 @@ export type AppRoute = {
   rootParamNames?: string[];
   /** Pre-split pattern segments (computed once at scan time, reused per request) */
   patternParts: string[];
+  /** Whether the page or any active ancestor layout opts into unstable_instant. */
+  hasInstant?: boolean;
 };
+
+function routeModuleHasInstant(filePath: string | null): boolean {
+  if (filePath === null) return false;
+  try {
+    return hasTruthyNamedExport(fs.readFileSync(filePath, "utf8"), "unstable_instant");
+  } catch {
+    return false;
+  }
+}
+
+function routeHasInstant(options: {
+  layouts: readonly string[];
+  pagePath: string | null;
+  parallelSlots: readonly ParallelSlot[];
+}): boolean {
+  return (
+    routeModuleHasInstant(options.pagePath) ||
+    options.layouts.some((layoutPath) => routeModuleHasInstant(layoutPath)) ||
+    options.parallelSlots.some(
+      (slot) =>
+        routeModuleHasInstant(slot.pagePath) ||
+        (slot.configLayoutPaths ?? []).some((layoutPath) => routeModuleHasInstant(layoutPath)),
+    )
+  );
+}
 
 export type AppRouteSemanticIds = {
   route: string;
@@ -1100,6 +1128,7 @@ function discoverSlotSubRoutes(
       }
       return slot;
     });
+    route.hasInstant = routeHasInstant(route);
   };
 
   // Iterate real routes first so that later ghost-parent passes can detect
@@ -1300,6 +1329,11 @@ function discoverSlotSubRoutes(
         params: [...parentRoute.params, ...subParams],
         rootParamNames: parentRoute.rootParamNames,
         patternParts: [...parentRoute.patternParts, ...urlParts],
+        hasInstant: routeHasInstant({
+          layouts: parentRoute.layouts,
+          pagePath: childrenFallback,
+          parallelSlots: subSlots,
+        }),
         siblingIntercepts: [],
       };
       syntheticRoutes.push(newRoute);
@@ -1564,6 +1598,7 @@ function directoryToAppRoute(
     params,
     rootParamNames: computeRootParamNames(segments, layoutTreePositions),
     patternParts: urlSegments,
+    hasInstant: routeHasInstant({ layouts, pagePath, parallelSlots }),
     siblingIntercepts: [],
   };
 }

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -12,7 +12,7 @@ import { findFileWithExts, scanWithExtensions, type ValidFileMatcher } from "./f
 import { validateRoutePatterns } from "./route-validation.js";
 import { compareStrings } from "../utils/compare.js";
 import { normalizePathSeparators } from "../utils/path.js";
-import { hasTruthyNamedExport } from "../build/report.js";
+import { hasNamedExportObjectStringProperty } from "../build/report.js";
 
 type InterceptingRoute = {
   /** The interception convention: "." | ".." | "../.." | "..." */
@@ -199,7 +199,12 @@ export type AppRoute = {
 function routeModuleHasInstant(filePath: string | null): boolean {
   if (filePath === null) return false;
   try {
-    return hasTruthyNamedExport(fs.readFileSync(filePath, "utf8"), "unstable_instant");
+    return hasNamedExportObjectStringProperty(
+      fs.readFileSync(filePath, "utf8"),
+      "unstable_instant",
+      "prefetch",
+      "runtime",
+    );
   } catch {
     return false;
   }

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -221,6 +221,7 @@ function routeHasInstant(options: {
     options.parallelSlots.some(
       (slot) =>
         routeModuleHasInstant(slot.pagePath) ||
+        routeModuleHasInstant(slot.layoutPath ?? null) ||
         (slot.configLayoutPaths ?? []).some((layoutPath) => routeModuleHasInstant(layoutPath)),
     )
   );

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -22,6 +22,7 @@ import { notifyAppRouterTransitionStart } from "../client/instrumentation-client
 import {
   __basePath,
   appRouterInstance,
+  attachPrefetchInvalidationCallback,
   commitClientNavigationState,
   consumePrefetchResponseForNavigation,
   createCachedRscResponseSnapshot,
@@ -446,24 +447,38 @@ async function learnOptimisticRouteTemplateFromPrefetch(options: {
     createFromFetch<AppWireElements>(Promise.resolve(restoreRscResponse(options.entry.snapshot))),
   );
   const template = createOptimisticRouteTemplate({
-    allowLoadingShell: options.entry.optimisticRouteShell === true,
+    allowLoadingShell:
+      options.entry.optimisticRouteShell === true || options.entry.instantShell === true,
     basePath: __basePath,
     elements,
     href: options.entry.snapshot.url || source.rscUrl,
     interceptionContext: options.interceptionContext,
     mountedSlotsHeader: options.mountedSlotsHeader,
+    preservePageElements: options.entry.instantShell === true,
     routeManifest: options.routeManifest,
   });
   if (template === null) return false;
 
-  optimisticRouteTemplates.set(
-    getOptimisticRouteTemplateKey({
+  const templateKey = getOptimisticRouteTemplateKey({
+    concreteHrefKey: template.concreteHrefKey,
+    interceptionContext: options.interceptionContext,
+    mountedSlotsHeader: options.mountedSlotsHeader,
+    routeId: template.routeId,
+  });
+  optimisticRouteTemplates.set(templateKey, template);
+  if (options.entry.instantShell === true) {
+    const sourceKey = getOptimisticPrefetchSourceKey({
+      cacheKey: options.cacheKey,
       interceptionContext: options.interceptionContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
-      routeId: template.routeId,
-    }),
-    template,
-  );
+    });
+    attachPrefetchInvalidationCallback(options.cacheKey, () => {
+      if (optimisticRouteTemplates.get(templateKey) === template) {
+        optimisticRouteTemplates.delete(templateKey);
+        optimisticRouteTemplateSources.delete(sourceKey);
+      }
+    });
+  }
   return true;
 }
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -465,20 +465,26 @@ async function learnOptimisticRouteTemplateFromPrefetch(options: {
     mountedSlotsHeader: options.mountedSlotsHeader,
     routeId: template.routeId,
   });
-  optimisticRouteTemplates.set(templateKey, template);
+  const sourceKey = getOptimisticPrefetchSourceKey({
+    cacheKey: options.cacheKey,
+    interceptionContext: options.interceptionContext,
+    mountedSlotsHeader: options.mountedSlotsHeader,
+  });
   if (options.entry.instantShell === true) {
-    const sourceKey = getOptimisticPrefetchSourceKey({
-      cacheKey: options.cacheKey,
-      interceptionContext: options.interceptionContext,
-      mountedSlotsHeader: options.mountedSlotsHeader,
-    });
-    attachPrefetchInvalidationCallback(options.cacheKey, () => {
-      if (optimisticRouteTemplates.get(templateKey) === template) {
-        optimisticRouteTemplates.delete(templateKey);
+    const attached = attachPrefetchInvalidationCallback(
+      options.cacheKey,
+      () => {
+        if (optimisticRouteTemplates.get(templateKey) === template) {
+          optimisticRouteTemplates.delete(templateKey);
+        }
         optimisticRouteTemplateSources.delete(sourceKey);
-      }
-    });
+      },
+      options.entry,
+    );
+    if (!attached) return false;
   }
+  optimisticRouteTemplates.set(templateKey, template);
+  optimisticRouteTemplateSources.add(sourceKey);
   return true;
 }
 
@@ -507,9 +513,7 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
       mountedSlotsHeader: options.mountedSlotsHeader,
       routeManifest: options.routeManifest,
     })
-      .then((learned) => {
-        if (learned) optimisticRouteTemplateSources.add(sourceKey);
-      })
+      .then(() => {})
       .finally(() => {
         optimisticRouteTemplateLearning.delete(sourceKey);
       });

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -1,4 +1,4 @@
-import { createElement, isValidElement, Suspense } from "react";
+import { cloneElement, createElement, isValidElement, Suspense, type ReactNode } from "react";
 import { isUnknownRecord } from "../utils/record.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { buildParams, decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
@@ -26,6 +26,7 @@ type OptimisticRouteMatch = {
 };
 
 export type OptimisticRouteTemplate = {
+  concreteHrefKey: string | null;
   elements: AppElements;
   mountedSlotsHeader: string | null;
   pageElementIds: readonly string[];
@@ -44,11 +45,12 @@ const routeTrieCache = new WeakMap<RouteManifest, OptimisticRouteTrieNode>();
 const OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER = new Promise<never>(() => {});
 
 export function getOptimisticRouteTemplateKey(options: {
+  concreteHrefKey?: string | null;
   interceptionContext: string | null;
   mountedSlotsHeader: string | null;
   routeId: string;
 }): string {
-  return `${options.routeId}\0${options.interceptionContext ?? ""}\0${options.mountedSlotsHeader ?? ""}`;
+  return `${options.routeId}\0${options.interceptionContext ?? ""}\0${options.mountedSlotsHeader ?? ""}\0${options.concreteHrefKey ?? ""}`;
 }
 
 export function getOptimisticPrefetchSourceKey(options: {
@@ -198,6 +200,18 @@ function hrefToRouteParts(href: string, basePath: string): string[] | null {
   return splitPathnameForRouteMatch(appPathname === "" ? "/" : appPathname);
 }
 
+function getConcreteOptimisticHrefKey(href: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(href, "https://vinext.local");
+  } catch {
+    return null;
+  }
+  stripRscCacheBustingSearchParam(url);
+  url.pathname = stripRscSuffix(url.pathname);
+  return `${url.pathname}${url.search}`;
+}
+
 export function matchOptimisticRouteManifestRoute(options: {
   basePath: string;
   href: string;
@@ -280,8 +294,49 @@ function getPageElementIds(elements: AppElements): string[] {
     .sort();
 }
 
+function getRenderableElementIds(elements: AppElements): string[] {
+  return Object.keys(elements)
+    .filter((key) => AppElementsWire.parseElementKey(key) !== null)
+    .sort();
+}
+
 function OptimisticRouteSegment(): null {
   throw OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER;
+}
+
+const REACT_LAZY_TYPE = Symbol.for("react.lazy");
+const SUSPENDED_LAZY_STATUSES = new Set(["pending", "blocked", "halted", "rejected"]);
+
+function sanitizeInstantShellValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeInstantShellValue);
+
+  if (isUnknownRecord(value) && value.$$typeof === REACT_LAZY_TYPE) {
+    const payload = value._payload;
+    const initialize = value._init;
+    if (
+      isUnknownRecord(payload) &&
+      typeof payload.status === "string" &&
+      SUSPENDED_LAZY_STATUSES.has(payload.status)
+    ) {
+      return createElement(OptimisticRouteSegment);
+    }
+    if (typeof initialize === "function") {
+      return sanitizeInstantShellValue(Reflect.apply(initialize, undefined, [payload]));
+    }
+  }
+
+  if (!isValidElement(value) || !isUnknownRecord(value.props)) return value;
+  const children = value.props.children;
+  if (children === undefined) return value;
+  return cloneElement(value, undefined, sanitizeInstantShellValue(children) as ReactNode);
+}
+
+export function sanitizeInstantShellElements(elements: AppElements): AppElements {
+  const sanitized: Record<string, AppElementValue> = { ...elements };
+  for (const elementId of getRenderableElementIds(elements)) {
+    sanitized[elementId] = sanitizeInstantShellValue(elements[elementId]) as AppElementValue;
+  }
+  return sanitized;
 }
 
 export function createOptimisticRouteTemplate(options: {
@@ -291,6 +346,7 @@ export function createOptimisticRouteTemplate(options: {
   href: string;
   interceptionContext: string | null;
   mountedSlotsHeader: string | null;
+  preservePageElements?: boolean;
   routeManifest: RouteManifest;
 }): OptimisticRouteTemplate | null {
   const match = matchOptimisticRouteManifestRoute({
@@ -312,6 +368,7 @@ export function createOptimisticRouteTemplate(options: {
   if (!options.allowLoadingShell && !elementHasSuspenseFallback(routeElement)) return null;
   if (
     options.allowLoadingShell &&
+    options.preservePageElements !== true &&
     options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] !== "LoadingBoundary"
   ) {
     return null;
@@ -325,9 +382,14 @@ export function createOptimisticRouteTemplate(options: {
   if (pageElementIds.length === 0) return null;
 
   return {
-    elements: options.elements,
+    concreteHrefKey: options.preservePageElements
+      ? getConcreteOptimisticHrefKey(options.href)
+      : null,
+    elements: options.preservePageElements
+      ? sanitizeInstantShellElements(options.elements)
+      : options.elements,
     mountedSlotsHeader: options.mountedSlotsHeader,
-    pageElementIds,
+    pageElementIds: options.preservePageElements ? [] : pageElementIds,
     routeId: match.route.id,
   };
 }
@@ -360,13 +422,23 @@ export function resolveOptimisticNavigationPayload(options: {
   });
   if (match === null) return null;
 
-  const template = options.templates.get(
+  const exactTemplate = options.templates.get(
     getOptimisticRouteTemplateKey({
+      concreteHrefKey: getConcreteOptimisticHrefKey(options.href),
       interceptionContext: options.interceptionContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
       routeId: match.route.id,
     }),
   );
+  const template =
+    exactTemplate ??
+    options.templates.get(
+      getOptimisticRouteTemplateKey({
+        interceptionContext: options.interceptionContext,
+        mountedSlotsHeader: options.mountedSlotsHeader,
+        routeId: match.route.id,
+      }),
+    );
   if (template === undefined) return null;
   if (template.mountedSlotsHeader !== options.mountedSlotsHeader) return null;
 

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -333,9 +333,13 @@ function sanitizeInstantShellValue(value: unknown): unknown {
   }
 
   if (!isValidElement(value) || !isUnknownRecord(value.props)) return value;
-  const children = value.props.children;
-  if (children === undefined) return value;
-  return cloneElement(value, undefined, sanitizeInstantShellValue(children) as ReactNode);
+  const props = Object.fromEntries(
+    Object.entries(value.props).map(([name, propValue]) => [
+      name,
+      sanitizeInstantShellValue(propValue),
+    ]),
+  );
+  return cloneElement(value, props as Record<string, ReactNode>);
 }
 
 export function sanitizeInstantShellElements(elements: AppElements): AppElements {

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -321,7 +321,14 @@ function sanitizeInstantShellValue(value: unknown): unknown {
       return createElement(OptimisticRouteSegment);
     }
     if (typeof initialize === "function") {
-      return sanitizeInstantShellValue(Reflect.apply(initialize, undefined, [payload]));
+      try {
+        return sanitizeInstantShellValue(Reflect.apply(initialize, undefined, [payload]));
+      } catch (error) {
+        if (error === payload || (isUnknownRecord(error) && typeof error.then === "function")) {
+          return createElement(OptimisticRouteSegment);
+        }
+        throw error;
+      }
     }
   }
 

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -21,6 +21,7 @@ import {
 } from "./app-page-execution.js";
 import { probeAppPageBeforeRender } from "./app-page-probe.js";
 import {
+  cancelPrefetchSuspenseShellAbort,
   createPrefetchSuspenseShellState,
   runWithPrefetchSuspenseShellState,
   schedulePrefetchSuspenseShellAbort,
@@ -44,6 +45,7 @@ import {
   type AppPageSsrHandler,
 } from "./app-page-stream.js";
 import {
+  APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL,
   APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
@@ -700,17 +702,24 @@ export async function renderAppPageLifecycle(
   let prefetchSuspenseShellWasAborted = false;
   let rscStream = await runWithFetchDedupe(async () => {
     if (
-      options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL &&
+      (options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL ||
+        options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL) &&
       options.prerenderToReadableStream
     ) {
-      const shellState = createPrefetchSuspenseShellState(options.cleanPathname);
+      const shellState = createPrefetchSuspenseShellState(
+        options.cleanPathname,
+        options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL,
+      );
       const pendingResult = runWithPrefetchSuspenseShellState(shellState, () =>
         options.prerenderToReadableStream!(outgoingElement, {
           onError: rscErrorTracker.onRenderError,
           signal: shellState.reactAbortController.signal,
         }),
       );
-      const cancelAbort = schedulePrefetchSuspenseShellAbort(shellState);
+      const cancelAbort =
+        options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL
+          ? schedulePrefetchSuspenseShellAbort(shellState)
+          : () => cancelPrefetchSuspenseShellAbort(shellState);
       try {
         const result = await pendingResult;
         prefetchSuspenseShellWasAborted = wasPrefetchSuspenseShellAborted(shellState);
@@ -832,7 +841,8 @@ export async function renderAppPageLifecycle(
       mountedSlotsHeader: options.mountedSlotsHeader,
       params: options.navigationParams,
       partialShell:
-        options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL &&
+        (options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL ||
+          options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL) &&
         prefetchSuspenseShellWasAborted,
       policy: rscResponsePolicy,
       timing: buildResponseTiming({

--- a/packages/vinext/src/server/app-rsc-render-mode.ts
+++ b/packages/vinext/src/server/app-rsc-render-mode.ts
@@ -2,6 +2,7 @@ export type AppRscRenderMode =
   | "navigation"
   | "prefetch-loading-shell"
   | "prefetch-suspense-shell"
+  | "prefetch-instant-shell"
   | "refresh-preserve-ui"
   | "action-rerender-preserve-ui";
 
@@ -10,6 +11,8 @@ export const APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL =
   "prefetch-loading-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL =
   "prefetch-suspense-shell" satisfies AppRscRenderMode;
+export const APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL =
+  "prefetch-instant-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI =
   "refresh-preserve-ui" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI =
@@ -33,6 +36,9 @@ export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | n
   if (mode === APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL) {
     return "prefetch-suspense-shell";
   }
+  if (mode === APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL) {
+    return "prefetch-instant-shell";
+  }
 
   return shouldUsePreserveUiCacheVariant(mode) ? "preserve-ui" : null;
 }
@@ -43,6 +49,8 @@ export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
       return APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
     case APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL:
       return APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL;
+    case APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL:
+      return APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL;
     case APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI:
       return APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI;
     case APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI:

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -66,12 +66,11 @@ import { appendSearchParamsToUrl, type UrlQuery, urlQueryToSearchParams } from "
 import { addLocalePrefix, getDomainLocaleUrl, type DomainLocale } from "../utils/domain-locale.js";
 import { getI18nContext } from "./i18n-context.js";
 import type { VinextLinkPrefetchRoute, VinextNextData } from "../client/vinext-next-data.js";
+import { resolveAppRoutePrefetchPolicy } from "../client/app-route-prefetch-policy.js";
 import {
   navigatePagesRouterLinkWithFallback,
   resolvePagesRouterQueryOnlyHref,
 } from "../client/pages-router-link-navigation.js";
-import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
-import { stripBasePath } from "../utils/base-path.js";
 import {
   prefetchPagesData,
   resolvePagesDataNavigationTarget,
@@ -184,7 +183,6 @@ const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 /** trailingSlash from next.config.js, injected by the plugin at build time */
 const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
 const __prefetchInlining: boolean = process.env.__VINEXT_PREFETCH_INLINING === "true";
-const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
 function resolveHref(href: LinkProps["href"]): string {
   if (typeof href === "string") return href;
@@ -315,70 +313,12 @@ export function resolveLinkPrefetchMode(
   return "auto";
 }
 
-function toSameOriginRouteHref(href: string): string | null {
-  if (typeof window === "undefined") return null;
-
-  let url: URL;
-  try {
-    url = new URL(href, window.location.href);
-  } catch {
-    return null;
-  }
-
-  if (url.origin !== window.location.origin) return null;
-
-  return `${stripBasePath(url.pathname, __basePath)}${url.search}`;
-}
-
 function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
-function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
-  cacheForNavigation: boolean;
-  prefetchInstantShell: boolean;
-  prefetchSuspenseShell: boolean;
-  prefetchShellFirst: boolean;
-  shouldPrefetch: boolean;
-} {
-  const hasLoadingShell = route.canPrefetchLoadingShell;
-  if (route.hasInstant) {
-    return {
-      cacheForNavigation: true,
-      prefetchInstantShell: true,
-      prefetchSuspenseShell: true,
-      prefetchShellFirst: false,
-      shouldPrefetch: true,
-    };
-  }
-
-  return {
-    // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
-    // Routes with loading boundaries prefetch a shell first so navigation can
-    // commit loading.js immediately. Dynamic routes without loading-shell
-    // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
-    // keyed by the concrete RSC URL, so this cannot reuse data across params.
-    cacheForNavigation: !hasLoadingShell,
-    prefetchInstantShell: false,
-    prefetchSuspenseShell: route.isDynamic && !hasLoadingShell,
-    prefetchShellFirst: !route.isDynamic,
-    shouldPrefetch: true,
-  };
-}
-
 export function canAutoPrefetchFullAppRoute(href: string): boolean {
-  if (typeof window === "undefined") return false;
-
-  const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
-  if (!routes) return false;
-
-  const routeHref = toSameOriginRouteHref(href);
-  if (routeHref === null) return false;
-
-  const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
-  if (!match) return false;
-
-  return resolveMatchedAutoAppRoutePrefetch(match.route).cacheForNavigation;
+  return resolveAutoAppRoutePrefetch(href).cacheForNavigation;
 }
 
 export function resolveAutoAppRoutePrefetch(href: string): {
@@ -398,40 +338,12 @@ export function resolveAutoAppRoutePrefetch(href: string): {
     };
   }
 
-  const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
-  if (!routes) {
-    return {
-      cacheForNavigation: false,
-      prefetchInstantShell: false,
-      prefetchShellFirst: false,
-      prefetchSuspenseShell: false,
-      shouldPrefetch: false,
-    };
-  }
-
-  const routeHref = toSameOriginRouteHref(href);
-  if (routeHref === null) {
-    return {
-      cacheForNavigation: false,
-      prefetchInstantShell: false,
-      prefetchShellFirst: false,
-      prefetchSuspenseShell: false,
-      shouldPrefetch: false,
-    };
-  }
-
-  const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
-  if (!match) {
-    return {
-      cacheForNavigation: false,
-      prefetchInstantShell: false,
-      prefetchShellFirst: false,
-      prefetchSuspenseShell: false,
-      shouldPrefetch: false,
-    };
-  }
-
-  return resolveMatchedAutoAppRoutePrefetch(match.route);
+  return resolveAppRoutePrefetchPolicy({
+    basePath: __basePath,
+    currentHref: window.location.href,
+    href,
+    routes: window.__VINEXT_LINK_PREFETCH_ROUTES__,
+  });
 }
 
 export function resolveAppRoutePrefetch(

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -44,6 +44,7 @@ import {
 } from "../server/app-rsc-cache-busting.js";
 import {
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+  APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL,
   APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
 } from "../server/app-rsc-render-mode.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "../server/headers.js";
@@ -335,11 +336,22 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
 
 function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
   cacheForNavigation: boolean;
+  prefetchInstantShell: boolean;
   prefetchSuspenseShell: boolean;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
   const hasLoadingShell = route.canPrefetchLoadingShell;
+  if (route.hasInstant) {
+    return {
+      cacheForNavigation: true,
+      prefetchInstantShell: true,
+      prefetchSuspenseShell: true,
+      prefetchShellFirst: false,
+      shouldPrefetch: true,
+    };
+  }
+
   return {
     // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
     // Routes with loading boundaries prefetch a shell first so navigation can
@@ -347,6 +359,7 @@ function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
     // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
     // keyed by the concrete RSC URL, so this cannot reuse data across params.
     cacheForNavigation: !hasLoadingShell,
+    prefetchInstantShell: false,
     prefetchSuspenseShell: route.isDynamic && !hasLoadingShell,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
@@ -370,6 +383,7 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
+  prefetchInstantShell: boolean;
   prefetchShellFirst: boolean;
   prefetchSuspenseShell: boolean;
   shouldPrefetch: boolean;
@@ -377,6 +391,7 @@ export function resolveAutoAppRoutePrefetch(href: string): {
   if (typeof window === "undefined") {
     return {
       cacheForNavigation: false,
+      prefetchInstantShell: false,
       prefetchShellFirst: false,
       prefetchSuspenseShell: false,
       shouldPrefetch: false,
@@ -387,6 +402,7 @@ export function resolveAutoAppRoutePrefetch(href: string): {
   if (!routes) {
     return {
       cacheForNavigation: false,
+      prefetchInstantShell: false,
       prefetchShellFirst: false,
       prefetchSuspenseShell: false,
       shouldPrefetch: false,
@@ -397,6 +413,7 @@ export function resolveAutoAppRoutePrefetch(href: string): {
   if (routeHref === null) {
     return {
       cacheForNavigation: false,
+      prefetchInstantShell: false,
       prefetchShellFirst: false,
       prefetchSuspenseShell: false,
       shouldPrefetch: false,
@@ -407,6 +424,7 @@ export function resolveAutoAppRoutePrefetch(href: string): {
   if (!match) {
     return {
       cacheForNavigation: false,
+      prefetchInstantShell: false,
       prefetchShellFirst: false,
       prefetchSuspenseShell: false,
       shouldPrefetch: false,
@@ -414,6 +432,32 @@ export function resolveAutoAppRoutePrefetch(href: string): {
   }
 
   return resolveMatchedAutoAppRoutePrefetch(match.route);
+}
+
+export function resolveAppRoutePrefetch(
+  href: string,
+  mode: LinkPrefetchMode,
+): ReturnType<typeof resolveAutoAppRoutePrefetch> {
+  if (mode === "disabled") {
+    return {
+      cacheForNavigation: false,
+      prefetchInstantShell: false,
+      prefetchShellFirst: false,
+      prefetchSuspenseShell: false,
+      shouldPrefetch: false,
+    };
+  }
+
+  const matched = resolveAutoAppRoutePrefetch(href);
+  if (mode === "auto" || matched.prefetchInstantShell) return matched;
+
+  return {
+    cacheForNavigation: true,
+    prefetchInstantShell: false,
+    prefetchShellFirst: true,
+    prefetchSuspenseShell: false,
+    shouldPrefetch: true,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -450,11 +494,14 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
     return;
   }
 
-  const appAutoPrefetch =
-    hasAppNavigationRuntime() && mode === "auto" ? resolveAutoAppRoutePrefetch(prefetchHref) : null;
+  const appPrefetch = hasAppNavigationRuntime()
+    ? mode === "auto"
+      ? resolveAutoAppRoutePrefetch(prefetchHref)
+      : resolveAppRoutePrefetch(prefetchHref, mode)
+    : null;
 
   const schedule =
-    priority === "high" || appAutoPrefetch?.prefetchSuspenseShell === true
+    priority === "high" || appPrefetch?.prefetchSuspenseShell === true
       ? (fn: () => void) => {
           fn();
         }
@@ -474,15 +521,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
         if (hybridOwner === "pages" || hybridOwner === "document") {
           return;
         }
-        const autoPrefetch =
-          mode === "auto"
-            ? (appAutoPrefetch ?? resolveAutoAppRoutePrefetch(prefetchHref))
-            : {
-                cacheForNavigation: true,
-                prefetchShellFirst: true,
-                prefetchSuspenseShell: false,
-                shouldPrefetch: true,
-              };
+        const autoPrefetch = appPrefetch ?? resolveAppRoutePrefetch(prefetchHref, mode);
         if (!autoPrefetch.shouldPrefetch) return;
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
@@ -494,7 +533,9 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           renderMode: isOptimisticRouteShellPrefetch
             ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
             : autoPrefetch.prefetchSuspenseShell
-              ? APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL
+              ? autoPrefetch.prefetchInstantShell
+                ? APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL
+                : APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL
               : undefined,
         });
         if (mountedSlotsHeader) {
@@ -578,6 +619,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           undefined,
           {
             cacheForNavigation: autoPrefetch.cacheForNavigation,
+            instantShell: autoPrefetch.prefetchInstantShell,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
           },
         );

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -246,6 +246,7 @@ export type PrefetchCacheEntry = {
   mountedSlotsHeader?: string | null;
   onInvalidateCallbacks?: Set<() => void>;
   optimisticRouteShell?: boolean;
+  instantShell?: boolean;
   partialSuspenseShell?: boolean;
   outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
@@ -576,7 +577,7 @@ function addPrefetchInvalidationCallback(
   entry.onInvalidateCallbacks.add(onInvalidate);
 }
 
-function attachPrefetchInvalidationCallback(
+export function attachPrefetchInvalidationCallback(
   cacheKey: string,
   onInvalidate: (() => void) | undefined,
 ): void {
@@ -730,7 +731,11 @@ export function prefetchRscResponse(
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
   options?: PrefetchOptions,
-  behavior: { cacheForNavigation?: boolean; optimisticRouteShell?: boolean } = {},
+  behavior: {
+    cacheForNavigation?: boolean;
+    instantShell?: boolean;
+    optimisticRouteShell?: boolean;
+  } = {},
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
@@ -739,6 +744,7 @@ export function prefetchRscResponse(
 
   const entry: PrefetchCacheEntry = {
     cacheForNavigation: behavior.cacheForNavigation ?? true,
+    instantShell: behavior.instantShell === true,
     mountedSlotsHeader,
     optimisticRouteShell: behavior.optimisticRouteShell === true,
     outcome: "pending",

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -18,10 +18,7 @@ import {
 } from "../client/navigation-runtime.js";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import { resolveAppRoutePrefetchPolicy } from "../client/app-route-prefetch-policy.js";
-import {
-  APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL,
-  APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
-} from "../server/app-rsc-render-mode.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL } from "../server/app-rsc-render-mode.js";
 import {
   clearAppNavigationFailureTarget,
   stageAppNavigationFailureTarget,
@@ -1931,16 +1928,11 @@ const _appRouter: AppRouterInstance = {
         href: fullHref,
         routes: window.__VINEXT_LINK_PREFETCH_ROUTES__,
       });
-      const cacheForNavigation = prefetchPolicy.shouldPrefetch
-        ? prefetchPolicy.cacheForNavigation
-        : true;
       const headers = createRscRequestHeaders({
         interceptionContext,
         renderMode: prefetchPolicy.prefetchInstantShell
           ? APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL
-          : prefetchPolicy.prefetchSuspenseShell
-            ? APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL
-            : undefined,
+          : undefined,
       });
       if (mountedSlotsHeader) {
         headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
@@ -1964,7 +1956,7 @@ const _appRouter: AppRouterInstance = {
         mountedSlotsHeader,
         options,
         {
-          cacheForNavigation,
+          cacheForNavigation: true,
           instantShell: prefetchPolicy.prefetchInstantShell,
         },
       );

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -580,14 +580,16 @@ function addPrefetchInvalidationCallback(
 export function attachPrefetchInvalidationCallback(
   cacheKey: string,
   onInvalidate: (() => void) | undefined,
-): void {
-  if (onInvalidate === undefined) return;
+  expectedEntry?: PrefetchCacheEntry,
+): boolean {
+  if (onInvalidate === undefined) return false;
   const entry = getPrefetchCache().get(cacheKey);
-  if (!entry) return;
+  if (!entry || (expectedEntry !== undefined && entry !== expectedEntry)) return false;
   addPrefetchInvalidationCallback(entry, onInvalidate);
   if (entry.outcome === "cache-seeded") {
     schedulePrefetchInvalidation(cacheKey, entry);
   }
+  return true;
 }
 
 export function invalidatePrefetchCache(): void {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -17,6 +17,11 @@ import {
   type NavigationRuntimeVisibleCommitMode,
 } from "../client/navigation-runtime.js";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
+import { resolveAppRoutePrefetchPolicy } from "../client/app-route-prefetch-policy.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL,
+  APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL,
+} from "../server/app-rsc-render-mode.js";
 import {
   clearAppNavigationFailureTarget,
   stageAppNavigationFailureTarget,
@@ -1920,7 +1925,23 @@ const _appRouter: AppRouterInstance = {
       const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
       const interceptionContext = getPrefetchInterceptionContext(fullHref);
       const mountedSlotsHeader = getMountedSlotsHeader();
-      const headers = createRscRequestHeaders({ interceptionContext });
+      const prefetchPolicy = resolveAppRoutePrefetchPolicy({
+        basePath: __basePath,
+        currentHref: window.location.href,
+        href: fullHref,
+        routes: window.__VINEXT_LINK_PREFETCH_ROUTES__,
+      });
+      const cacheForNavigation = prefetchPolicy.shouldPrefetch
+        ? prefetchPolicy.cacheForNavigation
+        : true;
+      const headers = createRscRequestHeaders({
+        interceptionContext,
+        renderMode: prefetchPolicy.prefetchInstantShell
+          ? APP_RSC_RENDER_MODE_PREFETCH_INSTANT_SHELL
+          : prefetchPolicy.prefetchSuspenseShell
+            ? APP_RSC_RENDER_MODE_PREFETCH_SUSPENSE_SHELL
+            : undefined,
+      });
       if (mountedSlotsHeader) {
         headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
       }
@@ -1942,6 +1963,10 @@ const _appRouter: AppRouterInstance = {
         interceptionContext,
         mountedSlotsHeader,
         options,
+        {
+          cacheForNavigation,
+          instantShell: prefetchPolicy.prefetchInstantShell,
+        },
       );
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);

--- a/packages/vinext/src/shims/prefetch-suspense-shell.ts
+++ b/packages/vinext/src/shims/prefetch-suspense-shell.ts
@@ -5,6 +5,8 @@ type PrefetchSuspenseShellState = {
   dynamicAbortController: AbortController;
   reactAbortController: AbortController;
   aborted: boolean;
+  instant: boolean;
+  cancelAbort: (() => void) | null;
   route: string;
 };
 
@@ -12,11 +14,16 @@ const prefetchSuspenseShellAls = getOrCreateAls<PrefetchSuspenseShellState>(
   "vinext.prefetchSuspenseShell.als",
 );
 
-export function createPrefetchSuspenseShellState(route: string): PrefetchSuspenseShellState {
+export function createPrefetchSuspenseShellState(
+  route: string,
+  instant = false,
+): PrefetchSuspenseShellState {
   return {
     dynamicAbortController: new AbortController(),
     reactAbortController: new AbortController(),
     aborted: false,
+    instant,
+    cancelAbort: null,
     route,
   };
 }
@@ -29,28 +36,37 @@ export function runWithPrefetchSuspenseShellState<T>(
 }
 
 export function schedulePrefetchSuspenseShellAbort(state: PrefetchSuspenseShellState): () => void {
+  if (state.cancelAbort) return state.cancelAbort;
   let innerTimer: ReturnType<typeof setTimeout> | undefined;
   const outerTimer = setTimeout(() => {
     innerTimer = setTimeout(() => {
       state.aborted = true;
       state.reactAbortController.abort();
-      state.dynamicAbortController.abort();
+      if (!state.instant) state.dynamicAbortController.abort();
     }, 0);
   }, 0);
 
-  return () => {
+  state.cancelAbort = () => {
     clearTimeout(outerTimer);
     if (innerTimer !== undefined) clearTimeout(innerTimer);
+    state.cancelAbort = null;
   };
+  return state.cancelAbort;
 }
 
 export function wasPrefetchSuspenseShellAborted(state: PrefetchSuspenseShellState): boolean {
   return state.aborted;
 }
 
+export function cancelPrefetchSuspenseShellAbort(state: PrefetchSuspenseShellState): void {
+  state.cancelAbort?.();
+}
+
 export function suspendPrefetchSuspenseShell(expression: string): Promise<never> | null {
   const state = prefetchSuspenseShellAls.getStore();
   if (!state) return null;
+  if (state.instant && expression !== "connection()") return null;
+  if (state.instant) schedulePrefetchSuspenseShellAbort(state);
 
   return makeHangingPromise(state.dynamicAbortController.signal, state.route, expression);
 }

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -417,6 +417,30 @@ describe("App Router optimistic routing", () => {
     },
   );
 
+  it.each(["resolved_model", "resolved_module"])(
+    "suspends %s lazy children when initialization is still blocked",
+    (status) => {
+      const pending = new Promise<never>(() => {});
+      const suspendedLazy = {
+        $$typeof: Symbol.for("react.lazy"),
+        _init() {
+          throw pending;
+        },
+        _payload: { status },
+      };
+      const pageId = AppElementsWire.encodePageId("/instant", null);
+      const elements = {
+        [pageId]: createElement(Suspense, { fallback: "dynamic" }, suspendedLazy as never),
+      } as AppElements;
+
+      const sanitized = sanitizeInstantShellElements(elements);
+
+      expect(sanitized[pageId]).toMatchObject({
+        props: { children: { type: expect.any(Function) } },
+      });
+    },
+  );
+
   it.each([
     ["layout", AppElementsWire.encodeLayoutId("/")],
     ["parallel slot", AppElementsWire.encodeSlotId("modal", "/")],

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -12,6 +12,7 @@ import {
   getOptimisticRouteTemplateKey,
   matchOptimisticRouteManifestRoute,
   resolveOptimisticNavigationPayload,
+  sanitizeInstantShellElements,
   type OptimisticRouteTemplate,
 } from "../packages/vinext/src/server/app-optimistic-routing.js";
 import type {
@@ -251,6 +252,7 @@ describe("App Router optimistic routing", () => {
     });
 
     expect(template).toMatchObject<Partial<OptimisticRouteTemplate>>({
+      concreteHrefKey: null,
       routeId: "route:/blog/:slug",
     });
     if (template === null) {
@@ -281,6 +283,171 @@ describe("App Router optimistic routing", () => {
 
     expect(navigationPayload?.params).toEqual({ slug: "post-2" });
     expect(navigationPayload?.elements[pageId]).not.toBe(elements[pageId]);
+  });
+
+  it("accepts instant shells without a loading-boundary marker", () => {
+    const routeManifest = blogManifest();
+    const elements = createBlogElements();
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc?_rsc=abc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      preservePageElements: true,
+      routeManifest,
+    });
+
+    expect(template).toMatchObject<Partial<OptimisticRouteTemplate>>({
+      concreteHrefKey: "/blog/post-1",
+      pageElementIds: [],
+      routeId: "route:/blog/:slug",
+    });
+  });
+
+  it("does not reuse preserved instant content across dynamic params", () => {
+    const routeManifest = blogManifest();
+    const elements = createBlogElements();
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc?_rsc=abc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      preservePageElements: true,
+      routeManifest,
+    });
+    if (template === null) throw new Error("Expected instant template");
+
+    const templates = new Map([
+      [
+        getOptimisticRouteTemplateKey({
+          concreteHrefKey: template.concreteHrefKey,
+          interceptionContext: null,
+          mountedSlotsHeader: null,
+          routeId: template.routeId,
+        }),
+        template,
+      ],
+    ]);
+
+    expect(
+      resolveOptimisticNavigationPayload({
+        basePath: "",
+        href: "/blog/post-1",
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+        templates,
+      }),
+    ).not.toBeNull();
+    expect(
+      resolveOptimisticNavigationPayload({
+        basePath: "",
+        href: "/blog/post-2",
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+        templates,
+      }),
+    ).toBeNull();
+  });
+
+  it("preserves fulfilled instant content and suspends rejected lazy children", () => {
+    const rejectedLazy = {
+      $$typeof: Symbol.for("react.lazy"),
+      _init() {
+        throw new Error("should not initialize rejected lazy child");
+      },
+      _payload: { status: "rejected" },
+    };
+    const resolvedLazy = {
+      $$typeof: Symbol.for("react.lazy"),
+      _init() {
+        return createElement("div", { id: "cached-content" }, "Cached content");
+      },
+      _payload: { status: "resolved_model" },
+    };
+    const pageId = AppElementsWire.encodePageId("/instant", null);
+    const elements = {
+      [pageId]: createElement(
+        "main",
+        null,
+        createElement(Suspense, { fallback: "cached" }, resolvedLazy as never),
+        createElement(Suspense, { fallback: "dynamic" }, rejectedLazy as never),
+      ),
+    } as AppElements;
+
+    const sanitized = sanitizeInstantShellElements(elements);
+    const page = sanitized[pageId];
+    expect(page).not.toBe(elements[pageId]);
+    expect(page).toMatchObject({
+      props: {
+        children: [
+          { props: { children: { props: { children: "Cached content", id: "cached-content" } } } },
+          { props: { children: { type: expect.any(Function) } } },
+        ],
+      },
+    });
+  });
+
+  it.each(["pending", "blocked", "halted"])(
+    "suspends %s instant lazy children without initializing them",
+    (status) => {
+      const payload = { status };
+      const suspendedLazy = {
+        $$typeof: Symbol.for("react.lazy"),
+        _init(receivedPayload: unknown) {
+          throw receivedPayload;
+        },
+        _payload: payload,
+      };
+      const pageId = AppElementsWire.encodePageId("/instant", null);
+      const elements = {
+        [pageId]: createElement(Suspense, { fallback: "dynamic" }, suspendedLazy as never),
+      } as AppElements;
+
+      const sanitized = sanitizeInstantShellElements(elements);
+
+      expect(sanitized[pageId]).toMatchObject({
+        props: { children: { type: expect.any(Function) } },
+      });
+    },
+  );
+
+  it.each([
+    ["layout", AppElementsWire.encodeLayoutId("/")],
+    ["parallel slot", AppElementsWire.encodeSlotId("modal", "/")],
+  ])("sanitizes suspended instant content in %s elements", (_kind, elementId) => {
+    const payload = { status: "pending" };
+    const suspendedLazy = {
+      $$typeof: Symbol.for("react.lazy"),
+      _init(receivedPayload: unknown) {
+        throw receivedPayload;
+      },
+      _payload: payload,
+    };
+    const routeId = AppElementsWire.encodeRouteId("/instant", null);
+    const pageId = AppElementsWire.encodePageId("/instant", null);
+    const elements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: [AppElementsWire.encodeLayoutId("/")],
+        rootLayoutTreePath: "/",
+        routeId,
+      }),
+      [elementId]: createElement(Suspense, { fallback: "dynamic" }, suspendedLazy as never),
+      [pageId]: createElement("main", null, "Page"),
+      [routeId]: createElement("main", null, "Route"),
+    } as AppElements;
+
+    const sanitized = sanitizeInstantShellElements(elements);
+
+    expect(sanitized[elementId]).toMatchObject({
+      props: { children: { type: expect.any(Function) } },
+    });
   });
 
   it("includes active parallel slot params in optimistic navigation payloads", () => {

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createElement, Suspense } from "react";
+import { createElement, Suspense, type ReactNode } from "react";
 import {
   AppElementsWire,
   APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
@@ -440,6 +440,30 @@ describe("App Router optimistic routing", () => {
       });
     },
   );
+
+  it("sanitizes suspended instant content in named element props", () => {
+    const payload = { status: "pending" };
+    const suspendedLazy = {
+      $$typeof: Symbol.for("react.lazy"),
+      _init(receivedPayload: unknown) {
+        throw receivedPayload;
+      },
+      _payload: payload,
+    };
+    const ClientShell = (_props: { content: ReactNode }) => null;
+    const pageId = AppElementsWire.encodePageId("/instant", null);
+    const elements = {
+      [pageId]: createElement(ClientShell, {
+        content: createElement(Suspense, { fallback: "dynamic" }, suspendedLazy as never),
+      }),
+    } as AppElements;
+
+    const sanitized = sanitizeInstantShellElements(elements);
+
+    expect(sanitized[pageId]).toMatchObject({
+      props: { content: { props: { children: { type: expect.any(Function) } } } },
+    });
+  });
 
   it.each([
     ["layout", AppElementsWire.encodeLayoutId("/")],

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -297,6 +297,23 @@ describe("App Router route graph builder", () => {
     });
   });
 
+  it("detects unstable_instant on parallel-slot root layouts", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "dashboard/page.tsx", EMPTY_PAGE);
+      await writeAppFile(
+        appDir,
+        "dashboard/@team/layout.tsx",
+        `export const unstable_instant = { prefetch: "runtime" };\n${EMPTY_LAYOUT}`,
+      );
+      await writeAppFile(appDir, "dashboard/@team/default.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+
+      expect(findRoute(graph.routes, "/dashboard").hasInstant).toBe(true);
+    });
+  });
+
   // Regression for https://github.com/cloudflare/vinext/issues/1339
   // Ported from Next.js: test/e2e/app-dir/parallel-routes-layouts/
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/parallel-routes-layouts/parallel-routes-layouts.test.ts

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -119,12 +119,18 @@ describe("App Router route graph builder", () => {
         "export const unstable_instant = { prefetch: 'runtime' }; export default function Layout() {}",
       );
       await writeAppFile(appDir, "layout-instant/page.tsx", EMPTY_PAGE);
+      await writeAppFile(
+        appDir,
+        "static-instant/page.tsx",
+        "export const unstable_instant = { prefetch: 'static' }; export default function Page() {}",
+      );
       await writeAppFile(appDir, "plain/page.tsx", EMPTY_PAGE);
 
       const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
 
       expect(findRoute(graph.routes, "/page-instant").hasInstant).toBe(true);
       expect(findRoute(graph.routes, "/layout-instant").hasInstant).toBe(true);
+      expect(findRoute(graph.routes, "/static-instant").hasInstant).toBe(false);
       expect(findRoute(graph.routes, "/plain").hasInstant).toBe(false);
     });
   });

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -101,6 +101,34 @@ async function createSemanticIdsFixture(appDir: string): Promise<void> {
 }
 
 describe("App Router route graph builder", () => {
+  it("propagates unstable_instant from pages and ancestor layouts", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(
+        appDir,
+        "layout.tsx",
+        "export const unstable_instant = false; export default function Layout() {}",
+      );
+      await writeAppFile(
+        appDir,
+        "page-instant/page.tsx",
+        "export const unstable_instant = { prefetch: 'runtime' }; export default function Page() {}",
+      );
+      await writeAppFile(
+        appDir,
+        "layout-instant/layout.tsx",
+        "export const unstable_instant = { prefetch: 'runtime' }; export default function Layout() {}",
+      );
+      await writeAppFile(appDir, "layout-instant/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "plain/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+
+      expect(findRoute(graph.routes, "/page-instant").hasInstant).toBe(true);
+      expect(findRoute(graph.routes, "/layout-instant").hasInstant).toBe(true);
+      expect(findRoute(graph.routes, "/plain").hasInstant).toBe(false);
+    });
+  });
+
   it("materializes pages, handlers, layouts, and inherited parallel slots", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
@@ -220,6 +248,46 @@ describe("App Router route graph builder", () => {
         pagePath: path.join(appDir, "dashboard/@team/members/page.tsx"),
         routeSegments: ["members"],
       });
+    });
+  });
+
+  it("propagates ancestor unstable_instant to synthetic parallel-slot routes", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(
+        appDir,
+        "dashboard/layout.tsx",
+        `export const unstable_instant = { prefetch: "runtime" };\n${EMPTY_LAYOUT}`,
+      );
+      await writeAppFile(appDir, "dashboard/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/@team/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/@team/members/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+
+      expect(findRoute(graph.routes, "/dashboard").hasInstant).toBe(true);
+      expect(findRoute(graph.routes, "/dashboard/members").hasInstant).toBe(true);
+    });
+  });
+
+  it("detects unstable_instant on active parallel-slot pages and layouts", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, "dashboard/page.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/default.tsx", EMPTY_PAGE);
+      await writeAppFile(appDir, "dashboard/@team/page.tsx", EMPTY_PAGE);
+      await writeAppFile(
+        appDir,
+        "dashboard/@team/members/layout.tsx",
+        `export const unstable_instant = { prefetch: "runtime" };\n${EMPTY_LAYOUT}`,
+      );
+      await writeAppFile(appDir, "dashboard/@team/members/page.tsx", EMPTY_PAGE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+
+      expect(findRoute(graph.routes, "/dashboard").hasInstant).toBe(false);
+      expect(findRoute(graph.routes, "/dashboard/members").hasInstant).toBe(true);
     });
   });
 

--- a/tests/build-report.test.ts
+++ b/tests/build-report.test.ts
@@ -11,6 +11,7 @@ import os from "node:os";
 import fs from "node:fs/promises";
 import {
   hasNamedExport,
+  hasTruthyNamedExport,
   extractExportConstString,
   extractExportConstNumber,
   extractGetStaticPropsRevalidate,
@@ -87,6 +88,80 @@ describe("hasNamedExport", () => {
 export function getServerSideProps() {}
 */`;
     expect(hasNamedExport(code, "getServerSideProps")).toBe(false);
+  });
+});
+
+describe("hasTruthyNamedExport", () => {
+  it("recognizes object-valued instant configuration", () => {
+    expect(
+      hasTruthyNamedExport(
+        "export const unstable_instant = { prefetch: 'runtime', samples: [] };",
+        "unstable_instant",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat explicit false as an instant opt-in", () => {
+    expect(hasTruthyNamedExport("export const unstable_instant = false;", "unstable_instant")).toBe(
+      false,
+    );
+  });
+
+  it("does not treat shorthand-exported false as an instant opt-in", () => {
+    expect(
+      hasTruthyNamedExport(
+        "const unstable_instant = false; export { unstable_instant };",
+        "unstable_instant",
+      ),
+    ).toBe(false);
+  });
+
+  it("recognizes an aliased local instant export", () => {
+    expect(
+      hasTruthyNamedExport(
+        "const config = { prefetch: 'runtime' }; export { config as unstable_instant };",
+        "unstable_instant",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores an instant-named local exported under another name", () => {
+    expect(
+      hasTruthyNamedExport(
+        "const unstable_instant = { prefetch: 'runtime' }; export { unstable_instant as config };",
+        "unstable_instant",
+      ),
+    ).toBe(false);
+  });
+
+  it("conservatively recognizes an aliased external re-export", () => {
+    expect(
+      hasTruthyNamedExport(
+        "export { config as unstable_instant } from './config';",
+        "unstable_instant",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores a type-only instant re-export", () => {
+    expect(
+      hasTruthyNamedExport("export type { unstable_instant } from './types';", "unstable_instant"),
+    ).toBe(false);
+  });
+
+  it("ignores an aliased type-only instant export", () => {
+    expect(
+      hasTruthyNamedExport(
+        "export { type Config as unstable_instant } from './types';",
+        "unstable_instant",
+      ),
+    ).toBe(false);
+  });
+
+  it("conservatively recognizes re-exported instant configuration", () => {
+    expect(
+      hasTruthyNamedExport("export { unstable_instant } from './config';", "unstable_instant"),
+    ).toBe(true);
   });
 });
 

--- a/tests/build-report.test.ts
+++ b/tests/build-report.test.ts
@@ -11,6 +11,7 @@ import os from "node:os";
 import fs from "node:fs/promises";
 import {
   hasNamedExport,
+  hasNamedExportObjectStringProperty,
   hasTruthyNamedExport,
   extractExportConstString,
   extractExportConstNumber,
@@ -162,6 +163,52 @@ describe("hasTruthyNamedExport", () => {
     expect(
       hasTruthyNamedExport("export { unstable_instant } from './config';", "unstable_instant"),
     ).toBe(true);
+  });
+});
+
+describe("hasNamedExportObjectStringProperty", () => {
+  it("matches runtime instant configuration", () => {
+    expect(
+      hasNamedExportObjectStringProperty(
+        "export const unstable_instant = { prefetch: 'runtime', samples: [] };",
+        "unstable_instant",
+        "prefetch",
+        "runtime",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match static instant configuration", () => {
+    expect(
+      hasNamedExportObjectStringProperty(
+        "export const unstable_instant = { prefetch: 'static', samples: [] };",
+        "unstable_instant",
+        "prefetch",
+        "runtime",
+      ),
+    ).toBe(false);
+  });
+
+  it("matches aliased local configuration", () => {
+    expect(
+      hasNamedExportObjectStringProperty(
+        "const config = { prefetch: 'runtime' }; export { config as unstable_instant };",
+        "unstable_instant",
+        "prefetch",
+        "runtime",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not guess external re-export values", () => {
+    expect(
+      hasNamedExportObjectStringProperty(
+        "export { config as unstable_instant } from './config';",
+        "unstable_instant",
+        "prefetch",
+        "runtime",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/suspense-prefetch.browser.spec.ts
@@ -48,7 +48,11 @@ async function writeFixture(fixtureRoot: string): Promise<void> {
   const appDir = path.join(fixtureRoot, "app");
   const sourceDir = path.join(appDir, "mismatching-prefetch");
   const dynamicDir = path.join(sourceDir, "dynamic-page", "[param]");
+  const instantPageDir = path.join(appDir, "instant-page");
+  const instantLayoutDir = path.join(appDir, "instant-layout");
   await fs.mkdir(dynamicDir, { recursive: true });
+  await fs.mkdir(instantPageDir, { recursive: true });
+  await fs.mkdir(instantLayoutDir, { recursive: true });
   await linkFixtureNodeModules(fixtureRoot);
 
   await fs.writeFile(
@@ -82,6 +86,45 @@ export default function Page() {
 }
 `,
   );
+  await fs.writeFile(
+    path.join(appDir, "page.tsx"),
+    `"use client";
+import Link from "next/link";
+import { useState } from "react";
+function InstantLink({ id, href, children }: { id: string; href: string; children: React.ReactNode }) {
+  const [visible, setVisible] = useState(false);
+  return <div>
+    <button id={"reveal-" + id} onClick={() => setVisible(true)}>Reveal</button>
+    {visible ? <Link id={id} href={href} prefetch={true}>{children}</Link> : null}
+  </div>;
+}
+export default function Page() { return <main>
+  <InstantLink id="instant-page-link" href="/instant-page">Page instant</InstantLink>
+  <InstantLink id="instant-layout-link" href="/instant-layout">Layout instant</InstantLink>
+</main>; }
+`,
+  );
+  const instantPage = `import { Suspense } from "react";
+import { cookies } from "next/headers";
+import { connection } from "next/server";
+async function Cached() { const value = (await cookies()).get("test")?.value ?? "default"; return <div id="cached-content">Cached content: {value}</div>; }
+async function Dynamic() { await connection(); return <div id="dynamic-content">Dynamic content</div>; }
+export default function Page() { return <>
+  <Suspense fallback={<div>Loading cached...</div>}><Cached /></Suspense>
+  <Suspense fallback={<div>Loading dynamic...</div>}><Dynamic /></Suspense>
+</>; }
+`;
+  await fs.writeFile(
+    path.join(instantPageDir, "page.tsx"),
+    `export const unstable_instant = { prefetch: "runtime", samples: [] };\n${instantPage}`,
+  );
+  await fs.writeFile(
+    path.join(instantLayoutDir, "layout.tsx"),
+    `export const unstable_instant = { prefetch: "runtime", samples: [] };
+export default function Layout({ children }: { children: React.ReactNode }) { return <>{children}</>; }
+`,
+  );
+  await fs.writeFile(path.join(instantLayoutDir, "page.tsx"), instantPage);
   await fs.writeFile(
     path.join(dynamicDir, "page.tsx"),
     `import { Suspense } from "react";
@@ -215,3 +258,33 @@ test("prefetches a fallback from a user Suspense boundary", async ({ page }) => 
     await fs.rm(app.fixtureRoot, { recursive: true, force: true });
   }
 });
+
+for (const [linkId, pathname] of [
+  ["instant-page-link", "/instant-page"],
+  ["instant-layout-link", "/instant-layout"],
+] as const) {
+  test(`prefetch={true} respects unstable_instant on ${pathname}`, async ({ page }) => {
+    const app = await buildAndServeFixture();
+    try {
+      await page.goto(app.baseUrl);
+      await waitForAppRouterHydration(page);
+      const responsePromise = page.waitForResponse((response) => {
+        const request = response.request();
+        return (
+          new URL(response.url()).pathname === pathname &&
+          request.headers()["x-vinext-rsc-render-mode"] === "prefetch-instant-shell"
+        );
+      });
+      await page.locator(`#reveal-${linkId}`).click();
+      const response = await responsePromise;
+      expect(response.ok()).toBe(true);
+      const payload = await response.text();
+      expect(payload).toContain("Cached content");
+      expect(payload).toContain("Loading dynamic...");
+      expect(payload).not.toContain("Dynamic content");
+    } finally {
+      await closeServer(app.server);
+      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+    }
+  });
+}

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -183,6 +183,7 @@ describe("App Router generated manifest construction", () => {
         templateTreePositions: [],
         layoutTreePositions: [0],
         isDynamic: true,
+        hasInstant: true,
         params: ["slug"],
         siblingIntercepts: [],
       },
@@ -223,7 +224,7 @@ describe("App Router generated manifest construction", () => {
       '{"canPrefetchLoadingShell":false,"patternParts":["blog",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
+      '{"canPrefetchLoadingShell":true,"hasInstant":true,"patternParts":["docs",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["modal-host"],"isDynamic":false}',

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -17,6 +17,7 @@ import ReactDOMServer from "react-dom/server";
 // Link is a "use client" component but renderToString still works for SSR output.
 import Link, {
   canAutoPrefetchFullAppRoute,
+  resolveAppRoutePrefetch,
   resolveAutoAppRoutePrefetch,
   resolveLinkPrefetchMode,
   useLinkStatus,
@@ -286,6 +287,12 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: true, patternParts: ["docs", ":slug+"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
+        {
+          canPrefetchLoadingShell: false,
+          hasInstant: true,
+          patternParts: ["instant"],
+          isDynamic: false,
+        },
       ],
     };
 
@@ -318,32 +325,63 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
         { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
+        {
+          canPrefetchLoadingShell: false,
+          hasInstant: true,
+          patternParts: ["instant"],
+          isDynamic: false,
+        },
       ],
     };
 
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        prefetchInstantShell: false,
         prefetchShellFirst: true,
         prefetchSuspenseShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        prefetchInstantShell: false,
         prefetchShellFirst: false,
         prefetchSuspenseShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
+        prefetchInstantShell: false,
         prefetchShellFirst: true,
         prefetchSuspenseShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        prefetchInstantShell: false,
         prefetchShellFirst: false,
         prefetchSuspenseShell: true,
+        shouldPrefetch: true,
+      });
+      expect(resolveAppRoutePrefetch("/instant", "full")).toEqual({
+        cacheForNavigation: true,
+        prefetchInstantShell: true,
+        prefetchShellFirst: false,
+        prefetchSuspenseShell: true,
+        shouldPrefetch: true,
+      });
+      expect(resolveAppRoutePrefetch("/products/1", "full")).toEqual({
+        cacheForNavigation: true,
+        prefetchInstantShell: false,
+        prefetchShellFirst: true,
+        prefetchSuspenseShell: false,
+        shouldPrefetch: true,
+      });
+      expect(resolveAppRoutePrefetch("/about", "full")).toEqual({
+        cacheForNavigation: true,
+        prefetchInstantShell: false,
+        prefetchShellFirst: true,
+        prefetchSuspenseShell: false,
         shouldPrefetch: true,
       });
       // Ported from Next.js:
@@ -351,12 +389,14 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        prefetchInstantShell: false,
         prefetchShellFirst: false,
         prefetchSuspenseShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
+        prefetchInstantShell: false,
         prefetchShellFirst: false,
         prefetchSuspenseShell: false,
         shouldPrefetch: false,

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -576,6 +576,35 @@ describe("prefetch cache eviction", () => {
     });
   });
 
+  it("keeps ordinary router.prefetch responses available for navigation", async () => {
+    const fetch = vi.fn(() =>
+      Promise.resolve(new Response("flight", { headers: { "content-type": "text/x-component" } })),
+    );
+    (globalThis as any).fetch = fetch;
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: true,
+        isDynamic: false,
+        patternParts: ["dashboard"],
+      },
+    ];
+    (globalThis as any).window[Symbol.for("vinext.navigationRuntime")] = {
+      bootstrap: { routeManifest: null, rsc: undefined },
+      functions: { navigate: vi.fn() },
+    };
+
+    appRouterInstance.prefetch("/dashboard");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);
+    await waitForPrefetchSetup(() =>
+      [...getPrefetchCache().values()].some((entry) => entry.outcome === "cache-seeded"),
+    );
+
+    expect([...getPrefetchCache().values()][0]).toMatchObject({
+      cacheForNavigation: true,
+      instantShell: false,
+    });
+  });
+
   it("awaits an in-flight prefetch instead of missing the navigation cache", async () => {
     const rscUrl = "/dashboard.rsc";
     const deferred = createDeferredResponse();

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -209,10 +209,33 @@ describe("prefetch cache eviction", () => {
     );
     await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
 
-    attachPrefetchInvalidationCallback(rscUrl, onInvalidate);
+    expect(attachPrefetchInvalidationCallback(rscUrl, onInvalidate)).toBe(true);
     invalidatePrefetchCache();
 
     expect(onInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attach invalidation ownership to a replaced prefetch entry", async () => {
+    const rscUrl = "/instant-shell.rsc";
+    const onInvalidate = vi.fn();
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(new Response("first", { headers: { "content-type": "text/x-component" } })),
+    );
+    await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
+    const firstEntry = getPrefetchCache().get(rscUrl);
+    if (firstEntry === undefined) throw new Error("Expected first prefetch entry");
+
+    invalidatePrefetchCache();
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(new Response("second", { headers: { "content-type": "text/x-component" } })),
+    );
+    await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
+
+    expect(attachPrefetchInvalidationCallback(rscUrl, onInvalidate, firstEntry)).toBe(false);
+    invalidatePrefetchCache();
+    expect(onInvalidate).not.toHaveBeenCalled();
   });
 
   it("reuses a prefetched response only when mounted-slot context matches", () => {

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -535,6 +535,47 @@ describe("prefetch cache eviction", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  it("uses instant-shell policy for router.prefetch on runtime instant routes", async () => {
+    let fetchedHeaders: Headers | undefined;
+    const fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      fetchedHeaders = new Headers(init?.headers);
+      return Promise.resolve(
+        new Response("instant shell", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1",
+          },
+        }),
+      );
+    });
+    (globalThis as any).fetch = fetch;
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: false,
+        hasInstant: true,
+        isDynamic: false,
+        patternParts: ["instant"],
+      },
+    ];
+    (globalThis as any).window[Symbol.for("vinext.navigationRuntime")] = {
+      bootstrap: { routeManifest: null, rsc: undefined },
+      functions: { navigate: vi.fn() },
+    };
+
+    appRouterInstance.prefetch("/instant");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length > 0);
+
+    expect(fetchedHeaders?.get("x-vinext-rsc-render-mode")).toBe("prefetch-instant-shell");
+    await waitForPrefetchSetup(() =>
+      [...getPrefetchCache().values()].some((entry) => entry.outcome === "cache-seeded"),
+    );
+    expect([...getPrefetchCache().values()][0]).toMatchObject({
+      cacheForNavigation: false,
+      instantShell: true,
+      partialSuspenseShell: true,
+    });
+  });
+
   it("awaits an in-flight prefetch instead of missing the navigation cache", async () => {
     const rscUrl = "/dashboard.rsc";
     const deferred = createDeferredResponse();

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -29,6 +29,7 @@ let PREFETCH_CACHE_TTL: Navigation["PREFETCH_CACHE_TTL"];
 let snapshotRscResponse: Navigation["snapshotRscResponse"];
 let restoreRscResponse: Navigation["restoreRscResponse"];
 let prefetchRscResponse: Navigation["prefetchRscResponse"];
+let attachPrefetchInvalidationCallback: Navigation["attachPrefetchInvalidationCallback"];
 let invalidatePrefetchCache: Navigation["invalidatePrefetchCache"];
 let hasPrefetchCacheEntryForNavigation: Navigation["hasPrefetchCacheEntryForNavigation"];
 let appRouterInstance: Navigation["appRouterInstance"];
@@ -62,6 +63,7 @@ beforeEach(async () => {
   snapshotRscResponse = nav.snapshotRscResponse;
   restoreRscResponse = nav.restoreRscResponse;
   prefetchRscResponse = nav.prefetchRscResponse;
+  attachPrefetchInvalidationCallback = nav.attachPrefetchInvalidationCallback;
   invalidatePrefetchCache = nav.invalidatePrefetchCache;
   hasPrefetchCacheEntryForNavigation = nav.hasPrefetchCacheEntryForNavigation;
   appRouterInstance = nav.appRouterInstance;
@@ -196,6 +198,21 @@ describe("prefetch cache eviction", () => {
 
     expect(firstInvalidate).toHaveBeenCalledTimes(1);
     expect(secondInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies callbacks attached after a prefetched response settles", async () => {
+    const rscUrl = "/instant-shell.rsc";
+    const onInvalidate = vi.fn();
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(new Response("flight", { headers: { "content-type": "text/x-component" } })),
+    );
+    await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
+
+    attachPrefetchInvalidationCallback(rscUrl, onInvalidate);
+    invalidatePrefetchCache();
+
+    expect(onInvalidate).toHaveBeenCalledTimes(1);
   });
 
   it("reuses a prefetched response only when mounted-slot context matches", () => {
@@ -369,6 +386,34 @@ describe("prefetch cache eviction", () => {
     entry!.cacheForNavigation = true;
 
     expect(hasPrefetchCacheEntryForNavigation(rscUrl)).toBe(false);
+    expect(consumePrefetchResponse(rscUrl)).toBeNull();
+  });
+
+  it("keeps instant partial shells for optimistic learning without direct navigation reuse", async () => {
+    const rscUrl = "/instant-shell.rsc";
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("instant shell", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_RSC_PARTIAL_SHELL_HEADER]: "1",
+          },
+        }),
+      ),
+      null,
+      null,
+      undefined,
+      { instantShell: true },
+    );
+
+    await waitForPrefetchSetup(() => getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded");
+
+    expect(getPrefetchCache().get(rscUrl)).toMatchObject({
+      cacheForNavigation: false,
+      instantShell: true,
+      partialSuspenseShell: true,
+    });
     expect(consumePrefetchResponse(rscUrl)).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- detect truthy `unstable_instant` exports on pages and ancestor layouts
- downgrade explicit `prefetch={true}` to an instant runtime shell for those routes
- preserve cached content while suspending `connection()` content until the navigation response arrives
- retain instant shells for optimistic navigation without treating them as authoritative full-prefetch responses

## Next.js parity

Ported against:
- `test/e2e/app-dir/prefetch-true-instant/prefetch-true-instant.test.ts`

## Validation

- `vp check` on all 19 touched source/test files
- 1,550 focused unit/integration assertions pass
- exact Next.js v16.2.6 deploy target: 2 passed, 0 failed
- package builds: `vinext`, `cloudflare`

## Stack

Depends on #2364 (`codex/fix-suspense-derived-prefetch`) for user-authored Suspense shell prefetching.
