### PR TITLE
fix(pages): preload initial dev stylesheets

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -371,8 +371,8 @@ function toRelativeFileEntry(root: string, absPath: string): string {
 }
 
 const DEV_PAGES_CLIENT_ENTRY = "/@id/__x00__virtual:vinext-client-entry";
-const STYLESHEET_IMPORT_RE = /\.(?:css|scss|sass|less)$/i;
-const STYLESHEET_FILE_RE = /\.(?:css|scss|sass|less)$/i;
+const STYLESHEET_IMPORT_RE = /\.(?:css|scss|sass)$/i;
+const STYLESHEET_FILE_RE = /\.(?:css|scss|sass)$/i;
 const SCRIPT_IMPORT_RE = /\.(?:[cm]?[jt]sx?)$/i;
 
 type ResolveFromImporter = (
@@ -398,8 +398,7 @@ function parserLanguageForScript(id: string): "ts" | "tsx" {
 }
 
 function isStylesheetSpecifier(specifier: string): boolean {
-  if (specifier.includes("?") || specifier.includes("#")) return false;
-  return STYLESHEET_IMPORT_RE.test(specifier.toLowerCase());
+  return STYLESHEET_IMPORT_RE.test(stripViteModuleQuery(specifier).toLowerCase());
 }
 
 function isScriptModuleId(id: string): boolean {
@@ -2947,14 +2946,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       resolveId: {
-        // Hook filter: only invoke JS for handled Next/Vinext compatibility modules.
+        // Hook filter: only invoke JS for handled compatibility modules.
         // Matches "next/navigation", "next/router.js", "virtual:vinext-rsc-entry",
-        // direct @vercel/og imports in metadata routes, and \0-prefixed
-        // re-imports from @vitejs/plugin-rsc.
+        // direct @vercel/og imports in metadata routes, CSS imports carrying
+        // query/hash suffixes, and \0-prefixed re-imports from @vitejs/plugin-rsc.
         filter: {
-          id: /(?:next\/|vinext\/(?:shims\/|server\/app-rsc-handler)|virtual:vinext-|@vercel\/og(?:\.js)?$)/,
+          id: /(?:next\/|vinext\/(?:shims\/|server\/app-rsc-handler)|virtual:vinext-|@vercel\/og(?:\.js)?$|\.(?:css|scss|sass)[?#])/,
         },
-        handler(id, importer) {
+        async handler(id, importer) {
           // Strip \0 prefix if present — @vitejs/plugin-rsc's generated
           // browser entry imports our virtual module using the already-resolved
           // ID (with \0 prefix). We need to re-resolve it so the client
@@ -2967,6 +2966,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // `E:\proj\virtual:vinext-rsc-entry`. normalizePathSeparators is a
           // no-op on POSIX.
           const cleanId = normalizePathSeparators(id.startsWith(VIRTUAL_PREFIX) ? id.slice(1) : id);
+
+          const cleanStylesheetId = stripViteModuleQuery(cleanId);
+          if (cleanStylesheetId !== cleanId && isStylesheetSpecifier(cleanId)) {
+            return await this.resolve(cleanStylesheetId, importer, { skipSelf: true });
+          }
 
           if (cleanId === "vinext/server/app-rsc-handler") {
             if (

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -398,7 +398,8 @@ function parserLanguageForScript(id: string): "ts" | "tsx" {
 }
 
 function isStylesheetSpecifier(specifier: string): boolean {
-  return STYLESHEET_IMPORT_RE.test(stripViteModuleQuery(specifier).toLowerCase());
+  if (specifier.includes("?") || specifier.includes("#")) return false;
+  return STYLESHEET_IMPORT_RE.test(specifier.toLowerCase());
 }
 
 function isScriptModuleId(id: string): boolean {
@@ -2948,12 +2949,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       resolveId: {
         // Hook filter: only invoke JS for handled compatibility modules.
         // Matches "next/navigation", "next/router.js", "virtual:vinext-rsc-entry",
-        // direct @vercel/og imports in metadata routes, CSS imports carrying
-        // query/hash suffixes, and \0-prefixed re-imports from @vitejs/plugin-rsc.
+        // direct @vercel/og imports in metadata routes, and \0-prefixed
+        // re-imports from @vitejs/plugin-rsc.
         filter: {
-          id: /(?:next\/|vinext\/(?:shims\/|server\/app-rsc-handler)|virtual:vinext-|@vercel\/og(?:\.js)?$|\.(?:css|scss|sass)[?#])/,
+          id: /(?:next\/|vinext\/(?:shims\/|server\/app-rsc-handler)|virtual:vinext-|@vercel\/og(?:\.js)?$)/,
         },
-        async handler(id, importer) {
+        handler(id, importer) {
           // Strip \0 prefix if present — @vitejs/plugin-rsc's generated
           // browser entry imports our virtual module using the already-resolved
           // ID (with \0 prefix). We need to re-resolve it so the client
@@ -2966,11 +2967,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // `E:\proj\virtual:vinext-rsc-entry`. normalizePathSeparators is a
           // no-op on POSIX.
           const cleanId = normalizePathSeparators(id.startsWith(VIRTUAL_PREFIX) ? id.slice(1) : id);
-
-          const cleanStylesheetId = stripViteModuleQuery(cleanId);
-          if (cleanStylesheetId !== cleanId && isStylesheetSpecifier(cleanId)) {
-            return await this.resolve(cleanStylesheetId, importer, { skipSelf: true });
-          }
 
           if (cleanId === "vinext/server/app-rsc-handler") {
             if (

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3623,17 +3623,16 @@ export const loadServerActionClient = ${
           return relativeAppPath.startsWith("..") || path.isAbsolute(relativeAppPath);
         };
         const pagesAppChanged = isPagesAppFile(options.file);
+        const pagesAssetGraphScriptChanged = isPotentialPagesAssetGraphScript(options.file);
         const pagesAssetGraphChanged =
-          pagesAppChanged ||
-          STYLESHEET_FILE_RE.test(options.file) ||
-          isPotentialPagesAssetGraphScript(options.file);
+          pagesAppChanged || STYLESHEET_FILE_RE.test(options.file) || pagesAssetGraphScriptChanged;
         if (pagesAssetGraphChanged) {
           for (const env of Object.values(options.server.environments)) {
             const mod = env.moduleGraph.getModuleById(RESOLVED_PAGES_CLIENT_ASSETS);
             if (mod) env.moduleGraph.invalidateModule(mod);
           }
         }
-        if (pagesAppChanged || isPotentialPagesAssetGraphScript(options.file)) {
+        if (pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged)) {
           options.server.ws.send({ type: "full-reload" });
           return [];
         }
@@ -3869,13 +3868,15 @@ export const loadServerActionClient = ${
 
         server.watcher.on("add", (filePath: string) => {
           let routeChanged = false;
+          const pagesAppChanged = isPagesAppFile(filePath);
+          const pagesAssetGraphScriptChanged = isPotentialPagesAssetGraphScript(filePath);
           if (
             hasPagesDir &&
-            (isPagesAppFile(filePath) ||
-              STYLESHEET_FILE_RE.test(filePath) ||
-              isPotentialPagesAssetGraphScript(filePath))
+            (pagesAppChanged || STYLESHEET_FILE_RE.test(filePath) || pagesAssetGraphScriptChanged)
           ) {
-            invalidatePagesClientAssetsModule(true);
+            invalidatePagesClientAssetsModule(
+              pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged),
+            );
           }
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);
@@ -3893,26 +3894,28 @@ export const loadServerActionClient = ${
           }
         });
         server.watcher.on("change", (filePath: string) => {
+          const pagesAppChanged = isPagesAppFile(filePath);
+          const pagesAssetGraphScriptChanged = isPotentialPagesAssetGraphScript(filePath);
           if (
             hasPagesDir &&
-            (isPagesAppFile(filePath) ||
-              STYLESHEET_FILE_RE.test(filePath) ||
-              isPotentialPagesAssetGraphScript(filePath))
+            (pagesAppChanged || STYLESHEET_FILE_RE.test(filePath) || pagesAssetGraphScriptChanged)
           ) {
             invalidatePagesClientAssetsModule(
-              isPagesAppFile(filePath) || isPotentialPagesAssetGraphScript(filePath),
+              pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged),
             );
           }
         });
         server.watcher.on("unlink", (filePath: string) => {
           let routeChanged = false;
+          const pagesAppChanged = isPagesAppFile(filePath);
+          const pagesAssetGraphScriptChanged = isPotentialPagesAssetGraphScript(filePath);
           if (
             hasPagesDir &&
-            (isPagesAppFile(filePath) ||
-              STYLESHEET_FILE_RE.test(filePath) ||
-              isPotentialPagesAssetGraphScript(filePath))
+            (pagesAppChanged || STYLESHEET_FILE_RE.test(filePath) || pagesAssetGraphScriptChanged)
           ) {
-            invalidatePagesClientAssetsModule(true);
+            invalidatePagesClientAssetsModule(
+              pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged),
+            );
           }
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -370,6 +370,129 @@ function toRelativeFileEntry(root: string, absPath: string): string {
   return path.relative(root, absPath).split(path.sep).join("/");
 }
 
+const DEV_PAGES_CLIENT_ENTRY = "/@id/__x00__virtual:vinext-client-entry";
+const STYLESHEET_IMPORT_RE = /\.(?:css|scss|sass|less)$/i;
+const STYLESHEET_FILE_RE = /\.(?:css|scss|sass|less)$/i;
+const SCRIPT_IMPORT_RE = /\.(?:[cm]?[jt]sx?)$/i;
+
+type ResolveFromImporter = (
+  id: string,
+  importer?: string,
+  options?: { skipSelf?: boolean },
+) => Promise<{ id: string } | null | undefined>;
+
+type AstStaticDependencyDeclaration = ASTNode & {
+  type?: string;
+  importKind?: string;
+  exportKind?: string;
+  source?: { value?: unknown };
+  specifiers?: Array<{ importKind?: string; exportKind?: string }>;
+  attributes?: unknown[];
+};
+
+function parserLanguageForScript(id: string): "ts" | "tsx" {
+  const cleanId = stripViteModuleQuery(id).toLowerCase();
+  return cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")
+    ? "ts"
+    : "tsx";
+}
+
+function isStylesheetSpecifier(specifier: string): boolean {
+  if (specifier.includes("?") || specifier.includes("#")) return false;
+  return STYLESHEET_IMPORT_RE.test(specifier.toLowerCase());
+}
+
+function isScriptModuleId(id: string): boolean {
+  return SCRIPT_IMPORT_RE.test(stripViteModuleQuery(id).toLowerCase());
+}
+
+function hasOnlyTypeSpecifiers(statement: AstStaticDependencyDeclaration): boolean {
+  return (
+    statement.specifiers !== undefined &&
+    statement.specifiers.length > 0 &&
+    statement.specifiers.every(
+      (specifier) => specifier.importKind === "type" || specifier.exportKind === "type",
+    )
+  );
+}
+
+function resolvedStylesheetToDevManifestAsset(root: string, resolvedId: string): string | null {
+  const cleanId = stripViteModuleQuery(resolvedId);
+  if (!path.isAbsolute(cleanId)) return null;
+
+  const rootForRelative = tryRealpathSync(root) ?? root;
+  const fileForRelative = tryRealpathSync(cleanId) ?? cleanId;
+  const relativePath = path.relative(rootForRelative, fileForRelative);
+  if (relativePath !== "" && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
+    return normalizePathSeparators(relativePath);
+  }
+
+  const normalized = normalizePathSeparators(cleanId);
+  return `@fs/${normalized.replace(/^\/+/, "")}`;
+}
+
+async function collectDevPagesAppStylesheetAssets(
+  root: string,
+  appFilePath: string,
+  resolve: ResolveFromImporter,
+): Promise<string[]> {
+  const stylesheetAssets: string[] = [];
+  const seenAssets = new Set<string>();
+  const seenModules = new Set<string>();
+
+  async function visitModule(modulePath: string): Promise<void> {
+    const cleanModulePath = stripViteModuleQuery(modulePath);
+    if (!path.isAbsolute(cleanModulePath) || !fs.existsSync(cleanModulePath)) return;
+    if (seenModules.has(cleanModulePath)) return;
+    seenModules.add(cleanModulePath);
+
+    let ast: ReturnType<typeof parseAst>;
+    try {
+      ast = parseAst(fs.readFileSync(cleanModulePath, "utf-8"), {
+        lang: parserLanguageForScript(cleanModulePath),
+      });
+    } catch {
+      return;
+    }
+
+    for (const statement of ast.body as AstStaticDependencyDeclaration[]) {
+      if (
+        statement.type !== "ImportDeclaration" &&
+        statement.type !== "ExportNamedDeclaration" &&
+        statement.type !== "ExportAllDeclaration"
+      ) {
+        continue;
+      }
+      if (statement.importKind === "type") continue;
+      if (statement.exportKind === "type") continue;
+      if (hasOnlyTypeSpecifiers(statement)) continue;
+      if (statement.attributes && statement.attributes.length > 0) continue;
+
+      const specifier = statement.source?.value;
+      if (typeof specifier !== "string") continue;
+
+      const resolved = await resolve(specifier, cleanModulePath, { skipSelf: true });
+      if (!resolved?.id) continue;
+
+      if (isStylesheetSpecifier(specifier)) {
+        const asset = resolvedStylesheetToDevManifestAsset(root, resolved.id);
+        if (!asset || seenAssets.has(asset)) continue;
+        seenAssets.add(asset);
+        stylesheetAssets.push(asset);
+        continue;
+      }
+
+      if (specifier.includes("?") || specifier.includes("#")) continue;
+      if (isScriptModuleId(resolved.id)) {
+        await visitModule(resolved.id);
+      }
+    }
+  }
+
+  await visitModule(appFilePath);
+  return stylesheetAssets;
+}
+
 const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
 
 function resolveTsconfigPathCandidate(candidate: string): string | null {
@@ -2953,7 +3076,29 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           return await generateClientEntry();
         }
         if (id === RESOLVED_PAGES_CLIENT_ASSETS) {
-          return "export default { clientEntry: '/@id/__x00__virtual:vinext-client-entry' };";
+          const metadata: {
+            clientEntry: string;
+            ssrManifest?: Record<string, string[]>;
+          } = { clientEntry: DEV_PAGES_CLIENT_ENTRY };
+          const ssrManifest: Record<string, string[]> = {};
+          const appFilePath = findFileWithExts(pagesDir, "_app", fileMatcher);
+          const pagesRoutes = await pagesRouter(pagesDir, nextConfig?.pageExtensions, fileMatcher);
+          const moduleFilePaths = [
+            ...(appFilePath ? [appFilePath] : []),
+            ...pagesRoutes.map((route) => route.filePath),
+          ];
+          for (const moduleFilePath of moduleFilePaths) {
+            const stylesheetAssets = await collectDevPagesAppStylesheetAssets(
+              root,
+              moduleFilePath,
+              this.resolve.bind(this),
+            );
+            if (stylesheetAssets.length > 0) {
+              ssrManifest[normalizePathSeparators(moduleFilePath)] = stylesheetAssets;
+            }
+          }
+          if (Object.keys(ssrManifest).length > 0) metadata.ssrManifest = ssrManifest;
+          return `export default ${JSON.stringify(metadata)};`;
         }
         // App Router virtual modules
         if (id === RESOLVED_RSC_ENTRY && hasAppDir) {
@@ -3449,7 +3594,46 @@ export const loadServerActionClient = ${
       // sending full-reload ensures changes are always reflected in
       // the browser.
       hotUpdate(options: { file: string; server: ViteDevServer; modules: unknown[] }) {
-        if (!hasPagesDir || hasAppDir) return;
+        if (!hasPagesDir) return;
+        const isPagesAppFile = (filePath: string): boolean => {
+          const relativePath = normalizePathSeparators(path.relative(pagesDir, filePath));
+          return (
+            !relativePath.includes("/") &&
+            relativePath.startsWith("_app.") &&
+            fileMatcher.extensionRegex.test(filePath)
+          );
+        };
+        const isPotentialPagesAssetGraphScript = (filePath: string): boolean => {
+          const cleanPath = stripViteModuleQuery(filePath);
+          if (!path.isAbsolute(cleanPath)) return false;
+          if (!isScriptModuleId(cleanPath) || cleanPath.endsWith(".d.ts")) return false;
+          const relativeRootPath = normalizePathSeparators(path.relative(root, cleanPath));
+          if (relativeRootPath.startsWith("..") || path.isAbsolute(relativeRootPath)) return false;
+          if (
+            relativeRootPath.includes("/node_modules/") ||
+            relativeRootPath.startsWith("node_modules/")
+          ) {
+            return false;
+          }
+          const relativeAppPath = normalizePathSeparators(path.relative(appDir, cleanPath));
+          return relativeAppPath.startsWith("..") || path.isAbsolute(relativeAppPath);
+        };
+        const pagesAppChanged = isPagesAppFile(options.file);
+        const pagesAssetGraphChanged =
+          pagesAppChanged ||
+          STYLESHEET_FILE_RE.test(options.file) ||
+          isPotentialPagesAssetGraphScript(options.file);
+        if (pagesAssetGraphChanged) {
+          for (const env of Object.values(options.server.environments)) {
+            const mod = env.moduleGraph.getModuleById(RESOLVED_PAGES_CLIENT_ASSETS);
+            if (mod) env.moduleGraph.invalidateModule(mod);
+          }
+        }
+        if (pagesAppChanged || isPotentialPagesAssetGraphScript(options.file)) {
+          options.server.ws.send({ type: "full-reload" });
+          return [];
+        }
+        if (hasAppDir) return;
         if (options.file.startsWith(pagesDir) && fileMatcher.extensionRegex.test(options.file)) {
           options.server.environments.client.hot.send({ type: "full-reload" });
           return [];
@@ -3543,6 +3727,15 @@ export const loadServerActionClient = ${
           pagesRunner?.clearCache();
         }
 
+        function invalidatePagesClientAssetsModule(reloadDocument = false) {
+          for (const env of Object.values(server.environments)) {
+            const mod = env.moduleGraph.getModuleById(RESOLVED_PAGES_CLIENT_ASSETS);
+            if (mod) env.moduleGraph.invalidateModule(mod);
+          }
+          pagesRunner?.clearCache();
+          if (reloadDocument) server.ws.send({ type: "full-reload" });
+        }
+
         function invalidateAppRoutingModules() {
           invalidateAppRouteCache();
           invalidateMetadataFileCache();
@@ -3599,6 +3792,31 @@ export const loadServerActionClient = ${
         let appRouteTypeGeneration: Promise<void> | null = null;
         let appRouteTypeGenerationPending = false;
 
+        function isPagesAppFile(filePath: string): boolean {
+          const relativePath = normalizePathSeparators(path.relative(pagesDir, filePath));
+          return (
+            !relativePath.includes("/") &&
+            relativePath.startsWith("_app.") &&
+            fileMatcher.extensionRegex.test(filePath)
+          );
+        }
+
+        function isPotentialPagesAssetGraphScript(filePath: string): boolean {
+          const cleanPath = stripViteModuleQuery(filePath);
+          if (!path.isAbsolute(cleanPath)) return false;
+          if (!isScriptModuleId(cleanPath) || cleanPath.endsWith(".d.ts")) return false;
+          const relativeRootPath = normalizePathSeparators(path.relative(root, cleanPath));
+          if (relativeRootPath.startsWith("..") || path.isAbsolute(relativeRootPath)) return false;
+          if (
+            relativeRootPath.includes("/node_modules/") ||
+            relativeRootPath.startsWith("node_modules/")
+          ) {
+            return false;
+          }
+          const relativeAppPath = normalizePathSeparators(path.relative(appDir, cleanPath));
+          return relativeAppPath.startsWith("..") || path.isAbsolute(relativeAppPath);
+        }
+
         function warnRouteTypeGenerationFailure(error: unknown) {
           server.config.logger.warn(
             `[vinext] Failed to regenerate route types: ${
@@ -3647,6 +3865,14 @@ export const loadServerActionClient = ${
 
         server.watcher.on("add", (filePath: string) => {
           let routeChanged = false;
+          if (
+            hasPagesDir &&
+            (isPagesAppFile(filePath) ||
+              STYLESHEET_FILE_RE.test(filePath) ||
+              isPotentialPagesAssetGraphScript(filePath))
+          ) {
+            invalidatePagesClientAssetsModule(true);
+          }
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);
             routeChanged = true;
@@ -3662,8 +3888,28 @@ export const loadServerActionClient = ${
             revalidateHybridRoutes();
           }
         });
+        server.watcher.on("change", (filePath: string) => {
+          if (
+            hasPagesDir &&
+            (isPagesAppFile(filePath) ||
+              STYLESHEET_FILE_RE.test(filePath) ||
+              isPotentialPagesAssetGraphScript(filePath))
+          ) {
+            invalidatePagesClientAssetsModule(
+              isPagesAppFile(filePath) || isPotentialPagesAssetGraphScript(filePath),
+            );
+          }
+        });
         server.watcher.on("unlink", (filePath: string) => {
           let routeChanged = false;
+          if (
+            hasPagesDir &&
+            (isPagesAppFile(filePath) ||
+              STYLESHEET_FILE_RE.test(filePath) ||
+              isPotentialPagesAssetGraphScript(filePath))
+          ) {
+            invalidatePagesClientAssetsModule(true);
+          }
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);
             routeChanged = true;

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -35,7 +35,12 @@ import "vinext/shims/router-state";
 import { runWithHeadState } from "vinext/shims/head-state";
 import { runWithServerInsertedHTMLState } from "vinext/shims/navigation-state";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
-import { createInlineScriptTag, createNonceAttribute, safeJsonStringify } from "./html.js";
+import {
+  createInlineScriptTag,
+  createNonceAttribute,
+  escapeHtmlAttr,
+  safeJsonStringify,
+} from "./html.js";
 import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
 import { getScriptNonceFromNodeHeaderSources } from "./csp.js";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
@@ -45,6 +50,7 @@ import { renderToReadableStream } from "react-dom/server.edge";
 import { logRequest, now } from "./request-log.js";
 import {
   createValidFileMatcher,
+  findFileWithExts,
   findFileWithExtensions,
   type ValidFileMatcher,
 } from "../routing/file-matcher.js";
@@ -62,7 +68,8 @@ import {
   matchesPagesStaticPath,
   type PagesStaticPathsEntry,
 } from "./pages-page-data.js";
-import { createPagesDevModuleUrl } from "./pages-dev-module-url.js";
+import { createPagesDevAssetUrl, createPagesDevModuleUrl } from "./pages-dev-module-url.js";
+import { getManifestFilesForModule } from "./pages-asset-tags.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 import {
   loadUserDocumentInitialProps,
@@ -105,6 +112,37 @@ async function renderIsrPassToStringAsync(element: React.ReactElement): Promise<
       ),
     ),
   );
+}
+
+const DEV_STYLESHEET_ASSET_RE = /\.(?:css|scss|sass|less)$/i;
+
+type PagesClientAssetsModule = {
+  default?: {
+    ssrManifest?: Record<string, string[]>;
+  };
+};
+
+function createDevInitialStylesheetHeadHTML(options: {
+  ssrManifest: Record<string, string[]> | null | undefined;
+  moduleIds: (string | null | undefined)[];
+  nonceAttr: string;
+}): string {
+  const { ssrManifest, moduleIds, nonceAttr } = options;
+  if (!ssrManifest || moduleIds.length === 0) return "";
+
+  const seen = new Set<string>();
+  let html = "";
+  for (const moduleId of moduleIds) {
+    const files = getManifestFilesForModule(ssrManifest, moduleId);
+    if (!files) continue;
+    for (const file of files) {
+      if (!DEV_STYLESHEET_ASSET_RE.test(file) || seen.has(file)) continue;
+      seen.add(file);
+      const href = createPagesDevAssetUrl(file);
+      html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(href)}" />\n  `;
+    }
+  }
+  return html;
 }
 
 /**
@@ -182,6 +220,7 @@ async function streamPageToResponse(
     url: string;
     server: ViteDevServer;
     fontHeadHTML: string;
+    assetHeadHTML?: string;
     scripts: string;
     DocumentComponent: React.ComponentType | null;
     statusCode?: number;
@@ -221,6 +260,7 @@ async function streamPageToResponse(
     url,
     server,
     fontHeadHTML,
+    assetHeadHTML = "",
     scripts,
     DocumentComponent,
     statusCode,
@@ -307,8 +347,11 @@ async function streamPageToResponse(
     // Replace __NEXT_MAIN__ with our stream marker
     docHtml = docHtml.replace("__NEXT_MAIN__", STREAM_BODY_MARKER);
     // Inject head tags
-    if (headHTML || fontHeadHTML) {
-      docHtml = docHtml.replace("</head>", `  ${fontHeadHTML}${headHTML}\n</head>`);
+    if (headHTML || fontHeadHTML || assetHeadHTML) {
+      docHtml = docHtml.replace(
+        "</head>",
+        `  ${fontHeadHTML}${headHTML}\n  ${assetHeadHTML}\n</head>`,
+      );
     }
     // Inject scripts: replace placeholder or append before </body>
     docHtml = docHtml.replace("<!-- __NEXT_SCRIPTS__ -->", scripts);
@@ -324,6 +367,7 @@ async function streamPageToResponse(
 <html>
 <head>
   ${fontHeadHTML}${headHTML}
+  ${assetHeadHTML}
 </head>
 <body>
   <div id="__next">${STREAM_BODY_MARKER}</div>
@@ -1508,6 +1552,21 @@ export function createSSRHandler(
 
         // Collect SSR font links (Google Fonts <link> tags) and font class styles
         let fontHeadHTML = "";
+        let assetHeadHTML = "";
+        try {
+          const appAssetPath = AppComponent ? findFileWithExts(pagesDir, "_app", matcher) : null;
+          const pagesClientAssets = (await runner.import(
+            "virtual:vinext-pages-client-assets",
+          )) as PagesClientAssetsModule;
+          assetHeadHTML += createDevInitialStylesheetHeadHTML({
+            ssrManifest: pagesClientAssets.default?.ssrManifest,
+            moduleIds: [appAssetPath, route.filePath],
+            nonceAttr,
+          });
+        } catch {
+          // If dev asset metadata is unavailable, keep the existing client-graph
+          // CSS behavior instead of failing the page render.
+        }
         const allFontStyles: string[] = [];
         const allFontPreloads: Array<{ href: string; type: string }> = [];
         try {
@@ -1720,6 +1779,7 @@ hydrate();
           url,
           server,
           fontHeadHTML,
+          assetHeadHTML,
           scripts: allScripts,
           DocumentComponent,
           statusCode,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -114,7 +114,7 @@ async function renderIsrPassToStringAsync(element: React.ReactElement): Promise<
   );
 }
 
-const DEV_STYLESHEET_ASSET_RE = /\.(?:css|scss|sass|less)$/i;
+const DEV_STYLESHEET_ASSET_RE = /\.(?:css|scss|sass)$/i;
 
 type PagesClientAssetsModule = {
   default?: {
@@ -143,6 +143,27 @@ function createDevInitialStylesheetHeadHTML(options: {
     }
   }
   return html;
+}
+
+async function collectDevInitialStylesheetHeadHTML(
+  runner: ModuleImporter,
+  moduleIds: (string | null | undefined)[],
+  nonceAttr: string,
+): Promise<string> {
+  try {
+    const pagesClientAssets = (await runner.import(
+      "virtual:vinext-pages-client-assets",
+    )) as PagesClientAssetsModule;
+    return createDevInitialStylesheetHeadHTML({
+      ssrManifest: pagesClientAssets.default?.ssrManifest,
+      moduleIds,
+      nonceAttr,
+    });
+  } catch {
+    // If dev asset metadata is unavailable, keep the existing client-graph
+    // CSS behavior instead of failing the page render.
+    return "";
+  }
 }
 
 /**
@@ -1552,21 +1573,12 @@ export function createSSRHandler(
 
         // Collect SSR font links (Google Fonts <link> tags) and font class styles
         let fontHeadHTML = "";
-        let assetHeadHTML = "";
-        try {
-          const appAssetPath = AppComponent ? findFileWithExts(pagesDir, "_app", matcher) : null;
-          const pagesClientAssets = (await runner.import(
-            "virtual:vinext-pages-client-assets",
-          )) as PagesClientAssetsModule;
-          assetHeadHTML += createDevInitialStylesheetHeadHTML({
-            ssrManifest: pagesClientAssets.default?.ssrManifest,
-            moduleIds: [appAssetPath, route.filePath],
-            nonceAttr,
-          });
-        } catch {
-          // If dev asset metadata is unavailable, keep the existing client-graph
-          // CSS behavior instead of failing the page render.
-        }
+        const appAssetPath = AppComponent ? findFileWithExts(pagesDir, "_app", matcher) : null;
+        const assetHeadHTML = await collectDevInitialStylesheetHeadHTML(
+          runner,
+          [appAssetPath, route.filePath],
+          nonceAttr,
+        );
         const allFontStyles: string[] = [];
         const allFontPreloads: Array<{ href: string; type: string }> = [];
         try {
@@ -1871,7 +1883,7 @@ hydrate();
           const isrBodyHtml = await renderIsrPassToStringAsync(
             withScriptNonce(isrElement, scriptNonce),
           );
-          const isrHtml = `<!DOCTYPE html><html><head></head><body><div id="__next">${isrBodyHtml}</div>${allScripts}</body></html>`;
+          const isrHtml = `<!DOCTYPE html><html><head>${assetHeadHTML}</head><body><div id="__next">${isrBodyHtml}</div>${allScripts}</body></html>`;
           const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
           await isrSet(cacheKey, buildPagesCacheValue(isrHtml, pageProps), isrRevalidateSeconds);
           setRevalidateDuration(cacheKey, isrRevalidateSeconds);
@@ -1958,10 +1970,10 @@ async function renderErrorPage(
 
   for (const candidate of candidates) {
     try {
-      const candidatePath = path.join(pagesDir, candidate);
-      if (!findFileWithExtensions(candidatePath, matcher)) continue;
+      const errorAssetPath = findFileWithExts(pagesDir, candidate, matcher);
+      if (!errorAssetPath) continue;
 
-      const errorModule = await importModule(runner, candidatePath);
+      const errorModule = await importModule(runner, errorAssetPath);
       const ErrorComponent = errorModule.default;
       if (!ErrorComponent) continue;
 
@@ -1969,9 +1981,10 @@ async function renderErrorPage(
       // oxlint-disable-next-line typescript/no-explicit-any
       let AppComponent: any = null;
       const appPathErr = path.join(pagesDir, "_app");
+      const appAssetPath = findFileWithExts(pagesDir, "_app", matcher);
       if (findFileWithExtensions(appPathErr, matcher)) {
         try {
-          const appModule = await importModule(runner, appPathErr);
+          const appModule = await importModule(runner, appAssetPath ?? appPathErr);
           AppComponent = appModule.default ?? null;
         } catch {
           // _app exists but failed to load
@@ -2034,6 +2047,14 @@ async function renderErrorPage(
       const element = createErrorElement(AppComponent, ErrorComponent);
       const headShim = await importModule(runner, "next/head");
       if (typeof headShim.resetSSRHead === "function") headShim.resetSSRHead();
+      const responseHeaders = typeof res.getHeaders === "function" ? res.getHeaders() : undefined;
+      const scriptNonce = getScriptNonceFromNodeHeaderSources(req.headers, responseHeaders);
+      const nonceAttr = createNonceAttribute(scriptNonce);
+      const assetHeadHTML = await collectDevInitialStylesheetHeadHTML(
+        runner,
+        [appAssetPath, errorAssetPath],
+        nonceAttr,
+      );
 
       if (DocumentComponent) {
         const errorPathname = candidate === "_error" ? "/_error" : `/${candidate}`;
@@ -2041,6 +2062,7 @@ async function renderErrorPage(
           url,
           server,
           fontHeadHTML: "",
+          assetHeadHTML,
           scripts: "",
           DocumentComponent,
           statusCode,
@@ -2077,6 +2099,7 @@ async function renderErrorPage(
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  ${assetHeadHTML}
 </head>
 <body>
   <div id="__next">${bodyHtml}</div>

--- a/packages/vinext/src/server/pages-dev-module-url.ts
+++ b/packages/vinext/src/server/pages-dev-module-url.ts
@@ -5,7 +5,7 @@ function normalizeBase(base: string): string {
   return `/${base.replace(/^\/+|\/+$/g, "")}/`;
 }
 
-export function encodePagesDevModulePath(modulePath: string): string {
+function encodePagesDevModulePath(modulePath: string): string {
   return encodeURI(modulePath)
     .replace(/%5B/gi, "[")
     .replace(/%5D/gi, "]")

--- a/packages/vinext/src/server/pages-dev-module-url.ts
+++ b/packages/vinext/src/server/pages-dev-module-url.ts
@@ -5,12 +5,17 @@ function normalizeBase(base: string): string {
   return `/${base.replace(/^\/+|\/+$/g, "")}/`;
 }
 
-function encodeModulePath(modulePath: string): string {
+export function encodePagesDevModulePath(modulePath: string): string {
   return encodeURI(modulePath)
     .replace(/%5B/gi, "[")
     .replace(/%5D/gi, "]")
     .replace(/\?/g, "%3F")
     .replace(/#/g, "%23");
+}
+
+export function createPagesDevAssetUrl(assetPath: string): string {
+  const normalizedAssetPath = assetPath.replace(/^\/+/, "");
+  return "/" + encodePagesDevModulePath(normalizedAssetPath);
 }
 
 export function createPagesDevModuleUrl(
@@ -20,5 +25,5 @@ export function createPagesDevModuleUrl(
 ): string {
   const pathImpl = /^[A-Za-z]:[\\/]/.test(viteRoot) ? path.win32 : path;
   const relativePath = pathImpl.relative(viteRoot, moduleFilePath).replace(/\\/g, "/");
-  return normalizeBase(viteBase) + encodeModulePath(relativePath);
+  return normalizeBase(viteBase) + encodePagesDevModulePath(relativePath);
 }

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -710,12 +710,13 @@ export function createPagesPageHandler(
           return buildNextDataPropsJsonResponse(renderProps, safeJsonStringify, init);
         }
 
-        // Include both the matched page module and the global _app module.
+        // Include both the global _app module and the matched page module.
         // _app is wrapped around every page and any CSS/JS it imports must
-        // be linked from the rendered HTML (LHF-5 symptom).
+        // be linked from the rendered HTML (LHF-5 symptom). Match Next.js
+        // document ordering: shared _app files first, then page files.
         const pageModuleIds: (string | null | undefined)[] = [];
-        if (route.filePath) pageModuleIds.push(route.filePath);
         if (appAssetPath) pageModuleIds.push(appAssetPath);
+        if (route.filePath) pageModuleIds.push(route.filePath);
         const assetTags = collectAssetTags({
           manifest,
           moduleIds: pageModuleIds,

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -127,9 +127,15 @@ export default function middleware(request: NextRequest) {
 type PagesAppGlobalCssFixture = {
   appPath: string;
   pagePath: string;
+  isrPagePath: string;
+  errorPagePath: string;
   devStylesheetHrefs: string[];
+  isrDevStylesheetHrefs: string[];
+  errorDevStylesheetHrefs: string[];
   appManifestAssets: string[];
   pageManifestAssets: string[];
+  isrManifestAssets: string[];
+  errorManifestAssets: string[];
   cssMarkers: string[];
 };
 
@@ -187,8 +193,20 @@ function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixtur
     ".typeOnlyText { margin-right: 31px; }\n",
   );
   fs.writeFileSync(
-    path.join(stylesDir, "ignored.css"),
-    ".ignored-css-query { border-bottom-width: 23px; }\n",
+    path.join(stylesDir, "query.css"),
+    ".query-css-import { border-bottom-width: 23px; }\n",
+  );
+  fs.writeFileSync(
+    path.join(stylesDir, "hash.css"),
+    ".hash-css-import { border-bottom-width: 37px; }\n",
+  );
+  fs.writeFileSync(
+    path.join(stylesDir, "isr.module.css"),
+    ".isrText { border-bottom-width: 41px; }\n",
+  );
+  fs.writeFileSync(
+    path.join(stylesDir, "error.module.css"),
+    ".errorText { border-bottom-width: 43px; }\n",
   );
   fs.writeFileSync(
     path.join(libDir, "transitive.ts"),
@@ -211,7 +229,8 @@ function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixtur
     'import "@/styles/global style.css";\n' +
       'import moduleStyles from "@/styles/app.module.css";\n' +
       'import { transitiveClassName } from "@/lib/reexport";\n' +
-      'import "@/styles/ignored.css?raw";\n' +
+      'import "@/styles/query.css?raw";\n' +
+      'import "@/styles/hash.css#hash";\n' +
       'export { type TypeOnlyTheme } from "@/lib/type-only";\n' +
       "export default function App({ Component, pageProps }: any) {\n" +
       "  return <div className={`${moduleStyles.moduleText} ${transitiveClassName}`}><Component {...pageProps} /></div>;\n" +
@@ -229,26 +248,69 @@ function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixtur
       "  </>;\n" +
       "}\n",
   );
+  const isrPagePath = path.join(pagesDir, "isr.tsx");
+  fs.writeFileSync(
+    isrPagePath,
+    'import isrStyles from "@/styles/isr.module.css";\n' +
+      "export function getStaticProps() { return { props: {}, revalidate: 60 }; }\n" +
+      "export default function IsrPage() {\n" +
+      "  return <div className={isrStyles.isrText}>Global CSS ISR Test</div>;\n" +
+      "}\n",
+  );
+  const errorPagePath = path.join(pagesDir, "404.tsx");
+  fs.writeFileSync(
+    errorPagePath,
+    'import errorStyles from "@/styles/error.module.css";\n' +
+      "export default function Custom404() {\n" +
+      "  return <div className={errorStyles.errorText}>Global CSS Error Test</div>;\n" +
+      "}\n",
+  );
 
   return {
     appPath: appPath.split(path.sep).join("/"),
     pagePath: pagePath.split(path.sep).join("/"),
+    isrPagePath: isrPagePath.split(path.sep).join("/"),
+    errorPagePath: errorPagePath.split(path.sep).join("/"),
     devStylesheetHrefs: [
       "/styles/global%20style.css",
       "/styles/app.module.css",
       "/styles/transitive.module.css",
+      "/styles/query.css",
+      "/styles/hash.css",
       "/styles/page.module.css",
+    ],
+    isrDevStylesheetHrefs: [
+      "/styles/global%20style.css",
+      "/styles/app.module.css",
+      "/styles/transitive.module.css",
+      "/styles/query.css",
+      "/styles/hash.css",
+      "/styles/isr.module.css",
+    ],
+    errorDevStylesheetHrefs: [
+      "/styles/global%20style.css",
+      "/styles/app.module.css",
+      "/styles/transitive.module.css",
+      "/styles/query.css",
+      "/styles/hash.css",
+      "/styles/error.module.css",
     ],
     appManifestAssets: [
       "styles/global style.css",
       "styles/app.module.css",
       "styles/transitive.module.css",
+      "styles/query.css",
+      "styles/hash.css",
     ],
     pageManifestAssets: ["styles/page.module.css"],
+    isrManifestAssets: ["styles/isr.module.css"],
+    errorManifestAssets: ["styles/error.module.css"],
     cssMarkers: [
       "border-top-width: 13px",
       "padding-left: 17px",
       "margin-top: 19px",
+      "border-bottom-width: 23px",
+      "border-bottom-width: 37px",
       "margin-left: 29px",
     ],
   };
@@ -2751,7 +2813,6 @@ describe("Virtual server entry generation", () => {
       for (const href of fixture.devStylesheetHrefs) {
         expect(stylesheetHrefs).toContain(href);
       }
-      expect(html).not.toContain("ignored.css");
       expect(html).not.toContain("type-only.module.css");
 
       const headStyleIndex = html.indexOf(".global-css-pages-text { border-top-width: 0px; }");
@@ -2777,9 +2838,81 @@ describe("Virtual server entry generation", () => {
       expect(assets.clientEntry).toBe("/@id/__x00__virtual:vinext-client-entry");
       expect(assets.ssrManifest?.[fixture.appPath]).toEqual(fixture.appManifestAssets);
       expect(assets.ssrManifest?.[fixture.pagePath]).toEqual(fixture.pageManifestAssets);
+      expect(assets.ssrManifest?.[fixture.isrPagePath]).toEqual(fixture.isrManifestAssets);
+      expect(assets.ssrManifest?.[fixture.errorPagePath]).toEqual(fixture.errorManifestAssets);
       expect(Object.values(assets.ssrManifest ?? {}).flat()).not.toContain(
         "styles/type-only.module.css",
       );
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dev Pages cached ISR HTML keeps initial stylesheet links", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-isr-"));
+    const fixture = writePagesAppGlobalCssFixture(tmpDir);
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+      const baseUrl = `http://localhost:${addr.port}`;
+
+      const firstRes = await fetch(`${baseUrl}/isr`);
+      const firstHtml = await firstRes.text();
+      expect(firstRes.status).toBe(200);
+      expect(firstRes.headers.get("x-vinext-cache")).toBe("MISS");
+      expect(firstHtml).toContain("Global CSS ISR Test");
+      for (const href of fixture.isrDevStylesheetHrefs) {
+        expect(getStylesheetHrefs(firstHtml)).toContain(href);
+      }
+
+      const secondRes = await fetch(`${baseUrl}/isr`);
+      const secondHtml = await secondRes.text();
+      expect(secondRes.status).toBe(200);
+      expect(secondRes.headers.get("x-vinext-cache")).toBe("HIT");
+      expect(secondHtml).toContain("Global CSS ISR Test");
+      for (const href of fixture.isrDevStylesheetHrefs) {
+        expect(getStylesheetHrefs(secondHtml)).toContain(href);
+      }
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dev Pages custom error HTML includes _app and error page stylesheet links", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-error-"));
+    const fixture = writePagesAppGlobalCssFixture(tmpDir);
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/missing-page`);
+      const html = await res.text();
+      expect(res.status).toBe(404);
+      expect(html).toContain("Global CSS Error Test");
+      const stylesheetHrefs = getStylesheetHrefs(html);
+      for (const href of fixture.errorDevStylesheetHrefs) {
+        expect(stylesheetHrefs).toContain(href);
+      }
     } finally {
       await testServer.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -2927,7 +3060,54 @@ describe("Virtual server entry generation", () => {
         "styles/app.module.css",
         "styles/transitive.module.css",
         "styles/late-transitive.module.css",
+        "styles/query.css",
+        "styles/hash.css",
       ]);
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dev Pages client assets do not treat Less as a built-in Next.js stylesheet", async () => {
+    // Next.js built-in CSS rules cover css/scss/sass, not less:
+    // .nextjs-ref/packages/next/src/build/webpack/config/blocks/css/index.ts regexLikeCss.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-less-css-"));
+    fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "styles"), { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(path.join(tmpDir, "styles", "site.less"), ".lessText { color: red; }\n");
+    const appPath = path.join(tmpDir, "pages", "_app.tsx");
+    fs.writeFileSync(
+      appPath,
+      'import "@/styles/site.less";\n' +
+        "export default function App({ Component, pageProps }: any) {\n" +
+        "  return <Component {...pageProps} />;\n" +
+        "}\n",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "pages", "index.tsx"),
+      "export default function Home() { return <div>Less should not be linked</div>; }\n",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@/*": ["./*"] } } }, null, 2),
+    );
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      const assetsModule = await testServer.ssrLoadModule("virtual:vinext-pages-client-assets");
+      const assets = assetsModule.default as {
+        ssrManifest?: Record<string, string[]>;
+      };
+      expect(assets.ssrManifest?.[appPath.split(path.sep).join("/")]).toBeUndefined();
+      expect(Object.values(assets.ssrManifest ?? {}).flat()).not.toContain("styles/site.less");
     } finally {
       await testServer.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -2960,7 +3140,6 @@ describe("Virtual server entry generation", () => {
         const html = await res.text();
         expect(res.status).toBe(200);
         expect(html).toContain("Global CSS Pages Test");
-        expect(html).not.toContain("ignored.css");
 
         const stylesheetHrefs = getStylesheetHrefs(html);
         expect(stylesheetHrefs.length).toBeGreaterThan(0);
@@ -2978,7 +3157,6 @@ describe("Virtual server entry generation", () => {
         for (const marker of fixture.cssMarkers) {
           expect(compactCssText).toContain(marker.replace(/\s+/g, ""));
         }
-        expect(compactCssText).not.toContain("border-bottom-width:23px");
       } finally {
         await new Promise<void>((resolve) => prodServer.close(() => resolve()));
       }

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3202,6 +3202,71 @@ describe("Virtual server entry generation", () => {
       await testServer.close();
     }
   });
+
+  it("does not force full reload for shared App Router code in hybrid apps", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-hybrid-pages-assets-hmr-"));
+    const sharedPath = path.join(tmpDir, "lib", "shared.ts");
+    fs.mkdirSync(path.join(tmpDir, "app"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
+    fs.mkdirSync(path.dirname(sharedPath), { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(sharedPath, 'export const shared = "shared";\n');
+    fs.writeFileSync(
+      path.join(tmpDir, "app", "layout.tsx"),
+      "export default function RootLayout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }\n",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "app", "page.tsx"),
+      'import { shared } from "../lib/shared";\n' +
+        "export default function AppPage() { return <div>{shared}</div>; }\n",
+    );
+    fs.writeFileSync(path.join(tmpDir, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+    fs.writeFileSync(
+      path.join(tmpDir, "pages", "index.tsx"),
+      'import { shared } from "../lib/shared";\n' +
+        "export default function Home() { return <div>{shared}</div>; }\n",
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+    const wsSend = vi.spyOn(testServer.ws, "send");
+    const clientHotSend = vi.spyOn(testServer.environments.client.hot, "send");
+
+    try {
+      const pagesPlugin = testServer.config.plugins.find(
+        (plugin): plugin is any => plugin.name === "vinext:pages-router",
+      );
+      expect(pagesPlugin).toBeDefined();
+      const hotUpdate = pagesPlugin.hotUpdate;
+      expect(hotUpdate).toBeDefined();
+      const hotUpdateResult =
+        typeof hotUpdate === "function"
+          ? await hotUpdate.call(pagesPlugin, {
+              file: sharedPath,
+              server: testServer,
+              modules: [{ id: sharedPath }],
+            })
+          : await hotUpdate.handler.call(pagesPlugin, {
+              file: sharedPath,
+              server: testServer,
+              modules: [{ id: sharedPath }],
+            });
+
+      expect(hotUpdateResult).toBeUndefined();
+      expect(wsSend).not.toHaveBeenCalledWith({ type: "full-reload" });
+      expect(clientHotSend).not.toHaveBeenCalledWith({ type: "full-reload" });
+    } finally {
+      wsSend.mockRestore();
+      clientHotSend.mockRestore();
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("Plugin config", () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -124,6 +124,136 @@ export default function middleware(request: NextRequest) {
   );
 }
 
+type PagesAppGlobalCssFixture = {
+  appPath: string;
+  pagePath: string;
+  devStylesheetHrefs: string[];
+  appManifestAssets: string[];
+  pageManifestAssets: string[];
+  cssMarkers: string[];
+};
+
+function getHtmlAttr(tag: string, attrName: string): string | null {
+  const match = tag.match(new RegExp(`\\s${attrName}=(["'])(.*?)\\1`, "i"));
+  return match?.[2] ?? null;
+}
+
+function getStylesheetHrefs(html: string): string[] {
+  return Array.from(html.matchAll(/<link\b[^>]*>/gi), (match) => match[0])
+    .filter((tag) => getHtmlAttr(tag, "rel") === "stylesheet")
+    .map((tag) => getHtmlAttr(tag, "href"))
+    .filter((href): href is string => href !== null);
+}
+
+function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixture {
+  const pagesDir = path.join(rootDir, "pages");
+  const libDir = path.join(rootDir, "lib");
+  const stylesDir = path.join(rootDir, "styles");
+  fs.mkdirSync(pagesDir, { recursive: true });
+  fs.mkdirSync(libDir, { recursive: true });
+  fs.mkdirSync(stylesDir, { recursive: true });
+
+  const nmLink = path.join(rootDir, "node_modules");
+  if (!fs.existsSync(nmLink)) {
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), nmLink);
+  }
+
+  fs.writeFileSync(
+    path.join(rootDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          baseUrl: ".",
+          jsx: "react-jsx",
+          paths: { "@/*": ["./*"] },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(stylesDir, "global style.css"),
+    ".global-css-pages-text { border-top-width: 13px; }\n",
+  );
+  fs.writeFileSync(path.join(stylesDir, "app.module.css"), ".moduleText { padding-left: 17px; }\n");
+  fs.writeFileSync(
+    path.join(stylesDir, "transitive.module.css"),
+    ".transitiveText { margin-top: 19px; }\n",
+  );
+  fs.writeFileSync(path.join(stylesDir, "page.module.css"), ".pageText { margin-left: 29px; }\n");
+  fs.writeFileSync(
+    path.join(stylesDir, "type-only.module.css"),
+    ".typeOnlyText { margin-right: 31px; }\n",
+  );
+  fs.writeFileSync(
+    path.join(stylesDir, "ignored.css"),
+    ".ignored-css-query { border-bottom-width: 23px; }\n",
+  );
+  fs.writeFileSync(
+    path.join(libDir, "transitive.ts"),
+    'import transitiveStyles from "../styles/transitive.module.css";\n' +
+      "export const transitiveClassName = transitiveStyles.transitiveText;\n",
+  );
+  fs.writeFileSync(
+    path.join(libDir, "reexport.ts"),
+    'export { transitiveClassName } from "./transitive";\n',
+  );
+  fs.writeFileSync(
+    path.join(libDir, "type-only.ts"),
+    'import "../styles/type-only.module.css";\n' +
+      "export type TypeOnlyTheme = { name: string };\n",
+  );
+
+  const appPath = path.join(pagesDir, "_app.tsx");
+  fs.writeFileSync(
+    appPath,
+    'import "@/styles/global style.css";\n' +
+      'import moduleStyles from "@/styles/app.module.css";\n' +
+      'import { transitiveClassName } from "@/lib/reexport";\n' +
+      'import "@/styles/ignored.css?raw";\n' +
+      'export { type TypeOnlyTheme } from "@/lib/type-only";\n' +
+      "export default function App({ Component, pageProps }: any) {\n" +
+      "  return <div className={`${moduleStyles.moduleText} ${transitiveClassName}`}><Component {...pageProps} /></div>;\n" +
+      "}\n",
+  );
+  const pagePath = path.join(pagesDir, "index.tsx");
+  fs.writeFileSync(
+    pagePath,
+    'import Head from "next/head";\n' +
+      'import pageStyles from "@/styles/page.module.css";\n' +
+      "export default function Home() {\n" +
+      "  return <>\n" +
+      '    <Head><style>{".global-css-pages-text { border-top-width: 0px; }"}</style></Head>\n' +
+      "    <div className={`global-css-pages-text ${pageStyles.pageText}`}>Global CSS Pages Test</div>\n" +
+      "  </>;\n" +
+      "}\n",
+  );
+
+  return {
+    appPath: appPath.split(path.sep).join("/"),
+    pagePath: pagePath.split(path.sep).join("/"),
+    devStylesheetHrefs: [
+      "/styles/global%20style.css",
+      "/styles/app.module.css",
+      "/styles/transitive.module.css",
+      "/styles/page.module.css",
+    ],
+    appManifestAssets: [
+      "styles/global style.css",
+      "styles/app.module.css",
+      "styles/transitive.module.css",
+    ],
+    pageManifestAssets: ["styles/page.module.css"],
+    cssMarkers: [
+      "border-top-width: 13px",
+      "padding-left: 17px",
+      "margin-top: 19px",
+      "margin-left: 29px",
+    ],
+  };
+}
+
 function writeEncodedSlashPagesFixture(rootDir: string): void {
   fs.mkdirSync(path.join(rootDir, "pages", "a"), { recursive: true });
   const nmLink = path.join(rootDir, "node_modules");
@@ -2591,6 +2721,269 @@ describe("Virtual server entry generation", () => {
       expect(codeWithoutPrefetchManifest).not.toContain(":slug*");
     } finally {
       await testServer.close();
+    }
+  });
+
+  it("dev Pages client assets expose _app global CSS for initial stylesheet links", async () => {
+    // Next.js includes /_app files in every Pages document before collecting
+    // stylesheets:
+    // .nextjs-ref/packages/next/src/pages/_document.tsx getDocumentFiles().
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-"));
+    const fixture = writePagesAppGlobalCssFixture(tmpDir);
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/`);
+      const html = await res.text();
+      expect(res.status).toBe(200);
+      expect(html).toContain("Global CSS Pages Test");
+      const stylesheetHrefs = getStylesheetHrefs(html);
+      for (const href of fixture.devStylesheetHrefs) {
+        expect(stylesheetHrefs).toContain(href);
+      }
+      expect(html).not.toContain("ignored.css");
+      expect(html).not.toContain("type-only.module.css");
+
+      const headStyleIndex = html.indexOf(".global-css-pages-text { border-top-width: 0px; }");
+      const firstAppStylesheetIndex = html.indexOf(fixture.devStylesheetHrefs[0]);
+      expect(headStyleIndex).toBeGreaterThan(-1);
+      expect(firstAppStylesheetIndex).toBeGreaterThan(headStyleIndex);
+
+      for (const [index, href] of fixture.devStylesheetHrefs.entries()) {
+        const stylesheetRes = await fetch(`http://localhost:${addr.port}${href}`, {
+          headers: { accept: "text/css,*/*;q=0.1" },
+        });
+        expect(stylesheetRes.status).toBe(200);
+        expect(stylesheetRes.headers.get("content-type")).toContain("text/css");
+        const stylesheetText = (await stylesheetRes.text()).replace(/\s+/g, "");
+        expect(stylesheetText).toContain(fixture.cssMarkers[index]!.replace(/\s+/g, ""));
+      }
+
+      const assetsModule = await testServer.ssrLoadModule("virtual:vinext-pages-client-assets");
+      const assets = assetsModule.default as {
+        clientEntry?: string;
+        ssrManifest?: Record<string, string[]>;
+      };
+      expect(assets.clientEntry).toBe("/@id/__x00__virtual:vinext-client-entry");
+      expect(assets.ssrManifest?.[fixture.appPath]).toEqual(fixture.appManifestAssets);
+      expect(assets.ssrManifest?.[fixture.pagePath]).toEqual(fixture.pageManifestAssets);
+      expect(Object.values(assets.ssrManifest ?? {}).flat()).not.toContain(
+        "styles/type-only.module.css",
+      );
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dev Pages _app stylesheet links use basePath source URLs, not assetPrefix build URLs", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-prefix-"));
+    const fixture = writePagesAppGlobalCssFixture(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.mjs"),
+      `export default { basePath: "/docs", assetPrefix: "/cdn" };\n`,
+    );
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/docs/`);
+      const html = await res.text();
+      expect(res.status).toBe(200);
+      expect(html).toContain("Global CSS Pages Test");
+      const stylesheetHrefs = getStylesheetHrefs(html);
+      for (const href of fixture.devStylesheetHrefs.map((value) => `/docs${value}`)) {
+        expect(stylesheetHrefs).toContain(href);
+        const stylesheetRes = await fetch(`http://localhost:${addr.port}${href}`, {
+          headers: { accept: "text/css,*/*;q=0.1" },
+        });
+        expect(stylesheetRes.status).toBe(200);
+        expect(stylesheetRes.headers.get("content-type")).toContain("text/css");
+      }
+      for (const href of fixture.devStylesheetHrefs) {
+        expect(stylesheetHrefs).not.toContain(href);
+      }
+      expect(stylesheetHrefs.some((href) => href.startsWith("/cdn/"))).toBe(false);
+      expect(stylesheetHrefs.some((href) => href.startsWith("/docs/cdn/"))).toBe(false);
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dev Pages _app stylesheet metadata updates when _app imports change", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-hmr-"));
+    const fixture = writePagesAppGlobalCssFixture(tmpDir);
+    const appPath = fixture.appPath;
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+      const baseUrl = `http://localhost:${addr.port}`;
+
+      const firstHtml = await (await fetch(`${baseUrl}/`)).text();
+      expect(getStylesheetHrefs(firstHtml)).toContain("/styles/global%20style.css");
+      expect(getStylesheetHrefs(firstHtml)).not.toContain("/styles/late.css");
+
+      fs.writeFileSync(path.join(tmpDir, "styles", "late.css"), ".late-css { color: green; }\n");
+      fs.writeFileSync(
+        appPath,
+        'import "@/styles/global style.css";\n' +
+          'import "@/styles/late.css";\n' +
+          "export default function App({ Component, pageProps }: any) {\n" +
+          "  return <Component {...pageProps} />;\n" +
+          "}\n",
+      );
+      testServer.watcher.emit("change", appPath);
+
+      const secondHtml = await (await fetch(`${baseUrl}/`)).text();
+      const secondHrefs = getStylesheetHrefs(secondHtml);
+      expect(secondHrefs).toContain("/styles/global%20style.css");
+      expect(secondHrefs).toContain("/styles/late.css");
+
+      const assetsModule = await testServer.ssrLoadModule("virtual:vinext-pages-client-assets");
+      const assets = assetsModule.default as {
+        ssrManifest?: Record<string, string[]>;
+      };
+      expect(assets.ssrManifest?.[appPath]).toEqual(["styles/global style.css", "styles/late.css"]);
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dev Pages _app stylesheet metadata updates when transitive imports change", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-transitive-"));
+    const fixture = writePagesAppGlobalCssFixture(tmpDir);
+    const transitivePath = path.join(tmpDir, "lib", "transitive.ts");
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+      const baseUrl = `http://localhost:${addr.port}`;
+
+      const firstHtml = await (await fetch(`${baseUrl}/`)).text();
+      expect(getStylesheetHrefs(firstHtml)).toContain("/styles/transitive.module.css");
+      expect(getStylesheetHrefs(firstHtml)).not.toContain("/styles/late-transitive.module.css");
+
+      fs.writeFileSync(
+        path.join(tmpDir, "styles", "late-transitive.module.css"),
+        ".lateTransitiveText { color: green; }\n",
+      );
+      fs.writeFileSync(
+        transitivePath,
+        'import transitiveStyles from "../styles/transitive.module.css";\n' +
+          'import lateStyles from "../styles/late-transitive.module.css";\n' +
+          "export const transitiveClassName = `${transitiveStyles.transitiveText} ${lateStyles.lateTransitiveText}`;\n",
+      );
+      testServer.watcher.emit("change", transitivePath);
+
+      const secondHtml = await (await fetch(`${baseUrl}/`)).text();
+      const secondHrefs = getStylesheetHrefs(secondHtml);
+      expect(secondHrefs).toContain("/styles/transitive.module.css");
+      expect(secondHrefs).toContain("/styles/late-transitive.module.css");
+
+      const assetsModule = await testServer.ssrLoadModule("virtual:vinext-pages-client-assets");
+      const assets = assetsModule.default as {
+        ssrManifest?: Record<string, string[]>;
+      };
+      expect(assets.ssrManifest?.[fixture.appPath]).toEqual([
+        "styles/global style.css",
+        "styles/app.module.css",
+        "styles/transitive.module.css",
+        "styles/late-transitive.module.css",
+      ]);
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("production Pages asset tags include _app stylesheet assets for the same graph", async () => {
+    // Dev and prod should get their initial blocking CSS from the same concept:
+    // the Pages `_app` entry graph that Next.js includes in every document.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-prod-"));
+    const outDir = path.join(tmpDir, "dist");
+    const fixture = writePagesAppGlobalCssFixture(tmpDir);
+
+    try {
+      await buildPagesFixtureToOutDir(tmpDir, outDir);
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      const prodServer = unwrapStartedProdServer(
+        await startProdServer({
+          port: 0,
+          host: "127.0.0.1",
+          outDir,
+          noCompression: true,
+        }),
+      );
+
+      try {
+        const addr = prodServer.address() as { port: number };
+        const baseUrl = `http://127.0.0.1:${addr.port}`;
+        const res = await fetch(`${baseUrl}/`);
+        const html = await res.text();
+        expect(res.status).toBe(200);
+        expect(html).toContain("Global CSS Pages Test");
+        expect(html).not.toContain("ignored.css");
+
+        const stylesheetHrefs = getStylesheetHrefs(html);
+        expect(stylesheetHrefs.length).toBeGreaterThan(0);
+
+        const cssText = (
+          await Promise.all(
+            stylesheetHrefs.map(async (href) => {
+              const stylesheetRes = await fetch(`${baseUrl}${href}`);
+              expect(stylesheetRes.status).toBe(200);
+              return stylesheetRes.text();
+            }),
+          )
+        ).join("\n");
+        const compactCssText = cssText.replace(/\s+/g, "");
+        for (const marker of fixture.cssMarkers) {
+          expect(compactCssText).toContain(marker.replace(/\s+/g, ""));
+        }
+        expect(compactCssText).not.toContain("border-bottom-width:23px");
+      } finally {
+        await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -197,10 +197,6 @@ function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixtur
     ".query-css-import { border-bottom-width: 23px; }\n",
   );
   fs.writeFileSync(
-    path.join(stylesDir, "hash.css"),
-    ".hash-css-import { border-bottom-width: 37px; }\n",
-  );
-  fs.writeFileSync(
     path.join(stylesDir, "isr.module.css"),
     ".isrText { border-bottom-width: 41px; }\n",
   );
@@ -230,7 +226,6 @@ function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixtur
       'import moduleStyles from "@/styles/app.module.css";\n' +
       'import { transitiveClassName } from "@/lib/reexport";\n' +
       'import "@/styles/query.css?raw";\n' +
-      'import "@/styles/hash.css#hash";\n' +
       'export { type TypeOnlyTheme } from "@/lib/type-only";\n' +
       "export default function App({ Component, pageProps }: any) {\n" +
       "  return <div className={`${moduleStyles.moduleText} ${transitiveClassName}`}><Component {...pageProps} /></div>;\n" +
@@ -275,32 +270,24 @@ function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixtur
       "/styles/global%20style.css",
       "/styles/app.module.css",
       "/styles/transitive.module.css",
-      "/styles/query.css",
-      "/styles/hash.css",
       "/styles/page.module.css",
     ],
     isrDevStylesheetHrefs: [
       "/styles/global%20style.css",
       "/styles/app.module.css",
       "/styles/transitive.module.css",
-      "/styles/query.css",
-      "/styles/hash.css",
       "/styles/isr.module.css",
     ],
     errorDevStylesheetHrefs: [
       "/styles/global%20style.css",
       "/styles/app.module.css",
       "/styles/transitive.module.css",
-      "/styles/query.css",
-      "/styles/hash.css",
       "/styles/error.module.css",
     ],
     appManifestAssets: [
       "styles/global style.css",
       "styles/app.module.css",
       "styles/transitive.module.css",
-      "styles/query.css",
-      "styles/hash.css",
     ],
     pageManifestAssets: ["styles/page.module.css"],
     isrManifestAssets: ["styles/isr.module.css"],
@@ -309,8 +296,6 @@ function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixtur
       "border-top-width: 13px",
       "padding-left: 17px",
       "margin-top: 19px",
-      "border-bottom-width: 23px",
-      "border-bottom-width: 37px",
       "margin-left: 29px",
     ],
   };
@@ -2843,6 +2828,7 @@ describe("Virtual server entry generation", () => {
       expect(Object.values(assets.ssrManifest ?? {}).flat()).not.toContain(
         "styles/type-only.module.css",
       );
+      expect(Object.values(assets.ssrManifest ?? {}).flat()).not.toContain("styles/query.css");
     } finally {
       await testServer.close();
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -3060,8 +3046,6 @@ describe("Virtual server entry generation", () => {
         "styles/app.module.css",
         "styles/transitive.module.css",
         "styles/late-transitive.module.css",
-        "styles/query.css",
-        "styles/hash.css",
       ]);
     } finally {
       await testServer.close();
@@ -3157,6 +3141,7 @@ describe("Virtual server entry generation", () => {
         for (const marker of fixture.cssMarkers) {
           expect(compactCssText).toContain(marker.replace(/\s+/g, ""));
         }
+        expect(compactCssText).not.toContain("border-bottom-width:23px");
       } finally {
         await new Promise<void>((resolve) => prodServer.close(() => resolve()));
       }

--- a/tests/scss.test.ts
+++ b/tests/scss.test.ts
@@ -39,6 +39,18 @@ const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
 // emit any of these forms (rgb(), 6-digit hex, 3-digit hex, named colour).
 const RESOLVED_BLUE_REGEX = /rgb\(\s*0\s*,\s*0\s*,\s*255\s*\)|#0000ff\b|#00f\b|\bblue\b/;
 
+function getHtmlAttr(tag: string, attrName: string): string | null {
+  const match = tag.match(new RegExp(`\\s${attrName}=(["'])(.*?)\\1`, "i"));
+  return match?.[2] ?? null;
+}
+
+function getStylesheetHrefs(html: string): string[] {
+  return Array.from(html.matchAll(/<link\b[^>]*>/gi), (match) => match[0])
+    .filter((tag) => getHtmlAttr(tag, "rel") === "stylesheet")
+    .map((tag) => getHtmlAttr(tag, "href"))
+    .filter((href): href is string => href !== null);
+}
+
 /**
  * Materialize a minimal Pages Router fixture in a fresh tmpdir.
  *
@@ -103,8 +115,6 @@ describe("SCSS preprocessing (Pages Router)", () => {
     if (addr && typeof addr === "object") {
       baseUrl = `http://localhost:${addr.port}`;
     }
-
-    await fetch(`${baseUrl}/`).catch(() => {});
   }, 60_000);
 
   afterAll(async () => {
@@ -117,12 +127,16 @@ describe("SCSS preprocessing (Pages Router)", () => {
     expect(res.status).toBe(200);
     expect(html).toContain("SCSS Pages Test");
 
-    // Pages Router dev does not server-render `<link>` tags for CSS — the
-    // browser loads CSS via the JS module graph when it executes `_app`.
-    // Ask Vite for the compiled CSS via `?direct` to confirm the SCSS
-    // variable resolved (preprocessor ran) rather than being inlined verbatim.
-    const scssDirectUrl = "/styles/global.scss?direct";
-    const cssRes = await fetch(new URL(scssDirectUrl, baseUrl));
+    // Pages Router dev must emit the _app stylesheet as an initial blocking
+    // link, matching Next.js's shared /_app asset handling and avoiding FOUC.
+    const stylesheetHref = getStylesheetHrefs(html).find((href) =>
+      href.endsWith("/styles/global.scss"),
+    );
+    expect(stylesheetHref).toBe("/styles/global.scss");
+
+    // Fetch the exact linked stylesheet URL to confirm the browser-facing CSS
+    // is served and Sass variables resolved before it reaches the browser.
+    const cssRes = await fetch(new URL(stylesheetHref!, baseUrl));
     expect(cssRes.status).toBe(200);
     const css = await cssRes.text();
     expect(css).not.toContain("$var");
@@ -182,10 +196,10 @@ describe("SCSS preprocessing (Pages Router)", () => {
         // If the CSS file isn't linked, the browser never loads any
         // styles for the SCSS-defined classes — the exact failure mode
         // of LHF-5 (`rgb(0, 0, 0)` instead of the SCSS colour).
-        const linkMatch = html.match(/<link[^>]+rel="stylesheet"[^>]+href="([^"]+\.css)"/);
-        expect(linkMatch, 'expected <link rel="stylesheet"> in the served HTML').not.toBeNull();
+        const stylesheetHref = getStylesheetHrefs(html).find((href) => href.endsWith(".css"));
+        expect(stylesheetHref, 'expected <link rel="stylesheet"> in the served HTML').toBeTruthy();
 
-        const cssRes = await fetch(new URL(linkMatch![1]!, prodUrl));
+        const cssRes = await fetch(new URL(stylesheetHref!, prodUrl));
         expect(cssRes.status).toBe(200);
         const css = await cssRes.text();
         expect(css).not.toContain("$var");


### PR DESCRIPTION
## Summary
- emit Pages Router dev initial stylesheet links from the _app and matched page CSS graph
- include CSS Modules, static re-exported dependencies, page-level CSS, and source URL/basePath handling
- align production Pages asset ordering with Next.js by collecting _app assets before page assets

## Validation
- vp check --fix packages/vinext/src/index.ts packages/vinext/src/server/dev-server.ts packages/vinext/src/server/pages-dev-module-url.ts packages/vinext/src/server/pages-page-handler.ts tests/pages-router.test.ts tests/scss.test.ts
- vp test run tests/pages-router.test.ts -t "dev Pages client assets expose _app global CSS|basePath source URLs|metadata updates|production Pages asset tags include _app stylesheet assets"
- vp test run tests/scss.test.ts
- git diff --check
