### PR TITLE
fix(pages): expose parsed cookies on request objects

### DIFF
--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -19,7 +19,6 @@ import {
   parseQueryString,
   urlQueryToSearchParams,
 } from "../utils/query.js";
-import { parseCookieHeader } from "../utils/parse-cookie.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { isEdgeApiRuntime } from "./edge-api-runtime.js";
 import {
@@ -30,6 +29,7 @@ import { resolveRequestProtocol, resolveRequestHost } from "./proxy-trust.js";
 import { performOnDemandRevalidate, type RevalidateOptions } from "./pages-revalidate.js";
 import { NextRequest } from "vinext/shims/server";
 import { hasBasePath } from "../utils/base-path.js";
+import { attachPagesRequestCookies } from "./pages-node-compat.js";
 
 /**
  * Extend the Node.js request with Next.js-style helpers.
@@ -136,13 +136,6 @@ async function parseBody(
       }
     });
   });
-}
-
-/**
- * Parse cookies from the Cookie header.
- */
-function parseCookies(req: IncomingMessage): Record<string, string> {
-  return parseCookieHeader(req.headers.cookie);
 }
 
 function isEdgeApiRouteModule(module: Record<string, unknown>): module is EdgeApiRouteModule {
@@ -287,11 +280,11 @@ function enhanceApiObjects(
   query: Record<string, string | string[]>,
   body: unknown,
 ): { apiReq: NextApiRequest; apiRes: NextApiResponse } {
-  const apiReq: NextApiRequest = Object.assign(req, {
+  const apiReq = Object.assign(req, {
     body,
-    cookies: parseCookies(req),
     query,
-  });
+  }) as NextApiRequest;
+  attachPagesRequestCookies(apiReq);
 
   const apiRes: NextApiResponse = Object.assign(res, {
     status(this: NextApiResponse, code: number) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -75,6 +75,7 @@ import {
   loadDevAppInitialProps,
   loadPagesGetInitialProps,
 } from "./pages-get-initial-props.js";
+import { attachPagesRequestCookies } from "./pages-node-compat.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 
@@ -482,6 +483,7 @@ export function createSSRHandler(
     const _reqStart = now();
     let _compileEnd: number | undefined;
     let _renderEnd: number | undefined;
+    attachPagesRequestCookies(req);
 
     res.on("finish", () => {
       const totalMs = now() - _reqStart;
@@ -1886,6 +1888,7 @@ async function renderErrorPage(
   fileMatcher?: ValidFileMatcher,
   err?: Error,
 ): Promise<void> {
+  attachPagesRequestCookies(req);
   const matcher = fileMatcher ?? createValidFileMatcher();
   // Try specific status page first, then _error, then fallback
   const candidates =

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -43,6 +43,13 @@ export type PagesReqResResponse = Writable & {
   revalidate: (urlPath: string, opts?: RevalidateOptions) => Promise<void>;
 };
 
+type PagesRequestCookiesCarrier = {
+  headers: {
+    cookie?: string | string[] | null | undefined;
+  };
+  cookies?: unknown;
+};
+
 type CreatePagesReqResOptions = {
   body: unknown;
   query: PagesRequestQuery;
@@ -152,6 +159,37 @@ function createRequestReadable(request: Request): Readable {
   // byte stream like `IncomingMessage` (`setEncoding()`/`read(n)` byte
   // semantics, byte-based highWaterMark).
   return Readable.from(requestBodyChunks(request), { objectMode: false });
+}
+
+function parsePagesRequestCookies(cookieHeader: string | string[] | null | undefined) {
+  return parseCookieHeader(Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader);
+}
+
+export function attachPagesRequestCookies(req: PagesRequestCookiesCarrier): void {
+  if (Object.hasOwn(req, "cookies")) return;
+
+  Object.defineProperty(req, "cookies", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      const cookies = parsePagesRequestCookies(req.headers.cookie);
+      Object.defineProperty(req, "cookies", {
+        configurable: true,
+        enumerable: true,
+        value: cookies,
+        writable: true,
+      });
+      return cookies;
+    },
+    set(value: unknown) {
+      Object.defineProperty(req, "cookies", {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true,
+      });
+    },
+  });
 }
 
 class PagesResponseStream extends Writable {
@@ -393,14 +431,14 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
   // objects. The Workers/prod adapter starts from a Fetch Request, so expose a
   // real Readable here instead of a plain object. That keeps both documented
   // raw-body iteration and legacy stream proxying (`req.pipe(...)`) working.
-  const req: PagesReqResRequest = Object.assign(createRequestReadable(options.request), {
+  const req = Object.assign(createRequestReadable(options.request), {
     method: options.request.method,
     url: options.url,
     headers: headersObj,
     query: options.query,
     body: options.body,
-    cookies: parseCookieHeader(options.request.headers.get("cookie")),
-  });
+  }) as PagesReqResRequest;
+  attachPagesRequestCookies(req);
 
   let resolveResponse!: (value: Response) => void;
   let rejectResponse!: (error: Error) => void;

--- a/tests/fixtures/pages-basic/pages/api/cookies.ts
+++ b/tests/fixtures/pages-basic/pages/api/cookies.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json(req.cookies);
+}

--- a/tests/fixtures/pages-basic/pages/ssr-cookies.tsx
+++ b/tests/fixtures/pages-basic/pages/ssr-cookies.tsx
@@ -1,0 +1,15 @@
+type Props = {
+  cookies: Record<string, string>;
+};
+
+export async function getServerSideProps({ req }: { req: { cookies: Record<string, string> } }) {
+  return {
+    props: {
+      cookies: req.cookies,
+    },
+  };
+}
+
+export default function SsrCookies({ cookies }: Props) {
+  return <pre id="cookies">{JSON.stringify(cookies)}</pre>;
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -612,6 +612,28 @@ describe("Pages Router integration", () => {
     expect(html).toContain("Rendered at:");
   });
 
+  // Ported from Next.js: test/e2e/typescript/typescript.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/typescript/typescript.test.ts
+  //
+  // Next.js attaches `req.cookies` before Pages SSR in render.tsx:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx
+  it("passes parsed request cookies to getServerSideProps", async () => {
+    const emptyRes = await fetch(`${baseUrl}/ssr-cookies`);
+    expect(emptyRes.status).toBe(200);
+    expect(await emptyRes.text()).toContain('<pre id="cookies">{}</pre>');
+
+    const res = await fetch(`${baseUrl}/ssr-cookies`, {
+      headers: {
+        Cookie: "_api_session=trusted; theme=dark",
+      },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain(
+      '<pre id="cookies">{&quot;_api_session&quot;:&quot;trusted&quot;,&quot;theme&quot;:&quot;dark&quot;}</pre>',
+    );
+  });
+
   // Regression test for #1459: Next.js explicitly supports a Promise value
   // for `getServerSideProps` `props`. vinext must `await` the value before
   // serialising — otherwise pageProps end up as a Promise and the rendered
@@ -999,6 +1021,28 @@ describe("Pages Router integration", () => {
 
     const data = await res.json();
     expect(data).toEqual({ message: "Hello from API!" });
+  });
+
+  // Ported from Next.js: test/e2e/api-support/api-support.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/api-support/api-support.test.ts
+  //
+  // Next.js attaches `req.cookies` before Pages API handlers in api-resolver.ts:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/api-utils/node/api-resolver.ts
+  it("passes parsed request cookies to API routes", async () => {
+    const emptyRes = await fetch(`${baseUrl}/api/cookies`);
+    expect(emptyRes.status).toBe(200);
+    await expect(emptyRes.json()).resolves.toEqual({});
+
+    const res = await fetch(`${baseUrl}/api/cookies`, {
+      headers: {
+        Cookie: "_api_session=trusted; theme=dark",
+      },
+    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      _api_session: "trusted",
+      theme: "dark",
+    });
   });
 
   it("handles dynamic API routes with query params", async () => {
@@ -4450,6 +4494,16 @@ export default function CounterPage() {
       const ssrHtml = await ssrRes.text();
       expect(ssrHtml).toContain("Server-Side Rendered");
 
+      const ssrCookiesRes = await fetch(`${prodUrl}/ssr-cookies`, {
+        headers: {
+          Cookie: "_api_session=trusted; theme=dark",
+        },
+      });
+      expect(ssrCookiesRes.status).toBe(200);
+      expect(await ssrCookiesRes.text()).toContain(
+        '<pre id="cookies">{&quot;_api_session&quot;:&quot;trusted&quot;,&quot;theme&quot;:&quot;dark&quot;}</pre>',
+      );
+
       // Regression for #1461: user-set Cache-Control via res.setHeader sticks.
       const ssrCcRes = await fetch(`${prodUrl}/ssr-cache-control`);
       expect(ssrCcRes.status).toBe(200);
@@ -4473,6 +4527,17 @@ export default function CounterPage() {
       expect(apiRes.status).toBe(200);
       const apiData = await apiRes.json();
       expect(apiData).toEqual({ message: "Hello from API!" });
+
+      const apiCookiesRes = await fetch(`${prodUrl}/api/cookies`, {
+        headers: {
+          Cookie: "_api_session=trusted; theme=dark",
+        },
+      });
+      expect(apiCookiesRes.status).toBe(200);
+      await expect(apiCookiesRes.json()).resolves.toEqual({
+        _api_session: "trusted",
+        theme: "dark",
+      });
 
       const invalidJsonRes = await fetch(`${prodUrl}/api/parse`, {
         method: "POST",


### PR DESCRIPTION
## Summary
- add a shared Pages request cookie attachment helper using the existing Next-style Cookie parser
- use the helper for dev Pages SSR and Node Pages API request objects, aligning them with the Workers/prod Pages req/res adapter
- add Pages SSR and API fixtures/tests ported from the matching Next.js coverage

## Tests
- vp test run tests/pages-router.test.ts -t "passes parsed request cookies"
- vp test run tests/pages-bodyparser-config.test.ts -t "preserves duplicate ordering and the public object API"
- vp test run tests/pages-router.test.ts -t "serves pages from production build end-to-end"
- vp check packages/vinext/src/server/dev-server.ts packages/vinext/src/server/api-handler.ts packages/vinext/src/server/pages-node-compat.ts tests/pages-router.test.ts tests/fixtures/pages-basic/pages/ssr-cookies.tsx tests/fixtures/pages-basic/pages/api/cookies.ts