### PR TITLE
perf(routing): cache app-route-graph directory reads — 5000-route build −32%

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1328,6 +1328,42 @@ function discoverSlotSubRoutes(
  */
 type SlotSubPageEntry = { relativePath: string; pagePath: string };
 
+// Per-scan memo of raw directory reads (withFileTypes). Inherited parallel-slot
+// discovery walks every ancestor directory of a route and reads it with
+// `fs.readdirSync` to look for `@slot` directories; because routes share
+// ancestors, the same directory is otherwise read once per descendant route
+// (super-linear: a route dir with N siblings is read O(N) times across the
+// scan). Keyed by the per-scan matcher clone (like `findSlotSubPagesCache`
+// below) so it is scoped to a single scan and collected afterwards — no
+// cross-scan pollution in long-lived dev servers.
+const dirEntriesCache = new WeakMap<ValidFileMatcher, Map<string, fs.Dirent[]>>();
+
+function readDirEntriesCached(dir: string, matcher: ValidFileMatcher): fs.Dirent[] {
+  let perMatcher = dirEntriesCache.get(matcher);
+  if (!perMatcher) {
+    perMatcher = new Map();
+    dirEntriesCache.set(matcher, perMatcher);
+  }
+  let entries = perMatcher.get(dir);
+  if (entries === undefined) {
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (error) {
+      // Only a *missing* directory is an expected empty result — this replaces
+      // the prior `fs.existsSync(dir)` guard, and caching [] keeps a known-absent
+      // dir from being re-probed for every descendant route. Any other fault
+      // (EACCES, EMFILE/ENFILE, …) is real: rethrow it like the original
+      // unguarded `readdirSync` did, rather than silently caching an empty
+      // listing that would drop routes/slots for the rest of the scan.
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
+      entries = [];
+    }
+    perMatcher.set(dir, entries);
+  }
+  return entries;
+}
+
 // Per-scan memo: a slot directory's sub-pages depend only on the directory
 // contents and the matcher's accepted extensions. Inherited slots get scanned
 // once per descendant route, so without memoization a route N segments deep
@@ -2136,12 +2172,7 @@ function findSlotRootPage(slotDir: string, matcher: ValidFileMatcher): string | 
   if (directPage) return directPage;
 
   // Walk route-group subdirectories (transparent in the URL).
-  let entries: fs.Dirent[];
-  try {
-    entries = fs.readdirSync(slotDir, { withFileTypes: true });
-  } catch {
-    return null;
-  }
+  const entries = readDirEntriesCached(slotDir, matcher);
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     if (!entry.name.startsWith("(") || !entry.name.endsWith(")")) continue;
@@ -2167,9 +2198,7 @@ function discoverParallelSlots(
   matcher: ValidFileMatcher,
   includeNestedOnlySlots = false,
 ): AppRouteGraphParallelSlot[] {
-  if (!fs.existsSync(dir)) return [];
-
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const entries = readDirEntriesCached(dir, matcher);
   const slots: AppRouteGraphParallelSlot[] = [];
 
   for (const entry of entries) {


### PR DESCRIPTION
> **No dependencies — reviewable and mergeable on its own.** Touches only `routing/app-route-graph.ts`.

## What

Memoizes the raw `fs.readdirSync(dir, { withFileTypes: true })` calls in the App Router graph scan, via a per-scan `WeakMap<ValidFileMatcher, Map<string, Dirent[]>>` (the same pattern as the existing `findFileProbeCache` / `findSlotSubPagesCache`). `discoverParallelSlots` and `findSlotRootPage` read through it.

## Why

`discoverInheritedParallelSlots` reads **every ancestor directory** of each route to look for `@slot` dirs; because routes share ancestors, a directory with N sibling routes is re-read once per descendant route — super-linear in route-directory width. `findFileProbeCache` memoizes `findFile`, but not these raw `readdirSync`/`existsSync` calls. The graph is scanned both during **build** and at **dev-server startup**.

## Measured

Before/after this cache on the generated stress app ([#2388](https://github.com/cloudflare/vinext/pull/2388) adds the 5000-route scenario), local wall-clock. The effect is super-linear, so it grows with scale:

| Scale | Metric | Baseline | With cache | Change |
| --- | --- | --: | --: | :-: |
| **5,000 routes** | Production build | ~30 s | ~20 s | **−32%** |
| **5,000 routes** | Dev-server cold start | ~29 s | ~10 s | **−67%** |
| **10,000 routes** | Production build | ~86 s | ~42 s | **−52%** |
| **10,000 routes** | Dev-server cold start | ~101 s | ~17 s | **−83%** |

`readDirEntriesCached` returns exactly the entries `fs.readdirSync` would for each directory, so the discovered route/file set — and the module transforms that follow — are **unchanged** (verified by an identical module-transform count). Dev cold start improves because the route scan runs synchronously at *every* dev (re)start, independent of the `.vite` cache — so this isn't only a cold-cache effect.

## At scale vs Next.js (Turbopack)

With this cache in place, vinext's build-time lead over Next.js (Turbopack) widens sharply with route count — same machine, same generated app, clean production builds (median of 3, local wall-clock):

| Scale | vinext | Next.js (Turbopack) | vinext faster |
| --- | --: | --: | :-: |
| 33 routes | 2.6 s | 5.1 s | **1.95×** |
| 5,033 routes | 20.2 s | 106.0 s | **5.26×** |

Marginal cost per added route ≈ **3.5 ms (vinext)** vs **20 ms (Turbopack)**. Keeping the route-graph scan near-linear (this PR) is part of why vinext holds its lead as apps grow.

## Memory safety

The `WeakMap` is keyed on the per-scan matcher clone (like `findSlotSubPagesCache`), so entries are released when the scan's matcher is GC'd — nothing accumulates across rebuilds/restarts in a long-lived dev server (a module-level `Map` would leak here; the `WeakMap`-per-scan-matcher does not).

## Correctness

- `readDirEntriesCached` caches `[]` **only for a missing directory** (`ENOENT`/`ENOTDIR`) — exactly replacing the prior `fs.existsSync(dir)` guard — and **rethrows any real fault** (`EACCES`, `EMFILE`/`ENFILE`, …), matching the original unguarded `readdirSync`. A genuine FS error still fails the build loudly rather than silently caching an empty listing and dropping slots. The cache returns exactly the entries `readdirSync` would, so the discovered file set and resulting transforms are identical (same module-transform count).
- Route/slot suites pass — `app-route-graph`, `slot`, `app-optimistic-routing`, `routing`, `route-sorting`, `app-rsc-route-matching`, `hybrid-route-priority`, `app-page-route-wiring`, `pages-router`, `intercepting-routes-build`, `app-browser-interception-context`: **662 tests**. `vp lint` clean.
