### PR TITLE
fix(app-router): revalidate dynamic intercepted actions

### DIFF
--- a/packages/vinext/src/server/app-browser-server-action-client.ts
+++ b/packages/vinext/src/server/app-browser-server-action-client.ts
@@ -143,6 +143,10 @@ export async function invokeClientServerAction(
     actionId: id,
     basePath: deps.basePath,
     elements: actionInitiation.routerState.elements,
+    interceptionContext:
+      actionInitiation.routerState.interception !== null
+        ? actionInitiation.routerState.interceptionContext
+        : null,
     previousNextUrl: actionInitiation.routerState.previousNextUrl,
   }).headers;
   const fetchResponse = await fetch(createServerActionRequestUrl(actionInitiation.path), {

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -249,6 +249,7 @@ type ResolveServerActionRequestStateOptions = {
   actionId: string;
   basePath: string;
   elements: AppElements;
+  interceptionContext?: string | null;
   previousNextUrl: string | null;
 };
 
@@ -274,10 +275,10 @@ export function resolveServerActionRequestState(
   headers.set(RSC_ACTION_HEADER, options.actionId);
   headers.set(NEXT_ACTION_HEADER, options.actionId);
 
-  const interceptionContext = resolveInterceptionContextFromPreviousNextUrl(
-    options.previousNextUrl,
-    options.basePath,
-  );
+  const interceptionContext =
+    resolveInterceptionContextFromPreviousNextUrl(options.previousNextUrl, options.basePath) ??
+    options.interceptionContext ??
+    null;
   if (interceptionContext !== null) {
     headers.set(VINEXT_INTERCEPTION_CONTEXT_HEADER, interceptionContext);
   }

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1423,6 +1423,7 @@ export async function handleServerActionRscRequest<
     const match = options.matchRoute(options.cleanPathname);
     let element: TElement;
     let errorPattern = match ? match.route.pattern : options.cleanPathname;
+    const actionRerenderIsRscRequest = true;
     if (match) {
       const { route: actionRoute, params: actionParams } = match;
       const actionRerenderTarget = await resolveAppPageActionRerenderTarget({
@@ -1432,7 +1433,7 @@ export async function handleServerActionRscRequest<
         findIntercept: options.findIntercept,
         getRouteParamNames: options.getRouteParamNames,
         getSourceRoute: options.getSourceRoute,
-        isRscRequest: options.isRscRequest,
+        isRscRequest: actionRerenderIsRscRequest,
         toInterceptOpts: options.toInterceptOpts,
       });
 
@@ -1477,7 +1478,7 @@ export async function handleServerActionRscRequest<
         options.buildPageElement({
           cleanPathname: options.cleanPathname,
           interceptOpts: actionRerenderTarget.interceptOpts,
-          isRscRequest: options.isRscRequest,
+          isRscRequest: actionRerenderIsRscRequest,
           mountedSlotsHeader: options.mountedSlotsHeader,
           params: actionRerenderTarget.params,
           request: options.request,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -8091,6 +8091,22 @@ describe("resolveServerActionRequestState", () => {
     );
   });
 
+  it("falls back to the active interception context for server action requests", () => {
+    const elements = createResolvedElements("route:/dynamic-interception-revalidate/en", "/");
+
+    const { headers } = resolveServerActionRequestState({
+      actionId: "revalidate-photo",
+      basePath: "",
+      elements,
+      interceptionContext: "/dynamic-interception-revalidate/en",
+      previousNextUrl: null,
+    });
+
+    expect(headers.get("X-Vinext-Interception-Context")).toBe(
+      "/dynamic-interception-revalidate/en",
+    );
+  });
+
   it("strips the base path when deriving the interception context", () => {
     const elements = createResolvedElements("route:/photos/42", "/");
     const previousNextUrl = "/app/feed";

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect, type Page } from "@playwright/test";
-import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../helpers";
+import {
+  isAppRouterRscRequestForPath,
+  isAppRouterServerActionRequestForPath,
+  waitForAppRouterHydration,
+} from "../helpers";
 
 const BASE = "http://localhost:4174";
 const FEED_DRAFT_VALUE = "source draft survives";
@@ -408,6 +412,38 @@ test.describe("Intercepting Routes", () => {
     await waitForAppRouterHydration(page);
     await expect(page.locator('[data-testid="photo-page"]')).toBeVisible();
     await expect(page.locator('[data-testid="photo-modal"]')).not.toBeVisible();
+  });
+
+  test("revalidating server action from dynamic intercepted modal returns a result", async ({
+    page,
+  }) => {
+    // Ported from Next.js: test/e2e/app-dir/dynamic-interception-route-revalidate/dynamic-interception-route-revalidate.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/dynamic-interception-route-revalidate/dynamic-interception-route-revalidate.test.ts
+    await page.goto(`${BASE}/dynamic-interception-revalidate/en`);
+    await waitForAppRouterHydration(page);
+
+    await page.click("[href='/dynamic-interception-revalidate/en/photos/1/view']");
+    await expect(page.locator("#dynamic-interception-revalidate-intercepted")).toBeVisible();
+    await expect(page.locator("h2")).toHaveText("Photo Id: 1");
+
+    const actionRequest = page.waitForRequest((request) =>
+      isAppRouterServerActionRequestForPath(
+        request,
+        "/dynamic-interception-revalidate/en/photos/1/view",
+      ),
+    );
+    await page.click("#dynamic-interception-revalidate-button");
+    expect((await actionRequest).headers()["x-vinext-interception-context"]).toBe(
+      "/dynamic-interception-revalidate/en",
+    );
+    await expect(page.locator("#dynamic-interception-revalidate-loading")).toBeVisible();
+    await expect(page.locator("#dynamic-interception-revalidate-result")).toHaveText("Result: 0");
+
+    await expect(page.locator("#dynamic-interception-revalidate-intercepted")).toBeVisible();
+    await page.reload();
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#dynamic-interception-revalidate-intercepted")).not.toBeVisible();
+    await expect(page.locator("#dynamic-interception-revalidate-full")).toBeVisible();
   });
 
   test("sibling (..) intercepted navigation mounts the modal slot", async ({ page }) => {

--- a/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/@modal/(.)photos/[id]/view/page.tsx
+++ b/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/@modal/(.)photos/[id]/view/page.tsx
@@ -1,0 +1,15 @@
+import { RevalidateModal } from "../../../../modal";
+
+export default async function InterceptedPhotoPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <div>
+      <h1 id="dynamic-interception-revalidate-intercepted">Intercepted Page</h1>
+      <RevalidateModal photoId={id} />
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/@modal/default.tsx
+++ b/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/actions.ts
+++ b/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/actions.ts
@@ -1,0 +1,8 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateInterceptedPhoto(): Promise<number> {
+  revalidatePath("/dynamic-interception-revalidate/en/photos/1/view");
+  return 0;
+}

--- a/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/layout.tsx
+++ b/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/layout.tsx
@@ -1,0 +1,20 @@
+export default function DynamicInterceptionRevalidateLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <div>
+      {children}
+      {modal}
+    </div>
+  );
+}
+
+export const revalidate = 0;
+
+export function generateStaticParams() {
+  return [{ locale: "en" }];
+}

--- a/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/modal.tsx
+++ b/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/modal.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+import { revalidateInterceptedPhoto } from "./actions";
+
+export function RevalidateModal({ photoId }: { photoId: string }) {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<number>();
+
+  async function handleClick() {
+    setLoading(true);
+    const nextResult = await revalidateInterceptedPhoto();
+    setLoading(false);
+    setResult(nextResult);
+  }
+
+  return (
+    <>
+      <h2>Photo Id: {photoId}</h2>
+      <button id="dynamic-interception-revalidate-button" onClick={handleClick}>
+        Revalidate
+      </button>
+      {loading ? <div id="dynamic-interception-revalidate-loading">Loading...</div> : null}
+      {result !== undefined ? (
+        <div id="dynamic-interception-revalidate-result">Result: {result}</div>
+      ) : null}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/page.tsx
+++ b/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default async function DynamicInterceptionRevalidatePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <div>
+      <h1 id="dynamic-interception-revalidate-home">Dynamic Interception Revalidate</h1>
+      <Link href={`/dynamic-interception-revalidate/${locale}/photos/1/view`}>To Photo</Link>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/photos/[id]/view/page.tsx
+++ b/tests/fixtures/app-basic/app/dynamic-interception-revalidate/[locale]/photos/[id]/view/page.tsx
@@ -1,0 +1,4 @@
+export default async function FullPhotoPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <h1 id="dynamic-interception-revalidate-full">Full Photo {id}</h1>;
+}


### PR DESCRIPTION
## Summary
- preserve active interception context on client-initiated server actions
- force action rerender target resolution through the RSC request path so intercepted routes refresh correctly
- add a dynamic intercepted modal fixture and regression coverage

## Validation
- `vp check packages/vinext/src/server/app-browser-server-action-client.ts packages/vinext/src/server/app-browser-state.ts packages/vinext/src/server/app-server-action-execution.ts tests/app-browser-entry.test.ts tests/e2e/app-router/advanced.spec.ts tests/fixtures/app-basic/app/dynamic-interception-revalidate`
- `vp test run tests/app-browser-entry.test.ts -t "resolveServerActionRequestState"`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/advanced.spec.ts -g "revalidating server action from dynamic intercepted modal"` (ran the app-router advanced slice: 34 passed, 1 skipped)
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/dynamic-interception-route-revalidate/dynamic-interception-route-revalidate.test.ts` (1/1)

Targeted Next.js e2e verification is path-filtered, not a full deploy-suite rerun.