### PR TITLE
fix: sync trailing slash fixture lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1112,6 +1112,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
 
+  tests/fixtures/app-trailing-slash-isr: {}
+
   tests/fixtures/app-with-src:
     dependencies:
       '@vitejs/plugin-rsc':


### PR DESCRIPTION
## Summary

- add the missing `tests/fixtures/app-trailing-slash-isr` workspace importer to `pnpm-lock.yaml`
- keep `vp install` from dirtying a clean checkout of `main`
- unblock agent workflows that install dependencies before switching to a PR branch

## Validation

- ran `vp install` twice and confirmed the second run leaves the lockfile unchanged
- ran `vp run check`
- ran `git diff --check`
- independent review found no issues