### PR TITLE
fix(test): stop autoscroll fixture servers correctly

### DIFF
--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts
@@ -179,8 +179,11 @@ for (const clickMode of ["playwright", "javascript"] as const) {
       await expect(page).toHaveURL(`${app.baseUrl}/css-module/0`);
       await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
     } finally {
-      await app.server.close();
-      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+      try {
+        await stopChildProductionServer(app.server);
+      } finally {
+        await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary

- use the shared child-process teardown helper for the new CSS Module autoscroll cases
- preserve fixture cleanup when server shutdown reports a failure
- keep the browser behavior assertions unchanged

## Root cause

The fixture is started with `startChildViteDevServer()`, which returns a `ChildProductionServer` descriptor rather than a Vite server instance. The new cases called a nonexistent `server.close()` method, causing both the type-check job and browser jobs to fail after the product assertions had passed.

## Validation

- `vp check tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts`
- `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific vp exec playwright test tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts`
- `PLAYWRIGHT_PROJECT=app-router-webkit-browser-specific vp exec playwright test tests/e2e/app-router/nextjs-compat/router-autoscroll-hoisted.browser.spec.ts`
- `vp run vinext#build`
- `vp run check`
- independent agent review: no findings
