### PR TITLE
fix(app-router): preserve app rewrite filtering

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1010,6 +1010,9 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       const response = buildNextDataNotFoundResponse();
       const headers = new Headers(response.headers);
       headers.set("x-nextjs-matched-path", matchPathname(canonicalPathname));
+      if (resolvedUrl !== originalResolvedUrl) {
+        headers.set("x-nextjs-rewrite", resolvedUrl);
+      }
       return new Response("{}", { status: 200, headers });
     }
     return buildNextDataNotFoundResponse();

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2553,6 +2553,13 @@ async function navigateClient(
           middlewareDataResponse = middlewareEffect.response;
         }
         if (middlewareEffect.rewriteTarget) {
+          const rewrittenOwner = resolveDirectHybridClientRouteOwner(
+            middlewareEffect.rewriteTarget,
+            __basePath,
+          );
+          if (rewrittenOwner === "app" || rewrittenOwner === "document") {
+            scheduleHardNavigationAndThrow(browserUrl, "Navigation rewritten to a non-Pages route");
+          }
           const rewrittenTarget =
             middlewareRewrittenTarget ??
             resolvePagesDataNavigationTarget(middlewareEffect.rewriteTarget, __basePath);

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -2222,6 +2222,43 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  it.each([
+    { convention: "middleware", isProxy: false },
+    { convention: "proxy", isProxy: true },
+  ])(
+    "exposes $convention rewrites to App routes on hybrid Pages data responses",
+    async ({ isProxy }) => {
+      const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+      const renderPagesFallback = vi.fn(async () => new Response("pages-data"));
+      const handler = createHandler({
+        configHeaders: [],
+        dispatchMatchedPage,
+        isMiddlewareProxy: isProxy,
+        middlewareModule: {
+          default: (request: Request) =>
+            new Response(null, {
+              headers: {
+                "x-middleware-rewrite": new URL("/docs/about", request.url).toString(),
+              },
+            }),
+        },
+        renderPagesFallback,
+      });
+
+      const response = await handler(
+        new Request("https://example.test/docs/_next/data/build-id/rewrite-to-app.json"),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("application/json");
+      expect(response.headers.get("x-nextjs-rewrite")).toBe("/about");
+      expect(await response.text()).toBe("{}");
+      expect(dispatchMatchedPage).not.toHaveBeenCalled();
+      expect(renderPagesFallback).not.toHaveBeenCalled();
+    },
+  );
+
   it("uses the soft redirect protocol for URL-recognized Pages data requests", async () => {
     const handler = createHandler({
       configHeaders: [],

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16778,6 +16778,66 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("hard-navigates when a middleware rewrite target is App-owned before a dynamic Pages route", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const sourceLoader = vi.fn(async () => ({ default: () => null }));
+    Object.assign(win.location, { origin: "http://localhost" });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    Object.assign(win, {
+      __VINEXT_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, patternParts: ["headers"], isDynamic: false },
+      ],
+      __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, patternParts: ["[slug]"], isDynamic: true },
+      ],
+      __VINEXT_PAGE_PATTERNS__: ["/[slug]"],
+      __VINEXT_PAGE_LOADERS__: {
+        "/[slug]": sourceLoader,
+      },
+    });
+    const hrefAssignments = trackHrefAssignments(win);
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(
+      async () =>
+        new Response("{}", {
+          headers: {
+            "content-type": "application/json",
+            "x-nextjs-matched-path": "/rewrite-to-app",
+            "x-nextjs-rewrite": "/headers",
+          },
+        }),
+    );
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/rewrite-to-app");
+
+      expect(result).toBe(false);
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(sourceLoader).not.toHaveBeenCalled();
+      expect(render).not.toHaveBeenCalled();
+      expect(hrefAssignments).toEqual(["http://localhost/rewrite-to-app", "/rewrite-to-app"]);
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("does not double-prefix basePath for middleware data redirects", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

- include `x-nextjs-rewrite` on trusted hybrid Pages data responses when middleware/proxy resolves into an App route
- make the Pages client hard navigate when a middleware rewrite target is App/document-owned before dynamic Pages route matching can claim it
- add focused server/client regressions for App middleware and proxy rewrite filtering

## Next.js parity

Fixes the App Router middleware/proxy rewrite-filtering failures from deploy-suite run 28478866791:

- `test/e2e/app-dir/app-middleware/app-middleware.test.ts`
- `test/e2e/app-dir/app-middleware-proxy/app-middleware-proxy.test.ts`

## Validation

From the shared worktree before packaging this clean branch:

- `vp test run tests/app-rsc-handler.test.ts tests/shims.test.ts -t "..."` — 4 passed
- `vp check packages/vinext/src/server/app-rsc-handler.ts packages/vinext/src/shims/router.ts tests/app-rsc-handler.test.ts tests/shims.test.ts`
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/app-middleware/app-middleware.test.ts` — 21 passed
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/app-middleware-proxy/app-middleware-proxy.test.ts` — 17 passed, 3 skipped
- independent review agent: no findings
- `git diff --check` on this clean branch

Clean-branch `vp` validation was blocked because this new worktree has no dependency links and the machine is currently nearly out of disk space after the first clean PR worktree install.
