### PR TITLE
fix(link): avoid reusing dynamic app route prefetches

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -13,6 +13,7 @@ export type VinextLinkPrefetchRoute = {
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];
+  requiresDynamicNavigationRequest?: boolean;
 };
 
 /**
@@ -30,6 +31,7 @@ export type VinextPagesLinkPrefetchRoute = {
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];
+  requiresDynamicNavigationRequest?: boolean;
 };
 
 export type VinextNextData = {

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -65,12 +65,17 @@ export function toDocumentOnlyAppRoute(route: AppRoute): VinextLinkPrefetchRoute
   };
 }
 
+function requiresDynamicNavigationRequest(route: AppRoute): boolean {
+  return route.isDynamic && route.parallelSlots.length > 0;
+}
+
 /** Project an `AppRoute` down to the public `VinextLinkPrefetchRoute` shape. */
 export function toLinkPrefetchRoute(route: AppRoute): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: route.loadingPath !== null,
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
+    ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),
   };
 }
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -318,11 +318,11 @@ function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
 } {
   const hasLoadingShell = route.canPrefetchLoadingShell;
   return {
-    // Automatic prefetches are only authoritative navigation payloads for
-    // static routes without a loading shell. Dynamic routes still warm an
-    // optimistic shell, but the click must issue the dynamic request so params
-    // from active parallel route branches are derived from the target tree.
-    cacheForNavigation: !hasLoadingShell && !route.isDynamic,
+    // Automatic prefetches are only unsafe as authoritative navigation
+    // payloads for dynamic routes whose active parallel branches must be
+    // derived from the click-time target tree. Other concrete dynamic URLs can
+    // match Next.js's full-prefetch behavior, including client-param routes.
+    cacheForNavigation: !hasLoadingShell && route.requiresDynamicNavigationRequest !== true,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -318,12 +318,11 @@ function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
 } {
   const hasLoadingShell = route.canPrefetchLoadingShell;
   return {
-    // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
-    // Routes with loading boundaries prefetch a shell first so navigation can
-    // commit loading.js immediately. Dynamic routes without loading-shell
-    // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
-    // keyed by the concrete RSC URL, so this cannot reuse data across params.
-    cacheForNavigation: !hasLoadingShell,
+    // Automatic prefetches are only authoritative navigation payloads for
+    // static routes without a loading shell. Dynamic routes still warm an
+    // optimistic shell, but the click must issue the dynamic request so params
+    // from active parallel route branches are derived from the target tree.
+    cacheForNavigation: !hasLoadingShell && !route.isDynamic,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,7 +45,11 @@ const projectServers = {
   "app-router": {
     testDir: "./tests/e2e",
     testMatch: ["**/app-router/**/*.spec.ts", "**/og-image.spec.ts"],
-    testIgnore: [appRouterBrowserSpecificTests, "**/app-router/nextjs-compat/client-cache.spec.ts"],
+    testIgnore: [
+      appRouterBrowserSpecificTests,
+      "**/app-router/nextjs-compat/client-cache.spec.ts",
+      "**/app-router/nextjs-compat/segment-cache-client-params.spec.ts",
+    ],
     use: { baseURL: "http://localhost:4174" },
     server: appRouterServer,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,7 +51,7 @@ const projectServers = {
   },
   "app-router-client-cache": {
     testDir: "./tests/e2e/app-router/nextjs-compat",
-    testMatch: "client-cache.spec.ts",
+    testMatch: ["client-cache.spec.ts", "segment-cache-client-params.spec.ts"],
     use: { baseURL: "http://localhost:4191" },
     server: {
       command:

--- a/tests/e2e/app-router/nextjs-compat/segment-cache-client-params.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/segment-cache-client-params.spec.ts
@@ -1,0 +1,57 @@
+// Ported from Next.js:
+// test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
+
+import { expect, test, type Page, type Request } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const ROOT = "/nextjs-compat/segment-cache-client-params";
+
+type RscRequest = {
+  partial: boolean;
+  pathname: string;
+};
+
+function trackRscRequests(page: Page): RscRequest[] {
+  const requests: RscRequest[] = [];
+  page.on("request", (request: Request) => {
+    const url = new URL(request.url());
+    if (!url.searchParams.has("_rsc") || request.headers()["rsc"] !== "1") return;
+    requests.push({
+      partial: request.headers()["x-vinext-rsc-render-mode"] === "prefetch-loading-shell",
+      pathname: url.pathname,
+    });
+  });
+  return requests;
+}
+
+function requestsFor(requests: RscRequest[], pathname: string): RscRequest[] {
+  return requests.filter((request) => request.pathname === pathname);
+}
+
+test.describe("Next.js compat: segment-cache client params", () => {
+  test("client segments that access dynamic params are fully statically prefetchable", async ({
+    page,
+  }) => {
+    const targetPath = `${ROOT}/clothing/1`;
+    const requests = trackRscRequests(page);
+
+    await page.goto(ROOT);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#segment-cache-client-params-home")).toBeVisible();
+
+    await page.locator(`input[data-link-accordion="${targetPath}"]`).click();
+    await page.locator(`a[href="${targetPath}"]`).hover();
+    await expect
+      .poll(() => requestsFor(requests, targetPath).some((request) => !request.partial), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+
+    requests.length = 0;
+    await page.locator(`a[href="${targetPath}"]`).click();
+    await expect(page.locator("#category-header")).toHaveText("Category: clothing");
+    await expect(page.locator("#product")).toHaveText("Product: 1");
+    expect(requestsFor(requests, targetPath)).toEqual([]);
+  });
+});

--- a/tests/e2e/app-router/parallel-route-navigations.spec.ts
+++ b/tests/e2e/app-router/parallel-route-navigations.spec.ts
@@ -61,6 +61,19 @@ test.describe("parallel-route-navigations", () => {
   });
 
   test("should render the right parameters on client navigations", async ({ page }) => {
+    let hadLocked = 0;
+    let unlock: (() => void) | undefined;
+    let lock: Promise<void> | undefined;
+
+    await page.route("**/*", async (route) => {
+      if (lock) {
+        hadLocked++;
+        await lock;
+      }
+
+      await route.continue();
+    });
+
     await page.goto(`${BASE}/parallel-route-navigations/vercel/sub/folder`);
     await waitForAppRouterHydration(page);
 
@@ -68,8 +81,18 @@ test.describe("parallel-route-navigations", () => {
       teamID: "vercel",
       catchAll: ["sub", "folder"],
     });
+    await page.waitForLoadState("networkidle");
+
+    lock = new Promise((resolve) => {
+      unlock = resolve;
+    });
 
     await page.locator('a[href="/parallel-route-navigations/vercel/sub/other-folder"]').click();
+
+    await expectStable(async () => {
+      expect(hadLocked).toBe(1);
+    });
+    unlock?.();
 
     await expectStable(async () => {
       await expectSlotParams(page, {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -187,6 +187,47 @@ describe("App Router generated manifest construction", () => {
         siblingIntercepts: [],
       },
       {
+        pattern: "/teams/:team/dashboard",
+        patternParts: ["teams", ":team", "dashboard"],
+        pagePath: "/tmp/test/app/teams/[team]/dashboard/page.tsx",
+        routePath: null,
+        layouts: ["/tmp/test/app/layout.tsx", "/tmp/test/app/teams/[team]/layout.tsx"],
+        templates: [],
+        parallelSlots: [
+          {
+            id: "slot:analytics:/teams/:team/dashboard",
+            key: "analytics:/tmp/test/app/teams/[team]/dashboard/@analytics",
+            name: "analytics",
+            ownerDir: "/tmp/test/app/teams/[team]/dashboard/@analytics",
+            ownerTreePath: "/teams/:team/dashboard",
+            hasPage: true,
+            pagePath: "/tmp/test/app/teams/[team]/dashboard/@analytics/page.tsx",
+            defaultPath: "/tmp/test/app/teams/[team]/dashboard/@analytics/default.tsx",
+            layoutPath: null,
+            loadingPath: null,
+            errorPath: null,
+            interceptingRoutes: [],
+            layoutIndex: 1,
+            routeSegments: ["teams", ":team", "dashboard", "@analytics"],
+          },
+        ],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [null, null],
+        notFoundPath: null,
+        notFoundPaths: [null, null],
+        forbiddenPaths: [null, null],
+        forbiddenPath: null,
+        unauthorizedPaths: [null, null],
+        unauthorizedPath: null,
+        routeSegments: ["teams", ":team", "dashboard"],
+        templateTreePositions: [],
+        layoutTreePositions: [0, 1],
+        isDynamic: true,
+        params: ["team"],
+        siblingIntercepts: [],
+      },
+      {
         pattern: "/api",
         patternParts: ["api"],
         pagePath: null,
@@ -224,6 +265,9 @@ describe("App Router generated manifest construction", () => {
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["teams",":team","dashboard"],"isDynamic":true,"requiresDynamicNavigationRequest":true}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["modal-host"],"isDynamic":false}',

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/[category]/[product]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/[category]/[product]/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Suspense, use } from "react";
+
+function Content({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ product: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { product } = use(params);
+  const searchParamsDict = use(searchParams);
+  const query = Object.keys(searchParamsDict).length > 0 ? JSON.stringify(searchParamsDict) : null;
+
+  return (
+    <>
+      <p id="product">Product: {product}</p>
+      <p id="query">Query: {query ? query : "(none)"}</p>
+    </>
+  );
+}
+
+export default function ProductPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ product: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return (
+    <Suspense fallback="Loading...">
+      <Content params={params} searchParams={searchParams} />
+    </Suspense>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/[category]/layout.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/[category]/layout.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Suspense, use } from "react";
+
+function Content({ params }: { params: Promise<{ category: string }> }) {
+  const { category } = use(params);
+  return <h1 id="category-header">Category: {category}</h1>;
+}
+
+export default function CategoryLayout({
+  params,
+  children,
+}: {
+  params: Promise<{ category: string }>;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Suspense fallback="Loading...">
+        <Content params={params} />
+      </Suspense>
+      {children}
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/components/link-accordion.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/components/link-accordion.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link, { type LinkProps } from "next/link";
+import { useState } from "react";
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string;
+  children: React.ReactNode;
+  prefetch?: LinkProps["prefetch"];
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-client-params/page.tsx
@@ -1,0 +1,16 @@
+import { LinkAccordion } from "./components/link-accordion";
+
+export default function Page() {
+  return (
+    <main>
+      <h1 id="segment-cache-client-params-home">Segment cache client params</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/nextjs-compat/segment-cache-client-params/clothing/1">
+            /clothing/1
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1556,7 +1556,7 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("full-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
+  it("shell-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
     const observer = stubIntersectionObserver();
 
     const result = await renderIsolatedLink({
@@ -1582,12 +1582,12 @@ describe("Link prefetch scheduling", () => {
       );
       const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
-        null,
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
       );
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
-      expect(entry?.cacheForNavigation).toBe(true);
-      expect(entry?.optimisticRouteShell).toBe(false);
+      expect(entry?.cacheForNavigation).toBe(false);
+      expect(entry?.optimisticRouteShell).toBe(true);
     } finally {
       result.restoreNodeEnv();
     }
@@ -1879,7 +1879,7 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("does not issue a prefetchInlining shell request for dynamic routes without loading shells", async () => {
+  it("uses a shell-only automatic prefetch for dynamic routes without loading shells", async () => {
     vi.stubEnv("__VINEXT_PREFETCH_INLINING", "true");
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
@@ -1903,7 +1903,7 @@ describe("Link prefetch scheduling", () => {
       );
       const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
-        null,
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
       );
     } finally {
       result.restoreNodeEnv();

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -55,6 +55,12 @@ const linkPrefetchRoutes = [
   { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
+  {
+    canPrefetchLoadingShell: false,
+    patternParts: ["teams", ":team", "dashboard"],
+    isDynamic: true,
+    requiresDynamicNavigationRequest: true,
+  },
 ] satisfies VinextLinkPrefetchRoute[];
 
 function createTestNavigationRuntime(navigate: unknown) {
@@ -1556,7 +1562,7 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("shell-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
+  it("full-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
     const observer = stubIntersectionObserver();
 
     const result = await renderIsolatedLink({
@@ -1582,12 +1588,12 @@ describe("Link prefetch scheduling", () => {
       );
       const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
-        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+        null,
       );
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
-      expect(entry?.cacheForNavigation).toBe(false);
-      expect(entry?.optimisticRouteShell).toBe(true);
+      expect(entry?.cacheForNavigation).toBe(true);
+      expect(entry?.optimisticRouteShell).toBe(false);
     } finally {
       result.restoreNodeEnv();
     }
@@ -1879,11 +1885,11 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("uses a shell-only automatic prefetch for dynamic routes without loading shells", async () => {
+  it("uses a shell-only automatic prefetch for dynamic routes requiring fresh navigation", async () => {
     vi.stubEnv("__VINEXT_PREFETCH_INLINING", "true");
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
-      href: "/clothing/1",
+      href: "/teams/vercel/dashboard",
       nodeEnv: "production",
     });
 
@@ -1895,7 +1901,7 @@ describe("Link prefetch scheduling", () => {
       expect(result.fetch).toHaveBeenCalledTimes(1);
       expectCanonicalRscFetchCall(
         result.fetch.mock.calls[0],
-        "/clothing/1",
+        "/teams/vercel/dashboard",
         expect.objectContaining({
           credentials: "include",
           priority: "low",

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -273,7 +273,7 @@ describe("Link App Router prefetch mode", () => {
     expect(resolveLinkPrefetchMode(true, true)).toBe("disabled");
   });
 
-  it("allows automatic full RSC prefetch only for static routes without loading-shell prefetches", () => {
+  it("allows automatic full RSC prefetch for routes that do not require fresh navigation", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -285,6 +285,12 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
         { canPrefetchLoadingShell: true, patternParts: ["docs", ":slug+"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: false,
+          patternParts: ["teams", ":team", "dashboard"],
+          isDynamic: true,
+          requiresDynamicNavigationRequest: true,
+        },
         { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
       ],
     };
@@ -293,7 +299,8 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/about")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
-      expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
+      expect(canAutoPrefetchFullAppRoute("/teams/vercel/dashboard")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/settings")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
     } finally {
@@ -305,7 +312,7 @@ describe("Link App Router prefetch mode", () => {
     }
   });
 
-  it("shell-prefetches dynamic routes and routes with loading boundaries", () => {
+  it("shell-prefetches dynamic routes that require fresh navigation and routes with loading boundaries", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -317,6 +324,12 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: false,
+          patternParts: ["teams", ":team", "dashboard"],
+          isDynamic: true,
+          requiresDynamicNavigationRequest: true,
+        },
         { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
       ],
     };
@@ -338,7 +351,7 @@ describe("Link App Router prefetch mode", () => {
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
-        cacheForNavigation: false,
+        cacheForNavigation: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
@@ -346,6 +359,11 @@ describe("Link App Router prefetch mode", () => {
       // test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
+        cacheForNavigation: true,
+        prefetchShellFirst: false,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/teams/vercel/dashboard")).toEqual({
         cacheForNavigation: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -273,7 +273,7 @@ describe("Link App Router prefetch mode", () => {
     expect(resolveLinkPrefetchMode(true, true)).toBe("disabled");
   });
 
-  it("allows automatic full RSC prefetch only for routes without loading-shell prefetches", () => {
+  it("allows automatic full RSC prefetch only for static routes without loading-shell prefetches", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -293,7 +293,7 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/about")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
-      expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
+      expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/settings")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
     } finally {
@@ -305,7 +305,7 @@ describe("Link App Router prefetch mode", () => {
     }
   });
 
-  it("shell-prefetches routes with loading boundaries and full-prefetches routes without them", () => {
+  it("shell-prefetches dynamic routes and routes with loading boundaries", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -338,7 +338,7 @@ describe("Link App Router prefetch mode", () => {
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
-        cacheForNavigation: true,
+        cacheForNavigation: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
@@ -346,7 +346,7 @@ describe("Link App Router prefetch mode", () => {
       // test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
-        cacheForNavigation: true,
+        cacheForNavigation: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });


### PR DESCRIPTION
## Summary
- stop treating automatic dynamic App Router prefetches as authoritative navigation payloads
- keep shell warming for dynamic links so click navigations issue a fresh dynamic request and derive params from the target tree
- add parallel-route navigation coverage that blocks the request and verifies the dynamic request happens before asserting updated slot params

## Tests
- `vp test run tests/link.test.ts tests/link-navigation.test.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/parallel-route-navigations.spec.ts`
- upstream Next.js e2e: `test/e2e/app-dir/parallel-route-navigations/parallel-route-navigations.test.ts`
- scoped `vp check`

## Review
- Independent review by Locke: NO FINDINGS