### PR TITLE
fix(pages): preserve middleware rewrite navigation state

### DIFF
--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -299,13 +299,16 @@ async function hydrate() {
   window.__NEXT_HYDRATED_AT = hydratedAt;
   window.__NEXT_HYDRATED_CB?.();
 
-  if (nextData.isFallback) {
+  const shouldHydrateQuery =
+    nextData.isFallback ||
+    (nextData.gsp && (window.location.search || nextData.__vinext?.hasRewrites));
+  if (shouldHydrateQuery) {
     const currentUrl = window.location.pathname + window.location.search + window.location.hash;
     const routeUrl = nextData.__vinext?.routeUrl;
     await Router.replace(
-      routeUrl || currentUrl,
-      routeUrl ? currentUrl : undefined,
-      { _h: 1, scroll: false },
+      nextData.isFallback && routeUrl ? routeUrl : nextData.page,
+      currentUrl,
+      { _h: 1, shallow: !nextData.isFallback, scroll: false },
     );
   }
 }

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -306,7 +306,9 @@ async function hydrate() {
     const currentUrl = window.location.pathname + window.location.search + window.location.hash;
     const routeUrl = nextData.__vinext?.routeUrl;
     await Router.replace(
-      nextData.isFallback && routeUrl ? routeUrl : nextData.page,
+      nextData.isFallback && routeUrl
+        ? routeUrl
+        : { pathname: nextData.page, query: nextData.query },
       currentUrl,
       { _h: 1, shallow: !nextData.isFallback, scroll: false },
     );

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4962,6 +4962,7 @@ export const loadServerActionClient = ${
                   req.__vinextMiddlewareStatus,
                   pipelineResult.isDataReq,
                   originalRequestUrl,
+                  pipelineResult.renderOptions?.rewriteQueryKeys,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -5544,6 +5544,7 @@ export const loadServerActionClient = ${
                         hasMiddlewareRewrite,
                       )
                     : undefined,
+                  pipelineResult.renderOptions?.rewriteQueryKeys,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -5519,6 +5519,7 @@ export const loadServerActionClient = ${
                       nextConfig?.htmlLimitedBots,
                       nextConfig?.reactStrictMode === true,
                       nextConfig?.expireTime,
+                      nextConfig?.rewrites,
                     ),
                   };
                 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -34,6 +34,7 @@ import {
   findFileWithExts,
 } from "./routing/file-matcher.js";
 import { createSSRHandler } from "./server/dev-server.js";
+import { getPagesMiddlewareRewriteCacheState } from "./server/pages-middleware-rewrite-cache.js";
 import { handleApiRoute } from "./server/api-handler.js";
 import {
   DEFAULT_DEVICE_SIZES,
@@ -5528,6 +5529,8 @@ export const loadServerActionClient = ${
                 }
                 // Update req.url to the resolved URL so SSR sees the post-mw path
                 req.url = pipelineResult.resolvedUrl;
+                const hasMiddlewareRewrite =
+                  pipelineResult.renderOptions?.hasMiddlewareRewrite === true;
                 await cachedSSRHandler.handler(
                   req,
                   res,
@@ -5535,6 +5538,12 @@ export const loadServerActionClient = ${
                   req.__vinextMiddlewareStatus,
                   pipelineResult.isDataReq,
                   originalRequestUrl,
+                  hasMiddlewareRewrite
+                    ? getPagesMiddlewareRewriteCacheState(
+                        pipelineResult.resolvedUrl,
+                        hasMiddlewareRewrite,
+                      )
+                    : undefined,
                 );
               }
             } catch (e) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -85,6 +85,7 @@ import {
 import { attachPagesRequestCookies } from "./pages-node-compat.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
+import { buildInitialPagesRouterQuery } from "./pages-request-pipeline.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -554,6 +555,7 @@ export function createSSRHandler(
      */
     isDataReq: boolean = false,
     originalUrl: string = url,
+    rewriteQueryKeys: string[] = [],
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -663,6 +665,7 @@ export function createSSRHandler(
       ? params
       : null;
     const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
+    const initialQuery = buildInitialPagesRouterQuery(query, params, rewriteQueryKeys);
 
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
@@ -734,6 +737,7 @@ export function createSSRHandler(
           routerShim.setSSRContext({
             pathname: patternToNextFormat(route.pattern),
             query,
+            initialQuery,
             asPath: requestAsPath,
             navigationIsReady,
             nextData: pagesNextData,
@@ -857,6 +861,7 @@ export function createSSRHandler(
               routerShim.setSSRContext({
                 pathname: patternToNextFormat(route.pattern),
                 query,
+                initialQuery,
                 asPath: requestAsPath,
                 navigationIsReady: false,
                 locale: locale ?? currentDefaultLocale,
@@ -1135,6 +1140,7 @@ export function createSSRHandler(
                   ssrContext: {
                     pathname: patternToNextFormat(route.pattern),
                     query,
+                    initialQuery,
                     asPath: requestAsPath,
                     navigationIsReady,
                     locale: locale ?? currentDefaultLocale,
@@ -1238,6 +1244,7 @@ export function createSSRHandler(
                         routerShim.setSSRContext({
                           pathname: patternToNextFormat(route.pattern),
                           query,
+                          initialQuery,
                           asPath: requestAsPath,
                           navigationIsReady,
                           locale: locale ?? currentDefaultLocale,
@@ -1302,7 +1309,7 @@ export function createSSRHandler(
                         {
                           props: freshRenderProps,
                           page: patternToNextFormat(route.pattern),
-                          query: params,
+                          query: initialQuery,
                           buildId: process.env.__VINEXT_BUILD_ID,
                           isFallback: false,
                           locale: locale ?? currentDefaultLocale,
@@ -1738,7 +1745,7 @@ hydrate();
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: params,
+            query: initialQuery,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -88,6 +88,7 @@ import {
 } from "./pages-preview.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import type { PagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
+import { buildInitialPagesRouterQuery } from "./pages-request-pipeline.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -698,6 +699,7 @@ export function createSSRHandler(
     isDataReq: boolean = false,
     originalUrl: string = url,
     middlewareRewriteCacheState?: PagesMiddlewareRewriteCacheState,
+    rewriteQueryKeys: string[] = [],
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -822,6 +824,7 @@ export function createSSRHandler(
       ? params
       : null;
     let query = mergeRouteParamsIntoQuery(parseQuery(url), params);
+    const initialQuery = buildInitialPagesRouterQuery(query, params, rewriteQueryKeys);
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
     const closeRequest = () => void closeAfterResponse(requestContext);
@@ -923,6 +926,7 @@ export function createSSRHandler(
           routerShim.setSSRContext({
             pathname: patternToNextFormat(route.pattern),
             query,
+            initialQuery,
             asPath: requestAsPath,
             navigationIsReady,
             nextData: pagesNextData,
@@ -1059,6 +1063,7 @@ export function createSSRHandler(
               routerShim.setSSRContext({
                 pathname: patternToNextFormat(route.pattern),
                 query: {},
+                initialQuery: {},
                 asPath: patternToNextFormat(route.pattern),
                 navigationIsReady: false,
                 locale: locale ?? currentDefaultLocale,
@@ -1591,7 +1596,7 @@ export function createSSRHandler(
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: isFallbackRender ? {} : query,
+            query: isFallbackRender ? {} : initialQuery,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -64,7 +64,10 @@ import {
 } from "./pages-page-data.js";
 import { sanitizeDestination } from "../config/config-matchers.js";
 import { createPagesDevAssetUrl, createPagesDevModuleUrl } from "./pages-dev-module-url.js";
-import { createPagesDevHydrationScript } from "./pages-dev-hydration.js";
+import {
+  createPagesDevHydrationScript,
+  type PagesDevHydrationOptions,
+} from "./pages-dev-hydration.js";
 import { getManifestFilesForModule } from "./pages-asset-tags.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 import { isDangerousScheme } from "vinext/shims/url-safety";
@@ -660,6 +663,7 @@ export function createSSRHandler(
   reactStrictMode = false,
   /** Next.js `expireTime`, used when formatting terminal GSP responses. */
   expireTime = PAGES_CACHE_ONE_YEAR_SECONDS,
+  clientRewrites?: PagesDevHydrationOptions["clientRewrites"],
 ) {
   const matcher = fileMatcher ?? createValidFileMatcher();
 
@@ -1586,6 +1590,7 @@ export function createSSRHandler(
 
         const hydrationScript = createPagesDevHydrationScript({
           appModuleSource,
+          clientRewrites,
           pageModuleSource,
           reactStrictMode: reactStrictMode === true,
           replaceFallbackRoute: true,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -87,6 +87,7 @@ import {
   type PagesPreviewState,
 } from "./pages-preview.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
+import type { PagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -696,6 +697,7 @@ export function createSSRHandler(
      */
     isDataReq: boolean = false,
     originalUrl: string = url,
+    middlewareRewriteCacheState?: PagesMiddlewareRewriteCacheState,
   ): Promise<void> => {
     const _reqStart = now();
     let _compileEnd: number | undefined;
@@ -865,7 +867,7 @@ export function createSSRHandler(
         const isStaticPropsRender =
           typeof pageModule.getStaticProps === "function" &&
           typeof pageModule.getServerSideProps !== "function";
-        if (isStaticPropsRender) {
+        if (isStaticPropsRender && !middlewareRewriteCacheState) {
           // Match Next.js's Pages handler: getStaticProps renders receive only
           // route params and a resolved asPath without request search state.
           query = mergeRouteParamsIntoQuery({}, params);
@@ -1589,7 +1591,7 @@ export function createSSRHandler(
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: isFallbackRender ? {} : params,
+            query: isFallbackRender ? {} : query,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/pages-dev-hydration.ts
+++ b/packages/vinext/src/server/pages-dev-hydration.ts
@@ -1,7 +1,13 @@
 import { createNonceAttribute } from "./html.js";
+import type { NextRewrite } from "../config/next-config.js";
 
 export type PagesDevHydrationOptions = {
   appModuleSource: string | null;
+  clientRewrites?: {
+    afterFiles: NextRewrite[];
+    beforeFiles: NextRewrite[];
+    fallback: NextRewrite[];
+  };
   forceRouterReady?: boolean;
   normalizePageProps?: boolean;
   pageModuleSource: string;
@@ -23,10 +29,19 @@ export function createPagesDevHydrationScript(options: PagesDevHydrationOptions)
     options.normalizePageProps === false
       ? "const pageProps = rawPageProps ?? {};"
       : 'const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};';
-  const fallbackReplacement = options.replaceFallbackRoute
+  const hydrationQueryReplacement = options.replaceFallbackRoute
     ? `
-  if (nextData.isFallback) {
-    await Router.replace(window.location.pathname + window.location.search + window.location.hash, undefined, { _h: 1, scroll: false });
+  const shouldHydrateQuery =
+    nextData.isFallback ||
+    (nextData.gsp && (window.location.search || nextData.__vinext?.hasRewrites));
+  if (shouldHydrateQuery) {
+    const currentUrl = window.location.pathname + window.location.search + window.location.hash;
+    const routeUrl = nextData.__vinext?.routeUrl;
+    await Router.replace(
+      nextData.isFallback && routeUrl ? routeUrl : nextData.page,
+      currentUrl,
+      { _h: 1, shallow: !nextData.isFallback, scroll: false },
+    );
   }`
     : "";
   const createElement = options.appModuleSource
@@ -68,6 +83,9 @@ window.__VINEXT_PAGE_LOADERS__ = { [nextData.page]: () => import(${JSON.stringif
 ${pagePatterns}
 window.__VINEXT_APP_LOADER__ = ${options.appModuleSource ? `() => import(${JSON.stringify(options.appModuleSource)})` : "undefined"};
 window.__VINEXT_REACT_STRICT_MODE__ = ${JSON.stringify(options.reactStrictMode)};
+window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(
+    options.clientRewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
+  )};
 
 async function hydrate() {
   let hydrateRootOptions;
@@ -96,7 +114,7 @@ async function hydrate() {
   window.__VINEXT_HYDRATED_AT = hydratedAt;
   window.__NEXT_HYDRATED = true;
   window.__NEXT_HYDRATED_AT = hydratedAt;
-  window.__NEXT_HYDRATED_CB?.();${fallbackReplacement}
+  window.__NEXT_HYDRATED_CB?.();${hydrationQueryReplacement}
 }
 hydrate();
 </script>`;

--- a/packages/vinext/src/server/pages-dev-hydration.ts
+++ b/packages/vinext/src/server/pages-dev-hydration.ts
@@ -38,7 +38,9 @@ export function createPagesDevHydrationScript(options: PagesDevHydrationOptions)
     const currentUrl = window.location.pathname + window.location.search + window.location.hash;
     const routeUrl = nextData.__vinext?.routeUrl;
     await Router.replace(
-      nextData.isFallback && routeUrl ? routeUrl : nextData.page,
+      nextData.isFallback && routeUrl
+        ? routeUrl
+        : { pathname: nextData.page, query: nextData.query },
       currentUrl,
       { _h: 1, shallow: !nextData.isFallback, scroll: false },
     );

--- a/packages/vinext/src/server/pages-i18n.ts
+++ b/packages/vinext/src/server/pages-i18n.ts
@@ -115,7 +115,10 @@ export function extractLocaleFromUrl(
 
   if (parts.length > 0 && i18nConfig.locales.includes(parts[0])) {
     const locale = parts[0];
-    const rest = "/" + parts.slice(1).join("/");
+    // Slice the locale prefix from the original pathname so significant path
+    // spelling such as a configured trailing slash survives normalization.
+    // This mirrors Next.js' normalizeLocalePath() behavior.
+    const rest = pathname.slice(locale.length + 1) || "/";
     return { locale, url: (rest || "/") + query, hadPrefix: true };
   }
 

--- a/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
+++ b/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
@@ -1,0 +1,20 @@
+export type PagesMiddlewareRewriteCacheState = {
+  cachePathname: string;
+  bypassCdnCache: boolean;
+};
+
+export function getPagesMiddlewareRewriteCacheState(
+  routeUrl: string,
+  hasMiddlewareRewrite: boolean,
+): PagesMiddlewareRewriteCacheState {
+  const url = new URL(routeUrl, "http://vinext.local");
+  if (!hasMiddlewareRewrite || !url.search) {
+    return { cachePathname: url.pathname || "/", bypassCdnCache: false };
+  }
+
+  url.searchParams.sort();
+  return {
+    cachePathname: `${url.pathname || "/"}?${url.searchParams.toString()}`,
+    bypassCdnCache: true,
+  };
+}

--- a/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
+++ b/packages/vinext/src/server/pages-middleware-rewrite-cache.ts
@@ -1,7 +1,15 @@
+import type { isrGet, isrSet } from "./isr-cache.js";
+
 export type PagesMiddlewareRewriteCacheState = {
   cachePathname: string;
   bypassCdnCache: boolean;
+  /** Query-specific SSR state must not be read from or written to the shared origin ISR cache. */
+  bypassOriginCache: boolean;
 };
+
+/** Request-local cache dependencies for query-varying middleware rewrites. */
+export const bypassedPagesIsrGet: typeof isrGet = async () => null;
+export const bypassedPagesIsrSet: typeof isrSet = async () => {};
 
 export function getPagesMiddlewareRewriteCacheState(
   routeUrl: string,
@@ -9,12 +17,17 @@ export function getPagesMiddlewareRewriteCacheState(
 ): PagesMiddlewareRewriteCacheState {
   const url = new URL(routeUrl, "http://vinext.local");
   if (!hasMiddlewareRewrite || !url.search) {
-    return { cachePathname: url.pathname || "/", bypassCdnCache: false };
+    return {
+      cachePathname: url.pathname || "/",
+      bypassCdnCache: false,
+      bypassOriginCache: false,
+    };
   }
 
   url.searchParams.sort();
   return {
     cachePathname: `${url.pathname || "/"}?${url.searchParams.toString()}`,
     bypassCdnCache: true,
+    bypassOriginCache: true,
   };
 }

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -11,6 +11,7 @@ import {
   buildPagesNextDataScript,
   etagMatches,
   generatePagesETag,
+  getCacheSafePagesInitialQuery,
   isPagesStreamingBot,
   requestsNoCache,
   type PagesGsspResponse,
@@ -129,6 +130,7 @@ type RenderPagesIsrHtmlOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  initialQuery?: Record<string, unknown>;
   renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
   routePattern: string;
   safeJsonStringify: (value: unknown) => string;
@@ -201,6 +203,7 @@ export type ResolvePagesPageDataOptions = {
   AppComponent?: unknown;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
+  initialQuery?: Record<string, unknown>;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -644,6 +647,7 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    initialQuery: getCacheSafePagesInitialQuery(options.params, options.initialQuery),
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     // Serialize the same readiness flags (gssp/gsp/autoExport/…) the initial
@@ -919,6 +923,7 @@ export async function resolvePagesPageData(
                 pageProps: freshPageProps,
                 props: freshRenderProps,
                 params: options.params,
+                initialQuery: options.initialQuery,
                 renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
                 routePattern: options.routePattern,
                 safeJsonStringify: options.safeJsonStringify,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -38,6 +38,7 @@ import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { isDangerousScheme } from "vinext/shims/url-safety";
 import { encodeCacheTag } from "../utils/encode-cache-tag.js";
+import { bypassedPagesIsrGet, bypassedPagesIsrSet } from "./pages-middleware-rewrite-cache.js";
 
 export type PagesRedirectResult = {
   destination: string;
@@ -316,6 +317,8 @@ export type ResolvePagesPageDataOptions = {
   query: Record<string, unknown>;
   nextDataQuery?: Record<string, unknown>;
   bypassCdnCache?: boolean;
+  /** Skip shared origin ISR reads and writes for request-specific rewrite state. */
+  bypassOriginCache?: boolean;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -1060,6 +1063,8 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
 export async function resolvePagesPageData(
   options: ResolvePagesPageDataOptions,
 ): Promise<ResolvePagesPageDataResult> {
+  const requestIsrGet = options.bypassOriginCache ? bypassedPagesIsrGet : options.isrGet;
+  const requestIsrSet = options.bypassOriginCache ? bypassedPagesIsrSet : options.isrSet;
   // Next.js passes `params: null` (effectively) to gSSP/gSP context for
   // non-dynamic routes — see render.tsx's `...(pageIsDynamic ? { params } : undefined)`.
   // Internal bookkeeping (route param hydration, ISR HTML, getStaticPaths
@@ -1130,7 +1135,7 @@ export async function resolvePagesPageData(
     options.revalidateOnlyGenerated
   ) {
     const pathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
-    onDemandPreviousCacheEntry = await options.isrGet(options.isrCacheKey("pages", pathname));
+    onDemandPreviousCacheEntry = await requestIsrGet(options.isrCacheKey("pages", pathname));
     if (!onDemandPreviousCacheEntry) {
       return {
         kind: "response",
@@ -1177,7 +1182,7 @@ export async function resolvePagesPageData(
 
   if (isFallback) {
     const pathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
-    const cached = await options.isrGet(options.isrCacheKey("pages", pathname));
+    const cached = await requestIsrGet(options.isrCacheKey("pages", pathname));
     if (cached?.value.value?.kind !== "PAGES") {
       const appShortCircuit = await loadForegroundAppInitialRenderProps();
       if (appShortCircuit) return appShortCircuit;
@@ -1270,7 +1275,7 @@ export async function resolvePagesPageData(
     const cached =
       onDemandPreviousCacheEntry !== undefined
         ? onDemandPreviousCacheEntry
-        : await options.isrGet(cacheKey);
+        : await requestIsrGet(cacheKey);
     const cachedValue = cached?.value.value;
     const isLegacyCachedNotFound =
       cachedValue?.kind === "PAGES" &&
@@ -1311,7 +1316,7 @@ export async function resolvePagesPageData(
                 routeUrl: options.routeUrl,
                 sanitizeDestination: options.sanitizeDestination,
               });
-              await options.isrSet(
+              await requestIsrSet(
                 cacheKey,
                 {
                   kind: "REDIRECT",
@@ -1325,7 +1330,7 @@ export async function resolvePagesPageData(
             }
 
             if (freshResult.notFound) {
-              await options.isrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
+              await requestIsrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
               return;
             }
 
@@ -1353,7 +1358,7 @@ export async function resolvePagesPageData(
                 nextData: options.nextData,
                 vinext: options.vinext,
               });
-              await options.isrSet(
+              await requestIsrSet(
                 cacheKey,
                 buildPagesCacheValue(freshHtml, freshRenderProps, options.statusCode),
                 revalidateSeconds,
@@ -1366,7 +1371,7 @@ export async function resolvePagesPageData(
             // A cached redirect/not-found has no reusable HTML shell. Persist
             // the resolved props and let the next foreground request render
             // the canonical PAGES representation without re-running user code.
-            await options.isrSet(
+            await requestIsrSet(
               cacheKey,
               {
                 kind: "PAGES",
@@ -1598,7 +1603,7 @@ export async function resolvePagesPageData(
           routeUrl: options.routeUrl,
           sanitizeDestination: options.sanitizeDestination,
         });
-        await options.isrSet(
+        await requestIsrSet(
           cacheKey,
           {
             kind: "REDIRECT",
@@ -1620,7 +1625,7 @@ export async function resolvePagesPageData(
       const revalidateSeconds = resolvePagesRevalidateSeconds(result, options.routeUrl);
       const expireSeconds = resolvePagesExpireSeconds(result, options.expireSeconds);
       if (previewData === false) {
-        await options.isrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
+        await requestIsrSet(cacheKey, null, revalidateSeconds, undefined, expireSeconds);
       }
       const notFoundResult = buildPagesNotFoundResult(
         options,
@@ -1670,7 +1675,7 @@ export async function resolvePagesPageData(
 
     if (shouldPersistFallbackData && previewData === false) {
       const revalidateSeconds = isrRevalidateSeconds ?? false;
-      await options.isrSet(
+      await requestIsrSet(
         cacheKey,
         {
           kind: "PAGES",

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -1346,6 +1346,7 @@ export async function resolvePagesPageData(
                 pageProps: freshPageProps,
                 props: freshRenderProps,
                 params: options.params,
+                nextDataQuery: options.nextDataQuery,
                 renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
                 routePattern: options.routePattern,
                 safeJsonStringify: options.safeJsonStringify,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -10,7 +10,7 @@ import type {
   CacheControlMetadata,
 } from "vinext/shims/cache-handler";
 import { applyCdnResponseHeaders } from "./cache-control.js";
-import { buildMissIsrCacheControl, decideIsr } from "./isr-decision.js";
+import { buildMissIsrCacheControl, decideIsr, ISR_NO_STORE_CACHE_CONTROL } from "./isr-decision.js";
 import { buildCacheStateHeaders } from "./cache-headers.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
 import type { PagesPreviewData } from "./pages-preview.js";
@@ -230,6 +230,7 @@ type RenderPagesIsrHtmlOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  nextDataQuery?: Record<string, unknown>;
   renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
   routePattern: string;
   safeJsonStringify: (value: unknown) => string;
@@ -313,6 +314,8 @@ export type ResolvePagesPageDataOptions = {
   router?: PagesGetInitialPropsRouter;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
+  nextDataQuery?: Record<string, unknown>;
+  bypassCdnCache?: boolean;
   asPath?: string;
   resolvedUrl?: string;
   route: Pick<Route, "isDynamic">;
@@ -449,8 +452,15 @@ function applyCachedPagesRepresentationHeaders(
   response: Response,
   cacheState: "HIT" | "STALE",
   entry: CacheHandlerValue,
-  options: Pick<ResolvePagesPageDataOptions, "expireSeconds">,
+  options: Pick<ResolvePagesPageDataOptions, "expireSeconds" | "bypassCdnCache">,
 ): Response {
+  if (options.bypassCdnCache) {
+    response.headers.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
+    for (const [name, value] of Object.entries(buildCacheStateHeaders(cacheState))) {
+      response.headers.set(name, value);
+    }
+    return response;
+  }
   const { cacheControl } = decideIsr({
     cacheState,
     kind: "pages",
@@ -906,6 +916,7 @@ function buildPagesCacheResponse(
   cacheControl?: CacheControlMetadata,
   status?: number,
   cachedHeaders?: Record<string, string | string[]>,
+  bypassCdnCache?: boolean,
 ): Response {
   // Legacy cache entries written before cacheControl metadata existed can still
   // hit this path without a persisted revalidate value; keep the historic
@@ -925,7 +936,11 @@ function buildPagesCacheResponse(
     "Content-Type": "text/html; charset=utf-8",
     ...buildCacheStateHeaders(cacheState),
   });
-  applyCdnResponseHeaders(headers, { cacheControl: cacheControlHeader });
+  if (bypassCdnCache) {
+    headers.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
+  } else {
+    applyCdnResponseHeaders(headers, { cacheControl: cacheControlHeader });
+  }
 
   if (fontLinkHeader) {
     headers.set("Link", fontLinkHeader);
@@ -1029,6 +1044,7 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.nextDataQuery,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     // Serialize the same readiness flags (gssp/gsp/autoExport/…) the initial
@@ -1439,6 +1455,7 @@ export async function resolvePagesPageData(
         cached.value.cacheControl,
         cachedValue.status,
         cachedValue.headers,
+        options.bypassCdnCache,
       );
       // Bot / crawler ETag consistency: attach an ETag to cache-HIT responses
       // for bot UAs so they are consistent with fresh-MISS bot responses (which
@@ -1518,6 +1535,7 @@ export async function resolvePagesPageData(
         cached.value.cacheControl,
         cachedValue.status,
         cachedValue.headers,
+        options.bypassCdnCache,
       );
       // Bot / crawler ETag consistency: same as the HIT branch — attach an
       // ETag to STALE responses for bot UAs and honour If-None-Match / 304.

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -14,6 +14,7 @@
 
 import type { ComponentType, ReactNode } from "react";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
+import { buildInitialPagesRouterQuery } from "./pages-request-pipeline.js";
 import { patternToNextFormat } from "../routing/route-validation.js";
 import { resolvePagesI18nRequest } from "./pages-i18n.js";
 import { createPagesReqRes } from "./pages-node-compat.js";
@@ -192,6 +193,7 @@ type RenderPageOptions = {
   statusCode?: number;
   asPath?: string;
   originalUrl?: string;
+  rewriteQueryKeys?: string[];
   renderErrorPageOnMiss?: boolean;
   __isInternalErrorRender?: boolean;
   __forcedRoute?: PageRoute;
@@ -429,6 +431,7 @@ export function createPagesPageHandler(
         const renderStatusCode =
           renderStatusCodeOverride ?? (routePattern === "/404" ? 404 : undefined);
         const query = mergeRouteParamsIntoQuery(parseQuery(routeUrl), params);
+        const initialQuery = buildInitialPagesRouterQuery(query, params, options?.rewriteQueryKeys);
 
         // Model Pages Router readiness for `next/navigation` compat hooks. The
         // serialized `__NEXT_DATA__` flags (gssp/gsp/gip/appGip/autoExport) plus
@@ -454,6 +457,7 @@ export function createPagesPageHandler(
             setSSRContext({
               pathname: routePattern,
               query,
+              initialQuery,
               asPath: renderAsPath ?? routeUrl,
               navigationIsReady,
               locale,
@@ -594,6 +598,7 @@ export function createPagesPageHandler(
           AppComponent,
           params,
           query,
+          initialQuery,
           asPath: renderAsPath ?? routeUrl,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
@@ -657,6 +662,7 @@ export function createPagesPageHandler(
           setSSRContext({
             pathname: routePattern,
             query,
+            initialQuery,
             asPath: renderAsPath ?? routeUrl,
             navigationIsReady: false,
             locale,
@@ -763,6 +769,7 @@ export function createPagesPageHandler(
           pageProps,
           props: renderProps,
           params,
+          initialQuery,
           query,
           renderDocumentToString(element) {
             return renderToStringAsync(element);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -974,6 +974,7 @@ export function createPagesPageHandler(
           // publishes the concrete URL after the fallback data request lands.
           applySSRContext({
             query: {},
+            initialQuery: {},
             asPath: routePattern,
             navigationIsReady: false,
             isFallback: true,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -32,6 +32,7 @@ import {
   bypassedPagesIsrSet,
   getPagesMiddlewareRewriteCacheState,
 } from "./pages-middleware-rewrite-cache.js";
+import { buildInitialPagesRouterQuery } from "./pages-request-pipeline.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
@@ -319,6 +320,7 @@ export type CreatePagesPageHandlerOptions = {
 type RenderPageOptions = {
   isDataReq?: boolean;
   hasMiddlewareRewrite?: boolean;
+  rewriteQueryKeys?: string[];
   statusCode?: number;
   asPath?: string;
   originalUrl?: string;
@@ -656,6 +658,12 @@ export function createPagesPageHandler(
           : undefined;
         const errorResponseCachePathname = options?.__notFoundCachePathname ?? isrCachePathname;
         const query = mergeRouteParamsIntoQuery(parseQuery(renderRouteUrl), params);
+        const resolvedQuery = mergeRouteParamsIntoQuery(parseQuery(routeUrl), params);
+        const initialQuery = buildInitialPagesRouterQuery(
+          resolvedQuery,
+          params,
+          options?.rewriteQueryKeys,
+        );
 
         // Model Pages Router readiness for `next/navigation` compat hooks. The
         // serialized `__NEXT_DATA__` flags (gssp/gsp/gip/appGip/autoExport) plus
@@ -702,6 +710,7 @@ export function createPagesPageHandler(
             setSSRContext({
               pathname: routePattern,
               query,
+              initialQuery,
               asPath: routerAsPath,
               navigationIsReady,
               locale,
@@ -857,7 +866,7 @@ export function createPagesPageHandler(
           router,
           params,
           query,
-          nextDataQuery: query,
+          nextDataQuery: initialQuery,
           bypassCdnCache,
           bypassOriginCache,
           asPath: routerAsPath,
@@ -1090,6 +1099,7 @@ export function createPagesPageHandler(
           pageProps,
           props: renderProps,
           params,
+          initialQuery,
           query,
           bypassCdnCache,
           bypassOriginCache,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -27,7 +27,11 @@ import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { renderPagesPageResponse } from "./pages-page-response.js";
-import { getPagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
+import {
+  bypassedPagesIsrGet,
+  bypassedPagesIsrSet,
+  getPagesMiddlewareRewriteCacheState,
+} from "./pages-middleware-rewrite-cache.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
@@ -121,8 +125,20 @@ function applyPagesErrorCachePolicy(
   revalidateSeconds: number | false | undefined,
   expireSeconds: number | undefined,
   cacheTagPathname: string,
+  bypassSharedCache = false,
 ): Response {
   const headers = new Headers(response.headers);
+  if (bypassSharedCache) {
+    headers.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
+    headers.delete("CDN-Cache-Control");
+    headers.delete("Cloudflare-CDN-Cache-Control");
+    headers.delete("Cache-Tag");
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
   const browserPolicy = headers.get("Cache-Control");
   const sharedPolicies = [
     headers.get("CDN-Cache-Control"),
@@ -315,6 +331,8 @@ type RenderPageOptions = {
   __notFoundExpireSeconds?: number;
   /** Source-page identity used for the outgoing notFound cache tag. */
   __notFoundCachePathname?: string;
+  /** Keep a request-private source render and its nested error page out of shared caches. */
+  __bypassRequestCache?: boolean;
   /** Internal recursion guard while a top-level on-demand request owns the batch. */
   __skipOnDemandCoalesce?: boolean;
   err?: unknown;
@@ -613,6 +631,12 @@ export function createPagesPageHandler(
           renderRouteUrl,
           hasMiddlewareRewrite,
         );
+        const bypassOriginCache =
+          rewriteCacheState.bypassOriginCache || options?.__bypassRequestCache === true;
+        const bypassCdnCache =
+          rewriteCacheState.bypassCdnCache || options?.__bypassRequestCache === true;
+        const requestIsrGet = bypassOriginCache ? bypassedPagesIsrGet : isrGet;
+        const requestIsrSet = bypassOriginCache ? bypassedPagesIsrSet : isrSet;
         const isrCachePathname =
           isStaticPropsRender &&
           (routePattern === "/404" || routePattern === "/500" || routePattern === "/_error")
@@ -809,8 +833,8 @@ export function createPagesPageHandler(
           fontLinkHeader,
           i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
           isrCacheKey: pageIsrCacheKey,
-          isrGet,
-          isrSet,
+          isrGet: requestIsrGet,
+          isrSet: requestIsrSet,
           expireSeconds: vinextConfig.expireTime,
           isBuildTimePrerendering:
             typeof process !== "undefined" && process.env && process.env.VINEXT_PRERENDER === "1",
@@ -834,7 +858,8 @@ export function createPagesPageHandler(
           params,
           query,
           nextDataQuery: query,
-          bypassCdnCache: rewriteCacheState.bypassCdnCache,
+          bypassCdnCache,
+          bypassOriginCache,
           asPath: routerAsPath,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
@@ -879,6 +904,7 @@ export function createPagesPageHandler(
               __notFoundRevalidateSeconds: pageDataResult.revalidateSeconds,
               __notFoundExpireSeconds: pageDataResult.expireSeconds,
               __notFoundCachePathname: isrCachePathname,
+              __bypassRequestCache: bypassOriginCache || bypassCdnCache,
             });
           } else {
             notFoundResponse = buildDefaultPagesNotFoundResponse();
@@ -902,6 +928,7 @@ export function createPagesPageHandler(
               errorPageRevalidateSeconds,
               errorPageExpireSeconds,
               errorResponseCachePathname,
+              bypassCdnCache,
             );
           }
           return finalizePagesPreviewResponse(response, preview);
@@ -958,7 +985,7 @@ export function createPagesPageHandler(
               init.headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
             }
           }
-          if (rewriteCacheState.bypassCdnCache) {
+          if (bypassCdnCache) {
             init.headers["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
           } else if (gsspRes) {
             // Default Cache-Control for gSSP-driven _next/data responses —
@@ -1057,14 +1084,15 @@ export function createPagesPageHandler(
           isrRevalidateSeconds,
           isOnDemandRevalidate,
           isStaticPropsRoute,
-          isrSet,
+          isrSet: requestIsrSet,
           i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
           isFallback: isFallbackRender,
           pageProps,
           props: renderProps,
           params,
           query,
-          bypassCdnCache: rewriteCacheState.bypassCdnCache,
+          bypassCdnCache,
+          bypassOriginCache,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },
@@ -1088,6 +1116,7 @@ export function createPagesPageHandler(
             errorPageRevalidateSeconds,
             errorPageExpireSeconds,
             errorResponseCachePathname,
+            bypassCdnCache,
           );
         }
         return finalizePagesPreviewResponse(pageResponse, preview);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -69,7 +69,11 @@ import {
   NEXTJS_DEPLOYMENT_ID_HEADER,
   VINEXT_CACHE_HEADER,
 } from "./headers.js";
-import { buildMissIsrCacheControl, ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
+import {
+  buildMissIsrCacheControl,
+  ISR_NEVER_CACHE_CONTROL,
+  ISR_NO_STORE_CACHE_CONTROL,
+} from "./isr-decision.js";
 import { encodeCacheTag } from "../utils/encode-cache-tag.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
 import {
@@ -582,9 +586,10 @@ export function createPagesPageHandler(
     const hasMiddlewareRewrite = options?.hasMiddlewareRewrite === true;
     const renderRouteUrl =
       isStaticPropsRender && !hasMiddlewareRewrite ? routeUrl.split("?")[0] : routeUrl;
-    const routerAsPathSource = isStaticPropsRender
-      ? renderRouteUrl
-      : (renderAsPath ?? renderRouteUrl);
+    const routerAsPathSource =
+      isStaticPropsRender && !hasMiddlewareRewrite
+        ? renderRouteUrl
+        : (renderAsPath ?? renderRouteUrl);
     const routerAsPath = i18nConfig
       ? extractLocaleFromUrl(routerAsPathSource, i18nConfig, locale).url
       : routerAsPathSource;
@@ -953,7 +958,9 @@ export function createPagesPageHandler(
               init.headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
             }
           }
-          if (gsspRes) {
+          if (rewriteCacheState.bypassCdnCache) {
+            init.headers["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
+          } else if (gsspRes) {
             // Default Cache-Control for gSSP-driven _next/data responses —
             // skip when gSSP already set one via res.setHeader. Fixes #1461.
             let hasUserCacheControl = false;

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -27,6 +27,7 @@ import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { renderPagesPageResponse } from "./pages-page-response.js";
+import { getPagesMiddlewareRewriteCacheState } from "./pages-middleware-rewrite-cache.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
@@ -297,6 +298,7 @@ export type CreatePagesPageHandlerOptions = {
 // Internal render options (mirrors the options shape passed to `renderPage`).
 type RenderPageOptions = {
   isDataReq?: boolean;
+  hasMiddlewareRewrite?: boolean;
   statusCode?: number;
   asPath?: string;
   originalUrl?: string;
@@ -577,7 +579,9 @@ export function createPagesPageHandler(
     // Pages getStaticProps renders are shared by pathname. Match Next.js by
     // removing request search state before exposing the render URL or router
     // context; otherwise a cold/stale request can persist its query in ISR.
-    const renderRouteUrl = isStaticPropsRender ? routeUrl.split("?")[0] : routeUrl;
+    const hasMiddlewareRewrite = options?.hasMiddlewareRewrite === true;
+    const renderRouteUrl =
+      isStaticPropsRender && !hasMiddlewareRewrite ? routeUrl.split("?")[0] : routeUrl;
     const routerAsPathSource = isStaticPropsRender
       ? renderRouteUrl
       : (renderAsPath ?? renderRouteUrl);
@@ -600,11 +604,15 @@ export function createPagesPageHandler(
         // custom 404 module (and its getStaticProps) runs. Keep this separate
         // from routeUrl so router, _document, and getInitialProps contexts
         // continue to observe the original request-facing URL.
+        const rewriteCacheState = getPagesMiddlewareRewriteCacheState(
+          renderRouteUrl,
+          hasMiddlewareRewrite,
+        );
         const isrCachePathname =
           isStaticPropsRender &&
           (routePattern === "/404" || routePattern === "/500" || routePattern === "/_error")
             ? routePattern
-            : renderRouteUrl.split("?")[0];
+            : rewriteCacheState.cachePathname;
         const isNotFoundErrorRender =
           routePattern === "/404" || (routePattern === "/_error" && renderStatusCode === 404);
         const isStatusErrorRender =
@@ -820,6 +828,8 @@ export function createPagesPageHandler(
           router,
           params,
           query,
+          nextDataQuery: query,
+          bypassCdnCache: rewriteCacheState.bypassCdnCache,
           asPath: routerAsPath,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
@@ -1047,6 +1057,7 @@ export function createPagesPageHandler(
           props: renderProps,
           params,
           query,
+          bypassCdnCache: rewriteCacheState.bypassCdnCache,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -194,6 +194,7 @@ type RenderPagesPageResponseOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  initialQuery?: Record<string, unknown>;
   query?: Record<string, unknown>;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
@@ -253,6 +254,33 @@ function buildPagesFontHeadHtml(
   return html;
 }
 
+function queryValueEquals(left: unknown, right: unknown): boolean {
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    return left.every((value, index) => value === right[index]);
+  }
+  return left === right;
+}
+
+function hasRewriteSpecificInitialQuery(
+  params: Record<string, unknown>,
+  initialQuery?: Record<string, unknown>,
+): boolean {
+  if (!initialQuery) return false;
+  for (const [key, value] of Object.entries(initialQuery)) {
+    if (!queryValueEquals(params[key], value)) return true;
+  }
+  return false;
+}
+
+export function getCacheSafePagesInitialQuery(
+  params: Record<string, unknown>,
+  initialQuery?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return hasRewriteSpecificInitialQuery(params, initialQuery) ? undefined : initialQuery;
+}
+
 export function buildPagesNextDataScript(
   options: Pick<
     RenderPagesPageResponseOptions,
@@ -262,6 +290,7 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "initialQuery"
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
@@ -273,7 +302,7 @@ export function buildPagesNextDataScript(
   const nextDataPayload: Record<string, unknown> = {
     props: options.props ?? { pageProps: options.pageProps },
     page: options.routePattern,
-    query: options.params,
+    query: options.initialQuery ?? options.params,
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -491,6 +520,7 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    initialQuery: options.initialQuery,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,
@@ -612,6 +642,7 @@ export async function renderPagesPageResponse(
     // Keep nonce-bearing pages out of ISR writes: rewritePagesCachedHtml()
     // later matches the cached __NEXT_DATA__ block via a bare <script> marker.
     !options.scriptNonce &&
+    !hasRewriteSpecificInitialQuery(options.params, options.initialQuery) &&
     options.isrRevalidateSeconds !== null &&
     options.isrRevalidateSeconds > 0
   ) {

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -197,6 +197,7 @@ type RenderPagesPageResponseOptions = {
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
+  initialQuery?: Record<string, unknown>;
   query?: Record<string, unknown>;
   bypassCdnCache?: boolean;
   /** Skip shared origin ISR writes for request-specific rewrite state. */
@@ -270,6 +271,7 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "initialQuery"
     | "query"
     | "routePattern"
     | "safeJsonStringify"
@@ -285,7 +287,8 @@ export function buildPagesNextDataScript(
     // Next.js fallback:true shells intentionally omit the matched route
     // params. The live slug is published by the hydration query update after
     // the fallback data request resolves.
-    query: options.isFallback === true ? {} : (options.query ?? options.params),
+    query:
+      options.isFallback === true ? {} : (options.initialQuery ?? options.query ?? options.params),
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -503,6 +506,7 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    initialQuery: options.initialQuery,
     query: options.query,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -29,6 +29,7 @@ import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { NEXTJS_CACHE_HEADER } from "./headers.js";
+import { bypassedPagesIsrSet } from "./pages-middleware-rewrite-cache.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
@@ -198,6 +199,8 @@ type RenderPagesPageResponseOptions = {
   params: Record<string, unknown>;
   query?: Record<string, unknown>;
   bypassCdnCache?: boolean;
+  /** Skip shared origin ISR writes for request-specific rewrite state. */
+  bypassOriginCache?: boolean;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -618,6 +621,7 @@ export async function renderPagesPageResponse(
   );
 
   let responseBodyStream = bodyStream;
+  const requestIsrSet = options.bypassOriginCache ? bypassedPagesIsrSet : options.isrSet;
   if (
     // Keep nonce-bearing pages out of ISR writes: rewritePagesCachedHtml()
     // later matches the cached __NEXT_DATA__ block via a bare <script> marker.
@@ -640,7 +644,7 @@ export async function renderPagesPageResponse(
       pageData: options.props ?? { pageProps: options.pageProps },
       revalidateSeconds: options.isrRevalidateSeconds,
       routePattern: options.routePattern,
-      setCache: options.isrSet,
+      setCache: requestIsrSet,
       shellPrefix,
       shellSuffix,
       status: finalStatus,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -197,6 +197,7 @@ type RenderPagesPageResponseOptions = {
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
   query?: Record<string, unknown>;
+  bypassCdnCache?: boolean;
   renderDocumentToString: (element: ReactNode) => Promise<string>;
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
   resetSSRHead?: (() => void) | undefined;
@@ -266,6 +267,7 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "query"
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
@@ -280,7 +282,7 @@ export function buildPagesNextDataScript(
     // Next.js fallback:true shells intentionally omit the matched route
     // params. The live slug is published by the hydration query update after
     // the fallback data request resolves.
-    query: options.isFallback === true ? {} : options.params,
+    query: options.isFallback === true ? {} : (options.query ?? options.params),
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -498,6 +500,7 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.query,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,
@@ -668,7 +671,7 @@ export async function renderPagesPageResponse(
   // this point, so the captured value matches main's original capture site.
   const userSetCacheControl = responseHeaders.has("Cache-Control");
 
-  if (options.scriptNonce) {
+  if (options.scriptNonce || options.bypassCdnCache) {
     responseHeaders.set("Cache-Control", ISR_NO_STORE_CACHE_CONTROL);
   } else if (options.isrRevalidateSeconds !== null) {
     // Fresh ISR (MISS) response: route through the CDN adapter so edge adapters

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -38,7 +38,7 @@ import {
 import type { HeaderRecord } from "./request-pipeline.js";
 import { mergeHeaders } from "./worker-utils.js";
 import { normalizeDefaultLocalePathname, stripI18nLocaleForApiRoute } from "./pages-i18n.js";
-import { mergeRewriteQuery } from "../utils/query.js";
+import { mergeRewriteQuery, mergeRouteParamsIntoQuery, setQueryValue } from "../utils/query.js";
 import { addBasePathToPathname, hasBasePath } from "../utils/base-path.js";
 import { patternToNextFormat } from "../routing/route-validation.js";
 
@@ -47,6 +47,7 @@ export type PagesRenderOptions = {
   isDataReq?: boolean;
   renderErrorPageOnMiss?: boolean;
   originalUrl?: string;
+  rewriteQueryKeys?: string[];
 };
 
 export type FilesystemRoutePhase = "direct" | "beforeFiles" | "afterFiles" | "fallback";
@@ -309,6 +310,21 @@ export async function runPagesRequest(
   // Step 5: Middleware
   const originalResolvedUrl = pathname + search;
   let resolvedUrl = originalResolvedUrl;
+  const rewriteQueryKeys = new Set<string>();
+  const recordRewriteQueryKeys = (rewriteUrl: string, inheritedUrl?: string): void => {
+    const rewriteParams = new URL(rewriteUrl, url).searchParams;
+    const inheritedParams = inheritedUrl ? new URL(inheritedUrl, url).searchParams : null;
+    for (const key of rewriteParams.keys()) {
+      if (
+        inheritedParams &&
+        inheritedParams.has(key) &&
+        JSON.stringify(inheritedParams.getAll(key)) === JSON.stringify(rewriteParams.getAll(key))
+      ) {
+        continue;
+      }
+      rewriteQueryKeys.add(key);
+    }
+  };
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
   const serveFilesystemRoute = async (
@@ -399,7 +415,9 @@ export async function runPagesRequest(
     }
 
     if (result.rewriteUrl) {
+      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = result.rewriteUrl;
+      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
     }
 
     // Reconciled superset: result.status takes priority over result.rewriteStatus
@@ -507,7 +525,9 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, rewritten) };
       }
+      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       configRewriteFired = true;
     }
@@ -586,7 +606,9 @@ export async function runPagesRequest(
           // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
           return { type: "response", response: await proxyExternal(request, rewritten) };
         }
+        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameChanged = true;
         const afterFilesFilesystemResult = await serveFilesystemRoute(
@@ -634,7 +656,9 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
+        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
+        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         const fallbackFilesystemResult = await serveFilesystemRoute(resolvedPathname, "fallback");
         if (fallbackFilesystemResult) return fallbackFilesystemResult;
@@ -653,11 +677,22 @@ export async function runPagesRequest(
     // All adapters normalize real `/_next/data/` URLs before this point.
     const shouldDeferErrorPageOnMiss =
       !isDataReq && !isDataRequest && !!deps.matchPageRoute && !renderPageMatch;
-    const initialRenderOptions: PagesRenderOptions | undefined = shouldDeferErrorPageOnMiss
-      ? { renderErrorPageOnMiss: false }
-      : isDataReq
-        ? { isDataReq: true }
-        : undefined;
+    const buildRenderOptions = (
+      extra?: Omit<PagesRenderOptions, "rewriteQueryKeys">,
+    ): PagesRenderOptions | undefined => {
+      if (!extra && rewriteQueryKeys.size === 0) return undefined;
+      return {
+        ...extra,
+        ...(rewriteQueryKeys.size > 0 ? { rewriteQueryKeys: [...rewriteQueryKeys] } : {}),
+      };
+    };
+    const initialRenderOptions = buildRenderOptions(
+      shouldDeferErrorPageOnMiss
+        ? { renderErrorPageOnMiss: false }
+        : isDataReq
+          ? { isDataReq: true }
+          : undefined,
+    );
 
     // Convert staged middleware headers to a Web Headers object for renderPage.
     // Adapters that need to inject per-request values (e.g. CSP nonces) into the
@@ -691,7 +726,9 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
+        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
+        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         const fallbackFilesystemResult = await serveFilesystemRoute(resolvedPathname, "fallback");
         if (fallbackFilesystemResult) return fallbackFilesystemResult;
@@ -700,7 +737,7 @@ export async function runPagesRequest(
         renderPageMatch = deps.matchPageRoute
           ? deps.matchPageRoute(resolvedPathname, request)
           : null;
-        response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+        response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
         matchedFallbackRewrite = true;
         if (response.status !== 404) break;
       }
@@ -708,7 +745,7 @@ export async function runPagesRequest(
 
     // Deferred 404 re-render
     if (response.status === 404 && shouldDeferErrorPageOnMiss && !matchedFallbackRewrite) {
-      response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+      response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
     }
 
     const matchedPathHeaders = { ...middlewareHeaders };
@@ -773,7 +810,9 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, fallbackRewrite) };
       }
+      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
+      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       const fallbackFilesystemResult = await serveFilesystemRoute(resolvedPathname, "fallback");
       if (fallbackFilesystemResult) return fallbackFilesystemResult;
@@ -790,10 +829,31 @@ export async function runPagesRequest(
   return {
     type: "render",
     resolvedUrl,
-    renderOptions: isDataReq ? { isDataReq: true } : undefined,
+    renderOptions:
+      isDataReq || rewriteQueryKeys.size > 0
+        ? {
+            ...(isDataReq ? { isDataReq: true } : {}),
+            ...(rewriteQueryKeys.size > 0 ? { rewriteQueryKeys: [...rewriteQueryKeys] } : {}),
+          }
+        : undefined,
     stagedHeaders: middlewareHeaders,
     requestHeaders: request.headers,
     middlewareStatus,
     isDataReq,
   };
+}
+
+export function buildInitialPagesRouterQuery(
+  resolvedQuery: Record<string, string | string[]>,
+  params: Record<string, string | string[]>,
+  rewriteQueryKeys: readonly string[] = [],
+): Record<string, string | string[]> {
+  const initialQuery: Record<string, string | string[]> = {};
+  for (const key of rewriteQueryKeys) {
+    const value = resolvedQuery[key];
+    if (typeof value === "string" || Array.isArray(value)) {
+      setQueryValue(initialQuery, key, Array.isArray(value) ? [...value] : value);
+    }
+  }
+  return mergeRouteParamsIntoQuery(initialQuery, params);
 }

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -43,11 +43,17 @@ import { isOnDemandRevalidateRequest, PRERENDER_REVALIDATE_HEADER } from "./isr-
 // All "render options" that are passed through to the renderPage callback
 export type PagesRenderOptions = {
   isDataReq?: boolean;
+  hasMiddlewareRewrite?: boolean;
   renderErrorPageOnMiss?: boolean;
   originalUrl?: string;
 };
 
-export type FilesystemRoutePhase = "direct" | "beforeFiles" | "afterFiles" | "fallback";
+export type FilesystemRoutePhase =
+  | "direct"
+  | "middlewareRewrite"
+  | "beforeFiles"
+  | "afterFiles"
+  | "fallback";
 
 type PageRouteMatch = {
   route: { isDynamic: boolean; pattern?: string; dataKind?: "static" | "server" | "none" };
@@ -332,6 +338,7 @@ export async function runPagesRequest(
   const originalResolvedUrl = pathname + search;
   let resolvedUrl = originalResolvedUrl;
   let resolvedPathnameIsRequestPathname = true;
+  let middlewareRewriteFired = false;
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
   const serveFilesystemRoute = async (
@@ -427,6 +434,7 @@ export async function runPagesRequest(
     if (result.rewriteUrl) {
       resolvedUrl = result.rewriteUrl;
       resolvedPathnameIsRequestPathname = false;
+      middlewareRewriteFired = true;
     }
 
     // Reconciled superset: result.status takes priority over result.rewriteStatus
@@ -521,7 +529,10 @@ export async function runPagesRequest(
   // before rewrites so a real public file wins over a fallback rewrite — matching the
   // pre-refactor prod-server ordering. Adapter callbacks own their path guards;
   // a true result means Node already wrote the response.
-  const directFilesystemResult = await serveFilesystemRoute(pathname, "direct");
+  const directFilesystemResult = await serveFilesystemRoute(
+    middlewareRewriteFired ? resolvedPathname : pathname,
+    middlewareRewriteFired ? "middlewareRewrite" : "direct",
+  );
   if (directFilesystemResult) return directFilesystemResult;
 
   // Step 9: beforeFiles rewrites
@@ -698,11 +709,17 @@ export async function runPagesRequest(
     // All adapters normalize real `/_next/data/` URLs before this point.
     const shouldDeferErrorPageOnMiss =
       !isDataReq && !isDataRequest && !!deps.matchPageRoute && !renderPageMatch;
-    const initialRenderOptions: PagesRenderOptions | undefined = shouldDeferErrorPageOnMiss
-      ? { renderErrorPageOnMiss: false }
-      : isDataReq
-        ? { isDataReq: true }
-        : undefined;
+    const buildRenderOptions = (extra?: PagesRenderOptions): PagesRenderOptions | undefined => {
+      if (!isDataReq && !middlewareRewriteFired && !extra) return undefined;
+      return {
+        ...(isDataReq ? { isDataReq: true } : {}),
+        ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+        ...extra,
+      };
+    };
+    const initialRenderOptions = buildRenderOptions(
+      shouldDeferErrorPageOnMiss ? { renderErrorPageOnMiss: false } : undefined,
+    );
 
     // Convert staged middleware headers to a Web Headers object for renderPage.
     // Adapters that need to inject per-request values (e.g. CSP nonces) into the
@@ -747,7 +764,7 @@ export async function runPagesRequest(
         renderPageMatch = deps.matchPageRoute
           ? deps.matchPageRoute(resolvedPathname, request)
           : null;
-        response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+        response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
         matchedFallbackRewrite = true;
         if (response.status !== 404) break;
       }
@@ -755,7 +772,7 @@ export async function runPagesRequest(
 
     // Deferred 404 re-render
     if (response.status === 404 && shouldDeferErrorPageOnMiss && !matchedFallbackRewrite) {
-      response = await deps.renderPage(request, resolvedUrl, undefined, stagedHeaders);
+      response = await deps.renderPage(request, resolvedUrl, buildRenderOptions(), stagedHeaders);
     }
 
     const matchedPathHeaders = { ...middlewareHeaders };
@@ -842,7 +859,13 @@ export async function runPagesRequest(
   return {
     type: "render",
     resolvedUrl,
-    renderOptions: isDataReq ? { isDataReq: true } : undefined,
+    renderOptions:
+      isDataReq || middlewareRewriteFired
+        ? {
+            ...(isDataReq ? { isDataReq: true } : {}),
+            ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+          }
+        : undefined,
     stagedHeaders: middlewareHeaders,
     requestHeaders: request.headers,
     middlewareStatus,

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -341,16 +341,9 @@ export async function runPagesRequest(
   let resolvedPathnameIsRequestPathname = true;
   let middlewareRewriteFired = false;
   const rewriteQueryKeys = new Set<string>();
-  const recordRewriteQueryKeys = (rewriteUrl: string, inheritedUrl?: string): void => {
+  const recordRewriteQueryKeys = (rewriteUrl: string): void => {
     const rewriteParams = new URL(rewriteUrl, url).searchParams;
-    const inheritedParams = inheritedUrl ? new URL(inheritedUrl, url).searchParams : null;
     for (const key of rewriteParams.keys()) {
-      if (
-        inheritedParams?.has(key) &&
-        JSON.stringify(inheritedParams.getAll(key)) === JSON.stringify(rewriteParams.getAll(key))
-      ) {
-        continue;
-      }
       rewriteQueryKeys.add(key);
     }
   };
@@ -447,9 +440,8 @@ export async function runPagesRequest(
     }
 
     if (result.rewriteUrl) {
-      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = result.rewriteUrl;
-      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
+      recordRewriteQueryKeys(resolvedUrl);
       resolvedPathnameIsRequestPathname = false;
       middlewareRewriteFired = true;
     }

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -35,7 +35,7 @@ import { applyConfigHeadersToHeaderRecord } from "./config-headers.js";
 import type { HeaderRecord } from "./request-pipeline.js";
 import { mergeHeaders } from "./worker-utils.js";
 import { normalizeDefaultLocalePathname, stripI18nLocaleForApiRoute } from "./pages-i18n.js";
-import { mergeRewriteQuery } from "../utils/query.js";
+import { mergeRewriteQuery, mergeRouteParamsIntoQuery, setQueryValue } from "../utils/query.js";
 import { addBasePathToPathname, hasBasePath } from "../utils/base-path.js";
 import { patternToNextFormat } from "../routing/route-validation.js";
 import { isOnDemandRevalidateRequest, PRERENDER_REVALIDATE_HEADER } from "./isr-cache.js";
@@ -44,6 +44,7 @@ import { isOnDemandRevalidateRequest, PRERENDER_REVALIDATE_HEADER } from "./isr-
 export type PagesRenderOptions = {
   isDataReq?: boolean;
   hasMiddlewareRewrite?: boolean;
+  rewriteQueryKeys?: string[];
   renderErrorPageOnMiss?: boolean;
   originalUrl?: string;
 };
@@ -339,6 +340,20 @@ export async function runPagesRequest(
   let resolvedUrl = originalResolvedUrl;
   let resolvedPathnameIsRequestPathname = true;
   let middlewareRewriteFired = false;
+  const rewriteQueryKeys = new Set<string>();
+  const recordRewriteQueryKeys = (rewriteUrl: string, inheritedUrl?: string): void => {
+    const rewriteParams = new URL(rewriteUrl, url).searchParams;
+    const inheritedParams = inheritedUrl ? new URL(inheritedUrl, url).searchParams : null;
+    for (const key of rewriteParams.keys()) {
+      if (
+        inheritedParams?.has(key) &&
+        JSON.stringify(inheritedParams.getAll(key)) === JSON.stringify(rewriteParams.getAll(key))
+      ) {
+        continue;
+      }
+      rewriteQueryKeys.add(key);
+    }
+  };
   const middlewareHeaders: HeaderRecord = {};
   let middlewareStatus: number | undefined;
   const serveFilesystemRoute = async (
@@ -432,7 +447,9 @@ export async function runPagesRequest(
     }
 
     if (result.rewriteUrl) {
+      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = result.rewriteUrl;
+      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
       resolvedPathnameIsRequestPathname = false;
       middlewareRewriteFired = true;
     }
@@ -551,7 +568,9 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, rewritten) };
       }
+      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       resolvedPathnameIsRequestPathname = false;
       configRewriteFired = true;
@@ -633,7 +652,9 @@ export async function runPagesRequest(
           // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
           return { type: "response", response: await proxyExternal(request, rewritten) };
         }
+        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
+        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameIsRequestPathname = false;
         configRewriteFired = true;
@@ -687,7 +708,9 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
+        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
+        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameIsRequestPathname = false;
         configRewriteFired = true;
@@ -714,6 +737,7 @@ export async function runPagesRequest(
       return {
         ...(isDataReq ? { isDataReq: true } : {}),
         ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+        ...(rewriteQueryKeys.size > 0 ? { rewriteQueryKeys: [...rewriteQueryKeys] } : {}),
         ...extra,
       };
     };
@@ -753,7 +777,9 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
+        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
+        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameIsRequestPathname = false;
         configRewriteFired = true;
@@ -839,7 +865,9 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, fallbackRewrite) };
       }
+      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
+      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       resolvedPathnameIsRequestPathname = false;
       configRewriteFired = true;
@@ -864,6 +892,7 @@ export async function runPagesRequest(
         ? {
             ...(isDataReq ? { isDataReq: true } : {}),
             ...(middlewareRewriteFired ? { hasMiddlewareRewrite: true } : {}),
+            ...(rewriteQueryKeys.size > 0 ? { rewriteQueryKeys: [...rewriteQueryKeys] } : {}),
           }
         : undefined,
     stagedHeaders: middlewareHeaders,
@@ -871,4 +900,19 @@ export async function runPagesRequest(
     middlewareStatus,
     isDataReq,
   };
+}
+
+export function buildInitialPagesRouterQuery(
+  resolvedQuery: Record<string, string | string[]>,
+  params: Record<string, string | string[]>,
+  rewriteQueryKeys: readonly string[] = [],
+): Record<string, string | string[]> {
+  const initialQuery: Record<string, string | string[]> = {};
+  for (const key of rewriteQueryKeys) {
+    const value = resolvedQuery[key];
+    if (typeof value === "string" || Array.isArray(value)) {
+      setQueryValue(initialQuery, key, Array.isArray(value) ? [...value] : value);
+    }
+  }
+  return mergeRouteParamsIntoQuery(initialQuery, params);
 }

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -568,9 +568,7 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, rewritten) };
       }
-      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
-      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       resolvedPathnameIsRequestPathname = false;
       configRewriteFired = true;
@@ -652,9 +650,7 @@ export async function runPagesRequest(
           // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
           return { type: "response", response: await proxyExternal(request, rewritten) };
         }
-        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
-        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameIsRequestPathname = false;
         configRewriteFired = true;
@@ -708,9 +704,7 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
-        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
-        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameIsRequestPathname = false;
         configRewriteFired = true;
@@ -777,9 +771,7 @@ export async function runPagesRequest(
             response: await proxyExternal(request, fallbackRewrite),
           };
         }
-        const previousResolvedUrl = resolvedUrl;
         resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
-        recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
         resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
         resolvedPathnameIsRequestPathname = false;
         configRewriteFired = true;
@@ -865,9 +857,7 @@ export async function runPagesRequest(
         // Bare proxy — no middleware-header merge (see Step 8 asymmetry note).
         return { type: "response", response: await proxyExternal(request, fallbackRewrite) };
       }
-      const previousResolvedUrl = resolvedUrl;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
-      recordRewriteQueryKeys(resolvedUrl, previousResolvedUrl);
       resolvedPathname = pathnameForResolvedUrl(resolvedUrl);
       resolvedPathnameIsRequestPathname = false;
       configRewriteFired = true;

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1499,9 +1499,12 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       // identifies the request as a public/static-file lookup. Middleware may
       // still handle or rewrite the request by returning a non-404 response.
       if (missingBuildAsset && response.status === 404) {
-        cancelResponseBody(response);
-        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-        res.end("Not Found");
+        await sendWebResponse(
+          finalizeMissingStaticAssetResponse(response, true),
+          req,
+          res,
+          compress,
+        );
         return;
       }
 

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -47,7 +47,7 @@ import {
   type PagesPipelineDeps,
   type PagesRenderOptions,
 } from "./pages-request-pipeline.js";
-import { mergeHeaders } from "./worker-utils.js";
+import { finalizeMissingStaticAssetResponse, mergeHeaders } from "./worker-utils.js";
 import {
   normalizeNextDataPagePathname,
   isNextDataPathname,
@@ -2012,9 +2012,12 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       if (result.type === "response") {
         const { response } = result;
         if (missingBuildAsset && response.status === 404) {
-          cancelResponseBody(response);
-          res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-          res.end("Not Found");
+          await sendWebResponse(
+            finalizeMissingStaticAssetResponse(response, true),
+            req,
+            res,
+            compress,
+          );
           return;
         }
         const shouldStream = isVinextStreamedHtmlResponse(response);

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -15,6 +15,23 @@ import { notFoundStaticAssetResponse } from "./http-error-responses.js";
  * Keep this in sync with prod-server.ts.
  */
 const NO_BODY_RESPONSE_STATUSES = new Set([204, 205, 304]);
+const REPLACED_BODY_HEADERS = new Set([
+  "accept-ranges",
+  "content-digest",
+  "content-disposition",
+  "content-encoding",
+  "content-language",
+  "content-length",
+  "content-location",
+  "content-md5",
+  "content-range",
+  "digest",
+  "etag",
+  "last-modified",
+  "repr-digest",
+  "trailer",
+  "transfer-encoding",
+]);
 
 type ResponseWithVinextStreamingMetadata = Response & {
   __vinextStreamedHtmlResponse?: boolean;
@@ -44,6 +61,7 @@ export function finalizeMissingStaticAssetResponse(
   cancelResponseBody(response);
   const notFound = notFoundStaticAssetResponse();
   const headers = new Headers(response.headers);
+  for (const name of REPLACED_BODY_HEADERS) headers.delete(name);
   headers.set("Content-Type", notFound.headers.get("Content-Type")!);
   return new Response(notFound.body, { status: 404, headers });
 }

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -42,7 +42,10 @@ export function finalizeMissingStaticAssetResponse(
 ): Response {
   if (!missingBuildAsset || response.status !== 404) return response;
   cancelResponseBody(response);
-  return notFoundStaticAssetResponse();
+  const notFound = notFoundStaticAssetResponse();
+  const headers = new Headers(response.headers);
+  headers.set("Content-Type", notFound.headers.get("Content-Type")!);
+  return new Response(notFound.body, { status: 404, headers });
 }
 
 function buildHeaderRecord(

--- a/packages/vinext/src/shims/client-locale.ts
+++ b/packages/vinext/src/shims/client-locale.ts
@@ -31,6 +31,8 @@ export function getCurrentBrowserLocale({
   return (
     detectDomainLocale(domainLocales, hostname ?? undefined)?.defaultLocale ??
     window.__VINEXT_LOCALE__ ??
-    window.__VINEXT_DEFAULT_LOCALE__
+    window.__NEXT_DATA__?.locale ??
+    window.__VINEXT_DEFAULT_LOCALE__ ??
+    window.__NEXT_DATA__?.defaultLocale
   );
 }

--- a/packages/vinext/src/shims/internal/pages-data-target.ts
+++ b/packages/vinext/src/shims/internal/pages-data-target.ts
@@ -108,31 +108,40 @@ function clientMiddlewareSourceMatches(pathname: string, source: string): boolea
   return pathIndex === pathParts.length;
 }
 
-function clientMiddlewareMatcherMatches(pathname: string, matcher: unknown): boolean {
-  if (matcher === undefined) return true;
+function matchClientMiddleware(
+  pathname: string,
+  matcher: unknown,
+): { localeAware: boolean } | null {
+  if (matcher === undefined) return { localeAware: true };
   if (typeof matcher === "string") {
-    return clientMiddlewareSourceMatches(stripLocaleForMiddlewareMatcher(pathname), matcher);
+    return clientMiddlewareSourceMatches(stripLocaleForMiddlewareMatcher(pathname), matcher)
+      ? { localeAware: true }
+      : null;
   }
-  if (!Array.isArray(matcher)) return true;
+  if (!Array.isArray(matcher)) return { localeAware: true };
 
   for (const item of matcher) {
     if (typeof item === "string") {
       if (clientMiddlewareSourceMatches(stripLocaleForMiddlewareMatcher(pathname), item)) {
-        return true;
+        return { localeAware: true };
       }
       continue;
     }
-    if (!isClientMiddlewareMatcherObject(item)) return true;
+    if (!isClientMiddlewareMatcherObject(item)) return { localeAware: true };
     const candidate = item.locale === false ? pathname : stripLocaleForMiddlewareMatcher(pathname);
     if (clientMiddlewareSourceMatches(candidate, item.source)) {
-      return true;
+      return { localeAware: item.locale !== false };
     }
   }
 
-  return false;
+  return null;
 }
 
-export function getPagesMiddlewareDataHref(browserUrl: string, basePath: string): string | null {
+export function getPagesMiddlewareDataHref(
+  browserUrl: string,
+  basePath: string,
+  options: { locale?: string } = {},
+): string | null {
   const nextData = window.__NEXT_DATA__;
   if (!nextData || !hasVinextMiddleware(nextData)) return null;
   const buildId = nextData.buildId;
@@ -146,9 +155,15 @@ export function getPagesMiddlewareDataHref(browserUrl: string, basePath: string)
   }
   if (parsed.origin !== window.location.origin) return null;
 
-  const pathname = stripBasePath(parsed.pathname, basePath);
-  if (!clientMiddlewareMatcherMatches(pathname, window.__VINEXT_MIDDLEWARE_MATCHER__)) {
-    return null;
+  let pathname = stripBasePath(parsed.pathname, basePath);
+  const middlewareMatch = matchClientMiddleware(pathname, window.__VINEXT_MIDDLEWARE_MATCHER__);
+  if (!middlewareMatch) return null;
+  if (
+    options.locale &&
+    middlewareMatch.localeAware &&
+    !getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__)
+  ) {
+    pathname = `/${options.locale}${pathname === "/" ? "" : pathname}`;
   }
 
   return buildPagesDataHref(basePath, buildId, pathname, parsed.search);
@@ -224,7 +239,8 @@ export function resolvePagesDataNavigationTarget(
         : "none";
   const explicitLocale =
     options.locale === false ? window.__VINEXT_DEFAULT_LOCALE__ : options.locale;
-  const currentLocale = locale ?? explicitLocale ?? window.__VINEXT_LOCALE__;
+  const currentLocale =
+    locale ?? explicitLocale ?? window.__VINEXT_LOCALE__ ?? window.__VINEXT_DEFAULT_LOCALE__;
   const prefetchPagePath =
     locale || !currentLocale || !window.__VINEXT_LOCALES__?.includes(currentLocale)
       ? pagePath

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -431,6 +431,7 @@ function prefetchUrl(
   priority: "low" | "high" = "low",
   pagesRouteHref?: string,
   locale?: string | false,
+  shallow = false,
 ): void {
   if (typeof window === "undefined") return;
   const navigationEpoch = linkPrefetchNavigationEpoch;
@@ -466,6 +467,7 @@ function prefetchUrl(
   }
 
   const runPrefetch = () => {
+    if (navigationEpoch !== linkPrefetchNavigationEpoch) return;
     void (async () => {
       if (hasAppNavigationRuntime()) {
         if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
@@ -822,13 +824,10 @@ function prefetchUrl(
             fullRouteHref === fullHref
               ? dataTarget.middlewareDataHref
               : (getPagesMiddlewareDataHref(fullHref, __basePath) ?? undefined);
-          // A direct gSSP Link prefetch only warms the page chunk. Probing
-          // middleware here would execute the server page before a click and
-          // makes shallow Links issue observable data requests. Keep the
-          // middleware probe for SSG routes and explicit href/as masks, where
-          // it is needed to resolve/cache the destination ahead of navigation.
           const shouldProbeMiddleware =
-            dataTarget.dataKind === "static" || fullRouteHref !== fullHref;
+            dataTarget.dataKind === "static" ||
+            fullRouteHref !== fullHref ||
+            (priority === "high" && !shallow);
           prefetchPagesData({
             ...dataTarget,
             middlewareDataHref: shouldProbeMiddleware ? middlewareDataHref : undefined,
@@ -856,6 +855,14 @@ function prefetchUrl(
       console.error("[vinext] RSC prefetch setup error:", error);
     });
   };
+
+  if (priority === "high" && HAS_PAGES_ROUTER && !hasAppNavigationRuntime()) {
+    // Pointer intent can be immediately followed by a click in the same
+    // interaction. Defer Pages setup so the click can cancel this redundant
+    // middleware probe before the real navigation request starts.
+    setTimeout(runPrefetch, 0);
+    return;
+  }
 
   if (priority === "high" || hasAppNavigationRuntime()) {
     runPrefetch();
@@ -913,6 +920,7 @@ type LinkPrefetchInstance = {
   pagesRouteHref?: string;
   queuedViewportPrefetch: boolean;
   routerMode: LinkPrefetchRouterMode;
+  shallow: boolean;
   viewportPrefetched: boolean;
 };
 
@@ -928,7 +936,14 @@ function drainVisibleAppPrefetchQueue(): void {
     if (!instance) return;
     instance.queuedViewportPrefetch = false;
     if (!instance.isVisible || instance.routerMode !== "app") continue;
-    prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+    prefetchUrl(
+      instance.href,
+      instance.mode,
+      "low",
+      instance.pagesRouteHref,
+      instance.locale,
+      instance.shallow,
+    );
   }
 }
 
@@ -949,7 +964,14 @@ function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boole
     if (instance.routerMode === "app") {
       scheduleVisibleAppPrefetch(instance);
     } else {
-      prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref, instance.locale);
+      prefetchUrl(
+        instance.href,
+        instance.mode,
+        "low",
+        instance.pagesRouteHref,
+        instance.locale,
+        instance.shallow,
+      );
     }
     instance.viewportPrefetched = true;
   } else {
@@ -1322,6 +1344,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
             }) ?? undefined),
       queuedViewportPrefetch: false,
       routerMode: getLinkPrefetchRouterMode(),
+      shallow,
       viewportPrefetched: false,
     };
     observedLinkPrefetches.set(node, instance);
@@ -1333,7 +1356,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       visibleLinkPrefetches.delete(instance);
       instance.isVisible = false;
     };
-  }, [shouldViewportPrefetch, prefetchMode, normalizedHref, normalizedRouteHref, locale]);
+  }, [shouldViewportPrefetch, prefetchMode, normalizedHref, normalizedRouteHref, locale, shallow]);
 
   const prefetchOnIntent = useCallback(() => {
     if (
@@ -1360,6 +1383,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       "high",
       normalizedRouteHref === normalizedHref ? undefined : normalizedRouteHref,
       locale,
+      shallow,
     );
   }, [
     prefetchProp,
@@ -1368,6 +1392,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     normalizedHref,
     normalizedRouteHref,
     locale,
+    shallow,
     unstable_dynamicOnHover,
   ]);
 
@@ -1437,6 +1462,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     e.preventDefault();
 
     const hasAppNavigationRuntime = Boolean(getNavigationRuntime()?.functions.navigate);
+    if (!hasAppNavigationRuntime) {
+      notifyLinkNavigationStartAndCancelPrefetchSetup();
+    }
     const pagesNavigateHref =
       HAS_PAGES_ROUTER && resolvedHref.startsWith("?")
         ? resolvePagesLinkNavigationHref(resolvedHref, locale)

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -822,7 +822,17 @@ function prefetchUrl(
             fullRouteHref === fullHref
               ? dataTarget.middlewareDataHref
               : (getPagesMiddlewareDataHref(fullHref, __basePath) ?? undefined);
-          prefetchPagesData({ ...dataTarget, middlewareDataHref });
+          // A direct gSSP Link prefetch only warms the page chunk. Probing
+          // middleware here would execute the server page before a click and
+          // makes shallow Links issue observable data requests. Keep the
+          // middleware probe for SSG routes and explicit href/as masks, where
+          // it is needed to resolve/cache the destination ahead of navigation.
+          const shouldProbeMiddleware =
+            dataTarget.dataKind === "static" || fullRouteHref !== fullHref;
+          prefetchPagesData({
+            ...dataTarget,
+            middlewareDataHref: shouldProbeMiddleware ? middlewareDataHref : undefined,
+          });
         } else {
           // The target is not a Pages Router route — mark it on the Pages
           // Router `components` map if it matches an App Router route in the

--- a/packages/vinext/src/shims/router-state.ts
+++ b/packages/vinext/src/shims/router-state.ts
@@ -24,6 +24,7 @@ import {
 export type SSRContext = {
   pathname: string;
   query: Record<string, string | string[]>;
+  initialQuery?: Record<string, string | string[]>;
   asPath: string;
   navigationIsReady?: boolean;
   locale?: string;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -72,6 +72,7 @@ import {
   mergeRewriteQuery,
   mergeRouteParamsIntoQuery,
   parseQueryString,
+  setQueryValue,
   type UrlQuery,
   urlQueryToSearchParams,
 } from "../utils/query.js";
@@ -149,6 +150,8 @@ function PagesRouterCommitBoundaryHelper({
 function renderPagesRouterElement(
   element: ReactElement,
   scroll?: ScrollPosition | null,
+  beforeCommit?: () => void,
+  pendingAsPath?: string,
 ): Promise<void> {
   const root = window.__VINEXT_ROOT__;
   if (!root) {
@@ -157,8 +160,27 @@ function renderPagesRouterElement(
 
   cancelPreviousRenderCommit();
 
+  const pendingSnapshotToken =
+    pendingAsPath !== undefined ? Symbol("vinext.pagesRouter.pendingSnapshot") : null;
+  if (pendingSnapshotToken && pendingAsPath !== undefined) {
+    routerRuntimeState.pendingRouterSnapshot = {
+      token: pendingSnapshotToken,
+      snapshot: getRouterSnapshotForAsPath(pendingAsPath),
+    };
+  }
+
+  const clearPendingSnapshotIfCurrent = () => {
+    if (
+      pendingSnapshotToken &&
+      routerRuntimeState.pendingRouterSnapshot?.token === pendingSnapshotToken
+    ) {
+      routerRuntimeState.pendingRouterSnapshot = undefined;
+    }
+  };
+
   return new Promise<void>((resolve, reject) => {
     const cancel = () => {
+      clearPendingSnapshotIfCurrent();
       if (routerRuntimeState.cancelPendingRenderCommit === cancel) {
         routerRuntimeState.cancelPendingRenderCommit = null;
       }
@@ -190,23 +212,29 @@ function renderPagesRouterElement(
             if (!isCurrent()) return;
 
             try {
+              beforeCommit?.();
               await scrollHandler();
               if (!isCurrent()) return;
+              clearPendingSnapshotIfCurrent();
               clearIfCurrent();
               resolve();
             } catch (err) {
+              clearPendingSnapshotIfCurrent();
               clearIfCurrent();
               reject(err);
             }
           })();
         },
         (error) => {
+          clearPendingSnapshotIfCurrent();
           clearIfCurrent();
           reject(error);
         },
       ),
     );
     if (!hasBrowserDocument()) {
+      beforeCommit?.();
+      clearPendingSnapshotIfCurrent();
       clearIfCurrent();
       resolve();
     }
@@ -418,6 +446,10 @@ function createRouterEvents(): RouterEvents {
 type PagesRouterRuntimeState = {
   events: RouterEvents;
   components?: PagesRouterRuntimeComponents;
+  pendingRouterSnapshot?: {
+    token: symbol;
+    snapshot: PagesRouterSnapshot;
+  };
   currentHistoryKey?: string;
   historyKeyCounter: number;
   navigationId: number;
@@ -440,6 +472,13 @@ type PagesRouterRuntimeComponents = {
     onError: (error: Error) => void;
   }>;
   Provider: ComponentType<{ children: ReactNode }>;
+};
+
+type PagesRouterSnapshot = {
+  pathname: string;
+  query: Record<string, string | string[]>;
+  asPath: string;
+  isReady: boolean;
 };
 
 const PAGES_ROUTER_RUNTIME_STATE_KEY = Symbol.for("vinext.pagesRouter.runtimeState");
@@ -914,6 +953,7 @@ function readScrollPositionFromSessionStorage(key: string): ScrollPosition | nul
 type SSRContext = {
   pathname: string;
   query: Record<string, string | string[]>;
+  initialQuery?: Record<string, string | string[]>;
   asPath: string;
   navigationIsReady?: boolean;
   nextData?: VinextNextData;
@@ -1015,6 +1055,37 @@ function _buildClientPagesNavigationContext(
   return ctx;
 }
 
+function getPendingPagesNavigationContext(
+  nextData: VinextNextData | undefined,
+): PagesNavigationContextShape | null {
+  const pending = routerRuntimeState.pendingRouterSnapshot?.snapshot;
+  if (!pending) return null;
+
+  let resolvedPath: string;
+  let searchString: string;
+  try {
+    const pendingUrl = new URL(
+      toBrowserNavigationHref(pending.asPath, window.location.href, __basePath),
+      window.location.href,
+    );
+    resolvedPath = stripBasePath(pendingUrl.pathname, __basePath);
+    searchString = pendingUrl.search;
+  } catch {
+    resolvedPath = stripHash(pending.asPath).split("?", 1)[0] || pending.pathname;
+    searchString = pending.asPath.includes("?") ? `?${pending.asPath.split("?", 2)[1]}` : "";
+  }
+
+  const routePattern =
+    resolvePagesRoutePatternForPath(pending.pathname, resolvedPath) ?? pending.pathname;
+  return _buildClientPagesNavigationContext(
+    routePattern,
+    resolvedPath,
+    searchString,
+    pending.isReady,
+    nextData,
+  );
+}
+
 // Server-side cache for snapshot stability. React's `useSyncExternalStore`
 // expects `getServerSnapshot` to return a stable reference within a single
 // render so it can use Object.is to decide whether to bail out. The SSR ctx is
@@ -1091,8 +1162,11 @@ export function getPagesNavigationContext(): PagesNavigationContextShape | null 
   // carry __NEXT_DATA__, so treating that alone as a Pages signal would let
   // compat fallback state shadow App Router navigation snapshots.
   if (!isPagesRouterDocumentActive()) return null;
-  const resolvedPath = stripBasePath(window.location.pathname, __basePath);
   const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
+  const pendingCtx = getPendingPagesNavigationContext(nextData);
+  if (pendingCtx) return pendingCtx;
+
+  const resolvedPath = stripBasePath(window.location.pathname, __basePath);
   const pattern = resolvePagesRoutePatternForPath(nextData?.page, resolvedPath);
   if (!pattern) return null;
   return _buildClientPagesNavigationContext(
@@ -1256,14 +1330,35 @@ function getPathnameAndQuery(): {
     const _ssrCtx = _getSSRContext();
     if (_ssrCtx) {
       const query: Record<string, string | string[]> = {};
-      for (const [key, value] of Object.entries(_ssrCtx.query)) {
-        query[key] = Array.isArray(value) ? [...value] : value;
+      const sourceQuery =
+        _ssrCtx.navigationIsReady === false ? (_ssrCtx.initialQuery ?? {}) : _ssrCtx.query;
+      for (const [key, value] of Object.entries(sourceQuery)) {
+        setQueryValue(query, key, Array.isArray(value) ? [...value] : value);
       }
       return { pathname: _ssrCtx.pathname, query, asPath: _ssrCtx.asPath };
     }
     return { pathname: "/", query: {}, asPath: "/" };
   }
-  const resolvedPath = stripBasePath(window.location.pathname, __basePath);
+
+  return getPathnameAndQueryForBrowserLocation(
+    window.location.pathname,
+    window.location.search,
+    window.location.hash,
+    getCurrentHistoryAsPath(),
+  );
+}
+
+function getPathnameAndQueryForBrowserLocation(
+  locationPathname: string,
+  locationSearch: string,
+  locationHash: string,
+  asPathOverride?: string | null,
+): {
+  pathname: string;
+  query: Record<string, string | string[]>;
+  asPath: string;
+} {
+  const resolvedPath = stripBasePath(locationPathname, __basePath);
   // In Next.js, router.pathname is the route pattern (e.g., "/posts/[id]"),
   // not the resolved path ("/posts/42"). __NEXT_DATA__.page holds the route
   // pattern and is updated by navigateClient() on every client-side navigation.
@@ -1272,15 +1367,43 @@ function getPathnameAndQuery(): {
   const routeQuery = getRouteQueryFromNextData(nextData, resolvedPath);
   // URL search params always reflect the current URL
   const searchQuery: Record<string, string | string[]> = {};
-  const params = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams(locationSearch);
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
   const query = { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern
-  const asPath =
-    getCurrentHistoryAsPath() ?? resolvedPath + window.location.search + window.location.hash;
+  const asPath = asPathOverride ?? resolvedPath + locationSearch + locationHash;
   return { pathname, query, asPath };
+}
+
+function getRouterSnapshotForAsPath(asPath: string): PagesRouterSnapshot {
+  let browserPathname: string;
+  let browserSearch: string;
+  let browserHash: string;
+  try {
+    const browserUrl = new URL(
+      toBrowserNavigationHref(asPath, window.location.href, __basePath),
+      window.location.href,
+    );
+    browserPathname = browserUrl.pathname;
+    browserSearch = browserUrl.search;
+    browserHash = browserUrl.hash;
+  } catch {
+    const asPathWithoutHash = stripHash(asPath);
+    browserPathname = asPathWithoutHash.split("?", 1)[0] || window.location.pathname;
+    browserSearch = asPathWithoutHash.includes("?") ? `?${asPathWithoutHash.split("?", 2)[1]}` : "";
+    browserHash = extractHash(asPath);
+  }
+  return {
+    ...getPathnameAndQueryForBrowserLocation(browserPathname, browserSearch, browserHash, asPath),
+    isReady: isPagesRouterReady(),
+  };
+}
+
+function getAppAsPathFromBrowserHref(href: string): string {
+  const browserUrl = new URL(href, window.location.href);
+  return stripBasePath(browserUrl.pathname, __basePath) + browserUrl.search + browserUrl.hash;
 }
 
 function getCurrentHistoryAsPath(): string | null {
@@ -1393,7 +1516,11 @@ function PagesRouterHydrationMarker(): null {
   return null;
 }
 
-function getRouterSnapshot(): ReturnType<typeof getPathnameAndQuery> & { isReady: boolean } {
+function getRouterSnapshot(): PagesRouterSnapshot {
+  if (typeof window !== "undefined" && routerRuntimeState.pendingRouterSnapshot) {
+    return routerRuntimeState.pendingRouterSnapshot.snapshot;
+  }
+
   // On the server, derive `router.isReady` from the SSR navigation-readiness
   // context (auto-export dynamic / query-string / rewrite-capable routes are
   // not ready until the client router publishes the live URL). Mirrors Next.js
@@ -1406,6 +1533,10 @@ function getRouterSnapshot(): ReturnType<typeof getPathnameAndQuery> & { isReady
       ? (_getSSRContext()?.navigationIsReady ?? true)
       : isPagesRouterReady();
   return { ...getPathnameAndQuery(), isReady };
+}
+
+function getActiveRouterUrlSnapshot(): PagesRouterSnapshot {
+  return getRouterSnapshot();
 }
 
 function notifyNextNavigationPagesContext(): void {
@@ -1452,7 +1583,10 @@ function scheduleHardNavigationAndThrow(url: string, message: string): never {
 
 type NavigateClientOptions = {
   allowNotFoundResponse?: boolean;
+  beforeCommit?: () => void;
   locale?: string;
+  pendingAsPath?: string;
+  setHistoryCommitTarget?: (target: RedirectHistoryCommitTarget) => void;
   /**
    * The history mode of the originating navigation. Used when a gSSP/gSP data
    * response carries a `__N_REDIRECT` marker so the re-entrant navigation to
@@ -1462,6 +1596,21 @@ type NavigateClientOptions = {
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
 };
+
+type RedirectHistoryCommitTarget = {
+  fullUrl: string;
+  appAsPath: string;
+};
+
+function withRedirectedNavigationTarget(
+  options: NavigateClientOptions,
+  redirectedHref: string,
+): NavigateClientOptions {
+  const pendingAsPath = getAppAsPathFromBrowserHref(redirectedHref);
+  options.setHistoryCommitTarget?.({ fullUrl: redirectedHref, appAsPath: pendingAsPath });
+  if (options.pendingAsPath === pendingAsPath) return options;
+  return { ...options, pendingAsPath };
+}
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
 type PagesDataResponse = {
@@ -1825,6 +1974,7 @@ type MiddlewareDataEffect = {
   dataHref: string;
   redirectLocation: string | null;
   rewriteTarget: string | null;
+  skip: boolean;
   response: Response;
 };
 
@@ -1862,6 +2012,7 @@ async function resolveMiddlewareDataEffect(
       dataHref: getPagesDataCacheHref(dataUrl),
       redirectLocation: res.headers.get("x-nextjs-redirect"),
       rewriteTarget: res.headers.get("x-nextjs-rewrite"),
+      skip: res.headers.get("x-middleware-skip") !== null,
       response: res,
     };
   } catch {
@@ -2044,7 +2195,12 @@ async function renderPagesNavigationTarget(
   const nextData = buildPagesNavigationNextData(target, props);
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  await renderPagesRouterElement(element, options.scroll);
+  await renderPagesRouterElement(
+    element,
+    options.scroll,
+    options.beforeCommit,
+    options.pendingAsPath,
+  );
   assertStillCurrent();
 }
 
@@ -2175,10 +2331,14 @@ async function navigateClientData(
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
     }
 
-    window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-    await navigateClientHtml(redirectedUrl, redirectedUrl, controller, navId, assertStillCurrent);
+    await navigateClientHtml(
+      redirectedUrl,
+      redirectedUrl,
+      controller,
+      navId,
+      assertStillCurrent,
+      withRedirectedNavigationTarget(options, redirectedUrl),
+    );
     return;
   }
 
@@ -2254,7 +2414,7 @@ async function navigateClientHtml(
   options: NavigateClientOptions = {},
 ): Promise<void> {
   let browserUrl = url;
-  let pendingRedirectHistoryUrl: string | null = fetchUrl === url ? null : url;
+  let redirectedHistoryUrl: string | null = null;
   const root = window.__VINEXT_ROOT__;
   if (!root) {
     // No React root yet — fall back to hard navigation
@@ -2282,7 +2442,7 @@ async function navigateClientHtml(
     const redirectedUrl = resolveSameOriginRedirectedUrl(res.url);
     if (redirectedUrl) {
       browserUrl = redirectedUrl;
-      pendingRedirectHistoryUrl = redirectedUrl;
+      redirectedHistoryUrl = redirectedUrl;
     }
   }
 
@@ -2403,14 +2563,17 @@ async function navigateClientHtml(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
-  if (pendingRedirectHistoryUrl) {
-    window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-  }
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  await renderPagesRouterElement(element, options.scroll);
+  const renderOptions = redirectedHistoryUrl
+    ? withRedirectedNavigationTarget(options, redirectedHistoryUrl)
+    : options;
+  await renderPagesRouterElement(
+    element,
+    renderOptions.scroll,
+    renderOptions.beforeCommit,
+    renderOptions.pendingAsPath,
+  );
   assertStillCurrent();
 }
 
@@ -2484,12 +2647,12 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(configRedirect, "Navigation redirected externally");
         }
-        window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-        routerRuntimeState.lastPathnameAndSearch =
-          window.location.pathname + window.location.search;
-        routerRuntimeState.lastHash = window.location.hash;
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
+      }
+      let activeNavigateOptions = options;
+      if (configRedirect) {
+        activeNavigateOptions = withRedirectedNavigationTarget(options, browserUrl);
       }
       let routeLookupUrl = configRedirect ? browserUrl : routeUrl;
       if (routeUrl === url && hasClientRewriteRules()) {
@@ -2565,17 +2728,14 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
         }
-        window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-        routerRuntimeState.lastPathnameAndSearch =
-          window.location.pathname + window.location.search;
-        routerRuntimeState.lastHash = window.location.hash;
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
+        activeNavigateOptions = withRedirectedNavigationTarget(options, redirectedUrl);
       } else if (middlewareEffect) {
         // A masked navigation probes middleware using the browser-visible URL but must fetch page
         // data using the route URL. Without a rewrite header those are different requests, so do
         // not reuse the probe response even though that means one extra request for this rare path.
-        if (middlewareEffect.rewriteTarget || routeUrl === url) {
+        if (!middlewareEffect.skip && (middlewareEffect.rewriteTarget || routeUrl === url)) {
           middlewareDataResponse = middlewareEffect.response;
         }
         if (middlewareEffect.rewriteTarget) {
@@ -2605,11 +2765,17 @@ async function navigateClient(
           controller,
           navId,
           assertStillCurrent,
-          options,
+          activeNavigateOptions,
           middlewareDataResponse,
         );
       } else if (dataTarget) {
-        await navigateClientNoData(browserUrl, dataTarget, controller, assertStillCurrent, options);
+        await navigateClientNoData(
+          browserUrl,
+          dataTarget,
+          controller,
+          assertStillCurrent,
+          activeNavigateOptions,
+        );
       } else {
         await navigateClientHtml(
           browserUrl,
@@ -2617,7 +2783,7 @@ async function navigateClient(
           controller,
           navId,
           assertStillCurrent,
-          options,
+          activeNavigateOptions,
         );
       }
     }
@@ -3124,14 +3290,78 @@ async function performNavigation(
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
-  routerEvents.emit("beforeHistoryChange", resolved, { shallow });
-  updateHistory(mode, full, navState);
   if (!shallow) {
+    const delayHistoryUntilRenderCommit = hasBrowserDocument();
+    const historyCommitOrigin = delayHistoryUntilRenderCommit
+      ? window.location.pathname + window.location.search + window.location.hash
+      : null;
+    let historyCommitTarget: RedirectHistoryCommitTarget | null = null;
+    let didCommitHistory = false;
+    const getCommitMode = (targetFullUrl: string) =>
+      mode === "push" && historyCommitOrigin === targetFullUrl ? "replace" : mode;
+    const commitHistoryTarget = (
+      target: RedirectHistoryCommitTarget,
+      targetMode = getCommitMode(target.fullUrl),
+    ) => {
+      const appAsPath = target.appAsPath;
+      const appStatePath = stripHash(appAsPath);
+      routerEvents.emit("beforeHistoryChange", appAsPath, { shallow });
+      updateHistory(targetMode, target.fullUrl, {
+        url: appStatePath,
+        as: appStatePath,
+        options: navStateOptions,
+      });
+    };
+    const setHistoryCommitTarget = (target: RedirectHistoryCommitTarget) => {
+      historyCommitTarget = target;
+      if (!delayHistoryUntilRenderCommit && didCommitHistory) {
+        commitHistoryTarget(target, "replace");
+      }
+    };
+    const commitNavigationHistory = () => {
+      if (didCommitHistory) return;
+      didCommitHistory = true;
+      if (historyCommitTarget) {
+        commitHistoryTarget(historyCommitTarget);
+        return;
+      }
+      if (
+        historyCommitOrigin !== null &&
+        window.location.pathname + window.location.search + window.location.hash !==
+          historyCommitOrigin
+      ) {
+        const currentFullUrl =
+          window.location.pathname + window.location.search + window.location.hash;
+        const currentAs =
+          stripBasePath(window.location.pathname, __basePath) +
+          window.location.search +
+          window.location.hash;
+        const currentStatePath = stripHash(currentAs);
+        routerEvents.emit("beforeHistoryChange", currentAs, { shallow });
+        updateHistory(getCommitMode(currentFullUrl), currentFullUrl, {
+          url: currentStatePath,
+          as: currentStatePath,
+          options: navStateOptions,
+        });
+        return;
+      }
+      routerEvents.emit("beforeHistoryChange", resolved, { shallow });
+      updateHistory(mode, full, navState);
+    };
+    if (!delayHistoryUntilRenderCommit) {
+      commitNavigationHistory();
+    }
     const result = await runNavigateClient(
       full,
       resolved,
       htmlFetchUrl,
-      navigateOptions,
+      {
+        ...navigateOptions,
+        beforeCommit: delayHistoryUntilRenderCommit ? commitNavigationHistory : undefined,
+        pendingAsPath: delayHistoryUntilRenderCommit ? resolved : undefined,
+        setHistoryCommitTarget,
+        mode,
+      },
       // When href and as differ, the data fetch must target the route URL
       // (the module that actually renders), not the masked display URL.
       // fullRouteUrl === full when there is no mask, so this is a no-op
@@ -3141,6 +3371,8 @@ async function performNavigation(
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {
+    routerEvents.emit("beforeHistoryChange", resolved, { shallow });
+    updateHistory(mode, full, navState);
     // Shallow navigations skip the render-commit path, so apply the scroll
     // reset synchronously here — before routeChangeComplete. This matches the
     // non-shallow path, where the x/y reset runs inside the render-commit
@@ -3245,7 +3477,9 @@ export function useRouter(): NextRouter {
 }
 
 function PagesRouterProvider({ children }: { children: ReactNode }): ReactElement {
-  const [{ pathname, query, asPath, isReady }, setState] = useState(getRouterSnapshot);
+  const [state, setState] = useState(getRouterSnapshot);
+  const activeSnapshot = routerRuntimeState.pendingRouterSnapshot?.snapshot ?? state;
+  const { pathname, query, asPath, isReady } = activeSnapshot;
 
   // Popstate is handled by the Pages Router client entry via
   // installPagesRouterRuntime() so beforePopState() is consistently enforced
@@ -3507,6 +3741,22 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // their locale-qualified HTML endpoint (parity with the push path).
   const stateLocale = isNextRouterState(state) ? state.options?.locale : undefined;
   const effectiveLocale = typeof stateLocale === "string" ? stateLocale : window.__VINEXT_LOCALE__;
+  const popStateOptions: { locale?: string; shallow: boolean } = { shallow: false };
+  if (typeof stateLocale === "string") popStateOptions.locale = stateLocale;
+  let redirectedPopStateTarget: RedirectHistoryCommitTarget | null = null;
+  const setPopStateHistoryCommitTarget = (target: RedirectHistoryCommitTarget) => {
+    redirectedPopStateTarget = target;
+  };
+  const commitRedirectedPopStateHistory = () => {
+    if (!redirectedPopStateTarget) return;
+
+    const appStatePath = stripHash(redirectedPopStateTarget.appAsPath);
+    updateHistory("replace", redirectedPopStateTarget.fullUrl, {
+      url: appStatePath,
+      as: appStatePath,
+      options: popStateOptions,
+    });
+  };
 
   const fullAppUrl = appUrl + window.location.hash;
   routerEvents.emit("routeChangeStart", fullAppUrl, { shallow: false });
@@ -3555,7 +3805,11 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
       browserUrl,
       fullAppUrl,
       getPagesHtmlFetchUrl(stateRouteUrl, effectiveLocale),
-      { scroll: scrollTarget },
+      {
+        scroll: scrollTarget,
+        beforeCommit: commitRedirectedPopStateHistory,
+        setHistoryCommitTarget: setPopStateHistoryCommitTarget,
+      },
       stateRouteUrl,
     );
     if (result === "completed") {
@@ -3782,13 +4036,13 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
     pathname: {
       enumerable: true,
       get(): string {
-        return getPathnameAndQuery().pathname;
+        return getActiveRouterUrlSnapshot().pathname;
       },
     },
     route: {
       enumerable: true,
       get(): string {
-        const { pathname } = getPathnameAndQuery();
+        const { pathname } = getActiveRouterUrlSnapshot();
         if (typeof window === "undefined") return pathname;
         const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
         return nextData?.page ?? pathname;
@@ -3797,13 +4051,13 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
     query: {
       enumerable: true,
       get(): Record<string, string | string[]> {
-        return getPathnameAndQuery().query;
+        return getActiveRouterUrlSnapshot().query;
       },
     },
     asPath: {
       enumerable: true,
       get(): string {
-        return getPathnameAndQuery().asPath;
+        return getActiveRouterUrlSnapshot().asPath;
       },
     },
     basePath: { enumerable: true, value: __basePath, writable: false },

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -3660,10 +3660,11 @@ function PagesRouterProvider({ children }: { children: ReactNode }): ReactElemen
       if (cancelled) return;
 
       const becameReady = markPagesRouterReady();
-      if (becameReady) {
-        setState(getRouterSnapshot());
-        notifyNextNavigationPagesContext();
-      }
+      // A hydration `_h` replace can publish readiness before this passive
+      // effect installs its event listener. Always synchronize the provider's
+      // local snapshot on mount so that early update is not lost.
+      setState(getRouterSnapshot());
+      if (becameReady) notifyNextNavigationPagesContext();
     }, 0);
     return () => {
       cancelled = true;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -158,6 +158,8 @@ function PagesRouterCommitBoundaryHelper({
 function renderPagesRouterElement(
   element: ReactElement,
   scroll?: ScrollPosition | null,
+  beforeCommit?: () => void,
+  pendingAsPath?: string,
 ): Promise<void> {
   const root = window.__VINEXT_ROOT__;
   if (!root) {
@@ -166,8 +168,27 @@ function renderPagesRouterElement(
 
   cancelPreviousRenderCommit();
 
+  const pendingSnapshotToken =
+    pendingAsPath !== undefined ? Symbol("vinext.pagesRouter.pendingSnapshot") : null;
+  if (pendingSnapshotToken && pendingAsPath !== undefined) {
+    routerRuntimeState.pendingRouterSnapshot = {
+      token: pendingSnapshotToken,
+      snapshot: getRouterSnapshotForAsPath(pendingAsPath),
+    };
+  }
+
+  const clearPendingSnapshotIfCurrent = () => {
+    if (
+      pendingSnapshotToken &&
+      routerRuntimeState.pendingRouterSnapshot?.token === pendingSnapshotToken
+    ) {
+      routerRuntimeState.pendingRouterSnapshot = undefined;
+    }
+  };
+
   return new Promise<void>((resolve, reject) => {
     const cancel = () => {
+      clearPendingSnapshotIfCurrent();
       if (routerRuntimeState.cancelPendingRenderCommit === cancel) {
         routerRuntimeState.cancelPendingRenderCommit = null;
       }
@@ -199,23 +220,29 @@ function renderPagesRouterElement(
             if (!isCurrent()) return;
 
             try {
+              beforeCommit?.();
               await scrollHandler();
               if (!isCurrent()) return;
+              clearPendingSnapshotIfCurrent();
               clearIfCurrent();
               resolve();
             } catch (err) {
+              clearPendingSnapshotIfCurrent();
               clearIfCurrent();
               reject(err);
             }
           })();
         },
         (error) => {
+          clearPendingSnapshotIfCurrent();
           clearIfCurrent();
           reject(error);
         },
       ),
     );
     if (!hasBrowserDocument()) {
+      beforeCommit?.();
+      clearPendingSnapshotIfCurrent();
       clearIfCurrent();
       resolve();
     }
@@ -426,6 +453,10 @@ function createRouterEvents(): RouterEvents {
 type PagesRouterRuntimeState = {
   events: RouterEvents;
   components?: PagesRouterRuntimeComponents;
+  pendingRouterSnapshot?: {
+    token: symbol;
+    snapshot: PagesRouterSnapshot;
+  };
   currentHistoryKey?: string;
   historyKeyCounter: number;
   navigationId: number;
@@ -448,6 +479,13 @@ type PagesRouterRuntimeComponents = {
     onError: (error: Error) => void;
   }>;
   Provider: ComponentType<{ children: ReactNode }>;
+};
+
+type PagesRouterSnapshot = {
+  pathname: string;
+  query: Record<string, string | string[]>;
+  asPath: string;
+  isReady: boolean;
 };
 
 const PAGES_ROUTER_RUNTIME_STATE_KEY = Symbol.for("vinext.pagesRouter.runtimeState");
@@ -938,6 +976,7 @@ function readScrollPositionFromSessionStorage(key: string): ScrollPosition | nul
 type SSRContext = {
   pathname: string;
   query: Record<string, string | string[]>;
+  initialQuery?: Record<string, string | string[]>;
   asPath: string;
   navigationIsReady?: boolean;
   nextData?: VinextNextData;
@@ -1040,6 +1079,37 @@ function _buildClientPagesNavigationContext(
   return ctx;
 }
 
+function getPendingPagesNavigationContext(
+  nextData: VinextNextData | undefined,
+): PagesNavigationContextShape | null {
+  const pending = routerRuntimeState.pendingRouterSnapshot?.snapshot;
+  if (!pending) return null;
+
+  let resolvedPath: string;
+  let searchString: string;
+  try {
+    const pendingUrl = new URL(
+      toBrowserNavigationHref(pending.asPath, window.location.href, __basePath),
+      window.location.href,
+    );
+    resolvedPath = removeNavigationLocalePrefix(stripBasePath(pendingUrl.pathname, __basePath));
+    searchString = pendingUrl.search;
+  } catch {
+    resolvedPath = stripHash(pending.asPath).split("?", 1)[0] || pending.pathname;
+    searchString = pending.asPath.includes("?") ? `?${pending.asPath.split("?", 2)[1]}` : "";
+  }
+
+  const routePattern =
+    resolvePagesRoutePatternForPath(pending.pathname, resolvedPath) ?? pending.pathname;
+  return _buildClientPagesNavigationContext(
+    routePattern,
+    resolvedPath,
+    searchString,
+    pending.isReady,
+    nextData,
+  );
+}
+
 // Server-side cache for snapshot stability. React's `useSyncExternalStore`
 // expects `getServerSnapshot` to return a stable reference within a single
 // render so it can use Object.is to decide whether to bail out. The SSR ctx is
@@ -1116,10 +1186,13 @@ export function getPagesNavigationContext(): PagesNavigationContextShape | null 
   // carry __NEXT_DATA__, so treating that alone as a Pages signal would let
   // compat fallback state shadow App Router navigation snapshots.
   if (!isPagesRouterDocumentActive()) return null;
+  const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
+  const pendingCtx = getPendingPagesNavigationContext(nextData);
+  if (pendingCtx) return pendingCtx;
+
   const resolvedPath = removeNavigationLocalePrefix(
     stripBasePath(window.location.pathname, __basePath),
   );
-  const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
   const pattern = resolvePagesRoutePatternForPath(nextData?.page, resolvedPath);
   if (!pattern) return null;
   return _buildClientPagesNavigationContext(
@@ -1294,14 +1367,35 @@ function getPathnameAndQuery(): {
     const _ssrCtx = _getSSRContext();
     if (_ssrCtx) {
       const query: Record<string, string | string[]> = {};
-      for (const [key, value] of Object.entries(_ssrCtx.query)) {
+      const sourceQuery =
+        _ssrCtx.navigationIsReady === false ? (_ssrCtx.initialQuery ?? {}) : _ssrCtx.query;
+      for (const [key, value] of Object.entries(sourceQuery)) {
         query[key] = Array.isArray(value) ? [...value] : value;
       }
       return { pathname: _ssrCtx.pathname, query, asPath: _ssrCtx.asPath };
     }
     return { pathname: "/", query: {}, asPath: "/" };
   }
-  const resolvedPath = stripBasePath(window.location.pathname, __basePath);
+  return getPathnameAndQueryForBrowserLocation(
+    window.location.pathname,
+    window.location.search,
+    window.location.hash,
+    getCurrentHistoryAsPath(),
+  );
+}
+
+function getPathnameAndQueryForBrowserLocation(
+  locationPathname: string,
+  locationSearch: string,
+  locationHash: string,
+  asPathOverride?: string | null,
+  forceReady = false,
+): {
+  pathname: string;
+  query: Record<string, string | string[]>;
+  asPath: string;
+} {
+  const resolvedPath = stripBasePath(locationPathname, __basePath);
   const canonicalResolvedPath = removeNavigationLocalePrefix(resolvedPath);
   // In Next.js, router.pathname is the route pattern (e.g., "/posts/[id]"),
   // not the resolved path ("/posts/42"). __NEXT_DATA__.page holds the route
@@ -1313,28 +1407,69 @@ function getPathnameAndQuery(): {
   // shells). router.asPath is different: it is constructed from the live
   // browser URL, including search/hash, even while router.query is still in
   // that pre-ready state.
-  if (!isPagesRouterReady() && !routerRuntimeState.routerDidNavigate && nextData) {
+  if (!forceReady && !isPagesRouterReady() && !routerRuntimeState.routerDidNavigate && nextData) {
     return {
       pathname,
       query: getSerializedRouteQuery(nextData),
-      asPath:
-        getCurrentHistoryAsPath() ??
-        canonicalResolvedPath + window.location.search + window.location.hash,
+      asPath: asPathOverride ?? canonicalResolvedPath + locationSearch + locationHash,
     };
   }
   const routeQuery = getRouteQueryFromNextData(nextData, resolvedPath);
   // URL search params always reflect the current URL
   const searchQuery: Record<string, string | string[]> = {};
-  const params = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams(locationSearch);
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
-  const query = { ...searchQuery, ...routeQuery };
+  const query = { ...routeQuery, ...searchQuery };
+  // Route params are derived from the matched page rather than the visible
+  // query string and therefore retain precedence over same-named search keys.
+  // Other serialized values (notably rewrite-added query state) yield to the
+  // live URL so shallow navigation cannot resurrect stale search parameters.
+  for (const key of extractRouteParamNames(pathname)) {
+    const value = routeQuery[key];
+    if (typeof value === "string" || Array.isArray(value)) {
+      query[key] = Array.isArray(value) ? [...value] : value;
+    }
+  }
   // asPath uses the resolved browser path, not the route pattern
-  const asPath =
-    getCurrentHistoryAsPath() ??
-    canonicalResolvedPath + window.location.search + window.location.hash;
+  const asPath = asPathOverride ?? canonicalResolvedPath + locationSearch + locationHash;
   return { pathname, query, asPath };
+}
+
+function getRouterSnapshotForAsPath(asPath: string): PagesRouterSnapshot {
+  let browserPathname: string;
+  let browserSearch: string;
+  let browserHash: string;
+  try {
+    const browserUrl = new URL(
+      toBrowserNavigationHref(asPath, window.location.href, __basePath),
+      window.location.href,
+    );
+    browserPathname = browserUrl.pathname;
+    browserSearch = browserUrl.search;
+    browserHash = browserUrl.hash;
+  } catch {
+    const asPathWithoutHash = stripHash(asPath);
+    browserPathname = asPathWithoutHash.split("?", 1)[0] || window.location.pathname;
+    browserSearch = asPathWithoutHash.includes("?") ? `?${asPathWithoutHash.split("?", 2)[1]}` : "";
+    browserHash = extractHash(asPath);
+  }
+  return {
+    ...getPathnameAndQueryForBrowserLocation(
+      browserPathname,
+      browserSearch,
+      browserHash,
+      asPath,
+      true,
+    ),
+    isReady: isPagesRouterReady(),
+  };
+}
+
+function getAppAsPathFromBrowserHref(href: string): string {
+  const browserUrl = new URL(href, window.location.href);
+  return stripBasePath(browserUrl.pathname, __basePath) + browserUrl.search + browserUrl.hash;
 }
 
 function getCurrentHistoryAsPath(): string | null {
@@ -1452,7 +1587,11 @@ function PagesRouterHydrationMarker(): null {
   return null;
 }
 
-function getRouterSnapshot(): ReturnType<typeof getPathnameAndQuery> & { isReady: boolean } {
+function getRouterSnapshot(): PagesRouterSnapshot {
+  if (typeof window !== "undefined" && routerRuntimeState.pendingRouterSnapshot) {
+    return routerRuntimeState.pendingRouterSnapshot.snapshot;
+  }
+
   // On the server, derive `router.isReady` from the ServerRouter readiness
   // context. The browser independently applies the Pages Router constructor's
   // predicate to __NEXT_DATA__ and the live URL; notably, queryless GSP pages
@@ -1462,6 +1601,10 @@ function getRouterSnapshot(): ReturnType<typeof getPathnameAndQuery> & { isReady
       ? (_getSSRContext()?.navigationIsReady ?? true)
       : isPagesRouterReady();
   return { ...getPathnameAndQuery(), isReady };
+}
+
+function getActiveRouterUrlSnapshot(): PagesRouterSnapshot {
+  return getRouterSnapshot();
 }
 
 function notifyNextNavigationPagesContext(): void {
@@ -1509,8 +1652,11 @@ function scheduleHardNavigationAndThrow(url: string, message: string): never {
 
 type NavigateClientOptions = {
   allowNotFoundResponse?: boolean;
+  beforeCommit?: () => void;
   locale?: string;
   isHydrationQueryUpdate?: boolean;
+  pendingAsPath?: string;
+  setHistoryCommitTarget?: (target: RedirectHistoryCommitTarget) => void;
   /**
    * The history mode of the originating navigation. Used when a gSSP/gSP data
    * response carries a `__N_REDIRECT` marker so the re-entrant navigation to
@@ -1520,6 +1666,21 @@ type NavigateClientOptions = {
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
 };
+
+type RedirectHistoryCommitTarget = {
+  fullUrl: string;
+  appAsPath: string;
+};
+
+function withRedirectedNavigationTarget(
+  options: NavigateClientOptions,
+  redirectedHref: string,
+): NavigateClientOptions {
+  const pendingAsPath = getAppAsPathFromBrowserHref(redirectedHref);
+  options.setHistoryCommitTarget?.({ fullUrl: redirectedHref, appAsPath: pendingAsPath });
+  if (options.pendingAsPath === pendingAsPath) return options;
+  return { ...options, pendingAsPath };
+}
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
 type PagesDataResponse = {
@@ -1861,9 +2022,24 @@ function getMiddlewarePagesDataFetchUrl(
 ): string | null {
   const middlewareDataHref = getPagesMiddlewareDataHref(browserUrl, __basePath);
   if (!middlewareDataHref) return null;
+  if (dataTarget?.prefetchLocale) {
+    const localizedHref = getPagesMiddlewareDataHref(browserUrl, __basePath, {
+      locale: dataTarget.prefetchLocale,
+    });
+    if (localizedHref) return localizedHref;
+  }
+  if (!dataTarget) {
+    const currentLocale = getCurrentUrlLocale();
+    if (currentLocale) {
+      const localizedHref = getPagesMiddlewareDataHref(browserUrl, __basePath, {
+        locale: currentLocale,
+      });
+      if (localizedHref) return localizedHref;
+    }
+  }
   if (
-    dataTarget?.dataKind === "static" &&
-    dataTarget.middlewareDataHref === middlewareDataHref &&
+    dataTarget?.dataKind !== "none" &&
+    dataTarget?.middlewareDataHref === middlewareDataHref &&
     dataTarget.prefetchDataHref
   ) {
     return dataTarget.prefetchDataHref;
@@ -1883,6 +2059,7 @@ type MiddlewareDataEffect = {
   dataHref: string;
   redirectLocation: string | null;
   rewriteTarget: string | null;
+  skip: boolean;
   response: Response;
 };
 
@@ -1920,6 +2097,7 @@ async function resolveMiddlewareDataEffect(
       dataHref: getPagesDataCacheHref(dataUrl),
       redirectLocation: res.headers.get("x-nextjs-redirect"),
       rewriteTarget: res.headers.get("x-nextjs-rewrite"),
+      skip: res.headers.has("x-middleware-skip"),
       response: res,
     };
   } catch {
@@ -2106,7 +2284,12 @@ async function renderPagesNavigationTarget(
   const nextData = buildPagesNavigationNextData(target, props);
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  await renderPagesRouterElement(element, options.scroll);
+  await renderPagesRouterElement(
+    element,
+    options.scroll,
+    options.beforeCommit,
+    options.pendingAsPath,
+  );
   assertStillCurrent();
 }
 
@@ -2239,10 +2422,14 @@ async function navigateClientData(
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
     }
 
-    window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-    await navigateClientHtml(redirectedUrl, redirectedUrl, controller, navId, assertStillCurrent);
+    await navigateClientHtml(
+      redirectedUrl,
+      redirectedUrl,
+      controller,
+      navId,
+      assertStillCurrent,
+      withRedirectedNavigationTarget(options, redirectedUrl),
+    );
     return;
   }
 
@@ -2327,7 +2514,7 @@ async function navigateClientHtml(
   options: NavigateClientOptions = {},
 ): Promise<void> {
   let browserUrl = url;
-  let pendingRedirectHistoryUrl: string | null = fetchUrl === url ? null : url;
+  let redirectedHistoryUrl: string | null = null;
   const root = window.__VINEXT_ROOT__;
   if (!root) {
     // No React root yet — fall back to hard navigation
@@ -2355,7 +2542,7 @@ async function navigateClientHtml(
     const redirectedUrl = resolveSameOriginRedirectedUrl(res.url);
     if (redirectedUrl) {
       browserUrl = redirectedUrl;
-      pendingRedirectHistoryUrl = redirectedUrl;
+      redirectedHistoryUrl = redirectedUrl;
     }
   }
 
@@ -2477,14 +2664,17 @@ async function navigateClientHtml(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
-  if (pendingRedirectHistoryUrl) {
-    window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-  }
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
-  await renderPagesRouterElement(element, options.scroll);
+  const renderOptions = redirectedHistoryUrl
+    ? withRedirectedNavigationTarget(options, redirectedHistoryUrl)
+    : options;
+  await renderPagesRouterElement(
+    element,
+    renderOptions.scroll,
+    renderOptions.beforeCommit,
+    renderOptions.pendingAsPath,
+  );
   assertStillCurrent();
 }
 
@@ -2558,13 +2748,12 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(configRedirect, "Navigation redirected externally");
         }
-        window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-        routerRuntimeState.lastPathnameAndSearch =
-          window.location.pathname + window.location.search;
-        routerRuntimeState.lastHash = window.location.hash;
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
       }
+      let activeNavigateOptions = configRedirect
+        ? withRedirectedNavigationTarget(options, browserUrl)
+        : options;
       let routeLookupUrl = configRedirect ? browserUrl : routeUrl;
       if (routeUrl === url && hasClientRewriteRules()) {
         const syncConfigRewrite = hasClientAppRouteManifest()
@@ -2639,17 +2828,14 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
         }
-        window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-        routerRuntimeState.lastPathnameAndSearch =
-          window.location.pathname + window.location.search;
-        routerRuntimeState.lastHash = window.location.hash;
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
+        activeNavigateOptions = withRedirectedNavigationTarget(options, redirectedUrl);
       } else if (middlewareEffect) {
         // A masked navigation probes middleware using the browser-visible URL but must fetch page
         // data using the route URL. Without a rewrite header those are different requests, so do
         // not reuse the probe response even though that means one extra request for this rare path.
-        if (middlewareEffect.rewriteTarget || routeUrl === url) {
+        if (!middlewareEffect.skip && (middlewareEffect.rewriteTarget || routeUrl === url)) {
           middlewareDataResponse = middlewareEffect.response;
         }
         if (middlewareEffect.rewriteTarget) {
@@ -2686,11 +2872,17 @@ async function navigateClient(
           controller,
           navId,
           assertStillCurrent,
-          options,
+          activeNavigateOptions,
           middlewareDataResponse,
         );
       } else if (dataTarget) {
-        await navigateClientNoData(browserUrl, dataTarget, controller, assertStillCurrent, options);
+        await navigateClientNoData(
+          browserUrl,
+          dataTarget,
+          controller,
+          assertStillCurrent,
+          activeNavigateOptions,
+        );
       } else {
         await navigateClientHtml(
           browserUrl,
@@ -2698,7 +2890,7 @@ async function navigateClient(
           controller,
           navId,
           assertStillCurrent,
-          options,
+          activeNavigateOptions,
         );
       }
     }
@@ -3252,14 +3444,56 @@ async function performNavigation(
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
-  routerEvents.emit("beforeHistoryChange", resolved, { shallow });
-  updateHistory(mode, full, navState);
   if (!shallow) {
+    const delayHistoryUntilRenderCommit = hasBrowserDocument();
+    const historyCommitOrigin = delayHistoryUntilRenderCommit
+      ? window.location.pathname + window.location.search + window.location.hash
+      : null;
+    let historyCommitTarget: RedirectHistoryCommitTarget | null = null;
+    let didCommitHistory = false;
+    const getCommitMode = (targetFullUrl: string) =>
+      mode === "push" && historyCommitOrigin === targetFullUrl ? "replace" : mode;
+    const commitHistoryTarget = (
+      target: RedirectHistoryCommitTarget,
+      targetMode = getCommitMode(target.fullUrl),
+    ) => {
+      const appStatePath = stripHash(target.appAsPath);
+      routerEvents.emit("beforeHistoryChange", target.appAsPath, { shallow });
+      updateHistory(targetMode, target.fullUrl, {
+        url: appStatePath,
+        as: appStatePath,
+        options: navStateOptions,
+      });
+    };
+    const setHistoryCommitTarget = (target: RedirectHistoryCommitTarget) => {
+      historyCommitTarget = target;
+      if (!delayHistoryUntilRenderCommit && didCommitHistory) {
+        commitHistoryTarget(target, "replace");
+      }
+    };
+    const commitNavigationHistory = () => {
+      if (didCommitHistory) return;
+      didCommitHistory = true;
+      if (historyCommitTarget) {
+        commitHistoryTarget(historyCommitTarget);
+        return;
+      }
+      routerEvents.emit("beforeHistoryChange", resolved, { shallow });
+      updateHistory(mode, full, navState);
+    };
+    if (!delayHistoryUntilRenderCommit) {
+      commitNavigationHistory();
+    }
     const result = await runNavigateClient(
       full,
       resolved,
       htmlFetchUrl,
-      navigateOptions,
+      {
+        ...navigateOptions,
+        beforeCommit: delayHistoryUntilRenderCommit ? commitNavigationHistory : undefined,
+        pendingAsPath: delayHistoryUntilRenderCommit ? resolved : undefined,
+        setHistoryCommitTarget,
+      },
       // When href and as differ, the data fetch must target the route URL
       // (the module that actually renders), not the masked display URL.
       // fullRouteUrl === full when there is no mask, so this is a no-op
@@ -3269,6 +3503,8 @@ async function performNavigation(
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {
+    routerEvents.emit("beforeHistoryChange", resolved, { shallow });
+    updateHistory(mode, full, navState);
     // Shallow navigations skip the render-commit path, so apply the scroll
     // reset synchronously here — before routeChangeComplete. This matches the
     // non-shallow path, where the x/y reset runs inside the render-commit
@@ -3373,7 +3609,9 @@ export function useRouter(): NextRouter {
 }
 
 function PagesRouterProvider({ children }: { children: ReactNode }): ReactElement {
-  const [{ pathname, query, asPath, isReady }, setState] = useState(getRouterSnapshot);
+  const [state, setState] = useState(getRouterSnapshot);
+  const activeSnapshot = routerRuntimeState.pendingRouterSnapshot?.snapshot ?? state;
+  const { pathname, query, asPath, isReady } = activeSnapshot;
 
   // Popstate is handled by the Pages Router client entry via
   // installPagesRouterRuntime() so beforePopState() is consistently enforced
@@ -3636,6 +3874,22 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // their locale-qualified HTML endpoint (parity with the push path).
   const stateLocale = isNextRouterState(state) ? state.options?.locale : undefined;
   const effectiveLocale = typeof stateLocale === "string" ? stateLocale : window.__VINEXT_LOCALE__;
+  const popStateOptions: { locale?: string; shallow: boolean } = { shallow: false };
+  if (typeof stateLocale === "string") popStateOptions.locale = stateLocale;
+  let redirectedPopStateTarget: RedirectHistoryCommitTarget | null = null;
+  const setPopStateHistoryCommitTarget = (target: RedirectHistoryCommitTarget) => {
+    redirectedPopStateTarget = target;
+  };
+  const commitRedirectedPopStateHistory = () => {
+    if (!redirectedPopStateTarget) return;
+
+    const appStatePath = stripHash(redirectedPopStateTarget.appAsPath);
+    updateHistory("replace", redirectedPopStateTarget.fullUrl, {
+      url: appStatePath,
+      as: appStatePath,
+      options: popStateOptions,
+    });
+  };
 
   const fullAppUrl = appUrl + window.location.hash;
   routerEvents.emit("routeChangeStart", fullAppUrl, { shallow: false });
@@ -3684,7 +3938,11 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
       browserUrl,
       fullAppUrl,
       getPagesHtmlFetchUrl(stateRouteUrl, effectiveLocale),
-      { scroll: scrollTarget },
+      {
+        scroll: scrollTarget,
+        beforeCommit: commitRedirectedPopStateHistory,
+        setHistoryCommitTarget: setPopStateHistoryCommitTarget,
+      },
       stateRouteUrl,
     );
     if (result === "completed") {
@@ -3922,13 +4180,13 @@ const singletonRouter: typeof RouterMethods & Omit<NextRouter, keyof typeof Rout
     pathname: {
       enumerable: true,
       get(): string {
-        return getPathnameAndQuery().pathname;
+        return getActiveRouterUrlSnapshot().pathname;
       },
     },
     route: {
       enumerable: true,
       get(): string {
-        const { pathname } = getPathnameAndQuery();
+        const { pathname } = getActiveRouterUrlSnapshot();
         if (typeof window === "undefined") return pathname;
         const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
         return nextData?.page ?? pathname;
@@ -3937,13 +4195,13 @@ const singletonRouter: typeof RouterMethods & Omit<NextRouter, keyof typeof Rout
     query: {
       enumerable: true,
       get(): Record<string, string | string[]> {
-        return getPathnameAndQuery().query;
+        return getActiveRouterUrlSnapshot().query;
       },
     },
     asPath: {
       enumerable: true,
       get(): string {
-        return getPathnameAndQuery().asPath;
+        return getActiveRouterUrlSnapshot().asPath;
       },
     },
     basePath: { enumerable: true, value: __basePath, writable: false },

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -212,36 +212,45 @@ function renderPagesRouterElement(
       }
     };
 
-    root.render(
-      wrapWithRouterContext(
-        element,
-        () => {
-          void (async () => {
-            if (!isCurrent()) return;
-
-            try {
-              beforeCommit?.();
-              await scrollHandler();
-              if (!isCurrent()) return;
-              clearPendingSnapshotIfCurrent();
-              clearIfCurrent();
-              resolve();
-            } catch (err) {
-              clearPendingSnapshotIfCurrent();
-              clearIfCurrent();
-              reject(err);
-            }
-          })();
-        },
-        (error) => {
-          clearPendingSnapshotIfCurrent();
-          clearIfCurrent();
-          reject(error);
-        },
-      ),
-    );
-    if (!hasBrowserDocument()) {
+    try {
+      // Next.js updates history after route/data resolution but before the new
+      // React tree renders. Keep the pending router snapshot installed across
+      // this update so render-time router reads still observe the destination.
       beforeCommit?.();
+      root.render(
+        wrapWithRouterContext(
+          element,
+          () => {
+            void (async () => {
+              if (!isCurrent()) return;
+
+              try {
+                await scrollHandler();
+                if (!isCurrent()) return;
+                clearPendingSnapshotIfCurrent();
+                clearIfCurrent();
+                resolve();
+              } catch (err) {
+                clearPendingSnapshotIfCurrent();
+                clearIfCurrent();
+                reject(err);
+              }
+            })();
+          },
+          (error) => {
+            clearPendingSnapshotIfCurrent();
+            clearIfCurrent();
+            reject(error);
+          },
+        ),
+      );
+    } catch (error) {
+      clearPendingSnapshotIfCurrent();
+      clearIfCurrent();
+      reject(error);
+      return;
+    }
+    if (!hasBrowserDocument()) {
       clearPendingSnapshotIfCurrent();
       clearIfCurrent();
       resolve();
@@ -3283,6 +3292,28 @@ async function performNavigation(
       interpolatedRoute = resolved;
     }
   }
+
+  // Initial GSP hydration starts from the destination page serialized by the
+  // server, while the browser URL can still be a next.config rewrite source.
+  // Resolve that visible URL locally and publish only the client-side query
+  // state. The server render and ISR entry deliberately remain keyed by the
+  // destination pathname, matching Next.js's auto-export hydration pass.
+  if (isHydrationQueryUpdate && hasClientRewriteRules()) {
+    const { resolveHybridClientRewriteHref } =
+      await import("./internal/hybrid-client-route-owner.js");
+    const rewrittenHref = resolveHybridClientRewriteHref(resolved, __basePath);
+    if (rewrittenHref) {
+      const target = resolvePagesDataNavigationTarget(rewrittenHref, __basePath, {
+        locale: navigationLocale,
+      });
+      const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
+      if (target && nextData) {
+        nextData.query = mergeRouteParamsIntoQuery(parseQueryString(target.search), target.params);
+        resolvedRoute = rewrittenHref;
+        interpolatedRoute = rewrittenHref;
+      }
+    }
+  }
   // Recompute `full` after potential `resolved` rewrite above. Cheap when
   // unchanged; correctness-critical when bracket interpolation rewrote it.
   const full = normalizePathTrailingSlash(
@@ -3515,6 +3546,7 @@ async function performNavigation(
       else window.scrollTo(0, 0);
     }
   }
+  if (isQueryUpdating) markPagesRouterReady();
   onStateUpdate?.();
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeComplete", resolved, { shallow });

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -170,9 +170,15 @@ export class NextRequest extends Request {
         }
       : undefined;
     this._nextUrl = new NextURL(url, undefined, urlConfig);
-    this._url = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE
-      ? url.toString()
-      : this._nextUrl.toString();
+    // File-shaped requests keep their original URL spelling even when
+    // trailingSlash is enabled. NextURL still exposes the configured slash
+    // policy, but middleware's request.url must not turn a missing static
+    // asset such as `manifest.json` into `manifest.json/`.
+    const preserveFileRequestUrl = /\.[^/]+$/.test(url.pathname);
+    this._url =
+      process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE || preserveFileRequestUrl
+        ? url.toString()
+        : this._nextUrl.toString();
     this._cookies = new RequestCookies(this.headers);
   }
 

--- a/packages/vinext/src/utils/query.ts
+++ b/packages/vinext/src/utils/query.ts
@@ -6,7 +6,7 @@ type UrlQueryValue = string | number | boolean | null | undefined;
 
 export type UrlQuery = Record<string, UrlQueryValue | readonly UrlQueryValue[]>;
 
-function setOwnQueryValue(
+export function setQueryValue(
   obj: Record<string, string | string[]>,
   key: string,
   value: string | string[],
@@ -26,13 +26,13 @@ export function addQueryParam(
 ): void {
   if (Object.hasOwn(obj, key)) {
     const current = obj[key];
-    setOwnQueryValue(
+    setQueryValue(
       obj,
       key,
       Array.isArray(current) ? current.concat(value) : [current as string, value],
     );
   } else {
-    setOwnQueryValue(obj, key, value);
+    setQueryValue(obj, key, value);
   }
 }
 
@@ -48,7 +48,7 @@ export function mergeRouteParamsIntoQuery(
 ): Record<string, string | string[]> {
   const merged: Record<string, string | string[]> = { ...query };
   for (const [key, value] of Object.entries(params)) {
-    setOwnQueryValue(merged, key, Array.isArray(value) ? [...value] : value);
+    setQueryValue(merged, key, Array.isArray(value) ? [...value] : value);
   }
   return merged;
 }

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1229,6 +1229,22 @@ describe("App Router Production server (startProdServer)", () => {
     expect(res.headers.get("cache-control")).toContain("immutable");
   });
 
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("finalizes missing build assets after preserving App middleware headers", async () => {
+    const res = await fetch(`${baseUrl}/_next/static/middleware-finalized-404.js`, {
+      headers: { "accept-encoding": "identity" },
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(res.headers.get("x-missing-asset-middleware")).toBe("yes");
+    expect(res.headers.get("content-encoding")).toBeNull();
+    expect(res.headers.get("content-length")).toBeNull();
+    expect(res.headers.get("etag")).toBeNull();
+    expect(await res.text()).toBe("Not Found");
+  });
+
   it("serves public files from the build output", async () => {
     // Ported from Next.js: test/production/export/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/production/export/index.test.ts

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1646,12 +1646,16 @@ describe("readPagesRouterEntrySource", () => {
           canceled = true;
         },
       }),
-      { status: 404, headers: { "content-type": "text/html" } },
+      {
+        status: 404,
+        headers: { "content-type": "text/html", "x-from-middleware": "yes" },
+      },
     );
 
     const finalized = finalizeMissingStaticAssetResponse(routed404, true);
     expect(finalized.status).toBe(404);
     expect(finalized.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(finalized.headers.get("x-from-middleware")).toBe("yes");
     expect(await finalized.text()).toBe("Not Found");
     await vi.waitFor(() => expect(canceled).toBe(true));
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1648,13 +1648,50 @@ describe("readPagesRouterEntrySource", () => {
       }),
       {
         status: 404,
-        headers: { "content-type": "text/html", "x-from-middleware": "yes" },
+        headers: {
+          "accept-ranges": "bytes",
+          "content-digest": "sha-256=:stale:",
+          "content-disposition": 'attachment; filename="chunk.js"',
+          "content-type": "text/html",
+          "content-encoding": "gzip",
+          "content-language": "fr",
+          "content-length": "999",
+          "content-location": "/old-chunk.js",
+          "content-md5": "stale",
+          "content-range": "bytes 0-5/999",
+          etag: '"stale"',
+          digest: "sha-256=stale",
+          "last-modified": "Wed, 01 Jan 2025 00:00:00 GMT",
+          "repr-digest": "sha-256=:stale:",
+          trailer: "Digest",
+          "transfer-encoding": "chunked",
+          "x-from-middleware": "yes",
+        },
       },
     );
 
     const finalized = finalizeMissingStaticAssetResponse(routed404, true);
     expect(finalized.status).toBe(404);
     expect(finalized.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    for (const name of [
+      "accept-ranges",
+      "content-digest",
+      "content-disposition",
+      "content-encoding",
+      "content-language",
+      "content-length",
+      "content-location",
+      "content-md5",
+      "content-range",
+      "digest",
+      "etag",
+      "last-modified",
+      "repr-digest",
+      "trailer",
+      "transfer-encoding",
+    ]) {
+      expect(finalized.headers.get(name)).toBeNull();
+    }
     expect(finalized.headers.get("x-from-middleware")).toBe("yes");
     expect(await finalized.text()).toBe("Not Found");
     await vi.waitFor(() => expect(canceled).toBe(true));

--- a/tests/e2e/pages-router-prod/isr-query-context.browser.spec.ts
+++ b/tests/e2e/pages-router-prod/isr-query-context.browser.spec.ts
@@ -279,9 +279,10 @@ test("hydrates a localized dynamic GSP with locale-free navigation state", async
   ).toBe(false);
 
   await expect(page.locator("#ready")).toHaveText("true");
-  await expect(page.locator("#query")).toHaveText(
-    JSON.stringify({ utm: victimToken, slug: "known" }),
-  );
+  expect(JSON.parse((await page.locator("#query").textContent()) ?? "null")).toEqual({
+    utm: victimToken,
+    slug: "known",
+  });
   await expect(page.locator("#as-path")).toHaveText(`/dynamic/known?utm=${victimToken}`);
   await expect(page.locator("#navigation-pathname")).toHaveText("/dynamic/known");
   await expect(page.locator("#navigation-params")).toHaveText(JSON.stringify({ slug: "known" }));
@@ -357,9 +358,10 @@ test("keeps fallback:true params out of the shell until hydration", async ({
     ),
   ).toBe(false);
 
-  await expect(page.locator("#query")).toHaveText(
-    JSON.stringify({ from: "browser", slug: browserSlug }),
-  );
+  expect(JSON.parse((await page.locator("#query").textContent()) ?? "null")).toEqual({
+    from: "browser",
+    slug: browserSlug,
+  });
   await expect(page.locator("#as-path")).toHaveText(
     `/fallback/${browserSlug}?from=browser#client-fragment`,
   );

--- a/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = "http://localhost:4175";
+
+test.describe("Pages middleware rewrite cache parity", () => {
+  test("query-invariant ISR rewrite preserves shared caching", async ({ request }) => {
+    const response = await request.get(`${BASE}/mw-rewrite-isr`);
+
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toContain("Hello from ISR");
+    expect(response.headers()["cache-control"]).toContain("s-maxage=1");
+  });
+
+  test("query-invariant static GSP rewrite does not force no-cache", async ({ request }) => {
+    const htmlResponse = await request.get(`${BASE}/mw-rewrite-static-gsp`);
+    expect(htmlResponse.status()).toBe(200);
+    expect(await htmlResponse.text()).toContain("Hello from static GSP");
+    expect(htmlResponse.headers()["cache-control"]).toBeUndefined();
+
+    const dataResponse = await request.get(
+      `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp.json`,
+    );
+    expect(dataResponse.status()).toBe(200);
+    expect(await dataResponse.json()).toMatchObject({
+      pageProps: { message: "Hello from static GSP" },
+    });
+    expect(dataResponse.headers()["cache-control"]).toBeUndefined();
+  });
+});

--- a/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
@@ -24,6 +24,28 @@ test.describe("Pages middleware rewrite cache parity", () => {
     expect(await dataResponse.json()).toMatchObject({
       pageProps: { message: "Hello from static GSP" },
     });
-    expect(dataResponse.headers()["cache-control"]).toBeUndefined();
+    expect(dataResponse.headers()["cache-control"]).toContain("s-maxage=");
+  });
+
+  test("query-varying static GSP rewrites stay private and preserve source router state", async ({
+    page,
+    request,
+  }) => {
+    const dataResponse = await request.get(
+      `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp-query.json?variant=one`,
+    );
+    expect(dataResponse.status()).toBe(200);
+    expect(dataResponse.headers()["cache-control"]).toBe("no-store, must-revalidate");
+    expect(await dataResponse.json()).toMatchObject({
+      pageProps: { message: "Hello from static GSP" },
+    });
+
+    await page.goto(`${BASE}/mw-rewrite-static-gsp-query?variant=one`);
+    await expect(page.getByTestId("as-path")).toHaveText(
+      "/mw-rewrite-static-gsp-query?variant=one",
+    );
+    await expect(page.getByTestId("query")).toHaveText(
+      JSON.stringify({ variant: "one", from: "middleware" }),
+    );
   });
 });

--- a/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
@@ -46,8 +46,9 @@ test.describe("Pages middleware rewrite cache parity", () => {
     await expect(page.getByTestId("as-path")).toHaveText(
       "/mw-rewrite-static-gsp-query?variant=one",
     );
-    await expect(page.getByTestId("query")).toHaveText(
-      JSON.stringify({ variant: "one", from: "middleware" }),
-    );
+    expect(JSON.parse((await page.getByTestId("query").textContent()) ?? "null")).toEqual({
+      variant: "one",
+      from: "middleware",
+    });
   });
 });

--- a/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
+++ b/tests/e2e/pages-router-prod/middleware-rewrite-cache.spec.ts
@@ -15,7 +15,9 @@ test.describe("Pages middleware rewrite cache parity", () => {
     const htmlResponse = await request.get(`${BASE}/mw-rewrite-static-gsp`);
     expect(htmlResponse.status()).toBe(200);
     expect(await htmlResponse.text()).toContain("Hello from static GSP");
-    expect(htmlResponse.headers()["cache-control"]).toBeUndefined();
+    expect(htmlResponse.headers()["cache-control"]).toBe(
+      "s-maxage=31536000, stale-while-revalidate",
+    );
 
     const dataResponse = await request.get(
       `${BASE}/_next/data/test-build-id/mw-rewrite-static-gsp.json`,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1662,7 +1662,8 @@ describe("Pages Router entry template", () => {
       expect(code).toContain("if (shouldHydrateQuery) {");
       expect(code).toContain("const routeUrl = nextData.__vinext?.routeUrl;");
       expect(code).toContain("await Router.replace(");
-      expect(code).toContain("nextData.isFallback && routeUrl ? routeUrl : nextData.page,");
+      expect(code).toContain("? routeUrl");
+      expect(code).toContain(": { pathname: nextData.page, query: nextData.query },");
       expect(code).toContain("currentUrl,");
       expect(code).toContain("{ _h: 1, shallow: !nextData.isFallback, scroll: false },");
       expect(code).not.toContain("function VinextHydrationMarker");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1655,12 +1655,16 @@ describe("Pages Router entry template", () => {
       expect(code).not.toContain("pageProps: rawPageProps,");
       expect(code).toContain("element = wrapWithRouterContext(element, resolveHydrationCommit);");
       expect(code).toContain("await hydrationCommitted;");
-      expect(code).toContain("if (nextData.isFallback) {");
+      expect(code).toContain("const shouldHydrateQuery =");
+      expect(code).toContain(
+        "nextData.gsp && (window.location.search || nextData.__vinext?.hasRewrites)",
+      );
+      expect(code).toContain("if (shouldHydrateQuery) {");
       expect(code).toContain("const routeUrl = nextData.__vinext?.routeUrl;");
       expect(code).toContain("await Router.replace(");
-      expect(code).toContain("routeUrl || currentUrl,");
-      expect(code).toContain("routeUrl ? currentUrl : undefined,");
-      expect(code).toContain("{ _h: 1, scroll: false },");
+      expect(code).toContain("nextData.isFallback && routeUrl ? routeUrl : nextData.page,");
+      expect(code).toContain("currentUrl,");
+      expect(code).toContain("{ _h: 1, shallow: !nextData.isFallback, scroll: false },");
       expect(code).not.toContain("function VinextHydrationMarker");
       expect(code).not.toContain("React.createElement(VinextHydrationMarker");
       expect(code).toContain("hydrateRoot(container, element, hydrateRootOptions)");

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1044,6 +1044,11 @@ describe("extractLocaleFromUrl", () => {
     expect(result).toEqual({ locale: "de", url: "/", hadPrefix: true });
   });
 
+  it("preserves a trailing slash after extracting the locale prefix", () => {
+    const result = extractLocaleFromUrl("/fr/about/?foo=bar", i18nConfig);
+    expect(result).toEqual({ locale: "fr", url: "/about/?foo=bar", hadPrefix: true });
+  });
+
   it("returns default locale when no prefix", () => {
     const result = extractLocaleFromUrl("/about", i18nConfig);
     expect(result).toEqual({ locale: "en", url: "/about", hadPrefix: false });

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -33,6 +33,15 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     });
   }
 
+  if (pathname === "/_next/static/middleware-finalized-404.js") {
+    const response = NextResponse.next();
+    response.headers.set("content-encoding", "gzip");
+    response.headers.set("content-length", "999");
+    response.headers.set("etag", '"stale-build-asset"');
+    response.headers.set("x-missing-asset-middleware", "yes");
+    return response;
+  }
+
   if (pathname === "/%61dmin") {
     return NextResponse.rewrite(new URL("/admin", request.url));
   }
@@ -411,6 +420,7 @@ export const config = {
     "/mw-gated-before",
     "/mw-gated-fallback",
     "/_next/static/middleware-rewrite.js",
+    "/_next/static/middleware-finalized-404.js",
     {
       source: "/mw-object-gated",
       has: [{ type: "header", key: "x-mw-allow", value: "1" }],

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -37,6 +37,20 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/ssr", request.url));
   }
 
+  if (url.pathname === "/mw-rewrite-isr") {
+    return NextResponse.rewrite(new URL("/isr-test", request.url));
+  }
+
+  if (url.pathname === "/mw-rewrite-static-gsp") {
+    return NextResponse.rewrite(new URL("/static-gsp", request.url));
+  }
+
+  // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
+  // Missing Pages chunks still reach middleware, which may rewrite the 404.
+  if (url.pathname.includes("/_next/static/chunks/pages/_app-non-existent.js")) {
+    return NextResponse.rewrite(new URL("/about", request.url));
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware-node.js
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-general/app/middleware-node.js
   if (url.pathname === "/middleware-general-ssr") {
@@ -304,6 +318,7 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/_next/static/chunks/pages/_app-non-existent.js",
     "/api/edge-search-params",
     "/edge-api-rewrite/:path*",
     "/((?!api|_next|favicon\\.ico|mw-object-gated).*)",

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -45,6 +45,13 @@ export function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL("/static-gsp", request.url));
   }
 
+  if (url.pathname === "/mw-rewrite-static-gsp-query") {
+    const target = request.nextUrl.clone();
+    target.pathname = "/static-gsp";
+    target.searchParams.set("from", "middleware");
+    return NextResponse.rewrite(target);
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware.js
   // Missing Pages chunks still reach middleware, which may rewrite the 404.
   if (url.pathname.includes("/_next/static/chunks/pages/_app-non-existent.js")) {

--- a/tests/fixtures/pages-basic/pages/static-gsp.tsx
+++ b/tests/fixtures/pages-basic/pages/static-gsp.tsx
@@ -1,0 +1,15 @@
+type StaticGspProps = {
+  message: string;
+};
+
+export function getStaticProps() {
+  return {
+    props: {
+      message: "Hello from static GSP",
+    },
+  };
+}
+
+export default function StaticGsp({ message }: StaticGspProps) {
+  return <p data-testid="message">{message}</p>;
+}

--- a/tests/fixtures/pages-basic/pages/static-gsp.tsx
+++ b/tests/fixtures/pages-basic/pages/static-gsp.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from "next/router";
+
 type StaticGspProps = {
   message: string;
 };
@@ -11,5 +13,12 @@ export function getStaticProps() {
 }
 
 export default function StaticGsp({ message }: StaticGspProps) {
-  return <p data-testid="message">{message}</p>;
+  const router = useRouter();
+  return (
+    <>
+      <p data-testid="message">{message}</p>
+      <p data-testid="as-path">{router.asPath}</p>
+      <p data-testid="query">{JSON.stringify(router.query)}</p>
+    </>
+  );
 }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -2725,6 +2725,42 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("keeps direct middleware-matched gSSP Link prefetches chunk-only", async () => {
+    const observer = stubIntersectionObserver();
+    const shallowLoader = vi.fn(async () => ({ default: null }));
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/sha?hello=world",
+      nodeEnv: "production",
+      windowOverrides: {
+        __NEXT_DATA__: {
+          buildId: "build-id",
+          __vinext: { hasMiddleware: true },
+        },
+        __VINEXT_MIDDLEWARE_MATCHER__: ["/sha"],
+        __VINEXT_PAGE_LOADERS__: { "/sha": shallowLoader },
+        __VINEXT_PAGE_PATTERNS__: ["/sha"],
+        __VINEXT_PAGES_SSG_PATTERNS__: [],
+        __VINEXT_PAGES_SSP_PATTERNS__: ["/sha"],
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await flushPrefetchTasks();
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(shallowLoader).toHaveBeenCalled();
+      expect(result.fetch).not.toHaveBeenCalled();
+      expect(result.pagePrefetchLinks).toEqual([]);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("prefetches implicit dynamic Pages Router links through a concrete route URL", async () => {
     const observer = stubIntersectionObserver();
     const dynamicLoader = vi.fn(async () => ({ default: null }));

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -2727,15 +2727,82 @@ describe("Link prefetch scheduling", () => {
 
   // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
-  it("keeps direct middleware-matched gSSP Link prefetches chunk-only", async () => {
+  it("probes middleware for direct gSSP Link prefetches without caching page data", async () => {
+    const observer = stubIntersectionObserver();
+    const gsspLoader = vi.fn(async () => ({ default: null }));
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/sha?hello=world",
+      nodeEnv: "production",
+      props: {
+        onNavigate: (event: { preventDefault(): void }) => event.preventDefault(),
+      },
+      windowOverrides: {
+        __NEXT_DATA__: {
+          buildId: "build-id",
+          __vinext: { hasMiddleware: true },
+        },
+        __VINEXT_MIDDLEWARE_MATCHER__: ["/sha"],
+        __VINEXT_PAGE_LOADERS__: { "/sha": gsspLoader },
+        __VINEXT_PAGE_PATTERNS__: ["/sha"],
+        __VINEXT_PAGES_SSG_PATTERNS__: [],
+        __VINEXT_PAGES_SSP_PATTERNS__: ["/sha"],
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await flushPrefetchTasks();
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      const clickEvent = {
+        button: 0,
+        currentTarget: { hasAttribute: () => false, target: "" },
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+      } satisfies CapturedClickEvent;
+      await result.capturedAnchorProps.onClick?.(clickEvent);
+      await flushPrefetchTasks();
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(gsspLoader).toHaveBeenCalled();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+      for (const call of result.fetch.mock.calls) {
+        expect(call).toEqual([
+          "/_next/data/build-id/sha.json?hello=world",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              purpose: "prefetch",
+              "x-middleware-prefetch": "1",
+              "x-nextjs-data": "1",
+            }),
+          }),
+        ]);
+      }
+      expect(result.pagePrefetchLinks).toEqual([]);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps shallow middleware-matched gSSP Link prefetches chunk-only", async () => {
     const observer = stubIntersectionObserver();
     const shallowLoader = vi.fn(async () => ({ default: null }));
     const result = await renderIsolatedLink({
       appNavigation: false,
       href: "/sha?hello=world",
       nodeEnv: "production",
+      props: { shallow: true },
       windowOverrides: {
         __NEXT_DATA__: {
+          page: "/sha",
+          query: {},
           buildId: "build-id",
           __vinext: { hasMiddleware: true },
         },

--- a/tests/pages-dev-hydration.test.ts
+++ b/tests/pages-dev-hydration.test.ts
@@ -28,6 +28,7 @@ describe("createPagesDevHydrationScript", () => {
       "nextData.gsp && (window.location.search || nextData.__vinext?.hasRewrites)",
     );
     expect(script).toContain("{ _h: 1, shallow: !nextData.isFallback, scroll: false }");
+    expect(script).toContain(": { pathname: nextData.page, query: nextData.query },");
     expect(script).not.toContain("window.__VINEXT_PAGE_PATTERNS__ = [nextData.page]");
   });
 

--- a/tests/pages-dev-hydration.test.ts
+++ b/tests/pages-dev-hydration.test.ts
@@ -5,6 +5,11 @@ describe("createPagesDevHydrationScript", () => {
   it("generates the normal Pages Router hydration entry", () => {
     const script = createPagesDevHydrationScript({
       appModuleSource: "/pages/_app.tsx",
+      clientRewrites: {
+        beforeFiles: [{ source: "/article/:slug", destination: "/ssg" }],
+        afterFiles: [],
+        fallback: [],
+      },
       pageModuleSource: "/pages/index.tsx",
       reactStrictMode: true,
       replaceFallbackRoute: true,
@@ -17,7 +22,12 @@ describe("createPagesDevHydrationScript", () => {
     expect(script).toContain('() => import("/pages/_app.tsx")');
     expect(script).toContain("const appRouter = Router;");
     expect(script).not.toContain("pageProps: rawPageProps,");
-    expect(script).toContain("if (nextData.isFallback)");
+    expect(script).toContain('window.__VINEXT_CLIENT_REWRITES__ = {"beforeFiles"');
+    expect(script).toContain("const shouldHydrateQuery =");
+    expect(script).toContain(
+      "nextData.gsp && (window.location.search || nextData.__vinext?.hasRewrites)",
+    );
+    expect(script).toContain("{ _h: 1, shallow: !nextData.isFallback, scroll: false }");
     expect(script).not.toContain("window.__VINEXT_PAGE_PATTERNS__ = [nextData.page]");
   });
 
@@ -36,7 +46,7 @@ describe("createPagesDevHydrationScript", () => {
     expect(script).toContain('() => import("next/error")');
     expect(script).toContain("const pageProps = rawPageProps ?? {};");
     expect(script).toContain("element = React.createElement(PageComponent, pageProps);");
-    expect(script).not.toContain("if (nextData.isFallback)");
+    expect(script).not.toContain("const shouldHydrateQuery =");
     expect(script).not.toContain("const appRouter =");
   });
 

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -113,6 +113,29 @@ describe("pages page data", () => {
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
   });
 
+  it("does not write rewrite-specific initial query into regenerated ISR HTML", async () => {
+    const html = await renderPagesIsrHtml({
+      buildId: "build-123",
+      cachedHtml:
+        '<!DOCTYPE html><html><head></head><body><div id="__next"><div>stale-body</div></div><script id="__NEXT_DATA__" type="application/json">{"old":1}</script></body></html>',
+      createPageElement(_pageProps: Record<string, unknown>) {
+        return "page";
+      },
+      i18n: {},
+      initialQuery: { slug: "post", rewriteSlug: "from-rewrite" },
+      pageProps: { title: "fresh" },
+      params: { slug: "post" },
+      renderIsrPassToStringAsync: vi.fn(async () => "<div>fresh-body</div>"),
+      routePattern: "/posts/[slug]",
+      safeJsonStringify(value: unknown) {
+        return JSON.stringify(value);
+      },
+    });
+
+    expect(html).toContain('"query":{"slug":"post"}');
+    expect(html).not.toContain("from-rewrite");
+  });
+
   it("preserves custom app props in fallback shells", async () => {
     const AppComponent = Object.assign(function App() {}, {
       getInitialProps() {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -160,7 +160,8 @@ describe("pages page data", () => {
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
   });
 
-  it("isolates middleware rewrite query variants in the ISR cache", async () => {
+  it("bypasses origin ISR reads for middleware rewrite query variants", async () => {
+    const getStaticProps = vi.fn(() => ({ props: { fresh: true }, revalidate: 60 }));
     const isrGet = vi.fn().mockResolvedValue({
       isStale: false,
       value: {
@@ -177,22 +178,19 @@ describe("pages page data", () => {
       createOptions({
         isrGet,
         pageModule: {
-          getStaticProps() {
-            return { props: { fresh: true }, revalidate: 60 };
-          },
+          getStaticProps,
         },
         query: { from: "middleware", slug: "post" },
         isrCachePathname: "/posts/post?from=middleware",
         bypassCdnCache: true,
+        bypassOriginCache: true,
         nextDataQuery: { from: "middleware", slug: "post" },
       }),
     );
 
-    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post?from=middleware");
-    expect(result).toMatchObject({ kind: "response" });
-    if (result.kind === "response") {
-      expect(result.response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
-    }
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(getStaticProps).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ kind: "render" });
   });
 
   it("reuses a query-invariant middleware rewrite ISR entry", async () => {
@@ -264,55 +262,49 @@ describe("pages page data", () => {
     }
   });
 
-  it("preserves middleware rewrite query state in stale ISR regeneration HTML", async () => {
+  it("does not read or regenerate legacy query-varying middleware rewrite entries", async () => {
     const isrSet = vi.fn(async () => {});
-    let regenerationPromise: Promise<void> | undefined;
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: true,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: '<div id="__next">stale</div><script>window.__NEXT_DATA__ = {}</script>',
+          pageData: { pageProps: { stale: true } },
+        },
+      },
+    });
+    const triggerBackgroundRegeneration = vi.fn();
     const result = await resolvePagesPageData(
       createOptions({
         isrCachePathname: "/posts/post?plant=rose",
         nextDataQuery: { plant: "rose", slug: "post" },
-        isrGet: vi.fn().mockResolvedValue({
-          isStale: true,
-          value: {
-            cacheControl: { revalidate: 60 },
-            value: {
-              kind: "PAGES",
-              html: '<div id="__next">stale</div><script>window.__NEXT_DATA__ = {}</script>',
-              pageData: { pageProps: { stale: true } },
-            },
-          },
-        }),
+        bypassOriginCache: true,
+        isrGet,
         isrSet,
         pageModule: {
           getStaticProps() {
             return { props: { fresh: true }, revalidate: 60 };
           },
         },
-        triggerBackgroundRegeneration: vi.fn((_key, callback) => {
-          regenerationPromise = callback();
-        }),
+        triggerBackgroundRegeneration,
       }),
     );
 
-    expect(result).toMatchObject({ kind: "response" });
-    await regenerationPromise;
-    expect(isrSet).toHaveBeenCalledWith(
-      "pages:/posts/post?plant=rose",
-      expect.objectContaining({
-        html: expect.stringContaining('"query":{"plant":"rose","slug":"post"}'),
-      }),
-      60,
-      undefined,
-      300,
-    );
+    expect(result).toMatchObject({ kind: "render" });
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(triggerBackgroundRegeneration).not.toHaveBeenCalled();
+    expect(isrSet).not.toHaveBeenCalled();
   });
 
-  it("persists fallback data under an isolated middleware rewrite query key", async () => {
+  it("does not persist fallback data for a query-varying middleware rewrite", async () => {
     const isrSet = vi.fn(async () => {});
     await resolvePagesPageData(
       createOptions({
         isrCachePathname: "/posts/post?from=middleware",
         bypassCdnCache: true,
+        bypassOriginCache: true,
         isDataReq: true,
         isrSet,
         pageModule: {
@@ -328,13 +320,31 @@ describe("pages page data", () => {
       }),
     );
 
-    expect(isrSet).toHaveBeenCalledWith(
-      "pages:/posts/post?from=middleware",
-      expect.objectContaining({ generatedFromDataRequest: true }),
-      expect.any(Number),
-      undefined,
-      300,
-    );
+    expect(isrSet).not.toHaveBeenCalled();
+  });
+
+  it("does not persist redirect or notFound results for query-varying rewrites", async () => {
+    for (const result of [
+      { redirect: { destination: "/elsewhere", permanent: false }, revalidate: 60 },
+      { notFound: true, revalidate: 60 },
+    ]) {
+      const isrSet = vi.fn(async () => {});
+      await resolvePagesPageData(
+        createOptions({
+          bypassCdnCache: true,
+          bypassOriginCache: true,
+          isrCachePathname: "/posts/post?from=middleware",
+          isrSet,
+          pageModule: {
+            getStaticProps() {
+              return result;
+            },
+          },
+        }),
+      );
+
+      expect(isrSet).not.toHaveBeenCalled();
+    }
   });
 
   it("preserves custom app props in fallback shells", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -264,6 +264,49 @@ describe("pages page data", () => {
     }
   });
 
+  it("preserves middleware rewrite query state in stale ISR regeneration HTML", async () => {
+    const isrSet = vi.fn(async () => {});
+    let regenerationPromise: Promise<void> | undefined;
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrCachePathname: "/posts/post?plant=rose",
+        nextDataQuery: { plant: "rose", slug: "post" },
+        isrGet: vi.fn().mockResolvedValue({
+          isStale: true,
+          value: {
+            cacheControl: { revalidate: 60 },
+            value: {
+              kind: "PAGES",
+              html: '<div id="__next">stale</div><script>window.__NEXT_DATA__ = {}</script>',
+              pageData: { pageProps: { stale: true } },
+            },
+          },
+        }),
+        isrSet,
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        triggerBackgroundRegeneration: vi.fn((_key, callback) => {
+          regenerationPromise = callback();
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({ kind: "response" });
+    await regenerationPromise;
+    expect(isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post?plant=rose",
+      expect.objectContaining({
+        html: expect.stringContaining('"query":{"plant":"rose","slug":"post"}'),
+      }),
+      60,
+      undefined,
+      300,
+    );
+  });
+
   it("persists fallback data under an isolated middleware rewrite query key", async () => {
     const isrSet = vi.fn(async () => {});
     await resolvePagesPageData(

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -142,6 +142,7 @@ describe("pages page data", () => {
       },
       pageProps: { title: "fresh" },
       params: { slug: "post" },
+      nextDataQuery: { from: "middleware", slug: "post" },
       renderIsrPassToStringAsync: vi.fn(async () => "<div>fresh-body</div>"),
       routePattern: "/posts/[slug]",
       safeJsonStringify(value: unknown) {
@@ -153,9 +154,144 @@ describe("pages page data", () => {
     expect(html).toContain("<div>fresh-body</div>");
     expect(html).toContain('<aside data-gap="1"></aside>');
     expect(html).toContain('<script src="/tail.js"></script>');
+    expect(html).toContain('"query":{"from":"middleware","slug":"post"}');
     expect(html).toContain('"page":"/posts/[slug]"');
     expect(html).toContain('"slug":"post"');
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
+  });
+
+  it("isolates middleware rewrite query variants in the ISR cache", async () => {
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: false,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>cached</html>",
+          pageData: { pageProps: { cached: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        query: { from: "middleware", slug: "post" },
+        isrCachePathname: "/posts/post?from=middleware",
+        bypassCdnCache: true,
+        nextDataQuery: { from: "middleware", slug: "post" },
+      }),
+    );
+
+    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post?from=middleware");
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    }
+  });
+
+  it("reuses a query-invariant middleware rewrite ISR entry", async () => {
+    const getStaticProps = vi.fn(async () => ({ props: { fresh: true }, revalidate: 60 }));
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: false,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>cached rewrite</html>",
+          pageData: { pageProps: { cached: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        isrCachePathname: "/posts/post",
+        pageModule: { getStaticProps },
+      }),
+    );
+
+    expect(isrGet).toHaveBeenCalledWith("pages:/posts/post");
+    expect(getStaticProps).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("x-vinext-cache")).toBe("HIT");
+      expect(result.response.headers.get("Cache-Control")).toContain("s-maxage=60");
+    }
+  });
+
+  it("revalidates a stale query-invariant middleware rewrite entry", async () => {
+    const triggerBackgroundRegeneration = vi.fn();
+    const isrGet = vi.fn().mockResolvedValue({
+      isStale: true,
+      value: {
+        cacheControl: { revalidate: 60 },
+        value: {
+          kind: "PAGES",
+          html: "<html>stale rewrite</html>",
+          pageData: { pageProps: { stale: true } },
+        },
+      },
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet,
+        isrCachePathname: "/posts/post",
+        pageModule: {
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        triggerBackgroundRegeneration,
+      }),
+    );
+
+    expect(triggerBackgroundRegeneration).toHaveBeenCalledWith(
+      "pages:/posts/post",
+      expect.any(Function),
+      expect.objectContaining({ routePath: "/posts/[slug]" }),
+    );
+    expect(result).toMatchObject({ kind: "response" });
+    if (result.kind === "response") {
+      expect(result.response.headers.get("x-vinext-cache")).toBe("STALE");
+    }
+  });
+
+  it("persists fallback data under an isolated middleware rewrite query key", async () => {
+    const isrSet = vi.fn(async () => {});
+    await resolvePagesPageData(
+      createOptions({
+        isrCachePathname: "/posts/post?from=middleware",
+        bypassCdnCache: true,
+        isDataReq: true,
+        isrSet,
+        pageModule: {
+          default: function Page() {},
+          getStaticPaths() {
+            return { fallback: true, paths: [] };
+          },
+          getStaticProps() {
+            return { props: { fresh: true }, revalidate: 60 };
+          },
+        },
+        route: { isDynamic: true },
+      }),
+    );
+
+    expect(isrSet).toHaveBeenCalledWith(
+      "pages:/posts/post?from=middleware",
+      expect.objectContaining({ generatedFromDataRequest: true }),
+      expect.any(Number),
+      undefined,
+      300,
+    );
   });
 
   it("preserves custom app props in fallback shells", async () => {

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -537,6 +537,57 @@ describe("createPagesPageHandler — _next/data", () => {
       setCdnCacheAdapter(new DefaultCdnCacheAdapter());
     }
   });
+
+  // Ported from Next.js's config-rewrite GSP hydration contract in:
+  // packages/next/src/client/index.tsx
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/index.tsx
+  it("shares config-rewritten GSP HTML without serializing source captures", async () => {
+    const routePath = `/config-rewrite-gsp-${Date.now()}`;
+    const getStaticProps = vi.fn(async () => ({
+      props: { message: "shared destination" },
+      revalidate: 60,
+    }));
+    const setSSRContext = vi.fn();
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [makeRoute(routePath, makePageModule({ getStaticProps }))],
+        hasRewrites: true,
+        setSSRContext,
+      }),
+    );
+
+    const first = await handler(
+      makeRequest("/article/first"),
+      `${routePath}?slug=first`,
+      null,
+      null,
+      undefined,
+    );
+    const firstHtml = await first.text();
+    const second = await handler(
+      makeRequest("/article/second"),
+      `${routePath}?slug=second`,
+      null,
+      null,
+      undefined,
+    );
+    const secondHtml = await second.text();
+
+    expect(getStaticProps).toHaveBeenCalledOnce();
+    expect(first.headers.get("x-nextjs-cache")).toBe("MISS");
+    expect(second.headers.get("x-nextjs-cache")).toBe("HIT");
+    expect(secondHtml).toBe(firstHtml);
+    expect(firstHtml).not.toContain('"slug":"first"');
+    expect(secondHtml).not.toContain('"slug":"second"');
+    const renderContexts = setSSRContext.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (value): value is { asPath: string; query: Record<string, unknown> } => value !== null,
+      );
+    expect(renderContexts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ asPath: routePath, query: {} })]),
+    );
+  });
 });
 
 describe("createPagesPageHandler — preview responses", () => {

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -445,6 +445,29 @@ describe("createPagesPageHandler — _next/data", () => {
       pageProps: { previewData: { draft: true } },
     });
   });
+
+  it("keeps query-varying middleware rewrite SSG data misses private", async () => {
+    const routeModule = makePageModule({
+      getStaticProps: async () => ({ props: { message: "rewritten" }, revalidate: 60 }),
+    });
+    const handler = createPagesPageHandler(
+      makeOpts({ pageRoutes: [makeRoute("/static-gsp", routeModule)] }),
+    );
+    const dataUrl = "/_next/data/test-build-id/source.json";
+
+    const response = await handler(
+      makeRequest(dataUrl),
+      "/static-gsp?variant=middleware",
+      null,
+      null,
+      { isDataReq: true, hasMiddlewareRewrite: true, originalUrl: dataUrl },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(await response.json()).toMatchObject({ pageProps: { message: "rewritten" } });
+  });
 });
 
 describe("createPagesPageHandler — preview responses", () => {
@@ -901,6 +924,64 @@ describe("createPagesPageHandler — SSR context", () => {
       | undefined;
     expect(ctx?.asPath).toBe("/about?hello=world");
   });
+
+  it.each([
+    {
+      label: "plain source URL",
+      i18nConfig: null,
+      requestUrl: "/source/?browser=one",
+      rewrittenUrl: "/posts/first?from=middleware",
+      expectedAsPath: "/source/?browser=one",
+    },
+    {
+      label: "locale-prefixed trailing-slash source URL",
+      i18nConfig: { locales: ["en", "fr"], defaultLocale: "en" },
+      requestUrl: "/en/source/?browser=one",
+      rewrittenUrl: "/en/posts/first?from=middleware",
+      expectedAsPath: "/source/?browser=one",
+    },
+  ])(
+    "preserves the $label as asPath for a static middleware rewrite",
+    async ({ i18nConfig, requestUrl, rewrittenUrl, expectedAsPath }) => {
+      const setSSRContext = vi.fn();
+      const route = makeRoute(
+        "/posts/:id",
+        makePageModule({
+          getStaticProps: async () => ({ props: { message: "rewritten" } }),
+        }),
+      );
+      const handler = createPagesPageHandler(
+        makeOpts({
+          pageRoutes: [route],
+          i18nConfig,
+          setSSRContext,
+          vinextConfig: {
+            basePath: "",
+            assetPrefix: "",
+            trailingSlash: true,
+            disableOptimizedLoading: true,
+          },
+          matchRoute: (url) =>
+            url.split("?")[0] === "/posts/first" ? { route, params: { id: "first" } } : null,
+        }),
+      );
+
+      await handler(makeRequest(requestUrl), rewrittenUrl, null, null, {
+        asPath: requestUrl,
+        hasMiddlewareRewrite: true,
+        originalUrl: requestUrl,
+      });
+
+      const ctx = setSSRContext.mock.calls.find((call) => call[0] !== null)?.[0] as
+        | { pathname?: string; query?: Record<string, unknown>; asPath?: string }
+        | undefined;
+      expect(ctx).toMatchObject({
+        pathname: "/posts/[id]",
+        query: { from: "middleware", id: "first" },
+        asPath: expectedAsPath,
+      });
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -269,6 +269,58 @@ describe("createPagesPageHandler — route miss", () => {
       expect(genericResponse.headers.get("cache-control")).toBe("no-store");
       expect(genericResponse.headers.get("cdn-cache-control")).toBeNull();
       expect(genericResponse.headers.get("cache-tag")).toBeNull();
+      await sourceResponse.text();
+      await genericResponse.text();
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
+  it("keeps query-varying rewrite notFound error renders out of shared caches", async () => {
+    const originGet = vi.fn(async () => null);
+    const originSet = vi.fn(async () => {});
+    setCdnCacheAdapter({
+      ownsBackgroundRevalidation: false,
+      get: originGet,
+      set: originSet,
+      async revalidateTag() {},
+      buildResponseHeaders(input) {
+        return { "Cache-Control": input.cacheControl };
+      },
+    });
+    try {
+      const sourceRoute = makeRoute(
+        "/source",
+        makePageModule({ getStaticProps: async () => ({ notFound: true, revalidate: 7 }) }),
+      );
+      const notFoundRoute = makeRoute(
+        "/404",
+        makePageModule({ getStaticProps: async () => ({ props: {}, revalidate: 6000 }) }),
+      );
+      const handler = createPagesPageHandler(
+        makeOpts({ pageRoutes: [sourceRoute, notFoundRoute] }),
+      );
+
+      const response = await handler(
+        makeRequest("/middleware-source"),
+        "/source?from=middleware",
+        null,
+        null,
+        { hasMiddlewareRewrite: true },
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+      expect(response.headers.get("cdn-cache-control")).toBeNull();
+      expect(response.headers.get("cloudflare-cdn-cache-control")).toBeNull();
+      expect(response.headers.get("cache-tag")).toBeNull();
+      await response.text();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(originGet).not.toHaveBeenCalled();
+      expect(originSet).not.toHaveBeenCalled();
     } finally {
       setCdnCacheAdapter(new DefaultCdnCacheAdapter());
     }
@@ -447,6 +499,17 @@ describe("createPagesPageHandler — _next/data", () => {
   });
 
   it("keeps query-varying middleware rewrite SSG data misses private", async () => {
+    const originGet = vi.fn(async () => null);
+    const originSet = vi.fn(async () => {});
+    setCdnCacheAdapter({
+      ownsBackgroundRevalidation: false,
+      get: originGet,
+      set: originSet,
+      buildResponseHeaders() {
+        return {};
+      },
+      async revalidateTag() {},
+    });
     const routeModule = makePageModule({
       getStaticProps: async () => ({ props: { message: "rewritten" }, revalidate: 60 }),
     });
@@ -455,18 +518,24 @@ describe("createPagesPageHandler — _next/data", () => {
     );
     const dataUrl = "/_next/data/test-build-id/source.json";
 
-    const response = await handler(
-      makeRequest(dataUrl),
-      "/static-gsp?variant=middleware",
-      null,
-      null,
-      { isDataReq: true, hasMiddlewareRewrite: true, originalUrl: dataUrl },
-    );
+    try {
+      const response = await handler(
+        makeRequest(dataUrl),
+        "/static-gsp?variant=middleware",
+        null,
+        null,
+        { isDataReq: true, hasMiddlewareRewrite: true, originalUrl: dataUrl },
+      );
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
-    expect(response.headers.get("cdn-cache-control")).toBeNull();
-    expect(await response.json()).toMatchObject({ pageProps: { message: "rewritten" } });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+      expect(response.headers.get("cdn-cache-control")).toBeNull();
+      expect(await response.json()).toMatchObject({ pageProps: { message: "rewritten" } });
+      expect(originGet).not.toHaveBeenCalled();
+      expect(originSet).not.toHaveBeenCalled();
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
   });
 });
 

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -250,6 +250,22 @@ describe("pages page response", () => {
     );
   });
 
+  it("does not cache ISR HTML with rewrite-specific initial query", async () => {
+    const common = createCommonOptions();
+
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      initialQuery: { slug: "post", rewriteSlug: "from-rewrite" },
+      isrRevalidateSeconds: 60,
+    });
+
+    const html = await response.text();
+    expect(html).toContain('"query":{"slug":"post","rewriteSlug":"from-rewrite"}');
+    await settleMicrotasks();
+
+    expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
   it("records split UTF-8 chunks without corrupting cached ISR HTML", async () => {
     const common = createCommonOptions();
     common.renderToReadableStream.mockResolvedValue(

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -198,11 +198,12 @@ describe("pages page response", () => {
     }
   });
 
-  it("stores query-varying rewrite ISR output but keeps the CDN response private", async () => {
+  it("does not store query-varying rewrite ISR output and keeps the response private", async () => {
     const common = createCommonOptions();
     const response = await renderPagesPageResponse({
       ...common.options,
       bypassCdnCache: true,
+      bypassOriginCache: true,
       isrCachePathname: "/rewritten?variant=one",
       isrRevalidateSeconds: 60,
       routeUrl: "/rewritten?variant=one",
@@ -211,13 +212,7 @@ describe("pages page response", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
     await response.text();
     await settleMicrotasks();
-    expect(common.isrSet).toHaveBeenCalledWith(
-      "pages:/rewritten?variant=one",
-      expect.any(Object),
-      60,
-      undefined,
-      undefined,
-    );
+    expect(common.isrSet).not.toHaveBeenCalled();
   });
 
   it("renders the document shell, merges gSSP headers, and marks streamed HTML responses", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -7,6 +7,11 @@ import {
   etagMatches,
 } from "../packages/vinext/src/server/pages-page-response.js";
 import { resolvePagesPageData } from "../packages/vinext/src/server/pages-page-data.js";
+import {
+  setCdnCacheAdapter,
+  DefaultCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
 
 function createStream(chunks: string[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -149,6 +154,72 @@ describe("isPagesStreamingBot", () => {
 });
 
 describe("pages page response", () => {
+  it("keeps CDN tags for a query-invariant middleware rewrite MISS", async () => {
+    const common = createCommonOptions();
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders(input) {
+        return {
+          "Cache-Control": "no-store",
+          "CDN-Cache-Control": input.cacheControl,
+          "Cache-Tag": input.tags?.join(",") ?? null,
+        };
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(adapter);
+
+    try {
+      const response = await renderPagesPageResponse({
+        ...common.options,
+        isrCachePathname: "/rewritten",
+        isrRevalidateSeconds: 60,
+        routePattern: "/target",
+        routeUrl: "/rewritten",
+      });
+
+      expect(response.headers.get("CDN-Cache-Control")).toContain("s-maxage=60");
+      expect(response.headers.get("Cache-Tag")).toBe("_N_T_/rewritten");
+      await response.text();
+      await settleMicrotasks();
+      expect(common.isrSet).toHaveBeenCalledWith(
+        "pages:/rewritten",
+        expect.any(Object),
+        60,
+        undefined,
+        undefined,
+      );
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
+  it("stores query-varying rewrite ISR output but keeps the CDN response private", async () => {
+    const common = createCommonOptions();
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      bypassCdnCache: true,
+      isrCachePathname: "/rewritten?variant=one",
+      isrRevalidateSeconds: 60,
+      routeUrl: "/rewritten?variant=one",
+    });
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    await response.text();
+    await settleMicrotasks();
+    expect(common.isrSet).toHaveBeenCalledWith(
+      "pages:/rewritten?variant=one",
+      expect.any(Object),
+      60,
+      undefined,
+      undefined,
+    );
+  });
+
   it("renders the document shell, merges gSSP headers, and marks streamed HTML responses", async () => {
     const common = createCommonOptions();
 

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -261,6 +261,27 @@ describe("pages page response", () => {
     expect(common.renderDocumentToString).toHaveBeenCalledTimes(1);
   });
 
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("serializes rewrite-added query state into __NEXT_DATA__", async () => {
+    const common = createCommonOptions();
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      initialQuery: { slug: "post", rewriteSlug: "post-2" },
+      query: { slug: "post", ignoredRequestSearch: "value" },
+    });
+
+    const html = await response.text();
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).not.toBeNull();
+    expect(JSON.parse(nextDataMatch![1]!).query).toEqual({
+      slug: "post",
+      rewriteSlug: "post-2",
+    });
+  });
+
   it("preserves array-valued non-set-cookie headers from gSSP responses", async () => {
     const common = createCommonOptions();
 

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vite-plus/test";
 import {
+  buildInitialPagesRouterQuery,
   runPagesRequest,
   wrapMiddlewareWithBasePath,
   type PagesPipelineDeps,
@@ -42,6 +43,26 @@ function makeRenderPage(status = 200, body = "ok") {
       new Response(body, { status }),
   );
 }
+
+describe("buildInitialPagesRouterQuery", () => {
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("preserves source params added by a static config rewrite", () => {
+    expect(buildInitialPagesRouterQuery({ rewriteSlug: "post-2" }, {}, ["rewriteSlug"])).toEqual({
+      rewriteSlug: "post-2",
+    });
+  });
+
+  it("lets route params win over rewrite query params", () => {
+    expect(
+      buildInitialPagesRouterQuery(
+        { slug: "from-rewrite", rewriteSlug: "post-2" },
+        { slug: "route-param" },
+        ["slug", "rewriteSlug"],
+      ),
+    ).toEqual({ slug: "route-param", rewriteSlug: "post-2" });
+  });
+});
 
 // 1. Trailing-slash: /foo/ with trailingSlash: false → {type:"response"} with status 308
 describe("trailing slash normalization", () => {
@@ -456,6 +477,26 @@ describe("middleware", () => {
     );
   });
 
+  it("tracks query keys introduced by middleware rewrites", async () => {
+    const renderPage = makeRenderPage(200, "rewrite target");
+    const result = await runPagesRequest(
+      makeRequest("/foo"),
+      baseDeps({
+        runMiddleware: makeMiddleware({ continue: true, rewriteUrl: "/bar?mw=1" }),
+        renderPage,
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(renderPage).toHaveBeenCalledWith(
+      expect.any(Request),
+      "/bar?mw=1",
+      { rewriteQueryKeys: ["mw"] },
+      expect.any(Headers),
+    );
+  });
+
   it.each([
     { i18nConfig: null, requestPath: "/ssr-page", rewritePath: "/ssr-page-2" },
     {
@@ -707,7 +748,7 @@ describe("beforeFiles rewrites", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/to?keep=1&stage=1",
-      undefined,
+      { rewriteQueryKeys: ["stage"] },
       expect.any(Headers),
     );
   });
@@ -735,7 +776,7 @@ describe("beforeFiles rewrites", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/destination?first=1&second=2",
-      undefined,
+      { rewriteQueryKeys: ["first", "second"] },
       expect.any(Headers),
     );
     expect(result.response.headers.get("x-nextjs-rewrite")).toBe("/destination?first=1&second=2");
@@ -1200,7 +1241,7 @@ describe("afterFiles rewrites", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/ssg?slug=first",
-      { isDataReq: true },
+      { isDataReq: true, rewriteQueryKeys: ["slug"] },
       expect.any(Headers),
     );
     expect(result.response.headers.get("x-middleware-skip")).toBeNull();
@@ -1508,7 +1549,7 @@ describe("deferred error page re-render on 404", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/fallback-target?from=fallback",
-      undefined,
+      { rewriteQueryKeys: ["from"] },
       expect.any(Headers),
     );
     expect(result.response.headers.get("x-nextjs-rewrite")).toBe("/fallback-target?from=fallback");

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -587,7 +587,7 @@ describe("middleware", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/bar",
-      undefined,
+      { hasMiddlewareRewrite: true },
       expect.any(Headers),
     );
   });

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -49,10 +49,19 @@ function makeRenderPage(status = 200, body = "ok") {
 describe("buildInitialPagesRouterQuery", () => {
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
-  it("preserves query state introduced by a config rewrite", () => {
+  it("preserves query state carried through a middleware rewrite", () => {
     expect(buildInitialPagesRouterQuery({ rewriteSlug: "post-2" }, {}, ["rewriteSlug"])).toEqual({
       rewriteSlug: "post-2",
     });
+  });
+
+  it("preserves inherited request query state after a middleware rewrite", () => {
+    expect(
+      buildInitialPagesRouterQuery({ hello: "world", rewriteSlug: "post-2" }, {}, [
+        "hello",
+        "rewriteSlug",
+      ]),
+    ).toEqual({ hello: "world", rewriteSlug: "post-2" });
   });
 
   it("keeps route params authoritative over rewrite query values", () => {
@@ -608,6 +617,31 @@ describe("middleware", () => {
       expect.any(Request),
       "/bar",
       { hasMiddlewareRewrite: true },
+      expect.any(Headers),
+    );
+  });
+
+  it("serializes inherited and introduced query keys from middleware rewrites", async () => {
+    const renderPage = makeRenderPage(200, "rewrite target");
+    const result = await runPagesRequest(
+      makeRequest("/foo?hello=world"),
+      baseDeps({
+        runMiddleware: makeMiddleware({
+          continue: true,
+          rewriteUrl: "/bar?hello=world&from=middleware",
+        }),
+        renderPage,
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    expect(renderPage).toHaveBeenCalledWith(
+      expect.any(Request),
+      "/bar?hello=world&from=middleware",
+      {
+        hasMiddlewareRewrite: true,
+        rewriteQueryKeys: ["hello", "from"],
+      },
       expect.any(Headers),
     );
   });

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vite-plus/test";
 import {
+  buildInitialPagesRouterQuery,
   runPagesRequest,
   wrapMiddlewareWithBasePath,
   type PagesPipelineDeps,
@@ -44,6 +45,25 @@ function makeRenderPage(status = 200, body = "ok") {
       new Response(body, { status }),
   );
 }
+
+describe("buildInitialPagesRouterQuery", () => {
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("preserves query state introduced by a config rewrite", () => {
+    expect(buildInitialPagesRouterQuery({ rewriteSlug: "post-2" }, {}, ["rewriteSlug"])).toEqual({
+      rewriteSlug: "post-2",
+    });
+  });
+
+  it("keeps route params authoritative over rewrite query values", () => {
+    expect(
+      buildInitialPagesRouterQuery({ slug: "rewrite", rewriteSlug: "post-2" }, { slug: "route" }, [
+        "slug",
+        "rewriteSlug",
+      ]),
+    ).toEqual({ slug: "route", rewriteSlug: "post-2" });
+  });
+});
 
 describe("on-demand revalidation middleware bypass", () => {
   it("uses the runtime adapter's authoritative credential verifier", async () => {
@@ -1487,7 +1507,7 @@ describe("afterFiles rewrites", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/ssg?slug=first",
-      { isDataReq: true },
+      { isDataReq: true, rewriteQueryKeys: ["slug"] },
       expect.any(Headers),
     );
     expect(result.response.headers.get(MIDDLEWARE_SKIP_HEADER)).toBeNull();

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -1507,7 +1507,7 @@ describe("afterFiles rewrites", () => {
     expect(renderPage).toHaveBeenCalledWith(
       expect.any(Request),
       "/ssg?slug=first",
-      { isDataReq: true, rewriteQueryKeys: ["slug"] },
+      { isDataReq: true },
       expect.any(Headers),
     );
     expect(result.response.headers.get(MIDDLEWARE_SKIP_HEADER)).toBeNull();

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2301,6 +2301,7 @@ export default function Page({ marker }: { marker: string }) {
     expect(nextDataMatch).toBeTruthy();
     const nextData = JSON.parse(nextDataMatch![1]!);
     expect(nextData.props.pageProps.query).toMatchObject({ id: "first", hello: "world" });
+    expect(nextData.query).toEqual({ id: "first", hello: "world" });
   });
 
   it("middleware rewrite with target-side query lets rewrite-target win on key conflicts", async () => {
@@ -6730,6 +6731,14 @@ describe("Production server middleware (Pages Router)", () => {
     const html = await res.text();
     // /rewritten should serve the content of /ssr page
     expect(html).toContain("Server-Side Rendered");
+  });
+
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("lets middleware rewrite a missing Pages chunk in production", async () => {
+    const res = await fetch(`${prodUrl}/_next/static/chunks/pages/_app-non-existent.js`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("About");
   });
 
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16621,7 +16621,15 @@ describe("Pages Router concurrent navigation", () => {
         }),
       );
       expect(fetch).toHaveBeenNthCalledWith(2, "/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/new-home");
+      expect(replaceState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/new-home",
+          url: "/new-home",
+        }),
+        "",
+        "/new-home",
+      );
       expect(win.location.pathname).toBe("/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -16875,7 +16883,15 @@ describe("Pages Router concurrent navigation", () => {
       );
       expect(fetch).toHaveBeenNthCalledWith(2, "/docs/new-home", expect.any(Object));
       expect(fetch).not.toHaveBeenCalledWith("/docs/docs/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/docs/new-home");
+      expect(replaceState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/new-home",
+          url: "/new-home",
+        }),
+        "",
+        "/docs/new-home",
+      );
       expect(win.location.href).toBe("http://localhost/docs/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -18398,11 +18414,23 @@ describe("Pages Router _next/data client navigation", () => {
 
   it("applies config redirects before rendering a matching plain dynamic page", async () => {
     const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
     const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
 
     const dynamicLoader = vi.fn(async () => makePageModule("dynamic"));
-    const destinationLoader = vi.fn(async () => makePageModule("destination"));
-    const { win, replaceState } = createDataNavWindow({
+    const observed: Array<{
+      asPath: string;
+      query: Record<string, string | string[]>;
+    }> = [];
+    let useRouter: typeof import("../packages/vinext/src/shims/router.js").useRouter;
+    const DestinationPage = () => {
+      const router = useRouter();
+      observed.push({ asPath: router.asPath, query: { ...router.query } });
+      return "destination";
+    };
+    const destinationLoader = vi.fn(async () => ({ default: DestinationPage }));
+    const { win, render, pushState, replaceState } = createDataNavWindow({
       loaders: {
         "/": vi.fn(async () => makePageModule("home")),
         "/[id]": dynamicLoader,
@@ -18411,10 +18439,15 @@ describe("Pages Router _next/data client navigation", () => {
       ssgPatterns: [],
       sspPatterns: [],
     });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
     (win as any).__VINEXT_CLIENT_REDIRECTS__ = [
       { source: "/redirect-1", destination: "/somewhere/else", permanent: false },
     ];
     (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
     vi.resetModules();
 
     const fetchMock = vi.fn(async () => new Response("{}"));
@@ -18422,14 +18455,26 @@ describe("Pages Router _next/data client navigation", () => {
 
     try {
       const routerModule = await import("../packages/vinext/src/shims/router.js");
+      useRouter = routerModule.useRouter;
       const Router = routerModule.default;
-      const result = await Router.push("/redirect-1");
+      const result = await Router.push("/redirect-1", undefined, { scroll: false });
 
       expect(result).toBe(true);
       expect(fetchMock).not.toHaveBeenCalled();
       expect(dynamicLoader).not.toHaveBeenCalled();
       expect(destinationLoader).toHaveBeenCalledTimes(1);
-      expect(replaceState).toHaveBeenCalledWith(expect.anything(), "", "/somewhere/else");
+      expect(replaceState.mock.calls.some((call) => call[2] === "/somewhere/else")).toBe(false);
+      expect(pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/somewhere/else",
+          url: "/somewhere/else",
+        }),
+        "",
+        "/somewhere/else",
+      );
+      expect(win.location.pathname).toBe("/somewhere/else");
+      expect(observed).toEqual([{ asPath: "/somewhere/else", query: {} }]);
       expect(win.__NEXT_DATA__).toMatchObject({
         page: "/somewhere/else",
         props: { pageProps: {} },
@@ -18437,6 +18482,166 @@ describe("Pages Router _next/data client navigation", () => {
     } finally {
       if (previousWindow === undefined) delete (globalThis as any).window;
       else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("uses the pending URL for Pages next/navigation hooks during soft data navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const observed: Array<{
+      pathname: string | null;
+      search: string;
+      params: Record<string, string | string[]> | null;
+      locationPathname: string;
+    }> = [];
+    let navigation: typeof import("../packages/vinext/src/shims/navigation.js");
+    const DestinationPage = () => {
+      observed.push({
+        pathname: navigation.usePathname(),
+        search: navigation.useSearchParams().toString(),
+        params: navigation.useParams(),
+        locationPathname: window.location.pathname,
+      });
+      return "destination";
+    };
+    const destinationLoader = vi.fn(async () => ({ default: DestinationPage }));
+    const { win, render } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/search-params-pages/[foo]": destinationLoader,
+      },
+      sspPatterns: ["/search-params-pages/[foo]"],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    vi.resetModules();
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pageProps: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      navigation = await import("../packages/vinext/src/shims/navigation.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/search-params-pages/bar?tab=pending", undefined, {
+        scroll: false,
+      });
+
+      expect(result).toBe(true);
+      expect(destinationLoader).toHaveBeenCalledTimes(1);
+      expect(observed).toEqual([
+        {
+          pathname: "/search-params-pages/bar",
+          search: "tab=pending",
+          params: { foo: "bar" },
+          locationPathname: "/",
+        },
+      ]);
+      expect(win.location.pathname).toBe("/search-params-pages/bar");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("uses the redirected pending URL for Pages next/navigation hooks before history commit", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const observed: Array<{
+      pathname: string | null;
+      search: string;
+      params: Record<string, string | string[]> | null;
+      locationPathname: string;
+    }> = [];
+    let navigation: typeof import("../packages/vinext/src/shims/navigation.js");
+    const DestinationPage = () => {
+      observed.push({
+        pathname: navigation.usePathname(),
+        search: navigation.useSearchParams().toString(),
+        params: navigation.useParams(),
+        locationPathname: window.location.pathname,
+      });
+      return "destination";
+    };
+    const sourceLoader = vi.fn(async () => makePageModule("source"));
+    const destinationLoader = vi.fn(async () => ({ default: DestinationPage }));
+    const { win, render } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/redirect-source": sourceLoader,
+        "/search-params-pages/[foo]": destinationLoader,
+      },
+      ssgPatterns: [],
+      sspPatterns: [],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    (win as any).__VINEXT_CLIENT_REDIRECTS__ = [
+      {
+        source: "/redirect-source",
+        destination: "/search-params-pages/redirected?tab=redirect",
+        permanent: false,
+      },
+    ];
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    vi.resetModules();
+
+    const fetchMock = vi.fn(async () => new Response("{}"));
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      navigation = await import("../packages/vinext/src/shims/navigation.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/redirect-source", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(sourceLoader).not.toHaveBeenCalled();
+      expect(destinationLoader).toHaveBeenCalledTimes(1);
+      expect(observed).toEqual([
+        {
+          pathname: "/search-params-pages/redirected",
+          search: "tab=redirect",
+          params: { foo: "redirected" },
+          locationPathname: "/",
+        },
+      ]);
+      expect(win.location.pathname).toBe("/search-params-pages/redirected");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
       globalThis.fetch = originalFetch;
       vi.resetModules();
     }
@@ -18783,6 +18988,535 @@ describe("Pages Router _next/data client navigation", () => {
     } finally {
       if (previousWindow === undefined) delete (globalThis as any).window;
       else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("does not reuse an x-middleware-skip rewrite probe as page data", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+
+    const loaderAbout = vi.fn(async () => makePageModule("about"));
+    const { win, buildId } = createDataNavWindow({
+      loaders: { "/": vi.fn(async () => makePageModule("home")), "/about": loaderAbout },
+      ssgPatterns: ["/about"],
+      sspPatterns: [],
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/rewrite-me-to-about"];
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (url) => {
+        const href = getDataFetchHref(url);
+        if (href === `/_next/data/${buildId}/rewrite-me-to-about.json?override=internal`) {
+          return new Response("{}", {
+            headers: {
+              "Content-Type": "application/json",
+              "x-middleware-skip": "1",
+              "x-nextjs-rewrite": "/about?override=internal",
+            },
+          });
+        }
+        if (href === `/_next/data/${buildId}/about.json?override=internal`) {
+          return new Response(JSON.stringify({ pageProps: { title: "About Page" } }), {
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${href}`);
+      },
+    );
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/rewrite-me-to-about?override=internal");
+
+      expect(result).toBe(true);
+      expect(fetchMock.mock.calls.map(([url]) => getDataFetchHref(url))).toEqual([
+        `/_next/data/${buildId}/rewrite-me-to-about.json?override=internal`,
+        `/_next/data/${buildId}/about.json?override=internal`,
+      ]);
+      expect(loaderAbout).toHaveBeenCalledTimes(1);
+      expect(win.__NEXT_DATA__).toMatchObject({
+        page: "/about",
+        query: { override: "internal" },
+        props: { pageProps: { title: "About Page" } },
+      });
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("renders destination pages with the pending asPath and query before history commit", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const observed: Array<{
+      asPath: string;
+      query: Record<string, string | string[]>;
+      singletonAsPath: string;
+      singletonPathname: string;
+      singletonQuery: Record<string, string | string[]>;
+    }> = [];
+    let useRouter: typeof import("../packages/vinext/src/shims/router.js").useRouter;
+    let Router: typeof import("../packages/vinext/src/shims/router.js").default;
+    const AboutPage = () => {
+      const router = useRouter();
+      observed.push({
+        asPath: router.asPath,
+        query: { ...router.query },
+        singletonAsPath: Router.asPath,
+        singletonPathname: Router.pathname,
+        singletonQuery: { ...Router.query },
+      });
+      return "about";
+    };
+    const loaderAbout = vi.fn(async () => ({ default: AboutPage }));
+    const { win, render, pushState } = createDataNavWindow({
+      loaders: { "/": vi.fn(async () => makePageModule("home")), "/about": loaderAbout },
+      sspPatterns: ["/about"],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    vi.resetModules();
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pageProps: {} }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      useRouter = routerModule.useRouter;
+      Router = routerModule.default;
+
+      const result = await Router.push("/about?hello=world", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(observed).toEqual([
+        {
+          asPath: "/about?hello=world",
+          query: { hello: "world" },
+          singletonAsPath: "/about?hello=world",
+          singletonPathname: "/about",
+          singletonQuery: { hello: "world" },
+        },
+      ]);
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/about?hello=world",
+          url: "/about?hello=world",
+        }),
+        "",
+        "/about?hello=world",
+      );
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("commits a Next-shaped history state after an x-nextjs-redirect data soft redirect", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const observed: Array<{
+      asPath: string;
+      query: Record<string, string | string[]>;
+    }> = [];
+    let useRouter: typeof import("../packages/vinext/src/shims/router.js").useRouter;
+    const LoginPage = () => {
+      const router = useRouter();
+      observed.push({ asPath: router.asPath, query: { ...router.query } });
+      return "login";
+    };
+    const loginLoader = vi.fn(async () => ({ default: LoginPage }));
+    const { win, buildId, render, pushState, replaceState } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/source": vi.fn(async () => makePageModule("source")),
+        "/login": loginLoader,
+      },
+      sspPatterns: ["/source"],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    vi.resetModules();
+
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (url) => {
+        const href = getDataFetchHref(url);
+        if (href === `/_next/data/${buildId}/source.json?from=data`) {
+          return new Response("{}", {
+            headers: {
+              "Content-Type": "application/json",
+              "x-nextjs-redirect": "/login?via=soft",
+            },
+          });
+        }
+        if (href === "/login?via=soft") {
+          return new Response(buildNavHtmlLocal("/login", "/assets/login.js"), {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${href}`);
+      },
+    );
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      useRouter = routerModule.useRouter;
+      const Router = routerModule.default;
+
+      const result = await Router.push("/source?from=data", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(fetchMock.mock.calls.map(([url]) => getDataFetchHref(url))).toEqual([
+        `/_next/data/${buildId}/source.json?from=data`,
+        "/login?via=soft",
+      ]);
+      expect(loginLoader).toHaveBeenCalledTimes(1);
+      expect(observed).toEqual([{ asPath: "/login?via=soft", query: { via: "soft" } }]);
+      expect(replaceState.mock.calls.some((call) => call[2] === "/login?via=soft")).toBe(false);
+      expect(pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/login?via=soft",
+          url: "/login?via=soft",
+        }),
+        "",
+        "/login?via=soft",
+      );
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("preserves push history when middleware redirects a data navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const observed: Array<{
+      asPath: string;
+      query: Record<string, string | string[]>;
+    }> = [];
+    let useRouter: typeof import("../packages/vinext/src/shims/router.js").useRouter;
+    const LoginPage = () => {
+      const router = useRouter();
+      observed.push({ asPath: router.asPath, query: { ...router.query } });
+      return "login";
+    };
+    const loginLoader = vi.fn(async () => ({ default: LoginPage }));
+    const { win, buildId, render, pushState, replaceState } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/old-home": vi.fn(async () => makePageModule("old-home")),
+        "/login": loginLoader,
+      },
+      sspPatterns: ["/old-home"],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/old-home"];
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    vi.resetModules();
+
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (url) => {
+        const href = getDataFetchHref(url);
+        if (href === `/_next/data/${buildId}/old-home.json?from=middleware`) {
+          return new Response("{}", {
+            headers: {
+              "Content-Type": "application/json",
+              "x-nextjs-redirect": "/login?via=middleware",
+            },
+          });
+        }
+        if (href === "/login?via=middleware") {
+          return new Response(buildNavHtmlLocal("/login", "/assets/login.js"), {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${href}`);
+      },
+    );
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      useRouter = routerModule.useRouter;
+      const Router = routerModule.default;
+
+      const result = await Router.push("/old-home?from=middleware", undefined, {
+        scroll: false,
+      });
+
+      expect(result).toBe(true);
+      expect(fetchMock.mock.calls.map(([url]) => getDataFetchHref(url))).toEqual([
+        `/_next/data/${buildId}/old-home.json?from=middleware`,
+        `/_next/data/${buildId}/old-home.json?from=middleware`,
+        "/login?via=middleware",
+      ]);
+      expect(loginLoader).toHaveBeenCalledTimes(1);
+      expect(observed).toEqual([{ asPath: "/login?via=middleware", query: { via: "middleware" } }]);
+      expect(replaceState.mock.calls.some((call) => call[2] === "/login?via=middleware")).toBe(
+        false,
+      );
+      expect(pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/login?via=middleware",
+          url: "/login?via=middleware",
+        }),
+        "",
+        "/login?via=middleware",
+      );
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("replaces popstate redirect entries with the redirected Next-shaped state", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const originalCustomEvent = globalThis.CustomEvent;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const listeners = new Map<string, (event: any) => void>();
+
+    const observed: Array<{
+      asPath: string;
+      query: Record<string, string | string[]>;
+    }> = [];
+    let useRouter: typeof import("../packages/vinext/src/shims/router.js").useRouter;
+    const LoginPage = () => {
+      const router = useRouter();
+      observed.push({ asPath: router.asPath, query: { ...router.query } });
+      return "login";
+    };
+    const loginLoader = vi.fn(async () => ({ default: LoginPage }));
+    const { win, buildId, render, pushState, replaceState } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/protected": vi.fn(async () => makePageModule("protected")),
+        "/login": loginLoader,
+      },
+      sspPatterns: ["/protected"],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/protected"];
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    (globalThis as any).CustomEvent = class CustomEventMock {
+      constructor(public type: string) {}
+    } as any;
+    vi.resetModules();
+
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (url) => {
+        const href = getDataFetchHref(url);
+        if (href === `/_next/data/${buildId}/protected.json?from=pop`) {
+          return new Response("{}", {
+            headers: {
+              "Content-Type": "application/json",
+              "x-nextjs-redirect": "/login?via=pop",
+            },
+          });
+        }
+        if (href === "/login?via=pop") {
+          return new Response(buildNavHtmlLocal("/login", "/assets/login.js"), {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${href}`);
+      },
+    );
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      useRouter = routerModule.useRouter;
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+
+      win.location.pathname = "/protected";
+      win.location.search = "?from=pop";
+      win.location.href = "http://localhost/protected?from=pop";
+      popstateHandler!({
+        state: {
+          url: "/protected?from=pop",
+          as: "/protected?from=pop",
+          options: { shallow: false },
+          __N: true,
+          key: "pop-key",
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(pushState).not.toHaveBeenCalled();
+      expect(loginLoader).toHaveBeenCalledTimes(1);
+      expect(observed).toEqual([{ asPath: "/login?via=pop", query: { via: "pop" } }]);
+      expect(replaceState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/login?via=pop",
+          url: "/login?via=pop",
+        }),
+        "",
+        "/login?via=pop",
+      );
+      expect(win.location.href).toBe("http://localhost/login?via=pop");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      (globalThis as any).CustomEvent = originalCustomEvent;
+      vi.resetModules();
+    }
+  });
+
+  it("keeps concrete dynamic redirect URLs in final history state", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const observed: Array<{
+      asPath: string;
+      query: Record<string, string | string[]>;
+    }> = [];
+    let useRouter: typeof import("../packages/vinext/src/shims/router.js").useRouter;
+    const BlogPage = () => {
+      const router = useRouter();
+      observed.push({ asPath: router.asPath, query: { ...router.query } });
+      return "blog";
+    };
+    const blogLoader = vi.fn(async () => ({ default: BlogPage }));
+    const { win, buildId, render, pushState } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/source": vi.fn(async () => makePageModule("source")),
+        "/blog/[slug]": blogLoader,
+      },
+      sspPatterns: ["/source"],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    vi.resetModules();
+
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (url) => {
+        const href = getDataFetchHref(url);
+        if (href === `/_next/data/${buildId}/source.json`) {
+          return new Response("{}", {
+            headers: {
+              "Content-Type": "application/json",
+              "x-nextjs-redirect": "/blog/post-1?via=soft",
+            },
+          });
+        }
+        if (href === "/blog/post-1?via=soft") {
+          return new Response(buildNavHtmlLocal("/blog/[slug]", "/assets/blog.js"), {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${href}`);
+      },
+    );
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      useRouter = routerModule.useRouter;
+      const Router = routerModule.default;
+
+      const result = await Router.push("/source", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(blogLoader).toHaveBeenCalledTimes(1);
+      expect(observed).toEqual([
+        { asPath: "/blog/post-1?via=soft", query: { via: "soft", slug: "post-1" } },
+      ]);
+      expect(pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/blog/post-1?via=soft",
+          url: "/blog/post-1?via=soft",
+        }),
+        "",
+        "/blog/post-1?via=soft",
+      );
+      expect(win.__NEXT_DATA__).toMatchObject({
+        page: "/blog/[slug]",
+      });
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
       globalThis.fetch = originalFetch;
       vi.resetModules();
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11059,6 +11059,16 @@ describe("NextURL basePath and locale properties", () => {
     }
   });
 
+  it("NextRequest.url preserves file-shaped requests with trailingSlash enabled", async () => {
+    const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+    const req = new NextRequest("http://localhost/_next/static/build/manifest.json?foo=1", {
+      nextConfig: { trailingSlash: true },
+    });
+
+    expect(req.nextUrl.href).toBe("http://localhost/_next/static/build/manifest.json/?foo=1");
+    expect(req.url).toBe("http://localhost/_next/static/build/manifest.json?foo=1");
+  });
+
   it("NextRequest passes config when input is a Request object", async () => {
     const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
     const raw = new Request("http://localhost/app/fr/dashboard");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -20368,6 +20368,77 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  // Ported from Next.js: packages/next/src/client/index.tsx hydration replace
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/index.tsx
+  it("publishes config rewrite captures during GSP hydration without refetching", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, replaceState, render } = createDataNavWindow({
+      page: "/ssg",
+      pathname: "/article/first",
+      loaders: { "/ssg": vi.fn(async () => makePageModule("ssg")) },
+      ssgPatterns: ["/ssg"],
+    });
+    win.__NEXT_DATA__ = {
+      ...win.__NEXT_DATA__,
+      page: "/ssg",
+      query: {},
+      gsp: true,
+      __vinext: { hasRewrites: true },
+    };
+    (win as any).__NEXT_HYDRATED = true;
+    (win as any).__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: false,
+        isDynamic: false,
+        patternParts: ["ssg"],
+      },
+    ];
+    (win as any).__VINEXT_CLIENT_REWRITES__ = {
+      beforeFiles: [{ source: "/article/:slug", destination: "/ssg" }],
+      afterFiles: [],
+      fallback: [],
+    };
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn() as any;
+    vi.resetModules();
+
+    try {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      await expect(
+        Router.replace("/ssg", "/article/first", {
+          _h: 1,
+          shallow: true,
+          scroll: false,
+        }),
+      ).resolves.toBe(true);
+
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(render).not.toHaveBeenCalled();
+      expect(win.__NEXT_DATA__).toMatchObject({ page: "/ssg", query: { slug: "first" } });
+      expect(Router.pathname).toBe("/ssg");
+      expect(Router.query).toEqual({ slug: "first" });
+      expect(Router.asPath).toBe("/article/first");
+      expect(Router.isReady).toBe(true);
+      expect(win.dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "vinext:navigate" }),
+      );
+      expect(replaceState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          as: "/article/first",
+          url: "/ssg?slug=first",
+        }),
+        "",
+        "/article/first",
+      );
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("uses beforeFiles rewrites for plain pages while preserving the visible URL", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -20667,7 +20738,7 @@ describe("Pages Router _next/data client navigation", () => {
 
   // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
-  it("renders destination pages with pending router state before committing history", async () => {
+  it("commits destination history before rendering the destination page", async () => {
     const previousWindow = (globalThis as any).window;
     const previousDocument = (globalThis as any).document;
     const originalFetch = globalThis.fetch;
@@ -20725,7 +20796,7 @@ describe("Pages Router _next/data client navigation", () => {
           asPath: "/about?hello=world",
           pathname: "/about",
           query: { hello: "world" },
-          locationPathname: "/",
+          locationPathname: "/about",
         },
       ]);
       expect(pushState).toHaveBeenLastCalledWith(

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15983,6 +15983,75 @@ describe("Pages Router router helpers", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("does not restore stale rewrite search state after shallow navigation", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter: useCompatRouter } =
+      await import("../packages/vinext/src/shims/compat-router.js");
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+
+    const previousWindow = (globalThis as any).window;
+    const win = {
+      location: {
+        pathname: "/sha",
+        search: "?hello=goodbye",
+        hash: "",
+        href: "http://localhost/sha?hello=goodbye",
+        hostname: "localhost",
+        assign: vi.fn(),
+        replace: vi.fn(),
+        reload: vi.fn(),
+      },
+      history: {
+        state: null,
+        pushState: vi.fn((_state: unknown, _title: string, url: string) => {
+          const nextUrl = new URL(url, win.location.href);
+          win.location.pathname = nextUrl.pathname;
+          win.location.search = nextUrl.search;
+          win.location.hash = nextUrl.hash;
+          win.location.href = nextUrl.href;
+        }),
+        replaceState: vi.fn(),
+        back: vi.fn(),
+      },
+      dispatchEvent: vi.fn(),
+      scrollTo: vi.fn(),
+      scrollX: 0,
+      scrollY: 0,
+      __NEXT_DATA__: {
+        page: "/shallow",
+        query: { hello: "goodbye" },
+        isFallback: false,
+      },
+      __VINEXT_LOCALE__: undefined,
+      __VINEXT_LOCALES__: undefined,
+      __VINEXT_DEFAULT_LOCALE__: undefined,
+    };
+    (globalThis as any).window = win;
+
+    try {
+      await routerModule.default.push("/sha?hello=world", undefined, { shallow: true });
+
+      let captured: unknown = "NOT_SET";
+      function Probe() {
+        captured = useCompatRouter();
+        return React.createElement("div", null, "probe");
+      }
+      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
+
+      expect((captured as any).query).toEqual({ hello: "world" });
+      expect(win.__NEXT_DATA__.query).toEqual({ hello: "goodbye" });
+    } finally {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("exposes beforePopState on both the Router singleton and wrapped router context", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
@@ -18190,7 +18259,7 @@ describe("Pages Router concurrent navigation", () => {
 
     const fetch = vi.fn(async (url: RequestInfo | URL) => {
       const href = getFetchHref(url);
-      if (href === "/_next/data/build-1/old-home.json") {
+      if (href === "/_next/data/build-1/en/old-home.json") {
         return new Response("{}", {
           headers: { "x-nextjs-redirect": "/new-home" },
           status: 200,
@@ -18213,13 +18282,17 @@ describe("Pages Router concurrent navigation", () => {
       expect(result).toBe(true);
       expect(fetch).toHaveBeenNthCalledWith(
         1,
-        "/_next/data/build-1/old-home.json",
+        "/_next/data/build-1/en/old-home.json",
         expect.objectContaining({
           headers: expect.objectContaining({ "x-nextjs-data": "1" }),
         }),
       );
       expect(fetch).toHaveBeenNthCalledWith(2, "/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/new-home");
+      expect(replaceState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ __N: true, url: "/new-home", as: "/new-home" }),
+        "",
+        "/new-home",
+      );
       expect(win.location.pathname).toBe("/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -18533,7 +18606,15 @@ describe("Pages Router concurrent navigation", () => {
       );
       expect(fetch).toHaveBeenNthCalledWith(2, "/docs/new-home", expect.any(Object));
       expect(fetch).not.toHaveBeenCalledWith("/docs/docs/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/docs/new-home");
+      expect(replaceState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          url: "/new-home",
+          as: "/new-home",
+        }),
+        "",
+        "/docs/new-home",
+      );
       expect(win.location.href).toBe("http://localhost/docs/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -20525,6 +20606,199 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("does not reuse an x-middleware-skip rewrite probe as page data", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const loaderAbout = vi.fn(async () => makePageModule("about"));
+    const { win, buildId } = createDataNavWindow({
+      loaders: { "/": vi.fn(async () => makePageModule("home")), "/about": loaderAbout },
+      ssgPatterns: ["/about"],
+      sspPatterns: [],
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/rewrite-me-to-about"];
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getDataFetchHref(url);
+      if (href === `/_next/data/${buildId}/rewrite-me-to-about.json?override=internal`) {
+        return new Response("{}", {
+          headers: {
+            "content-type": "application/json",
+            "x-middleware-skip": "1",
+            "x-nextjs-rewrite": "/about?override=internal",
+          },
+        });
+      }
+      if (href === `/_next/data/${buildId}/about.json?override=internal`) {
+        return new Response(JSON.stringify({ pageProps: { title: "About Page" } }), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const result = await routerModule.default.push("/rewrite-me-to-about?override=internal");
+
+      expect(result).toBe(true);
+      expect(fetchMock.mock.calls.map(([url]) => getDataFetchHref(url))).toEqual([
+        `/_next/data/${buildId}/rewrite-me-to-about.json?override=internal`,
+        `/_next/data/${buildId}/about.json?override=internal`,
+      ]);
+      expect(loaderAbout).toHaveBeenCalledOnce();
+      expect(win.__NEXT_DATA__).toMatchObject({
+        page: "/about",
+        query: { override: "internal" },
+        props: { pageProps: { title: "About Page" } },
+      });
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+  it("renders destination pages with pending router state before committing history", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { renderToStaticMarkup } = await import("react-dom/server");
+
+    const observed: Array<{
+      asPath: string;
+      pathname: string;
+      query: Record<string, string | string[] | undefined>;
+      locationPathname: string;
+    }> = [];
+    let useRouter: typeof import("../packages/vinext/src/shims/router.js").useRouter;
+    const AboutPage = () => {
+      const router = useRouter();
+      observed.push({
+        asPath: router.asPath,
+        pathname: router.pathname,
+        query: { ...router.query },
+        locationPathname: window.location.pathname,
+      });
+      return "about";
+    };
+    const loaderAbout = vi.fn(async () => ({ default: AboutPage }));
+    const { win, render, pushState } = createDataNavWindow({
+      loaders: { "/": vi.fn(async () => makePageModule("home")), "/about": loaderAbout },
+      sspPatterns: ["/about"],
+    });
+    render.mockImplementation((element: unknown) => {
+      renderToStaticMarkup(element as any);
+      commitRenderedPagesRouterElement(element);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    vi.resetModules();
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pageProps: {} }), {
+          headers: { "content-type": "application/json" },
+        }),
+    ) as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      useRouter = routerModule.useRouter;
+
+      const result = await routerModule.default.push("/about?hello=world", undefined, {
+        scroll: false,
+      });
+
+      expect(result).toBe(true);
+      expect(loaderAbout).toHaveBeenCalledOnce();
+      expect(observed).toEqual([
+        {
+          asPath: "/about?hello=world",
+          pathname: "/about",
+          query: { hello: "world" },
+          locationPathname: "/",
+        },
+      ]);
+      expect(pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          __N: true,
+          as: "/about?hello=world",
+          url: "/about?hello=world",
+        }),
+        "",
+        "/about?hello=world",
+      );
+      expect(win.location.pathname).toBe("/about");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
+  it("locale-qualifies middleware probes before the rewrite target is known", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+
+    const shallowLoader = vi.fn(async () => makePageModule("shallow"));
+    const { win, buildId } = createDataNavWindow({
+      loaders: { "/shallow": shallowLoader },
+      sspPatterns: ["/shallow"],
+    });
+    Object.assign(win.__NEXT_DATA__ as any, {
+      __vinext: { hasMiddleware: true },
+      locale: "en",
+      locales: ["en", "fr"],
+      defaultLocale: "en",
+    });
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/sha"];
+    (win as any).__VINEXT_LOCALES__ = ["en", "fr"];
+    (win as any).__VINEXT_CLIENT_REWRITES__ = {
+      beforeFiles: [{ source: "/sha", destination: "/shallow" }],
+      afterFiles: [],
+      fallback: [],
+    };
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ pageProps: {} }), {
+            headers: { "x-nextjs-rewrite": "/shallow" },
+          }),
+        ),
+    );
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      await routerModule.default.push("/sha?hello=goodbye");
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`/_next/data/${buildId}/en/sha.json?hello=goodbye`);
+      expect(shallowLoader).toHaveBeenCalledOnce();
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("matches middleware probes for path parameters, locale=false entries, and regex fallbacks", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -20567,9 +20841,9 @@ describe("Pages Router _next/data client navigation", () => {
       await Router.push("/regex");
 
       expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
-        `/_next/data/${buildId}/api/hello/world.json`,
+        `/_next/data/${buildId}/en/api/hello/world.json`,
         `/_next/data/${buildId}/en/localized.json`,
-        `/_next/data/${buildId}/regex.json`,
+        `/_next/data/${buildId}/en/regex.json`,
       ]);
       expect(loaderApiPath).toHaveBeenCalledTimes(1);
       expect(loaderLocalized).toHaveBeenCalledTimes(1);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -20374,15 +20374,15 @@ describe("Pages Router _next/data client navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const { win, replaceState, render } = createDataNavWindow({
-      page: "/ssg",
-      pathname: "/article/first",
-      loaders: { "/ssg": vi.fn(async () => makePageModule("ssg")) },
-      ssgPatterns: ["/ssg"],
+      page: "/ssg/[slug]",
+      pathname: "/to-ssg",
+      loaders: { "/ssg/[slug]": vi.fn(async () => makePageModule("ssg")) },
+      ssgPatterns: ["/ssg/[slug]"],
     });
     win.__NEXT_DATA__ = {
       ...win.__NEXT_DATA__,
-      page: "/ssg",
-      query: {},
+      page: "/ssg/[slug]",
+      query: { slug: "hello" },
       gsp: true,
       __vinext: { hasRewrites: true },
     };
@@ -20391,11 +20391,11 @@ describe("Pages Router _next/data client navigation", () => {
       {
         canPrefetchLoadingShell: false,
         isDynamic: false,
-        patternParts: ["ssg"],
+        patternParts: ["ssg", ":slug"],
       },
     ];
     (win as any).__VINEXT_CLIENT_REWRITES__ = {
-      beforeFiles: [{ source: "/article/:slug", destination: "/ssg" }],
+      beforeFiles: [{ source: "/to-ssg", destination: "/ssg/hello" }],
       afterFiles: [],
       fallback: [],
     };
@@ -20406,7 +20406,7 @@ describe("Pages Router _next/data client navigation", () => {
     try {
       const { default: Router } = await import("../packages/vinext/src/shims/router.js");
       await expect(
-        Router.replace("/ssg", "/article/first", {
+        Router.replace({ pathname: "/ssg/[slug]", query: { slug: "hello" } }, "/to-ssg", {
           _h: 1,
           shallow: true,
           scroll: false,
@@ -20415,21 +20415,21 @@ describe("Pages Router _next/data client navigation", () => {
 
       expect(globalThis.fetch).not.toHaveBeenCalled();
       expect(render).not.toHaveBeenCalled();
-      expect(win.__NEXT_DATA__).toMatchObject({ page: "/ssg", query: { slug: "first" } });
-      expect(Router.pathname).toBe("/ssg");
-      expect(Router.query).toEqual({ slug: "first" });
-      expect(Router.asPath).toBe("/article/first");
+      expect(win.__NEXT_DATA__).toMatchObject({ page: "/ssg/[slug]", query: { slug: "hello" } });
+      expect(Router.pathname).toBe("/ssg/[slug]");
+      expect(Router.query).toEqual({ slug: "hello" });
+      expect(Router.asPath).toBe("/to-ssg");
       expect(Router.isReady).toBe(true);
       expect(win.dispatchEvent).toHaveBeenCalledWith(
         expect.objectContaining({ type: "vinext:navigate" }),
       );
       expect(replaceState).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          as: "/article/first",
-          url: "/ssg?slug=first",
+          as: "/to-ssg",
+          url: "/ssg/hello",
         }),
         "",
-        "/article/first",
+        "/to-ssg",
       );
     } finally {
       if (previousWindow === undefined) delete (globalThis as any).window;


### PR DESCRIPTION
## Summary
- preserve rewrite-only query state through Pages data responses and client transitions
- keep pending Pages router snapshots visible to `next/router` and Pages `next/navigation` compat hooks until delayed history commits
- stamp redirected soft navigations with concrete Next-shaped history state while preserving push/replace semantics

Stacked on #2451.

## Validation
- `vp test run tests/shims.test.ts -t "Pages Router _next/data client navigation"`
- `vp test run tests/shims.test.ts -t "Pages Router concurrent navigation"`
- `vp test run tests/pages-request-pipeline.test.ts tests/pages-page-response.test.ts tests/pages-page-data.test.ts`
- `vp check packages/vinext/src/shims/router.ts packages/vinext/src/shims/router-state.ts packages/vinext/src/server/pages-request-pipeline.ts packages/vinext/src/server/pages-page-response.ts packages/vinext/src/server/pages-page-data.ts packages/vinext/src/server/pages-page-handler.ts packages/vinext/src/server/dev-server.ts packages/vinext/src/utils/query.ts tests/shims.test.ts tests/pages-request-pipeline.test.ts tests/pages-page-response.test.ts tests/pages-page-data.test.ts`
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/middleware-rewrites/test/index.test.ts` -> 56 passed, 2 skipped

Independent review loop completed with no findings after follow-up fixes.