### PR TITLE
fix(e2e): stabilize nav regression suspense window

### DIFF
--- a/tests/e2e/app-router/navigation-regressions.spec.ts
+++ b/tests/e2e/app-router/navigation-regressions.spec.ts
@@ -143,8 +143,9 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
     await waitForAppRouterHydration(page);
     await expect(page.locator("#list-title")).toHaveText("Nav Flash List");
 
-    // Cross-route: list -> query-sync
-    await page.click("#to-query-sync");
+    // Use the slow fixture entry so the Suspense fallback is still mounted when
+    // the same-route navigation supersedes the cross-route stream.
+    await page.click("#to-query-sync-slow");
     await expect(page.locator("#query-title")).toHaveText("Search", { timeout: 10_000 });
     await expect(page.locator("#query-loading")).toBeVisible();
 

--- a/tests/e2e/app-router/navigation-regressions.spec.ts
+++ b/tests/e2e/app-router/navigation-regressions.spec.ts
@@ -5,6 +5,7 @@ import { waitForAppRouterHydration } from "../helpers";
 // this directory (navigation.spec.ts, server-client-only.spec.ts, after.spec.ts,
 // etc.). Port 4174 is the vite preview default for the app-basic fixture.
 const BASE = "http://localhost:4174";
+const SLOW_SEARCH_RESOLUTION_WAIT_MS = 5_500;
 
 type RouterSideEffectWindow = Window & {
   __APP_ROUTER_HISTORY_MARKER__?: string;
@@ -156,6 +157,10 @@ test.describe("Navigation regression tests (#652 Firefox hang fix)", () => {
     await expect(page.locator("#query-title")).toHaveText("Search: react", { timeout: 10_000 });
     await expect(page.locator("#hook-query")).toHaveText("q: react");
     expect(page.url()).toContain("q=react");
+
+    await page.waitForTimeout(SLOW_SEARCH_RESOLUTION_WAIT_MS);
+    await expect(page.locator("#query-title")).toHaveText("Search: react");
+    await expect(page.locator("#hook-query")).toHaveText("q: react");
   });
 
   test("usePathname reflects correct value during cross-route navigation", async ({ page }) => {

--- a/tests/fixtures/app-basic/app/nav-flash/list/page.tsx
+++ b/tests/fixtures/app-basic/app/nav-flash/list/page.tsx
@@ -16,6 +16,11 @@ export default function ListPage() {
           </Link>
         </li>
         <li>
+          <Link href="/nav-flash/query-sync?delay=slow" id="to-query-sync-slow">
+            Query Sync Slow
+          </Link>
+        </li>
+        <li>
           <Link href="/nav-flash/param-sync/active" id="to-param-sync">
             Param Sync
           </Link>

--- a/tests/fixtures/app-basic/app/nav-flash/query-sync/page.tsx
+++ b/tests/fixtures/app-basic/app/nav-flash/query-sync/page.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
 import { FilterControls } from "./FilterControls";
 
-async function SearchResults({ query }: { query: string }) {
-  await new Promise((r) => setTimeout(r, 200));
+async function SearchResults({ query, delayMs }: { query: string; delayMs: number }) {
+  await new Promise((r) => setTimeout(r, delayMs));
   if (!query) {
     return <p id="search-results">Enter a search query</p>;
   }
@@ -12,15 +12,16 @@ async function SearchResults({ query }: { query: string }) {
 export default async function QuerySyncPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string }>;
+  searchParams: Promise<{ q?: string; delay?: string }>;
 }) {
-  const { q = "" } = await searchParams;
+  const { q = "", delay } = await searchParams;
+  const delayMs = delay === "slow" ? 5_000 : 200;
   return (
     <div>
       <h1 id="query-title">{q ? `Search: ${q}` : "Search"}</h1>
       <FilterControls />
       <Suspense fallback={<div id="query-loading">Searching...</div>}>
-        <SearchResults query={q} />
+        <SearchResults query={q} delayMs={delayMs} />
       </Suspense>
     </div>
   );

--- a/tests/fixtures/app-basic/app/nav-flash/query-sync/page.tsx
+++ b/tests/fixtures/app-basic/app/nav-flash/query-sync/page.tsx
@@ -1,6 +1,9 @@
 import { Suspense } from "react";
 import { FilterControls } from "./FilterControls";
 
+const DEFAULT_SEARCH_DELAY_MS = 200;
+const SLOW_SEARCH_DELAY_MS = 5_000;
+
 async function SearchResults({ query, delayMs }: { query: string; delayMs: number }) {
   await new Promise((r) => setTimeout(r, delayMs));
   if (!query) {
@@ -15,7 +18,9 @@ export default async function QuerySyncPage({
   searchParams: Promise<{ q?: string; delay?: string }>;
 }) {
   const { q = "", delay } = await searchParams;
-  const delayMs = delay === "slow" ? 5_000 : 200;
+  // The slow path must stay comfortably above the default path so navigation
+  // tests can supersede a committed page while its Suspense boundary is pending.
+  const delayMs = delay === "slow" ? SLOW_SEARCH_DELAY_MS : DEFAULT_SEARCH_DELAY_MS;
   return (
     <div>
       <h1 id="query-title">{q ? `Search: ${q}` : "Search"}</h1>


### PR DESCRIPTION
Fixes #2407.

The regression test depended on a 200ms Suspense fallback still being visible after cross-route navigation, which was not deterministic on CI. Add a dedicated slow fixture entry for that race case so the test reliably starts the same-route navigation while the cross-route stream is still resolving, without changing the normal query-sync path.

Validation: `PLAYWRIGHT_PROJECT=app-router vp exec playwright test tests/e2e/app-router/navigation-regressions.spec.ts -g "cross-route then same-route navigation works" --repeat-each=5`; `vp check tests/e2e/app-router/navigation-regressions.spec.ts tests/fixtures/app-basic/app/nav-flash/list/page.tsx tests/fixtures/app-basic/app/nav-flash/query-sync/page.tsx`; pre-commit full check + knip.