### PR TITLE
fix(app-router): support route tree prefetch inlining

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -706,6 +706,7 @@ export default createAppRscHandler({
   basePath: __basePath,
   buildId: process.env.__VINEXT_BUILD_ID ?? null,
   ensureRouteLoaded: __ensureRouteLoaded,
+  renderToReadableStream,
   clearRequestContext() {
     __clearRequestContext();
   },

--- a/packages/vinext/src/server/app-route-tree-prefetch.ts
+++ b/packages/vinext/src/server/app-route-tree-prefetch.ts
@@ -1,0 +1,374 @@
+import {
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXTJS_DEPLOYMENT_ID_HEADER,
+  RSC_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+} from "./headers.js";
+import {
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_VARY_HEADER,
+  applyRscCompatibilityIdHeader,
+} from "./app-rsc-cache-busting.js";
+import { createElement, type ComponentType } from "react";
+import { getDeploymentId } from "../utils/deployment-id.js";
+
+const HAS_RUNTIME_PREFETCH = 0b00001;
+const PARENT_INLINED_INTO_SELF = 0b100000;
+const INLINED_INTO_CHILD = 0b1000000;
+const HEAD_INLINED_INTO_SELF = 0b10000000;
+const PREFETCH_DISABLED = 0b10000000000;
+const STATIC_PREFETCH_DISABLED = HAS_RUNTIME_PREFETCH | PREFETCH_DISABLED;
+
+const PAGE_SEGMENT = "__PAGE__";
+const SLOT_SEGMENT = "(__SLOT__)";
+const SEGMENT_INLINE_SIZE = 1;
+const SEGMENT_OUTLINE_SIZE = 4096;
+const SEGMENT_INLINE_THRESHOLD = 2048;
+const HEAD_INLINE_SIZE = 1;
+const MAX_INLINE_BUNDLE_SIZE = 10240;
+const NEXT_DID_POSTPONE_HEADER = "x-nextjs-postponed";
+
+type AppRouteTreePrefetchParams = Record<string, string | string[]>;
+
+export type RouteTreePrefetchRenderer = (
+  model: unknown,
+  options?: unknown,
+) => Promise<ReadableStream<Uint8Array>>;
+
+type DynamicParamTypeShort = "d" | "c" | "oc";
+
+type TreePrefetchParam = {
+  type: DynamicParamTypeShort;
+  key: null;
+  siblings: readonly string[] | null;
+};
+
+type AppRouteTreePrefetchSlot = {
+  layout?: unknown;
+  layoutIndex?: number;
+  name: string;
+  page?: unknown;
+  routeSegments?: readonly string[] | null;
+};
+
+export type AppRouteTreePrefetchRoute = {
+  layoutTreePositions?: readonly number[];
+  layouts?: readonly unknown[];
+  page?: unknown;
+  routeSegments: readonly string[];
+  slots?: Readonly<Record<string, AppRouteTreePrefetchSlot>> | null;
+};
+
+export type TreePrefetch = {
+  name: string;
+  param: TreePrefetchParam | null;
+  prefetchHints: number;
+  slots: null | Record<string, TreePrefetch>;
+};
+
+type RouteTreePrefetchResponseOptions = {
+  buildId?: string | null;
+  deploymentId?: string;
+};
+
+type MutableTreePrefetch = TreePrefetch & {
+  prefetchSize: number | null;
+  slots: null | Record<string, MutableTreePrefetch>;
+};
+
+export function isRouteTreePrefetchRequest(request: Request): boolean {
+  return (
+    request.headers.get(RSC_HEADER) === "1" &&
+    request.headers.get(NEXT_ROUTER_PREFETCH_HEADER) === "1" &&
+    request.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER) === "/_tree"
+  );
+}
+
+async function createNode(
+  segment: string,
+  module: unknown,
+  params: AppRouteTreePrefetchParams,
+  renderToReadableStream: RouteTreePrefetchRenderer,
+): Promise<MutableTreePrefetch> {
+  const { name, param } = routeTreeSegment(segment);
+  const measuredSize = await estimatePrefetchSize(module, params, renderToReadableStream);
+  const virtualSegmentSize =
+    (module === null || module === undefined) && segment !== PAGE_SEGMENT
+      ? SEGMENT_INLINE_SIZE
+      : null;
+  return {
+    name,
+    param,
+    prefetchSize: measuredSize ?? virtualSegmentSize,
+    prefetchHints: 0,
+    slots: null,
+  };
+}
+
+function ensureSlots(node: MutableTreePrefetch): Record<string, MutableTreePrefetch> {
+  if (node.slots === null) {
+    node.slots = {};
+  }
+  return node.slots;
+}
+
+function addChild(node: MutableTreePrefetch, key: string, child: MutableTreePrefetch): void {
+  ensureSlots(node)[key] = child;
+}
+
+function routeTreeSegment(segment: string): { name: string; param: TreePrefetchParam | null } {
+  if (segment.startsWith(":")) {
+    const rest = segment.slice(1);
+    if (rest.endsWith("+")) {
+      return dynamicRouteTreeSegment(rest.slice(0, -1), "c");
+    }
+    if (rest.endsWith("*")) {
+      return dynamicRouteTreeSegment(rest.slice(0, -1), "oc");
+    }
+    return dynamicRouteTreeSegment(rest, "d");
+  }
+  if (segment.startsWith("[[...") && segment.endsWith("]]")) {
+    return dynamicRouteTreeSegment(segment.slice(5, -2), "oc");
+  }
+  if (segment.startsWith("[...") && segment.endsWith("]")) {
+    return dynamicRouteTreeSegment(segment.slice(4, -1), "c");
+  }
+  if (segment.startsWith("[") && segment.endsWith("]")) {
+    return dynamicRouteTreeSegment(segment.slice(1, -1), "d");
+  }
+  return { name: segment, param: null };
+}
+
+function dynamicRouteTreeSegment(
+  name: string,
+  type: DynamicParamTypeShort,
+): { name: string; param: TreePrefetchParam } {
+  return {
+    name,
+    param: {
+      key: null,
+      siblings: null,
+      type,
+    },
+  };
+}
+
+function explicitPrefetchSize(module: unknown): number | null {
+  if (typeof module !== "object" || module === null) return null;
+  const value = (module as { prefetchSize?: unknown }).prefetchSize;
+  if (value === "large") return SEGMENT_OUTLINE_SIZE;
+  if (value === "small") return SEGMENT_INLINE_SIZE;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+async function gzipStreamByteLength(stream: ReadableStream<Uint8Array>): Promise<number> {
+  const ready = (stream as ReadableStream<Uint8Array> & { allReady?: Promise<void> }).allReady;
+  if (ready) {
+    await ready;
+  }
+
+  const gzip = new CompressionStream("gzip") as unknown as ReadableWritablePair<
+    Uint8Array,
+    Uint8Array
+  >;
+  const compressed = stream.pipeThrough(gzip);
+  return (await new Response(compressed).arrayBuffer()).byteLength;
+}
+
+async function estimatePrefetchSize(
+  module: unknown,
+  params: AppRouteTreePrefetchParams,
+  renderToReadableStream: RouteTreePrefetchRenderer,
+): Promise<number | null> {
+  const explicitSize = explicitPrefetchSize(module);
+  if (explicitSize !== null) return explicitSize;
+
+  if (typeof module !== "object" || module === null) return null;
+  const Component = (module as { default?: unknown }).default;
+  if (typeof Component !== "function") return null;
+
+  try {
+    const props = {
+      children: null,
+      params: Promise.resolve(params),
+      searchParams: Promise.resolve({}),
+    };
+    return await gzipStreamByteLength(
+      await renderToReadableStream(createElement(Component as ComponentType<typeof props>, props)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function layoutModuleByTreePosition(route: AppRouteTreePrefetchRoute): Map<number, unknown> {
+  const layouts = route.layouts ?? [];
+  const positions = route.layoutTreePositions ?? [];
+  const byPosition = new Map<number, unknown>();
+  for (const [index, position] of positions.entries()) {
+    byPosition.set(position, layouts[index]);
+  }
+  return byPosition;
+}
+
+async function buildTree(
+  route: AppRouteTreePrefetchRoute,
+  params: AppRouteTreePrefetchParams,
+  renderToReadableStream: RouteTreePrefetchRenderer,
+): Promise<MutableTreePrefetch> {
+  const layoutsByPosition = layoutModuleByTreePosition(route);
+  const root = await createNode("", layoutsByPosition.get(0), params, renderToReadableStream);
+  const nodesByPosition = new Map<number, MutableTreePrefetch>([[0, root]]);
+  let current = root;
+
+  for (const [index, segment] of route.routeSegments.entries()) {
+    const position = index + 1;
+    const child = await createNode(
+      segment,
+      layoutsByPosition.get(position),
+      params,
+      renderToReadableStream,
+    );
+    addChild(current, "children", child);
+    nodesByPosition.set(position, child);
+    current = child;
+  }
+
+  addChild(
+    current,
+    "children",
+    await createNode(PAGE_SEGMENT, route.page, params, renderToReadableStream),
+  );
+
+  for (const slot of Object.values(route.slots ?? {})) {
+    const ownerPosition =
+      slot.layoutIndex === undefined || slot.layoutIndex < 0
+        ? route.routeSegments.length
+        : (route.layoutTreePositions?.[slot.layoutIndex] ?? route.routeSegments.length);
+    const owner = nodesByPosition.get(ownerPosition) ?? current;
+    const slotRoot = await createNode(SLOT_SEGMENT, slot.layout, params, renderToReadableStream);
+    let slotCurrent = slotRoot;
+    for (const segment of slot.routeSegments ?? []) {
+      const child = await createNode(segment, null, params, renderToReadableStream);
+      addChild(slotCurrent, "children", child);
+      slotCurrent = child;
+    }
+    addChild(
+      slotCurrent,
+      "children",
+      await createNode(PAGE_SEGMENT, slot.page, params, renderToReadableStream),
+    );
+    addChild(owner, slot.name, slotRoot);
+  }
+
+  return root;
+}
+
+function computePrefetchHints(
+  node: MutableTreePrefetch,
+  parentGzipSize: number | null,
+  headInlineState: { inlined: boolean },
+): number {
+  const staticPrefetchDisabled = (node.prefetchHints & STATIC_PREFETCH_DISABLED) !== 0;
+  const currentGzipSize = staticPrefetchDisabled ? null : node.prefetchSize;
+  const sizeToInline =
+    currentGzipSize !== null && currentGzipSize < SEGMENT_INLINE_THRESHOLD ? currentGzipSize : null;
+
+  let didInlineIntoChild = false;
+  let acceptingChildInlinedBytes = 0;
+  let smallestChildInlinedBytes = Number.POSITIVE_INFINITY;
+  let hasChildren = false;
+
+  for (const child of Object.values(node.slots ?? {})) {
+    hasChildren = true;
+    const childParentSize = didInlineIntoChild
+      ? null
+      : staticPrefetchDisabled
+        ? parentGzipSize
+        : sizeToInline;
+    const childInlinedBytes = computePrefetchHints(child, childParentSize, headInlineState);
+
+    if ((child.prefetchHints & PARENT_INLINED_INTO_SELF) !== 0) {
+      didInlineIntoChild = true;
+      acceptingChildInlinedBytes = childInlinedBytes;
+    } else if (!didInlineIntoChild && childInlinedBytes < smallestChildInlinedBytes) {
+      smallestChildInlinedBytes = childInlinedBytes;
+    }
+  }
+
+  if (!hasChildren) {
+    smallestChildInlinedBytes = 0;
+  }
+
+  let hints = node.prefetchHints;
+  if (didInlineIntoChild) {
+    hints |= INLINED_INTO_CHILD;
+  }
+
+  let inlinedBytes = didInlineIntoChild ? acceptingChildInlinedBytes : smallestChildInlinedBytes;
+  const isBundleTerminal = !didInlineIntoChild && !staticPrefetchDisabled;
+  if (
+    !headInlineState.inlined &&
+    isBundleTerminal &&
+    node.name === PAGE_SEGMENT &&
+    inlinedBytes + HEAD_INLINE_SIZE < MAX_INLINE_BUNDLE_SIZE
+  ) {
+    hints |= HEAD_INLINED_INTO_SELF;
+    inlinedBytes += HEAD_INLINE_SIZE;
+    headInlineState.inlined = true;
+  }
+
+  if (parentGzipSize !== null) {
+    const canAcceptParent = !staticPrefetchDisabled || didInlineIntoChild;
+    if (canAcceptParent && inlinedBytes + parentGzipSize < MAX_INLINE_BUNDLE_SIZE) {
+      hints |= PARENT_INLINED_INTO_SELF;
+      inlinedBytes += parentGzipSize;
+    }
+  }
+
+  node.prefetchHints = hints;
+  return inlinedBytes;
+}
+
+function stripMutableFields(node: MutableTreePrefetch): TreePrefetch {
+  const slots =
+    node.slots === null
+      ? null
+      : Object.fromEntries(
+          Object.entries(node.slots).map(([key, child]) => [key, stripMutableFields(child)]),
+        );
+  return {
+    name: node.name,
+    param: node.param,
+    prefetchHints: node.prefetchHints,
+    slots,
+  };
+}
+
+export async function createRouteTreePrefetchResponse(
+  route: AppRouteTreePrefetchRoute,
+  renderToReadableStream: RouteTreePrefetchRenderer,
+  params: AppRouteTreePrefetchParams = {},
+  options: RouteTreePrefetchResponseOptions = {},
+): Promise<Response> {
+  const tree = await buildTree(route, params, renderToReadableStream);
+  computePrefetchHints(tree, null, { inlined: false });
+  const headers = new Headers({
+    "Cache-Control": "no-store",
+    "Content-Type": VINEXT_RSC_CONTENT_TYPE,
+    [NEXT_DID_POSTPONE_HEADER]: "2",
+    Vary: VINEXT_RSC_VARY_HEADER,
+  });
+  applyRscCompatibilityIdHeader(headers);
+  const deploymentId = options.deploymentId ?? getDeploymentId();
+  if (deploymentId) headers.set(NEXTJS_DEPLOYMENT_ID_HEADER, deploymentId);
+
+  const payload: {
+    buildId?: string;
+    staleTime: number;
+    tree: TreePrefetch;
+  } = { tree: stripMutableFields(tree), staleTime: -1 };
+  if (options.buildId) payload.buildId = options.buildId;
+
+  return new Response(`0:${JSON.stringify(payload)}\n`, { headers });
+}

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -88,6 +88,12 @@ import {
   createServerActionNotFoundResponse,
   getServerActionNotFoundMessage,
 } from "./server-action-not-found.js";
+import {
+  createRouteTreePrefetchResponse,
+  isRouteTreePrefetchRequest,
+  type AppRouteTreePrefetchRoute,
+  type RouteTreePrefetchRenderer,
+} from "./app-route-tree-prefetch.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
@@ -109,12 +115,15 @@ type AppRscHandlerRoute = {
   __loadPage?: unknown;
   __loadRouteHandler?: unknown;
   isDynamic: boolean;
+  layouts?: readonly unknown[];
+  layoutTreePositions?: readonly number[];
   params?: readonly string[];
   page?: unknown;
   pattern: string;
   rootParamNames?: readonly string[];
   routeHandler?: unknown;
   routeSegments: readonly string[];
+  slots?: AppRouteTreePrefetchRoute["slots"];
 };
 
 type AppRscRouteMatch<TRoute> = {
@@ -314,6 +323,7 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   publicFiles: ReadonlySet<string>;
   renderNotFound: (options: RenderNotFoundOptions<TRoute>) => Promise<Response | null>;
   renderPagesFallback?: (options: RenderPagesFallbackOptions) => Promise<Response | null>;
+  renderToReadableStream: RouteTreePrefetchRenderer;
   rootParamNamesByPattern?: RootParamNamesMap;
   setNavigationContext: (context: NavigationContextValue) => void;
   staticParamsMap: StaticParamsMap;
@@ -1047,6 +1057,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   // Hydrate lazy page/route-handler modules before the page-vs-handler dispatch
   // branch and any downstream synchronous module reads.
   if (options.ensureRouteLoaded) await options.ensureRouteLoaded(route);
+  if (isRouteTreePrefetchRequest(request) && route.page) {
+    return createRouteTreePrefetchResponse(route, options.renderToReadableStream, params, {
+      buildId: options.buildId,
+    });
+  }
   const prerenderRouteParamsPayload = readTrustedPrerenderRouteParams(request);
   const prerenderRouteParamsMatch = matchPrerenderRouteParamsPayload(
     prerenderRouteParamsPayload,

--- a/tests/app-route-tree-prefetch.test.ts
+++ b/tests/app-route-tree-prefetch.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vite-plus/test";
+import { renderToReadableStream } from "react-dom/server.edge";
+import {
+  createRouteTreePrefetchResponse,
+  isRouteTreePrefetchRequest,
+  type AppRouteTreePrefetchRoute,
+  type RouteTreePrefetchRenderer,
+  type TreePrefetch,
+} from "../packages/vinext/src/server/app-route-tree-prefetch.js";
+
+const ParentInlinedIntoSelf = 0b100000;
+const InlinedIntoChild = 0b1000000;
+const HeadInlinedIntoSelf = 0b10000000;
+
+type RootTreePrefetch = {
+  buildId?: string;
+  staleTime: number;
+  tree: TreePrefetch;
+};
+
+const smallModule = { default() {} };
+const largeModule = {
+  prefetchSize: "large",
+};
+const renderedLargeModule = {
+  default() {
+    return "x".repeat(3000);
+  },
+};
+const sourceTrapModule = {
+  default() {
+    return "NoInline";
+  },
+};
+
+async function readTree(response: Response): Promise<RootTreePrefetch> {
+  const text = await response.text();
+  return JSON.parse(text.slice(text.indexOf(":") + 1));
+}
+
+function routeTreeResponse(
+  route: AppRouteTreePrefetchRoute,
+  params: Record<string, string | string[]> = {},
+  options: Parameters<typeof createRouteTreePrefetchResponse>[3] = {},
+): Promise<Response> {
+  return createRouteTreePrefetchResponse(
+    route,
+    renderToReadableStream as unknown as RouteTreePrefetchRenderer,
+    params,
+    options,
+  );
+}
+
+function renderInliningTree(tree: TreePrefetch): string {
+  const lines: string[] = [];
+  collectNodes(tree, "", true, false, lines);
+  return lines.join("\n");
+}
+
+function collectNodes(
+  node: TreePrefetch,
+  prefix: string,
+  isLast: boolean,
+  hasParent: boolean,
+  lines: string[],
+  slotKey?: string,
+): void {
+  const inlinedIntoChild = (node.prefetchHints & InlinedIntoChild) !== 0;
+  const headInlined = (node.prefetchHints & HeadInlinedIntoSelf) !== 0;
+  const slotPrefix = slotKey !== undefined && slotKey !== "children" ? `@${slotKey}/` : "";
+  const name = hasParent
+    ? `${slotPrefix}"${node.name}"${headInlined ? " (+metadata)" : ""}`
+    : "root";
+  const tag = inlinedIntoChild ? "inlined" : "outlined";
+  const connector = hasParent ? (isLast ? "`-- " : "|-- ") : "";
+  lines.push(`${tag} ${prefix}${connector}${name}`);
+
+  if (node.slots) {
+    const childPrefix = prefix + (hasParent ? (isLast ? "    " : "|   ") : "");
+    const keys = Object.keys(node.slots);
+    for (let i = 0; i < keys.length; i++) {
+      collectNodes(
+        node.slots[keys[i]],
+        childPrefix,
+        i === keys.length - 1,
+        true,
+        lines,
+        keys.length > 1 ? keys[i] : undefined,
+      );
+    }
+  }
+}
+
+describe("App Router route tree prefetch", () => {
+  it("detects segment-cache route tree prefetch requests", () => {
+    expect(
+      isRouteTreePrefetchRequest(
+        new Request("https://example.test/dashboard", {
+          headers: {
+            RSC: "1",
+            "Next-Router-Prefetch": "1",
+            "Next-Router-Segment-Prefetch": "/_tree",
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(isRouteTreePrefetchRequest(new Request("https://example.test/dashboard"))).toBe(false);
+  });
+
+  // Mirrors the route-tree hint assertions in Next.js:
+  // test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+  it("emits deterministic inlining hints for static route trees", async () => {
+    const data = await readTree(
+      await routeTreeResponse({
+        layoutTreePositions: [0, 1],
+        layouts: [smallModule, smallModule],
+        page: smallModule,
+        routeSegments: ["test-small-chain"],
+      }),
+    );
+
+    expect(renderInliningTree(data.tree)).toBe(
+      [
+        "inlined root",
+        'inlined `-- "test-small-chain"',
+        'outlined     `-- "__PAGE__" (+metadata)',
+      ].join("\n"),
+    );
+  });
+
+  it("breaks the inlining chain around large segments", async () => {
+    const data = await readTree(
+      await routeTreeResponse({
+        layoutTreePositions: [0, 1, 2, 3],
+        layouts: [smallModule, smallModule, largeModule, smallModule],
+        page: smallModule,
+        routeSegments: ["test-restart", "large-middle", "after"],
+      }),
+    );
+
+    expect(renderInliningTree(data.tree)).toBe(
+      [
+        "inlined root",
+        'inlined `-- "test-restart"',
+        'outlined     `-- "large-middle"',
+        'inlined         `-- "after"',
+        'outlined             `-- "__PAGE__" (+metadata)',
+      ].join("\n"),
+    );
+  });
+
+  it("uses rendered segment size rather than source-string names for inlining hints", async () => {
+    const renderedLarge = await readTree(
+      await routeTreeResponse({
+        layoutTreePositions: [0, 1],
+        layouts: [smallModule, renderedLargeModule],
+        page: smallModule,
+        routeSegments: ["test-rendered-large"],
+      }),
+    );
+    expect(renderInliningTree(renderedLarge.tree)).toBe(
+      [
+        "inlined root",
+        'inlined `-- "test-rendered-large"',
+        'outlined     `-- "__PAGE__" (+metadata)',
+      ].join("\n"),
+    );
+
+    const sourceTrap = await readTree(
+      await routeTreeResponse({
+        layoutTreePositions: [0, 1],
+        layouts: [smallModule, sourceTrapModule],
+        page: smallModule,
+        routeSegments: ["test-source-trap"],
+      }),
+    );
+    expect(renderInliningTree(sourceTrap.tree)).toBe(
+      [
+        "inlined root",
+        'inlined `-- "test-source-trap"',
+        'outlined     `-- "__PAGE__" (+metadata)',
+      ].join("\n"),
+    );
+  });
+
+  it("orders the page segment before parallel slots", async () => {
+    const data = await readTree(
+      await routeTreeResponse({
+        layoutTreePositions: [0, 1],
+        layouts: [smallModule, smallModule],
+        page: smallModule,
+        routeSegments: ["test-parallel"],
+        slots: {
+          sidebar: {
+            name: "sidebar",
+            page: smallModule,
+            routeSegments: [],
+          },
+        },
+      }),
+    );
+
+    expect(renderInliningTree(data.tree)).toBe(
+      [
+        "inlined root",
+        'inlined `-- "test-parallel"',
+        'outlined     |-- "__PAGE__" (+metadata)',
+        'inlined     `-- @sidebar/"(__SLOT__)"',
+        'outlined         `-- "__PAGE__"',
+      ].join("\n"),
+    );
+  });
+
+  it("serializes dynamic segment params for client-side segment cache keys", async () => {
+    const response = await routeTreeResponse(
+      {
+        layoutTreePositions: [0, 1],
+        layouts: [smallModule, largeModule],
+        page: smallModule,
+        routeSegments: ["test-dynamic", ":slug"],
+      },
+      { slug: "hello" },
+    );
+    const data = await readTree(response);
+
+    const dynamicSegment = data.tree.slots?.children?.slots?.children;
+    expect(dynamicSegment?.name).toBe("slug");
+    expect(dynamicSegment?.param).toEqual({ key: null, siblings: null, type: "d" });
+    expect((dynamicSegment?.prefetchHints ?? 0) & ParentInlinedIntoSelf).toBe(0);
+    expect(response.headers.get("x-nextjs-postponed")).toBe("2");
+  });
+
+  it("includes route-tree identity accepted by the segment-cache client", async () => {
+    const response = await routeTreeResponse(
+      {
+        layoutTreePositions: [0],
+        layouts: [smallModule],
+        page: smallModule,
+        routeSegments: [],
+      },
+      {},
+      { buildId: "build-route-tree", deploymentId: "deployment-route-tree" },
+    );
+    const data = await readTree(response);
+
+    expect(data.buildId).toBe("build-route-tree");
+    expect(data.staleTime).toBe(-1);
+    expect(response.headers.get("x-nextjs-deployment-id")).toBe("deployment-route-tree");
+    expect(response.headers.get("x-nextjs-deployment-id") ?? data.buildId).toBe(
+      "deployment-route-tree",
+    );
+  });
+});

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -127,6 +127,8 @@ function createHandler(overrides: Partial<TestHandlerOptions> = {}) {
         : undefined),
     publicFiles: overrides.publicFiles ?? new Set<string>(),
     registerCacheAdapters: () => {},
+    renderToReadableStream:
+      overrides.renderToReadableStream ?? (async () => new ReadableStream<Uint8Array>()),
     renderNotFound: overrides.renderNotFound ?? (async () => null),
     renderPagesFallback: overrides.renderPagesFallback,
     rootParamNamesByPattern: overrides.rootParamNamesByPattern,

--- a/tests/e2e/app-router/nextjs-compat/prefetch-inlining.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/prefetch-inlining.browser.spec.ts
@@ -1,0 +1,335 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { test as base, expect } from "../../fixtures";
+
+const HasRuntimePrefetch = 0b00001;
+const ParentInlinedIntoSelf = 0b100000;
+const InlinedIntoChild = 0b1000000;
+const HeadInlinedIntoSelf = 0b10000000;
+const HeadOutlined = 0b100000000;
+const PrefetchDisabled = 0b10000000000;
+
+type TreePrefetch = {
+  name: string;
+  param: null | {
+    type: string;
+    key: string | null;
+    siblings: readonly string[] | null;
+  };
+  prefetchHints: number;
+  slots: null | { [key: string]: TreePrefetch };
+};
+
+type RootTreePrefetch = {
+  buildId?: string;
+  staleTime: number;
+  tree: TreePrefetch;
+};
+
+type ProductionApp = {
+  baseUrl: string;
+  buildId: string;
+  fixtureRoot: string;
+  server: Server;
+};
+
+async function closeServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await closed;
+}
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+
+  await fs.mkdir(targetNodeModules, { recursive: true });
+  for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+async function preparePrefetchInliningFixture(): Promise<string> {
+  const sourceRoot = path.resolve(process.cwd(), "tests/fixtures/app-prefetch-inlining");
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-prefetch-inlining-"));
+  await fs.cp(sourceRoot, fixtureRoot, {
+    recursive: true,
+    filter: (source) => !source.includes(`${path.sep}.next`) && !source.includes(`${path.sep}dist`),
+  });
+  await linkFixtureNodeModules(fixtureRoot);
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});
+`,
+  );
+
+  return fixtureRoot;
+}
+
+async function buildAndServePrefetchInliningFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await preparePrefetchInliningFixture();
+  const outDir = path.join(fixtureRoot, "dist");
+  await fs.rm(outDir, { recursive: true, force: true });
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+  const buildId = (await fs.readFile(path.join(outDir, "server", "BUILD_ID"), "utf8")).trim();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const { startProdServer } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/server/prod-server.js")).href
+  );
+  const started = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir,
+    noCompression: true,
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${started.port}`,
+    buildId,
+    fixtureRoot,
+    server: started.server,
+  };
+}
+
+/* oxlint-disable eslint-plugin-react-hooks/rules-of-hooks -- Playwright fixture `use`, not a React hook */
+const test = base.extend<{ prefetchInliningApp: ProductionApp }>({
+  prefetchInliningApp: async ({ page }, use) => {
+    const app = await buildAndServePrefetchInliningFixture();
+
+    try {
+      await use(app);
+    } finally {
+      await page.close();
+      await closeServer(app.server);
+      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+    }
+  },
+});
+/* oxlint-enable eslint-plugin-react-hooks/rules-of-hooks */
+
+test.setTimeout(90_000);
+
+async function fetchRouteTreePrefetch(
+  baseUrl: string,
+  pathname: string,
+  expectedBuildId?: string,
+): Promise<RootTreePrefetch> {
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    headers: {
+      RSC: "1",
+      "Next-Router-Prefetch": "1",
+      "Next-Router-Segment-Prefetch": "/_tree",
+    },
+  });
+  const text = await response.text();
+  expect(response.headers.get("x-nextjs-postponed")).toBe("2");
+  const jsonStart = text.indexOf(":");
+  if (jsonStart === -1) {
+    throw new Error(`Missing Flight row prefix in response: ${text.slice(0, 80)}`);
+  }
+  const data = JSON.parse(text.slice(jsonStart + 1));
+  if (expectedBuildId !== undefined) {
+    expect(data.buildId).toBe(expectedBuildId);
+    expect(response.headers.get("x-nextjs-deployment-id") ?? data.buildId).toBe(expectedBuildId);
+  }
+  return data;
+}
+
+function renderInliningTree(tree: TreePrefetch): string {
+  const lines: string[] = [];
+  const isHeadOutlined = (tree.prefetchHints & HeadOutlined) !== 0;
+  collectNodes(tree, "", !isHeadOutlined, false, lines);
+  if (isHeadOutlined) {
+    lines.push("outlined metadata");
+  }
+  return lines.join("\n");
+}
+
+function collectNodes(
+  node: TreePrefetch,
+  prefix: string,
+  isLast: boolean,
+  hasParent: boolean,
+  lines: string[],
+  slotKey?: string,
+): void {
+  const hasRuntimePrefetch = (node.prefetchHints & HasRuntimePrefetch) !== 0;
+  const prefetchDisabled = (node.prefetchHints & PrefetchDisabled) !== 0;
+  const inlinedIntoChild = (node.prefetchHints & InlinedIntoChild) !== 0;
+  const headInlined = (node.prefetchHints & HeadInlinedIntoSelf) !== 0;
+
+  const slotPrefix = slotKey !== undefined && slotKey !== "children" ? `@${slotKey}/` : "";
+  const headSuffix = headInlined ? " (+metadata)" : "";
+  const name = hasParent ? `${slotPrefix}"${node.name}"${headSuffix}` : "root";
+  const tag = hasRuntimePrefetch
+    ? "runtime"
+    : prefetchDisabled
+      ? "dynamic"
+      : inlinedIntoChild
+        ? "inlined"
+        : "outlined";
+  const connector = hasParent ? (isLast ? "`-- " : "|-- ") : "";
+  lines.push(`${tag} ${prefix}${connector}${name}`);
+
+  if (node.slots) {
+    const children = Object.values(node.slots);
+    const childrenWithParentInlined = children.filter(
+      (child) => (child.prefetchHints & ParentInlinedIntoSelf) !== 0,
+    );
+    if (inlinedIntoChild && childrenWithParentInlined.length === 0) {
+      throw new Error(`"${node.name}" has InlinedIntoChild but no inlined child`);
+    }
+    if (!inlinedIntoChild && childrenWithParentInlined.length > 0) {
+      throw new Error(`"${node.name}" has inlined child without InlinedIntoChild`);
+    }
+
+    const childPrefix = prefix + (hasParent ? (isLast ? "    " : "|   ") : "");
+    const keys = Object.keys(node.slots);
+    const hasMultipleSlots = keys.length > 1;
+    for (let i = 0; i < keys.length; i++) {
+      collectNodes(
+        node.slots[keys[i]],
+        childPrefix,
+        i === keys.length - 1,
+        true,
+        lines,
+        hasMultipleSlots ? keys[i] : undefined,
+      );
+    }
+  }
+}
+
+test.describe("App Router segment-cache prefetch inlining", () => {
+  // Ported from Next.js: test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+  test("emits route-tree inlining hints for static App Router prefetches", async ({
+    prefetchInliningApp,
+  }) => {
+    const cases = [
+      {
+        pathname: "/test-small-chain",
+        expected: [
+          "inlined root",
+          'inlined `-- "test-small-chain"',
+          'outlined     `-- "__PAGE__" (+metadata)',
+        ].join("\n"),
+      },
+      {
+        pathname: "/test-outlined",
+        expected: [
+          "inlined root",
+          'outlined `-- "test-outlined"',
+          'outlined     `-- "__PAGE__" (+metadata)',
+        ].join("\n"),
+      },
+      {
+        pathname: "/test-parallel",
+        expected: [
+          "inlined root",
+          'inlined `-- "test-parallel"',
+          'outlined     |-- "__PAGE__" (+metadata)',
+          'inlined     `-- @sidebar/"(__SLOT__)"',
+          'outlined         `-- "__PAGE__"',
+        ].join("\n"),
+      },
+      {
+        pathname: "/",
+        expected: ["inlined root", 'outlined `-- "__PAGE__" (+metadata)'].join("\n"),
+      },
+      {
+        pathname: "/test-restart/large-middle/after",
+        expected: [
+          "inlined root",
+          'inlined `-- "test-restart"',
+          'outlined     `-- "large-middle"',
+          'inlined         `-- "after"',
+          'outlined             `-- "__PAGE__" (+metadata)',
+        ].join("\n"),
+      },
+      {
+        pathname: "/test-deep/a/b/c",
+        expected: [
+          "inlined root",
+          'inlined `-- "test-deep"',
+          'inlined     `-- "a"',
+          'inlined         `-- "b"',
+          'inlined             `-- "c"',
+          'outlined                 `-- "__PAGE__" (+metadata)',
+        ].join("\n"),
+      },
+      {
+        pathname: "/test-compressible",
+        expected: [
+          "inlined root",
+          'inlined `-- "test-compressible"',
+          'outlined     `-- "__PAGE__" (+metadata)',
+        ].join("\n"),
+      },
+      {
+        pathname: "/test-dynamic/hello",
+        expected: [
+          "inlined root",
+          'inlined `-- "test-dynamic"',
+          'outlined     `-- "slug"',
+          'outlined         `-- "__PAGE__" (+metadata)',
+        ].join("\n"),
+      },
+    ];
+
+    for (const { pathname, expected } of cases) {
+      const data = await fetchRouteTreePrefetch(
+        prefetchInliningApp.baseUrl,
+        pathname,
+        prefetchInliningApp.buildId,
+      );
+      expect(renderInliningTree(data.tree)).toBe(expected);
+    }
+
+    const firstDynamic = await fetchRouteTreePrefetch(
+      prefetchInliningApp.baseUrl,
+      "/test-dynamic/hello",
+      prefetchInliningApp.buildId,
+    );
+    const secondDynamic = await fetchRouteTreePrefetch(
+      prefetchInliningApp.baseUrl,
+      "/test-dynamic/world",
+      prefetchInliningApp.buildId,
+    );
+    const firstDynamicSegment = firstDynamic.tree.slots?.children?.slots?.children;
+    expect(firstDynamicSegment?.name).toBe("slug");
+    expect(firstDynamicSegment?.param).toEqual({ key: null, siblings: null, type: "d" });
+    expect(renderInliningTree(secondDynamic.tree)).toBe(renderInliningTree(firstDynamic.tree));
+  });
+});

--- a/tests/fixtures/app-prefetch-inlining/app/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">Prefetch inlining home</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-compressible/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-compressible/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <div style={{ display: "none" }}>{"x".repeat(3000)}</div>
+      {children}
+    </div>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-compressible/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-compressible/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Compressible page</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-deep/a/b/c/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-deep/a/b/c/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-deep/a/b/c/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-deep/a/b/c/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page-deep">Deep page</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-deep/a/b/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-deep/a/b/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-deep/a/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-deep/a/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-deep/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-deep/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-dynamic/[slug]/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-dynamic/[slug]/layout.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { NoInline } from "../../../components/no-inline";
+
+export const prefetchSize = "large";
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return (
+    <div>
+      <NoInline />
+      <p>{`Dynamic layout for: ${slug}`}</p>
+      {children}
+    </div>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-dynamic/[slug]/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-dynamic/[slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <p id="page-dynamic">{`Dynamic page: ${slug}`}</p>;
+}
+
+export function generateStaticParams() {
+  return [{ slug: "hello" }, { slug: "world" }];
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-outlined/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-outlined/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { NoInline } from "../../components/no-inline";
+
+export const prefetchSize = "large";
+
+export default function LargeLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <NoInline />
+      {children}
+    </div>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-outlined/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-outlined/page.tsx
@@ -1,0 +1,3 @@
+export default function OutlinedPage() {
+  return <p id="page-outlined">Outlined test page</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-parallel/@sidebar/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-parallel/@sidebar/page.tsx
@@ -1,0 +1,3 @@
+export default function Sidebar() {
+  return <p>Sidebar content</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-parallel/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-parallel/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export default function ParallelLayout({
+  children,
+  sidebar,
+}: {
+  children: ReactNode;
+  sidebar: ReactNode;
+}) {
+  return (
+    <div>
+      <main>{children}</main>
+      <aside>{sidebar}</aside>
+    </div>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-parallel/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-parallel/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page-parallel">Main content</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-restart/large-middle/after/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-restart/large-middle/after/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function AfterLayout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-restart/large-middle/after/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-restart/large-middle/after/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page-restart">After page</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-restart/large-middle/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-restart/large-middle/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { NoInline } from "../../../components/no-inline";
+
+export const prefetchSize = "large";
+
+export default function LargeLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <NoInline />
+      {children}
+    </div>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-restart/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-restart/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function RestartLayout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-small-chain/layout.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-small-chain/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function SmallChainLayout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>;
+}

--- a/tests/fixtures/app-prefetch-inlining/app/test-small-chain/page.tsx
+++ b/tests/fixtures/app-prefetch-inlining/app/test-small-chain/page.tsx
@@ -1,0 +1,3 @@
+export default function SmallChainPage() {
+  return <p id="page-small-chain">Small chain page</p>;
+}

--- a/tests/fixtures/app-prefetch-inlining/components/no-inline.tsx
+++ b/tests/fixtures/app-prefetch-inlining/components/no-inline.tsx
@@ -1,0 +1,9 @@
+export function NoInline() {
+  return (
+    <div style={{ display: "none" }}>
+      {Array.from({ length: 256 }, (_, index) => (
+        <span key={index}>Hidden content to keep this segment outlined. </span>
+      ))}
+    </div>
+  );
+}

--- a/tests/fixtures/app-prefetch-inlining/vite.config.ts
+++ b/tests/fixtures/app-prefetch-inlining/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});


### PR DESCRIPTION
## Summary
- add App Router route-tree prefetch handling so inlined segment-cache prefetch payloads include the expected deployment/build metadata
- size route-tree inlining against gzip-compressed bytes
- add focused route-tree unit coverage plus a local compat fixture/spec for prefetch inlining

## Validation
- `vp test run tests/app-route-tree-prefetch.test.ts`
- targeted upstream `test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts` passed 7/7 before PR
- independent review: NO FINDINGS