### PR TITLE
test(routing): cover optional catch-all root with empty params

### DIFF
--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -322,6 +322,47 @@ export default function middleware() {
   );
 }
 
+/**
+ * Fixture: a ROOT-level optional catch-all page `pages/[[...markdownPath]].js`
+ * whose getStaticPaths emits an empty-params entry (`{ markdownPath: [] }`) for
+ * the homepage plus one concrete path. Models the react.dev shape where nearly
+ * everything is served from `src/pages/[[...markdownPath]].js` and the homepage
+ * is the empty-params root. Under Next.js this serves `/` with empty params.
+ *
+ * Regression for issue #3: vinext must serve the root `/` (and its
+ * `/_next/data/<id>/index.json`) for an optional catch-all root, not 404.
+ */
+function writeOptionalCatchAllRootFixture(rootDir: string): void {
+  fs.mkdirSync(path.join(rootDir, "pages"), { recursive: true });
+  const nmLink = path.join(rootDir, "node_modules");
+  if (!fs.existsSync(nmLink)) {
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), nmLink);
+  }
+  fs.writeFileSync(
+    path.join(rootDir, "next.config.js"),
+    `module.exports = { generateBuildId: () => "test-build-id" };\n`,
+  );
+  fs.writeFileSync(path.join(rootDir, "pages", "_app.js"), PAGES_APP_COMPONENT);
+  fs.writeFileSync(
+    path.join(rootDir, "pages", "[[...markdownPath]].js"),
+    `export default function MarkdownPage({ markdownPath }) {
+  return <main><p id="content">Path: [{(markdownPath || []).join("/")}]</p></main>;
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [{ params: { markdownPath: [] } }, { params: { markdownPath: ["learn"] } }],
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }) {
+  return { props: { markdownPath: params.markdownPath ?? [] } };
+}
+`,
+  );
+}
+
 function writeGsspAppInitialPropsContextFixture(rootDir: string): void {
   fs.mkdirSync(path.join(rootDir, "pages", "blog", "[post]"), { recursive: true });
   fs.mkdirSync(path.join(rootDir, "pages", "rewrite-target"), { recursive: true });
@@ -1613,6 +1654,46 @@ describe("Pages Router integration", () => {
 
     const unlistedRes = await fetch(`${baseUrl}/mixed-catchall/unlisted`);
     expect(unlistedRes.status).toBe(404);
+  });
+
+  // Regression for issue #3: a ROOT-level optional catch-all
+  // `pages/[[...markdownPath]].js` whose getStaticPaths emits the empty-params
+  // entry `{ markdownPath: [] }` must serve the root `/` (HTML) and its
+  // `/_next/data/<id>/index.json` endpoint, not 404. This is the react.dev
+  // shape; the existing optional catch-all test only covers a non-root subpath.
+  it("serves the root / for an optional catch-all root with empty params (dev)", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-optional-catchall-root-"));
+    writeOptionalCatchAllRootFixture(tmpDir);
+
+    let tempServer: ViteDevServer | undefined;
+    try {
+      const started = await startFixtureServer(tmpDir);
+      tempServer = started.server;
+
+      // (b) dev renders the root `/` HTML with empty params.
+      const rootRes = await fetch(`${started.baseUrl}/`);
+      expect(rootRes.status).toBe(200);
+      const rootHtml = await rootRes.text();
+      expect(rootHtml).toMatch(/Path: \[(?:<!-- -->)?\]/);
+
+      // (c) the `_next/data/<id>/index.json` endpoint serves the root data.
+      const dataRes = await fetch(`${started.baseUrl}/_next/data/test-build-id/index.json`);
+      expect(dataRes.status).toBe(200);
+      const data = (await dataRes.json()) as { pageProps: { markdownPath: string[] } };
+      expect(data.pageProps.markdownPath).toEqual([]);
+
+      // A non-root concrete path still works (proves the root case is specific).
+      const learnRes = await fetch(`${started.baseUrl}/learn`);
+      expect(learnRes.status).toBe(200);
+      expect(await learnRes.text()).toContain("Path: [");
+
+      // An unlisted path with fallback:false is still a 404.
+      const unlistedRes = await fetch(`${started.baseUrl}/unlisted-path`);
+      expect(unlistedRes.status).toBe(404);
+    } finally {
+      await tempServer?.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("renders pre-listed paths with getStaticPaths fallback: blocking", async () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -323,14 +323,11 @@ export default function middleware() {
 }
 
 /**
- * Fixture: a ROOT-level optional catch-all page `pages/[[...markdownPath]].js`
+ * Fixture: a root-level optional catch-all page `pages/[[...markdownPath]].js`
  * whose getStaticPaths emits an empty-params entry (`{ markdownPath: [] }`) for
  * the homepage plus one concrete path. Models the react.dev shape where nearly
  * everything is served from `src/pages/[[...markdownPath]].js` and the homepage
  * is the empty-params root. Under Next.js this serves `/` with empty params.
- *
- * Regression for issue #3: vinext must serve the root `/` (and its
- * `/_next/data/<id>/index.json`) for an optional catch-all root, not 404.
  */
 function writeOptionalCatchAllRootFixture(rootDir: string): void {
   fs.mkdirSync(path.join(rootDir, "pages"), { recursive: true });
@@ -1656,7 +1653,9 @@ describe("Pages Router integration", () => {
     expect(unlistedRes.status).toBe(404);
   });
 
-  // Regression for issue #3: a ROOT-level optional catch-all
+  // Ported from Next.js: test/e2e/dynamic-optional-routing-root-static-paths
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/dynamic-optional-routing-root-static-paths/dynamic-optional-routing-root-static-paths.test.ts
+  // A root-level optional catch-all
   // `pages/[[...markdownPath]].js` whose getStaticPaths emits the empty-params
   // entry `{ markdownPath: [] }` must serve the root `/` (HTML) and its
   // `/_next/data/<id>/index.json` endpoint, not 404. This is the react.dev
@@ -1670,13 +1669,13 @@ describe("Pages Router integration", () => {
       const started = await startFixtureServer(tmpDir);
       tempServer = started.server;
 
-      // (b) dev renders the root `/` HTML with empty params.
+      // Dev renders the root `/` HTML with empty params.
       const rootRes = await fetch(`${started.baseUrl}/`);
       expect(rootRes.status).toBe(200);
       const rootHtml = await rootRes.text();
       expect(rootHtml).toMatch(/Path: \[(?:<!-- -->)?\]/);
 
-      // (c) the `_next/data/<id>/index.json` endpoint serves the root data.
+      // The `_next/data/<id>/index.json` endpoint serves the root data.
       const dataRes = await fetch(`${started.baseUrl}/_next/data/test-build-id/index.json`);
       expect(dataRes.status).toBe(200);
       const data = (await dataRes.json()) as { pageProps: { markdownPath: string[] } };
@@ -1685,7 +1684,7 @@ describe("Pages Router integration", () => {
       // A non-root concrete path still works (proves the root case is specific).
       const learnRes = await fetch(`${started.baseUrl}/learn`);
       expect(learnRes.status).toBe(200);
-      expect(await learnRes.text()).toContain("Path: [");
+      expect(await learnRes.text()).toMatch(/Path: \[(?:<!-- -->)?learn(?:<!-- -->)?\]/);
 
       // An unlisted path with fallback:false is still a 404.
       const unlistedRes = await fetch(`${started.baseUrl}/unlisted-path`);


### PR DESCRIPTION
## Context
A user reported that a root-level optional catch-all page `pages/[[...slug]].js` whose `getStaticPaths` emits `{ slug: [] }` did not serve `/` (404). react.dev serves its homepage this way.

## Finding
This is **already fixed on current `main`**: the radix route trie matches a zero-segment optional catch-all at the root (`routing/route-trie.ts`), `fillRoutePatternSegments` maps an empty array to `/`, and `matchesPagesStaticPath` treats an empty optional catch-all entry as matching the root (matching Next.js `build/static-paths/pages.ts`). Related: #2238.

## What this PR adds
A **regression test only** (no production change) covering the exact reported case end-to-end through the dev server: a root `pages/[[...markdownPath]].js` with `getStaticPaths` `[{ params: { markdownPath: [] } }]`, `fallback: false`, asserting `GET /` → 200 with empty params, `_next/data/<id>/index.json` → 200, a non-root concrete path → 200, and an unlisted path → 404. Verified load-bearing (disabling the trie's zero-segment branch reproduces the original 404 and fails the test). The existing trie unit test covers the pure matcher; this adds the missing full-stack integration coverage.

`pnpm run check` clean.
