### PR TITLE
perf(build): parallelize prerender across a pool of render processes

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -40,6 +40,9 @@ export default {
         "src/server/app-browser-entry.ts",
         "src/server/app-browser-server-action-client.ts",
         "src/server/app-ssr-entry.ts",
+        // Forked as a child process by prerender-server-pool.ts via a path
+        // constant (child_process.fork), so knip can't trace it as imported.
+        "src/build/prerender-server-entry.ts",
         // Runtime helpers imported by generated virtual entries. The imports
         // are emitted as strings, so knip cannot trace them statically.
         "src/server/app-middleware.ts",

--- a/packages/vinext/src/build/prerender-server-entry.ts
+++ b/packages/vinext/src/build/prerender-server-entry.ts
@@ -1,0 +1,55 @@
+/**
+ * Child-process entry for a parallel prerender render server.
+ *
+ * Forked by `prerender-server-pool.ts`. React SSR/RSC rendering is CPU-bound
+ * JS, so a single-process promise pool serializes every render on one core.
+ * This entry lets the prerender phase fan rendering out across N OS processes
+ * (one per core, like Next.js's static worker pool): each child starts a normal
+ * vinext production server on an ephemeral port and reports it to the parent
+ * over IPC. The parent then load-balances per-route fetches across the pool.
+ *
+ * `VINEXT_PRERENDER` / `VINEXT_PRERENDER_OUTDIR` are passed via the fork env so
+ * they are set before any module loads (some server modules read the flag at
+ * import time).
+ */
+import { startProdServer } from "../server/prod-server.js";
+import { NoOpCacheHandler, setCacheHandler } from "vinext/shims/cache-handler";
+
+async function main(): Promise<void> {
+  const outDir = process.env.VINEXT_PRERENDER_OUTDIR;
+  if (!outDir) {
+    throw new Error("[vinext] prerender server worker: VINEXT_PRERENDER_OUTDIR not set");
+  }
+  // Match the single-process prerender path, which installs a NoOp cache
+  // handler in the build process (prerenderPages/prerenderApp). The cache
+  // handler is a process-global (globalThis + Symbol.for), so setting it here
+  // makes this child render byte-identically to the in-process server — no ISR
+  // / unstable_cache / fetch-cache reuse across routes within a worker.
+  setCacheHandler(new NoOpCacheHandler());
+  const { port } = await startProdServer({
+    port: 0,
+    host: "127.0.0.1",
+    outDir,
+    noCompression: true,
+    purpose: "prerender",
+  });
+  if (typeof process.send === "function") {
+    process.send({ type: "ready", port });
+  } else {
+    throw new Error("[vinext] prerender server worker: no IPC channel to parent");
+  }
+}
+
+// If the parent build process dies (crash, SIGKILL, cancelled CI job), the IPC
+// channel closes — exit so this listening server doesn't survive as an orphan
+// holding its port and ~hundreds of MB.
+process.on("disconnect", () => process.exit(0));
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  if (typeof process.send === "function") {
+    process.send({ type: "error", error: message });
+  }
+  // Give the IPC message a tick to flush before exiting.
+  setTimeout(() => process.exit(1), 50);
+});

--- a/packages/vinext/src/build/prerender-server-entry.ts
+++ b/packages/vinext/src/build/prerender-server-entry.ts
@@ -32,6 +32,7 @@ async function main(): Promise<void> {
     outDir,
     noCompression: true,
     purpose: "prerender",
+    silent: true,
   });
   if (typeof process.send === "function") {
     process.send({ type: "ready", port });
@@ -48,8 +49,8 @@ process.on("disconnect", () => process.exit(0));
 main().catch((err: unknown) => {
   const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
   if (typeof process.send === "function") {
-    process.send({ type: "error", error: message });
+    process.send({ type: "error", error: message }, () => process.exit(1));
+    return;
   }
-  // Give the IPC message a tick to flush before exiting.
-  setTimeout(() => process.exit(1), 50);
+  process.exit(1);
 });

--- a/packages/vinext/src/build/prerender-server-pool.ts
+++ b/packages/vinext/src/build/prerender-server-pool.ts
@@ -40,12 +40,24 @@ const MAX_POOL_SIZE = 8;
  * parallel-render saving (measured: a 2-worker pool only reliably beats the
  * single server from ~50 routes/worker up). */
 const MIN_ROUTES_PER_WORKER = 48;
+/** Rough memory budget reserved for the main build process plus its in-process
+ * prerender server. */
+const APPROX_MAIN_PROCESS_BYTES = 768 * 1024 * 1024;
 /** Rough memory budget per worker (a worker loads the whole server bundle).
- * Used to cap the pool on memory-constrained machines so K render processes
- * don't OOM. Conservative — measured ~260-380 MB/worker for a mid-size app. */
+ * Used with total system memory as a coarse upper bound on constrained machines
+ * so K render processes don't OOM. Deliberately under-forks rather than risking
+ * OOM; measured mid-size apps are usually lower (~260-380 MB/worker). */
 const APPROX_BYTES_PER_WORKER = 768 * 1024 * 1024;
 /** Per-worker readiness timeout. */
 const WORKER_READY_TIMEOUT_MS = 60_000;
+/** Best-effort close timeout so build cleanup is not blocked forever by a wedged child. */
+const WORKER_CLOSE_TIMEOUT_MS = 5_000;
+const PRERENDER_WORKER_TRANSPORT_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EPIPE",
+  "UND_ERR_SOCKET",
+]);
 
 export type PrerenderServerPool = {
   /** Ports of the forked render servers, for round-robin per-route fetches. */
@@ -59,6 +71,11 @@ export type PrerenderServerPool = {
    * design, where a server crash takes the whole build down loudly.
    */
   assertHealthy: () => void;
+  /**
+   * Record a failed fetch to a render worker. This closes the tiny ordering gap
+   * where the request can fail before Node has delivered the child `exit` event.
+   */
+  recordRenderError: (err: unknown) => void;
   /** Kill every forked server. Safe to call more than once. */
   close: () => Promise<void>;
 };
@@ -68,17 +85,36 @@ export type PrerenderServerPool = {
  *
  * Returns 1 to mean "don't fork — render in-process as before" (small apps,
  * single/dual-core, low memory, or an explicit `--prerender-concurrency 1`).
- * `maxOverride` comes from `--prerender-concurrency`.
+ * `maxOverride` comes from `--prerender-concurrency`, which caps both the
+ * number of in-flight route fetches and the worker count (the default is capped
+ * at `min(cores, 8)`).
  */
 export function resolvePrerenderPoolSize(routeCount: number, maxOverride?: number): number {
   const cores = Math.max(1, os.availableParallelism());
   // Leave one core for the main thread (fetch + file writes) and OS.
   const byCores = Math.max(1, Math.min(cores - 1, MAX_POOL_SIZE));
-  // Cap by available memory so K bundles don't OOM on constrained CI.
-  const byMemory = Math.max(1, Math.floor(os.totalmem() / APPROX_BYTES_PER_WORKER));
+  // Cap by total memory, reserving room for the main process/in-process server
+  // first. This is still a coarse upper bound (not live free memory), so worker
+  // OOMs remain fatal via assertHealthy().
+  const memoryForWorkers = Math.max(0, os.totalmem() - APPROX_MAIN_PROCESS_BYTES);
+  const byMemory = Math.max(1, Math.floor(memoryForWorkers / APPROX_BYTES_PER_WORKER));
   const cap = maxOverride && maxOverride > 0 ? Math.min(maxOverride, byCores) : byCores;
   const byRoutes = Math.floor(routeCount / MIN_ROUTES_PER_WORKER);
   return Math.max(1, Math.min(cap, byMemory, byRoutes));
+}
+
+function getErrorCauseCode(err: unknown): string | undefined {
+  if (!(err instanceof Error)) return undefined;
+  const cause = err.cause as { code?: unknown } | undefined;
+  return typeof cause?.code === "string" ? cause.code : undefined;
+}
+
+function isWorkerTransportError(err: unknown): boolean {
+  const code = getErrorCauseCode(err);
+  if (code && PRERENDER_WORKER_TRANSPORT_ERROR_CODES.has(code)) return true;
+  // A render-worker fetch transport failure means the route response was never
+  // produced. Fail loud even if the worker exit has not been observed yet.
+  return err instanceof TypeError && err.message === "fetch failed";
 }
 
 /**
@@ -89,17 +125,16 @@ export function resolvePrerenderPoolSize(routeCount: number, maxOverride?: numbe
 export async function startPrerenderServerPool(
   outDir: string,
   size: number,
+  entry = WORKER_ENTRY,
 ): Promise<PrerenderServerPool> {
-  const entry = WORKER_ENTRY;
   const children: ChildProcess[] = [];
   let shuttingDown = false;
   let crash: { port?: number; code: number | null; signal: NodeJS.Signals | null } | null = null;
+  let renderTransportError: Error | null = null;
 
   const close = async (): Promise<void> => {
     shuttingDown = true;
-    for (const child of children) {
-      if (!child.killed) child.kill("SIGKILL");
-    }
+    await Promise.all(children.map(closeChild));
   };
 
   try {
@@ -120,13 +155,22 @@ export async function startPrerenderServerPool(
         const timer = setTimeout(() => {
           reject(new Error("[vinext] prerender render server did not start within 60s"));
         }, WORKER_READY_TIMEOUT_MS);
-        child.once("message", (msg: { type?: string; port?: number; error?: string }) => {
+
+        const cleanupStartupListeners = () => {
           clearTimeout(timer);
+          child.off("message", onMessage);
+          child.off("error", onError);
+          child.off("exit", onStartupExit);
+        };
+        const onMessage = (msg: { type?: string; port?: number; error?: string }) => {
+          cleanupStartupListeners();
           if (msg?.type === "ready" && typeof msg.port === "number") {
             // Once ready, a later exit before close() is a crash — record it so
             // assertHealthy() can fail the build instead of shipping partial output.
             child.once("exit", (code, signal) => {
               if (!shuttingDown && !crash) {
+                // First crash is enough to fail the build; keep the earliest
+                // port/code in the error rather than collecting every exit.
                 crash = { port: msg.port, code, signal };
               }
             });
@@ -136,28 +180,37 @@ export async function startPrerenderServerPool(
               new Error(`[vinext] prerender render server failed: ${msg?.error ?? "unknown"}`),
             );
           }
-        });
-        child.once("error", (err) => {
-          clearTimeout(timer);
+        };
+        const onError = (err: Error) => {
+          cleanupStartupListeners();
           reject(err);
-        });
-        // A child killed by signal reports code === null; reject on either so an
-        // OOM-killed (SIGKILL) startup fails fast instead of waiting out the 60s
-        // readiness timeout.
-        child.once("exit", (code, signal) => {
-          if (code || signal) {
-            clearTimeout(timer);
+        };
+        const onStartupExit = (code: number | null, signal: NodeJS.Signals | null) => {
+          if (code !== null || signal !== null) {
+            cleanupStartupListeners();
             reject(
               new Error(
                 `[vinext] prerender render server exited during startup (code ${code}, signal ${signal})`,
               ),
             );
           }
-        });
+        };
+
+        child.once("message", onMessage);
+        child.once("error", onError);
+        // A child killed by signal reports code === null; reject on either so an
+        // OOM-killed (SIGKILL) startup fails fast instead of waiting out the 60s
+        // readiness timeout.
+        child.once("exit", onStartupExit);
       });
     });
 
     const ports = await Promise.all(readies);
+    const recordRenderError = (err: unknown): void => {
+      if (!renderTransportError && isWorkerTransportError(err)) {
+        renderTransportError = err instanceof Error ? err : new Error(String(err));
+      }
+    };
     const assertHealthy = (): void => {
       if (crash) {
         throw new Error(
@@ -167,10 +220,38 @@ export async function startPrerenderServerPool(
             `This is often an out-of-memory kill — try a lower --prerender-concurrency.`,
         );
       }
+      if (renderTransportError) {
+        const causeCode = getErrorCauseCode(renderTransportError);
+        throw new Error(
+          `[vinext] A prerender render worker request failed` +
+            (causeCode ? ` (${causeCode})` : "") +
+            ` before the worker exit was observed. ` +
+            `Prerender output is incomplete; failing the build. ` +
+            `This is often an out-of-memory kill — try a lower --prerender-concurrency.`,
+        );
+      }
     };
-    return { ports, assertHealthy, close };
+    return { ports, assertHealthy, recordRenderError, close };
   } catch (err) {
     await close();
     throw err;
   }
+}
+
+async function closeChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  const exited = new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, WORKER_CLOSE_TIMEOUT_MS);
+    timer.unref?.();
+    const finish = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    child.once("exit", finish);
+    if (child.exitCode !== null || child.signalCode !== null) finish();
+  });
+
+  if (!child.killed) child.kill("SIGKILL");
+  await exited;
 }

--- a/packages/vinext/src/build/prerender-server-pool.ts
+++ b/packages/vinext/src/build/prerender-server-pool.ts
@@ -1,0 +1,176 @@
+/**
+ * Parallel prerender server pool.
+ *
+ * React SSR/RSC rendering during prerender is CPU-bound JS. vinext renders
+ * every route by fetching it from a single in-process production server, so the
+ * promise pool in `prerender.ts` only overlaps I/O — the actual rendering
+ * serializes on one core. This module forks a pool of OS processes (one vinext
+ * production server each, on its own ephemeral port) so the prerender phase can
+ * spread rendering across cores, mirroring Next.js's static worker pool. The
+ * caller load-balances per-route fetches across `ports`.
+ *
+ * child_process (not worker_threads) is deliberate: worker threads share the
+ * process and contend badly for CPU on this workload (measured ~2× slower
+ * per route and non-scaling), which is also why Next.js uses processes.
+ */
+import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKER_ENTRY = path.join(__dirname, "prerender-server-entry.js");
+
+/**
+ * Whether the forkable worker entry exists as a runnable `.js` sibling. False
+ * when vinext runs from source (e.g. the test suite transpiles `.ts` on the
+ * fly and a forked plain-node child can't load `.ts`); callers fall back to the
+ * single in-process server. True in the published/built package.
+ */
+export function prerenderPoolAvailable(): boolean {
+  return fs.existsSync(WORKER_ENTRY);
+}
+
+/** Hard cap on render processes. Beyond this the main thread (which collects
+ * HTML and writes files) becomes the bottleneck, so more workers don't help. */
+const MAX_POOL_SIZE = 8;
+/** Don't fork a dedicated process unless a worker gets at least this many
+ * routes — below this the fork + bundle-import startup cost outweighs the
+ * parallel-render saving (measured: a 2-worker pool only reliably beats the
+ * single server from ~50 routes/worker up). */
+const MIN_ROUTES_PER_WORKER = 48;
+/** Rough memory budget per worker (a worker loads the whole server bundle).
+ * Used to cap the pool on memory-constrained machines so K render processes
+ * don't OOM. Conservative — measured ~260-380 MB/worker for a mid-size app. */
+const APPROX_BYTES_PER_WORKER = 768 * 1024 * 1024;
+/** Per-worker readiness timeout. */
+const WORKER_READY_TIMEOUT_MS = 60_000;
+
+export type PrerenderServerPool = {
+  /** Ports of the forked render servers, for round-robin per-route fetches. */
+  ports: number[];
+  /**
+   * Throw if any worker exited unexpectedly (i.e. not via `close()`). The
+   * caller MUST call this after the render loop: a crashed worker makes every
+   * route routed to it fail with a connection error, which the per-route
+   * handler records as a (non-fatal) error — without this check the build
+   * would emit partial output and still exit 0. Mirrors the single-process
+   * design, where a server crash takes the whole build down loudly.
+   */
+  assertHealthy: () => void;
+  /** Kill every forked server. Safe to call more than once. */
+  close: () => Promise<void>;
+};
+
+/**
+ * Choose how many render processes to fork for `routeCount` routes.
+ *
+ * Returns 1 to mean "don't fork — render in-process as before" (small apps,
+ * single/dual-core, low memory, or an explicit `--prerender-concurrency 1`).
+ * `maxOverride` comes from `--prerender-concurrency`.
+ */
+export function resolvePrerenderPoolSize(routeCount: number, maxOverride?: number): number {
+  const cores = Math.max(1, os.availableParallelism());
+  // Leave one core for the main thread (fetch + file writes) and OS.
+  const byCores = Math.max(1, Math.min(cores - 1, MAX_POOL_SIZE));
+  // Cap by available memory so K bundles don't OOM on constrained CI.
+  const byMemory = Math.max(1, Math.floor(os.totalmem() / APPROX_BYTES_PER_WORKER));
+  const cap = maxOverride && maxOverride > 0 ? Math.min(maxOverride, byCores) : byCores;
+  const byRoutes = Math.floor(routeCount / MIN_ROUTES_PER_WORKER);
+  return Math.max(1, Math.min(cap, byMemory, byRoutes));
+}
+
+/**
+ * Fork `size` production servers against `outDir` and resolve once all are
+ * listening. Each child reports its port over IPC. Rejects (and tears down any
+ * already-started children) if any child fails to come up.
+ */
+export async function startPrerenderServerPool(
+  outDir: string,
+  size: number,
+): Promise<PrerenderServerPool> {
+  const entry = WORKER_ENTRY;
+  const children: ChildProcess[] = [];
+  let shuttingDown = false;
+  let crash: { port?: number; code: number | null; signal: NodeJS.Signals | null } | null = null;
+
+  const close = async (): Promise<void> => {
+    shuttingDown = true;
+    for (const child of children) {
+      if (!child.killed) child.kill("SIGKILL");
+    }
+  };
+
+  try {
+    const readies = Array.from({ length: size }, () => {
+      const child = fork(entry, [], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          VINEXT_PRERENDER: "1",
+          VINEXT_PRERENDER_OUTDIR: outDir,
+        },
+        // Inherit stdout/stderr so server-side errors surface; keep IPC.
+        stdio: ["ignore", "inherit", "inherit", "ipc"],
+      });
+      children.push(child);
+
+      return new Promise<number>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error("[vinext] prerender render server did not start within 60s"));
+        }, WORKER_READY_TIMEOUT_MS);
+        child.once("message", (msg: { type?: string; port?: number; error?: string }) => {
+          clearTimeout(timer);
+          if (msg?.type === "ready" && typeof msg.port === "number") {
+            // Once ready, a later exit before close() is a crash — record it so
+            // assertHealthy() can fail the build instead of shipping partial output.
+            child.once("exit", (code, signal) => {
+              if (!shuttingDown && !crash) {
+                crash = { port: msg.port, code, signal };
+              }
+            });
+            resolve(msg.port);
+          } else {
+            reject(
+              new Error(`[vinext] prerender render server failed: ${msg?.error ?? "unknown"}`),
+            );
+          }
+        });
+        child.once("error", (err) => {
+          clearTimeout(timer);
+          reject(err);
+        });
+        // A child killed by signal reports code === null; reject on either so an
+        // OOM-killed (SIGKILL) startup fails fast instead of waiting out the 60s
+        // readiness timeout.
+        child.once("exit", (code, signal) => {
+          if (code || signal) {
+            clearTimeout(timer);
+            reject(
+              new Error(
+                `[vinext] prerender render server exited during startup (code ${code}, signal ${signal})`,
+              ),
+            );
+          }
+        });
+      });
+    });
+
+    const ports = await Promise.all(readies);
+    const assertHealthy = (): void => {
+      if (crash) {
+        throw new Error(
+          `[vinext] A prerender render worker (port ${crash.port}) exited unexpectedly ` +
+            `(code ${crash.code}, signal ${crash.signal}) during the build. ` +
+            `Prerender output is incomplete; failing the build. ` +
+            `This is often an out-of-memory kill — try a lower --prerender-concurrency.`,
+        );
+      }
+    };
+    return { ports, assertHealthy, close };
+  } catch (err) {
+    await close();
+    throw err;
+  }
+}

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -48,6 +48,12 @@ import {
   type PrerenderRouteParamsPayload,
 } from "../server/prerender-route-params.js";
 import { startProdServer } from "../server/prod-server.js";
+import {
+  prerenderPoolAvailable,
+  resolvePrerenderPoolSize,
+  startPrerenderServerPool,
+  type PrerenderServerPool,
+} from "./prerender-server-pool.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 import { getOutputPath, getRscOutputPath } from "../utils/prerender-output-paths.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
@@ -595,6 +601,8 @@ export async function prerenderPages({
   // ownedProdServerHandle: a prod server we started ourselves and must close in finally.
   // When the caller passes options._prodServer we use that and do NOT close it.
   let ownedProdServerHandle: { server: HttpServer; port: number } | null = null;
+  // Forked render-server pool (declared out here so the finally can close it).
+  let renderPool: PrerenderServerPool | null = null;
   try {
     // Read the prerender secret written at build time by vinext:server-manifest.
     // When _prerenderSecret is provided by the caller (hybrid builds where
@@ -653,8 +661,22 @@ export async function prerenderPages({
       filePath: string;
     };
 
-    const renderPage = (urlPath: string) =>
-      fetch(`${baseUrl}${urlPath}`, { headers: secretHeaders, redirect: "manual" });
+    // Render servers the per-route fetches are load-balanced across. Starts as
+    // the single in-process server (`baseUrl`); when there are enough routes
+    // (and we started our own server, i.e. not a hybrid shared server) we fork
+    // a pool of production servers below and repoint these ports at them so
+    // rendering — which is CPU-bound and otherwise serialized on one core —
+    // spreads across cores. getStaticPaths/secret endpoints keep using
+    // `baseUrl` (the in-process server).
+    let renderPorts: number[] = [prodServer.port];
+    let renderRoundRobin = 0;
+    const renderPage = (urlPath: string) => {
+      const port = renderPorts[renderRoundRobin++ % renderPorts.length];
+      return fetch(`http://127.0.0.1:${port}${urlPath}`, {
+        headers: secretHeaders,
+        redirect: "manual",
+      });
+    };
 
     // Build the bundlePageRoutes list from static file analysis + route info.
     // getStaticPaths is fetched from the prod server via a prerender endpoint.
@@ -816,11 +838,28 @@ export async function prerenderPages({
       }
     }
 
+    // ── Spread rendering across a pool of production servers ──────────────
+    // Only when we own the server (not a hybrid shared server) and there are
+    // enough routes to outweigh the fork/startup cost. The main thread keeps
+    // doing the per-route fetch + file write; the forked servers do the
+    // CPU-bound rendering on their own cores.
+    let effectiveConcurrency = concurrency;
+    if (!options._prodServer && pagesBundlePath && prerenderPoolAvailable()) {
+      const poolSize = resolvePrerenderPoolSize(pagesToRender.length, concurrency);
+      if (poolSize > 1) {
+        const poolOutDir = path.dirname(path.dirname(pagesBundlePath));
+        renderPool = await startPrerenderServerPool(poolOutDir, poolSize);
+        renderPorts = renderPool.ports;
+        // Keep every server busy and overlap the main thread's writes.
+        effectiveConcurrency = Math.max(concurrency, renderPorts.length * 2);
+      }
+    }
+
     // ── Render each page ──────────────────────────────────────────────────
     let completed = 0;
     const pageResults = await runWithConcurrency(
       pagesToRender,
-      concurrency,
+      effectiveConcurrency,
       async ({ route, urlPath, revalidate }) => {
         let result: PrerenderRouteResult;
         try {
@@ -882,6 +921,11 @@ export async function prerenderPages({
     );
     results.push(...pageResults);
 
+    // A worker that crashed mid-render makes its routes fail with connection
+    // errors that are otherwise recorded as non-fatal — fail the build loudly
+    // instead of shipping partial output.
+    renderPool?.assertHealthy();
+
     // ── Render 404 page ───────────────────────────────────────────────────
     const hasCustom404 = findFileWithExtensions(path.join(pagesDir, "404"), fileMatcher);
     const hasErrorPage = findFileWithExtensions(path.join(pagesDir, "_error"), fileMatcher);
@@ -915,6 +959,7 @@ export async function prerenderPages({
 
     return { routes: results };
   } finally {
+    if (renderPool) await renderPool.close();
     setCacheHandler(previousHandler);
     if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
     else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
@@ -976,6 +1021,12 @@ export async function prerenderApp({
   // ownedProdServer: a prod server we started ourselves and must close in finally.
   // When the caller passes options._prodServer we use that and do NOT close it.
   let ownedProdServerHandle: { server: HttpServer; port: number } | null = null;
+  // Forked render-server pool (declared out here so the finally can close it).
+  let renderPool: PrerenderServerPool | null = null;
+  // Render servers the per-route fetches are load-balanced across. Starts as the
+  // single in-process server; repointed at the forked pool below for large apps.
+  let renderPorts: number[] = [];
+  let renderRoundRobin = 0;
 
   try {
     // Start a local prod server and fetch via HTTP.
@@ -1009,12 +1060,14 @@ export async function prerenderApp({
         })();
 
     const baseUrl = `http://127.0.0.1:${prodServer.port}`;
+    renderPorts = [prodServer.port];
     const secretHeaders: Record<string, string> = prerenderSecret
       ? { [VINEXT_PRERENDER_SECRET_HEADER]: prerenderSecret }
       : {};
 
     rscHandler = (req: Request) => {
-      // Forward the request to the local prod server.
+      // Forward the request to a prod server (round-robin across the render
+      // pool when one was forked; otherwise the single in-process server).
       // `redirect: "manual"` ensures pages that call `redirect()` surface as
       // their original 3xx response — otherwise fetch follows the Location
       // header server-side, the prerender harness sees a 200 for the
@@ -1024,7 +1077,8 @@ export async function prerenderApp({
       // document load. Mirrors the pages-prerender `renderPage` helper above.
       // See: https://github.com/cloudflare/vinext/issues/1530
       const parsed = new URL(req.url);
-      const url = `${baseUrl}${parsed.pathname}${parsed.search}`;
+      const port = renderPorts[renderRoundRobin++ % renderPorts.length];
+      const url = `http://127.0.0.1:${port}${parsed.pathname}${parsed.search}`;
       return fetch(url, {
         method: req.method,
         headers: { ...secretHeaders, ...Object.fromEntries(req.headers.entries()) },
@@ -1502,18 +1556,41 @@ export async function prerenderApp({
       }
     }
 
+    // ── Spread rendering across a pool of production servers ──────────────
+    // Only when we own the server (not a hybrid shared server) and there are
+    // enough routes to outweigh the fork/startup cost. The main thread keeps
+    // collecting HTML/RSC and writing files; the forked servers render on
+    // their own cores.
+    let effectiveConcurrencyApp = concurrency;
+    if (!options._prodServer && prerenderPoolAvailable()) {
+      const poolSize = resolvePrerenderPoolSize(urlsToRender.length, concurrency);
+      if (poolSize > 1) {
+        renderPool = await startPrerenderServerPool(path.dirname(serverDir), poolSize);
+        renderPorts = renderPool.ports;
+        effectiveConcurrencyApp = Math.max(concurrency, renderPorts.length * 2);
+      }
+    }
+
     let completedApp = 0;
-    const appResults = await runWithConcurrency(urlsToRender, concurrency, async (urlToRender) => {
-      const result = await renderUrl(urlToRender);
-      onProgress?.({
-        completed: ++completedApp,
-        total: urlsToRender.length,
-        route: urlToRender.urlPath,
-        status: result.status,
-      });
-      return result;
-    });
+    const appResults = await runWithConcurrency(
+      urlsToRender,
+      effectiveConcurrencyApp,
+      async (urlToRender) => {
+        const result = await renderUrl(urlToRender);
+        onProgress?.({
+          completed: ++completedApp,
+          total: urlsToRender.length,
+          route: urlToRender.urlPath,
+          status: result.status,
+        });
+        return result;
+      },
+    );
     results.push(...appResults);
+
+    // Fail loudly if a render worker crashed mid-build (otherwise its routes
+    // fail with connection errors recorded as non-fatal → partial output).
+    renderPool?.assertHealthy();
 
     const outputFiles =
       mode === "export" && metadataRoutes.length > 0
@@ -1559,6 +1636,7 @@ export async function prerenderApp({
       ...(outputFiles.length > 0 ? { outputFiles } : {}),
     };
   } finally {
+    if (renderPool) await renderPool.close();
     setCacheHandler(previousHandler);
     if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
     else process.env.VINEXT_PRERENDER = previousPrerenderFlag;

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -39,6 +39,7 @@ import { createValidFileMatcher, findFileWithExtensions } from "../routing/file-
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import { navigationRuntimeRscBootstrapExpression } from "../server/app-ssr-stream.js";
 import {
+  VINEXT_PRERENDER_CACHE_LIFE_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "../server/headers.js";
@@ -77,6 +78,25 @@ function getErrorMessageWithStack(err: Error): string {
   // and the server bundle includes sourcemaps, this resolves bundled stack frames to
   // original source files, matching Next.js's enablePrerenderSourceMaps behavior.
   return err.stack || err.message;
+}
+
+async function startOptionalPrerenderServerPool(
+  outDir: string,
+  poolSize: number,
+): Promise<PrerenderServerPool | null> {
+  try {
+    return await startPrerenderServerPool(outDir, poolSize);
+  } catch (e) {
+    // The pool is a performance optimization layered over the already-running
+    // in-process prerender server. Startup failure is still before any route has
+    // rendered, so degrade; render-time worker failures remain fatal later.
+    console.warn(
+      `[vinext] prerender render pool failed to start; falling back to single-process render: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+    return null;
+  }
 }
 
 // A user's generateStaticParams/getStaticPaths threw, surfaced by the prerender
@@ -843,15 +863,12 @@ export async function prerenderPages({
     // enough routes to outweigh the fork/startup cost. The main thread keeps
     // doing the per-route fetch + file write; the forked servers do the
     // CPU-bound rendering on their own cores.
-    let effectiveConcurrency = concurrency;
     if (!options._prodServer && pagesBundlePath && prerenderPoolAvailable()) {
       const poolSize = resolvePrerenderPoolSize(pagesToRender.length, concurrency);
       if (poolSize > 1) {
         const poolOutDir = path.dirname(path.dirname(pagesBundlePath));
-        renderPool = await startPrerenderServerPool(poolOutDir, poolSize);
-        renderPorts = renderPool.ports;
-        // Keep every server busy and overlap the main thread's writes.
-        effectiveConcurrency = Math.max(concurrency, renderPorts.length * 2);
+        renderPool = await startOptionalPrerenderServerPool(poolOutDir, poolSize);
+        if (renderPool) renderPorts = renderPool.ports;
       }
     }
 
@@ -859,7 +876,7 @@ export async function prerenderPages({
     let completed = 0;
     const pageResults = await runWithConcurrency(
       pagesToRender,
-      effectiveConcurrency,
+      concurrency,
       async ({ route, urlPath, revalidate }) => {
         let result: PrerenderRouteResult;
         try {
@@ -903,6 +920,7 @@ export async function prerenderPages({
             ...(urlPath !== route.pattern ? { path: urlPath } : {}),
           };
         } catch (e) {
+          renderPool?.recordRenderError(e);
           const err = e as Error;
           result = {
             route: route.pattern,
@@ -945,10 +963,14 @@ export async function prerenderPages({
             router: "pages",
           });
         }
-      } catch {
-        // No custom 404
+      } catch (e) {
+        // No custom 404. When the render-worker pool is active, a transport
+        // failure here is still captured by assertHealthy() below so a crashed
+        // worker cannot silently skip an existing custom 404.
+        renderPool?.recordRenderError(e);
       }
     }
+    renderPool?.assertHealthy();
 
     // ── Write vinext-prerender.json ───────────────────────────────────────────
     if (!skipManifest)
@@ -1417,6 +1439,7 @@ export async function prerenderApp({
             const response = await rscHandler(htmlRequest);
             const cacheControl = response.headers.get("cache-control") ?? "";
             const linkHeader = response.headers.get("link");
+            const responseCacheLife = readPrerenderCacheLifeHeader(response.headers);
             if (!response.ok || (isSpeculative && cacheControl.includes("no-store"))) {
               await response.body?.cancel();
               return {
@@ -1430,12 +1453,16 @@ export async function prerenderApp({
             }
 
             const html = await response.text();
+            // Prefer the response side channel so single-process and pooled
+            // prerender record the same cache-life metadata; still consume the
+            // process-local value to drain/fallback when no header exists.
+            const processCacheLife = _consumeRequestScopedCacheLife();
             return {
               cacheControl,
               linkHeader,
               html,
               ok: true,
-              requestCacheLife: _consumeRequestScopedCacheLife(),
+              requestCacheLife: responseCacheLife ?? processCacheLife,
               status: response.status,
             };
           },
@@ -1546,6 +1573,7 @@ export async function prerenderApp({
           ...(isFallback ? { fallback: true } : {}),
         };
       } catch (e) {
+        renderPool?.recordRenderError(e);
         if (isSpeculative) {
           return { route: routePattern, status: "skipped", reason: "dynamic" };
         }
@@ -1561,31 +1589,25 @@ export async function prerenderApp({
     // enough routes to outweigh the fork/startup cost. The main thread keeps
     // collecting HTML/RSC and writing files; the forked servers render on
     // their own cores.
-    let effectiveConcurrencyApp = concurrency;
     if (!options._prodServer && prerenderPoolAvailable()) {
       const poolSize = resolvePrerenderPoolSize(urlsToRender.length, concurrency);
       if (poolSize > 1) {
-        renderPool = await startPrerenderServerPool(path.dirname(serverDir), poolSize);
-        renderPorts = renderPool.ports;
-        effectiveConcurrencyApp = Math.max(concurrency, renderPorts.length * 2);
+        renderPool = await startOptionalPrerenderServerPool(path.dirname(serverDir), poolSize);
+        if (renderPool) renderPorts = renderPool.ports;
       }
     }
 
     let completedApp = 0;
-    const appResults = await runWithConcurrency(
-      urlsToRender,
-      effectiveConcurrencyApp,
-      async (urlToRender) => {
-        const result = await renderUrl(urlToRender);
-        onProgress?.({
-          completed: ++completedApp,
-          total: urlsToRender.length,
-          route: urlToRender.urlPath,
-          status: result.status,
-        });
-        return result;
-      },
-    );
+    const appResults = await runWithConcurrency(urlsToRender, concurrency, async (urlToRender) => {
+      const result = await renderUrl(urlToRender);
+      onProgress?.({
+        completed: ++completedApp,
+        total: urlsToRender.length,
+        route: urlToRender.urlPath,
+        status: result.status,
+      });
+      return result;
+    });
     results.push(...appResults);
 
     // Fail loudly if a render worker crashed mid-build (otherwise its routes
@@ -1620,9 +1642,14 @@ export async function prerenderApp({
           router: "app",
         });
       }
-    } catch {
-      // No custom 404 — skip silently
+    } catch (e) {
+      // No custom 404. When the render-worker pool is active, a transport
+      // failure here is still captured by assertHealthy() below so a crashed
+      // worker cannot silently skip an existing custom 404 (mirrors the
+      // Pages Router 404 path).
+      renderPool?.recordRenderError(e);
     }
+    renderPool?.assertHealthy();
 
     // ── Write vinext-prerender.json ───────────────────────────────────────────
     if (!skipManifest)
@@ -1665,6 +1692,27 @@ function resolveRenderedCacheControl(
       }),
     ...(revalidate === undefined ? {} : { revalidate }),
   };
+}
+
+function readPrerenderCacheLifeHeader(
+  headers: Headers,
+): { expire?: number; revalidate?: number } | null {
+  const value = headers.get(VINEXT_PRERENDER_CACHE_LIFE_HEADER);
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as { expire?: unknown; revalidate?: unknown };
+    const cacheLife: { expire?: number; revalidate?: number } = {};
+    if (typeof parsed.revalidate === "number" && Number.isFinite(parsed.revalidate)) {
+      cacheLife.revalidate = parsed.revalidate;
+    }
+    if (typeof parsed.expire === "number" && Number.isFinite(parsed.expire)) {
+      cacheLife.expire = parsed.expire;
+    }
+    return cacheLife.revalidate === undefined && cacheLife.expire === undefined ? null : cacheLife;
+  } catch {
+    return null;
+  }
 }
 
 function resolveRenderedExpireSeconds(options: {

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -756,11 +756,13 @@ export async function renderAppPageLifecycle(
   }
 
   if (options.isRscRequest) {
+    let requestCacheLifeForPrerender: AppPageRequestCacheLife | null = null;
     if (options.isPrerender === true) {
       await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+      requestCacheLifeForPrerender = readRequestCacheLifeForPrerender(options);
       ({ expireSeconds, revalidateSeconds } = applyRequestCacheLife({
         expireSeconds,
-        requestCacheLife: readRequestCacheLifeForPrerender(options),
+        requestCacheLife: requestCacheLifeForPrerender,
         revalidateSeconds,
       }));
     }
@@ -803,6 +805,7 @@ export async function renderAppPageLifecycle(
       mountedSlotsHeader: options.mountedSlotsHeader,
       params: options.navigationParams,
       policy: rscResponsePolicy,
+      requestCacheLife: requestCacheLifeForPrerender,
       timing: buildResponseTiming({
         compileEnd,
         handlerStart: options.handlerStart,
@@ -982,11 +985,13 @@ export async function renderAppPageLifecycle(
   }
 
   // Eagerly read values that must be captured before the stream is consumed.
+  let requestCacheLifeForPrerender: AppPageRequestCacheLife | null = null;
   if (options.isPrerender === true) {
     await settleCapturedRscRenderForCacheMetadata(htmlRender.capturedRscData);
+    requestCacheLifeForPrerender = readRequestCacheLifeForPrerender(options);
     ({ expireSeconds, revalidateSeconds } = applyRequestCacheLife({
       expireSeconds,
-      requestCacheLife: readRequestCacheLifeForPrerender(options),
+      requestCacheLife: requestCacheLifeForPrerender,
       revalidateSeconds,
     }));
   }
@@ -1039,6 +1044,7 @@ export async function renderAppPageLifecycle(
         status: 500,
       },
       policy: { cacheControl: NEVER_CACHE_CONTROL },
+      requestCacheLife: requestCacheLifeForPrerender,
       timing: htmlResponseTiming,
     });
     applyCdnResponseHeaders(response.headers, { cacheControl: NEVER_CACHE_CONTROL });
@@ -1062,6 +1068,7 @@ export async function renderAppPageLifecycle(
       isEdgeRuntime: options.isEdgeRuntime,
       middlewareContext: options.middlewareContext,
       policy: htmlResponsePolicy,
+      requestCacheLife: requestCacheLifeForPrerender,
       timing: htmlResponseTiming,
     });
 
@@ -1128,6 +1135,7 @@ export async function renderAppPageLifecycle(
     isEdgeRuntime: options.isEdgeRuntime,
     middlewareContext: options.middlewareContext,
     policy: htmlResponsePolicy,
+    requestCacheLife: requestCacheLifeForPrerender,
     timing: htmlResponseTiming,
   });
 }

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -7,6 +7,7 @@ import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
+  VINEXT_PRERENDER_CACHE_LIFE_HEADER,
   VINEXT_TIMING_HEADER,
 } from "./headers.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
@@ -32,6 +33,11 @@ export type AppPageResponseTiming = {
 type AppPageResponsePolicy = {
   cacheControl?: string;
   cacheState?: "MISS" | "STATIC";
+};
+
+type AppPagePrerenderCacheLife = {
+  expire?: number;
+  revalidate?: number;
 };
 
 type ResolveAppPageResponsePolicyBaseOptions = {
@@ -65,6 +71,7 @@ type BuildAppPageRscResponseOptions = {
   mountedSlotsHeader?: string | null;
   params?: Record<string, unknown>;
   policy: AppPageResponsePolicy;
+  requestCacheLife?: AppPagePrerenderCacheLife | null;
   timing?: AppPageResponseTiming;
 };
 
@@ -75,6 +82,7 @@ type BuildAppPageHtmlResponseOptions = {
   isEdgeRuntime?: boolean;
   middlewareContext: AppPageMiddlewareContext;
   policy: AppPageResponsePolicy;
+  requestCacheLife?: AppPagePrerenderCacheLife | null;
   timing?: AppPageResponseTiming;
 };
 
@@ -104,6 +112,25 @@ function applyDynamicStaleTimeHeader(headers: Headers, dynamicStaleTimeSeconds?:
   ) {
     headers.set(VINEXT_DYNAMIC_STALE_TIME_HEADER, String(dynamicStaleTimeSeconds));
   }
+}
+
+function applyPrerenderCacheLifeHeader(
+  headers: Headers,
+  requestCacheLife: AppPagePrerenderCacheLife | null | undefined,
+): void {
+  if (!requestCacheLife) return;
+  const payload: AppPagePrerenderCacheLife = {};
+  if (
+    typeof requestCacheLife.revalidate === "number" &&
+    Number.isFinite(requestCacheLife.revalidate)
+  ) {
+    payload.revalidate = requestCacheLife.revalidate;
+  }
+  if (typeof requestCacheLife.expire === "number" && Number.isFinite(requestCacheLife.expire)) {
+    payload.expire = requestCacheLife.expire;
+  }
+  if (payload.revalidate === undefined && payload.expire === undefined) return;
+  headers.set(VINEXT_PRERENDER_CACHE_LIFE_HEADER, JSON.stringify(payload));
 }
 
 export function resolveAppPageRscResponsePolicy(
@@ -278,6 +305,7 @@ export function buildAppPageRscResponse(
   }
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
   applyRscCompatibilityIdHeader(headers);
+  applyPrerenderCacheLifeHeader(headers, options.requestCacheLife);
 
   applyTimingHeader(headers, options.timing);
 
@@ -312,6 +340,7 @@ export function buildAppPageHtmlResponse(
   }
 
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
+  applyPrerenderCacheLifeHeader(headers, options.requestCacheLife);
 
   applyTimingHeader(headers, options.timing);
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -58,6 +58,9 @@ export const VINEXT_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
 /** Per-page dynamic stale time in seconds for App Router RSC responses. */
 export const VINEXT_DYNAMIC_STALE_TIME_HEADER = "X-Vinext-Dynamic-Stale-Time";
 
+/** Prerender-only JSON side channel carrying request cacheLife metadata. */
+export const VINEXT_PRERENDER_CACHE_LIFE_HEADER = "x-vinext-prerender-cache-life";
+
 /** Route interception context for parallel/intercepting routes. */
 export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context";
 
@@ -205,4 +208,7 @@ export const INTERNAL_HEADERS = [
 ];
 
 /** Vinext-only internal headers stripped alongside Next.js protocol internals. */
-export const VINEXT_INTERNAL_HEADERS = [VINEXT_PRERENDER_ROUTE_PARAMS_HEADER];
+export const VINEXT_INTERNAL_HEADERS = [
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+  VINEXT_PRERENDER_CACHE_LIFE_HEADER,
+];

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -212,6 +212,8 @@ export type ProdServerOptions = {
    * remains stable.
    */
   purpose?: "prerender";
+  /** Suppress the startup log for internal child-process servers. */
+  silent?: boolean;
 };
 
 /** Content types that benefit from compression. */
@@ -955,6 +957,7 @@ export async function startProdServer(options: ProdServerOptions = {}) {
     outDir = path.resolve("dist"),
     noCompression = false,
     purpose,
+    silent = false,
   } = options;
 
   const compress = !noCompression;
@@ -974,10 +977,18 @@ export async function startProdServer(options: ProdServerOptions = {}) {
   }
 
   if (isAppRouter) {
-    return startAppRouterServer({ port, host, clientDir, rscEntryPath, compress, purpose });
+    return startAppRouterServer({ port, host, clientDir, rscEntryPath, compress, purpose, silent });
   }
 
-  return startPagesRouterServer({ port, host, clientDir, serverEntryPath, compress, purpose });
+  return startPagesRouterServer({
+    port,
+    host,
+    clientDir,
+    serverEntryPath,
+    compress,
+    purpose,
+    silent,
+  });
 }
 
 // ─── App Router Production Server ─────────────────────────────────────────────
@@ -989,6 +1000,7 @@ type AppRouterServerOptions = {
   rscEntryPath: string;
   compress: boolean;
   purpose?: ProdServerOptions["purpose"];
+  silent?: boolean;
 };
 
 type WorkerAppRouterEntry = {
@@ -1192,7 +1204,7 @@ function installPagesClientAssets(options: {
  * 4. Stream the Web Response back (with optional compression)
  */
 async function startAppRouterServer(options: AppRouterServerOptions) {
-  const { port, host, clientDir, rscEntryPath, compress, purpose } = options;
+  const { port, host, clientDir, rscEntryPath, compress, purpose, silent } = options;
 
   // Load prerender secret written at build time by vinext:server-manifest plugin.
   // Used to authenticate internal /__vinext/prerender/* HTTP endpoints.
@@ -1466,7 +1478,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     server.listen(port, host, () => {
       const addr = server.address();
       const actualPort = typeof addr === "object" && addr ? addr.port : port;
-      logProdServerStarted(host, actualPort, purpose);
+      if (!silent) logProdServerStarted(host, actualPort, purpose);
       resolve();
     });
   });
@@ -1485,6 +1497,7 @@ type PagesRouterServerOptions = {
   serverEntryPath: string;
   compress: boolean;
   purpose?: ProdServerOptions["purpose"];
+  silent?: boolean;
 };
 
 type PagesServerEntryPageRoute = {
@@ -1519,7 +1532,7 @@ function readPagesServerEntryPageRoutes(value: unknown): PagesServerEntryPageRou
  * - vinextConfig — embedded next.config.js settings
  */
 async function startPagesRouterServer(options: PagesRouterServerOptions) {
-  const { port, host, clientDir, serverEntryPath, compress, purpose } = options;
+  const { port, host, clientDir, serverEntryPath, compress, purpose, silent } = options;
 
   // Import the server entry module. importServerEntryModule uses the bare
   // file:// URL so lazy chunks that import the entry back resolve to the same
@@ -1930,7 +1943,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     server.listen(port, host, () => {
       const addr = server.address();
       const actualPort = typeof addr === "object" && addr ? addr.port : port;
-      logProdServerStarted(host, actualPort, purpose);
+      if (!silent) logProdServerStarted(host, actualPort, purpose);
       resolve();
     });
   });

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -27,7 +27,10 @@ import {
   type ClientReuseManifestParseResult,
   type ClientReuseManifestSkipDisposition,
 } from "../packages/vinext/src/server/client-reuse-manifest.js";
-import { VINEXT_DYNAMIC_STALE_TIME_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  VINEXT_DYNAMIC_STALE_TIME_HEADER,
+  VINEXT_PRERENDER_CACHE_LIFE_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
 import {
   DefaultCdnCacheAdapter,
@@ -1034,6 +1037,9 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe("s-maxage=1");
+    expect(response.headers.get(VINEXT_PRERENDER_CACHE_LIFE_HEADER)).toBe(
+      '{"revalidate":1,"expire":1}',
+    );
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(consumeRequestCacheLife()).toEqual({ revalidate: 1, expire: 1 });
   });
@@ -1069,6 +1075,9 @@ describe("app page render lifecycle", () => {
     });
 
     expect(response.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=2");
+    expect(response.headers.get(VINEXT_PRERENDER_CACHE_LIFE_HEADER)).toBe(
+      '{"revalidate":1,"expire":3}',
+    );
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("<html>page</html>");
     expect(common.waitUntilPromises).toHaveLength(0);

--- a/tests/prerender-server-pool.test.ts
+++ b/tests/prerender-server-pool.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolvePrerenderPoolSize,
+  startPrerenderServerPool,
+} from "../packages/vinext/src/build/prerender-server-pool.js";
+
+describe("prerender server pool sizing", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockMachine(cores: number, totalmem: number): void {
+    vi.spyOn(os, "availableParallelism").mockReturnValue(cores);
+    vi.spyOn(os, "totalmem").mockReturnValue(totalmem);
+  }
+
+  it("keeps small prerenders in the in-process server", () => {
+    mockMachine(16, 64 * 1024 * 1024 * 1024);
+
+    expect(resolvePrerenderPoolSize(47)).toBe(1);
+  });
+
+  it("caps by routes, cores, memory, and the explicit worker override", () => {
+    mockMachine(16, 64 * 1024 * 1024 * 1024);
+
+    expect(resolvePrerenderPoolSize(96, 2)).toBe(2);
+    expect(resolvePrerenderPoolSize(384)).toBe(8);
+
+    mockMachine(4, 64 * 1024 * 1024 * 1024);
+    expect(resolvePrerenderPoolSize(384)).toBe(3);
+
+    mockMachine(16, 2 * 1024 * 1024 * 1024);
+    expect(resolvePrerenderPoolSize(384)).toBe(1);
+
+    mockMachine(16, 2.5 * 1024 * 1024 * 1024);
+    expect(resolvePrerenderPoolSize(384)).toBe(2);
+  });
+
+  it("treats an explicit concurrency of 1 as opting out of the process pool", () => {
+    mockMachine(16, 64 * 1024 * 1024 * 1024);
+
+    expect(resolvePrerenderPoolSize(384, 1)).toBe(1);
+  });
+
+  function writeWorkerEntry(source: string): { dir: string; entry: string } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prerender-pool-worker-"));
+    const entry = path.join(dir, "worker.js");
+    fs.writeFileSync(entry, source, "utf-8");
+    return { dir, entry };
+  }
+
+  it("starts and closes stub render workers", async () => {
+    const { dir, entry } = writeWorkerEntry(`
+      process.send({ type: "ready", port: 30000 + (process.pid % 10000) });
+      setInterval(() => {}, 1000);
+    `);
+
+    try {
+      const pool = await startPrerenderServerPool(dir, 2, entry);
+      try {
+        expect(pool.ports).toHaveLength(2);
+        expect(pool.ports.every((port) => typeof port === "number")).toBe(true);
+        expect(() => pool.assertHealthy()).not.toThrow();
+      } finally {
+        await pool.close();
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails assertHealthy immediately after a worker transport error", async () => {
+    const { dir, entry } = writeWorkerEntry(`
+      process.send({ type: "ready", port: 4124 });
+      setInterval(() => {}, 1000);
+    `);
+
+    try {
+      const pool = await startPrerenderServerPool(dir, 1, entry);
+      try {
+        pool.recordRenderError(new Error("renderPage returned 500"));
+        expect(() => pool.assertHealthy()).not.toThrow();
+
+        const transportError = Object.assign(new TypeError("fetch failed"), {
+          cause: { code: "ECONNRESET" },
+        });
+        pool.recordRenderError(transportError);
+        expect(() => pool.assertHealthy()).toThrow(/request failed \(ECONNRESET\)/);
+      } finally {
+        await pool.close();
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails assertHealthy when a ready worker exits unexpectedly", async () => {
+    const { dir, entry } = writeWorkerEntry(`
+      process.send({ type: "ready", port: 4123 });
+      setTimeout(() => process.exit(42), 25);
+    `);
+
+    try {
+      const pool = await startPrerenderServerPool(dir, 1, entry);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(() => pool.assertHealthy()).toThrow(/exited unexpectedly .*code 42/);
+      } finally {
+        await pool.close();
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects when a worker exits before reporting ready", async () => {
+    const { dir, entry } = writeWorkerEntry("process.exit(0);");
+
+    try {
+      await expect(startPrerenderServerPool(dir, 1, entry)).rejects.toThrow(
+        "exited during startup (code 0, signal null)",
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -18,7 +18,10 @@ import {
   processMiddlewareHeaders,
   VINEXT_INTERNAL_HEADERS,
 } from "../packages/vinext/src/server/request-pipeline.js";
-import { VINEXT_PRERENDER_ROUTE_PARAMS_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  VINEXT_PRERENDER_CACHE_LIFE_HEADER,
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../packages/vinext/src/utils/middleware-request-headers.js";
 
 // ── guardProtocolRelativeUrl ────────────────────────────────────────────
@@ -784,6 +787,7 @@ describe("filterInternalHeaders", () => {
 
   it("strips vinext-only internal headers without extending Next.js INTERNAL_HEADERS", () => {
     const headers = new Headers({
+      [VINEXT_PRERENDER_CACHE_LIFE_HEADER]: "forged",
       [VINEXT_PRERENDER_ROUTE_PARAMS_HEADER]: "forged",
       "user-agent": "test",
     });
@@ -791,8 +795,16 @@ describe("filterInternalHeaders", () => {
     const result = filterInternalHeaders(headers);
 
     expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER);
-    expect(VINEXT_INTERNAL_HEADERS).toEqual([VINEXT_PRERENDER_ROUTE_PARAMS_HEADER]);
+    expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_CACHE_LIFE_HEADER);
+    expect(VINEXT_INTERNAL_HEADERS).toEqual([
+      VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+      VINEXT_PRERENDER_CACHE_LIFE_HEADER,
+    ]);
+    for (const name of VINEXT_INTERNAL_HEADERS) {
+      expect(name).toBe(name.toLowerCase());
+    }
     expect(result.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)).toBe(false);
+    expect(result.has(VINEXT_PRERENDER_CACHE_LIFE_HEADER)).toBe(false);
     expect(result.get("user-agent")).toBe("test");
   });
 


### PR DESCRIPTION
## Problem

`vinext build` (with `--prerender-all`, `output: 'export'`, or a `prerender` config) renders every static route by fetching it from a **single in-process production server**, driven by a bounded promise pool (`runWithConcurrency` in `build/prerender.ts`). React SSR/RSC rendering is CPU-bound JS, so the promise pool only overlaps I/O — every render serializes on one core, and raising `--prerender-concurrency` changes nothing. Next.js forks a worker pool and saturates every core. On static-heavy sites vinext therefore wins the bundle phase (rolldown) but loses the prerender phase, and loses total build time.

## Change

Fork a pool of production-server child processes (one per core) and round-robin the per-route render fetch across them. All orchestration — route scanning, `getStaticPaths`/`generateStaticParams` resolution, file writing, the manifest — stays on the main process; only *where the render runs* changes. The render path is otherwise untouched.

- **`build/prerender-server-pool.ts`** (new): `startPrerenderServerPool(outDir, size)` forks `size` `startProdServer` children, each reporting its ephemeral port over IPC. `resolvePrerenderPoolSize(routeCount, maxOverride)` scales by cores (`availableParallelism() - 1`, capped at 8), available memory, **and** routes (≥48/worker), returning `1` (= no fork, current behavior) for small apps, low-memory/low-core machines, or `--prerender-concurrency 1`.
- **`build/prerender-server-entry.ts`** (new): the child entry — installs the same `NoOpCacheHandler` the in-process prerender path uses, then `startProdServer({ port: 0, purpose: "prerender" })`.
- **`build/prerender.ts`**: `prerenderPages` and `prerenderApp` keep the in-process server for the resolution endpoints; when they own the server (non-hybrid), the worker entry exists (built package), and the pool size > 1, they fork the pool and round-robin renders across the child ports, closing it in `finally`. Hybrid (`_prodServer`) is unchanged. Running from source (no built `.js` entry) falls back to single-process.

**`child_process`, not `worker_threads`:** worker threads contend for CPU on this workload — measured ~2× slower per route and non-scaling — which is also why Next.js uses processes.

## Results — react.dev (real app, 809 routes)

Same machine (14-core), **cold** (`.next`/`dist` + MDX `node_modules/.cache` + Vite cache cleared before each run), phase-split via per-line timestamps. Next is built from a pristine react.dev tree (the app's real **webpack** build — see note); vinext is rolldown. Both emit 809 pages.

| Phase | vinext — multi-worker (this PR) | vinext — single (today) | Next.js (webpack) | faster |
|---|---|---|---|---|
| Bundler (rolldown / webpack) | ~6.9 s | ~6.5 s | ~8.6 s | 🟢 vinext |
| **Prerender** (MDX compile + render) | **~7.7 s** | ~22.0 s | ~10.5 s | 🟢 vinext (pool) / 🔴 single |
| Finalize + traces | ~0 | ~0 | ~0.5 s | — |
| **Total** | **~14.6 s** | ~28.6 s | ~19.7 s | 🟢 **vinext (pool)** |

The prerender phase is the whole story: single-process loses it **2.1×** (22.0 vs 10.5), and the pool flips it to a **win** (7.7 vs 10.5) — so total goes from 1.45× slower than Next to **1.35× faster**. (Totals corroborated across 2 full runs: pool ~15.1 s, single ~29.9 s, Next ~19.3 s.)

> **Why webpack for react.dev?** react.dev's `next.config.js` uses webpack-only loaders/plugins (raw-loader, `NormalModuleReplacementPlugin`, `IgnorePlugin`), and Next 15.1.12's `next build` has no `--turbopack` option — so its real build is webpack. The bundle phase is anyway not what this PR changes; the prerender phase is bundler-independent.

## Results — synthetic 801-route static fixture (vs Next 16 + **Turbopack**)

So the win isn't just "rolldown vs webpack" — same machine, cold, vs Next 16's Turbopack build:

| Phase | vinext — multi-worker | Next.js 16 (Turbopack) |
|---|---|---|
| Bundler | ~0.5 s | ~0.5 s |
| Prerender (data + static-gen) | ~1.6 s | ~1.3–3.0 s |
| Finalize | ~0 | ~0.7 s |
| **Total** | **~2.1 s** | ~2.8–4.4 s (first-ever-cold ~8.4 s) |

vinext (multi-worker) is faster than Turbopack-Next on total here too; the Next numbers are noisier (Turbopack engine + worker warmup).

## Correctness

- On a deterministic fixture, prerender output is **byte-identical** single-process vs pooled (same bundle).
- Workers install the same `NoOpCacheHandler` as the in-process path (the handler is a process-global), so no ISR/`unstable_cache`/fetch-cache reuse leaks across routes within a worker.
- A render worker that exits unexpectedly (e.g. OOM kill) **fails the build loudly** via `assertHealthy()` rather than emitting partial output and exiting 0; children exit on parent `disconnect` so they don't orphan; a signal-killed startup fails fast instead of waiting out the readiness timeout.

## Tuning

Existing `--prerender-concurrency N` caps the render-process count. Default = cores − 1, max 8.

## Out of scope (separate issue)

vinext's prerender uses streaming `renderToReadableStream`, so a Suspense boundary backed by a lazy `import()` serializes in streamed-deferred form on a cold render and inline-resolved form when warm (reproducible single-process — not caused by this change). Deterministic SSG output would use `react-dom/static`'s `prerender`.
