### PR TITLE
test(perf): pin benchmark validator repository in fork CI

### DIFF
--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -937,6 +937,7 @@ process.stdout.write(JSON.stringify(response));
       env: {
         ...process.env,
         PATH: `${directory}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: "cloudflare/vinext",
         GITHUB_TOKEN: "test",
         VINEXT_PERF_SOURCE_EVENT: sourceEvent,
         VINEXT_PERF_SOURCE_RUN_ID: "123",


### PR DESCRIPTION
## Summary

- Fix fork `main` CI failures that were generating failure notifications after upstream merges.
- Pin the benchmark validator unit test's spawned `GITHUB_REPOSITORY` to `cloudflare/vinext`, matching its mocked GitHub API responses.
- Keep production benchmark validation behavior unchanged.

## Cause

Fork CI sets `GITHUB_REPOSITORY=NathanDrake2406/vinext`, but `tests/performance-benchmarks.test.ts` mocks `gh api` responses for `cloudflare/vinext`. That made `Vitest (unit 3/3)` fail with `Unexpected gh api request: repos/NathanDrake2406/vinext/actions/runs/123` every time the fork synced `main`.

## Validation

- `vp test run --project unit tests/performance-benchmarks.test.ts`
- `git diff --check`

Note: the commit hook's repo-wide `vp run check` is still blocked locally by unrelated current type errors around image optimizer and Shiki imports.
