### PR TITLE
test(fonts): mock google font files in unit tests

### DIFF
--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -42,6 +42,22 @@ function mockGoogleFontsCSS(
   return { urls, count: () => urls.length };
 }
 
+function mockGoogleFontFiles(body = new Uint8Array([0, 1, 2, 3])): { urls: string[] } {
+  const urls: string[] = [];
+  server.use(
+    http.get("https://fonts.gstatic.com/*", ({ request }) => {
+      urls.push(request.url);
+      return new HttpResponse(body, {
+        headers: {
+          "content-type": "font/woff2",
+          "cache-control": "public, max-age=31536000",
+        },
+      });
+    }),
+  );
+  return { urls };
+}
+
 /** Extract the vinext:google-fonts plugin from the plugin array */
 function getGoogleFontsPlugin(): Plugin {
   const plugins = vinext() as Plugin[];
@@ -727,6 +743,16 @@ describe("vinext:google-fonts plugin", () => {
     const root = path.join(import.meta.dirname, ".test-font-root");
     initPlugin(plugin, { command: "build", root });
 
+    mockGoogleFontsCSS(
+      [
+        "@font-face {",
+        "  font-family: 'Inter';",
+        "  src: url(https://fonts.gstatic.com/s/inter/v19/inter-latin-400.woff2) format('woff2');",
+        "}",
+      ].join("\n"),
+    );
+    mockGoogleFontFiles();
+
     const transform = unwrapHook(plugin.transform);
     const code = [
       `import { Inter } from 'next/font/google';`,
@@ -1346,6 +1372,16 @@ describe("fetchAndCacheFont", () => {
     // Use the plugin's transform which internally calls fetchAndCacheFont
     const plugin = getGoogleFontsPlugin();
     initPlugin(plugin, { command: "build", root });
+
+    mockGoogleFontsCSS(
+      [
+        "@font-face {",
+        "  font-family: 'Inter';",
+        "  src: url(https://fonts.gstatic.com/s/inter/v19/inter-latin-400.woff2) format('woff2');",
+        "}",
+      ].join("\n"),
+    );
+    mockGoogleFontFiles();
 
     const transform = unwrapHook(plugin.transform);
     const code = [


### PR DESCRIPTION
Fixes #2411

## Overview

The Google font self-hosting unit tests now mock both the CSS request to `fonts.googleapis.com` and the font binary request to `fonts.gstatic.com`.

## Why

The flaky CI failure was a real test isolation bug. The plugin intentionally treats raw Google Fonts fetch failures as recoverable offline behavior and skips `_vinext.font` injection, but this unit test expected deterministic self-hosted output while relying on external network availability.

## What changed

- Added an MSW helper for Google font file responses.
- Mocked Google CSS and `.woff2` responses in the self-hosting transform test.
- Mocked the same responses in the fetch/cache integration test so it still proves downloaded `.woff2` cache output without external network.

## Validation

- `for i in 1 2 3 4 5; do vp test run tests/font-google.test.ts || exit $?; done`
- `vp check tests/font-google.test.ts`

Note: local pre-commit was run and its staged file check passed, but its broad repo check failed in this fresh worktree because `packages/vinext/node_modules/react-dom` was not linked. The targeted checks above passed against the changed file.