### PR TITLE
perf(plugins): skip dynamic-request AST parse for static-import-only modules — 5000-route build −21%

### DIFF
--- a/packages/vinext/src/plugins/ast-utils.ts
+++ b/packages/vinext/src/plugins/ast-utils.ts
@@ -10,6 +10,36 @@ export type AstRange = AstRecord & {
   end: number;
 };
 
+/**
+ * Cheap pre-parse gate for plugins that only transform *dynamic* `import(...)`.
+ *
+ * Static imports — `import x from "..."`, `import { ... } from "..."`,
+ * `import "..."` — never place a `(` (nor a comment leading to one) immediately
+ * after the `import` keyword. Plugins that act only on dynamic `import(...)` use
+ * this to skip `parseAst` for the overwhelming majority of modules in a large
+ * app: at ~5k routes, where almost every module is a static-import-only page,
+ * it removes most of the build's AST-parse/GC cost. This is a deliberate,
+ * measured performance filter — keep it a regex, never a parse.
+ *
+ * It intentionally errs toward over-matching: a false positive costs one
+ * redundant parse, whereas a false negative would silently skip a real dynamic
+ * import (a correctness bug). `\s*[(/]` therefore tolerates whitespace and
+ * block/line comments between the `import` keyword and its parenthesis.
+ *
+ * Usable directly as a Rolldown `transform.filter.code` regex, or via
+ * {@link mayContainDynamicImport} for an in-handler prescan.
+ */
+export const DYNAMIC_IMPORT_PRESCAN = /\bimport\s*[(/]/;
+
+/**
+ * Whether `code` might contain a dynamic `import(...)` call. See
+ * {@link DYNAMIC_IMPORT_PRESCAN} — a cheap, deliberately over-inclusive regex
+ * gate used to avoid parsing static-import-only modules.
+ */
+export function mayContainDynamicImport(code: string): boolean {
+  return DYNAMIC_IMPORT_PRESCAN.test(code);
+}
+
 const SKIP_CHILD_KEYS = new Set(["type", "parent", "loc", "start", "end"]);
 
 function getObjectProperty(value: unknown, key: string): unknown {

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -1,6 +1,13 @@
 import MagicString from "magic-string";
 import { parseAst, type Plugin, type ResolvedConfig } from "vite";
-import { forEachAstChild, hasRange, isAstRecord, nodeArray, type AstRecord } from "./ast-utils.js";
+import {
+  DYNAMIC_IMPORT_PRESCAN,
+  forEachAstChild,
+  hasRange,
+  isAstRecord,
+  nodeArray,
+  type AstRecord,
+} from "./ast-utils.js";
 
 const MODULE_EXTENSIONS = [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"];
 const TRANSFORMABLE_EXTENSIONS = new Set([
@@ -38,7 +45,7 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
           include: /\.(?:[cm]?[jt]s|[jt]sx)(?:\?.*)?$/i,
           exclude: /[\\/]node_modules[\\/]/,
         },
-        code: /\bimport\s*\(/,
+        code: DYNAMIC_IMPORT_PRESCAN,
       },
       handler(code, id) {
         const lang = langForId(id)!;

--- a/packages/vinext/src/plugins/ignore-dynamic-requests.ts
+++ b/packages/vinext/src/plugins/ignore-dynamic-requests.ts
@@ -8,6 +8,7 @@ import {
   hasRange,
   isAstRecord,
   isIdentifierNamed,
+  mayContainDynamicImport,
   nodeArray,
   type AstRecord,
 } from "./ast-utils.js";
@@ -720,7 +721,12 @@ function dynamicImportReplacement(): string {
 }
 
 function transformVeryDynamicRequests(code: string, id: string) {
-  if (!code.includes("require") && !code.includes("import")) return null;
+  // Pre-parse gate. `require` stays a broad substring check (it also covers
+  // aliasing and comment-separated `require/* … */(`), but the `import` side is
+  // narrowed to dynamic-call syntax via the shared `mayContainDynamicImport`:
+  // bare `import` (static ESM) otherwise matched ~every module, so this plugin
+  // parsed the whole graph. See DYNAMIC_IMPORT_PRESCAN for the rationale.
+  if (!code.includes("require") && !mayContainDynamicImport(code)) return null;
 
   const extension = path.extname(id.split("?", 1)[0]);
   const lang =


### PR DESCRIPTION
> **No dependencies — reviewable and mergeable on its own.** Touches only `plugins/` (`ast-utils` + `ignore-dynamic-requests` + `extensionless-dynamic-import`).

## What

Extracts a shared, documented pre-parse gate — `DYNAMIC_IMPORT_PRESCAN` / `mayContainDynamicImport` in `ast-utils` — and uses it as the "might this module contain a dynamic `import(...)`?" check in:

- **`ignore-dynamic-requests`** (in-handler prescan), and
- **`extensionless-dynamic-import`** (Rolldown `transform.filter.code`, which already used the same idea inline).

## Why

`ignore-dynamic-requests` pre-filtered with:

```js
if (!code.includes("require") && !code.includes("import")) return null;
```

The `import` substring matches **almost every ESM module** (every static `import x from "…"`), so the plugin ran `parseAst` + a full AST walk on essentially the entire module graph — then found nothing to do in the vast majority. It was the **only one of vinext's AST-walking transform plugins without a tight code filter**; the siblings already gate natively (`require-context` → `/\brequire\b…\.context/`, `extensionless-dynamic-import` → `import(`, `typeof-window` → `typeof window`, `import-meta-url` → `import.meta…`).

Static imports never put a `(` (or a comment leading to one) right after the `import` keyword, so narrowing the **import** side to dynamic-call syntax skips static-import-only modules entirely. The **require** side stays a broad substring check (it must keep covering aliasing and comment-separated `require/* … */(`).

Pulling the pattern into a named, documented helper makes the intent explicit — this is a deliberate, measured performance gate, not an incidental regex — and lets both plugins share one source of truth. `extensionless-dynamic-import` additionally gains correct handling of comment-separated dynamic imports (`import/* … */("…")`), which its old `\bimport\s*\(` filter missed.

## Measured

On the 5000-route stress fixture from [#2388](https://github.com/cloudflare/vinext/pull/2388) (same machine, clean builds, median of 3):

| | Build (5000 routes) |
| --- | --: |
| before | ~22.2 s |
| after | ~17.5 s |
| | **−21%** |

CPU profile of the build: `jsonParseAst` **1536 → 510 ms**, `forEachAstChild` **1199 ms → off the chart**, with matching GC relief — i.e. ~5000 redundant module parses removed. The saving is in AST parsing and is **orthogonal to [#2389](https://github.com/cloudflare/vinext/pull/2389)** (the route-graph read cache); they stack.

## Correctness

- The gate is intentionally **over-inclusive**: a false positive costs one redundant parse, a false negative would silently skip a real dynamic import — so `\s*[(/]` tolerates whitespace and block/line comments between `import` and `(`, and `require` stays broad.
- Dynamic-request / dynamic-import suites pass — `dynamic-requests-build`, `extensionless-dynamic-import`, `import-meta-url`: **100 tests**. `vp lint` clean.
- Equivalence is asserted via these suites and unchanged transform behavior, not output bytes: vinext's production build is not bit-reproducible run-to-run.
