### PR TITLE
fix(test): pin deploy suite init to node

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -643,7 +643,7 @@ fi
 # vinext loads CJS next.config.js in `"type": "module"` packages via a temp
 # .cjs sibling (see config/next-config.ts), so we don't rewrite the user's
 # config file here.
-run_pnpm exec vinext init --skip-check --force >> "${BUILD_LOG}" 2>&1
+run_pnpm exec vinext init --platform=node --skip-check --force >> "${BUILD_LOG}" 2>&1
 
 run_pnpm exec vinext build --prerender-all >> "${BUILD_LOG}" 2>&1
 

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -4,6 +4,12 @@ import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vite-plus/test";
 
 describe("Next.js deploy harness logging", () => {
+  it("initializes fixtures for the Node deployment platform", () => {
+    const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
+
+    expect(script).toContain("vinext init --platform=node --skip-check --force");
+  });
+
   it("removes install-time deprecation noise from application cliOutput", () => {
     const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
 


### PR DESCRIPTION
## Summary

- pass `--platform=node` to `vinext init` in the Next.js deploy harness
- prevent the harness from following the new Cloudflare default introduced by #2279
- add a focused regression assertion for the init invocation

## Root cause

#2279 changed the default `vinext init` platform from Node to Cloudflare. The Next.js deploy harness relied on the old implicit default, so generated Cloudflare configuration instead of the Node production-server setup expected by `scripts/e2e-deploy.sh`. Across the historical runs, the final report changed from 2,436 passed / 372 failed at `c5e16b1a` to 329 passed / 2,479 failed at `25a3c26f`.

## Validation

- `vp test run tests/e2e-deploy-script.test.ts`
- `vp check tests/e2e-deploy-script.test.ts scripts/e2e-deploy.sh`
