### PR TITLE
ci: deploy CNA smoke with vinext cloudflare CLI

### DIFF
--- a/.github/workflows/create-next-app-cloudflare-deploy.yml
+++ b/.github/workflows/create-next-app-cloudflare-deploy.yml
@@ -92,12 +92,20 @@ jobs:
             fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
           '
 
+      - name: Build generated Cloudflare project
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: vp exec vinext build
+
+      - name: Verify generated Cloudflare build output
+        working-directory: ${{ runner.temp }}/cna-cloudflare
+        run: test -f dist/server/wrangler.json
+
       - name: Deploy generated Cloudflare project
         working-directory: ${{ runner.temp }}/cna-cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: vp exec vinext-cloudflare deploy
+        run: vp exec vinext-cloudflare deploy --skip-build
 
       - name: Smoke test generated Cloudflare deployment
         run: |

--- a/.github/workflows/create-next-app-cloudflare-deploy.yml
+++ b/.github/workflows/create-next-app-cloudflare-deploy.yml
@@ -92,20 +92,12 @@ jobs:
             fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
           '
 
-      - name: Build generated Cloudflare project
-        working-directory: ${{ runner.temp }}/cna-cloudflare
-        run: vp exec vinext build
-
-      - name: Verify generated Cloudflare build output
-        working-directory: ${{ runner.temp }}/cna-cloudflare
-        run: test -f dist/server/wrangler.json
-
-      - name: Deploy generated Cloudflare build
+      - name: Deploy generated Cloudflare project
         working-directory: ${{ runner.temp }}/cna-cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: vp exec wrangler deploy --config dist/server/wrangler.json
+        run: vp exec vinext-cloudflare deploy
 
       - name: Smoke test generated Cloudflare deployment
         run: |


### PR DESCRIPTION
## Summary
- switch the create-next-app Cloudflare smoke deploy workflow to use `vp exec vinext-cloudflare deploy`
- let the package deploy command own the build and wrangler deploy steps

## Testing
- `git diff --check -- .github/workflows/create-next-app-cloudflare-deploy.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/create-next-app-cloudflare-deploy.yml"); puts "ok"'`