### PR TITLE
fix(ci): handle npm-pinned deploy fixtures

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -304,6 +304,24 @@ const workspaceConfig = fs.readFileSync(
   'utf8',
 )
 
+// The deploy adapter always installs with pnpm below. Some Next.js fixtures pin
+// packageManager to npm/yarn/bun to exercise Next's own install command, but
+// pnpm refuses to run in those projects before it can link vinext.
+const originalPackageManager =
+  typeof pkg.packageManager === 'string' && pkg.packageManager.length > 0
+    ? pkg.packageManager
+    : null
+const harnessPackageManager =
+  typeof rootPkg.packageManager === 'string' && rootPkg.packageManager.length > 0
+    ? rootPkg.packageManager
+    : 'pnpm@11.1.1'
+if (originalPackageManager && !originalPackageManager.startsWith('pnpm@')) {
+  pkg.packageManager = harnessPackageManager
+  console.log(
+    `Replaced packageManager ${originalPackageManager} with ${harnessPackageManager} for vinext deploy harness pnpm install`,
+  )
+}
+
 // Minimal YAML parser for the pnpm workspace catalog. Assumes the simple
 // block mapping format used in this repo's pnpm-workspace.yaml (2-space
 // indent, no flow syntax, no nested catalogs). This avoids pulling in a
@@ -642,6 +660,11 @@ if [ ! -d "node_modules/vinext" ]; then
   echo "pnpm install failed: node_modules/vinext not found" >&2
   exit 1
 fi
+VINEXT_BIN="./node_modules/.bin/vinext"
+if [ ! -x "${VINEXT_BIN}" ]; then
+  echo "pnpm install failed: ${VINEXT_BIN} not found or not executable" >&2
+  exit 1
+fi
 if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts && pkg.scripts.setup ? 0 : 1)" >/dev/null 2>&1; then
   run_pnpm run setup >> "${BUILD_LOG}" 2>&1
 fi
@@ -655,9 +678,9 @@ fi
 # vinext loads CJS next.config.js in `"type": "module"` packages via a temp
 # .cjs sibling (see config/next-config.ts), so we don't rewrite the user's
 # config file here.
-run_pnpm exec vinext init --platform=node --skip-check --force >> "${BUILD_LOG}" 2>&1
+"${VINEXT_BIN}" init --platform=node --skip-check --force >> "${BUILD_LOG}" 2>&1
 
-run_pnpm exec vinext build --prerender-all >> "${BUILD_LOG}" 2>&1
+"${VINEXT_BIN}" build --prerender-all >> "${BUILD_LOG}" 2>&1
 
 # Next.js emits large-page-data warnings during build. Specific deploy tests
 # (e.g. test/e2e/prerender) assert these strings appear in the build output,
@@ -684,7 +707,7 @@ BUILD_ID="$(read_build_id)"
 
 echo "${PORT}" > "${PORT_FILE}"
 
-run_pnpm exec vinext start --port "${PORT}" --hostname 127.0.0.1 >> "${SERVER_LOG}" 2>&1 &
+"${VINEXT_BIN}" start --port "${PORT}" --hostname 127.0.0.1 >> "${SERVER_LOG}" 2>&1 &
 SERVER_PID="$!"
 echo "${SERVER_PID}" > "${PID_FILE}"
 

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -7,7 +7,27 @@ describe("Next.js deploy harness logging", () => {
   it("initializes fixtures for the Node deployment platform", () => {
     const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
 
-    expect(script).toContain("vinext init --platform=node --skip-check --force");
+    expect(script).toContain('"${VINEXT_BIN}" init --platform=node --skip-check --force');
+  });
+
+  it("runs the installed vinext binary directly after pnpm install", () => {
+    const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
+
+    expect(script).toContain('VINEXT_BIN="./node_modules/.bin/vinext"');
+    expect(script).toContain('if [ ! -x "${VINEXT_BIN}" ]; then');
+    expect(script).toContain('"${VINEXT_BIN}" build --prerender-all');
+    expect(script).toContain('"${VINEXT_BIN}" start --port "${PORT}" --hostname 127.0.0.1');
+    expect(script).not.toContain("run_pnpm exec vinext");
+  });
+
+  it("normalizes non-pnpm packageManager pins before pnpm install", () => {
+    const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
+
+    expect(script).toContain(
+      "originalPackageManager && !originalPackageManager.startsWith('pnpm@')",
+    );
+    expect(script).toContain("pkg.packageManager = harnessPackageManager");
+    expect(script).toContain("for vinext deploy harness pnpm install");
   });
 
   it("removes install-time deprecation noise from application cliOutput", () => {


### PR DESCRIPTION
## Summary
- normalize non-pnpm `packageManager` pins inside the Next.js deploy harness before running pnpm
- call the installed `./node_modules/.bin/vinext` binary directly after install so pnpm ignored-build approval does not break `init`, `build`, or `start`
- add focused harness regression checks for both deploy setup failure modes

## Root cause
`test/e2e/handle-non-hoisted-swc-helpers/index.test.ts` pins `packageManager: "npm@10.9.2"`. The vinext deploy harness always runs pnpm, so pnpm refused to install before `node_modules/vinext` was linked. After normalizing the fixture manifest, pnpm 11 still returned `ERR_PNPM_IGNORED_BUILDS` for `sharp` and `pnpm exec vinext init` re-entered pnpm's dependency-status check, causing a second deploy setup failure before the SWC helper assertion.

## Validation
- `bash -n scripts/e2e-deploy.sh`
- `pnpm run fmt:check -- scripts/e2e-deploy.sh tests/e2e-deploy-script.test.ts`
- `vp test run tests/e2e-deploy-script.test.ts`
- `vp test run tests/pages-router.test.ts -t "framework-owned SWC helpers"`

## Targeted deploy-suite run
- PASS: https://github.com/cloudflare/vinext/actions/runs/28364256784