### PR TITLE
fix(test): mark app trailing slash ISR fixture private

### DIFF
--- a/tests/fixtures/app-trailing-slash-isr/package.json
+++ b/tests/fixtures/app-trailing-slash-isr/package.json
@@ -1,4 +1,5 @@
 {
   "name": "app-trailing-slash-isr-fixture",
+  "private": true,
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- mark `app-trailing-slash-isr-fixture` as private so pnpm treats it like the other local fixtures

## Verification
- `vp install` (lockfile reported up to date)