### PR TITLE
fix(config): resolve and bundle extensionless .cjs config imports

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1426,7 +1426,24 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     createIgnoreDynamicRequestsPlugin(() => nextConfig?.turbopackTranspilePackages ?? []),
     // Transform CJS require()/module.exports to ESM before other plugins
     // analyze imports (RSC directive scanning, shim resolution, etc.)
-    commonjs(),
+    //
+    // Skip project-local `.cjs`/`.cts` files. `vinext init` renames CJS config
+    // files to `.cjs` (e.g. `tailwind.config.js` → `tailwind.config.cjs`) when
+    // it adds `"type": "module"`, and app code imports them extensionlessly
+    // (`import cfg from "../tailwind.config"`). If `vite-plugin-commonjs`
+    // rewrites their `module.exports` to ESM `export {}`, rolldown still infers
+    // `moduleType: "cjs"` from the `.cjs`/`.cts` extension and re-parses the
+    // rewritten output as CommonJS, failing with "Cannot use export statement
+    // outside a module". Returning `false` makes vite-plugin-commonjs skip these
+    // project-local files so rolldown's own CJS interop bundles them instead.
+    // For everything else we return `undefined` to preserve the plugin's
+    // defaults — including its existing skip of node_modules `.cjs` files.
+    commonjs({
+      filter: (id: string) =>
+        /\.c[jt]s(?:\?.*)?$/.test(id) && !id.split("?")[0].includes("/node_modules/")
+          ? false
+          : undefined,
+    }),
     // Enable JSX in plain .js files. Next.js allows JSX in .js files
     // (Babel/SWC handle it transparently), but Vite 8's built-in `vite:oxc`
     // plugin excludes .js files by default (`exclude: /\.js$/`) AND infers

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -431,6 +431,11 @@ function isScriptModuleId(id: string): boolean {
   return SCRIPT_IMPORT_RE.test(stripViteModuleQuery(id).toLowerCase());
 }
 
+function skipCommonjsForLocalCjs(id: string): false | undefined {
+  const cleanId = normalizePathSeparators(stripViteModuleQuery(id));
+  return /\.c[jt]s$/i.test(cleanId) && !cleanId.includes("node_modules") ? false : undefined;
+}
+
 function hasOnlyTypeSpecifiers(statement: AstStaticDependencyDeclaration): boolean {
   return (
     statement.specifiers !== undefined &&
@@ -1439,10 +1444,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // For everything else we return `undefined` to preserve the plugin's
     // defaults — including its existing skip of node_modules `.cjs` files.
     commonjs({
-      filter: (id: string) =>
-        /\.c[jt]s(?:\?.*)?$/.test(id) && !id.split("?")[0].includes("/node_modules/")
-          ? false
-          : undefined,
+      filter: skipCommonjsForLocalCjs,
     }),
     // Enable JSX in plain .js files. Next.js allows JSX in .js files
     // (Babel/SWC handle it transparently), but Vite 8's built-in `vite:oxc`

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2929,6 +2929,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
         const configuredExtensions =
           name === "client" ? nextConfig.resolveExtensions : nextConfig.serverResolveExtensions;
+        // Explicit resolver extensions replace vinext's defaults, matching
+        // Next.js/Turbopack semantics; callers who override them must include
+        // `.cjs`/`.cts` if they need extensionless imports of CJS config files.
         const extensions =
           configuredExtensions === null
             ? buildViteResolveExtensions(nextConfig.pageExtensions, config.resolve?.extensions)

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -121,11 +121,17 @@ export function findFileWithExts(
  *  1. User-configured pageExtensions go first (each prefixed with `.`) so
  *     the user's priority wins. e.g. `.platform.tsx` resolves before `.tsx`.
  *  2. Vite's defaults follow, with duplicates removed.
+ *  3. `.cjs`/`.cts` go last (lowest priority). Neither Vite's defaults nor the
+ *     user's pageExtensions include them, but `vinext init` renames CJS config
+ *     files (e.g. `tailwind.config.js` → `tailwind.config.cjs`) when it adds
+ *     `"type": "module"`, and app code imports those extensionlessly
+ *     (`import cfg from "../tailwind.config"`). Without these, the bundle fails
+ *     with "[UNRESOLVED_IMPORT] Could not resolve '../tailwind.config'".
  *
  * The user's pageExtensions retain their relative order, which is what
  * Next.js / Turbopack do via the `resolveExtensions` config option.
  *
- * See: cloudflare/vinext#1502
+ * See: cloudflare/vinext#1502, cloudflare/vinext#13
  */
 export function buildViteResolveExtensions(
   pageExtensions?: readonly string[] | null,
@@ -135,7 +141,7 @@ export function buildViteResolveExtensions(
   const dotted = normalized.map((ext) => `.${ext}`);
   const seen = new Set<string>();
   const result: string[] = [];
-  for (const ext of [...dotted, ...viteDefaults]) {
+  for (const ext of [...dotted, ...viteDefaults, ".cjs", ".cts"]) {
     if (seen.has(ext)) continue;
     seen.add(ext);
     result.push(ext);

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -131,7 +131,8 @@ export function findFileWithExts(
  * The user's pageExtensions retain their relative order, which is what
  * Next.js / Turbopack do via the `resolveExtensions` config option.
  *
- * See: cloudflare/vinext#1502
+ * See: cloudflare/vinext#1502 for page-extension ordering, and
+ * cloudflare/vinext#2435 for extensionless `.cjs` config imports.
  */
 export function buildViteResolveExtensions(
   pageExtensions?: readonly string[] | null,

--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -131,7 +131,7 @@ export function findFileWithExts(
  * The user's pageExtensions retain their relative order, which is what
  * Next.js / Turbopack do via the `resolveExtensions` config option.
  *
- * See: cloudflare/vinext#1502, cloudflare/vinext#13
+ * See: cloudflare/vinext#1502
  */
 export function buildViteResolveExtensions(
   pageExtensions?: readonly string[] | null,

--- a/tests/init-cjs-config-resolve.test.ts
+++ b/tests/init-cjs-config-resolve.test.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
+import { createBuilder } from "vite";
+import { describe, expect, it } from "vite-plus/test";
+
+// Regression test for cloudflare/vinext#13.
+//
+// `vinext init` renames CJS config files like `tailwind.config.js` and
+// `postcss.config.js` to `.cjs` when it adds `"type": "module"` to
+// package.json (see renameCJSConfigs in utils/project.ts). react.dev imports
+// the renamed config extensionlessly, e.g.:
+//
+//   import tailwindConfig from "../../tailwind.config";
+//
+// Vite's default `resolve.extensions` does NOT include `.cjs`, so the bundle
+// fails with "[UNRESOLVED_IMPORT] Could not resolve '../../tailwind.config'".
+// vinext overrides `resolve.extensions` for the app graph, so `.cjs` must be in
+// the override list for these renamed configs to resolve extensionlessly.
+describe("vinext init .cjs config extensionless import", () => {
+  it("resolves an extensionless import of a renamed tailwind.config.cjs", async () => {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-init-cjs-resolve-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+    // ESM package — mirrors what `vinext init` writes when it renames CJS
+    // configs to `.cjs` and adds `"type": "module"`.
+    await fs.writeFile(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "init-cjs-resolve-fixture", private: true, type: "module" }),
+    );
+
+    // The renamed CJS config (`tailwind.config.js` → `tailwind.config.cjs`).
+    await fs.writeFile(
+      path.join(tmpDir, "tailwind.config.cjs"),
+      `module.exports = { content: ["./app/**/*.{ts,tsx}"], theme: { tokenMarker: "tailwind-cjs-token" } };`,
+    );
+
+    await fs.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      `export default function Layout({ children }) { return <html><body>{children}</body></html>; }`,
+    );
+    // Extensionless import of the renamed config (react.dev pattern).
+    await fs.writeFile(
+      path.join(tmpDir, "app", "page.tsx"),
+      `import tailwindConfig from "../tailwind.config";
+export default function Page() { return <p>{tailwindConfig.theme.tokenMarker}</p>; }`,
+    );
+
+    try {
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const builtFiles = await fs.readdir(path.join(tmpDir, "dist", "server"), {
+        recursive: true,
+        encoding: "utf8",
+      });
+      const serverOutput = (
+        await Promise.all(
+          builtFiles
+            .filter((file) => file.endsWith(".js"))
+            .map((file) => fs.readFile(path.join(tmpDir, "dist", "server", file), "utf8")),
+        )
+      ).join("\n");
+      expect(serverOutput).toContain("tailwind-cjs-token");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 30000);
+});

--- a/tests/init-cjs-config-resolve.test.ts
+++ b/tests/init-cjs-config-resolve.test.ts
@@ -4,6 +4,63 @@ import fs from "node:fs/promises";
 import { createBuilder } from "vite";
 import { describe, expect, it } from "vite-plus/test";
 
+async function buildAppWithExtensionlessTailwindConfig(
+  configFileName: string,
+  configSource: string,
+  expectedToken: string,
+): Promise<void> {
+  const vinext = (await import("../packages/vinext/src/index.js")).default;
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-init-cjs-resolve-"));
+  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+
+  // ESM package — mirrors what `vinext init` writes when it renames CJS
+  // configs to `.cjs` and adds `"type": "module"`.
+  await fs.writeFile(
+    path.join(tmpDir, "package.json"),
+    JSON.stringify({ name: "init-cjs-resolve-fixture", private: true, type: "module" }),
+  );
+
+  await fs.writeFile(path.join(tmpDir, configFileName), configSource);
+
+  await fs.mkdir(path.join(tmpDir, "app"), { recursive: true });
+  await fs.writeFile(
+    path.join(tmpDir, "app", "layout.tsx"),
+    `export default function Layout({ children }) { return <html><body>{children}</body></html>; }`,
+  );
+  // Extensionless import of the renamed config (react.dev pattern).
+  await fs.writeFile(
+    path.join(tmpDir, "app", "page.tsx"),
+    `import tailwindConfig from "../tailwind.config";
+export default function Page() { return <p>{tailwindConfig.theme.tokenMarker}</p>; }`,
+  );
+
+  try {
+    const builder = await createBuilder({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      logLevel: "silent",
+    });
+    await builder.buildApp();
+
+    const builtFiles = await fs.readdir(path.join(tmpDir, "dist", "server"), {
+      recursive: true,
+      encoding: "utf8",
+    });
+    const serverOutput = (
+      await Promise.all(
+        builtFiles
+          .filter((file) => file.endsWith(".js"))
+          .map((file) => fs.readFile(path.join(tmpDir, "dist", "server", file), "utf8")),
+      )
+    ).join("\n");
+    expect(serverOutput).toContain(expectedToken);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
 // Regression test for extensionless imports of vinext init-renamed CJS configs.
 //
 // `vinext init` renames CJS config files like `tailwind.config.js` and
@@ -15,63 +72,29 @@ import { describe, expect, it } from "vite-plus/test";
 //
 // Vite's default `resolve.extensions` does NOT include `.cjs`, so the bundle
 // fails with "[UNRESOLVED_IMPORT] Could not resolve '../../tailwind.config'".
-// vinext overrides `resolve.extensions` for the app graph, so `.cjs` must be in
-// the override list for these renamed configs to resolve extensionlessly.
-describe("vinext init .cjs config extensionless import", () => {
+// vinext overrides `resolve.extensions` for the app graph, so CJS config
+// extensions must be in the override list for these configs to resolve
+// extensionlessly. `.cts` is covered defensively for TypeScript CJS configs;
+// Next.js has matching .cts PostCSS config coverage.
+describe("vinext init CJS config extensionless import", () => {
   it("resolves an extensionless import of a renamed tailwind.config.cjs", async () => {
-    const vinext = (await import("../packages/vinext/src/index.js")).default;
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-init-cjs-resolve-"));
-    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
-    await fs.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
-
-    // ESM package — mirrors what `vinext init` writes when it renames CJS
-    // configs to `.cjs` and adds `"type": "module"`.
-    await fs.writeFile(
-      path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "init-cjs-resolve-fixture", private: true, type: "module" }),
-    );
-
-    // The renamed CJS config (`tailwind.config.js` → `tailwind.config.cjs`).
-    await fs.writeFile(
-      path.join(tmpDir, "tailwind.config.cjs"),
+    await buildAppWithExtensionlessTailwindConfig(
+      "tailwind.config.cjs",
       `module.exports = { content: ["./app/**/*.{ts,tsx}"], theme: { tokenMarker: "tailwind-cjs-token" } };`,
+      "tailwind-cjs-token",
     );
+  }, 30000);
 
-    await fs.mkdir(path.join(tmpDir, "app"), { recursive: true });
-    await fs.writeFile(
-      path.join(tmpDir, "app", "layout.tsx"),
-      `export default function Layout({ children }) { return <html><body>{children}</body></html>; }`,
+  it("resolves an extensionless import of a TypeScript tailwind.config.cts", async () => {
+    // .cts is not produced by `vinext init`, but Next.js supports TypeScript
+    // CJS config files. Keep it covered because `.cts` shares the same
+    // resolution and CommonJS-transform skip path as `.cjs`.
+    await buildAppWithExtensionlessTailwindConfig(
+      "tailwind.config.cts",
+      `type TailwindConfig = { content: string[]; theme: { tokenMarker: string } };
+const config: TailwindConfig = { content: ["./app/**/*.{ts,tsx}"], theme: { tokenMarker: "tailwind-cts-token" } };
+module.exports = config;`,
+      "tailwind-cts-token",
     );
-    // Extensionless import of the renamed config (react.dev pattern).
-    await fs.writeFile(
-      path.join(tmpDir, "app", "page.tsx"),
-      `import tailwindConfig from "../tailwind.config";
-export default function Page() { return <p>{tailwindConfig.theme.tokenMarker}</p>; }`,
-    );
-
-    try {
-      const builder = await createBuilder({
-        root: tmpDir,
-        configFile: false,
-        plugins: [vinext({ appDir: tmpDir })],
-        logLevel: "silent",
-      });
-      await builder.buildApp();
-
-      const builtFiles = await fs.readdir(path.join(tmpDir, "dist", "server"), {
-        recursive: true,
-        encoding: "utf8",
-      });
-      const serverOutput = (
-        await Promise.all(
-          builtFiles
-            .filter((file) => file.endsWith(".js"))
-            .map((file) => fs.readFile(path.join(tmpDir, "dist", "server", file), "utf8")),
-        )
-      ).join("\n");
-      expect(serverOutput).toContain("tailwind-cjs-token");
-    } finally {
-      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-    }
   }, 30000);
 });

--- a/tests/init-cjs-config-resolve.test.ts
+++ b/tests/init-cjs-config-resolve.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import { createBuilder } from "vite";
 import { describe, expect, it } from "vite-plus/test";
 
-// Regression test for cloudflare/vinext#13.
+// Regression test for extensionless imports of vinext init-renamed CJS configs.
 //
 // `vinext init` renames CJS config files like `tailwind.config.js` and
 // `postcss.config.js` to `.cjs` when it adds `"type": "module"` to

--- a/tests/page-extensions-resolve.test.ts
+++ b/tests/page-extensions-resolve.test.ts
@@ -23,7 +23,7 @@ describe("buildViteResolveExtensions", () => {
     // Even without a user-set pageExtensions, vinext normalises to the
     // Next.js defaults `["tsx", "ts", "jsx", "js"]` and uses that order.
     // `.cjs`/`.cts` trail the list so `vinext init`-renamed CJS configs
-    // (`tailwind.config.cjs`) resolve extensionlessly — cloudflare/vinext#13.
+    // (`tailwind.config.cjs`) resolve extensionlessly.
     const extensions = buildViteResolveExtensions(undefined);
     expect(extensions).toEqual([
       ".tsx",

--- a/tests/page-extensions-resolve.test.ts
+++ b/tests/page-extensions-resolve.test.ts
@@ -22,13 +22,35 @@ describe("buildViteResolveExtensions", () => {
   it("applies Next.js default pageExtensions priority when pageExtensions is undefined", () => {
     // Even without a user-set pageExtensions, vinext normalises to the
     // Next.js defaults `["tsx", "ts", "jsx", "js"]` and uses that order.
+    // `.cjs`/`.cts` trail the list so `vinext init`-renamed CJS configs
+    // (`tailwind.config.cjs`) resolve extensionlessly — cloudflare/vinext#13.
     const extensions = buildViteResolveExtensions(undefined);
-    expect(extensions).toEqual([".tsx", ".ts", ".jsx", ".js", ".mjs", ".mts", ".json"]);
+    expect(extensions).toEqual([
+      ".tsx",
+      ".ts",
+      ".jsx",
+      ".js",
+      ".mjs",
+      ".mts",
+      ".json",
+      ".cjs",
+      ".cts",
+    ]);
   });
 
   it("returns the same list when pageExtensions matches the Next.js defaults", () => {
     const extensions = buildViteResolveExtensions(["tsx", "ts", "jsx", "js"]);
-    expect(extensions).toEqual([".tsx", ".ts", ".jsx", ".js", ".mjs", ".mts", ".json"]);
+    expect(extensions).toEqual([
+      ".tsx",
+      ".ts",
+      ".jsx",
+      ".js",
+      ".mjs",
+      ".mts",
+      ".json",
+      ".cjs",
+      ".cts",
+    ]);
   });
 
   it("prepends configured pageExtensions so user priority wins", () => {


### PR DESCRIPTION
## Problem
After `vinext init` renames `tailwind.config.js` / `postcss.config.js` to `.cjs` (required under `"type": "module"`), app code that imports the config extensionlessly — e.g. `import tailwindConfig from '../../tailwind.config'` (react.dev's `Themes.tsx`) — fails to build. Two failures: `UNRESOLVED_IMPORT` (`.cjs` not in the app graph's `resolve.extensions`), and once resolved, `Cannot use export statement outside a module` (the `.cjs` couldn't be bundled).

## Root cause
- vinext's default `resolve.extensions` (`buildViteResolveExtensions`) omitted `.cjs`/`.cts`. Vite's own default also omits them; the `.cjs` entry in the config-loader extensions applied only to loading `next.config`, not the app module graph.
- `vite-plugin-commonjs` rewrote the project `.cjs` `module.exports` to ESM `export {}`, but rolldown infers `moduleType: "cjs"` from the extension and re-parsed it as CommonJS.

## Fix
- Append `.cjs`/`.cts` (lowest priority, after `.json`) to the default `resolve.extensions` so extensionless imports of the renamed configs resolve. Only in the default branch — a user-set `resolveExtensions` is untouched.
- Give `commonjs()` a filter that returns `false` for project-local `.cjs`/`.cts` so they skip vite-plugin-commonjs and let rolldown's native CJS interop bundle them; node_modules `.cjs` keep their existing default-skip behavior.

## Notes
Distinct from #1958/#1959 (resolve-extensions / webpack-config work) — neither covered the renamed-`.cjs` config import. Tailored to vinext's own `init` renames (Next.js doesn't rename configs); additive and lowest-priority, so no `.js`/`.ts`/`.tsx` sibling is shadowed.

## Tests
`tests/init-cjs-config-resolve.test.ts`: a real `buildApp()` over an ESM-type package with a renamed `tailwind.config.cjs` imported extensionlessly — both failures gone. `tests/page-extensions-resolve.test.ts` assertions updated. `pnpm run check` clean.
