### PR TITLE
fix(dev): seed Cloudflare Pages Router worker deps

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -246,6 +246,9 @@ const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
   "react-dom/server.edge",
   "react/jsx-runtime",
   "react/jsx-dev-runtime",
+]);
+
+const OPTIONAL_PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
   "use-sync-external-store/with-selector",
 ]);
 
@@ -340,6 +343,25 @@ function resolveOptionalDependency(projectRoot: string, specifier: string): stri
   } catch {}
 
   return null;
+}
+
+function canResolveProjectDependency(projectRoot: string, specifier: string): boolean {
+  try {
+    const projectRequire = createRequire(path.join(projectRoot, "package.json"));
+    projectRequire.resolve(specifier);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getPagesCloudflareWorkerOptimizeDepsInclude(projectRoot: string): string[] {
+  return [
+    ...PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE,
+    ...OPTIONAL_PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE.filter((specifier) =>
+      canResolveProjectDependency(projectRoot, specifier),
+    ),
+  ];
 }
 
 async function loadVite7TsconfigPathsPlugin(projectRoot: string): Promise<Plugin> {
@@ -2877,7 +2899,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           );
           config.optimizeDeps.include = mergeStringArrayValues(
             config.optimizeDeps.include,
-            PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE,
+            getPagesCloudflareWorkerOptimizeDepsInclude(root),
           );
           config.optimizeDeps.exclude = mergeOptimizeDepsExclude(
             config.optimizeDeps.exclude ?? [],

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -246,6 +246,7 @@ const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
   "react-dom/server.edge",
   "react/jsx-runtime",
   "react/jsx-dev-runtime",
+  "use-sync-external-store/with-selector",
 ]);
 
 // Install the process-level peer-disconnect backstop at module load.

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -246,9 +246,6 @@ const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
   "react-dom/server.edge",
   "react/jsx-runtime",
   "react/jsx-dev-runtime",
-]);
-
-const OPTIONAL_PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
   "use-sync-external-store/with-selector",
 ]);
 
@@ -343,25 +340,6 @@ function resolveOptionalDependency(projectRoot: string, specifier: string): stri
   } catch {}
 
   return null;
-}
-
-function canResolveProjectDependency(projectRoot: string, specifier: string): boolean {
-  try {
-    const projectRequire = createRequire(path.join(projectRoot, "package.json"));
-    projectRequire.resolve(specifier);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function getPagesCloudflareWorkerOptimizeDepsInclude(projectRoot: string): string[] {
-  return [
-    ...PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE,
-    ...OPTIONAL_PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE.filter((specifier) =>
-      canResolveProjectDependency(projectRoot, specifier),
-    ),
-  ];
 }
 
 async function loadVite7TsconfigPathsPlugin(projectRoot: string): Promise<Plugin> {
@@ -2899,7 +2877,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           );
           config.optimizeDeps.include = mergeStringArrayValues(
             config.optimizeDeps.include,
-            getPagesCloudflareWorkerOptimizeDepsInclude(root),
+            PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE,
           );
           config.optimizeDeps.exclude = mergeOptimizeDepsExclude(
             config.optimizeDeps.exclude ?? [],

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -235,6 +235,19 @@ import {
   type VinextPrerenderConfig,
 } from "./config/prerender.js";
 
+const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
+  "vinext/server/fetch-handler",
+  "vinext/server/pages-router-entry",
+]);
+
+const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
+  "react",
+  "react-dom",
+  "react-dom/server.edge",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+]);
+
 // Install the process-level peer-disconnect backstop at module load.
 // Vite plugin lifecycle hooks (config / configureServer) proved
 // timing-fragile in vite-plus — install was silently skipped,
@@ -576,6 +589,14 @@ function getVinextVersion(): string {
 type UserResolveConfigWithTsconfigPaths = NonNullable<UserConfig["resolve"]> & {
   tsconfigPaths?: boolean;
 };
+
+function mergeStringArrayValues(
+  value: string | readonly string[] | undefined,
+  additions: readonly string[],
+): string[] {
+  const existing = value === undefined ? [] : Array.isArray(value) ? value : [value];
+  return [...new Set([...existing, ...additions])];
+}
 
 // Cache materialized tsconfig/jsconfig aliases so Vite's glob and dynamic-import
 // transforms can see them via resolve.alias without re-reading config files per env.
@@ -960,6 +981,8 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let hasCloudflarePlugin = false;
   let warnedInlineNextConfigOverride = false;
   let hasNitroPlugin = false;
+  let isServeCommand = false;
+  let pagesOptimizeEntries: string[] = [];
   const pagesClientAssetsOutputDirs = new Set<string>();
   let pagesClientAssetsModule: string | null = null;
   let rscCompatibilityId: string | undefined;
@@ -1368,6 +1391,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       >),
 
       async config(config, env) {
+        isServeCommand = env.command === "serve";
         root = normalizePathSeparators(config.root ?? process.cwd());
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
         const shouldEnableNativeTsconfigPaths =
@@ -2407,7 +2431,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             plugins: [depOptimizeAliasPlugin],
           },
         };
-        const pagesOptimizeEntries = !hasAppDir
+        pagesOptimizeEntries = !hasAppDir
           ? [
               ...(hasPagesDir
                 ? [toRelativeFileEntry(root, pagesDir) + "/**/*.{tsx,ts,jsx,js}"]
@@ -2710,6 +2734,34 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       configEnvironment(name, config) {
+        if (
+          isServeCommand &&
+          hasCloudflarePlugin &&
+          hasPagesDir &&
+          !hasAppDir &&
+          name !== "client"
+        ) {
+          // The Cloudflare plugin owns the Worker dev environment. Seed it
+          // with Pages Router server entries so Vite does not discover vinext's
+          // Worker entry and React's CJS edge renderer on the first request,
+          // trigger a full reload, and execute raw CJS in the Worker module
+          // runner.
+          config.optimizeDeps ??= {};
+          config.optimizeDeps.entries = mergeStringArrayValues(
+            config.optimizeDeps.entries,
+            pagesOptimizeEntries,
+          );
+          config.optimizeDeps.include = mergeStringArrayValues(
+            config.optimizeDeps.include,
+            PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE,
+          );
+          config.optimizeDeps.exclude = mergeOptimizeDepsExclude(
+            config.optimizeDeps.exclude ?? [],
+            VINEXT_OPTIMIZE_DEPS_EXCLUDE,
+            PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_EXCLUDE,
+          );
+        }
+
         const configuredExtensions =
           name === "client" ? nextConfig.resolveExtensions : nextConfig.serverResolveExtensions;
         const extensions =

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   CSSModulesOptions,
+  Logger,
   Plugin,
   PluginOption,
   ResolvedConfig,
@@ -248,6 +249,10 @@ const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
   "react/jsx-dev-runtime",
   "use-sync-external-store/with-selector",
 ]);
+
+const OPTIONAL_OPTIMIZE_DEPS_WARNING_RE =
+  /Failed to resolve dependency: .*use-sync-external-store\/with-selector.*present in .* 'optimizeDeps\.include'/;
+const VINEXT_FILTERED_OPTIMIZE_DEPS_WARN = Symbol.for("vinext.filteredOptimizeDepsWarn");
 
 // Install the process-level peer-disconnect backstop at module load.
 // Vite plugin lifecycle hooks (config / configureServer) proved
@@ -720,6 +725,18 @@ function mergeStringArrayValues(
 ): string[] {
   const existing = value === undefined ? [] : Array.isArray(value) ? value : [value];
   return [...new Set([...existing, ...additions])];
+}
+
+function suppressOptionalOptimizeDepsWarnings(logger: Logger): void {
+  const marker = logger as Logger & { [VINEXT_FILTERED_OPTIMIZE_DEPS_WARN]?: true };
+  if (marker[VINEXT_FILTERED_OPTIMIZE_DEPS_WARN]) return;
+
+  const warn = logger.warn.bind(logger);
+  logger.warn = (msg, options) => {
+    if (OPTIONAL_OPTIMIZE_DEPS_WARNING_RE.test(msg)) return;
+    warn(msg, options);
+  };
+  marker[VINEXT_FILTERED_OPTIMIZE_DEPS_WARN] = true;
 }
 
 // Cache materialized tsconfig/jsconfig aliases so Vite's glob and dynamic-import
@@ -2900,6 +2917,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       async configResolved(config) {
         const cacheDirPrefix = getCacheDirPrefix(config.cacheDir);
         typeofWindowIdFilter.exclude = new RegExp(`^${escapeRegExp(cacheDirPrefix)}`);
+        if (isServeCommand && hasCloudflarePlugin && hasPagesDir && !hasAppDir) {
+          suppressOptionalOptimizeDepsWarnings(config.logger);
+        }
 
         // Provide the resolved config to the Sass-aware CSS Modules Loader so
         // it can call Vite's `preprocessCSS` when processing SCSS files

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -253,6 +253,7 @@ const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
 const OPTIONAL_OPTIMIZE_DEPS_WARNING_RE =
   /Failed to resolve dependency: .*use-sync-external-store\/with-selector.*present in .* 'optimizeDeps\.include'/;
 const VINEXT_FILTERED_OPTIMIZE_DEPS_WARN = Symbol.for("vinext.filteredOptimizeDepsWarn");
+const ANSI_ESCAPE_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 
 // Install the process-level peer-disconnect backstop at module load.
 // Vite plugin lifecycle hooks (config / configureServer) proved
@@ -727,13 +728,17 @@ function mergeStringArrayValues(
   return [...new Set([...existing, ...additions])];
 }
 
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE_RE, "");
+}
+
 function suppressOptionalOptimizeDepsWarnings(logger: Logger): void {
   const marker = logger as Logger & { [VINEXT_FILTERED_OPTIMIZE_DEPS_WARN]?: true };
   if (marker[VINEXT_FILTERED_OPTIMIZE_DEPS_WARN]) return;
 
   const warn = logger.warn.bind(logger);
   logger.warn = (msg, options) => {
-    if (OPTIONAL_OPTIMIZE_DEPS_WARNING_RE.test(msg)) return;
+    if (OPTIONAL_OPTIMIZE_DEPS_WARNING_RE.test(stripAnsi(msg))) return;
     warn(msg, options);
   };
   marker[VINEXT_FILTERED_OPTIMIZE_DEPS_WARN] = true;

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -608,6 +608,61 @@ describe("optimizeDeps.exclude for vinext", () => {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);
+
+  it("seeds Cloudflare Pages Router worker optimizer entries during dev", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
+      (p: any) =>
+        p.name === "vinext:config" &&
+        typeof p.config === "function" &&
+        typeof p.configEnvironment === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-cf-pages-dev-optdeps-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+
+    try {
+      await (mainPlugin as any).config(
+        {
+          root: tmpDir,
+          build: {},
+          plugins: [{ name: "vite-plugin-cloudflare" }],
+        },
+        { command: "serve" },
+      );
+
+      const workerEnvConfig = {
+        optimizeDeps: {
+          entries: ["already-present.ts"],
+          include: ["already-included"],
+          exclude: ["already-excluded"],
+        },
+      };
+      (mainPlugin as any).configEnvironment("worker", workerEnvConfig);
+
+      expect(workerEnvConfig.optimizeDeps.entries).toContain("already-present.ts");
+      expect(workerEnvConfig.optimizeDeps.entries).toContain("pages/**/*.{tsx,ts,jsx,js}");
+      expect(workerEnvConfig.optimizeDeps.include).toContain("already-included");
+      expect(workerEnvConfig.optimizeDeps.include).toContain("react");
+      expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom");
+      expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom/server.edge");
+      expect(workerEnvConfig.optimizeDeps.exclude).toContain("already-excluded");
+      expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext");
+      expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext/server/fetch-handler");
+      expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext/server/pages-router-entry");
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
 });
 
 // ─── process.env.NODE_ENV define ─────────────────────────────────────────────

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -621,13 +621,8 @@ describe("optimizeDeps.exclude for vinext", () => {
     expect(mainPlugin).toBeDefined();
 
     const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-cf-pages-dev-optdeps-"));
-    await fsp.mkdir(path.join(tmpDir, "node_modules", "use-sync-external-store"), {
-      recursive: true,
-    });
-    await fsp.writeFile(
-      path.join(tmpDir, "node_modules", "use-sync-external-store", "with-selector.js"),
-      `module.exports = {};`,
-    );
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
     await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
     await fsp.writeFile(
       path.join(tmpDir, "pages", "index.tsx"),
@@ -667,53 +662,6 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext");
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext/server/fetch-handler");
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext/server/pages-router-entry");
-    } finally {
-      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }, 15000);
-
-  it("does not seed optional Cloudflare Pages Router worker optimizer deps when absent", async () => {
-    const vinext = (await import("../packages/vinext/src/index.js")).default;
-    const plugins = vinext();
-    const mainPlugin = plugins.find(
-      (p: any) =>
-        p.name === "vinext:config" &&
-        typeof p.config === "function" &&
-        typeof p.configEnvironment === "function",
-    );
-    expect(mainPlugin).toBeDefined();
-
-    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-cf-pages-dev-optdeps-absent-"));
-    await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
-    await fsp.writeFile(
-      path.join(tmpDir, "pages", "index.tsx"),
-      `export default function Home() { return <h1>Home</h1>; }`,
-    );
-    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
-
-    try {
-      await (mainPlugin as any).config(
-        {
-          root: tmpDir,
-          build: {},
-          plugins: [{ name: "vite-plugin-cloudflare" }],
-        },
-        { command: "serve" },
-      );
-
-      const workerEnvConfig = {
-        optimizeDeps: {
-          include: [],
-        },
-      };
-      (mainPlugin as any).configEnvironment("worker", workerEnvConfig);
-
-      expect(workerEnvConfig.optimizeDeps.include).toContain("react");
-      expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom");
-      expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom/server.edge");
-      expect(workerEnvConfig.optimizeDeps.include).not.toContain(
-        "use-sync-external-store/with-selector",
-      );
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -621,8 +621,13 @@ describe("optimizeDeps.exclude for vinext", () => {
     expect(mainPlugin).toBeDefined();
 
     const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-cf-pages-dev-optdeps-"));
-    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
-    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "node_modules", "use-sync-external-store"), {
+      recursive: true,
+    });
+    await fsp.writeFile(
+      path.join(tmpDir, "node_modules", "use-sync-external-store", "with-selector.js"),
+      `module.exports = {};`,
+    );
     await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
     await fsp.writeFile(
       path.join(tmpDir, "pages", "index.tsx"),
@@ -662,6 +667,53 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext");
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext/server/fetch-handler");
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext/server/pages-router-entry");
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("does not seed optional Cloudflare Pages Router worker optimizer deps when absent", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
+      (p: any) =>
+        p.name === "vinext:config" &&
+        typeof p.config === "function" &&
+        typeof p.configEnvironment === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-cf-pages-dev-optdeps-absent-"));
+    await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+
+    try {
+      await (mainPlugin as any).config(
+        {
+          root: tmpDir,
+          build: {},
+          plugins: [{ name: "vite-plugin-cloudflare" }],
+        },
+        { command: "serve" },
+      );
+
+      const workerEnvConfig = {
+        optimizeDeps: {
+          include: [],
+        },
+      };
+      (mainPlugin as any).configEnvironment("worker", workerEnvConfig);
+
+      expect(workerEnvConfig.optimizeDeps.include).toContain("react");
+      expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom");
+      expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom/server.edge");
+      expect(workerEnvConfig.optimizeDeps.include).not.toContain(
+        "use-sync-external-store/with-selector",
+      );
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -726,6 +726,9 @@ describe("optimizeDeps.exclude for vinext", () => {
         "Failed to resolve dependency: use-sync-external-store/with-selector, present in worker 'optimizeDeps.include'",
       );
       logger.warn(
+        "Failed to resolve dependency: \x1b[36muse-sync-external-store/with-selector\x1b[39m, present in worker 'optimizeDeps.include'",
+      );
+      logger.warn(
         "Failed to resolve dependency: other-package, present in worker 'optimizeDeps.include'",
       );
 

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -666,6 +666,76 @@ describe("optimizeDeps.exclude for vinext", () => {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);
+
+  it("suppresses missing optional Cloudflare Pages Router worker optimizer warnings", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext();
+    const mainPlugin = plugins.find(
+      (p: any) =>
+        p.name === "vinext:config" &&
+        typeof p.config === "function" &&
+        typeof p.configResolved === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-cf-pages-dev-optwarn-"));
+    await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "pages", "index.tsx"),
+      `export default function Home() { return <h1>Home</h1>; }`,
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+
+    try {
+      await (mainPlugin as any).config(
+        {
+          root: tmpDir,
+          build: {},
+          plugins: [{ name: "vite-plugin-cloudflare" }],
+        },
+        { command: "serve" },
+      );
+
+      const warned: string[] = [];
+      const logger = {
+        hasWarned: false,
+        info() {},
+        warn(msg: string) {
+          warned.push(msg);
+        },
+        warnOnce(msg: string) {
+          warned.push(msg);
+        },
+        error() {},
+        clearScreen() {},
+        hasErrorLogged() {
+          return false;
+        },
+      };
+
+      await (mainPlugin as any).configResolved({
+        cacheDir: path.join(tmpDir, "node_modules", ".vite"),
+        command: "serve",
+        configFile: false,
+        environments: {},
+        logger,
+        plugins: [],
+      });
+
+      logger.warn(
+        "Failed to resolve dependency: use-sync-external-store/with-selector, present in worker 'optimizeDeps.include'",
+      );
+      logger.warn(
+        "Failed to resolve dependency: other-package, present in worker 'optimizeDeps.include'",
+      );
+
+      expect(warned).toEqual([
+        "Failed to resolve dependency: other-package, present in worker 'optimizeDeps.include'",
+      ]);
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
 });
 
 // ─── process.env.NODE_ENV define ─────────────────────────────────────────────

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -655,6 +655,9 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(workerEnvConfig.optimizeDeps.include).toContain("react");
       expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom");
       expect(workerEnvConfig.optimizeDeps.include).toContain("react-dom/server.edge");
+      expect(workerEnvConfig.optimizeDeps.include).toContain(
+        "use-sync-external-store/with-selector",
+      );
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("already-excluded");
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext");
       expect(workerEnvConfig.optimizeDeps.exclude).toContain("vinext/server/fetch-handler");


### PR DESCRIPTION
## Summary
- seed Cloudflare-owned worker dev environments for Pages Router with Pages source entries
- pre-include React framework deps used by the Pages Router worker/server entry
- exclude vinext worker entry subpaths from dependency optimization so they stay live-transformed

## Tests
- vp test run tests/build-optimization.test.ts -t "seeds Cloudflare Pages Router worker optimizer entries during dev"
- vp test run tests/build-optimization.test.ts
- vp check tests/build-optimization.test.ts
- vp check packages/vinext/src/index.ts