### PR TITLE
feat(pages): enforce reactStrictMode by wrapping client root in <StrictMode>

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -288,7 +288,7 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   reactStrictMode: {
     status: "partial",
     detail:
-      "config option recognized but not yet enforced; root is not wrapped in <React.StrictMode>",
+      "enforced for the Pages Router (client root wrapped in <React.StrictMode> when true); App Router is not yet wrapped (Next.js defaults App Router strict mode on)",
   },
   poweredByHeader: {
     status: "supported",

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -216,6 +216,14 @@ export type NextConfig = {
     /** Content-Security-Policy header for image responses. Defaults to "script-src 'none'; frame-src 'none'; sandbox;" */
     contentSecurityPolicy?: string;
   };
+  /**
+   * Enable React Strict Mode. When `true`, the client root is wrapped in
+   * `<React.StrictMode>` so React runs its dev-only strict checks (double-
+   * invoked effects/render, deprecation warnings). `null`/unset resolves per
+   * router: OFF for the Pages Router, ON for the App Router — matching Next.js.
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/reactStrictMode
+   */
+  reactStrictMode?: boolean | null;
   /** Build output mode: 'export' for full static export, 'standalone' for single server */
   output?: "export" | "standalone";
   /** File extensions treated as routable pages/routes (Next.js pageExtensions) */
@@ -470,6 +478,16 @@ export type ResolvedNextConfig = {
    * `test/e2e/optimized-loading` test fixture.
    */
   disableOptimizedLoading: boolean;
+  /**
+   * Resolved `reactStrictMode` from next.config, preserved as `boolean | null`
+   * so each router can apply its own default (Next.js resolves `null` to OFF
+   * for the Pages Router and ON for the App Router). When the effective value
+   * is `true`, the client root is wrapped in `<React.StrictMode>`.
+   *
+   * See `.nextjs-ref/packages/next/src/build/define-env.ts`
+   * (`__NEXT_STRICT_MODE` / `__NEXT_STRICT_MODE_APP`).
+   */
+  reactStrictMode: boolean | null;
   /**
    * Mirrors Next.js `experimental.scrollRestoration`. When true, the Pages
    * Router client takes ownership of browser history scroll restoration by
@@ -1371,6 +1389,7 @@ export async function resolveNextConfig(
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      reactStrictMode: null,
       scrollRestoration: false,
       compilerDefine: {},
       compilerDefineServer: {},
@@ -1724,6 +1743,9 @@ export async function resolveNextConfig(
     // Next.js stores this under `experimental.disableOptimizedLoading`.
     // Default `false` matches Next.js: page scripts get `defer` in <head>.
     disableOptimizedLoading: experimental?.disableOptimizedLoading === true,
+    // Preserve `null` (unset) so each router applies its own default — Next.js
+    // resolves `null` to OFF for Pages Router, ON for App Router.
+    reactStrictMode: typeof config.reactStrictMode === "boolean" ? config.reactStrictMode : null,
     scrollRestoration: experimental?.scrollRestoration === true,
     compilerDefine: serializeCompilerDefine(config.compiler?.define),
     compilerDefineServer: serializeCompilerDefine(config.compiler?.defineServer),

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -125,6 +125,15 @@ export async function generateClientEntry(
   const reactPreambleImport =
     options.reactPreamble === false ? "" : 'import "@vitejs/plugin-react/preamble";\n';
 
+  // Pages Router React Strict Mode flag. Next.js resolves the `null`/unset
+  // default to OFF for the Pages Router (`reactStrictMode === null ? false` in
+  // .nextjs-ref/packages/next/src/build/define-env.ts), so the wrap is enabled
+  // only when the option is explicitly `true`. The actual <React.StrictMode>
+  // wrap lives in `wrapWithRouterContext` (next/router), which runs for both
+  // the initial hydration here and every client-side navigation — mirroring
+  // Next.js's `process.env.__NEXT_STRICT_MODE` branch in `client/index.tsx`.
+  const reactStrictModeEnabled = nextConfig.reactStrictMode === true;
+
   return `${userInstrumentationImport}${reactPreambleImport}
 import "vinext/instrumentation-client";
 import React from "react";
@@ -161,6 +170,9 @@ const appLoader = undefined;
 // can iterate in order and trust the first match.
 window.__VINEXT_PAGE_LOADERS__ = pageLoaders;
 window.__VINEXT_PAGE_PATTERNS__ = Object.keys(pageLoaders);
+// reactStrictMode flag — read by wrapWithRouterContext (next/router) so the
+// <React.StrictMode> wrap is applied on initial hydration and every navigation.
+window.__VINEXT_REACT_STRICT_MODE__ = ${JSON.stringify(reactStrictModeEnabled)};
 window.__VINEXT_PAGES_SSG_PATTERNS__ = ${JSON.stringify(pagesSsgPatterns)};
 window.__VINEXT_PAGES_SSP_PATTERNS__ = ${JSON.stringify(pagesSspPatterns)};
 window.__VINEXT_MIDDLEWARE_MATCHER__ = ${JSON.stringify(options.middlewareMatcher)};
@@ -262,6 +274,9 @@ async function hydrate() {
   });
 
   // Wrap with RouterContext.Provider so next/router and next/compat/router work during hydration.
+  // When reactStrictMode is enabled, wrapWithRouterContext also wraps the tree
+  // in <React.StrictMode> (see next/router) — applied here and on every
+  // navigation render, matching Next.js.
   element = wrapWithRouterContext(element, resolveHydrationCommit);
 
   const container = document.getElementById("__next");

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -43,6 +43,17 @@ declare global {
     __VINEXT_ROOT__: Root | undefined;
 
     /**
+     * Whether `reactStrictMode: true` is set in next.config for the Pages
+     * Router. Set by the generated client entry and the dev hydration script
+     * before `hydrateRoot()`. Read by `wrapWithRouterContext` in
+     * `shims/router.ts` so the StrictMode wrap is applied on the initial
+     * hydration AND every client-side navigation render — mirroring Next.js's
+     * `process.env.__NEXT_STRICT_MODE` branch in `client/index.tsx`, which runs
+     * for both the initial hydrate and subsequent `reactRoot.render()` calls.
+     */
+    __VINEXT_REACT_STRICT_MODE__: boolean | undefined;
+
+    /**
      * High-resolution timestamp recorded after client hydration is usable.
      * Pages Router writes from the stable router provider after passive
      * effects can attach; App Router writes after the first committed tree

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4874,6 +4874,7 @@ export const loadServerActionClient = ${
                         (nextConfig?.rewrites.fallback.length ?? 0) > 0,
                       nextConfig?.clientTraceMetadata,
                       nextConfig?.htmlLimitedBots,
+                      nextConfig?.reactStrictMode === true,
                     ),
                   };
                 }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -507,6 +507,15 @@ export function createSSRHandler(
    */
   clientTraceMetadata?: readonly string[],
   htmlLimitedBots?: string,
+  /**
+   * Whether `reactStrictMode: true` is set in next.config. When true, the dev
+   * hydration script sets `window.__VINEXT_REACT_STRICT_MODE__` so
+   * `wrapWithRouterContext` wraps the tree in `<React.StrictMode>` on the
+   * initial hydration and every navigation. Pages Router default is OFF
+   * (Next.js: `reactStrictMode === null ? false`), so callers pass
+   * `nextConfig?.reactStrictMode === true`.
+   */
+  reactStrictMode = false,
 ) {
   const matcher = fileMatcher ?? createValidFileMatcher();
 
@@ -1670,6 +1679,9 @@ const rawPageProps = props.pageProps;
 const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};
 window.__VINEXT_PAGE_LOADERS__ = { [nextData.page]: () => import("${pageModuleSource}") };
 window.__VINEXT_APP_LOADER__ = ${appModuleSource ? `() => import("${appModuleSource}")` : "undefined"};
+// reactStrictMode flag — read by wrapWithRouterContext so the <React.StrictMode>
+// wrap is applied on initial hydration and every navigation (matches Next.js).
+window.__VINEXT_REACT_STRICT_MODE__ = ${JSON.stringify(reactStrictMode === true)};
 
 async function hydrate() {
   let hydrateRootOptions;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -3573,6 +3573,8 @@ export function wrapWithRouterContext(
   // CommitBoundary stays outside StrictMode so its commit `useLayoutEffect`
   // is not double-invoked (Next.js keeps `<Root>` outside <StrictMode> too).
   let inner: ReactElement = createElement(Provider, null, element);
+  // Re-read the static page-load flag on each render so hydration and
+  // navigation share this single wrapping path.
   if (typeof window !== "undefined" && window.__VINEXT_REACT_STRICT_MODE__ === true) {
     inner = createElement(StrictMode, null, inner);
   }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -13,6 +13,7 @@ import {
   useLayoutEffect,
   Fragment,
   Component,
+  StrictMode,
   createElement,
   type ReactElement,
   type ReactNode,
@@ -3561,11 +3562,21 @@ export function wrapWithRouterContext(
   onError: (error: Error) => void = noopCommit,
 ): ReactElement {
   const { CommitBoundary, Provider } = getPagesRouterRuntimeComponents();
-  return createElement(
-    CommitBoundary,
-    { onCommit, onError },
-    createElement(Provider, null, element),
-  );
+  // React Strict Mode (Pages Router). When `reactStrictMode: true`, wrap the
+  // router-context subtree in <React.StrictMode> so React runs its dev-only
+  // strict checks. We read a client-only `window` flag rather than wrapping
+  // unconditionally so the server-rendered tree is never wrapped (matching
+  // Next.js, which only wraps client-side in `client/index.tsx`). Because this
+  // wrap lives in `wrapWithRouterContext` — called by the initial hydration
+  // entry AND every navigation `root.render()` — StrictMode survives soft
+  // navigations, mirroring Next.js's `doRender` closure used for both. The
+  // CommitBoundary stays outside StrictMode so its commit `useLayoutEffect`
+  // is not double-invoked (Next.js keeps `<Root>` outside <StrictMode> too).
+  let inner: ReactElement = createElement(Provider, null, element);
+  if (typeof window !== "undefined" && window.__VINEXT_REACT_STRICT_MODE__ === true) {
+    inner = createElement(StrictMode, null, inner);
+  }
+  return createElement(CommitBoundary, { onCommit, onError }, inner);
 }
 
 /**

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -290,9 +290,9 @@ describe("analyzeConfig", () => {
     const items = analyzeConfig(tmpDir);
     expect(items.find((i) => i.name === "basePath")?.status).toBe("supported");
     expect(items.find((i) => i.name === "trailingSlash")?.status).toBe("supported");
-    // reactStrictMode is reported as `partial` until vinext actually wraps the
-    // hydrated root in `<React.StrictMode>` — currently the config is read but
-    // not enforced. See `packages/vinext/src/check.ts` for the rationale.
+    // reactStrictMode is enforced for the Pages Router (client root wrapped in
+    // `<React.StrictMode>` when `true`) but the App Router is not yet wrapped,
+    // so the status is `partial`. See `packages/vinext/src/check.ts`.
     expect(items.find((i) => i.name === "reactStrictMode")?.status).toBe("partial");
   });
 

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1385,4 +1385,76 @@ describe("Pages Router entry template", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  // Ported from Next.js: `reactStrictMode` wraps the client tree in
+  // <React.StrictMode> via the `process.env.__NEXT_STRICT_MODE` branch in
+  // .nextjs-ref/packages/next/src/client/index.tsx (around line 787). vinext
+  // signals this to its router shim via `window.__VINEXT_REACT_STRICT_MODE__`,
+  // which `wrapWithRouterContext` reads so the wrap is applied on the initial
+  // hydration AND every navigation render (Next.js's `doRender` closure runs
+  // for both). For the Pages Router the default is OFF —
+  // `reactStrictMode === null ? false` in
+  // .nextjs-ref/packages/next/src/build/define-env.ts — so the flag is `true`
+  // only when the option is explicitly `true`.
+  it("publishes the reactStrictMode flag to the client entry when reactStrictMode is true", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-strict-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      const code = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({ reactStrictMode: true }),
+        createValidFileMatcher(),
+      );
+
+      // The flag is set before hydrate() runs so wrapWithRouterContext sees it
+      // on the very first render.
+      const flagIndex = code.indexOf("window.__VINEXT_REACT_STRICT_MODE__ = true;");
+      const hydrateRootIndex = code.indexOf("hydrateRoot(container, element, hydrateRootOptions)");
+
+      expect(flagIndex).toBeGreaterThanOrEqual(0);
+      expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
+      expect(flagIndex).toBeLessThan(hydrateRootIndex);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("publishes a false reactStrictMode flag for the Pages Router by default or when disabled", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-entry-no-strict-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      // Unset → Pages Router default is OFF (Next.js: `reactStrictMode === null ? false`).
+      const defaultCode = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({}),
+        createValidFileMatcher(),
+      );
+      expect(defaultCode).toContain("window.__VINEXT_REACT_STRICT_MODE__ = false;");
+      expect(defaultCode).not.toContain("window.__VINEXT_REACT_STRICT_MODE__ = true;");
+
+      // Explicit false → also OFF.
+      const disabledCode = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({ reactStrictMode: false }),
+        createValidFileMatcher(),
+      );
+      expect(disabledCode).toContain("window.__VINEXT_REACT_STRICT_MODE__ = false;");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -2038,6 +2038,7 @@ describe("detectNextIntlConfig", () => {
       sassOptions: null,
       removeConsole: false,
       disableOptimizedLoading: false,
+      reactStrictMode: null,
       scrollRestoration: false,
       compilerDefine: {},
       compilerDefineServer: {},

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1161,6 +1161,11 @@ describe("Pages Router integration", () => {
     expect(hydrationProxy).toContain(
       'hydrateRoot(document.getElementById("__next"), element, hydrateRootOptions)',
     );
+    // The dev hydration script publishes the reactStrictMode flag so
+    // wrapWithRouterContext applies the <React.StrictMode> wrap (dev-only, where
+    // StrictMode actually fires). This fixture does not set reactStrictMode, so
+    // the Pages Router default (OFF) is emitted.
+    expect(hydrationProxy).toContain("window.__VINEXT_REACT_STRICT_MODE__ = false;");
   });
 
   it("wraps pages with custom _app.tsx", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3434,6 +3434,87 @@ describe("next/router withRouter HOC", () => {
   });
 });
 
+// reactStrictMode (Pages Router). The <React.StrictMode> wrap lives in
+// `wrapWithRouterContext`, the single seam every render path funnels through:
+// the initial hydration entry AND every client-side navigation `root.render()`
+// (`renderPagesRouterElement` in shims/router.ts). This mirrors Next.js, whose
+// `doRender` closure wraps in <React.StrictMode> for both the initial hydrate
+// and subsequent `reactRoot.render()` calls (client/index.tsx ~787). The wrap
+// is gated on a client-only `window.__VINEXT_REACT_STRICT_MODE__` flag so the
+// server-rendered tree is never wrapped (Next.js wraps client-side only).
+describe("next/router wrapWithRouterContext reactStrictMode wrap", () => {
+  let previousWindow: unknown;
+
+  // Recursively search a React element tree for a node whose type is
+  // React.StrictMode.
+  function treeContainsStrictMode(node: unknown, StrictMode: unknown): boolean {
+    if (!node || typeof node !== "object") return false;
+    const el = node as { type?: unknown; props?: { children?: unknown } };
+    if (el.type === StrictMode) return true;
+    const children = el.props?.children;
+    if (Array.isArray(children)) {
+      return children.some((child) => treeContainsStrictMode(child, StrictMode));
+    }
+    return treeContainsStrictMode(children, StrictMode);
+  }
+
+  beforeEach(() => {
+    previousWindow = (globalThis as any).window;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (previousWindow === undefined) {
+      delete (globalThis as any).window;
+    } else {
+      (globalThis as any).window = previousWindow;
+    }
+    vi.resetModules();
+  });
+
+  it("wraps the router-context tree in React.StrictMode when the client flag is true", async () => {
+    (globalThis as any).window = {
+      __VINEXT_REACT_STRICT_MODE__: true,
+      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+    };
+    const React = await import("react");
+    const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
+
+    const tree = wrapWithRouterContext(React.createElement("span", null, "ok"));
+    expect(treeContainsStrictMode(tree, React.StrictMode)).toBe(true);
+  });
+
+  it("does not wrap in React.StrictMode when the client flag is false or unset", async () => {
+    const baseWindow = {
+      location: { pathname: "/", search: "", hash: "", href: "http://localhost/" },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+    };
+    (globalThis as any).window = { ...baseWindow, __VINEXT_REACT_STRICT_MODE__: false };
+    const React = await import("react");
+    const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
+
+    const falseTree = wrapWithRouterContext(React.createElement("span", null, "ok"));
+    expect(treeContainsStrictMode(falseTree, React.StrictMode)).toBe(false);
+
+    // Unset flag → also no wrap.
+    (globalThis as any).window = { ...baseWindow };
+    const unsetTree = wrapWithRouterContext(React.createElement("span", null, "ok"));
+    expect(treeContainsStrictMode(unsetTree, React.StrictMode)).toBe(false);
+  });
+
+  it("never wraps in React.StrictMode on the server (no window), matching Next.js", async () => {
+    delete (globalThis as any).window;
+    const React = await import("react");
+    const { wrapWithRouterContext } = await import("../packages/vinext/src/shims/router.js");
+
+    const tree = wrapWithRouterContext(React.createElement("span", null, "ok"));
+    expect(treeContainsStrictMode(tree, React.StrictMode)).toBe(false);
+  });
+});
+
 describe("next/headers shim", () => {
   it("exports cookies, headers, draftMode", async () => {
     const mod = await import("../packages/vinext/src/shims/headers.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14700,6 +14700,7 @@ describe("Pages Router concurrent navigation", () => {
       __VINEXT_LOCALE__: undefined as string | undefined,
       __VINEXT_LOCALES__: undefined as string[] | undefined,
       __VINEXT_DEFAULT_LOCALE__: undefined as string | undefined,
+      __VINEXT_REACT_STRICT_MODE__: undefined as boolean | undefined,
     };
 
     // Make pushState update location to simulate real browser behavior
@@ -14802,6 +14803,47 @@ describe("Pages Router concurrent navigation", () => {
     });
     return { promise, resolve, reject };
   }
+
+  function treeContainsReactType(node: unknown, type: unknown): boolean {
+    if (!node || typeof node !== "object") return false;
+    const el = node as { type?: unknown; props?: { children?: unknown } };
+    if (el.type === type) return true;
+    const children = el.props?.children;
+    if (Array.isArray(children))
+      return children.some((child) => treeContainsReactType(child, type));
+    return treeContainsReactType(children, type);
+  }
+
+  it("keeps reactStrictMode wrapping on client navigation renders", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const React = await import("react");
+    const { win, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    win.__VINEXT_REACT_STRICT_MODE__ = true;
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(
+      async () => new Response(buildNavHtml("/next", pageModuleUrl), { status: 200 }),
+    );
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(Router.push("/next")).resolves.toBe(true);
+
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(treeContainsReactType(render.mock.calls[0]?.[0], React.StrictMode)).toBe(true);
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
 
   it("preserves cross-origin domain-locale targets during query-only same-segment navigation", async () => {
     const previousWindow = (globalThis as any).window;


### PR DESCRIPTION
## Problem
`reactStrictMode: true` in `next.config` is recognized by `vinext check` but not enforced — the Pages Router client root was never wrapped in `<React.StrictMode>`, so the dev-only strict checks an app opts into (double-invoked effects/render, deprecation warnings) are silently lost. Found while porting react.dev, which sets `reactStrictMode: true`.

## Root cause
- `reactStrictMode` was not parsed into resolved config at all.
- The Pages Router client tree renders through `wrapWithRouterContext` — used by both initial hydration (prod & dev) and every client-side navigation `root.render()` — which never applied StrictMode.

## Fix
- Parse `reactStrictMode` into `ResolvedNextConfig` as `boolean | null`, preserving Next's per-router default (`null` → OFF for Pages Router, ON for App Router).
- Wrap the router-context subtree in `<React.StrictMode>` inside `wrapWithRouterContext`, gated on a client-only `window.__VINEXT_REACT_STRICT_MODE__` flag set by the prod client entry and the dev hydration script. Because that function is the single seam every render path funnels through, StrictMode applies on initial hydration and survives soft navigations — mirroring Next.js's `doRender` closure. `CommitBoundary` stays outside StrictMode so its commit effect isn't double-invoked (matching Next keeping `<Root>` outside). The server render is never wrapped (StrictMode emits no DOM, so hydration is unaffected).
- `vinext check`: updated to `partial` with an accurate detail (Pages Router enforced; App Router not yet wrapped — Next defaults App Router strict mode on).

## Scope
App Router is intentionally out of scope: its root is mounted by the `@vitejs/plugin-rsc` client runtime, not vinext-owned code, so wrapping it is a separate, larger change. Production behavior is unchanged (StrictMode is dev-only).

## Tests
- `tests/shims.test.ts`: `wrapWithRouterContext` wraps in StrictMode iff the client flag is set (true → wrapped; false/unset/no-window → not).
- `tests/entry-templates.test.ts`: prod client entry publishes the flag (true/false/default).
- `tests/pages-router.test.ts`: the running dev hydration script emits the flag.
- `tests/check.test.ts`, `tests/next-config.test.ts` updated.
- `pnpm run check` clean; unit 7626 passed, pages-router integration 344 passed.
