### PR TITLE
fix(cloudflare): allow pages deploy without custom worker

### DIFF
--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -343,7 +343,6 @@ export async function deploy(options: DeployOptions): Promise<void> {
   const missingScaffolding = [
     !info.hasViteConfig && "Vite config",
     !info.hasWranglerConfig && "Wrangler config",
-    info.isPagesRouter && !info.hasWorkerEntry && "Worker entry",
   ].filter((value): value is string => Boolean(value));
   if (missingScaffolding.length > 0) {
     throw new Error(

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -198,6 +198,19 @@ describe("deploy environment validation", () => {
 
     await expect(deploy({ root: tmpDir, dryRun: true })).rejects.not.toThrow("Worker entry");
   });
+
+  it("does not require a custom Worker entry for Pages Router deployments", async () => {
+    writeFile(tmpDir, "package.json", '{"name":"pages"}\n');
+    writeFile(tmpDir, "pages/index.tsx", "export default function Page() { return null; }\n");
+    writeFile(tmpDir, "vite.config.ts", "export default {};\n");
+    writeFile(
+      tmpDir,
+      "wrangler.jsonc",
+      '{"main":"vinext/server/fetch-handler","assets":{"directory":"dist/client"}}\n',
+    );
+
+    await expect(deploy({ root: tmpDir, dryRun: true })).rejects.not.toThrow("Worker entry");
+  });
 });
 
 // ─── CLOUDFLARE_ENV propagation (issue #1210) ──────────────────────────────


### PR DESCRIPTION
## Summary
- stop requiring Pages Router Cloudflare deploys to include a custom worker entry
- add dry-run regression coverage that Pages Router projects can use `vinext/server/fetch-handler` like App Router projects

## Tests
- `vp test run tests/deploy.test.ts`
- `vp check tests/deploy.test.ts`