### PR TITLE
fix(app-router): avoid repeated hover prefetches

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2134,6 +2134,9 @@ function bootstrapHydration(
                     ? { dynamicStaleTimeSeconds: metadata.dynamicStaleTimeSeconds }
                     : {}),
                 }),
+            // A navigation that consumes prefetched Flight data keeps that
+            // prefetch freshness window when committed, matching Next's
+            // segment-cache handoff instead of recomputing dynamic freshness.
             ...(navResponseExpiresAt !== undefined ? { expiresAt: navResponseExpiresAt } : {}),
             mountedSlotsHeader: getMountedSlotIdsHeader(renderedElements),
           };

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -438,7 +438,6 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           getMountedSlotsHeader,
           hasPrefetchCacheEntryForNavigation,
           prefetchRscResponse,
-          DYNAMIC_NAVIGATION_CACHE_TTL,
           PREFETCH_CACHE_TTL,
         } = navigation;
         const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
@@ -550,7 +549,7 @@ function prefetchUrl(href: string, mode: LinkPrefetchMode, priority: "low" | "hi
           undefined,
           {
             cacheForNavigation: autoPrefetch.cacheForNavigation,
-            fallbackTtlMs: mode === "full" ? PREFETCH_CACHE_TTL : DYNAMIC_NAVIGATION_CACHE_TTL,
+            fallbackTtlMs: PREFETCH_CACHE_TTL,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
           },
         );

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -366,7 +366,7 @@ function resolvePrefetchedRscResponseExpiresAt(
   }
   const seconds = cached.dynamicStaleTimeSeconds;
   if (!isDynamicStaleTimeSeconds(seconds)) {
-    return timestamp + fallbackTtlMs;
+    return timestamp + Math.max(fallbackTtlMs, MIN_PREFETCH_STALE_TIME_MS);
   }
   return timestamp + Math.max(seconds * 1000, MIN_PREFETCH_STALE_TIME_MS);
 }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -229,6 +229,7 @@ export const PREFETCH_CACHE_TTL = resolveClientRouterStaleTime(
   process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME,
   30_000,
 );
+const MIN_PREFETCH_STALE_TIME_MS = 30_000;
 
 /** A buffered RSC response stored as an ArrayBuffer for replay. */
 export type CachedRscResponse = {
@@ -353,6 +354,21 @@ export function resolveCachedRscResponseExpiresAt(
     return cached.expiresAt;
   }
   return timestamp + resolveCachedRscResponseTtlMs(cached, fallbackTtlMs);
+}
+
+function resolvePrefetchedRscResponseExpiresAt(
+  timestamp: number,
+  cached: Pick<CachedRscResponse, "dynamicStaleTimeSeconds" | "expiresAt">,
+  fallbackTtlMs: number,
+): number {
+  if (isCacheExpiresAt(cached.expiresAt)) {
+    return cached.expiresAt;
+  }
+  const seconds = cached.dynamicStaleTimeSeconds;
+  if (!isDynamicStaleTimeSeconds(seconds)) {
+    return timestamp + fallbackTtlMs;
+  }
+  return timestamp + Math.max(seconds * 1000, MIN_PREFETCH_STALE_TIME_MS);
 }
 
 function resolvePrefetchCacheEntryExpiresAt(entry: PrefetchCacheEntry): number {
@@ -793,7 +809,7 @@ export function prefetchRscResponse(
     .then(async (response) => {
       if (response.ok) {
         entry.snapshot = await snapshotRscResponse(response);
-        entry.expiresAt = resolveCachedRscResponseExpiresAt(
+        entry.expiresAt = resolvePrefetchedRscResponseExpiresAt(
           entry.timestamp,
           entry.snapshot,
           behavior.fallbackTtlMs ?? PREFETCH_CACHE_TTL,

--- a/tests/app-visited-response-cache.test.ts
+++ b/tests/app-visited-response-cache.test.ts
@@ -71,6 +71,28 @@ describe("visited response cache freshness", () => {
     );
   });
 
+  it("inherits the expiry carried by a consumed prefetch snapshot", () => {
+    const now = 1_000_000;
+    const prefetchedExpiresAt = now + 30_000;
+    const entry = createVisitedResponseCacheEntry({
+      fallbackTtlMs: 0,
+      now,
+      params: {},
+      response: createCachedResponse({
+        dynamicStaleTimeSeconds: 0,
+        expiresAt: prefetchedExpiresAt,
+      }),
+    });
+
+    expect(entry.expiresAt).toBe(prefetchedExpiresAt);
+    expect(
+      isVisitedResponseCacheEntryFresh(entry, {
+        navigationKind: "navigate",
+        now: now + 29_999,
+      }),
+    ).toBe(true);
+  });
+
   it("retains decoded committed elements for partial Flight payload reuse", () => {
     // Ported from Next.js: test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
     const elements = { "page:/dynamic": "cached page" } satisfies AppElements;

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1492,6 +1492,32 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("does not re-prefetch a visible full-prefetch Link just because dynamic stale time is zero", async () => {
+    vi.stubEnv("__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME", "0");
+    vi.stubEnv("__NEXT_CLIENT_ROUTER_STATIC_STALETIME", "300");
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      vi.spyOn(Date, "now").mockReturnValue(1_000_001);
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("prefetches visible dynamic links in automatic production mode without seeding navigation cache", async () => {
     const observer = stubIntersectionObserver();
 

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -465,7 +465,7 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
   });
 
-  it("honors an explicit fallback stale window for prefetched responses", async () => {
+  it("honors an explicit fallback stale window above the minimum for prefetched responses", async () => {
     const now = 1_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const rscUrl = "/auto-full.rsc";
@@ -476,11 +476,32 @@ describe("prefetch cache eviction", () => {
       null,
       null,
       undefined,
-      { fallbackTtlMs: DYNAMIC_NAVIGATION_CACHE_TTL },
+      { fallbackTtlMs: 60_000 },
     );
     await getPrefetchCache().get(rscUrl)?.pending;
 
-    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + DYNAMIC_NAVIGATION_CACHE_TTL);
+    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 60_000);
+  });
+
+  it("floors explicit fallback stale windows for prefetched responses", async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const rscUrl = "/short-static-stale-prefetch.rsc";
+
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(new Response("flight", { headers: { "content-type": "text/x-component" } })),
+      null,
+      null,
+      undefined,
+      { fallbackTtlMs: 5_000 },
+    );
+    await getPrefetchCache().get(rscUrl)?.pending;
+
+    // Ported from Next.js segment-cache prefetch behavior:
+    // packages/next/src/client/components/segment-cache/cache.ts:getStaleTimeMs
+    // clamps all configured prefetch stale times to at least 30s.
+    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 30_000);
   });
 
   it("uses Next.js's minimum prefetch stale window for server stale time zero", async () => {
@@ -510,6 +531,9 @@ describe("prefetch cache eviction", () => {
     // clamps prefetch stale time to at least 30s so too-short server stale
     // times do not prevent prefetching from being useful.
     expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 30_000);
+
+    const consumed = consumePrefetchResponse(rscUrl, null, null);
+    expect(consumed?.expiresAt).toBe(now + 30_000);
   });
 
   it("leaves a resolved in-flight prefetch for a newer navigation when the old navigation is stale", async () => {

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -465,7 +465,7 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
   });
 
-  it("uses the dynamic stale window for automatic full prefetches", async () => {
+  it("honors an explicit fallback stale window for prefetched responses", async () => {
     const now = 1_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const rscUrl = "/auto-full.rsc";
@@ -481,6 +481,35 @@ describe("prefetch cache eviction", () => {
     await getPrefetchCache().get(rscUrl)?.pending;
 
     expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + DYNAMIC_NAVIGATION_CACHE_TTL);
+  });
+
+  it("uses Next.js's minimum prefetch stale window for server stale time zero", async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const rscUrl = "/zero-stale-prefetch.rsc";
+
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("flight", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "0",
+          },
+        }),
+      ),
+      null,
+      null,
+      undefined,
+      { fallbackTtlMs: PREFETCH_CACHE_TTL },
+    );
+    await getPrefetchCache().get(rscUrl)?.pending;
+
+    // Ported from Next.js segment-cache prefetch behavior:
+    // packages/next/src/client/components/segment-cache/cache.ts:getStaleTimeMs
+    // clamps prefetch stale time to at least 30s so too-short server stale
+    // times do not prevent prefetching from being useful.
+    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 30_000);
   });
 
   it("leaves a resolved in-flight prefetch for a newer navigation when the old navigation is stale", async () => {


### PR DESCRIPTION
## Summary

Fixes the hover/visible-link RSC prefetch regression introduced after client cache reuse landed.

The bug was that Link-triggered full prefetches were using the dynamic navigation stale window as their fallback freshness. With Next.js defaults (`staleTimes.dynamic = 0`), a just-prefetched payload could be treated as stale by the visible-link ping/dedupe path, so app-router commits or hover/focus churn could issue extra RSC prefetch requests instead of reusing the existing prefetch entry.

This keeps committed navigation snapshots on dynamic freshness, but restores fetched prefetch entries to prefetch-cache freshness:

- Link prefetches use the static/full prefetch window as their fallback freshness.
- Server-provided stale time headers on fetched prefetch responses are clamped to a 30s minimum, matching Next.js segment-cache behavior (`getStaleTimeMs`).
- Added regression coverage for visible-link pings with `dynamic=0` and for the minimum prefetch stale-time clamp.

## Validation

- `vp test run tests/link-navigation.test.ts tests/prefetch-cache.test.ts`
- `vp check packages/vinext/src/shims/link.tsx packages/vinext/src/shims/navigation.ts tests/link-navigation.test.ts tests/prefetch-cache.test.ts`
