### PR TITLE
fix(app-router): full prefetch static loading routes

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -11,6 +11,7 @@ import { isUnknownRecord } from "../utils/record.js";
 export type VinextLinkPrefetchRoute = {
   canPrefetchLoadingShell: boolean;
   documentOnly?: boolean;
+  hasGenerateStaticParams?: boolean;
   isDynamic: boolean;
   patternParts: string[];
   requiresDynamicNavigationRequest?: boolean;

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { resolveClientRuntimeModule, resolveRuntimeEntryModule } from "./runtime-entry-module.js";
 import type {
   VinextLinkPrefetchRoute,
@@ -6,6 +7,7 @@ import type {
 import type { AppRoute } from "../routing/app-router.js";
 import { patternsStructurallyEquivalent, type RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
+import { hasNamedExport } from "../build/report.js";
 
 /**
  * Generate the virtual browser entry module.
@@ -67,6 +69,22 @@ function requiresDynamicNavigationRequest(route: AppRoute): boolean {
   return route.isDynamic && route.parallelSlots.length > 0;
 }
 
+function fileHasGenerateStaticParams(filePath: string | null | undefined): boolean {
+  if (!filePath) return false;
+  try {
+    return hasNamedExport(fs.readFileSync(filePath, "utf8"), "generateStaticParams");
+  } catch {
+    return false;
+  }
+}
+
+function hasGenerateStaticParams(route: AppRoute): boolean {
+  return (
+    fileHasGenerateStaticParams(route.pagePath) ||
+    route.layouts.some((layoutPath) => fileHasGenerateStaticParams(layoutPath))
+  );
+}
+
 function splitPatternParts(pattern: string): string[] {
   return pattern.split("/").filter(Boolean);
 }
@@ -107,6 +125,7 @@ export function toLinkPrefetchRoute(
 ): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: hasLoadingBoundary(route, hasSiblingInterceptLoading),
+    ...(route.isDynamic && hasGenerateStaticParams(route) ? { hasGenerateStaticParams: true } : {}),
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
     ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -532,6 +532,9 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
     if (optimisticRouteTemplateSources.has(sourceKey)) continue;
     if (optimisticRouteTemplateLearning.has(sourceKey)) continue;
     if (!isSettledPrefetchCacheEntry(entry)) continue;
+    if (entry.prefetchKind === "loading-shell" && entry.automaticFullPrefetchEligible === false) {
+      continue;
+    }
     if (entry.prefetchKind === "route-tree") continue;
 
     const promise = learnOptimisticRouteTemplateFromPrefetch({

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -532,7 +532,6 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
     if (optimisticRouteTemplateSources.has(sourceKey)) continue;
     if (optimisticRouteTemplateLearning.has(sourceKey)) continue;
     if (!isSettledPrefetchCacheEntry(entry)) continue;
-    if (entry.navigationCacheRejected === true) continue;
     if (entry.prefetchKind === "route-tree") continue;
 
     const promise = learnOptimisticRouteTemplateFromPrefetch({

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -532,6 +532,7 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
     if (optimisticRouteTemplateSources.has(sourceKey)) continue;
     if (optimisticRouteTemplateLearning.has(sourceKey)) continue;
     if (!isSettledPrefetchCacheEntry(entry)) continue;
+    if (entry.navigationCacheRejected === true) continue;
     if (entry.prefetchKind === "route-tree") continue;
 
     const promise = learnOptimisticRouteTemplateFromPrefetch({

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -318,12 +318,11 @@ function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
 } {
   const hasLoadingShell = route.canPrefetchLoadingShell;
   return {
-    // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
-    // Routes with loading boundaries prefetch a shell first so navigation can
-    // commit loading.js immediately. Dynamic routes without loading-shell
-    // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
-    // keyed by the concrete RSC URL, so this cannot reuse data across params.
-    cacheForNavigation: !hasLoadingShell,
+    // Next.js fully prefetches static routes, even when a loading boundary is
+    // present. Dynamic routes with loading boundaries prefetch only the shell
+    // so navigation can commit loading.js immediately; dynamic routes without
+    // loading-shell fallbacks are exact-URL full prefetches.
+    cacheForNavigation: !hasLoadingShell || !route.isDynamic,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -328,12 +328,10 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
-type NavigationCacheResponsePolicy = "reject-no-store" | "require-shared-cache";
-
 type AppRoutePrefetchPolicy = {
   cacheForNavigation: boolean;
+  cacheForNavigationOnComplete?: boolean;
   fetchFullPayload: boolean;
-  navigationCacheResponsePolicy?: NavigationCacheResponsePolicy;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 };
@@ -350,20 +348,13 @@ function resolveMatchedAutoAppRoutePrefetch(
     (!hasLoadingShell || canAttemptFullLoadingPrefetch) &&
     route.requiresDynamicNavigationRequest !== true;
   return {
-    // Filesystem route shape cannot prove render staticness: a fixed pathname
-    // may be force-dynamic, while a generateStaticParams pathname may have a
-    // static artifact. For loading-boundary candidates the server response is
-    // authoritative. Fixed paths are admitted unless the response says
-    // no-store; generated-param candidates require positive shared-cache proof.
-    cacheForNavigation: fetchFullPayload && !canProbeGeneratedDynamicPath,
+    // Full prefetches behind a loading boundary start provisionally invisible
+    // to navigation. A click while the stream is incomplete must use the
+    // loading shell/fresh request instead of waiting for the prefetch body to
+    // reach EOF. Once complete, reuse it like Next's Full segment prefetch.
+    cacheForNavigation: fetchFullPayload && !hasLoadingShell,
     fetchFullPayload,
-    ...(hasLoadingShell && fetchFullPayload
-      ? {
-          navigationCacheResponsePolicy: canProbeGeneratedDynamicPath
-            ? ("require-shared-cache" as const)
-            : ("reject-no-store" as const),
-        }
-      : {}),
+    ...(fetchFullPayload && hasLoadingShell ? { cacheForNavigationOnComplete: true } : {}),
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -381,7 +372,7 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) return false;
 
-  return resolveAutoAppRoutePrefetch(href).cacheForNavigation;
+  return resolveAutoAppRoutePrefetch(href).fetchFullPayload;
 }
 
 export function resolveAutoAppRoutePrefetch(
@@ -434,7 +425,7 @@ export function resolveAutoAppRoutePrefetch(
       ...prefetch,
       cacheForNavigation: false,
       fetchFullPayload: false,
-      navigationCacheResponsePolicy: undefined,
+      cacheForNavigationOnComplete: undefined,
       prefetchShellFirst: true,
     };
   }
@@ -611,7 +602,7 @@ function prefetchUrl(
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
         const shouldSendSegmentPrefetchHeaders = isOptimisticRouteShellPrefetch || mode === "auto";
-        if (__prefetchInlining && autoPrefetch.cacheForNavigation) {
+        if (__prefetchInlining && autoPrefetch.fetchFullPayload) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/__PAGE__");
         } else if (shouldSendSegmentPrefetchHeaders) {
@@ -633,7 +624,10 @@ function prefetchUrl(
           }
 
           const existing = getPrefetchCache().get(cacheKey);
-          if (existing?.cacheForNavigation === false && existing.navigationCacheRejected !== true) {
+          if (
+            existing?.cacheForNavigation === false &&
+            existing.cacheForNavigationOnComplete !== true
+          ) {
             existing.cacheForNavigation = true;
           }
         }
@@ -846,13 +840,18 @@ function prefetchUrl(
           undefined,
           {
             cacheForNavigation: autoPrefetch.cacheForNavigation,
+            cacheForNavigationOnComplete: autoPrefetch.cacheForNavigationOnComplete,
             fallbackTtlMs: PREFETCH_CACHE_TTL,
-            navigationCacheResponsePolicy: autoPrefetch.navigationCacheResponsePolicy,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
             prefetchKind: isOptimisticRouteShellPrefetch ? "loading-shell" : "navigation",
             searchAgnosticShell: isAutomaticSearchParamShell && !hasSearchAgnosticShell,
           },
         );
+        // Keep a separate loading shell available while a provisional Full
+        // prefetch is incomplete and therefore invisible to navigation.
+        if (autoPrefetch.cacheForNavigationOnComplete === true) {
+          void fetchLoadingShellForReuse();
+        }
       } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {
         // Pages Router prefetch. When a code-split loader is registered for
         // the target route (prod builds expose them on window via the
@@ -922,7 +921,7 @@ async function promotePrefetchEntriesForNavigation(href: string): Promise<void> 
 
   for (const [cacheKey, entry] of getPrefetchCache()) {
     if (entry.optimisticRouteShell === true) continue;
-    if (entry.navigationCacheRejected === true) continue;
+    if (entry.cacheForNavigationOnComplete === true) continue;
     if (entry.prefetchKind === "route-tree") continue;
 
     const [rscUrl] = cacheKey.split("\0", 1);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -353,14 +353,18 @@ function resolveMatchedAutoAppRoutePrefetch(
     // tree instead of assuming that a fixed pathname or generateStaticParams
     // export is static. Vinext uses the loading-shell response as the concrete
     // capability probe and starts the Full request only after positive proof.
-    // This does not affect explicit/intent Full prefetches: once started, those
-    // remain reusable client state regardless of HTTP cache policy.
-    cacheForNavigation: fetchFullPayload && !hasLoadingShell,
+    // This does not affect explicit/intent Full prefetches: once completed,
+    // those remain reusable client state regardless of HTTP cache policy.
+    // Full responses are snapshotted before the router can consume them. Keep
+    // every newly-started Full request hidden until that snapshot reaches EOF;
+    // otherwise a click would join the pending snapshot and suppress the
+    // independently available loading shell/fresh navigation path.
+    cacheForNavigation: false,
     fetchFullPayload,
-    ...(fetchFullPayload && hasLoadingShell
+    ...(fetchFullPayload
       ? {
-          automaticFullPrefetchProbe: "loading-shell" as const,
           cacheForNavigationOnComplete: true,
+          ...(hasLoadingShell ? { automaticFullPrefetchProbe: "loading-shell" as const } : {}),
         }
       : {}),
     prefetchShellFirst: !route.isDynamic,
@@ -444,7 +448,8 @@ export function resolveAutoAppRoutePrefetch(
 
 function resolveFullAppRoutePrefetch(): AppRoutePrefetchPolicy {
   return {
-    cacheForNavigation: true,
+    cacheForNavigation: false,
+    cacheForNavigationOnComplete: true,
     fetchFullPayload: true,
     prefetchShellFirst: true,
     shouldPrefetch: true,
@@ -578,7 +583,8 @@ function prefetchUrl(
             ? resolveAutoAppRoutePrefetch(prefetchPolicyHref, interceptionContext !== null)
             : mode === "full-after-shell"
               ? {
-                  cacheForNavigation: true,
+                  cacheForNavigation: false,
+                  cacheForNavigationOnComplete: true,
                   fetchFullPayload: true,
                   prefetchShellFirst: true,
                   shouldPrefetch: true,
@@ -640,11 +646,14 @@ function prefetchUrl(
         }
         const prefetched = getPrefetchedUrls();
         if (prefetched.has(cacheKey)) {
-          if (!autoPrefetch.cacheForNavigation) {
+          if (!autoPrefetch.fetchFullPayload) {
             return;
           }
 
           const existing = getPrefetchCache().get(cacheKey);
+          if (existing?.cacheForNavigationOnComplete === true && existing.pending !== undefined) {
+            return;
+          }
           if (
             existing?.cacheForNavigation === false &&
             existing.cacheForNavigationOnComplete !== true
@@ -731,11 +740,11 @@ function prefetchUrl(
           });
         };
         const hasExactNavigationCacheEntry =
-          autoPrefetch.cacheForNavigation &&
+          autoPrefetch.fetchFullPayload &&
           hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader);
         const hasNavigationCacheEntry =
           hasExactNavigationCacheEntry ||
-          (autoPrefetch.cacheForNavigation &&
+          (autoPrefetch.fetchFullPayload &&
             hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader, {
               additionalRscUrls,
             }));
@@ -784,7 +793,7 @@ function prefetchUrl(
                 }
                 return fetchFullRscPayload();
               })()
-            : autoPrefetch.cacheForNavigation && (gateViaRouteTree || gateViaLoadingShell)
+            : autoPrefetch.fetchFullPayload && (gateViaRouteTree || gateViaLoadingShell)
               ? (async () => {
                   if (gateViaLoadingShell) {
                     await fetchLoadingShellForReuse();
@@ -863,7 +872,7 @@ function prefetchUrl(
               : fetchFullRscPayload();
         if (
           mode === "full" &&
-          autoPrefetch.cacheForNavigation &&
+          autoPrefetch.fetchFullPayload &&
           autoPrefetch.prefetchShellFirst &&
           mountedSlotsHeader === null &&
           !gateViaExplicitSearchShell

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -328,24 +328,42 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
+type NavigationCacheResponsePolicy = "reject-no-store" | "require-shared-cache";
+
+type AppRoutePrefetchPolicy = {
+  cacheForNavigation: boolean;
+  fetchFullPayload: boolean;
+  navigationCacheResponsePolicy?: NavigationCacheResponsePolicy;
+  prefetchShellFirst: boolean;
+  shouldPrefetch: boolean;
+};
+
 function resolveMatchedAutoAppRoutePrefetch(
   route: VinextLinkPrefetchRoute,
   hasInterceptionContext = false,
-): {
-  cacheForNavigation: boolean;
-  prefetchShellFirst: boolean;
-  shouldPrefetch: boolean;
-} {
+): AppRoutePrefetchPolicy {
   const hasLoadingShell = route.canPrefetchLoadingShell;
+  const canProbeGeneratedDynamicPath = route.isDynamic && route.hasGenerateStaticParams === true;
+  const canAttemptFullLoadingPrefetch =
+    !hasInterceptionContext && (!route.isDynamic || canProbeGeneratedDynamicPath);
+  const fetchFullPayload =
+    (!hasLoadingShell || canAttemptFullLoadingPrefetch) &&
+    route.requiresDynamicNavigationRequest !== true;
   return {
-    // Next.js fully prefetches static routes, even when a loading boundary is
-    // present. Intercepted targets and dynamic routes with loading boundaries
-    // prefetch only the shell so navigation can commit loading.js in the active
-    // source tree. Exact dynamic URLs can use a full prefetch unless their
-    // active parallel branches must be derived from the click-time target tree.
-    cacheForNavigation:
-      (!hasLoadingShell || (!route.isDynamic && !hasInterceptionContext)) &&
-      route.requiresDynamicNavigationRequest !== true,
+    // Filesystem route shape cannot prove render staticness: a fixed pathname
+    // may be force-dynamic, while a generateStaticParams pathname may have a
+    // static artifact. For loading-boundary candidates the server response is
+    // authoritative. Fixed paths are admitted unless the response says
+    // no-store; generated-param candidates require positive shared-cache proof.
+    cacheForNavigation: fetchFullPayload && !canProbeGeneratedDynamicPath,
+    fetchFullPayload,
+    ...(hasLoadingShell && fetchFullPayload
+      ? {
+          navigationCacheResponsePolicy: canProbeGeneratedDynamicPath
+            ? ("require-shared-cache" as const)
+            : ("reject-no-store" as const),
+        }
+      : {}),
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -369,28 +387,44 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 export function resolveAutoAppRoutePrefetch(
   href: string,
   hasInterceptionContext = false,
-): {
-  cacheForNavigation: boolean;
-  prefetchShellFirst: boolean;
-  shouldPrefetch: boolean;
-} {
+): AppRoutePrefetchPolicy {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      fetchFullPayload: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      fetchFullPayload: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      fetchFullPayload: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      fetchFullPayload: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const prefetch = resolveMatchedAutoAppRoutePrefetch(match.route, hasInterceptionContext);
@@ -399,6 +433,8 @@ export function resolveAutoAppRoutePrefetch(
     return {
       ...prefetch,
       cacheForNavigation: false,
+      fetchFullPayload: false,
+      navigationCacheResponsePolicy: undefined,
       prefetchShellFirst: true,
     };
   }
@@ -406,13 +442,10 @@ export function resolveAutoAppRoutePrefetch(
   return prefetch;
 }
 
-function resolveFullAppRoutePrefetch(): {
-  cacheForNavigation: true;
-  prefetchShellFirst: boolean;
-  shouldPrefetch: true;
-} {
+function resolveFullAppRoutePrefetch(): AppRoutePrefetchPolicy {
   return {
     cacheForNavigation: true,
+    fetchFullPayload: true,
     prefetchShellFirst: true,
     shouldPrefetch: true,
   };
@@ -543,12 +576,17 @@ function prefetchUrl(
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchPolicyHref, interceptionContext !== null)
             : mode === "full-after-shell"
-              ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
+              ? {
+                  cacheForNavigation: true,
+                  fetchFullPayload: true,
+                  prefetchShellFirst: true,
+                  shouldPrefetch: true,
+                }
               : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
 
         const mountedSlotsHeader = getMountedSlotsHeader();
-        const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+        const isOptimisticRouteShellPrefetch = !autoPrefetch.fetchFullPayload;
         const hasSearchParams = new URL(fullHref, window.location.href).search !== "";
         const isAutomaticSearchParamShell =
           mode === "auto" && isOptimisticRouteShellPrefetch && hasSearchParams;
@@ -595,7 +633,7 @@ function prefetchUrl(
           }
 
           const existing = getPrefetchCache().get(cacheKey);
-          if (existing?.cacheForNavigation === false) {
+          if (existing?.cacheForNavigation === false && existing.navigationCacheRejected !== true) {
             existing.cacheForNavigation = true;
           }
         }
@@ -809,6 +847,7 @@ function prefetchUrl(
           {
             cacheForNavigation: autoPrefetch.cacheForNavigation,
             fallbackTtlMs: PREFETCH_CACHE_TTL,
+            navigationCacheResponsePolicy: autoPrefetch.navigationCacheResponsePolicy,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
             prefetchKind: isOptimisticRouteShellPrefetch ? "loading-shell" : "navigation",
             searchAgnosticShell: isAutomaticSearchParamShell && !hasSearchAgnosticShell,
@@ -883,6 +922,7 @@ async function promotePrefetchEntriesForNavigation(href: string): Promise<void> 
 
   for (const [cacheKey, entry] of getPrefetchCache()) {
     if (entry.optimisticRouteShell === true) continue;
+    if (entry.navigationCacheRejected === true) continue;
     if (entry.prefetchKind === "route-tree") continue;
 
     const [rscUrl] = cacheKey.split("\0", 1);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -328,18 +328,24 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
-function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
+function resolveMatchedAutoAppRoutePrefetch(
+  route: VinextLinkPrefetchRoute,
+  hasInterceptionContext = false,
+): {
   cacheForNavigation: boolean;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
   const hasLoadingShell = route.canPrefetchLoadingShell;
   return {
-    // Automatic prefetches are only unsafe as authoritative navigation
-    // payloads for dynamic routes whose active parallel branches must be
-    // derived from the click-time target tree. Other concrete dynamic URLs can
-    // match Next.js's full-prefetch behavior, including client-param routes.
-    cacheForNavigation: !hasLoadingShell && route.requiresDynamicNavigationRequest !== true,
+    // Next.js fully prefetches static routes, even when a loading boundary is
+    // present. Intercepted targets and dynamic routes with loading boundaries
+    // prefetch only the shell so navigation can commit loading.js in the active
+    // source tree. Exact dynamic URLs can use a full prefetch unless their
+    // active parallel branches must be derived from the click-time target tree.
+    cacheForNavigation:
+      (!hasLoadingShell || (!route.isDynamic && !hasInterceptionContext)) &&
+      route.requiresDynamicNavigationRequest !== true,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -360,7 +366,10 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
   return resolveAutoAppRoutePrefetch(href).cacheForNavigation;
 }
 
-export function resolveAutoAppRoutePrefetch(href: string): {
+export function resolveAutoAppRoutePrefetch(
+  href: string,
+  hasInterceptionContext = false,
+): {
   cacheForNavigation: boolean;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
@@ -384,7 +393,7 @@ export function resolveAutoAppRoutePrefetch(href: string): {
     return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
   }
 
-  const prefetch = resolveMatchedAutoAppRoutePrefetch(match.route);
+  const prefetch = resolveMatchedAutoAppRoutePrefetch(match.route, hasInterceptionContext);
   const url = new URL(routeHref, "http://vinext.local");
   if (url.search !== "") {
     return {
@@ -529,15 +538,15 @@ function prefetchUrl(
           ? hybridRouteOwner!.resolveHybridClientRewriteHref(fullHref, __basePath)
           : null;
         const prefetchPolicyHref = rewrittenPrefetchHref ?? prefetchHref;
+        const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const autoPrefetch =
           mode === "auto"
-            ? resolveAutoAppRoutePrefetch(prefetchPolicyHref)
+            ? resolveAutoAppRoutePrefetch(prefetchPolicyHref, interceptionContext !== null)
             : mode === "full-after-shell"
               ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
               : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
 
-        const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
         const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
         const hasSearchParams = new URL(fullHref, window.location.href).search !== "";

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -329,6 +329,7 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
 }
 
 type AppRoutePrefetchPolicy = {
+  automaticFullPrefetchProbe?: "loading-shell";
   cacheForNavigation: boolean;
   cacheForNavigationOnComplete?: boolean;
   fetchFullPayload: boolean;
@@ -348,13 +349,20 @@ function resolveMatchedAutoAppRoutePrefetch(
     (!hasLoadingShell || canAttemptFullLoadingPrefetch) &&
     route.requiresDynamicNavigationRequest !== true;
   return {
-    // Full prefetches behind a loading boundary start provisionally invisible
-    // to navigation. A click while the stream is incomplete must use the
-    // loading shell/fresh request instead of waiting for the prefetch body to
-    // reach EOF. Once complete, reuse it like Next's Full segment prefetch.
+    // Next's automatic strategy discovers cacheable segments from the route
+    // tree instead of assuming that a fixed pathname or generateStaticParams
+    // export is static. Vinext uses the loading-shell response as the concrete
+    // capability probe and starts the Full request only after positive proof.
+    // This does not affect explicit/intent Full prefetches: once started, those
+    // remain reusable client state regardless of HTTP cache policy.
     cacheForNavigation: fetchFullPayload && !hasLoadingShell,
     fetchFullPayload,
-    ...(fetchFullPayload && hasLoadingShell ? { cacheForNavigationOnComplete: true } : {}),
+    ...(fetchFullPayload && hasLoadingShell
+      ? {
+          automaticFullPrefetchProbe: "loading-shell" as const,
+          cacheForNavigationOnComplete: true,
+        }
+      : {}),
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -425,6 +433,7 @@ export function resolveAutoAppRoutePrefetch(
       ...prefetch,
       cacheForNavigation: false,
       fetchFullPayload: false,
+      automaticFullPrefetchProbe: undefined,
       cacheForNavigationOnComplete: undefined,
       prefetchShellFirst: true,
     };
@@ -532,6 +541,7 @@ function prefetchUrl(
           getPrefetchCache,
           getPrefetchedUrls,
           getMountedSlotsHeader,
+          findProvisionalFullPrefetchEntryForNavigation,
           hasSearchAgnosticPrefetchShellForRoute,
           hasPrefetchCacheEntryForNavigation,
           peekPrefetchResponseForNavigation,
@@ -617,6 +627,17 @@ function prefetchUrl(
             ? [await createRscRequestUrl(rewrittenPrefetchHref, headers)]
             : [];
         const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+        if (
+          mode === "full-after-shell" &&
+          findProvisionalFullPrefetchEntryForNavigation(
+            rscUrl,
+            interceptionContext,
+            mountedSlotsHeader,
+            additionalRscUrls,
+          ) !== null
+        ) {
+          return;
+        }
         const prefetched = getPrefetchedUrls();
         if (prefetched.has(cacheKey)) {
           if (!autoPrefetch.cacheForNavigation) {
@@ -643,7 +664,9 @@ function prefetchUrl(
               }),
             priority,
           );
-        const fetchLoadingShellForReuse = async (): Promise<void> => {
+        const fetchLoadingShellForReuse = async (
+          recordAutomaticFullPrefetchEligibility = false,
+        ): Promise<boolean> => {
           const shellHeaders = createRscRequestHeaders({
             interceptionContext,
             renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
@@ -679,11 +702,13 @@ function prefetchUrl(
                 cacheForNavigation: false,
                 optimisticRouteShell: true,
                 prefetchKind: "loading-shell",
+                recordAutomaticFullPrefetchEligibility,
               },
             );
             shellEntry = shellCache.get(shellCacheKey);
           }
           await shellEntry?.pending?.catch(() => {});
+          return shellEntry?.automaticFullPrefetchEligible === true;
         };
         const fetchAliasCacheHitProbe = async (): Promise<Response> => {
           const probeHeaders = createRscRequestHeaders({
@@ -749,80 +774,93 @@ function prefetchUrl(
           (mode === "full-after-shell" || gateViaExplicitSearchShell) &&
           autoPrefetch.prefetchShellFirst;
         const fetchPromise =
-          autoPrefetch.cacheForNavigation && (gateViaRouteTree || gateViaLoadingShell)
+          mode === "auto" && autoPrefetch.automaticFullPrefetchProbe !== undefined
             ? (async () => {
-                if (gateViaLoadingShell) {
-                  await fetchLoadingShellForReuse();
-                  return fetchFullRscPayload();
+                const eligible =
+                  autoPrefetch.automaticFullPrefetchProbe === "loading-shell" &&
+                  (await fetchLoadingShellForReuse(true));
+                if (!eligible) {
+                  throw new Error("Automatic Full prefetch requires concrete static proof");
                 }
-                const shellHeaders = createRscRequestHeaders({
-                  interceptionContext,
-                  renderMode: undefined,
-                });
-                shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-                shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
-                if (mountedSlotsHeader) {
-                  shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
-                }
-                const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
-                const shellCacheKey = AppElementsWire.encodeCacheKey(
-                  shellRscUrl,
-                  interceptionContext,
-                );
-                const shellCache = getPrefetchCache();
-                let shellEntry = shellCache.get(shellCacheKey);
-                if (shellEntry === undefined) {
-                  getPrefetchedUrls().add(shellCacheKey);
-                  prefetchRscResponse(
-                    shellRscUrl,
-                    scheduleAppPrefetchFetch(
-                      () =>
-                        fetch(shellRscUrl, {
-                          headers: shellHeaders,
-                          credentials: "include",
-                          priority,
-                          // @ts-expect-error — purpose is a valid fetch option in some browsers
-                          purpose: "prefetch",
-                        }),
-                      priority,
-                    ),
-                    interceptionContext,
-                    mountedSlotsHeader,
-                    undefined,
-                    {
-                      cacheForNavigation: false,
-                      optimisticRouteShell: false,
-                      prefetchKind: "route-tree",
-                    },
-                  );
-                  shellEntry = shellCache.get(shellCacheKey);
-                }
-                await shellEntry?.pending?.catch(() => {});
-                const renderedPathAndSearch = shellEntry?.snapshot?.renderedPathAndSearch;
-                if (renderedPathAndSearch) {
-                  const renderedRscUrl = await createRscRequestUrl(renderedPathAndSearch, headers);
-                  const cachedRenderedResponse = peekPrefetchResponseForNavigation(
-                    renderedRscUrl,
-                    interceptionContext,
-                    mountedSlotsHeader,
-                  );
-                  if (cachedRenderedResponse) {
-                    return restoreRscResponse(cachedRenderedResponse);
-                  }
-                }
-                return scheduleAppPrefetchFetch(
-                  () =>
-                    fetch(rscUrl, {
-                      headers,
-                      credentials: "include",
-                      priority,
-                      // @ts-expect-error — purpose is a valid fetch option in some browsers
-                      purpose: "prefetch",
-                    }),
-                  priority,
-                );
+                return fetchFullRscPayload();
               })()
-            : fetchFullRscPayload();
+            : autoPrefetch.cacheForNavigation && (gateViaRouteTree || gateViaLoadingShell)
+              ? (async () => {
+                  if (gateViaLoadingShell) {
+                    await fetchLoadingShellForReuse();
+                    return fetchFullRscPayload();
+                  }
+                  const shellHeaders = createRscRequestHeaders({
+                    interceptionContext,
+                    renderMode: undefined,
+                  });
+                  shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+                  shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+                  if (mountedSlotsHeader) {
+                    shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+                  }
+                  const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
+                  const shellCacheKey = AppElementsWire.encodeCacheKey(
+                    shellRscUrl,
+                    interceptionContext,
+                  );
+                  const shellCache = getPrefetchCache();
+                  let shellEntry = shellCache.get(shellCacheKey);
+                  if (shellEntry === undefined) {
+                    getPrefetchedUrls().add(shellCacheKey);
+                    prefetchRscResponse(
+                      shellRscUrl,
+                      scheduleAppPrefetchFetch(
+                        () =>
+                          fetch(shellRscUrl, {
+                            headers: shellHeaders,
+                            credentials: "include",
+                            priority,
+                            // @ts-expect-error — purpose is a valid fetch option in some browsers
+                            purpose: "prefetch",
+                          }),
+                        priority,
+                      ),
+                      interceptionContext,
+                      mountedSlotsHeader,
+                      undefined,
+                      {
+                        cacheForNavigation: false,
+                        optimisticRouteShell: false,
+                        prefetchKind: "route-tree",
+                      },
+                    );
+                    shellEntry = shellCache.get(shellCacheKey);
+                  }
+                  await shellEntry?.pending?.catch(() => {});
+                  const renderedPathAndSearch = shellEntry?.snapshot?.renderedPathAndSearch;
+                  if (renderedPathAndSearch) {
+                    const renderedRscUrl = await createRscRequestUrl(
+                      renderedPathAndSearch,
+                      headers,
+                    );
+                    const cachedRenderedResponse = peekPrefetchResponseForNavigation(
+                      renderedRscUrl,
+                      interceptionContext,
+                      mountedSlotsHeader,
+                    );
+                    if (cachedRenderedResponse) {
+                      return restoreRscResponse(cachedRenderedResponse);
+                    }
+                  }
+                  return scheduleAppPrefetchFetch(
+                    () =>
+                      fetch(rscUrl, {
+                        headers,
+                        credentials: "include",
+                        priority,
+                        // @ts-expect-error — purpose is a valid fetch option in some browsers
+                        purpose: "prefetch",
+                      }),
+                    priority,
+                  );
+                })()
+              : fetchFullRscPayload();
         if (
           mode === "full" &&
           autoPrefetch.cacheForNavigation &&
@@ -847,11 +885,6 @@ function prefetchUrl(
             searchAgnosticShell: isAutomaticSearchParamShell && !hasSearchAgnosticShell,
           },
         );
-        // Keep a separate loading shell available while a provisional Full
-        // prefetch is incomplete and therefore invisible to navigation.
-        if (autoPrefetch.cacheForNavigationOnComplete === true) {
-          void fetchLoadingShellForReuse();
-        }
       } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {
         // Pages Router prefetch. When a code-split loader is registered for
         // the target route (prod builds expose them on window via the

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -40,6 +40,7 @@ import {
 import { hasPendingAppRouterPageRedirect } from "../server/app-browser-mpa-navigation.js";
 import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
+  VINEXT_CACHE_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
@@ -284,8 +285,11 @@ export type PrefetchOptions = {
 
 export type PrefetchCacheKind = "loading-shell" | "navigation" | "route-tree";
 
+type NavigationCacheResponsePolicy = "reject-no-store" | "require-shared-cache";
+
 export type PrefetchCacheEntry = {
   cacheForNavigation?: boolean;
+  navigationCacheRejected?: boolean;
   expiresAt?: number;
   invalidationTimer?: ReturnType<typeof setTimeout>;
   mountedSlotsHeader?: string | null;
@@ -983,6 +987,7 @@ export function prefetchRscResponse(
   behavior: {
     cacheForNavigation?: boolean;
     fallbackTtlMs?: number;
+    navigationCacheResponsePolicy?: NavigationCacheResponsePolicy;
     optimisticRouteShell?: boolean;
     prefetchKind?: PrefetchCacheKind;
     searchAgnosticShell?: boolean;
@@ -1014,6 +1019,12 @@ export function prefetchRscResponse(
   entry.pending = fetchPromise
     .then(async (response) => {
       if (response.ok) {
+        const responsePolicy = behavior.navigationCacheResponsePolicy;
+        if (responsePolicy !== undefined) {
+          const admitted = responseAllowsNavigationCache(response, responsePolicy);
+          entry.cacheForNavigation = admitted;
+          entry.navigationCacheRejected = !admitted;
+        }
         const snapshot = await snapshotRscResponse(response);
         if (cache.get(cacheKey) !== entry) return;
         const previousSize = getPrefetchCacheEntrySize(entry);
@@ -1049,6 +1060,27 @@ export function prefetchRscResponse(
   // entries inserted before it are candidates for removal.
   cache.set(cacheKey, entry);
   evictPrefetchCacheIfNeeded();
+}
+
+function responseAllowsNavigationCache(
+  response: Response,
+  policy: NavigationCacheResponsePolicy,
+): boolean {
+  const cacheControl = [
+    response.headers.get("cache-control"),
+    response.headers.get("cdn-cache-control"),
+  ]
+    .filter((value): value is string => value !== null)
+    .join(",");
+  const directives = cacheControl.split(",").map((directive) => directive.trim().toLowerCase());
+  if (directives.includes("no-store")) return false;
+  if (policy === "reject-no-store") return true;
+
+  if (directives.some((directive) => directive.startsWith("s-maxage="))) {
+    return true;
+  }
+  const cacheState = response.headers.get(VINEXT_CACHE_HEADER)?.toUpperCase();
+  return cacheState === "HIT" || cacheState === "STALE" || cacheState === "STATIC";
 }
 
 function addRenderedPathAndSearchPrefetchAlias(

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -39,6 +39,7 @@ import {
 } from "../server/app-rsc-cache-busting.js";
 import { hasPendingAppRouterPageRedirect } from "../server/app-browser-mpa-navigation.js";
 import {
+  VINEXT_CACHE_HEADER,
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
@@ -285,6 +286,7 @@ export type PrefetchOptions = {
 export type PrefetchCacheKind = "loading-shell" | "navigation" | "route-tree";
 
 export type PrefetchCacheEntry = {
+  automaticFullPrefetchEligible?: boolean;
   cacheForNavigation?: boolean;
   cacheForNavigationOnComplete?: boolean;
   expiresAt?: number;
@@ -551,6 +553,31 @@ export function hasPrefetchCacheEntryForNavigation(
     options.notifyInvalidation ?? true,
   );
   return false;
+}
+
+export function findProvisionalFullPrefetchEntryForNavigation(
+  rscUrl: string,
+  interceptionContext: string | null = null,
+  mountedSlotsHeader: string | null = null,
+  additionalRscUrls: readonly string[] = [],
+): PrefetchCacheEntry | null {
+  const normalizedTargets = new Set(
+    [rscUrl, ...additionalRscUrls]
+      .map((lookupRscUrl) => normalizeRscCacheLookupUrl(lookupRscUrl))
+      .filter((lookupRscUrl): lookupRscUrl is string => lookupRscUrl !== null),
+  );
+  if (normalizedTargets.size === 0) return null;
+
+  for (const [cacheKey, entry] of getPrefetchCache()) {
+    if (entry.cacheForNavigationOnComplete !== true || entry.pending === undefined) continue;
+    const source = parsePrefetchCacheKey(cacheKey);
+    if (source.interceptionContext !== interceptionContext) continue;
+    const normalizedSource = normalizeRscCacheLookupUrl(source.rscUrl);
+    if (normalizedSource === null || !normalizedTargets.has(normalizedSource)) continue;
+    if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) continue;
+    return entry;
+  }
+  return null;
 }
 
 export function hasSearchAgnosticPrefetchShellForRoute(
@@ -985,6 +1012,7 @@ export function prefetchRscResponse(
     cacheForNavigation?: boolean;
     cacheForNavigationOnComplete?: boolean;
     fallbackTtlMs?: number;
+    recordAutomaticFullPrefetchEligibility?: boolean;
     optimisticRouteShell?: boolean;
     prefetchKind?: PrefetchCacheKind;
     searchAgnosticShell?: boolean;
@@ -1017,6 +1045,10 @@ export function prefetchRscResponse(
   entry.pending = fetchPromise
     .then(async (response) => {
       if (response.ok) {
+        if (behavior.recordAutomaticFullPrefetchEligibility === true) {
+          entry.automaticFullPrefetchEligible =
+            responseProvesAutomaticFullPrefetchEligibility(response);
+        }
         const snapshot = await snapshotRscResponse(response);
         if (cache.get(cacheKey) !== entry) return;
         const previousSize = getPrefetchCacheEntrySize(entry);
@@ -1060,6 +1092,23 @@ export function prefetchRscResponse(
   // entries inserted before it are candidates for removal.
   cache.set(cacheKey, entry);
   evictPrefetchCacheIfNeeded();
+}
+
+function responseProvesAutomaticFullPrefetchEligibility(response: Response): boolean {
+  const cacheControl = [
+    response.headers.get("cache-control"),
+    response.headers.get("cdn-cache-control"),
+  ]
+    .filter((value): value is string => value !== null)
+    .join(",");
+  const hasPositiveSharedLifetime = cacheControl.split(",").some((directive) => {
+    const match = /^\s*s-maxage=(\d+)\s*$/i.exec(directive);
+    return match !== null && Number(match[1]) > 0;
+  });
+  if (hasPositiveSharedLifetime) return true;
+
+  const cacheState = response.headers.get(VINEXT_CACHE_HEADER)?.toUpperCase();
+  return cacheState === "HIT" || cacheState === "STALE" || cacheState === "STATIC";
 }
 
 function addRenderedPathAndSearchPrefetchAlias(

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -40,7 +40,6 @@ import {
 import { hasPendingAppRouterPageRedirect } from "../server/app-browser-mpa-navigation.js";
 import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
-  VINEXT_CACHE_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
@@ -285,11 +284,9 @@ export type PrefetchOptions = {
 
 export type PrefetchCacheKind = "loading-shell" | "navigation" | "route-tree";
 
-type NavigationCacheResponsePolicy = "reject-no-store" | "require-shared-cache";
-
 export type PrefetchCacheEntry = {
   cacheForNavigation?: boolean;
-  navigationCacheRejected?: boolean;
+  cacheForNavigationOnComplete?: boolean;
   expiresAt?: number;
   invalidationTimer?: ReturnType<typeof setTimeout>;
   mountedSlotsHeader?: string | null;
@@ -986,8 +983,8 @@ export function prefetchRscResponse(
   options?: PrefetchOptions,
   behavior: {
     cacheForNavigation?: boolean;
+    cacheForNavigationOnComplete?: boolean;
     fallbackTtlMs?: number;
-    navigationCacheResponsePolicy?: NavigationCacheResponsePolicy;
     optimisticRouteShell?: boolean;
     prefetchKind?: PrefetchCacheKind;
     searchAgnosticShell?: boolean;
@@ -1004,6 +1001,7 @@ export function prefetchRscResponse(
 
   const entry: PrefetchCacheEntry = {
     cacheForNavigation: behavior.cacheForNavigation ?? true,
+    cacheForNavigationOnComplete: behavior.cacheForNavigationOnComplete === true,
     cacheKeys: new Set([cacheKey]),
     mountedSlotsHeader,
     optimisticRouteShell: behavior.optimisticRouteShell === true,
@@ -1019,12 +1017,6 @@ export function prefetchRscResponse(
   entry.pending = fetchPromise
     .then(async (response) => {
       if (response.ok) {
-        const responsePolicy = behavior.navigationCacheResponsePolicy;
-        if (responsePolicy !== undefined) {
-          const admitted = responseAllowsNavigationCache(response, responsePolicy);
-          entry.cacheForNavigation = admitted;
-          entry.navigationCacheRejected = !admitted;
-        }
         const snapshot = await snapshotRscResponse(response);
         if (cache.get(cacheKey) !== entry) return;
         const previousSize = getPrefetchCacheEntrySize(entry);
@@ -1036,6 +1028,14 @@ export function prefetchRscResponse(
           entry.snapshot,
           behavior.fallbackTtlMs ?? PREFETCH_CACHE_TTL,
         );
+        // Next.js intentionally treats a completed Full prefetch as reusable
+        // client state even when it contains dynamic data. Keep it invisible
+        // while the stream is incomplete so a click never waits for body EOF;
+        // once snapshotted, it is the same navigation response fetched early.
+        // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/segment-cache/scheduler.ts
+        if (behavior.cacheForNavigationOnComplete === true) {
+          entry.cacheForNavigation = true;
+        }
         addRenderedPathAndSearchPrefetchAlias(cache, prefetched, cacheKey, entry);
         evictPrefetchCacheIfNeeded();
       } else {
@@ -1060,27 +1060,6 @@ export function prefetchRscResponse(
   // entries inserted before it are candidates for removal.
   cache.set(cacheKey, entry);
   evictPrefetchCacheIfNeeded();
-}
-
-function responseAllowsNavigationCache(
-  response: Response,
-  policy: NavigationCacheResponsePolicy,
-): boolean {
-  const cacheControl = [
-    response.headers.get("cache-control"),
-    response.headers.get("cdn-cache-control"),
-  ]
-    .filter((value): value is string => value !== null)
-    .join(",");
-  const directives = cacheControl.split(",").map((directive) => directive.trim().toLowerCase());
-  if (directives.includes("no-store")) return false;
-  if (policy === "reject-no-store") return true;
-
-  if (directives.some((directive) => directive.startsWith("s-maxage="))) {
-    return true;
-  }
-  const cacheState = response.headers.get(VINEXT_CACHE_HEADER)?.toUpperCase();
-  return cacheState === "HIT" || cacheState === "STALE" || cacheState === "STATIC";
 }
 
 function addRenderedPathAndSearchPrefetchAlias(

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -437,6 +437,35 @@ describe("App Router generated manifest construction", () => {
     }
   });
 
+  it("advertises generateStaticParams routes as full-prefetch candidates", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prefetch-static-params-"));
+    const appDir = path.join(tmpDir, "app");
+    try {
+      fs.mkdirSync(path.join(appDir, "posts", "[slug]"), { recursive: true });
+      fs.writeFileSync(path.join(appDir, "layout.tsx"), "export default function Layout() {}\n");
+      fs.writeFileSync(
+        path.join(appDir, "posts", "[slug]", "page.tsx"),
+        `export function generateStaticParams() { return [{ slug: "hello" }] }\nexport default function Page() {}\n`,
+      );
+      fs.writeFileSync(
+        path.join(appDir, "posts", "[slug]", "loading.tsx"),
+        "export default function Loading() {}\n",
+      );
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      expect(toLinkPrefetchRoutes(graph.routes)).toContainEqual(
+        expect.objectContaining({
+          canPrefetchLoadingShell: true,
+          hasGenerateStaticParams: true,
+          isDynamic: true,
+          patternParts: ["posts", ":slug"],
+        }),
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("constructs route module imports and route entries from the scanned app shape", () => {
     const routes = [
       {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -48,6 +48,11 @@ const linkPrefetchRoutes = [
   { canPrefetchLoadingShell: false, patternParts: ["intent-prefetch-target"], isDynamic: false },
   { canPrefetchLoadingShell: false, patternParts: ["touch-prefetch-target"], isDynamic: false },
   {
+    canPrefetchLoadingShell: true,
+    patternParts: ["metadata-await-promise", "nested"],
+    isDynamic: false,
+  },
+  {
     canPrefetchLoadingShell: false,
     patternParts: ["same-origin-intent-prefetch-target"],
     isDynamic: false,
@@ -1582,6 +1587,45 @@ describe("Link prefetch scheduling", () => {
       );
       const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(true);
+      expect(entry?.optimisticRouteShell).toBe(false);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("full-prefetches visible static links with loading boundaries", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/metadata-await-promise/nested",
+      nodeEnv: "production",
+    });
+
+    try {
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/metadata-await-promise/nested",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
         null,
       );
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1491,7 +1491,7 @@ describe("Link prefetch scheduling", () => {
     try {
       expect(observer.observe).toHaveBeenCalledWith(result.anchor);
       observer.dispatchIntersectingEntry(result.anchor);
-      await waitForFetchCalls(result.fetch, 1);
+      await waitForFetchCalls(result.fetch, 2);
 
       expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
       expectCanonicalRscFetchCall(
@@ -1957,9 +1957,14 @@ describe("Link prefetch scheduling", () => {
     });
 
     try {
+      result.fetch.mockResolvedValueOnce(
+        new Response("static-flight", {
+          headers: { "cache-control": "s-maxage=31536000, stale-while-revalidate" },
+        }),
+      );
       expect(observer.observe).toHaveBeenCalledWith(result.anchor);
       observer.dispatchIntersectingEntry(result.anchor);
-      await waitForFetchCalls(result.fetch, 1);
+      await waitForFetchCalls(result.fetch, 2);
 
       // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
       // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
@@ -1982,15 +1987,25 @@ describe("Link prefetch scheduling", () => {
         (fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
       ).toBe("1");
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
-      const entry = Array.from(getPrefetchCache().values())[0];
+      const entry = Array.from(getPrefetchCache().values()).find(
+        (candidate) => candidate.optimisticRouteShell !== true,
+      );
+      await entry?.pending;
+      await flushPrefetchTasks();
       expect(entry?.cacheForNavigation).toBe(true);
       expect(entry?.optimisticRouteShell).toBe(false);
+      expect(
+        Array.from(getPrefetchCache().values()).some(
+          (candidate) =>
+            candidate.cacheForNavigation === false && candidate.optimisticRouteShell === true,
+        ),
+      ).toBe(true);
     } finally {
       result.restoreNodeEnv();
     }
   });
 
-  it("does not reuse a no-store full prefetch for a fixed loading-boundary route", async () => {
+  it("keeps pending Full prefetches non-consumable, then reuses the completed response", async () => {
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
       href: "/personalized-loading",
@@ -1999,24 +2014,37 @@ describe("Link prefetch scheduling", () => {
     });
 
     try {
-      // A fixed pathname is not proof of a static render. This models a route
-      // with loading.tsx that exports force-dynamic and reads a request cookie.
+      // Next's Full prefetch is a navigation request issued ahead of time. It
+      // intentionally becomes reusable client state once complete, including
+      // for dynamic/no-store responses.
+      let closeFullResponse = () => {};
+      const fullBody = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("prefetched-cookie=before"));
+          closeFullResponse = () => controller.close();
+        },
+      });
       result.fetch.mockResolvedValueOnce(
-        new Response("prefetched-cookie=before", {
+        new Response(fullBody, {
           headers: { "cache-control": "no-store, must-revalidate" },
         }),
       );
       observer.dispatchIntersectingEntry(result.anchor);
-      await waitForFetchCalls(result.fetch, 1);
+      await waitForFetchCalls(result.fetch, 2);
 
       const { consumePrefetchResponseForNavigation, getPrefetchCache } =
         await import("../packages/vinext/src/shims/navigation.js");
-      const entry = Array.from(getPrefetchCache().values())[0];
-      await entry?.pending;
+      const entry = Array.from(getPrefetchCache().values()).find(
+        (candidate) => candidate.optimisticRouteShell !== true,
+      );
+      await flushPrefetchTasks();
 
       expect(entry?.cacheForNavigation).toBe(false);
-      // After the cookie/request state changes, navigation cannot consume the
-      // old prefetched payload and therefore must issue a fresh RSC request.
+      expect(
+        Array.from(getPrefetchCache().values()).some(
+          (candidate) => candidate.optimisticRouteShell === true,
+        ),
+      ).toBe(true);
       const fetchCall = result.fetch.mock.calls[0];
       const prefetchedUrl = fetchCall?.[0];
       expect(typeof prefetchedUrl).toBe("string");
@@ -2024,16 +2052,21 @@ describe("Link prefetch scheduling", () => {
         await consumePrefetchResponseForNavigation(prefetchedUrl as string, null, null),
       ).toBeNull();
 
-      result.fetch.mockResolvedValueOnce(new Response("prefetched-cookie=after"));
+      // Pointer intent must not promote the still-open Full response and make
+      // a click join its body. The separately cached loading shell remains the
+      // provisional navigation path.
       result.capturedAnchorProps.onMouseEnter?.({
         currentTarget: result.anchor,
       } as CapturedIntentEvent);
-      await waitForFetchCalls(result.fetch, 2);
-      expect(result.fetch.mock.calls.length).toBeGreaterThanOrEqual(2);
-      const freshFetchInit = result.fetch.mock.calls.at(-1)?.[1] as RequestInit | undefined;
+      await flushPrefetchTasks();
+      expect(entry?.cacheForNavigation).toBe(false);
+
+      closeFullResponse();
+      await entry?.pending;
+      expect(entry?.cacheForNavigation).toBe(true);
       expect(
-        (freshFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
-      ).toBeNull();
+        await consumePrefetchResponseForNavigation(prefetchedUrl as string, null, null),
+      ).not.toBeNull();
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -59,6 +59,11 @@ const linkPrefetchRoutes = [
     isDynamic: false,
   },
   {
+    canPrefetchLoadingShell: true,
+    patternParts: ["personalized-loading"],
+    isDynamic: false,
+  },
+  {
     canPrefetchLoadingShell: false,
     patternParts: ["same-origin-intent-prefetch-target"],
     isDynamic: false,
@@ -1980,6 +1985,55 @@ describe("Link prefetch scheduling", () => {
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry?.cacheForNavigation).toBe(true);
       expect(entry?.optimisticRouteShell).toBe(false);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not reuse a no-store full prefetch for a fixed loading-boundary route", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/personalized-loading",
+      nodeEnv: "production",
+      props: { unstable_dynamicOnHover: true },
+    });
+
+    try {
+      // A fixed pathname is not proof of a static render. This models a route
+      // with loading.tsx that exports force-dynamic and reads a request cookie.
+      result.fetch.mockResolvedValueOnce(
+        new Response("prefetched-cookie=before", {
+          headers: { "cache-control": "no-store, must-revalidate" },
+        }),
+      );
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const { consumePrefetchResponseForNavigation, getPrefetchCache } =
+        await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      await entry?.pending;
+
+      expect(entry?.cacheForNavigation).toBe(false);
+      // After the cookie/request state changes, navigation cannot consume the
+      // old prefetched payload and therefore must issue a fresh RSC request.
+      const fetchCall = result.fetch.mock.calls[0];
+      const prefetchedUrl = fetchCall?.[0];
+      expect(typeof prefetchedUrl).toBe("string");
+      expect(
+        await consumePrefetchResponseForNavigation(prefetchedUrl as string, null, null),
+      ).toBeNull();
+
+      result.fetch.mockResolvedValueOnce(new Response("prefetched-cookie=after"));
+      result.capturedAnchorProps.onMouseEnter?.({
+        currentTarget: result.anchor,
+      } as CapturedIntentEvent);
+      await waitForFetchCalls(result.fetch, 2);
+      expect(result.fetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+      const freshFetchInit = result.fetch.mock.calls.at(-1)?.[1] as RequestInit | undefined;
+      expect(
+        (freshFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+      ).toBeNull();
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -54,6 +54,11 @@ const linkPrefetchRoutes = [
   { canPrefetchLoadingShell: false, patternParts: ["intent-prefetch-target"], isDynamic: false },
   { canPrefetchLoadingShell: false, patternParts: ["touch-prefetch-target"], isDynamic: false },
   {
+    canPrefetchLoadingShell: true,
+    patternParts: ["metadata-await-promise", "nested"],
+    isDynamic: false,
+  },
+  {
     canPrefetchLoadingShell: false,
     patternParts: ["same-origin-intent-prefetch-target"],
     isDynamic: false,
@@ -1929,6 +1934,48 @@ describe("Link prefetch scheduling", () => {
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
         null,
       );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(true);
+      expect(entry?.optimisticRouteShell).toBe(false);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("full-prefetches visible static links with loading boundaries", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/metadata-await-promise/nested",
+      nodeEnv: "production",
+    });
+
+    try {
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/metadata-await-promise/nested",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
+        "1",
+      );
+      expect(
+        (fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
+      ).toBe("1");
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry?.cacheForNavigation).toBe(true);

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -64,6 +64,12 @@ const linkPrefetchRoutes = [
     isDynamic: false,
   },
   {
+    canPrefetchLoadingShell: true,
+    hasGenerateStaticParams: true,
+    patternParts: ["generated-posts", ":slug"],
+    isDynamic: true,
+  },
+  {
     canPrefetchLoadingShell: false,
     patternParts: ["same-origin-intent-prefetch-target"],
     isDynamic: false,
@@ -1958,7 +1964,7 @@ describe("Link prefetch scheduling", () => {
 
     try {
       result.fetch.mockResolvedValueOnce(
-        new Response("static-flight", {
+        new Response("static-shell", {
           headers: { "cache-control": "s-maxage=31536000, stale-while-revalidate" },
         }),
       );
@@ -1968,15 +1974,20 @@ describe("Link prefetch scheduling", () => {
 
       // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
       // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+      const fullFetchCall = result.fetch.mock.calls.find(([, init]) => {
+        const headers = (init as RequestInit | undefined)?.headers as Headers | undefined;
+        return headers?.get(VINEXT_RSC_RENDER_MODE_HEADER) === null;
+      });
+      expect(fullFetchCall).toBeDefined();
       expectCanonicalRscFetchCall(
-        result.fetch.mock.calls[0],
+        fullFetchCall!,
         "/metadata-await-promise/nested",
         expect.objectContaining({
           credentials: "include",
           priority: "low",
         }),
       );
-      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      const fetchInit = fullFetchCall?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
         null,
       );
@@ -2024,11 +2035,17 @@ describe("Link prefetch scheduling", () => {
           closeFullResponse = () => controller.close();
         },
       });
-      result.fetch.mockResolvedValueOnce(
-        new Response(fullBody, {
-          headers: { "cache-control": "no-store, must-revalidate" },
-        }),
-      );
+      result.fetch
+        .mockResolvedValueOnce(
+          new Response("static-shell", {
+            headers: { "cache-control": "s-maxage=31536000" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(fullBody, {
+            headers: { "cache-control": "no-store, must-revalidate" },
+          }),
+        );
       observer.dispatchIntersectingEntry(result.anchor);
       await waitForFetchCalls(result.fetch, 2);
 
@@ -2037,6 +2054,8 @@ describe("Link prefetch scheduling", () => {
       const entry = Array.from(getPrefetchCache().values()).find(
         (candidate) => candidate.optimisticRouteShell !== true,
       );
+      expect(entry).toBeDefined();
+      const cacheEntryAtAutoPrefetch = entry;
       await flushPrefetchTasks();
 
       expect(entry?.cacheForNavigation).toBe(false);
@@ -2059,7 +2078,15 @@ describe("Link prefetch scheduling", () => {
         currentTarget: result.anchor,
       } as CapturedIntentEvent);
       await flushPrefetchTasks();
-      expect(entry?.cacheForNavigation).toBe(false);
+      const currentFullEntry = Array.from(getPrefetchCache().values()).find(
+        (candidate) => candidate.optimisticRouteShell !== true,
+      );
+      expect(currentFullEntry).toBe(cacheEntryAtAutoPrefetch);
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      expect(currentFullEntry?.cacheForNavigation).toBe(false);
+      expect(
+        await consumePrefetchResponseForNavigation(prefetchedUrl as string, null, null),
+      ).toBeNull();
 
       closeFullResponse();
       await entry?.pending;
@@ -2071,6 +2098,49 @@ describe("Link prefetch scheduling", () => {
       result.restoreNodeEnv();
     }
   });
+
+  it.each([
+    ["fixed force-dynamic route", "/personalized-loading", "no-store, must-revalidate"],
+    ["non-generated fallback param", "/generated-posts/fallback", undefined],
+  ])(
+    "keeps automatic %s prefetches shell-only without concrete static proof",
+    async (_name, href, cacheControl) => {
+      const observer = stubIntersectionObserver();
+      const result = await renderIsolatedLink({ href, nodeEnv: "production" });
+
+      try {
+        result.fetch.mockResolvedValueOnce(
+          new Response("dynamic-shell", {
+            headers: cacheControl === undefined ? undefined : { "cache-control": cacheControl },
+          }),
+        );
+        observer.dispatchIntersectingEntry(result.anchor);
+        await waitForFetchCalls(result.fetch, 1);
+        await flushPrefetchTasks();
+
+        expect(result.fetch).toHaveBeenCalledTimes(1);
+        const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+        expect(
+          (fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+        ).toBe(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
+        const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+        expect(
+          Array.from(getPrefetchCache().values()).some(
+            (entry) => entry.prefetchKind === "navigation",
+          ),
+        ).toBe(false);
+        expect(
+          Array.from(getPrefetchCache().values()).some(
+            (entry) =>
+              entry.prefetchKind === "loading-shell" &&
+              entry.automaticFullPrefetchEligible === false,
+          ),
+        ).toBe(true);
+      } finally {
+        result.restoreNodeEnv();
+      }
+    },
+  );
 
   it("full-prefetches visible dynamic links when prefetch is explicitly true", async () => {
     const observer = stubIntersectionObserver();

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1947,6 +1947,7 @@ describe("Link prefetch scheduling", () => {
       );
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
+      await entry?.pending;
       expect(entry?.cacheForNavigation).toBe(true);
       expect(entry?.optimisticRouteShell).toBe(false);
     } finally {
@@ -2093,6 +2094,154 @@ describe("Link prefetch scheduling", () => {
       expect(entry?.cacheForNavigation).toBe(true);
       expect(
         await consumePrefetchResponseForNavigation(prefetchedUrl as string, null, null),
+      ).not.toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps a newly started hover Full prefetch non-consumable until body EOF", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+      props: { unstable_dynamicOnHover: true },
+    });
+
+    let closeFullResponse = () => {};
+    const fullBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial-hover-full"));
+        closeFullResponse = () => controller.close();
+      },
+    });
+    result.fetch
+      .mockResolvedValueOnce(new Response("dynamic-loading-shell"))
+      .mockResolvedValueOnce(new Response(fullBody));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+      await flushPrefetchTasks();
+
+      result.capturedAnchorProps.onMouseEnter?.({
+        currentTarget: result.anchor,
+      } as CapturedIntentEvent);
+      await waitForFetchCalls(result.fetch, 2);
+
+      const { consumePrefetchResponseForNavigation, getPrefetchCache } =
+        await import("../packages/vinext/src/shims/navigation.js");
+      const fullEntry = Array.from(getPrefetchCache().values()).find(
+        (candidate) => candidate.optimisticRouteShell !== true,
+      );
+      const fullFetchCall = result.fetch.mock.calls.find(([, init]) => {
+        const headers = (init as RequestInit | undefined)?.headers as Headers | undefined;
+        return headers?.get(VINEXT_RSC_RENDER_MODE_HEADER) === null;
+      });
+      const fullRscUrl = fullFetchCall?.[0];
+      expect(fullEntry).toBeDefined();
+      expect(typeof fullRscUrl).toBe("string");
+      expect(fullEntry?.cacheForNavigation).toBe(false);
+      expect(fullEntry?.cacheForNavigationOnComplete).toBe(true);
+      expect(
+        Array.from(getPrefetchCache().values()).some(
+          (candidate) => candidate.optimisticRouteShell === true,
+        ),
+      ).toBe(true);
+      expect(
+        await consumePrefetchResponseForNavigation(fullRscUrl as string, null, null),
+      ).toBeNull();
+
+      result.capturedAnchorProps.onMouseEnter?.({
+        currentTarget: result.anchor,
+      } as CapturedIntentEvent);
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      expect(
+        Array.from(getPrefetchCache().values()).find(
+          (candidate) => candidate.optimisticRouteShell !== true,
+        ),
+      ).toBe(fullEntry);
+
+      closeFullResponse();
+      await fullEntry?.pending;
+      expect(fullEntry?.cacheForNavigation).toBe(true);
+      expect(
+        await consumePrefetchResponseForNavigation(fullRscUrl as string, null, null),
+      ).not.toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps an explicit Full prefetch non-consumable until body EOF", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+      props: { prefetch: true },
+    });
+
+    let closeFullResponse = () => {};
+    const fullBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial-explicit-full"));
+        closeFullResponse = () => controller.close();
+      },
+    });
+    result.fetch.mockImplementation((_input, init) => {
+      const headers = init?.headers as Headers | undefined;
+      return Promise.resolve(
+        headers?.get(VINEXT_RSC_RENDER_MODE_HEADER) === null
+          ? new Response(fullBody)
+          : new Response("explicit-loading-shell"),
+      );
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 2);
+
+      const { consumePrefetchResponseForNavigation, getPrefetchCache } =
+        await import("../packages/vinext/src/shims/navigation.js");
+      const fullEntry = Array.from(getPrefetchCache().values()).find(
+        (candidate) => candidate.optimisticRouteShell !== true,
+      );
+      const fullFetchCall = result.fetch.mock.calls.find(([, init]) => {
+        const headers = (init as RequestInit | undefined)?.headers as Headers | undefined;
+        return headers?.get(VINEXT_RSC_RENDER_MODE_HEADER) === null;
+      });
+      const fullRscUrl = fullFetchCall?.[0];
+      expect(fullEntry).toBeDefined();
+      expect(typeof fullRscUrl).toBe("string");
+      expect(fullEntry?.cacheForNavigation).toBe(false);
+      expect(fullEntry?.cacheForNavigationOnComplete).toBe(true);
+      expect(
+        Array.from(getPrefetchCache().values()).some(
+          (candidate) => candidate.optimisticRouteShell === true,
+        ),
+      ).toBe(true);
+      expect(
+        await consumePrefetchResponseForNavigation(fullRscUrl as string, null, null),
+      ).toBeNull();
+
+      result.capturedAnchorProps.onMouseEnter?.({
+        currentTarget: result.anchor,
+      } as CapturedIntentEvent);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      expect(
+        Array.from(getPrefetchCache().values()).find(
+          (candidate) => candidate.optimisticRouteShell !== true,
+        ),
+      ).toBe(fullEntry);
+
+      closeFullResponse();
+      await fullEntry?.pending;
+      expect(fullEntry?.cacheForNavigation).toBe(true);
+      expect(
+        await consumePrefetchResponseForNavigation(fullRscUrl as string, null, null),
       ).not.toBeNull();
     } finally {
       result.restoreNodeEnv();

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -273,7 +273,7 @@ describe("Link App Router prefetch mode", () => {
     expect(resolveLinkPrefetchMode(true, true)).toBe("disabled");
   });
 
-  it("allows automatic full RSC prefetch only for routes without loading-shell prefetches", () => {
+  it("allows automatic full RSC prefetch for static routes and dynamic routes without loading shells", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -294,7 +294,7 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
-      expect(canAutoPrefetchFullAppRoute("/settings")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/settings")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
     } finally {
       if (originalWindow === undefined) {
@@ -305,7 +305,7 @@ describe("Link App Router prefetch mode", () => {
     }
   });
 
-  it("shell-prefetches routes with loading boundaries and full-prefetches routes without them", () => {
+  it("full-prefetches static routes with loading boundaries while preserving dynamic shell-only prefetch", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -333,7 +333,7 @@ describe("Link App Router prefetch mode", () => {
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
-        cacheForNavigation: false,
+        cacheForNavigation: true,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -362,6 +362,7 @@ describe("Link App Router prefetch mode", () => {
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/posts/hello-world")).toEqual({
+        automaticFullPrefetchProbe: "loading-shell",
         cacheForNavigation: false,
         cacheForNavigationOnComplete: true,
         fetchFullPayload: true,
@@ -369,6 +370,7 @@ describe("Link App Router prefetch mode", () => {
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
+        automaticFullPrefetchProbe: "loading-shell",
         cacheForNavigation: false,
         cacheForNavigationOnComplete: true,
         fetchFullPayload: true,

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -284,6 +284,12 @@ describe("Link App Router prefetch mode", () => {
       __VINEXT_LINK_PREFETCH_ROUTES__: [
         { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: true,
+          hasGenerateStaticParams: true,
+          patternParts: ["posts", ":slug"],
+          isDynamic: true,
+        },
         { canPrefetchLoadingShell: true, patternParts: ["docs", ":slug+"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         {
@@ -299,6 +305,9 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(canAutoPrefetchFullAppRoute("/about")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
+      // Generated dynamic paths start provisionally non-consumable until the
+      // server response supplies positive static-cache proof.
+      expect(canAutoPrefetchFullAppRoute("/posts/hello-world")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/teams/vercel/dashboard")).toBe(false);
@@ -323,6 +332,12 @@ describe("Link App Router prefetch mode", () => {
       __VINEXT_LINK_PREFETCH_ROUTES__: [
         { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: true,
+          hasGenerateStaticParams: true,
+          patternParts: ["posts", ":slug"],
+          isDynamic: true,
+        },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
         {
@@ -338,21 +353,33 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        fetchFullPayload: true,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        fetchFullPayload: false,
+        prefetchShellFirst: false,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/posts/hello-world")).toEqual({
+        cacheForNavigation: false,
+        fetchFullPayload: true,
+        navigationCacheResponsePolicy: "require-shared-cache",
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: true,
+        fetchFullPayload: true,
+        navigationCacheResponsePolicy: "reject-no-store",
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        fetchFullPayload: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
@@ -361,16 +388,19 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        fetchFullPayload: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/teams/vercel/dashboard")).toEqual({
         cacheForNavigation: false,
+        fetchFullPayload: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
+        fetchFullPayload: false,
         prefetchShellFirst: false,
         shouldPrefetch: false,
       });

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -302,7 +302,7 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/teams/vercel/dashboard")).toBe(false);
-      expect(canAutoPrefetchFullAppRoute("/settings")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/settings")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
     } finally {
       if (originalWindow === undefined) {
@@ -313,7 +313,7 @@ describe("Link App Router prefetch mode", () => {
     }
   });
 
-  it("shell-prefetches dynamic routes that require fresh navigation and routes with loading boundaries", () => {
+  it("full-prefetches static routes with loading boundaries while preserving dynamic shell-only prefetch", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -347,7 +347,7 @@ describe("Link App Router prefetch mode", () => {
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
-        cacheForNavigation: false,
+        cacheForNavigation: true,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -350,7 +350,8 @@ describe("Link App Router prefetch mode", () => {
 
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
-        cacheForNavigation: true,
+        cacheForNavigation: false,
+        cacheForNavigationOnComplete: true,
         fetchFullPayload: true,
         prefetchShellFirst: true,
         shouldPrefetch: true,
@@ -378,7 +379,8 @@ describe("Link App Router prefetch mode", () => {
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
-        cacheForNavigation: true,
+        cacheForNavigation: false,
+        cacheForNavigationOnComplete: true,
         fetchFullPayload: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
@@ -387,7 +389,8 @@ describe("Link App Router prefetch mode", () => {
       // test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
-        cacheForNavigation: true,
+        cacheForNavigation: false,
+        cacheForNavigationOnComplete: true,
         fetchFullPayload: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -305,9 +305,7 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(canAutoPrefetchFullAppRoute("/about")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
-      // Generated dynamic paths start provisionally non-consumable until the
-      // server response supplies positive static-cache proof.
-      expect(canAutoPrefetchFullAppRoute("/posts/hello-world")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/posts/hello-world")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/teams/vercel/dashboard")).toBe(false);
@@ -365,15 +363,15 @@ describe("Link App Router prefetch mode", () => {
       });
       expect(resolveAutoAppRoutePrefetch("/posts/hello-world")).toEqual({
         cacheForNavigation: false,
+        cacheForNavigationOnComplete: true,
         fetchFullPayload: true,
-        navigationCacheResponsePolicy: "require-shared-cache",
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
-        cacheForNavigation: true,
+        cacheForNavigation: false,
+        cacheForNavigationOnComplete: true,
         fetchFullPayload: true,
-        navigationCacheResponsePolicy: "reject-no-store",
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -564,6 +564,67 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
   });
 
+  it("rejects no-store automatic full prefetches from navigation reuse", async () => {
+    const rscUrl = "/personalized-loading.rsc";
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("cookie=before", {
+          headers: {
+            "cache-control": "no-store, must-revalidate",
+            "content-type": "text/x-component",
+          },
+        }),
+      ),
+      null,
+      null,
+      undefined,
+      { cacheForNavigation: true, navigationCacheResponsePolicy: "reject-no-store" },
+    );
+
+    const entry = getPrefetchCache().get(rscUrl);
+    await entry?.pending;
+    expect(entry?.cacheForNavigation).toBe(false);
+    expect(entry?.navigationCacheRejected).toBe(true);
+    await expect(consumePrefetchResponseForNavigation(rscUrl, null, null)).resolves.toBeNull();
+  });
+
+  it("admits generated dynamic paths only with positive shared-cache proof", async () => {
+    const staticUrl = "/posts/static.rsc";
+    const fallbackUrl = "/posts/fallback.rsc";
+    for (const [rscUrl, cacheControl] of [
+      [staticUrl, "s-maxage=31536000, stale-while-revalidate"],
+      [fallbackUrl, null],
+    ] as const) {
+      prefetchRscResponse(
+        rscUrl,
+        Promise.resolve(
+          new Response(rscUrl, {
+            headers: {
+              ...(cacheControl === null ? {} : { "cache-control": cacheControl }),
+              "content-type": "text/x-component",
+            },
+          }),
+        ),
+        null,
+        null,
+        undefined,
+        {
+          cacheForNavigation: false,
+          navigationCacheResponsePolicy: "require-shared-cache",
+        },
+      );
+      await getPrefetchCache().get(rscUrl)?.pending;
+    }
+
+    expect(getPrefetchCache().get(staticUrl)?.cacheForNavigation).toBe(true);
+    expect(getPrefetchCache().get(fallbackUrl)?.cacheForNavigation).toBe(false);
+    await expect(
+      consumePrefetchResponseForNavigation(staticUrl, null, null),
+    ).resolves.not.toBeNull();
+    await expect(consumePrefetchResponseForNavigation(fallbackUrl, null, null)).resolves.toBeNull();
+  });
+
   it("honors an explicit fallback stale window above the minimum for prefetched responses", async () => {
     const now = 1_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -564,7 +564,7 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
   });
 
-  it("rejects no-store automatic full prefetches from navigation reuse", async () => {
+  it("reuses a completed full prefetch regardless of HTTP cache policy", async () => {
     const rscUrl = "/personalized-loading.rsc";
     prefetchRscResponse(
       rscUrl,
@@ -579,50 +579,52 @@ describe("prefetch cache eviction", () => {
       null,
       null,
       undefined,
-      { cacheForNavigation: true, navigationCacheResponsePolicy: "reject-no-store" },
+      { cacheForNavigation: false, cacheForNavigationOnComplete: true },
     );
 
     const entry = getPrefetchCache().get(rscUrl);
     await entry?.pending;
-    expect(entry?.cacheForNavigation).toBe(false);
-    expect(entry?.navigationCacheRejected).toBe(true);
-    await expect(consumePrefetchResponseForNavigation(rscUrl, null, null)).resolves.toBeNull();
+    expect(entry?.cacheForNavigation).toBe(true);
+    await expect(consumePrefetchResponseForNavigation(rscUrl, null, null)).resolves.not.toBeNull();
   });
 
-  it("admits generated dynamic paths only with positive shared-cache proof", async () => {
-    const staticUrl = "/posts/static.rsc";
-    const fallbackUrl = "/posts/fallback.rsc";
-    for (const [rscUrl, cacheControl] of [
-      [staticUrl, "s-maxage=31536000, stale-while-revalidate"],
-      [fallbackUrl, null],
-    ] as const) {
-      prefetchRscResponse(
-        rscUrl,
-        Promise.resolve(
-          new Response(rscUrl, {
-            headers: {
-              ...(cacheControl === null ? {} : { "cache-control": cacheControl }),
-              "content-type": "text/x-component",
-            },
-          }),
-        ),
-        null,
-        null,
-        undefined,
-        {
-          cacheForNavigation: false,
-          navigationCacheResponsePolicy: "require-shared-cache",
-        },
-      );
-      await getPrefetchCache().get(rscUrl)?.pending;
-    }
+  it("does not make navigation await a provisional full-prefetch body", async () => {
+    const rscUrl = "/pending-personalized-loading.rsc";
+    let closeBody = () => {};
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+        closeBody = () => controller.close();
+      },
+    });
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response(body, {
+          headers: {
+            "cache-control": "no-store, must-revalidate",
+            "content-type": "text/x-component",
+          },
+        }),
+      ),
+      null,
+      null,
+      undefined,
+      { cacheForNavigation: false, cacheForNavigationOnComplete: true },
+    );
 
-    expect(getPrefetchCache().get(staticUrl)?.cacheForNavigation).toBe(true);
-    expect(getPrefetchCache().get(fallbackUrl)?.cacheForNavigation).toBe(false);
-    await expect(
-      consumePrefetchResponseForNavigation(staticUrl, null, null),
-    ).resolves.not.toBeNull();
-    await expect(consumePrefetchResponseForNavigation(fallbackUrl, null, null)).resolves.toBeNull();
+    // The fetch promise has resolved with headers, but snapshotting is still
+    // blocked on EOF. A click must use the independently prefetched loading
+    // shell/fresh response immediately rather than joining this stream.
+    await Promise.resolve();
+    await expect(consumePrefetchResponseForNavigation(rscUrl, null, null)).resolves.toBeNull();
+    expect(getPrefetchCache().get(rscUrl)?.pending).toBeDefined();
+
+    closeBody();
+    await getPrefetchCache().get(rscUrl)?.pending;
+    const entry = getPrefetchCache().get(rscUrl);
+    expect(entry?.cacheForNavigation).toBe(true);
+    await expect(consumePrefetchResponseForNavigation(rscUrl, null, null)).resolves.not.toBeNull();
   });
 
   it("honors an explicit fallback stale window above the minimum for prefetched responses", async () => {


### PR DESCRIPTION
## Summary

- full-prefetch static App Router routes even when they have loading boundaries
- keep dynamic loading-boundary routes shell-only so loading UI can still commit on navigation
- update Link prefetch tests for static loading-boundary cache reuse

## Next.js parity

Targets the App Router navigation behavior covered by:

- `test/e2e/app-dir/navigation/navigation.test.ts`

This fixes the case where a visible static link with a loading boundary has already completed prefetch: navigation should use the prefetched full RSC payload rather than showing the fallback again.

## Validation

- `vp test run tests/link.test.ts -t "automatic full RSC prefetch|full-prefetches static routes|distinguishes automatic prefetch"`
- `vp test run tests/link-navigation.test.ts -t "full-prefetches visible static links with loading boundaries"`
- `vp check tests/link.test.ts tests/link-navigation.test.ts packages/vinext/src/shims/link.tsx`
- `REPO="/Users/jamesanderson/.codex/worktrees/async-metadata-prefetch-fallback/vinext" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/navigation/navigation.test.ts` (50/50 passed)
