### PR TITLE
fix(ci): skip create-next-app deploy on forks

### DIFF
--- a/.github/workflows/create-next-app-cloudflare-deploy.yml
+++ b/.github/workflows/create-next-app-cloudflare-deploy.yml
@@ -13,6 +13,10 @@ concurrency:
 
 jobs:
   deploy:
+    # This workflow deploys a fixed Cloudflare Worker using repository secrets.
+    # Forks still receive pushes to their own main branch, but they do not have
+    # the canonical repo's Cloudflare credentials.
+    if: github.repository_owner == 'cloudflare'
     name: Deploy and smoke test
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

- skip the create-next-app Cloudflare deploy job outside Cloudflare-owned repositories
- document why the guard exists at the workflow boundary

Closes #2413.

## Root cause

`create-next-app-cloudflare-deploy.yml` runs on `push` to `main`, so fork `main` branches run it too. The job deploys a fixed Cloudflare Worker and reads `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` from repository secrets. In forks those secrets resolve to empty values, so Wrangler fails in the non-interactive deploy step even though the generated project build and `dist/server/wrangler.json` verification already passed.

This is not a flaky test. It is a secret-backed deploy job running in a repository context where the required secrets are intentionally unavailable.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/create-next-app-cloudflare-deploy.yml`
- `vp run fmt:check -- .github/workflows/create-next-app-cloudflare-deploy.yml`
- pre-commit hook: `vp check --fix` on staged file and full check
