### PR TITLE
fix(app-router): send deployment id on RSC responses

### DIFF
--- a/packages/vinext/src/server/app-page-boundary.ts
+++ b/packages/vinext/src/server/app-page-boundary.ts
@@ -5,6 +5,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
+  applyRscDeploymentIdHeader,
 } from "./app-rsc-cache-busting.js";
 import { resolveAppPageSegmentParams } from "./app-page-params.js";
 
@@ -297,6 +298,7 @@ export async function renderAppPageBoundaryResponse<TElement>(
     applyEdgeRuntimeHeader(headers, options.isEdgeRuntime);
     mergeMiddlewareResponseHeaders(headers, options.middlewareHeaders ?? null);
     applyRscCompatibilityIdHeader(headers);
+    applyRscDeploymentIdHeader(headers);
 
     return new Response(rscStream, {
       status: options.status,

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -3,6 +3,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
+  applyRscDeploymentIdHeader,
 } from "./app-rsc-cache-busting.js";
 import { applyCdnResponseHeaders } from "./cache-control.js";
 import { decideIsr } from "./isr-decision.js";
@@ -227,6 +228,7 @@ export function buildAppPageCachedResponse(
       mountedSlotsHeader: options.mountedSlotsHeader,
     });
     applyRscCompatibilityIdHeader(rscHeaders);
+    applyRscDeploymentIdHeader(rscHeaders);
 
     return new Response(cachedValue.rscData, {
       status,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -70,6 +70,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
+  applyRscDeploymentIdHeader,
 } from "./app-rsc-cache-busting.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
@@ -859,6 +860,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       });
       mergeMiddlewareResponseHeaders(interceptHeaders, options.middlewareContext.headers);
       applyRscCompatibilityIdHeader(interceptHeaders);
+      applyRscDeploymentIdHeader(interceptHeaders);
       return new Response(interceptStream, {
         status: options.middlewareContext.status ?? 200,
         headers: interceptHeaders,

--- a/packages/vinext/src/server/app-page-execution.ts
+++ b/packages/vinext/src/server/app-page-execution.ts
@@ -2,6 +2,7 @@ import type { LayoutFlags } from "./app-elements.js";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
 import {
   applyRscCompatibilityIdHeader,
+  applyRscDeploymentIdHeader,
   createRscRedirectLocation,
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
@@ -390,6 +391,7 @@ export async function buildAppPageSpecialErrorResponse(
       // ID. Without it, the client treats the response as cross-build and hard-
       // navigates instead of following the redirect through the soft-nav loop.
       applyRscCompatibilityIdHeader(headers);
+      applyRscDeploymentIdHeader(headers);
       // Preserve middleware response headers (Set-Cookie, custom headers, etc.)
       // exactly like the 307 path does — the client will still see them.
       mergeMiddlewareResponseHeaders(headers, options.middlewareContext?.headers ?? null);

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -16,6 +16,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
+  applyRscDeploymentIdHeader,
 } from "./app-rsc-cache-busting.js";
 
 export type AppPageMiddlewareContext = {
@@ -305,6 +306,7 @@ export function buildAppPageRscResponse(
   }
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
   applyRscCompatibilityIdHeader(headers);
+  applyRscDeploymentIdHeader(headers);
   applyPrerenderCacheLifeHeader(headers, options.requestCacheLife);
 
   applyTimingHeader(headers, options.timing);

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -13,9 +13,10 @@ import {
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
+  NEXTJS_DEPLOYMENT_ID_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "./headers.js";
-import { applyDeploymentIdHeader } from "../utils/deployment-id.js";
+import { applyDeploymentIdHeader, getDeploymentId } from "../utils/deployment-id.js";
 
 /**
  * RSC cache-busting hashes cover the headers that make an RSC payload vary.
@@ -87,6 +88,15 @@ export function applyRscCompatibilityIdHeader(
     headers.set(VINEXT_RSC_COMPATIBILITY_ID_HEADER, normalized);
   } else {
     headers.delete(VINEXT_RSC_COMPATIBILITY_ID_HEADER);
+  }
+}
+
+export function applyRscDeploymentIdHeader(headers: Headers): void {
+  const deploymentId = getDeploymentId();
+  if (deploymentId) {
+    headers.set(NEXTJS_DEPLOYMENT_ID_HEADER, deploymentId);
+  } else {
+    headers.delete(NEXTJS_DEPLOYMENT_ID_HEADER);
   }
 }
 

--- a/tests/app-router-deployment-id.test.ts
+++ b/tests/app-router-deployment-id.test.ts
@@ -1,0 +1,56 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ViteDevServer } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { APP_FIXTURE_DIR, startFixtureServer } from "./helpers.js";
+
+describe("App Router deployment ID", () => {
+  let baseUrl: string;
+  let previousNextDeploymentId: string | undefined;
+  let previousVinextDeploymentId: string | undefined;
+  let server: ViteDevServer | undefined;
+  let tmpDir: string | undefined;
+
+  beforeAll(async () => {
+    previousNextDeploymentId = process.env.NEXT_DEPLOYMENT_ID;
+    previousVinextDeploymentId = process.env.__VINEXT_DEPLOYMENT_ID;
+    process.env.NEXT_DEPLOYMENT_ID = "test-deployment-id";
+    delete process.env.__VINEXT_DEPLOYMENT_ID;
+
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-app-rsc-dpl-"));
+    await fsp.cp(APP_FIXTURE_DIR, tmpDir, { recursive: true });
+    await fsp.rm(path.join(tmpDir, "node_modules", ".vite"), { recursive: true, force: true });
+
+    ({ server, baseUrl } = await startFixtureServer(tmpDir, { appRouter: true }));
+  }, 30000);
+
+  afterAll(async () => {
+    await server?.close();
+    if (tmpDir) {
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
+    if (previousNextDeploymentId === undefined) {
+      delete process.env.NEXT_DEPLOYMENT_ID;
+    } else {
+      process.env.NEXT_DEPLOYMENT_ID = previousNextDeploymentId;
+    }
+    if (previousVinextDeploymentId === undefined) {
+      delete process.env.__VINEXT_DEPLOYMENT_ID;
+    } else {
+      process.env.__VINEXT_DEPLOYMENT_ID = previousVinextDeploymentId;
+    }
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+  it("sets the deployment ID header on RSC responses", async () => {
+    const res = await fetch(`${baseUrl}/about.rsc?_rsc=`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/x-component");
+    expect(res.headers.get("x-nextjs-deployment-id")).toBe("test-deployment-id");
+  });
+});

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -222,39 +222,6 @@ describe("App Router integration", () => {
     expect(res.headers.get("content-type")).toBe("text/x-component");
   });
 
-  // Ported from Next.js: test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
-  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
-  it("sets the deployment ID header on RSC responses", async () => {
-    const previousNextDeploymentId = process.env.NEXT_DEPLOYMENT_ID;
-    const previousVinextDeploymentId = process.env.__VINEXT_DEPLOYMENT_ID;
-    let deploymentServer: ViteDevServer | undefined;
-    process.env.NEXT_DEPLOYMENT_ID = "test-deployment-id";
-    delete process.env.__VINEXT_DEPLOYMENT_ID;
-
-    try {
-      const deploymentFixture = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true });
-      deploymentServer = deploymentFixture.server;
-      const res = await fetch(`${deploymentFixture.baseUrl}/about.rsc?_rsc=`, {
-        headers: { Accept: "text/x-component", RSC: "1" },
-      });
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toBe("text/x-component");
-      expect(res.headers.get("x-nextjs-deployment-id")).toBe("test-deployment-id");
-    } finally {
-      await deploymentServer?.close();
-      if (previousNextDeploymentId === undefined) {
-        delete process.env.NEXT_DEPLOYMENT_ID;
-      } else {
-        process.env.NEXT_DEPLOYMENT_ID = previousNextDeploymentId;
-      }
-      if (previousVinextDeploymentId === undefined) {
-        delete process.env.__VINEXT_DEPLOYMENT_ID;
-      } else {
-        process.env.__VINEXT_DEPLOYMENT_ID = previousVinextDeploymentId;
-      }
-    }
-  });
-
   // Dual-router coexistence: the app-basic fixture has both app/ and pages/
   // (pages/old-school.tsx activates hasPagesDir). This verifies the Pages Router
   // still renders its own pages correctly when both routers are active — the

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -222,6 +222,39 @@ describe("App Router integration", () => {
     expect(res.headers.get("content-type")).toBe("text/x-component");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+  it("sets the deployment ID header on RSC responses", async () => {
+    const previousNextDeploymentId = process.env.NEXT_DEPLOYMENT_ID;
+    const previousVinextDeploymentId = process.env.__VINEXT_DEPLOYMENT_ID;
+    let deploymentServer: ViteDevServer | undefined;
+    process.env.NEXT_DEPLOYMENT_ID = "test-deployment-id";
+    delete process.env.__VINEXT_DEPLOYMENT_ID;
+
+    try {
+      const deploymentFixture = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true });
+      deploymentServer = deploymentFixture.server;
+      const res = await fetch(`${deploymentFixture.baseUrl}/about.rsc?_rsc=`, {
+        headers: { Accept: "text/x-component", RSC: "1" },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/x-component");
+      expect(res.headers.get("x-nextjs-deployment-id")).toBe("test-deployment-id");
+    } finally {
+      await deploymentServer?.close();
+      if (previousNextDeploymentId === undefined) {
+        delete process.env.NEXT_DEPLOYMENT_ID;
+      } else {
+        process.env.NEXT_DEPLOYMENT_ID = previousNextDeploymentId;
+      }
+      if (previousVinextDeploymentId === undefined) {
+        delete process.env.__VINEXT_DEPLOYMENT_ID;
+      } else {
+        process.env.__VINEXT_DEPLOYMENT_ID = previousVinextDeploymentId;
+      }
+    }
+  });
+
   // Dual-router coexistence: the app-basic fixture has both app/ and pages/
   // (pages/old-school.tsx activates hasPagesDir). This verifies the Pages Router
   // still renders its own pages correctly when both routers are active — the

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   applyRscCompatibilityIdHeader,
+  applyRscDeploymentIdHeader,
   computeRscCacheBustingSearchParam,
   createRscRequestHeaders,
   createRscRequestUrl,
@@ -330,6 +331,37 @@ describe("App Router RSC cache-busting", () => {
     );
 
     expect(headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-env");
+  });
+
+  it("leaves the Next.js deployment ID header out of compatibility-only response headers", () => {
+    const headers = new Headers();
+
+    withEnvVar("__VINEXT_DEPLOYMENT_ID", "deployment-a", () =>
+      applyRscCompatibilityIdHeader(headers, "compat-a"),
+    );
+
+    expect(headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER)).toBe("compat-a");
+    expect(headers.has("x-nextjs-deployment-id")).toBe(false);
+  });
+
+  it("applies the Next.js deployment ID header to App Router RSC page response headers", () => {
+    const headers = new Headers();
+
+    withEnvVar("__VINEXT_DEPLOYMENT_ID", "deployment-a", () => applyRscDeploymentIdHeader(headers));
+
+    expect(headers.get("x-nextjs-deployment-id")).toBe("deployment-a");
+  });
+
+  it("removes a spoofed Next.js deployment ID header when none is configured", () => {
+    const headers = new Headers({
+      "x-nextjs-deployment-id": "spoofed-deployment",
+    });
+
+    withEnvVar("__VINEXT_DEPLOYMENT_ID", undefined, () =>
+      withEnvVar("NEXT_DEPLOYMENT_ID", undefined, () => applyRscDeploymentIdHeader(headers)),
+    );
+
+    expect(headers.has("x-nextjs-deployment-id")).toBe(false);
   });
 
   it("removes a spoofed compatibility ID header when no framework ID is available", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -159,6 +159,7 @@ export default defineConfig({
             // When adding a test that calls startFixtureServer() or createServer(),
             // move it here.
             "tests/app-router-client-preloading.test.ts",
+            "tests/app-router-deployment-id.test.ts",
             "tests/app-router-dev-server.test.ts",
             "tests/app-router-external-rewrite.test.ts",
             "tests/app-router-font-google-prod.test.ts",
@@ -217,6 +218,7 @@ export default defineConfig({
           // `setupServer` rather than reverting this exclusion.
           include: [
             "tests/app-router-client-preloading.test.ts",
+            "tests/app-router-deployment-id.test.ts",
             "tests/app-router-dev-server.test.ts",
             "tests/app-router-external-rewrite.test.ts",
             "tests/app-router-font-google-prod.test.ts",


### PR DESCRIPTION
## Summary
- include the configured Next.js deployment ID in App Router RSC response headers
- remove spoofed deployment ID headers when no deployment ID is configured
- add helper coverage plus a dev-server integration case ported from Next.js deployment-skew coverage

## Validation
- Targeted upstream Next.js e2e passed: `test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts` 1/1
- Independent review: NO FINDINGS
- Local focused tests/check passed