### PR TITLE
fix(ci): resolve setup-vp version from catalog

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,32 +33,7 @@ runs:
         if [ -n "$INPUT_VERSION" ]; then
           version="$INPUT_VERSION"
         else
-          version="$(node <<'NODE'
-        const fs = require("node:fs");
-
-        const workspace = fs.readFileSync("pnpm-workspace.yaml", "utf8");
-        let inCatalog = false;
-
-        for (const line of workspace.split(/\r?\n/)) {
-          if (/^\S/.test(line)) {
-            inCatalog = line === "catalog:";
-            continue;
-          }
-
-          if (!inCatalog) {
-            continue;
-          }
-
-          const vitePlus = line.match(/^\s{2}vite-plus:\s*["']?([^"'\s#]+)["']?/);
-          if (vitePlus) {
-            process.stdout.write(vitePlus[1]);
-            process.exit(0);
-          }
-        }
-
-        throw new Error("Missing vite-plus catalog entry in pnpm-workspace.yaml");
-        NODE
-          )"
+          version="$(node "$GITHUB_ACTION_PATH/resolve-vite-plus-version.cjs")"
         fi
 
         echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,13 +14,59 @@ inputs:
     description: Whether to run `vp install` after setup
     required: false
     default: true
+  version:
+    description: Vite+ version to install. Defaults to the workspace catalog entry.
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
+    - name: Resolve Vite+ version
+      id: vite-plus-version
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "$INPUT_VERSION" ]; then
+          version="$INPUT_VERSION"
+        else
+          version="$(node <<'NODE'
+        const fs = require("node:fs");
+
+        const workspace = fs.readFileSync("pnpm-workspace.yaml", "utf8");
+        let inCatalog = false;
+
+        for (const line of workspace.split(/\r?\n/)) {
+          if (/^\S/.test(line)) {
+            inCatalog = line === "catalog:";
+            continue;
+          }
+
+          if (!inCatalog) {
+            continue;
+          }
+
+          const vitePlus = line.match(/^\s{2}vite-plus:\s*["']?([^"'\s#]+)["']?/);
+          if (vitePlus) {
+            process.stdout.write(vitePlus[1]);
+            process.exit(0);
+          }
+        }
+
+        throw new Error("Missing vite-plus catalog entry in pnpm-workspace.yaml");
+        NODE
+          )"
+        fi
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Setup Vite+
       uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache }}
         run-install: ${{ inputs.run-install }}
+        version: ${{ steps.vite-plus-version.outputs.version }}

--- a/.github/actions/setup/resolve-vite-plus-version.cjs
+++ b/.github/actions/setup/resolve-vite-plus-version.cjs
@@ -1,6 +1,8 @@
 const fs = require("node:fs");
+const path = require("node:path");
 
-const workspace = fs.readFileSync("pnpm-workspace.yaml", "utf8");
+const workspaceRoot = process.env.GITHUB_WORKSPACE || process.cwd();
+const workspace = fs.readFileSync(path.join(workspaceRoot, "pnpm-workspace.yaml"), "utf8");
 let inCatalog = false;
 
 for (const line of workspace.split(/\r?\n/)) {

--- a/.github/actions/setup/resolve-vite-plus-version.cjs
+++ b/.github/actions/setup/resolve-vite-plus-version.cjs
@@ -1,0 +1,23 @@
+const fs = require("node:fs");
+
+const workspace = fs.readFileSync("pnpm-workspace.yaml", "utf8");
+let inCatalog = false;
+
+for (const line of workspace.split(/\r?\n/)) {
+  if (/^\S/.test(line)) {
+    inCatalog = line === "catalog:";
+    continue;
+  }
+
+  if (!inCatalog) {
+    continue;
+  }
+
+  const vitePlus = line.match(/^\s{2}vite-plus:\s*["']?([^"'\s#]+)["']?/);
+  if (vitePlus) {
+    process.stdout.write(vitePlus[1]);
+    process.exit(0);
+  }
+}
+
+throw new Error("Missing vite-plus catalog entry in pnpm-workspace.yaml");


### PR DESCRIPTION
Deploy Examples failed before deploy because parallel jobs let setup-vp resolve `vite-plus@latest`, and one npm latest lookup returned 1015. Resolve the Vite+ version from `pnpm-workspace.yaml` in the shared setup wrapper so normal catalog bumps stay the source of truth.

Validation: YAML parsed, resolver script tested for catalog and override paths, `vp fmt --check .github/actions/setup/action.yml`, pre-commit `vp check --fix` and full check.