### PR TITLE
fix(init): only detect pnpm approve-builds failures from pnpm-specific output

### DIFF
--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -57,8 +57,9 @@ function isApproveBuildsError(error: unknown): boolean {
     typeof error === "object" && error && "stdout" in error ? String(error.stdout) : "",
     typeof error === "object" && error && "stderr" in error ? String(error.stderr) : "",
   ].join("\n");
-  return /approve-builds|ignored build scripts|blocked build scripts|ERR_PNPM_.*BUILD/i.test(
-    details,
+  return (
+    /approve-builds|ERR_PNPM_.*BUILD/i.test(details) ||
+    (/pnpm/i.test(details) && /(ignored build scripts|blocked build scripts)/i.test(details))
   );
 }
 


### PR DESCRIPTION
## What changed

Tightened `vinext init`'s approve-builds error detection so it only treats install failures as pnpm build-approval issues when the output is actually pnpm-specific.

In practice, this narrows `isApproveBuildsError()` to match:

- explicit `approve-builds` output
- `ERR_PNPM_*BUILD`
- generic `ignored build scripts` / `blocked build scripts` text only when `pnpm` is also present

## Why

`vinext init` was previously too eager here and could misclassify a generic install failure as a pnpm `approve-builds` case.

That led to the CLI swallowing the real install error and printing pnpm recovery instructions even when the failure was not actually a pnpm build-approval problem.

## Impact

- preserves the real install error for non-pnpm or unrelated failures
- keeps the pnpm `approve-builds` recovery flow working when the output is genuinely pnpm-specific
- improves `vinext init` failure reporting and recovery guidance

## Root cause

The approve-builds matcher was keyed off broad phrases like `ignored build scripts` without requiring enough pnpm-specific context.

## Validation

Ran:

- `pnpm test tests/init.test.ts -t "does not classify non-pnpm install failures as approve-builds errors"`
- `pnpm test tests/init.test.ts -t "approve-builds"`
- `pnpm test tests/init.test.ts`