### PR TITLE
fix(app-router): normalize trailing slash in implicit cache tags

### DIFF
--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -126,7 +126,10 @@ function recordAppPageCacheOutcome(
 }
 
 export function buildAppPageCacheTags(pathname: string, extraTags: readonly string[]): string[] {
-  const tags = [pathname, `_N_T_${pathname}`, "_N_T_/layout"];
+  // Strip trailing slash for the _N_T_ tag so it matches revalidatePath(),
+  // which also strips trailing slash before building the tag.
+  const stem = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  const tags = [pathname, `_N_T_${stem}`, "_N_T_/layout"];
   const segments = pathname.split("/");
   let built = "";
   for (let index = 1; index < segments.length; index++) {

--- a/packages/vinext/src/server/implicit-tags.ts
+++ b/packages/vinext/src/server/implicit-tags.ts
@@ -59,7 +59,8 @@ export function buildPageCacheTags(
   routeSegments: string[],
   leafKind: AppCacheLeafKind,
 ): string[] {
-  const tags = [pathname, `${NEXT_CACHE_IMPLICIT_TAG_ID}${pathname}`];
+  const normalizedPathname = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  const tags = [pathname, `${NEXT_CACHE_IMPLICIT_TAG_ID}${normalizedPathname}`];
   if (pathname === "/") appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}/index`);
   if (pathname === "/index") appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}/`);
   appendDerivedTags(tags, buildRouteCachePath(routeSegments, leafKind));

--- a/packages/vinext/src/server/implicit-tags.ts
+++ b/packages/vinext/src/server/implicit-tags.ts
@@ -59,7 +59,8 @@ export function buildPageCacheTags(
   routeSegments: string[],
   leafKind: AppCacheLeafKind,
 ): string[] {
-  const normalizedPathname = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  const normalizedPathname =
+    pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
   const tags = [pathname, `${NEXT_CACHE_IMPLICIT_TAG_ID}${normalizedPathname}`];
   if (pathname === "/") appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}/index`);
   if (pathname === "/index") appendUnique(tags, `${NEXT_CACHE_IMPLICIT_TAG_ID}/`);

--- a/tests/app-trailing-slash-isr.test.ts
+++ b/tests/app-trailing-slash-isr.test.ts
@@ -47,6 +47,7 @@ describe("App Router trailing-slash ISR with generated static params", () => {
     expect(response.status).toBe(200);
     expect(response.url).toBe(`${baseUrl}/en/`);
     expect(html).toContain('id="generated-at"');
-    expect(html).toContain("generated-<!-- -->en");
+    expect(html).toMatch(/id="generated-at">[^<]{10,}/);
+    expect(html).toContain('id="lang">en');
   });
 });

--- a/tests/e2e/app-router/trailingslash-revalidate.browser.spec.ts
+++ b/tests/e2e/app-router/trailingslash-revalidate.browser.spec.ts
@@ -9,10 +9,7 @@ import {
 } from "../production-server";
 import { waitForAppRouterHydration } from "../helpers";
 
-const FIXTURE_DIR = path.resolve(
-  process.cwd(),
-  "tests/fixtures/app-trailing-slash-isr",
-);
+const FIXTURE_DIR = path.resolve(process.cwd(), "tests/fixtures/app-trailing-slash-isr");
 
 type ProductionApp = {
   baseUrl: string;
@@ -21,10 +18,7 @@ type ProductionApp = {
 };
 
 async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
-  const sourceNodeModules = path.resolve(
-    process.cwd(),
-    "tests/fixtures/app-basic/node_modules",
-  );
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
   const targetNodeModules = path.join(fixtureRoot, "node_modules");
   await fs.mkdir(targetNodeModules, { recursive: true });
   for (const entry of await fs.readdir(sourceNodeModules, {
@@ -40,14 +34,11 @@ async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
 }
 
 async function buildAndServeFixture(): Promise<ProductionApp> {
-  const fixtureRoot = await fs.mkdtemp(
-    path.join(os.tmpdir(), "vinext-ts-revalidate-"),
-  );
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-ts-revalidate-"));
   await fs.cp(FIXTURE_DIR, fixtureRoot, { recursive: true });
   await linkFixtureNodeModules(fixtureRoot);
 
-  const vinext = (await import("../../../packages/vinext/src/index.js"))
-    .default;
+  const vinext = (await import("../../../packages/vinext/src/index.js")).default;
   const { createBuilder } = await import("vite");
   const builder = await createBuilder({
     root: fixtureRoot,
@@ -87,35 +78,25 @@ for (const withSlash of [true, false]) {
     await page.goto(`${app.baseUrl}/en`);
     await waitForAppRouterHydration(page);
 
-    const initialGeneratedAt = await page
-      .locator("#generated-at")
-      .textContent();
+    const initialGeneratedAt = await page.locator("#generated-at").textContent();
     expect(initialGeneratedAt).toBeTruthy();
     expect(initialGeneratedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
 
     await page.reload();
     await waitForAppRouterHydration(page);
-    const refreshedGeneratedAt = await page
-      .locator("#generated-at")
-      .textContent();
+    const refreshedGeneratedAt = await page.locator("#generated-at").textContent();
 
     await expect(async () => {
       await page.reload();
       await waitForAppRouterHydration(page);
-      const refreshedAgainGeneratedAt = await page
-        .locator("#generated-at")
-        .textContent();
+      const refreshedAgainGeneratedAt = await page.locator("#generated-at").textContent();
       expect(refreshedAgainGeneratedAt).toBe(refreshedGeneratedAt);
     }).toPass({ timeout: 10_000 });
 
-    const buttonId = withSlash
-      ? "revalidate-button-with-slash"
-      : "revalidate-button-no-slash";
+    const buttonId = withSlash ? "revalidate-button-with-slash" : "revalidate-button-no-slash";
     await page.locator(`#${buttonId}`).click();
 
-    await expect(page.locator("#revalidate-result")).toContainText(
-      "Revalidated",
-    );
+    await expect(page.locator("#revalidate-result")).toContainText("Revalidated");
 
     await expect(async () => {
       await page.reload();

--- a/tests/e2e/app-router/trailingslash-revalidate.browser.spec.ts
+++ b/tests/e2e/app-router/trailingslash-revalidate.browser.spec.ts
@@ -65,7 +65,6 @@ async function buildAndServeFixture(): Promise<ProductionApp> {
   };
 }
 
-// One shared production app for all tests in this file
 let app: ProductionApp;
 
 test.beforeAll(async () => {
@@ -94,7 +93,6 @@ for (const withSlash of [true, false]) {
     expect(initialGeneratedAt).toBeTruthy();
     expect(initialGeneratedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
 
-    // In production mode: verify the page is stable across consecutive refreshes
     await page.reload();
     await waitForAppRouterHydration(page);
     const refreshedGeneratedAt = await page

--- a/tests/e2e/app-router/trailingslash-revalidate.browser.spec.ts
+++ b/tests/e2e/app-router/trailingslash-revalidate.browser.spec.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+  startChildProductionServer,
+  stopChildProductionServer,
+  type ChildProductionServer,
+} from "../production-server";
+import { waitForAppRouterHydration } from "../helpers";
+
+const FIXTURE_DIR = path.resolve(
+  process.cwd(),
+  "tests/fixtures/app-trailing-slash-isr",
+);
+
+type ProductionApp = {
+  baseUrl: string;
+  fixtureRoot: string;
+  server: ChildProductionServer;
+};
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(
+    process.cwd(),
+    "tests/fixtures/app-basic/node_modules",
+  );
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+  await fs.mkdir(targetNodeModules, { recursive: true });
+  for (const entry of await fs.readdir(sourceNodeModules, {
+    withFileTypes: true,
+  })) {
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+async function buildAndServeFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "vinext-ts-revalidate-"),
+  );
+  await fs.cp(FIXTURE_DIR, fixtureRoot, { recursive: true });
+  await linkFixtureNodeModules(fixtureRoot);
+
+  const vinext = (await import("../../../packages/vinext/src/index.js"))
+    .default;
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: false,
+    plugins: [vinext({ appDir: fixtureRoot })],
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const server = await startChildProductionServer(fixtureRoot);
+  return {
+    baseUrl: `http://127.0.0.1:${server.port}`,
+    fixtureRoot,
+    server,
+  };
+}
+
+// One shared production app for all tests in this file
+let app: ProductionApp;
+
+test.beforeAll(async () => {
+  test.setTimeout(120_000);
+  app = await buildAndServeFixture();
+});
+
+test.afterAll(async () => {
+  await stopChildProductionServer(app.server);
+  await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+});
+
+test.setTimeout(60_000);
+
+// Ported from Next.js: test/e2e/app-dir/trailingslash/trailingslash.test.ts
+for (const withSlash of [true, false]) {
+  test(`should revalidate a page with generated static params (withSlash=${withSlash})`, async ({
+    page,
+  }) => {
+    await page.goto(`${app.baseUrl}/en`);
+    await waitForAppRouterHydration(page);
+
+    const initialGeneratedAt = await page
+      .locator("#generated-at")
+      .textContent();
+    expect(initialGeneratedAt).toBeTruthy();
+    expect(initialGeneratedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+    // In production mode: verify the page is stable across consecutive refreshes
+    await page.reload();
+    await waitForAppRouterHydration(page);
+    const refreshedGeneratedAt = await page
+      .locator("#generated-at")
+      .textContent();
+
+    await expect(async () => {
+      await page.reload();
+      await waitForAppRouterHydration(page);
+      const refreshedAgainGeneratedAt = await page
+        .locator("#generated-at")
+        .textContent();
+      expect(refreshedAgainGeneratedAt).toBe(refreshedGeneratedAt);
+    }).toPass({ timeout: 10_000 });
+
+    const buttonId = withSlash
+      ? "revalidate-button-with-slash"
+      : "revalidate-button-no-slash";
+    await page.locator(`#${buttonId}`).click();
+
+    await expect(page.locator("#revalidate-result")).toContainText(
+      "Revalidated",
+    );
+
+    await expect(async () => {
+      await page.reload();
+      await waitForAppRouterHydration(page);
+      const generatedAt = await page.locator("#generated-at").textContent();
+      expect(generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(generatedAt).not.toBe(initialGeneratedAt);
+    }).toPass({ timeout: 30_000, intervals: [1000] });
+  });
+}

--- a/tests/fixtures/app-trailing-slash-isr/app/[lang]/legacy/page.tsx
+++ b/tests/fixtures/app-trailing-slash-isr/app/[lang]/legacy/page.tsx
@@ -1,6 +1,16 @@
+import { RevalidateButton } from "../revalidate-button.js";
+
 export const revalidate = 900;
 
 export default async function Page({ params }: { params: Promise<{ lang: string }> }) {
   const { lang } = await params;
-  return <span id="generated-at">generated-{lang}</span>;
+  const generatedAt = new Date().toISOString();
+
+  return (
+    <div>
+      <span id="generated-at">{generatedAt}</span>
+      <span id="lang">{lang}</span>
+      <RevalidateButton lang={lang} />
+    </div>
+  );
 }

--- a/tests/fixtures/app-trailing-slash-isr/app/[lang]/revalidate-button.tsx
+++ b/tests/fixtures/app-trailing-slash-isr/app/[lang]/revalidate-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+export function RevalidateButton({ lang }: { lang: string }) {
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<string | null>(null);
+
+  function handleRevalidate(withSlash: boolean) {
+    startTransition(async () => {
+      try {
+        const data = await fetch(`/api/revalidate/?lang=${lang}&withSlash=${withSlash}`).then(
+          (res) => res.json() as Promise<{ timestamp: string }>,
+        );
+        startTransition(() => {
+          setResult(`Revalidated at: ${data.timestamp}`);
+        });
+      } catch (e) {
+        startTransition(() => {
+          setResult(`Error: ${String(e)}`);
+        });
+      }
+    });
+  }
+
+  return (
+    <div>
+      <button onClick={() => handleRevalidate(true)} disabled={isPending} id="revalidate-button-with-slash">
+        {isPending ? "Revalidating..." : `Revalidate /${lang}/`}
+      </button>
+      <button onClick={() => handleRevalidate(false)} disabled={isPending} id="revalidate-button-no-slash">
+        {isPending ? "Revalidating..." : `Revalidate /${lang} (no slash)`}
+      </button>
+      {result && <pre id="revalidate-result">{result}</pre>}
+    </div>
+  );
+}

--- a/tests/fixtures/app-trailing-slash-isr/app/[lang]/revalidate-button.tsx
+++ b/tests/fixtures/app-trailing-slash-isr/app/[lang]/revalidate-button.tsx
@@ -25,10 +25,18 @@ export function RevalidateButton({ lang }: { lang: string }) {
 
   return (
     <div>
-      <button onClick={() => handleRevalidate(true)} disabled={isPending} id="revalidate-button-with-slash">
+      <button
+        onClick={() => handleRevalidate(true)}
+        disabled={isPending}
+        id="revalidate-button-with-slash"
+      >
         {isPending ? "Revalidating..." : `Revalidate /${lang}/`}
       </button>
-      <button onClick={() => handleRevalidate(false)} disabled={isPending} id="revalidate-button-no-slash">
+      <button
+        onClick={() => handleRevalidate(false)}
+        disabled={isPending}
+        id="revalidate-button-no-slash"
+      >
         {isPending ? "Revalidating..." : `Revalidate /${lang} (no slash)`}
       </button>
       {result && <pre id="revalidate-result">{result}</pre>}

--- a/tests/fixtures/app-trailing-slash-isr/app/api/revalidate/route.ts
+++ b/tests/fixtures/app-trailing-slash-isr/app/api/revalidate/route.ts
@@ -1,0 +1,13 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const lang = url.searchParams.get("lang") ?? "en";
+  const withSlash = url.searchParams.get("withSlash") !== "false";
+
+  const path = withSlash ? `/${lang}/legacy/` : `/${lang}/legacy`;
+  await revalidatePath(path);
+
+  return NextResponse.json({ timestamp: new Date().toISOString() });
+}


### PR DESCRIPTION
## Summary

`revalidatePath()` strips the trailing slash before constructing its `_N_T_` implicit cache tag. Pages served at trailing-slash URLs (e.g. `/en/`) were building their own tags _with_ the slash, so the tags never matched and revalidation silently did nothing.

Fix: normalize the pathname (strip trailing `/`) in both tag-building sites before generating the `_N_T_` tag, matching what `revalidatePath()` produces.

## Files touched

| File | Change |
|---|---|
| `packages/vinext/src/server/app-page-cache.ts` | Strip trailing slash from `stem` before building `_N_T_${stem}` tag in `buildAppPageCacheTags()` |
| `packages/vinext/src/server/implicit-tags.ts` | Same normalization in `buildPageCacheTags()` — `normalizedPathname` used for the implicit tag |
| `tests/fixtures/app-trailing-slash-isr/app/[lang]/legacy/page.tsx` | Extend fixture page to render ISO timestamp + `<span id="lang">` + `RevalidateButton` |
| `tests/fixtures/app-trailing-slash-isr/app/[lang]/revalidate-button.tsx` | New client component — triggers `/api/revalidate` and surfaces result |
| `tests/fixtures/app-trailing-slash-isr/app/api/revalidate/route.ts` | New API route — calls `revalidatePath()` with the path supplied by the button |
| `tests/e2e/app-router/trailingslash-revalidate.browser.spec.ts` | New Playwright spec — ports the revalidation test from Next.js (see Reference) |
| `tests/app-trailing-slash-isr.test.ts` | Add timestamp content check |

## Testing plan

- Pass the new Playwright spec: `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific pnpm playwright test trailingslash-revalidate`
  - Both `withSlash=true` and `withSlash=false` variants pass
  - Verified the timestamp changes after clicking the revalidate button
- Pass the existing vitest integration test: `pnpm vitest run tests/app-trailing-slash-isr.test.ts`
  - Checks `/en/legacy/` returns 200 with timestamp content
  - Checks `/en` redirects to `/en/` and renders correct `lang` param

## Reference

https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/trailingslash/trailingslash.test.ts
Fix #1832