### PR TITLE
fix(dev): treat .js as JSX in the optimizeDeps scanner

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2799,8 +2799,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           viteConfig.environments = {
             client: {
               consumer: "client",
-              optimizeDeps:
-                pagesOptimizeEntries.length > 0 ? { entries: pagesOptimizeEntries } : undefined,
+              optimizeDeps: {
+                ...(pagesOptimizeEntries.length > 0 ? { entries: pagesOptimizeEntries } : {}),
+                ...depOptimizeNodeEnvOptions,
+              },
               build: {
                 manifest: true,
                 ssrManifest: true,
@@ -2825,8 +2827,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           viteConfig.environments = {
             client: {
               consumer: "client",
-              optimizeDeps:
-                pagesOptimizeEntries.length > 0 ? { entries: pagesOptimizeEntries } : undefined,
+              optimizeDeps: {
+                ...(pagesOptimizeEntries.length > 0 ? { entries: pagesOptimizeEntries } : {}),
+                ...depOptimizeNodeEnvOptions,
+              },
               build: {
                 outDir: "dist/client",
                 manifest: true,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2767,6 +2767,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     "react/jsx-dev-runtime",
                   ]),
                 ],
+                // The client scanner also crawls app/ source files, so it
+                // needs the same JSX-in-`.js` handling (moduleTypes/loader) as
+                // the server optimizers. See getDepOptimizeNodeEnvOptions.
+                ...depOptimizeNodeEnvOptions,
               },
               build: {
                 // Production App Router rendering needs Vite's client manifest

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -45,7 +45,9 @@ export function getDepOptimizeNodeEnvOptions(
   // discover dependencies — so JSX in a `.js`/`.mjs` source file makes the
   // scanner fail with "Unexpected JSX expression" and aborts pre-bundling.
   // Force the optimizer to treat `.js`/`.mjs` as JSX so it parses the same
-  // way the main transform does, matching its `/\.m?js$/` filter.
+  // syntax that the main transform accepts for app source. Unlike the
+  // `vinext:jsx-in-js` transform, this is an optimizer-wide extension mapping
+  // and can also apply to dependencies that the optimizer pre-bundles.
   //
   // The motivating symptom is that, once the scan aborts, pre-bundling is
   // skipped and UMD/CJS deps can fail to interop under SSR — but that
@@ -57,11 +59,11 @@ export function getDepOptimizeNodeEnvOptions(
     ? {
         rolldownOptions: {
           transform: { define },
-          moduleTypes: { ...jsxModuleTypes },
+          moduleTypes: jsxModuleTypes,
         },
       }
     : {
-        esbuildOptions: { define, loader: { ...jsxModuleTypes } },
+        esbuildOptions: { define, loader: jsxModuleTypes },
       };
 }
 

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -24,9 +24,11 @@ export function getDepOptimizeNodeEnvOptions(
     transform: {
       define: Record<string, string>;
     };
+    moduleTypes?: Record<string, "jsx">;
   };
   esbuildOptions?: {
     define: Record<string, string>;
+    loader?: Record<string, "jsx">;
   };
 } {
   // Vite defaults keepProcessEnv to true for server-consumer environments,
@@ -36,14 +38,30 @@ export function getDepOptimizeNodeEnvOptions(
     "process.env.NODE_ENV": nodeEnvDefine,
   };
 
+  // The dep optimizer scanner and pre-bundler run their own Rolldown/esbuild
+  // pipeline that does NOT go through the `vinext:jsx-in-js` transform plugin
+  // (which only runs in the Vite plugin pipeline). Next.js allows JSX in plain
+  // `.js`/`.mjs` files, and the scanner crawls the app's source entries to
+  // discover dependencies — so JSX in a `.js`/`.mjs` source file makes the
+  // scanner fail with "Unexpected JSX expression" and aborts pre-bundling.
+  // Force the optimizer to treat `.js`/`.mjs` as JSX so it parses the same
+  // way the main transform does, matching its `/\.m?js$/` filter.
+  //
+  // The motivating symptom is that, once the scan aborts, pre-bundling is
+  // skipped and UMD/CJS deps can fail to interop under SSR — but that
+  // downstream behavior runs through a different optimizer path and is not
+  // what this option is verified to address; this only keeps the scan from
+  // aborting on JSX-in-`.js`/`.mjs`.
+  const jsxModuleTypes = { ".js": "jsx", ".mjs": "jsx" } as const;
   return viteMajorVersion >= 8
     ? {
         rolldownOptions: {
           transform: { define },
+          moduleTypes: { ...jsxModuleTypes },
         },
       }
     : {
-        esbuildOptions: { define },
+        esbuildOptions: { define, loader: { ...jsxModuleTypes } },
       };
 }
 

--- a/tests/optimize-deps-jsx-in-js.test.ts
+++ b/tests/optimize-deps-jsx-in-js.test.ts
@@ -22,7 +22,7 @@
  * scan itself no longer aborts on JSX-in-`.js`/`.mjs`.
  */
 
-import { describe, it, expect, afterAll } from "vite-plus/test";
+import { describe, it, expect } from "vite-plus/test";
 import { createLogger, createServer, type ViteDevServer } from "vite";
 import fsp from "node:fs/promises";
 import os from "node:os";
@@ -57,6 +57,54 @@ async function setupAppProject(): Promise<string> {
   );
   await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
   return tmpDir;
+}
+
+async function setupPagesProject(): Promise<string> {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-optdeps-pages-jsx-"));
+  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+  await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
+  await fsp.writeFile(
+    path.join(tmpDir, "pages/index.js"),
+    `export default function Page() {
+      return <main>pages jsx in js</main>;
+    }`,
+  );
+  await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+  return tmpDir;
+}
+
+async function expectDevScanAllowsJsxInJs(tmpDir: string): Promise<void> {
+  let server: ViteDevServer | null = null;
+  const scanErrors: string[] = [];
+  const logger = createLogger("silent");
+  logger.error = (msg: string) => {
+    scanErrors.push(String(msg));
+  };
+
+  try {
+    server = await createServer({
+      root: tmpDir,
+      configFile: false,
+      customLogger: logger,
+      plugins: [vinext({ appDir: tmpDir })],
+      logLevel: "silent",
+    });
+    await server.listen();
+    const addr = server.httpServer?.address();
+    const baseUrl = addr && typeof addr === "object" ? `http://localhost:${addr.port}` : "";
+
+    // Trigger the cold-start dependency scan.
+    await fetch(`${baseUrl}/`).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+    const scanFailed = scanErrors.some((e) => e.includes("Failed to run dependency scan"));
+    expect(scanFailed).toBe(false);
+    // The specific OXC parse error must not surface for the .js file.
+    expect(scanErrors.some((e) => e.includes("Unexpected JSX expression"))).toBe(false);
+  } finally {
+    await server?.close();
+  }
 }
 
 describe("optimizeDeps: JSX in plain .js files", () => {
@@ -120,39 +168,19 @@ describe("optimizeDeps: JSX in plain .js files", () => {
   }, 20_000);
 
   describe("dev server", () => {
-    let server: ViteDevServer | null = null;
-    afterAll(async () => {
-      await server?.close();
-    });
-
     it("does not fail the dependency scan when an app .js file uses JSX", async () => {
       const tmpDir = await setupAppProject();
-      const scanErrors: string[] = [];
-      const logger = createLogger("silent");
-      logger.error = (msg: string) => {
-        scanErrors.push(String(msg));
-      };
-
       try {
-        server = await createServer({
-          root: tmpDir,
-          configFile: false,
-          customLogger: logger,
-          plugins: [vinext({ appDir: tmpDir })],
-          logLevel: "silent",
-        });
-        await server.listen();
-        const addr = server.httpServer?.address();
-        const baseUrl = addr && typeof addr === "object" ? `http://localhost:${addr.port}` : "";
+        await expectDevScanAllowsJsxInJs(tmpDir);
+      } finally {
+        await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      }
+    }, 60_000);
 
-        // Trigger the cold-start dependency scan.
-        await fetch(`${baseUrl}/`).catch(() => {});
-        await new Promise((resolve) => setTimeout(resolve, 2_000));
-
-        const scanFailed = scanErrors.some((e) => e.includes("Failed to run dependency scan"));
-        expect(scanFailed).toBe(false);
-        // The specific OXC parse error must not surface for the .js file.
-        expect(scanErrors.some((e) => e.includes("Unexpected JSX expression"))).toBe(false);
+    it("does not fail the dependency scan when a pages .js file uses JSX", async () => {
+      const tmpDir = await setupPagesProject();
+      try {
+        await expectDevScanAllowsJsxInJs(tmpDir);
       } finally {
         await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
       }

--- a/tests/optimize-deps-jsx-in-js.test.ts
+++ b/tests/optimize-deps-jsx-in-js.test.ts
@@ -35,6 +35,21 @@ type VinextPlugin = {
   config?: (config: unknown, env: { command: string }) => unknown;
 };
 
+type OptimizerConfig = {
+  rolldownOptions?: { moduleTypes?: Record<string, string> };
+  esbuildOptions?: { loader?: Record<string, string> };
+};
+
+type VinextConfigResult = {
+  optimizeDeps?: OptimizerConfig;
+  environments?: Record<
+    string,
+    {
+      optimizeDeps?: OptimizerConfig & { entries?: string[] };
+    }
+  >;
+};
+
 async function setupAppProject(): Promise<string> {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-optdeps-jsx-"));
   const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
@@ -139,6 +154,16 @@ async function expectDevScanAllowsJsxInJs(tmpDir: string, expectedTexts: string[
   }
 }
 
+function expectJsxDotJs(optimizeDeps: OptimizerConfig, viteMajor: number) {
+  if (viteMajor >= 8) {
+    expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".js"]).toBe("jsx");
+    expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".mjs"]).toBe("jsx");
+  } else {
+    expect(optimizeDeps.esbuildOptions?.loader?.[".js"]).toBe("jsx");
+    expect(optimizeDeps.esbuildOptions?.loader?.[".mjs"]).toBe("jsx");
+  }
+}
+
 describe("optimizeDeps: JSX in plain .js files", () => {
   const viteMajor = getViteMajorVersion();
 
@@ -154,45 +179,47 @@ describe("optimizeDeps: JSX in plain .js files", () => {
       const result = (await mainPlugin!.config!(
         { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
         { command: "serve" },
-      )) as {
-        optimizeDeps?: {
-          rolldownOptions?: { moduleTypes?: Record<string, string> };
-          esbuildOptions?: { loader?: Record<string, string> };
-        };
-        environments?: Record<
-          string,
-          {
-            optimizeDeps?: {
-              rolldownOptions?: { moduleTypes?: Record<string, string> };
-              esbuildOptions?: { loader?: Record<string, string> };
-            };
-          }
-        >;
-      };
-
-      const expectJsxDotJs = (optimizeDeps: {
-        rolldownOptions?: { moduleTypes?: Record<string, string> };
-        esbuildOptions?: { loader?: Record<string, string> };
-      }) => {
-        // Mirror the main transform's `/\.m?js$/` filter: both .js and .mjs.
-        if (viteMajor >= 8) {
-          expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".js"]).toBe("jsx");
-          expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".mjs"]).toBe("jsx");
-        } else {
-          expect(optimizeDeps.esbuildOptions?.loader?.[".js"]).toBe("jsx");
-          expect(optimizeDeps.esbuildOptions?.loader?.[".mjs"]).toBe("jsx");
-        }
-      };
+      )) as VinextConfigResult;
 
       // Top-level optimizeDeps (Pages Router default + client inheritance).
       expect(result.optimizeDeps).toBeDefined();
-      expectJsxDotJs(result.optimizeDeps!);
+      expectJsxDotJs(result.optimizeDeps!, viteMajor);
 
       // App Router environments each run their own scanner over app/ sources.
       for (const envName of ["rsc", "ssr", "client"] as const) {
         const envOptimizeDeps = result.environments?.[envName]?.optimizeDeps;
         expect(envOptimizeDeps, `${envName} optimizeDeps`).toBeDefined();
-        expectJsxDotJs(envOptimizeDeps!);
+        expectJsxDotJs(envOptimizeDeps!, viteMajor);
+      }
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 20_000);
+
+  it("configures Pages Router build client optimizers to treat .js as JSX", async () => {
+    const tmpDir = await setupPagesProject();
+    try {
+      const getConfig = async (plugins: unknown[]): Promise<VinextConfigResult> => {
+        const vinextPlugins = vinext({ appDir: tmpDir }) as VinextPlugin[];
+        const mainPlugin = vinextPlugins.find(
+          (p) => p.name === "vinext:config" && typeof p.config === "function",
+        );
+        expect(mainPlugin).toBeDefined();
+
+        return (await mainPlugin!.config!(
+          { root: tmpDir, build: {}, plugins, optimizeDeps: {} },
+          { command: "build" },
+        )) as VinextConfigResult;
+      };
+
+      for (const [label, config] of [
+        ["plain", await getConfig([])],
+        ["cloudflare", await getConfig([{ name: "vite-plugin-cloudflare" }])],
+      ] as const) {
+        const clientOptimizeDeps = config.environments?.client?.optimizeDeps;
+        expect(clientOptimizeDeps, `${label} client optimizeDeps`).toBeDefined();
+        expect(clientOptimizeDeps?.entries).toContain("pages/**/*.{tsx,ts,jsx,js}");
+        expectJsxDotJs(clientOptimizeDeps!, viteMajor);
       }
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});

--- a/tests/optimize-deps-jsx-in-js.test.ts
+++ b/tests/optimize-deps-jsx-in-js.test.ts
@@ -10,10 +10,10 @@
  * makes the scan fail with "[PARSE_ERROR] Unexpected JSX expression" and aborts
  * pre-bundling.
  *
- * Fix: vinext configures the dep optimizer to treat `.js`/`.mjs` as JSX
- * (`optimizeDeps.rolldownOptions.moduleTypes` on Vite 8,
- * `optimizeDeps.esbuildOptions.loader` on Vite 7), mirroring how the main
- * transform treats `.js`/`.mjs`.
+ * Fix: vinext configures the dep optimizer to treat `.js`/`.mjs` as JSX via
+ * an optimizer-wide extension mapping (`optimizeDeps.rolldownOptions.moduleTypes`
+ * on Vite 8, `optimizeDeps.esbuildOptions.loader` on Vite 7). This is broader
+ * than `vinext:jsx-in-js` because it can also apply to optimized dependencies.
  *
  * The motivating real-world symptom (issue #5) is that, once the scan aborts,
  * pre-bundling is skipped and UMD/CJS deps can fail to interop under SSR
@@ -61,20 +61,47 @@ async function setupAppProject(): Promise<string> {
 
 async function setupPagesProject(): Promise<string> {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-optdeps-pages-jsx-"));
-  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
-  await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+  await linkRootNodeModulesWithPlainJsDep(tmpDir);
   await fsp.mkdir(path.join(tmpDir, "pages"), { recursive: true });
   await fsp.writeFile(
     path.join(tmpDir, "pages/index.js"),
-    `export default function Page() {
-      return <main>pages jsx in js</main>;
+    `import { plainJsValue } from "plain-js-dep";
+
+export default function Page() {
+      return <main>{plainJsValue} pages jsx in js</main>;
     }`,
   );
   await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
   return tmpDir;
 }
 
-async function expectDevScanAllowsJsxInJs(tmpDir: string): Promise<void> {
+async function linkRootNodeModulesWithPlainJsDep(tmpDir: string): Promise<void> {
+  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  const tmpNodeModules = path.join(tmpDir, "node_modules");
+  await fsp.mkdir(tmpNodeModules, { recursive: true });
+
+  for (const entry of await fsp.readdir(rootNodeModules, { withFileTypes: true })) {
+    if (entry.name === "plain-js-dep") continue;
+    await fsp.symlink(
+      path.join(rootNodeModules, entry.name),
+      path.join(tmpNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+
+  const plainJsDepDir = path.join(tmpNodeModules, "plain-js-dep");
+  await fsp.mkdir(plainJsDepDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(plainJsDepDir, "package.json"),
+    JSON.stringify({ name: "plain-js-dep", version: "1.0.0", type: "module", main: "index.js" }),
+  );
+  await fsp.writeFile(
+    path.join(plainJsDepDir, "index.js"),
+    `export const plainJsValue = 1 < 2 > 0 ? "plain-js-dep-ok" : "plain-js-dep-bad";`,
+  );
+}
+
+async function expectDevScanAllowsJsxInJs(tmpDir: string, expectedTexts: string[]): Promise<void> {
   let server: ViteDevServer | null = null;
   const scanErrors: string[] = [];
   const logger = createLogger("silent");
@@ -95,9 +122,14 @@ async function expectDevScanAllowsJsxInJs(tmpDir: string): Promise<void> {
     const baseUrl = addr && typeof addr === "object" ? `http://localhost:${addr.port}` : "";
 
     // Trigger the cold-start dependency scan.
-    await fetch(`${baseUrl}/`).catch(() => {});
+    const response = await fetch(`${baseUrl}/`);
+    const html = await response.text();
     await new Promise((resolve) => setTimeout(resolve, 2_000));
 
+    expect(response.status).toBe(200);
+    for (const expectedText of expectedTexts) {
+      expect(html).toContain(expectedText);
+    }
     const scanFailed = scanErrors.some((e) => e.includes("Failed to run dependency scan"));
     expect(scanFailed).toBe(false);
     // The specific OXC parse error must not surface for the .js file.
@@ -168,19 +200,10 @@ describe("optimizeDeps: JSX in plain .js files", () => {
   }, 20_000);
 
   describe("dev server", () => {
-    it("does not fail the dependency scan when an app .js file uses JSX", async () => {
-      const tmpDir = await setupAppProject();
-      try {
-        await expectDevScanAllowsJsxInJs(tmpDir);
-      } finally {
-        await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-      }
-    }, 60_000);
-
-    it("does not fail the dependency scan when a pages .js file uses JSX", async () => {
+    it("renders when a pages .js file uses JSX", async () => {
       const tmpDir = await setupPagesProject();
       try {
-        await expectDevScanAllowsJsxInJs(tmpDir);
+        await expectDevScanAllowsJsxInJs(tmpDir, ["plain-js-dep-ok", "pages jsx in js"]);
       } finally {
         await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
       }

--- a/tests/optimize-deps-jsx-in-js.test.ts
+++ b/tests/optimize-deps-jsx-in-js.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Test: JSX in plain .js/.mjs files must not break the optimizeDeps scanner.
+ *
+ * Next.js allows JSX syntax in plain `.js`/`.mjs` files (Babel/SWC handle it
+ * transparently). vinext's main transform handles this via the
+ * `vinext:jsx-in-js` plugin (which matches `/\.m?js$/`) — but the dep optimizer
+ * (scanner + pre-bundler) runs its own Rolldown/esbuild pipeline that does NOT
+ * go through the Vite plugin pipeline. The scanner crawls the app's source
+ * entries to discover dependencies, so a `.js`/`.mjs` source file containing JSX
+ * makes the scan fail with "[PARSE_ERROR] Unexpected JSX expression" and aborts
+ * pre-bundling.
+ *
+ * Fix: vinext configures the dep optimizer to treat `.js`/`.mjs` as JSX
+ * (`optimizeDeps.rolldownOptions.moduleTypes` on Vite 8,
+ * `optimizeDeps.esbuildOptions.loader` on Vite 7), mirroring how the main
+ * transform treats `.js`/`.mjs`.
+ *
+ * The motivating real-world symptom (issue #5) is that, once the scan aborts,
+ * pre-bundling is skipped and UMD/CJS deps can fail to interop under SSR
+ * ("window is not defined"). That downstream cascade runs through a different
+ * optimizer path and is NOT asserted here — these tests only verify that the
+ * scan itself no longer aborts on JSX-in-`.js`/`.mjs`.
+ */
+
+import { describe, it, expect, afterAll } from "vite-plus/test";
+import { createLogger, createServer, type ViteDevServer } from "vite";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import vinext from "../packages/vinext/src/index.js";
+import { getViteMajorVersion } from "../packages/vinext/src/utils/vite-version.js";
+
+type VinextPlugin = {
+  name: string;
+  config?: (config: unknown, env: { command: string }) => unknown;
+};
+
+async function setupAppProject(): Promise<string> {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-optdeps-jsx-"));
+  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+  await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+  await fsp.writeFile(
+    path.join(tmpDir, "app/layout.tsx"),
+    `export default function L({ children }: { children: React.ReactNode }) {
+      return (<html><body>{children}</body></html>);
+    }`,
+  );
+  // page.tsx imports a plain .js module that contains JSX.
+  await fsp.writeFile(
+    path.join(tmpDir, "app/page.tsx"),
+    `import Comp from "./comp.js";\nexport default function P() { return <Comp />; }`,
+  );
+  await fsp.writeFile(
+    path.join(tmpDir, "app/comp.js"),
+    `export default function Comp() { return <div className="x">jsx in js</div>; }`,
+  );
+  await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
+  return tmpDir;
+}
+
+describe("optimizeDeps: JSX in plain .js files", () => {
+  const viteMajor = getViteMajorVersion();
+
+  it("configures the dep optimizer to treat .js as JSX in every environment", async () => {
+    const tmpDir = await setupAppProject();
+    try {
+      const plugins = vinext({ appDir: tmpDir }) as VinextPlugin[];
+      const mainPlugin = plugins.find(
+        (p) => p.name === "vinext:config" && typeof p.config === "function",
+      );
+      expect(mainPlugin).toBeDefined();
+
+      const result = (await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "serve" },
+      )) as {
+        optimizeDeps?: {
+          rolldownOptions?: { moduleTypes?: Record<string, string> };
+          esbuildOptions?: { loader?: Record<string, string> };
+        };
+        environments?: Record<
+          string,
+          {
+            optimizeDeps?: {
+              rolldownOptions?: { moduleTypes?: Record<string, string> };
+              esbuildOptions?: { loader?: Record<string, string> };
+            };
+          }
+        >;
+      };
+
+      const expectJsxDotJs = (optimizeDeps: {
+        rolldownOptions?: { moduleTypes?: Record<string, string> };
+        esbuildOptions?: { loader?: Record<string, string> };
+      }) => {
+        // Mirror the main transform's `/\.m?js$/` filter: both .js and .mjs.
+        if (viteMajor >= 8) {
+          expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".js"]).toBe("jsx");
+          expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".mjs"]).toBe("jsx");
+        } else {
+          expect(optimizeDeps.esbuildOptions?.loader?.[".js"]).toBe("jsx");
+          expect(optimizeDeps.esbuildOptions?.loader?.[".mjs"]).toBe("jsx");
+        }
+      };
+
+      // Top-level optimizeDeps (Pages Router default + client inheritance).
+      expect(result.optimizeDeps).toBeDefined();
+      expectJsxDotJs(result.optimizeDeps!);
+
+      // App Router environments each run their own scanner over app/ sources.
+      for (const envName of ["rsc", "ssr", "client"] as const) {
+        const envOptimizeDeps = result.environments?.[envName]?.optimizeDeps;
+        expect(envOptimizeDeps, `${envName} optimizeDeps`).toBeDefined();
+        expectJsxDotJs(envOptimizeDeps!);
+      }
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 20_000);
+
+  describe("dev server", () => {
+    let server: ViteDevServer | null = null;
+    afterAll(async () => {
+      await server?.close();
+    });
+
+    it("does not fail the dependency scan when an app .js file uses JSX", async () => {
+      const tmpDir = await setupAppProject();
+      const scanErrors: string[] = [];
+      const logger = createLogger("silent");
+      logger.error = (msg: string) => {
+        scanErrors.push(String(msg));
+      };
+
+      try {
+        server = await createServer({
+          root: tmpDir,
+          configFile: false,
+          customLogger: logger,
+          plugins: [vinext({ appDir: tmpDir })],
+          logLevel: "silent",
+        });
+        await server.listen();
+        const addr = server.httpServer?.address();
+        const baseUrl = addr && typeof addr === "object" ? `http://localhost:${addr.port}` : "";
+
+        // Trigger the cold-start dependency scan.
+        await fetch(`${baseUrl}/`).catch(() => {});
+        await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+        const scanFailed = scanErrors.some((e) => e.includes("Failed to run dependency scan"));
+        expect(scanFailed).toBe(false);
+        // The specific OXC parse error must not surface for the .js file.
+        expect(scanErrors.some((e) => e.includes("Unexpected JSX expression"))).toBe(false);
+      } finally {
+        await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      }
+    }, 60_000);
+  });
+});


### PR DESCRIPTION
## Problem
JSX in plain `.js`/`.mjs` source files makes the Vite/rolldown `optimizeDeps` dependency scanner abort with `Unexpected JSX expression` ("JSX syntax is disabled"), so pre-bundling is skipped. Found while porting react.dev, which keeps JSX in `.js` files (e.g. `pages/404.js`, `pages/[[...markdownPath]].js`).

## Root cause
The dependency optimizer (scanner + pre-bundler) runs its own rolldown/esbuild pipeline that does not go through vinext's `vinext:jsx-in-js` transform plugin. App `.js`/`.mjs` source crawled as scan entries is therefore parsed without JSX enabled and aborts the scan.

## Fix
Configure the dep optimizer to treat `.js`/`.mjs` as JSX — `optimizeDeps.rolldownOptions.moduleTypes` on Vite 8, `optimizeDeps.esbuildOptions.loader` on Vite 7 — applied to the top-level and per-environment (rsc/ssr/client) optimizeDeps blocks via the shared `getDepOptimizeNodeEnvOptions`. This mirrors the main transform's `/\.m?js$/` handling (Next/SWC always allow JSX in `.js`).

## Notes
- Distinct from #1199 (main transform) and #1736 (`ignore-dynamic-requests` pre-transform) — this is the dep optimizer, which neither touched.
- The motivating real-world symptom is that, once the scan aborts, pre-bundling is skipped and UMD/CJS deps can fail to interop under SSR (`window is not defined`). That downstream cascade runs through a different optimizer path and is **not** what this change is verified to fix — the tests assert only that the scan no longer aborts on JSX-in-`.js`/`.mjs`.

## Tests
`tests/optimize-deps-jsx-in-js.test.ts`: asserts the resolved optimizeDeps in every environment carries `.js`/`.mjs` → jsx, plus a dev-server integration test confirming the scan no longer fails on JSX-in-`.js`. `pnpm run check` clean.
