### PR TITLE
fix(prod-server): reuse RSC entry after prerender

### DIFF
--- a/packages/vinext/src/build/inject-pregenerated-paths.ts
+++ b/packages/vinext/src/build/inject-pregenerated-paths.ts
@@ -1,20 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import { readPrerenderManifest } from "../server/prerender-manifest.js";
-import { escapeRegExp } from "../utils/regex.js";
-
-const VINEXT_PREGEN_START = "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_START__ */";
-const VINEXT_PREGEN_END = "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_END__ */";
-const VINEXT_PREGEN_RE = new RegExp(
-  `${escapeRegExp(VINEXT_PREGEN_START)}[\\s\\S]*?${escapeRegExp(VINEXT_PREGEN_END)}\\n?`,
-  "g",
-);
+import {
+  stripPregeneratedConcretePathsInjection,
+  VINEXT_PREGENERATED_CONCRETE_PATHS_END,
+  VINEXT_PREGENERATED_CONCRETE_PATHS_START,
+} from "../server/pregenerated-concrete-paths-injection.js";
 
 export function injectPregeneratedConcretePaths(root: string): void {
   const workerEntry = path.resolve(root, "dist", "server", "index.js");
   if (!fs.existsSync(workerEntry)) return;
 
-  let code = fs.readFileSync(workerEntry, "utf-8").replace(VINEXT_PREGEN_RE, "");
+  let code = stripPregeneratedConcretePathsInjection(fs.readFileSync(workerEntry, "utf-8"));
   const manifest = readPrerenderManifest(
     path.join(root, "dist", "server", "vinext-prerender.json"),
   );
@@ -22,9 +19,9 @@ export function injectPregeneratedConcretePaths(root: string): void {
 
   if (table.length > 0) {
     code =
-      `${VINEXT_PREGEN_START}\n` +
+      `${VINEXT_PREGENERATED_CONCRETE_PATHS_START}\n` +
       `globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = ${JSON.stringify(table)};\n` +
-      `${VINEXT_PREGEN_END}\n` +
+      `${VINEXT_PREGENERATED_CONCRETE_PATHS_END}\n` +
       code;
   }
 

--- a/packages/vinext/src/server/pregenerated-concrete-paths-injection.ts
+++ b/packages/vinext/src/server/pregenerated-concrete-paths-injection.ts
@@ -1,0 +1,15 @@
+import { escapeRegExp } from "../utils/regex.js";
+
+export const VINEXT_PREGENERATED_CONCRETE_PATHS_START =
+  "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_START__ */";
+export const VINEXT_PREGENERATED_CONCRETE_PATHS_END =
+  "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_END__ */";
+
+const pregeneratedConcretePathsInjectionPattern = new RegExp(
+  `${escapeRegExp(VINEXT_PREGENERATED_CONCRETE_PATHS_START)}[\\s\\S]*?${escapeRegExp(VINEXT_PREGENERATED_CONCRETE_PATHS_END)}\\n?`,
+  "g",
+);
+
+export function stripPregeneratedConcretePathsInjection(code: string): string {
+  return code.replace(pregeneratedConcretePathsInjectionPattern, "");
+}

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -21,6 +21,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { Readable, pipeline } from "node:stream";
 import { pathToFileURL } from "node:url";
 import fs from "node:fs";
+import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import zlib from "node:zlib";
@@ -79,6 +80,7 @@ import {
   resolveRequestProtocol,
   resolveRequestHost as resolveHost,
 } from "./proxy-trust.js";
+import { stripPregeneratedConcretePathsInjection } from "./pregenerated-concrete-paths-injection.js";
 import {
   negotiateEncoding,
   parseAcceptedEncodings,
@@ -91,7 +93,12 @@ import {
  * build forever, so rebuilds to the same path must be detected and loaded
  * through a cache-busted URL instead.
  */
-const bareServerEntryMtimes = new Map<string, number>();
+const bareServerEntries = new Map<string, { mtime: number; fingerprint: string }>();
+
+function fingerprintServerEntry(entryPath: string): string {
+  const code = stripPregeneratedConcretePathsInjection(fs.readFileSync(entryPath, "utf-8"));
+  return createHash("sha256").update(code).digest("base64url");
+}
 
 /**
  * Import a built server entry module (App Router RSC entry or Pages Router
@@ -111,9 +118,13 @@ const bareServerEntryMtimes = new Map<string, number>();
  * https://github.com/cloudflare/vinext/issues/1923.
  *
  * A `?t=<mtime>` query string is appended only when the same path is
- * imported again after a rebuild (different mtime) — e.g. test suites that
- * rebuild a fixture to the same output path within one process — where the
- * bare URL's cache entry would return the stale previous build. Note this
+ * imported again after a rebuild with different executable code — e.g. test
+ * suites that rebuild a fixture to the same output path within one process —
+ * where the bare URL's cache entry would return the stale previous build.
+ * The post-prerender concrete-path prologue is ignored when fingerprinting:
+ * Node startup seeds the same data from the manifest, and re-importing the
+ * entry just for that prologue would instantiate a second React RSC renderer.
+ * Note this
  * rebuild branch trades the single-instance guarantee back: chunks that
  * import the entry by bare path still resolve to the FIRST build's cache
  * entry, so freshness and single-instance only hold together on the first
@@ -141,9 +152,16 @@ export function resolveServerEntryImportUrl(entryPath: string): string {
   }
   const href = pathToFileURL(canonicalEntryPath).href;
   const mtime = fs.statSync(canonicalEntryPath).mtimeMs;
-  const bareMtime = bareServerEntryMtimes.get(href);
-  if (bareMtime === undefined || bareMtime === mtime) {
-    bareServerEntryMtimes.set(href, mtime);
+  const bareEntry = bareServerEntries.get(href);
+  if (bareEntry === undefined) {
+    bareServerEntries.set(href, { mtime, fingerprint: fingerprintServerEntry(canonicalEntryPath) });
+    return href;
+  }
+  if (bareEntry.mtime === mtime) {
+    return href;
+  }
+  if (bareEntry.fingerprint === fingerprintServerEntry(canonicalEntryPath)) {
+    bareEntry.mtime = mtime;
     return href;
   }
   return `${href}?t=${mtime}`;

--- a/tests/prod-server-entry-import.test.ts
+++ b/tests/prod-server-entry-import.test.ts
@@ -111,6 +111,27 @@ describe("server entry import URL resolution", () => {
     expect(thirdImportUrl).toBe(secondBuildUrl);
   });
 
+  it("reuses the bare entry after prerender injects concrete paths", () => {
+    const dir = makeTmpDir();
+    const entryPath = path.join(dir, "entry.mjs");
+    const originalCode = `export const state = { marker: "build-1" };\n`;
+
+    fs.writeFileSync(entryPath, originalCode);
+    const firstBuildUrl = resolveServerEntryImportUrl(entryPath);
+
+    fs.writeFileSync(
+      entryPath,
+      `/* __VINEXT_PREGENERATED_CONCRETE_PATHS_START__ */\n` +
+        `globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = [["/blog/:slug",["/blog/post-a"]]];\n` +
+        `/* __VINEXT_PREGENERATED_CONCRETE_PATHS_END__ */\n` +
+        originalCode,
+    );
+    const bumped = new Date(Date.now() + 10_000);
+    fs.utimesSync(entryPath, bumped, bumped);
+
+    expect(resolveServerEntryImportUrl(entryPath)).toBe(firstBuildUrl);
+  });
+
   it("shares the module instance with chunks that import the entry by bare specifier", async () => {
     const dir = makeTmpDir();
     const entryPath = path.join(dir, "entry.mjs");


### PR DESCRIPTION
## Summary

- avoid cache-busting the App Router server entry when prerender only injects the concrete-path metadata prologue
- keep cache-busting for actual rebuilt server code
- share the injection markers/stripping helper between build and runtime code

## Root cause

`runPrerender()` imports `dist/server/index.js`, then injects pregenerated concrete paths into that same file. `startProdServer()` saw the changed mtime and re-imported it with a query string, evaluating a second bundled React RSC renderer in the same process. React rejects subsequent renders with `Currently React only supports one RSC renderer at a time.`

The Node production path already seeds concrete paths from `vinext-prerender.json`, so the injected prologue does not require a fresh entry module there.

## Validation

- `vp check packages/vinext/src/server/pregenerated-concrete-paths-injection.ts packages/vinext/src/build/inject-pregenerated-paths.ts packages/vinext/src/server/prod-server.ts tests/prod-server-entry-import.test.ts`
- `vp test run tests/prod-server-entry-import.test.ts tests/inject-pregenerated-paths.test.ts tests/pregenerated-concrete-paths.test.ts`
- `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific vp exec playwright test tests/e2e/app-router/nextjs-compat/prefetch-bot.browser.spec.ts --workers=1`

Fixes the failure in https://github.com/cloudflare/vinext/actions/runs/28259094466/job/83729689423.
