### PR TITLE
fix(ci): avoid loading commit diffs in benchmark validation

### DIFF
--- a/benchmarks/perf/validate-results.mjs
+++ b/benchmarks/perf/validate-results.mjs
@@ -581,10 +581,9 @@ if (sourceEvent === "pull_request") {
   }
 }
 
-const commit = githubApi(`repos/${commitRepository}/commits/${payload.run.commitSha}`);
+const commit = githubApi(`repos/${commitRepository}/git/commits/${payload.run.commitSha}`);
 assert(
-  new Date(payload.run.measuredAt).toISOString() ===
-    new Date(commit.commit.committer.date).toISOString(),
+  new Date(payload.run.measuredAt).toISOString() === new Date(commit.committer.date).toISOString(),
   "Performance measuredAt does not match the commit timestamp",
 );
 

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -667,7 +667,7 @@ describe("paired performance benchmarks", () => {
             scenarios: [performanceScenario([{ id: "vinext", label: "vinext" }])],
           }),
         ),
-      [`repos/cloudflare/vinext/commits/${headSha}`]: commit(measuredAt),
+      [`repos/cloudflare/vinext/git/commits/${headSha}`]: commit(measuredAt),
     });
   });
 
@@ -709,7 +709,7 @@ describe("paired performance benchmarks", () => {
         ),
       [`repos/cloudflare/vinext/git/trees/${baseSha}?recursive=1`]: githubTree(nextjsInputs),
       [`repos/cloudflare/vinext/git/trees/${headSha}?recursive=1`]: githubTree(nextjsInputs),
-      [`repos/cloudflare/vinext/commits/${headSha}`]: commit(measuredAt),
+      [`repos/cloudflare/vinext/git/commits/${headSha}`]: commit(measuredAt),
     });
   });
 
@@ -745,7 +745,7 @@ describe("paired performance benchmarks", () => {
             scenarios: [performanceScenario([{ id: "vinext", label: "vinext" }])],
           }),
         ),
-      [`repos/cloudflare/vinext/commits/${commitSha}`]: commit(measuredAt),
+      [`repos/cloudflare/vinext/git/commits/${commitSha}`]: commit(measuredAt),
     });
   }, 15_000);
 
@@ -807,7 +807,7 @@ describe("paired performance benchmarks", () => {
       [`repos/cloudflare/vinext/git/trees/${baseSha}?recursive=1`]: githubTree(baseInputs),
       [`repos/cloudflare/vinext/git/trees/${mergeSha}?recursive=1`]: githubTree(baseInputs),
       [`repos/cloudflare/vinext/git/trees/${headSha}?recursive=1`]: githubTree(staleHeadInputs),
-      [`repos/cloudflare/vinext/commits/${headSha}`]: commit(measuredAt),
+      [`repos/cloudflare/vinext/git/commits/${headSha}`]: commit(measuredAt),
     });
   });
 
@@ -881,7 +881,7 @@ describe("paired performance benchmarks", () => {
             ],
           }),
         ),
-      [`repos/cloudflare/vinext/commits/${headSha}`]: commit(measuredAt),
+      [`repos/cloudflare/vinext/git/commits/${headSha}`]: commit(measuredAt),
     };
 
     expect(() => validatePerformancePayload(payload, "pull_request", responses)).not.toThrow();
@@ -1142,5 +1142,5 @@ function githubTree(tree: Array<ReturnType<typeof gitTreeEntry>>) {
 }
 
 function commit(measuredAt: string) {
-  return { commit: { committer: { date: measuredAt } } };
+  return { committer: { date: measuredAt } };
 }


### PR DESCRIPTION
## Problem

The benchmark source job can finish successfully, but the trusted publisher can still fail before uploading results or posting a PR comment. The failure this fixes is in `Validate benchmark metadata`:

```text
Error: spawnSync gh ENOBUFS
spawnargs: [
  'api',
  'repos/NathanDrake2406/vinext/commits/<sha>'
]
```

That validator shells out to `gh api` and captures the full JSON response in memory. It only needs the commit timestamp, but the repository commit endpoint may include file and stat diff metadata. For large merge commits, that response can exceed Node's default child process buffer and crash validation. The benchmark result itself is valid; the publisher was asking GitHub for much more data than it needed.

## Overview

| Area | Details |
| --- | --- |
| Goal | Keep benchmark publishing validation from crashing on large commit API responses. |
| Core change | Fetch the raw Git commit object for `committer.date` instead of the repository commit response with diff metadata. |
| Review path | `benchmarks/perf/validate-results.mjs`, then `tests/performance-benchmarks.test.ts`. |
| Expected impact | Trusted publisher validation avoids buffering large commit diff payloads while preserving the measuredAt timestamp check. |

## Why

The publisher only needs the commit timestamp to verify `payload.run.measuredAt`. The repository commit endpoint can include file diff metadata for the commit, which is unnecessary for this validator and can overflow the default child process buffer when `gh api` output is captured synchronously. The Git Database commit endpoint returns the raw commit object with `committer.date` and avoids pulling diff file payloads into the validator.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Benchmark timestamp validation | `GET /repos/{owner}/{repo}/commits/{sha}` and read `commit.committer.date`. | `GET /repos/{owner}/{repo}/git/commits/{sha}` and read `committer.date`. |
| Validator tests | Mocked the heavier repository commit response shape. | Mock the Git Database commit endpoint and raw commit response shape. |

## Validation

- `vp check --fix tests/performance-benchmarks.test.ts benchmarks/perf/validate-results.mjs`
- `vp test run --project unit tests/performance-benchmarks.test.ts`
- Pre-commit hook: staged checks, full check, staged unit and integration tests, knip

## References

| Reference | Why it matters |
| --- | --- |
| https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit | Documents the repository commit endpoint that includes commit-level metadata used by the old validator path. |
| https://docs.github.com/en/rest/git/commits?apiVersion=2022-11-28#get-a-commit-object | Documents the raw Git commit object endpoint used by this PR for `committer.date`. |
