### PR TITLE
chore(benchmarks): add 5000-route production-build stress scenario

### DIFF
--- a/benchmarks/generate-app.mjs
+++ b/benchmarks/generate-app.mjs
@@ -559,6 +559,123 @@ export default function ${title}Page() {
   );
 }
 
+// ─── Large-scale volume (opt-in via VINEXT_BENCH_EXTRA_ROUTES) ──────────────────
+// Generates N additional realistic routes so the benchmark can surface build-time
+// effects that are invisible at the default 33-route scale. Each generated route is
+// a server page that links via next/link, renders a shared client component, and
+// imports a plain-.js utility — exercising the RSC/SSR/client boundary scan and the
+// per-module transform pipeline at scale. Default 0 keeps the canonical 33-route app.
+const cliArgs = process.argv.slice(2);
+const getCliArg = (name) => {
+  const i = cliArgs.indexOf(name);
+  return i >= 0 ? cliArgs[i + 1] : undefined;
+};
+// Scale via `--extra <n>` (or VINEXT_BENCH_EXTRA_ROUTES) and emit to a single
+// project via `--target <name>` (default: both nextjs + vinext). Setup steps
+// pass argv, so CLI flags are the supported path there.
+const EXTRA = Number.parseInt(
+  getCliArg("--extra") ?? process.env.VINEXT_BENCH_EXTRA_ROUTES ?? "0",
+  10,
+);
+const targetArg = getCliArg("--target");
+if (Number.isFinite(EXTRA) && EXTRA > 0) {
+  const NUM_CLIENT = Math.max(8, Math.floor(EXTRA / 8));
+  const NUM_UTIL = Math.max(8, Math.floor(EXTRA / 8));
+  for (let i = 0; i < NUM_CLIENT; i++) {
+    write(
+      `_gen/widget-${i}.tsx`,
+      `
+"use client";
+import { useState } from "react";
+export function Widget${i}({ label = "W${i}" }: { label?: string }) {
+  const [n, setN] = useState(0);
+  return <button onClick={() => setN(v => v + 1)}>{label}: {n}</button>;
+}
+`,
+    );
+  }
+  for (let i = 0; i < NUM_UTIL; i++) {
+    write(
+      `_gen/util-${i}.js`,
+      `
+export function compute${i}(a, b) {
+  const r = a * ${i + 1} + b;
+  return r > 0 ? r : -r;
+}
+export const LABEL_${i} = "util-${i}";
+`,
+    );
+  }
+  for (let i = 0; i < EXTRA; i++) {
+    const w0 = i % NUM_CLIENT;
+    const w1 = (i + 1) % NUM_CLIENT;
+    const w2 = (i + 2) % NUM_CLIENT;
+    const u = i % NUM_UTIL;
+    write(
+      `gen/r${i}/page.tsx`,
+      `
+import Link from "next/link";
+import { Widget${w0} } from "../../_gen/widget-${w0}";
+import { Widget${w1} } from "../../_gen/widget-${w1}";
+import { Widget${w2} } from "../../_gen/widget-${w2}";
+import { compute${u}, LABEL_${u} } from "../../_gen/util-${u}";
+
+export const metadata = { title: "Gen ${i}", description: "Generated route ${i} for build benchmarking" };
+
+interface Row { id: number; name: string; value: number; tag: string; }
+
+const rows: Row[] = Array.from({ length: 24 }, (_, k) => ({
+  id: k,
+  name: \`Item \${k} of route ${i}\`,
+  value: compute${u}(${i} + k, k * 3),
+  tag: k % 2 === 0 ? "even" : "odd",
+}));
+
+function Section({ title, rows }: { title: string; rows: Row[] }) {
+  return (
+    <section style={{ marginBottom: "1rem" }}>
+      <h2>{title}</h2>
+      <table>
+        <thead><tr><th>ID</th><th>Name</th><th>Value</th><th>Tag</th></tr></thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id}>
+              <td>{r.id}</td><td>{r.name}</td><td>{r.value}</td><td>{r.tag}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+export default function Gen${i}Page() {
+  const total = rows.reduce((acc, r) => acc + r.value, 0);
+  return (
+    <div>
+      <h1>Generated route ${i} — {LABEL_${u}} (total {total})</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor. Route ${i}.</p>
+      <nav style={{ display: "flex", gap: "0.5rem" }}>
+        <Link href={\`/gen/r${(i + 1) % EXTRA}\`}>next</Link>
+        <Link href={\`/gen/r${(i + 2) % EXTRA}\`}>skip</Link>
+        <Link href="/">home</Link>
+      </nav>
+      <Section title="Primary" rows={rows.slice(0, 12)} />
+      <Section title="Secondary" rows={rows.slice(12)} />
+      <div style={{ display: "flex", gap: "0.5rem" }}>
+        <Widget${w0} label="A${i}" />
+        <Widget${w1} label="B${i}" />
+        <Widget${w2} label="C${i}" />
+      </div>
+    </div>
+  );
+}
+`,
+    );
+  }
+  console.log(`  + ${EXTRA} extra routes, ${NUM_CLIENT} client widgets, ${NUM_UTIL} .js utils`);
+}
+
 // Count results
 function countFiles(dir, name) {
   let count = 0;
@@ -578,7 +695,8 @@ console.log(
 
 // Copy to each benchmark project (symlinks don't work with Turbopack)
 const BASE = benchmarkRoot;
-for (const project of ["nextjs", "vinext"]) {
+const copyTargets = targetArg ? [targetArg] : ["nextjs", "vinext"];
+for (const project of copyTargets) {
   const dest = join(BASE, project, "app");
   rmSync(dest, { recursive: true, force: true });
   cpSync(APP, dest, { recursive: true });

--- a/benchmarks/perf/README.md
+++ b/benchmarks/perf/README.md
@@ -86,3 +86,24 @@ the pull request head SHA as their identity for dashboard history and comments.
 CI sets `CODSPEED_SKIP_UPLOAD=true`. Results and profiles remain local to the
 GitHub runner, are normalized into the owned payload format, and are uploaded
 only to the vinext dashboard.
+
+## Scaling the benchmark app
+
+The shared benchmark app defaults to 33 routes. At that size some build-time
+effects are smaller than run-to-run noise, even with the paired AB/BA rounds.
+Set `VINEXT_BENCH_EXTRA_ROUTES=<n>` when generating the app to append `n`
+additional realistic routes (server pages with `next/link`, shared client
+components, and `.js` utilities), which makes per-module build costs large
+enough to measure:
+
+```bash
+# moderate scale (~1k routes) — surfaces per-module costs
+VINEXT_BENCH_EXTRA_ROUTES=1000 node benchmarks/generate-app.mjs
+
+# stress scale (~10k routes) — surfaces super-linear costs in scanning/graph work
+VINEXT_BENCH_EXTRA_ROUTES=10000 node benchmarks/generate-app.mjs
+```
+
+The default (`0`) keeps the canonical 33-route app, so this is opt-in and does
+not change existing benchmark numbers. Larger scales are useful for catching
+super-linear regressions that are invisible at small route counts.

--- a/benchmarks/perf/build-time.mjs
+++ b/benchmarks/perf/build-time.mjs
@@ -25,15 +25,16 @@ function targetEnvironment() {
   };
 }
 
-if (framework !== "vinext" && framework !== "nextjs") {
-  console.error("Usage: node benchmarks/perf/build-time.mjs <vinext|nextjs>");
+const isVinext = framework === "vinext" || framework === "vinext-large";
+if (!isVinext && framework !== "nextjs") {
+  console.error("Usage: node benchmarks/perf/build-time.mjs <vinext|vinext-large|nextjs>");
   process.exit(1);
 }
 
 const projectDir = join(benchmarkDir, framework);
 
 async function cleanBuildOutput() {
-  const outputDirectory = join(projectDir, framework === "vinext" ? "dist" : ".next");
+  const outputDirectory = join(projectDir, isVinext ? "dist" : ".next");
   await mkdir(outputDirectory, { recursive: true });
   const entries = await readdir(outputDirectory);
   await Promise.all(
@@ -43,7 +44,7 @@ async function cleanBuildOutput() {
 
 function buildCommand() {
   let command;
-  if (framework === "vinext") {
+  if (isVinext) {
     const vpPath = profiling
       ? join(projectDir, "node_modules/vite-plus/bin/vp")
       : execFileSync("which", ["vp"], { encoding: "utf8" }).trim();

--- a/benchmarks/perf/scenarios.json
+++ b/benchmarks/perf/scenarios.json
@@ -3,6 +3,17 @@
     { "command": ["vp", "run", "build"] },
     { "command": ["node", "benchmarks/generate-app.mjs"], "trusted": true },
     {
+      "command": [
+        "node",
+        "benchmarks/generate-app.mjs",
+        "--extra",
+        "5000",
+        "--target",
+        "vinext-large"
+      ],
+      "trusted": true
+    },
+    {
       "command": ["npm", "install"],
       "cwd": "benchmarks/nextjs",
       "implementationId": "nextjs"
@@ -54,6 +65,23 @@
           "profile": true,
           "compareBase": true,
           "command": ["node", "benchmarks/perf/build-time.mjs", "vinext"]
+        }
+      ]
+    },
+    {
+      "id": "production-build-large",
+      "suite": "Build",
+      "label": "Production build time (5000 routes)",
+      "description": "Clean production build of a generated 5000-route app. Stress scenario that surfaces super-linear build-time effects (e.g. route-graph scanning) which are invisible at the default app size. vinext only; uses a separate fixture so the headline comparison is unaffected.",
+      "unit": "ms",
+      "lowerIsBetter": true,
+      "implementations": [
+        {
+          "id": "vinext-large",
+          "label": "vinext",
+          "profile": false,
+          "compareBase": true,
+          "command": ["node", "benchmarks/perf/build-time.mjs", "vinext-large"]
         }
       ]
     },

--- a/benchmarks/vinext-large/package.json
+++ b/benchmarks/vinext-large/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "benchmark-vinext-large",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-server-dom-webpack": "catalog:",
+    "vinext": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-rsc": "catalog:",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/benchmarks/vinext-large/tsconfig.json
+++ b/benchmarks/vinext-large/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/benchmarks/vinext-large/vite.config.ts
+++ b/benchmarks/vinext-large/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite-plus";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ catalogs:
     '@vitest/coverage-istanbul':
       specifier: 4.1.9
       version: 4.1.9
+    am-i-vibing:
+      specifier: ^0.5.0
+      version: 0.5.0
     better-auth:
       specifier: ^1.5.6
       version: 1.5.6
@@ -395,6 +398,34 @@ importers:
         version: 4.80.0(@cloudflare/workers-types@4.20260313.1)
 
   benchmarks/vinext:
+    dependencies:
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      react-server-dom-webpack:
+        specifier: 'catalog:'
+        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      vinext:
+        specifier: workspace:*
+        version: link:../../packages/vinext
+    devDependencies:
+      '@vitejs/plugin-rsc':
+        specifier: 'catalog:'
+        version: 0.5.27(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.1
+        version: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
+
+  benchmarks/vinext-large:
     dependencies:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
@@ -4720,6 +4751,7 @@ packages:
 
   am-i-vibing@0.5.0:
     resolution: {integrity: sha512-KLcsDhqf1XRrJmJr+9I/C0EX2K+sGrAGZFgkmd84c8TJO9zJBu+/kFInjazu1KfJWFhWDKdRWkpBzEs7s35DVA==}
+    hasBin: true
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -6553,6 +6585,7 @@ packages:
 
   process-ancestry@0.1.0:
     resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
+    engines: {node: '>=18.0.0'}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - "!tests/fixtures/global-not-found-not-present"
   - tests/fixtures/ecosystem/*
   - benchmarks/vinext
+  - benchmarks/vinext-large
 
 catalog:
   "@cloudflare/kumo": ^2.2.0


### PR DESCRIPTION
> **No dependencies (standalone benchmark infra).** ⚠️ Needs a small `perf.yml` wiring change (see the bottom of this description) before the scenario runs in CI.

## What

- A vinext-only perf scenario **"Production build time (5000 routes)"** that builds a generated 5000-route app, via a separate `benchmarks/vinext-large` fixture.
- `generate-app.mjs` gains `--extra <n>` / `--target <name>` (and the `VINEXT_BENCH_EXTRA_ROUTES` env) to scale and target the generated app.

## Why

The default benchmark app is ~33 routes. At that size, super-linear build-time effects — e.g. route-graph directory scanning that re-reads shared ancestor directories once per descendant route — are smaller than run-to-run noise, so regressions (or fixes) in them are invisible to the perf bot. **5000** is the smallest scale where such effects clearly clear the ±1.5% band while keeping CI cost moderate (a scaling sweep showed the relevant delta going ~noise at 1k → ~−32% at 5k → ~−52% at 10k, with signal flattening past ~5–8k).

## Notes

- vinext-only and a separate fixture, so the headline vinext-vs-Next comparison and the existing scenarios are unchanged.
- Adds `benchmarks/vinext-large` to the workspace (lockfile updated).
- The generate step is intentionally **always-run** (no `implementationId`), so the 5000-route app is generated even on PR runs that skip Next.js via `--implementation=vinext`.

## ⚠️ CI wiring needed (for a maintainer)

This scenario builds a **new project** (`benchmarks/vinext-large`) under the isolated `vinext-perf-head` user, which `perf.yml` doesn't yet know about. I've **left the `perf.yml` change to whoever owns the perf workflow**, since it touches the isolated-user ACL model and I couldn't exercise that path locally. To run green it needs the same treatment `benchmarks/vinext` already gets:

- **`grant_write_paths`** — add `benchmarks/vinext-large` to `project_roots`, and `benchmarks/vinext-large/{dist,.vite,node_modules/.vite,node_modules/.vite-temp}` to `paths`. Without the write-ACL, `vp build` (run as `vinext-perf-head`) hits `EACCES` writing `dist`.
- **"Validate performance workspace paths"** — add `benchmarks/vinext-large` (+ its `app`/`dist`) to the directory / symlink checks, for parity.

No change is needed to the trusted-manifest/harness-copy steps (they only gate `vinext`/`nextjs`): the build reads the fixture from the target checkout and its scripts from the trusted harness.
