### PR TITLE
fix(pages): pass req res to document initial props

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -223,7 +223,7 @@ async function streamPageToResponse(
     fontHeadHTML,
     scripts,
     DocumentComponent,
-    statusCode = 200,
+    statusCode,
     extraHeaders,
     getHeadHTML,
     enhancePageElement,
@@ -248,6 +248,7 @@ async function streamPageToResponse(
     scriptNonce,
     context: documentContext,
   });
+  if (res.headersSent || res.writableEnded) return;
 
   let bodyStream: ReadableStream<Uint8Array>;
   if (documentRenderPage.status === "rendered") {
@@ -356,7 +357,7 @@ async function streamPageToResponse(
       }
     }
   }
-  res.writeHead(statusCode, headers);
+  res.writeHead(statusCode ?? res.statusCode, headers);
 
   // Write the document prefix (head, opening body)
   res.write(prefix);
@@ -1726,11 +1727,12 @@ hydrate();
           // Forward the per-request nonce so the shared renderPage helper can
           // apply `withScriptNonce` once (it owns that responsibility).
           scriptNonce,
-          // Minimal DocumentContext for `getInitialProps`, matching prod parity.
+          // DocumentContext for `getInitialProps`, matching prod parity.
           documentContext: {
             pathname: patternToNextFormat(route.pattern),
             query,
             asPath: requestAsPath,
+            ...(pagesNextData.autoExport === true ? {} : { req, res }),
           },
           // Used by `_document.getInitialProps` -> `ctx.renderPage` to wrap
           // App/Component with user enhancers (e.g. styled-components,

--- a/packages/vinext/src/server/pages-document-initial-props.ts
+++ b/packages/vinext/src/server/pages-document-initial-props.ts
@@ -199,10 +199,10 @@ export async function runDocumentRenderPage(
   };
 
   const docInitialProps = await DocCtor.getInitialProps({
-    // Minimal `DocumentContext` shim — vinext does not yet thread the full
-    // context (req/res/AppTree/locale). Subclasses that just forward to
-    // `ctx.renderPage` (the styled-components / emotion pattern) work
-    // without those fields.
+    // Pages renderers pass the request-scoped context they can provide
+    // (pathname/query/asPath plus req/res when available). Subclasses that
+    // forward to `ctx.renderPage` (the styled-components / emotion pattern)
+    // also work through the defaultGetInitialProps helper below.
     renderPage,
     defaultGetInitialProps: async (ctx: { renderPage: typeof renderPage }) => {
       // Mirrors Next.js's `ctx.defaultGetInitialProps`: wrap App in an

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -244,6 +244,7 @@ export type ResolvePagesPageDataOptions = {
 
 type ResolvePagesPageDataRenderResult = {
   kind: "render";
+  documentReqRes: PagesGsspContextResponse | null;
   gsspRes: PagesGsspResponse | null;
   isrRevalidateSeconds: number | null;
   pageProps: Record<string, unknown>;
@@ -741,6 +742,7 @@ export async function resolvePagesPageData(
       renderProps = { ...renderProps, pageProps };
       return {
         kind: "render",
+        documentReqRes: sharedReqRes,
         gsspRes: null,
         isrRevalidateSeconds: null,
         pageProps,
@@ -1089,6 +1091,7 @@ export async function resolvePagesPageData(
 
   return {
     kind: "render",
+    documentReqRes: sharedReqRes,
     gsspRes,
     isrRevalidateSeconds,
     pageProps,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -546,6 +546,13 @@ export function createPagesPageHandler(
         const parsedRouteUrl = new URL(routeUrl, originalRequestUrl);
         const routePathname = parsedRouteUrl.pathname || "/";
         const pagesResolvedUrl = routePathname + originalRequestUrl.search;
+        const createPageReqRes = () =>
+          createPagesReqRes({
+            body: undefined,
+            query,
+            request,
+            url: originalRequestPathAndSearch,
+          });
 
         const pageDataResult = await resolvePagesPageData({
           isDataReq,
@@ -554,14 +561,7 @@ export function createPagesPageHandler(
           buildId,
           deploymentId: process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
           htmlLimitedBots: vinextConfig.htmlLimitedBots,
-          createGsspReqRes() {
-            return createPagesReqRes({
-              body: undefined,
-              query,
-              request,
-              url: originalRequestPathAndSearch,
-            });
-          },
+          createGsspReqRes: createPageReqRes,
           createAppTree(appTreeProps) {
             const el = createPageElement(PageComponent, AppComponent, appTreeProps);
             return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
@@ -644,6 +644,10 @@ export function createPagesPageHandler(
           renderProps = { ...renderProps, pageProps };
         }
         const gsspRes = pageDataResult.gsspRes;
+        const documentReqRes =
+          serializedPagesNextData.autoExport === true
+            ? null
+            : (pageDataResult.documentReqRes ?? createPageReqRes());
         const isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
         const isFallbackRender = pageDataResult.isFallback === true;
 
@@ -747,6 +751,7 @@ export function createPagesPageHandler(
           clientTraceMetadata: shouldEmitPagesClientTraceMetadata(pageModule, AppComponent)
             ? vinextConfig.clientTraceMetadata
             : undefined,
+          documentReqRes,
           gsspRes,
           isrCacheKey: pageIsrCacheKey,
           expireSeconds: vinextConfig.expireTime,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -124,8 +124,15 @@ export type PagesI18nRenderContext = {
 };
 
 export type PagesGsspResponse = {
+  headersSent?: boolean;
   statusCode: number;
   getHeaders(): Record<string, string | number | boolean | string[]>;
+};
+
+type PagesDocumentReqRes = {
+  req: unknown;
+  res: PagesGsspResponse;
+  responsePromise?: Promise<Response>;
 };
 
 type PagesStreamedHtmlResponse = {
@@ -164,6 +171,7 @@ type RenderPagesPageResponseOptions = {
    */
   clientTraceMetadata?: readonly string[] | undefined;
   setDocumentInitialHead?: ((head: ReactNode[]) => void) | undefined;
+  documentReqRes?: PagesDocumentReqRes | null;
   gsspRes: PagesGsspResponse | null;
   isrCacheKey: (router: string, pathname: string) => string;
   expireSeconds?: number;
@@ -513,11 +521,16 @@ export async function renderPagesPageResponse(
     scriptNonce: options.scriptNonce,
     context: {
       err: options.err,
+      req: options.documentReqRes?.req,
+      res: options.documentReqRes?.res,
       pathname: options.routePattern,
       query: options.query ?? options.params,
       asPath: options.routeUrl,
     },
   });
+  if (options.documentReqRes?.res.headersSent && options.documentReqRes.responsePromise) {
+    return options.documentReqRes.responsePromise;
+  }
 
   let bodyStream: ReadableStream<Uint8Array>;
   if (documentRenderPage.status === "rendered") {
@@ -588,7 +601,11 @@ export async function renderPagesPageResponse(
   const shellPrefix = shellHtml.slice(0, markerIndex);
   const shellSuffix = shellHtml.slice(markerIndex + bodyMarker.length);
   const responseHeaders = new Headers({ "Content-Type": "text/html" });
-  const finalStatus = applyGsspHeaders(responseHeaders, options.gsspRes, options.statusCode);
+  const finalStatus = applyGsspHeaders(
+    responseHeaders,
+    options.gsspRes ?? options.documentReqRes?.res ?? null,
+    options.statusCode,
+  );
 
   let responseBodyStream = bodyStream;
   if (

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -1223,6 +1223,7 @@ describe("pages page data", () => {
 
     expect(result).toEqual({
       kind: "render",
+      documentReqRes: null,
       gsspRes: null,
       isrRevalidateSeconds: 30,
       pageProps: { title: "hello" },

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -562,6 +562,47 @@ describe("pages page response", () => {
     expect(enhancePageElement).toHaveBeenCalledTimes(1);
   });
 
+  it("passes req/res into _document.getInitialProps and applies res headers/status", async () => {
+    const common = createCommonOptions();
+    const documentHeaders: Record<string, string | number | boolean | string[]> = {};
+    const documentRes = {
+      headersSent: false,
+      statusCode: 200,
+      getHeaders: () => documentHeaders,
+      setHeader(name: string, value: string | number | boolean | string[]) {
+        documentHeaders[name] = value;
+      },
+    };
+
+    function MyDocument() {
+      return null;
+    }
+    (MyDocument as unknown as { getInitialProps: unknown }).getInitialProps = async (ctx: {
+      req?: { cookies?: Record<string, string> };
+      res?: typeof documentRes;
+      renderPage: () => Promise<{ html: string }>;
+    }) => {
+      ctx.res?.setHeader("x-document-cookie", ctx.req?.cookies?.theme ?? "missing");
+      if (ctx.res) ctx.res.statusCode = 202;
+      const result = await ctx.renderPage();
+      return { html: result.html };
+    };
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      DocumentComponent: MyDocument as unknown as React.ComponentType,
+      documentReqRes: {
+        req: { cookies: { theme: "dark" } },
+        res: documentRes,
+      },
+      enhancePageElement: () => React.createElement("p", null, "page"),
+    });
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("x-document-cookie")).toBe("dark");
+    expect(await response.text()).toContain("live-body");
+  });
+
   // Edge case: `getInitialProps` returns `styles` (the styled-components /
   // emotion pattern collects style tags and returns them). They must be
   // rendered to a string and merged into the document head.

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -5728,6 +5728,23 @@ export default function Page({ throwPage }: { throwPage: boolean }) {
 `,
     );
     await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "static.tsx"),
+      `export default function StaticPage() {
+  return <p id="static-page-content">STATIC</p>;
+}
+`,
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "static-gsp.tsx"),
+      `export function getStaticProps() {
+  return { props: {} };
+}
+export default function StaticGspPage() {
+  return <p id="static-gsp-page-content">STATIC GSP</p>;
+}
+`,
+    );
+    await fsp.writeFile(
       path.join(fixtureRoot, "pages", "_error.tsx"),
       `import { renderCounts } from "../render-counts";
 function ErrorPage({ message }: { message: string }) {
@@ -5780,6 +5797,29 @@ export default class CustomDocument extends Document {
         enhanceApp: ctx.query.withEnhanceApp ? enhanceApp : undefined,
       };
     }
+    const documentCookie = ctx.req?.cookies?.theme ?? "missing";
+    const documentRequestContext = [
+      ctx.req?.url ?? "missing-url",
+      documentCookie,
+      ctx.res ? "has-res" : "missing-res",
+    ].join("|");
+    if (ctx.query?.documentHeader) {
+      ctx.res?.setHeader("x-document-cookie", documentCookie);
+    }
+    if (ctx.query?.documentStatus && ctx.res) {
+      ctx.res.statusCode = 202;
+    }
+    if (ctx.query?.documentEnd && ctx.res) {
+      ctx.res.statusCode = 203;
+      ctx.res.setHeader("x-document-ended", "yes");
+      ctx.res.end("DOCUMENT ENDED");
+      return {
+        html: '<article id="should-not-render">SHOULD NOT RENDER</article>',
+        documentProp: "DOCUMENT",
+        documentErrorContext: "",
+        documentRequestContext,
+      };
+    }
     if (ctx.pathname !== "/_error" && ctx.query?.invalidDocumentHtml) return { html: null };
     if (ctx.query?.manualDocumentHtml) {
       return {
@@ -5787,6 +5827,7 @@ export default class CustomDocument extends Document {
         styles: <style data-manual-document-style>{".manual{color:blue}"}</style>,
         documentProp: "DOCUMENT",
         documentErrorContext: "",
+        documentRequestContext,
       };
     }
     const originalRenderPage = ctx.renderPage;
@@ -5804,6 +5845,7 @@ export default class CustomDocument extends Document {
             ? <ThrowingStyle />
             : initialProps.styles,
       documentProp: "DOCUMENT",
+      documentRequestContext,
       documentErrorContext:
         ctx.pathname === "/_error"
           ? [ctx.pathname, Object.keys(ctx.query ?? {})[0] ?? "", ctx.err?.message ?? ""].join("|")
@@ -5812,7 +5854,7 @@ export default class CustomDocument extends Document {
   }
   render() {
     return (
-      <Html><Head /><body><p id="document-prop">{(this.props as any).documentProp}</p><p id="document-error-context">{(this.props as any).documentErrorContext}</p><Main /><NextScript /></body></Html>
+      <Html><Head /><body><p id="document-prop">{(this.props as any).documentProp}</p><p id="document-request-context">{(this.props as any).documentRequestContext}</p><p id="document-error-context">{(this.props as any).documentErrorContext}</p><Main /><NextScript /></body></Html>
     );
   }
 }
@@ -5869,6 +5911,74 @@ export default class CustomDocument extends Document {
       expect(html).toContain(".manual{color:blue}");
       expect(html).not.toContain('id="page-content"');
       expect(html).not.toContain('id="app-shell"');
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    // Next.js builds a base context with req/res and passes `{ ...ctx, renderPage }`
+    // to `_document.getInitialProps` in packages/next/src/server/render.tsx.
+    "passes req/res into _document.getInitialProps in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/?documentHeader=true&documentStatus=true`, {
+        headers: {
+          Cookie: "theme=dark",
+        },
+      });
+      expect(response.status).toBe(202);
+      expect(response.headers.get("x-document-cookie")).toBe("dark");
+      const html = await response.text();
+      expect(html).toContain(
+        'id="document-request-context">/?documentHeader=true&amp;documentStatus=true|dark|has-res',
+      );
+      expect(html).toContain('id="page-content">PAGE');
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "passes req/res into _document.getInitialProps for getStaticProps pages in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/static-gsp?documentHeader=true&documentStatus=true`, {
+        headers: {
+          Cookie: "theme=dark",
+        },
+      });
+      expect(response.status).toBe(202);
+      expect(response.headers.get("x-document-cookie")).toBe("dark");
+      const html = await response.text();
+      expect(html).toContain(
+        'id="document-request-context">/static-gsp?documentHeader=true&amp;documentStatus=true|dark|has-res',
+      );
+      expect(html).toContain('id="static-gsp-page-content">STATIC GSP');
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "honors _document.getInitialProps responses that end early in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/?documentEnd=true`);
+      expect(response.status).toBe(203);
+      expect(response.headers.get("x-document-ended")).toBe("yes");
+      expect(await response.text()).toBe("DOCUMENT ENDED");
+    },
+  );
+
+  it.each(["dev", "prod"] as const)(
+    "omits req/res from _document.getInitialProps for auto-export pages in %s",
+    async (mode) => {
+      const url = mode === "dev" ? devUrl : prodUrl;
+      const response = await fetch(`${url}/static?documentHeader=true&documentStatus=true`, {
+        headers: {
+          Cookie: "theme=dark",
+        },
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-document-cookie")).toBeNull();
+      const html = await response.text();
+      expect(html).toContain('id="document-request-context">missing-url|missing|missing-res');
+      expect(html).toContain('id="static-page-content">STATIC');
     },
   );
 


### PR DESCRIPTION
## Summary
- thread the shared Pages req/res into `_document.getInitialProps` during production HTML renders
- create a document req/res for plain Pages routes that do not already run gSSP, `_app.getInitialProps`, or page `getInitialProps`
- mirror the normal dev render path and preserve status/headers set through `_document`

## Validation
- `vp test run tests/pages-page-response.test.ts -t "passes req/res into _document"`
- `vp test run tests/pages-router.test.ts -t "passes req/res into _document"`
- `vp test run tests/pages-router.test.ts -t "Pages _document renderPage enhancers"`
- `vp test run tests/pages-page-response.test.ts`
- `vp check packages/vinext/src/server/dev-server.ts packages/vinext/src/server/pages-document-initial-props.ts packages/vinext/src/server/pages-page-data.ts packages/vinext/src/server/pages-page-handler.ts packages/vinext/src/server/pages-page-response.ts tests/pages-page-response.test.ts tests/pages-router.test.ts`