### PR TITLE
test(e2e): wait for hydration before dev overlay recovery click

### DIFF
--- a/tests/e2e/app-with-src/dev-overlay-recovery.spec.ts
+++ b/tests/e2e/app-with-src/dev-overlay-recovery.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4181";
 
@@ -13,22 +14,7 @@ test.describe("Dev recovery boundary (no global-error.tsx)", () => {
   test("soft-nav to a broken route still updates the URL", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("#app-with-src-home")).toBeVisible();
-    await page.waitForFunction(
-      () => {
-        const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
-        return (
-          typeof runtime === "object" &&
-          runtime !== null &&
-          "functions" in runtime &&
-          typeof runtime.functions === "object" &&
-          runtime.functions !== null &&
-          "navigate" in runtime.functions &&
-          typeof runtime.functions.navigate === "function"
-        );
-      },
-      undefined,
-      { timeout: 10_000 },
-    );
+    await waitForAppRouterHydration(page);
     await page.evaluate(() => {
       (window as unknown as { __vinextReloadCanary?: boolean }).__vinextReloadCanary = true;
     });


### PR DESCRIPTION
Fixes #2409

## Overview

The `app-with-src` dev overlay recovery E2E now waits for the shared App Router hydration signal before setting the reload canary and clicking the recovery `Link`.

## Why

The flaky failure was a real test race: the previous wait only proved that the navigation runtime object existed. It did not prove React had hydrated the client tree that intercepts the `Link` click, so CI could occasionally perform a hard navigation before the soft-nav path was ready.

## What changed

- Replaced the partial runtime-exists polling with `waitForAppRouterHydration(page)`.
- Kept the actual browser click path so the test still covers the user-visible recovery flow.

## Validation

- `PLAYWRIGHT_PROJECT=app-with-src vp exec playwright test tests/e2e/app-with-src/dev-overlay-recovery.spec.ts --project=app-with-src --repeat-each=10 --retries=0`
- `PLAYWRIGHT_PROJECT=app-with-src vp exec playwright test --project=app-with-src --retries=0`
- `vp check tests/e2e/app-with-src/dev-overlay-recovery.spec.ts`