### PR TITLE
ci: smoke test create-next-app Cloudflare deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,10 @@ jobs:
   create-next-app-cloudflare:
     name: create-next-app (cloudflare init)
     runs-on: ubuntu-latest
+    env:
+      CNA_CLOUDFLARE_WORKER: create-next-app-cloudflare
+      # Public test namespace already used by examples/workers-cache.
+      CNA_CLOUDFLARE_KV_NAMESPACE_ID: b38f84f642aa4bd4ba17a37bb516f0b5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -316,9 +320,30 @@ jobs:
           --data-cache=kv
           --image-optimization=cloudflare-images
 
+      - name: Configure generated Cloudflare deployment
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const configPath = "wrangler.jsonc";
+            const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+            config.name = process.env.CNA_CLOUDFLARE_WORKER;
+            config.preview_urls = true;
+            for (const namespace of config.kv_namespaces ?? []) {
+              if (namespace.binding === "VINEXT_KV_CACHE") {
+                namespace.id = process.env.CNA_CLOUDFLARE_KV_NAMESPACE_ID;
+              }
+            }
+            fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+          '
+
       - name: Build generated Cloudflare project
         working-directory: ${{ runner.temp }}/cna-cloudflare
         run: vp exec vinext build
+
+      - name: Verify generated Cloudflare build output
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: test -f dist/server/wrangler.json
 
   e2e:
     name: E2E (${{ matrix.label }})
@@ -499,7 +524,8 @@ jobs:
   ci:
     name: CI
     if: ${{ always() }}
-    needs: [check, test-unit, test-integration-merge, create-next-app, e2e]
+    needs:
+      [check, test-unit, test-integration-merge, create-next-app, create-next-app-cloudflare, e2e]
     runs-on: ubuntu-latest
     steps:
       - name: All checks passed

--- a/.github/workflows/create-next-app-cloudflare-deploy.yml
+++ b/.github/workflows/create-next-app-cloudflare-deploy.yml
@@ -1,0 +1,126 @@
+name: create-next-app Cloudflare Deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cna-cloudflare-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy and smoke test
+    runs-on: ubuntu-latest
+    env:
+      CNA_CLOUDFLARE_WORKER: create-next-app-cloudflare
+      # Public test namespace already used by examples/workers-cache.
+      CNA_CLOUDFLARE_KV_NAMESPACE_ID: b38f84f642aa4bd4ba17a37bb516f0b5
+      CNA_CLOUDFLARE_EXPECTED_TEXT: Get started
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      - name: Build packages
+        run: vp run build
+
+      - name: Pack vinext packages for local install
+        working-directory: packages/vinext
+        run: |
+          vp pm pack --pack-destination "${{ runner.temp }}"
+          cd ../cloudflare
+          vp pm pack --pack-destination "${{ runner.temp }}"
+
+      - name: Scaffold a fresh create-next-app project
+        run: vp dlx create-next-app@16.2.7 "${{ runner.temp }}/cna-cloudflare" --yes
+
+      - name: Pin pnpm in scaffolded project to vinext's version
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: |
+          PKG_MGR=$(cd "${{ github.workspace }}" && node -p "require('./package.json').packageManager")
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+            pkg.packageManager = '$PKG_MGR';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Allow required native dependency builds
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: |
+          node -e '
+            const fs = require("fs");
+            const f = "pnpm-workspace.yaml";
+            let y = fs.existsSync(f) ? fs.readFileSync(f, "utf8") : "";
+            y = y.replace(/allowBuilds:[\s\S]*?(?=\n\S|\n*$)/, "");
+            y = y.trimEnd() + "\n\nallowBuilds:\n  esbuild: true\n  sharp: true\n  unrs-resolver: true\n  workerd: true\n";
+            fs.writeFileSync(f, y);
+          '
+
+      - name: Install local vinext packages
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: |
+          vp add "${{ runner.temp }}"/vinext-[0-9]*.tgz
+          vp add "${{ runner.temp }}"/vinext-cloudflare-*.tgz
+
+      - name: Run Cloudflare init
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: >-
+          vp exec vinext init --skip-check --platform=cloudflare
+          --data-cache=kv
+          --image-optimization=cloudflare-images
+
+      - name: Configure generated Cloudflare deployment
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const configPath = "wrangler.jsonc";
+            const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+            config.name = process.env.CNA_CLOUDFLARE_WORKER;
+            config.preview_urls = true;
+            for (const namespace of config.kv_namespaces ?? []) {
+              if (namespace.binding === "VINEXT_KV_CACHE") {
+                namespace.id = process.env.CNA_CLOUDFLARE_KV_NAMESPACE_ID;
+              }
+            }
+            fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+          '
+
+      - name: Build generated Cloudflare project
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: vp exec vinext build
+
+      - name: Verify generated Cloudflare build output
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: test -f dist/server/wrangler.json
+
+      - name: Deploy generated Cloudflare build
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: vp exec wrangler deploy --config dist/server/wrangler.json
+
+      - name: Smoke test generated Cloudflare deployment
+        run: |
+          URL="https://${CNA_CLOUDFLARE_WORKER}.vinext.workers.dev/"
+          BODY_FILE="$(mktemp)"
+          trap 'rm -f "$BODY_FILE"' EXIT
+
+          for attempt in $(seq 1 45); do
+            STATUS=$(curl -sS -o "$BODY_FILE" -w "%{http_code}" -L --max-time 10 "$URL" || echo "000")
+            echo "HTTP status from ${URL}: ${STATUS} (attempt ${attempt})"
+            if [ "$STATUS" = "200" ] && grep -qiF "$CNA_CLOUDFLARE_EXPECTED_TEXT" "$BODY_FILE"; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Generated Cloudflare deployment did not return expected content"
+          exit 1


### PR DESCRIPTION
## Summary
- keep the pull_request CI job limited to create-next-app Cloudflare scaffold/init/build/output verification with no secrets references
- add a separate push-to-main workflow that deploys the generated Cloudflare build and smoke-tests the trusted Worker URL
- include the create-next-app Cloudflare CI job in the aggregate CI gate

## Security note
The deploy workflow is separate from ci.yml and only triggers on pushes to main. ci.yml contains no Cloudflare secret references, so ordinary PR CI cannot receive deploy credentials.

## Validation
- temporary branch-triggered deploy workflow passed: https://github.com/cloudflare/vinext/actions/runs/28360692235
- git diff --check
- ruby -e 'require "psych"; ARGV.each { |f| Psych.parse_file(f); puts "#{f}: yaml syntax ok" }' .github/workflows/ci.yml .github/workflows/create-next-app-cloudflare-deploy.yml\n- actionlint -ignore 'SC2129' -ignore 'SC2086' .github/workflows/ci.yml .github/workflows/create-next-app-cloudflare-deploy.yml\n- vp fmt --check .github/workflows/ci.yml .github/workflows/create-next-app-cloudflare-deploy.yml\n- vp run check\n\nNote: plain actionlint on ci.yml still reports pre-existing shellcheck warnings at lines 82 and 97, unrelated to this change.