### PR TITLE
fix(app-router): preserve dynamic segment-cache navigation

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -13,6 +13,7 @@ export type VinextLinkPrefetchRoute = {
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];
+  requiresDynamicNavigationRequest?: boolean;
 };
 
 /**
@@ -30,6 +31,7 @@ export type VinextPagesLinkPrefetchRoute = {
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];
+  requiresDynamicNavigationRequest?: boolean;
 };
 
 export type VinextNextData = {

--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -36,7 +36,7 @@ type TsconfigPathResolution = {
   pathAliases: TsconfigPathAlias[];
 };
 
-export type TsconfigPathAlias = {
+type TsconfigPathAlias = {
   find: string;
   kind: "exact" | "prefix";
   replacement: string;

--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -33,6 +33,18 @@ const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
 type TsconfigPathResolution = {
   aliases: Record<string, string>;
   baseUrl: string | null;
+  pathAliases: TsconfigPathAlias[];
+};
+
+export type TsconfigPathAlias = {
+  find: string;
+  kind: "exact" | "prefix";
+  replacement: string;
+};
+
+type MaterializedAliases = {
+  aliases: Record<string, string>;
+  pathAliases: TsconfigPathAlias[];
 };
 
 function resolveTsconfigPathCandidate(candidate: string): string | null {
@@ -86,8 +98,9 @@ function resolveTsconfigExtends(configPath: string, specifier: string): string |
 function materializeAliases(
   pathsConfig: Record<string, unknown>,
   baseUrl: string,
-): Record<string, string> {
+): MaterializedAliases {
   const aliases: Record<string, string> = {};
+  const pathAliases: TsconfigPathAlias[] = [];
 
   for (const [find, rawTargets] of Object.entries(pathsConfig)) {
     const target = Array.isArray(rawTargets)
@@ -108,18 +121,35 @@ function materializeAliases(
       const targetDir = target.slice(0, -2);
       if (!aliasKey || !targetDir) continue;
 
-      aliases[aliasKey] = path.resolve(baseUrl, targetDir);
+      const replacement = path.resolve(baseUrl, targetDir);
+      aliases[aliasKey] = replacement;
+      pathAliases.push({ find: aliasKey, kind: "prefix", replacement });
       continue;
     }
 
-    aliases[find] = path.resolve(baseUrl, target);
+    const replacement = path.resolve(baseUrl, target);
+    aliases[find] = replacement;
+    pathAliases.push({ find, kind: "exact", replacement });
   }
 
-  return aliases;
+  return { aliases, pathAliases };
+}
+
+function mergePathAliases(
+  current: readonly TsconfigPathAlias[],
+  next: readonly TsconfigPathAlias[],
+): TsconfigPathAlias[] {
+  return [
+    ...current.filter(
+      (entry) =>
+        !next.some((nextEntry) => nextEntry.find === entry.find && nextEntry.kind === entry.kind),
+    ),
+    ...next,
+  ];
 }
 
 function emptyResolution(): TsconfigPathResolution {
-  return { aliases: {}, baseUrl: null };
+  return { aliases: {}, baseUrl: null, pathAliases: [] };
 }
 
 function loadResolutionFromTsconfigFile(
@@ -149,6 +179,7 @@ function loadResolutionFromTsconfigFile(
       resolution = {
         aliases: { ...resolution.aliases, ...parent.aliases },
         baseUrl: parent.baseUrl ?? resolution.baseUrl,
+        pathAliases: mergePathAliases(resolution.pathAliases, parent.pathAliases),
       };
     }
   }
@@ -166,17 +197,20 @@ function loadResolutionFromTsconfigFile(
     return {
       aliases: resolution.aliases,
       baseUrl,
+      pathAliases: resolution.pathAliases,
     };
   }
 
   const pathsBaseUrl = baseUrl ?? path.dirname(configPath);
+  const materialized = materializeAliases(pathsConfig, pathsBaseUrl);
 
   return {
     aliases: {
       ...resolution.aliases,
-      ...materializeAliases(pathsConfig, pathsBaseUrl),
+      ...materialized.aliases,
     },
     baseUrl,
+    pathAliases: mergePathAliases(resolution.pathAliases, materialized.pathAliases),
   };
 }
 

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -80,7 +80,14 @@ export function toDocumentOnlyAppRoute(
 }
 
 const dynamicRequestApiPattern =
-  /\b(?:connection|headers|cookies|draftMode|noStore|unstable_noStore)\s*\(/;
+  /\b(?:connection|headers|cookies|draftMode|noStore|unstable_noStore)\s*(?:\?\.)?\s*\(/;
+const dynamicRequestApiModules = new Map([
+  ["next/cache", new Set(["noStore", "unstable_noStore"])],
+  ["next/headers", new Set(["headers", "cookies", "draftMode"])],
+  ["next/server", new Set(["connection"])],
+]);
+const staticImportPattern = /import\s+(?!type\b)([\s\S]*?)\s+from\s*["']([^"']+)["']/g;
+const reExportPattern = /export\s+(?!type\b)([\s\S]*?)\s+from\s*["']([^"']+)["']/g;
 const importSpecifierPattern =
   /(?:import|export)\s+(?:[^'"]*?\s+from\s*)?["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
 const routeSourceExtensions = [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"];
@@ -230,6 +237,107 @@ function isAliasShapedLocalSpecifier(specifier: string): boolean {
   );
 }
 
+function normalizeDynamicRequestApiModule(specifier: string): string {
+  return specifier.endsWith(".js") ? specifier.slice(0, -".js".length) : specifier;
+}
+
+function getDynamicRequestApiExports(specifier: string): Set<string> | null {
+  return dynamicRequestApiModules.get(normalizeDynamicRequestApiModule(specifier)) ?? null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+function stripBlockAndLineComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n\r]*/g, "");
+}
+
+function splitImportSpecifiers(specifiers: string): string[] {
+  return specifiers
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .filter(Boolean);
+}
+
+function getNamedImportLocalBindings(importClause: string, exportedApis: Set<string>): Set<string> {
+  const localBindings = new Set<string>();
+  const namedMatch = /\{([\s\S]*?)\}/.exec(importClause);
+  if (!namedMatch) return localBindings;
+
+  for (const specifier of splitImportSpecifiers(namedMatch[1] ?? "")) {
+    const match = /^(?:type\s+)?([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/.exec(specifier);
+    if (!match) continue;
+    const importedName = match[1] ?? "";
+    if (exportedApis.has(importedName)) {
+      localBindings.add(match[2] ?? importedName);
+    }
+  }
+
+  return localBindings;
+}
+
+function getNamespaceImportBinding(importClause: string): string | null {
+  return /\*\s+as\s+([A-Za-z_$][\w$]*)/.exec(importClause)?.[1] ?? null;
+}
+
+function sourceCallsImportedBinding(source: string, binding: string): boolean {
+  const escaped = escapeRegExp(binding);
+  return new RegExp(`(?<![\\w$.:])${escaped}\\s*(?:\\?\\.)?\\s*\\(`).test(source);
+}
+
+function sourceCallsNamespaceImport(
+  source: string,
+  namespace: string,
+  exportedApis: Set<string>,
+): boolean {
+  const escapedNamespace = escapeRegExp(namespace);
+  const escapedApis = [...exportedApis].map(escapeRegExp).join("|");
+  return new RegExp(
+    `(?<![\\w$])${escapedNamespace}\\s*\\.\\s*(?:${escapedApis})\\s*(?:\\?\\.)?\\s*\\(`,
+  ).test(source);
+}
+
+function sourceUsesImportedDynamicRequestApi(source: string): boolean {
+  const sourceWithoutComments = stripBlockAndLineComments(source);
+
+  staticImportPattern.lastIndex = 0;
+  for (;;) {
+    const match = staticImportPattern.exec(sourceWithoutComments);
+    if (!match) break;
+    const importClause = match[1] ?? "";
+    const exportedApis = getDynamicRequestApiExports(match[2] ?? "");
+    if (!exportedApis) continue;
+
+    const namespace = getNamespaceImportBinding(importClause);
+    if (namespace && sourceCallsNamespaceImport(sourceWithoutComments, namespace, exportedApis)) {
+      return true;
+    }
+
+    for (const binding of getNamedImportLocalBindings(importClause, exportedApis)) {
+      if (sourceCallsImportedBinding(sourceWithoutComments, binding)) {
+        return true;
+      }
+    }
+  }
+
+  // Re-exported dynamic request APIs can be called under arbitrary aliases from
+  // downstream modules. Keep these modules on the dynamic request path instead
+  // of caching a potentially request-scoped prefetch artifact.
+  reExportPattern.lastIndex = 0;
+  for (;;) {
+    const match = reExportPattern.exec(sourceWithoutComments);
+    if (!match) break;
+    const exportedApis = getDynamicRequestApiExports(match[2] ?? "");
+    if (!exportedApis) continue;
+    if (getNamedImportLocalBindings(match[1] ?? "", exportedApis).size > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function resolveRouteImport(
   fromFile: string,
   specifier: string,
@@ -283,6 +391,7 @@ function fileUsesDynamicRequestApi(
   }
 
   if (dynamicRequestApiPattern.test(source)) return true;
+  if (sourceUsesImportedDynamicRequestApi(source)) return true;
 
   importSpecifierPattern.lastIndex = 0;
   for (;;) {

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
 import { resolveClientRuntimeModule, resolveRuntimeEntryModule } from "./runtime-entry-module.js";
 import type {
   VinextLinkPrefetchRoute,
   VinextPagesLinkPrefetchRoute,
 } from "../client/vinext-next-data.js";
+import { loadTsconfigResolutionForRoot } from "../config/tsconfig-paths.js";
 import type { AppRoute } from "../routing/app-router.js";
 import type { RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
@@ -23,11 +27,15 @@ export function generateBrowserEntry(
     beforeFiles: [],
     fallback: [],
   },
+  projectRoot?: string,
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
+  const dynamicRequestDetection = createDynamicRequestDetectionContext(projectRoot);
   const prefetchRoutes: VinextLinkPrefetchRoute[] = routes.map((route) =>
-    isLinkPrefetchRoute(route) ? toLinkPrefetchRoute(route) : toDocumentOnlyAppRoute(route),
+    isLinkPrefetchRoute(route)
+      ? toLinkPrefetchRoute(route, dynamicRequestDetection)
+      : toDocumentOnlyAppRoute(route, dynamicRequestDetection),
   );
 
   return `import { registerNavigationRuntimeBootstrap } from ${JSON.stringify(navigationRuntimePath)};
@@ -56,21 +64,284 @@ export function isLinkPrefetchRoute(route: AppRoute): boolean {
   return route.routePath === null && route.layouts.length > 0;
 }
 
-export function toDocumentOnlyAppRoute(route: AppRoute): VinextLinkPrefetchRoute {
+export function toDocumentOnlyAppRoute(
+  route: AppRoute,
+  context = createDynamicRequestDetectionContext(),
+): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: false,
     documentOnly: true,
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
+    ...(requiresDynamicNavigationRequest(route, context)
+      ? { requiresDynamicNavigationRequest: true }
+      : {}),
   };
 }
 
+const dynamicRequestApiPattern =
+  /\b(?:connection|headers|cookies|draftMode|noStore|unstable_noStore)\s*\(/;
+const importSpecifierPattern =
+  /(?:import|export)\s+(?:[^'"]*?\s+from\s*)?["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
+const routeSourceExtensions = [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"];
+const configFiles = ["tsconfig.json", "jsconfig.json"];
+const UNRESOLVED_LOCAL_IMPORT = Symbol("unresolved-local-import");
+
+type TsconfigResolution = ReturnType<typeof loadTsconfigResolutionForRoot>;
+type ResolvedRouteImport = string | typeof UNRESOLVED_LOCAL_IMPORT | null;
+type DynamicRequestDetectionContext = {
+  packageResolutionCache: Map<string, boolean>;
+  projectRoot: string | null;
+  tsconfigResolutionCache: Map<string, TsconfigResolution>;
+};
+
+function createDynamicRequestDetectionContext(
+  projectRoot?: string,
+): DynamicRequestDetectionContext {
+  return {
+    packageResolutionCache: new Map(),
+    projectRoot: projectRoot ? path.resolve(projectRoot) : null,
+    tsconfigResolutionCache: new Map(),
+  };
+}
+
+function resolveRouteSourceFile(candidate: string): string | null {
+  const candidates = [
+    candidate,
+    ...routeSourceExtensions.map((extension) => `${candidate}${extension}`),
+    ...routeSourceExtensions.map((extension) => path.join(candidate, `index${extension}`)),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isFile()) return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return null;
+}
+
+function findTsconfigRootForFile(filePath: string): string | null {
+  let current = path.dirname(filePath);
+  for (;;) {
+    if (configFiles.some((name) => fs.existsSync(path.join(current, name)))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function getTsconfigResolutionForRoot(
+  context: DynamicRequestDetectionContext,
+  root: string,
+): TsconfigResolution {
+  const normalizedRoot = path.resolve(root);
+  const cached = context.tsconfigResolutionCache.get(normalizedRoot);
+  if (cached) return cached;
+
+  const resolution = loadTsconfigResolutionForRoot(normalizedRoot);
+  context.tsconfigResolutionCache.set(normalizedRoot, resolution);
+  return resolution;
+}
+
+function getTsconfigResolutionsForFile(
+  context: DynamicRequestDetectionContext,
+  filePath: string,
+): TsconfigResolution[] {
+  const roots = new Set<string>();
+  if (context.projectRoot) roots.add(context.projectRoot);
+  const inferredRoot = findTsconfigRootForFile(filePath);
+  if (inferredRoot) roots.add(inferredRoot);
+
+  return [...roots].map((root) => getTsconfigResolutionForRoot(context, root));
+}
+
+function isNodeBuiltinOrUrlSpecifier(specifier: string): boolean {
+  return (
+    specifier.startsWith("node:") ||
+    specifier.startsWith("data:") ||
+    specifier.startsWith("http:") ||
+    specifier.startsWith("https:")
+  );
+}
+
+function resolveAliasImport(
+  specifier: string,
+  resolution: TsconfigResolution,
+): ResolvedRouteImport {
+  let bestPrefixAlias: TsconfigResolution["pathAliases"][number] | null = null;
+
+  for (const alias of resolution.pathAliases) {
+    if (alias.kind === "exact") {
+      if (specifier === alias.find) {
+        return resolveRouteSourceFile(alias.replacement) ?? UNRESOLVED_LOCAL_IMPORT;
+      }
+      continue;
+    }
+
+    if (specifier.startsWith(`${alias.find}/`)) {
+      if (bestPrefixAlias === null || alias.find.length > bestPrefixAlias.find.length) {
+        bestPrefixAlias = alias;
+      }
+    }
+  }
+
+  if (bestPrefixAlias !== null) {
+    const rest = specifier.slice(bestPrefixAlias.find.length + 1);
+    return (
+      resolveRouteSourceFile(path.join(bestPrefixAlias.replacement, rest)) ??
+      UNRESOLVED_LOCAL_IMPORT
+    );
+  }
+
+  return null;
+}
+
+function canResolvePackageSpecifier(
+  context: DynamicRequestDetectionContext,
+  specifier: string,
+  fromFile: string,
+): boolean {
+  const cacheKey = `${fromFile}\0${specifier}`;
+  const cached = context.packageResolutionCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  try {
+    createRequire(fromFile).resolve(specifier);
+    context.packageResolutionCache.set(cacheKey, true);
+    return true;
+  } catch {
+    context.packageResolutionCache.set(cacheKey, false);
+    return false;
+  }
+}
+
+function isAliasShapedLocalSpecifier(specifier: string): boolean {
+  return (
+    specifier.startsWith("@") ||
+    specifier.startsWith("~/") ||
+    specifier.startsWith("#") ||
+    specifier.startsWith("$")
+  );
+}
+
+function resolveRouteImport(
+  fromFile: string,
+  specifier: string,
+  context: DynamicRequestDetectionContext,
+): ResolvedRouteImport {
+  if (!specifier || isNodeBuiltinOrUrlSpecifier(specifier)) return null;
+
+  if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("\\")) {
+    const base = specifier.startsWith(".")
+      ? path.resolve(path.dirname(fromFile), specifier)
+      : path.resolve(specifier);
+    return resolveRouteSourceFile(base) ?? UNRESOLVED_LOCAL_IMPORT;
+  }
+
+  for (const resolution of getTsconfigResolutionsForFile(context, fromFile)) {
+    const aliasResolved = resolveAliasImport(specifier, resolution);
+    if (aliasResolved !== null) return aliasResolved;
+
+    if (resolution.baseUrl) {
+      const baseUrlResolved = resolveRouteSourceFile(path.resolve(resolution.baseUrl, specifier));
+      if (baseUrlResolved) return baseUrlResolved;
+
+      if (!canResolvePackageSpecifier(context, specifier, fromFile)) {
+        return UNRESOLVED_LOCAL_IMPORT;
+      }
+    }
+  }
+
+  if (isAliasShapedLocalSpecifier(specifier)) {
+    return canResolvePackageSpecifier(context, specifier, fromFile)
+      ? null
+      : UNRESOLVED_LOCAL_IMPORT;
+  }
+
+  return null;
+}
+
+function fileUsesDynamicRequestApi(
+  filePath: string | null | undefined,
+  context: DynamicRequestDetectionContext,
+  seen: Set<string>,
+): boolean {
+  if (!filePath || seen.has(filePath)) return false;
+  seen.add(filePath);
+
+  let source: string;
+  try {
+    source = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return false;
+  }
+
+  if (dynamicRequestApiPattern.test(source)) return true;
+
+  importSpecifierPattern.lastIndex = 0;
+  for (;;) {
+    const match = importSpecifierPattern.exec(source);
+    if (!match) break;
+    const imported = resolveRouteImport(filePath, match[1] ?? match[2] ?? "", context);
+    if (imported === UNRESOLVED_LOCAL_IMPORT) return true;
+    if (imported && fileUsesDynamicRequestApi(imported, context, seen)) return true;
+  }
+
+  return false;
+}
+
+function routeUsesDynamicRequestApi(
+  route: AppRoute,
+  context: DynamicRequestDetectionContext,
+): boolean {
+  const routeFiles = [
+    route.pagePath,
+    ...route.layouts,
+    ...route.templates,
+    ...route.parallelSlots.flatMap((slot) => [
+      slot.pagePath,
+      slot.defaultPath,
+      slot.layoutPath,
+      ...(slot.configLayoutPaths ?? []),
+      ...slot.interceptingRoutes.flatMap((intercept) => [
+        intercept.pagePath,
+        ...intercept.layoutPaths,
+      ]),
+    ]),
+    ...route.siblingIntercepts.flatMap((intercept) => [
+      intercept.pagePath,
+      ...intercept.layoutPaths,
+    ]),
+  ];
+  const seen = new Set<string>();
+  return routeFiles.some((file) => fileUsesDynamicRequestApi(file, context, seen));
+}
+
+function requiresDynamicNavigationRequest(
+  route: AppRoute,
+  context: DynamicRequestDetectionContext,
+): boolean {
+  return route.parallelSlots.length > 0 || routeUsesDynamicRequestApi(route, context);
+}
+
 /** Project an `AppRoute` down to the public `VinextLinkPrefetchRoute` shape. */
-export function toLinkPrefetchRoute(route: AppRoute): VinextLinkPrefetchRoute {
+export function toLinkPrefetchRoute(
+  route: AppRoute,
+  context = createDynamicRequestDetectionContext(),
+): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: route.loadingPath !== null,
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
+    ...(requiresDynamicNavigationRequest(route, context)
+      ? { requiresDynamicNavigationRequest: true }
+      : {}),
   };
 }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -137,6 +137,7 @@ import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js"
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
 import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
+import { createRscReferenceValidationNormalizerPlugin } from "./plugins/rsc-reference-validation-normalizer.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
 import {
@@ -6214,6 +6215,7 @@ export const loadServerActionClient = ${
   // Append auto-injected RSC plugins if applicable
   if (rscPluginPromise) {
     plugins.push(rscPluginPromise);
+    plugins.push(createRscReferenceValidationNormalizerPlugin());
     plugins.push(createRscClientReferenceLoadersPlugin());
   }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3371,6 +3371,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             graph.routeManifest,
             pagesPrefetchRoutes,
             nextConfig.rewrites,
+            root,
           );
         }
         if (id === RESOLVED_APP_CAPABILITIES && hasAppDir) {

--- a/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
+++ b/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
@@ -1,0 +1,74 @@
+import type { Plugin } from "vite";
+import type { PluginApi } from "@vitejs/plugin-rsc";
+
+const REFERENCE_VALIDATION_ID_PREFIX = "\0virtual:vite-rsc/reference-validation?";
+
+type RscPluginWithApi = Plugin & {
+  api?: PluginApi;
+};
+
+type RscReferenceMeta =
+  | PluginApi["manager"]["clientReferenceMetaMap"][string]
+  | PluginApi["manager"]["serverReferenceMetaMap"][string];
+
+function parseReferenceValidationQuery(id: string): { type?: string; id?: string } | null {
+  const queryStart = id.indexOf("?");
+  if (queryStart === -1) return null;
+  return Object.fromEntries(new URLSearchParams(id.slice(queryStart + 1)));
+}
+
+function normalizeReferenceKey(id: string): string {
+  return id.replaceAll("\0", "__x00__").replace(/\$\$cache=.*$/, "");
+}
+
+function hasReference(
+  referenceMetaMap: Record<string, RscReferenceMeta> | undefined,
+  referenceId: string | undefined,
+): boolean {
+  if (!referenceMetaMap || !referenceId) return false;
+
+  const normalizedReferenceId = normalizeReferenceKey(referenceId);
+  return Object.values(referenceMetaMap).some(
+    (meta) => normalizeReferenceKey(meta.referenceKey) === normalizedReferenceId,
+  );
+}
+
+/**
+ * @vitejs/plugin-rsc stores dev virtual client-reference keys in Vite's encoded
+ * `/@id/__x00__...` form, but React's SSR consumer can ask validation for the
+ * decoded `/@id/\0...` form. Treat those as equivalent and fall through to the
+ * upstream validator for all other invalid references.
+ */
+export function createRscReferenceValidationNormalizerPlugin(): Plugin {
+  let rscApi: PluginApi | undefined;
+
+  return {
+    name: "vinext:rsc-reference-validation-normalizer",
+    enforce: "pre",
+    apply: "serve",
+    configResolved(config) {
+      rscApi = (
+        config.plugins.find((plugin) => plugin.name === "rsc:minimal") as
+          | RscPluginWithApi
+          | undefined
+      )?.api;
+    },
+    load(id) {
+      if (!id.startsWith(REFERENCE_VALIDATION_ID_PREFIX)) return null;
+
+      const query = parseReferenceValidationQuery(id);
+      if (!query) return null;
+
+      const manager = rscApi?.manager;
+      if (query.type === "client" && hasReference(manager?.clientReferenceMetaMap, query.id)) {
+        return "export {}";
+      }
+
+      if (query.type === "server" && hasReference(manager?.serverReferenceMetaMap, query.id)) {
+        return "export {}";
+      }
+
+      return null;
+    },
+  };
+}

--- a/packages/vinext/src/server/app-browser-client-reuse-manifest.ts
+++ b/packages/vinext/src/server/app-browser-client-reuse-manifest.ts
@@ -7,6 +7,7 @@ import {
 import {
   CLIENT_REUSE_MANIFEST_SKIP_VERIFICATION_ENTRY_BUDGET,
   countUtf8Bytes,
+  createClientReusePayloadHash,
   DEFAULT_CLIENT_REUSE_MANIFEST_LIMITS,
   serializeClientReuseManifest,
 } from "./client-reuse-manifest.js";
@@ -31,6 +32,8 @@ type BrowserClientReuseManifestEntry = Readonly<{
 }>;
 
 type CreateClientReuseManifestHeaderOptions = Readonly<{
+  includeDynamicLayouts?: boolean;
+  includeUnclassifiedStaticShellLayouts?: boolean;
   limits?: ClientReuseManifestLimits;
 }>;
 
@@ -130,6 +133,19 @@ function createStaticLayoutEntry(input: {
   };
 }
 
+function createVisibleLayoutEntry(input: {
+  artifactCompatibility: ArtifactCompatibilityEnvelope;
+  layoutId: string;
+}): BrowserClientReuseManifestEntry {
+  return {
+    artifactCompatibility: input.artifactCompatibility,
+    id: input.layoutId,
+    payloadHash: createClientReusePayloadHash(input.layoutId),
+    privacy: "public",
+    variantCacheKey: "visible-layout",
+  };
+}
+
 export function createClientReuseManifestHeaderFromVisibleAppState(
   state: VisibleAppState,
   options: CreateClientReuseManifestHeaderOptions = {},
@@ -143,16 +159,25 @@ export function createClientReuseManifestHeaderFromVisibleAppState(
   for (const layoutId of metadata.layoutIds) {
     if (entries.length >= limits.maxEntryCount) break;
     if (layoutId.length > limits.maxEntryIdLength) continue;
-    if (metadata.layoutFlags[layoutId] !== "s") continue;
+    const layoutFlag = metadata.layoutFlags[layoutId];
+    const isStaticLayout =
+      layoutFlag === "s" ||
+      (layoutFlag === undefined && options.includeUnclassifiedStaticShellLayouts === true);
+    if (!isStaticLayout && options.includeDynamicLayouts !== true) continue;
     if (!hasRetainedElement(state.elements, layoutId)) continue;
 
     const parsedKey = AppElementsWire.parseElementKey(layoutId);
     if (parsedKey?.kind !== "layout") continue;
 
-    const entry = createStaticLayoutEntry({
-      artifactCompatibility: metadata.artifactCompatibility,
-      layoutId,
-    });
+    const entry = isStaticLayout
+      ? createStaticLayoutEntry({
+          artifactCompatibility: metadata.artifactCompatibility,
+          layoutId,
+        })
+      : createVisibleLayoutEntry({
+          artifactCompatibility: metadata.artifactCompatibility,
+          layoutId,
+        });
     if (entry) {
       entries.push(entry);
     }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -492,6 +492,7 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
   routeManifest: RouteManifest | null;
 }): Promise<void> {
   if (options.routeManifest === null) return;
+  const routeManifest = options.routeManifest;
 
   const learning: Promise<void>[] = [...optimisticRouteTemplateLearning.values()];
   for (const [cacheKey, entry] of getPrefetchCache()) {
@@ -509,7 +510,7 @@ async function learnOptimisticRouteTemplatesFromPrefetchCache(options: {
       entry,
       interceptionContext: options.interceptionContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
-      routeManifest: options.routeManifest,
+      routeManifest,
     })
       .then((learned) => {
         if (learned) optimisticRouteTemplateSources.add(sourceKey);
@@ -777,6 +778,21 @@ function storeVisitedResponseSnapshot(
 // an already-stripped path) so both sides reduce to the same canonical form.
 function clientNavigationSnapshotHref(snapshot: ClientNavigationRenderSnapshot): string {
   return `${window.location.origin}${createSnapshotPathAndSearch(snapshot)}`;
+}
+
+function isSamePathAndSearchNavigation(currentHref: string, nextUrl: URL): boolean {
+  let current: URL;
+  try {
+    current = new URL(currentHref);
+  } catch {
+    return false;
+  }
+
+  return (
+    current.origin === nextUrl.origin &&
+    current.pathname === nextUrl.pathname &&
+    current.searchParams.toString() === nextUrl.searchParams.toString()
+  );
 }
 
 type NavigationRequestState = {
@@ -1704,11 +1720,12 @@ function bootstrapHydration(
         // already short-circuited before reaching this loop, so for a "navigate"
         // here the decision is always a flight navigation and only its
         // cache-bypass bit is consumed.
+        const navStartHref = clientNavigationSnapshotHref(routerStateAtNavStart.navigationSnapshot);
         const earlyIntentDecision =
           navigationKind === "navigate"
             ? navigationPlanner.classifyEarlyNavigationIntent({
                 basePath: __basePath,
-                currentHref: clientNavigationSnapshotHref(routerStateAtNavStart.navigationSnapshot),
+                currentHref: navStartHref,
                 // This loop only consumes the flight-navigation cache policy;
                 // hash-only intents already return before a request is queued.
                 mode: "push",
@@ -1719,16 +1736,23 @@ function bootstrapHydration(
         const shouldBypassNavigationCache =
           earlyIntentDecision?.kind === "flightNavigation" &&
           earlyIntentDecision.bypassNavigationCache;
+        const shouldPreserveLayoutsForSameUrlNavigation =
+          navigationKind === "navigate" &&
+          shouldBypassNavigationCache &&
+          isSamePathAndSearchNavigation(navStartHref, url);
         // The client reuse manifest is excluded from VINEXT_RSC_VARY_HEADER, so
         // it never affects the cache-busting URL. Defer producing it until the
         // visited-response cache miss is confirmed below — its producer iterates
         // the visible layout ids and binary-searches a byte budget, which is
         // pure waste on the cache-hit soft-nav path.
+        const renderMode =
+          navigationKind === "refresh" || shouldPreserveLayoutsForSameUrlNavigation
+            ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI
+            : undefined;
         const requestHeaders = createRscRequestHeaders({
           interceptionContext: requestInterceptionContext,
           mountedSlotsHeader,
-          renderMode:
-            navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
+          renderMode,
         });
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
         const visitedResponseCandidate = shouldBypassNavigationCache
@@ -1912,6 +1936,7 @@ function bootstrapHydration(
         // real fetch commits, but that shell is a detached commit (see below)
         // that is always superseded by the authoritative fetch — the same as
         // cross-route navigations — so it never persists stale page content.
+        let optimisticShellElementsForClientReuse: AppElements | null = null;
         if (!navResponse && fallbackReuseDecision.kind === "attemptOptimisticRouteShell") {
           await learnOptimisticRouteTemplatesFromPrefetchCache({
             interceptionContext: requestInterceptionContext,
@@ -1932,6 +1957,7 @@ function bootstrapHydration(
 
             if (optimisticPayload !== null) {
               detachedNavigationCommits = true;
+              optimisticShellElementsForClientReuse = optimisticPayload.elements;
               const optimisticNavigationSnapshot = createClientNavigationRenderSnapshot(
                 currentHref,
                 optimisticPayload.params,
@@ -1958,7 +1984,7 @@ function bootstrapHydration(
                 scrollIntent,
                 restoredBfcacheIds,
                 reuseCurrentBfcacheIds,
-                visibleCommitMode,
+                "synchronous",
                 undefined,
                 "detached",
               ).catch((error) => {
@@ -1976,8 +2002,21 @@ function bootstrapHydration(
           // Computed from the nav-start router state so it matches the snapshot
           // the request would have carried if produced earlier.
           if (navigationKind === "navigate") {
-            const clientReuseManifestHeader =
-              createClientReuseManifestHeaderFromVisibleAppState(routerStateAtNavStart);
+            const clientReuseManifestState =
+              optimisticShellElementsForClientReuse === null
+                ? routerStateAtNavStart
+                : {
+                    elements: optimisticShellElementsForClientReuse,
+                    visibleCommitVersion: routerStateAtNavStart.visibleCommitVersion + 1,
+                  };
+            const clientReuseManifestHeader = createClientReuseManifestHeaderFromVisibleAppState(
+              clientReuseManifestState,
+              {
+                includeDynamicLayouts: shouldPreserveLayoutsForSameUrlNavigation,
+                includeUnclassifiedStaticShellLayouts:
+                  optimisticShellElementsForClientReuse !== null,
+              },
+            );
             if (clientReuseManifestHeader !== null) {
               requestHeaders.set(VINEXT_CLIENT_REUSE_MANIFEST_HEADER, clientReuseManifestHeader);
             }

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -1,4 +1,11 @@
-import { createElement, isValidElement, Suspense } from "react";
+import {
+  cloneElement,
+  createElement,
+  isValidElement,
+  Suspense,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { isUnknownRecord } from "../utils/record.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { buildParams, decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
@@ -42,6 +49,8 @@ const routeTrieCache = new WeakMap<RouteManifest, OptimisticRouteTrieNode>();
 // Shared never-settling thenable used to suspend optimistic page segments until
 // the real RSC payload replaces them.
 const OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER = new Promise<never>(() => {});
+const REACT_LAZY_TYPE = Symbol.for("react.lazy");
+const REACT_SUSPENSE_TYPE = Symbol.for("react.suspense");
 
 export function getOptimisticRouteTemplateKey(options: {
   interceptionContext: string | null;
@@ -300,6 +309,94 @@ function OptimisticRouteSegment(): null {
   throw OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER;
 }
 
+function cloneElementWithChildren(element: ReactElement, children: unknown): ReactElement {
+  return Array.isArray(children)
+    ? cloneElement(element, undefined, ...(children as ReactNode[]))
+    : cloneElement(element, undefined, children as ReactNode);
+}
+
+function readResolvedLazyNode(value: Record<string, unknown>): unknown {
+  const init = Reflect.get(value, "_init");
+  if (typeof init !== "function") return undefined;
+
+  try {
+    return init(Reflect.get(value, "_payload"));
+  } catch {
+    return undefined;
+  }
+}
+
+function replaceSuspenseChildrenWithOptimisticSegments(
+  value: unknown,
+  depth = 0,
+  withinSuspense = false,
+): unknown {
+  if (depth > 100) return value;
+
+  if (isUnknownRecord(value) && Reflect.get(value, "$$typeof") === REACT_LAZY_TYPE) {
+    if (withinSuspense) {
+      return createElement(OptimisticRouteSegment);
+    }
+
+    const resolved = readResolvedLazyNode(value);
+    if (resolved === undefined || resolved === value) return value;
+    return replaceSuspenseChildrenWithOptimisticSegments(resolved, depth + 1, withinSuspense);
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((entry) => {
+      const replaced = replaceSuspenseChildrenWithOptimisticSegments(
+        entry,
+        depth + 1,
+        withinSuspense,
+      );
+      if (replaced !== entry) changed = true;
+      return replaced;
+    });
+    return changed ? next : value;
+  }
+
+  if (!isValidElement(value)) return value;
+
+  const props = Reflect.get(value, "props");
+  const elementType: unknown = Reflect.get(value, "type");
+  if (
+    withinSuspense &&
+    isUnknownRecord(elementType) &&
+    Reflect.get(elementType, "$$typeof") === REACT_LAZY_TYPE
+  ) {
+    return createElement(OptimisticRouteSegment);
+  }
+
+  if ((elementType === Suspense || elementType === REACT_SUSPENSE_TYPE) && isUnknownRecord(props)) {
+    const fallback = Reflect.get(props, "fallback");
+    if (fallback !== null && fallback !== undefined) {
+      return cloneElement(value, undefined, createElement(OptimisticRouteSegment));
+    }
+  }
+
+  if (!isUnknownRecord(props)) return value;
+
+  const children = Reflect.get(props, "children");
+  const nextChildren = replaceSuspenseChildrenWithOptimisticSegments(
+    children,
+    depth + 1,
+    withinSuspense,
+  );
+  if (nextChildren === children) return value;
+
+  return cloneElementWithChildren(value, nextChildren);
+}
+
+function createDynamicShellOptimisticElements(elements: AppElements): AppElements {
+  const next: Record<string, AppElementValue> = {};
+  for (const [key, value] of Object.entries(elements)) {
+    next[key] = replaceSuspenseChildrenWithOptimisticSegments(value) as AppElementValue;
+  }
+  return next;
+}
+
 export function createOptimisticRouteTemplate(options: {
   allowLoadingShell?: boolean;
   basePath: string;
@@ -326,22 +423,29 @@ export function createOptimisticRouteTemplate(options: {
   // Suspense fallback. Authoritative loading-shell prefetches use the marker
   // check below instead.
   if (!options.allowLoadingShell && !elementHasSuspenseFallback(routeElement)) return null;
-  if (
-    options.allowLoadingShell &&
-    options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] !== "LoadingBoundary"
-  ) {
+  const shellMarker = options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY];
+  const isLoadingBoundaryShell = shellMarker === "LoadingBoundary";
+  const isDynamicShell = shellMarker === "DynamicShell";
+  if (options.allowLoadingShell && !isLoadingBoundaryShell && !isDynamicShell) {
     return null;
   }
   // Shell prefetches must include the eagerly-rendered loading component. A
   // null route element means the server had no route loading boundary.
-  if (options.allowLoadingShell && (routeElement === undefined || routeElement === null))
+  if (
+    options.allowLoadingShell &&
+    isLoadingBoundaryShell &&
+    (routeElement === undefined || routeElement === null)
+  ) {
     return null;
+  }
 
-  const pageElementIds = getPageElementIds(options.elements, match.route);
-  if (pageElementIds.length === 0) return null;
+  const pageElementIds = isDynamicShell ? [] : getPageElementIds(options.elements, match.route);
+  if (!isDynamicShell && pageElementIds.length === 0) return null;
 
   return {
-    elements: options.elements,
+    elements: isDynamicShell
+      ? createDynamicShellOptimisticElements(options.elements)
+      : options.elements,
     mountedSlotsHeader: options.mountedSlotsHeader,
     pageElementIds,
     routeId: match.route.id,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -8,7 +8,14 @@ import {
 } from "vinext/shims/cache-request-state";
 import type { CachedAppPageValue } from "vinext/shims/cache-handler";
 import type { RootParams } from "vinext/shims/root-params";
-import type { PprFallbackShellState } from "vinext/shims/ppr-fallback-shell";
+import {
+  beginPprFallbackShellFinalRender,
+  createPprFallbackShellState,
+  getPprFallbackShellState,
+  preparePprFallbackShellFinalRender,
+  runWithPprFallbackShellState,
+  type PprFallbackShellState,
+} from "vinext/shims/ppr-fallback-shell";
 import {
   consumeDynamicUsage,
   consumeInvalidDynamicUsageError,
@@ -73,6 +80,7 @@ import {
 } from "./app-rsc-cache-busting.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
   shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
@@ -529,6 +537,18 @@ export async function dispatchAppPage<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
 ): Promise<Response> {
   const dispatch = () => runWithFetchDedupe(() => dispatchAppPageInner(options));
+  if (
+    !options.pprFallbackShell &&
+    options.isRscRequest &&
+    options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL
+  ) {
+    const fallbackShellState = createPprFallbackShellState({
+      fallbackParamNames: [],
+      routePattern: options.route.pattern,
+    });
+    preparePprFallbackShellFinalRender(fallbackShellState);
+    return await runWithPprFallbackShellState(fallbackShellState, dispatch);
+  }
   if (!options.pprFallbackShell || !options.pprRuntime) {
     return await dispatch();
   }
@@ -958,7 +978,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     route,
     options.debugClassification,
   );
-  const activeFallbackShellState = options.pprRuntime?.getState() ?? null;
+  const activeFallbackShellState = getPprFallbackShellState();
   const pprFallbackShellSignal = activeFallbackShellState?.abortController.signal;
   const pprFallbackShellReactSignal = activeFallbackShellState?.reactAbortController.signal;
 
@@ -1017,11 +1037,16 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     params: options.params,
     pprFallbackShellSignal,
     pprFallbackShellReactSignal,
-    abortPprFallbackShell: activeFallbackShellState
-      ? () => {
-          options.pprRuntime!.beginFinalRender(activeFallbackShellState);
-        }
-      : undefined,
+    abortPprFallbackShell:
+      activeFallbackShellState !== null
+        ? () => {
+            if (options.pprRuntime) {
+              options.pprRuntime.beginFinalRender(activeFallbackShellState);
+            } else {
+              beginPprFallbackShellFinalRender(activeFallbackShellState);
+            }
+          }
+        : undefined,
     layoutParamAccess,
     rootParams: options.rootParams,
     peekRenderObservationState() {

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -210,19 +210,37 @@ type RenderAppPageLifecycleOptions = {
 
 async function readAppPageInitialBinaryStream(
   stream: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
 ): Promise<ArrayBuffer> {
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
 
   try {
     while (true) {
-      const idle = Symbol("idle");
-      const result = await Promise.race([
-        reader.read(),
-        new Promise<typeof idle>((resolve) => setTimeout(() => resolve(idle), 25)),
-      ]);
+      const aborted = Symbol("aborted");
+      let removeAbortListener = () => {};
+      const abortPromise =
+        signal === undefined
+          ? null
+          : new Promise<typeof aborted>((resolve) => {
+              const onAbort = () => resolve(aborted);
+              if (signal.aborted) {
+                resolve(aborted);
+                return;
+              }
+              signal.addEventListener("abort", onAbort, { once: true });
+              removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+            });
+      let result: ReadableStreamReadResult<Uint8Array> | typeof aborted;
+      try {
+        result = await (abortPromise === null
+          ? reader.read()
+          : Promise.race([reader.read(), abortPromise]));
+      } finally {
+        removeAbortListener();
+      }
 
-      if (result === idle || result.done) {
+      if (result === aborted || result.done) {
         break;
       }
 
@@ -815,7 +833,12 @@ export async function renderAppPageLifecycle(
   });
 
   if (isPrefetchDynamicShell) {
-    pprFallbackShellRsc = new Uint8Array(await readAppPageInitialBinaryStream(rscStream));
+    if (options.abortPprFallbackShell) {
+      setTimeout(options.abortPprFallbackShell, 0);
+    }
+    pprFallbackShellRsc = new Uint8Array(
+      await readAppPageInitialBinaryStream(rscStream, options.pprFallbackShellSignal),
+    );
   } else if (options.pprFallbackShellSignal) {
     try {
       pprFallbackShellRsc = new Uint8Array(await readAppPageBinaryStream(rscStream));

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -5,7 +5,7 @@ import type { CachedAppPageValue } from "vinext/shims/cache-handler";
 import type { RootParams } from "vinext/shims/root-params";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { AppElementsWire, isAppElementsRecord, type AppOutgoingElements } from "./app-elements.js";
-import { hasDigest } from "./app-rsc-errors.js";
+import { getDigestForWellKnownError, hasDigest } from "./app-rsc-errors.js";
 import {
   finalizeAppPageHtmlCacheResponse,
   finalizeAppPageRscCacheResponse,
@@ -37,7 +37,11 @@ import {
   renderAppPageHtmlStreamWithRecovery,
   type AppPageSsrHandler,
 } from "./app-page-stream.js";
-import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
+  type AppRscRenderMode,
+} from "./app-rsc-render-mode.js";
 import {
   createArtifactCompatibilityEnvelope,
   createArtifactCompatibilityGraphVersion,
@@ -204,6 +208,41 @@ type RenderAppPageLifecycleOptions = {
   classification?: LayoutClassificationOptions | null;
 };
 
+async function readAppPageInitialBinaryStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<ArrayBuffer> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+
+  try {
+    while (true) {
+      const idle = Symbol("idle");
+      const result = await Promise.race([
+        reader.read(),
+        new Promise<typeof idle>((resolve) => setTimeout(() => resolve(idle), 25)),
+      ]);
+
+      if (result === idle || result.done) {
+        break;
+      }
+
+      chunks.push(result.value);
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+
+  const totalLength = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+  const out = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
+}
+
 function buildResponseTiming(
   options: Pick<RenderAppPageLifecycleOptions, "handlerStart" | "isProduction"> & {
     compileEnd?: number;
@@ -312,6 +351,17 @@ function createRenderAndSendSkipDisposition(): ClientReuseManifestSkipDispositio
   };
 }
 
+function createPreserveUiLayoutSkipDisposition(
+  skippedEntryIds: readonly string[],
+): ClientReuseManifestSkipDisposition {
+  return {
+    code: "SKIP_STATIC_LAYOUT_VERIFIED",
+    enabled: true,
+    mode: "skipStaticLayout",
+    skippedEntryIds: [...skippedEntryIds],
+  };
+}
+
 function rejectStaticLayoutObservation(
   entry: ClientReuseManifestEntry,
   code: StaticLayoutObservationSkipRejection["code"],
@@ -361,6 +411,7 @@ function createRenderLifecycleSkipDisposition(input: {
   isRscRequest: boolean;
   layoutFlags: Readonly<Record<string, "s" | "d">>;
   layoutParamAccess: AppLayoutParamAccessTracker | undefined;
+  renderMode: AppRscRenderMode | undefined;
 }): ClientReuseManifestSkipDisposition | undefined {
   if (!input.isRscRequest || input.clientReuseManifest === undefined) {
     return undefined;
@@ -384,9 +435,30 @@ function createRenderLifecycleSkipDisposition(input: {
       .filter(([, flag]) => flag === "s")
       .map(([layoutId]) => layoutId),
   );
+  const canPreserveVisibleLayouts = input.renderMode === APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI;
   const plan = createClientReuseSkipTransportPlan({
     manifest: clientReuseManifest,
     verifyEntry(entry) {
+      if (
+        canPreserveVisibleLayouts &&
+        entry.kind === "layout" &&
+        Object.hasOwn(input.layoutFlags, entry.id) &&
+        Object.hasOwn(element, entry.id) &&
+        AppElementsWire.parseElementKey(entry.id)?.kind === "layout"
+      ) {
+        return {
+          code: "SKIP_CACHE_CROSS_CHECK_PASSED",
+          entryId: entry.id,
+          fields: {
+            entryKind: entry.kind,
+            reuseClass: "visible-layout",
+            variantCacheKeyHash: entry.variantCacheKey,
+          },
+          kind: "verified",
+          skipDisposition: createPreserveUiLayoutSkipDisposition([entry.id]),
+        };
+      }
+
       if (
         entry.kind !== "layout" ||
         !staticLayoutIds.has(entry.id) ||
@@ -668,6 +740,7 @@ export async function renderAppPageLifecycle(
       isRscRequest: options.isRscRequest,
       layoutFlags,
       layoutParamAccess: options.layoutParamAccess,
+      renderMode: options.renderMode,
     });
   const shouldBypassRscCacheForSkipTransport =
     options.isRscRequest && isSkipTransportEnabled(skipDisposition);
@@ -687,6 +760,25 @@ export async function renderAppPageLifecycle(
   const compileEnd = options.isProduction ? undefined : performance.now();
   const baseOnError = options.createRscOnErrorHandler(options.cleanPathname, options.routePattern);
   const rscErrorTracker = createAppPageRscErrorTracker(baseOnError);
+  const isPrefetchDynamicShell =
+    options.isRscRequest && options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL;
+  const onRscRenderError = (
+    error: unknown,
+    requestInfo: unknown,
+    errorContext: unknown,
+  ): unknown => {
+    if (options.pprFallbackShellSignal?.aborted) {
+      return getDigestForWellKnownError(error);
+    }
+    if (resolveAppPageSpecialError(error) !== null) {
+      return rscErrorTracker.onRenderError(error, requestInfo, errorContext);
+    }
+    const digest = getDigestForWellKnownError(error);
+    if (digest !== undefined) {
+      return digest;
+    }
+    return rscErrorTracker.onRenderError(error, requestInfo, errorContext);
+  };
   // Defensive wrap for standalone callers. In the normal dispatch path this is
   // a no-op since dispatchAppPage already activated dedupe. Note that
   // renderToReadableStream returns synchronously — the actual fetch calls
@@ -694,11 +786,17 @@ export async function renderAppPageLifecycle(
   // standalone call would establish here is only effective if the caller has
   // an outer runWithRequestContext / runWithFetchDedupe scope keeping the ALS
   // store alive across that consumption.
-  let rscStream = await runWithFetchDedupe(async () => {
-    if (options.pprFallbackShellSignal && options.prerenderToReadableStream) {
+  let rscStream: ReadableStream<Uint8Array>;
+  let pprFallbackShellRsc: Uint8Array | null = null;
+  rscStream = await runWithFetchDedupe(async () => {
+    if (
+      !isPrefetchDynamicShell &&
+      options.pprFallbackShellSignal &&
+      options.prerenderToReadableStream
+    ) {
       const reactSignal = options.pprFallbackShellReactSignal ?? options.pprFallbackShellSignal;
       const pendingResult = options.prerenderToReadableStream(outgoingElement, {
-        onError: rscErrorTracker.onRenderError,
+        onError: onRscRenderError,
         signal: reactSignal,
       });
       if (options.abortPprFallbackShell) {
@@ -708,13 +806,20 @@ export async function renderAppPageLifecycle(
     }
 
     return options.renderToReadableStream(outgoingElement, {
-      onError: rscErrorTracker.onRenderError,
+      onError: onRscRenderError,
     });
   });
 
-  let pprFallbackShellRsc: Uint8Array | null = null;
-  if (options.pprFallbackShellSignal) {
-    pprFallbackShellRsc = new Uint8Array(await readAppPageBinaryStream(rscStream));
+  if (isPrefetchDynamicShell) {
+    pprFallbackShellRsc = new Uint8Array(await readAppPageInitialBinaryStream(rscStream));
+  } else if (options.pprFallbackShellSignal) {
+    try {
+      pprFallbackShellRsc = new Uint8Array(await readAppPageBinaryStream(rscStream));
+    } catch (error) {
+      if (!options.pprFallbackShellSignal.aborted) {
+        throw error;
+      }
+    }
   }
 
   let revalidateSeconds = options.revalidateSeconds;
@@ -739,7 +844,7 @@ export async function renderAppPageLifecycle(
     });
   const rscCapture = pprFallbackShellRsc
     ? {
-        ssrStream: createBufferedRscStream(false),
+        ssrStream: createBufferedRscStream(options.isRscRequest),
         ...(shouldCaptureRscForCacheMetadata ? { sideStream: createBufferedRscStream(true) } : {}),
       }
     : teeAppPageRscStreamForCapture(rscStream, shouldCaptureRscForCacheMetadata);

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -767,10 +767,14 @@ export async function renderAppPageLifecycle(
     requestInfo: unknown,
     errorContext: unknown,
   ): unknown => {
+    const specialError = resolveAppPageSpecialError(error);
+    if (specialError !== null && isPrefetchDynamicShell) {
+      return rscErrorTracker.onRenderError(error, requestInfo, errorContext);
+    }
     if (options.pprFallbackShellSignal?.aborted) {
       return getDigestForWellKnownError(error);
     }
-    if (resolveAppPageSpecialError(error) !== null) {
+    if (specialError !== null) {
       return rscErrorTracker.onRenderError(error, requestInfo, errorContext);
     }
     const digest = getDigestForWellKnownError(error);

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -46,6 +46,7 @@ import {
 import { probeReactServerSubtree } from "./app-page-probe.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
   shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
@@ -698,13 +699,17 @@ export function buildAppPageElements<
 
   const routeLoadingComponent = getDefaultExport(options.route.loading);
   const isPrefetchLoadingShell = renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
-  const shouldRenderPrefetchLoadingShell = isPrefetchLoadingShell && routeLoadingComponent !== null;
-  if (shouldRenderPrefetchLoadingShell) {
+  const isPrefetchDynamicShell = renderMode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL;
+  const shouldMarkPrefetchShell =
+    isPrefetchDynamicShell || (isPrefetchLoadingShell && routeLoadingComponent !== null);
+  if (shouldMarkPrefetchShell) {
     // Client loading components serialize as module references in Flight. Keep
     // a durable marker in the shell payload so external router tests and
     // diagnostics can recognize this as a loading-boundary response without
     // requiring source text to appear in client component references.
-    elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] = "LoadingBoundary";
+    elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] = isPrefetchDynamicShell
+      ? "DynamicShell"
+      : "LoadingBoundary";
   }
 
   elements[pageElementId] = isPrefetchLoadingShell

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -1,5 +1,6 @@
 import { resolveAppPageSpecialError } from "./app-page-execution.js";
 import { isNavigationSignalError } from "../utils/navigation-signal.js";
+import { HANGING_PROMISE_REJECTION_DIGEST } from "vinext/shims/internal/make-hanging-promise";
 
 type DigestError = Error & { digest?: string };
 
@@ -53,7 +54,8 @@ export function getDigestForWellKnownError(error: unknown): string | undefined {
   if (
     isNavigationSignalError(error) ||
     digest === BAILOUT_TO_CSR_DIGEST ||
-    digest === DYNAMIC_SERVER_USAGE_DIGEST
+    digest === DYNAMIC_SERVER_USAGE_DIGEST ||
+    digest === HANGING_PROMISE_REJECTION_DIGEST
   ) {
     return digest;
   }

--- a/packages/vinext/src/server/app-rsc-render-mode.ts
+++ b/packages/vinext/src/server/app-rsc-render-mode.ts
@@ -1,12 +1,15 @@
 export type AppRscRenderMode =
   | "navigation"
   | "prefetch-loading-shell"
+  | "prefetch-dynamic-shell"
   | "refresh-preserve-ui"
   | "action-rerender-preserve-ui";
 
 export const APP_RSC_RENDER_MODE_NAVIGATION = "navigation" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL =
   "prefetch-loading-shell" satisfies AppRscRenderMode;
+export const APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL =
+  "prefetch-dynamic-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI =
   "refresh-preserve-ui" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI =
@@ -27,6 +30,9 @@ export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | n
   if (mode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL) {
     return "prefetch-loading-shell";
   }
+  if (mode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL) {
+    return "prefetch-dynamic-shell";
+  }
 
   return shouldUsePreserveUiCacheVariant(mode) ? "preserve-ui" : null;
 }
@@ -35,6 +41,8 @@ export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
   switch (value) {
     case APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL:
       return APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
+    case APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL:
+      return APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL;
     case APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI:
       return APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI;
     case APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI:

--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -625,13 +625,21 @@ function classifyEarlyNavigationIntent(
   // key order. We intentionally do not sort, since query order can be observable.
   const sameSearch = current.searchParams.toString() === next.searchParams.toString();
 
-  if (samePathname && sameSearch && next.hash !== "") {
+  if (samePathname && sameSearch && current.hash !== next.hash && next.hash !== "") {
     return {
       hash: next.hash,
       kind: "sameDocumentScroll",
       mode: facts.mode,
       scroll: facts.scroll,
       trace: createEarlyNavigationIntentTrace(NavigationTraceReasonCodes.sameDocumentScroll, facts),
+    };
+  }
+
+  if (samePathname && sameSearch && current.search === next.search && current.hash === next.hash) {
+    return {
+      bypassNavigationCache: true,
+      kind: "flightNavigation",
+      trace: createEarlyNavigationIntentTrace(NavigationTraceReasonCodes.samePageSearch, facts),
     };
   }
 

--- a/packages/vinext/src/shims/internal/make-hanging-promise.ts
+++ b/packages/vinext/src/shims/internal/make-hanging-promise.ts
@@ -10,7 +10,11 @@
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dynamic-rendering-utils.ts
  */
 
+export const HANGING_PROMISE_REJECTION_DIGEST = "HANGING_PROMISE_REJECTION";
+
 class HangingPromiseRejectionError extends Error {
+  digest = HANGING_PROMISE_REJECTION_DIGEST;
+
   constructor(route: string, expression: string) {
     super(
       `Route ${route} used ${expression} during prerendering but the render was aborted. ` +

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -115,6 +115,12 @@ type LinkProps = {
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">;
 
 type LinkPrefetchMode = "disabled" | "auto" | "full" | "full-after-shell";
+type AutoAppRoutePrefetch = {
+  cacheForNavigation: boolean;
+  prefetchDynamicShell: boolean;
+  prefetchShellFirst: boolean;
+  shouldPrefetch: boolean;
+};
 
 declare global {
   // Window is an ambient interface from lib.dom; interface merging is required
@@ -311,19 +317,16 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
-function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
-  cacheForNavigation: boolean;
-  prefetchShellFirst: boolean;
-  shouldPrefetch: boolean;
-} {
+function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): AutoAppRoutePrefetch {
   const hasLoadingShell = route.canPrefetchLoadingShell;
+  const requiresDynamicNavigationRequest = route.requiresDynamicNavigationRequest === true;
   return {
-    // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
-    // Routes with loading boundaries prefetch a shell first so navigation can
-    // commit loading.js immediately. Dynamic routes without loading-shell
-    // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
-    // keyed by the concrete RSC URL, so this cannot reuse data across params.
-    cacheForNavigation: !hasLoadingShell,
+    // Routes with loading boundaries or reachable dynamic request APIs prefetch
+    // only the static shell. The click still issues a live Flight request for
+    // dynamic holes, matching the Segment Cache's static-shell/dynamic-request
+    // split without implementing cacheComponents.
+    cacheForNavigation: !hasLoadingShell && !requiresDynamicNavigationRequest,
+    prefetchDynamicShell: !hasLoadingShell && requiresDynamicNavigationRequest,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -346,26 +349,47 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
+  prefetchDynamicShell: boolean;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchDynamicShell: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchDynamicShell: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchDynamicShell: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchDynamicShell: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   return resolveMatchedAutoAppRoutePrefetch(match.route);
@@ -373,11 +397,13 @@ export function resolveAutoAppRoutePrefetch(href: string): {
 
 function resolveFullAppRoutePrefetch(): {
   cacheForNavigation: true;
+  prefetchDynamicShell: false;
   prefetchShellFirst: boolean;
   shouldPrefetch: true;
 } {
   return {
     cacheForNavigation: true,
+    prefetchDynamicShell: false,
     prefetchShellFirst: true,
     shouldPrefetch: true,
   };
@@ -395,8 +421,9 @@ function resolveFullAppRoutePrefetch(): {
  * For Pages Router: warms the page chunk, prefetches data only for SSG pages,
  * and falls back to a document prefetch hint when no page loader matches.
  *
- * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
- * the main thread during initial page load.
+ * App Router and high-priority prefetches start immediately. Low-priority
+ * Pages Router fallback prefetches use `requestIdleCallback` (or `setTimeout`
+ * fallback) to avoid blocking the main thread during initial page load.
  */
 function prefetchUrl(
   href: string,
@@ -436,14 +463,7 @@ function prefetchUrl(
     return;
   }
 
-  const schedule =
-    priority === "high"
-      ? (fn: () => void) => {
-          fn();
-        }
-      : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
-
-  schedule(() => {
+  const runPrefetch = () => {
     void (async () => {
       if (hasAppNavigationRuntime()) {
         if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
@@ -452,7 +472,10 @@ function prefetchUrl(
           navigation,
           { AppElementsWire },
           rscCacheBusting,
-          { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL },
+          {
+            APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+            APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+          },
           headersModule,
           { resolveHybridClientRouteOwner },
         ] = await Promise.all([
@@ -489,7 +512,12 @@ function prefetchUrl(
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchHref)
             : mode === "full-after-shell"
-              ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
+              ? {
+                  cacheForNavigation: true,
+                  prefetchDynamicShell: false,
+                  prefetchShellFirst: true,
+                  shouldPrefetch: true,
+                }
               : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
 
@@ -500,7 +528,9 @@ function prefetchUrl(
         const headers = createRscRequestHeaders({
           interceptionContext,
           renderMode: isOptimisticRouteShellPrefetch
-            ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
+            ? autoPrefetch.prefetchDynamicShell
+              ? APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL
+              : APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
             : undefined,
         });
         if (mountedSlotsHeader) {
@@ -650,7 +680,15 @@ function prefetchUrl(
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);
     });
-  });
+  };
+
+  if (priority === "high" || hasAppNavigationRuntime()) {
+    runPrefetch();
+    return;
+  }
+
+  const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
+  schedule(runPrefetch);
 }
 
 async function promotePrefetchEntriesForNavigation(href: string): Promise<void> {

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -1060,6 +1060,11 @@ export async function connection(): Promise<void> {
   markRenderRequestApiUsage("connection");
   throwIfInsideCacheScope("connection()");
   markDynamicUsage();
+  const { createPprFallbackShellSuspensePromise } = await import("./ppr-fallback-shell.js");
+  const fallbackShellPromise = createPprFallbackShellSuspensePromise<void>("`connection()`");
+  if (fallbackShellPromise) {
+    await fallbackShellPromise;
+  }
   const pendingProbe = suspendConnectionProbe();
   if (pendingProbe) {
     await pendingProbe;

--- a/tests/app-browser-client-reuse-manifest.test.ts
+++ b/tests/app-browser-client-reuse-manifest.test.ts
@@ -73,6 +73,33 @@ describe("app browser client reuse manifest", () => {
     });
   });
 
+  it("can propose retained unclassified dynamic-shell layouts for server verification", () => {
+    // Mirrors the static-layout skip expectation from Next.js:
+    // test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+    const header = createClientReuseManifestHeaderFromVisibleAppState(
+      createVisibleState({
+        extraEntries: {
+          "layout:/partially-static/target-page": "shell layout",
+        },
+        layoutFlags: {},
+        layoutIds: ["layout:/partially-static/target-page"],
+        routeId: "route:/partially-static/target-page",
+      }),
+      { includeUnclassifiedStaticShellLayouts: true },
+    );
+
+    const parsed = parseClientReuseManifestHeader(header);
+
+    expect(parsed.kind).toBe("parsed");
+    if (parsed.kind !== "parsed") {
+      throw new Error("Expected client reuse manifest to parse");
+    }
+    expect(parsed.manifest.entries.map((entry) => entry.id)).toEqual([
+      "layout:/partially-static/target-page",
+    ]);
+  });
+
   it("keeps retained static layout proofs stable across source routes", () => {
     function readLayoutEntry(routeId: string, graphVersion: string) {
       const header = createClientReuseManifestHeaderFromVisibleAppState(

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createElement, Suspense } from "react";
+import { createElement, lazy, Suspense, type ReactNode } from "react";
+import ReactDOMServer from "react-dom/server";
 import {
   AppElementsWire,
   APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
@@ -136,6 +137,31 @@ function createBlogLoadingShellElements(): AppElements {
     [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
     [pageId]: null,
     [routeId]: createElement("p", { id: "loading-message" }, "Loading post-1..."),
+  };
+}
+
+function createBlogDynamicShellElements(): AppElements {
+  const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+  const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+  return {
+    ...AppElementsWire.createMetadataEntries({
+      interceptionContext: null,
+      layoutIds: ["layout:/"],
+      rootLayoutTreePath: "/",
+      routeId,
+    }),
+    [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "DynamicShell",
+    [pageId]: createElement(
+      "article",
+      null,
+      createElement("span", null, "Static shell with Suspense fallback"),
+      createElement(
+        Suspense,
+        { fallback: createElement("p", { id: "loading-message" }, "Loading dynamic...") },
+        createElement("div", { id: "closed-flight-child" }, "Closed stream child"),
+      ),
+    ),
+    [routeId]: createElement("main", { id: "shell" }, "Static shell"),
   };
 }
 
@@ -281,6 +307,111 @@ describe("App Router optimistic routing", () => {
 
     expect(navigationPayload?.params).toEqual({ slug: "post-2" });
     expect(navigationPayload?.elements[pageId]).not.toBe(elements[pageId]);
+  });
+
+  it("replaces dynamic-shell Suspense children with optimistic placeholders", () => {
+    const routeManifest = blogManifest();
+    const elements = createBlogDynamicShellElements();
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc?_rsc=abc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    if (template === null) {
+      throw new Error("Expected optimistic route template");
+    }
+
+    const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+    const optimisticElements = createOptimisticRouteElements(template);
+    expect(optimisticElements[pageId]).not.toBe(elements[pageId]);
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      optimisticElements[pageId] as React.ReactElement,
+    );
+    expect(html).toContain("Static shell with Suspense fallback");
+    expect(html).toContain("Loading dynamic...");
+    expect(html).not.toContain("Closed stream child");
+  });
+
+  it("preserves lazy shell elements outside Suspense in dynamic-shell templates", () => {
+    const routeManifest = blogManifest();
+    const routeId = AppElementsWire.encodeRouteId("/blog/post-1", null);
+    const LazyShell = lazy(async () => ({
+      default: function LazyShell() {
+        return createElement("section", null, "Lazy shell");
+      },
+    }));
+    const lazyShellElement = createElement(LazyShell, null, "Static shell");
+    const elements = {
+      ...createBlogDynamicShellElements(),
+      [routeId]: lazyShellElement,
+    };
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc?_rsc=abc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    if (template === null) {
+      throw new Error("Expected optimistic route template");
+    }
+
+    const optimisticElements = createOptimisticRouteElements(template);
+    expect(optimisticElements[routeId]).toBe(lazyShellElement);
+  });
+
+  it("sanitizes fulfilled lazy RSC shell nodes in dynamic-shell templates", () => {
+    const routeManifest = blogManifest();
+    const pageId = AppElementsWire.encodePageId("/blog/post-1", null);
+    const fulfilledLazyShell = {
+      $$typeof: Symbol.for("react.lazy"),
+      _init: () =>
+        createElement(
+          "article",
+          null,
+          createElement("span", null, "Static fulfilled shell"),
+          createElement(
+            Suspense,
+            { fallback: createElement("p", null, "Loading fulfilled dynamic...") },
+            createElement("div", null, "Closed fulfilled child"),
+          ),
+        ),
+      _payload: null,
+    } as unknown as ReactNode;
+    const elements = {
+      ...createBlogDynamicShellElements(),
+      [pageId]: fulfilledLazyShell,
+    };
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/blog/post-1.rsc?_rsc=abc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+
+    if (template === null) {
+      throw new Error("Expected optimistic route template");
+    }
+
+    const optimisticElements = createOptimisticRouteElements(template);
+    const html = ReactDOMServer.renderToStaticMarkup(
+      optimisticElements[pageId] as React.ReactElement,
+    );
+    expect(html).toContain("Static fulfilled shell");
+    expect(html).toContain("Loading fulfilled dynamic...");
+    expect(html).not.toContain("Closed fulfilled child");
   });
 
   it("includes active parallel slot params in optimistic navigation payloads", () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -22,6 +22,7 @@ import type { LayoutClassificationOptions } from "../packages/vinext/src/server/
 import { createClientReuseManifestHeaderFromVisibleAppState } from "../packages/vinext/src/server/app-browser-client-reuse-manifest.js";
 import { createAppLayoutParamAccessTracker } from "../packages/vinext/src/server/app-layout-param-observation.js";
 import { renderAppPageLifecycle } from "../packages/vinext/src/server/app-page-render.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   parseClientReuseManifestHeader,
   type ClientReuseManifestParseResult,
@@ -522,6 +523,33 @@ describe("app page render lifecycle", () => {
       kind: "http-access-fallback",
       statusCode: 404,
     });
+  });
+
+  it("captures prefetch dynamic-shell special errors even when a fallback-shell signal is aborted", async () => {
+    const common = createCommonOptions();
+    const notFoundError = Object.assign(new Error("NEXT_NOT_FOUND"), { digest: "NEXT_NOT_FOUND" });
+    const abortController = new AbortController();
+    abortController.abort();
+    const baseOnError = vi.fn(() => "NEXT_NOT_FOUND");
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      createRscOnErrorHandler() {
+        return baseOnError;
+      },
+      hasLoadingBoundary: true,
+      isRscRequest: true,
+      pprFallbackShellSignal: abortController.signal,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+      renderToReadableStream(_element, opts) {
+        expect(opts.onError(notFoundError, null, null)).toBe("NEXT_NOT_FOUND");
+        return createStream(["flight-data"]);
+      },
+    });
+
+    await expect(response.text()).resolves.toBe("flight-data");
+    expect(baseOnError).toHaveBeenCalledTimes(1);
+    expect(baseOnError).toHaveBeenCalledWith(notFoundError, null, null);
   });
 
   it("returns RSC responses and schedules an ISR cache write through waitUntil", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -552,6 +552,41 @@ describe("app page render lifecycle", () => {
     expect(baseOnError).toHaveBeenCalledWith(notFoundError, null, null);
   });
 
+  it("reads prefetch dynamic-shell RSC until the fallback-shell abort signal", async () => {
+    const common = createCommonOptions();
+    const abortController = new AbortController();
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      abortPprFallbackShell() {
+        setTimeout(() => abortController.abort(), 70);
+      },
+      hasLoadingBoundary: true,
+      isRscRequest: true,
+      pprFallbackShellSignal: abortController.signal,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+      renderToReadableStream() {
+        const timers: Array<ReturnType<typeof setTimeout>> = [];
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("static-shell"));
+            timers.push(
+              setTimeout(() => controller.enqueue(new TextEncoder().encode("-late")), 40),
+              setTimeout(() => controller.close(), 120),
+            );
+          },
+          cancel() {
+            for (const timer of timers) {
+              clearTimeout(timer);
+            }
+          },
+        });
+      },
+    });
+
+    await expect(response.text()).resolves.toBe("static-shell-late");
+  });
+
   it("returns RSC responses and schedules an ISR cache write through waitUntil", async () => {
     const common = createCommonOptions();
     const consumeDynamicUsage = vi.fn(() => false);

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -136,6 +136,66 @@ describe("App Router generated manifest construction", () => {
   });
 
   it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prefetch-manifest-"));
+    const appDir = path.join(tmpDir, "app");
+    fs.mkdirSync(path.join(appDir, "streaming"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "lib"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "features"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "src", "ui"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "src", "features"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "node_modules", "@acme", "ui"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@/*": ["./*"],
+            "@/features/*": ["./src/features/*"],
+            "@acme/ui": ["./src/ui"],
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(tmpDir, "src", "ui", "index.ts"), "export const local = true;\n");
+    fs.writeFileSync(
+      path.join(tmpDir, "node_modules", "@acme", "ui", "button.js"),
+      "exports.Button = function Button() { return null; };\n",
+    );
+    fs.writeFileSync(
+      path.join(appDir, "streaming", "streaming-text.tsx"),
+      'import { connection } from "next/server";\nexport async function StreamingText() { await connection(); return null; }\n',
+    );
+    fs.writeFileSync(
+      path.join(appDir, "streaming", "page.tsx"),
+      'import { StreamingText } from "./streaming-text";\nexport default function Page() { return <StreamingText />; }\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "lib", "aliased-streaming-text.tsx"),
+      'import { connection } from "next/server";\nexport async function AliasedStreamingText() { await connection(); return null; }\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "features", "streaming.tsx"),
+      "export function OverlappingAliasedStreamingText() { return null; }\n",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "features", "streaming.tsx"),
+      'import { connection } from "next/server";\nexport async function OverlappingAliasedStreamingText() { await connection(); return null; }\n',
+    );
+    fs.mkdirSync(path.join(appDir, "alias-streaming"), { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "alias-streaming", "page.tsx"),
+      'import { AliasedStreamingText } from "@/lib/aliased-streaming-text";\nexport default function Page() { return <AliasedStreamingText />; }\n',
+    );
+    fs.mkdirSync(path.join(appDir, "overlapping-alias-streaming"), { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "overlapping-alias-streaming", "page.tsx"),
+      'import { OverlappingAliasedStreamingText } from "@/features/streaming";\nexport default function Page() { return <OverlappingAliasedStreamingText />; }\n',
+    );
+    fs.mkdirSync(path.join(appDir, "package-subpath"), { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "package-subpath", "page.tsx"),
+      'import { Button } from "@acme/ui/button";\nexport default function Page() { return <Button />; }\n',
+    );
     const code = generateBrowserEntry([
       ...minimalAppRoutes,
       {
@@ -187,6 +247,102 @@ describe("App Router generated manifest construction", () => {
         siblingIntercepts: [],
       },
       {
+        pattern: "/streaming",
+        patternParts: ["streaming"],
+        pagePath: path.join(appDir, "streaming", "page.tsx"),
+        routePath: null,
+        layouts: [],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [],
+        notFoundPath: null,
+        notFoundPaths: [],
+        forbiddenPaths: [],
+        forbiddenPath: null,
+        unauthorizedPaths: [],
+        unauthorizedPath: null,
+        routeSegments: ["streaming"],
+        templateTreePositions: [],
+        layoutTreePositions: [],
+        isDynamic: false,
+        params: [],
+        siblingIntercepts: [],
+      },
+      {
+        pattern: "/alias-streaming",
+        patternParts: ["alias-streaming"],
+        pagePath: path.join(appDir, "alias-streaming", "page.tsx"),
+        routePath: null,
+        layouts: [],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [],
+        notFoundPath: null,
+        notFoundPaths: [],
+        forbiddenPaths: [],
+        forbiddenPath: null,
+        unauthorizedPaths: [],
+        unauthorizedPath: null,
+        routeSegments: ["alias-streaming"],
+        templateTreePositions: [],
+        layoutTreePositions: [],
+        isDynamic: false,
+        params: [],
+        siblingIntercepts: [],
+      },
+      {
+        pattern: "/overlapping-alias-streaming",
+        patternParts: ["overlapping-alias-streaming"],
+        pagePath: path.join(appDir, "overlapping-alias-streaming", "page.tsx"),
+        routePath: null,
+        layouts: [],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [],
+        notFoundPath: null,
+        notFoundPaths: [],
+        forbiddenPaths: [],
+        forbiddenPath: null,
+        unauthorizedPaths: [],
+        unauthorizedPath: null,
+        routeSegments: ["overlapping-alias-streaming"],
+        templateTreePositions: [],
+        layoutTreePositions: [],
+        isDynamic: false,
+        params: [],
+        siblingIntercepts: [],
+      },
+      {
+        pattern: "/package-subpath",
+        patternParts: ["package-subpath"],
+        pagePath: path.join(appDir, "package-subpath", "page.tsx"),
+        routePath: null,
+        layouts: [],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [],
+        notFoundPath: null,
+        notFoundPaths: [],
+        forbiddenPaths: [],
+        forbiddenPath: null,
+        unauthorizedPaths: [],
+        unauthorizedPath: null,
+        routeSegments: ["package-subpath"],
+        templateTreePositions: [],
+        layoutTreePositions: [],
+        isDynamic: false,
+        params: [],
+        siblingIntercepts: [],
+      },
+      {
         pattern: "/api",
         patternParts: ["api"],
         pagePath: null,
@@ -224,6 +380,24 @@ describe("App Router generated manifest construction", () => {
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["streaming"],"isDynamic":false,"requiresDynamicNavigationRequest":true}',
+    );
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["alias-streaming"],"isDynamic":false,"requiresDynamicNavigationRequest":true}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["overlapping-alias-streaming"],"isDynamic":false,"requiresDynamicNavigationRequest":true}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["package-subpath"],"isDynamic":false}',
+    );
+    expect(code).not.toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["package-subpath"],"isDynamic":false,"requiresDynamicNavigationRequest":true}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["modal-host"],"isDynamic":false}',

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -186,6 +186,11 @@ describe("App Router generated manifest construction", () => {
       path.join(appDir, "alias-streaming", "page.tsx"),
       'import { AliasedStreamingText } from "@/lib/aliased-streaming-text";\nexport default function Page() { return <AliasedStreamingText />; }\n',
     );
+    fs.mkdirSync(path.join(appDir, "alias-cookies"), { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "alias-cookies", "page.tsx"),
+      'import { cookies as getCookies } from "next/headers";\nexport default async function Page() { await getCookies(); return null; }\n',
+    );
     fs.mkdirSync(path.join(appDir, "overlapping-alias-streaming"), { recursive: true });
     fs.writeFileSync(
       path.join(appDir, "overlapping-alias-streaming", "page.tsx"),
@@ -319,6 +324,30 @@ describe("App Router generated manifest construction", () => {
         siblingIntercepts: [],
       },
       {
+        pattern: "/alias-cookies",
+        patternParts: ["alias-cookies"],
+        pagePath: path.join(appDir, "alias-cookies", "page.tsx"),
+        routePath: null,
+        layouts: [],
+        templates: [],
+        parallelSlots: [],
+        loadingPath: null,
+        errorPath: null,
+        layoutErrorPaths: [],
+        notFoundPath: null,
+        notFoundPaths: [],
+        forbiddenPaths: [],
+        forbiddenPath: null,
+        unauthorizedPaths: [],
+        unauthorizedPath: null,
+        routeSegments: ["alias-cookies"],
+        templateTreePositions: [],
+        layoutTreePositions: [],
+        isDynamic: false,
+        params: [],
+        siblingIntercepts: [],
+      },
+      {
         pattern: "/package-subpath",
         patternParts: ["package-subpath"],
         pagePath: path.join(appDir, "package-subpath", "page.tsx"),
@@ -389,6 +418,9 @@ describe("App Router generated manifest construction", () => {
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["alias-streaming"],"isDynamic":false,"requiresDynamicNavigationRequest":true}',
+    );
+    expect(code).toContain(
+      '{"canPrefetchLoadingShell":false,"patternParts":["alias-cookies"],"isDynamic":false,"requiresDynamicNavigationRequest":true}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["overlapping-alias-streaming"],"isDynamic":false,"requiresDynamicNavigationRequest":true}',

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -8,7 +8,10 @@ import {
   type LinkPrefetchDecision,
   type LinkPrefetchRouterMode,
 } from "../packages/vinext/src/shims/link-prefetch.js";
-import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
@@ -55,6 +58,12 @@ const linkPrefetchRoutes = [
   { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
+  {
+    canPrefetchLoadingShell: false,
+    patternParts: ["streaming"],
+    isDynamic: false,
+    requiresDynamicNavigationRequest: true,
+  },
 ] satisfies VinextLinkPrefetchRoute[];
 
 function createTestNavigationRuntime(navigate: unknown) {
@@ -1283,6 +1292,34 @@ describe("Link prefetch scheduling", () => {
     };
   }
 
+  it("starts App Router viewport prefetches before browser idle callbacks", async () => {
+    const observer = stubIntersectionObserver();
+    const requestIdleCallback = vi.fn(() => 1);
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("prefetches visible links in production with low priority", async () => {
     const observer = stubIntersectionObserver();
 
@@ -1543,6 +1580,46 @@ describe("Link prefetch scheduling", () => {
       const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
         APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
+        "1",
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(false);
+      expect(entry?.optimisticRouteShell).toBe(true);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("prefetches visible dynamic-request links as dynamic shells", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/streaming",
+      nodeEnv: "production",
+    });
+
+    try {
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      // Ported from Next.js:
+      // test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/streaming",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
       );
       expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
         "1",

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -273,7 +273,7 @@ describe("Link App Router prefetch mode", () => {
     expect(resolveLinkPrefetchMode(true, true)).toBe("disabled");
   });
 
-  it("allows automatic full RSC prefetch only for routes without loading-shell prefetches", () => {
+  it("allows automatic full RSC prefetch only for routes without shell prefetches", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -285,6 +285,12 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
         { canPrefetchLoadingShell: true, patternParts: ["docs", ":slug+"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: false,
+          patternParts: ["streaming"],
+          isDynamic: false,
+          requiresDynamicNavigationRequest: true,
+        },
         { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
       ],
     };
@@ -294,6 +300,7 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/blog/hello-world")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
+      expect(canAutoPrefetchFullAppRoute("/streaming")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/settings")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
     } finally {
@@ -305,7 +312,7 @@ describe("Link App Router prefetch mode", () => {
     }
   });
 
-  it("shell-prefetches routes with loading boundaries and full-prefetches routes without them", () => {
+  it("shell-prefetches dynamic-request routes and full-prefetches routes without them", () => {
     const originalWindow = globalThis.window;
     (globalThis as any).window = {
       location: {
@@ -317,6 +324,12 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: false,
+          patternParts: ["streaming"],
+          isDynamic: false,
+          requiresDynamicNavigationRequest: true,
+        },
         { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
       ],
     };
@@ -324,22 +337,32 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        prefetchDynamicShell: false,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        prefetchDynamicShell: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
+        prefetchDynamicShell: false,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        prefetchDynamicShell: false,
         prefetchShellFirst: false,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/streaming")).toEqual({
+        cacheForNavigation: false,
+        prefetchDynamicShell: true,
+        prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       // Ported from Next.js:
@@ -347,11 +370,13 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        prefetchDynamicShell: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
+        prefetchDynamicShell: false,
         prefetchShellFirst: false,
         shouldPrefetch: false,
       });

--- a/tests/navigation-planner-early-intent.test.ts
+++ b/tests/navigation-planner-early-intent.test.ts
@@ -136,13 +136,32 @@ describe("navigationPlanner early navigation intent classification", () => {
     expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
   });
 
-  it("does not treat an identical URL as a same-document scroll", () => {
+  it("classifies an identical URL as a cache-bypassing flight navigation", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
     const decision = classify({
       currentHref: "https://example.com/docs?q=1",
       targetHref: "https://example.com/docs?q=1",
     });
 
-    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: false });
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: true });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.samePageSearch, {
+      targetHref: "https://example.com/docs?q=1",
+    });
+  });
+
+  it("classifies a repeated hash URL as a cache-bypassing flight navigation", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+    const decision = classify({
+      currentHref: "https://example.com/docs?q=1#section",
+      targetHref: "https://example.com/docs?q=1#section",
+    });
+
+    expect(decision).toMatchObject({ kind: "flightNavigation", bypassNavigationCache: true });
+    expectSingleTraceEntry(decision, NavigationTraceReasonCodes.samePageSearch, {
+      targetHref: "https://example.com/docs?q=1#section",
+    });
   });
 
   it("treats hash removal as a flight navigation, not a same-document scroll", () => {


### PR DESCRIPTION
## Summary
- preserve client route alias resolution for segment-cache navigations with dynamic segments
- add coverage for longest wildcard aliases and exact package aliases in the app browser route manifest

## Validation
- vp test run tests/entry-templates.test.ts tests/link.test.ts tests/navigation-planner-early-intent.test.ts
- vp test run tests/app-browser-client-reuse-manifest.test.ts tests/app-optimistic-routing.test.ts tests/link-navigation.test.ts
- REPO="/Users/jamesanderson/.codex/worktrees/segment-cache-basic-28478866791/vinext" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts