### PR TITLE
fix(app-router): reuse shared loading state for searched routes

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -33,6 +33,7 @@ import {
   getBfcacheIdMapContext,
   getPrefetchCache,
   hasPrefetchCacheEntryForNavigation,
+  isNoStoreCacheControl,
   invalidatePrefetchCache,
   seedPrefetchResponseSnapshot,
   decodeRedirectError,
@@ -282,6 +283,8 @@ const discardedServerActionRefreshScheduler = hasServerActions
     };
 const NavigationCommitSignal = browserNavigationController.NavigationCommitSignal;
 const ACTION_HTTP_FALLBACK_ROBOTS_META_ATTR = "data-vinext-action-http-fallback";
+const HYDRATION_NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
+const HYDRATION_STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
 
 function syncServerActionHttpFallbackHead(status: number | null): void {
   document.head
@@ -433,6 +436,14 @@ function isSettledPrefetchCacheEntry(
   );
 }
 
+function canLearnOptimisticRouteTemplateFromPrefetch(
+  entry: PrefetchCacheEntry & { snapshot: CachedRscResponse },
+): boolean {
+  if (entry.optimisticRouteShell === true) return true;
+  const cacheControl = entry.snapshot.cacheControl;
+  return typeof cacheControl !== "string" || !isNoStoreCacheControl(cacheControl);
+}
+
 function parsePrefetchCacheKey(cacheKey: string): {
   interceptionContext: string | null;
   rscUrl: string;
@@ -503,6 +514,7 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
     if (optimisticRouteTemplateSources.has(sourceKey)) continue;
     if (optimisticRouteTemplateLearning.has(sourceKey)) continue;
     if (!isSettledPrefetchCacheEntry(entry)) continue;
+    if (!canLearnOptimisticRouteTemplateFromPrefetch(entry)) continue;
 
     const promise = learnOptimisticRouteTemplateFromPrefetch({
       cacheKey,
@@ -1490,6 +1502,10 @@ function bootstrapHydration(
       const rscUrl = await createRscRequestUrl(initialPathAndSearch, headers);
       if (cacheGeneration !== clientNavigationCacheGeneration) return;
       const snapshot = {
+        cacheControl:
+          initialRscBootstrap?.initialCacheKind === "static"
+            ? HYDRATION_STATIC_CACHE_CONTROL
+            : HYDRATION_NO_STORE_CACHE_CONTROL,
         compatibilityIdHeader: CLIENT_RSC_COMPATIBILITY_ID,
         buffer,
         contentType: VINEXT_RSC_CONTENT_TYPE,
@@ -1767,7 +1783,7 @@ function bootstrapHydration(
             rscUrl,
             requestInterceptionContext,
             mountedSlotsHeader,
-            { notifyInvalidation: false },
+            { allowEmptySearchFallback: true, notifyInvalidation: false },
           );
         const reuseDecision = navigationPlanner.classifyNavigationReuse({
           bypassNavigationCache: shouldBypassNavigationCache,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -599,6 +599,7 @@ function prefetchUrl(
           mountedSlotsHeader,
           undefined,
           {
+            allowEmptySearchFallbackWithoutCacheControl: autoPrefetch.cacheForNavigation,
             cacheForNavigation: autoPrefetch.cacheForNavigation,
             fallbackTtlMs: PREFETCH_CACHE_TTL,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -395,8 +395,9 @@ function resolveFullAppRoutePrefetch(): {
  * For Pages Router: warms the page chunk, prefetches data only for SSG pages,
  * and falls back to a document prefetch hint when no page loader matches.
  *
- * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
- * the main thread during initial page load.
+ * App Router and high-priority prefetches start immediately. Low-priority
+ * Pages Router fallback prefetches use `requestIdleCallback` (or `setTimeout`
+ * fallback) to avoid blocking the main thread during initial page load.
  */
 function prefetchUrl(
   href: string,
@@ -436,14 +437,7 @@ function prefetchUrl(
     return;
   }
 
-  const schedule =
-    priority === "high"
-      ? (fn: () => void) => {
-          fn();
-        }
-      : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
-
-  schedule(() => {
+  const runPrefetch = () => {
     void (async () => {
       if (hasAppNavigationRuntime()) {
         if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
@@ -650,7 +644,15 @@ function prefetchUrl(
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);
     });
-  });
+  };
+
+  if (priority === "high" || hasAppNavigationRuntime()) {
+    runPrefetch();
+    return;
+  }
+
+  const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
+  schedule(runPrefetch);
 }
 
 async function promotePrefetchEntriesForNavigation(href: string): Promise<void> {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -233,6 +233,7 @@ const MIN_PREFETCH_STALE_TIME_MS = 30_000;
 
 /** A buffered RSC response stored as an ArrayBuffer for replay. */
 export type CachedRscResponse = {
+  cacheControl?: string | null;
   compatibilityIdHeader?: string | null;
   buffer: ArrayBuffer;
   contentType: string;
@@ -249,6 +250,7 @@ export type PrefetchOptions = {
 };
 
 export type PrefetchCacheEntry = {
+  allowEmptySearchFallbackWithoutCacheControl?: boolean;
   cacheForNavigation?: boolean;
   expiresAt?: number;
   invalidationTimer?: ReturnType<typeof setTimeout>;
@@ -386,14 +388,56 @@ export function resolvePrefetchCacheEntryMountedSlotsHeader(
   return entry.snapshot?.mountedSlotsHeader ?? null;
 }
 
-function normalizeRscCacheLookupUrl(rscUrl: string): string | null {
+type NormalizedRscCacheLookupUrl = {
+  pathname: string;
+  search: string;
+};
+
+function normalizeRscCacheLookupUrl(rscUrl: string): NormalizedRscCacheLookupUrl | null {
   try {
     const url = new URL(rscUrl, "http://vinext.local");
     stripRscCacheBustingSearchParam(url);
-    return `${url.pathname}${url.search}`;
+    return {
+      pathname: url.pathname,
+      search: url.search,
+    };
   } catch {
     return null;
   }
+}
+
+function isSameRscLookupUrl(
+  left: NormalizedRscCacheLookupUrl | null,
+  right: NormalizedRscCacheLookupUrl,
+): boolean {
+  return left !== null && left.pathname === right.pathname && left.search === right.search;
+}
+
+function canUseEmptySearchPrefetchFallback(
+  source: NormalizedRscCacheLookupUrl | null,
+  target: NormalizedRscCacheLookupUrl,
+): boolean {
+  // Mirrors Next.js segment-cache's optimistic fallback: when a searched URL has
+  // no exact route entry, try the same pathname that was prefetched without
+  // search params.
+  return (
+    source !== null &&
+    target.search !== "" &&
+    source.search === "" &&
+    source.pathname === target.pathname
+  );
+}
+
+export function isNoStoreCacheControl(cacheControl: string): boolean {
+  return cacheControl.split(",").some((directive) => directive.trim().toLowerCase() === "no-store");
+}
+
+function canUseEmptySearchPrefetchFallbackEntry(entry: PrefetchCacheEntry): boolean {
+  if (entry.cacheForNavigation === false) return false;
+  if (entry.optimisticRouteShell === true) return false;
+  const cacheControl = entry.snapshot?.cacheControl;
+  if (cacheControl == null) return entry.allowEmptySearchFallbackWithoutCacheControl === true;
+  return !isNoStoreCacheControl(cacheControl);
 }
 
 function parsePrefetchCacheKey(cacheKey: string): {
@@ -427,11 +471,19 @@ function isPrefetchCacheEntryCompatibleWithMountedSlots(
   return (entry.snapshot?.mountedSlotsHeader ?? null) === mountedSlotsHeader;
 }
 
+type PrefetchCacheEntryMatch = {
+  cacheKey: string;
+  entry: PrefetchCacheEntry;
+  isEmptySearchFallback?: boolean;
+  responseUrl?: string;
+};
+
 function findPrefetchCacheEntryForNavigation(
   rscUrl: string,
   interceptionContext: string | null,
   mountedSlotsHeader: string | null,
-): { cacheKey: string; entry: PrefetchCacheEntry } | null {
+  options: { allowEmptySearchFallback?: boolean } = {},
+): PrefetchCacheEntryMatch | null {
   const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
   const exactEntry = cache.get(exactCacheKey);
@@ -452,10 +504,62 @@ function findPrefetchCacheEntryForNavigation(
 
     const source = parsePrefetchCacheKey(cacheKey);
     if (source.interceptionContext !== interceptionContext) continue;
-    if (normalizeRscCacheLookupUrl(source.rscUrl) !== normalizedTarget) continue;
+    if (!isSameRscLookupUrl(normalizeRscCacheLookupUrl(source.rscUrl), normalizedTarget)) continue;
     if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) continue;
 
     return { cacheKey, entry };
+  }
+
+  if (options.allowEmptySearchFallback === true) {
+    for (const [cacheKey, entry] of cache) {
+      if (cacheKey === exactCacheKey) continue;
+      if (!canUseEmptySearchPrefetchFallbackEntry(entry)) continue;
+
+      const source = parsePrefetchCacheKey(cacheKey);
+      if (source.interceptionContext !== interceptionContext) continue;
+      if (
+        !canUseEmptySearchPrefetchFallback(
+          normalizeRscCacheLookupUrl(source.rscUrl),
+          normalizedTarget,
+        )
+      )
+        continue;
+      if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) continue;
+
+      return { cacheKey, entry, isEmptySearchFallback: true, responseUrl: rscUrl };
+    }
+  }
+
+  return null;
+}
+
+function findSettledEmptySearchPrefetchFallbackForNavigation(
+  rscUrl: string,
+  interceptionContext: string | null,
+  mountedSlotsHeader: string | null,
+): PrefetchCacheEntryMatch | null {
+  const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+  const normalizedTarget = normalizeRscCacheLookupUrl(rscUrl);
+  if (normalizedTarget === null) return null;
+
+  for (const [cacheKey, entry] of getPrefetchCache()) {
+    if (cacheKey === exactCacheKey) continue;
+    if (!canUseEmptySearchPrefetchFallbackEntry(entry)) continue;
+    if (entry.pending !== undefined || entry.outcome !== "cache-seeded") continue;
+
+    const source = parsePrefetchCacheKey(cacheKey);
+    if (source.interceptionContext !== interceptionContext) continue;
+    if (
+      !canUseEmptySearchPrefetchFallback(
+        normalizeRscCacheLookupUrl(source.rscUrl),
+        normalizedTarget,
+      )
+    )
+      continue;
+    if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) continue;
+    if (resolvePrefetchCacheEntryExpiresAt(entry) <= Date.now()) continue;
+
+    return { cacheKey, entry, isEmptySearchFallback: true, responseUrl: rscUrl };
   }
 
   return null;
@@ -465,12 +569,13 @@ export function hasPrefetchCacheEntryForNavigation(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
-  options: { notifyInvalidation?: boolean } = {},
+  options: { allowEmptySearchFallback?: boolean; notifyInvalidation?: boolean } = {},
 ): boolean {
   const match = findPrefetchCacheEntryForNavigation(
     rscUrl,
     interceptionContext,
     mountedSlotsHeader,
+    { allowEmptySearchFallback: options.allowEmptySearchFallback === true },
   );
   if (match === null) return false;
 
@@ -718,6 +823,7 @@ export function createCachedRscResponseSnapshot(
     response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER),
   );
   return {
+    cacheControl: response.headers.get("cache-control"),
     compatibilityIdHeader: response.headers.get(VINEXT_RSC_COMPATIBILITY_ID_HEADER),
     buffer,
     contentType: response.headers.get("content-type") ?? VINEXT_RSC_CONTENT_TYPE,
@@ -759,6 +865,9 @@ export function restoreRscResponse(cached: CachedRscResponse, copy = true): Resp
   if (cached.compatibilityIdHeader != null) {
     headers.set(VINEXT_RSC_COMPATIBILITY_ID_HEADER, cached.compatibilityIdHeader);
   }
+  if (cached.cacheControl != null) {
+    headers.set("cache-control", cached.cacheControl);
+  }
   if (isDynamicStaleTimeSeconds(cached.dynamicStaleTimeSeconds)) {
     headers.set(VINEXT_DYNAMIC_STALE_TIME_HEADER, String(cached.dynamicStaleTimeSeconds));
   }
@@ -786,6 +895,7 @@ export function prefetchRscResponse(
   mountedSlotsHeader: string | null = null,
   options?: PrefetchOptions,
   behavior: {
+    allowEmptySearchFallbackWithoutCacheControl?: boolean;
     cacheForNavigation?: boolean;
     fallbackTtlMs?: number;
     optimisticRouteShell?: boolean;
@@ -809,6 +919,12 @@ export function prefetchRscResponse(
     .then(async (response) => {
       if (response.ok) {
         entry.snapshot = await snapshotRscResponse(response);
+        if (
+          entry.snapshot.cacheControl == null &&
+          behavior.allowEmptySearchFallbackWithoutCacheControl === true
+        ) {
+          entry.allowEmptySearchFallbackWithoutCacheControl = true;
+        }
         entry.expiresAt = resolvePrefetchedRscResponseExpiresAt(
           entry.timestamp,
           entry.snapshot,
@@ -861,16 +977,31 @@ export function consumePrefetchResponse(
     rscUrl,
     interceptionContext,
     mountedSlotsHeader,
+    { allowEmptySearchFallback: true },
   );
   if (!match) return null;
-  const { cacheKey, entry } = match;
 
+  return consumePrefetchCacheEntryMatch(match, mountedSlotsHeader);
+}
+
+function consumePrefetchCacheEntryMatch(
+  match: PrefetchCacheEntryMatch,
+  mountedSlotsHeader: string | null,
+  options: { deleteEntry?: boolean } = {},
+): CachedRscResponse | null {
+  const cache = getPrefetchCache();
+  const { cacheKey, entry, responseUrl } = match;
   // Skip in-flight snapshots and error-path residue where pending cleared
   // without a successful transition to a cache-seeded entry.
   if (entry.pending || entry.outcome !== "cache-seeded") return null;
   if (entry.cacheForNavigation === false) return null;
+  if (match.isEmptySearchFallback === true && !canUseEmptySearchPrefetchFallbackEntry(entry)) {
+    return null;
+  }
 
-  deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, false);
+  if (options.deleteEntry !== false && match.isEmptySearchFallback !== true) {
+    deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, false);
+  }
 
   if (entry.snapshot) {
     if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) {
@@ -889,7 +1020,11 @@ export function consumePrefetchResponse(
       return {
         ...entry.snapshot,
         expiresAt: resolvePrefetchCacheEntryExpiresAt(entry),
+        ...(responseUrl !== undefined ? { url: responseUrl } : {}),
       };
+    }
+    if (responseUrl !== undefined) {
+      return { ...entry.snapshot, url: responseUrl };
     }
     return entry.snapshot;
   }
@@ -919,18 +1054,28 @@ export async function consumePrefetchResponseForNavigation(
     rscUrl,
     interceptionContext,
     mountedSlotsHeader,
+    { allowEmptySearchFallback: true },
   );
   if (!match) return null;
   const { cacheKey, entry } = match;
 
   if (entry.pending !== undefined) {
+    const fallback = findSettledEmptySearchPrefetchFallbackForNavigation(
+      rscUrl,
+      interceptionContext,
+      mountedSlotsHeader,
+    );
+    if (fallback) {
+      if (options?.shouldConsume?.() === false) return null;
+      return consumePrefetchCacheEntryMatch(fallback, mountedSlotsHeader, { deleteEntry: false });
+    }
     await entry.pending.catch(() => {});
     if (cache.get(cacheKey) !== entry) return null;
   }
 
   if (options?.shouldConsume?.() === false) return null;
 
-  return consumePrefetchResponse(rscUrl, interceptionContext, mountedSlotsHeader);
+  return consumePrefetchCacheEntryMatch(match, mountedSlotsHeader);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -231,6 +231,7 @@ declare module "next/navigation" {
 
   // RSC prefetch cache utilities (shared between link.tsx and browser entry)
   export type CachedRscResponse = {
+    cacheControl?: string | null;
     compatibilityIdHeader?: string | null;
     buffer: ArrayBuffer;
     contentType: string;
@@ -241,6 +242,7 @@ declare module "next/navigation" {
     url: string;
   };
   export type PrefetchCacheEntry = {
+    allowEmptySearchFallbackWithoutCacheControl?: boolean;
     cacheForNavigation?: boolean;
     expiresAt?: number;
     invalidationTimer?: ReturnType<typeof setTimeout>;
@@ -266,7 +268,7 @@ declare module "next/navigation" {
     rscUrl: string,
     interceptionContext?: string | null,
     mountedSlotsHeader?: string | null,
-    options?: { notifyInvalidation?: boolean },
+    options?: { allowEmptySearchFallback?: boolean; notifyInvalidation?: boolean },
   ): boolean;
   export function storePrefetchResponse(
     rscUrl: string,
@@ -290,6 +292,7 @@ declare module "next/navigation" {
     mountedSlotsHeader?: string | null,
     options?: { onInvalidate?: () => void },
     behavior?: {
+      allowEmptySearchFallbackWithoutCacheControl?: boolean;
       cacheForNavigation?: boolean;
       fallbackTtlMs?: number;
       optimisticRouteShell?: boolean;

--- a/tests/e2e/app-router-prefetch-searchparams/search-params-shared-loading-state.spec.ts
+++ b/tests/e2e/app-router-prefetch-searchparams/search-params-shared-loading-state.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test } from "@playwright/test";
+
+test.describe.configure({ timeout: 60_000 });
+
+// Ported from Next.js: test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
+test("reuses a static full prefetch across search params for shared loading state", async ({
+  page,
+}) => {
+  const targetPath = "/search-params-shared-loading-state/target-page";
+  let noSearchPrefetchComplete: (() => void) | undefined;
+  let exactSearchVariantStarted: (() => void) | undefined;
+  let exactSearchVariantRequests = 0;
+  let blockExactSearchVariant = false;
+  const releaseBlockedExactRequests = new Set<() => void>();
+
+  const noSearchPrefetched = new Promise<void>((resolve) => {
+    noSearchPrefetchComplete = resolve;
+  });
+  const exactSearchVariantPrefetchStarted = new Promise<void>((resolve) => {
+    exactSearchVariantStarted = resolve;
+  });
+
+  await page.route(`**${targetPath}*`, async (route) => {
+    const request = route.request();
+    const headers = request.headers();
+    const url = new URL(request.url());
+    const isRscRequest = url.pathname === targetPath && headers.rsc === "1";
+
+    if (
+      isRscRequest &&
+      url.searchParams.get("param") === null &&
+      headers["x-vinext-rsc-render-mode"] !== "prefetch-loading-shell"
+    ) {
+      const response = await route.fetch();
+      await route.fulfill({ response });
+      noSearchPrefetchComplete?.();
+      return;
+    }
+
+    if (isRscRequest && url.searchParams.get("param") === "test") {
+      exactSearchVariantRequests += 1;
+      exactSearchVariantStarted?.();
+      if (blockExactSearchVariant) {
+        await new Promise<void>((resolve) => {
+          releaseBlockedExactRequests.add(resolve);
+        });
+        await route.abort();
+        return;
+      }
+    }
+
+    await route.continue();
+  });
+
+  try {
+    await page.goto("/search-params-shared-loading-state");
+
+    await page
+      .locator('input[data-link-accordion="/search-params-shared-loading-state/target-page"]')
+      .click();
+    await noSearchPrefetched;
+
+    blockExactSearchVariant = true;
+    await page
+      .locator(
+        'input[data-link-accordion="/search-params-shared-loading-state/target-page?param=test"]',
+      )
+      .click();
+    await exactSearchVariantPrefetchStarted;
+    expect(exactSearchVariantRequests).toBe(1);
+
+    await page
+      .locator('a[href="/search-params-shared-loading-state/target-page?param=test"]')
+      .click();
+
+    await expect(page.locator("#static-content")).toHaveText("Static content");
+    await expect(page.locator("#search-params-content")).toHaveText("Search param value: test");
+    expect(exactSearchVariantRequests).toBe(1);
+  } finally {
+    blockExactSearchVariant = false;
+    for (const release of releaseBlockedExactRequests) {
+      release();
+    }
+  }
+});
+
+test("waits for exact searched data when the server page renders searchParams", async ({
+  page,
+}) => {
+  const targetPath = "/search-params-shared-loading-state/target-page-server-search";
+  let noSearchPrefetchComplete: (() => void) | undefined;
+  let exactSearchVariantStarted: (() => void) | undefined;
+  let releaseExactSearchVariant: (() => void) | undefined;
+  let exactSearchVariantRequests = 0;
+
+  const noSearchPrefetched = new Promise<void>((resolve) => {
+    noSearchPrefetchComplete = resolve;
+  });
+  const exactSearchVariantPrefetchStarted = new Promise<void>((resolve) => {
+    exactSearchVariantStarted = resolve;
+  });
+  const exactSearchVariantReleased = new Promise<void>((resolve) => {
+    releaseExactSearchVariant = resolve;
+  });
+
+  await page.route(`**${targetPath}*`, async (route) => {
+    const request = route.request();
+    const headers = request.headers();
+    const url = new URL(request.url());
+    const isRscRequest = url.pathname === targetPath && headers.rsc === "1";
+
+    if (isRscRequest && url.searchParams.get("param") === null) {
+      const response = await route.fetch();
+      await route.fulfill({ response });
+      noSearchPrefetchComplete?.();
+      return;
+    }
+
+    if (isRscRequest && url.searchParams.get("param") === "test") {
+      exactSearchVariantRequests += 1;
+      exactSearchVariantStarted?.();
+      await exactSearchVariantReleased;
+    }
+
+    await route.continue();
+  });
+
+  await page.goto("/search-params-shared-loading-state");
+
+  await page
+    .locator(
+      'input[data-link-accordion="/search-params-shared-loading-state/target-page-server-search"]',
+    )
+    .click();
+  await noSearchPrefetched;
+
+  await page
+    .locator(
+      'input[data-link-accordion="/search-params-shared-loading-state/target-page-server-search?param=test"]',
+    )
+    .click();
+  await exactSearchVariantPrefetchStarted;
+  expect(exactSearchVariantRequests).toBe(1);
+
+  await page
+    .locator('a[href="/search-params-shared-loading-state/target-page-server-search?param=test"]')
+    .click();
+
+  await expect(page.locator("#server-search-param")).toHaveCount(0);
+  releaseExactSearchVariant?.();
+  await expect(page.locator("#server-search-param")).toHaveText("Server search param value: test");
+  expect(exactSearchVariantRequests).toBeGreaterThanOrEqual(1);
+});
+
+test("does not reuse hydration-seeded no-search data for searched server searchParams", async ({
+  page,
+}) => {
+  const targetPath = "/search-params-shared-loading-state/target-page-server-search";
+  let releaseExactSearchVariant: (() => void) | undefined;
+  let exactSearchVariantRequests = 0;
+
+  const exactSearchVariantReleased = new Promise<void>((resolve) => {
+    releaseExactSearchVariant = resolve;
+  });
+
+  await page.route(`**${targetPath}*`, async (route) => {
+    const request = route.request();
+    const headers = request.headers();
+    const url = new URL(request.url());
+    const isRscRequest = url.pathname === targetPath && headers.rsc === "1";
+
+    if (isRscRequest && url.searchParams.get("param") === "test") {
+      exactSearchVariantRequests += 1;
+      await exactSearchVariantReleased;
+    }
+
+    await route.continue();
+  });
+
+  try {
+    await page.goto(targetPath);
+    await expect(page.locator("#server-search-param")).toHaveText(
+      "Server search param value: none",
+    );
+
+    const clickPromise = page.locator("#server-search-param-link").click();
+    await expect
+      .poll(() => exactSearchVariantRequests, { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(1);
+    await expect(page.locator("#server-search-param")).toHaveText(
+      "Server search param value: none",
+    );
+
+    releaseExactSearchVariant?.();
+    await clickPromise;
+    await expect(page.locator("#server-search-param")).toHaveText(
+      "Server search param value: test",
+    );
+  } finally {
+    releaseExactSearchVariant?.();
+  }
+});

--- a/tests/fixtures/app-basic/app/search-params-shared-loading-state/link-accordion.tsx
+++ b/tests/fixtures/app-basic/app/search-params-shared-loading-state/link-accordion.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link, { type LinkProps } from "next/link";
+import { useState } from "react";
+
+export function LinkAccordion({
+  children,
+  href,
+  prefetch,
+}: {
+  children: React.ReactNode;
+  href: string;
+  prefetch?: LinkProps["prefetch"];
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  return (
+    <>
+      <input
+        checked={isVisible}
+        data-link-accordion={href}
+        onChange={() => setIsVisible(!isVisible)}
+        type="checkbox"
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/search-params-shared-loading-state/page.tsx
+++ b/tests/fixtures/app-basic/app/search-params-shared-loading-state/page.tsx
@@ -1,0 +1,41 @@
+import { LinkAccordion } from "./link-accordion";
+
+export default function SearchParamsSharedLoadingStatePage() {
+  return (
+    <div>
+      <p>
+        This page tests whether a prefetched URL without search params can share its loading state
+        with a navigation to the same URL with search params.
+      </p>
+
+      <ul>
+        <li>
+          <LinkAccordion href="/search-params-shared-loading-state/target-page" prefetch>
+            Prefetch target (no search params)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/search-params-shared-loading-state/target-page?param=test" prefetch>
+            Prefetch target (with search params)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            href="/search-params-shared-loading-state/target-page-server-search"
+            prefetch
+          >
+            Prefetch server-search target (no search params)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            href="/search-params-shared-loading-state/target-page-server-search?param=test"
+            prefetch
+          >
+            Prefetch server-search target (with search params)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/search-params-shared-loading-state/target-page-server-search/page.tsx
+++ b/tests/fixtures/app-basic/app/search-params-shared-loading-state/target-page-server-search/page.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+export default async function TargetPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ param?: string }>;
+}) {
+  const { param = "none" } = await searchParams;
+
+  return (
+    <div>
+      <h1>Server Search Target Page</h1>
+      <p id="server-search-param">Server search param value: {param}</p>
+      <Link
+        href="/search-params-shared-loading-state/target-page-server-search?param=test"
+        id="server-search-param-link"
+        prefetch={false}
+      >
+        Search with param
+      </Link>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/search-params-shared-loading-state/target-page/client.tsx
+++ b/tests/fixtures/app-basic/app/search-params-shared-loading-state/target-page/client.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export function SearchParamsDisplay() {
+  const searchParams = useSearchParams();
+  const param = searchParams.get("param");
+
+  return <div id="search-params-content">Search param value: {param || "none"}</div>;
+}

--- a/tests/fixtures/app-basic/app/search-params-shared-loading-state/target-page/page.tsx
+++ b/tests/fixtures/app-basic/app/search-params-shared-loading-state/target-page/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from "react";
+
+import { SearchParamsDisplay } from "./client";
+
+export default function TargetPage() {
+  return (
+    <div>
+      <h1>Target Page</h1>
+      <p id="static-content">Static content</p>
+      <Suspense fallback={<div id="search-params-loading">Loading search params...</div>}>
+        <SearchParamsDisplay />
+      </Suspense>
+    </div>
+  );
+}

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1283,6 +1283,34 @@ describe("Link prefetch scheduling", () => {
     };
   }
 
+  it("starts App Router viewport prefetches before browser idle callbacks", async () => {
+    const observer = stubIntersectionObserver();
+    const requestIdleCallback = vi.fn(() => 1);
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("prefetches visible links in production with low priority", async () => {
     const observer = stubIntersectionObserver();
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -45,6 +45,16 @@ type CapturedPrefetchLinkElement = {
 
 const linkPrefetchRoutes = [
   { canPrefetchLoadingShell: false, patternParts: ["viewport-prefetch-target"], isDynamic: false },
+  {
+    canPrefetchLoadingShell: false,
+    patternParts: ["search-params-shared-loading-state", "target-page"],
+    isDynamic: false,
+  },
+  {
+    canPrefetchLoadingShell: false,
+    patternParts: ["search-params-shared-loading-state", "target-page-server-search"],
+    isDynamic: false,
+  },
   { canPrefetchLoadingShell: false, patternParts: ["intent-prefetch-target"], isDynamic: false },
   { canPrefetchLoadingShell: false, patternParts: ["touch-prefetch-target"], isDynamic: false },
   {
@@ -1333,6 +1343,52 @@ describe("Link prefetch scheduling", () => {
           priority: "low",
         }),
       );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("prefetches a searched visible link when only the no-search RSC URL is cached", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/search-params-shared-loading-state/target-page?param=test",
+      nodeEnv: "production",
+    });
+
+    try {
+      const { getPrefetchCache, getPrefetchedUrls } =
+        await import("../packages/vinext/src/shims/navigation.js");
+      const cachedRscUrl = "/search-params-shared-loading-state/target-page?_rsc=test";
+      getPrefetchCache().set(cachedRscUrl, {
+        outcome: "cache-seeded",
+        snapshot: {
+          buffer: new TextEncoder().encode("static-flight").buffer,
+          contentType: "text/x-component",
+          mountedSlotsHeader: null,
+          paramsHeader: null,
+          url: cachedRscUrl,
+        },
+        timestamp: Date.now(),
+      });
+      getPrefetchedUrls().add(cachedRscUrl);
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/search-params-shared-loading-state/target-page",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInput = result.fetch.mock.calls[0]?.[0];
+      expect(typeof fetchInput).toBe("string");
+      if (typeof fetchInput !== "string") return;
+      const fetchUrl = new URL(fetchInput, "https://example.com");
+      expect(fetchUrl.searchParams.get("param")).toBe("test");
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -317,6 +317,186 @@ describe("prefetch cache eviction", () => {
     expect(prefetched.has(originalRscUrl)).toBe(false);
   });
 
+  it("reuses an empty-search prefetch for a searched navigation to the same pathname", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const prefetchedRscUrl = "/search-params-shared-loading-state/target-page?_rsc=prefetched";
+    const targetRscUrl =
+      "/search-params-shared-loading-state/target-page?param=test&_rsc=navigation";
+    const snapshot = {
+      buffer: new TextEncoder().encode("static-flight").buffer,
+      cacheControl: "s-maxage=31536000",
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: prefetchedRscUrl,
+    };
+
+    cache.set(prefetchedRscUrl, { outcome: "cache-seeded", snapshot, timestamp: Date.now() });
+    prefetched.add(prefetchedRscUrl);
+
+    expect(hasPrefetchCacheEntryForNavigation(targetRscUrl, null, null)).toBe(false);
+    expect(
+      hasPrefetchCacheEntryForNavigation(targetRscUrl, null, null, {
+        allowEmptySearchFallback: true,
+      }),
+    ).toBe(true);
+    expect(consumePrefetchResponse(targetRscUrl, null, null)).toEqual({
+      ...snapshot,
+      url: targetRscUrl,
+    });
+    expect(cache.has(prefetchedRscUrl)).toBe(true);
+    expect(prefetched.has(prefetchedRscUrl)).toBe(true);
+  });
+
+  it("does not reuse a no-store empty-search prefetch for a searched navigation", () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const prefetchedRscUrl = "/search-params-shared-loading-state/target-page?_rsc=prefetched";
+    const targetRscUrl =
+      "/search-params-shared-loading-state/target-page?param=test&_rsc=navigation";
+    const snapshot = {
+      buffer: new TextEncoder().encode("static-flight").buffer,
+      cacheControl: "no-store, must-revalidate",
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: prefetchedRscUrl,
+    };
+
+    cache.set(prefetchedRscUrl, { outcome: "cache-seeded", snapshot, timestamp: Date.now() });
+    prefetched.add(prefetchedRscUrl);
+
+    expect(hasPrefetchCacheEntryForNavigation(targetRscUrl, null, null)).toBe(false);
+    expect(
+      hasPrefetchCacheEntryForNavigation(targetRscUrl, null, null, {
+        allowEmptySearchFallback: true,
+      }),
+    ).toBe(false);
+    expect(consumePrefetchResponse(targetRscUrl, null, null)).toBeNull();
+    expect(cache.has(prefetchedRscUrl)).toBe(true);
+    expect(prefetched.has(prefetchedRscUrl)).toBe(true);
+  });
+
+  it("awaits a pending searched prefetch instead of reusing a hydration-seeded snapshot with unknown cache metadata", async () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const prefetchedRscUrl =
+      "/search-params-shared-loading-state/target-page-server-search?_rsc=hydration";
+    const targetRscUrl =
+      "/search-params-shared-loading-state/target-page-server-search?param=test&_rsc=navigation";
+    const fallbackSnapshot = {
+      buffer: new TextEncoder().encode("stale-server-search:none").buffer,
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: prefetchedRscUrl,
+    };
+    const deferred = createDeferredResponse();
+
+    seedPrefetchResponseSnapshot(prefetchedRscUrl, fallbackSnapshot);
+    expect(
+      hasPrefetchCacheEntryForNavigation(targetRscUrl, null, null, {
+        allowEmptySearchFallback: true,
+      }),
+    ).toBe(false);
+
+    prefetchRscResponse(targetRscUrl, deferred.promise, null, null);
+
+    let settled = false;
+    const consumedPromise = consumePrefetchResponseForNavigation(targetRscUrl, null, null).then(
+      (snapshot) => {
+        settled = true;
+        return snapshot;
+      },
+    );
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    deferred.resolve(
+      new Response("fresh-server-search:test", { headers: { "content-type": "text/x-component" } }),
+    );
+
+    const consumed = await consumedPromise;
+    expect(settled).toBe(true);
+    expect(consumed).not.toBeNull();
+    if (consumed === null) return;
+    await expect(restoreRscResponse(consumed).text()).resolves.toBe("fresh-server-search:test");
+    expect(cache.has(prefetchedRscUrl)).toBe(true);
+    expect(prefetched.has(prefetchedRscUrl)).toBe(true);
+  });
+
+  it("does not consume a pending empty-search fallback without explicit safe cache metadata", async () => {
+    const cache = getPrefetchCache();
+    const prefetchedRscUrl = "/search-params-shared-loading-state/target-page?_rsc=prefetched";
+    const targetRscUrl =
+      "/search-params-shared-loading-state/target-page?param=test&_rsc=navigation";
+    const deferred = createDeferredResponse();
+
+    prefetchRscResponse(prefetchedRscUrl, deferred.promise, null, null);
+
+    await expect(
+      consumePrefetchResponseForNavigation(targetRscUrl, null, null),
+    ).resolves.toBeNull();
+    expect(
+      hasPrefetchCacheEntryForNavigation(targetRscUrl, null, null, {
+        allowEmptySearchFallback: true,
+      }),
+    ).toBe(false);
+
+    deferred.resolve(
+      new Response("stale-server-search:none", {
+        headers: {
+          "cache-control": "no-store, must-revalidate",
+          "content-type": "text/x-component",
+        },
+      }),
+    );
+
+    await waitForPrefetchSetup(
+      () => getPrefetchCache().get(prefetchedRscUrl)?.outcome === "cache-seeded",
+    );
+    expect(cache.get(prefetchedRscUrl)?.outcome).toBe("cache-seeded");
+    expect(cache.has(prefetchedRscUrl)).toBe(true);
+  });
+
+  it("allows a completed full prefetch without cache-control to seed an empty-search fallback", async () => {
+    const cache = getPrefetchCache();
+    const prefetchedRscUrl = "/search-params-shared-loading-state/target-page?_rsc=prefetched";
+    const targetRscUrl =
+      "/search-params-shared-loading-state/target-page?param=test&_rsc=navigation";
+
+    prefetchRscResponse(
+      prefetchedRscUrl,
+      Promise.resolve(
+        new Response("static-flight", { headers: { "content-type": "text/x-component" } }),
+      ),
+      null,
+      null,
+      undefined,
+      {
+        allowEmptySearchFallbackWithoutCacheControl: true,
+        cacheForNavigation: true,
+      },
+    );
+
+    await waitForPrefetchSetup(
+      () => getPrefetchCache().get(prefetchedRscUrl)?.outcome === "cache-seeded",
+    );
+    expect(cache.get(prefetchedRscUrl)?.snapshot?.cacheControl).toBeNull();
+    expect(
+      hasPrefetchCacheEntryForNavigation(targetRscUrl, null, null, {
+        allowEmptySearchFallback: true,
+      }),
+    ).toBe(true);
+    const consumed = consumePrefetchResponse(targetRscUrl, null, null);
+    expect(consumed?.url).toBe(targetRscUrl);
+    await expect(restoreRscResponse(consumed!).text()).resolves.toBe("static-flight");
+  });
+
   it("keeps learning-only prefetch responses out of navigation consumption", () => {
     const cache = getPrefetchCache();
     const prefetched = getPrefetchedUrls();
@@ -463,6 +643,156 @@ describe("prefetch cache eviction", () => {
     await expect(restoreRscResponse(consumed).text()).resolves.toBe("flight");
     expect(getPrefetchCache().has(rscUrl)).toBe(false);
     expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
+  });
+
+  it("uses an empty-search fallback instead of awaiting a pending searched navigation prefetch", async () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const prefetchedRscUrl = "/search-params-shared-loading-state/target-page?_rsc=prefetched";
+    const targetRscUrl =
+      "/search-params-shared-loading-state/target-page?param=test&_rsc=navigation";
+    const fallbackSnapshot = {
+      buffer: new TextEncoder().encode("static-flight").buffer,
+      cacheControl: "s-maxage=31536000",
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: prefetchedRscUrl,
+    };
+    const deferred = createDeferredResponse();
+
+    cache.set(prefetchedRscUrl, {
+      outcome: "cache-seeded",
+      snapshot: fallbackSnapshot,
+      timestamp: Date.now(),
+    });
+    prefetched.add(prefetchedRscUrl);
+    prefetchRscResponse(targetRscUrl, deferred.promise, null, null);
+
+    let settled = false;
+    const consumedPromise = consumePrefetchResponseForNavigation(targetRscUrl, null, null).then(
+      (snapshot) => {
+        settled = true;
+        return snapshot;
+      },
+    );
+
+    await Promise.resolve();
+    const settledBeforeSearchedPrefetch = settled;
+    if (!settledBeforeSearchedPrefetch) {
+      deferred.resolve(
+        new Response("searched-flight", { headers: { "content-type": "text/x-component" } }),
+      );
+    }
+
+    const consumed = await consumedPromise;
+    expect(settledBeforeSearchedPrefetch).toBe(true);
+    expect(consumed).toEqual({
+      ...fallbackSnapshot,
+      url: targetRscUrl,
+    });
+    expect(cache.has(prefetchedRscUrl)).toBe(true);
+    expect(prefetched.has(prefetchedRscUrl)).toBe(true);
+
+    deferred.resolve(
+      new Response("searched-flight", { headers: { "content-type": "text/x-component" } }),
+    );
+  });
+
+  it("awaits a pending searched prefetch instead of reusing a no-store empty-search snapshot", async () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const prefetchedRscUrl = "/server-search/target-page?_rsc=prefetched";
+    const targetRscUrl = "/server-search/target-page?param=test&_rsc=navigation";
+    const fallbackSnapshot = {
+      buffer: new TextEncoder().encode("stale-server-search:none").buffer,
+      cacheControl: "no-store, must-revalidate",
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: prefetchedRscUrl,
+    };
+    const deferred = createDeferredResponse();
+
+    cache.set(prefetchedRscUrl, {
+      outcome: "cache-seeded",
+      snapshot: fallbackSnapshot,
+      timestamp: Date.now(),
+    });
+    prefetched.add(prefetchedRscUrl);
+    prefetchRscResponse(targetRscUrl, deferred.promise, null, null);
+
+    let settled = false;
+    const consumedPromise = consumePrefetchResponseForNavigation(targetRscUrl, null, null).then(
+      (snapshot) => {
+        settled = true;
+        return snapshot;
+      },
+    );
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    deferred.resolve(
+      new Response("fresh-server-search:test", { headers: { "content-type": "text/x-component" } }),
+    );
+
+    const consumed = await consumedPromise;
+    expect(settled).toBe(true);
+    expect(consumed).not.toBeNull();
+    if (consumed === null) return;
+    await expect(restoreRscResponse(consumed).text()).resolves.toBe("fresh-server-search:test");
+    expect(cache.has(prefetchedRscUrl)).toBe(true);
+    expect(prefetched.has(prefetchedRscUrl)).toBe(true);
+  });
+
+  it("awaits a pending searched prefetch instead of reusing an empty-search snapshot without cache metadata", async () => {
+    const cache = getPrefetchCache();
+    const prefetched = getPrefetchedUrls();
+    const prefetchedRscUrl = "/server-search/target-page?_rsc=prefetched";
+    const targetRscUrl = "/server-search/target-page?param=test&_rsc=navigation";
+    const fallbackSnapshot = {
+      buffer: new TextEncoder().encode("stale-server-search:none").buffer,
+      cacheControl: null,
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: prefetchedRscUrl,
+    };
+    const deferred = createDeferredResponse();
+
+    cache.set(prefetchedRscUrl, {
+      outcome: "cache-seeded",
+      snapshot: fallbackSnapshot,
+      timestamp: Date.now(),
+    });
+    prefetched.add(prefetchedRscUrl);
+    prefetchRscResponse(targetRscUrl, deferred.promise, null, null);
+
+    let settled = false;
+    const consumedPromise = consumePrefetchResponseForNavigation(targetRscUrl, null, null).then(
+      (snapshot) => {
+        settled = true;
+        return snapshot;
+      },
+    );
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    deferred.resolve(
+      new Response("fresh-server-search:test", { headers: { "content-type": "text/x-component" } }),
+    );
+
+    const consumed = await consumedPromise;
+    expect(settled).toBe(true);
+    expect(consumed).not.toBeNull();
+    if (consumed === null) return;
+    await expect(restoreRscResponse(consumed).text()).resolves.toBe("fresh-server-search:test");
+    expect(cache.has(prefetchedRscUrl)).toBe(true);
+    expect(prefetched.has(prefetchedRscUrl)).toBe(true);
   });
 
   it("honors an explicit fallback stale window above the minimum for prefetched responses", async () => {


### PR DESCRIPTION
## Summary
- reuse safe empty-search prefetches as the optimistic fallback for searched App Router navigations
- prevent no-store, hydration-seeded, or missing cache metadata snapshots from leaking stale server-search payloads
- add focused cache/navigation coverage and an e2e port for the shared loading-state scenario

## Validation
- vp test run tests/prefetch-cache.test.ts tests/link-navigation.test.ts
- PLAYWRIGHT_PROJECT=app-router-prefetch-searchparams pnpm run test:e2e -- tests/e2e/app-router-prefetch-searchparams/search-params-shared-loading-state.spec.ts --workers=1 --retries=0
- REPO="/Users/jamesanderson/.codex/worktrees/search-params-shared-loading-state-28478866791/vinext" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts