### PR TITLE
fix: use normalizePathSeparators in formatAppFilePath for Windows compatibility

### DIFF
--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -1105,9 +1105,9 @@ function validatePageRouteConflicts(routes: readonly AppRoute[], appDir: string)
 }
 
 function formatAppFilePath(filePath: string, appDir: string): string {
-  const relativePath = path.relative(appDir, filePath).replace(/\\/g, "/");
+  const relativePath = normalizePathSeparators(path.relative(appDir, filePath));
   const parsedPath = path.parse(relativePath);
-  const withoutExtension = path.join(parsedPath.dir, parsedPath.name).replace(/\\/g, "/");
+  const withoutExtension = normalizePathSeparators(path.join(parsedPath.dir, parsedPath.name));
   return withoutExtension.startsWith("/") ? withoutExtension : `/${withoutExtension}`;
 }
 


### PR DESCRIPTION

## Summary

`formatAppFilePath` in `app-route-graph.ts` was using inline `.replace(/\\\\/g, "/")` to normalize path separators instead of the shared `normalizePathSeparators` utility already imported at the top of the file.

This fixes two call sites within `formatAppFilePath`:

```diff
- const relativePath = path.relative(appDir, filePath).replace(/\\\\/g, "/");
+ const relativePath = normalizePathSeparators(path.relative(appDir, filePath));
  const parsedPath = path.parse(relativePath);
- const withoutExtension = path.join(parsedPath.dir, parsedPath.name).replace(/\\\\/g, "/");
+ const withoutExtension = normalizePathSeparators(path.join(parsedPath.dir, parsedPath.name));
```

`normalizePathSeparators` was already imported and used in `scanWithExtensions` (file-matcher.ts) for the same reason — this migrates the remaining per-callsite inline replacements in `app-route-graph.ts` to the shared utility, consistent with how #1578 and #1604 addressed the same class of bug elsewhere.