### PR TITLE
fix(app-router): recover mismatched prefetch rewrites

### DIFF
--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -6,6 +6,7 @@ import type {
 import type { AppRoute } from "../routing/app-router.js";
 import type { RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
+import type { StaticMiddlewareMatcher } from "../build/report.js";
 
 /**
  * Generate the virtual browser entry module.
@@ -23,6 +24,7 @@ export function generateBrowserEntry(
     beforeFiles: [],
     fallback: [],
   },
+  middlewareMatcher?: StaticMiddlewareMatcher,
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
@@ -39,6 +41,7 @@ window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
 // the same — whichever entry runs first emits both globals).
 window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(pagesPrefetchRoutes)};
 window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(rewrites)};
+window.__VINEXT_MIDDLEWARE_MATCHER__ = ${JSON.stringify(middlewareMatcher)};
 registerNavigationRuntimeBootstrap({
     routeManifest: ${buildRouteManifestExpression(routeManifest)}
 });

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -365,7 +365,10 @@ import {
   resolveAppPageChildSegments as __resolveAppPageChildSegments,
 } from ${JSON.stringify(appPageRouteWiringPath)};
 import { buildPageElements as __buildPageElements } from ${JSON.stringify(appPageElementBuilderPath)};
-import { buildAppPageProbes as __buildAppPageProbes } from ${JSON.stringify(appPageProbePath)};
+import {
+  buildAppPageProbes as __buildAppPageProbes,
+  renderAppPageForLoadingShellProbe as __renderAppPageForLoadingShellProbe,
+} from ${JSON.stringify(appPageProbePath)};
 import {
   dispatchAppPage as __dispatchAppPage,
 } from ${JSON.stringify(appPageDispatchPath)};
@@ -887,6 +890,13 @@ export default createAppRscHandler({
           matchedParams: params,
           makeThenableParams,
         }));
+      },
+      probePageLoadingShellFallback(probeSearchParams = searchParams) {
+        return __renderAppPageForLoadingShellProbe({
+          pageComponent: PageComponent,
+          asyncRouteParams: _asyncRouteParams,
+          searchParams: probeSearchParams,
+        });
       },
       renderErrorBoundaryPage(renderErr, errorOrigin) {
         const __activeIntercept = findIntercept(cleanPathname, interceptionContext);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -137,6 +137,7 @@ import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js"
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
 import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
+import { createRscReferenceValidationNormalizerPlugin } from "./plugins/rsc-reference-validation-normalizer.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
 import {
@@ -6214,6 +6215,7 @@ export const loadServerActionClient = ${
   // Append auto-injected RSC plugins if applicable
   if (rscPluginPromise) {
     plugins.push(rscPluginPromise);
+    plugins.push(createRscReferenceValidationNormalizerPlugin());
     plugins.push(createRscClientReferenceLoadersPlugin());
   }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3371,6 +3371,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             graph.routeManifest,
             pagesPrefetchRoutes,
             nextConfig.rewrites,
+            middlewarePath ? extractMiddlewareMatcherConfig(middlewarePath) : undefined,
           );
         }
         if (id === RESOLVED_APP_CAPABILITIES && hasAppDir) {

--- a/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
+++ b/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
@@ -1,0 +1,74 @@
+import type { Plugin } from "vite";
+import type { PluginApi } from "@vitejs/plugin-rsc";
+
+const REFERENCE_VALIDATION_ID_PREFIX = "\0virtual:vite-rsc/reference-validation?";
+
+type RscPluginWithApi = Plugin & {
+  api?: PluginApi;
+};
+
+type RscReferenceMeta =
+  | PluginApi["manager"]["clientReferenceMetaMap"][string]
+  | PluginApi["manager"]["serverReferenceMetaMap"][string];
+
+function parseReferenceValidationQuery(id: string): { type?: string; id?: string } | null {
+  const queryStart = id.indexOf("?");
+  if (queryStart === -1) return null;
+  return Object.fromEntries(new URLSearchParams(id.slice(queryStart + 1)));
+}
+
+function normalizeReferenceKey(id: string): string {
+  return id.replaceAll("\0", "__x00__").replace(/\$\$cache=.*$/, "");
+}
+
+function hasReference(
+  referenceMetaMap: Record<string, RscReferenceMeta> | undefined,
+  referenceId: string | undefined,
+): boolean {
+  if (!referenceMetaMap || !referenceId) return false;
+
+  const normalizedReferenceId = normalizeReferenceKey(referenceId);
+  return Object.values(referenceMetaMap).some(
+    (meta) => normalizeReferenceKey(meta.referenceKey) === normalizedReferenceId,
+  );
+}
+
+/**
+ * @vitejs/plugin-rsc stores dev virtual client-reference keys in Vite's encoded
+ * `/@id/__x00__...` form, but React's SSR consumer can ask validation for the
+ * decoded `/@id/\0...` form. Treat those as equivalent and fall through to the
+ * upstream validator for all other invalid references.
+ */
+export function createRscReferenceValidationNormalizerPlugin(): Plugin {
+  let rscApi: PluginApi | undefined;
+
+  return {
+    name: "vinext:rsc-reference-validation-normalizer",
+    enforce: "pre",
+    apply: "serve",
+    configResolved(config) {
+      rscApi = (
+        config.plugins.find((plugin) => plugin.name === "rsc:minimal") as
+          | RscPluginWithApi
+          | undefined
+      )?.api;
+    },
+    load(id) {
+      if (!id.startsWith(REFERENCE_VALIDATION_ID_PREFIX)) return null;
+
+      const query = parseReferenceValidationQuery(id);
+      if (!query) return null;
+
+      const manager = rscApi?.manager;
+      if (query.type === "client" && hasReference(manager?.clientReferenceMetaMap, query.id)) {
+        return "export {}";
+      }
+
+      if (query.type === "server" && hasReference(manager?.serverReferenceMetaMap, query.id)) {
+        return "export {}";
+      }
+
+      return null;
+    },
+  };
+}

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -246,6 +246,7 @@ export async function applyAppMiddleware(
       isDataRequest: options.isDataRequest,
       isProxy: options.isProxy,
       module: options.module,
+      matcherRequest: options.request,
       normalizedPathname: cleanPathname,
       request: middlewareRequest,
       trailingSlash: options.trailingSlash,

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -1,4 +1,4 @@
-import { createElement, isValidElement, Suspense } from "react";
+import { cloneElement, createElement, isValidElement, Suspense, type ReactNode } from "react";
 import { isUnknownRecord } from "../utils/record.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { buildParams, decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
@@ -7,9 +7,9 @@ import { matchRoutePattern } from "../routing/route-pattern.js";
 import { stripRscCacheBustingSearchParam, stripRscSuffix } from "./app-rsc-cache-busting.js";
 import {
   AppElementsWire,
-  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
   type AppElementValue,
   type AppElements,
+  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
 } from "./app-elements.js";
 
 type OptimisticRouteTrieNode = {
@@ -27,6 +27,7 @@ type OptimisticRouteMatch = {
 
 export type OptimisticRouteTemplate = {
   elements: AppElements;
+  loadingShell: boolean;
   mountedSlotsHeader: string | null;
   pageElementIds: readonly string[];
   routeId: string;
@@ -296,8 +297,48 @@ function getPageElementIds(
   return Array.from(pageElementIds).sort();
 }
 
+function hasRouteOrPageSuspenseFallback(
+  elements: AppElements,
+  routeElement: AppElementValue | undefined,
+  pageElementIds: readonly string[],
+): boolean {
+  if (elementHasSuspenseFallback(routeElement)) return true;
+  return pageElementIds.some((pageElementId) =>
+    elementHasSuspenseFallback(elements[pageElementId]),
+  );
+}
+
 function OptimisticRouteSegment(): null {
   throw OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER;
+}
+
+function createSuspendingElementInsideFirstSuspense(value: unknown, depth = 0): ReactNode | null {
+  if (depth > 100) return null;
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((entry) => {
+      const transformed = createSuspendingElementInsideFirstSuspense(entry, depth + 1);
+      if (transformed === null) return entry as ReactNode;
+      changed = true;
+      return transformed;
+    });
+    return changed ? next : null;
+  }
+  if (!isValidElement(value)) return null;
+
+  const props = Reflect.get(value, "props");
+  if (value.type === Suspense && isUnknownRecord(props)) {
+    const fallback = Reflect.get(props, "fallback");
+    if (fallback !== null && fallback !== undefined) {
+      return cloneElement(value, undefined, createElement(OptimisticRouteSegment));
+    }
+  }
+
+  if (!isUnknownRecord(props)) return null;
+  const children = Reflect.get(props, "children") as ReactNode;
+  const transformedChildren = createSuspendingElementInsideFirstSuspense(children, depth + 1);
+  if (transformedChildren === null) return null;
+  return cloneElement(value, undefined, transformedChildren);
 }
 
 export function createOptimisticRouteTemplate(options: {
@@ -314,18 +355,32 @@ export function createOptimisticRouteTemplate(options: {
     href: options.href,
     routeManifest: options.routeManifest,
   });
-  if (match === null || (!options.allowLoadingShell && !match.route.isDynamic)) return null;
-  if (options.interceptionContext !== null) return null;
+  if (match === null) {
+    return null;
+  }
+  if (options.interceptionContext !== null) {
+    return null;
+  }
 
   const metadata = AppElementsWire.readMetadata(options.elements);
-  if (metadata.interception !== null || metadata.interceptionContext !== null) return null;
+  if (metadata.interception !== null || metadata.interceptionContext !== null) {
+    return null;
+  }
 
   const routeElement = options.elements[metadata.routeId];
+  const pageElementIds = getPageElementIds(options.elements, match.route);
+  if (pageElementIds.length === 0) {
+    return null;
+  }
   // Full-prefetch learning is intentionally heuristic: legacy full prefetches
-  // are accepted only when the serialized route subtree still contains a
-  // Suspense fallback. Authoritative loading-shell prefetches use the marker
-  // check below instead.
-  if (!options.allowLoadingShell && !elementHasSuspenseFallback(routeElement)) return null;
+  // are accepted only when the serialized route or page subtree still contains
+  // a Suspense fallback. Loading-shell prefetches with route loading UI encode
+  // null page entries and can be accepted via the marker path below.
+  if (!options.allowLoadingShell) {
+    if (!hasRouteOrPageSuspenseFallback(options.elements, routeElement, pageElementIds)) {
+      return null;
+    }
+  }
   if (
     options.allowLoadingShell &&
     options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] !== "LoadingBoundary"
@@ -334,14 +389,13 @@ export function createOptimisticRouteTemplate(options: {
   }
   // Shell prefetches must include the eagerly-rendered loading component. A
   // null route element means the server had no route loading boundary.
-  if (options.allowLoadingShell && (routeElement === undefined || routeElement === null))
+  if (options.allowLoadingShell && (routeElement === undefined || routeElement === null)) {
     return null;
-
-  const pageElementIds = getPageElementIds(options.elements, match.route);
-  if (pageElementIds.length === 0) return null;
+  }
 
   return {
     elements: options.elements,
+    loadingShell: options.allowLoadingShell === true,
     mountedSlotsHeader: options.mountedSlotsHeader,
     pageElementIds,
     routeId: match.route.id,
@@ -350,8 +404,12 @@ export function createOptimisticRouteTemplate(options: {
 
 export function createOptimisticRouteElements(template: OptimisticRouteTemplate): AppElements {
   const elements: Record<string, AppElementValue> = { ...template.elements };
+  if (template.loadingShell) return elements;
+
   for (const pageElementId of template.pageElementIds) {
-    elements[pageElementId] = createElement(OptimisticRouteSegment);
+    elements[pageElementId] =
+      createSuspendingElementInsideFirstSuspense(elements[pageElementId]) ??
+      createElement(OptimisticRouteSegment);
   }
   return elements;
 }

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -19,6 +19,7 @@ import {
   markDynamicUsage,
   peekDynamicUsage,
   peekRenderRequestApiUsage,
+  runWithConnectionProbe,
   setHeadersContext,
 } from "vinext/shims/headers";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
@@ -33,7 +34,12 @@ import {
   setCurrentForceDynamicFetchDefault,
   setCurrentFetchSoftTags,
 } from "vinext/shims/fetch-cache";
-import { AppElementsWire, type AppOutgoingElements } from "./app-elements.js";
+import {
+  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
+  AppElementsWire,
+  isAppElementsRecord,
+  type AppOutgoingElements,
+} from "./app-elements.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
 import type { WarmPprFallbackShellCachesOptions } from "./app-ppr-fallback-shell-render.js";
 import {
@@ -73,6 +79,7 @@ import {
 } from "./app-rsc-cache-busting.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
@@ -87,6 +94,7 @@ import {
   isAppLayoutObservationUnsafeForStaticReuse,
   type AppLayoutParamAccessTracker,
 } from "./app-layout-param-observation.js";
+import { isPromiseLike } from "../utils/promise.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type AppPageElement = ReactNode | Readonly<Record<string, ReactNode>>;
@@ -115,6 +123,110 @@ type AppPageBackgroundRegenerator = (
   renderFn: () => Promise<void>,
   errorContext?: AppPageBackgroundRegenerationErrorContext,
 ) => void;
+type AppPageDispatchRouteIds = {
+  page: string | null;
+  slots: Readonly<Record<string, string>>;
+};
+
+async function extractFirstSuspenseFallback(value: unknown, depth = 0): Promise<ReactNode | null> {
+  if (depth > 100) return null;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const fallback = await extractFirstSuspenseFallback(entry, depth + 1);
+      if (fallback !== null) return fallback;
+    }
+    return null;
+  }
+  if (!React.isValidElement(value)) return null;
+
+  const props = value.props as Record<string, unknown>;
+  if (value.type === React.Suspense && props.fallback !== null && props.fallback !== undefined) {
+    return props.fallback as ReactNode;
+  }
+
+  if (typeof value.type === "function") {
+    const result = (value.type as (componentProps: Record<string, unknown>) => unknown)(props);
+    const resolved = isPromiseLike(result) ? await result : result;
+    return extractFirstSuspenseFallback(resolved, depth + 1);
+  }
+
+  return extractFirstSuspenseFallback(props.children, depth + 1);
+}
+
+async function probePrefetchLoadingShellFallback(options: {
+  probePageLoadingShellFallback: () => unknown;
+  runWithSuppressedHookWarning<T>(probe: () => Promise<T>): Promise<T>;
+}): Promise<ReactNode | null> {
+  try {
+    return await options.runWithSuppressedHookWarning(async () => {
+      const outcome = await runWithConnectionProbe(async () => {
+        const result = options.probePageLoadingShellFallback();
+        const resolved = isPromiseLike(result) ? await result : result;
+        return extractFirstSuspenseFallback(resolved);
+      });
+      return outcome.completed ? outcome.result : null;
+    });
+  } catch {
+    return null;
+  }
+}
+
+function isAppPagePayloadEntryKey(key: string): boolean {
+  const parsed = AppElementsWire.parseElementKey(key);
+  return parsed?.kind === "page" || (parsed?.kind === "slot" && parsed.name === "children");
+}
+
+function getAppPagePayloadEntryIds(
+  element: Readonly<Record<string, unknown>>,
+  route: AppPageDispatchRoute,
+): string[] {
+  const ids = new Set<string>();
+  if (route.ids?.page && Object.hasOwn(element, route.ids.page)) {
+    ids.add(route.ids.page);
+  }
+  const routeSlotIds = [route.childrenSlot?.id, ...Object.values(route.ids?.slots ?? {})];
+  for (const slotId of routeSlotIds) {
+    if (slotId && isAppPagePayloadEntryKey(slotId) && Object.hasOwn(element, slotId)) {
+      ids.add(slotId);
+    }
+  }
+  for (const key of Object.keys(element)) {
+    if (AppElementsWire.parseElementKey(key)?.kind === "page") {
+      ids.add(key);
+    }
+  }
+  return Array.from(ids).sort();
+}
+
+function replaceAppPageElementWithFallback<TElement>(
+  element: TElement | null,
+  fallback: ReactNode,
+  route: AppPageDispatchRoute,
+): { element: TElement | null; replaced: boolean } {
+  if (!isAppElementsRecord(element)) return { element, replaced: false };
+
+  let replaced = false;
+  const next: Record<string, unknown> = { ...element };
+  for (const elementId of getAppPagePayloadEntryIds(next, route)) {
+    next[elementId] = fallback;
+    replaced = true;
+  }
+
+  return {
+    element: replaced ? (next as TElement) : element,
+    replaced,
+  };
+}
+
+function removePrefetchLoadingShellMarker<TElement>(element: TElement | null): TElement | null {
+  if (!isAppElementsRecord(element) || !(APP_PREFETCH_LOADING_SHELL_MARKER_KEY in element)) {
+    return element;
+  }
+
+  const next: Record<string, unknown> = { ...element };
+  delete next[APP_PREFETCH_LOADING_SHELL_MARKER_KEY];
+  return next as TElement;
+}
 
 type AppPageDispatchIntercept<TPage = unknown> = {
   // Lazy-loaded layout modules: typed `unknown` because they arrive as
@@ -172,10 +284,12 @@ type EffectiveLayoutClassifications = Readonly<{
 export type AppPageDispatchRoute = {
   __buildTimeClassifications?: LayoutClassificationOptions["buildTimeClassifications"];
   __buildTimeReasons?: LayoutClassificationOptions["buildTimeReasons"];
+  childrenSlot?: { id: string } | null;
   error?: AppPageModule | null;
   errors?: readonly (AppPageModule | null | undefined)[];
   forbidden?: AppPageModule | null;
   forbiddens?: readonly (AppPageModule | null | undefined)[];
+  ids?: AppPageDispatchRouteIds | null;
   isDynamic: boolean;
   layouts: readonly AppPageModule[];
   layoutTreePositions?: readonly number[];
@@ -313,6 +427,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   rootParams?: RootParams;
   probeLayoutAt: (layoutIndex: number, layoutParamAccess?: AppLayoutParamAccessTracker) => unknown;
   probePage: (searchParams?: URLSearchParams) => unknown;
+  probePageLoadingShellFallback?: (searchParams?: URLSearchParams) => unknown;
   expireSeconds?: number;
   renderErrorBoundaryPage: (
     error: unknown,
@@ -940,6 +1055,30 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const pageBuildResult = await buildCurrentPageElement();
   if (pageBuildResult.response) {
     return pageBuildResult.response;
+  }
+  if (
+    options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL &&
+    !route.loading?.default
+  ) {
+    const loadingShellFallback = options.probePageLoadingShellFallback
+      ? await probePrefetchLoadingShellFallback({
+          probePageLoadingShellFallback: () =>
+            options.probePageLoadingShellFallback!(pageSearchParams),
+          runWithSuppressedHookWarning: (probe) => options.runWithSuppressedHookWarning(probe),
+        })
+      : null;
+    if (loadingShellFallback !== null) {
+      const replacement = replaceAppPageElementWithFallback(
+        pageBuildResult.element,
+        loadingShellFallback,
+        route,
+      );
+      pageBuildResult.element = replacement.replaced
+        ? replacement.element
+        : removePrefetchLoadingShellMarker(replacement.element);
+    } else {
+      pageBuildResult.element = removePrefetchLoadingShellMarker(pageBuildResult.element);
+    }
   }
 
   const navigationParams = resolveAppPageNavigationParams(

--- a/packages/vinext/src/server/app-page-probe.ts
+++ b/packages/vinext/src/server/app-page-probe.ts
@@ -276,6 +276,26 @@ export function probeAppPage(options: {
   return result;
 }
 
+export function renderAppPageForLoadingShellProbe(options: {
+  pageComponent: unknown;
+  asyncRouteParams: unknown;
+  searchParams: URLSearchParams | null | undefined;
+}): unknown {
+  const { pageComponent, asyncRouteParams, searchParams } = options;
+  if (typeof pageComponent !== "function") {
+    return null;
+  }
+  const { pageSearchParams } = collectAppPageSearchParams(searchParams);
+  const asyncSearchParams = makeObservedAppPageSearchParamsThenable(pageSearchParams, {
+    observeReactPromiseStatus: true,
+  });
+  const pageProps = markAppPagePropsForUseCache({
+    params: asyncRouteParams,
+    searchParams: asyncSearchParams,
+  });
+  return (pageComponent as (props: Record<string, unknown>) => unknown)(pageProps);
+}
+
 type AppPageProbeModule = Readonly<{ default?: unknown }> | null | undefined;
 
 type AppPageProbeSlot = Readonly<{ page?: AppPageProbeModule }> | null | undefined;

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -698,7 +698,7 @@ export function buildAppPageElements<
 
   const routeLoadingComponent = getDefaultExport(options.route.loading);
   const isPrefetchLoadingShell = renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
-  const shouldRenderPrefetchLoadingShell = isPrefetchLoadingShell && routeLoadingComponent !== null;
+  const shouldRenderPrefetchLoadingShell = isPrefetchLoadingShell;
   if (shouldRenderPrefetchLoadingShell) {
     // Client loading components serialize as module references in Flight. Keep
     // a durable marker in the shell payload so external router tests and
@@ -707,9 +707,10 @@ export function buildAppPageElements<
     elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] = "LoadingBoundary";
   }
 
-  elements[pageElementId] = isPrefetchLoadingShell
-    ? null
-    : renderAfterAppDependencies(options.element, pageDependencies);
+  elements[pageElementId] =
+    isPrefetchLoadingShell && routeLoadingComponent !== null
+      ? null
+      : renderAfterAppDependencies(options.element, pageDependencies);
 
   for (const templateEntry of templateEntries) {
     const templateComponent = getDefaultExport(templateEntry.templateModule);
@@ -942,7 +943,14 @@ export function buildAppPageElements<
     // effect belongs to the real render that replaces this shell (handled in the
     // else branch below).
     if (routeLoadingComponent === null) {
-      routeChildren = null;
+      routeChildren = (
+        <LayoutSegmentProvider
+          providerId={pageElementId}
+          segmentMap={{ children: [APP_PAGE_SEGMENT_KEY] }}
+        >
+          <Slot id={pageElementId} />
+        </LayoutSegmentProvider>
+      );
     } else {
       const RouteLoadingComponent = routeLoadingComponent;
       routeChildren = <RouteLoadingComponent />;

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -77,6 +77,13 @@ type ExecuteMiddlewareOptions = {
   normalizedPathname?: string;
   request: Request;
   /**
+   * Optional unmodified request used only for matcher has/missing evaluation.
+   * App Router strips Flight headers before invoking user middleware, but Next.js
+   * evaluates matcher conditions before that strip so `missing:
+   * Next-Router-Prefetch` can exclude prefetch requests.
+   */
+  matcherRequest?: Request;
+  /**
    * The user's `trailingSlash` config. Plumbed into the NextRequest's NextURL
    * so `request.nextUrl.toString()` formats with the configured slash policy,
    * which feeds into `NextResponse.redirect(request.nextUrl)` Location headers.
@@ -306,7 +313,7 @@ export async function executeMiddleware(
     !matchesMiddleware(
       matchPathname,
       middlewareMatcher(options.module),
-      options.request,
+      options.matcherRequest ?? options.request,
       options.i18nConfig,
     )
   ) {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -307,6 +307,195 @@ function toSameOriginRouteHref(href: string): string | null {
   return `${stripBasePath(url.pathname, __basePath)}${url.search}`;
 }
 
+type ClientMiddlewareMatcherObject = {
+  source: string;
+  locale?: false;
+  has?: unknown[];
+  missing?: unknown[];
+};
+
+type ClientMiddlewareMatcherCondition = {
+  type: "header" | "cookie" | "query" | "host";
+  key?: string;
+  value?: string;
+};
+
+function isClientMiddlewareMatcherObject(value: unknown): value is ClientMiddlewareMatcherObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string") return false;
+  if (record.locale !== undefined && record.locale !== false) return false;
+  if (record.has !== undefined && !Array.isArray(record.has)) return false;
+  if (record.missing !== undefined && !Array.isArray(record.missing)) return false;
+  return true;
+}
+
+function isClientMiddlewareMatcherCondition(
+  condition: unknown,
+): condition is ClientMiddlewareMatcherCondition {
+  if (!condition || typeof condition !== "object" || Array.isArray(condition)) return false;
+  const record = condition as Record<string, unknown>;
+  if (
+    record.type !== "header" &&
+    record.type !== "cookie" &&
+    record.type !== "query" &&
+    record.type !== "host"
+  ) {
+    return false;
+  }
+  if (record.key !== undefined && typeof record.key !== "string") return false;
+  if (record.value !== undefined && typeof record.value !== "string") return false;
+  return true;
+}
+
+function isRouterPrefetchHeaderCondition(condition: ClientMiddlewareMatcherCondition): boolean {
+  return (
+    condition.type === "header" &&
+    typeof condition.key === "string" &&
+    condition.key.toLowerCase() === "next-router-prefetch"
+  );
+}
+
+function conditionValueMatches(value: string, pattern: string | undefined): boolean {
+  if (pattern === undefined || pattern === "") return value !== "";
+  try {
+    return new RegExp(`^${pattern}$`).test(value);
+  } catch {
+    return false;
+  }
+}
+
+function readClientCookie(name: string | undefined): string | undefined {
+  if (!name || typeof document === "undefined") return undefined;
+  const cookies = document.cookie ? document.cookie.split(";") : [];
+  for (const cookie of cookies) {
+    const [rawKey, ...rawValue] = cookie.split("=");
+    if (rawKey?.trim() === name) return rawValue.join("=").trim();
+  }
+  return undefined;
+}
+
+function clientMatcherConditionMatches(
+  condition: ClientMiddlewareMatcherCondition,
+  target: URL,
+): boolean | "unknown" {
+  switch (condition.type) {
+    case "query": {
+      if (!condition.key) return false;
+      const values = target.searchParams.getAll(condition.key);
+      if (values.length === 0) return false;
+      if (condition.value === undefined || condition.value === "") {
+        return values.some((value) => value !== "");
+      }
+      return conditionValueMatches(values[values.length - 1] ?? "", condition.value);
+    }
+    case "host": {
+      const hostname = target.host.split(":", 1)[0]?.toLowerCase() ?? "";
+      return conditionValueMatches(hostname, condition.value);
+    }
+    case "header": {
+      if (condition.key?.toLowerCase() === "next-router-prefetch") return false;
+      return "unknown";
+    }
+    case "cookie": {
+      const value = readClientCookie(condition.key);
+      if (value === undefined) return "unknown";
+      return conditionValueMatches(value, condition.value);
+    }
+  }
+}
+
+function routerPrefetchHeaderConditionMatchesPrefetch(
+  condition: ClientMiddlewareMatcherCondition,
+): boolean {
+  return isRouterPrefetchHeaderCondition(condition) && conditionValueMatches("1", condition.value);
+}
+
+function stripLocaleForMiddlewareMatcher(pathname: string): string {
+  const locales = window.__VINEXT_LOCALES__;
+  if (!locales || locales.length === 0 || pathname === "/") return pathname;
+  const firstSegment = pathname.split("/")[1];
+  if (!firstSegment || !locales.includes(firstSegment)) return pathname;
+  return "/" + pathname.split("/").slice(2).join("/");
+}
+
+function clientMiddlewareSourceMatches(pathname: string, source: string): boolean {
+  if (!/[\\():*+?]/.test(source)) {
+    return (
+      normalizePathTrailingSlash(pathname, false) === normalizePathTrailingSlash(source, false)
+    );
+  }
+
+  if (source.includes("(") || source.includes("\\")) return false;
+
+  const sourceParts = source.split("/").filter(Boolean);
+  const pathParts = pathname.split("/").filter(Boolean);
+  let pathIndex = 0;
+
+  for (const sourcePart of sourceParts) {
+    if (sourcePart.startsWith(":")) {
+      if (sourcePart.endsWith("*")) return true;
+      if (sourcePart.endsWith("+")) return pathIndex < pathParts.length;
+      if (pathIndex >= pathParts.length) return false;
+      pathIndex++;
+      continue;
+    }
+
+    if (pathParts[pathIndex] !== sourcePart) return false;
+    pathIndex++;
+  }
+
+  return pathIndex === pathParts.length;
+}
+
+function middlewareMatcherConditionsMatchNavigation(
+  matcher: ClientMiddlewareMatcherObject,
+  target: URL,
+): boolean {
+  let foundPrefetchMissingCondition = false;
+
+  for (const rawCondition of matcher.has ?? []) {
+    if (!isClientMiddlewareMatcherCondition(rawCondition)) return false;
+    if (clientMatcherConditionMatches(rawCondition, target) !== true) return false;
+  }
+
+  for (const rawCondition of matcher.missing ?? []) {
+    if (!isClientMiddlewareMatcherCondition(rawCondition)) return false;
+
+    if (routerPrefetchHeaderConditionMatchesPrefetch(rawCondition)) {
+      foundPrefetchMissingCondition = true;
+      continue;
+    }
+
+    const matches = clientMatcherConditionMatches(rawCondition, target);
+    if (matches !== false) return false;
+  }
+
+  return foundPrefetchMissingCondition;
+}
+
+function middlewareMatcherMaySkipRouterPrefetch(target: URL, matcher: unknown): boolean {
+  if (!Array.isArray(matcher)) return false;
+  const pathname = stripBasePath(target.pathname, __basePath);
+
+  for (const item of matcher) {
+    if (!isClientMiddlewareMatcherObject(item)) continue;
+    if (!middlewareMatcherConditionsMatchNavigation(item, target)) continue;
+
+    const candidate = item.locale === false ? pathname : stripLocaleForMiddlewareMatcher(pathname);
+    if (clientMiddlewareSourceMatches(candidate, item.source)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function automaticSearchPrefetchMayMismatchNavigation(target: URL): boolean {
+  if (target.search === "") return false;
+  return middlewareMatcherMaySkipRouterPrefetch(target, window.__VINEXT_MIDDLEWARE_MATCHER__);
+}
+
 function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
@@ -436,14 +625,7 @@ function prefetchUrl(
     return;
   }
 
-  const schedule =
-    priority === "high"
-      ? (fn: () => void) => {
-          fn();
-        }
-      : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
-
-  schedule(() => {
+  const runPrefetch = () => {
     void (async () => {
       if (hasAppNavigationRuntime()) {
         if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
@@ -495,7 +677,10 @@ function prefetchUrl(
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
-        const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+        const cacheForNavigation =
+          autoPrefetch.cacheForNavigation &&
+          !(mode === "auto" && automaticSearchPrefetchMayMismatchNavigation(target));
+        const isOptimisticRouteShellPrefetch = !cacheForNavigation;
         if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
         const headers = createRscRequestHeaders({
           interceptionContext,
@@ -506,16 +691,14 @@ function prefetchUrl(
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
-        if (isOptimisticRouteShellPrefetch) {
-          headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-        }
+        headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
         const rscUrl = await createRscRequestUrl(fullHref, headers);
         const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
         const prefetched = getPrefetchedUrls();
         if (prefetched.has(cacheKey)) {
-          if (!autoPrefetch.cacheForNavigation) {
+          if (!cacheForNavigation) {
             return;
           }
 
@@ -528,7 +711,7 @@ function prefetchUrl(
         // an equivalent `_rsc` variant; the helper also deletes any stale exact
         // entry, so a stale `prefetched` member is harmlessly re-added below.
         if (
-          autoPrefetch.cacheForNavigation &&
+          cacheForNavigation &&
           hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)
         ) {
           return;
@@ -540,7 +723,7 @@ function prefetchUrl(
         // request to preserve the same pending/dedup observable contract.
         const fetchPromise =
           (mode === "full" || mode === "full-after-shell" || __prefetchInlining) &&
-          autoPrefetch.cacheForNavigation &&
+          cacheForNavigation &&
           autoPrefetch.prefetchShellFirst &&
           (mode !== "full" || mountedSlotsHeader === null)
             ? (async () => {
@@ -605,7 +788,7 @@ function prefetchUrl(
           mountedSlotsHeader,
           undefined,
           {
-            cacheForNavigation: autoPrefetch.cacheForNavigation,
+            cacheForNavigation,
             fallbackTtlMs: PREFETCH_CACHE_TTL,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
           },
@@ -650,7 +833,15 @@ function prefetchUrl(
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);
     });
-  });
+  };
+
+  if (priority === "high" || hasAppNavigationRuntime()) {
+    runPrefetch();
+    return;
+  }
+
+  const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
+  schedule(runPrefetch);
 }
 
 async function promotePrefetchEntriesForNavigation(href: string): Promise<void> {

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createElement, Suspense } from "react";
+import { createElement, Suspense, type ReactNode } from "react";
+import ReactDOMServer from "react-dom/server";
 import {
   AppElementsWire,
   APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
@@ -20,6 +21,10 @@ import type {
   RouteManifestRoute,
   RouteManifestSlotBinding,
 } from "../packages/vinext/src/routing/app-route-graph.js";
+
+function renderAppElement(value: AppElements[string]) {
+  return ReactDOMServer.renderToString(value as ReactNode);
+}
 
 function route(input: {
   id: string;
@@ -394,6 +399,113 @@ describe("App Router optimistic routing", () => {
     expect(createOptimisticRouteElements(template!)[childrenSlotId]).not.toBe(
       elements[childrenSlotId],
     );
+  });
+
+  it("learns dynamic route templates when the Suspense fallback is on the page element", () => {
+    const routeManifest = blogManifest();
+    const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+    const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+    const elements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: ["layout:/"],
+        rootLayoutTreePath: "/",
+        routeId,
+      }),
+      [pageId]: createElement(
+        Suspense,
+        { fallback: createElement("p", { id: "page-loading" }, "Loading page") },
+        createElement("article", null, "Post 1"),
+      ),
+      [routeId]: createElement("main", null, "Route wrapper"),
+    };
+
+    const template = createOptimisticRouteTemplate({
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    expect(template).toMatchObject<Partial<OptimisticRouteTemplate>>({
+      pageElementIds: [pageId],
+      routeId: "route:/blog/:slug",
+    });
+    if (template === null) {
+      throw new Error("Expected optimistic route template");
+    }
+
+    const optimisticElements = createOptimisticRouteElements(template);
+    expect(renderAppElement(optimisticElements[pageId])).toContain("Loading page");
+  });
+
+  it("uses fallback-only loading-shell page entries unchanged during optimistic navigation", () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    const routeManifest = blogManifest();
+    const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+    const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+    const elements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: ["layout:/"],
+        rootLayoutTreePath: "/",
+        routeId,
+      }),
+      [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+      [pageId]: createElement("p", { id: "page-loading" }, "Loading page"),
+      [routeId]: createElement("main", null, "Route wrapper"),
+    };
+
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    if (template === null) {
+      throw new Error("Expected optimistic route template");
+    }
+
+    const optimisticElements = createOptimisticRouteElements(template);
+    expect(optimisticElements[pageId]).toBe(elements[pageId]);
+    const html = renderAppElement(optimisticElements[pageId]);
+    expect(html).toContain("Loading page");
+  });
+
+  it("does not learn loading-shell templates without the shell marker", () => {
+    const routeManifest = blogManifest();
+    const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+    const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+    const elements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: ["layout:/"],
+        rootLayoutTreePath: "/",
+        routeId,
+      }),
+      [pageId]: createElement("article", null, "Post 1"),
+      [routeId]: createElement("main", null, "Route wrapper"),
+    };
+
+    expect(
+      createOptimisticRouteTemplate({
+        allowLoadingShell: true,
+        basePath: "",
+        elements,
+        href: "/blog/post-1.rsc",
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+      }),
+    ).toBeNull();
   });
 
   it("does not learn routes without a loading boundary", () => {

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -1,11 +1,13 @@
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
+  APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
   APP_ROOT_LAYOUT_KEY,
   APP_ROUTE_KEY,
   AppElementsWire,
 } from "../packages/vinext/src/server/app-elements.js";
 import { dispatchAppPage } from "../packages/vinext/src/server/app-page-dispatch.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { createClientReuseManifestHeaderFromVisibleAppState } from "../packages/vinext/src/server/app-browser-client-reuse-manifest.js";
 import type { AppLayoutParamAccessTracker } from "../packages/vinext/src/server/app-layout-param-observation.js";
 import {
@@ -56,9 +58,11 @@ import { isUnknownRecord } from "../packages/vinext/src/utils/record.js";
 
 type TestRoute = {
   __buildTimeClassifications?: ReadonlyMap<number, "static" | "dynamic"> | null;
+  childrenSlot?: { id: string } | null;
   error?: { default?: unknown } | null;
   errors?: readonly ({ default?: unknown } | null | undefined)[];
   forbiddens?: readonly ({ default?: unknown } | null | undefined)[];
+  ids?: { page: string | null; slots: Readonly<Record<string, string>> } | null;
   isDynamic: boolean;
   layouts: readonly { default?: unknown; dynamic?: unknown; revalidate?: unknown }[];
   layoutTreePositions?: readonly number[];
@@ -295,7 +299,9 @@ type CreateDispatchOptionsOverrides = {
   pprRuntime?: DispatchOptions["pprRuntime"];
   probeLayoutAt?: DispatchOptions["probeLayoutAt"];
   probePage?: DispatchOptions["probePage"];
+  probePageLoadingShellFallback?: DispatchOptions["probePageLoadingShellFallback"];
   renderedConcreteUrlPaths?: DispatchOptions["renderedConcreteUrlPaths"];
+  renderMode?: DispatchOptions["renderMode"];
   renderToReadableStream?: DispatchOptions["renderToReadableStream"];
   request?: Request;
   revalidateSeconds?: number | null;
@@ -387,7 +393,9 @@ function createDispatchOptions(overrides: CreateDispatchOptionsOverrides = {}) {
     pprRuntime: overrides.pprRuntime,
     probeLayoutAt: overrides.probeLayoutAt ?? createLayoutParamProbe(route, params, []),
     probePage: overrides.probePage ?? (() => null),
+    probePageLoadingShellFallback: overrides.probePageLoadingShellFallback,
     renderedConcreteUrlPaths: overrides.renderedConcreteUrlPaths,
+    renderMode: overrides.renderMode,
     renderErrorBoundaryPage: vi.fn(async () => null),
     renderHttpAccessFallbackPage: vi.fn(async () => null),
     renderToReadableStream,
@@ -615,6 +623,126 @@ describe("app page dispatch", () => {
     consumeDynamicUsage();
     consumeRenderRequestApiUsage();
     vi.unstubAllEnvs();
+  });
+
+  it("replaces implicit children slot page entries with page Suspense fallbacks for loading-shell prefetches", async () => {
+    const childrenSlotId = AppElementsWire.encodeSlotId("children", "/nested");
+    const fallback = React.createElement("div", { id: "dynamic-page-loading-a" }, "Loading a...");
+    const pageElement = React.createElement(
+      React.Suspense,
+      { fallback },
+      React.createElement("div", { id: "dynamic-page-content-a" }, "Dynamic page a"),
+    );
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const { options } = createDispatchOptions({
+      buildPageElement: async () => ({
+        [APP_ROUTE_KEY]: "route:/nested/settings",
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+        [childrenSlotId]: pageElement,
+        "route:/nested/settings": React.createElement("main", null, "Route"),
+      }),
+      cleanPathname: "/nested/settings",
+      isRscRequest: true,
+      probePageLoadingShellFallback: () => pageElement,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      renderToReadableStream(payload) {
+        capturedPayloads.push(captureRecord(payload));
+        return createStream(["flight"]);
+      },
+      route: createRoute({
+        childrenSlot: { id: childrenSlotId },
+        ids: { page: "page:/nested/settings", slots: {} },
+        pattern: "/nested/settings",
+        routeSegments: ["nested", "settings"],
+      }),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    expect(capturedPayloads).toHaveLength(1);
+    expect(capturedPayloads[0][childrenSlotId]).toBe(fallback);
+    expect(capturedPayloads[0][APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBe("LoadingBoundary");
+  });
+
+  it("replaces loading-shell page entries with Suspense fallbacks inside server wrappers", async () => {
+    const childrenSlotId = AppElementsWire.encodeSlotId("children", "/nested");
+    const fallback = React.createElement("div", { id: "dynamic-page-loading-a" }, "Loading a...");
+    const dynamicChild = vi.fn(() =>
+      React.createElement("div", { id: "dynamic-page-content-a" }, "Dynamic page a"),
+    );
+    async function Wrapper() {
+      return React.createElement(React.Suspense, { fallback }, React.createElement(dynamicChild));
+    }
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const { options } = createDispatchOptions({
+      buildPageElement: async () => ({
+        [APP_ROUTE_KEY]: "route:/nested/settings",
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+        [childrenSlotId]: React.createElement("div", { id: "placeholder" }, "Placeholder"),
+        "route:/nested/settings": React.createElement("main", null, "Route"),
+      }),
+      cleanPathname: "/nested/settings",
+      isRscRequest: true,
+      probePageLoadingShellFallback: () => React.createElement(Wrapper),
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      renderToReadableStream(payload) {
+        capturedPayloads.push(captureRecord(payload));
+        return createStream(["flight"]);
+      },
+      route: createRoute({
+        childrenSlot: { id: childrenSlotId },
+        ids: { page: "page:/nested/settings", slots: {} },
+        pattern: "/nested/settings",
+        routeSegments: ["nested", "settings"],
+      }),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    expect(capturedPayloads).toHaveLength(1);
+    expect(capturedPayloads[0][childrenSlotId]).toBe(fallback);
+    expect(dynamicChild).not.toHaveBeenCalled();
+  });
+
+  it("removes the loading-shell marker when no page entry is replaced", async () => {
+    const fallback = React.createElement("div", { id: "page-loading" }, "Loading page");
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const { options } = createDispatchOptions({
+      buildPageElement: async () => ({
+        [APP_ROUTE_KEY]: "route:/dashboard",
+        [APP_ROOT_LAYOUT_KEY]: "/",
+        [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+        "route:/dashboard": React.createElement("main", null, "Route"),
+      }),
+      cleanPathname: "/dashboard",
+      isRscRequest: true,
+      probePageLoadingShellFallback: () =>
+        React.createElement(
+          React.Suspense,
+          { fallback },
+          React.createElement("div", null, "Dashboard"),
+        ),
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      renderToReadableStream(payload) {
+        capturedPayloads.push(captureRecord(payload));
+        return createStream(["flight"]);
+      },
+      route: createRoute({
+        ids: { page: "page:/dashboard", slots: {} },
+        pattern: "/dashboard",
+        routeSegments: ["dashboard"],
+      }),
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(response.status).toBe(200);
+    expect(capturedPayloads).toHaveLength(1);
+    expect(Object.hasOwn(capturedPayloads[0], APP_PREFETCH_LOADING_SHELL_MARKER_KEY)).toBe(false);
   });
 
   it("serves cached production HTML instead of revalidating params or rendering", async () => {

--- a/tests/app-page-probe.test.ts
+++ b/tests/app-page-probe.test.ts
@@ -5,11 +5,13 @@ import {
   probeAppPage,
   probeAppPageBeforeRender,
   probeReactServerSubtree,
+  renderAppPageForLoadingShellProbe,
 } from "../packages/vinext/src/server/app-page-probe.js";
 import {
   consumeDynamicUsage,
   consumeRenderRequestApiUsage,
 } from "../packages/vinext/src/shims/headers.js";
+import { connection } from "../packages/vinext/src/shims/server.js";
 
 // Mirrors makeThenableParams() from app-rsc-entry.ts — the function that
 // converts raw null-prototype params into objects that work with both
@@ -690,6 +692,37 @@ describe("probeAppPage", () => {
     }) as Promise<unknown>;
 
     await expect(result).rejects.toBe(REDIRECT);
+  });
+});
+
+describe("renderAppPageForLoadingShellProbe", () => {
+  it("exposes the page Suspense fallback without walking into connection() children", async () => {
+    const child = vi.fn(async function Child() {
+      await connection();
+      return React.createElement("div", null, "Loaded");
+    });
+
+    async function Page(props: { params: Promise<{ slug: string }> }) {
+      const { slug } = await props.params;
+      return React.createElement(
+        React.Suspense,
+        { fallback: React.createElement("div", { id: `loading-${slug}` }, `Loading ${slug}...`) },
+        React.createElement(child),
+      );
+    }
+
+    const result = (await renderAppPageForLoadingShellProbe({
+      pageComponent: Page,
+      asyncRouteParams: makeThenableParams({ slug: "a" }),
+      searchParams: null,
+    })) as React.ReactElement<{ fallback: React.ReactElement<{ id: string; children: string }> }>;
+
+    expect(React.isValidElement(result)).toBe(true);
+    expect(result.props.fallback.props).toMatchObject({
+      children: "Loading a...",
+      id: "loading-a",
+    });
+    expect(child).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -905,7 +905,7 @@ describe("app page route wiring helpers", () => {
     expect(html).not.toContain("Page");
   });
 
-  it("does not render page content for loading-shell prefetches without a route loading boundary", async () => {
+  it("keeps the page entry for loading-shell prefetches without a route loading boundary", async () => {
     const elements = buildAppPageElements({
       element: createElement(PageProbe),
       makeThenableParams(params) {
@@ -931,11 +931,14 @@ describe("app page route wiring helpers", () => {
       renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
     });
 
-    expect(elements["page:/dashboard"]).toBeNull();
-    expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBeUndefined();
+    // Page-level Suspense fallbacks are discovered from this entry by the
+    // dispatch layer. Shells without a usable fallback have their marker removed
+    // there instead of being learned as optimistic templates.
+    expect(elements["page:/dashboard"]).toBeDefined();
+    expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBe("LoadingBoundary");
     const html = await renderRouteEntry(elements, "route:/dashboard");
 
-    expect(html).not.toContain("Page");
+    expect(html).toContain("Page");
   });
 
   it("uses override params for slot segment maps when an override page is active", async () => {

--- a/tests/e2e/app-router/nextjs-compat/mismatching-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/mismatching-prefetch.browser.spec.ts
@@ -3,7 +3,7 @@ import type { Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Route } from "@playwright/test";
 import { waitForAppRouterHydration } from "../../helpers";
 
 type ProductionApp = {
@@ -73,25 +73,28 @@ export default function Page() {
 `,
   );
   await fs.writeFile(
-    path.join(dynamicDir, "loading.tsx"),
-    `export default function Loading() {
-  return <div id="dynamic-page-loading-a">Loading a...</div>;
-}
-`,
-  );
-  await fs.writeFile(
     path.join(dynamicDir, "page.tsx"),
     `import { connection } from "next/server";
+import { Suspense, type ReactNode } from "react";
 
 export function generateStaticParams() {
   return [{ param: "a" }, { param: "b" }];
 }
 
-export default async function Page({ params }: { params: Promise<{ param: string }> }) {
+async function DynamicContent({ children }: { children: ReactNode }) {
   await connection();
+  return children;
+}
+
+export default async function Page({ params }: { params: Promise<{ param: string }> }) {
   const { param } = await params;
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  return <div id={\`dynamic-page-content-\${param}\`}>{\`Dynamic page \${param}\`}</div>;
+  return (
+    <Suspense fallback={<div id={\`dynamic-page-loading-\${param}\`}>{\`Loading \${param}...\`}</div>}>
+      <DynamicContent>
+        <div id={\`dynamic-page-content-\${param}\`}>{\`Dynamic page \${param}\`}</div>
+      </DynamicContent>
+    </Suspense>
+  );
 }
 `,
   );
@@ -100,14 +103,18 @@ export default async function Page({ params }: { params: Promise<{ param: string
     `import { NextResponse, type NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
-  if (request.headers.get("x-vinext-rsc-render-mode") === "prefetch-loading-shell") {
-    return NextResponse.next();
-  }
   const destination = request.nextUrl.searchParams.get("mismatch-rewrite");
   return destination ? NextResponse.rewrite(new URL(destination, request.url)) : NextResponse.next();
 }
 
-export const config = { matcher: "/mismatching-prefetch/:path*" };
+export const config = {
+  matcher: [
+    {
+      source: "/mismatching-prefetch/:path*",
+      missing: [{ type: "header", key: "Next-Router-Prefetch" }],
+    },
+  ],
+};
 `,
   );
 
@@ -173,13 +180,18 @@ test("recovers when navigation middleware rewrites away from the prefetched rout
     const prefetchResponse = page.waitForResponse((response) => {
       const request = response.request();
       return (
-        request.headers()["x-vinext-rsc-render-mode"] === "prefetch-loading-shell" &&
-        response.url().includes("/mismatching-prefetch/dynamic-page/a?")
+        request.headers().rsc === "1" &&
+        response.url().includes("/mismatching-prefetch/dynamic-page/a")
       );
     });
     await page.click("#reveal-link");
     await page.hover("#mismatch-link");
-    expect((await prefetchResponse).ok()).toBe(true);
+    const prefetchedShell = await prefetchResponse;
+    expect(prefetchedShell.ok()).toBe(true);
+    // Ported from Next.js:
+    // test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    expect(await prefetchedShell.text()).toContain("Loading a...");
 
     await page.evaluate(() => {
       (window as Window & { __MISMATCH_PREFETCH_MARKER__?: boolean }).__MISMATCH_PREFETCH_MARKER__ =
@@ -192,8 +204,38 @@ test("recovers when navigation middleware rewrites away from the prefetched rout
       }
     });
 
-    await page.click("#mismatch-link");
-    await expect(page.locator("#dynamic-page-content-b")).toHaveText("Dynamic page b");
+    let dynamicRequestReleasedValue = false;
+    let releaseDynamicRequest!: () => void;
+    const dynamicRequestReleased = new Promise<void>((resolve) => {
+      releaseDynamicRequest = () => {
+        if (dynamicRequestReleasedValue) return;
+        dynamicRequestReleasedValue = true;
+        resolve();
+      };
+    });
+    const holdDynamicRequest = async (route: Route) => {
+      const request = route.request();
+      if (
+        request.headers().rsc === "1" &&
+        request.url().includes("/mismatching-prefetch/dynamic-page/a")
+      ) {
+        await dynamicRequestReleased;
+      }
+      await route.continue();
+    };
+    await page.route("**/mismatching-prefetch/dynamic-page/a**", holdDynamicRequest);
+
+    try {
+      await page.click("#mismatch-link");
+      // Ported from Next.js:
+      // test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+      // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+      await expect(page.locator("#dynamic-page-loading-a")).toHaveText("Loading a...");
+      releaseDynamicRequest();
+      await expect(page.locator("#dynamic-page-content-b")).toHaveText("Dynamic page b");
+    } finally {
+      releaseDynamicRequest();
+    }
     expect(new URL(page.url()).pathname).toBe("/mismatching-prefetch/dynamic-page/a");
     expect(new URL(page.url()).search).toBe("?mismatch-rewrite=./b");
     expect(documentRequests).toEqual([]);

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -259,6 +259,25 @@ describe("App Router generated manifest construction", () => {
     }
   });
 
+  it("embeds the App middleware matcher in the browser entry", () => {
+    const code = generateBrowserEntry(
+      [],
+      null,
+      [],
+      { afterFiles: [], beforeFiles: [], fallback: [] },
+      [
+        {
+          source: "/products/:path*",
+          missing: [{ type: "header", key: "Next-Router-Prefetch" }],
+        },
+      ],
+    );
+
+    expect(code).toContain(
+      'window.__VINEXT_MIDDLEWARE_MATCHER__ = [{"source":"/products/:path*","missing":[{"type":"header","key":"Next-Router-Prefetch"}]}]',
+    );
+  });
+
   it("constructs route module imports and route entries from the scanned app shape", () => {
     const routes = [
       {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -181,8 +181,10 @@ async function flushPrefetchTasks(): Promise<void> {
   // requestIdleCallback is mocked as sync, then prefetchUrl enters an async
   // IIFE that may resolve lazy runtime modules before hashing headers and
   // writing caches. Dynamic imports can cross a macrotask boundary, so drain
-  // one event-loop turn rather than relying on a fixed microtask depth.
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  // several event-loop turns rather than relying on a fixed microtask depth.
+  for (let turn = 0; turn < 5; turn += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 async function waitForFetchCalls(
@@ -373,7 +375,8 @@ describe("Link prefetch pure decisions", () => {
   });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await flushPrefetchTasks();
   vi.doUnmock("react");
   vi.doUnmock("react/jsx-runtime");
   vi.doUnmock("react/jsx-dev-runtime");
@@ -1556,6 +1559,39 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("dispatches visible App Router prefetches without waiting for idle time", async () => {
+    const observer = stubIntersectionObserver();
+    const idleCallbacks: Array<() => void> = [];
+    const requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expect(idleCallbacks).toEqual([]);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/blog/hello",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("full-prefetches visible dynamic links without a loading shell boundary for client params", async () => {
     const observer = stubIntersectionObserver();
 
@@ -1735,7 +1771,9 @@ describe("Link prefetch scheduling", () => {
       await import("../packages/vinext/src/server/app-rsc-cache-busting.js");
     const { consumePrefetchResponse, getPrefetchCache, getPrefetchedUrls } =
       await import("../packages/vinext/src/shims/navigation.js");
-    const rscUrl = await createRscRequestUrl("/intent-prefetch-target", createRscRequestHeaders());
+    const headers = createRscRequestHeaders();
+    headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+    const rscUrl = await createRscRequestUrl("/intent-prefetch-target", headers);
     const snapshot = {
       buffer: new TextEncoder().encode("flight").buffer,
       contentType: "text/x-component",
@@ -1874,6 +1912,172 @@ describe("Link prefetch scheduling", () => {
           entry.pending === undefined ? [] : [entry.pending.catch(() => {})],
         ),
       );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps ordinary automatic query prefetches reusable for navigation", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/products/1?color=red",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/products/1",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
+        "1",
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(true);
+      expect(entry?.optimisticRouteShell).toBe(false);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("stores automatic query prefetches as optimistic shells when middleware skips prefetches", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/products/1?mismatch-rewrite=./2",
+      nodeEnv: "production",
+      windowOverrides: {
+        __VINEXT_MIDDLEWARE_MATCHER__: [
+          {
+            source: "/products/:path*",
+            missing: [{ type: "header", key: "Next-Router-Prefetch" }],
+          },
+        ],
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/products/1",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
+        "1",
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(false);
+      expect(entry?.optimisticRouteShell).toBe(true);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps automatic query prefetches reusable when middleware query conditions do not match", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/products/1?color=red",
+      nodeEnv: "production",
+      windowOverrides: {
+        __VINEXT_MIDDLEWARE_MATCHER__: [
+          {
+            source: "/products/:path*",
+            has: [{ type: "query", key: "mismatch-rewrite" }],
+            missing: [{ type: "header", key: "Next-Router-Prefetch" }],
+          },
+        ],
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/products/1",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
+        "1",
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(true);
+      expect(entry?.optimisticRouteShell).toBe(false);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps automatic query prefetches reusable for regex-style middleware sources", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/products/1?mismatch-rewrite=./2",
+      nodeEnv: "production",
+      windowOverrides: {
+        __VINEXT_MIDDLEWARE_MATCHER__: [
+          {
+            source: "/products/(.*)",
+            missing: [{ type: "header", key: "Next-Router-Prefetch" }],
+          },
+        ],
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/products/1",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        null,
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(true);
+      expect(entry?.optimisticRouteShell).toBe(false);
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8061,6 +8061,42 @@ describe("double-encoded path handling in middleware", () => {
     expect(capturedHeaders?.get("x-user-visible")).toBe("keep");
   });
 
+  it("App Router middleware matcher checks prefetch headers before stripping them", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/concurrent-navigations/proxy.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/concurrent-navigations/proxy.ts
+    const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
+    const middleware = vi.fn(() => new Response(null, { headers: { "x-middleware-next": "1" } }));
+    const module = {
+      default: middleware,
+      config: {
+        matcher: [
+          {
+            source: "/:path*",
+            missing: [{ type: "header", key: "Next-Router-Prefetch" }],
+          },
+        ],
+      },
+    };
+
+    const result = await applyAppMiddleware({
+      cleanPathname: "/dashboard",
+      context: { headers: null, requestHeaders: null, status: null },
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/dashboard", {
+        headers: {
+          rsc: "1",
+          "next-router-prefetch": "1",
+          "x-user-visible": "keep",
+        },
+      }),
+    });
+
+    expect(result.kind).toBe("continue");
+    expect(middleware).not.toHaveBeenCalled();
+  });
+
   it("App Router Flight header stripping does not lock the original request body", async () => {
     const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
     const request = new Request("http://localhost:3000/actions", {


### PR DESCRIPTION
## Summary
- recover App Router navigations when a prefetched URL is rewritten to a different route
- preserve optimistic loading shells by probing nested server-component Suspense fallbacks
- only demote query-string prefetch cache reuse when middleware matcher conditions confidently require skipping prefetch requests

## Validation
- `vp check packages/vinext/src/shims/link.tsx tests/link-navigation.test.ts packages/vinext/src/server/app-optimistic-routing.ts packages/vinext/src/server/app-page-route-wiring.tsx`
- `vp test run tests/link-navigation.test.ts tests/app-page-probe.test.ts tests/app-page-dispatch.test.ts tests/app-optimistic-routing.test.ts tests/app-page-route-wiring.test.ts`
- `vp exec playwright test -c tests/e2e/app-router/nextjs-compat/playwright.nextjs-compat.config.ts tests/e2e/app-router/nextjs-compat/mismatching-prefetch.browser.spec.ts --project=chrome-browser-specific`

Independent review loop completed with no findings after follow-up fixes.