### PR TITLE
fix(link): bound viewport prefetch concurrency

### DIFF
--- a/packages/vinext/src/shims/form.tsx
+++ b/packages/vinext/src/shims/form.tsx
@@ -355,7 +355,7 @@ const Form = forwardRef(function Form(props: FormProps, ref: ForwardedRef<HTMLFo
                 // @ts-expect-error — purpose is a valid fetch option in some browsers
                 purpose: "prefetch",
               });
-              prefetchRscResponse(
+              void prefetchRscResponse(
                 rscUrl,
                 fetchPromise,
                 interceptionContext,

--- a/packages/vinext/src/shims/internal/viewport-prefetch-scheduler.ts
+++ b/packages/vinext/src/shims/internal/viewport-prefetch-scheduler.ts
@@ -1,0 +1,41 @@
+export type ViewportPrefetchTask = {
+  cancel(): void;
+};
+
+type QueuedViewportPrefetch = {
+  cancelled: boolean;
+  run: () => Promise<void>;
+};
+
+export function createViewportPrefetchScheduler(maxConcurrentRequests = 4): {
+  schedule(run: () => Promise<void>): ViewportPrefetchTask;
+} {
+  const queue: QueuedViewportPrefetch[] = [];
+  let activeRequests = 0;
+
+  function processQueue(): void {
+    while (activeRequests < maxConcurrentRequests && queue.length > 0) {
+      const queued = queue.shift();
+      if (!queued || queued.cancelled) continue;
+
+      activeRequests += 1;
+      void queued.run().finally(() => {
+        activeRequests -= 1;
+        processQueue();
+      });
+    }
+  }
+
+  return {
+    schedule(run) {
+      const queued: QueuedViewportPrefetch = { cancelled: false, run };
+      queue.push(queued);
+      processQueue();
+      return {
+        cancel() {
+          queued.cancelled = true;
+        },
+      };
+    },
+  };
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -164,6 +164,7 @@ const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 /** trailingSlash from next.config.js, injected by the plugin at build time */
 const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
 const __prefetchInlining: boolean = process.env.__VINEXT_PREFETCH_INLINING === "true";
+const __cacheComponents: boolean = process.env.__NEXT_CACHE_COMPONENTS === "true";
 const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
 function resolveHref(href: LinkProps["href"]): string {
@@ -439,7 +440,11 @@ function prefetchUrl(
           { AppElementsWire },
           rscCacheBusting,
           { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL },
-          { VINEXT_MOUNTED_SLOTS_HEADER },
+          {
+            NEXT_ROUTER_PREFETCH_HEADER,
+            NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+            VINEXT_MOUNTED_SLOTS_HEADER,
+          },
           { resolveHybridClientRouteOwner },
         ] = await Promise.all([
           import("./navigation.js"),
@@ -485,6 +490,10 @@ function prefetchUrl(
             ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
             : undefined,
         });
+        if (__cacheComponents) {
+          headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, target.pathname || "/");
+        }
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
@@ -554,7 +563,7 @@ function prefetchUrl(
                 // @ts-expect-error — purpose is a valid fetch option in some browsers
                 purpose: "prefetch",
               });
-          await prefetchRscResponse(
+        await prefetchRscResponse(
           rscUrl,
           fetchPromise,
           interceptionContext,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -554,7 +554,7 @@ function prefetchUrl(
                 // @ts-expect-error — purpose is a valid fetch option in some browsers
                 purpose: "prefetch",
               });
-        prefetchRscResponse(
+          await prefetchRscResponse(
           rscUrl,
           fetchPromise,
           interceptionContext,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -55,6 +55,10 @@ import {
 } from "./internal/pages-data-target.js";
 import { interpolateDynamicRouteHref } from "./internal/interpolate-as.js";
 import { markAppRouteDetectedOnPrefetch } from "./internal/app-route-detection.js";
+import {
+  createViewportPrefetchScheduler,
+  type ViewportPrefetchTask,
+} from "./internal/viewport-prefetch-scheduler.js";
 import { getCurrentBrowserLocale } from "./client-locale.js";
 import {
   clearLinkForCurrentNavigation,
@@ -390,15 +394,22 @@ function prefetchUrl(
   mode: LinkPrefetchMode,
   priority: "low" | "high" = "low",
   scheduling: "idle" | "immediate" = priority === "high" ? "immediate" : "idle",
+  onComplete?: () => void,
 ): void {
-  if (typeof window === "undefined") return;
+  if (typeof window === "undefined") {
+    onComplete?.();
+    return;
+  }
 
   const prefetchHref = getLinkPrefetchHref({
     href,
     basePath: __basePath,
     currentOrigin: window.location.origin,
   });
-  if (prefetchHref == null) return;
+  if (prefetchHref == null) {
+    onComplete?.();
+    return;
+  }
 
   const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
   const target = new URL(fullHref, window.location.href);
@@ -407,6 +418,7 @@ function prefetchUrl(
     target.pathname === window.location.pathname &&
     target.search === window.location.search
   ) {
+    onComplete?.();
     return;
   }
 
@@ -587,9 +599,11 @@ function prefetchUrl(
           document.head.appendChild(link);
         }
       }
-    })().catch((error) => {
-      console.error("[vinext] RSC prefetch setup error:", error);
-    });
+    })()
+      .catch((error) => {
+        console.error("[vinext] RSC prefetch setup error:", error);
+      })
+      .finally(onComplete);
   });
 }
 
@@ -636,11 +650,45 @@ type LinkPrefetchInstance = {
   isVisible: boolean;
   mode: LinkPrefetchMode;
   routerMode: LinkPrefetchRouterMode;
+  viewportTask: ViewportPrefetchTask | null;
   viewportPrefetched: boolean;
 };
 
 const observedLinkPrefetches = new WeakMap<Element, LinkPrefetchInstance>();
 const visibleLinkPrefetches = new Set<LinkPrefetchInstance>();
+const viewportPrefetchScheduler = createViewportPrefetchScheduler();
+
+function scheduleViewportPrefetch(instance: LinkPrefetchInstance): void {
+  if (instance.viewportTask !== null) return;
+  let task: ViewportPrefetchTask | null = null;
+  let completedSynchronously = false;
+  const scheduledTask = viewportPrefetchScheduler.schedule(
+    () =>
+      new Promise<void>((resolve) => {
+        if (!instance.isVisible) {
+          resolve();
+          return;
+        }
+        prefetchUrl(instance.href, instance.mode, "low", "immediate", () => {
+          if (task === null) {
+            completedSynchronously = true;
+          } else if (instance.viewportTask === task) {
+            instance.viewportTask = null;
+          }
+          resolve();
+        });
+      }),
+  );
+  task = scheduledTask;
+  instance.viewportTask = completedSynchronously ? null : scheduledTask;
+}
+
+function cancelQueuedViewportPrefetch(instance: LinkPrefetchInstance): void {
+  const task = instance.viewportTask;
+  if (task === null) return;
+  task.cancel();
+  instance.viewportTask = null;
+}
 
 function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boolean): void {
   instance.isVisible = isVisible;
@@ -650,10 +698,15 @@ function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boole
     // IntersectionObserver already moved this work off the render path. Start
     // the request now so router-act can observe it during the same interaction,
     // while retaining low network priority for viewport-driven prefetches.
-    prefetchUrl(instance.href, instance.mode, "low", "immediate");
+    if (instance.routerMode === "app") {
+      scheduleViewportPrefetch(instance);
+    } else {
+      prefetchUrl(instance.href, instance.mode, "low", "immediate");
+    }
     instance.viewportPrefetched = true;
   } else {
     visibleLinkPrefetches.delete(instance);
+    cancelQueuedViewportPrefetch(instance);
   }
 }
 
@@ -665,7 +718,7 @@ function registerVisibleLinkPing(): void {
 function pingVisibleLinkPrefetches(): void {
   for (const instance of visibleLinkPrefetches) {
     if (instance.isVisible && instance.routerMode === "app") {
-      prefetchUrl(instance.href, instance.mode, "low");
+      scheduleViewportPrefetch(instance);
     }
   }
 }
@@ -964,6 +1017,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       isVisible: false,
       mode: prefetchMode,
       routerMode: getLinkPrefetchRouterMode(),
+      viewportTask: null,
       viewportPrefetched: false,
     };
     observedLinkPrefetches.set(node, instance);
@@ -972,7 +1026,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     return () => {
       observer.unobserve(node);
       observedLinkPrefetches.delete(node);
-      visibleLinkPrefetches.delete(instance);
+      setVisibleLinkPrefetch(instance, false);
     };
   }, [shouldViewportPrefetch, prefetchMode, normalizedHref]);
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -724,7 +724,7 @@ export function prefetchRscResponse(
   mountedSlotsHeader: string | null = null,
   options?: PrefetchOptions,
   behavior: { cacheForNavigation?: boolean; optimisticRouteShell?: boolean } = {},
-): void {
+): Promise<void> {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
   const prefetched = getPrefetchedUrls();
@@ -768,6 +768,7 @@ export function prefetchRscResponse(
   // entries inserted before it are candidates for removal.
   cache.set(cacheKey, entry);
   evictPrefetchCacheIfNeeded();
+  return entry.pending;
 }
 
 /**
@@ -1906,7 +1907,7 @@ const _appRouter: AppRouterInstance = {
         return;
       }
       prefetched.add(cacheKey);
-      prefetchRscResponse(
+      void prefetchRscResponse(
         rscUrl,
         fetch(rscUrl, {
           headers,

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -272,7 +272,7 @@ declare module "next/navigation" {
     response: Response,
     interceptionContext?: string | null,
     options?: { onInvalidate?: () => void },
-  ): void;
+  ): Promise<void>;
   export function snapshotRscResponse(response: Response): Promise<CachedRscResponse>;
   export function restoreRscResponse(cached: CachedRscResponse, copy?: boolean): Response;
   export function prefetchRscResponse(

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -9,7 +9,11 @@ import {
   type LinkPrefetchRouterMode,
 } from "../packages/vinext/src/shims/link-prefetch.js";
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
-import { VINEXT_RSC_RENDER_MODE_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  VINEXT_RSC_RENDER_MODE_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
 
 type CapturedEffect = () => void | (() => void);
@@ -1325,6 +1329,32 @@ describe("Link prefetch scheduling", () => {
         result.fetch.mock.calls[0],
         "/viewport-prefetch-target",
         expect.objectContaining({ priority: "low" }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("marks cache-components viewport requests as segment prefetches", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const init = result.fetch.mock.calls[0]?.[1];
+      expect(init?.headers).toBeInstanceOf(Headers);
+      if (!(init?.headers instanceof Headers)) {
+        throw new Error("Expected prefetch request headers");
+      }
+      expect(init.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(init.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe(
+        "/viewport-prefetch-target",
       );
     } finally {
       result.restoreNodeEnv();

--- a/tests/viewport-prefetch-scheduler.test.ts
+++ b/tests/viewport-prefetch-scheduler.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createViewportPrefetchScheduler } from "../packages/vinext/src/shims/internal/viewport-prefetch-scheduler.js";
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("viewport prefetch scheduler", () => {
+  it("matches Next.js viewport bandwidth and cancellation semantics", async () => {
+    // Ported from Next.js:
+    // packages/next/src/client/components/segment-cache/scheduler.ts
+    // test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
+    const scheduler = createViewportPrefetchScheduler();
+    const requests = Array.from({ length: 6 }, () => deferred());
+    const starts = requests.map((request) => vi.fn(() => request.promise));
+    const tasks = starts.map((start) => scheduler.schedule(start));
+
+    expect(starts.map((start) => start.mock.calls.length)).toEqual([1, 1, 1, 1, 0, 0]);
+
+    tasks[4]?.cancel();
+    requests[0]?.resolve();
+    await requests[0]?.promise;
+    await Promise.resolve();
+
+    expect(starts[4]).not.toHaveBeenCalled();
+    expect(starts[5]).toHaveBeenCalledOnce();
+
+    tasks[0]?.cancel();
+    requests[1]?.resolve();
+    await requests[1]?.promise;
+    await Promise.resolve();
+
+    expect(starts[1]).toHaveBeenCalledOnce();
+  });
+
+  it("reschedules a cancelled viewport prefetch after re-entry", async () => {
+    const scheduler = createViewportPrefetchScheduler(1);
+    const blocker = deferred();
+    scheduler.schedule(() => blocker.promise);
+
+    const firstAttempt = vi.fn(() => Promise.resolve());
+    scheduler.schedule(firstAttempt).cancel();
+    const secondAttempt = vi.fn(() => Promise.resolve());
+    scheduler.schedule(secondAttempt);
+
+    blocker.resolve();
+    await blocker.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(firstAttempt).not.toHaveBeenCalled();
+    expect(secondAttempt).toHaveBeenCalledOnce();
+  });
+
+  it("drains the 59-link Next.js memory-pressure shape without flooding requests", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/page.tsx
+    const scheduler = createViewportPrefetchScheduler();
+    let activeRequests = 0;
+    let peakActiveRequests = 0;
+    const starts: number[] = [];
+    const completions: number[] = [];
+
+    const tasks = Array.from({ length: 59 }, (_, index) =>
+      scheduler.schedule(async () => {
+        starts.push(index);
+        activeRequests += 1;
+        peakActiveRequests = Math.max(peakActiveRequests, activeRequests);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        activeRequests -= 1;
+        completions.push(index);
+      }),
+    );
+
+    expect(starts).toHaveLength(4);
+    expect(tasks).toHaveLength(59);
+
+    await vi.waitFor(() => {
+      expect(completions).toHaveLength(59);
+    });
+
+    expect(peakActiveRequests).toBe(4);
+    expect(activeRequests).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- queue App Router viewport prefetches with the same four-request bandwidth limit as Next.js
- cancel queued viewport work when links leave the viewport or unmount
- preserve immediate first-request scheduling and reschedule visible links after invalidation
- add parity coverage for cancellation, re-entry, and the 59-link memory-pressure shape

## Validation
- `vp check packages/vinext/src/shims/link.tsx packages/vinext/src/shims/internal/viewport-prefetch-scheduler.ts tests/viewport-prefetch-scheduler.test.ts`
- `vp test run tests/viewport-prefetch-scheduler.test.ts tests/link-navigation.test.ts tests/prefetch-cache.test.ts tests/form.test.ts`
- `vp run vinext#build`

## Next.js parity
Matches `packages/next/src/client/components/segment-cache/scheduler.ts`, which limits default viewport prefetches to four concurrent requests, and `packages/next/src/client/components/links.ts`, which cancels queued tasks when links leave the viewport.