### PR TITLE
fix(cli): respect Vite dev server config host+port

### DIFF
--- a/packages/vinext/src/cli-dev-config.ts
+++ b/packages/vinext/src/cli-dev-config.ts
@@ -13,6 +13,8 @@ export function applyDevServerDefaults(server: ServerOptions, options: DevServer
 export function createDevServerConfigPlugin(options: DevServerCliOptions): Plugin {
   return {
     name: "vinext:dev-server-config",
+    // Both levels are required: `enforce` places this after the user's normal
+    // plugins, while the hook `order` places it after their config handlers.
     enforce: "post",
     config: {
       order: "post",

--- a/packages/vinext/src/cli-dev-config.ts
+++ b/packages/vinext/src/cli-dev-config.ts
@@ -1,0 +1,30 @@
+import type { Plugin, ServerOptions } from "vite";
+
+export type DevServerCliOptions = {
+  port?: number;
+  hostname?: string;
+};
+
+export function applyDevServerDefaults(server: ServerOptions, options: DevServerCliOptions): void {
+  server.port = options.port ?? server.port ?? 3000;
+  server.host = options.hostname ?? server.host ?? "localhost";
+}
+
+export function createDevServerConfigPlugin(options: DevServerCliOptions): Plugin {
+  return {
+    name: "vinext:dev-server-config",
+    enforce: "post",
+    config: {
+      order: "post",
+      handler(config) {
+        const server = (config.server ??= {});
+        applyDevServerDefaults(server, options);
+      },
+    },
+  };
+}
+
+export function normalizeDevServerHostname(host: string | boolean | undefined): string {
+  if (typeof host === "string") return host;
+  return host === true ? "0.0.0.0" : "localhost";
+}

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -50,6 +50,7 @@ import {
 } from "./server/dev-lockfile.js";
 import { generateRouteTypes } from "./typegen.js";
 import { normalizePathSeparators } from "./utils/path.js";
+import { createDevServerConfigPlugin, normalizeDevServerHostname } from "./cli-dev-config.js";
 
 // ─── Resolve Vite from the project root ────────────────────────────────────────
 //
@@ -315,8 +316,8 @@ async function dev() {
 
   const vite = await loadVite();
 
-  const port = parsed.port ?? 3000;
-  const host = parsed.hostname ?? "localhost";
+  const initialPort = parsed.port ?? 3000;
+  const initialHost = parsed.hostname ?? "localhost";
 
   // Acquire the dev lock file. If another live `vinext dev` is running in this
   // directory, print an actionable error (PID + URL) and exit. This is
@@ -334,14 +335,14 @@ async function dev() {
     // Substitute "localhost" for wildcard binds so the URL is actually
     // clickable when surfaced in the lock file before server.listen() has
     // had a chance to resolve the real URL.
-    const initialDisplayHost = host === "0.0.0.0" ? "localhost" : host;
+    const initialDisplayHost = initialHost === "0.0.0.0" ? "localhost" : initialHost;
     const acquired = tryAcquireLockfile({
       root,
       info: {
         pid: process.pid,
-        port,
-        hostname: host,
-        appUrl: `http://${initialDisplayHost}:${port}`,
+        port: initialPort,
+        hostname: initialHost,
+        appUrl: `http://${initialDisplayHost}:${initialPort}`,
         startedAt,
         cwd: root,
       },
@@ -363,9 +364,9 @@ async function dev() {
 
   console.log(`\n  vinext dev  (Vite ${getViteVersion()})\n`);
 
-  const config = buildViteConfig({
-    server: { port, host },
-  });
+  const config = buildViteConfig();
+  const plugins = (config.plugins ??= []) as import("vite").PluginOption[];
+  plugins.push(createDevServerConfigPlugin(parsed));
 
   // If anything between here and the first successful listen() throws (e.g.
   // strictPort and the port is taken), release the lock immediately so we
@@ -375,6 +376,18 @@ async function dev() {
   let server;
   try {
     server = await vite.createServer(config);
+    const port = server.config.server.port ?? 3000;
+    const host = normalizeDevServerHostname(server.config.server.host);
+
+    lockfile?.update({
+      pid: process.pid,
+      port,
+      hostname: host,
+      appUrl: `http://${host === "0.0.0.0" ? "localhost" : host}:${port}`,
+      startedAt,
+      cwd: process.cwd(),
+    });
+
     await server.listen();
   } catch (err) {
     lockfile?.release();
@@ -391,8 +404,10 @@ async function dev() {
   // actually clickable. Fall back to httpServer.address() if Vite didn't
   // populate resolvedUrls for some reason.
   if (lockfile) {
+    const configuredPort = server.config.server.port ?? 3000;
+    const configuredHost = normalizeDevServerHostname(server.config.server.host);
     const resolved = server.resolvedUrls?.local[0];
-    let actualPort = port;
+    let actualPort = configuredPort;
     let appUrl: string;
     if (resolved) {
       appUrl = resolved.replace(/\/$/, "");
@@ -404,13 +419,13 @@ async function dev() {
       }
     } else {
       const address = server.httpServer?.address();
-      actualPort = typeof address === "object" && address ? address.port : port;
-      appUrl = `http://${host === "0.0.0.0" ? "localhost" : host}:${actualPort}`;
+      actualPort = typeof address === "object" && address ? address.port : configuredPort;
+      appUrl = `http://${configuredHost === "0.0.0.0" ? "localhost" : configuredHost}:${actualPort}`;
     }
     lockfile.update({
       pid: process.pid,
       port: actualPort,
-      hostname: host,
+      hostname: configuredHost,
       appUrl,
       // Preserve the original acquire-time startedAt rather than resetting
       // to "now". startedAt represents when the process started.

--- a/tests/cli-dev-config.test.ts
+++ b/tests/cli-dev-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveConfig, type Plugin, type ServerOptions } from "vite";
+import {
+  applyDevServerDefaults,
+  createDevServerConfigPlugin,
+  normalizeDevServerHostname,
+} from "../packages/vinext/src/cli-dev-config.js";
+
+describe("applyDevServerDefaults", () => {
+  it("uses vinext defaults when neither config nor CLI flags specify values", () => {
+    const server: ServerOptions = {};
+
+    applyDevServerDefaults(server, {});
+
+    expect(server).toMatchObject({ host: "localhost", port: 3000 });
+  });
+
+  it("preserves host and port from the Vite config", () => {
+    const server: ServerOptions = { host: "dev.internal.test", port: 4321 };
+
+    applyDevServerDefaults(server, {});
+
+    expect(server).toMatchObject({ host: "dev.internal.test", port: 4321 });
+  });
+
+  it("lets explicit CLI flags override the Vite config", () => {
+    const server: ServerOptions = { host: "dev.internal.test", port: 4321 };
+
+    applyDevServerDefaults(server, { hostname: "0.0.0.0", port: 4000 });
+
+    expect(server).toMatchObject({ host: "0.0.0.0", port: 4000 });
+  });
+});
+
+describe("createDevServerConfigPlugin", () => {
+  it("applies explicit CLI flags after user config hooks", async () => {
+    const lateUserConfigPlugin: Plugin = {
+      name: "test:late-user-config",
+      enforce: "post",
+      config: {
+        order: "post",
+        handler(config) {
+          config.server ??= {};
+          config.server.host = "late.example.test";
+          config.server.port = 4999;
+        },
+      },
+    };
+
+    const config = await resolveConfig(
+      {
+        configFile: false,
+        plugins: [
+          lateUserConfigPlugin,
+          createDevServerConfigPlugin({ hostname: "127.0.0.1", port: 4000 }),
+        ],
+      },
+      "serve",
+    );
+
+    expect(config.server).toMatchObject({ host: "127.0.0.1", port: 4000 });
+  });
+});
+
+describe("normalizeDevServerHostname", () => {
+  it("normalizes Vite boolean host values for lockfile metadata", () => {
+    expect(normalizeDevServerHostname(true)).toBe("0.0.0.0");
+    expect(normalizeDevServerHostname(false)).toBe("localhost");
+    expect(normalizeDevServerHostname(undefined)).toBe("localhost");
+  });
+});


### PR DESCRIPTION
## Summary

- respect `server.host` and `server.port` from the project's Vite config when running `vinext dev`
- keep explicit CLI flags as the highest-precedence values while preserving vinext's existing defaults
- update dev lockfile metadata from Vite's resolved server configuration

## Testing

- `vp test run tests/cli-dev-config.test.ts tests/cli-args.test.ts tests/dev-lockfile.test.ts`
- `vp check packages/vinext/src/cli.ts packages/vinext/src/cli-dev-config.ts tests/cli-dev-config.test.ts`
- `vp run vinext#build`
