### PR TITLE
fix(build): keep dynamic third-party imports bare in published dist

### DIFF
--- a/packages/vinext/vite.config.ts
+++ b/packages/vinext/vite.config.ts
@@ -15,6 +15,52 @@ import { defineConfig } from "vite-plus";
  */
 const cloudflareCacheSrc = fileURLToPath(new URL("../cloudflare/src/cache", import.meta.url));
 
+/**
+ * Keep third-party bare specifiers external — even when imported dynamically.
+ *
+ * `deps.neverBundle` (below) decides externalization on the *resolved* id
+ * (`id.includes("node_modules")`). Rolldown already preserves the bare specifier
+ * for *static* imports, but for a *dynamic* `await import("react")` it resolves
+ * the literal to an absolute path inside vinext's own `node_modules` *before*
+ * `neverBundle` runs, then bakes that path into `dist`
+ * (e.g. `import("/<vinext>/node_modules/.pnpm/next@.../next/router.js")`). That
+ * path only exists on the machine that built vinext, so on any other machine —
+ * including CI and every consumer — the build fails with
+ * `[UNRESOLVED_IMPORT] Could not resolve '/.../next/router.js'`. This regressed
+ * every dynamically-imported peer/dependency (`next/router`, `react`,
+ * `react-dom/*`, `vite`, `@vercel/og`, `@vitejs/plugin-rsc`, ...) when
+ * `skipNodeModulesBundle: true` — which externalized on the *unresolved* bare
+ * specifier — was replaced by the `neverBundle` predicate.
+ *
+ * Deciding on the unresolved specifier restores that behaviour, so dynamic
+ * imports stay bare like static ones. `isResolved` short-circuits to keep the
+ * resolved-path branch owned by `neverBundle`.
+ */
+const isFirstParty = (id: string) =>
+  id === "vinext" || id.startsWith("vinext/") || id.startsWith("@vinext/");
+
+const externalizeBareThirdPartySpecifiers = (
+  id: string,
+  _importer: string | undefined,
+  isResolved: boolean,
+) => {
+  if (isResolved) return false;
+  // Relative/absolute paths, virtual modules, and protocol-prefixed ids
+  // resolve normally.
+  if (id.startsWith(".") || id.startsWith("/") || id.startsWith("\0") || id.includes(":")) {
+    return false;
+  }
+  // First-party `vinext`/`@vinext/*` self-imports must keep resolving so the
+  // shim modules are emitted relative and shared as a single instance across
+  // Vite's separate RSC/SSR/client graphs (e.g. `instanceof
+  // ReadonlyURLSearchParams`). `@vinext/cloudflare/cache` is aliased to source.
+  if (isFirstParty(id)) return false;
+  // Packages inlined into `dist` via `alwaysBundle` must keep resolving so they
+  // get bundled rather than externalized.
+  if (id === "am-i-vibing" || id === "process-ancestry") return false;
+  return true;
+};
+
 export default defineConfig({
   pack: {
     entry: ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"],
@@ -37,6 +83,7 @@ export default defineConfig({
           "@vinext/cloudflare/cache": cloudflareCacheSrc,
         },
       },
+      external: externalizeBareThirdPartySpecifiers,
     },
     dts: true,
     fixedExtension: false,


### PR DESCRIPTION
## Problem

Consumer (and CI) builds against the published `vinext` fail with:

```
[UNRESOLVED_IMPORT] Could not resolve
'/home/runner/work/vinext/vinext/node_modules/.pnpm/next@.../node_modules/next/router.js'
in .../vinext/dist/shims/link.js
```

The published `dist/shims/link.js` baked an **absolute build-machine path** into the lazy Pages Router import:

```js
loadRouter: async () =>
  (await import("/home/runner/work/vinext/.../node_modules/next/router.js")).default,
```

That path only exists on the machine that built vinext, so it can never resolve on a consumer's machine.

## Root cause

#2279 replaced `deps.skipNodeModulesBundle: true` with a `deps.neverBundle` predicate that decides externalization on the **resolved** id (`id.includes("node_modules")`).

Rolldown resolves a dynamic `import()` literal to an absolute path **before** `neverBundle` runs, so the bare specifier is lost for **dynamic** imports. Static imports (e.g. `import Router from "next/router"` in `dev-server.js`) were unaffected and stayed bare — which is why only the dynamic `import("next/router")` in `link.js` broke.

`skipNodeModulesBundle: true` previously externalized on the **unresolved** bare specifier, so dynamic imports stayed bare.

## Fix

Externalize on the unresolved bare specifier via `inputOptions.external`, restoring the pre-#2279 behaviour so dynamic imports stay bare like static ones. Excluded from forced-externalization (so they keep resolving/bundling as before):

- First-party `vinext` / `@vinext/*` self-imports — must stay relative/bundled so shim modules are a single instance across Vite's RSC/SSR/client graphs (the `instanceof ReadonlyURLSearchParams` hazard the old `skipNodeModulesBundle` comment called out).
- `alwaysBundle` packages `am-i-vibing` / `process-ancestry` — must stay inlined.

## Verification

- Emitted `dist` is **byte-identical** to the current build except the single fixed line: `import("/abs/.../next/router.js")` → `import("next/router")`.
- `am-i-vibing` dependency tree (`am-i-vibing` → `process-ancestry`, no further deps) is still inlined under `dist/node_modules/` and is **checksum-identical** to the current build.
- Zero baked absolute `node_modules` dynamic imports remain in `dist`.