### PR TITLE
feat(web): compare deploy suite runs

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,3 +1,6 @@
 # Required by compatibility and benchmark ingest endpoints.
 # Generate with: node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"
 COMPAT_INGEST_SECRET=""
+
+# Optional. Raises GitHub API rate limits for deploy-suite report comparison.
+GITHUB_TOKEN=""

--- a/apps/web/app/api/compatibility/compare/route.ts
+++ b/apps/web/app/api/compatibility/compare/route.ts
@@ -1,0 +1,398 @@
+/**
+ * POST /api/compatibility/compare
+ *
+ * Downloads the `deploy-suite-report` artifacts for two GitHub Actions run ids
+ * and returns assertion-level pass/fail changes. The baseline run id defaults
+ * to the latest ingested main deploy-suite run from D1.
+ */
+import { inflateRawSync } from "node:zlib";
+import { desc, eq } from "drizzle-orm";
+import { getDb, getGitHubToken } from "../../../lib/db/client";
+import { compatRuns } from "../../../lib/db/schema";
+
+const OWNER = "cloudflare";
+const REPO = "vinext";
+const DEFAULT_KIND = "deploy";
+const REPORT_ARTIFACT_NAME = "deploy-suite-report";
+const REPORT_FILE_NAME = "deploy-suite-report.json";
+const RUN_ID_RE = /^\d+$/;
+
+type ReportTest = {
+  suite: string;
+  test: string;
+};
+
+type DeploySuiteReport = {
+  timestamp?: string;
+  vinextRef?: string;
+  nextRef?: string;
+  suiteFilter?: string;
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+  };
+  failed: ReportTest[];
+  passed: ReportTest[];
+};
+
+type ComparedRun = {
+  runId: string;
+  htmlUrl: string;
+  report: Pick<
+    DeploySuiteReport,
+    "timestamp" | "vinextRef" | "nextRef" | "suiteFilter" | "summary"
+  >;
+};
+
+type Change = ReportTest & {
+  before: "passed" | "failed" | "missing";
+  after: "passed" | "failed" | "missing";
+};
+
+type ChangeGroups = {
+  regressions: Change[];
+  newFailures: Change[];
+  fixes: Change[];
+  noLongerFailing: Change[];
+};
+
+type CompareBody = {
+  baselineRunId?: string;
+  targetRunId?: string;
+};
+
+type GitHubArtifactsResponse = {
+  artifacts?: Array<{
+    name?: string;
+    expired?: boolean;
+    archive_download_url?: string;
+  }>;
+};
+
+class HttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  let body: CompareBody;
+  try {
+    const parsed = await request.json();
+    body = parsed && typeof parsed === "object" ? (parsed as CompareBody) : {};
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const targetRunId = normalizeRunId(body.targetRunId);
+  if (!targetRunId) {
+    return Response.json({ error: "A comparison run id is required" }, { status: 400 });
+  }
+
+  let baselineRunId = normalizeRunId(body.baselineRunId);
+  if (!baselineRunId) {
+    try {
+      baselineRunId = await loadLatestMainRunId();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return Response.json(
+        { error: "Failed to load the latest main baseline run id", detail },
+        { status: 500 },
+      );
+    }
+  }
+
+  if (!baselineRunId) {
+    return Response.json({ error: "No baseline run id was provided or ingested" }, { status: 400 });
+  }
+
+  try {
+    const token = getGitHubToken();
+    const [baselineReport, targetReport] = await Promise.all([
+      downloadDeploySuiteReport(baselineRunId, token),
+      downloadDeploySuiteReport(targetRunId, token),
+    ]);
+    const changes = compareDeploySuiteReports(baselineReport, targetReport);
+
+    return Response.json({
+      baseline: toComparedRun(baselineRunId, baselineReport),
+      target: toComparedRun(targetRunId, targetReport),
+      delta: {
+        total: targetReport.summary.total - baselineReport.summary.total,
+        passed: targetReport.summary.passed - baselineReport.summary.passed,
+        failed: targetReport.summary.failed - baselineReport.summary.failed,
+        skipped: targetReport.summary.skipped - baselineReport.summary.skipped,
+      },
+      changes,
+      totals: Object.fromEntries(
+        Object.entries(changes).map(([key, value]) => [key, value.length]),
+      ),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = error instanceof HttpError ? error.status : 500;
+    console.error("[/api/compatibility/compare] comparison failed:", message);
+    return Response.json({ error: message }, { status });
+  }
+}
+
+async function loadLatestMainRunId(): Promise<string | null> {
+  const db = getDb();
+  const rows = await db
+    .select({ runKey: compatRuns.runKey })
+    .from(compatRuns)
+    .where(eq(compatRuns.kind, DEFAULT_KIND))
+    .orderBy(desc(compatRuns.createdAt), desc(compatRuns.id))
+    .limit(1);
+  return normalizeRunId(rows[0]?.runKey);
+}
+
+function normalizeRunId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return RUN_ID_RE.test(trimmed) ? trimmed : null;
+}
+
+function toComparedRun(runId: string, report: DeploySuiteReport): ComparedRun {
+  return {
+    runId,
+    htmlUrl: `https://github.com/${OWNER}/${REPO}/actions/runs/${runId}`,
+    report: {
+      timestamp: report.timestamp,
+      vinextRef: report.vinextRef,
+      nextRef: report.nextRef,
+      suiteFilter: report.suiteFilter,
+      summary: report.summary,
+    },
+  };
+}
+
+async function downloadDeploySuiteReport(
+  runId: string,
+  token: string | undefined,
+): Promise<DeploySuiteReport> {
+  const artifactsUrl = `https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${runId}/artifacts?per_page=100`;
+  const artifactsResponse = await fetch(artifactsUrl, { headers: githubHeaders(token) });
+  if (!artifactsResponse.ok) {
+    throw new HttpError(
+      `Failed to list artifacts for run ${runId} (${artifactsResponse.status})`,
+      artifactsResponse.status,
+    );
+  }
+
+  const payload = (await artifactsResponse.json()) as GitHubArtifactsResponse;
+  const artifact = payload.artifacts?.find((entry) => entry.name === REPORT_ARTIFACT_NAME);
+  if (!artifact?.archive_download_url) {
+    throw new HttpError(`Run ${runId} does not have a ${REPORT_ARTIFACT_NAME} artifact`, 404);
+  }
+  if (artifact.expired) {
+    throw new HttpError(`The ${REPORT_ARTIFACT_NAME} artifact for run ${runId} has expired`, 410);
+  }
+
+  const archiveResponse = await fetch(artifact.archive_download_url, {
+    headers: githubHeaders(token),
+  });
+  if (!archiveResponse.ok) {
+    throw new HttpError(
+      `Failed to download ${REPORT_ARTIFACT_NAME} for run ${runId} (${archiveResponse.status})`,
+      archiveResponse.status,
+    );
+  }
+
+  const reportText = extractZipTextFile(
+    new Uint8Array(await archiveResponse.arrayBuffer()),
+    REPORT_FILE_NAME,
+  );
+  const report = JSON.parse(reportText) as unknown;
+  if (!isDeploySuiteReport(report)) {
+    throw new HttpError(`Run ${runId} has an invalid ${REPORT_FILE_NAME}`, 502);
+  }
+  return report;
+}
+
+function githubHeaders(token: string | undefined): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "vinext-web-compatibility",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+export function compareDeploySuiteReports(
+  baseline: DeploySuiteReport,
+  target: DeploySuiteReport,
+): ChangeGroups {
+  const baselineIndex = indexReportTests(baseline);
+  const targetIndex = indexReportTests(target);
+  const allKeys = new Set([...baselineIndex.keys(), ...targetIndex.keys()]);
+  const changes: ChangeGroups = {
+    regressions: [],
+    newFailures: [],
+    fixes: [],
+    noLongerFailing: [],
+  };
+
+  for (const key of allKeys) {
+    const before = baselineIndex.get(key);
+    const after = targetIndex.get(key);
+    if (before?.status === after?.status) continue;
+
+    const test = after?.test ?? before?.test;
+    if (!test) continue;
+
+    const change: Change = {
+      suite: test.suite,
+      test: test.test,
+      before: before?.status ?? "missing",
+      after: after?.status ?? "missing",
+    };
+
+    if (change.before === "passed" && change.after === "failed") {
+      changes.regressions.push(change);
+    } else if (change.before === "missing" && change.after === "failed") {
+      changes.newFailures.push(change);
+    } else if (change.before === "failed" && change.after === "passed") {
+      changes.fixes.push(change);
+    } else if (change.before === "failed" && change.after === "missing") {
+      changes.noLongerFailing.push(change);
+    }
+  }
+
+  for (const group of Object.values(changes)) {
+    group.sort(compareChange);
+  }
+  return changes;
+}
+
+function indexReportTests(report: DeploySuiteReport): Map<
+  string,
+  {
+    status: "passed" | "failed";
+    test: ReportTest;
+  }
+> {
+  const index = new Map<string, { status: "passed" | "failed"; test: ReportTest }>();
+  for (const test of report.passed) index.set(testKey(test), { status: "passed", test });
+  for (const test of report.failed) index.set(testKey(test), { status: "failed", test });
+  return index;
+}
+
+function testKey(test: ReportTest): string {
+  return `${test.suite}\0${test.test}`;
+}
+
+function compareChange(left: Change, right: Change): number {
+  return left.suite.localeCompare(right.suite) || left.test.localeCompare(right.test);
+}
+
+function isDeploySuiteReport(value: unknown): value is DeploySuiteReport {
+  if (!value || typeof value !== "object") return false;
+  const report = value as Record<string, unknown>;
+  if (!isSummary(report.summary)) return false;
+  return (
+    Array.isArray(report.failed) &&
+    report.failed.every(isReportTest) &&
+    Array.isArray(report.passed) &&
+    report.passed.every(isReportTest)
+  );
+}
+
+function isSummary(value: unknown): value is DeploySuiteReport["summary"] {
+  if (!value || typeof value !== "object") return false;
+  const summary = value as Record<string, unknown>;
+  return (
+    typeof summary.total === "number" &&
+    typeof summary.passed === "number" &&
+    typeof summary.failed === "number" &&
+    typeof summary.skipped === "number"
+  );
+}
+
+function isReportTest(value: unknown): value is ReportTest {
+  if (!value || typeof value !== "object") return false;
+  const test = value as Record<string, unknown>;
+  return typeof test.suite === "string" && typeof test.test === "string";
+}
+
+function extractZipTextFile(zip: Uint8Array, wantedFileName: string): string {
+  const eocdOffset = findEndOfCentralDirectory(zip);
+  const centralDirectoryOffset = readUInt32(zip, eocdOffset + 16);
+  const totalEntries = readUInt16(zip, eocdOffset + 10);
+  let cursor = centralDirectoryOffset;
+
+  for (let entry = 0; entry < totalEntries; entry++) {
+    if (readUInt32(zip, cursor) !== 0x02014b50) {
+      throw new HttpError("Invalid artifact zip central directory", 502);
+    }
+
+    const compressionMethod = readUInt16(zip, cursor + 10);
+    const compressedSize = readUInt32(zip, cursor + 20);
+    const fileNameLength = readUInt16(zip, cursor + 28);
+    const extraLength = readUInt16(zip, cursor + 30);
+    const commentLength = readUInt16(zip, cursor + 32);
+    const localHeaderOffset = readUInt32(zip, cursor + 42);
+    const fileName = decodeAscii(zip.subarray(cursor + 46, cursor + 46 + fileNameLength));
+
+    if (fileName === wantedFileName || fileName.endsWith(`/${wantedFileName}`)) {
+      return readZipEntry(zip, localHeaderOffset, compressedSize, compressionMethod);
+    }
+
+    cursor += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  throw new HttpError(`Artifact zip did not contain ${wantedFileName}`, 404);
+}
+
+function readZipEntry(
+  zip: Uint8Array,
+  localHeaderOffset: number,
+  compressedSize: number,
+  compressionMethod: number,
+): string {
+  if (readUInt32(zip, localHeaderOffset) !== 0x04034b50) {
+    throw new HttpError("Invalid artifact zip local header", 502);
+  }
+
+  const fileNameLength = readUInt16(zip, localHeaderOffset + 26);
+  const extraLength = readUInt16(zip, localHeaderOffset + 28);
+  const dataStart = localHeaderOffset + 30 + fileNameLength + extraLength;
+  const data = zip.subarray(dataStart, dataStart + compressedSize);
+
+  if (compressionMethod === 0) return new TextDecoder().decode(data);
+  if (compressionMethod === 8) return inflateRawSync(data).toString("utf8");
+  throw new HttpError(`Unsupported zip compression method ${compressionMethod}`, 502);
+}
+
+function findEndOfCentralDirectory(zip: Uint8Array): number {
+  for (let offset = zip.length - 22; offset >= 0; offset--) {
+    if (readUInt32(zip, offset) === 0x06054b50) return offset;
+  }
+  throw new HttpError("Invalid artifact zip: missing end of central directory", 502);
+}
+
+function readUInt16(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8);
+}
+
+function readUInt32(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset] |
+      (bytes[offset + 1] << 8) |
+      (bytes[offset + 2] << 16) |
+      (bytes[offset + 3] << 24)) >>>
+    0
+  );
+}
+
+function decodeAscii(bytes: Uint8Array): string {
+  let text = "";
+  for (const byte of bytes) text += String.fromCharCode(byte);
+  return text;
+}

--- a/apps/web/app/api/compatibility/compare/route.ts
+++ b/apps/web/app/api/compatibility/compare/route.ts
@@ -183,7 +183,7 @@ function toComparedRun(runId: string, report: DeploySuiteReport): ComparedRun {
 
 async function downloadDeploySuiteReport(runId: string, token: string): Promise<DeploySuiteReport> {
   const artifactsUrl = `https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${runId}/artifacts?per_page=100`;
-  const artifactsResponse = await fetch(artifactsUrl, { headers: githubHeaders(token) });
+  const artifactsResponse = await fetch(artifactsUrl, { headers: githubHeaders() });
   if (!artifactsResponse.ok) {
     throw new HttpError(
       `Failed to list artifacts for run ${runId} (${artifactsResponse.status})`,
@@ -204,8 +204,12 @@ async function downloadDeploySuiteReport(runId: string, token: string): Promise<
     headers: githubHeaders(token),
   });
   if (!archiveResponse.ok) {
+    const hint =
+      archiveResponse.status === 401 || archiveResponse.status === 403
+        ? "; check that GITHUB_TOKEN can read Actions artifacts for cloudflare/vinext and is authorized for the Cloudflare organization"
+        : "";
     throw new HttpError(
-      `Failed to download ${REPORT_ARTIFACT_NAME} for run ${runId} (${archiveResponse.status})`,
+      `Failed to download ${REPORT_ARTIFACT_NAME} for run ${runId} (${archiveResponse.status})${hint}`,
       archiveResponse.status,
     );
   }
@@ -221,7 +225,7 @@ async function downloadDeploySuiteReport(runId: string, token: string): Promise<
   return report;
 }
 
-function githubHeaders(token: string | undefined): HeadersInit {
+function githubHeaders(token?: string): HeadersInit {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "vinext-web-compatibility",

--- a/apps/web/app/api/compatibility/compare/route.ts
+++ b/apps/web/app/api/compatibility/compare/route.ts
@@ -113,6 +113,15 @@ export async function POST(request: Request): Promise<Response> {
 
   try {
     const token = getGitHubToken();
+    if (!token) {
+      return Response.json(
+        {
+          error:
+            "GITHUB_TOKEN is not configured on the worker; deploy-suite artifact downloads require authentication.",
+        },
+        { status: 503 },
+      );
+    }
     const [baselineReport, targetReport] = await Promise.all([
       downloadDeploySuiteReport(baselineRunId, token),
       downloadDeploySuiteReport(targetRunId, token),
@@ -172,10 +181,7 @@ function toComparedRun(runId: string, report: DeploySuiteReport): ComparedRun {
   };
 }
 
-async function downloadDeploySuiteReport(
-  runId: string,
-  token: string | undefined,
-): Promise<DeploySuiteReport> {
+async function downloadDeploySuiteReport(runId: string, token: string): Promise<DeploySuiteReport> {
   const artifactsUrl = `https://api.github.com/repos/${OWNER}/${REPO}/actions/runs/${runId}/artifacts?per_page=100`;
   const artifactsResponse = await fetch(artifactsUrl, { headers: githubHeaders(token) });
   if (!artifactsResponse.ok) {

--- a/apps/web/app/compatibility/deploy-suite-compare.tsx
+++ b/apps/web/app/compatibility/deploy-suite-compare.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type Summary = {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+};
+
+type ComparedRun = {
+  runId: string;
+  htmlUrl: string;
+  report: {
+    timestamp?: string;
+    vinextRef?: string;
+    nextRef?: string;
+    suiteFilter?: string;
+    summary: Summary;
+  };
+};
+
+type Change = {
+  suite: string;
+  test: string;
+  before: "passed" | "failed" | "missing";
+  after: "passed" | "failed" | "missing";
+};
+
+type ChangeGroups = {
+  regressions: Change[];
+  newFailures: Change[];
+  fixes: Change[];
+  noLongerFailing: Change[];
+};
+
+type CompareResult = {
+  baseline: ComparedRun;
+  target: ComparedRun;
+  delta: Summary;
+  changes: ChangeGroups;
+};
+
+const GROUPS: ReadonlyArray<{
+  key: keyof ChangeGroups;
+  title: string;
+  empty: string;
+}> = [
+  { key: "regressions", title: "Regressions", empty: "No pass-to-fail changes." },
+  { key: "newFailures", title: "New failures", empty: "No newly failing tests." },
+  { key: "fixes", title: "Fixes", empty: "No fail-to-pass changes." },
+  {
+    key: "noLongerFailing",
+    title: "No longer failing in report",
+    empty: "No failing tests disappeared from the target report.",
+  },
+];
+
+const inputClass =
+  "h-10 w-full rounded-md border border-kumo-hairline bg-kumo-base px-3 font-mono text-sm text-kumo-default outline-none transition focus:border-kumo-primary focus:ring-2 focus:ring-kumo-primary/20";
+
+const metricClass = "rounded-md bg-kumo-elevated p-3 ring ring-kumo-hairline";
+
+export function DeploySuiteCompare({ defaultBaselineRunId }: { defaultBaselineRunId: string }) {
+  const [baselineRunId, setBaselineRunId] = useState(defaultBaselineRunId);
+  const [targetRunId, setTargetRunId] = useState("");
+  const [result, setResult] = useState<CompareResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const hasChanges = useMemo(() => {
+    if (!result) return false;
+    return Object.values(result.changes).some((group) => group.length > 0);
+  }, [result]);
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const target = targetRunId.trim();
+    if (!target) {
+      setError("Enter a comparison run id.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await fetch("/api/compatibility/compare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          baselineRunId: baselineRunId.trim() || undefined,
+          targetRunId: target,
+        }),
+      });
+      const payload = (await response.json()) as
+        | CompareResult
+        | { error?: string; detail?: string };
+      if (!response.ok) {
+        const message =
+          "error" in payload && payload.error
+            ? payload.detail
+              ? `${payload.error}: ${payload.detail}`
+              : payload.error
+            : "Failed to compare runs.";
+        throw new Error(message);
+      }
+      setResult(payload as CompareResult);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <form className="grid gap-4 lg:grid-cols-[1fr_1fr_auto]" onSubmit={onSubmit}>
+        <label className="flex flex-col gap-2 text-sm text-kumo-subtle">
+          Baseline run
+          <input
+            className={inputClass}
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={baselineRunId}
+            placeholder="Latest main run"
+            onChange={(event) => setBaselineRunId(event.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-kumo-subtle">
+          Comparison run
+          <input
+            className={inputClass}
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={targetRunId}
+            placeholder="GitHub Actions run id"
+            onChange={(event) => setTargetRunId(event.target.value)}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={loading}
+          className="mt-7 h-10 rounded-md bg-kumo-primary px-4 text-sm font-medium text-white transition hover:bg-kumo-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {loading ? "Comparing..." : "Compare"}
+        </button>
+      </form>
+
+      {error ? (
+        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 ring ring-red-200">
+          {error}
+        </div>
+      ) : null}
+
+      {result ? (
+        <div className="flex flex-col gap-5">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <Metric label="Passed" value={result.delta.passed} />
+            <Metric label="Failed" value={result.delta.failed} />
+            <Metric label="Skipped" value={result.delta.skipped} />
+            <Metric label="Total" value={result.delta.total} />
+          </div>
+
+          <div className="grid gap-3 text-sm md:grid-cols-2">
+            <RunSummary label="Baseline" run={result.baseline} />
+            <RunSummary label="Comparison" run={result.target} />
+          </div>
+
+          {!hasChanges ? (
+            <div className="rounded-md bg-kumo-elevated p-4 text-sm text-kumo-subtle ring ring-kumo-hairline">
+              No pass/fail changes found between these reports.
+            </div>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {GROUPS.map((group) => (
+                <ChangeGroup
+                  key={group.key}
+                  title={group.title}
+                  empty={group.empty}
+                  changes={result.changes[group.key]}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  const formatted = value > 0 ? `+${value}` : String(value);
+  const tone = value > 0 ? "text-red-600" : value < 0 ? "text-green-600" : "text-kumo-default";
+  return (
+    <div className={metricClass}>
+      <div className={`text-2xl font-semibold tracking-tight ${tone}`}>{formatted}</div>
+      <div className="text-xs text-kumo-subtle">{label} delta</div>
+    </div>
+  );
+}
+
+function RunSummary({ label, run }: { label: string; run: ComparedRun }) {
+  const summary = run.report.summary;
+  return (
+    <div className="rounded-md bg-kumo-elevated p-4 ring ring-kumo-hairline">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <span className="font-medium text-kumo-default">{label}</span>
+        <a className="font-mono text-xs text-kumo-primary hover:underline" href={run.htmlUrl}>
+          {run.runId}
+        </a>
+      </div>
+      <div className="text-kumo-subtle">
+        {summary.passed} passed · {summary.failed} failed · {summary.skipped} skipped
+      </div>
+      <div className="mt-1 font-mono text-xs text-kumo-subtle">
+        {run.report.vinextRef ?? "unknown vinext ref"} ·{" "}
+        {run.report.nextRef ?? "unknown Next.js ref"}
+      </div>
+    </div>
+  );
+}
+
+function ChangeGroup({
+  title,
+  empty,
+  changes,
+}: {
+  title: string;
+  empty: string;
+  changes: Change[];
+}) {
+  return (
+    <section className="rounded-md bg-kumo-elevated p-4 ring ring-kumo-hairline">
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h4 className="text-sm font-medium text-kumo-default">{title}</h4>
+        <span className="text-xs text-kumo-subtle">{changes.length}</span>
+      </div>
+      {changes.length === 0 ? (
+        <p className="text-sm text-kumo-subtle">{empty}</p>
+      ) : (
+        <ul className="max-h-96 space-y-3 overflow-auto pr-2">
+          {changes.map((change) => (
+            <li key={`${change.suite}\0${change.test}`} className="text-sm">
+              <div className="font-mono text-xs text-kumo-subtle">{change.suite}</div>
+              <div className="mt-1 text-kumo-default">{change.test}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/compatibility/deploy-suite-compare.tsx
+++ b/apps/web/app/compatibility/deploy-suite-compare.tsx
@@ -60,7 +60,10 @@ const GROUPS: ReadonlyArray<{
 const inputClass =
   "h-10 w-full rounded-md border border-kumo-hairline bg-kumo-base px-3 font-mono text-sm text-kumo-default outline-none transition focus:border-kumo-primary focus:ring-2 focus:ring-kumo-primary/20";
 
-const metricClass = "rounded-md bg-kumo-elevated p-3 ring ring-kumo-hairline";
+const buttonClass =
+  "inline-flex h-10 w-full items-center justify-center rounded-md bg-zinc-950 px-4 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-60 lg:w-auto";
+
+const metricClass = "rounded-md bg-kumo-elevated p-4 ring ring-kumo-hairline";
 
 export function DeploySuiteCompare({ defaultBaselineRunId }: { defaultBaselineRunId: string }) {
   const [baselineRunId, setBaselineRunId] = useState(defaultBaselineRunId);
@@ -116,57 +119,73 @@ export function DeploySuiteCompare({ defaultBaselineRunId }: { defaultBaselineRu
   }
 
   return (
-    <div className="flex flex-col gap-5">
-      <form className="grid gap-4 lg:grid-cols-[1fr_1fr_auto]" onSubmit={onSubmit}>
-        <label className="flex flex-col gap-2 text-sm text-kumo-subtle">
-          Baseline run
-          <input
-            className={inputClass}
-            inputMode="numeric"
-            pattern="[0-9]*"
-            value={baselineRunId}
-            placeholder="Latest main run"
-            onChange={(event) => setBaselineRunId(event.target.value)}
-          />
-        </label>
-        <label className="flex flex-col gap-2 text-sm text-kumo-subtle">
-          Comparison run
-          <input
-            className={inputClass}
-            inputMode="numeric"
-            pattern="[0-9]*"
-            value={targetRunId}
-            placeholder="GitHub Actions run id"
-            onChange={(event) => setTargetRunId(event.target.value)}
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={loading}
-          className="mt-7 h-10 rounded-md bg-kumo-primary px-4 text-sm font-medium text-white transition hover:bg-kumo-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {loading ? "Comparing..." : "Compare"}
-        </button>
+    <div className="flex flex-col gap-6">
+      <form className="rounded-md bg-kumo-elevated p-4 ring ring-kumo-hairline" onSubmit={onSubmit}>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] lg:items-end">
+          <label className="flex min-w-0 flex-col gap-2 text-sm text-kumo-subtle">
+            <span className="font-medium text-kumo-default">Baseline run</span>
+            <input
+              className={inputClass}
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={baselineRunId}
+              placeholder="Latest main run"
+              onChange={(event) => setBaselineRunId(event.target.value)}
+            />
+          </label>
+          <label className="flex min-w-0 flex-col gap-2 text-sm text-kumo-subtle">
+            <span className="font-medium text-kumo-default">Comparison run</span>
+            <input
+              className={inputClass}
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={targetRunId}
+              placeholder="GitHub Actions run id"
+              onChange={(event) => setTargetRunId(event.target.value)}
+            />
+          </label>
+          <button type="submit" disabled={loading} className={buttonClass}>
+            {loading ? "Comparing..." : "Compare runs"}
+          </button>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-kumo-subtle">
+          {defaultBaselineRunId ? (
+            <span>
+              Latest main run:{" "}
+              <span className="font-mono text-kumo-default">{defaultBaselineRunId}</span>
+            </span>
+          ) : null}
+          {baselineRunId !== defaultBaselineRunId && defaultBaselineRunId ? (
+            <button
+              type="button"
+              className="font-medium text-kumo-primary hover:underline"
+              onClick={() => setBaselineRunId(defaultBaselineRunId)}
+            >
+              Reset baseline
+            </button>
+          ) : null}
+        </div>
       </form>
 
       {error ? (
-        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 ring ring-red-200">
-          {error}
+        <div className="rounded-md bg-red-50 p-4 text-sm text-red-700 ring ring-red-200">
+          <div className="font-medium">Comparison failed</div>
+          <div className="mt-1 leading-relaxed">{error}</div>
         </div>
       ) : null}
 
       {result ? (
-        <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4">
+          <div className="grid gap-3 text-sm md:grid-cols-2">
+            <RunSummary label="Baseline" run={result.baseline} />
+            <RunSummary label="Comparison" run={result.target} />
+          </div>
+
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <Metric label="Passed" value={result.delta.passed} />
             <Metric label="Failed" value={result.delta.failed} />
             <Metric label="Skipped" value={result.delta.skipped} />
             <Metric label="Total" value={result.delta.total} />
-          </div>
-
-          <div className="grid gap-3 text-sm md:grid-cols-2">
-            <RunSummary label="Baseline" run={result.baseline} />
-            <RunSummary label="Comparison" run={result.target} />
           </div>
 
           {!hasChanges ? (
@@ -196,8 +215,8 @@ function Metric({ label, value }: { label: string; value: number }) {
   const tone = value > 0 ? "text-red-600" : value < 0 ? "text-green-600" : "text-kumo-default";
   return (
     <div className={metricClass}>
-      <div className={`text-2xl font-semibold tracking-tight ${tone}`}>{formatted}</div>
-      <div className="text-xs text-kumo-subtle">{label} delta</div>
+      <div className="text-xs font-medium text-kumo-subtle">{label}</div>
+      <div className={`mt-1 text-2xl font-semibold tracking-tight ${tone}`}>{formatted}</div>
     </div>
   );
 }
@@ -208,12 +227,19 @@ function RunSummary({ label, run }: { label: string; run: ComparedRun }) {
     <div className="rounded-md bg-kumo-elevated p-4 ring ring-kumo-hairline">
       <div className="mb-2 flex items-center justify-between gap-3">
         <span className="font-medium text-kumo-default">{label}</span>
-        <a className="font-mono text-xs text-kumo-primary hover:underline" href={run.htmlUrl}>
+        <a
+          className="shrink-0 font-mono text-xs text-kumo-primary hover:underline"
+          href={run.htmlUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
           {run.runId}
         </a>
       </div>
-      <div className="text-kumo-subtle">
-        {summary.passed} passed · {summary.failed} failed · {summary.skipped} skipped
+      <div className="flex flex-wrap gap-x-3 gap-y-1 text-kumo-subtle">
+        <span>{summary.passed} passed</span>
+        <span>{summary.failed} failed</span>
+        <span>{summary.skipped} skipped</span>
       </div>
       <div className="mt-1 font-mono text-xs text-kumo-subtle">
         {run.report.vinextRef ?? "unknown vinext ref"} ·{" "}
@@ -236,7 +262,9 @@ function ChangeGroup({
     <section className="rounded-md bg-kumo-elevated p-4 ring ring-kumo-hairline">
       <div className="mb-3 flex items-baseline justify-between gap-3">
         <h4 className="text-sm font-medium text-kumo-default">{title}</h4>
-        <span className="text-xs text-kumo-subtle">{changes.length}</span>
+        <span className="rounded-full bg-kumo-base px-2 py-0.5 text-xs text-kumo-subtle ring ring-kumo-hairline">
+          {changes.length}
+        </span>
       </div>
       {changes.length === 0 ? (
         <p className="text-sm text-kumo-subtle">{empty}</p>

--- a/apps/web/app/compatibility/page.tsx
+++ b/apps/web/app/compatibility/page.tsx
@@ -24,6 +24,7 @@ import { CompatibilityViews } from "./compatibility-views";
 import type { GridCell } from "./contribution-grid";
 import type { TrendPoint } from "./compatibility-line-chart";
 import { bucketByRouter, bucketPassRate } from "./router-buckets";
+import { DeploySuiteCompare } from "./deploy-suite-compare";
 
 // ISR: rebuild this page at most every 5 minutes. Compat data only changes
 // when a nightly deploy-suite run lands, so 5 minutes of staleness is fine
@@ -427,6 +428,17 @@ export default async function CompatibilityPage() {
           >
             View deploy suite runs
           </LinkButton>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 pb-24">
+        <div className="mb-4">
+          <Text variant="heading2" as="h2">
+            Compare deploy suite runs
+          </Text>
+        </div>
+        <div className={CARD}>
+          <DeploySuiteCompare defaultBaselineRunId={latestRun?.runKey ?? ""} />
         </div>
       </section>
     </>

--- a/apps/web/app/compatibility/page.tsx
+++ b/apps/web/app/compatibility/page.tsx
@@ -432,10 +432,11 @@ export default async function CompatibilityPage() {
       </section>
 
       <section className="mx-auto w-full max-w-6xl px-6 pb-24">
-        <div className="mb-4">
+        <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
           <Text variant="heading2" as="h2">
-            Compare deploy suite runs
+            Deploy suite comparison
           </Text>
+          <span className="text-sm text-kumo-subtle">Compare GitHub Actions report artifacts</span>
         </div>
         <div className={CARD}>
           <DeploySuiteCompare defaultBaselineRunId={latestRun?.runKey ?? ""} />

--- a/apps/web/app/lib/db/client.ts
+++ b/apps/web/app/lib/db/client.ts
@@ -5,6 +5,7 @@ import * as schema from "./schema";
 type CloudflareEnv = {
   DB: D1Database;
   COMPAT_INGEST_SECRET?: string;
+  GITHUB_TOKEN?: string;
 };
 
 /**
@@ -19,4 +20,8 @@ export function getDb() {
 
 export function getIngestSecret(): string | undefined {
   return (env as CloudflareEnv).COMPAT_INGEST_SECRET;
+}
+
+export function getGitHubToken(): string | undefined {
+  return (env as CloudflareEnv).GITHUB_TOKEN;
 }

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -14,6 +14,7 @@ type Env = {
   VINEXT_KV_CACHE: KVNamespace;
   PERFORMANCE_PROFILES: R2Bucket;
   COMPAT_INGEST_SECRET?: string;
+  GITHUB_TOKEN?: string;
 };
 
 type ExecutionContext = {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -51,6 +51,6 @@
     },
   },
   "secrets": {
-    "required": ["COMPAT_INGEST_SECRET"],
+    "required": ["COMPAT_INGEST_SECRET", "GITHUB_TOKEN"],
   },
 }

--- a/tests/web-compatibility-compare.test.ts
+++ b/tests/web-compatibility-compare.test.ts
@@ -1,0 +1,214 @@
+import { deflateRawSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDb = vi.fn();
+const getGitHubToken = vi.fn();
+
+vi.mock("../apps/web/app/lib/db/client", () => ({ getDb, getGitHubToken }));
+
+const { POST, compareDeploySuiteReports } =
+  await import("../apps/web/app/api/compatibility/compare/route");
+
+type Report = Parameters<typeof compareDeploySuiteReports>[0];
+
+const baselineReport: Report = {
+  timestamp: "2026-06-28T00:00:00.000Z",
+  vinextRef: "main",
+  nextRef: "v16.2.6",
+  suiteFilter: "all",
+  summary: { total: 4, passed: 2, failed: 2, skipped: 0 },
+  passed: [
+    { suite: "test/e2e/app-dir/a/a.test.ts", test: "a passes" },
+    { suite: "test/e2e/app-dir/shared/shared.test.ts", test: "shared stays passing" },
+  ],
+  failed: [
+    { suite: "test/e2e/app-dir/b/b.test.ts", test: "b fails" },
+    { suite: "test/e2e/app-dir/c/c.test.ts", test: "c fails" },
+  ],
+};
+
+const targetReport: Report = {
+  timestamp: "2026-06-29T00:00:00.000Z",
+  vinextRef: "feature",
+  nextRef: "v16.2.6",
+  suiteFilter: "all",
+  summary: { total: 5, passed: 3, failed: 2, skipped: 0 },
+  passed: [
+    { suite: "test/e2e/app-dir/b/b.test.ts", test: "b fails" },
+    { suite: "test/e2e/app-dir/d/d.test.ts", test: "d passes" },
+    { suite: "test/e2e/app-dir/shared/shared.test.ts", test: "shared stays passing" },
+  ],
+  failed: [
+    { suite: "test/e2e/app-dir/a/a.test.ts", test: "a passes" },
+    { suite: "test/e2e/app-dir/e/e.test.ts", test: "e newly fails" },
+  ],
+};
+
+describe("deploy-suite report comparison", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    getDb.mockReset();
+    getGitHubToken.mockReset();
+    getGitHubToken.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("groups pass/fail changes between two deploy-suite reports", () => {
+    expect(compareDeploySuiteReports(baselineReport, targetReport)).toEqual({
+      regressions: [
+        {
+          suite: "test/e2e/app-dir/a/a.test.ts",
+          test: "a passes",
+          before: "passed",
+          after: "failed",
+        },
+      ],
+      newFailures: [
+        {
+          suite: "test/e2e/app-dir/e/e.test.ts",
+          test: "e newly fails",
+          before: "missing",
+          after: "failed",
+        },
+      ],
+      fixes: [
+        {
+          suite: "test/e2e/app-dir/b/b.test.ts",
+          test: "b fails",
+          before: "failed",
+          after: "passed",
+        },
+      ],
+      noLongerFailing: [
+        {
+          suite: "test/e2e/app-dir/c/c.test.ts",
+          test: "c fails",
+          before: "failed",
+          after: "missing",
+        },
+      ],
+    });
+  });
+
+  it("defaults the baseline to the latest ingested main run and downloads both report artifacts", async () => {
+    getDb.mockReturnValue(createDb([{ runKey: "111" }]));
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/runs/111/artifacts")) {
+        return Response.json({
+          artifacts: [
+            {
+              name: "deploy-suite-report",
+              expired: false,
+              archive_download_url: "https://artifacts.example/baseline.zip",
+            },
+          ],
+        });
+      }
+      if (url.includes("/runs/222/artifacts")) {
+        return Response.json({
+          artifacts: [
+            {
+              name: "deploy-suite-report",
+              expired: false,
+              archive_download_url: "https://artifacts.example/target.zip",
+            },
+          ],
+        });
+      }
+      if (url === "https://artifacts.example/baseline.zip") {
+        return new Response(zipReport(baselineReport));
+      }
+      if (url === "https://artifacts.example/target.zip") {
+        return new Response(zipReport(targetReport));
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const response = await POST(
+      new Request("https://example.com/api/compatibility/compare", {
+        method: "POST",
+        body: JSON.stringify({ targetRunId: "222" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      baseline: {
+        runId: "111",
+        report: { summary: baselineReport.summary },
+      },
+      target: {
+        runId: "222",
+        report: { summary: targetReport.summary },
+      },
+      delta: { total: 1, passed: 1, failed: 0, skipped: 0 },
+      totals: {
+        regressions: 1,
+        newFailures: 1,
+        fixes: 1,
+        noLongerFailing: 1,
+      },
+    });
+  });
+
+  it("rejects missing comparison run ids", async () => {
+    const response = await POST(
+      new Request("https://example.com/api/compatibility/compare", {
+        method: "POST",
+        body: JSON.stringify({ baselineRunId: "111" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "A comparison run id is required" });
+  });
+});
+
+function createDb(rows: Array<{ runKey: string }>) {
+  const query = {
+    from: vi.fn(() => query),
+    where: vi.fn(() => query),
+    orderBy: vi.fn(() => query),
+    limit: vi.fn(async () => rows),
+  };
+  return { select: vi.fn(() => query) };
+}
+
+function zipReport(report: Report): ArrayBuffer {
+  const fileName = Buffer.from("deploy-suite-report.json");
+  const content = Buffer.from(JSON.stringify(report));
+  const compressed = deflateRawSync(content);
+  const localHeader = Buffer.alloc(30);
+  localHeader.writeUInt32LE(0x04034b50, 0);
+  localHeader.writeUInt16LE(20, 4);
+  localHeader.writeUInt16LE(8, 8);
+  localHeader.writeUInt32LE(compressed.length, 18);
+  localHeader.writeUInt32LE(content.length, 22);
+  localHeader.writeUInt16LE(fileName.length, 26);
+
+  const centralDirectory = Buffer.alloc(46);
+  centralDirectory.writeUInt32LE(0x02014b50, 0);
+  centralDirectory.writeUInt16LE(20, 4);
+  centralDirectory.writeUInt16LE(20, 6);
+  centralDirectory.writeUInt16LE(8, 10);
+  centralDirectory.writeUInt32LE(compressed.length, 20);
+  centralDirectory.writeUInt32LE(content.length, 24);
+  centralDirectory.writeUInt16LE(fileName.length, 28);
+
+  const centralDirectoryOffset = localHeader.length + fileName.length + compressed.length;
+  const centralDirectorySize = centralDirectory.length + fileName.length;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(centralDirectorySize, 12);
+  eocd.writeUInt32LE(centralDirectoryOffset, 16);
+
+  const zip = Buffer.concat([localHeader, fileName, compressed, centralDirectory, fileName, eocd]);
+  return zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength) as ArrayBuffer;
+}

--- a/tests/web-compatibility-compare.test.ts
+++ b/tests/web-compatibility-compare.test.ts
@@ -96,8 +96,10 @@ describe("deploy-suite report comparison", () => {
 
   it("defaults the baseline to the latest ingested main run and downloads both report artifacts", async () => {
     getDb.mockReturnValue(createDb([{ runKey: "111" }]));
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const requests: Array<{ url: string; authorization: string | null }> = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      requests.push({ url, authorization: readAuthorization(init?.headers) });
       if (url.includes("/runs/111/artifacts")) {
         return Response.json({
           artifacts: [
@@ -154,6 +156,18 @@ describe("deploy-suite report comparison", () => {
         noLongerFailing: 1,
       },
     });
+    expect(requests).toEqual([
+      {
+        url: "https://api.github.com/repos/cloudflare/vinext/actions/runs/111/artifacts?per_page=100",
+        authorization: null,
+      },
+      {
+        url: "https://api.github.com/repos/cloudflare/vinext/actions/runs/222/artifacts?per_page=100",
+        authorization: null,
+      },
+      { url: "https://artifacts.example/baseline.zip", authorization: "Bearer github-token" },
+      { url: "https://artifacts.example/target.zip", authorization: "Bearer github-token" },
+    ]);
   });
 
   it("rejects missing comparison run ids", async () => {
@@ -194,6 +208,15 @@ function createDb(rows: Array<{ runKey: string }>) {
     limit: vi.fn(async () => rows),
   };
   return { select: vi.fn(() => query) };
+}
+
+function readAuthorization(headers: HeadersInit | undefined): string | null {
+  if (!headers) return null;
+  if (headers instanceof Headers) return headers.get("authorization");
+  if (Array.isArray(headers)) {
+    return headers.find(([name]) => name.toLowerCase() === "authorization")?.[1] ?? null;
+  }
+  return headers.Authorization ?? headers.authorization ?? null;
 }
 
 function zipReport(report: Report): ArrayBuffer {

--- a/tests/web-compatibility-compare.test.ts
+++ b/tests/web-compatibility-compare.test.ts
@@ -50,7 +50,7 @@ describe("deploy-suite report comparison", () => {
   beforeEach(() => {
     getDb.mockReset();
     getGitHubToken.mockReset();
-    getGitHubToken.mockReturnValue(undefined);
+    getGitHubToken.mockReturnValue("github-token");
   });
 
   afterEach(() => {
@@ -166,6 +166,23 @@ describe("deploy-suite report comparison", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "A comparison run id is required" });
+  });
+
+  it("returns a configuration error when artifact downloads cannot be authenticated", async () => {
+    getGitHubToken.mockReturnValue(undefined);
+
+    const response = await POST(
+      new Request("https://example.com/api/compatibility/compare", {
+        method: "POST",
+        body: JSON.stringify({ baselineRunId: "111", targetRunId: "222" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "GITHUB_TOKEN is not configured on the worker; deploy-suite artifact downloads require authentication.",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add a compatibility-page panel for comparing two Next.js deploy-suite workflow run IDs
- add `/api/compatibility/compare` to download `deploy-suite-report` artifacts and group assertion-level changes
- default the baseline input from the latest ingested main deploy-suite run
- require a Worker-side `GITHUB_TOKEN` because GitHub artifact archive downloads return 401 without authentication
- list public run artifacts without auth so an under-scoped token cannot break the public artifact-listing step
- polish the comparison panel with a clearer control layout, visible `Compare runs` button, reset-baseline affordance, and clearer result cards

## Tests
- `vp check apps/web/app/api/compatibility/compare/route.ts apps/web/app/compatibility/deploy-suite-compare.tsx apps/web/app/compatibility/page.tsx apps/web/app/lib/db/client.ts apps/web/worker/index.ts apps/web/wrangler.jsonc tests/web-compatibility-compare.test.ts tests/web-compatibility-failures.test.ts`
- `vp check apps/web/app/compatibility/deploy-suite-compare.tsx apps/web/app/compatibility/page.tsx`
- `vp check apps/web/app/api/compatibility/compare/route.ts tests/web-compatibility-compare.test.ts`
- `vp test run tests/web-compatibility-failures.test.ts tests/web-compatibility-compare.test.ts`
- `vp run @apps/web#build:vinext`
- local browser smoke of `/compatibility` comparison panel

Note: local web build warned that `COMPAT_INGEST_SECRET` and `GITHUB_TOKEN` are not configured, which is expected in this worktree.