### PR TITLE
fix(test): name trailing slash ISR fixture

### DIFF
--- a/tests/fixtures/app-trailing-slash-isr/package.json
+++ b/tests/fixtures/app-trailing-slash-isr/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "app-trailing-slash-isr-fixture",
   "type": "module"
 }


### PR DESCRIPTION
## Summary

- add the missing `name` field to the trailing-slash ISR fixture package manifest
- follow the existing `<fixture>-fixture` naming convention

## Validation

- repository-wide package manifest scan confirms all workspace `package.json` files have names
- `git diff --check`

`vp check tests/fixtures/app-trailing-slash-isr/package.json` could not load the repo config because the existing shared dependency install has a stale `vite-plus` symlink.
